### PR TITLE
feat(ci): integrate discordsh into CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -301,12 +301,12 @@ jobs:
             items: |
                 [
                   { "name": "kilobase", "target": "container", "condition": "${{ needs.alter.outputs.kilobase }}" },
-                  { "name": "disoxide", "target": "container", "condition": "${{ needs.alter.outputs.disoxide }}" },
                   { "name": "notification-bot", "target": "container", "condition": "${{ needs.alter.outputs.notification_bot }}" },
                   { "name": "kbve-hyperlane", "target": "container", "condition": "${{ needs.alter.outputs.hyperlane }}" },
                   { "name": "herbmail", "target": "container", "condition": "${{ needs.alter.outputs.herbmail }}", "image": "kbve/herbmail", "cargo_toml": "apps/herbmail/axum-herbmail/Cargo.toml" },
                   { "name": "memes", "target": "container", "condition": "${{ needs.alter.outputs.memes }}", "image": "kbve/memes", "cargo_toml": "apps/memes/axum-memes/Cargo.toml" },
-                  { "name": "irc-gateway", "target": "container", "condition": "${{ needs.alter.outputs.irc_gateway }}", "image": "kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml" }
+                  { "name": "irc-gateway", "target": "container", "condition": "${{ needs.alter.outputs.irc_gateway }}", "image": "kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml" },
+                  { "name": "discordsh", "target": "container", "condition": "${{ needs.alter.outputs.discordsh }}", "image": "kbve/discordsh", "cargo_toml": "apps/discordsh/axum-discordsh/Cargo.toml" }
                 ]
 
     generate_e2e_docker_matrix:
@@ -317,7 +317,8 @@ jobs:
                 [
                   { "name": "herbmail", "condition": "${{ needs.alter.outputs.herbmail }}" },
                   { "name": "memes", "condition": "${{ needs.alter.outputs.memes }}" },
-                  { "name": "irc", "condition": "${{ needs.alter.outputs.irc_gateway }}" }
+                  { "name": "irc", "condition": "${{ needs.alter.outputs.irc_gateway }}" },
+                  { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}" }
                 ]
 
     test_docker:
@@ -355,7 +356,8 @@ jobs:
                 [
                   { "name": "herbmail", "condition": "${{ needs.alter.outputs.herbmail }}", "image_name": "ghcr.io/kbve/herbmail", "cargo_toml": "apps/herbmail/axum-herbmail/Cargo.toml", "deployment_yaml": "apps/kube/herbmail/manifest/herbmail-deployment.yaml" },
                   { "name": "memes", "condition": "${{ needs.alter.outputs.memes }}", "image_name": "ghcr.io/kbve/memes", "cargo_toml": "apps/memes/axum-memes/Cargo.toml", "deployment_yaml": "apps/kube/memes/manifest/memes-deployment.yaml" },
-                  { "name": "irc-gateway", "condition": "${{ needs.alter.outputs.irc_gateway }}", "image_name": "ghcr.io/kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml", "deployment_yaml": "apps/kube/irc/manifests/irc-gateway-deployment.yaml" }
+                  { "name": "irc-gateway", "condition": "${{ needs.alter.outputs.irc_gateway }}", "image_name": "ghcr.io/kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml", "deployment_yaml": "apps/kube/irc/manifests/irc-gateway-deployment.yaml" },
+                  { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}", "image_name": "ghcr.io/kbve/discordsh", "cargo_toml": "apps/discordsh/axum-discordsh/Cargo.toml", "deployment_yaml": "apps/kube/discordsh/manifest/deployment.yaml" }
                 ]
 
     update_kube_manifests:

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -33,9 +33,6 @@ on:
       kilobase:
         description: "Kilobase package changed"
         value: ${{ jobs.alter.outputs.kilobase }}
-      disoxide:
-        description: "Disoxide package changed"
-        value: ${{ jobs.alter.outputs.disoxide }}
       hyperlane:
         description: "Hyperlane package changed"
         value: ${{ jobs.alter.outputs.hyperlane }}
@@ -139,7 +136,6 @@ jobs:
       erust_crate: ${{ steps.delta.outputs.erust_crate_any_changed }}
       holy_crate: ${{ steps.delta.outputs.holy_crate_any_changed }}
       kilobase: ${{ steps.delta.outputs.kilobase_any_changed }}
-      disoxide: ${{ steps.delta.outputs.disoxide_any_changed }}
       hyperlane: ${{ steps.delta.outputs.hyperlane_any_changed }}
       # py_atlas: ${{ steps.delta.outputs.py_atlas_any_changed }}  # Atlas migrated into pydesk
       py_lib_fudster: ${{ steps.delta.outputs.py_lib_fudster_any_changed }}
@@ -192,8 +188,6 @@ jobs:
                 - 'packages/rust/holy/src/**'
             kilobase:
                 -  'apps/kbve/kilobase/README.md'
-            disoxide:
-                - 'apps/discord/disoxide/README.md'
             hyperlane:
                 - 'apps/kbve/kbve-hyperlane/README.md'
             rareicon_unity:
@@ -223,7 +217,7 @@ jobs:
             astro_rareicon:
                 - 'apps/rareicon/rareicon.com/**'
             discordsh:
-                - 'apps/discord.sh/**'
+                - 'apps/discordsh/**'
             proxy:
                 - 'apps/proxy/**'
             saber:


### PR DESCRIPTION
## Summary
- Add discordsh to Docker build matrix (builds `kbve/discordsh` from `axum-discordsh/Cargo.toml` version)
- Add discordsh to e2e test matrix (runs `discordsh-e2e` Playwright tests)
- Add discordsh to kube update matrix (auto-PR bumps `apps/kube/discordsh/manifest/deployment.yaml`)
- Fix file alteration glob from nonexistent `apps/discord.sh/**` to `apps/discordsh/**`

## Pipeline cycle after merge
1. Change in `apps/discordsh/**` triggers file alteration
2. Docker image built and tagged from `Cargo.toml` version
3. E2E tests run against Docker container
4. After publish, auto-PR bumps deployment.yaml image tag

## Test plan
- [ ] Verify file alteration detects changes in `apps/discordsh/`
- [ ] Verify Docker build matrix includes discordsh
- [ ] Verify e2e matrix includes discordsh
- [ ] Verify kube update auto-PR targets correct deployment.yaml path