### PR TITLE
Enable astro prefetch on various links

### DIFF
--- a/apps/kbve/astro-kbve/src/layouts/core/Navbar.astro
+++ b/apps/kbve/astro-kbve/src/layouts/core/Navbar.astro
@@ -163,10 +163,10 @@ import BrandLogo from 'src/layouts/core/BrandLogo.astro';
         <button id="close-member-modal" class="absolute top-2 right-2 text-neutral-400 hover:text-red-400 text-xl font-bold">&times;</button>
         <h2 class="text-xl font-bold mb-4 text-cyan-700 dark:text-cyan-200">Member Menu</h2>
         <ul class="flex flex-col gap-3 mb-4">
-          <li><a href="/profile" class="text-cyan-600 dark:text-cyan-300 hover:underline">Profile</a></li>
-          <li><a href="/logout" class="text-cyan-600 dark:text-cyan-300 hover:underline">Logout</a></li>
-          <li><a href="/messages" class="text-cyan-600 dark:text-cyan-300 hover:underline">Messages</a></li>
-          <li><a href="/igbc" class="text-cyan-600 dark:text-cyan-300 hover:underline">IGBC</a></li>
+          <li><a href="/profile" data-astro-prefetch class="text-cyan-600 dark:text-cyan-300 hover:underline">Profile</a></li>
+          <li><a href="/logout" data-astro-prefetch class="text-cyan-600 dark:text-cyan-300 hover:underline">Logout</a></li>
+          <li><a href="/messages" data-astro-prefetch class="text-cyan-600 dark:text-cyan-300 hover:underline">Messages</a></li>
+          <li><a href="/igbc" data-astro-prefetch class="text-cyan-600 dark:text-cyan-300 hover:underline">IGBC</a></li>
         </ul>
       </div>
     `;

--- a/apps/kbve/astro-kbve/src/layouts/core/panels/StaticRight.astro
+++ b/apps/kbve/astro-kbve/src/layouts/core/panels/StaticRight.astro
@@ -13,6 +13,7 @@ import PanelCloseButton from './PanelCloseButton.astro';
   <div class="mt-6 space-y-4" id="auth-login-register">
     <a
       href="/login"
+      data-astro-prefetch
       class="block w-full rounded-md bg-cyan-600 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-cyan-700 transition"
     >
       Login
@@ -20,21 +21,22 @@ import PanelCloseButton from './PanelCloseButton.astro';
 
     <a
       href="/register"
+      data-astro-prefetch
       class="block w-full rounded-md bg-purple-600 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-purple-700 transition"
     >
       Register
     </a>
 
     <div class="mt-6 text-xs text-center text-neutral-500 dark:text-neutral-400">
-      Need help? <a href="/support" class="underline hover:text-cyan-500">Contact Support</a>
+      Need help? <a href="/support" data-astro-prefetch class="underline hover:text-cyan-500">Contact Support</a>
     </div>
   </div>
 
   <div class="mt-6 space-y-4 hidden" id="member-links-panel">
-    <a href="/settings" class="block w-full rounded-md bg-cyan-700 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-cyan-800 transition">Settings</a>
-    <a href="/support" class="block w-full rounded-md bg-purple-700 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-purple-800 transition">Support</a>
-    <a href="/profile" class="block w-full rounded-md bg-cyan-600 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-cyan-700 transition">Profile</a>
-    <a href="/marketplace" class="block w-full rounded-md bg-purple-600 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-purple-700 transition">Marketplace</a>
+    <a href="/settings" data-astro-prefetch class="block w-full rounded-md bg-cyan-700 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-cyan-800 transition">Settings</a>
+    <a href="/support" data-astro-prefetch class="block w-full rounded-md bg-purple-700 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-purple-800 transition">Support</a>
+    <a href="/profile" data-astro-prefetch class="block w-full rounded-md bg-cyan-600 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-cyan-700 transition">Profile</a>
+    <a href="/marketplace" data-astro-prefetch class="block w-full rounded-md bg-purple-600 text-white text-center py-2 px-4 text-sm font-semibold hover:bg-purple-700 transition">Marketplace</a>
   </div>
 </div>
 

--- a/apps/kbve/astro-kbve/src/pages/login.astro
+++ b/apps/kbve/astro-kbve/src/pages/login.astro
@@ -351,7 +351,7 @@ import OppsAuth from 'src/layouts/client/supabase/auth/OppsAuth';
             </div>
           </a>
           
-          <a href="/register" 
+          <a href="/register" data-astro-prefetch
             class="group/card flex flex-col items-center p-6 rounded-xl bg-zinc-900/50 border border-zinc-700/30 hover:border-green-500/50 transition-all duration-300 hover:bg-zinc-900/70 hover:scale-105">
             <div class="w-12 h-12 rounded-lg bg-gradient-to-r from-green-500 to-emerald-600 flex items-center justify-center mb-4 shadow-md group-hover/card:scale-110 transition-transform duration-300">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- opt‑in to prefetch on the register link
- add prefetch to member modal links in the navbar
- prefetch links in the right panel menu

## Testing
- `pnpm exec nx format:write` *(fails: Could not find `.modules.yaml`)*
- `pnpm install` *(fails: 403 Forbidden while fetching grpc-tools binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6864368a3c548322968cf8aadd8d3bbc