### PR TITLE
Add Adsense pad to Brainrot Laptop itemdb

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/brainrot-laptop.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/brainrot-laptop.mdx
@@ -47,6 +47,7 @@ import {
     LinkCard,
     Code,
 } from '@astrojs/starlight/components';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -119,6 +120,8 @@ sudo brainrot --purge-cache
     }
   ]}
 />
+
+<Adsense />
 
 ---
 


### PR DESCRIPTION
## Summary
- import Adsense astro pad in the Brainrot Laptop docs page
- embed `<Adsense />` component before the DevLog section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845304a52208322a5610a238be4d7be