### PR TITLE
fix(ci): add Python and UV setup to CI lint workflows for pydesk

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -316,6 +316,14 @@ jobs:
             - name: Install pnpm Dependencies
               run: pnpm install
 
+            - name: Setup Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: '3.12'
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=origin/dev --head=HEAD --no-cloud
 
@@ -527,7 +535,16 @@ jobs:
     workflow_summary:
         name: 'Workflow Summary'
         runs-on: ubuntu-latest
-        needs: [authorize_actor, validate_branch, check_pr_status, create_pr, run_tests, security_check, auto_merge]
+        needs:
+            [
+                authorize_actor,
+                validate_branch,
+                check_pr_status,
+                create_pr,
+                run_tests,
+                security_check,
+                auto_merge,
+            ]
         if: always()
         timeout-minutes: 5
 

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -267,6 +267,14 @@ jobs:
             - name: Install pnpm Dependencies
               run: pnpm install
 
+            - name: Setup Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: '3.12'
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=origin/staging --head=origin/dev --no-cloud
 

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -251,6 +251,14 @@ jobs:
             - name: Install pnpm Dependencies
               run: pnpm install
 
+            - name: Setup Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: '3.12'
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=origin/main --head=origin/staging --no-cloud
 


### PR DESCRIPTION
## Summary
- Added `actions/setup-python@v6` (Python 3.12) and `astral-sh/setup-uv@v7` to CI workflows that run `nx affected --target=lint`
- Fixes `pydesk:lint` failure in CI where `@nxlv/python:flake8` executor requires UV (detected via `uv.lock`) but UV was not installed
- Updated workflows: `ci-dev.yml`, `ci-atom.yml`, `ci-staging.yml`

## Root Cause
The `pydesk` project uses `@nxlv/python:flake8` for linting. This executor auto-detects the Python package manager from lockfiles — since `uv.lock` exists, it requires the `uv` command. The CI lint jobs had Node/pnpm setup but were missing Python/UV setup.

## Test plan
- [x] `nx run pydesk:lint` passes locally
- [ ] CI lint workflow succeeds with Python/UV available