### PR TITLE
fix(nx): isolate cache directory per worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,12 @@ All work must happen in isolated git worktrees branched from `dev`. Never commit
    NX_WORKSPACE_ROOT=/absolute/path/to/worktree
    NX_WORKSPACE_ROOT_PATH=/absolute/path/to/worktree
    NX_WORKSPACE_DATA_DIRECTORY=.nx/workspace-data-<worktree-basename>
+   NX_CACHE_DIRECTORY=.nx/cache
    NX_DAEMON=false
    ```
    `NX_WORKSPACE_ROOT_PATH` is critical — Nx resolves the workspace root at module-load time (before dotenv), so it must be a real shell env var. Use `./kbve.sh -nx` (which auto-sources `.env.local`) or manually `export NX_WORKSPACE_ROOT_PATH=$PWD` after entering the worktree.
    `NX_WORKSPACE_DATA_DIRECTORY` gives each worktree its own project-graph/daemon cache, preventing cross-worktree crosstalk.
+   `NX_CACHE_DIRECTORY` isolates the task cache per worktree so cached outputs don't collide across checkouts.
 
 3. **Install dependencies** (skipped if `kbve.sh -worktree` was used):
    ```bash
@@ -61,7 +63,8 @@ All work must happen in isolated git worktrees branched from `dev`. Never commit
 - Branch naming: `trunk/<task-name>-<MM-DD-YYYY>`
 - Worktree path: `../kbve-<task-name>` (adjacent to main repo)
 - Always `pnpm install` in new worktrees
-- Always create `.env.local` with `NX_WORKSPACE_ROOT`, `NX_WORKSPACE_DATA_DIRECTORY`, and `NX_DAEMON=false` — or use `./kbve.sh -worktree` which handles this automatically
+- Always create `.env.local` with `NX_WORKSPACE_ROOT`, `NX_WORKSPACE_DATA_DIRECTORY`, `NX_CACHE_DIRECTORY`, and `NX_DAEMON=false` — or use `./kbve.sh -worktree` which handles this automatically
+- **Always use `./kbve.sh -nx` instead of bare `pnpm nx` in worktrees** — it sources `.env.local` before running Nx, ensuring daemon/cache isolation is applied. Running `pnpm nx` directly skips `.env.local` and can cause stale graph or cache collisions
 - PRs target `dev`, never `main`
 - No co-authoring lines in commits
 - Keep PR descriptions concise

--- a/kbve.sh
+++ b/kbve.sh
@@ -336,6 +336,7 @@ create_worktree() {
 NX_WORKSPACE_ROOT=$worktree_dir
 NX_WORKSPACE_ROOT_PATH=$worktree_dir
 NX_WORKSPACE_DATA_DIRECTORY=.nx/workspace-data-${worktree_basename}
+NX_CACHE_DIRECTORY=.nx/cache
 NX_DAEMON=false
 ENVEOF
 


### PR DESCRIPTION
## Summary
- Add `NX_CACHE_DIRECTORY=.nx/cache` to the `.env.local` generated by `kbve.sh -worktree`, preventing cache collisions across worktrees
- Document the `NX_CACHE_DIRECTORY` variable and the requirement to use `./kbve.sh -nx` (instead of bare `pnpm nx`) in worktrees in AGENTS.md

## Test plan
- [ ] Create a worktree with `./kbve.sh -worktree test` and verify `.env.local` contains `NX_CACHE_DIRECTORY=.nx/cache`
- [ ] Run `./kbve.sh -nx <target>` in a worktree and confirm cache writes to `.nx/cache` locally