### PR TITLE
fix(irc-e2e): update frontend tests for Starlight migration

### DIFF
--- a/apps/irc/irc-e2e/e2e/frontend.spec.ts
+++ b/apps/irc/irc-e2e/e2e/frontend.spec.ts
@@ -1,18 +1,27 @@
 import { test, expect } from '@playwright/test';
 
+// ─── Starlight Index / Splash Page ──────────────────────────────────────────
+// The Astro build produces index.html at the root. The Axum gateway serves it
+// via ServeDir with append_index_html_on_directories(true).
+
 test.describe('Frontend: Index Page', () => {
-	test('GET / returns HTML with 200', async ({ request }) => {
+	test('GET / returns 200 with HTML', async ({ request }) => {
 		const response = await request.get('/');
 		expect(response.status()).toBe(200);
 		const contentType = response.headers()['content-type'] ?? '';
 		expect(contentType).toContain('text/html');
 	});
 
-	test('index page contains expected content', async ({ page }) => {
+	test('index page title contains site name', async ({ page }) => {
 		await page.goto('/');
-		await expect(page).toHaveTitle(/IRC/i);
+		// Starlight sets <title> from the config: "KBVE IRC"
+		await expect(page).toHaveTitle(/KBVE\s*IRC/i);
 	});
 });
+
+// ─── 404 Handling ───────────────────────────────────────────────────────────
+// The gateway loads 404.html from the Astro build and returns it as the
+// fallback response for unknown routes.
 
 test.describe('Frontend: 404 Page', () => {
 	test('unknown route returns 404 with HTML', async ({ request }) => {
@@ -29,30 +38,72 @@ test.describe('Frontend: 404 Page', () => {
 	});
 });
 
+// ─── Auth Pages (Astro pages served through the Axum gateway) ───────────────
+// Auth routes live in src/pages/auth/ and build to auth/*/index.html.
+// ServeDir requires a trailing slash for directory resolution; without it the
+// gateway returns 301 → /path/. Tests use trailing slashes to hit the pages
+// directly, plus one redirect test to validate the 301 behaviour.
+
 test.describe('Frontend: Auth Pages', () => {
-	test('GET /auth/ returns HTML', async ({ request }) => {
-		const response = await request.get('/auth/', {
+	test('GET /auth/ serves the auth index page', async ({ request }) => {
+		const response = await request.get('/auth/');
+		expect(response.status()).toBe(200);
+		const contentType = response.headers()['content-type'] ?? '';
+		expect(contentType).toContain('text/html');
+	});
+
+	test('GET /auth/callback/ serves the callback page', async ({
+		request,
+	}) => {
+		const response = await request.get('/auth/callback/');
+		expect(response.status()).toBe(200);
+		const contentType = response.headers()['content-type'] ?? '';
+		expect(contentType).toContain('text/html');
+	});
+
+	test('GET /auth/logout/ serves the logout page', async ({ request }) => {
+		const response = await request.get('/auth/logout/');
+		expect(response.status()).toBe(200);
+		const contentType = response.headers()['content-type'] ?? '';
+		expect(contentType).toContain('text/html');
+	});
+
+	test('GET /auth/callback without trailing slash redirects', async ({
+		request,
+	}) => {
+		// ServeDir 301-redirects bare directory paths to add a trailing slash
+		const response = await request.get('/auth/callback', {
 			maxRedirects: 0,
 		});
-		const status = response.status();
-		// Auth index redirects to / or serves HTML
-		expect([200, 301, 302]).toContain(status);
-	});
-
-	test('GET /auth/callback returns HTML', async ({ request }) => {
-		const response = await request.get('/auth/callback');
-		expect(response.status()).toBe(200);
-		const contentType = response.headers()['content-type'] ?? '';
-		expect(contentType).toContain('text/html');
-	});
-
-	test('GET /auth/logout returns HTML', async ({ request }) => {
-		const response = await request.get('/auth/logout');
-		expect(response.status()).toBe(200);
-		const contentType = response.headers()['content-type'] ?? '';
-		expect(contentType).toContain('text/html');
+		expect(response.status()).toBe(301);
 	});
 });
+
+// ─── Starlight Content Pages ────────────────────────────────────────────────
+// Starlight generates pages from src/content/docs/ into the build output.
+// Validate that the guides section builds and serves correctly.
+
+test.describe('Frontend: Starlight Content Pages', () => {
+	test('GET /guides/getting-started/ returns 200 with HTML', async ({
+		request,
+	}) => {
+		const response = await request.get('/guides/getting-started/');
+		expect(response.status()).toBe(200);
+		const contentType = response.headers()['content-type'] ?? '';
+		expect(contentType).toContain('text/html');
+	});
+
+	test('getting-started page renders with correct title', async ({
+		page,
+	}) => {
+		await page.goto('/guides/getting-started/');
+		// Starlight titles: "<page title> | <site title>"
+		await expect(page).toHaveTitle(/Getting Started/i);
+	});
+});
+
+// ─── Security Headers on Static Pages ───────────────────────────────────────
+// The Axum middleware adds security headers to every response.
 
 test.describe('Frontend: Security Headers on Static Pages', () => {
 	test('static pages include security headers', async ({ request }) => {


### PR DESCRIPTION
## Summary
- Update e2e frontend tests to work with the Starlight framework migration
- Auth route tests now use trailing slashes so the Axum gateway's `ServeDir` resolves `directory/index.html` correctly (root cause of the 404s)
- Add Starlight content page tests (`/guides/getting-started/`) to validate the docs build pipeline
- Add trailing-slash redirect assertion to verify `ServeDir` 301 behaviour
- Title regex updated to match Starlight's `"KBVE IRC"` title format

## Test plan
- [ ] CI runs `nx e2e irc-e2e` — all 5 previously failing frontend tests should now pass
- [ ] Auth pages (`/auth/`, `/auth/callback/`, `/auth/logout/`) return 200 with trailing slashes
- [ ] Starlight content page `/guides/getting-started/` returns 200
- [ ] Security headers still asserted on static responses