### PR TITLE
Add Adsense import to Feb 15 journal

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/02-15.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/02-15.mdx
@@ -9,6 +9,7 @@ description: Daily Log for February 15th for each year!
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
 
 ## Notes
 
@@ -105,3 +106,5 @@ I decided to begin building out a hybrid gitlab, one that will be hosted on gitl
 The goal of having additional repo locations is to avoid any issue with github, ideally making it so that the cicd pipeline is git agnostic.
 
 The private gitlab instance could be a docker instance or a kubernetes setup, I am not too sure yet but I will write out a couple plans that we can use.
+
+<Adsense />


### PR DESCRIPTION
## Summary
- add missing Adsense component import to February 15th journal entry
- include `<Adsense />` at the end of the entry

## Testing
- `pnpm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843f8dff0748322a39d721770394403