### PR TITLE
chore(ssdb): bump version to 0.0.26 and update broadcast channel name

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseBroadcastFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseBroadcastFDW.cs
@@ -31,7 +31,7 @@ namespace KBVE.SSDB.SupabaseFDW
         public ReactiveProperty<bool> IsBroadcasting { get; } = new(false);
         public ReactiveProperty<string> SessionId { get; } = new(string.Empty);
         public ReactiveProperty<DateTime> LaunchTime { get; } = new(DateTime.UtcNow);
-        public ReactiveProperty<string> BroadcastChannelName { get; } = new("demo");
+        public ReactiveProperty<string> BroadcastChannelName { get; } = new("broadcast:demo");
         
         [Inject]
         public SupabaseBroadcastFDW(SupabaseRealtimeFDW realtimeFDW, SupabaseAuthFDW authFDW, ISupabaseInstance supabaseInstance)


### PR DESCRIPTION
- Updated package version from 0.0.25 to 0.0.26.
- Changed default broadcast channel name from "demo" to "broadcast:demo".
- Simplified anonymous connection handling in SupabaseRealtimeFDW by directly using the anon key for realtime connections.