### PR TITLE
fix(irc): add astro sync to build target

### DIFF
--- a/apps/irc/astro-irc/project.json
+++ b/apps/irc/astro-irc/project.json
@@ -22,6 +22,8 @@
       "options": {
         "cwd": "apps/irc/astro-irc",
         "commands": [
+          "rm -rf .astro",
+          "nx exec -- astro sync",
           "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
         ],
         "parallel": false


### PR DESCRIPTION
## Summary
- Adds `rm -rf .astro` and `astro sync` steps to the `astro-irc` build target, matching the dev target
- Fixes the `astro:` protocol ESM loader error that was failing the e2e pipeline (Run #1497)

## Test plan
- [ ] Verify the IRC e2e CI pipeline passes with the updated build target