### PR TITLE
fix(ci): add PostgreSQL 17 + pgrx setup for kilobase lint in CI

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -324,6 +324,16 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v7
 
+            - name: Setup PostgreSQL 17 for pgrx
+              run: |
+                  sudo install -d /usr/share/postgresql-common/pgdg
+                  sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+                  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+                  sudo apt-get update
+                  sudo apt-get install -y postgresql-server-dev-17 libclang-dev
+                  mkdir -p ~/.pgrx
+                  printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=origin/dev --head=HEAD --no-cloud
 

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -275,6 +275,16 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v7
 
+            - name: Setup PostgreSQL 17 for pgrx
+              run: |
+                  sudo install -d /usr/share/postgresql-common/pgdg
+                  sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+                  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+                  sudo apt-get update
+                  sudo apt-get install -y postgresql-server-dev-17 libclang-dev
+                  mkdir -p ~/.pgrx
+                  printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=origin/staging --head=origin/dev --no-cloud
 

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -259,6 +259,16 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v7
 
+            - name: Setup PostgreSQL 17 for pgrx
+              run: |
+                  sudo install -d /usr/share/postgresql-common/pgdg
+                  sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+                  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+                  sudo apt-get update
+                  sudo apt-get install -y postgresql-server-dev-17 libclang-dev
+                  mkdir -p ~/.pgrx
+                  printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=origin/main --head=origin/staging --no-cloud
 


### PR DESCRIPTION
## Summary
- Installs `postgresql-server-dev-17` from PGDG apt repo and `libclang-dev` in CI workflows
- Creates `~/.pgrx/config.toml` pointing to the PG17 `pg_config` binary
- Fixes `$PGRX_HOME does not exist` error when running `kilobase:lint` (`cargo clippy`) in CI

## Context
The kilobase extension uses [pgrx](https://github.com/pgcentralfoundation/pgrx) which requires PostgreSQL development headers and a valid `~/.pgrx/config.toml` to compile `pgrx-pg-sys` bindings. CI lacked this setup, causing the build to fail before clippy could run.

## Files Changed
- `.github/workflows/ci-dev.yml` — Added "Setup PostgreSQL 17 for pgrx" step
- `.github/workflows/ci-atom.yml` — Added "Setup PostgreSQL 17 for pgrx" step
- `.github/workflows/ci-staging.yml` — Added "Setup PostgreSQL 17 for pgrx" step

## Test plan
- [ ] CI `kilobase:lint` passes with the new PostgreSQL setup step