### PR TITLE
Add missing Adsense component

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/kryptonite-book.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/kryptonite-book.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -59,6 +60,8 @@ Not recognized by any official doctrine or heroic registry.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- display ads on Kryptonite Book page

## Testing
- `npx nx --help` *(fails: needs package install)*

------
https://chatgpt.com/codex/tasks/task_e_6844065ebf1883228cca74c57b7b825d