### PR TITLE
Add Adsense to Stardust item

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/alchemist-stardust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/alchemist-stardust.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -57,6 +58,7 @@ Either way, its properties are stable in 5D.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include Adsense import from astropad in `alchemist-stardust.mdx`
- add `<Adsense />` component after the item details panel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684428da3a2483229b8aa1a311b7aa5c