### PR TITLE
Add Adsense to Jelly Jam item

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/eds-jelly-jam.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/eds-jelly-jam.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -56,6 +57,8 @@ Made in a solar-powered food truck from synthetic grapes or whatever was growing
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add Adsense import and component to `eds-jelly-jam` docs entry

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68468efed4108322aabcba0999a7a9e0