### PR TITLE
feat(axum-memes): self-contained Docker build for astro-memes

### DIFF
--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -1,5 +1,32 @@
 # ============================================================================
-# [STAGE A] - Precompress Static Assets (built by container-prep on host)
+# [STAGE A] - Build Astro Static Site
+# ============================================================================
+FROM --platform=linux/amd64 node:24-alpine AS astro-builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy root dependency and config files (layer-cached separately from source)
+COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+
+# Install all dependencies (hoisted mode - all go to root node_modules)
+RUN pnpm install --frozen-lockfile
+
+# Copy workspace package sources (TypeScript path aliases resolve to these)
+COPY packages/npm/astro/ packages/npm/astro/
+COPY packages/npm/droid/ packages/npm/droid/
+
+# Copy astro-memes source
+COPY apps/memes/astro-memes/ apps/memes/astro-memes/
+
+# Build astro site
+WORKDIR /app/apps/memes/astro-memes
+RUN rm -rf .astro && npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+
+# ============================================================================
+# [STAGE B] - Precompress Static Assets
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS astro-precompressor
 
@@ -7,7 +34,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gzip brotli && \
     rm -rf /var/lib/apt/lists/*
 
-COPY apps/memes/axum-memes/dist /static
+COPY --from=astro-builder /app/dist/apps/astro-memes /static
 
 WORKDIR /static
 RUN find . -type f \( \
@@ -25,7 +52,7 @@ RUN find . -type f \( \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# [STAGE B] - Rust Base Image
+# [STAGE C] - Rust Base Image
 # ============================================================================
 FROM --platform=linux/amd64 rust:1.90-slim AS rust-base
 
@@ -43,7 +70,7 @@ RUN rustup target add x86_64-unknown-linux-gnu && \
 WORKDIR /app
 
 # ============================================================================
-# [STAGE C] - Cargo Chef Planner
+# [STAGE D] - Cargo Chef Planner
 # ============================================================================
 FROM rust-base AS planner
 
@@ -67,7 +94,7 @@ COPY packages/data/proto packages/data/proto
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ============================================================================
-# [STAGE D] - Cargo Chef Builder (Cache Dependencies)
+# [STAGE E] - Cargo Chef Builder (Cache Dependencies)
 # ============================================================================
 FROM rust-base AS builder-deps
 
@@ -84,7 +111,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo chef cook --release --recipe-path recipe.json -p axum-memes
 
 # ============================================================================
-# [STAGE E] - Build Application
+# [STAGE F] - Build Application
 # ============================================================================
 FROM rust-base AS builder
 
@@ -114,7 +141,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     strip target/release/axum-memes
 
 # ============================================================================
-# [STAGE F] - Chisel Ubuntu Base (Minimal Runtime)
+# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
 
@@ -139,7 +166,7 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         openssl_config
 
 # ============================================================================
-# [STAGE G] - Jemalloc
+# [STAGE H] - Jemalloc
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
 


### PR DESCRIPTION
## Summary
- Adds a new `node:24-alpine` Docker stage (Stage A) that builds `astro-memes` from source inside the multi-stage build
- Replaces the host-copied `COPY apps/memes/axum-memes/dist /static` with `COPY --from=astro-builder` from the in-Docker build output
- Mirrors the self-contained pattern used by `herbmail`'s Dockerfile — no pre-built `dist/` needed on the host

## Test plan
- [ ] Verify Docker build completes successfully: `docker build -f apps/memes/axum-memes/Dockerfile .`
- [ ] Confirm the astro-memes static assets are served correctly at runtime
- [ ] Validate precompressed assets (gzip + brotli) are present in the final image

🤖 Generated with [Claude Code](https://claude.com/claude-code)