### PR TITLE
chore: bump disoxide image to 1.4.4

### DIFF
--- a/apps/kube/disoxide/manifest/deployment.yaml
+++ b/apps/kube/disoxide/manifest/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: disoxide-sa
       containers:
       - name: disoxide
-        image: kbve/disoxide:1.4.3
+        image: kbve/disoxide:1.4.4
         imagePullPolicy: Always
         ports:
         - name: http


### PR DESCRIPTION
## Summary
- update disoxide deployment image to v1.4.4

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68951845b3c0832297de7bf78fd9c391