### PR TITLE
Add Adsense to gravity-boots itemdb entry

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/gravity-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/gravity-boots.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -53,6 +54,8 @@ Their thrusters hum softly, adjusting magnetic grip as you step.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include Adsense import from astropad in `gravity-boots.mdx`
- render `<Adsense />` below the item panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e18e0fc88322b9ca7a3445a130f1