### PR TITLE
Fix quantum coffee image path

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/quantum-coffee.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/quantum-coffee.mdx
@@ -9,7 +9,7 @@ ref: '01JX0YM8XTR59QQ83STSSM0P93'
 name: 'Quantum Coffee'
 type: 'Drink'
 category: 392
-img: '/assets/items/skills/cooking/materials/quantum_coffee.png'
+img: '/assets/items/potion/space/quantum_coffee.png'
 pixelDensity: 64
 sortingLayer: Ground
 sortingOrder: 59


### PR DESCRIPTION
## Summary
- correct the quantum coffee image path in the item database

## Testing
- `npx prettier -w apps/kbve/astro-kbve/src/content/docs/itemdb/quantum-coffee.mdx` *(fails: Cannot find package 'prettier-plugin-astro')*


------
https://chatgpt.com/codex/tasks/task_e_6843d416669883229413ec776aa40aec