### PR TITLE
feat(herbmail): add Kubernetes deployment manifests for ArgoCD

### DIFF
--- a/apps/kube/herbmail/application.yaml
+++ b/apps/kube/herbmail/application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: herbmail
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/KBVE/kbve
+    targetRevision: HEAD
+    path: apps/kube/herbmail/manifest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: herbmail
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - PrunePropagationPolicy=foreground
+    - PruneLast=true
+    - RespectIgnoreDifferences=true
+    - Replace=false

--- a/apps/kube/herbmail/manifest/herbmail-deployment.yaml
+++ b/apps/kube/herbmail/manifest/herbmail-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: herbmail-deployment
+  namespace: herbmail
+  labels:
+    app: herbmail
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: herbmail
+  template:
+    metadata:
+      annotations:
+        rollout-restart: "2026-02-15T00:00:00Z"
+      labels:
+        app: herbmail
+        version: "0.1.0"
+    spec:
+      containers:
+      - name: herbmail
+        image: ghcr.io/kbve/herbmail:0.1.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 4321
+          protocol: TCP
+        env:
+        - name: PORT
+          value: "4321"
+        - name: SUPABASE_URL
+          value: "http://kong.kilobase.svc.cluster.local:8000"
+        - name: SUPABASE_ANON_KEY
+          valueFrom:
+            secretKeyRef:
+              name: supabase-shared
+              key: anon-key
+        - name: SUPABASE_SERVICE_ROLE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: supabase-shared
+              key: service-role-key
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "2000m"
+          limits:
+            memory: "1024Mi"
+            cpu: "4000m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: herbmail-service
+  namespace: herbmail
+  labels:
+    app: herbmail
+spec:
+  type: ClusterIP
+  selector:
+    app: herbmail
+  ports:
+  - port: 4321
+    targetPort: 4321
+    protocol: TCP

--- a/apps/kube/herbmail/manifest/herbmail-externalsecret.yaml
+++ b/apps/kube/herbmail/manifest/herbmail-externalsecret.yaml
@@ -1,0 +1,58 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: kilobase-remote-secret-store
+  namespace: herbmail
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: kilobase
+      auth:
+        serviceAccount:
+          name: herbmail-external-secrets
+          namespace: herbmail
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: herbmail-supabase-secrets
+  namespace: herbmail
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kilobase-remote-secret-store
+    kind: SecretStore
+  target:
+    name: supabase-shared
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        jwt-secret: "{{ .jwtsecret }}"
+        anon-key: "{{ .anonkey }}"
+        service-role-key: "{{ .servicekey }}"
+        db-url: "postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase"
+  data:
+  - secretKey: jwtsecret
+    remoteRef:
+      key: supabase-jwt
+      property: secret
+  - secretKey: anonkey
+    remoteRef:
+      key: supabase-jwt
+      property: anon-key
+  - secretKey: servicekey
+    remoteRef:
+      key: supabase-jwt
+      property: service-key
+  - secretKey: dbpassword
+    remoteRef:
+      key: supabase-postgres
+      property: password

--- a/apps/kube/herbmail/manifest/herbmail-serviceaccount.yaml
+++ b/apps/kube/herbmail/manifest/herbmail-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: herbmail-external-secrets
+  namespace: herbmail

--- a/apps/kube/herbmail/manifest/kustomization.yaml
+++ b/apps/kube/herbmail/manifest/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: herbmail
+
+resources:
+  - herbmail-serviceaccount.yaml
+  - herbmail-externalsecret.yaml
+  - herbmail-deployment.yaml
+  - nginx-ingress.yaml

--- a/apps/kube/herbmail/manifest/nginx-ingress.yaml
+++ b/apps/kube/herbmail/manifest/nginx-ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: herbmail-ingress
+  namespace: herbmail
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: herbmail.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: herbmail-service
+            port:
+              number: 4321
+  - host: www.herbmail.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: herbmail-service
+            port:
+              number: 4321

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -44,6 +44,7 @@ resources:
   - staryo/application.yaml
   - rentearth/application.yaml
   - cityvote/application.yaml
+  - herbmail/application.yaml
   # GitHub Actions Runner Controller (ARC)
   # Consolidated: controller includes helm chart + sealed secret + RBAC
   # Consolidated: runners includes helm chart + ExternalSecret/SecretStore


### PR DESCRIPTION
Add herbmail kube manifests mirroring the kbve.com deployment pattern with ExternalSecret operator for supabase credentials from kilobase namespace, ClusterIP service on port 4321, and nginx ingress for herbmail.com and www.herbmail.com.