### PR TITLE
fix(irc,herbmail): use direct tags for local container builds

### DIFF
--- a/apps/herbmail/axum-herbmail/project.json
+++ b/apps/herbmail/axum-herbmail/project.json
@@ -111,10 +111,7 @@
         "local": {
           "load": true,
           "push": false,
-          "metadata": {
-            "images": ["kbve/herbmail"],
-            "tags": ["latest"]
-          }
+          "tags": ["kbve/herbmail:latest"]
         },
         "production": {
           "load": true,

--- a/apps/irc/irc-gateway/project.json
+++ b/apps/irc/irc-gateway/project.json
@@ -111,10 +111,7 @@
         "local": {
           "load": true,
           "push": false,
-          "metadata": {
-            "images": ["kbve/irc-gateway"],
-            "tags": ["latest"]
-          }
+          "tags": ["kbve/irc-gateway:latest"]
         },
         "production": {
           "load": true,


### PR DESCRIPTION
## Summary
- Replace `metadata` with direct `tags` in local `containerx` configurations for both irc-gateway and axum-herbmail
- The `@nx-tools/nx-container` executor calls the GitHub API whenever `metadata.images` is present on GitHub Actions, even without ghcr.io images — this caused `Missing github token` failures
- Local builds now use `tags: ["kbve/irc-gateway:latest"]` directly, bypassing metadata resolution entirely
- Production configs retain `metadata` for GHCR integration

## Test plan
- [ ] CI `docker-test-app` workflow passes for irc without `Missing github token` error
- [ ] Docker e2e tests still run and pass (27 Playwright tests + docker-based e2e)