### PR TITLE
Add Adsense to taco itemdb file

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/fried-fish-taco.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/fried-fish-taco.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -58,6 +59,8 @@ Crafted during the Crossbay Riots but the recipe was lost to time, thus the **Fi
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- ensure fried fish taco itemdb entry imports the Adsense component
- render the `<Adsense />` component below the ItemDB panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e5686d74832294e8b6decfd3a397