### PR TITLE
Fix adsense in itemdb garlic bread

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/garlic-bread.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/garlic-bread.mdx
@@ -39,6 +39,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -51,6 +52,7 @@ Common fare among wanderers craving comfort between battles.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add Adsense import and component to garlic bread item in the itemdb

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68453363cf2883228ec50b60bfb80887