### PR TITLE
fix(kube): update discordsh image to ghcr.io/kbve/discordsh:0.1.2

### DIFF
--- a/apps/kube/discordsh/manifest/deployment.yaml
+++ b/apps/kube/discordsh/manifest/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: discordsh-sa
       containers:
       - name: discordsh
-        image: kbve/discordsh:0.1.0
+        image: ghcr.io/kbve/discordsh:0.1.2
         imagePullPolicy: Always
         ports:
         - name: http


### PR DESCRIPTION
## Summary
- Updates discordsh deployment manifest image from `kbve/discordsh:0.1.0` (Docker Hub) to `ghcr.io/kbve/discordsh:0.1.2` (GHCR)
- Fixes the kube manifest update workflow failing with "nothing to commit" because the sed command was looking for `ghcr.io/kbve/discordsh:` but the manifest had `kbve/discordsh:`
- Aligns with the GHCR convention used by herbmail, memes, and irc-gateway
- Once merged to main, ArgoCD will deploy v0.1.2

## Test plan
- [ ] Verify kube update workflow will match `ghcr.io/kbve/discordsh:` going forward
- [ ] Verify ArgoCD syncs and deploys v0.1.2 after merge to main