### PR TITLE
Add prefetch attributes on internal links

### DIFF
--- a/apps/kbve/astro-kbve/src/layouts/client/supabase/auth/MembersOnly.tsx
+++ b/apps/kbve/astro-kbve/src/layouts/client/supabase/auth/MembersOnly.tsx
@@ -61,12 +61,14 @@ const MembersOnly: React.FC = () => {
           <div className="flex gap-3 mt-2">
             <a
               href="/login"
+              data-astro-prefetch
               className="bg-gradient-to-br from-cyan-400 to-purple-500 text-white font-semibold py-2 px-6 rounded-full shadow hover:from-cyan-300 hover:to-purple-400 hover:shadow-lg transition border-2 border-transparent hover:border-cyan-400"
             >
               Login
             </a>
             <a
               href="/register"
+              data-astro-prefetch
               className="bg-gradient-to-br from-purple-500 to-cyan-400 text-white font-semibold py-2 px-6 rounded-full shadow hover:from-purple-400 hover:to-cyan-300 hover:shadow-lg transition border-2 border-transparent hover:border-purple-400"
             >
               Register

--- a/apps/kbve/astro-kbve/src/layouts/components/dashboard/basic/about/KBVEAbout.astro
+++ b/apps/kbve/astro-kbve/src/layouts/components/dashboard/basic/about/KBVEAbout.astro
@@ -264,9 +264,10 @@ import ReactAbout from './ReactAbout';
 								</div>
 							</div>
 							
-							<a 
-								href="/community" 
-								class="inline-flex items-center gap-2 bg-gradient-to-r from-indigo-500 to-purple-600 text-white px-6 py-3 rounded-xl font-semibold hover:from-indigo-400 hover:to-purple-500 transition-all duration-200 shadow-lg hover:shadow-xl hover:-translate-y-0.5">
+                                                        <a
+                                                                href="/community"
+                                                                data-astro-prefetch
+                                                                class="inline-flex items-center gap-2 bg-gradient-to-r from-indigo-500 to-purple-600 text-white px-6 py-3 rounded-xl font-semibold hover:from-indigo-400 hover:to-purple-500 transition-all duration-200 shadow-lg hover:shadow-xl hover:-translate-y-0.5">
 								<span>Join Community</span>
 								<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
 									<path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"/>

--- a/apps/kbve/astro-kbve/src/layouts/components/dashboard/home/components/CreditsModal.tsx
+++ b/apps/kbve/astro-kbve/src/layouts/components/dashboard/home/components/CreditsModal.tsx
@@ -379,6 +379,7 @@ const CreditsModal: React.FC<CreditsModalProps> = memo(({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <a
               href="/igbc"
+              data-astro-prefetch
               className="flex items-center space-x-3 p-3 bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors duration-200 group"
             >
               <Award className="w-5 h-5 text-yellow-400 group-hover:text-yellow-300" />
@@ -391,6 +392,7 @@ const CreditsModal: React.FC<CreditsModalProps> = memo(({
             
             <a
               href="/docs/credits"
+              data-astro-prefetch
               className="flex items-center space-x-3 p-3 bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors duration-200 group"
             >
               <BookOpen className="w-5 h-5 text-blue-400 group-hover:text-blue-300" />
@@ -403,6 +405,7 @@ const CreditsModal: React.FC<CreditsModalProps> = memo(({
             
             <a
               href="/marketplace"
+              data-astro-prefetch
               className="flex items-center space-x-3 p-3 bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors duration-200 group"
             >
               <ShoppingCart className="w-5 h-5 text-green-400 group-hover:text-green-300" />
@@ -415,6 +418,7 @@ const CreditsModal: React.FC<CreditsModalProps> = memo(({
             
             <a
               href="/earn"
+              data-astro-prefetch
               className="flex items-center space-x-3 p-3 bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors duration-200 group"
             >
               <TrendingUp className="w-5 h-5 text-purple-400 group-hover:text-purple-300" />
@@ -427,6 +431,7 @@ const CreditsModal: React.FC<CreditsModalProps> = memo(({
             
             <a
               href="/referrals"
+              data-astro-prefetch
               className="flex items-center space-x-3 p-3 bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors duration-200 group"
             >
               <Users className="w-5 h-5 text-cyan-400 group-hover:text-cyan-300" />
@@ -439,6 +444,7 @@ const CreditsModal: React.FC<CreditsModalProps> = memo(({
             
             <a
               href="/support"
+              data-astro-prefetch
               className="flex items-center space-x-3 p-3 bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors duration-200 group"
             >
               <BookOpen className="w-5 h-5 text-orange-400 group-hover:text-orange-300" />


### PR DESCRIPTION
## Summary
- add `data-astro-prefetch` for the community link
- prefetch auth links in `MembersOnly` component
- prefetch quick links in `CreditsModal`

## Testing
- `npx nx run-many --target=test` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_6868d123f3c08322a638b8ea9758e7fc