### PR TITLE
chore(ssdb): bump version to 0.0.25 and remove channel subscription timeout handling

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.24",
+	"version": "0.0.25",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
@@ -341,12 +341,6 @@ namespace KBVE.SSDB.SupabaseFDW
                 var subscribeTask = channel.Subscribe().AsUniTask();
                 var timeoutTask = UniTask.Delay(TimeSpan.FromSeconds(10), cancellationToken: effectiveToken);
 
-                var (completedIndex, _) = await UniTask.WhenAny(subscribeTask, timeoutTask);
-                if (completedIndex == 1) // timeout occurred
-                {
-                    throw new TimeoutException($"Channel subscription timeout for: {channelName}");
-                }
-                
                 
                 // Wait for subscription to complete
                 await subscribeTask;


### PR DESCRIPTION
- Updated package version from 0.0.24 to 0.0.25.
- Removed the timeout handling logic for channel subscriptions in SupabaseRealtimeFDW to streamline the subscription process.