### PR TITLE
chore(deps): create dependabot labels and add security/update tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       labels:
           - dependencies
           - npm
+          - security
+          - update
 
     - package-ecosystem: pip
       directory: /
@@ -22,6 +24,8 @@ updates:
       labels:
           - dependencies
           - python
+          - security
+          - update
 
     - package-ecosystem: cargo
       directory: /
@@ -33,6 +37,8 @@ updates:
       labels:
           - dependencies
           - rust
+          - security
+          - update
 
     - package-ecosystem: github-actions
       directory: /
@@ -44,6 +50,8 @@ updates:
       labels:
           - dependencies
           - ci
+          - security
+          - update
 
     - package-ecosystem: docker
       directory: /
@@ -54,3 +62,5 @@ updates:
       labels:
           - dependencies
           - docker
+          - security
+          - update


### PR DESCRIPTION
## Summary
- Created missing GitHub labels required by dependabot: `dependencies`, `rust`, `npm`, `python`, `ci`, `docker`
- Added `security` and `update` labels to all dependabot ecosystem entries in `dependabot.yml`

## Test plan
- [ ] Verify all labels exist on the repo via `gh label list`
- [ ] Confirm Dependabot no longer reports missing label errors
- [ ] Check that new Dependabot PRs are tagged with security and update labels