### PR TITLE
Add Adsense imports to April journal entries

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-09.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-09.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-10.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-10.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-11.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-11.mdx
@@ -11,6 +11,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## Notes

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-13.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-13.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-14.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-14.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Notes
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-15.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-15.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## Notes

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-16.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-16.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## Notes

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-17.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-17.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## 2025
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-18.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-18.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## 2025

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-19.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-19.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## 2025
 


### PR DESCRIPTION
## Summary
- add missing Adsense imports to a set of April journal entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aaea87e108322895bd66dace6ffbd