### PR TITLE
fix(herbmail): add Playwright browser install for CI e2e tests

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -47,5 +47,8 @@ jobs:
             - name: Install pnpm Dependencies
               run: pnpm install
 
+            - name: Install Playwright Browsers
+              run: pnpm exec playwright install --with-deps chromium
+
             - name: Nx e2e ${{ inputs.project }}
               run: pnpm nx e2e ${{ inputs.project }} --no-cloud

--- a/apps/herbmail/herbmail-e2e/project.json
+++ b/apps/herbmail/herbmail-e2e/project.json
@@ -9,6 +9,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
+					"pnpm exec playwright install --with-deps chromium",
 					"pnpm exec playwright test --config=apps/herbmail/herbmail-e2e/playwright.config.ts"
 				],
 				"cwd": "{workspaceRoot}"
@@ -18,6 +19,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
+					"pnpm exec playwright install --with-deps chromium",
 					"E2E_DOCKER=true pnpm exec playwright test --config=apps/herbmail/herbmail-e2e/playwright.config.ts"
 				],
 				"cwd": "{workspaceRoot}"


### PR DESCRIPTION
Install Chromium with OS dependencies before running Playwright tests in both the reusable docker-test-app workflow and the herbmail-e2e project targets to prevent missing browser failures in CI.