### PR TITLE
Add Adsense to Auto Cooker item page

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/auto-cooker-9000.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/auto-cooker-9000.mdx
@@ -39,6 +39,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -55,6 +56,7 @@ Reverse-engineered from a crashed alien food drone and reprogrammed with culinar
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add Adsense import from astropad to `auto-cooker-9000.mdx`
- insert `<Adsense />` component after the ItemDBPanel section

## Testing
- `grep -n "Adsense" apps/kbve/astro-kbve/src/content/docs/itemdb/auto-cooker-9000.mdx`

------
https://chatgpt.com/codex/tasks/task_e_684429934e60832280170366027c15ca