### PR TITLE
Add Adsense to Bone itemdb

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/bone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/bone.mdx
@@ -39,6 +39,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -55,6 +56,7 @@ Just be very careful with bones around them damn neighborhood hell hounds doe an
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include the Adsense component in the Bone itemdb entry to match other docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844aef8c4488322a6cbfc3536d72e29