### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ This is an open source Unity game that is currently located under `/apps/saber/`
 #### Atlas
 
 Atlas is a [Python pip package](https://pypi.org/p/kbve) for generic baseline ml applications.
-Atlas currently only has `pyautogen` but a couple other packages are planned but as of right now, we are waiting on the stablization of the OpenAI v1 API.
+Atlas currently only has `ag2` but a couple other packages are planned but as of right now, we are waiting on the stablization of the OpenAI v1 API.
 The Atlas Library is currently broken needs to be wait on a couple packages to be updated, including LiteLLM.
 
 #### AstroVe

--- a/apps/atlas/pyproject.toml
+++ b/apps/atlas/pyproject.toml
@@ -47,7 +47,7 @@ readme = 'README.md'
 
   [tool.poetry.dependencies]
   python = ">=3.10,<3.13"
-  pyautogen = {extras = ["lmm", "redis"], version = "^0.2.23"}
+  ag2 = {extras = ["lmm", "redis"], version = "^0.2.23"}
   docker = "^7.0.0"
   beautifulsoup4 = "^4.12.3"
   litellm = "^1.34.39"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
