### PR TITLE
fix(kbve): switch diesel backend from mysql to postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,11 +2808,10 @@ dependencies = [
  "byteorder",
  "chrono",
  "diesel_derives",
- "mysqlclient-sys",
- "percent-encoding",
+ "itoa 1.0.15",
+ "pq-sys",
  "r2d2",
  "serde_json",
- "url",
 ]
 
 [[package]]
@@ -5769,17 +5768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "mysqlclient-sys"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a34a2bdec189f1060343ba712983e14cad7e87515cfd9ac4653e207535b6b1"
-dependencies = [
- "pkg-config",
- "semver",
- "vcpkg",
-]
-
-[[package]]
 name = "naga"
 version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7112,6 +7100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pq-sys"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574ddd6a267294433f140b02a726b0640c43cf7c6f717084684aaa3b285aba61"
+dependencies = [
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/apps/kbve/rust_api_profile/Cargo.toml
+++ b/apps/kbve/rust_api_profile/Cargo.toml
@@ -16,7 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower = { version = "0.4.13", features = ["timeout"] }
 tower-http = { version = "0.4.4", features = ["cors"] }
 r2d2 = "0.8.9"
-diesel = { version = "2.0.0", features = ["mysql", "chrono", "r2d2"] }
+diesel = { version = "2.0.0", features = ["postgres", "chrono", "r2d2"] }
 jedi = { path = "../../../packages/rust/jedi" }
 # rathole = "0.5"
 # hyper = "1.3.1"

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -17,7 +17,7 @@ argon2 = "0.5.0"
 async-trait = "0.1.74"
 chrono = { version = "0.4.24", features = ["serde"] }
 diesel = { version = "2.0.0", features = [
-    "mysql",
+    "postgres",
     "chrono",
     "r2d2",
     "serde_json",

--- a/packages/rust/kbve/src/db.rs
+++ b/packages/rust/kbve/src/db.rs
@@ -2,10 +2,10 @@ use std::env;
 use std::result::Result;
 use std::fs;
 use diesel::prelude::*;
-use diesel::mysql::MysqlConnection;
+use diesel::pg::PgConnection;
 use diesel::r2d2::{self, ConnectionManager};
 
-pub type Pool = r2d2::Pool<ConnectionManager<diesel::MysqlConnection>>;
+pub type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
 
 fn get_env_var(name: &str) -> Result<String, String> {
     match env::var(name) {
@@ -18,16 +18,16 @@ fn get_env_var(name: &str) -> Result<String, String> {
     }
 }
 
-pub fn establish_connection_dev() -> Result<MysqlConnection, String> {
+pub fn establish_connection_dev() -> Result<PgConnection, String> {
     establish_connection_generic("DATABASE_URL_DEV")
 }
-pub fn establish_connection_prod() -> Result<MysqlConnection, String> {
+pub fn establish_connection_prod() -> Result<PgConnection, String> {
     establish_connection_generic("DATABASE_URL_PROD")
 }
 
-fn establish_connection_generic(env_var: &str) -> Result<MysqlConnection, String> {
+fn establish_connection_generic(env_var: &str) -> Result<PgConnection, String> {
     let database_url = get_env_var(env_var)?;
-    MysqlConnection::establish(&database_url)
+    PgConnection::establish(&database_url)
         .map_err(|err| format!("Error connecting to {}: {}", database_url, err))
 }
 
@@ -36,7 +36,7 @@ pub fn establish_connection_pool() -> Pool {
     let database_url = get_env_var("DATABASE_URL_PROD")
     .expect("DATABASE_URL_PROD must be set for production");
 
-    let manager = ConnectionManager::<MysqlConnection>::new(database_url);
+    let manager = ConnectionManager::<PgConnection>::new(database_url);
 
     r2d2::Pool::builder()
     .build(manager)

--- a/packages/rust/kbve/src/models.rs
+++ b/packages/rust/kbve/src/models.rs
@@ -11,7 +11,7 @@ use chrono::NaiveDateTime;
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = apikey)]
 pub struct Apikey {
-    pub id: u64,
+    pub id: i64,
     pub ulid: Vec<u8>,
     pub userid: Vec<u8>,
     pub permissions: String,
@@ -22,7 +22,7 @@ pub struct Apikey {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = appwrite)]
 pub struct Appwrite {
-    pub id: u64,
+    pub id: i64,
     pub ulid: Vec<u8>,
     pub userid: Vec<u8>,
     pub appwrite_endpoint: String,
@@ -35,7 +35,7 @@ pub struct Appwrite {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = auth)]
 pub struct Auth {
-    pub id: u64,
+    pub id: i64,
     pub ulid: Vec<u8>,
     pub userid: Vec<u8>,
     pub email: String,
@@ -56,7 +56,7 @@ pub struct Auth {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = characters)]
 pub struct Character {
-    pub id: u64,
+    pub id: i64,
     pub cid: Vec<u8>,
     pub userid: Vec<u8>,
     pub hp: i32,
@@ -79,7 +79,7 @@ pub struct Character {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = globals)]
 pub struct Global {
-    pub id: u64,
+    pub id: i64,
     pub key: String,
     pub value: String,
 }
@@ -87,7 +87,7 @@ pub struct Global {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = invoice)]
 pub struct Invoice {
-    pub id: u64,
+    pub id: i64,
     pub ulid: Vec<u8>,
     pub userid: Vec<u8>,
     pub items: Json,
@@ -95,7 +95,7 @@ pub struct Invoice {
     pub total: f64,
     pub balance: f64,
     pub external: String,
-    pub due: u64,
+    pub due: i64,
     pub visibility: i32,
     pub status: i32,
 }
@@ -103,7 +103,7 @@ pub struct Invoice {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = n8n)]
 pub struct N8n {
-    pub id: u64,
+    pub id: i64,
     pub ulid: Vec<u8>,
     pub userid: Vec<u8>,
     pub webhook: String,
@@ -115,7 +115,7 @@ pub struct N8n {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = profile)]
 pub struct Profile {
-    pub id: u64,
+    pub id: i64,
     pub ulid: Vec<u8>,
     pub name: String,
     pub bio: String,
@@ -129,7 +129,7 @@ pub struct Profile {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = settings)]
 pub struct Setting {
-    pub id: u64,
+    pub id: i64,
     pub ulid: Vec<u8>,
     pub userid: Vec<u8>,
     pub key: String,
@@ -139,7 +139,7 @@ pub struct Setting {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = users)]
 pub struct User {
-    pub id: u64,
+    pub id: i64,
     pub userid: Vec<u8>,
     pub username: String,
     pub role: i32,

--- a/packages/rust/kbve/src/schema.rs
+++ b/packages/rust/kbve/src/schema.rs
@@ -2,11 +2,11 @@
 
 diesel::table! {
     apikey (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        ulid -> Binary,
+        ulid -> Bytea,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
         #[max_length = 255]
         permissions -> Varchar,
         #[max_length = 255]
@@ -18,11 +18,11 @@ diesel::table! {
 
 diesel::table! {
     appwrite (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        ulid -> Binary,
+        ulid -> Bytea,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
         #[max_length = 255]
         appwrite_endpoint -> Varchar,
         #[max_length = 255]
@@ -37,11 +37,11 @@ diesel::table! {
 
 diesel::table! {
     auth (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        ulid -> Binary,
+        ulid -> Bytea,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
         #[max_length = 255]
         email -> Varchar,
         #[max_length = 255]
@@ -66,11 +66,11 @@ diesel::table! {
 
 diesel::table! {
     characters (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        cid -> Binary,
+        cid -> Bytea,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
         hp -> Integer,
         mp -> Integer,
         ep -> Integer,
@@ -93,7 +93,7 @@ diesel::table! {
 
 diesel::table! {
     globals (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 255]
         key -> Varchar,
         #[max_length = 255]
@@ -103,18 +103,18 @@ diesel::table! {
 
 diesel::table! {
     invoice (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        ulid -> Binary,
+        ulid -> Bytea,
         #[max_length = 16]
-        userid -> Binary,
-        items -> Json,
-        paid -> Decimal,
-        total -> Decimal,
-        balance -> Decimal,
+        userid -> Bytea,
+        items -> Jsonb,
+        paid -> Float8,
+        total -> Float8,
+        balance -> Float8,
         #[max_length = 255]
         external -> Varchar,
-        due -> Unsigned<Bigint>,
+        due -> Int8,
         visibility -> Integer,
         status -> Integer,
     }
@@ -122,11 +122,11 @@ diesel::table! {
 
 diesel::table! {
     n8n (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        ulid -> Binary,
+        ulid -> Bytea,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
         #[max_length = 255]
         webhook -> Varchar,
         #[max_length = 255]
@@ -140,9 +140,9 @@ diesel::table! {
 
 diesel::table! {
     profile (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        ulid -> Binary,
+        ulid -> Bytea,
         #[max_length = 255]
         name -> Varchar,
         #[max_length = 64]
@@ -156,17 +156,17 @@ diesel::table! {
         #[max_length = 64]
         discord -> Varchar,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
     }
 }
 
 diesel::table! {
     settings (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        ulid -> Binary,
+        ulid -> Bytea,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
         #[max_length = 255]
         key -> Varchar,
         #[max_length = 255]
@@ -176,9 +176,9 @@ diesel::table! {
 
 diesel::table! {
     users (id) {
-        id -> Unsigned<Bigint>,
+        id -> Int8,
         #[max_length = 16]
-        userid -> Binary,
+        userid -> Bytea,
         #[max_length = 255]
         username -> Varchar,
         role -> Integer,


### PR DESCRIPTION
Replace MysqlConnection with PgConnection, swap diesel feature flag to postgres, and update schema types (Unsigned<Bigint> to Int8, Binary to Bytea, Json to Jsonb, Decimal to Float8) and model types (u64 to i64).