### PR TITLE
Add Adsense component to April-May journals

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-21.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-21.mdx
@@ -11,6 +11,10 @@ tags:
     - daily
 ---
 
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 ## 2025
 
 ### Svelte Panels

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-22.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-22.mdx
@@ -11,6 +11,10 @@ tags:
     - daily
 ---
 
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 ## 2025
 
 ### Svelte 5

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-23.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-23.mdx
@@ -11,6 +11,10 @@ tags:
     - daily
 ---
 
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 ## 2025
 
 ### Astro Askama

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-24.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-24.mdx
@@ -11,6 +11,10 @@ tags:
     - daily
 ---
 
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 ## 2025
 
 ### Astro Web Workers

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-25.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-25.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## 2025

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-26.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-26.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 
 ## 2025

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-27.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-27.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## 2025
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-28.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-28.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## 2025
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/04-29.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/04-29.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## 2025
 

--- a/apps/kbve/astro-kbve/src/content/docs/journal/05-02.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/journal/05-02.mdx
@@ -10,6 +10,10 @@ description: |
 tags:
     - daily
 ---
+import { Adsense } from '@kbve/astropad';
+
+<Adsense />
+
 
 ## Quote
 


### PR DESCRIPTION
## Summary
- include `Adsense` import and component on several April and May journal entries

## Testing
- `grep -n Adsense apps/kbve/astro-kbve/src/content/docs/journal/05-02.mdx`

------
https://chatgpt.com/codex/tasks/task_e_684b6575e08c8322a1d0fee1c234e0bd