### PR TITLE
chore(ssdb): bump version to 0.0.28 and update anonymous connection handling

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.27",
+	"version": "0.0.28",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
@@ -133,9 +133,10 @@ namespace KBVE.SSDB.SupabaseFDW
                         }
                         else
                         {
-                            // For anonymous connections, set auth without token (like web implementation)
-                            Operator.D("[SupabaseRealtimeFDW] No auth session found, using default config for realtime");
-                            _supabaseInstance.Client.Realtime.SetAuth();
+                            // For anonymous connections, use anon key (Unity C# requires parameter)
+                            Operator.D("[SupabaseRealtimeFDW] No auth session found, using anon key for realtime");
+                            var anonKey = SupabaseInfo.AnonKey;
+                            _supabaseInstance.Client.Realtime.SetAuth(anonKey);
                         }
                     }
                     else


### PR DESCRIPTION
- Updated package version from 0.0.27 to 0.0.28.
- Modified anonymous connection handling in SupabaseRealtimeFDW to use the anon key for realtime connections instead of the default config.