### PR TITLE
fix(irc,herbmail): fix containerx config structure and ghcr.io token requirement

### DIFF
--- a/apps/herbmail/axum-herbmail/project.json
+++ b/apps/herbmail/axum-herbmail/project.json
@@ -85,10 +85,16 @@
       },
       "configurations": {
         "local": {
-          "commands": ["./kbve.sh -nx axum-herbmail:containerx"]
+          "commands": [
+            "./kbve.sh -nx axum-herbmail:containerx",
+            "VERSION=$(grep '^version' apps/herbmail/axum-herbmail/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/herbmail:latest kbve/herbmail:$VERSION && echo \"Tagged kbve/herbmail:$VERSION\""
+          ]
         },
         "production": {
-          "commands": ["./kbve.sh -nx axum-herbmail:containerx --configuration=production"]
+          "commands": [
+            "./kbve.sh -nx axum-herbmail:containerx --configuration=production",
+            "VERSION=$(grep '^version' apps/herbmail/axum-herbmail/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/herbmail:latest kbve/herbmail:$VERSION && docker tag ghcr.io/kbve/herbmail:latest ghcr.io/kbve/herbmail:$VERSION && echo \"Tagged kbve/herbmail:$VERSION\""
+          ]
         }
       }
     },
@@ -99,26 +105,30 @@
         "engine": "docker",
         "context": ".",
         "file": "apps/herbmail/axum-herbmail/Dockerfile",
-        "load": true,
-        "metadata": {
-          "images": ["ghcr.io/kbve/herbmail", "kbve/herbmail"],
-          "tags": ["0.1.0", "0.1"]
-        },
-        "configurations": {
-          "local": {
-            "load": true,
-            "push": false
-          },
-          "production": {
-            "load": true,
-            "push": false,
-            "cache-from": [
-              "type=registry,ref=ghcr.io/kbve/herbmail:buildcache"
-            ],
-            "cache-to": [
-              "type=registry,ref=ghcr.io/kbve/herbmail:buildcache,mode=max"
-            ]
+        "load": true
+      },
+      "configurations": {
+        "local": {
+          "load": true,
+          "push": false,
+          "metadata": {
+            "images": ["kbve/herbmail"],
+            "tags": ["latest"]
           }
+        },
+        "production": {
+          "load": true,
+          "push": false,
+          "metadata": {
+            "images": ["ghcr.io/kbve/herbmail", "kbve/herbmail"],
+            "tags": ["latest"]
+          },
+          "cache-from": [
+            "type=registry,ref=ghcr.io/kbve/herbmail:buildcache"
+          ],
+          "cache-to": [
+            "type=registry,ref=ghcr.io/kbve/herbmail:buildcache,mode=max"
+          ]
         }
       }
     }

--- a/apps/irc/irc-gateway/project.json
+++ b/apps/irc/irc-gateway/project.json
@@ -74,7 +74,7 @@
         "local": {
           "commands": [
             "./kbve.sh -nx irc-gateway:containerx",
-            "VERSION=$(grep '^version' apps/irc/irc-gateway/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/irc-gateway:latest kbve/irc-gateway:$VERSION && docker tag ghcr.io/kbve/irc-gateway:latest ghcr.io/kbve/irc-gateway:$VERSION && echo \"Tagged kbve/irc-gateway:$VERSION\""
+            "VERSION=$(grep '^version' apps/irc/irc-gateway/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/irc-gateway:latest kbve/irc-gateway:$VERSION && echo \"Tagged kbve/irc-gateway:$VERSION\""
           ]
         },
         "production": {
@@ -105,26 +105,30 @@
         "engine": "docker",
         "context": ".",
         "file": "apps/irc/irc-gateway/Dockerfile",
-        "load": true,
-        "metadata": {
-          "images": ["ghcr.io/kbve/irc-gateway", "kbve/irc-gateway"],
-          "tags": ["latest"]
-        },
-        "configurations": {
-          "local": {
-            "load": true,
-            "push": false
-          },
-          "production": {
-            "load": true,
-            "push": false,
-            "cache-from": [
-              "type=registry,ref=ghcr.io/kbve/irc-gateway:buildcache"
-            ],
-            "cache-to": [
-              "type=registry,ref=ghcr.io/kbve/irc-gateway:buildcache,mode=max"
-            ]
+        "load": true
+      },
+      "configurations": {
+        "local": {
+          "load": true,
+          "push": false,
+          "metadata": {
+            "images": ["kbve/irc-gateway"],
+            "tags": ["latest"]
           }
+        },
+        "production": {
+          "load": true,
+          "push": false,
+          "metadata": {
+            "images": ["ghcr.io/kbve/irc-gateway", "kbve/irc-gateway"],
+            "tags": ["latest"]
+          },
+          "cache-from": [
+            "type=registry,ref=ghcr.io/kbve/irc-gateway:buildcache"
+          ],
+          "cache-to": [
+            "type=registry,ref=ghcr.io/kbve/irc-gateway:buildcache,mode=max"
+          ]
         }
       }
     }


### PR DESCRIPTION
## Summary
- Moved `configurations` from inside `options` to the target level in `containerx` targets for both irc-gateway and axum-herbmail — Nx was ignoring all configuration overrides
- Isolated `ghcr.io/...` images to production-only metadata so local/CI builds no longer require a GitHub token
- Aligned herbmail docker version tagging with Cargo.toml as source of truth (matching irc-gateway pattern)

## Test plan
- [ ] CI `docker-test-app` workflow passes for irc without `Missing github token` error
- [ ] Local `nx run irc-gateway:containerx:local` builds without requiring `GITHUB_TOKEN`
- [ ] Production config still includes ghcr.io images and cache settings