### PR TITLE
chore(deps): bump tower 0.5.3 and tower-http 0.6.8

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 thiserror = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tower = { version = "0.5.2", features = ["util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.6.1", features = [
+tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.6.8", features = [
     "compression-full",
     "limit",
     "trace",

--- a/apps/herbmail/axum-herbmail/Cargo.toml
+++ b/apps/herbmail/axum-herbmail/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 thiserror = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tower = { version = "0.5.2", features = ["util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.6.1", features = [
+tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.6.8", features = [
     "compression-full",
     "limit",
     "trace",

--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 thiserror = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tower = { version = "0.5.2", features = ["util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.6.1", features = ["compression-full", "limit", "trace", "cors", "set-header", "fs"] }
+tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.6.8", features = ["compression-full", "limit", "trace", "cors", "set-header", "fs"] }
 tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/apps/memes/axum-memes/Cargo.toml
+++ b/apps/memes/axum-memes/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 thiserror = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tower = { version = "0.5.2", features = ["util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.6.1", features = [
+tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.6.8", features = [
     "compression-full",
     "limit",
     "trace",

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -28,8 +28,8 @@ ammonia = "4.0.0"
 bitflags = { version = "2.9.0", features = ["serde"] }
 thiserror = "2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tower = { version = "0.5.2", features = ["util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.6.1", features = [
+tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.6.8", features = [
     "add-extension",
     "auth",
     "compression-full",

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -42,8 +42,8 @@ reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
-tower = { version = "0.5.2", features = ["timeout"] }
-tower-http = { version = "0.6.1", features = ["cors"] }
+tower = { version = "0.5.3", features = ["timeout"] }
+tower-http = { version = "0.6.8", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 r2d2 = "0.8.9"


### PR DESCRIPTION
## Summary
- Bumps `tower` from 0.5.2 to 0.5.3 and `tower-http` from 0.6.1 to 0.6.8 across all 6 workspace crates that use them
- Updated crates: `kbve`, `jedi`, `axum-discordsh`, `axum-herbmail`, `axum-memes`, `irc-gateway`
- All updated crates pass `cargo check` successfully