### PR TITLE
fix(droid): resolve all lint errors in droid package

### DIFF
--- a/packages/npm/droid/.eslintrc.json
+++ b/packages/npm/droid/.eslintrc.json
@@ -27,7 +27,13 @@
 					{
 						"ignoredFiles": [
 							"{projectRoot}/eslint.config.{js,cjs,mjs}",
-							"{projectRoot}/vite.config.{js,ts,mjs,mts}"
+							"{projectRoot}/vite.config.{js,ts,mjs,mts}",
+							"{projectRoot}/src/setup-vitest.ts",
+							"{projectRoot}/src/**/*.spec.ts"
+						],
+						"ignoredDependencies": [
+							"@vitest/web-worker",
+							"fake-indexeddb"
 						]
 					}
 				]

--- a/packages/npm/droid/package.json
+++ b/packages/npm/droid/package.json
@@ -1,71 +1,69 @@
 {
-  "name": "@kbve/droid",
-  "version": "0.1.0",
-  "description": "A manager for web, shared and service workers, aimming to make it as modular and upgradable.",
-  "keywords": [
-    "workers",
-    "management"
-  ],
-  "homepage": "https://kbve.com/application/javascript/",
-  "bugs": {
-    "url": "https://github.com/KBVE/kbve/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/KBVE/kbve.git"
-  },
-  "author": "KBVE <hello@kbve.com>",
-  "license": "MIT",
-  "type": "module",
-  "main": "./droid.mjs",
-  "module": "./droid.mjs",
-  "types": "./index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./droid.mjs",
-      "require": "./droid.mjs"
-    },
-    "./lib/workers/canvas-worker": "./lib/workers/canvas-worker.js",
-    "./lib/workers/db-worker": "./lib/workers/db-worker.js",
-    "./lib/workers/ws-worker": "./lib/workers/ws-worker.js",
-    "./lib/workers/supabase-shared-worker": "./lib/workers/supabase-shared-worker.js",
-    "./lib/workers/supabase-db-worker": "./lib/workers/supabase-db-worker.js"
-  },
-  "files": [
-    "workers/",
-    "lib/workers/",
-    "lib/gateway/",
-    "assets/",
-    "src/",
-    "comlink*.js",
-    "reference*.js",
-    "droid.mjs",
-    "main.js",
-    "index.js",
-    "index.d.ts",
-    "*.md",
-    "LICENSE",
-    "*.json"
-  ],
-  "dependencies": {
-    "tslib": "^2.3.0",
-    "comlink": "^4.3.1",
-    "nanostores": "^0.9.5",
-    "@nanostores/persistent": "^0.9.1",
-    "dexie": "^4.0.9",
-    "zod": "^3.23.8",
-    "flatbuffers": "^25.9.23",
-    "@bufbuild/protobuf": "^2.5.2"
-  },
-  "peerDependencies": {
-    "@supabase/supabase-js": "^2.95.3"
-  },
-  "peerDependenciesMeta": {
-    "@supabase/supabase-js": {
-      "optional": true
-    }
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@kbve/droid",
+	"version": "0.1.0",
+	"description": "A manager for web, shared and service workers, aimming to make it as modular and upgradable.",
+	"keywords": [
+		"workers",
+		"management"
+	],
+	"homepage": "https://kbve.com/application/javascript/",
+	"bugs": {
+		"url": "https://github.com/KBVE/kbve/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/KBVE/kbve.git"
+	},
+	"author": "KBVE <hello@kbve.com>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./droid.mjs",
+	"module": "./droid.mjs",
+	"types": "./index.d.ts",
+	"exports": {
+		".": {
+			"import": "./droid.mjs",
+			"require": "./droid.mjs"
+		},
+		"./lib/workers/canvas-worker": "./lib/workers/canvas-worker.js",
+		"./lib/workers/db-worker": "./lib/workers/db-worker.js",
+		"./lib/workers/ws-worker": "./lib/workers/ws-worker.js",
+		"./lib/workers/supabase-shared-worker": "./lib/workers/supabase-shared-worker.js",
+		"./lib/workers/supabase-db-worker": "./lib/workers/supabase-db-worker.js"
+	},
+	"files": [
+		"workers/",
+		"lib/workers/",
+		"lib/gateway/",
+		"assets/",
+		"src/",
+		"comlink*.js",
+		"reference*.js",
+		"droid.mjs",
+		"main.js",
+		"index.js",
+		"index.d.ts",
+		"*.md",
+		"LICENSE",
+		"*.json"
+	],
+	"dependencies": {
+		"comlink": "^4.3.1",
+		"nanostores": "^1.1.0",
+		"@nanostores/persistent": "^1.3.3",
+		"dexie": "^4.0.9",
+		"zod": "^3.23.8",
+		"flatbuffers": "^25.2.10"
+	},
+	"peerDependencies": {
+		"@supabase/supabase-js": "^2.95.3"
+	},
+	"peerDependenciesMeta": {
+		"@supabase/supabase-js": {
+			"optional": true
+		}
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/npm/droid/src/lib/gateway/WorkerPool.ts
+++ b/packages/npm/droid/src/lib/gateway/WorkerPool.ts
@@ -3,8 +3,8 @@
 import type { WorkerMessage, WorkerResponse } from './types';
 
 export interface WorkerPoolConfig {
-  size: number;
-  workerUrl: string | URL;
+	size: number;
+	workerUrl: string | URL;
 }
 
 /**
@@ -17,237 +17,288 @@ export interface WorkerPoolConfig {
  * - Automatic error handling with exponential backoff retries
  */
 export class WorkerPool {
-  private workers: Worker[] = [];
-  private poolSize: number;
-  private roundRobinIndex = 0;
-  private pending = new Map<string, { resolve: Function; reject: Function; workerId: number }>();
-  private workerUrl: string | URL;
-  private workerRetryCount = new Map<number, number>();
-  private workerRetryTimers = new Map<number, ReturnType<typeof setTimeout>>();
+	private workers: Worker[] = [];
+	private poolSize: number;
+	private roundRobinIndex = 0;
+	private pending = new Map<
+		string,
+		{
+			resolve: (value: unknown) => void;
+			reject: (reason?: unknown) => void;
+			workerId: number;
+		}
+	>();
+	private workerUrl: string | URL;
+	private workerRetryCount = new Map<number, number>();
+	private workerRetryTimers = new Map<
+		number,
+		ReturnType<typeof setTimeout>
+	>();
 
-  private readonly MAX_RETRY_ATTEMPTS = 3;
-  private readonly BASE_RETRY_DELAY_MS = 1000;
-  private readonly MAX_RETRY_DELAY_MS = 8000;
-  private readonly REQUEST_TIMEOUT_MS = 30000;
+	private readonly MAX_RETRY_ATTEMPTS = 3;
+	private readonly BASE_RETRY_DELAY_MS = 1000;
+	private readonly MAX_RETRY_DELAY_MS = 8000;
+	private readonly REQUEST_TIMEOUT_MS = 30000;
 
-  constructor(config: WorkerPoolConfig) {
-    this.poolSize = config.size;
-    this.workerUrl = config.workerUrl;
-  }
+	constructor(config: WorkerPoolConfig) {
+		this.poolSize = config.size;
+		this.workerUrl = config.workerUrl;
+	}
 
-  /**
-   * Initialize the worker pool
-   */
-  async init(): Promise<void> {
-    console.log(`[WorkerPool] Initializing pool with ${this.poolSize} workers`);
+	/**
+	 * Initialize the worker pool
+	 */
+	async init(): Promise<void> {
+		console.log(
+			`[WorkerPool] Initializing pool with ${this.poolSize} workers`,
+		);
 
-    for (let i = 0; i < this.poolSize; i++) {
-      try {
-        const worker = new Worker(
-          this.workerUrl,
-          { type: 'module', name: `db-worker-${i}` }
-        );
+		for (let i = 0; i < this.poolSize; i++) {
+			try {
+				const worker = new Worker(this.workerUrl, {
+					type: 'module',
+					name: `db-worker-${i}`,
+				});
 
-        worker.onmessage = (e: MessageEvent) => this.handleMessage(e.data, i);
-        worker.onerror = (err) => this.handleError(err, i);
+				worker.onmessage = (e: MessageEvent) =>
+					this.handleMessage(e.data, i);
+				worker.onerror = (err) => this.handleError(err, i);
 
-        this.workers.push(worker);
-        console.log(`[WorkerPool] Worker ${i} initialized`);
-      } catch (err) {
-        console.error(`[WorkerPool] Failed to create worker ${i}:`, err);
-        throw err;
-      }
-    }
+				this.workers.push(worker);
+				console.log(`[WorkerPool] Worker ${i} initialized`);
+			} catch (err) {
+				console.error(
+					`[WorkerPool] Failed to create worker ${i}:`,
+					err,
+				);
+				throw err;
+			}
+		}
 
-    // Wait for all workers to be ready
-    await Promise.all(
-      this.workers.map((_worker, i) =>
-        this.sendToWorker(i, { id: crypto.randomUUID(), type: 'ping', payload: {} })
-      )
-    );
+		// Wait for all workers to be ready
+		await Promise.all(
+			this.workers.map((_worker, i) =>
+				this.sendToWorker(i, {
+					id: crypto.randomUUID(),
+					type: 'ping',
+					payload: {},
+				}),
+			),
+		);
 
-    console.log('[WorkerPool] All workers ready');
-  }
+		console.log('[WorkerPool] All workers ready');
+	}
 
-  private getNextWorker(): number {
-    const workerId = this.roundRobinIndex;
-    this.roundRobinIndex = (this.roundRobinIndex + 1) % this.poolSize;
-    return workerId;
-  }
+	private getNextWorker(): number {
+		const workerId = this.roundRobinIndex;
+		this.roundRobinIndex = (this.roundRobinIndex + 1) % this.poolSize;
+		return workerId;
+	}
 
-  private sendToWorker<T>(workerId: number, message: WorkerMessage): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      const worker = this.workers[workerId];
-      if (!worker) {
-        return reject(new Error(`Worker ${workerId} not available`));
-      }
+	private sendToWorker<T>(
+		workerId: number,
+		message: WorkerMessage,
+	): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			const worker = this.workers[workerId];
+			if (!worker) {
+				return reject(new Error(`Worker ${workerId} not available`));
+			}
 
-      const timer = setTimeout(() => {
-        if (this.pending.has(message.id)) {
-          this.pending.delete(message.id);
-          reject(new Error(`Worker ${workerId} request ${message.type} timed out after ${this.REQUEST_TIMEOUT_MS}ms`));
-        }
-      }, this.REQUEST_TIMEOUT_MS);
+			const timer = setTimeout(() => {
+				if (this.pending.has(message.id)) {
+					this.pending.delete(message.id);
+					reject(
+						new Error(
+							`Worker ${workerId} request ${message.type} timed out after ${this.REQUEST_TIMEOUT_MS}ms`,
+						),
+					);
+				}
+			}, this.REQUEST_TIMEOUT_MS);
 
-      this.pending.set(message.id, {
-        resolve: (value: unknown) => { clearTimeout(timer); resolve(value as T); },
-        reject: (err: unknown) => { clearTimeout(timer); reject(err); },
-        workerId,
-      });
+			this.pending.set(message.id, {
+				resolve: (value: unknown) => {
+					clearTimeout(timer);
+					resolve(value as T);
+				},
+				reject: (err: unknown) => {
+					clearTimeout(timer);
+					reject(err);
+				},
+				workerId,
+			});
 
-      try {
-        worker.postMessage(message);
-      } catch (err) {
-        clearTimeout(timer);
-        this.pending.delete(message.id);
-        reject(err);
-      }
-    });
-  }
+			try {
+				worker.postMessage(message);
+			} catch (err) {
+				clearTimeout(timer);
+				this.pending.delete(message.id);
+				reject(err);
+			}
+		});
+	}
 
-  /**
-   * Send message to next available worker (round-robin)
-   */
-  send<T>(type: string, payload?: any): Promise<T> {
-    const workerId = this.getNextWorker();
-    const id = crypto.randomUUID();
-    const message: WorkerMessage = { id, type, payload };
+	/**
+	 * Send message to next available worker (round-robin)
+	 */
+	send<T>(type: string, payload?: any): Promise<T> {
+		const workerId = this.getNextWorker();
+		const id = crypto.randomUUID();
+		const message: WorkerMessage = { id, type, payload };
 
-    return this.sendToWorker<T>(workerId, message);
-  }
+		return this.sendToWorker<T>(workerId, message);
+	}
 
-  private handleMessage(response: WorkerResponse, workerId: number) {
-    const { id, ok, data, error } = response;
+	private handleMessage(response: WorkerResponse, workerId: number) {
+		const { id, ok, data, error } = response;
 
-    if (!id) {
-      console.warn(`[WorkerPool] Worker ${workerId} sent message without ID:`, response);
-      return;
-    }
+		if (!id) {
+			console.warn(
+				`[WorkerPool] Worker ${workerId} sent message without ID:`,
+				response,
+			);
+			return;
+		}
 
-    const pending = this.pending.get(id);
-    if (!pending) {
-      console.warn(`[WorkerPool] Received response for unknown request ${id}`);
-      return;
-    }
+		const pending = this.pending.get(id);
+		if (!pending) {
+			console.warn(
+				`[WorkerPool] Received response for unknown request ${id}`,
+			);
+			return;
+		}
 
-    this.pending.delete(id);
+		this.pending.delete(id);
 
-    if (ok) {
-      pending.resolve(data);
-    } else {
-      pending.reject(new Error(error || 'Worker request failed'));
-    }
-  }
+		if (ok) {
+			pending.resolve(data);
+		} else {
+			pending.reject(new Error(error || 'Worker request failed'));
+		}
+	}
 
-  private handleError(error: ErrorEvent, workerId: number) {
-    console.error(`[WorkerPool] Worker ${workerId} error:`, error);
+	private handleError(error: ErrorEvent, workerId: number) {
+		console.error(`[WorkerPool] Worker ${workerId} error:`, error);
 
-    const failedRequests: string[] = [];
-    for (const [id, pending] of this.pending.entries()) {
-      if (pending.workerId === workerId) {
-        pending.reject(new Error(`Worker ${workerId} crashed: ${error.message}`));
-        failedRequests.push(id);
-      }
-    }
+		const failedRequests: string[] = [];
+		for (const [id, pending] of this.pending.entries()) {
+			if (pending.workerId === workerId) {
+				pending.reject(
+					new Error(`Worker ${workerId} crashed: ${error.message}`),
+				);
+				failedRequests.push(id);
+			}
+		}
 
-    failedRequests.forEach(id => this.pending.delete(id));
+		failedRequests.forEach((id) => this.pending.delete(id));
 
-    this.scheduleWorkerRecreation(workerId);
-  }
+		this.scheduleWorkerRecreation(workerId);
+	}
 
-  private scheduleWorkerRecreation(workerId: number) {
-    const retryCount = this.workerRetryCount.get(workerId) || 0;
+	private scheduleWorkerRecreation(workerId: number) {
+		const retryCount = this.workerRetryCount.get(workerId) || 0;
 
-    if (retryCount >= this.MAX_RETRY_ATTEMPTS) {
-      console.error(
-        `[WorkerPool] Worker ${workerId} has failed ${retryCount} times. Giving up.`
-      );
-      this.workerRetryCount.delete(workerId);
-      return;
-    }
+		if (retryCount >= this.MAX_RETRY_ATTEMPTS) {
+			console.error(
+				`[WorkerPool] Worker ${workerId} has failed ${retryCount} times. Giving up.`,
+			);
+			this.workerRetryCount.delete(workerId);
+			return;
+		}
 
-    const delay = Math.min(
-      this.BASE_RETRY_DELAY_MS * Math.pow(2, retryCount),
-      this.MAX_RETRY_DELAY_MS
-    );
+		const delay = Math.min(
+			this.BASE_RETRY_DELAY_MS * Math.pow(2, retryCount),
+			this.MAX_RETRY_DELAY_MS,
+		);
 
-    console.log(
-      `[WorkerPool] Scheduling worker ${workerId} recreation in ${delay}ms (attempt ${retryCount + 1}/${this.MAX_RETRY_ATTEMPTS})`
-    );
+		console.log(
+			`[WorkerPool] Scheduling worker ${workerId} recreation in ${delay}ms (attempt ${retryCount + 1}/${this.MAX_RETRY_ATTEMPTS})`,
+		);
 
-    const existingTimer = this.workerRetryTimers.get(workerId);
-    if (existingTimer) {
-      clearTimeout(existingTimer);
-    }
+		const existingTimer = this.workerRetryTimers.get(workerId);
+		if (existingTimer) {
+			clearTimeout(existingTimer);
+		}
 
-    const timer = setTimeout(() => {
-      this.workerRetryTimers.delete(workerId);
-      this.recreateWorker(workerId);
-    }, delay);
+		const timer = setTimeout(() => {
+			this.workerRetryTimers.delete(workerId);
+			this.recreateWorker(workerId);
+		}, delay);
 
-    this.workerRetryTimers.set(workerId, timer);
-    this.workerRetryCount.set(workerId, retryCount + 1);
-  }
+		this.workerRetryTimers.set(workerId, timer);
+		this.workerRetryCount.set(workerId, retryCount + 1);
+	}
 
-  private async recreateWorker(workerId: number) {
-    const retryCount = this.workerRetryCount.get(workerId) || 0;
-    console.log(`[WorkerPool] Attempting to recreate worker ${workerId} (attempt ${retryCount}/${this.MAX_RETRY_ATTEMPTS})`);
+	private async recreateWorker(workerId: number) {
+		const retryCount = this.workerRetryCount.get(workerId) || 0;
+		console.log(
+			`[WorkerPool] Attempting to recreate worker ${workerId} (attempt ${retryCount}/${this.MAX_RETRY_ATTEMPTS})`,
+		);
 
-    try {
-      const worker = new Worker(
-        this.workerUrl,
-        { type: 'module', name: `db-worker-${workerId}` }
-      );
+		try {
+			const worker = new Worker(this.workerUrl, {
+				type: 'module',
+				name: `db-worker-${workerId}`,
+			});
 
-      worker.onmessage = (e: MessageEvent) => this.handleMessage(e.data, workerId);
-      worker.onerror = (err) => this.handleError(err, workerId);
+			worker.onmessage = (e: MessageEvent) =>
+				this.handleMessage(e.data, workerId);
+			worker.onerror = (err) => this.handleError(err, workerId);
 
-      this.workers[workerId] = worker;
+			this.workers[workerId] = worker;
 
-      await this.sendToWorker(workerId, {
-        id: crypto.randomUUID(),
-        type: 'ping',
-        payload: {}
-      });
+			await this.sendToWorker(workerId, {
+				id: crypto.randomUUID(),
+				type: 'ping',
+				payload: {},
+			});
 
-      console.log(`[WorkerPool] Worker ${workerId} recreated successfully`);
-      this.workerRetryCount.delete(workerId);
-    } catch (err) {
-      console.error(`[WorkerPool] Failed to recreate worker ${workerId}:`, err);
-    }
-  }
+			console.log(
+				`[WorkerPool] Worker ${workerId} recreated successfully`,
+			);
+			this.workerRetryCount.delete(workerId);
+		} catch (err) {
+			console.error(
+				`[WorkerPool] Failed to recreate worker ${workerId}:`,
+				err,
+			);
+		}
+	}
 
-  /**
-   * Terminate all workers
-   */
-  terminate() {
-    console.log('[WorkerPool] Terminating all workers');
+	/**
+	 * Terminate all workers
+	 */
+	terminate() {
+		console.log('[WorkerPool] Terminating all workers');
 
-    this.workerRetryTimers.forEach((timer) => clearTimeout(timer));
-    this.workerRetryTimers.clear();
-    this.workerRetryCount.clear();
+		this.workerRetryTimers.forEach((timer) => clearTimeout(timer));
+		this.workerRetryTimers.clear();
+		this.workerRetryCount.clear();
 
-    this.workers.forEach((worker, i) => {
-      try {
-        worker.terminate();
-      } catch (err) {
-        console.error(`[WorkerPool] Error terminating worker ${i}:`, err);
-      }
-    });
+		this.workers.forEach((worker, i) => {
+			try {
+				worker.terminate();
+			} catch (err) {
+				console.error(
+					`[WorkerPool] Error terminating worker ${i}:`,
+					err,
+				);
+			}
+		});
 
-    this.workers = [];
-    this.pending.clear();
-  }
+		this.workers = [];
+		this.pending.clear();
+	}
 
-  /**
-   * Get pool statistics
-   */
-  getStats() {
-    return {
-      size: this.poolSize,
-      activeWorkers: this.workers.length,
-      pendingRequests: this.pending.size,
-      nextWorker: this.roundRobinIndex,
-    };
-  }
+	/**
+	 * Get pool statistics
+	 */
+	getStats() {
+		return {
+			size: this.poolSize,
+			activeWorkers: this.workers.length,
+			pendingRequests: this.pending.size,
+			nextWorker: this.roundRobinIndex,
+		};
+	}
 }

--- a/packages/npm/droid/src/lib/gateway/strategies/DirectStrategy.ts
+++ b/packages/npm/droid/src/lib/gateway/strategies/DirectStrategy.ts
@@ -2,10 +2,10 @@
 // Runs everything on the main thread
 
 import type {
-  ISupabaseStrategy,
-  SelectOptions,
-  SessionResponse,
-  WebSocketStatus
+	ISupabaseStrategy,
+	SelectOptions,
+	SessionResponse,
+	WebSocketStatus,
 } from '../types';
 
 /**
@@ -22,330 +22,398 @@ import type {
  * This strategy dynamically imports it to avoid bundling Supabase in the main droid build.
  */
 export class DirectStrategy implements ISupabaseStrategy {
-  private client: any = null;
-  private ws: WebSocket | null = null;
-  private wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private wsReconnectAttempts = 0;
-  private wsHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private wsLastPongTime: number = 0;
-  private subscriptions = new Map<string, { unsubscribe: () => Promise<void> | void }>();
-  private listeners = new Map<string, Set<(payload: any) => void>>();
+	private client: any = null;
+	private ws: WebSocket | null = null;
+	private wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private wsReconnectAttempts = 0;
+	private wsHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
+	private wsLastPongTime = 0;
+	private subscriptions = new Map<
+		string,
+		{ unsubscribe: () => Promise<void> | void }
+	>();
+	private listeners = new Map<string, Set<(payload: any) => void>>();
 
-  private readonly WS_MAX_RECONNECT_ATTEMPTS = 5;
-  private readonly WS_RECONNECT_DELAY_MS = 3000;
-  private readonly WS_HEARTBEAT_INTERVAL_MS = 30000;
-  private readonly WS_HEARTBEAT_TIMEOUT_MS = 60000;
+	private readonly WS_MAX_RECONNECT_ATTEMPTS = 5;
+	private readonly WS_RECONNECT_DELAY_MS = 3000;
+	private readonly WS_HEARTBEAT_INTERVAL_MS = 30000;
+	private readonly WS_HEARTBEAT_TIMEOUT_MS = 60000;
 
-  async init(url: string, anonKey: string, options?: any): Promise<SessionResponse> {
-    console.log('[DirectStrategy] Initializing...');
+	async init(
+		url: string,
+		anonKey: string,
+		options?: any,
+	): Promise<SessionResponse> {
+		console.log('[DirectStrategy] Initializing...');
 
-    // Dynamic import to avoid bundling Supabase when not using DirectStrategy
-    const { createClient } = await import('@supabase/supabase-js');
+		// Dynamic import to avoid bundling Supabase when not using DirectStrategy
+		const { createClient } = await import('@supabase/supabase-js');
 
-    this.client = createClient(url, anonKey, {
-      ...options,
-      auth: {
-        ...(options?.auth || {}),
-        autoRefreshToken: true,
-        persistSession: true,
-        detectSessionInUrl: false,
-      },
-    });
+		this.client = createClient(url, anonKey, {
+			...options,
+			auth: {
+				...(options?.auth || {}),
+				autoRefreshToken: true,
+				persistSession: true,
+				detectSessionInUrl: false,
+			},
+		});
 
-    this.client.auth.onAuthStateChange((_event: any, session: any) => {
-      this.emit('auth', { session });
-    });
+		this.client.auth.onAuthStateChange((_event: any, session: any) => {
+			this.emit('auth', { session });
+		});
 
-    const { data: { session }, error } = await this.client.auth.getSession();
+		const {
+			data: { session },
+			error,
+		} = await this.client.auth.getSession();
 
-    if (error) {
-      console.error('[DirectStrategy] Session error:', error);
-    }
+		if (error) {
+			console.error('[DirectStrategy] Session error:', error);
+		}
 
-    console.log('[DirectStrategy] Initialized');
+		console.log('[DirectStrategy] Initialized');
 
-    return {
-      session,
-      user: session?.user || null
-    };
-  }
+		return {
+			session,
+			user: session?.user || null,
+		};
+	}
 
-  on(event: string, callback: (payload: any) => void): () => void {
-    if (!this.listeners.has(event)) {
-      this.listeners.set(event, new Set());
-    }
-    this.listeners.get(event)!.add(callback);
+	on(event: string, callback: (payload: any) => void): () => void {
+		if (!this.listeners.has(event)) {
+			this.listeners.set(event, new Set());
+		}
+		this.listeners.get(event)!.add(callback);
 
-    return () => {
-      const set = this.listeners.get(event);
-      if (set) {
-        set.delete(callback);
-        if (set.size === 0) this.listeners.delete(event);
-      }
-    };
-  }
+		return () => {
+			const set = this.listeners.get(event);
+			if (set) {
+				set.delete(callback);
+				if (set.size === 0) this.listeners.delete(event);
+			}
+		};
+	}
 
-  private emit(event: string, payload: any) {
-    this.listeners.get(event)?.forEach((cb) => {
-      try {
-        cb(payload);
-      } catch (err) {
-        console.error(`[DirectStrategy] Listener error for ${event}:`, err);
-      }
-    });
-  }
+	private emit(event: string, payload: any) {
+		this.listeners.get(event)?.forEach((cb) => {
+			try {
+				cb(payload);
+			} catch (err) {
+				console.error(
+					`[DirectStrategy] Listener error for ${event}:`,
+					err,
+				);
+			}
+		});
+	}
 
-  // Auth
-  async getSession(): Promise<SessionResponse> {
-    if (!this.client) throw new Error('Client not initialized');
-    const { data, error } = await this.client.auth.getSession();
-    if (error) throw error;
-    return data;
-  }
+	// Auth
+	async getSession(): Promise<SessionResponse> {
+		if (!this.client) throw new Error('Client not initialized');
+		const { data, error } = await this.client.auth.getSession();
+		if (error) throw error;
+		return data;
+	}
 
-  async signInWithPassword(email: string, password: string): Promise<any> {
-    if (!this.client) throw new Error('Client not initialized');
-    const { data, error } = await this.client.auth.signInWithPassword({ email, password });
-    if (error) throw error;
-    return data;
-  }
+	async signInWithPassword(email: string, password: string): Promise<any> {
+		if (!this.client) throw new Error('Client not initialized');
+		const { data, error } = await this.client.auth.signInWithPassword({
+			email,
+			password,
+		});
+		if (error) throw error;
+		return data;
+	}
 
-  async signOut(): Promise<void> {
-    if (!this.client) throw new Error('Client not initialized');
-    const { error } = await this.client.auth.signOut();
-    if (error) throw error;
-  }
+	async signOut(): Promise<void> {
+		if (!this.client) throw new Error('Client not initialized');
+		const { error } = await this.client.auth.signOut();
+		if (error) throw error;
+	}
 
-  // Database
-  async select(table: string, opts?: SelectOptions): Promise<any> {
-    if (!this.client) throw new Error('Client not initialized');
-    let query = this.client.from(table).select(opts?.columns || '*');
-    if (opts?.match) {
-      for (const [key, value] of Object.entries(opts.match)) {
-        query = query.eq(key, value);
-      }
-    }
-    if (opts?.limit) query = query.limit(opts.limit);
-    const { data, error } = await query;
-    if (error) throw error;
-    return data;
-  }
+	// Database
+	async select(table: string, opts?: SelectOptions): Promise<any> {
+		if (!this.client) throw new Error('Client not initialized');
+		let query = this.client.from(table).select(opts?.columns || '*');
+		if (opts?.match) {
+			for (const [key, value] of Object.entries(opts.match)) {
+				query = query.eq(key, value);
+			}
+		}
+		if (opts?.limit) query = query.limit(opts.limit);
+		const { data, error } = await query;
+		if (error) throw error;
+		return data;
+	}
 
-  async insert(table: string, data: Record<string, any> | Record<string, any>[]): Promise<any> {
-    if (!this.client) throw new Error('Client not initialized');
-    const { data: result, error } = await this.client.from(table).insert(data).select();
-    if (error) throw error;
-    return result;
-  }
+	async insert(
+		table: string,
+		data: Record<string, any> | Record<string, any>[],
+	): Promise<any> {
+		if (!this.client) throw new Error('Client not initialized');
+		const { data: result, error } = await this.client
+			.from(table)
+			.insert(data)
+			.select();
+		if (error) throw error;
+		return result;
+	}
 
-  async update(table: string, data: Record<string, any>, match: Record<string, any>): Promise<any> {
-    if (!this.client) throw new Error('Client not initialized');
-    let query = this.client.from(table).update(data);
-    for (const [key, value] of Object.entries(match)) {
-      query = query.eq(key, value);
-    }
-    const { data: result, error } = await query.select();
-    if (error) throw error;
-    return result;
-  }
+	async update(
+		table: string,
+		data: Record<string, any>,
+		match: Record<string, any>,
+	): Promise<any> {
+		if (!this.client) throw new Error('Client not initialized');
+		let query = this.client.from(table).update(data);
+		for (const [key, value] of Object.entries(match)) {
+			query = query.eq(key, value);
+		}
+		const { data: result, error } = await query.select();
+		if (error) throw error;
+		return result;
+	}
 
-  async upsert(table: string, data: Record<string, any> | Record<string, any>[]): Promise<any> {
-    if (!this.client) throw new Error('Client not initialized');
-    const { data: result, error } = await this.client.from(table).upsert(data).select();
-    if (error) throw error;
-    return result;
-  }
+	async upsert(
+		table: string,
+		data: Record<string, any> | Record<string, any>[],
+	): Promise<any> {
+		if (!this.client) throw new Error('Client not initialized');
+		const { data: result, error } = await this.client
+			.from(table)
+			.upsert(data)
+			.select();
+		if (error) throw error;
+		return result;
+	}
 
-  async delete(table: string, match: Record<string, any>): Promise<any> {
-    if (!this.client) throw new Error('Client not initialized');
-    let query = this.client.from(table).delete();
-    for (const [key, value] of Object.entries(match)) {
-      query = query.eq(key, value);
-    }
-    const { data: result, error } = await query.select();
-    if (error) throw error;
-    return result;
-  }
+	async delete(table: string, match: Record<string, any>): Promise<any> {
+		if (!this.client) throw new Error('Client not initialized');
+		let query = this.client.from(table).delete();
+		for (const [key, value] of Object.entries(match)) {
+			query = query.eq(key, value);
+		}
+		const { data: result, error } = await query.select();
+		if (error) throw error;
+		return result;
+	}
 
-  async rpc(fn: string, args?: Record<string, any>): Promise<any> {
-    if (!this.client) throw new Error('Client not initialized');
-    const { data, error } = await this.client.rpc(fn, args || {});
-    if (error) throw error;
-    return data;
-  }
+	async rpc(fn: string, args?: Record<string, any>): Promise<any> {
+		if (!this.client) throw new Error('Client not initialized');
+		const { data, error } = await this.client.rpc(fn, args || {});
+		if (error) throw error;
+		return data;
+	}
 
-  // Realtime
-  subscribePostgres(key: string, params: any, callback: (payload: any) => void): () => void {
-    if (!this.client) throw new Error('Client not initialized');
+	// Realtime
+	subscribePostgres(
+		key: string,
+		params: any,
+		callback: (payload: any) => void,
+	): () => void {
+		if (!this.client) throw new Error('Client not initialized');
 
-    const channel = this.client
-      .channel(key)
-      .on('postgres_changes', params, (payload: any) => {
-        this.emit(`realtime:${key}`, payload);
-      });
+		const channel = this.client
+			.channel(key)
+			.on('postgres_changes', params, (payload: any) => {
+				this.emit(`realtime:${key}`, payload);
+			});
 
-    channel.subscribe();
-    this.subscriptions.set(key, {
-      unsubscribe: async () => { await channel.unsubscribe(); },
-    });
+		channel.subscribe();
+		this.subscriptions.set(key, {
+			unsubscribe: async () => {
+				await channel.unsubscribe();
+			},
+		});
 
-    const off = this.on(`realtime:${key}`, callback);
+		const off = this.on(`realtime:${key}`, callback);
 
-    return () => {
-      off();
-      const sub = this.subscriptions.get(key);
-      if (sub) {
-        sub.unsubscribe();
-        this.subscriptions.delete(key);
-      }
-    };
-  }
+		return () => {
+			off();
+			const sub = this.subscriptions.get(key);
+			if (sub) {
+				sub.unsubscribe();
+				this.subscriptions.delete(key);
+			}
+		};
+	}
 
-  // WebSocket
-  async connectWebSocket(wsUrl?: string): Promise<WebSocketStatus> {
-    if (this.ws && (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)) {
-      return this.getWebSocketStatus();
-    }
+	// WebSocket
+	async connectWebSocket(wsUrl?: string): Promise<WebSocketStatus> {
+		if (
+			this.ws &&
+			(this.ws.readyState === WebSocket.CONNECTING ||
+				this.ws.readyState === WebSocket.OPEN)
+		) {
+			return this.getWebSocketStatus();
+		}
 
-    if (!this.client) throw new Error('Client not initialized');
+		if (!this.client) throw new Error('Client not initialized');
 
-    const { data: { session }, error } = await this.client.auth.getSession();
-    if (error || !session?.access_token) {
-      throw new Error('No active session');
-    }
+		const {
+			data: { session },
+			error,
+		} = await this.client.auth.getSession();
+		if (error || !session?.access_token) {
+			throw new Error('No active session');
+		}
 
-    const url = wsUrl || this.getDefaultWebSocketUrl();
-    const authenticatedUrl = `${url}?token=${encodeURIComponent(session.access_token)}`;
+		const url = wsUrl || this.getDefaultWebSocketUrl();
+		const authenticatedUrl = `${url}?token=${encodeURIComponent(session.access_token)}`;
 
-    console.log('[DirectStrategy] Connecting to WebSocket:', url);
-    this.ws = new WebSocket(authenticatedUrl);
+		console.log('[DirectStrategy] Connecting to WebSocket:', url);
+		this.ws = new WebSocket(authenticatedUrl);
 
-    this.ws.onopen = () => {
-      this.wsReconnectAttempts = 0;
-      this.wsLastPongTime = Date.now();
-      this.startHeartbeat();
-      this.emit('ws.status', { status: 'connected', url });
-    };
+		this.ws.onopen = () => {
+			this.wsReconnectAttempts = 0;
+			this.wsLastPongTime = Date.now();
+			this.startHeartbeat();
+			this.emit('ws.status', { status: 'connected', url });
+		};
 
-    this.ws.onmessage = (event) => {
-      try {
-        const message = JSON.parse(event.data);
-        if (message.type === 'pong') {
-          this.wsLastPongTime = Date.now();
-          return;
-        }
-        this.emit('ws.message', message);
-      } catch (error) {
-        console.error('[DirectStrategy] Failed to parse message:', error);
-      }
-    };
+		this.ws.onmessage = (event) => {
+			try {
+				const message = JSON.parse(event.data);
+				if (message.type === 'pong') {
+					this.wsLastPongTime = Date.now();
+					return;
+				}
+				this.emit('ws.message', message);
+			} catch (error) {
+				console.error(
+					'[DirectStrategy] Failed to parse message:',
+					error,
+				);
+			}
+		};
 
-    this.ws.onerror = () => {
-      this.emit('ws.status', { status: 'error', error: 'Connection error' });
-    };
+		this.ws.onerror = () => {
+			this.emit('ws.status', {
+				status: 'error',
+				error: 'Connection error',
+			});
+		};
 
-    this.ws.onclose = (event) => {
-      this.ws = null;
-      this.stopHeartbeat();
-      this.emit('ws.status', { status: 'disconnected', code: event.code, reason: event.reason });
+		this.ws.onclose = (event) => {
+			this.ws = null;
+			this.stopHeartbeat();
+			this.emit('ws.status', {
+				status: 'disconnected',
+				code: event.code,
+				reason: event.reason,
+			});
 
-      if (event.code !== 1000 && this.wsReconnectAttempts < this.WS_MAX_RECONNECT_ATTEMPTS) {
-        this.wsReconnectAttempts++;
-        this.wsReconnectTimer = setTimeout(() => {
-          this.connectWebSocket(wsUrl).catch(() => {});
-        }, this.WS_RECONNECT_DELAY_MS);
-      }
-    };
+			if (
+				event.code !== 1000 &&
+				this.wsReconnectAttempts < this.WS_MAX_RECONNECT_ATTEMPTS
+			) {
+				this.wsReconnectAttempts++;
+				this.wsReconnectTimer = setTimeout(() => {
+					this.connectWebSocket(wsUrl).catch(() => {
+						/* reconnect best-effort */
+					});
+				}, this.WS_RECONNECT_DELAY_MS);
+			}
+		};
 
-    return this.getWebSocketStatus();
-  }
+		return this.getWebSocketStatus();
+	}
 
-  async disconnectWebSocket(): Promise<void> {
-    if (this.wsReconnectTimer) {
-      clearTimeout(this.wsReconnectTimer);
-      this.wsReconnectTimer = null;
-    }
-    this.stopHeartbeat();
-    if (this.ws) {
-      this.ws.close(1000, 'Client request');
-      this.ws = null;
-      this.wsReconnectAttempts = 0;
-      this.emit('ws.status', { status: 'disconnected' });
-    }
-  }
+	async disconnectWebSocket(): Promise<void> {
+		if (this.wsReconnectTimer) {
+			clearTimeout(this.wsReconnectTimer);
+			this.wsReconnectTimer = null;
+		}
+		this.stopHeartbeat();
+		if (this.ws) {
+			this.ws.close(1000, 'Client request');
+			this.ws = null;
+			this.wsReconnectAttempts = 0;
+			this.emit('ws.status', { status: 'disconnected' });
+		}
+	}
 
-  async sendWebSocketMessage(data: any): Promise<void> {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      throw new Error('WebSocket not connected');
-    }
-    const message = typeof data === 'string' ? data : JSON.stringify(data);
-    this.ws.send(message);
-  }
+	async sendWebSocketMessage(data: any): Promise<void> {
+		if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+			throw new Error('WebSocket not connected');
+		}
+		const message = typeof data === 'string' ? data : JSON.stringify(data);
+		this.ws.send(message);
+	}
 
-  async getWebSocketStatus(): Promise<WebSocketStatus> {
-    if (!this.ws) return { status: 'disconnected', readyState: null };
-    const readyStateMap: Record<number, WebSocketStatus['status']> = {
-      [WebSocket.CONNECTING]: 'connecting',
-      [WebSocket.OPEN]: 'connected',
-      [WebSocket.CLOSING]: 'disconnected',
-      [WebSocket.CLOSED]: 'disconnected'
-    };
-    return {
-      status: readyStateMap[this.ws.readyState] || 'disconnected',
-      readyState: this.ws.readyState
-    };
-  }
+	async getWebSocketStatus(): Promise<WebSocketStatus> {
+		if (!this.ws) return { status: 'disconnected', readyState: null };
+		const readyStateMap: Record<number, WebSocketStatus['status']> = {
+			[WebSocket.CONNECTING]: 'connecting',
+			[WebSocket.OPEN]: 'connected',
+			[WebSocket.CLOSING]: 'disconnected',
+			[WebSocket.CLOSED]: 'disconnected',
+		};
+		return {
+			status: readyStateMap[this.ws.readyState] || 'disconnected',
+			readyState: this.ws.readyState,
+		};
+	}
 
-  onWebSocketMessage(callback: (message: any) => void): () => void {
-    return this.on('ws.message', callback);
-  }
+	onWebSocketMessage(callback: (message: any) => void): () => void {
+		return this.on('ws.message', callback);
+	}
 
-  onWebSocketStatus(callback: (status: any) => void): () => void {
-    return this.on('ws.status', callback);
-  }
+	onWebSocketStatus(callback: (status: any) => void): () => void {
+		return this.on('ws.status', callback);
+	}
 
-  // Helpers
-  private getDefaultWebSocketUrl(): string {
-    if (typeof window === 'undefined') return 'ws://localhost:4321/ws';
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-    const port = isLocalhost ? '4321' : window.location.port;
-    const host = window.location.hostname;
-    return `${protocol}//${host}${port ? ':' + port : ''}/ws`;
-  }
+	// Helpers
+	private getDefaultWebSocketUrl(): string {
+		if (typeof window === 'undefined') return 'ws://localhost:4321/ws';
+		const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+		const isLocalhost =
+			window.location.hostname === 'localhost' ||
+			window.location.hostname === '127.0.0.1';
+		const port = isLocalhost ? '4321' : window.location.port;
+		const host = window.location.hostname;
+		return `${protocol}//${host}${port ? ':' + port : ''}/ws`;
+	}
 
-  private startHeartbeat() {
-    this.stopHeartbeat();
-    this.wsHeartbeatTimer = setInterval(() => {
-      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-        this.stopHeartbeat();
-        return;
-      }
-      if (this.wsLastPongTime > 0 && Date.now() - this.wsLastPongTime > this.WS_HEARTBEAT_TIMEOUT_MS) {
-        console.warn('[DirectStrategy] Heartbeat timeout');
-        this.stopHeartbeat();
-        this.ws.close(1001, 'Heartbeat timeout');
-        return;
-      }
-      try {
-        this.ws.send(JSON.stringify({ type: 'ping' }));
-      } catch (error) {
-        console.error('[DirectStrategy] Failed to send heartbeat:', error);
-      }
-    }, this.WS_HEARTBEAT_INTERVAL_MS);
-  }
+	private startHeartbeat() {
+		this.stopHeartbeat();
+		this.wsHeartbeatTimer = setInterval(() => {
+			if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+				this.stopHeartbeat();
+				return;
+			}
+			if (
+				this.wsLastPongTime > 0 &&
+				Date.now() - this.wsLastPongTime > this.WS_HEARTBEAT_TIMEOUT_MS
+			) {
+				console.warn('[DirectStrategy] Heartbeat timeout');
+				this.stopHeartbeat();
+				this.ws.close(1001, 'Heartbeat timeout');
+				return;
+			}
+			try {
+				this.ws.send(JSON.stringify({ type: 'ping' }));
+			} catch (error) {
+				console.error(
+					'[DirectStrategy] Failed to send heartbeat:',
+					error,
+				);
+			}
+		}, this.WS_HEARTBEAT_INTERVAL_MS);
+	}
 
-  private stopHeartbeat() {
-    if (this.wsHeartbeatTimer) {
-      clearInterval(this.wsHeartbeatTimer);
-      this.wsHeartbeatTimer = null;
-    }
-  }
+	private stopHeartbeat() {
+		if (this.wsHeartbeatTimer) {
+			clearInterval(this.wsHeartbeatTimer);
+			this.wsHeartbeatTimer = null;
+		}
+	}
 
-  terminate() {
-    this.disconnectWebSocket();
-    this.subscriptions.forEach(sub => sub.unsubscribe());
-    this.subscriptions.clear();
-    this.listeners.clear();
-  }
+	terminate() {
+		this.disconnectWebSocket();
+		this.subscriptions.forEach((sub) => sub.unsubscribe());
+		this.subscriptions.clear();
+		this.listeners.clear();
+	}
 }

--- a/packages/npm/droid/src/lib/gateway/strategies/SharedWorkerStrategy.ts
+++ b/packages/npm/droid/src/lib/gateway/strategies/SharedWorkerStrategy.ts
@@ -1,10 +1,10 @@
 // Strategy for desktop browsers with SharedWorker support
 
 import type {
-  ISupabaseStrategy,
-  SelectOptions,
-  SessionResponse,
-  WebSocketStatus
+	ISupabaseStrategy,
+	SelectOptions,
+	SessionResponse,
+	WebSocketStatus,
 } from '../types';
 import { WorkerPool } from '../WorkerPool';
 import { getWorkerCommunication } from '../WorkerCommunication';
@@ -20,197 +20,234 @@ import { getWorkerCommunication } from '../WorkerCommunication';
  * Best for: Desktop Chrome, Firefox, Edge
  */
 export class SharedWorkerStrategy implements ISupabaseStrategy {
-  private worker?: SharedWorker;
-  private port?: MessagePort;
-  private workerPool?: WorkerPool;
-  private pending = new Map<string, { resolve: Function; reject: Function }>();
-  private listeners = new Map<string, Set<(p: any) => void>>();
-  private comm = getWorkerCommunication();
-  private sharedWorkerUrl: string | URL;
-  private dbWorkerUrl: string | URL;
-  private poolSize: number;
+	private worker?: SharedWorker;
+	private port?: MessagePort;
+	private workerPool?: WorkerPool;
+	private pending = new Map<
+		string,
+		{
+			resolve: (value: unknown) => void;
+			reject: (reason?: unknown) => void;
+		}
+	>();
+	private listeners = new Map<string, Set<(p: any) => void>>();
+	private comm = getWorkerCommunication();
+	private sharedWorkerUrl: string | URL;
+	private dbWorkerUrl: string | URL;
+	private poolSize: number;
 
-  constructor(sharedWorkerUrl: string | URL, dbWorkerUrl: string | URL, poolSize = 3) {
-    this.sharedWorkerUrl = sharedWorkerUrl;
-    this.dbWorkerUrl = dbWorkerUrl;
-    this.poolSize = poolSize;
+	constructor(
+		sharedWorkerUrl: string | URL,
+		dbWorkerUrl: string | URL,
+		poolSize = 3,
+	) {
+		this.sharedWorkerUrl = sharedWorkerUrl;
+		this.dbWorkerUrl = dbWorkerUrl;
+		this.poolSize = poolSize;
 
-    if (typeof window === 'undefined') return;
-    if (!('SharedWorker' in window)) {
-      throw new Error('SharedWorker not supported');
-    }
-  }
+		if (typeof window === 'undefined') return;
+		if (!('SharedWorker' in window)) {
+			throw new Error('SharedWorker not supported');
+		}
+	}
 
-  async init(url: string, anonKey: string, options?: any): Promise<SessionResponse> {
-    console.log('[SharedWorkerStrategy] Initializing...');
+	async init(
+		url: string,
+		anonKey: string,
+		options?: any,
+	): Promise<SessionResponse> {
+		console.log('[SharedWorkerStrategy] Initializing...');
 
-    this.worker = new SharedWorker(
-      this.sharedWorkerUrl,
-      { type: 'module', name: 'supabase-shared' }
-    );
-    this.port = this.worker.port;
-    this.port.onmessage = (e) => this.onMessage(e.data);
-    this.port.start();
+		this.worker = new SharedWorker(this.sharedWorkerUrl, {
+			type: 'module',
+			name: 'supabase-shared',
+		});
+		this.port = this.worker.port;
+		this.port.onmessage = (e) => this.onMessage(e.data);
+		this.port.start();
 
-    this.workerPool = new WorkerPool({
-      size: this.poolSize,
-      workerUrl: this.dbWorkerUrl
-    });
-    await this.workerPool.init();
+		this.workerPool = new WorkerPool({
+			size: this.poolSize,
+			workerUrl: this.dbWorkerUrl,
+		});
+		await this.workerPool.init();
 
-    const sharedWorkerInit = this.send<SessionResponse>('init', { url, anonKey, options });
+		const sharedWorkerInit = this.send<SessionResponse>('init', {
+			url,
+			anonKey,
+			options,
+		});
 
-    const poolInitPromises = Array.from({ length: this.poolSize }, () =>
-      this.workerPool!.send('init', { url, anonKey, options })
-    );
+		const poolInitPromises = Array.from({ length: this.poolSize }, () =>
+			this.workerPool!.send('init', { url, anonKey, options }),
+		);
 
-    await Promise.all([sharedWorkerInit, ...poolInitPromises]);
+		await Promise.all([sharedWorkerInit, ...poolInitPromises]);
 
-    console.log(`[SharedWorkerStrategy] Initialized (SharedWorker + ${this.poolSize} DB workers)`);
+		console.log(
+			`[SharedWorkerStrategy] Initialized (SharedWorker + ${this.poolSize} DB workers)`,
+		);
 
-    return sharedWorkerInit;
-  }
+		return sharedWorkerInit;
+	}
 
-  private onMessage(msg: any) {
-    if (msg?.type === 'ready' || msg?.type === 'auth') {
-      this.emit(msg.type, msg);
-      return;
-    }
-    if (msg?.type === 'realtime' && msg.key) {
-      this.emit(`realtime:${msg.key}`, msg.payload);
-      return;
-    }
-    if (msg?.type === 'ws.message') {
-      this.emit('ws.message', msg.data);
-      return;
-    }
-    if (msg?.type === 'ws.status') {
-      this.emit('ws.status', msg);
-      return;
-    }
+	private onMessage(msg: any) {
+		if (msg?.type === 'ready' || msg?.type === 'auth') {
+			this.emit(msg.type, msg);
+			return;
+		}
+		if (msg?.type === 'realtime' && msg.key) {
+			this.emit(`realtime:${msg.key}`, msg.payload);
+			return;
+		}
+		if (msg?.type === 'ws.message') {
+			this.emit('ws.message', msg.data);
+			return;
+		}
+		if (msg?.type === 'ws.status') {
+			this.emit('ws.status', msg);
+			return;
+		}
 
-    const { id, ok, data, error } = msg ?? {};
-    if (id && this.pending.has(id)) {
-      const { resolve, reject } = this.pending.get(id)!;
-      this.pending.delete(id);
-      ok ? resolve(data) : reject(new Error(error));
-    }
-  }
+		const { id, ok, data, error } = msg ?? {};
+		if (id && this.pending.has(id)) {
+			const { resolve, reject } = this.pending.get(id)!;
+			this.pending.delete(id);
+			ok ? resolve(data) : reject(new Error(error));
+		}
+	}
 
-  private send<T>(type: string, payload?: any): Promise<T> {
-    const id = crypto.randomUUID();
-    return new Promise<T>((resolve, reject) => {
-      if (!this.port) return reject(new Error('SharedWorker unavailable'));
-      this.pending.set(id, { resolve, reject });
-      this.port.postMessage({ id, type, payload });
-    });
-  }
+	private send<T>(type: string, payload?: any): Promise<T> {
+		const id = crypto.randomUUID();
+		return new Promise<T>((resolve, reject) => {
+			if (!this.port)
+				return reject(new Error('SharedWorker unavailable'));
+			this.pending.set(id, { resolve, reject });
+			this.port.postMessage({ id, type, payload });
+		});
+	}
 
-  on(event: string, callback: (payload: any) => void): () => void {
-    if (!this.listeners.has(event)) {
-      this.listeners.set(event, new Set());
-    }
-    this.listeners.get(event)!.add(callback);
+	on(event: string, callback: (payload: any) => void): () => void {
+		if (!this.listeners.has(event)) {
+			this.listeners.set(event, new Set());
+		}
+		this.listeners.get(event)!.add(callback);
 
-    return () => {
-      const set = this.listeners.get(event);
-      if (set) {
-        set.delete(callback);
-        if (set.size === 0) this.listeners.delete(event);
-      }
-    };
-  }
+		return () => {
+			const set = this.listeners.get(event);
+			if (set) {
+				set.delete(callback);
+				if (set.size === 0) this.listeners.delete(event);
+			}
+		};
+	}
 
-  private emit(event: string, payload: any) {
-    this.listeners.get(event)?.forEach((cb) => cb(payload));
-  }
+	private emit(event: string, payload: any) {
+		this.listeners.get(event)?.forEach((cb) => cb(payload));
+	}
 
-  // Auth (via SharedWorker)
-  getSession(): Promise<SessionResponse> {
-    return this.send<SessionResponse>('getSession');
-  }
+	// Auth (via SharedWorker)
+	getSession(): Promise<SessionResponse> {
+		return this.send<SessionResponse>('getSession');
+	}
 
-  signInWithPassword(email: string, password: string): Promise<any> {
-    return this.send('signInWithPassword', { email, password });
-  }
+	signInWithPassword(email: string, password: string): Promise<any> {
+		return this.send('signInWithPassword', { email, password });
+	}
 
-  signOut(): Promise<void> {
-    return this.send('signOut');
-  }
+	signOut(): Promise<void> {
+		return this.send('signOut');
+	}
 
-  // Database (via worker pool)
-  select(table: string, opts?: SelectOptions): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.select', { table, ...(opts ?? {}) });
-  }
+	// Database (via worker pool)
+	select(table: string, opts?: SelectOptions): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.select', { table, ...(opts ?? {}) });
+	}
 
-  insert(table: string, data: Record<string, any> | Record<string, any>[]): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.insert', { table, data });
-  }
+	insert(
+		table: string,
+		data: Record<string, any> | Record<string, any>[],
+	): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.insert', { table, data });
+	}
 
-  update(table: string, data: Record<string, any>, match: Record<string, any>): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.update', { table, data, match });
-  }
+	update(
+		table: string,
+		data: Record<string, any>,
+		match: Record<string, any>,
+	): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.update', { table, data, match });
+	}
 
-  upsert(table: string, data: Record<string, any> | Record<string, any>[]): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.upsert', { table, data });
-  }
+	upsert(
+		table: string,
+		data: Record<string, any> | Record<string, any>[],
+	): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.upsert', { table, data });
+	}
 
-  delete(table: string, match: Record<string, any>): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.delete', { table, match });
-  }
+	delete(table: string, match: Record<string, any>): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.delete', { table, match });
+	}
 
-  rpc(fn: string, args?: Record<string, any>): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('rpc', { fn, args });
-  }
+	rpc(fn: string, args?: Record<string, any>): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('rpc', { fn, args });
+	}
 
-  // Realtime (via SharedWorker)
-  subscribePostgres(key: string, params: any, callback: (payload: any) => void): () => void {
-    const off = this.on(`realtime:${key}`, callback);
-    this.send('realtime.subscribe', { key, params }).catch((e) => {
-      off();
-      console.error(e);
-    });
-    return () => {
-      off();
-      this.send('realtime.unsubscribe', { key }).catch(() => {});
-    };
-  }
+	// Realtime (via SharedWorker)
+	subscribePostgres(
+		key: string,
+		params: any,
+		callback: (payload: any) => void,
+	): () => void {
+		const off = this.on(`realtime:${key}`, callback);
+		this.send('realtime.subscribe', { key, params }).catch((e) => {
+			off();
+			console.error(e);
+		});
+		return () => {
+			off();
+			this.send('realtime.unsubscribe', { key }).catch(() => {
+				/* best-effort */
+			});
+		};
+	}
 
-  // WebSocket (via SharedWorker)
-  connectWebSocket(wsUrl?: string): Promise<WebSocketStatus> {
-    return this.send<WebSocketStatus>('ws.connect', { wsUrl });
-  }
+	// WebSocket (via SharedWorker)
+	connectWebSocket(wsUrl?: string): Promise<WebSocketStatus> {
+		return this.send<WebSocketStatus>('ws.connect', { wsUrl });
+	}
 
-  disconnectWebSocket(): Promise<void> {
-    return this.send('ws.disconnect');
-  }
+	disconnectWebSocket(): Promise<void> {
+		return this.send('ws.disconnect');
+	}
 
-  sendWebSocketMessage(data: any): Promise<void> {
-    return this.send('ws.send', { data });
-  }
+	sendWebSocketMessage(data: any): Promise<void> {
+		return this.send('ws.send', { data });
+	}
 
-  getWebSocketStatus(): Promise<WebSocketStatus> {
-    return this.send<WebSocketStatus>('ws.status');
-  }
+	getWebSocketStatus(): Promise<WebSocketStatus> {
+		return this.send<WebSocketStatus>('ws.status');
+	}
 
-  onWebSocketMessage(callback: (message: any) => void): () => void {
-    return this.on('ws.message', callback);
-  }
+	onWebSocketMessage(callback: (message: any) => void): () => void {
+		return this.on('ws.message', callback);
+	}
 
-  onWebSocketStatus(callback: (status: any) => void): () => void {
-    return this.on('ws.status', callback);
-  }
+	onWebSocketStatus(callback: (status: any) => void): () => void {
+		return this.on('ws.status', callback);
+	}
 
-  terminate() {
-    this.workerPool?.terminate();
-    this.comm.close();
-    this.listeners.clear();
-    this.pending.clear();
-  }
+	terminate() {
+		this.workerPool?.terminate();
+		this.comm.close();
+		this.listeners.clear();
+		this.pending.clear();
+	}
 }

--- a/packages/npm/droid/src/lib/gateway/strategies/WebWorkerStrategy.ts
+++ b/packages/npm/droid/src/lib/gateway/strategies/WebWorkerStrategy.ts
@@ -1,10 +1,10 @@
 // Strategy for browsers without SharedWorker (Android, Safari)
 
 import type {
-  ISupabaseStrategy,
-  SelectOptions,
-  SessionResponse,
-  WebSocketStatus
+	ISupabaseStrategy,
+	SelectOptions,
+	SessionResponse,
+	WebSocketStatus,
 } from '../types';
 import { WorkerPool } from '../WorkerPool';
 import { getWorkerCommunication } from '../WorkerCommunication';
@@ -20,196 +20,234 @@ import { getWorkerCommunication } from '../WorkerCommunication';
  * Best for: Android, Safari, browsers without SharedWorker
  */
 export class WebWorkerStrategy implements ISupabaseStrategy {
-  private wsWorker?: Worker;
-  private workerPool?: WorkerPool;
-  private pending = new Map<string, { resolve: Function; reject: Function }>();
-  private listeners = new Map<string, Set<(p: any) => void>>();
-  private comm = getWorkerCommunication();
-  private wsWorkerUrl: string | URL;
-  private dbWorkerUrl: string | URL;
-  private poolSize: number;
+	private wsWorker?: Worker;
+	private workerPool?: WorkerPool;
+	private pending = new Map<
+		string,
+		{
+			resolve: (value: unknown) => void;
+			reject: (reason?: unknown) => void;
+		}
+	>();
+	private listeners = new Map<string, Set<(p: any) => void>>();
+	private comm = getWorkerCommunication();
+	private wsWorkerUrl: string | URL;
+	private dbWorkerUrl: string | URL;
+	private poolSize: number;
 
-  constructor(wsWorkerUrl: string | URL, dbWorkerUrl: string | URL, poolSize = 3) {
-    this.wsWorkerUrl = wsWorkerUrl;
-    this.dbWorkerUrl = dbWorkerUrl;
-    this.poolSize = poolSize;
+	constructor(
+		wsWorkerUrl: string | URL,
+		dbWorkerUrl: string | URL,
+		poolSize = 3,
+	) {
+		this.wsWorkerUrl = wsWorkerUrl;
+		this.dbWorkerUrl = dbWorkerUrl;
+		this.poolSize = poolSize;
 
-    if (typeof window === 'undefined') return;
-    if (!('Worker' in window)) {
-      throw new Error('Worker not supported');
-    }
-  }
+		if (typeof window === 'undefined') return;
+		if (!('Worker' in window)) {
+			throw new Error('Worker not supported');
+		}
+	}
 
-  async init(url: string, anonKey: string, options?: any): Promise<SessionResponse> {
-    console.log('[WebWorkerStrategy] Initializing...');
+	async init(
+		url: string,
+		anonKey: string,
+		options?: any,
+	): Promise<SessionResponse> {
+		console.log('[WebWorkerStrategy] Initializing...');
 
-    this.wsWorker = new Worker(
-      this.wsWorkerUrl,
-      { type: 'module', name: 'websocket-worker' }
-    );
-    this.wsWorker.onmessage = (e) => this.onMessage(e.data);
-    this.wsWorker.onerror = (err) => console.error('[WebWorkerStrategy] WebSocket worker error:', err);
+		this.wsWorker = new Worker(this.wsWorkerUrl, {
+			type: 'module',
+			name: 'websocket-worker',
+		});
+		this.wsWorker.onmessage = (e) => this.onMessage(e.data);
+		this.wsWorker.onerror = (err) =>
+			console.error('[WebWorkerStrategy] WebSocket worker error:', err);
 
-    this.workerPool = new WorkerPool({
-      size: this.poolSize,
-      workerUrl: this.dbWorkerUrl
-    });
-    await this.workerPool.init();
+		this.workerPool = new WorkerPool({
+			size: this.poolSize,
+			workerUrl: this.dbWorkerUrl,
+		});
+		await this.workerPool.init();
 
-    const wsWorkerInit = this.send<SessionResponse>('init', { url, anonKey, options });
+		const wsWorkerInit = this.send<SessionResponse>('init', {
+			url,
+			anonKey,
+			options,
+		});
 
-    const poolInitPromises = Array.from({ length: this.poolSize }, () =>
-      this.workerPool!.send('init', { url, anonKey, options })
-    );
+		const poolInitPromises = Array.from({ length: this.poolSize }, () =>
+			this.workerPool!.send('init', { url, anonKey, options }),
+		);
 
-    await Promise.all([wsWorkerInit, ...poolInitPromises]);
+		await Promise.all([wsWorkerInit, ...poolInitPromises]);
 
-    console.log(`[WebWorkerStrategy] Initialized (WebSocket worker + ${this.poolSize} DB workers)`);
+		console.log(
+			`[WebWorkerStrategy] Initialized (WebSocket worker + ${this.poolSize} DB workers)`,
+		);
 
-    return wsWorkerInit;
-  }
+		return wsWorkerInit;
+	}
 
-  private onMessage(msg: any) {
-    if (msg?.type === 'ready' || msg?.type === 'auth') {
-      this.emit(msg.type, msg);
-      return;
-    }
-    if (msg?.type === 'realtime' && msg.key) {
-      this.emit(`realtime:${msg.key}`, msg.payload);
-      return;
-    }
-    if (msg?.type === 'ws.message') {
-      this.emit('ws.message', msg.data);
-      return;
-    }
-    if (msg?.type === 'ws.status') {
-      this.emit('ws.status', msg);
-      return;
-    }
+	private onMessage(msg: any) {
+		if (msg?.type === 'ready' || msg?.type === 'auth') {
+			this.emit(msg.type, msg);
+			return;
+		}
+		if (msg?.type === 'realtime' && msg.key) {
+			this.emit(`realtime:${msg.key}`, msg.payload);
+			return;
+		}
+		if (msg?.type === 'ws.message') {
+			this.emit('ws.message', msg.data);
+			return;
+		}
+		if (msg?.type === 'ws.status') {
+			this.emit('ws.status', msg);
+			return;
+		}
 
-    const { id, ok, data, error } = msg ?? {};
-    if (id && this.pending.has(id)) {
-      const { resolve, reject } = this.pending.get(id)!;
-      this.pending.delete(id);
-      ok ? resolve(data) : reject(new Error(error));
-    }
-  }
+		const { id, ok, data, error } = msg ?? {};
+		if (id && this.pending.has(id)) {
+			const { resolve, reject } = this.pending.get(id)!;
+			this.pending.delete(id);
+			ok ? resolve(data) : reject(new Error(error));
+		}
+	}
 
-  private send<T>(type: string, payload?: any): Promise<T> {
-    const id = crypto.randomUUID();
-    return new Promise<T>((resolve, reject) => {
-      if (!this.wsWorker) return reject(new Error('WebSocket worker unavailable'));
-      this.pending.set(id, { resolve, reject });
-      this.wsWorker.postMessage({ id, type, payload });
-    });
-  }
+	private send<T>(type: string, payload?: any): Promise<T> {
+		const id = crypto.randomUUID();
+		return new Promise<T>((resolve, reject) => {
+			if (!this.wsWorker)
+				return reject(new Error('WebSocket worker unavailable'));
+			this.pending.set(id, { resolve, reject });
+			this.wsWorker.postMessage({ id, type, payload });
+		});
+	}
 
-  on(event: string, callback: (payload: any) => void): () => void {
-    if (!this.listeners.has(event)) {
-      this.listeners.set(event, new Set());
-    }
-    this.listeners.get(event)!.add(callback);
+	on(event: string, callback: (payload: any) => void): () => void {
+		if (!this.listeners.has(event)) {
+			this.listeners.set(event, new Set());
+		}
+		this.listeners.get(event)!.add(callback);
 
-    return () => {
-      const set = this.listeners.get(event);
-      if (set) {
-        set.delete(callback);
-        if (set.size === 0) this.listeners.delete(event);
-      }
-    };
-  }
+		return () => {
+			const set = this.listeners.get(event);
+			if (set) {
+				set.delete(callback);
+				if (set.size === 0) this.listeners.delete(event);
+			}
+		};
+	}
 
-  private emit(event: string, payload: any) {
-    this.listeners.get(event)?.forEach((cb) => cb(payload));
-  }
+	private emit(event: string, payload: any) {
+		this.listeners.get(event)?.forEach((cb) => cb(payload));
+	}
 
-  // Auth (via WebSocket worker)
-  getSession(): Promise<SessionResponse> {
-    return this.send<SessionResponse>('getSession');
-  }
+	// Auth (via WebSocket worker)
+	getSession(): Promise<SessionResponse> {
+		return this.send<SessionResponse>('getSession');
+	}
 
-  signInWithPassword(email: string, password: string): Promise<any> {
-    return this.send('signInWithPassword', { email, password });
-  }
+	signInWithPassword(email: string, password: string): Promise<any> {
+		return this.send('signInWithPassword', { email, password });
+	}
 
-  signOut(): Promise<void> {
-    return this.send('signOut');
-  }
+	signOut(): Promise<void> {
+		return this.send('signOut');
+	}
 
-  // Database (via worker pool)
-  select(table: string, opts?: SelectOptions): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.select', { table, ...(opts ?? {}) });
-  }
+	// Database (via worker pool)
+	select(table: string, opts?: SelectOptions): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.select', { table, ...(opts ?? {}) });
+	}
 
-  insert(table: string, data: Record<string, any> | Record<string, any>[]): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.insert', { table, data });
-  }
+	insert(
+		table: string,
+		data: Record<string, any> | Record<string, any>[],
+	): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.insert', { table, data });
+	}
 
-  update(table: string, data: Record<string, any>, match: Record<string, any>): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.update', { table, data, match });
-  }
+	update(
+		table: string,
+		data: Record<string, any>,
+		match: Record<string, any>,
+	): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.update', { table, data, match });
+	}
 
-  upsert(table: string, data: Record<string, any> | Record<string, any>[]): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.upsert', { table, data });
-  }
+	upsert(
+		table: string,
+		data: Record<string, any> | Record<string, any>[],
+	): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.upsert', { table, data });
+	}
 
-  delete(table: string, match: Record<string, any>): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('from.delete', { table, match });
-  }
+	delete(table: string, match: Record<string, any>): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('from.delete', { table, match });
+	}
 
-  rpc(fn: string, args?: Record<string, any>): Promise<any> {
-    if (!this.workerPool) throw new Error('Worker pool not initialized');
-    return this.workerPool.send('rpc', { fn, args });
-  }
+	rpc(fn: string, args?: Record<string, any>): Promise<any> {
+		if (!this.workerPool) throw new Error('Worker pool not initialized');
+		return this.workerPool.send('rpc', { fn, args });
+	}
 
-  // Realtime (via WebSocket worker)
-  subscribePostgres(key: string, params: any, callback: (payload: any) => void): () => void {
-    const off = this.on(`realtime:${key}`, callback);
-    this.send('realtime.subscribe', { key, params }).catch((e) => {
-      off();
-      console.error(e);
-    });
-    return () => {
-      off();
-      this.send('realtime.unsubscribe', { key }).catch(() => {});
-    };
-  }
+	// Realtime (via WebSocket worker)
+	subscribePostgres(
+		key: string,
+		params: any,
+		callback: (payload: any) => void,
+	): () => void {
+		const off = this.on(`realtime:${key}`, callback);
+		this.send('realtime.subscribe', { key, params }).catch((e) => {
+			off();
+			console.error(e);
+		});
+		return () => {
+			off();
+			this.send('realtime.unsubscribe', { key }).catch(() => {
+				/* best-effort */
+			});
+		};
+	}
 
-  // WebSocket (via dedicated worker)
-  connectWebSocket(wsUrl?: string): Promise<WebSocketStatus> {
-    return this.send<WebSocketStatus>('ws.connect', { wsUrl });
-  }
+	// WebSocket (via dedicated worker)
+	connectWebSocket(wsUrl?: string): Promise<WebSocketStatus> {
+		return this.send<WebSocketStatus>('ws.connect', { wsUrl });
+	}
 
-  disconnectWebSocket(): Promise<void> {
-    return this.send('ws.disconnect');
-  }
+	disconnectWebSocket(): Promise<void> {
+		return this.send('ws.disconnect');
+	}
 
-  sendWebSocketMessage(data: any): Promise<void> {
-    return this.send('ws.send', { data });
-  }
+	sendWebSocketMessage(data: any): Promise<void> {
+		return this.send('ws.send', { data });
+	}
 
-  getWebSocketStatus(): Promise<WebSocketStatus> {
-    return this.send<WebSocketStatus>('ws.status');
-  }
+	getWebSocketStatus(): Promise<WebSocketStatus> {
+		return this.send<WebSocketStatus>('ws.status');
+	}
 
-  onWebSocketMessage(callback: (message: any) => void): () => void {
-    return this.on('ws.message', callback);
-  }
+	onWebSocketMessage(callback: (message: any) => void): () => void {
+		return this.on('ws.message', callback);
+	}
 
-  onWebSocketStatus(callback: (status: any) => void): () => void {
-    return this.on('ws.status', callback);
-  }
+	onWebSocketStatus(callback: (status: any) => void): () => void {
+		return this.on('ws.status', callback);
+	}
 
-  terminate() {
-    this.wsWorker?.terminate();
-    this.workerPool?.terminate();
-    this.comm.close();
-    this.listeners.clear();
-    this.pending.clear();
-  }
+	terminate() {
+		this.wsWorker?.terminate();
+		this.workerPool?.terminate();
+		this.comm.close();
+		this.listeners.clear();
+		this.pending.clear();
+	}
 }

--- a/packages/npm/droid/src/lib/workers/supabase-shared-worker.ts
+++ b/packages/npm/droid/src/lib/workers/supabase-shared-worker.ts
@@ -7,88 +7,142 @@ import Dexie, { type Table } from 'dexie';
 import { getWorkerCommunication } from '../gateway/WorkerCommunication';
 
 type Req =
-  | { id: string; type: 'init'; payload: { url: string; anonKey: string; options?: any } }
-  | { id: string; type: 'getSession' }
-  | { id: string; type: 'signInWithPassword'; payload: { email: string; password: string } }
-  | { id: string; type: 'signOut' }
-  | { id: string; type: 'from.select'; payload: { table: string; columns?: string; match?: Record<string, any>; limit?: number } }
-  | { id: string; type: 'from.insert'; payload: { table: string; data: Record<string, any> | Record<string, any>[] } }
-  | { id: string; type: 'from.update'; payload: { table: string; data: Record<string, any>; match: Record<string, any> } }
-  | { id: string; type: 'from.upsert'; payload: { table: string; data: Record<string, any> | Record<string, any>[] } }
-  | { id: string; type: 'from.delete'; payload: { table: string; match: Record<string, any> } }
-  | { id: string; type: 'rpc'; payload: { fn: string; args?: Record<string, any> } }
-  | { id: string; type: 'realtime.subscribe'; payload: { key: string; params: any } }
-  | { id: string; type: 'realtime.unsubscribe'; payload: { key: string } }
-  | { id: string; type: 'ws.connect'; payload?: { wsUrl?: string } }
-  | { id: string; type: 'ws.disconnect' }
-  | { id: string; type: 'ws.send'; payload: { data: any } }
-  | { id: string; type: 'ws.status' };
+	| {
+			id: string;
+			type: 'init';
+			payload: { url: string; anonKey: string; options?: any };
+	  }
+	| { id: string; type: 'getSession' }
+	| {
+			id: string;
+			type: 'signInWithPassword';
+			payload: { email: string; password: string };
+	  }
+	| { id: string; type: 'signOut' }
+	| {
+			id: string;
+			type: 'from.select';
+			payload: {
+				table: string;
+				columns?: string;
+				match?: Record<string, any>;
+				limit?: number;
+			};
+	  }
+	| {
+			id: string;
+			type: 'from.insert';
+			payload: {
+				table: string;
+				data: Record<string, any> | Record<string, any>[];
+			};
+	  }
+	| {
+			id: string;
+			type: 'from.update';
+			payload: {
+				table: string;
+				data: Record<string, any>;
+				match: Record<string, any>;
+			};
+	  }
+	| {
+			id: string;
+			type: 'from.upsert';
+			payload: {
+				table: string;
+				data: Record<string, any> | Record<string, any>[];
+			};
+	  }
+	| {
+			id: string;
+			type: 'from.delete';
+			payload: { table: string; match: Record<string, any> };
+	  }
+	| {
+			id: string;
+			type: 'rpc';
+			payload: { fn: string; args?: Record<string, any> };
+	  }
+	| {
+			id: string;
+			type: 'realtime.subscribe';
+			payload: { key: string; params: any };
+	  }
+	| { id: string; type: 'realtime.unsubscribe'; payload: { key: string } }
+	| { id: string; type: 'ws.connect'; payload?: { wsUrl?: string } }
+	| { id: string; type: 'ws.disconnect' }
+	| { id: string; type: 'ws.send'; payload: { data: any } }
+	| { id: string; type: 'ws.status' };
 
 type Res =
-  | { id: string; ok: true; data?: any }
-  | { id: string; ok: false; error: string };
+	| { id: string; ok: true; data?: any }
+	| { id: string; ok: false; error: string };
 
 const ports = new Set<MessagePort>();
 
 /** Post to all connected ports, removing dead ones on failure */
 function safeBroadcast(msg: unknown) {
-  for (const p of ports) {
-    try {
-      p.postMessage(msg);
-    } catch {
-      ports.delete(p);
-    }
-  }
+	for (const p of ports) {
+		try {
+			p.postMessage(msg);
+		} catch {
+			ports.delete(p);
+		}
+	}
 }
 
 // ---- IDB-backed auth storage using Dexie 4 ----
 interface KVPair {
-  key: string;
-  value: string;
+	key: string;
+	value: string;
 }
 
 class AuthDB extends Dexie {
-  kv!: Table<KVPair>;
+	kv!: Table<KVPair>;
 
-  constructor() {
-    super('sb-auth-v2');
-    this.version(1).stores({
-      kv: 'key'
-    });
-  }
+	constructor() {
+		super('sb-auth-v2');
+		this.version(1).stores({
+			kv: 'key',
+		});
+	}
 }
 
 class IDBStorage {
-  private db: AuthDB;
+	private db: AuthDB;
 
-  constructor() {
-    this.db = new AuthDB();
-  }
+	constructor() {
+		this.db = new AuthDB();
+	}
 
-  async getItem(key: string): Promise<string | null> {
-    try {
-      const item = await this.db.kv.get(key);
-      return item?.value ?? null;
-    } catch (err) {
-      console.error('[Worker IDBStorage] getItem error:', err);
-      return null;
-    }
-  }
+	async getItem(key: string): Promise<string | null> {
+		try {
+			const item = await this.db.kv.get(key);
+			return item?.value ?? null;
+		} catch (err) {
+			console.error('[Worker IDBStorage] getItem error:', err);
+			return null;
+		}
+	}
 
-  async setItem(key: string, value: string): Promise<void> {
-    await this.db.kv.put({ key, value });
-  }
+	async setItem(key: string, value: string): Promise<void> {
+		await this.db.kv.put({ key, value });
+	}
 
-  async removeItem(key: string): Promise<void> {
-    await this.db.kv.delete(key);
-  }
+	async removeItem(key: string): Promise<void> {
+		await this.db.kv.delete(key);
+	}
 }
 
 // ---- Supabase management ----
 let client: SupabaseClient | null = null;
 const storage = new IDBStorage();
 const comm = getWorkerCommunication();
-const subscriptions = new Map<string, { unsubscribe: () => Promise<void> | void }>();
+const subscriptions = new Map<
+	string,
+	{ unsubscribe: () => Promise<void> | void }
+>();
 
 // ---- WebSocket management ----
 let ws: WebSocket | null = null;
@@ -99,302 +153,392 @@ const WS_RECONNECT_DELAY_MS = 3000;
 
 // ---- Heartbeat management ----
 let wsHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
-let wsLastPongTime: number = 0;
+let wsLastPongTime = 0;
 const WS_HEARTBEAT_INTERVAL_MS = 30000;
 const WS_HEARTBEAT_TIMEOUT_MS = 60000;
 
 function getWebSocketUrl(customUrl?: string): string {
-  if (customUrl) return customUrl;
-  if (typeof location !== 'undefined') {
-    const isLocalhost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
-    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const port = isLocalhost ? '4321' : location.port;
-    const host = location.hostname;
-    return `${protocol}//${host}${port ? ':' + port : ''}/ws`;
-  }
-  return 'ws://localhost:4321/ws';
+	if (customUrl) return customUrl;
+	if (typeof location !== 'undefined') {
+		const isLocalhost =
+			location.hostname === 'localhost' ||
+			location.hostname === '127.0.0.1';
+		const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+		const port = isLocalhost ? '4321' : location.port;
+		const host = location.hostname;
+		return `${protocol}//${host}${port ? ':' + port : ''}/ws`;
+	}
+	return 'ws://localhost:4321/ws';
 }
 
 async function connectWebSocket(wsUrl?: string) {
-  if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) {
-    return;
-  }
+	if (
+		ws &&
+		(ws.readyState === WebSocket.CONNECTING ||
+			ws.readyState === WebSocket.OPEN)
+	) {
+		return;
+	}
 
-  if (!client) throw new Error('Supabase client not initialized');
+	if (!client) throw new Error('Supabase client not initialized');
 
-  const { data: { session }, error } = await client.auth.getSession();
-  if (error || !session?.access_token) {
-    throw new Error('No active session');
-  }
+	const {
+		data: { session },
+		error,
+	} = await client.auth.getSession();
+	if (error || !session?.access_token) {
+		throw new Error('No active session');
+	}
 
-  const url = getWebSocketUrl(wsUrl);
-  const authenticatedUrl = `${url}?token=${encodeURIComponent(session.access_token)}`;
+	const url = getWebSocketUrl(wsUrl);
+	const authenticatedUrl = `${url}?token=${encodeURIComponent(session.access_token)}`;
 
-  console.log('[SharedWorker] Connecting to WebSocket:', url);
-  ws = new WebSocket(authenticatedUrl);
+	console.log('[SharedWorker] Connecting to WebSocket:', url);
+	ws = new WebSocket(authenticatedUrl);
 
-  ws.onopen = () => {
-    wsReconnectAttempts = 0;
-    wsLastPongTime = Date.now();
-    startHeartbeat();
+	ws.onopen = () => {
+		wsReconnectAttempts = 0;
+		wsLastPongTime = Date.now();
+		startHeartbeat();
 
-    safeBroadcast({ type: 'ws.status', status: 'connected', url });
-    comm.broadcast({ type: 'ws.status', data: { status: 'connected', url } });
-  };
+		safeBroadcast({ type: 'ws.status', status: 'connected', url });
+		comm.broadcast({
+			type: 'ws.status',
+			data: { status: 'connected', url },
+		});
+	};
 
-  ws.onmessage = (event) => {
-    try {
-      const message = JSON.parse(event.data);
-      if (message.type === 'pong') {
-        wsLastPongTime = Date.now();
-        return;
-      }
-      safeBroadcast({ type: 'ws.message', data: message });
-      comm.broadcast({ type: 'ws.message', data: message });
-    } catch (error) {
-      console.error('[SharedWorker] Failed to parse WebSocket message:', error);
-    }
-  };
+	ws.onmessage = (event) => {
+		try {
+			const message = JSON.parse(event.data);
+			if (message.type === 'pong') {
+				wsLastPongTime = Date.now();
+				return;
+			}
+			safeBroadcast({ type: 'ws.message', data: message });
+			comm.broadcast({ type: 'ws.message', data: message });
+		} catch (error) {
+			console.error(
+				'[SharedWorker] Failed to parse WebSocket message:',
+				error,
+			);
+		}
+	};
 
-  ws.onerror = () => {
-    safeBroadcast({ type: 'ws.status', status: 'error', error: 'WebSocket connection error' });
-  };
+	ws.onerror = () => {
+		safeBroadcast({
+			type: 'ws.status',
+			status: 'error',
+			error: 'WebSocket connection error',
+		});
+	};
 
-  ws.onclose = (event) => {
-    ws = null;
-    stopHeartbeat();
+	ws.onclose = (event) => {
+		ws = null;
+		stopHeartbeat();
 
-    safeBroadcast({ type: 'ws.status', status: 'disconnected', code: event.code, reason: event.reason });
+		safeBroadcast({
+			type: 'ws.status',
+			status: 'disconnected',
+			code: event.code,
+			reason: event.reason,
+		});
 
-    if (event.code !== 1000 && wsReconnectAttempts < WS_MAX_RECONNECT_ATTEMPTS) {
-      wsReconnectAttempts++;
-      wsReconnectTimer = setTimeout(() => {
-        connectWebSocket(wsUrl).catch(() => {});
-      }, WS_RECONNECT_DELAY_MS);
-    }
-  };
+		if (
+			event.code !== 1000 &&
+			wsReconnectAttempts < WS_MAX_RECONNECT_ATTEMPTS
+		) {
+			wsReconnectAttempts++;
+			wsReconnectTimer = setTimeout(() => {
+				connectWebSocket(wsUrl).catch(() => {
+					/* reconnect best-effort */
+				});
+			}, WS_RECONNECT_DELAY_MS);
+		}
+	};
 }
 
 function startHeartbeat() {
-  stopHeartbeat();
-  wsHeartbeatTimer = setInterval(() => {
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      stopHeartbeat();
-      return;
-    }
-    if (wsLastPongTime > 0 && Date.now() - wsLastPongTime > WS_HEARTBEAT_TIMEOUT_MS) {
-      console.warn('[SharedWorker] Heartbeat timeout');
-      stopHeartbeat();
-      ws.close(1001, 'Heartbeat timeout');
-      return;
-    }
-    try {
-      ws.send(JSON.stringify({ type: 'ping' }));
-    } catch (error) {
-      console.error('[SharedWorker] Failed to send heartbeat:', error);
-    }
-  }, WS_HEARTBEAT_INTERVAL_MS);
+	stopHeartbeat();
+	wsHeartbeatTimer = setInterval(() => {
+		if (!ws || ws.readyState !== WebSocket.OPEN) {
+			stopHeartbeat();
+			return;
+		}
+		if (
+			wsLastPongTime > 0 &&
+			Date.now() - wsLastPongTime > WS_HEARTBEAT_TIMEOUT_MS
+		) {
+			console.warn('[SharedWorker] Heartbeat timeout');
+			stopHeartbeat();
+			ws.close(1001, 'Heartbeat timeout');
+			return;
+		}
+		try {
+			ws.send(JSON.stringify({ type: 'ping' }));
+		} catch (error) {
+			console.error('[SharedWorker] Failed to send heartbeat:', error);
+		}
+	}, WS_HEARTBEAT_INTERVAL_MS);
 }
 
 function stopHeartbeat() {
-  if (wsHeartbeatTimer) {
-    clearInterval(wsHeartbeatTimer);
-    wsHeartbeatTimer = null;
-  }
+	if (wsHeartbeatTimer) {
+		clearInterval(wsHeartbeatTimer);
+		wsHeartbeatTimer = null;
+	}
 }
 
 function disconnectWebSocket() {
-  if (wsReconnectTimer) {
-    clearTimeout(wsReconnectTimer);
-    wsReconnectTimer = null;
-  }
-  stopHeartbeat();
-  if (ws) {
-    ws.close(1000, 'Requested by client');
-    ws = null;
-    wsReconnectAttempts = 0;
-    safeBroadcast({ type: 'ws.status', status: 'disconnected' });
-  }
+	if (wsReconnectTimer) {
+		clearTimeout(wsReconnectTimer);
+		wsReconnectTimer = null;
+	}
+	stopHeartbeat();
+	if (ws) {
+		ws.close(1000, 'Requested by client');
+		ws = null;
+		wsReconnectAttempts = 0;
+		safeBroadcast({ type: 'ws.status', status: 'disconnected' });
+	}
 }
 
 function sendWebSocketMessage(data: any) {
-  if (!ws || ws.readyState !== WebSocket.OPEN) throw new Error('WebSocket not connected');
-  const message = typeof data === 'string' ? data : JSON.stringify(data);
-  ws.send(message);
+	if (!ws || ws.readyState !== WebSocket.OPEN)
+		throw new Error('WebSocket not connected');
+	const message = typeof data === 'string' ? data : JSON.stringify(data);
+	ws.send(message);
 }
 
 function getWebSocketStatus() {
-  if (!ws) return { status: 'disconnected', readyState: null };
-  const readyStateMap: Record<number, string> = {
-    [WebSocket.CONNECTING]: 'connecting',
-    [WebSocket.OPEN]: 'connected',
-    [WebSocket.CLOSING]: 'closing',
-    [WebSocket.CLOSED]: 'disconnected'
-  };
-  return { status: readyStateMap[ws.readyState] || 'unknown', readyState: ws.readyState };
+	if (!ws) return { status: 'disconnected', readyState: null };
+	const readyStateMap: Record<number, string> = {
+		[WebSocket.CONNECTING]: 'connecting',
+		[WebSocket.OPEN]: 'connected',
+		[WebSocket.CLOSING]: 'closing',
+		[WebSocket.CLOSED]: 'disconnected',
+	};
+	return {
+		status: readyStateMap[ws.readyState] || 'unknown',
+		readyState: ws.readyState,
+	};
 }
 
 async function ensureClient(url: string, anonKey: string, options: any = {}) {
-  if (client) return client;
+	if (client) return client;
 
-  try { new URL(url); } catch { throw new Error(`Invalid Supabase URL: ${url}`); }
+	try {
+		new URL(url);
+	} catch {
+		throw new Error(`Invalid Supabase URL: ${url}`);
+	}
 
-  client = createClient(url, anonKey, {
-    auth: {
-      storage,
-      persistSession: true,
-      autoRefreshToken: true,
-    },
-    realtime: { params: { eventsPerSecond: 5 } },
-    ...options,
-  });
+	client = createClient(url, anonKey, {
+		auth: {
+			storage,
+			persistSession: true,
+			autoRefreshToken: true,
+		},
+		realtime: { params: { eventsPerSecond: 5 } },
+		...options,
+	});
 
-  client.auth.onAuthStateChange(async (_event, session) => {
-    safeBroadcast({ type: 'auth', session });
-    comm.broadcast({ type: 'auth', data: { session } });
-  });
+	client.auth.onAuthStateChange(async (_event, session) => {
+		safeBroadcast({ type: 'auth', session });
+		comm.broadcast({ type: 'auth', data: { session } });
+	});
 
-  return client;
+	return client;
 }
 
 function reply(port: MessagePort, msg: Res) {
-  port.postMessage(msg);
+	port.postMessage(msg);
 }
 
-(self as unknown as SharedWorkerGlobalScope).onconnect = (evt: MessageEvent) => {
-  const port = evt.ports[0];
-  ports.add(port);
+(self as unknown as SharedWorkerGlobalScope).onconnect = (
+	evt: MessageEvent,
+) => {
+	const port = evt.ports[0];
+	ports.add(port);
 
-  port.onmessage = async (e: MessageEvent<Req>) => {
-    const m = e.data;
-    try {
-      switch (m.type) {
-        case 'init': {
-          const c = await ensureClient(m.payload.url, m.payload.anonKey, m.payload.options);
-          const { data, error } = await c.auth.getSession();
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data: { session: data.session } });
-          break;
-        }
-        case 'getSession': {
-          if (!client) throw new Error('Not initialized');
-          const { data, error } = await client.auth.getSession();
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'signInWithPassword': {
-          if (!client) throw new Error('Not initialized');
-          const { email, password } = m.payload;
-          const { data, error } = await client.auth.signInWithPassword({ email, password });
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'signOut': {
-          if (!client) throw new Error('Not initialized');
-          const { error } = await client.auth.signOut();
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true });
-          break;
-        }
-        case 'from.select': {
-          if (!client) throw new Error('Not initialized');
-          let query = client.from(m.payload.table).select(m.payload.columns ?? '*');
-          if (m.payload.match) query = query.match(m.payload.match);
-          if (m.payload.limit) query = query.limit(m.payload.limit);
-          const { data, error } = await query;
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'from.insert': {
-          if (!client) throw new Error('Not initialized');
-          const { data, error } = await client.from(m.payload.table).insert(m.payload.data).select();
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'from.update': {
-          if (!client) throw new Error('Not initialized');
-          const { data, error } = await client.from(m.payload.table).update(m.payload.data).match(m.payload.match).select();
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'from.upsert': {
-          if (!client) throw new Error('Not initialized');
-          const { data, error } = await client.from(m.payload.table).upsert(m.payload.data).select();
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'from.delete': {
-          if (!client) throw new Error('Not initialized');
-          const { data, error } = await client.from(m.payload.table).delete().match(m.payload.match).select();
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'rpc': {
-          if (!client) throw new Error('Not initialized');
-          const { fn, args } = m.payload;
-          const { data, error } = await client.rpc(fn, args ?? {});
-          if (error) throw error;
-          reply(port, { id: m.id, ok: true, data });
-          break;
-        }
-        case 'realtime.subscribe': {
-          if (!client) throw new Error('Not initialized');
-          const { key, params } = m.payload;
-          const channel = client
-            .channel(key)
-            .on('postgres_changes', params, (payload) => {
-              safeBroadcast({ type: 'realtime', key, payload });
-            });
-          await channel.subscribe();
-          subscriptions.set(key, { unsubscribe: async () => { await channel.unsubscribe(); } });
-          reply(port, { id: m.id, ok: true });
-          break;
-        }
-        case 'realtime.unsubscribe': {
-          const sub = subscriptions.get(m.payload.key);
-          if (sub) {
-            await sub.unsubscribe();
-            subscriptions.delete(m.payload.key);
-          }
-          reply(port, { id: m.id, ok: true });
-          break;
-        }
-        case 'ws.connect': {
-          await connectWebSocket(m.payload?.wsUrl);
-          reply(port, { id: m.id, ok: true, data: getWebSocketStatus() });
-          break;
-        }
-        case 'ws.disconnect': {
-          disconnectWebSocket();
-          reply(port, { id: m.id, ok: true });
-          break;
-        }
-        case 'ws.send': {
-          sendWebSocketMessage(m.payload.data);
-          reply(port, { id: m.id, ok: true });
-          break;
-        }
-        case 'ws.status': {
-          reply(port, { id: m.id, ok: true, data: getWebSocketStatus() });
-          break;
-        }
-        default: {
-          const _exhaustive: never = m;
-          reply(port, { id: (_exhaustive as any).id, ok: false, error: 'Unknown message type' });
-        }
-      }
-    } catch (err: any) {
-      reply(port, { id: m.id, ok: false, error: String(err?.message ?? err) });
-    }
-  };
+	port.onmessage = async (e: MessageEvent<Req>) => {
+		const m = e.data;
+		try {
+			switch (m.type) {
+				case 'init': {
+					const c = await ensureClient(
+						m.payload.url,
+						m.payload.anonKey,
+						m.payload.options,
+					);
+					const { data, error } = await c.auth.getSession();
+					if (error) throw error;
+					reply(port, {
+						id: m.id,
+						ok: true,
+						data: { session: data.session },
+					});
+					break;
+				}
+				case 'getSession': {
+					if (!client) throw new Error('Not initialized');
+					const { data, error } = await client.auth.getSession();
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'signInWithPassword': {
+					if (!client) throw new Error('Not initialized');
+					const { email, password } = m.payload;
+					const { data, error } =
+						await client.auth.signInWithPassword({
+							email,
+							password,
+						});
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'signOut': {
+					if (!client) throw new Error('Not initialized');
+					const { error } = await client.auth.signOut();
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true });
+					break;
+				}
+				case 'from.select': {
+					if (!client) throw new Error('Not initialized');
+					let query = client
+						.from(m.payload.table)
+						.select(m.payload.columns ?? '*');
+					if (m.payload.match) query = query.match(m.payload.match);
+					if (m.payload.limit) query = query.limit(m.payload.limit);
+					const { data, error } = await query;
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'from.insert': {
+					if (!client) throw new Error('Not initialized');
+					const { data, error } = await client
+						.from(m.payload.table)
+						.insert(m.payload.data)
+						.select();
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'from.update': {
+					if (!client) throw new Error('Not initialized');
+					const { data, error } = await client
+						.from(m.payload.table)
+						.update(m.payload.data)
+						.match(m.payload.match)
+						.select();
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'from.upsert': {
+					if (!client) throw new Error('Not initialized');
+					const { data, error } = await client
+						.from(m.payload.table)
+						.upsert(m.payload.data)
+						.select();
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'from.delete': {
+					if (!client) throw new Error('Not initialized');
+					const { data, error } = await client
+						.from(m.payload.table)
+						.delete()
+						.match(m.payload.match)
+						.select();
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'rpc': {
+					if (!client) throw new Error('Not initialized');
+					const { fn, args } = m.payload;
+					const { data, error } = await client.rpc(fn, args ?? {});
+					if (error) throw error;
+					reply(port, { id: m.id, ok: true, data });
+					break;
+				}
+				case 'realtime.subscribe': {
+					if (!client) throw new Error('Not initialized');
+					const { key, params } = m.payload;
+					const channel = client
+						.channel(key)
+						.on('postgres_changes', params, (payload) => {
+							safeBroadcast({ type: 'realtime', key, payload });
+						});
+					await channel.subscribe();
+					subscriptions.set(key, {
+						unsubscribe: async () => {
+							await channel.unsubscribe();
+						},
+					});
+					reply(port, { id: m.id, ok: true });
+					break;
+				}
+				case 'realtime.unsubscribe': {
+					const sub = subscriptions.get(m.payload.key);
+					if (sub) {
+						await sub.unsubscribe();
+						subscriptions.delete(m.payload.key);
+					}
+					reply(port, { id: m.id, ok: true });
+					break;
+				}
+				case 'ws.connect': {
+					await connectWebSocket(m.payload?.wsUrl);
+					reply(port, {
+						id: m.id,
+						ok: true,
+						data: getWebSocketStatus(),
+					});
+					break;
+				}
+				case 'ws.disconnect': {
+					disconnectWebSocket();
+					reply(port, { id: m.id, ok: true });
+					break;
+				}
+				case 'ws.send': {
+					sendWebSocketMessage(m.payload.data);
+					reply(port, { id: m.id, ok: true });
+					break;
+				}
+				case 'ws.status': {
+					reply(port, {
+						id: m.id,
+						ok: true,
+						data: getWebSocketStatus(),
+					});
+					break;
+				}
+				default: {
+					const _exhaustive: never = m;
+					reply(port, {
+						id: (_exhaustive as any).id,
+						ok: false,
+						error: 'Unknown message type',
+					});
+				}
+			}
+		} catch (err: any) {
+			reply(port, {
+				id: m.id,
+				ok: false,
+				error: String(err?.message ?? err),
+			});
+		}
+	};
 
-  port.start();
-  port.postMessage({ type: 'ready' });
+	port.start();
+	port.postMessage({ type: 'ready' });
 };

--- a/packages/npm/droid/src/lib/workers/ws-worker.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.ts
@@ -13,7 +13,7 @@ let onStatusCallback: ((status: string) => void) | null = null;
 
 // Heartbeat
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-let lastPongTime: number = 0;
+let lastPongTime = 0;
 const HEARTBEAT_INTERVAL_MS = 30000;
 const HEARTBEAT_TIMEOUT_MS = 60000;
 
@@ -31,7 +31,10 @@ function startHeartbeat() {
 			stopHeartbeat();
 			return;
 		}
-		if (lastPongTime > 0 && Date.now() - lastPongTime > HEARTBEAT_TIMEOUT_MS) {
+		if (
+			lastPongTime > 0 &&
+			Date.now() - lastPongTime > HEARTBEAT_TIMEOUT_MS
+		) {
 			console.warn('[WS] Heartbeat timeout — closing connection');
 			stopHeartbeat();
 			ws.close(1001, 'Heartbeat timeout');
@@ -59,14 +62,18 @@ function broadcastStatus(status: string) {
 function attemptReconnect() {
 	if (!lastUrl || reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
 		if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-			console.error(`[WS] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached`);
+			console.error(
+				`[WS] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached`,
+			);
 			broadcastStatus('failed');
 		}
 		return;
 	}
 
 	reconnectAttempts++;
-	console.log(`[WS] Reconnecting (${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`);
+	console.log(
+		`[WS] Reconnecting (${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`,
+	);
 	broadcastStatus('reconnecting');
 
 	reconnectTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Remove unused `tslib` and `@bufbuild/protobuf` dependencies from package.json
- Update version specifiers for `nanostores` (^1.1.0), `@nanostores/persistent` (^1.3.3), and `flatbuffers` (^25.2.10) to match installed versions
- Configure `.eslintrc.json` to ignore test-only dependencies (`@vitest/web-worker`, `fake-indexeddb`) and test setup files
- Replace `Function` type with proper function signatures in WorkerPool, WebWorkerStrategy, and SharedWorkerStrategy
- Remove inferrable `: number` type annotations in DirectStrategy, supabase-shared-worker, and ws-worker
- Add comments to intentional empty catch blocks to satisfy `no-empty-function` rule

Resolves all 19 lint errors in `nx run droid:lint` (0 errors, 186 warnings remaining — all warnings are pre-existing `no-explicit-any`).

## Test plan
- [x] `nx run droid:lint` passes with 0 errors