### PR TITLE
fix(mapdb): classify crystal entries under stone assets

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/mapdb/adamantine-vein.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mapdb/adamantine-vein.mdx
@@ -1,0 +1,47 @@
+---
+id: "01K78ETM23RKMQNSJAEMKSWN24"
+guid: "f14b4ea6afbf4e2581059714913076c6"
+drafted: false
+title: "Adamantine Vein"
+name: "Adamantine Vein"
+description: "An impenetrable adamantine deposit with razor-edged crystalline facets"
+type: "resource"
+resourceType: "metal"
+imagePath: "/assets/mapdb/metal/adamantine/adamantine_vein.png"
+pixelsPerUnit: 25
+pivot: "Center"
+pivotX: 0.5
+pivotY: 0.5
+meshType: "FullRect"
+extrudeEdges: 1
+sortingLayer: "Foreground"
+sortingIndex: 0
+staticSorting: true
+wrapMode: "Clamp"
+amount: 150
+maxAmount: 150
+harvestYield: 6
+harvestTime: 8.5
+isHarvestable: true
+isDepleted: false
+spawnWeight: 0.05
+spawnCount: 4
+---
+
+import MapDBPanel from 'src/layouts/starlight/frontmatter/mapdb/MapDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
+
+# Adamantine Vein
+
+A nigh-indestructible adamantine vein that resists conventional mining. Only the most advanced extraction rigs can cleave these
+crystalline ridges, yielding metal fit for immortal relics.
+
+<MapDBPanel data={frontmatter} />
+
+<Adsense />
+
+## Mining Notes
+- Requires adamant drill with resonance dampeners
+- Yields 6 adamantine ore per successful extraction
+- Overheats tools rapidly without proper coolant cycles
+- Restricted claim zones due to strategic importance

--- a/apps/kbve/astro-kbve/src/content/docs/mapdb/jade-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mapdb/jade-crystal.mdx
@@ -1,0 +1,47 @@
+---
+id: "01K78ETM23Y98ZBY0TZKYWG0WB"
+guid: "bc45dbd7506d44ffb462cd2060b5b43f"
+drafted: false
+title: "Jade Crystal"
+name: "Jade Crystal"
+description: "A verdant jade crystal pillar infused with restorative earth energies"
+type: "resource"
+resourceType: "stone"
+imagePath: "/assets/mapdb/stone/jade/jade_crystal.png"
+pixelsPerUnit: 16
+pivot: "Center"
+pivotX: 0.5
+pivotY: 0.5
+meshType: "FullRect"
+extrudeEdges: 1
+sortingLayer: "Foreground"
+sortingIndex: 0
+staticSorting: true
+wrapMode: "Clamp"
+amount: 65
+maxAmount: 65
+harvestYield: 3
+harvestTime: 4.0
+isHarvestable: true
+isDepleted: false
+spawnWeight: 0.18
+spawnCount: 14
+---
+
+import MapDBPanel from 'src/layouts/starlight/frontmatter/mapdb/MapDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
+
+# Jade Crystal
+
+A towering jade monolith that pulses with gentle earth attunement. Herbalists and geomancers rely on the crystal's shards for
+potent tonics and grounding rituals.
+
+<MapDBPanel data={frontmatter} />
+
+<Adsense />
+
+## Harvesting Notes
+- Requires tempered chisel or geomantic extractor
+- Yields 3 jade shards per harvesting cycle
+- Restorative aura accelerates stamina recovery nearby
+- Frequently appears in ancient forest shrines and terraced valleys

--- a/apps/kbve/astro-kbve/src/content/docs/mapdb/mithril-vein.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mapdb/mithril-vein.mdx
@@ -1,0 +1,47 @@
+---
+id: "01K78ETM23E1GYNN50CK3XS512"
+guid: "e38eec3192374e99be8c77ed62465822"
+drafted: false
+title: "Mithril Vein"
+name: "Mithril Vein"
+description: "A shimmering mithril seam interwoven with ethereal silver-blue threads"
+type: "resource"
+resourceType: "metal"
+imagePath: "/assets/mapdb/metal/mithril/mithril_vein.png"
+pixelsPerUnit: 20
+pivot: "Center"
+pivotX: 0.5
+pivotY: 0.5
+meshType: "FullRect"
+extrudeEdges: 1
+sortingLayer: "Foreground"
+sortingIndex: 0
+staticSorting: true
+wrapMode: "Clamp"
+amount: 90
+maxAmount: 90
+harvestYield: 4
+harvestTime: 6.0
+isHarvestable: true
+isDepleted: false
+spawnWeight: 0.10
+spawnCount: 7
+---
+
+import MapDBPanel from 'src/layouts/starlight/frontmatter/mapdb/MapDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
+
+# Mithril Vein
+
+An elusive mithril deposit prized by master smiths. The ore is remarkably light yet durable, making it ideal for legendary armor
+and finely tuned weaponry.
+
+<MapDBPanel data={frontmatter} />
+
+<Adsense />
+
+## Mining Notes
+- Requires enchanted pickaxe to avoid fracturing the seam
+- Yields 4 mithril ore per extraction
+- Mining teams coordinate to prevent overloading delicate strata
+- Frequently forms near leyline intersections deep underground

--- a/apps/kbve/astro-kbve/src/content/docs/mapdb/ruby-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mapdb/ruby-crystal.mdx
@@ -1,0 +1,47 @@
+---
+id: "01K78ETM23TC8F9GB05D2RQ31X"
+guid: "7f48ce18a77645df9c3152c9de8ea3aa"
+drafted: false
+title: "Ruby Crystal"
+name: "Ruby Crystal"
+description: "A luminous ruby crystal cluster radiating intense heat and magical energy"
+type: "resource"
+resourceType: "stone"
+imagePath: "/assets/mapdb/stone/ruby/ruby_crystal.png"
+pixelsPerUnit: 16
+pivot: "Center"
+pivotX: 0.5
+pivotY: 0.5
+meshType: "FullRect"
+extrudeEdges: 1
+sortingLayer: "Foreground"
+sortingIndex: 0
+staticSorting: true
+wrapMode: "Clamp"
+amount: 60
+maxAmount: 60
+harvestYield: 2
+harvestTime: 5.0
+isHarvestable: true
+isDepleted: false
+spawnWeight: 0.12
+spawnCount: 10
+---
+
+import MapDBPanel from 'src/layouts/starlight/frontmatter/mapdb/MapDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
+
+# Ruby Crystal
+
+A radiant ruby crystal formation imbued with latent fire magic. These clusters are coveted by enchanters and jewelers for their
+vivid glow and ability to store arcane energy.
+
+<MapDBPanel data={frontmatter} />
+
+<Adsense />
+
+## Harvesting Notes
+- Requires precision mining tools or infused pickaxe
+- Yields 2 ruby shards per extraction
+- Emits ambient heat that can harm unprotected gatherers
+- Often found near volcanic vents and magma flows

--- a/apps/kbve/astro-kbve/src/content/docs/mapdb/sapphire-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mapdb/sapphire-crystal.mdx
@@ -1,0 +1,47 @@
+---
+id: "01K78ETM23VYYS8V4DZWRPWJK5"
+guid: "749872b0c8464205a2847526294bdaed"
+drafted: false
+title: "Sapphire Crystal"
+name: "Sapphire Crystal"
+description: "A serene sapphire crystal cluster humming with focused elemental water energy"
+type: "resource"
+resourceType: "stone"
+imagePath: "/assets/mapdb/stone/sapphire/sapphire_crystal.png"
+pixelsPerUnit: 16
+pivot: "Center"
+pivotX: 0.5
+pivotY: 0.5
+meshType: "FullRect"
+extrudeEdges: 1
+sortingLayer: "Foreground"
+sortingIndex: 0
+staticSorting: true
+wrapMode: "Clamp"
+amount: 55
+maxAmount: 55
+harvestYield: 2
+harvestTime: 4.5
+isHarvestable: true
+isDepleted: false
+spawnWeight: 0.14
+spawnCount: 12
+---
+
+import MapDBPanel from 'src/layouts/starlight/frontmatter/mapdb/MapDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
+
+# Sapphire Crystal
+
+A tranquil sapphire formation that resonates with the flow of underground springs. Artificers value the crystal's clarity for
+focus lenses and mana conduits.
+
+<MapDBPanel data={frontmatter} />
+
+<Adsense />
+
+## Harvesting Notes
+- Requires balanced chisel to prevent fracturing facets
+- Yields 2 sapphire shards per extraction
+- Stabilizes nearby water attunement rituals when intact
+- Commonly discovered in flooded caverns and glacial grottos

--- a/apps/kbve/astro-kbve/src/content/docs/mapdb/uranium-vein.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mapdb/uranium-vein.mdx
@@ -1,0 +1,47 @@
+---
+id: "01K78ETM2394KT9KTV2W2QVP56"
+guid: "55c2579f531b4ce2b3cca32887a59484"
+drafted: false
+title: "Uranium Vein"
+name: "Uranium Vein"
+description: "A volatile uranium deposit pulsing with unstable green luminescence"
+type: "resource"
+resourceType: "metal"
+imagePath: "/assets/mapdb/metal/uranium/uranium_vein.png"
+pixelsPerUnit: 25
+pivot: "Center"
+pivotX: 0.5
+pivotY: 0.5
+meshType: "FullRect"
+extrudeEdges: 1
+sortingLayer: "Foreground"
+sortingIndex: 0
+staticSorting: true
+wrapMode: "Clamp"
+amount: 120
+maxAmount: 120
+harvestYield: 4
+harvestTime: 7.5
+isHarvestable: true
+isDepleted: false
+spawnWeight: 0.08
+spawnCount: 6
+---
+
+import MapDBPanel from 'src/layouts/starlight/frontmatter/mapdb/MapDBPanel.astro';
+import { Adsense } from '@kbve/astropad';
+
+# Uranium Vein
+
+A hazardous uranium ore vein that emits a constant radioactive glow. Prospectors use specialized shielding to mine these deposits
+for advanced energy reactors and alchemical experiments.
+
+<MapDBPanel data={frontmatter} />
+
+<Adsense />
+
+## Mining Notes
+- Requires lead-lined drill or reinforced extractor
+- Yields 4 uranium ore per harvest cycle
+- Prolonged exposure inflicts radiation sickness without protection
+- Rarely appears outside deep subterranean fissures


### PR DESCRIPTION
## Summary
- update the ruby, sapphire, and jade crystal entries to use the stone resource type
- point crystal asset paths to the stone directory to match the new categorization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9b56bfc2c8322809417d7bfdd843d