### PR TITLE
Add ClickHouse Postgres connectivity configuration

### DIFF
--- a/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: clickhouse
 spec:
   configuration:
+    files:
+      postgresql.xml: |
+        <!-- Populated via the clickhouse-postgres-config ConfigMap mount. -->
     users:
       admin/password_sha256_hex: "8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92"  # "hello"
       admin/networks/ip:
@@ -23,7 +26,40 @@ spec:
     templates:
       dataVolumeClaimTemplate: data-storage
       logVolumeClaimTemplate: log-storage
+      podTemplate: clickhouse-with-postgres
   templates:
+    podTemplates:
+      - name: clickhouse-with-postgres
+        spec:
+          containers:
+            - name: clickhouse
+              env:
+                - name: CLICKHOUSE_POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: clickhouse-postgres-credentials
+                      key: username
+              volumeMounts:
+                - name: clickhouse-postgres-config
+                  mountPath: /etc/clickhouse-server/config.d/postgresql.xml
+                  subPath: postgresql.xml
+                - name: clickhouse-postgres-credentials
+                  mountPath: /etc/clickhouse-server/secrets/postgres-password
+                  subPath: password
+                  readOnly: true
+          volumes:
+            - name: clickhouse-postgres-config
+              configMap:
+                name: clickhouse-postgres-config
+                items:
+                  - key: postgresql.xml
+                    path: postgresql.xml
+            - name: clickhouse-postgres-credentials
+              secret:
+                secretName: clickhouse-postgres-credentials
+                items:
+                  - key: password
+                    path: password
     volumeClaimTemplates:
       - name: data-storage
         spec:

--- a/apps/kube/clickhouse/manifests/kustomization.yaml
+++ b/apps/kube/clickhouse/manifests/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - clickhouse-keeper.yaml
   - clickhouse-installation.yaml
+  - postgres-configmap.yaml
   - postgres-externalsecret.yaml

--- a/apps/kube/clickhouse/manifests/postgres-configmap.yaml
+++ b/apps/kube/clickhouse/manifests/postgres-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-postgres-config
+  namespace: clickhouse
+data:
+  postgresql.xml: |
+    <yandex>
+      <named_collections>
+        <supabase_postgres>
+          <host>supabase-cluster-rw.kilobase.svc.cluster.local</host>
+          <port>5432</port>
+          <database>supabase</database>
+          <user_from_env>CLICKHOUSE_POSTGRES_USER</user_from_env>
+          <password_file>/etc/clickhouse-server/secrets/postgres-password</password_file>
+        </supabase_postgres>
+      </named_collections>
+    </yandex>


### PR DESCRIPTION
## Summary
- add a ConfigMap that provides a PostgreSQL named collection pointing at the Supabase service
- mount the ConfigMap and database secret in the ClickHouse pods, exposing the password via file and username via env var
- register the new manifest with kustomize so ArgoCD applies it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e71c71e08322ab9cc9769a0949b4