### PR TITLE
Add Adsense import to Surfer Longboard

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/surfer-longboard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/surfer-longboard.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -53,6 +54,8 @@ Once belonged to a pacifist war courier who surfed through post-flood ruins.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include Adsense component in `surfer-longboard.mdx`

## Testing
- `grep -n "Adsense" apps/kbve/astro-kbve/src/content/docs/itemdb/surfer-longboard.mdx`

------
https://chatgpt.com/codex/tasks/task_e_6845ffc3d0948322a6a64fca8c9bcd17