### PR TITLE
Fix missing adsense import in journal entry

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/02-11.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/02-11.mdx
@@ -9,6 +9,9 @@ description: Daily Log for February 11th for each year!
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add Adsense embed to `02-11.mdx`

## Testing
- `npx nx --version` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6844067984d88322b6b4f0d4605ae8d5