### PR TITLE
chore(deps): remove unused sonner package

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
 		"rehype-mermaid": "^3.0.0",
 		"rollup-plugin-copy": "^3.5.0",
 		"shiki": "^1.22.0",
-		"sonner": "^1.7.0",
 		"styled-components": "5.3.6",
 		"tailwind-merge": "^2.5.4",
 		"tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
             shiki:
                 specifier: ^1.22.0
                 version: 1.29.2
-            sonner:
-                specifier: ^1.7.0
-                version: 1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
             styled-components:
                 specifier: 5.3.6
                 version: 5.3.6(@babel/core@7.26.10)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)
@@ -23219,15 +23216,6 @@ packages:
                 integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==,
             }
 
-    sonner@1.7.4:
-        resolution:
-            {
-                integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==,
-            }
-        peerDependencies:
-            react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-            react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-
     sort-keys-length@1.0.1:
         resolution:
             {
@@ -44098,11 +44086,6 @@ snapshots:
     sonic-boom@4.2.0:
         dependencies:
             atomic-sleep: 1.0.0
-
-    sonner@1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-        dependencies:
-            react: 19.2.4
-            react-dom: 19.2.4(react@19.2.4)
 
     sort-keys-length@1.0.1:
         dependencies:


### PR DESCRIPTION
## Summary

- Remove `sonner` (`^1.7.0`) from root `package.json` — it was added in Nov 2024 during shadcn-ui testing but is never imported or used anywhere in the codebase
- Zero import statements, zero `<Toaster />` components, zero `toast()` calls found across all source files
- Reduces install size and dependency surface

## Test plan

- [ ] `pnpm install` succeeds
- [ ] No build regressions (sonner was never imported)