### PR TITLE
fix(discordsh): make Cargo.toml single source of truth for version

### DIFF
--- a/apps/discordsh/axum-discordsh/project.json
+++ b/apps/discordsh/axum-discordsh/project.json
@@ -85,10 +85,16 @@
       },
       "configurations": {
         "local": {
-          "commands": ["./kbve.sh -nx axum-discordsh:containerx"]
+          "commands": [
+            "./kbve.sh -nx axum-discordsh:containerx",
+            "VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && docker tag ghcr.io/kbve/discordsh:latest ghcr.io/kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION\""
+          ]
         },
         "production": {
-          "commands": ["./kbve.sh -nx axum-discordsh:containerx --configuration=production"]
+          "commands": [
+            "./kbve.sh -nx axum-discordsh:containerx --configuration=production",
+            "VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && docker tag ghcr.io/kbve/discordsh:latest ghcr.io/kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION\""
+          ]
         }
       }
     },
@@ -102,7 +108,7 @@
         "load": true,
         "metadata": {
           "images": ["ghcr.io/kbve/discordsh", "kbve/discordsh"],
-          "tags": ["0.1.0", "0.1"]
+          "tags": ["latest"]
         },
         "configurations": {
           "local": {

--- a/apps/discordsh/discordsh-e2e/playwright.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { readFileSync } from 'fs';
 
 const mode =
 	process.env['E2E_DOCKER'] === 'true' ? 'docker' : 'dev';
@@ -6,9 +7,12 @@ const mode =
 const port = 4321;
 const baseURL = `http://localhost:${port}`;
 
+const cargoToml = readFileSync('apps/discordsh/axum-discordsh/Cargo.toml', 'utf-8');
+const version = cargoToml.match(/^version\s*=\s*"(.+)"/m)?.[1] ?? '0.1.0';
+
 const commands: Record<string, string> = {
 	dev: 'pnpm exec nx dev axum-discordsh',
-	docker: `docker run --rm -p ${port}:${port} kbve/discordsh:0.1.0`,
+	docker: `docker run --rm -p ${port}:${port} kbve/discordsh:${version}`,
 };
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Container `containerx` target builds with `latest` tag, then `container` target reads `Cargo.toml` version and docker-tags both `kbve/discordsh:<version>` and `ghcr.io/kbve/discordsh:<version>`
- Playwright e2e config reads version from `Cargo.toml` at runtime via `readFileSync` (same pattern as irc-gateway)
- Version only needs to be bumped in one place: `apps/discordsh/axum-discordsh/Cargo.toml`

## Test plan
- [x] `pnpm nx container axum-discordsh` builds and tags `latest` + `0.1.0`
- [x] `pnpm nx e2e:docker discordsh-e2e` — 12/12 tests pass