### PR TITLE
Add prefetch attributes to client links

### DIFF
--- a/apps/kbve/astro-kbve/src/layouts/components/section/clientsection/ClientsSection.astro
+++ b/apps/kbve/astro-kbve/src/layouts/components/section/clientsection/ClientsSection.astro
@@ -37,9 +37,10 @@ import EclipseSVG from './EclipseSVG.astro';
 		<!-- Clients Group SVGs -->
 
 		<!-- Javascript SVG -->
-		<a
-			href="/application/javascript/"
-			aria-label="Read more about Javascript applications">
+                <a
+                        href="/application/javascript/"
+                        data-astro-prefetch
+                        aria-label="Read more about Javascript applications">
 			<svg
 				class="mx-auto h-auto w-12 py-3 sm:mx-0 lg:w-16 lg:py-5 hover:scale-110 ease-in-out duration-500"
 				style="fill:#00FFFF;fill-opacity:1;fill-rule:nonzero;stroke:none"
@@ -67,9 +68,10 @@ import EclipseSVG from './EclipseSVG.astro';
 		</a>
 
 		<!-- Rust SVG -->
-		<a
-			href="/application/rust/"
-			aria-label="Read more about Rust applications">
+                <a
+                        href="/application/rust/"
+                        data-astro-prefetch
+                        aria-label="Read more about Rust applications">
 			<svg
 				class="mx-auto h-auto w-12 py-3 sm:mx-0 lg:w-16 lg:py-5 hover:scale-110 ease-in-out duration-500"
 				style="fill:#00FFFF;fill-opacity:1;fill-rule:nonzero;stroke:none"


### PR DESCRIPTION
## Summary
- opt into Astro prefetch on ClientSection internal links

## Testing
- `pcregrep -Mn '<a[^>]*href="/[^\"]*"(?![^>]*data-astro-prefetch)' apps/kbve/astro-kbve/src | head`

------
https://chatgpt.com/codex/tasks/task_e_6869f09a50cc8322868820b865705d04