### PR TITLE
Add Adsense to item page

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/cheddar-cheese.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/cheddar-cheese.mdx
@@ -42,6 +42,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -59,6 +60,7 @@ Made with [fresh milk](/itemdb/fresh-milk/).
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include Adsense embed for the Cheddar Cheese item

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845401520e08322bc11a04635098537