### PR TITLE
fix(irc): switch irc.kbve.com to HTTP01 cert to fix SSL redirect

### DIFF
--- a/apps/kube/irc/manifests/irc-domain-redirect.yaml
+++ b/apps/kube/irc/manifests/irc-domain-redirect.yaml
@@ -4,13 +4,14 @@ metadata:
     name: irc-domain-redirect
     namespace: irc
     annotations:
-        nginx.ingress.kubernetes.io/permanent-redirect: "https://chat.kbve.com$request_uri"
+        cert-manager.io/cluster-issuer: letsencrypt-http
+        nginx.ingress.kubernetes.io/permanent-redirect: 'https://chat.kbve.com$request_uri'
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
               - irc.kbve.com
-          secretName: ergo-irc-tls-secret
+          secretName: irc-redirect-tls-secret
     rules:
         - host: irc.kbve.com
           http:


### PR DESCRIPTION
## Summary
- Switch `irc.kbve.com` redirect ingress from DNS01 (Cloudflare) to HTTP01 cert-manager issuer
- Use a fresh TLS secret (`irc-redirect-tls-secret`) so cert-manager provisions a new cert
- This matches the working pattern used by `chat.kbve.com`

## Problem
`irc.kbve.com` was throwing SSL certificate errors, preventing the 301 redirect to `chat.kbve.com`. The DNS01 challenge via Cloudflare (`letsencrypt-dns`) was not issuing the cert successfully.

## Test plan
- [ ] After merge and ArgoCD sync, verify `curl -I https://irc.kbve.com` returns 301 to `https://chat.kbve.com`
- [ ] Verify no SSL errors in browser when visiting `irc.kbve.com`