### PR TITLE
Add Adsense to Feb 14 journal

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/02-14.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/02-14.mdx
@@ -10,6 +10,8 @@ tags:
     - daily
 ---
 
+import { Adsense } from '@kbve/astropad';
+
 ## Notes
 
 ## 2025
@@ -42,6 +44,8 @@ tags:
     The topic for the Brackeys 13 aka 2025.1 gamejam was announced!
     It seems to be `ERASE` with a couple wild cards, `MIMIC`, `STYLE SHIFT`, and `SHOPAHOLIC`.
     Let me update the notes for the game to reflect that.
+
+<Adsense />
 
 ## 2024
 


### PR DESCRIPTION
## Summary
- add missing Adsense component to February 14 journal

## Testing
- `npx nx run astro-kbve:check` *(fails: requires interactive npm package install)*

------
https://chatgpt.com/codex/tasks/task_e_6844ad8ca8548322a5007700f71663d6