### PR TITLE
Add questdb API endpoint

### DIFF
--- a/apps/kbve/astro-kbve/src/pages/api/questdb.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/questdb.json.ts
@@ -1,0 +1,32 @@
+import { getCollection } from 'astro:content';
+
+export const GET = async () => {
+  const questEntries = (await getCollection('questdb')).filter(
+    (entry) => !entry.id.endsWith('index.mdx')
+  );
+
+  const key: Record<string, number> = {};
+  const quests: any[] = [];
+
+  for (const entry of questEntries) {
+    const { id, guid } = entry.data as any;
+    if (!id || !guid) continue;
+
+    const quest = {
+      ...entry.data,
+      slug: `/questdb/${entry.id}`,
+    };
+
+    const index = quests.length;
+    quests.push(quest);
+
+    key[id] = index;
+    key[guid] = index;
+  }
+
+  return new Response(JSON.stringify({ quests, key }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- expose questdb collection as `/api/questdb.json`

## Testing
- `npx nx run astro-kbve:check` *(fails: No existing Nx Cloud client and failed to download new version)*

------
https://chatgpt.com/codex/tasks/task_e_68421667612c83229609ce715131167c