### PR TITLE
Add Adsense imports for some March journal pages

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-18.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-18.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## Notes

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-19.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-19.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-20.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-20.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-21.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-21.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## Notes

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-23.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-23.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-25.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-25.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## Notes

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-26.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-26.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-27.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-27.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## Notes

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-29.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-29.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-30.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-30.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add missing Adsense imports and components to March journal posts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a8345ceac83228bd3805863c81da4