### PR TITLE
fix(deps): bump ammonia 4.0.0 to 4.1.2 (RUSTSEC-2025-0071)

### DIFF
--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -24,7 +24,7 @@ dashmap = { version = "6.1.0", features = ["serde", "rayon"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = { version = "1", features = ["serde"] }
-ammonia = "4.0.0"
+ammonia = "4.1.2"
 bitflags = { version = "2.9.0", features = ["serde"] }
 thiserror = "2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -16,7 +16,7 @@ supabase = []
 
 [dependencies]
 anyhow = "1.0"
-ammonia = "4.0.0"
+ammonia = "4.1.2"
 argon2 = "0.5.0"
 askama = "0.15.4"
 async-trait = "0.1.74"


### PR DESCRIPTION
## Summary
- Bumps `ammonia` from 4.0.0 to 4.1.2 to address RUSTSEC-2025-0071 security advisory
- Updated in both crates that reference it: `kbve` and `jedi`
- Both crates pass `cargo check` successfully