### PR TITLE
Add Adsense imports to select journal entries

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-04.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-04.mdx
@@ -11,6 +11,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 
 
@@ -177,3 +179,4 @@ The `grid:bento:bento` is a referfence to the Astro VE `bento.astro` , the core 
 
 We are basically splitting the code to make it easier to reuse.
 
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-09.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-09.mdx
@@ -10,6 +10,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 
 ## Notes
@@ -88,3 +90,4 @@ I hate having to go through all the adsense policy changes, but the big ones see
 I am thinking I should at least add multiplayer for the Phaser game and try to sneak in a couple different concepts, maybe like a leaderboard and see what we can do from there.
 
 
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/03-31.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/03-31.mdx
@@ -10,6 +10,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 ## Notes
 
@@ -108,3 +110,5 @@ There are three really cool and amazing codepens that I found!
 - https://codepen.io/yudizsolutions/pen/bGzKbwm
 
 All of the three were amazing! I am thinking of taking them apart and adding them into the Astro VE library as a reference for future projects.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-01.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-01.mdx
@@ -11,6 +11,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 
 ## Notes
@@ -204,3 +206,4 @@ However there are a couple errors that are appearing in the source code, includi
 
 So there might be an issue with how we are doing the root / application rendering.
 
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-02.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-02.mdx
@@ -13,6 +13,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 
 ## Notes
@@ -119,3 +121,4 @@ networks:
 
 Mapping out the routes for the deployment has to be done right this round, including making sure that the applications that we build can easily be deployed and maintained.
 
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-03.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-03.mdx
@@ -12,6 +12,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 
 ## Notes
@@ -192,3 +194,4 @@ networks:
 
 We can have the n8n public facing from the start but eventually we would want to proxy this out as a subfolder? Hmm.
 
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-04.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-04.mdx
@@ -10,6 +10,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 ## Notes
 
@@ -74,3 +76,5 @@ Here is the guide that we will be [following and using as a reference.](https://
 ### 404
 
 The new 404 page will be ready by this weekend but I do need to focus on the Discord App Pitch, which might delay a bunch of progress on the website.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-05.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-05.mdx
@@ -10,6 +10,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 
 ## Notes
@@ -58,3 +60,5 @@ After looking through the options for a mailserver, the one that stands out the 
 It has a rust backend and is supported through an EU grant for Open source technology, which is a huge +1 for the application.
 The software has a decent amount of progress and provides an all-in-one solution that we were looking for, however my bigger concern would be the amount of storage that email servers would take.
 We could address this concern by keeping the emails only for 72 hours and/or forwarding them over to our GMAILs, but this is all for a future date.
+
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-06.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-06.mdx
@@ -10,6 +10,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 ## Notes
 
@@ -73,3 +75,4 @@ I am thinking the build failed because we had two additional files that we did n
 The best meal that I had today was a classic maggi soup made by my aunt!
 The taste of India hit all the notes that I was look for, savory, sweet, spicy, ect... there could be a food truck that only sold this meal and it would make thousands a week.
 
+<Adsense />

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-07.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-07.mdx
@@ -10,6 +10,8 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
 
 
 ## Notes
@@ -243,3 +245,5 @@ fn get_env_var(name: &str) -> Result<String, String> {
     fs::read_to_string(file_path).map_err(|err| format!("Error reading file for {}: {}", name, err))
 
 ```
+
+<Adsense />


### PR DESCRIPTION
## Summary
- add missing `Adsense` imports to several journal files
- insert `<Adsense />` component at the end of each updated journal entry

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a9f11eb20832282974d2b36cb72f6