### PR TITLE
Fix itemdb index metadata

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/index.mdx
@@ -3,7 +3,12 @@ title: ItemDB Game Index
 description: |
     Overview of the games set in the KBVE universe.
     This index also highlights how RareIcon and other titles connect to the ItemDB.
+id: 'itemdb-index'
+ref: '01S1S1S1S1S1S1S1S1S1S1S1SA'
+name: 'ItemDB Index'
+type: 'index'
 key: 0
+pixelDensity: 64
 sidebar:
     label: ItemDB
     order: 1


### PR DESCRIPTION
## Summary
- add missing `id`, `ref`, `name`, `type` and `pixelDensity` fields to the ItemDB docs index

## Testing
- `npx nx run astro-kbve:check` *(fails: No existing Nx Cloud client)*

------
https://chatgpt.com/codex/tasks/task_e_684215b106548322aa04a9d538d8486e