### PR TITLE
fix(kube): bind redis RBAC to discordsh-external-secrets SA

### DIFF
--- a/apps/kube/discordsh/manifest/rbac.yaml
+++ b/apps/kube/discordsh/manifest/rbac.yaml
@@ -1,81 +1,81 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: discordsh-sa
-  namespace: discordsh
+    name: discordsh-sa
+    namespace: discordsh
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: discordsh-redis-access
-  namespace: redis
+    name: discordsh-redis-access
+    namespace: redis
 rules:
-- apiGroups: [""]
-  resources: ["services", "endpoints"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["redis-auth"]
-  verbs: ["get"]
+    - apiGroups: ['']
+      resources: ['services', 'endpoints']
+      verbs: ['get', 'list']
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['redis-auth']
+      verbs: ['get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: discordsh-redis-access-binding
-  namespace: redis
+    name: discordsh-redis-access-binding
+    namespace: redis
 roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: discordsh-redis-access
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: discordsh-redis-access
 subjects:
-- kind: ServiceAccount
-  name: discordsh-sa
-  namespace: discordsh
+    - kind: ServiceAccount
+      name: discordsh-external-secrets
+      namespace: discordsh
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: discordsh-supabase-access
-  namespace: kilobase
+    name: discordsh-supabase-access
+    namespace: kilobase
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["supabase-jwt"]
-  verbs: ["get"]
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-jwt']
+      verbs: ['get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: discordsh-supabase-access-binding
-  namespace: kilobase
+    name: discordsh-supabase-access-binding
+    namespace: kilobase
 roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: discordsh-supabase-access
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: discordsh-supabase-access
 subjects:
-- kind: ServiceAccount
-  name: discordsh-external-secrets
-  namespace: discordsh
+    - kind: ServiceAccount
+      name: discordsh-external-secrets
+      namespace: discordsh
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-discordsh-to-redis
-  namespace: redis
+    name: allow-discordsh-to-redis
+    namespace: redis
 spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: redis
-  policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - namespaceSelector:
+    podSelector:
         matchLabels:
-          name: discordsh
-    - podSelector:
-        matchLabels:
-          app: discordsh
-    ports:
-    - protocol: TCP
-      port: 6379
+            app.kubernetes.io/name: redis
+    policyTypes:
+        - Ingress
+    ingress:
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        name: discordsh
+              - podSelector:
+                    matchLabels:
+                        app: discordsh
+          ports:
+              - protocol: TCP
+                port: 6379


### PR DESCRIPTION
## Summary
- Fix discordsh Redis RBAC RoleBinding: was granting `discordsh-sa` access to `redis-auth` secret, but the ExternalSecret operator uses `discordsh-external-secrets` service account
- This caused ESO to fail with "client is not allowed to get secrets", preventing `discordsh-redis-secret` from syncing

## Root Cause
The `discordsh-redis-access-binding` RoleBinding in the `redis` namespace bound the role to `discordsh-sa` instead of `discordsh-external-secrets`. The Supabase RoleBinding was correctly configured — this was just missed for Redis.

## Test plan
- [ ] Verify ArgoCD syncs the updated RBAC
- [ ] Confirm ExternalSecret `discordsh-redis-secrets` transitions to `SecretSynced`
- [ ] Confirm `discordsh-redis-secret` is created in `discordsh` namespace
- [ ] Verify discordsh pods start without "secret not found" error