### PR TITLE
Add adsense to microchip motherboard

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/microchip-motherboard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/microchip-motherboard.mdx
@@ -39,6 +39,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from "@kbve/astropad";
 
 ## Item
 
@@ -57,6 +58,7 @@ Psychotic once said, we chasing the rush of trying to decipher the code a decade
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- ensure itemdb entry for Microchip Motherboard includes Adsense import and component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684418f79ea48322a8ec01f567e60b80