### PR TITLE
feat(astro): add custom branded footers

### DIFF
--- a/apps/discordsh/astro-discordsh/src/components/starlight/Footer.astro
+++ b/apps/discordsh/astro-discordsh/src/components/starlight/Footer.astro
@@ -3,7 +3,201 @@ import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Footer.astro';
 import { DroidProvider } from '@kbve/astro';
 import { workerURLs } from '../../lib/workers';
+
+const currentYear = new Date().getFullYear();
 ---
 
 <DroidProvider client:only="react" workerURLs={workerURLs} />
 <Default {...Astro.props}><slot /></Default>
+
+<div class="site-footer not-content">
+  <div class="footer-main">
+    <div class="footer-brand">
+      <a href="/" class="brand-link" data-astro-prefetch>
+        <span class="brand-text">Discord.sh</span>
+      </a>
+      <p class="brand-desc">
+        Discover, compare, and list Discord servers.<br />
+        The modern topsite for communities.
+      </p>
+    </div>
+
+    <nav class="footer-col">
+      <h6 class="footer-title">Product</h6>
+      <a href="/servers/">Servers</a>
+      <a href="/bot/">Bot</a>
+      <a href="/dashboard/">Dashboard</a>
+    </nav>
+
+    <nav class="footer-col">
+      <h6 class="footer-title">Resources</h6>
+      <a href="/guides/getting-started/">Docs</a>
+      <a href="https://kbve.com">KBVE.com</a>
+      <a href="https://github.com/kbve/kbve">GitHub</a>
+    </nav>
+
+    <nav class="footer-col">
+      <h6 class="footer-title">Legal</h6>
+      <a href="https://kbve.com/legal/tos/">Terms of Use</a>
+      <a href="https://kbve.com/legal/privacy/">Privacy Policy</a>
+      <a href="https://kbve.com/legal/">Cookie Policy</a>
+    </nav>
+  </div>
+
+  <div class="footer-bottom">
+    <span>&copy; {currentYear} <a href="/">Discord.sh</a></span>
+    <div class="footer-socials">
+      <a href="https://github.com/kbve" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="GitHub">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="social-icon">
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+        </svg>
+      </a>
+      <a href="https://kbve.com/discord" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Discord">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="social-icon">
+          <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/>
+        </svg>
+      </a>
+      <a href="https://x.com/kaboragames" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="X (Twitter)">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="social-icon">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>
+
+<style>
+  .site-footer {
+    margin-top: 2.5rem;
+    padding: 2.5rem 1.5rem 0;
+    border-top: 1px solid var(--sl-color-hairline, #27272a);
+    background-color: var(--sl-color-bg, rgba(0, 0, 0, 0.15));
+  }
+
+  .footer-main {
+    display: grid;
+    grid-template-columns: 1.5fr repeat(3, 1fr);
+    gap: 2.5rem;
+    max-width: 72rem;
+    margin: 0 auto;
+    padding-bottom: 2rem;
+  }
+
+  .brand-link {
+    display: inline-flex;
+    text-decoration: none;
+  }
+
+  .brand-text {
+    font-size: 1.5rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: var(--sl-color-white, #e2e8f0);
+  }
+
+  .brand-desc {
+    margin-top: 0.75rem;
+    font-size: 0.8125rem;
+    line-height: 1.6;
+    color: var(--sl-color-gray-2, #a1a1aa);
+  }
+
+  .footer-col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+
+  .footer-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--sl-color-white, #e2e8f0);
+    margin-bottom: 0.25rem;
+  }
+
+  .footer-col a {
+    font-size: 0.8125rem;
+    color: var(--sl-color-gray-2, #a1a1aa);
+    text-decoration: none;
+    transition: color 150ms ease;
+  }
+
+  .footer-col a:hover {
+    color: var(--sl-color-accent, #8b5cf6);
+  }
+
+  .footer-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 1.25rem 0;
+    border-top: 1px solid var(--sl-color-hairline, #27272a);
+  }
+
+  .footer-bottom span {
+    font-size: 0.8125rem;
+    color: var(--sl-color-gray-3, #71717a);
+  }
+
+  .footer-bottom a {
+    color: var(--sl-color-gray-2, #a1a1aa);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 150ms ease;
+  }
+
+  .footer-bottom a:hover {
+    color: var(--sl-color-accent, #8b5cf6);
+  }
+
+  .footer-socials {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .social-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--sl-color-gray-2, #a1a1aa);
+    transition: color 150ms ease;
+  }
+
+  .social-link:hover {
+    color: var(--sl-color-accent, #8b5cf6);
+  }
+
+  .social-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  @media (max-width: 768px) {
+    .footer-main {
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+    }
+
+    .footer-brand {
+      grid-column: 1 / -1;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .footer-main {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+
+    .footer-bottom {
+      flex-direction: column;
+      gap: 1rem;
+      text-align: center;
+    }
+  }
+</style>

--- a/apps/herbmail/astro-herbmail/src/components/starlight/Footer.astro
+++ b/apps/herbmail/astro-herbmail/src/components/starlight/Footer.astro
@@ -3,7 +3,357 @@ import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Footer.astro';
 import { DroidProvider } from '@kbve/astro';
 import { workerURLs } from '../../lib/workers';
+
+const siteName = 'Herbmail';
+const siteDescription = 'Email service for developers and teams, by KBVE. Simple, reliable, open-source.';
+
+const socialLinks = [
+  { name: 'GitHub', href: 'https://github.com/kbve', icon: 'github' },
+  { name: 'Discord', href: 'https://kbve.com/discord', icon: 'discord' },
+];
+
+const resourceLinks = [
+  { href: '/guides/getting-started/', label: 'Documentation' },
+  { href: 'https://kbve.com', label: 'KBVE.com' },
+  { href: 'https://github.com/kbve/kbve', label: 'GitHub' },
+];
+
+const legalLinks = [
+  { href: 'https://kbve.com/legal/privacy/', label: 'Privacy' },
+  { href: 'https://kbve.com/legal/tos/', label: 'Terms' },
+  { href: 'https://kbve.com/legal/', label: 'Legal' },
+];
 ---
 
 <DroidProvider client:only="react" workerURLs={workerURLs} />
 <Default {...Astro.props}><slot /></Default>
+
+<footer class="kf-footer">
+  <div class="kf-hexgrid" aria-hidden="true">
+    {Array.from({ length: 4 }).map((_, row) =>
+      Array.from({ length: 13 }).map((_, i) => (
+        <div class="kf-hex" style={`--row: ${row}; --col: ${i - 6};`}></div>
+      ))
+    )}
+  </div>
+
+  <div class="kf-container">
+    <div class="kf-grid">
+      <div class="kf-brand">
+        <div class="kf-logo-group">
+          <div class="kf-logo-wrapper">
+            <svg viewBox="0 0 76 76" class="kf-logo-svg" xmlns="http://www.w3.org/2000/svg">
+              <path
+                fill="currentColor"
+                d="M 19.3919,37.5442C 19.6211,31.4744 22.697,25.8757 28.3209,22.1759C 28.3375,22.1822 28.4831,22.1291 28.4166,22.255C 27.9707,22.668 19.9618,32.1286 27.3341,39.5966C 27.3341,39.5966 31.2074,43.3197 34.2103,39.7866C 34.2103,39.7866 37.1747,35.9499 34.173,30.134C 34.173,30.134 33.4135,28.2344 30.6765,27.057L 32.8808,24.6247C 32.8808,24.6247 34.7436,25.424 36.1859,27.5916C 36.1859,27.5916 36.2626,25.3093 34.5143,22.8771L 37.9323,19L 41.3153,22.8411C 41.3153,22.8411 39.7596,25.0452 39.645,27.6276C 39.645,27.6276 40.7072,25.8795 42.9887,24.6247L 45.1531,27.057C 45.1531,27.057 43.0717,27.7423 41.6775,30.1087C 40.4786,32.3015 39.5556,36.9906 41.7314,39.867C 41.7314,39.867 44.1662,43.3197 48.45,39.663C 48.45,39.663 56.3257,32.6062 47.6423,22.4039C 47.6423,22.4039 47.168,21.9846 47.7007,22.2127C 51.5385,25.0066 56.1339,28.6918 56.6082,37.8876C 56.4214,49.0393 48.9535,57 38.0487,57C 27.3715,57 19.0713,48.0899 19.3919,37.5442 Z"
+              />
+            </svg>
+          </div>
+          <span class="kf-logo-text">{siteName}</span>
+        </div>
+        <p class="kf-description">{siteDescription}</p>
+        <div class="kf-social">
+          {socialLinks.map(({ name, href, icon }) => (
+            <a href={href} target="_blank" rel="noopener noreferrer" class="kf-social-link" aria-label={name}>
+              {icon === 'github' && (
+                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                </svg>
+              )}
+              {icon === 'discord' && (
+                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
+                  <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/>
+                </svg>
+              )}
+            </a>
+          ))}
+        </div>
+      </div>
+
+      <nav class="kf-nav" aria-labelledby="resources-heading">
+        <h3 id="resources-heading" class="kf-nav-title">Resources</h3>
+        <ul class="kf-nav-list">
+          {resourceLinks.map((link) => (
+            <li>
+              <a href={link.href} class="kf-nav-link">{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+
+    <div class="kf-bottom">
+      <div class="kf-bottom-content">
+        <p class="kf-copyright">&copy; {new Date().getFullYear()} KBVE. All rights reserved.</p>
+        <nav class="kf-legal" aria-label="Legal">
+          {legalLinks.map((link) => (
+            <a href={link.href} class="kf-legal-link">{link.label}</a>
+          ))}
+        </nav>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<style>
+  .kf-footer {
+    margin-top: auto;
+    background: var(--sl-color-bg);
+    border-top: 1px solid var(--sl-color-border);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .kf-hexgrid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .kf-hex {
+    --hex-size: 44px;
+    --hex-width: var(--hex-size);
+    --hex-height: calc(var(--hex-size) * 1.1547);
+    --hex-horiz: calc(var(--hex-width) * 0.75);
+    --hex-vert: calc(var(--hex-height) * 0.5);
+
+    position: absolute;
+    width: var(--hex-width);
+    height: var(--hex-height);
+    background: var(--sl-color-accent);
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+
+    left: calc(50% + (var(--col) * var(--hex-horiz)) - (var(--hex-width) * 0.5));
+    bottom: calc(var(--row) * var(--hex-vert) + 8px);
+
+    --dist-from-center: max(var(--col), calc(-1 * var(--col)));
+    --delay: calc(2s + (var(--row) * 0.4s) + (var(--dist-from-center) * 0.2s));
+    --drift-x: calc(var(--col) * 25px);
+    --drift-y: calc(-120px - (var(--row) * 30px));
+    --rotation: calc(var(--col) * 12deg);
+
+    opacity: 0.15;
+    animation: kf-hex-dissolve 14s ease-in-out infinite;
+    animation-delay: var(--delay);
+  }
+
+  .kf-hex[style*="--row: 1"],
+  .kf-hex[style*="--row: 3"] {
+    transform: translateX(calc(var(--hex-horiz) * 0.5));
+  }
+
+  .kf-hex[style*="--row: 0"],
+  .kf-hex[style*="--row: 2"] {
+    transform: translateX(0);
+  }
+
+  @keyframes kf-hex-dissolve {
+    0%, 20% {
+      opacity: 0.15;
+      transform: translateX(var(--row-offset, 0)) translateY(0) rotate(0deg) scale(1);
+    }
+    35% {
+      opacity: 0.12;
+      transform: translateX(var(--row-offset, 0)) translateY(-8px) rotate(0deg) scale(1);
+    }
+    55% {
+      opacity: 0.08;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.4))
+                 translateY(calc(var(--drift-y) * 0.4))
+                 rotate(calc(var(--rotation) * 0.3))
+                 scale(0.9);
+    }
+    75% {
+      opacity: 0.03;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.8))
+                 translateY(calc(var(--drift-y) * 0.7))
+                 rotate(calc(var(--rotation) * 0.7))
+                 scale(0.7);
+    }
+    90%, 100% {
+      opacity: 0;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x)))
+                 translateY(var(--drift-y))
+                 rotate(var(--rotation))
+                 scale(0.4);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .kf-hex {
+      animation: none;
+      opacity: 0.08;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .kf-hex { --hex-size: 36px; }
+  }
+
+  @media (max-width: 480px) {
+    .kf-hex { --hex-size: 28px; }
+  }
+
+  .kf-container {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    position: relative;
+    z-index: 1;
+  }
+
+  .kf-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  @media (min-width: 640px) {
+    .kf-grid { grid-template-columns: 2fr 1fr; }
+  }
+
+  .kf-brand {
+    grid-column: 1;
+  }
+
+  .kf-logo-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .kf-logo-wrapper {
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--sl-color-accent-low);
+    border-radius: 0.5rem;
+    border: 1px solid var(--sl-color-border);
+  }
+
+  .kf-logo-svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    color: var(--sl-color-accent);
+  }
+
+  .kf-logo-text {
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: var(--sl-color-text);
+  }
+
+  .kf-description {
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: var(--sl-color-gray-2);
+    max-width: 20rem;
+    margin-bottom: 1rem;
+  }
+
+  .kf-social {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .kf-social-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    color: var(--sl-color-gray-2);
+    background: var(--sl-color-accent-low);
+    border: 1px solid var(--sl-color-border);
+    border-radius: 0.375rem;
+    transition: all 0.2s ease;
+  }
+
+  .kf-social-link:hover {
+    color: var(--sl-color-accent);
+    border-color: var(--sl-color-accent);
+    transform: translateY(-2px);
+  }
+
+  .kf-social-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .kf-nav-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--sl-color-accent);
+    margin-bottom: 1rem;
+  }
+
+  .kf-nav-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .kf-nav-link {
+    font-size: 0.875rem;
+    color: var(--sl-color-gray-2);
+    text-decoration: none;
+    transition: color 0.2s ease;
+    display: inline-block;
+  }
+
+  .kf-nav-link:hover {
+    color: var(--sl-color-accent);
+  }
+
+  .kf-bottom {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--sl-color-border);
+  }
+
+  .kf-bottom-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    .kf-bottom-content {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
+
+  .kf-copyright {
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+    margin: 0;
+  }
+
+  .kf-legal {
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .kf-legal-link {
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .kf-legal-link:hover {
+    color: var(--sl-color-accent);
+  }
+</style>

--- a/apps/irc/astro-irc/src/components/starlight/Footer.astro
+++ b/apps/irc/astro-irc/src/components/starlight/Footer.astro
@@ -3,7 +3,357 @@ import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Footer.astro';
 import { DroidProvider } from '@kbve/astro';
 import { workerURLs } from '../../lib/workers';
+
+const siteName = 'KBVE IRC';
+const siteDescription = 'Real-time IRC chat client powered by KBVE. Connect, communicate, and collaborate.';
+
+const socialLinks = [
+  { name: 'GitHub', href: 'https://github.com/kbve', icon: 'github' },
+  { name: 'Discord', href: 'https://kbve.com/discord', icon: 'discord' },
+];
+
+const resourceLinks = [
+  { href: '/guides/getting-started/', label: 'Documentation' },
+  { href: 'https://kbve.com', label: 'KBVE.com' },
+  { href: 'https://github.com/kbve/kbve', label: 'GitHub' },
+];
+
+const legalLinks = [
+  { href: 'https://kbve.com/legal/privacy/', label: 'Privacy' },
+  { href: 'https://kbve.com/legal/tos/', label: 'Terms' },
+  { href: 'https://kbve.com/legal/', label: 'Legal' },
+];
 ---
 
 <DroidProvider client:only="react" workerURLs={workerURLs} />
 <Default {...Astro.props}><slot /></Default>
+
+<footer class="kf-footer">
+  <div class="kf-hexgrid" aria-hidden="true">
+    {Array.from({ length: 4 }).map((_, row) =>
+      Array.from({ length: 13 }).map((_, i) => (
+        <div class="kf-hex" style={`--row: ${row}; --col: ${i - 6};`}></div>
+      ))
+    )}
+  </div>
+
+  <div class="kf-container">
+    <div class="kf-grid">
+      <div class="kf-brand">
+        <div class="kf-logo-group">
+          <div class="kf-logo-wrapper">
+            <svg viewBox="0 0 76 76" class="kf-logo-svg" xmlns="http://www.w3.org/2000/svg">
+              <path
+                fill="currentColor"
+                d="M 19.3919,37.5442C 19.6211,31.4744 22.697,25.8757 28.3209,22.1759C 28.3375,22.1822 28.4831,22.1291 28.4166,22.255C 27.9707,22.668 19.9618,32.1286 27.3341,39.5966C 27.3341,39.5966 31.2074,43.3197 34.2103,39.7866C 34.2103,39.7866 37.1747,35.9499 34.173,30.134C 34.173,30.134 33.4135,28.2344 30.6765,27.057L 32.8808,24.6247C 32.8808,24.6247 34.7436,25.424 36.1859,27.5916C 36.1859,27.5916 36.2626,25.3093 34.5143,22.8771L 37.9323,19L 41.3153,22.8411C 41.3153,22.8411 39.7596,25.0452 39.645,27.6276C 39.645,27.6276 40.7072,25.8795 42.9887,24.6247L 45.1531,27.057C 45.1531,27.057 43.0717,27.7423 41.6775,30.1087C 40.4786,32.3015 39.5556,36.9906 41.7314,39.867C 41.7314,39.867 44.1662,43.3197 48.45,39.663C 48.45,39.663 56.3257,32.6062 47.6423,22.4039C 47.6423,22.4039 47.168,21.9846 47.7007,22.2127C 51.5385,25.0066 56.1339,28.6918 56.6082,37.8876C 56.4214,49.0393 48.9535,57 38.0487,57C 27.3715,57 19.0713,48.0899 19.3919,37.5442 Z"
+              />
+            </svg>
+          </div>
+          <span class="kf-logo-text">{siteName}</span>
+        </div>
+        <p class="kf-description">{siteDescription}</p>
+        <div class="kf-social">
+          {socialLinks.map(({ name, href, icon }) => (
+            <a href={href} target="_blank" rel="noopener noreferrer" class="kf-social-link" aria-label={name}>
+              {icon === 'github' && (
+                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                </svg>
+              )}
+              {icon === 'discord' && (
+                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
+                  <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/>
+                </svg>
+              )}
+            </a>
+          ))}
+        </div>
+      </div>
+
+      <nav class="kf-nav" aria-labelledby="resources-heading">
+        <h3 id="resources-heading" class="kf-nav-title">Resources</h3>
+        <ul class="kf-nav-list">
+          {resourceLinks.map((link) => (
+            <li>
+              <a href={link.href} class="kf-nav-link">{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+
+    <div class="kf-bottom">
+      <div class="kf-bottom-content">
+        <p class="kf-copyright">&copy; {new Date().getFullYear()} KBVE. All rights reserved.</p>
+        <nav class="kf-legal" aria-label="Legal">
+          {legalLinks.map((link) => (
+            <a href={link.href} class="kf-legal-link">{link.label}</a>
+          ))}
+        </nav>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<style>
+  .kf-footer {
+    margin-top: auto;
+    background: var(--sl-color-bg);
+    border-top: 1px solid var(--sl-color-border);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .kf-hexgrid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .kf-hex {
+    --hex-size: 44px;
+    --hex-width: var(--hex-size);
+    --hex-height: calc(var(--hex-size) * 1.1547);
+    --hex-horiz: calc(var(--hex-width) * 0.75);
+    --hex-vert: calc(var(--hex-height) * 0.5);
+
+    position: absolute;
+    width: var(--hex-width);
+    height: var(--hex-height);
+    background: var(--sl-color-accent);
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+
+    left: calc(50% + (var(--col) * var(--hex-horiz)) - (var(--hex-width) * 0.5));
+    bottom: calc(var(--row) * var(--hex-vert) + 8px);
+
+    --dist-from-center: max(var(--col), calc(-1 * var(--col)));
+    --delay: calc(2s + (var(--row) * 0.4s) + (var(--dist-from-center) * 0.2s));
+    --drift-x: calc(var(--col) * 25px);
+    --drift-y: calc(-120px - (var(--row) * 30px));
+    --rotation: calc(var(--col) * 12deg);
+
+    opacity: 0.15;
+    animation: kf-hex-dissolve 14s ease-in-out infinite;
+    animation-delay: var(--delay);
+  }
+
+  .kf-hex[style*="--row: 1"],
+  .kf-hex[style*="--row: 3"] {
+    transform: translateX(calc(var(--hex-horiz) * 0.5));
+  }
+
+  .kf-hex[style*="--row: 0"],
+  .kf-hex[style*="--row: 2"] {
+    transform: translateX(0);
+  }
+
+  @keyframes kf-hex-dissolve {
+    0%, 20% {
+      opacity: 0.15;
+      transform: translateX(var(--row-offset, 0)) translateY(0) rotate(0deg) scale(1);
+    }
+    35% {
+      opacity: 0.12;
+      transform: translateX(var(--row-offset, 0)) translateY(-8px) rotate(0deg) scale(1);
+    }
+    55% {
+      opacity: 0.08;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.4))
+                 translateY(calc(var(--drift-y) * 0.4))
+                 rotate(calc(var(--rotation) * 0.3))
+                 scale(0.9);
+    }
+    75% {
+      opacity: 0.03;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.8))
+                 translateY(calc(var(--drift-y) * 0.7))
+                 rotate(calc(var(--rotation) * 0.7))
+                 scale(0.7);
+    }
+    90%, 100% {
+      opacity: 0;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x)))
+                 translateY(var(--drift-y))
+                 rotate(var(--rotation))
+                 scale(0.4);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .kf-hex {
+      animation: none;
+      opacity: 0.08;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .kf-hex { --hex-size: 36px; }
+  }
+
+  @media (max-width: 480px) {
+    .kf-hex { --hex-size: 28px; }
+  }
+
+  .kf-container {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    position: relative;
+    z-index: 1;
+  }
+
+  .kf-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  @media (min-width: 640px) {
+    .kf-grid { grid-template-columns: 2fr 1fr; }
+  }
+
+  .kf-brand {
+    grid-column: 1;
+  }
+
+  .kf-logo-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .kf-logo-wrapper {
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--sl-color-accent-low);
+    border-radius: 0.5rem;
+    border: 1px solid var(--sl-color-border);
+  }
+
+  .kf-logo-svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    color: var(--sl-color-accent);
+  }
+
+  .kf-logo-text {
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: var(--sl-color-text);
+  }
+
+  .kf-description {
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: var(--sl-color-gray-2);
+    max-width: 20rem;
+    margin-bottom: 1rem;
+  }
+
+  .kf-social {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .kf-social-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    color: var(--sl-color-gray-2);
+    background: var(--sl-color-accent-low);
+    border: 1px solid var(--sl-color-border);
+    border-radius: 0.375rem;
+    transition: all 0.2s ease;
+  }
+
+  .kf-social-link:hover {
+    color: var(--sl-color-accent);
+    border-color: var(--sl-color-accent);
+    transform: translateY(-2px);
+  }
+
+  .kf-social-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .kf-nav-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--sl-color-accent);
+    margin-bottom: 1rem;
+  }
+
+  .kf-nav-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .kf-nav-link {
+    font-size: 0.875rem;
+    color: var(--sl-color-gray-2);
+    text-decoration: none;
+    transition: color 0.2s ease;
+    display: inline-block;
+  }
+
+  .kf-nav-link:hover {
+    color: var(--sl-color-accent);
+  }
+
+  .kf-bottom {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--sl-color-border);
+  }
+
+  .kf-bottom-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    .kf-bottom-content {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
+
+  .kf-copyright {
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+    margin: 0;
+  }
+
+  .kf-legal {
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .kf-legal-link {
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .kf-legal-link:hover {
+    color: var(--sl-color-accent);
+  }
+</style>

--- a/apps/memes/astro-memes/src/components/starlight/Footer.astro
+++ b/apps/memes/astro-memes/src/components/starlight/Footer.astro
@@ -3,7 +3,357 @@ import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Footer.astro';
 import { DroidProvider } from '@kbve/astro';
 import { workerURLs } from '../../lib/workers';
+
+const siteName = 'Meme.sh';
+const siteDescription = 'Meme sharing platform powered by KBVE. Discover, create, and share.';
+
+const socialLinks = [
+  { name: 'GitHub', href: 'https://github.com/kbve', icon: 'github' },
+  { name: 'Discord', href: 'https://kbve.com/discord', icon: 'discord' },
+];
+
+const resourceLinks = [
+  { href: '/guides/getting-started/', label: 'Documentation' },
+  { href: 'https://kbve.com', label: 'KBVE.com' },
+  { href: 'https://github.com/kbve/kbve', label: 'GitHub' },
+];
+
+const legalLinks = [
+  { href: 'https://kbve.com/legal/privacy/', label: 'Privacy' },
+  { href: 'https://kbve.com/legal/tos/', label: 'Terms' },
+  { href: 'https://kbve.com/legal/', label: 'Legal' },
+];
 ---
 
 <DroidProvider client:only="react" workerURLs={workerURLs} />
 <Default {...Astro.props}><slot /></Default>
+
+<footer class="kf-footer">
+  <div class="kf-hexgrid" aria-hidden="true">
+    {Array.from({ length: 4 }).map((_, row) =>
+      Array.from({ length: 13 }).map((_, i) => (
+        <div class="kf-hex" style={`--row: ${row}; --col: ${i - 6};`}></div>
+      ))
+    )}
+  </div>
+
+  <div class="kf-container">
+    <div class="kf-grid">
+      <div class="kf-brand">
+        <div class="kf-logo-group">
+          <div class="kf-logo-wrapper">
+            <svg viewBox="0 0 76 76" class="kf-logo-svg" xmlns="http://www.w3.org/2000/svg">
+              <path
+                fill="currentColor"
+                d="M 19.3919,37.5442C 19.6211,31.4744 22.697,25.8757 28.3209,22.1759C 28.3375,22.1822 28.4831,22.1291 28.4166,22.255C 27.9707,22.668 19.9618,32.1286 27.3341,39.5966C 27.3341,39.5966 31.2074,43.3197 34.2103,39.7866C 34.2103,39.7866 37.1747,35.9499 34.173,30.134C 34.173,30.134 33.4135,28.2344 30.6765,27.057L 32.8808,24.6247C 32.8808,24.6247 34.7436,25.424 36.1859,27.5916C 36.1859,27.5916 36.2626,25.3093 34.5143,22.8771L 37.9323,19L 41.3153,22.8411C 41.3153,22.8411 39.7596,25.0452 39.645,27.6276C 39.645,27.6276 40.7072,25.8795 42.9887,24.6247L 45.1531,27.057C 45.1531,27.057 43.0717,27.7423 41.6775,30.1087C 40.4786,32.3015 39.5556,36.9906 41.7314,39.867C 41.7314,39.867 44.1662,43.3197 48.45,39.663C 48.45,39.663 56.3257,32.6062 47.6423,22.4039C 47.6423,22.4039 47.168,21.9846 47.7007,22.2127C 51.5385,25.0066 56.1339,28.6918 56.6082,37.8876C 56.4214,49.0393 48.9535,57 38.0487,57C 27.3715,57 19.0713,48.0899 19.3919,37.5442 Z"
+              />
+            </svg>
+          </div>
+          <span class="kf-logo-text">{siteName}</span>
+        </div>
+        <p class="kf-description">{siteDescription}</p>
+        <div class="kf-social">
+          {socialLinks.map(({ name, href, icon }) => (
+            <a href={href} target="_blank" rel="noopener noreferrer" class="kf-social-link" aria-label={name}>
+              {icon === 'github' && (
+                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                </svg>
+              )}
+              {icon === 'discord' && (
+                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
+                  <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/>
+                </svg>
+              )}
+            </a>
+          ))}
+        </div>
+      </div>
+
+      <nav class="kf-nav" aria-labelledby="resources-heading">
+        <h3 id="resources-heading" class="kf-nav-title">Resources</h3>
+        <ul class="kf-nav-list">
+          {resourceLinks.map((link) => (
+            <li>
+              <a href={link.href} class="kf-nav-link">{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+
+    <div class="kf-bottom">
+      <div class="kf-bottom-content">
+        <p class="kf-copyright">&copy; {new Date().getFullYear()} KBVE. All rights reserved.</p>
+        <nav class="kf-legal" aria-label="Legal">
+          {legalLinks.map((link) => (
+            <a href={link.href} class="kf-legal-link">{link.label}</a>
+          ))}
+        </nav>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<style>
+  .kf-footer {
+    margin-top: auto;
+    background: var(--sl-color-bg);
+    border-top: 1px solid var(--sl-color-border);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .kf-hexgrid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .kf-hex {
+    --hex-size: 44px;
+    --hex-width: var(--hex-size);
+    --hex-height: calc(var(--hex-size) * 1.1547);
+    --hex-horiz: calc(var(--hex-width) * 0.75);
+    --hex-vert: calc(var(--hex-height) * 0.5);
+
+    position: absolute;
+    width: var(--hex-width);
+    height: var(--hex-height);
+    background: var(--sl-color-accent);
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+
+    left: calc(50% + (var(--col) * var(--hex-horiz)) - (var(--hex-width) * 0.5));
+    bottom: calc(var(--row) * var(--hex-vert) + 8px);
+
+    --dist-from-center: max(var(--col), calc(-1 * var(--col)));
+    --delay: calc(2s + (var(--row) * 0.4s) + (var(--dist-from-center) * 0.2s));
+    --drift-x: calc(var(--col) * 25px);
+    --drift-y: calc(-120px - (var(--row) * 30px));
+    --rotation: calc(var(--col) * 12deg);
+
+    opacity: 0.15;
+    animation: kf-hex-dissolve 14s ease-in-out infinite;
+    animation-delay: var(--delay);
+  }
+
+  .kf-hex[style*="--row: 1"],
+  .kf-hex[style*="--row: 3"] {
+    transform: translateX(calc(var(--hex-horiz) * 0.5));
+  }
+
+  .kf-hex[style*="--row: 0"],
+  .kf-hex[style*="--row: 2"] {
+    transform: translateX(0);
+  }
+
+  @keyframes kf-hex-dissolve {
+    0%, 20% {
+      opacity: 0.15;
+      transform: translateX(var(--row-offset, 0)) translateY(0) rotate(0deg) scale(1);
+    }
+    35% {
+      opacity: 0.12;
+      transform: translateX(var(--row-offset, 0)) translateY(-8px) rotate(0deg) scale(1);
+    }
+    55% {
+      opacity: 0.08;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.4))
+                 translateY(calc(var(--drift-y) * 0.4))
+                 rotate(calc(var(--rotation) * 0.3))
+                 scale(0.9);
+    }
+    75% {
+      opacity: 0.03;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.8))
+                 translateY(calc(var(--drift-y) * 0.7))
+                 rotate(calc(var(--rotation) * 0.7))
+                 scale(0.7);
+    }
+    90%, 100% {
+      opacity: 0;
+      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x)))
+                 translateY(var(--drift-y))
+                 rotate(var(--rotation))
+                 scale(0.4);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .kf-hex {
+      animation: none;
+      opacity: 0.08;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .kf-hex { --hex-size: 36px; }
+  }
+
+  @media (max-width: 480px) {
+    .kf-hex { --hex-size: 28px; }
+  }
+
+  .kf-container {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    position: relative;
+    z-index: 1;
+  }
+
+  .kf-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  @media (min-width: 640px) {
+    .kf-grid { grid-template-columns: 2fr 1fr; }
+  }
+
+  .kf-brand {
+    grid-column: 1;
+  }
+
+  .kf-logo-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .kf-logo-wrapper {
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--sl-color-accent-low);
+    border-radius: 0.5rem;
+    border: 1px solid var(--sl-color-border);
+  }
+
+  .kf-logo-svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    color: var(--sl-color-accent);
+  }
+
+  .kf-logo-text {
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: var(--sl-color-text);
+  }
+
+  .kf-description {
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: var(--sl-color-gray-2);
+    max-width: 20rem;
+    margin-bottom: 1rem;
+  }
+
+  .kf-social {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .kf-social-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    color: var(--sl-color-gray-2);
+    background: var(--sl-color-accent-low);
+    border: 1px solid var(--sl-color-border);
+    border-radius: 0.375rem;
+    transition: all 0.2s ease;
+  }
+
+  .kf-social-link:hover {
+    color: var(--sl-color-accent);
+    border-color: var(--sl-color-accent);
+    transform: translateY(-2px);
+  }
+
+  .kf-social-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .kf-nav-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--sl-color-accent);
+    margin-bottom: 1rem;
+  }
+
+  .kf-nav-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .kf-nav-link {
+    font-size: 0.875rem;
+    color: var(--sl-color-gray-2);
+    text-decoration: none;
+    transition: color 0.2s ease;
+    display: inline-block;
+  }
+
+  .kf-nav-link:hover {
+    color: var(--sl-color-accent);
+  }
+
+  .kf-bottom {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--sl-color-border);
+  }
+
+  .kf-bottom-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    .kf-bottom-content {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
+
+  .kf-copyright {
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+    margin: 0;
+  }
+
+  .kf-legal {
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .kf-legal-link {
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .kf-legal-link:hover {
+    color: var(--sl-color-accent);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add custom branded footer sections to astro-irc, astro-memes, astro-discordsh, and astro-herbmail
- Each footer renders below the default Starlight footer, preserving built-in prev/next links, edit link, etc.
- discordsh uses the old discord.sh style (4-column grid with Product/Resources/Legal columns)
- irc, memes, herbmail use hexgrid animation style with brand + resources layout
- All footers include social links, resource links, legal links, and dynamic copyright year
- Scoped CSS using Starlight theme variables for light/dark mode compatibility

## Test plan
- [x] `pnpm nx build astro-irc` passes
- [x] `pnpm nx build astro-memes` passes
- [x] `pnpm nx build astro-discordsh` passes
- [x] `pnpm nx build astro-herbmail` passes