### PR TITLE
Fix Discord theme type import

### DIFF
--- a/apps/kbve/astro-kbve/src/layouts/components/discord/ReactDiscordEmbed.tsx
+++ b/apps/kbve/astro-kbve/src/layouts/components/discord/ReactDiscordEmbed.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import clsx from 'clsx';
+import type { DiscordTheme } from './DiscordService';
 import {
-  DiscordTheme,
   createWidgetSrc,
   resolveInitialTheme,
   subscribeToAutoTheme,


### PR DESCRIPTION
## Summary
- mark the Discord theme import in ReactDiscordEmbed as type-only to avoid runtime export errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e18faebdf88322a5258555f7ce8caa