### PR TITLE
fix(e2e): chain unit tests + Docker build + Docker smoke in e2e target

### DIFF
--- a/apps/discordsh/project.json
+++ b/apps/discordsh/project.json
@@ -8,8 +8,9 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "nx e2e axum-discordsh",
-          "nx e2e discordsh-e2e"
+          "nx test axum-discordsh",
+          "nx container axum-discordsh",
+          "nx e2e:docker discordsh-e2e"
         ],
         "parallel": false
       }

--- a/apps/herbmail/project.json
+++ b/apps/herbmail/project.json
@@ -8,8 +8,9 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "nx e2e axum-herbmail",
-          "nx e2e herbmail-e2e"
+          "nx test axum-herbmail",
+          "nx container axum-herbmail",
+          "nx e2e:docker herbmail-e2e"
         ],
         "parallel": false
       }

--- a/apps/memes/project.json
+++ b/apps/memes/project.json
@@ -8,8 +8,9 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "nx e2e axum-memes",
-          "nx e2e memes-e2e"
+          "nx test axum-memes",
+          "nx container axum-memes",
+          "nx e2e:docker memes-e2e"
         ],
         "parallel": false
       }


### PR DESCRIPTION
## Summary
- Updates top-level `e2e` target for discordsh, herbmail, and memes to run the full pipeline
- **Before:** `nx e2e {name}` ran unit tests + local Playwright (no Docker)
- **After:** `nx e2e {name}` chains: Rust unit tests → Docker container build → Docker smoke tests
- This is what CI calls via `docker-test-app.yml`, so the full chain is now properly validated

## Test plan
- [x] `discordsh:e2e` runs full chain: 9 unit tests passed, Docker built, 9 smoke tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)