### PR TITLE
feat(herbmail): self-contained Docker build + e2e port cleanup

### DIFF
--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -1,5 +1,32 @@
 # ============================================================================
-# [STAGE A] - Precompress Static Assets (built by container-prep on host)
+# [STAGE A] - Build Astro Static Site
+# ============================================================================
+FROM --platform=linux/amd64 node:24-alpine AS astro-builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy root dependency and config files (layer-cached separately from source)
+COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+
+# Install all dependencies (hoisted mode - all go to root node_modules)
+RUN pnpm install --frozen-lockfile
+
+# Copy workspace package sources (TypeScript path aliases resolve to these)
+COPY packages/npm/astro/ packages/npm/astro/
+COPY packages/npm/droid/ packages/npm/droid/
+
+# Copy astro-herbmail source
+COPY apps/herbmail/astro-herbmail/ apps/herbmail/astro-herbmail/
+
+# Build astro site
+WORKDIR /app/apps/herbmail/astro-herbmail
+RUN rm -rf .astro && npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+
+# ============================================================================
+# [STAGE B] - Precompress Static Assets
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS astro-precompressor
 
@@ -7,7 +34,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gzip brotli && \
     rm -rf /var/lib/apt/lists/*
 
-COPY apps/herbmail/axum-herbmail/dist /static
+COPY --from=astro-builder /app/dist/apps/astro-herbmail /static
 
 WORKDIR /static
 RUN find . -type f \( \
@@ -25,7 +52,7 @@ RUN find . -type f \( \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# [STAGE B] - Rust Base Image
+# [STAGE C] - Rust Base Image
 # ============================================================================
 FROM --platform=linux/amd64 rust:1.90-slim AS rust-base
 
@@ -43,7 +70,7 @@ RUN rustup target add x86_64-unknown-linux-gnu && \
 WORKDIR /app
 
 # ============================================================================
-# [STAGE C] - Cargo Chef Planner
+# [STAGE D] - Cargo Chef Planner
 # ============================================================================
 FROM rust-base AS planner
 
@@ -67,7 +94,7 @@ COPY packages/data/proto packages/data/proto
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ============================================================================
-# [STAGE D] - Cargo Chef Builder (Cache Dependencies)
+# [STAGE E] - Cargo Chef Builder (Cache Dependencies)
 # ============================================================================
 FROM rust-base AS builder-deps
 
@@ -84,7 +111,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo chef cook --release --recipe-path recipe.json -p axum-herbmail
 
 # ============================================================================
-# [STAGE E] - Build Application
+# [STAGE F] - Build Application
 # ============================================================================
 FROM rust-base AS builder
 
@@ -114,7 +141,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     strip target/release/axum-herbmail
 
 # ============================================================================
-# [STAGE F] - Chisel Ubuntu Base (Minimal Runtime)
+# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
 
@@ -139,7 +166,7 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         openssl_config
 
 # ============================================================================
-# [STAGE G] - Jemalloc
+# [STAGE H] - Jemalloc
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
 

--- a/apps/herbmail/axum-herbmail/src/transport/https.rs
+++ b/apps/herbmail/axum-herbmail/src/transport/https.rs
@@ -76,17 +76,15 @@ fn router() -> Router {
         .load_shed()
         .layer(tower_http::limit::RequestBodyLimitLayer::new(1024 * 1024));
 
-    let static_router = crate::astro::build_static_router(&static_config)
-        .layer(axum::middleware::from_fn(fix_ts_mime))
-        .layer(axum::middleware::from_fn(cache_headers));
+    let static_router = crate::astro::build_static_router(&static_config);
 
     let public_router = Router::new()
         .route("/health", get(health));
 
-    let dynamic_router = public_router;
-
     static_router
-        .merge(dynamic_router)
+        .merge(public_router)
+        .layer(axum::middleware::from_fn(fix_ts_mime))
+        .layer(axum::middleware::from_fn(cache_headers))
         .layer(middleware)
 }
 

--- a/apps/herbmail/herbmail-e2e/project.json
+++ b/apps/herbmail/herbmail-e2e/project.json
@@ -6,23 +6,20 @@
 	"implicitDependencies": ["axum-herbmail", "astro-herbmail"],
 	"targets": {
 		"e2e": {
-			"executor": "nx:run-commands",
+			"executor": "@nx/playwright:playwright",
+			"cache": false,
 			"options": {
-				"commands": [
-					"pnpm exec playwright install --with-deps chromium",
-					"pnpm exec playwright test --config=apps/herbmail/herbmail-e2e/playwright.config.ts"
-				],
-				"cwd": "{workspaceRoot}"
+				"config": "apps/herbmail/herbmail-e2e/playwright.config.ts"
 			}
 		},
 		"e2e:docker": {
-			"executor": "nx:run-commands",
+			"executor": "@nx/playwright:playwright",
+			"cache": false,
 			"options": {
-				"commands": [
-					"pnpm exec playwright install --with-deps chromium",
-					"E2E_DOCKER=true pnpm exec playwright test --config=apps/herbmail/herbmail-e2e/playwright.config.ts"
-				],
-				"cwd": "{workspaceRoot}"
+				"config": "apps/herbmail/herbmail-e2e/playwright.config.ts",
+				"env": {
+					"E2E_DOCKER": "true"
+				}
 			}
 		}
 	},

--- a/apps/irc/irc-e2e/playwright.config.ts
+++ b/apps/irc/irc-e2e/playwright.config.ts
@@ -12,9 +12,11 @@ const jwtSecret = 'e2e-test-secret-do-not-use-in-production';
 const cargoToml = readFileSync('apps/irc/irc-gateway/Cargo.toml', 'utf-8');
 const version = cargoToml.match(/^version\s*=\s*"(.+)"/m)?.[1] ?? '0.1.0';
 
+const killPort = `lsof -ti:${port} | xargs kill -9 2>/dev/null; sleep 1;`;
+
 const commands: Record<string, string> = {
 	dev: `JWT_SECRET=${jwtSecret} nx dev irc-gateway --no-cloud`,
-	docker: `docker run --rm --name irc-e2e-test -p ${port}:${port} -e JWT_SECRET=${jwtSecret} kbve/irc-gateway:${version}`,
+	docker: `${killPort} docker run --rm --name irc-e2e-test -p ${port}:${port} -e JWT_SECRET=${jwtSecret} kbve/irc-gateway:${version}`,
 };
 
 export default defineConfig({
@@ -39,7 +41,7 @@ export default defineConfig({
 	webServer: {
 		command: commands[mode],
 		url: `${baseURL}/health`,
-		reuseExistingServer: !process.env['CI'],
+		reuseExistingServer: mode === 'dev' && !process.env['CI'],
 		timeout:
 			mode === 'docker'
 				? 30_000


### PR DESCRIPTION
## Summary
- Build Astro from source inside the Dockerfile (matching irc-gateway pattern) so the image is fully self-contained without host-side `container-prep`
- Switch herbmail-e2e to `@nx/playwright:playwright` executor (matching irc-e2e)
- Add port cleanup and disable `reuseExistingServer` in docker mode for both herbmail-e2e and irc-e2e to prevent e2e tests hitting stale servers
- Move middleware layers (`fix_ts_mime`, `cache_headers`) after router merge for correct static file serving

## Test plan
- [x] Docker image builds successfully via `nx run axum-herbmail:containerx`
- [x] All 12 e2e tests pass against Docker container (`nx run herbmail-e2e:e2e:docker`)
- [x] Container verified manually: `GET /` → 200, `/health` → 200, `/sitemap-index.xml` → 200, `/nonexistent` → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)