### PR TITLE
Add account type details for stock index

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/stock/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/stock/index.mdx
@@ -52,6 +52,8 @@ This area contains compiled data and information about various publicly traded c
   </Card>
 </CardGrid>
 
+
+
 ### Account Types
 
 <CardGrid>
@@ -64,10 +66,47 @@ This area contains compiled data and information about various publicly traded c
   <Card title="Traditional IRA" icon="archive">
     Tax-deferred retirement savings account
   </Card>
+  <Card title="HSA" icon="medkit">
+    Health Savings Account for medical expenses
+  </Card>
   <Card title="Taxable Account" icon="document">
     Standard brokerage investment account
   </Card>
 </CardGrid>
+
+### Roth IRA
+
+- Contributions are made with after-tax dollars
+- Qualified withdrawals in retirement are tax-free
+- Income limits may restrict eligibility
+- Ideal for long-term, tax-free growth
+
+### 401(k)
+
+- Employer-sponsored plan with pretax contributions
+- Potential for employer matching funds
+- Contribution limits reset annually
+- Early withdrawals may incur penalties
+
+### Traditional IRA
+
+- Contributions may be tax-deductible
+- Earnings grow tax-deferred until withdrawn
+- Withdrawals are taxed as ordinary income
+- Beneficial if you expect a lower tax bracket in retirement
+
+### HSA
+
+- Designed for high-deductible health plans
+- Contributions are tax-deductible and can be invested
+- Funds grow tax-free for medical expenses
+- Non-medical withdrawals after age 65 are taxed as income
+
+### Taxable Account
+
+- No contribution limits or withdrawal restrictions
+- Capital gains taxes apply on realized profits
+- Offers the most flexibility for non-retirement goals
 
 ### Disclaimer
 


### PR DESCRIPTION
## Summary
- expand `stock/index.mdx` with a Health Savings Account card
- add short explanations of each account type

## Testing
- `pnpm -r test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fc8d171c83229810c3c8b8829f46