### PR TITLE
chore(discordsh): bump version from 0.1.5 to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump `axum-discordsh` version from 0.1.5 to 0.1.6 (patch release)

## Test plan
- [x] Unit tests pass (9/9)
- [ ] CI/CD pipeline: dev → staging → main → Docker build + k8s manifest update