### PR TITLE
fix(herbmail): separate docker build from push and fix mangled paths

### DIFF
--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -116,9 +116,19 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.MY_GITHUB_TOKEN }}
 
-            - name: Build and Push Docker Image with Nx
+            - name: Build Docker Image with Nx
               if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               env:
                   INPUT_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
               run: |
-                  pnpm nx run ${{ inputs.project }}:${{ inputs.target }} --configuration=production --push
+                  pnpm nx run ${{ inputs.project }}:${{ inputs.target }} --configuration=production
+
+            - name: Push Docker Images
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && inputs.image != '' }}
+              run: |
+                  IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '${{ inputs.image }}' | grep -v '<none>')
+                  echo "Pushing images:"
+                  echo "$IMAGES"
+                  for IMG in $IMAGES; do
+                    docker push "$IMG"
+                  done

--- a/apps/herbmail/axum-herbmail/project.json
+++ b/apps/herbmail/axum-herbmail/project.json
@@ -2,7 +2,7 @@
   "name": "axum-herbmail",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "sourceRoot": "apps/kbve/herbmail/src",
+  "sourceRoot": "apps/herbmail/axum-herbmail/src",
   "targets": {
     "dev": {
       "executor": "nx:run-commands",
@@ -69,9 +69,9 @@
       "options": {
         "commands": [
           "./kbve.sh -nx astro-herbmail:build",
-          "rm -rf ./apps/kbve/herbmail/dist/",
-          "mkdir -p ./apps/kbve/herbmail/dist/",
-          "cp -a ./dist/apps/astro-herbmail/. ./apps/kbve/herbmail/dist/"
+          "rm -rf ./apps/herbmail/axum-herbmail/dist/",
+          "mkdir -p ./apps/herbmail/axum-herbmail/dist/",
+          "cp -a ./dist/apps/astro-herbmail/. ./apps/herbmail/axum-herbmail/dist/"
         ],
         "parallel": false
       }
@@ -90,7 +90,7 @@
       "options": {
         "engine": "docker",
         "context": ".",
-        "file": "apps/kbve/herbmail/Dockerfile",
+        "file": "apps/herbmail/axum-herbmail/Dockerfile",
         "metadata": {
           "images": ["ghcr.io/kbve/herbmail", "kbve/herbmail"],
           "load": true,
@@ -103,7 +103,7 @@
           },
           "production": {
             "tags": ["0.1.0", "0.1"],
-            "push": true,
+            "push": false,
             "cache-from": [
               "type=registry,ref=ghcr.io/kbve/herbmail:buildcache"
             ],


### PR DESCRIPTION
Nx build now runs with push:false, CI workflow handles docker push separately. Fixes file paths mangled by previous replace_all (apps/kbve/herbmail → apps/herbmail/axum-herbmail).