### PR TITLE
chore(ssdb): bump version to 0.0.29 and update anonymous connection handling

### DIFF
--- a/packages/unity/ssdb/package.json
+++ b/packages/unity/ssdb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.kbve.ssdb",
 	"displayName": "SSDB",
-	"version": "0.0.28",
+	"version": "0.0.29",
 	"description": "A SteamWorks & Heathen Wrapper",
 	"unity": "2023.1",
 	"author": {

--- a/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
+++ b/packages/unity/ssdb/ssdb/SupabaseFDW/SupabaseRealtimeFDW.cs
@@ -133,10 +133,9 @@ namespace KBVE.SSDB.SupabaseFDW
                         }
                         else
                         {
-                            // For anonymous connections, use anon key (Unity C# requires parameter)
-                            Operator.D("[SupabaseRealtimeFDW] No auth session found, using anon key for realtime");
-                            var anonKey = SupabaseInfo.AnonKey;
-                            _supabaseInstance.Client.Realtime.SetAuth(anonKey);
+                            // For anonymous connections, use default client auth (like web implementation)
+                            Operator.D("[SupabaseRealtimeFDW] No auth session found, using default client configuration");
+                            // Don't call SetAuth() - let client use the anon key from initialization
                         }
                     }
                     else


### PR DESCRIPTION
- Updated package version from 0.0.28 to 0.0.29.
- Modified anonymous connection handling in SupabaseRealtimeFDW to use the default client configuration instead of explicitly setting the anon key.