### PR TITLE
Add prefetch attribute to member and login links

### DIFF
--- a/apps/kbve/astro-kbve/src/layouts/client/supabase/login/Login.tsx
+++ b/apps/kbve/astro-kbve/src/layouts/client/supabase/login/Login.tsx
@@ -333,16 +333,16 @@ export const Login = () => {
         <div className="text-center space-y-2 pt-4 border-t border-zinc-700/50">
           <p className="text-zinc-400 text-sm">
             Don't have an account?{' '}
-            <a 
-              href="/register" 
+            <a data-astro-prefetch
+              href="/register"
               className="text-cyan-400 hover:text-cyan-300 font-medium transition-colors duration-200"
             >
               Create one here
             </a>
           </p>
           <p className="text-zinc-500 text-sm">
-            <a 
-              href="/reset" 
+            <a data-astro-prefetch
+              href="/reset"
               className="hover:text-zinc-400 transition-colors duration-200"
             >
               Forgot your password?

--- a/apps/kbve/astro-kbve/src/layouts/client/supabase/profile/UserEmailWarning.tsx
+++ b/apps/kbve/astro-kbve/src/layouts/client/supabase/profile/UserEmailWarning.tsx
@@ -48,7 +48,7 @@ const UserEmailWarning: React.FC = () => {
 
       <div className="flex flex-col gap-3 w-full max-w-sm">
         {!user?.email ? (
-          <a
+          <a data-astro-prefetch
             href="/settings"
             className={twMerge(
               'inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg',

--- a/apps/kbve/astro-kbve/src/layouts/client/supabase/profile/member/MemberCard.tsx
+++ b/apps/kbve/astro-kbve/src/layouts/client/supabase/profile/member/MemberCard.tsx
@@ -40,7 +40,7 @@ const MemberCard: React.FC = () => {
     return (
       <div className={twMerge('flex flex-col items-center justify-center gap-4 p-6 rounded-xl bg-gradient-to-br from-cyan-100/60 to-purple-100/40 dark:from-cyan-900/30 dark:to-purple-900/20 shadow-lg')}> 
         <div className="text-lg font-semibold text-neutral-700 dark:text-neutral-200">No member profile found.</div>
-        <a
+        <a data-astro-prefetch
           href="/onboarding"
           className={twMerge(
             'inline-block px-5 py-2 rounded-lg bg-gradient-to-r from-cyan-400 to-purple-400 text-white font-bold shadow hover:from-cyan-500 hover:to-purple-500 transition-colors duration-200',


### PR DESCRIPTION
## Summary
- prefetch internal links for onboarding and email warning
- prefetch login page links

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866d3e5a6d08322aa1c9f2744712172