### PR TITLE
fix(ci): prevent duplicate PR creation in dev/staging workflows

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -98,7 +98,7 @@ jobs:
               if: fromJson(steps.check_changes.outputs.result).hasChanges == false
               run: |
                   echo "Dev to Staging PR Status: NOT NEEDED"
-                  
+
                   if [[ "${{ fromJson(steps.check_changes.outputs.result).stagingAhead }}" == "true" ]]; then
                       echo "Staging is ${{ fromJson(steps.check_changes.outputs.result).stagingAheadBy }} commits ahead of dev"
                       echo "This is normal after a release - staging contains the latest tested code"
@@ -107,7 +107,7 @@ jobs:
                       echo "Dev and staging are synchronized"
                       echo "No new atomic commits to promote yet"
                   fi
-                  
+
                   echo ""
                   echo "This is a normal state that indicates:"
                   echo "- No new atomic commits have been merged to dev since last promotion"
@@ -151,7 +151,7 @@ jobs:
                       const path = require('path');
                       const utils = await import(path.resolve('.github/scripts/commit-utils.mjs'));
 
-                      const checkResult = ${{ toJson(steps.check_pr.outputs.result) }};
+                      const checkResult = ${{ steps.check_pr.outputs.result || 'null' }};
 
                       // Get commits between staging and dev
                       const comparison = await github.rest.repos.compareCommits({

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -25,7 +25,7 @@ jobs:
             contents: read
             pull-requests: write
             issues: write
-        
+
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -125,7 +125,7 @@ jobs:
                       const path = require('path');
                       const utils = await import(path.resolve('.github/scripts/commit-utils.mjs'));
 
-                      const checkResult = ${{ toJson(steps.check_pr.outputs.result) }};
+                      const checkResult = ${{ steps.check_pr.outputs.result || 'null' }};
 
                       // Get commits between main and staging
                       const comparison = await github.rest.repos.compareCommits({


### PR DESCRIPTION
## Summary

- **Root cause**: `toJson()` double-encodes the `github-script` output in both `ci-dev.yml` and `ci-staging.yml`. The returned object (e.g. `{"exists":true,"number":123}`) is already a JSON string — wrapping it in `toJson()` turns it into a quoted string literal (`"{\"exists\":true,...}"`), so `checkResult.exists` is always `undefined`.
- **Effect**: The workflow always falls through to `pulls.create`, which fails with `"A pull request already exists for KBVE:dev"` when a PR is already open.
- **Fix**: Replace `${{ toJson(steps.check_pr.outputs.result) }}` with `${{ steps.check_pr.outputs.result || 'null' }}` so `checkResult` is a proper JS object (or `null` when the step has no output).

## Files changed

- `.github/workflows/ci-dev.yml` — fix dev→staging PR upsert
- `.github/workflows/ci-staging.yml` — fix staging→main PR upsert (same bug)

## Test plan

- [ ] Push to `dev` when no open dev→staging PR exists — should create one
- [ ] Push to `dev` when an open dev→staging PR exists — should update title/body without error
- [ ] Same for staging→main flow