### PR TITLE
refactor(kbve.sh): add brew toolchain, worktree management, and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 /output.json
 apps/api/.env
 .env
+.env.local
 
 # Expo
 node_modules/

--- a/kbve.sh
+++ b/kbve.sh
@@ -327,11 +327,12 @@ create_worktree() {
         cp "$main_repo/.env" "$worktree_dir/.env"
     fi
 
-    # Copy .env.local if it exists
-    if [ -f "$main_repo/.env.local" ]; then
-        echo "Copying .env.local from main repo..."
-        cp "$main_repo/.env.local" "$worktree_dir/.env.local"
-    fi
+    # Generate .env.local with Nx workspace root pointing to the worktree
+    echo "Generating .env.local for Nx..."
+    cat > "$worktree_dir/.env.local" <<ENVEOF
+NX_WORKSPACE_ROOT=$worktree_dir
+NX_DAEMON=false
+ENVEOF
 
     # Install dependencies
     echo "Installing pnpm dependencies in worktree..."


### PR DESCRIPTION
## Summary
- **`-brew` command** — One-command install of the full dev toolchain (Rust, Go, Python, Protobuf, WASM tools, pnpm, etc.) via Homebrew
- **`-worktree` / `-worktree-rm` commands** — Managed git worktree creation with automatic `.env` copy, `.env.local` generation (`NX_WORKSPACE_ROOT`, `NX_DAEMON=false`), and `pnpm install`
- **Portable `sed_i` helper** — Fixes macOS vs Linux `sed -i` incompatibility across the script
- **Dead code cleanup** — Removed Unity plugin vars, `generate_ulid`, commented-out blocks, and simplified all install functions to use brew directly
- **`.env.local` added to `.gitignore`** — Prevents worktree-specific env files from being committed

## Test plan
- [ ] Run `./kbve.sh -brew` on macOS to verify toolchain installation
- [ ] Run `./kbve.sh -worktree my-branch` and verify `.env.local` is generated with correct `NX_WORKSPACE_ROOT`
- [ ] Run `./kbve.sh -worktree-rm my-branch` and verify worktree cleanup
- [ ] Verify existing commands (`-nx`, `-docker`, `-protobuf`, etc.) still work