### PR TITLE
fix(irc): dynamic docker tag from Cargo.toml version

### DIFF
--- a/apps/irc/irc-gateway/project.json
+++ b/apps/irc/irc-gateway/project.json
@@ -85,10 +85,16 @@
       },
       "configurations": {
         "local": {
-          "commands": ["./kbve.sh -nx irc-gateway:containerx"]
+          "commands": [
+            "./kbve.sh -nx irc-gateway:containerx",
+            "VERSION=$(grep '^version' apps/irc/irc-gateway/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/irc-gateway:latest kbve/irc-gateway:$VERSION && docker tag ghcr.io/kbve/irc-gateway:latest ghcr.io/kbve/irc-gateway:$VERSION && echo \"Tagged kbve/irc-gateway:$VERSION\""
+          ]
         },
         "production": {
-          "commands": ["./kbve.sh -nx irc-gateway:containerx --configuration=production"]
+          "commands": [
+            "./kbve.sh -nx irc-gateway:containerx --configuration=production",
+            "VERSION=$(grep '^version' apps/irc/irc-gateway/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/irc-gateway:latest kbve/irc-gateway:$VERSION && docker tag ghcr.io/kbve/irc-gateway:latest ghcr.io/kbve/irc-gateway:$VERSION && echo \"Tagged kbve/irc-gateway:$VERSION\""
+          ]
         }
       }
     },
@@ -102,7 +108,7 @@
         "load": true,
         "metadata": {
           "images": ["ghcr.io/kbve/irc-gateway", "kbve/irc-gateway"],
-          "tags": ["0.1.1", "0.1", "latest"]
+          "tags": ["latest"]
         },
         "configurations": {
           "local": {


### PR DESCRIPTION
## Summary
- Reverts containerx tags from hardcoded `["0.1.1", "0.1", "latest"]` back to `["latest"]`
- Container target now dynamically reads version from Cargo.toml and `docker tag`s the image, matching the discordsh pattern (#7052)
- No hardcoded version strings — Cargo.toml is the single source of truth

## Test plan
- [ ] `nx run irc-gateway:container` builds and tags with Cargo.toml version
- [ ] CI docker publish picks up correct version