### PR TITLE
fix(ci): add missing discordsh workflow output

### DIFF
--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -81,10 +81,9 @@ on:
       pirate17:
         description: "Pirate 17 Gamejam"
         value: ${{ jobs.alter.outputs.pirate17 }}
-      # TODO:
-      discordsh_website:
-        description: "Discord.sh changed"
-        value: ${{ jobs.alter.outputs.discordsh_website }}
+      discordsh:
+        description: "Discordsh app changed"
+        value: ${{ jobs.alter.outputs.discordsh }}
       rareicon:
         description: "Rareicon changed"
         value: ${{ jobs.alter.outputs.rareicon }}


### PR DESCRIPTION
## Summary
- The `discordsh` job-level output in `utils-file-alterations.yml` was never exposed as a workflow-level output
- This caused `ci-main.yml` to receive an empty string for `needs.alter.outputs.discordsh`, filtering discordsh out of the Docker build, E2E test, Docker publish, and kube manifest update matrices
- Replaced the unused `discordsh_website` output with the correct `discordsh` output

## Test plan
- [ ] Verify the next CI run on main includes discordsh in the Docker build matrix
- [ ] Confirm discordsh Docker image is published to Docker Hub and GHCR
- [ ] Confirm kube manifest PR is auto-created to update `kbve/discordsh:0.1.0` → `0.1.1`