### PR TITLE
Add Adsense to 02-09 journal entry

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/02-09.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/02-09.mdx
@@ -9,6 +9,7 @@ description: Daily Log for February 9th for each year!
 tags:
   - daily
 ---
+import { Adsense } from '@kbve/astropad';
 
 ## Notes
 
@@ -47,6 +48,7 @@ pnpm nx g move --project cryptothrone.com --destination apps/gamejam/cryptothron
 
 ```
 
+<Adsense />
 ## 2024
 
 #### Character


### PR DESCRIPTION
## Summary
- include Adsense astro pad in February 9 journal entry

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843f9d6cd68832293dac24758bc7bc7