### PR TITLE
Fix missing Adsense in May 12 journal entry

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/05-12.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/05-12.mdx
@@ -11,6 +11,10 @@ tags:
     - daily
 ---
 
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 ## 2025
 
 ### KBVE Rewrite


### PR DESCRIPTION
## Summary
- add Adsense import from astropad to May 12 entry
- insert `<Adsense />` component

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848089de03c83229f537d708ce9f074