### PR TITLE
chore(ssdb): bump version to 0.0.14 and simplify channel subscription handling

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
@@ -285,13 +285,8 @@ namespace KBVE.SSDB.SupabaseFDW
                 Operator.D($"[supabase] About to Register broadcast for channel: {channelName}");
                 
                 Operator.D($"[supabase] About to Subscribe to channel: {channelName}");
-                // Subscribe to the channel with error handling
-                var subscribeResult = await channel.Subscribe();
-                
-                if (subscribeResult == null || subscribeResult.Status != Supabase.Realtime.Constants.ChannelState.Subscribed)
-                {
-                    throw new Exception($"Failed to subscribe to channel: {channelName}. Status: {subscribeResult?.Status}");
-                }
+                // Subscribe to the channel - Subscribe() doesn't return status, it throws on error
+                await channel.Subscribe();
                 
                 _channels[channelName] = channel;
                 Operator.D($"Successfully created and subscribed to broadcast channel: {channelName}");


### PR DESCRIPTION
- Updated package version from 0.0.13 to 0.0.14.
- Simplified channel subscription logic in SupabaseRealtimeFDW by removing error handling that checks subscription status, as Subscribe() now throws on error.