### PR TITLE
chore(discordsh): bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "askama 0.15.4",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps discordsh version from 0.1.2 to 0.1.3
- Updates Cargo.lock accordingly
- Triggers CI pipeline to build and publish `ghcr.io/kbve/discordsh:0.1.3` to GHCR

## Context
The `ghcr.io/kbve/discordsh` package never existed on GHCR because the CI file alteration output was previously broken. Now that the output mapping and kube manifest are fixed, this version bump will trigger the full pipeline: build, publish, and kube manifest update.

## Test plan
- [ ] CI builds the Docker image successfully
- [ ] Image is published to GHCR as `ghcr.io/kbve/discordsh:0.1.3`
- [ ] Kube manifest update PR is created automatically
- [ ] ArgoCD deploys v0.1.3