### PR TITLE
Add label filter for GitHub issues

### DIFF
--- a/apps/kbve/astro-kbve/src/pages/i.astro
+++ b/apps/kbve/astro-kbve/src/pages/i.astro
@@ -7,16 +7,38 @@ const pageTitle = 'Issues | KBVE';
     <section class="px-6 py-12 sm:px-8 lg:px-12">
         <div class="mx-auto max-w-7xl space-y-6">
             <h1 class="text-4xl font-bold text-white text-center mb-4">GitHub Issues</h1>
+            <p id="filter-info" class="text-white text-center mb-4"></p>
             <div id="issues" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"></div>
         </div>
     </section>
     <script is:inline>
         document.addEventListener("DOMContentLoaded", () => {
             const container = document.getElementById('issues');
+            const filterInfo = document.getElementById('filter-info');
             if (!container) return;
 
+            const allowedLabels = [
+                'unity',
+                'error',
+                'bug',
+                'enhancement',
+                'question',
+                'documentation',
+            ];
+
+            const hash = window.location.hash.replace(/^#/, '');
+            const sanitized = hash.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+            const label = allowedLabels.includes(sanitized) ? sanitized : null;
+            const url = label
+                ? `https://api.github.com/repos/kbve/kbve/issues?labels=${encodeURIComponent(label)}`
+                : 'https://api.github.com/repos/kbve/kbve/issues';
+
+            if (filterInfo) {
+                filterInfo.textContent = label ? `Filtering by label: ${label}` : '';
+            }
+
             container.innerHTML = '';
-            fetch('https://api.github.com/repos/kbve/kbve/issues')
+            fetch(url)
                 .then((r) => r.json())
                 .then((issues) => {
                     issues.forEach((issue) => {


### PR DESCRIPTION
## Summary
- display filter information on issues page
- use URL hash (e.g. `#unity`) as label filter after sanitizing
- whitelist allowed labels to avoid XSS

## Testing
- `npx nx run astro-kbve:check` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_684f3b8c85f4832282b0765c42238258