### PR TITLE
feat(kilobase): upgrade pgrx 0.15.0 to 0.16.1 with safety improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,16 +782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-traits"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707f750b93bd1b739cf9ddf85f8fe7c97a4a62c60ccf8b6f232514bd9103bedc"
-dependencies = [
- "cfg-if",
- "rustc_version",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,19 +3300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui_tiles"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0255c0209b349b1a4a67a344556501e75accae669f3a25be6e07deb30fefa91"
-dependencies = [
- "ahash",
- "egui",
- "itertools 0.12.1",
- "log",
- "serde",
-]
-
-[[package]]
 name = "ehttp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,19 +3416,6 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -5240,17 +5204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6795,8 +6748,7 @@ version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
+ "supports-color",
 ]
 
 [[package]]
@@ -6967,17 +6919,14 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab5bc1d60d3bc3c966d307a3c7313b1ebfb49a0ec183be3f1a057df0bcc9988"
+checksum = "fdcfb88f7fa9ba42b4ea9d1f85a1d968bbb407cc30308b35f73bdfe6c966f64b"
 dependencies = [
- "atomic-traits",
  "bitflags 2.9.1",
  "bitvec",
  "enum-map",
- "heapless",
  "libc",
- "once_cell",
  "pgrx-macros",
  "pgrx-pg-sys",
  "pgrx-sql-entity-graph",
@@ -6991,9 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9804b74c211a9edd550cd974718f8cc407dec50d8e9cafb906e0b042ba434af0"
+checksum = "00e35193b7e71e2f612d336cecd00db0f049f4cc609f2b1c9a34755b5ec559d7"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -7010,9 +6959,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f230769493bf567f137de23264d604d267dd72b8a77c596528e43cf423c6208e"
+checksum = "dab542dd4041773874f90cd8e3448195749548dc3fb1daf501e7e11ebfb1dd22"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -7022,30 +6971,29 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b64c071c2a46a19ab4521120a25b02b598f4abf6e9b4b1769a7922edeee3de"
+checksum = "eff9b29df94c3f9fcb0cde220f92eea6975ed05962784a98fb557754ad663501"
 dependencies = [
  "cargo_toml",
  "codepage",
  "encoding_rs",
  "eyre",
- "home",
  "owo-colors",
  "pathsearch",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "toml 0.8.23",
+ "toml 0.9.5",
  "url",
  "winapi",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbfa98ec7a90252d13a78ac666541173dbb01a2fc1ba20131db6490c0711125"
+checksum = "934f2536953ccb6722bef2cfdfb1f8d6d3cd4a4f2c508d56ec85b649c5680c2b"
 dependencies = [
  "cee-scape",
  "libc",
@@ -7053,14 +7001,13 @@ dependencies = [
  "pgrx-macros",
  "pgrx-sql-entity-graph",
  "serde",
- "sptr",
 ]
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79bbf5a33cff6cfdc6dda3a976cd931c995eaa2c073a7c59b8f8fe8f6faa073"
+checksum = "07a767cb9faa612f1ba7f13718136d4006950d6f253b414ef487a03e85c47a94"
 dependencies = [
  "convert_case 0.8.0",
  "eyre",
@@ -7074,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9791c709882f3af9545bcca71670fdd82768f67a428b416b6210eae3773dbd0d"
+checksum = "e0d5d5f614a32310af2cc1b9587c69e041d97e8ab812d8d31fdcd3d33d27325c"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -8202,10 +8149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_p16_gameserver"
-version = "0.1.0"
-
-[[package]]
 name = "rust_rareicon_gameserver"
 version = "0.1.0"
 dependencies = [
@@ -8248,20 +8191,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "rust_wasm_embed"
-version = "0.1.0"
-dependencies = [
- "eframe",
- "egui",
- "egui_tiles",
- "env_logger 0.10.2",
- "erust",
- "log",
- "serde",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -9683,7 +9612,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8e777ec1afd733939b532a42492d888ec7c88d8b4127a5d867eb45c6eb5cd5"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger",
  "lazy_static",
  "libc",
  "log",
@@ -11041,12 +10970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11105,16 +11028,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
 
 [[package]]
 name = "supports-color"
@@ -11675,7 +11588,6 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_write",
  "winnow 0.7.12",
 ]
 
@@ -11687,12 +11599,6 @@ checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow 0.7.12",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"

--- a/apps/kbve/kilobase/Cargo.toml
+++ b/apps/kbve/kilobase/Cargo.toml
@@ -13,12 +13,13 @@ path = "./src/bin/pgrx_embed.rs"
 [features]
 default = ["pg17"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
 pg_test = []
 
 [dependencies]
 thiserror = "2.0.12"
-pgrx = { version = "=0.15.0", default-features = false }
+pgrx = { version = "=0.16.1", default-features = false }
 serde = "1.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.15.0"
+pgrx-tests = "=0.16.1"

--- a/apps/kbve/kilobase/Dockerfile
+++ b/apps/kbve/kilobase/Dockerfile
@@ -1,159 +1,89 @@
 ####################
-# Stage 1: Use Supabase's own Nix build system
+# Stage 0: Build kilobase extension
+####################
+FROM rust:bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl gnupg2 lsb-release ca-certificates \
+    libclang-dev pkg-config libssl-dev && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg && \
+    apt-get update && apt-get install -y --no-install-recommends postgresql-server-dev-17 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-pgrx --version "=0.16.1" --locked
+
+RUN cargo pgrx init --pg17=/usr/bin/pg_config
+
+WORKDIR /build
+COPY . .
+
+RUN cargo pgrx package --pg-config /usr/bin/pg_config --features pg17 && \
+    echo "=== Build passed ==="
+
+####################
+# Stage 1: Build Supabase PostgreSQL via Nix
 ####################
 FROM nixos/nix:latest AS supabase-nix-builder
 
-# Enable flakes and experimental features
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
 
-# Clone Supabase's PostgreSQL repository
 WORKDIR /build
 RUN nix-shell -p git --run "git clone https://github.com/supabase/postgres.git supabase-postgres"
 WORKDIR /build/supabase-postgres
 
-# Show what build targets are available
 RUN nix flake show . | head -20
 
-# Build PostgreSQL 17 with all Supabase extensions using their build system
 RUN echo "=== Building PostgreSQL 17 with Supabase's Nix system ===" && \
     nix build .#psql_17/bin --out-link /supabase-postgresql && \
     echo "=== Build completed ===" && \
-    ls -la /supabase-postgresql/ && \
-    echo "=== PostgreSQL version ===" && \
-    /supabase-postgresql/bin/pg_config --version && \
-    echo "=== Library directory ===" && \
-    echo $(/supabase-postgresql/bin/pg_config --pkglibdir) && \
-    echo "=== Share directory ===" && \
-    echo $(/supabase-postgresql/bin/pg_config --sharedir)
-
-# Now let's add our kilobase extension to this build
-COPY . /build/kilobase-source
-
-# Install Rust in the Nix environment and build kilobase
-RUN nix-shell -p rustc cargo pkg-config openssl --run " \
-    cd /build/kilobase-source && \
-    echo '=== Building kilobase extension with Supabase PostgreSQL ===' && \
-    export PG_CONFIG=/supabase-postgresql/bin/pg_config && \
-    \$PG_CONFIG --version && \
-    cargo pgrx init --pg17 \$PG_CONFIG && \
-    cargo pgrx package --pg-config \$PG_CONFIG --features pg17 --out-dir=./dist && \
-    echo '=== Kilobase build verification ===' && \
-    find ./dist -name '*.so' -o -name '*.control' -o -name '*.sql' | head -10 \
-"
+    /supabase-postgresql/bin/pg_config --version
 
 ####################
-# Stage 2: Create custom Nix derivation that includes kilobase
+# Stage 2: Combine Supabase PostgreSQL + kilobase artifacts
 ####################
 FROM nixos/nix:latest AS custom-postgresql-builder
 
-# Copy the Supabase PostgreSQL build
 COPY --from=supabase-nix-builder /supabase-postgresql /supabase-postgresql
-COPY --from=supabase-nix-builder /build/kilobase-source/dist /kilobase-dist
+COPY --from=builder /build/target/release/kilobase-pg17 /kilobase-dist
+COPY extend-supabase-postgresql.nix /extend-supabase-postgresql.nix
 
-# Create a new Nix derivation that extends the Supabase PostgreSQL
-RUN cat > /extend-supabase-postgresql.nix << 'EOF'
-let
-  pkgs = import <nixpkgs> {};
-  
-  # Reference the existing Supabase PostgreSQL build
-  supabasePostgreSQL = /supabase-postgresql;
-  
-  # Create an extended version with kilobase
-  extendedPostgreSQL = pkgs.stdenv.mkDerivation {
-    name = "supabase-postgresql-with-kilobase";
-    
-    unpackPhase = "true";
-    
-    installPhase = ''
-      # Start with the complete Supabase PostgreSQL installation
-      cp -r ${supabasePostgreSQL} $out
-      chmod -R +w $out
-      
-      # Add kilobase extension
-      KILOBASE_LIB=$(find /kilobase-dist -name "kilobase.so")
-      KILOBASE_CONTROL=$(find /kilobase-dist -name "kilobase.control")
-      KILOBASE_SQL=$(find /kilobase-dist -name "kilobase*.sql")
-      
-      if [ -n "$KILOBASE_LIB" ]; then
-        cp "$KILOBASE_LIB" $out/lib/
-        echo "Copied kilobase.so"
-      fi
-      
-      if [ -n "$KILOBASE_CONTROL" ]; then
-        mkdir -p $out/share/postgresql/extension
-        cp "$KILOBASE_CONTROL" $out/share/postgresql/extension/
-        echo "Copied kilobase.control"
-      fi
-      
-      if [ -n "$KILOBASE_SQL" ]; then
-        cp $KILOBASE_SQL $out/share/postgresql/extension/
-        echo "Copied kilobase SQL files"
-      fi
-      
-      # Set proper permissions
-      chmod 755 $out/lib/*.so 2>/dev/null || true
-      chmod 644 $out/share/postgresql/extension/* 2>/dev/null || true
-      
-
-      echo "=== Extended PostgreSQL contents ==="
-      ls -la $out/lib/ | grep kilobase || echo "No kilobase.so found"
-      ls -la $out/share/postgresql/extension/ | grep kilobase || echo "No kilobase extension files found"
-    '';
-  };
-
-in extendedPostgreSQL
-EOF
-
-# Build the extended PostgreSQL
 RUN nix-build /extend-supabase-postgresql.nix --out-link /extended-postgresql && \
     echo "=== Extended PostgreSQL built ===" && \
-    ls -la /extended-postgresql/ && \
-    echo "=== Verification ===" && \
-    ls -la /extended-postgresql/lib/ | grep kilobase || echo "kilobase.so not found" && \
-    ls -la /extended-postgresql/share/postgresql/extension/ | grep kilobase || echo "kilobase extension files not found"
+    ls -la /extended-postgresql/lib/ | grep kilobase && \
+    ls -la /extended-postgresql/share/postgresql/extension/ | grep kilobase
 
 ####################
-# Stage 3: Final image based on Supabase but with our extensions
+# Stage 3: Final image based on Supabase with kilobase
 ####################
 FROM supabase/postgres:17.4.1.068
 
-# Copy our extended PostgreSQL over the existing one
 COPY --from=custom-postgresql-builder /extended-postgresql /nix/store/extended-postgresql
 
-# Update the PATH to use our extended PostgreSQL
 ENV PATH="/nix/store/extended-postgresql/bin:$PATH"
 
-# Create symlinks to integrate with existing structure
 RUN CURRENT_PG_STORE=$(readlink -f $(which pg_config) | sed 's|/bin/pg_config||') && \
     echo "=== Integrating extended PostgreSQL ===" && \
     echo "Current PostgreSQL: $CURRENT_PG_STORE" && \
     echo "Extended PostgreSQL: /nix/store/extended-postgresql" && \
     \
-    # Backup current if needed and create links
     if [ -d "$CURRENT_PG_STORE/lib" ]; then \
-        # Copy kilobase files to current location
         cp /nix/store/extended-postgresql/lib/kilobase.so "$CURRENT_PG_STORE/lib/" 2>/dev/null || \
         mkdir -p "$CURRENT_PG_STORE/lib" && cp /nix/store/extended-postgresql/lib/kilobase.so "$CURRENT_PG_STORE/lib/"; \
     fi && \
     \
     if [ -d "$CURRENT_PG_STORE/share" ]; then \
-        # Copy kilobase extension files to current location
         cp /nix/store/extended-postgresql/share/postgresql/extension/kilobase* "$CURRENT_PG_STORE/share/postgresql/extension/" 2>/dev/null || \
         mkdir -p "$CURRENT_PG_STORE/share/postgresql/extension" && cp /nix/store/extended-postgresql/share/postgresql/extension/kilobase* "$CURRENT_PG_STORE/share/postgresql/extension/"; \
     fi && \
     \
-    # Set ownership
     chown -R postgres:postgres "$CURRENT_PG_STORE/lib" "$CURRENT_PG_STORE/share" 2>/dev/null || true
 
-# Final verification using the actual pg_config
-RUN echo "=== Final Verification with Integrated Extensions ===" && \
+RUN echo "=== Final Verification ===" && \
     pg_config --version && \
     PG_LIBDIR=$(pg_config --pkglibdir) && \
     PG_SHAREDIR=$(pg_config --sharedir) && \
-    echo "Library directory: $PG_LIBDIR" && \
-    echo "Share directory: $PG_SHAREDIR" && \
-    echo "Extensions found:" && \
-    ls -la "$PG_LIBDIR" | grep kilobase || echo "kilobase.so not found in $PG_LIBDIR" && \
-    ls -la "$PG_SHAREDIR/extension" | grep kilobase || echo "kilobase extension files not found in $PG_SHAREDIR/extension"
+    ls -la "$PG_LIBDIR" | grep kilobase && \
+    ls -la "$PG_SHAREDIR/extension" | grep kilobase
 
 USER postgres

--- a/apps/kbve/kilobase/extend-supabase-postgresql.nix
+++ b/apps/kbve/kilobase/extend-supabase-postgresql.nix
@@ -1,0 +1,44 @@
+let
+  pkgs = import <nixpkgs> {};
+
+  supabasePostgreSQL = /supabase-postgresql;
+
+  extendedPostgreSQL = pkgs.stdenv.mkDerivation {
+    name = "supabase-postgresql-with-kilobase";
+
+    unpackPhase = "true";
+
+    installPhase = ''
+      cp -r ${supabasePostgreSQL} $out
+      chmod -R +w $out
+
+      KILOBASE_LIB=$(find /kilobase-dist -name "kilobase.so")
+      KILOBASE_CONTROL=$(find /kilobase-dist -name "kilobase.control")
+      KILOBASE_SQL=$(find /kilobase-dist -name "kilobase*.sql")
+
+      if [ -n "$KILOBASE_LIB" ]; then
+        cp "$KILOBASE_LIB" $out/lib/
+        echo "Copied kilobase.so"
+      fi
+
+      if [ -n "$KILOBASE_CONTROL" ]; then
+        mkdir -p $out/share/postgresql/extension
+        cp "$KILOBASE_CONTROL" $out/share/postgresql/extension/
+        echo "Copied kilobase.control"
+      fi
+
+      if [ -n "$KILOBASE_SQL" ]; then
+        cp $KILOBASE_SQL $out/share/postgresql/extension/
+        echo "Copied kilobase SQL files"
+      fi
+
+      chmod 755 $out/lib/*.so 2>/dev/null || true
+      chmod 644 $out/share/postgresql/extension/* 2>/dev/null || true
+
+      echo "=== Extended PostgreSQL contents ==="
+      ls -la $out/lib/ | grep kilobase || echo "No kilobase.so found"
+      ls -la $out/share/postgresql/extension/ | grep kilobase || echo "No kilobase extension files found"
+    '';
+  };
+
+in extendedPostgreSQL

--- a/apps/kbve/kilobase/src/jobs.rs
+++ b/apps/kbve/kilobase/src/jobs.rs
@@ -1,4 +1,4 @@
-use pgrx::{datum::DatumWithOid, prelude::*};
+use pgrx::prelude::*;
 
 #[derive(Debug)]
 pub struct JobInfo {
@@ -17,57 +17,6 @@ impl JobInfo {
             interval_secs: job.get_by_name::<i32, _>("refresh_interval_seconds")?.unwrap_or(300),
         })
     }
-
-    pub fn process(&self, client: &mut pgrx::spi::SpiClient) -> Result<(), pgrx::spi::Error> {
-        log!("Processing refresh for {}.{} (job_id: {})", 
-             self.schema, self.view_name, self.id);
-
-        let refresh_result = crate::refresh_materialized_view(client, self);
-        self.update_next_refresh(client)?;
-
-        match refresh_result {
-            Ok(duration_ms) => {
-                log!("SUCCESS: Refreshed {}.{} in {}ms", 
-                     self.schema, self.view_name, duration_ms);
-            }
-            Err(error_msg) => {
-                log!("ERROR: Failed to refresh {}.{}: {}", 
-                     self.schema, self.view_name, error_msg);
-            }
-        }
-
-        Ok(())
-    }
-
-    fn update_next_refresh(&self, client: &mut pgrx::spi::SpiClient) -> Result<(), pgrx::spi::Error> {
-        let next_refresh_sql = format!(
-            "UPDATE matview_refresh_jobs 
-            SET last_refresh = NOW(), 
-                next_refresh = NOW() + INTERVAL '{} seconds'
-            WHERE id = $1",
-            self.interval_secs
-        );
-        
-        client.update(
-            &next_refresh_sql, 
-            None, 
-            &[unsafe { DatumWithOid::new(self.id.into_datum().unwrap(), pg_sys::INT4OID) }]
-        )?;
-        Ok(())
-    }
-}
-
-pub fn get_due_refresh_jobs<'a>(client: &'a mut pgrx::spi::SpiClient<'a>) -> Result<pgrx::spi::SpiTupleTable<'a>, pgrx::spi::Error> {
-    client.select(
-        "SELECT id, schema_name, view_name, refresh_interval_seconds
-         FROM matview_refresh_jobs 
-         WHERE is_active = true 
-           AND (next_refresh IS NULL OR next_refresh <= NOW())
-         ORDER BY next_refresh NULLS FIRST 
-         LIMIT 10",
-        None,
-        &[]
-    )
 }
 
 pub fn log_cycle_completion(jobs_processed: usize) {


### PR DESCRIPTION
Upgrade pgrx dependency to 0.16.1, convert SQL queries from format!()-based string interpolation to parameterized queries for safety, remove dead code (duplicate SpiClient-based implementations), and restructure Dockerfile to use a single Rust build stage.

- Upgrade pgrx/pgrx-tests from =0.15.0 to =0.16.1
- Add pg18 feature flag for future PostgreSQL 18 support
- Replace #[no_mangle] with #[unsafe(no_mangle)] per new Rust convention
- Convert update_next_refresh, log_refresh_success, log_refresh_failure from format!() SQL to parameterized queries via DatumWithOid
- Remove ~100 lines of unused SpiClient-based duplicate functions
- Fix clippy lint: result.len() > 0 → !result.is_empty()
- Restructure Dockerfile: single Rust build stage (Stage 0) reused by later stages via COPY --from=builder
- Extract Nix derivation to extend-supabase-postgresql.nix file