### PR TITLE
Fix missing Adsense import

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/02-10.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/02-10.mdx
@@ -9,6 +9,9 @@ description: Daily Log for February 10th for each year!
 tags:
   - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add missing Adsense import to February 10 journal entry
- insert `<Adsense />` component

## Testing
- `npx -y prettier -c apps/kbve/astro-kbve/src/content/docs/journal/02-10.mdx` *(fails: Cannot find package 'prettier-plugin-astro')*

------
https://chatgpt.com/codex/tasks/task_e_6843fba93e8883228f63333ab621ce88