### PR TITLE
fix(workflows): rename CI step labels from Node v22 to v24

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Checkout the repository using git
               uses: actions/checkout@v4
 
-            - name: Setup Node v22
+            - name: Setup Node v24
               uses: actions/setup-node@v4
               with:
                   node-version: 24

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -34,7 +34,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-cargo-
 
-            - name: Setup Node v22
+            - name: Setup Node v24
               uses: actions/setup-node@v4
               with:
                   node-version: 24

--- a/.github/workflows/npm-test-package.yml
+++ b/.github/workflows/npm-test-package.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup Node v22
+            - name: Setup Node v24
               uses: actions/setup-node@v4
               with:
                   node-version: 24

--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Checkout the monorepo
               uses: actions/checkout@v4
 
-            - name: Setup Node v22
+            - name: Setup Node v24
               uses: actions/setup-node@v4
               with:
                   node-version: 24

--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   components: clippy
 
-            - name: Setup Node v22
+            - name: Setup Node v24
               uses: actions/setup-node@v4
               with:
                   node-version: 24

--- a/.github/workflows/utils-npm-publish.yml
+++ b/.github/workflows/utils-npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node v22
+      - name: Setup Node v24
         uses: actions/setup-node@v4
         with:
           node-version: 24

--- a/.github/workflows/utils-nx-kbve-shell.yml
+++ b/.github/workflows/utils-nx-kbve-shell.yml
@@ -46,7 +46,7 @@ jobs:
               with:
                   ref: ${{ inputs.branch }}
 
-            - name: Setup Node v22
+            - name: Setup Node v24
               uses: actions/setup-node@v4
               with:
                   node-version: 24

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -62,7 +62,7 @@ jobs:
                     echo "should_publish=true" >> "$GITHUB_OUTPUT"
                   fi
 
-            - name: Setup Node v22
+            - name: Setup Node v24
               if: ${{ steps.version_check.outputs.should_publish != 'false' }}
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/utils-python-publish.yml
+++ b/.github/workflows/utils-python-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout the monorepo
         uses: actions/checkout@v4
 
-      - name: Setup Node v22
+      - name: Setup Node v24
         uses: actions/setup-node@v4
         with:
           node-version: 24


### PR DESCRIPTION
## Summary
- Renamed the `Setup Node v22` step label to `Setup Node v24` in all 9 CI workflow files
- The workflows already used `node-version: 24` but the step names were stale from the v22 era

## Files changed
- `ci-main.yml`
- `docker-test-app.yml`
- `npm-test-package.yml`
- `python-test-package.yml`
- `rust-test-crate.yml`
- `utils-npm-publish.yml`
- `utils-nx-kbve-shell.yml`
- `utils-publish-docker-image.yml`
- `utils-python-publish.yml`

## Test plan
- [ ] Verify CI logs now show "Setup Node v24" instead of "Setup Node v22"
- [ ] Confirm no functional change — only step name labels were updated