### PR TITLE
feat: allow switching between ally healer and attacker brains

### DIFF
--- a/packages/unity/mmextensions/mmextensions/Ai/AiAllyBrain.cs
+++ b/packages/unity/mmextensions/mmextensions/Ai/AiAllyBrain.cs
@@ -88,8 +88,8 @@ namespace KBVE.MMExtensions.Ai
       handleWeapon.ForceWeaponAimControl = true;
       handleWeapon.ForcedWeaponAimControl = WeaponAim.AimControls.Script;
       handleWeapon.OnWeaponChange += handleWeapon_OnWeaponChange;
-      SetupDecisionsAndActionsHealer();
-      SetupDecisions();
+      SetupDecisionsHealer();
+      SetupDecisionsAttacker();
       SetupActions();
       base.Awake();
     }
@@ -114,7 +114,7 @@ namespace KBVE.MMExtensions.Ai
       else
       {
         Debug.Log("Weapon Change Attack");
-        SetupAllyStates();
+        SetupAllyAttackerStates();
         foreach (AIState state in States)
         {
           state.SetBrain(this);
@@ -123,7 +123,7 @@ namespace KBVE.MMExtensions.Ai
       }
     }
 
-    protected virtual void SetupDecisions()
+    protected virtual void SetupDecisionsAttacker()
     {
       detectPlayerDecision = CreateDetectTarget2DDecision(PLAYER_LAYER_INT, 100f, false);
       detectEnemyDecision = CreateDetectTarget2DDecision(ENEMY_LAYER_INT, 20f);
@@ -148,7 +148,7 @@ namespace KBVE.MMExtensions.Ai
       aIActionShoot.AimAtTarget = true;
     }
 
-    protected virtual void SetupAllyStates()
+    protected virtual void SetupAllyAttackerStates()
     {
       States = new List<AIState>
       {
@@ -280,7 +280,7 @@ namespace KBVE.MMExtensions.Ai
 
     private AIDecisionDistanceToTarget distanceToTarget9fDecision;
 
-    protected virtual void SetupDecisionsAndActionsHealer()
+    protected virtual void SetupDecisionsHealer()
     {
       detectPlayerDecision = CreateDetectTarget2DDecision(PLAYER_LAYER_INT, 100f, false);
       distanceToTarget9fDecision = CreateDistanceToTarget2DDecision(

--- a/packages/unity/mmextensions/mmextensions/Weapons/HealWeapon.cs
+++ b/packages/unity/mmextensions/mmextensions/Weapons/HealWeapon.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class HealWeapon : MonoBehaviour
+{
+
+}

--- a/packages/unity/mmextensions/mmextensions/Weapons/HealWeapon.cs.meta
+++ b/packages/unity/mmextensions/mmextensions/Weapons/HealWeapon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c6bded9d6af4d3484c5a916491ee7f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
This still needs testing for the actual switching, however as is you can use this component to have an ally automatically start with the correct brain for their initial weapon. It should *just work* for when they switch weapons.