### PR TITLE
feat(holy): upgrade to syn 2, add generics/skip support, fix observer…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,12 +4568,12 @@ dependencies = [
 
 [[package]]
 name = "holy"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
- "crossbeam",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.104",
+ "trybuild",
 ]
 
 [[package]]
@@ -10901,6 +10901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11578,6 +11584,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.5",
+]
 
 [[package]]
 name = "ttf-parser"

--- a/packages/rust/holy/Cargo.toml
+++ b/packages/rust/holy/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "holy"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.2"
-edition = "2021"
+version = "0.2.0"
+edition = "2024"
 license = "MIT"
 description = "Holy is a proc-macro library that provides helper macros."
 homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/holy"
 readme = "README.md"
-rust-version = "1.75"
+rust-version = "1.85"
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-crossbeam = "0.8.4"
+
+[dev-dependencies]
+trybuild = "1.0"
 
 [lib]
 proc-macro = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/rust/holy/README.md
+++ b/packages/rust/holy/README.md
@@ -1,13 +1,55 @@
-
 ## Holy
 
-This package provides a Getter/Setter, used like this 
-    
-`#[derive(Getters, Setters)]` or with the crate scoped in, `#[derive(holy::Getters, holy::Setters)]`
+A proc-macro library providing derive macros for Rust structs.
 
-Furthermore, we added a visibility handler via attributes, so you can set certain fields visible or private via, `#[holy(public)]` or `#[holy(private)]`
+### Getters & Setters
 
-TODO: subscriber / observer.
+```rust
+#[derive(holy::Getters, holy::Setters)]
+pub struct User {
+    pub name: String,
+    pub age: u32,
+}
 
-WIP - as of 1/17/2023
+let mut user = User { name: "test".into(), age: 25 };
+let name: &String = user.name();    // getter
+user.set_age(26);                    // setter
+```
 
+Supports generic structs:
+
+```rust
+#[derive(holy::Getters, holy::Setters)]
+pub struct Container<T> {
+    pub value: T,
+}
+```
+
+### Attributes
+
+Control visibility and behavior per-field with `#[holy(...)]`:
+
+- `#[holy(public)]` — make the generated getter/setter `pub` regardless of field visibility
+- `#[holy(private)]` — make the generated getter/setter private regardless of field visibility
+- `#[holy(skip)]` — skip generating getter/setter for this field
+- `#[holy(observe)]` — mark field for observer pattern (used with `Observer` derive)
+
+### Observer
+
+Derive `Observer` to generate a companion struct for the observer pattern:
+
+```rust
+#[derive(holy::Observer)]
+pub struct Sensor {
+    #[holy(observe)]
+    pub temperature: f64,
+    pub name: String,
+}
+
+// Generates `SensorObservers` companion struct
+let mut observers = SensorObservers::new();
+observers.add_temperature_observer(|s: &Sensor| {
+    println!("temp: {}", s.temperature);
+});
+observers.notify_temperature_observers(&sensor);
+```

--- a/packages/rust/holy/src/getter/getter_macro.rs
+++ b/packages/rust/holy/src/getter/getter_macro.rs
@@ -1,67 +1,56 @@
-
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-    DeriveInput, Field, Fields, Data
-};
+use syn::{Data, DeriveInput, Field, Fields};
 
-use crate::utils::determine_visibility;
+use crate::utils::{determine_visibility, should_skip};
 
 pub fn impl_getters_macro(ast: &DeriveInput) -> Result<TokenStream, syn::Error> {
 	let name = &ast.ident;
+	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
 	let getters = match &ast.data {
-		Data::Struct(data) => {
-			match &data.fields {
-				Fields::Named(fields) => {
-					fields.named
-						.iter()
-						.map(|f| { generate_getter(f) })
-						.collect::<Result<Vec<_>, syn::Error>>()?
-				}
-				_ => {
-					return Err(
-						syn::Error::new_spanned(
-							&ast,
-							"Getters macro only supports structs with named fields"
-						)
-					);
-				}
+		Data::Struct(data) => match &data.fields {
+			Fields::Named(fields) => fields
+				.named
+				.iter()
+				.filter(|f| !should_skip(&f.attrs))
+				.map(|f| generate_getter(f))
+				.collect::<Result<Vec<_>, syn::Error>>()?,
+			_ => {
+				return Err(syn::Error::new_spanned(
+					ast,
+					"Getters macro only supports structs with named fields",
+				));
 			}
-		}
+		},
 		_ => {
-			return Err(
-				syn::Error::new_spanned(
-					&ast,
-					"Getters macro only supports structs"
-				)
-			);
+			return Err(syn::Error::new_spanned(
+				ast,
+				"Getters macro only supports structs",
+			));
 		}
 	};
 
-	let expanded =
-		quote! {
-        impl #name {
-            #(#getters)*
-        }
-    };
+	let expanded = quote! {
+		impl #impl_generics #name #ty_generics #where_clause {
+			#(#getters)*
+		}
+	};
 
 	Ok(TokenStream::from(expanded))
 }
 
-fn generate_getter(
-	field: &Field
-) -> Result<proc_macro2::TokenStream, syn::Error> {
+fn generate_getter(field: &Field) -> Result<proc_macro2::TokenStream, syn::Error> {
 	let field_name = &field.ident;
 	let field_type = &field.ty;
 	let vis = &field.vis;
 	let getter_vis = determine_visibility(vis, &field.attrs)?;
 
-	let getter =
-		quote! {
-        #getter_vis fn #field_name(&self) -> &#field_type {
-            &self.#field_name
-        }
-    };
+	let getter = quote! {
+		#getter_vis fn #field_name(&self) -> &#field_type {
+			&self.#field_name
+		}
+	};
 
 	Ok(getter)
 }

--- a/packages/rust/holy/src/lib.rs
+++ b/packages/rust/holy/src/lib.rs
@@ -1,35 +1,25 @@
-// lib.rs
-
-extern crate proc_macro;
 use proc_macro::TokenStream;
-
-use syn::{ parse_macro_input, DeriveInput };
+use syn::{parse_macro_input, DeriveInput};
 
 mod getter;
-mod setter;
 mod observer;
+mod setter;
 mod utils;
 
 #[proc_macro_derive(Getters, attributes(holy))]
 pub fn getters_derive(input: TokenStream) -> TokenStream {
 	let ast = parse_macro_input!(input as DeriveInput);
-	getter
-		::impl_getters_macro(&ast)
-		.unwrap_or_else(|e| e.to_compile_error().into())
+	getter::impl_getters_macro(&ast).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 #[proc_macro_derive(Observer, attributes(holy))]
 pub fn observer_derive(input: TokenStream) -> TokenStream {
 	let ast = parse_macro_input!(input as DeriveInput);
-	observer
-		::impl_observer_macro(&ast)
-		.unwrap_or_else(|e| e.to_compile_error().into())
+	observer::impl_observer_macro(&ast).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 #[proc_macro_derive(Setters, attributes(holy))]
 pub fn setters_derive(input: TokenStream) -> TokenStream {
 	let ast = parse_macro_input!(input as DeriveInput);
-	setter
-		::impl_setters_macro(&ast)
-		.unwrap_or_else(|e| e.to_compile_error().into())
+	setter::impl_setters_macro(&ast).unwrap_or_else(|e| e.to_compile_error().into())
 }

--- a/packages/rust/holy/src/observer/mod.rs
+++ b/packages/rust/holy/src/observer/mod.rs
@@ -1,3 +1,3 @@
 pub mod observer_macro;
 
-pub use observer_macro::*;
+pub use observer_macro::impl_observer_macro;

--- a/packages/rust/holy/src/observer/observer_macro.rs
+++ b/packages/rust/holy/src/observer/observer_macro.rs
@@ -1,66 +1,112 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-	DeriveInput,
-	Data,
-	Field,
-};
+use syn::{Data, DeriveInput, Fields};
+
+use crate::utils::has_holy_argument;
 
 pub fn impl_observer_macro(ast: &DeriveInput) -> Result<TokenStream, syn::Error> {
-
-
 	let struct_name = &ast.ident;
-    let fields = match &ast.data {
-        Data::Struct(data) => &data.fields,
-        _ => return Err(syn::Error::new_spanned(ast, "Observer macro only supports structs")),
-    };
+	let (_impl_generics, ty_generics, _where_clause) = ast.generics.split_for_impl();
 
-	let observer_fields = fields.iter().filter_map(|f| {
-		if has_observer_attribute(f) {
-			let field_name = f.ident.as_ref().unwrap();
-			// Generate the observer field identifier
-			let observer_field_ident = syn::Ident::new(&format!("{}_observers", field_name), field_name.span());
-			Some(quote! {
-				pub #observer_field_ident: crossbeam::atomic::AtomicCell<Option<Box<dyn Fn(&#struct_name) + Send + Sync>>>
-			})
-		} else {
-			None
+	let fields = match &ast.data {
+		Data::Struct(data) => match &data.fields {
+			Fields::Named(named) => &named.named,
+			_ => {
+				return Err(syn::Error::new_spanned(
+					ast,
+					"Observer macro only supports structs with named fields",
+				));
+			}
+		},
+		_ => {
+			return Err(syn::Error::new_spanned(
+				ast,
+				"Observer macro only supports structs",
+			));
+		}
+	};
+
+	let observed: Vec<_> = fields
+		.iter()
+		.filter(|f| has_holy_argument(&f.attrs, "observe"))
+		.collect();
+
+	if observed.is_empty() {
+		return Ok(TokenStream::from(quote! {}));
+	}
+
+	let companion_name =
+		syn::Ident::new(&format!("{}Observers", struct_name), struct_name.span());
+
+	let storage_fields = observed.iter().map(|f| {
+		let name = f.ident.as_ref().unwrap();
+		let observer_field =
+			syn::Ident::new(&format!("{}_observers", name), name.span());
+		quote! {
+			pub #observer_field: Vec<Box<dyn Fn(&#struct_name #ty_generics) + Send + Sync>>
 		}
 	});
-	
-	let observer_methods = fields.iter().filter_map(|f| {
-		if has_observer_attribute(f) {
-			let field_name = f.ident.as_ref().unwrap();
-			// Generate the observer field identifier for use in method
-			let observer_field_ident = syn::Ident::new(&format!("{}_observers", field_name), field_name.span());
-			let add_observer_method_name = syn::Ident::new(&format!("add_{}_observer", field_name), field_name.span());
-			Some(quote! {
-				pub fn #add_observer_method_name<F>(&self, observer: F)
-				where F: Fn(&#struct_name) + 'static + Send + Sync {
-					self.#observer_field_ident.store(Some(Box::new(observer)));
+
+	let storage_defaults = observed.iter().map(|f| {
+		let name = f.ident.as_ref().unwrap();
+		let observer_field =
+			syn::Ident::new(&format!("{}_observers", name), name.span());
+		quote! { #observer_field: Vec::new() }
+	});
+
+	let add_methods = observed.iter().map(|f| {
+		let name = f.ident.as_ref().unwrap();
+		let observer_field =
+			syn::Ident::new(&format!("{}_observers", name), name.span());
+		let method_name =
+			syn::Ident::new(&format!("add_{}_observer", name), name.span());
+		quote! {
+			pub fn #method_name<F>(&mut self, observer: F)
+			where
+				F: Fn(&#struct_name #ty_generics) + 'static + Send + Sync,
+			{
+				self.#observer_field.push(Box::new(observer));
+			}
+		}
+	});
+
+	let notify_methods = observed.iter().map(|f| {
+		let name = f.ident.as_ref().unwrap();
+		let observer_field =
+			syn::Ident::new(&format!("{}_observers", name), name.span());
+		let method_name =
+			syn::Ident::new(&format!("notify_{}_observers", name), name.span());
+		quote! {
+			pub fn #method_name(&self, target: &#struct_name #ty_generics) {
+				for observer in &self.#observer_field {
+					observer(target);
 				}
-			})
-		} else {
-			None
+			}
 		}
 	});
-	
 
-	// Generating the impl block
 	let expanded = quote! {
-        impl #struct_name {
-            #(#observer_fields)*
-            #(#observer_methods)*
-        }
-    };
+		pub struct #companion_name {
+			#(#storage_fields,)*
+		}
 
-    Ok(TokenStream::from(expanded))
-}
+		impl #companion_name {
+			pub fn new() -> Self {
+				Self {
+					#(#storage_defaults,)*
+				}
+			}
 
+			#(#add_methods)*
+			#(#notify_methods)*
+		}
 
+		impl Default for #companion_name {
+			fn default() -> Self {
+				Self::new()
+			}
+		}
+	};
 
-
-// Helper function to check for the observer attribute
-pub fn has_observer_attribute(field: &Field) -> bool {
-    field.attrs.iter().any(|attr| attr.path.is_ident("holy"))
+	Ok(TokenStream::from(expanded))
 }

--- a/packages/rust/holy/src/setter/setter_macro.rs
+++ b/packages/rust/holy/src/setter/setter_macro.rs
@@ -1,89 +1,60 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-	DeriveInput,
-	Data,
-	Fields,
-	Field,
-};
+use syn::{Data, DeriveInput, Field, Fields};
 
-use crate::utils::determine_visibility;
-use crate::observer::has_observer_attribute;
+use crate::utils::{determine_visibility, should_skip};
 
 pub fn impl_setters_macro(ast: &DeriveInput) -> Result<TokenStream, syn::Error> {
 	let name = &ast.ident;
+	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
 	let setters = match &ast.data {
-		Data::Struct(data) => {
-			match &data.fields {
-				Fields::Named(fields) => {
-					fields.named
-						.iter()
-						.map(|f| { generate_setter(f) })
-						.collect::<Result<Vec<_>, syn::Error>>()?
-				}
-				_ => {
-					return Err(
-						syn::Error::new_spanned(
-							&ast,
-							"Setters macro only supports structs with named fields"
-						)
-					);
-				}
+		Data::Struct(data) => match &data.fields {
+			Fields::Named(fields) => fields
+				.named
+				.iter()
+				.filter(|f| !should_skip(&f.attrs))
+				.map(|f| generate_setter(f))
+				.collect::<Result<Vec<_>, syn::Error>>()?,
+			_ => {
+				return Err(syn::Error::new_spanned(
+					ast,
+					"Setters macro only supports structs with named fields",
+				));
 			}
-		}
+		},
 		_ => {
-			return Err(
-				syn::Error::new_spanned(
-					&ast,
-					"Setters macro only supports structs"
-				)
-			);
+			return Err(syn::Error::new_spanned(
+				ast,
+				"Setters macro only supports structs",
+			));
 		}
 	};
 
-	let expanded =
-		quote! {
-        impl #name {
-            #(#setters)*
-        }
-    };
+	let expanded = quote! {
+		impl #impl_generics #name #ty_generics #where_clause {
+			#(#setters)*
+		}
+	};
 
 	Ok(TokenStream::from(expanded))
 }
 
-fn generate_setter(
-	field: &Field
-) -> Result<proc_macro2::TokenStream, syn::Error> {
-	let field_name = field.ident
+fn generate_setter(field: &Field) -> Result<proc_macro2::TokenStream, syn::Error> {
+	let field_name = field
+		.ident
 		.as_ref()
 		.ok_or_else(|| syn::Error::new_spanned(field, "Field without a name"))?;
 	let field_type = &field.ty;
 	let vis = &field.vis;
-	let setter_name = syn::Ident::new(
-		&format!("set_{}", field_name),
-		field_name.span()
-	);
+	let setter_name = syn::Ident::new(&format!("set_{}", field_name), field_name.span());
 	let setter_vis = determine_visibility(vis, &field.attrs)?;
 
-	 // Check if the field has an observer and generate the notification logic
-	 let _observer_check = if has_observer_attribute(field) {
-        let observer_field_name = syn::Ident::new(&format!("{}_observers", field_name), field_name.span());
-        quote! {
-            if let Some(observer) = self.#observer_field_name.load() {
-                (observer)(self);
-            }
-        }
-    } else {
-        quote! {}
-    };
-
-
-	let setter =
-		quote! {
-        #setter_vis fn #setter_name(&mut self, value: #field_type) {
-            self.#field_name = value;
-        }
-    };
+	let setter = quote! {
+		#setter_vis fn #setter_name(&mut self, value: #field_type) {
+			self.#field_name = value;
+		}
+	};
 
 	Ok(setter)
 }

--- a/packages/rust/holy/src/utils/visibility.rs
+++ b/packages/rust/holy/src/utils/visibility.rs
@@ -1,61 +1,68 @@
-
 use quote::quote;
-
-
-use syn::{
-    Visibility,
-    Attribute,
-    Meta,
-	NestedMeta,
-};
-
+use syn::{Attribute, Meta, Token, Visibility};
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
 
 pub fn determine_visibility(
 	vis: &Visibility,
-	attrs: &[Attribute]
+	attrs: &[Attribute],
 ) -> Result<proc_macro2::TokenStream, syn::Error> {
-	if
-		let Some(override_vis) = attrs
-			.iter()
-			.find(|attr| attr.path.is_ident("holy"))
-			.and_then(parse_visibility_override)
+	if let Some(override_vis) = attrs
+		.iter()
+		.find(|attr| attr.path().is_ident("holy"))
+		.and_then(parse_visibility_override)
 	{
 		Ok(override_vis)
 	} else {
 		match vis {
 			Visibility::Public(_) => Ok(quote! { pub }),
-			Visibility::Restricted(restricted) =>
-				Ok(quote! { pub(#restricted) }),
-			_ => Ok(quote! {}),
+			Visibility::Restricted(restricted) => Ok(quote! { #restricted }),
+			Visibility::Inherited => Ok(quote! {}),
 		}
 	}
 }
 
-pub fn parse_visibility_override(
-	attr: &Attribute
-) -> Option<proc_macro2::TokenStream> {
-	attr.parse_meta()
-		.ok()
-		.and_then(|meta| {
-			if let Meta::List(meta_list) = meta {
-				for nested_meta in meta_list.nested.iter() {
-					match nested_meta {
-						NestedMeta::Meta(Meta::Path(path)) if
-							path.is_ident("public")
-						=> {
-							return Some(quote! { pub });
-						}
-						NestedMeta::Meta(Meta::Path(path)) if
-							path.is_ident("private")
-						=> {
-							return Some(quote! {});
-						}
-						_ => {
-							continue;
-						}
-					}
-				}
+fn parse_visibility_override(attr: &Attribute) -> Option<proc_macro2::TokenStream> {
+	let Meta::List(meta_list) = &attr.meta else {
+		return None;
+	};
+
+	let nested = Punctuated::<Meta, Token![,]>::parse_terminated
+		.parse2(meta_list.tokens.clone())
+		.ok()?;
+
+	for meta in &nested {
+		if let Meta::Path(path) = meta {
+			if path.is_ident("public") {
+				return Some(quote! { pub });
 			}
-			None
-		})
+			if path.is_ident("private") {
+				return Some(quote! {});
+			}
+		}
+	}
+	None
+}
+
+pub fn should_skip(attrs: &[Attribute]) -> bool {
+	has_holy_argument(attrs, "skip")
+}
+
+pub fn has_holy_argument(attrs: &[Attribute], arg_name: &str) -> bool {
+	attrs.iter().any(|attr| {
+		if !attr.path().is_ident("holy") {
+			return false;
+		}
+		let Meta::List(meta_list) = &attr.meta else {
+			return false;
+		};
+		let Ok(nested) = Punctuated::<Meta, Token![,]>::parse_terminated
+			.parse2(meta_list.tokens.clone())
+		else {
+			return false;
+		};
+		nested
+			.iter()
+			.any(|meta| matches!(meta, Meta::Path(path) if path.is_ident(arg_name)))
+	})
 }

--- a/packages/rust/holy/tests/fail/01-enum-not-supported.rs
+++ b/packages/rust/holy/tests/fail/01-enum-not-supported.rs
@@ -1,0 +1,9 @@
+use holy::Getters;
+
+#[derive(Getters)]
+enum Nope {
+	A,
+	B,
+}
+
+fn main() {}

--- a/packages/rust/holy/tests/fail/01-enum-not-supported.stderr
+++ b/packages/rust/holy/tests/fail/01-enum-not-supported.stderr
@@ -1,0 +1,8 @@
+error: Getters macro only supports structs
+ --> tests/fail/01-enum-not-supported.rs:4:1
+  |
+4 | / enum Nope {
+5 | |     A,
+6 | |     B,
+7 | | }
+  | |_^

--- a/packages/rust/holy/tests/fail/02-tuple-struct.rs
+++ b/packages/rust/holy/tests/fail/02-tuple-struct.rs
@@ -1,0 +1,6 @@
+use holy::Getters;
+
+#[derive(Getters)]
+struct Nope(i32, i32);
+
+fn main() {}

--- a/packages/rust/holy/tests/fail/02-tuple-struct.stderr
+++ b/packages/rust/holy/tests/fail/02-tuple-struct.stderr
@@ -1,0 +1,5 @@
+error: Getters macro only supports structs with named fields
+ --> tests/fail/02-tuple-struct.rs:4:1
+  |
+4 | struct Nope(i32, i32);
+  | ^^^^^^^^^^^^^^^^^^^^^^

--- a/packages/rust/holy/tests/fail/03-skip-no-getter.rs
+++ b/packages/rust/holy/tests/fail/03-skip-no-getter.rs
@@ -1,0 +1,16 @@
+use holy::Getters;
+
+#[derive(Getters)]
+pub struct WithSkip {
+	pub name: String,
+	#[holy(skip)]
+	pub internal: u64,
+}
+
+fn main() {
+	let s = WithSkip {
+		name: "test".into(),
+		internal: 0,
+	};
+	let _ = s.internal();
+}

--- a/packages/rust/holy/tests/fail/03-skip-no-getter.stderr
+++ b/packages/rust/holy/tests/fail/03-skip-no-getter.stderr
@@ -1,0 +1,10 @@
+error[E0599]: no method named `internal` found for struct `WithSkip` in the current scope
+  --> tests/fail/03-skip-no-getter.rs:15:12
+   |
+ 4 | pub struct WithSkip {
+   | ------------------- method `internal` not found for this struct
+...
+15 |     let _ = s.internal();
+   |               ^^^^^^^^-- help: remove the arguments
+   |               |
+   |               field, not a method

--- a/packages/rust/holy/tests/pass/01-basic-getters.rs
+++ b/packages/rust/holy/tests/pass/01-basic-getters.rs
@@ -1,0 +1,16 @@
+use holy::Getters;
+
+#[derive(Getters)]
+pub struct Simple {
+	pub name: String,
+	pub age: u32,
+}
+
+fn main() {
+	let s = Simple {
+		name: "test".into(),
+		age: 5,
+	};
+	let _n: &String = s.name();
+	let _a: &u32 = s.age();
+}

--- a/packages/rust/holy/tests/pass/02-basic-setters.rs
+++ b/packages/rust/holy/tests/pass/02-basic-setters.rs
@@ -1,0 +1,16 @@
+use holy::Setters;
+
+#[derive(Setters)]
+pub struct Simple {
+	pub name: String,
+	pub age: u32,
+}
+
+fn main() {
+	let mut s = Simple {
+		name: "test".into(),
+		age: 5,
+	};
+	s.set_name("new".into());
+	s.set_age(10);
+}

--- a/packages/rust/holy/tests/pass/03-generics.rs
+++ b/packages/rust/holy/tests/pass/03-generics.rs
@@ -1,0 +1,17 @@
+use holy::{Getters, Setters};
+
+#[derive(Getters, Setters)]
+pub struct Container<T> {
+	pub value: T,
+	pub label: String,
+}
+
+fn main() {
+	let mut c = Container {
+		value: 42i32,
+		label: "test".into(),
+	};
+	let _v: &i32 = c.value();
+	c.set_value(100);
+	c.set_label("updated".into());
+}

--- a/packages/rust/holy/tests/pass/04-visibility-override.rs
+++ b/packages/rust/holy/tests/pass/04-visibility-override.rs
@@ -1,0 +1,23 @@
+mod inner {
+	use holy::{Getters, Setters};
+
+	#[derive(Getters, Setters)]
+	pub struct Mixed {
+		#[holy(public)]
+		name: String,
+		pub visible: u32,
+	}
+
+	impl Mixed {
+		pub fn new(name: String, visible: u32) -> Self {
+			Self { name, visible }
+		}
+	}
+}
+
+fn main() {
+	let s = inner::Mixed::new("pub".into(), 42);
+	// name getter is pub despite field being private
+	let _n: &String = s.name();
+	let _v: &u32 = s.visible();
+}

--- a/packages/rust/holy/tests/pass/05-skip-field.rs
+++ b/packages/rust/holy/tests/pass/05-skip-field.rs
@@ -1,0 +1,18 @@
+use holy::{Getters, Setters};
+
+#[derive(Getters, Setters)]
+pub struct WithSkip {
+	pub name: String,
+	#[holy(skip)]
+	pub internal: u64,
+}
+
+fn main() {
+	let mut s = WithSkip {
+		name: "test".into(),
+		internal: 0,
+	};
+	let _n: &String = s.name();
+	s.set_name("new".into());
+	// No getter/setter for `internal` — that's the point
+}

--- a/packages/rust/holy/tests/pass/06-where-clause.rs
+++ b/packages/rust/holy/tests/pass/06-where-clause.rs
@@ -1,0 +1,12 @@
+use holy::Getters;
+use std::fmt::Debug;
+
+#[derive(Getters)]
+pub struct Bounded<T: Debug> {
+	pub value: T,
+}
+
+fn main() {
+	let b = Bounded { value: 42 };
+	let _v: &i32 = b.value();
+}

--- a/packages/rust/holy/tests/pass/07-observer.rs
+++ b/packages/rust/holy/tests/pass/07-observer.rs
@@ -1,0 +1,21 @@
+use holy::Observer;
+
+#[derive(Observer)]
+pub struct Sensor {
+	#[holy(observe)]
+	pub temperature: f64,
+	pub name: String,
+}
+
+fn main() {
+	let sensor = Sensor {
+		temperature: 20.0,
+		name: "room".into(),
+	};
+
+	let mut observers = SensorObservers::new();
+	observers.add_temperature_observer(|s| {
+		let _ = s.temperature;
+	});
+	observers.notify_temperature_observers(&sensor);
+}

--- a/packages/rust/holy/tests/trybuild.rs
+++ b/packages/rust/holy/tests/trybuild.rs
@@ -1,0 +1,6 @@
+#[test]
+fn tests() {
+	let t = trybuild::TestCases::new();
+	t.pass("tests/pass/*.rs");
+	t.compile_fail("tests/fail/*.rs");
+}


### PR DESCRIPTION
… macro, add tests

Migrate from syn 1 to syn 2, remove crossbeam dependency, bump edition to 2024 and version to 0.2.0. Fix generics support in getter/setter macros, add #[holy(skip)] attribute, redesign observer macro to generate a companion struct instead of broken field-in-impl approach. Add 10 trybuild tests covering all macro features and error cases.