### PR TITLE
chore(deps): bump time 0.3.47 and jsonwebtoken 10.3.0

### DIFF
--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -21,7 +21,7 @@ socket2 = "0.6.1"
 num_cpus = "1.17.0"
 dotenvy = "0.15"
 tokio-tungstenite = "0.26"
-jsonwebtoken = "9"
+jsonwebtoken = "10.3.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 
 # Workspace path dependencies

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -33,11 +33,11 @@ axum-extra = { version = "0.12.1", features = ["cookie"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dashmap = { version = "6.1.0", features = ["serde"] }
-jsonwebtoken = "8.3.0"
+jsonwebtoken = "10.3.0"
 rand_core = { version = "0.6.4", features = ["std"] }
 tokio = { version = "1.0", features = ["full"] }
 thiserror = "2"
-time = "0.3.36"
+time = "0.3.47"
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",


### PR DESCRIPTION
## Summary
- Bumps `time` from 0.3.36 to 0.3.47 in `kbve` crate
- Bumps `jsonwebtoken` from 8.3.0 to 10.3.0 in `kbve` crate and from 9 to 10.3.0 in `irc-gateway`
- Both crates pass `cargo check` successfully