### PR TITLE
Add missing Adsense imports to itemdb files

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/frozen-pizza-rolls.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/frozen-pizza-rolls.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -57,6 +58,7 @@ Found in frozen bunkers, old vending rigs, or deep freezer caches.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/green-pasta-sauce.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/green-pasta-sauce.mdx
@@ -39,6 +39,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -53,6 +54,7 @@ Great with noodles, better in sunlight.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/grilled-fish-burrito.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/grilled-fish-burrito.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -54,6 +55,7 @@ Ideal for long journeys, power surges, and culinary-based buffs.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/herbal-medi-wrap.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/herbal-medi-wrap.mdx
@@ -42,6 +42,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -58,6 +59,7 @@ Its smell alone brings peace and its effect brings you home.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/holographic-arcade-token.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/holographic-arcade-token.mdx
@@ -38,6 +38,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -48,6 +49,7 @@ The **Holographic Arcade Token** pulses with retro energy. Drop it into a functi
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/ink-pasta-sauce.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/ink-pasta-sauce.mdx
@@ -37,6 +37,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -50,6 +51,7 @@ The sauce whispers back if eaten in silence.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/jar-of-honey.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/jar-of-honey.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -59,6 +60,7 @@ Processed by apiarists and monks of the Golden Bloom Order.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/jareds-teddy-bear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/jareds-teddy-bear.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -56,6 +57,7 @@ Wait... was it Jareds or Donalds teddy bear.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/krispee-air-fryer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/krispee-air-fryer.mdx
@@ -42,6 +42,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -55,6 +56,7 @@ It’s rumored that food cooked within retains a trace of soul… and crunch.
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/lobster-soup.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/lobster-soup.mdx
@@ -39,6 +39,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -52,6 +53,7 @@ Best enjoyed in silence or after battle, be sure to catch more [lobsters](/itemd
 <ItemDBPanel data={frontmatter} />
 
 ---
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- update various itemdb entries with Adsense import
- insert `<Adsense />` component after the item panel

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684b65d0177883228fadd06a848b0d36