### PR TITLE
chore(ssdb): bump version to 0.0.27 and update broadcast channel name

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseBroadcastFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseBroadcastFDW.cs
@@ -31,7 +31,7 @@ namespace KBVE.SSDB.SupabaseFDW
         public ReactiveProperty<bool> IsBroadcasting { get; } = new(false);
         public ReactiveProperty<string> SessionId { get; } = new(string.Empty);
         public ReactiveProperty<DateTime> LaunchTime { get; } = new(DateTime.UtcNow);
-        public ReactiveProperty<string> BroadcastChannelName { get; } = new("broadcast:demo");
+        public ReactiveProperty<string> BroadcastChannelName { get; } = new("demo");
         
         [Inject]
         public SupabaseBroadcastFDW(SupabaseRealtimeFDW realtimeFDW, SupabaseAuthFDW authFDW, ISupabaseInstance supabaseInstance)

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
@@ -133,10 +133,9 @@ namespace KBVE.SSDB.SupabaseFDW
                         }
                         else
                         {
-                            // For anonymous connections, use anon key directly (like web implementation)
-                            Operator.D("[SupabaseRealtimeFDW] No auth session found, using anon key for realtime");
-                            var anonKey = SupabaseInfo.AnonKey;
-                            _supabaseInstance.Client.Realtime.SetAuth(anonKey);
+                            // For anonymous connections, set auth without token (like web implementation)
+                            Operator.D("[SupabaseRealtimeFDW] No auth session found, using default config for realtime");
+                            _supabaseInstance.Client.Realtime.SetAuth();
                         }
                     }
                     else


### PR DESCRIPTION
- Updated package version from 0.0.26 to 0.0.27.
- Changed default broadcast channel name from "broadcast:demo" to "demo".
- Simplified anonymous connection handling in SupabaseRealtimeFDW by using default config for realtime connections.