### PR TITLE
fix(deps): bump diesel from 2.0.0 to 2.3.6 (RUSTSEC advisory)

### DIFF
--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -21,7 +21,7 @@ argon2 = "0.5.0"
 askama = "0.15.4"
 async-trait = "0.1.74"
 chrono = { version = "0.4.24", features = ["serde"] }
-diesel = { version = "2.0.0", features = [
+diesel = { version = "2.3.6", features = [
     "postgres",
     "chrono",
     "r2d2",


### PR DESCRIPTION
## Summary
- Bumps `diesel` from 2.0.0 to 2.3.6 to address Rust security advisory
- Only the `kbve` crate references diesel directly
- Passes `cargo check` successfully