### PR TITLE
chore(ssdb): bump version to 0.0.22 and enhance channel subscription error handling

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {


### PR DESCRIPTION
- Updated package version from 0.0.21 to 0.0.22.
- Improved error handling in SupabaseRealtimeFDW by refining the logging of channel subscription status and providing clearer exception messages for different failure scenarios.