### PR TITLE
Add Adsense to Astro index page

### DIFF
--- a/apps/kbve/astro-kbve/src/pages/index.astro
+++ b/apps/kbve/astro-kbve/src/pages/index.astro
@@ -13,6 +13,7 @@ import NeoGlassPanel from 'src/layouts/components/panel/NeoGlassPanel.astro';
 import QuadGlassPanel from 'src/layouts/components/panel/QuadGlassPanel.astro';
 
 import SimpleGlassImagePanel from 'src/layouts/components/panel/SimpleGlassImagePanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 function withBaseUrl(path: string, base: URL | string): string {
 	return new URL(path, base).toString();
@@ -111,9 +112,11 @@ const glassTiles = [
 
 	<SimpleGlassImagePanel />
 
-	<BentoGrid>
-		{tiles.map((tile) => <BentoTile {...tile} />)}
+        <BentoGrid>
+                {tiles.map((tile) => <BentoTile {...tile} />)}
 
-		{glassTiles.map((glassTile) => <NeoGlassBentoTile {...glassTile} />)}
-	</BentoGrid>
+                {glassTiles.map((glassTile) => <NeoGlassBentoTile {...glassTile} />)}
+        </BentoGrid>
+
+        <Adsense />
 </Layout>


### PR DESCRIPTION
## Summary
- import Adsense component from `@kbve/astropad`
- render `<Adsense />` on the home page

## Testing
- `npx nx run astro-kbve:check` *(fails: Command `nx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846003658908322abec137458b8f4c7