### PR TITLE
Add Adsense component to a single itemdb file

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/brown-curry-sauce.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/brown-curry-sauce.mdx
@@ -38,6 +38,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -50,6 +51,8 @@ Based on a culinary formula passed down through generations of mech-cooks and me
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- update brown-curry-sauce itemdb file with Adsense import
- include Adsense component after the ItemDB panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68443404bc5c8322b57b49718d4fdb8b