### PR TITLE
Add Adsense component to itemdb entries

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/punk-skateboard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/punk-skateboard.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -55,6 +56,8 @@ Wheels salvaged from a drone courier.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/quantum-coffee.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/quantum-coffee.mdx
@@ -38,6 +38,7 @@ scripts:
 ---
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -49,6 +50,8 @@ Its aroma sharpens the mind while briefly distorting the flow of time around you
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/quantum-energy-drink.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/quantum-energy-drink.mdx
@@ -38,6 +38,7 @@ scripts:
 ---
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
 
 ## Item
@@ -53,6 +54,8 @@ Some racers swear it lets them anticipate turns before they happen, though autho
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/quick-toolbelt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/quick-toolbelt.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -53,6 +54,8 @@ It may not look like much, but seconds saved are systems saved.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/rebel-radio.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/rebel-radio.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -57,6 +58,8 @@ Broadcast range limited by orbital interference.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/retro-crt-monitor.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/retro-crt-monitor.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -60,6 +61,8 @@ Do not worry if it breaks, it can be recycled for other parts, like [Microchip m
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/rubber-tire.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/rubber-tire.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -55,6 +56,8 @@ Recovered from junkyards, burnt-out cars, and forgotten racing arenas.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/salmon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/salmon.mdx
@@ -36,6 +36,8 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 
+import { Adsense } from '@kbve/astropad';
+
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
 
 import {
@@ -55,6 +57,8 @@ Salmon is a basic food item. It’s commonly caught in rivers and lakes. While n
 ---
 
 <ItemDBPanel data={frontmatter} />
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/spicy-nacho-supreme.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/spicy-nacho-supreme.mdx
@@ -40,6 +40,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -52,6 +53,8 @@ Legends say it was first cooked on a scavenged engine block during a long siege.
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/spicy-ramen.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/spicy-ramen.mdx
@@ -41,6 +41,7 @@ scripts:
 
 import ItemDBPanel from 'src/layouts/starlight/frontmatter/itemdb/ItemDBPanel.astro';
 import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
+import { Adsense } from '@kbve/astropad';
 
 ## Item
 
@@ -51,6 +52,8 @@ import VisualNovelPanel from 'src/layouts/components/vn/VisualNovelPanel.astro';
 <ItemDBPanel data={frontmatter} />
 
 ---
+
+<Adsense />
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- import `Adsense` from `@kbve/astropad` in ten itemdb entries
- render `<Adsense />` component near the top of those docs

## Testing
- `grep -n Adsense apps/kbve/astro-kbve/src/content/docs/itemdb/punk-skateboard.mdx`


------
https://chatgpt.com/codex/tasks/task_e_684c9960c6dc83229f9dd0db737418cd