### PR TITLE
Add Adsense to anime body pillow entry

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/anime-body-pillow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/anime-body-pillow.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -57,6 +58,7 @@ Fabric recovered from Expo Ruins.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add missing Adsense import to anime body pillow entry
- insert `<Adsense />` component

## Testing
- `grep -n Adsense apps/kbve/astro-kbve/src/content/docs/itemdb/anime-body-pillow.mdx`


------
https://chatgpt.com/codex/tasks/task_e_68442dc16af883228f4253db139f8422