### PR TITLE
Add Adsense component to Kiwi Jigsaw entry

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/kiwi-jigsaw.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/kiwi-jigsaw.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -60,6 +61,8 @@ Just kidding, you will lose the game, life, even the universe will be gone.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include Adsense component in Kiwi Jigsaw itemdb file

## Testing
- `grep -n "Adsense" apps/kbve/astro-kbve/src/content/docs/itemdb/kiwi-jigsaw.mdx`

------
https://chatgpt.com/codex/tasks/task_e_6845ed030b2483229571e181c564429c