### PR TITLE
feat(clickhouse): add postgres external secret

### DIFF
--- a/apps/kube/clickhouse/manifests/kustomization.yaml
+++ b/apps/kube/clickhouse/manifests/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - clickhouse-keeper.yaml
   - clickhouse-installation.yaml
+  - postgres-externalsecret.yaml

--- a/apps/kube/clickhouse/manifests/postgres-externalsecret.yaml
+++ b/apps/kube/clickhouse/manifests/postgres-externalsecret.yaml
@@ -1,0 +1,48 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: kilobase-remote-secret-store
+  namespace: clickhouse
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: kilobase
+      auth:
+        serviceAccount:
+          name: external-secrets-sa
+          namespace: kilobase
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: clickhouse-postgres-credentials
+  namespace: clickhouse
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kilobase-remote-secret-store
+    kind: SecretStore
+  target:
+    name: clickhouse-postgres-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        host: supabase-cluster-rw.kilobase.svc.cluster.local
+        database: supabase
+  data:
+  - secretKey: username
+    remoteRef:
+      key: supabase-postgres
+      property: username
+  - secretKey: password
+    remoteRef:
+      key: supabase-postgres
+      property: password


### PR DESCRIPTION
## Summary
- add a SecretStore for ClickHouse that connects to the kilobase namespace using the external-secrets service account
- create an ExternalSecret that materializes ClickHouse PostgreSQL credentials from the shared supabase-postgres secret
- include the new manifest in the ClickHouse kustomization so ArgoCD applies it automatically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3e5342ac4832295e3af7ae59f412c