### PR TITLE
fix(kube): switch ergo-irc-tls certificate to DNS01 validation

### DIFF
--- a/apps/kube/irc/manifests/ergo-certificate.yaml
+++ b/apps/kube/irc/manifests/ergo-certificate.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     secretName: ergo-irc-tls-secret
     issuerRef:
-        name: letsencrypt-http
+        name: letsencrypt-dns
         kind: ClusterIssuer
     dnsNames:
         - irc.kbve.com


### PR DESCRIPTION
## Summary
- The `ergo-irc-tls` Certificate for `irc.kbve.com` uses `letsencrypt-http` (HTTP01), which fails because the redirect ingress intercepts all HTTP traffic including ACME challenges
- This causes cert-manager to continuously retry, triggering ArgoCD sync loops via `selfHeal: true`
- Switches to `letsencrypt-dns` (Cloudflare DNS01) to match the redirect ingress fix from #7093

## Test plan
- [ ] After merge through dev → staging → main, verify ArgoCD sync loop stops
- [ ] Verify `ergo-irc-tls` Certificate shows `Ready=True` (`kubectl get certificate -n irc`)
- [ ] Confirm Ergo IRC TLS connections work on port 6697

🤖 Generated with [Claude Code](https://claude.com/claude-code)