### PR TITLE
chore(ssdb): bump version to 0.0.23 and refine channel subscription timeout handling

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.22",
+	"version": "0.0.23",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
@@ -341,9 +341,9 @@ namespace KBVE.SSDB.SupabaseFDW
                 var subscribeTask = channel.Subscribe().AsUniTask();
                 var timeoutTask = UniTask.Delay(TimeSpan.FromSeconds(10), cancellationToken: effectiveToken);
                 
-                var completedTask = await UniTask.WhenAny(subscribeTask, timeoutTask);
+                var (completedIndex, _) = await UniTask.WhenAny(subscribeTask, timeoutTask);
                 
-                if (completedTask == 1) // timeout occurred
+                if (completedIndex == 1) // timeout occurred
                 {
                     throw new TimeoutException($"Channel subscription timeout for: {channelName}");
                 }


### PR DESCRIPTION
- Updated package version from 0.0.22 to 0.0.23.
- Enhanced error handling in SupabaseRealtimeFDW by refining the timeout handling logic for channel subscriptions, improving clarity in the code.