### PR TITLE
feat(discordsh): scaffold axum-discordsh backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -1405,6 +1408,33 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-discordsh"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "askama 0.15.4",
+ "axum 0.8.8",
+ "axum-extra 0.12.5",
+ "dotenvy",
+ "http-body-util",
+ "jedi 0.2.1",
+ "kbve",
+ "num_cpus",
+ "serde",
+ "serde_json",
+ "serenity",
+ "serial_test",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tikv-jemallocator",
+ "tokio",
+ "tower 0.5.2",
+ "tower-http 0.6.6",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2854,6 +2884,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -2899,6 +2930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -5217,7 +5249,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "irc-gateway"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -8023,6 +8055,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -8041,6 +8074,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.2",
 ]
@@ -8301,6 +8335,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.14",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
@@ -8392,6 +8440,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.14",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.14",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -8509,6 +8568,16 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -8643,6 +8712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cow"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8772,6 +8850,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serenity"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bde37f42765dfdc34e2a039e0c84afbf79a3101c1941763b0beb816c2f17541"
+dependencies = [
+ "arrayvec",
+ "async-trait",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "bytes",
+ "dashmap 5.5.3",
+ "flate2",
+ "futures",
+ "mime_guess",
+ "parking_lot",
+ "percent-encoding",
+ "reqwest 0.12.22",
+ "rustc-hash 2.1.1",
+ "secrecy",
+ "serde",
+ "serde_cow",
+ "serde_json",
+ "time",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "tracing",
+ "typemap_rev",
+ "url",
 ]
 
 [[package]]
@@ -11485,6 +11594,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
@@ -11517,6 +11637,22 @@ dependencies = [
  "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
  "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite 0.21.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -11954,6 +12090,27 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
@@ -12042,6 +12199,12 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typemap_rev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
@@ -12182,6 +12345,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -12384,6 +12548,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 	'apps/herbmail/axum-herbmail',
 	'apps/memes/axum-memes',
 	'apps/irc/irc-gateway',
+	'apps/discordsh/axum-discordsh',
 ]
 
 [profile.dev]

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "axum-discordsh"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+thiserror = "2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tower = { version = "0.5.2", features = ["util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.6.1", features = [
+    "compression-full",
+    "limit",
+    "trace",
+    "fs",
+    "cors",
+    "set-header"
+] }
+tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+axum = { version = "0.8.5", features = ["ws", "macros"] }
+axum-extra = { version = "0.12.1", features = ["cookie"] }
+askama = "0.15.4"
+socket2 = "0.6.1"
+num_cpus = "1.17.0"
+dotenvy = "0.15"
+serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"] }
+
+# Workspace path dependencies
+jedi = { path = "../../../packages/rust/jedi" }
+kbve = { path = "../../../packages/rust/kbve" }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
+
+[dev-dependencies]
+serial_test = "3"
+http-body-util = "0.1"
+
+[features]
+default = []
+jemalloc = ["dep:tikv-jemallocator"]
+
+[package.metadata.askama]
+dirs = ["templates"]

--- a/apps/discordsh/axum-discordsh/Cargo.workspace.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.workspace.toml
@@ -1,0 +1,14 @@
+[workspace]
+resolver = "2"
+members = [
+    "apps/discordsh/axum-discordsh",
+    "packages/rust/jedi",
+    "packages/rust/kbve",
+]
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -1,0 +1,176 @@
+# ============================================================================
+# [STAGE A] - Precompress Static Assets (built by container-prep on host)
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS astro-precompressor
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gzip brotli && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY apps/discordsh/axum-discordsh/dist /static
+
+WORKDIR /static
+RUN find . -type f \( \
+        -name "*.css" -o \
+        -name "*.js" -o \
+        -name "*.json" -o \
+        -name "*.svg" -o \
+        -name "*.xml" -o \
+        -name "*.txt" -o \
+        -name "*.html" \
+    \) ! -path "*/askama/*" -exec sh -c ' \
+        gzip -9 -k "$1" && \
+        brotli --best --keep "$1" \
+    ' _ {} \; && \
+    echo "Precompression complete (brotli-11 + gzip-9)"
+
+# ============================================================================
+# [STAGE B] - Rust Base Image
+# ============================================================================
+FROM --platform=linux/amd64 rust:1.90-slim AS rust-base
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        protobuf-compiler \
+        libprotobuf-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-gnu && \
+    cargo install cargo-chef --locked
+
+WORKDIR /app
+
+# ============================================================================
+# [STAGE C] - Cargo Chef Planner
+# ============================================================================
+FROM rust-base AS planner
+
+# Minimal workspace with only discordsh's actual dependencies
+COPY apps/discordsh/axum-discordsh/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+# Copy only the 3 crates we need
+COPY apps/discordsh/axum-discordsh/Cargo.toml apps/discordsh/axum-discordsh/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+
+# Create stubs for cargo chef
+RUN mkdir -p apps/discordsh/axum-discordsh/src && echo "fn main() {}" > apps/discordsh/axum-discordsh/src/main.rs && \
+    mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
+
+# Copy proto files (needed for jedi build.rs)
+COPY packages/data/proto packages/data/proto
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ============================================================================
+# [STAGE D] - Cargo Chef Builder (Cache Dependencies)
+# ============================================================================
+FROM rust-base AS builder-deps
+
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
+COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
+
+# Copy proto files
+COPY packages/data/proto packages/data/proto
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo chef cook --release --recipe-path recipe.json -p axum-discordsh
+
+# ============================================================================
+# [STAGE E] - Build Application
+# ============================================================================
+FROM rust-base AS builder
+
+# Copy cached dependencies
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+# Copy Astro build output (precompressed)
+COPY --from=astro-precompressor /static /app/apps/discordsh/axum-discordsh/templates/dist
+
+# Use the same minimal workspace
+COPY --from=planner /app/Cargo.toml ./
+COPY Cargo.lock ./
+
+# Copy only the 3 crates (full source)
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+COPY apps/discordsh/axum-discordsh apps/discordsh/axum-discordsh
+COPY packages/data/proto packages/data/proto
+
+# Copy Askama templates
+COPY apps/discordsh/axum-discordsh/templates/askama /app/apps/discordsh/axum-discordsh/templates/askama
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p axum-discordsh && \
+    strip target/release/axum-discordsh
+
+# ============================================================================
+# [STAGE F] - Chisel Ubuntu Base (Minimal Runtime)
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
+
+RUN apt-get update && apt-get install -y wget ca-certificates
+
+WORKDIR /tmp
+
+RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
+    tar -xvf go1.23.4.linux-amd64.tar.gz && \
+    mv go /usr/local
+
+RUN GOBIN=/usr/local/bin/ /usr/local/go/bin/go install github.com/canonical/chisel/cmd/chisel@latest
+
+WORKDIR /rootfs
+RUN chisel cut --release ubuntu-24.04 --root /rootfs \
+        base-files_base \
+        base-files_release-info \
+        ca-certificates_data \
+        libgcc-s1_libs \
+        libc6_libs \
+        libstdc++6_libs \
+        openssl_config
+
+# ============================================================================
+# [STAGE G] - Jemalloc
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc-dev && \
+    apt-get autoremove -y && \
+    apt-get purge -y --auto-remove && \
+    rm -rf /var/lib/apt/lists/*
+
+# ============================================================================
+# [STAGE Z] - Runtime Image (Scratch + Chisel + Jemalloc)
+# ============================================================================
+FROM --platform=linux/amd64 scratch AS runtime
+
+COPY --from=chisel-builder /rootfs /
+
+COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/axum-discordsh /app/axum-discordsh
+
+COPY --from=builder /app/apps/discordsh/axum-discordsh/templates/dist /app/templates/dist
+COPY --from=builder /app/apps/discordsh/axum-discordsh/templates/askama /app/templates/askama
+
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
+ENV HTTP_HOST=0.0.0.0
+ENV HTTP_PORT=4321
+ENV RUST_LOG=info
+
+EXPOSE 4321
+
+ENTRYPOINT ["/app/axum-discordsh"]

--- a/apps/discordsh/axum-discordsh/askama.toml
+++ b/apps/discordsh/axum-discordsh/askama.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["templates"]

--- a/apps/discordsh/axum-discordsh/project.json
+++ b/apps/discordsh/axum-discordsh/project.json
@@ -1,0 +1,127 @@
+{
+  "name": "axum-discordsh",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/discordsh/axum-discordsh/src",
+  "targets": {
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "./kbve.sh -nx astro-discordsh:build",
+          "STATIC_DIR=./dist/apps/astro-discordsh STATIC_PRECOMPRESSED=false cargo run -p axum-discordsh"
+        ],
+        "parallel": false
+      }
+    },
+    "build": {
+      "executor": "@monodon/rust:build",
+      "outputs": ["{options.target-dir}"],
+      "options": {
+        "target-dir": "dist/target/axum-discordsh"
+      },
+      "configurations": {
+        "production": {
+          "release": true
+        }
+      }
+    },
+    "test": {
+      "executor": "@monodon/rust:test",
+      "outputs": ["{options.target-dir}"],
+      "options": {
+        "target-dir": "dist/target/axum-discordsh"
+      },
+      "configurations": {
+        "production": {
+          "release": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@monodon/rust:lint",
+      "outputs": ["{options.target-dir}"],
+      "options": {
+        "target-dir": "dist/target/axum-discordsh"
+      }
+    },
+    "run": {
+      "executor": "@monodon/rust:run",
+      "outputs": ["{options.target-dir}"],
+      "options": {
+        "target-dir": "dist/target/axum-discordsh"
+      },
+      "configurations": {
+        "production": {
+          "release": true
+        }
+      }
+    },
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["nx test axum-discordsh"],
+        "parallel": false
+      }
+    },
+    "container-prep": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "./kbve.sh -nx astro-discordsh:build",
+          "rm -rf ./apps/discordsh/axum-discordsh/dist/",
+          "mkdir -p ./apps/discordsh/axum-discordsh/dist/",
+          "cp -a ./dist/apps/astro-discordsh/. ./apps/discordsh/axum-discordsh/dist/"
+        ],
+        "parallel": false
+      }
+    },
+    "container": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["container-prep"],
+      "defaultConfiguration": "local",
+      "options": {
+        "parallel": false
+      },
+      "configurations": {
+        "local": {
+          "commands": ["./kbve.sh -nx axum-discordsh:containerx"]
+        },
+        "production": {
+          "commands": ["./kbve.sh -nx axum-discordsh:containerx --configuration=production"]
+        }
+      }
+    },
+    "containerx": {
+      "executor": "@nx-tools/nx-container:build",
+      "defaultConfiguration": "local",
+      "options": {
+        "engine": "docker",
+        "context": ".",
+        "file": "apps/discordsh/axum-discordsh/Dockerfile",
+        "load": true,
+        "metadata": {
+          "images": ["ghcr.io/kbve/discordsh", "kbve/discordsh"],
+          "tags": ["0.1.0", "0.1"]
+        },
+        "configurations": {
+          "local": {
+            "load": true,
+            "push": false
+          },
+          "production": {
+            "load": true,
+            "push": false,
+            "cache-from": [
+              "type=registry,ref=ghcr.io/kbve/discordsh:buildcache"
+            ],
+            "cache-to": [
+              "type=registry,ref=ghcr.io/kbve/discordsh:buildcache,mode=max"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/discordsh/axum-discordsh/src/astro/askama.rs
+++ b/apps/discordsh/axum-discordsh/src/astro/askama.rs
@@ -1,0 +1,49 @@
+use askama::Template;
+use axum::{
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+};
+
+#[derive(Template)]
+#[template(path = "askama/index.html")]
+pub struct AstroTemplate<'a> {
+    pub content: &'a str,
+    pub path: &'a str,
+    pub title: &'a str,
+    pub description: &'a str,
+}
+
+impl<'a> AstroTemplate<'a> {
+    pub fn new(
+        content: &'a str,
+        path: &'a str,
+        title: &'a str,
+        description: &'a str,
+    ) -> Self {
+        Self { content, path, title, description }
+    }
+}
+
+pub struct TemplateResponse<T: Template>(pub T);
+
+impl<T: Template> IntoResponse for TemplateResponse<T> {
+    fn into_response(self) -> Response {
+        match self.0.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(err) => {
+                tracing::error!(error = %err, "template rendering failed");
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to render template").into_response()
+            }
+        }
+    }
+}
+
+pub async fn fallback_handler() -> Response {
+    let template = AstroTemplate::new(
+        "<h1>Page Not Found</h1><p>The requested page does not exist.</p>",
+        "/404",
+        "404 - Not Found",
+        "Page not found",
+    );
+    (StatusCode::NOT_FOUND, TemplateResponse(template)).into_response()
+}

--- a/apps/discordsh/axum-discordsh/src/astro/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/astro/mod.rs
@@ -1,0 +1,158 @@
+pub mod askama;
+
+use axum::{
+    http::{header, StatusCode},
+    response::IntoResponse,
+    Router,
+};
+use std::convert::Infallible;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower_http::services::ServeDir;
+
+pub struct StaticConfig {
+    pub base_dir: PathBuf,
+    pub precompressed: bool,
+}
+
+impl StaticConfig {
+    pub fn from_env() -> Self {
+        let base_dir = std::env::var("STATIC_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("templates/dist"));
+        let precompressed = std::env::var("STATIC_PRECOMPRESSED")
+            .map(|v| v != "0" && v.to_lowercase() != "false")
+            .unwrap_or(true);
+        Self { base_dir, precompressed }
+    }
+}
+
+pub fn build_static_router(config: &StaticConfig) -> Router {
+    let base = &config.base_dir;
+    let precompressed = config.precompressed;
+
+    // Read Astro's 404.html at startup for the not-found fallback
+    let not_found_html = Arc::new(
+        std::fs::read_to_string(base.join("404.html")).unwrap_or_else(|_| {
+            "<html><body><h1>404 - Not Found</h1></body></html>".to_string()
+        }),
+    );
+
+    let serve_dir = |path: PathBuf| {
+        let svc = ServeDir::new(path);
+        if precompressed {
+            svc.precompressed_br().precompressed_gzip()
+        } else {
+            svc
+        }
+    };
+
+    // Content-hashed asset directories
+    let astro_service = serve_dir(base.join("_astro"));
+    let assets_service = serve_dir(base.join("assets"));
+    let chunks_service = serve_dir(base.join("chunks"));
+    let pagefind_service = serve_dir(base.join("pagefind"));
+
+    // Images are already compressed formats — skip precompression
+    let images_service = ServeDir::new(base.join("images"));
+
+    // 404 service: returns Astro's 404.html with proper status code
+    let not_found_svc = {
+        let html = not_found_html.clone();
+        tower::service_fn(move |_req: axum::extract::Request| {
+            let html = html.clone();
+            async move {
+                Ok::<_, Infallible>(
+                    (
+                        StatusCode::NOT_FOUND,
+                        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+                        (*html).clone(),
+                    )
+                        .into_response(),
+                )
+            }
+        })
+    };
+
+    // Root fallback: serves pages (/auth → /auth/index.html),
+    // falls back to Astro's 404.html for unknown routes
+    let fallback_svc = {
+        let svc = ServeDir::new(base)
+            .append_index_html_on_directories(true)
+            .fallback(not_found_svc);
+        if precompressed {
+            svc.precompressed_br().precompressed_gzip()
+        } else {
+            svc
+        }
+    };
+
+    Router::new()
+        .nest_service("/_astro", astro_service)
+        .nest_service("/assets", assets_service)
+        .nest_service("/chunks", chunks_service)
+        .nest_service("/images", images_service)
+        .nest_service("/pagefind", pagefind_service)
+        .fallback_service(fallback_svc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_static_config_defaults() {
+        std::env::remove_var("STATIC_DIR");
+        std::env::remove_var("STATIC_PRECOMPRESSED");
+
+        let config = StaticConfig::from_env();
+        assert_eq!(config.base_dir, PathBuf::from("templates/dist"));
+        assert!(config.precompressed);
+    }
+
+    #[test]
+    #[serial]
+    fn test_static_config_custom_dir() {
+        std::env::set_var("STATIC_DIR", "/tmp/my-static");
+        std::env::remove_var("STATIC_PRECOMPRESSED");
+
+        let config = StaticConfig::from_env();
+        assert_eq!(config.base_dir, PathBuf::from("/tmp/my-static"));
+        assert!(config.precompressed);
+
+        std::env::remove_var("STATIC_DIR");
+    }
+
+    #[test]
+    #[serial]
+    fn test_static_config_precompressed_false() {
+        std::env::remove_var("STATIC_DIR");
+        std::env::set_var("STATIC_PRECOMPRESSED", "false");
+
+        let config = StaticConfig::from_env();
+        assert!(!config.precompressed);
+
+        std::env::set_var("STATIC_PRECOMPRESSED", "0");
+        let config = StaticConfig::from_env();
+        assert!(!config.precompressed);
+
+        std::env::remove_var("STATIC_PRECOMPRESSED");
+    }
+
+    #[test]
+    #[serial]
+    fn test_static_config_precompressed_true_variants() {
+        std::env::set_var("STATIC_PRECOMPRESSED", "true");
+        assert!(StaticConfig::from_env().precompressed);
+
+        std::env::set_var("STATIC_PRECOMPRESSED", "1");
+        assert!(StaticConfig::from_env().precompressed);
+
+        std::env::set_var("STATIC_PRECOMPRESSED", "yes");
+        assert!(StaticConfig::from_env().precompressed);
+
+        std::env::remove_var("STATIC_PRECOMPRESSED");
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/bot.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/bot.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use serenity::async_trait;
+use serenity::model::channel::Message;
+use serenity::model::gateway::Ready;
+use serenity::prelude::*;
+use tracing::info;
+
+struct Handler;
+
+#[async_trait]
+impl EventHandler for Handler {
+    async fn message(&self, ctx: Context, msg: Message) {
+        if msg.author.bot {
+            return;
+        }
+
+        if msg.content == "!ping" {
+            if let Err(e) = msg.channel_id.say(&ctx.http, "Pong!").await {
+                tracing::error!(error = %e, "failed to send message");
+            }
+        }
+    }
+
+    async fn ready(&self, _ctx: Context, ready: Ready) {
+        info!("Discord bot connected as {}", ready.user.name);
+    }
+}
+
+pub async fn start() -> Result<()> {
+    let token = match std::env::var("DISCORD_TOKEN") {
+        Ok(t) if !t.is_empty() => t,
+        _ => {
+            info!("DISCORD_TOKEN not set, skipping Discord bot");
+            // Park this task so tokio::select! doesn't immediately resolve
+            std::future::pending::<()>().await;
+            return Ok(());
+        }
+    };
+
+    let intents = GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT;
+
+    let mut client = Client::builder(&token, intents)
+        .event_handler(Handler)
+        .await?;
+
+    info!("Starting Discord bot...");
+    client.start().await?;
+
+    Ok(())
+}

--- a/apps/discordsh/axum-discordsh/src/discord/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/mod.rs
@@ -1,0 +1,1 @@
+pub mod bot;

--- a/apps/discordsh/axum-discordsh/src/main.rs
+++ b/apps/discordsh/axum-discordsh/src/main.rs
@@ -1,0 +1,56 @@
+mod astro;
+mod discord;
+mod transport;
+
+use tracing::info;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[cfg(feature = "jemalloc")]
+mod allocator {
+    #[cfg(not(target_env = "msvc"))]
+    use tikv_jemallocator::Jemalloc;
+    #[cfg(not(target_env = "msvc"))]
+    #[global_allocator]
+    static GLOBAL: Jemalloc = Jemalloc;
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Load .env before anything reads env vars
+    dotenvy::dotenv().ok();
+
+    // Tracing
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| {
+                    format!("{}=info,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
+                }),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    info!("Discordsh v{}", env!("CARGO_PKG_VERSION"));
+
+    // Transports
+    let http = tokio::spawn(transport::https::serve());
+    let bot = tokio::spawn(discord::bot::start());
+
+    tokio::select! {
+        res = http => {
+            if let Ok(Err(e)) = res {
+                tracing::error!(error = %e, "HTTP server exited with error");
+            }
+        },
+        res = bot => {
+            if let Ok(Err(e)) = res {
+                tracing::error!(error = %e, "Discord bot exited with error");
+            }
+        },
+        _ = tokio::signal::ctrl_c() => {
+            info!("shutdown signal received");
+        }
+    }
+
+    Ok(())
+}

--- a/apps/discordsh/axum-discordsh/src/transport/https.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/https.rs
@@ -1,0 +1,334 @@
+use anyhow::Result;
+use std::{net::SocketAddr, time::Duration};
+
+use axum::{
+    extract::Request,
+    http::{header, HeaderName, HeaderValue},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use tokio::net::TcpListener;
+use tower_http::set_header::SetResponseHeaderLayer;
+use tracing::info;
+
+pub async fn serve() -> Result<()> {
+    let host = std::env::var("HTTP_HOST").unwrap_or_else(|_| "0.0.0.0".into());
+    let port: u16 = std::env::var("HTTP_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4321);
+    let addr: SocketAddr = format!("{host}:{port}").parse()?;
+
+    let listener = tuned_listener(addr)?;
+
+    info!("HTTP listening on http://{addr}");
+
+    let app = router();
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    Ok(())
+}
+
+fn router() -> Router {
+    let max_inflight: usize = num_cpus::get().max(1) * 1024;
+
+    let static_config = crate::astro::StaticConfig::from_env();
+
+    let middleware = tower::ServiceBuilder::new()
+        .layer(
+            tower_http::trace::TraceLayer::new_for_http().make_span_with(
+                tower_http::trace::DefaultMakeSpan::new().level(tracing::Level::INFO),
+            ),
+        )
+        .layer(tower_http::cors::CorsLayer::permissive())
+        // Security headers
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("referrer-policy"),
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
+        .layer(axum::error_handling::HandleErrorLayer::new(
+            |err: tower::BoxError| async move {
+                if err.is::<tower::timeout::error::Elapsed>() {
+                    (axum::http::StatusCode::REQUEST_TIMEOUT, "request timed out")
+                } else if err.is::<tower::load_shed::error::Overloaded>() {
+                    (axum::http::StatusCode::SERVICE_UNAVAILABLE, "service overloaded")
+                } else {
+                    tracing::warn!(error = %err, "middleware error");
+                    (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+                }
+            },
+        ))
+        .timeout(Duration::from_secs(10))
+        .concurrency_limit(max_inflight)
+        .load_shed()
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(1024 * 1024));
+
+    let static_router = crate::astro::build_static_router(&static_config)
+        .layer(axum::middleware::from_fn(fix_ts_mime))
+        .layer(axum::middleware::from_fn(cache_headers));
+
+    let public_router = Router::new()
+        .route("/health", get(health));
+
+    let dynamic_router = public_router;
+
+    static_router
+        .merge(dynamic_router)
+        .layer(middleware)
+}
+
+async fn health() -> impl IntoResponse {
+    "OK"
+}
+
+/// Set Cache-Control based on request path.
+async fn cache_headers(request: Request, next: Next) -> Response {
+    let path = request.uri().path().to_owned();
+    let mut response = next.run(request).await;
+
+    let cache_value = if path.starts_with("/_astro/") {
+        // Content-hashed Vite bundles — cache forever
+        "public, max-age=31536000, immutable"
+    } else if path.starts_with("/pagefind/") || path.starts_with("/images/") {
+        // Build-time generated, static until next deploy
+        "public, max-age=86400"
+    } else if path.ends_with(".html") || path == "/" || !path.contains('.') {
+        // Static HTML pages — immutable until next container deploy
+        "public, max-age=86400"
+    } else {
+        "public, max-age=86400"
+    };
+
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(cache_value),
+    );
+
+    response
+}
+
+/// Vite outputs worker files with `.ts` extensions. `mime_guess` maps `.ts` to
+/// `video/mp2t`, which browsers reject for Web Workers. Override to JS.
+async fn fix_ts_mime(request: Request, next: Next) -> Response {
+    let is_ts = request.uri().path().ends_with(".ts");
+    let mut response = next.run(request).await;
+    if is_ts {
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        );
+    }
+    response
+}
+
+fn tuned_listener(addr: SocketAddr) -> Result<TcpListener> {
+    use socket2::{Socket, Domain, Type, Protocol};
+
+    let domain = match addr {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+
+    socket.set_reuse_address(true)?;
+    socket.set_keepalive(true)?;
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        use socket2::TcpKeepalive;
+        let ka = TcpKeepalive::new()
+            .with_time(Duration::from_secs(30))
+            .with_interval(Duration::from_secs(10));
+        let _ = socket.set_tcp_keepalive(&ka);
+    }
+
+    socket.bind(&addr.into())?;
+    socket.listen(1024)?;
+
+    let std_listener = std::net::TcpListener::from(socket);
+    std_listener.set_nonblocking(true)?;
+    Ok(TcpListener::from_std(std_listener)?)
+}
+
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    /// Build a minimal router with just the health endpoint + middleware
+    /// (no static file serving, which requires a real directory).
+    fn test_router() -> Router {
+        let middleware = tower::ServiceBuilder::new()
+            .layer(SetResponseHeaderLayer::overriding(
+                header::X_CONTENT_TYPE_OPTIONS,
+                HeaderValue::from_static("nosniff"),
+            ))
+            .layer(SetResponseHeaderLayer::overriding(
+                header::X_FRAME_OPTIONS,
+                HeaderValue::from_static("DENY"),
+            ))
+            .layer(SetResponseHeaderLayer::overriding(
+                HeaderName::from_static("referrer-policy"),
+                HeaderValue::from_static("strict-origin-when-cross-origin"),
+            ));
+
+        Router::new()
+            .route("/health", get(health))
+            .layer(middleware)
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"OK");
+    }
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response.headers().get("x-frame-options").unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_astro_path() {
+        let app = Router::new()
+            .route("/_astro/{*path}", get(|| async { "asset" }))
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/_astro/bundle.abc123.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let cc = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("immutable"));
+        assert!(cc.contains("31536000"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_html_page() {
+        let app = Router::new()
+            .route("/", get(|| async { "page" }))
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let cc = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("86400"));
+    }
+
+    #[tokio::test]
+    async fn test_fix_ts_mime_rewrites() {
+        let app = Router::new()
+            .route("/worker.ts", get(|| async { "code" }))
+            .route("/script.js", get(|| async { "code" }))
+            .layer(axum::middleware::from_fn(fix_ts_mime));
+
+        // .ts file should get JS content-type
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/worker.ts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/javascript; charset=utf-8"
+        );
+
+        // .js file should NOT be rewritten
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/script.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let ct = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .map(|v| v.to_str().unwrap().to_string());
+        assert!(ct.is_none() || !ct.unwrap().contains("application/javascript"));
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/transport/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/mod.rs
@@ -1,0 +1,1 @@
+pub mod https;

--- a/apps/discordsh/axum-discordsh/templates/askama/index.html
+++ b/apps/discordsh/axum-discordsh/templates/askama/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ title }} - Discordsh</title>
+    <meta name="description" content="{{ description }}" />
+</head>
+<body>
+    {{ content|safe }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Scaffolds `apps/discordsh/axum-discordsh` Axum backend following `axum-herbmail` pattern
- HTTP server serves `astro-discordsh` static assets via `tower-http::ServeDir` with precompression, cache headers, and security headers
- Discord bot via `serenity` spawned alongside HTTP server using `tokio::spawn` + `tokio::select!` (gracefully skips if `DISCORD_TOKEN` not set)
- Includes 7-stage multi-stage Dockerfile with cargo-chef caching, Chisel minimal runtime, and jemalloc
- Nx `project.json` with dev, build, test, lint, container targets
- Askama HTML templates for fallback rendering

## Test plan
- [x] `cargo check -p axum-discordsh` passes
- [x] `pnpm nx build axum-discordsh` compiles in release mode
- [x] `pnpm nx container axum-discordsh` builds Docker image
- [x] E2E smoke tests pass against running container