### PR TITLE
feat(herbmail): add 404 fallback, security headers, precompression, a…

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -323,6 +323,29 @@ jobs:
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
             MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    ## Herbmail
+    test_herbmail:
+        needs: ['deploy', 'alter', 'globals']
+        name: Test Herbmail
+        if: needs.alter.outputs.herbmail == 'true'
+        uses: KBVE/kbve/.github/workflows/docker-test-app.yml@main
+        with:
+            project: herbmail
+
+    publish_herbmail:
+        needs: ['alter', 'test_herbmail']
+        name: Publish Herbmail
+        uses: KBVE/kbve/.github/workflows/utils-publish-docker-image.yml@main
+        with:
+            project: herbmail
+            target: container
+            image: herbmail/axum-herbmail
+            cargo_toml: apps/herbmail/axum-herbmail/Cargo.toml
+        secrets:
+            DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+            MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     #   ! Everything below this line will be removed and replaced with the matrix setup.
 
     #   [CryptoThrone]

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -1,0 +1,51 @@
+name: Docker App Test
+
+on:
+    workflow_call:
+        inputs:
+            project:
+                required: true
+                type: string
+
+jobs:
+    test:
+        name: Test ${{ inputs.project }} Docker App
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout the monorepo
+              uses: actions/checkout@v4
+
+            - name: Rust ToolChain
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Setup Node v22
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: Setup pnpm v10
+              uses: pnpm/action-setup@v3
+              with:
+                  version: 10
+                  run_install: false
+
+            - name: Get pnpm Store Path
+              id: pnpm-store
+              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+            - name: Setup pnpm Cache
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+
+            - name: Install pnpm Dependencies
+              run: pnpm install
+
+            - name: Nx e2e ${{ inputs.project }}
+              run: pnpm nx e2e ${{ inputs.project }} --no-cloud

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -63,6 +63,9 @@ on:
       astro_herbmail:
         description: "Herbmail.com changed"
         value: ${{ jobs.alter.outputs.astro_herbmail }}
+      herbmail:
+        description: "Herbmail app changed"
+        value: ${{ jobs.alter.outputs.herbmail }}
       astro_rareicon:
         description: "Rareicon.com changed"
         value: ${{ jobs.alter.outputs.astro_rareicon }}
@@ -138,6 +141,7 @@ jobs:
       astro_kbve: ${{ steps.delta.outputs.astro_kbve_any_changed }}
       astro_memes: ${{ steps.delta.outputs.astro_memes_any_changed }}
       astro_herbmail: ${{ steps.delta.outputs.astro_herbmail_any_changed }}
+      herbmail: ${{ steps.delta.outputs.herbmail_any_changed }}
       astro_rareicon: ${{ steps.delta.outputs.astro_rareicon_any_changed }}
       rareicon_unity: ${{ steps.delta.outputs.rareicon_unity_any_changed }}
       droid: ${{ steps.delta.outputs.droid_any_changed }}
@@ -202,6 +206,8 @@ jobs:
                 - 'apps/memes/astro-memes/**'
             astro_herbmail:
                 - 'apps/herbmail/README.md'
+            herbmail:
+                - 'apps/herbmail/**'
             astro_rareicon:
                 - 'apps/rareicon/rareicon.com/**'
             discordsh:

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -9,6 +9,15 @@ on:
             target:
                 required: true
                 type: string
+            image:
+                required: false
+                type: string
+                default: ''
+            cargo_toml:
+                description: 'Path to Cargo.toml to read version from'
+                required: false
+                type: string
+                default: ''
             branch:
                 required: false
                 type: string
@@ -34,22 +43,45 @@ jobs:
               with:
                 ref: ${{ inputs.branch }}
 
+            - name: Check version against Docker Hub
+              id: version_check
+              if: ${{ inputs.image != '' && inputs.cargo_toml != '' }}
+              run: |
+                  LOCAL_VERSION=$(grep -m1 '^version' "${{ inputs.cargo_toml }}" \
+                    | sed 's/version = "\(.*\)"/\1/')
+                  echo "Local version from Cargo.toml: $LOCAL_VERSION"
+
+                  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                    "https://hub.docker.com/v2/repositories/${{ inputs.image }}/tags/$LOCAL_VERSION")
+
+                  if [ "$STATUS" = "200" ]; then
+                    echo "Tag $LOCAL_VERSION already exists on Docker Hub — skipping."
+                    echo "should_publish=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "Tag $LOCAL_VERSION not found (HTTP $STATUS) — publishing."
+                    echo "should_publish=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Setup Node v22
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               uses: actions/setup-node@v4
               with:
                   node-version: 22
 
             - name: Setup pnpm v10
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               uses: pnpm/action-setup@v3
               with:
                   version: 10
                   run_install: false
 
             - name: Get pnpm Store
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               id: pnpm-store
               run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
             - name: Setup pnpm Cache
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               uses: actions/cache@v4
               with:
                   path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
@@ -58,21 +90,26 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               run: pnpm install
 
             - name: Set up QEMU
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               uses: docker/setup-qemu-action@v3
 
             - name: Set up Docker Buildx
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               uses: docker/setup-buildx-action@v3
 
             - name: Login to Docker Hub
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               uses: docker/login-action@v3
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and Push Docker Image with Nx
+              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               env:
                   INPUT_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
               run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,11 +1503,13 @@ dependencies = [
  "axum 0.8.8",
  "axum-extra 0.12.5",
  "dotenvy",
+ "http-body-util",
  "jedi 0.2.1",
  "kbve",
  "num_cpus",
  "serde",
  "serde_json",
+ "serial_test",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tikv-jemallocator",
@@ -4952,7 +4954,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -8369,6 +8371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8407,6 +8418,12 @@ dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -8673,6 +8690,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",

--- a/apps/herbmail/axum-herbmail/Cargo.toml
+++ b/apps/herbmail/axum-herbmail/Cargo.toml
@@ -36,6 +36,10 @@ kbve = { path = "../../../packages/rust/kbve" }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }
 
+[dev-dependencies]
+serial_test = "3"
+http-body-util = "0.1"
+
 [features]
 default = []
 jemalloc = ["dep:tikv-jemallocator"]

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -21,19 +21,22 @@ WORKDIR /app/apps/herbmail/astro-herbmail
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN pnpm exec astro build
 
-# Precompress static assets with gzip -9 (skip askama/ templates)
+# Precompress static assets with brotli-11 + gzip-9 (keep originals)
 WORKDIR /app/dist/apps/astro-herbmail
-RUN apk add --no-cache gzip && \
+RUN apk add --no-cache gzip brotli && \
     find . -type f \( \
         -name "*.css" -o \
         -name "*.js" -o \
         -name "*.json" -o \
         -name "*.svg" -o \
         -name "*.xml" -o \
-        -name "*.txt" \
-    \) -exec sh -c 'gzip -9 -c "$1" > "$1.gz" && rm "$1"' _ {} \; && \
-    find . -type f -name "*.html" ! -path "*/askama/*" -exec sh -c 'gzip -9 -c "$1" > "$1.gz" && rm "$1"' _ {} \; && \
-    echo "Precompression complete"
+        -name "*.txt" -o \
+        -name "*.html" \
+    \) ! -path "*/askama/*" -exec sh -c ' \
+        gzip -9 -k "$1" && \
+        brotli --best --keep "$1" \
+    ' _ {} \; && \
+    echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
 # [STAGE B] - Rust Base Image

--- a/apps/herbmail/axum-herbmail/project.json
+++ b/apps/herbmail/axum-herbmail/project.json
@@ -57,6 +57,13 @@
         }
       }
     },
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["nx test axum-herbmail"],
+        "parallel": false
+      }
+    },
     "container": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/herbmail/axum-herbmail/src/transport/https.rs
+++ b/apps/herbmail/axum-herbmail/src/transport/https.rs
@@ -3,12 +3,14 @@ use std::{net::SocketAddr, time::Duration};
 
 use axum::{
     extract::Request,
+    http::{header, HeaderName, HeaderValue},
     middleware::Next,
     response::{IntoResponse, Response},
     routing::get,
     Router,
 };
 use tokio::net::TcpListener;
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::info;
 
 pub async fn serve() -> Result<()> {
@@ -33,16 +35,9 @@ pub async fn serve() -> Result<()> {
 }
 
 fn router() -> Router {
-    use tower_http::compression::Predicate as _;
-
     let max_inflight: usize = num_cpus::get().max(1) * 1024;
 
     let static_config = crate::astro::StaticConfig::from_env();
-
-    let compression = tower_http::compression::CompressionLayer::new().compress_when(
-        tower_http::compression::predicate::DefaultPredicate::new()
-            .and(tower_http::compression::predicate::SizeAbove::new(1024)),
-    );
 
     let middleware = tower::ServiceBuilder::new()
         .layer(
@@ -51,7 +46,19 @@ fn router() -> Router {
             ),
         )
         .layer(tower_http::cors::CorsLayer::permissive())
-        .layer(compression)
+        // Security headers
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("referrer-policy"),
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
         .layer(axum::error_handling::HandleErrorLayer::new(
             |err: tower::BoxError| async move {
                 if err.is::<tower::timeout::error::Elapsed>() {
@@ -70,7 +77,8 @@ fn router() -> Router {
         .layer(tower_http::limit::RequestBodyLimitLayer::new(1024 * 1024));
 
     let static_router = crate::astro::build_static_router(&static_config)
-        .layer(axum::middleware::from_fn(fix_ts_mime));
+        .layer(axum::middleware::from_fn(fix_ts_mime))
+        .layer(axum::middleware::from_fn(cache_headers));
 
     let public_router = Router::new()
         .route("/health", get(health));
@@ -86,6 +94,32 @@ async fn health() -> impl IntoResponse {
     "OK"
 }
 
+/// Set Cache-Control based on request path.
+async fn cache_headers(request: Request, next: Next) -> Response {
+    let path = request.uri().path().to_owned();
+    let mut response = next.run(request).await;
+
+    let cache_value = if path.starts_with("/_astro/") {
+        // Content-hashed Vite bundles — cache forever
+        "public, max-age=31536000, immutable"
+    } else if path.starts_with("/pagefind/") || path.starts_with("/images/") {
+        // Build-time generated, static until next deploy
+        "public, max-age=86400"
+    } else if path.ends_with(".html") || path == "/" || !path.contains('.') {
+        // Static HTML pages — immutable until next container deploy
+        "public, max-age=86400"
+    } else {
+        "public, max-age=86400"
+    };
+
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(cache_value),
+    );
+
+    response
+}
+
 /// Vite outputs worker files with `.ts` extensions. `mime_guess` maps `.ts` to
 /// `video/mp2t`, which browsers reject for Web Workers. Override to JS.
 async fn fix_ts_mime(request: Request, next: Next) -> Response {
@@ -93,8 +127,8 @@ async fn fix_ts_mime(request: Request, next: Next) -> Response {
     let mut response = next.run(request).await;
     if is_ts {
         response.headers_mut().insert(
-            axum::http::header::CONTENT_TYPE,
-            "application/javascript; charset=utf-8".parse().unwrap(),
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
         );
     }
     response
@@ -131,4 +165,170 @@ fn tuned_listener(addr: SocketAddr) -> Result<TcpListener> {
 
 async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    /// Build a minimal router with just the health endpoint + middleware
+    /// (no static file serving, which requires a real directory).
+    fn test_router() -> Router {
+        let middleware = tower::ServiceBuilder::new()
+            .layer(SetResponseHeaderLayer::overriding(
+                header::X_CONTENT_TYPE_OPTIONS,
+                HeaderValue::from_static("nosniff"),
+            ))
+            .layer(SetResponseHeaderLayer::overriding(
+                header::X_FRAME_OPTIONS,
+                HeaderValue::from_static("DENY"),
+            ))
+            .layer(SetResponseHeaderLayer::overriding(
+                HeaderName::from_static("referrer-policy"),
+                HeaderValue::from_static("strict-origin-when-cross-origin"),
+            ));
+
+        Router::new()
+            .route("/health", get(health))
+            .layer(middleware)
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"OK");
+    }
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response.headers().get("x-frame-options").unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_astro_path() {
+        let app = Router::new()
+            .route("/_astro/{*path}", get(|| async { "asset" }))
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/_astro/bundle.abc123.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let cc = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("immutable"));
+        assert!(cc.contains("31536000"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_html_page() {
+        let app = Router::new()
+            .route("/", get(|| async { "page" }))
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let cc = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("86400"));
+    }
+
+    #[tokio::test]
+    async fn test_fix_ts_mime_rewrites() {
+        let app = Router::new()
+            .route("/worker.ts", get(|| async { "code" }))
+            .route("/script.js", get(|| async { "code" }))
+            .layer(axum::middleware::from_fn(fix_ts_mime));
+
+        // .ts file should get JS content-type
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/worker.ts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/javascript; charset=utf-8"
+        );
+
+        // .js file should NOT be rewritten
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/script.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let ct = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .map(|v| v.to_str().unwrap().to_string());
+        assert!(ct.is_none() || !ct.unwrap().contains("application/javascript"));
+    }
 }

--- a/apps/herbmail/herbmail-e2e/e2e/pagefind.spec.ts
+++ b/apps/herbmail/herbmail-e2e/e2e/pagefind.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Smoke: Pagefind Search', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+	});
+
+	test('search modal opens and pagefind-ui mounts', async ({ page }) => {
+		const trigger = page.locator('button[data-open-modal]');
+		await expect(trigger).toBeVisible({ timeout: 10_000 });
+		await trigger.click();
+
+		const dialog = page.locator('dialog[aria-label="Search"]');
+		await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+		const input = dialog.locator('.pagefind-ui__search-input');
+		await expect(input).toBeVisible({ timeout: 10_000 });
+	});
+
+	test('searching "guides" returns results', async ({ page }) => {
+		await page.locator('button[data-open-modal]').click();
+
+		const dialog = page.locator('dialog[aria-label="Search"]');
+		await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+		const input = dialog.locator('.pagefind-ui__search-input');
+		await expect(input).toBeVisible({ timeout: 10_000 });
+		await input.fill('guides');
+
+		const results = dialog.locator('.pagefind-ui__result');
+		await expect(results.first()).toBeVisible({ timeout: 10_000 });
+
+		const count = await results.count();
+		expect(count).toBeGreaterThan(0);
+	});
+
+	test('clicking a search result navigates to a valid page', async ({
+		page,
+	}) => {
+		await page.locator('button[data-open-modal]').click();
+
+		const dialog = page.locator('dialog[aria-label="Search"]');
+		const input = dialog.locator('.pagefind-ui__search-input');
+		await expect(input).toBeVisible({ timeout: 10_000 });
+		await input.fill('guides');
+
+		const firstResult = dialog.locator('.pagefind-ui__result a').first();
+		await expect(firstResult).toBeVisible({ timeout: 10_000 });
+
+		const href = await firstResult.getAttribute('href');
+		expect(href).toBeTruthy();
+
+		const [response] = await Promise.all([
+			page.waitForNavigation(),
+			firstResult.click(),
+		]);
+
+		expect(response).not.toBeNull();
+		expect(response!.status()).toBe(200);
+		expect(page.url()).toContain(href!);
+	});
+});

--- a/apps/herbmail/herbmail-e2e/e2e/sampler.ts
+++ b/apps/herbmail/herbmail-e2e/e2e/sampler.ts
@@ -1,0 +1,169 @@
+/**
+ * Sitemap-driven weighted route sampler.
+ *
+ * Pipeline:  sitemap → (core ∪ wsample(N, seed)) → routes
+ *
+ * - Core routes are always tested.
+ * - Remaining sitemap routes are weighted by prefix and sampled
+ *   using a deterministic seed (GITHUB_RUN_ID in CI, fixed locally).
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** Routes that are always tested regardless of sampling. */
+export const CORE_ROUTES = ['/', '/docs', '/pricing', '/auth/callback'];
+
+/** Prefix → weight.  0 = exclude entirely. */
+const PREFIX_WEIGHTS: [string, number][] = [
+	['/docs/', 5],
+	['/guides/', 5],
+	['/blog/', 2],
+	['/legal/', 1],
+	['/api/', 0],
+	['/auth/', 0],
+];
+
+const DEFAULT_WEIGHT = 1;
+
+/** How many non-core routes to sample. */
+const DEFAULT_SAMPLE_SIZE = 10;
+
+// ---------------------------------------------------------------------------
+// Seeded PRNG  (mulberry32)
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed: number): () => number {
+	return () => {
+		seed |= 0;
+		seed = (seed + 0x6d2b79f5) | 0;
+		let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function getSeed(): number {
+	const runId = process.env['GITHUB_RUN_ID'];
+	return runId ? parseInt(runId, 10) : 42;
+}
+
+// ---------------------------------------------------------------------------
+// Sitemap fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch sitemap-index.xml, resolve child sitemaps, extract all <loc> paths.
+ * Returns de-duped relative paths (e.g. "/docs/getting-started").
+ */
+export async function fetchSitemapRoutes(baseURL: string): Promise<string[]> {
+	const indexBody = await fetchText(`${baseURL}/sitemap-index.xml`);
+	const sitemapUrls = extractLocs(indexBody);
+
+	const allLocs: string[] = [];
+	for (const url of sitemapUrls) {
+		// Rewrite absolute sitemap URL to hit the local server
+		const path = new URL(url).pathname;
+		const body = await fetchText(`${baseURL}${path}`);
+		allLocs.push(...extractLocs(body));
+	}
+
+	// Convert absolute URLs to relative paths, de-dup
+	const seen = new Set<string>();
+	const routes: string[] = [];
+	for (const loc of allLocs) {
+		let path: string;
+		try {
+			path = new URL(loc).pathname;
+		} catch {
+			path = loc;
+		}
+		// Normalise: strip trailing slash (keep "/" as-is)
+		const normalised = path === '/' ? '/' : path.replace(/\/+$/, '');
+		if (!seen.has(normalised)) {
+			seen.add(normalised);
+			routes.push(normalised);
+		}
+	}
+	return routes;
+}
+
+function extractLocs(xml: string): string[] {
+	const matches: string[] = [];
+	const re = /<loc>(.*?)<\/loc>/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(xml)) !== null) {
+		matches.push(m[1]);
+	}
+	return matches;
+}
+
+async function fetchText(url: string): Promise<string> {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`${url} → ${res.status}`);
+	return res.text();
+}
+
+// ---------------------------------------------------------------------------
+// Weighted sampling  (Efraimidis-Spirakis)
+// ---------------------------------------------------------------------------
+
+function weightForRoute(route: string): number {
+	for (const [prefix, w] of PREFIX_WEIGHTS) {
+		if (route.startsWith(prefix)) return w;
+	}
+	return DEFAULT_WEIGHT;
+}
+
+function weightedSample(
+	candidates: string[],
+	k: number,
+	rng: () => number,
+): string[] {
+	const keyed = candidates
+		.map((route) => ({ route, weight: weightForRoute(route) }))
+		.filter((x) => x.weight > 0)
+		.map((x) => ({ route: x.route, key: Math.pow(rng(), 1 / x.weight) }));
+
+	keyed.sort((a, b) => b.key - a.key);
+	return keyed.slice(0, k).map((x) => x.route);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the final set of routes to smoke-test:
+ *   core (always)  ∪  weightedSample(remaining, N, seed)
+ */
+export async function sampleRoutes(
+	baseURL: string,
+	sampleSize = DEFAULT_SAMPLE_SIZE,
+): Promise<{ core: string[]; sampled: string[]; all: string[] }> {
+	let sitemapRoutes: string[];
+	try {
+		sitemapRoutes = await fetchSitemapRoutes(baseURL);
+	} catch {
+		// Sitemap missing or unparseable — fall back to core only
+		return { core: CORE_ROUTES, sampled: [], all: CORE_ROUTES };
+	}
+
+	const coreSet = new Set(CORE_ROUTES);
+
+	// Only keep core routes that actually exist in the sitemap (or keep all core as-is)
+	const core = CORE_ROUTES.filter(
+		(r) => sitemapRoutes.includes(r) || !sitemapRoutes.length,
+	);
+
+	// Candidates = sitemap routes minus core
+	const candidates = sitemapRoutes.filter((r) => !coreSet.has(r));
+
+	const rng = mulberry32(getSeed());
+	const k = Math.min(sampleSize, candidates.length);
+	const sampled = weightedSample(candidates, k, rng);
+
+	const allSet = new Set([...core, ...sampled]);
+	return { core, sampled, all: [...allSet] };
+}

--- a/apps/herbmail/herbmail-e2e/e2e/smoke.spec.ts
+++ b/apps/herbmail/herbmail-e2e/e2e/smoke.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import { sampleRoutes } from './sampler';
+
+test.describe('Smoke: Page Loading', () => {
+	test('main page loads with 200', async ({ page }) => {
+		const response = await page.goto('/');
+		expect(response).not.toBeNull();
+		expect(response!.status()).toBe(200);
+		await expect(page.locator('html')).toBeVisible();
+	});
+
+	test('404 page returns Astro custom 404', async ({ page }) => {
+		const response = await page.goto('/this-route-does-not-exist');
+		expect(response).not.toBeNull();
+		expect(response!.status()).toBe(404);
+
+		const body = await page.content();
+		expect(body.length).toBeGreaterThan(100);
+		expect(body).not.toContain('<h1>404 - Not Found</h1>');
+	});
+});
+
+test.describe('Smoke: Health Endpoint', () => {
+	test('GET /health returns OK', async ({ request }) => {
+		const response = await request.get('/health');
+		expect(response.status()).toBe(200);
+		expect(await response.text()).toBe('OK');
+	});
+});
+
+test.describe('Smoke: Security Headers', () => {
+	test('responses include security headers', async ({ request }) => {
+		const response = await request.get('/health');
+		const headers = response.headers();
+
+		expect(headers['x-content-type-options']).toBe('nosniff');
+		expect(headers['x-frame-options']).toBe('DENY');
+		expect(headers['referrer-policy']).toBe(
+			'strict-origin-when-cross-origin',
+		);
+	});
+});
+
+test.describe('Smoke: Cache-Control Headers', () => {
+	test('HTML pages have 86400 cache', async ({ request }) => {
+		const response = await request.get('/');
+		const cc = response.headers()['cache-control'] ?? '';
+		expect(cc).toContain('max-age=86400');
+	});
+
+	test('/_astro/ assets have immutable cache', async ({ page }) => {
+		const astroRequests: { cacheControl: string; url: string }[] = [];
+
+		page.on('response', (resp) => {
+			if (new URL(resp.url()).pathname.startsWith('/_astro/')) {
+				astroRequests.push({
+					url: resp.url(),
+					cacheControl:
+						resp.headers()['cache-control'] ?? '',
+				});
+			}
+		});
+
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+
+		if (astroRequests.length > 0) {
+			for (const req of astroRequests) {
+				expect(req.cacheControl).toContain('immutable');
+				expect(req.cacheControl).toContain('31536000');
+			}
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Sitemap-driven route sampling
+// ---------------------------------------------------------------------------
+
+const BASE_URL = process.env['BASE_URL'] || 'http://localhost:4321';
+
+test.describe('Smoke: Sitemap Routes', () => {
+	test('sitemap exists and is parseable', async ({ request }) => {
+		const response = await request.get('/sitemap-index.xml');
+		expect(response.status()).toBe(200);
+		const body = await response.text();
+		expect(body).toContain('<loc>');
+	});
+
+	test('core + sampled routes all return 200', async ({ page, request }) => {
+		const { core, sampled, all } = await sampleRoutes(BASE_URL);
+
+		test.info().annotations.push(
+			{ type: 'core_routes', description: core.join(', ') },
+			{ type: 'sampled_routes', description: sampled.join(', ') || '(none)' },
+			{
+				type: 'seed',
+				description: process.env['GITHUB_RUN_ID'] || '42 (local)',
+			},
+		);
+
+		for (const route of all) {
+			await test.step(`GET ${route} → 200`, async () => {
+				const resp = await request.get(route);
+				expect(
+					resp.status(),
+					`${route} returned ${resp.status()}`,
+				).toBe(200);
+			});
+		}
+	});
+
+	test('sampled routes have security headers', async ({ request }) => {
+		const { all } = await sampleRoutes(BASE_URL);
+
+		for (const route of all.slice(0, 5)) {
+			await test.step(`headers on ${route}`, async () => {
+				const resp = await request.get(route);
+				const h = resp.headers();
+				expect(h['x-content-type-options']).toBe('nosniff');
+				expect(h['x-frame-options']).toBe('DENY');
+			});
+		}
+	});
+});

--- a/apps/herbmail/herbmail-e2e/package.json
+++ b/apps/herbmail/herbmail-e2e/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "herbmail-e2e",
+	"private": true,
+	"version": "0.0.0"
+}

--- a/apps/herbmail/herbmail-e2e/playwright.config.ts
+++ b/apps/herbmail/herbmail-e2e/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const mode =
+	process.env['E2E_DOCKER'] === 'true' ? 'docker' : 'dev';
+
+const port = 4321;
+const baseURL = `http://localhost:${port}`;
+
+const commands: Record<string, string> = {
+	dev: 'pnpm exec nx dev axum-herbmail',
+	docker: `docker run --rm -p ${port}:${port} herbmail/axum-herbmail:0.1.0`,
+};
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: mode,
+			use: {
+				...devices['Desktop Chrome'],
+				baseURL,
+			},
+		},
+	],
+	webServer: {
+		command: commands[mode],
+		url: `${baseURL}/health`,
+		reuseExistingServer: !process.env['CI'],
+		timeout: mode === 'docker' ? 30_000 : 120_000,
+	},
+});

--- a/apps/herbmail/herbmail-e2e/project.json
+++ b/apps/herbmail/herbmail-e2e/project.json
@@ -1,0 +1,28 @@
+{
+	"name": "herbmail-e2e",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/herbmail/herbmail-e2e/e2e",
+	"implicitDependencies": ["axum-herbmail", "astro-herbmail"],
+	"targets": {
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"pnpm exec playwright test --config=apps/herbmail/herbmail-e2e/playwright.config.ts"
+				],
+				"cwd": "{workspaceRoot}"
+			}
+		},
+		"e2e:docker": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"E2E_DOCKER=true pnpm exec playwright test --config=apps/herbmail/herbmail-e2e/playwright.config.ts"
+				],
+				"cwd": "{workspaceRoot}"
+			}
+		}
+	},
+	"tags": []
+}

--- a/apps/herbmail/herbmail-e2e/tsconfig.json
+++ b/apps/herbmail/herbmail-e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true
+	},
+	"include": ["e2e/**/*.ts", "playwright.config.ts"]
+}

--- a/apps/herbmail/project.json
+++ b/apps/herbmail/project.json
@@ -1,0 +1,26 @@
+{
+  "name": "herbmail",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/herbmail",
+  "targets": {
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "nx e2e axum-herbmail",
+          "nx e2e herbmail-e2e"
+        ],
+        "parallel": false
+      }
+    },
+    "container": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["nx container axum-herbmail"],
+        "parallel": false
+      }
+    }
+  },
+  "tags": []
+}


### PR DESCRIPTION
…nd e2e test suite

- Serve Astro's static 404.html via ServeDir fallback with proper status code
- Add security headers (nosniff, DENY, strict-origin-when-cross-origin)
- Add path-based cache-control (immutable for /_astro/, 86400s for all else)
- Switch Dockerfile to brotli-11 + gzip-9 precompression, remove runtime CompressionLayer
- Add 9 Rust unit tests for StaticConfig parsing and middleware (health, headers, cache, MIME)
- Create herbmail-e2e Playwright project with smoke, sitemap-weighted sampling, and pagefind tests
- Add parent herbmail project.json as orchestration shell for e2e and container targets
- Wire CI workflows for docker test pipeline