### PR TITLE
fix(khashvault): resolve all lint errors in khashvault package

### DIFF
--- a/packages/npm/khashvault/.eslintrc.json
+++ b/packages/npm/khashvault/.eslintrc.json
@@ -28,7 +28,8 @@
 						"ignoredFiles": [
 							"{projectRoot}/eslint.config.{js,cjs,mjs}",
 							"{projectRoot}/vite.config.{js,ts,mjs,mts}"
-						]
+						],
+						"ignoredDependencies": ["@kbve/droid"]
 					}
 				]
 			}

--- a/packages/npm/khashvault/package.json
+++ b/packages/npm/khashvault/package.json
@@ -2,10 +2,23 @@
 	"name": "@kbve/khashvault",
 	"version": "0.1.0",
 	"description": "Browser-side cryptography and secure storage via Web Crypto API + OpenPGP",
-	"keywords": ["crypto", "webcrypto", "aes-gcm", "pgp", "openpgp", "indexeddb", "secure-storage"],
+	"keywords": [
+		"crypto",
+		"webcrypto",
+		"aes-gcm",
+		"pgp",
+		"openpgp",
+		"indexeddb",
+		"secure-storage"
+	],
 	"homepage": "https://kbve.com/application/javascript/",
-	"bugs": { "url": "https://github.com/KBVE/kbve/issues" },
-	"repository": { "type": "git", "url": "git+https://github.com/KBVE/kbve.git" },
+	"bugs": {
+		"url": "https://github.com/KBVE/kbve/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/KBVE/kbve.git"
+	},
 	"author": "KBVE <hello@kbve.com>",
 	"license": "MIT",
 	"type": "module",
@@ -25,15 +38,19 @@
 		"*.md"
 	],
 	"dependencies": {
-		"openpgp": "^5.11.0"
+		"openpgp": "^6.3.0"
 	},
 	"peerDependencies": {
 		"@kbve/droid": ">=0.1.0",
 		"comlink": ">=4.0.0"
 	},
 	"peerDependenciesMeta": {
-		"@kbve/droid": { "optional": true },
-		"comlink": { "optional": true }
+		"@kbve/droid": {
+			"optional": true
+		},
+		"comlink": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/npm/khashvault/src/lib/storage/indexeddb.ts
+++ b/packages/npm/khashvault/src/lib/storage/indexeddb.ts
@@ -79,9 +79,7 @@ export class SecureIndexedDB {
 						return;
 					}
 					try {
-						const { ciphertext, iv } = JSON.parse(
-							request.result,
-						);
+						const { ciphertext, iv } = JSON.parse(request.result);
 						const decrypted = await aesDecrypt(this.key, {
 							ciphertext,
 							iv,
@@ -132,9 +130,7 @@ export class SecureIndexedDB {
 			tx.objectStore(this.storeName).clear();
 			tx.oncomplete = () => resolve();
 			tx.onerror = () =>
-				reject(
-					new StorageError('Failed to clear IndexedDB store'),
-				);
+				reject(new StorageError('Failed to clear IndexedDB store'));
 		});
 	}
 
@@ -143,18 +139,19 @@ export class SecureIndexedDB {
 		return new Promise<string[]>((resolve, reject) => {
 			const tx = db.transaction(this.storeName, 'readonly');
 			const request = tx.objectStore(this.storeName).getAllKeys();
-			request.onsuccess = () =>
-				resolve(request.result as string[]);
+			request.onsuccess = () => resolve(request.result as string[]);
 			request.onerror = () =>
-				reject(
-					new StorageError('Failed to list IndexedDB keys'),
-				);
+				reject(new StorageError('Failed to list IndexedDB keys'));
 		});
 	}
 
 	close(): void {
 		if (this.dbPromise) {
-			this.dbPromise.then((db) => db.close()).catch(() => {});
+			this.dbPromise
+				.then((db) => db.close())
+				.catch(() => {
+					/* best-effort */
+				});
 			this.dbPromise = null;
 		}
 	}


### PR DESCRIPTION
## Summary
- Update `openpgp` version specifier from `^5.11.0` to `^6.3.0` to match installed version
- Add `@kbve/droid` to `ignoredDependencies` in `.eslintrc.json` (optional peer dep checked at runtime via `globalThis.kbve`, not imported)
- Fix empty catch block in `SecureIndexedDB.close()`

Resolves all 3 lint errors in `nx run khashvault:lint` (0 errors, 3 warnings remaining — all pre-existing `no-unused-vars`).

## Test plan
- [x] `nx run khashvault:lint` passes with 0 errors