### PR TITLE
Add Adsense embed to Feb 12 journal

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/02-12.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/02-12.mdx
@@ -9,6 +9,7 @@ description: Daily Log for February 12th for each year!
 tags:
     - daily
 ---
+import { Adsense } from "@kbve/astropad";
 
 ## Notes
 
@@ -230,3 +231,6 @@ The character section could be split into a couple different components, hmm, th
 During the pipeline roll out, it seems that the auto review passed on 3 of the test cases but faild on the remaining 7.
 
 I actually think the failure in the test case was on my end, I need to adjust the test casing again, which will be easier with finish products to test against.
+
+<Adsense />
+


### PR DESCRIPTION
## Summary
- add missing Adsense component import for February 12 journal entry
- embed `<Adsense />` component

## Testing
- `grep -n "Adsense" -n apps/kbve/astro-kbve/src/content/docs/journal/02-12.mdx`


------
https://chatgpt.com/codex/tasks/task_e_684417cbcd2483229df1d03c0472e9c7