### PR TITLE
Exclude index entry from itemdb

### DIFF
--- a/apps/kbve/astro-kbve/src/pages/api/itemdb.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/itemdb.json.ts
@@ -2,9 +2,10 @@ import { getCollection } from 'astro:content';
 
 import { validateItemUniqueness } from 'src/content/config';
 
-
 export const GET = async () => {
-	const itemEntries = await getCollection('itemdb');
+	const itemEntries = (await getCollection('itemdb')).filter(
+		(entry) => !entry.id.endsWith('index.mdx') && entry.data.key !== 0,
+	);
 
 	const key: Record<string, number> = {};
 	const items: any[] = [];


### PR DESCRIPTION
## Summary
- filter out `index.mdx` when generating item database

## Testing
- `npx vitest run` *(fails: Request failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_684208c45c7883229cd7c43c9ffd5be3