### PR TITLE
fix(soul): rename Cargo package to match Nx project name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7500,26 +7500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_soul"
-version = "0.1.0"
-dependencies = [
- "axum 0.8.8",
- "bitflags 2.11.0",
- "borsh 1.6.0",
- "borsh-derive 1.6.0",
- "papaya 0.1.9",
- "serde",
- "serde_json",
- "solana-client",
- "solana-program",
- "solana-sdk",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10312,6 +10292,26 @@ dependencies = [
  "solana-serialize-utils",
  "solana-short-vec",
  "solana-system-interface",
+]
+
+[[package]]
+name = "soul"
+version = "0.1.0"
+dependencies = [
+ "axum 0.8.8",
+ "bitflags 2.11.0",
+ "borsh 1.6.0",
+ "borsh-derive 1.6.0",
+ "papaya 0.1.9",
+ "serde",
+ "serde_json",
+ "solana-client",
+ "solana-program",
+ "solana-sdk",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/packages/rust/soul/Cargo.toml
+++ b/packages/rust/soul/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust_soul"
+name = "soul"
 authors = ["kbve", "h0lybyte"]
 version = "0.1.0"
 edition = "2021"


### PR DESCRIPTION
## Summary
- Renamed Cargo package from `rust_soul` to `soul` in `packages/rust/soul/Cargo.toml`
- The `@monodon/rust:lint` executor runs `cargo clippy -p {projectName}`, using the Nx project name (`soul`), but the Cargo package was named `rust_soul` — causing `package ID specification 'soul' did not match any packages`
- All other Rust packages in the workspace already have matching Nx/Cargo names

## Root Cause
The `@monodon/rust` executor automatically passes `-p {context.projectName}` to cargo commands. Since the Nx project name is `soul` but the Cargo.toml had `name = "rust_soul"`, cargo couldn't find the package.

## Test plan
- [x] `nx run soul:lint` passes locally (clippy completes with only warnings, no errors)
- [ ] CI lint workflow succeeds