### PR TITLE
fix(kube): switch irc.kbve.com redirect to DNS01 cert validation

### DIFF
--- a/apps/kube/irc/manifests/irc-domain-redirect.yaml
+++ b/apps/kube/irc/manifests/irc-domain-redirect.yaml
@@ -4,7 +4,7 @@ metadata:
     name: irc-domain-redirect
     namespace: irc
     annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-http
+        cert-manager.io/cluster-issuer: letsencrypt-dns
         nginx.ingress.kubernetes.io/permanent-redirect: "https://chat.kbve.com$request_uri"
 spec:
     ingressClassName: nginx


### PR DESCRIPTION
## Summary
- The `irc.kbve.com` redirect ingress uses `permanent-redirect` which intercepts **all** paths, including `/.well-known/acme-challenge/` needed by Let's Encrypt HTTP01 validation
- This prevents cert-manager from issuing a valid certificate, so nginx falls back to the `chat.kbve.com` cert — causing `ERR_TLS_CERT_ALTNAME_INVALID` for visitors
- Switches the ingress annotation from `letsencrypt-http` to `letsencrypt-dns` (Cloudflare DNS01 challenge), bypassing the redirect entirely

## Test plan
- [ ] After ArgoCD sync, verify cert-manager issues a new certificate for `irc.kbve.com` (`kubectl get certificate -n irc`)
- [ ] Confirm `https://irc.kbve.com` serves a valid cert with `irc.kbve.com` in SANs
- [ ] Confirm `https://irc.kbve.com` returns 301 redirect to `https://chat.kbve.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)