### PR TITLE
fix(ingress): webhook failurePolicy and sync options

### DIFF
--- a/apps/kube/ingress/application.yaml
+++ b/apps/kube/ingress/application.yaml
@@ -35,8 +35,6 @@ spec:
         syncOptions:
             - CreateNamespace=true
             - ServerSideApply=true
-            - Replace=true
-            - Force=true
             - RespectIgnoreDifferences=true
         retry:
             limit: 3

--- a/apps/kube/ingress/manifests/values.yaml
+++ b/apps/kube/ingress/manifests/values.yaml
@@ -61,6 +61,7 @@ controller:
 
     admissionWebhooks:
         enabled: true
+        failurePolicy: Ignore
         certManager:
             enabled: true
             issuerRef:


### PR DESCRIPTION
## Summary
- **`failurePolicy: Ignore`** on nginx admission webhook — ingress creation won't be blocked if the caBundle/cert is invalid
- **Remove `Replace=true` and `Force=true`** from ingress-nginx ArgoCD sync options — lets `ServerSideApply` + `RespectIgnoreDifferences` properly preserve the caBundle that cert-manager cainjector injects

## Context
ArgoCD's `Replace=true` was doing full resource replacement on every self-heal, wiping the webhook's `caBundle` that cert-manager injects. This blocked all new ingress creation cluster-wide (including herbmail).

## Test plan
- [ ] ArgoCD syncs ingress-nginx without errors
- [ ] Webhook caBundle gets populated by cainjector and stays populated
- [ ] Herbmail ingress is created successfully