### PR TITLE
refactor(ci): extract lint/test into reusable utils-ci-lint-test workflow

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -277,68 +277,14 @@ jobs:
     # Job 5: Run lint + test on affected projects
     run_tests:
         name: 'Run Tests'
-        runs-on: ubuntu-latest
         needs: [check_pr_status, create_pr]
         if: always() && !failure() && !cancelled() && (needs.check_pr_status.outputs.pr_exists == 'true' || needs.create_pr.outputs.pr_created == 'true')
-        timeout-minutes: 30
         permissions:
             contents: read
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-
-            - name: Setup Node v24
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Setup pnpm v10
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 10
-                  run_install: false
-
-            - name: Get pnpm Store Path
-              id: pnpm-store
-              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm Cache
-              uses: actions/cache@v5
-              with:
-                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install pnpm Dependencies
-              run: pnpm install
-
-            - name: Setup Python
-              uses: actions/setup-python@v6
-              with:
-                  python-version: '3.12'
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@v7
-
-            - name: Setup PostgreSQL 17 for pgrx
-              run: |
-                  sudo install -d /usr/share/postgresql-common/pgdg
-                  sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-                  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-                  sudo apt-get update
-                  sudo apt-get install -y postgresql-server-dev-17 libclang-dev
-                  mkdir -p ~/.pgrx
-                  printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
-
-            - name: Lint affected projects
-              run: pnpm nx affected --target=lint --base=origin/dev --head=HEAD --no-cloud
-
-            - name: Test affected projects
-              run: pnpm nx affected --target=test --base=origin/dev --head=HEAD --no-cloud
+        uses: ./.github/workflows/utils-ci-lint-test.yml
+        with:
+            base-ref: origin/dev
+            head-ref: HEAD
 
     # Job 6: Security check — defense-in-depth validation of PR author
     security_check:

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -230,63 +230,10 @@ jobs:
 
     validate_pr:
         name: 'Validate Dev→Staging PR'
-        runs-on: ubuntu-latest
         if: github.event_name == 'pull_request' && github.base_ref == 'staging' && github.head_ref == 'dev'
-        timeout-minutes: 30
         permissions:
             contents: read
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-
-            - name: Setup Node v24
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Setup pnpm v10
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 10
-                  run_install: false
-
-            - name: Get pnpm Store Path
-              id: pnpm-store
-              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm Cache
-              uses: actions/cache@v5
-              with:
-                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install pnpm Dependencies
-              run: pnpm install
-
-            - name: Setup Python
-              uses: actions/setup-python@v6
-              with:
-                  python-version: '3.12'
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@v7
-
-            - name: Setup PostgreSQL 17 for pgrx
-              run: |
-                  sudo install -d /usr/share/postgresql-common/pgdg
-                  sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-                  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-                  sudo apt-get update
-                  sudo apt-get install -y postgresql-server-dev-17 libclang-dev
-                  mkdir -p ~/.pgrx
-                  printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
-
-            - name: Lint affected projects
-              run: pnpm nx affected --target=lint --base=origin/staging --head=origin/dev --no-cloud
-
-            - name: Test affected projects
-              run: pnpm nx affected --target=test --base=origin/staging --head=origin/dev --no-cloud
+        uses: ./.github/workflows/utils-ci-lint-test.yml
+        with:
+            base-ref: origin/staging
+            head-ref: origin/dev

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -197,80 +197,11 @@ jobs:
 
     validate_staging_pr:
         name: 'Validate Staging→Main PR'
-        runs-on: ubuntu-latest
         if: github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'staging'
-        timeout-minutes: 30
         permissions:
             contents: read
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-
-            - name: Check for conflicts
-              run: |
-                  echo "Checking for merge conflicts..."
-
-                  # Try to merge main into staging (dry run)
-                  git config user.name "CI Bot"
-                  git config user.email "ci@example.com"
-
-                  if git merge --no-commit --no-ff origin/main; then
-                    echo "No merge conflicts detected"
-                    git merge --abort
-                  else
-                    echo "Merge conflicts detected! Please resolve before merging."
-                    git merge --abort
-                    exit 1
-                  fi
-
-            - name: Setup Node v24
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Setup pnpm v10
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 10
-                  run_install: false
-
-            - name: Get pnpm Store Path
-              id: pnpm-store
-              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm Cache
-              uses: actions/cache@v5
-              with:
-                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install pnpm Dependencies
-              run: pnpm install
-
-            - name: Setup Python
-              uses: actions/setup-python@v6
-              with:
-                  python-version: '3.12'
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@v7
-
-            - name: Setup PostgreSQL 17 for pgrx
-              run: |
-                  sudo install -d /usr/share/postgresql-common/pgdg
-                  sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-                  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-                  sudo apt-get update
-                  sudo apt-get install -y postgresql-server-dev-17 libclang-dev
-                  mkdir -p ~/.pgrx
-                  printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
-
-            - name: Lint affected projects
-              run: pnpm nx affected --target=lint --base=origin/main --head=origin/staging --no-cloud
-
-            - name: Test affected projects
-              run: pnpm nx affected --target=test --base=origin/main --head=origin/staging --no-cloud
+        uses: ./.github/workflows/utils-ci-lint-test.yml
+        with:
+            base-ref: origin/main
+            head-ref: origin/staging
+            check-conflicts: true

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -1,0 +1,97 @@
+name: CI - Lint and Test
+
+on:
+    workflow_call:
+        inputs:
+            base-ref:
+                required: true
+                type: string
+                description: 'Base ref for nx affected (e.g., origin/staging)'
+            head-ref:
+                required: true
+                type: string
+                description: 'Head ref for nx affected (e.g., origin/dev)'
+            check-conflicts:
+                required: false
+                type: boolean
+                default: false
+                description: 'Run merge conflict check before tests'
+
+jobs:
+    lint-and-test:
+        name: 'Lint and Test'
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Check for conflicts
+              if: ${{ inputs.check-conflicts }}
+              run: |
+                  echo "Checking for merge conflicts..."
+                  git config user.name "CI Bot"
+                  git config user.email "ci@example.com"
+
+                  if git merge --no-commit --no-ff origin/main; then
+                    echo "No merge conflicts detected"
+                    git merge --abort
+                  else
+                    echo "Merge conflicts detected! Please resolve before merging."
+                    git merge --abort
+                    exit 1
+                  fi
+
+            - name: Setup Node v24
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - name: Setup pnpm v10
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+                  run_install: false
+
+            - name: Get pnpm Store Path
+              id: pnpm-store
+              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+            - name: Setup pnpm Cache
+              uses: actions/cache@v5
+              with:
+                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+
+            - name: Install pnpm Dependencies
+              run: pnpm install
+
+            - name: Setup Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: '3.12'
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+
+            - name: Setup PostgreSQL 17 for pgrx
+              run: |
+                  sudo install -d /usr/share/postgresql-common/pgdg
+                  sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+                  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+                  sudo apt-get update
+                  sudo apt-get install -y postgresql-server-dev-17 libclang-dev
+                  mkdir -p ~/.pgrx
+                  printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
+
+            - name: Lint affected projects
+              run: pnpm nx affected --target=lint --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud
+
+            - name: Test affected projects
+              run: pnpm nx affected --target=test --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud


### PR DESCRIPTION
## Summary
- Creates `.github/workflows/utils-ci-lint-test.yml` reusable workflow with parameterized `base-ref`, `head-ref`, and `check-conflicts` inputs
- Replaces duplicated lint/test setup (~60-80 lines each) in `ci-dev.yml`, `ci-atom.yml`, and `ci-staging.yml` with ~6-line reusable workflow calls
- Net reduction: **-79 lines** of duplicated CI configuration

## Context
Follow-up to #7200. The identical Node/pnpm/Python/UV/PostgreSQL/pgrx setup was duplicated across 3 CI workflows, requiring every change (like adding pgrx support) to touch all 3 files. This extracts the shared logic into a single reusable workflow following the existing `utils-*` naming convention.

## Test plan
- [ ] CI lint/test passes on this PR (validates the reusable workflow works for ci-dev)
- [ ] Subsequent staging and atom branch pushes validate the other two callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)