### PR TITLE
fix(clickhouse): remove postgres-configmap from kustomization

### DIFF
--- a/apps/kube/clickhouse/manifests/kustomization.yaml
+++ b/apps/kube/clickhouse/manifests/kustomization.yaml
@@ -4,6 +4,5 @@ kind: Kustomization
 resources:
   - clickhouse-keeper.yaml
   - clickhouse-installation.yaml
-  - postgres-configmap.yaml
   - external-secrets-rbac.yaml
   - postgres-externalsecret.yaml


### PR DESCRIPTION
Remove reference to deleted postgres-configmap.yaml from kustomization.yaml since we now configure the postgres named collection directly via the operator's files configuration.
