### PR TITLE
fix(discordsh): remove ghcr tag from local Docker build config

### DIFF
--- a/apps/discordsh/axum-discordsh/project.json
+++ b/apps/discordsh/axum-discordsh/project.json
@@ -87,7 +87,7 @@
         "local": {
           "commands": [
             "./kbve.sh -nx axum-discordsh:containerx",
-            "VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && docker tag ghcr.io/kbve/discordsh:latest ghcr.io/kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION\""
+            "VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION\""
           ]
         },
         "production": {


### PR DESCRIPTION
## Summary
- Removes the `ghcr.io/kbve/discordsh` tag from the local Docker build configuration in `project.json`
- Local builds only create `kbve/discordsh:latest`, so attempting to tag the non-existent `ghcr.io/kbve/discordsh:latest` caused build failures
- Aligns with the pattern used by memes and irc-gateway projects

## Test plan
- [ ] Run `nx container axum-discordsh` locally and verify it completes without errors
- [ ] Verify production config still tags both Docker Hub and GHCR