### PR TITLE
fix(kube): resolve irc ArgoCD sync loop and cert consolidation

### DIFF
--- a/apps/kube/irc/application.yaml
+++ b/apps/kube/irc/application.yaml
@@ -12,6 +12,22 @@ spec:
     destination:
         server: https://kubernetes.default.svc
         namespace: irc
+    ignoreDifferences:
+        - group: cert-manager.io
+          kind: Certificate
+          jsonPointers:
+              - /status
+        - group: networking.k8s.io
+          kind: Ingress
+          jsonPointers:
+              - /status
+              - /metadata/annotations/cert-manager.io~1issuer-name
+              - /metadata/annotations/cert-manager.io~1issuer-kind
+              - /metadata/annotations/cert-manager.io~1issuer-group
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jsonPointers:
+              - /status
     syncPolicy:
         automated:
             selfHeal: true

--- a/apps/kube/irc/manifests/ergo-deployment.yaml
+++ b/apps/kube/irc/manifests/ergo-deployment.yaml
@@ -73,3 +73,4 @@ spec:
                 - name: tls-certs
                   secret:
                       secretName: ergo-irc-tls-secret
+                      optional: true

--- a/apps/kube/irc/manifests/irc-domain-redirect.yaml
+++ b/apps/kube/irc/manifests/irc-domain-redirect.yaml
@@ -4,14 +4,13 @@ metadata:
     name: irc-domain-redirect
     namespace: irc
     annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-dns
         nginx.ingress.kubernetes.io/permanent-redirect: "https://chat.kbve.com$request_uri"
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
               - irc.kbve.com
-          secretName: irc-domain-redirect-tls-secret
+          secretName: ergo-irc-tls-secret
     rules:
         - host: irc.kbve.com
           http:


### PR DESCRIPTION
## Summary
- **Removed `cert-manager.io/cluster-issuer` annotation** from the `irc-domain-redirect` ingress — cert-manager was modifying the Ingress resource (adding tracking annotations), causing ArgoCD to detect drift and re-sync in a loop
- **Consolidated to one certificate** — both the redirect ingress and ergo deployment now share `ergo-irc-tls-secret` instead of maintaining two separate certs for `irc.kbve.com`
- **Added `ignoreDifferences`** to the ArgoCD Application for Certificate status, Ingress status/annotations, and ExternalSecret status (matching patterns used by ingress-nginx, kilobase, and argocd apps in this repo)
- **Made ergo TLS volume optional** — the pod can start while cert-manager issues the certificate, preventing a deployment deadlock

## Test plan
- [ ] Verify ArgoCD sync loop stops after merge to main
- [ ] Confirm `ergo-irc-tls` Certificate reaches Ready=True (`kubectl get certificate -n irc`)
- [ ] Verify `https://irc.kbve.com` serves valid cert and returns 301 to `https://chat.kbve.com`
- [ ] Check ergo pod starts and IRC TLS works on port 6697

🤖 Generated with [Claude Code](https://claude.com/claude-code)