### PR TITLE
fix(notification-bot): prevent information exposure through exceptions

### DIFF
--- a/apps/discordsh/notification-bot/notification_bot/api/discord/commands/bot_offline.py
+++ b/apps/discordsh/notification-bot/notification_bot/api/discord/commands/bot_offline.py
@@ -2,11 +2,14 @@
 Bot offline command module - Manual Dishka resolution
 """
 import asyncio
+import logging
 import os
 import signal
 from fastapi import APIRouter, Request
 from ....api.discord.discord_service import DiscordBotService
 from ....models.responses import StandardResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -34,9 +37,10 @@ async def take_bot_offline(request: Request, shutdown_app: bool = False) -> Stan
             else:
                 return {"status": "success", "message": "Discord bot taken offline"}
     except Exception as e:
+        logger.exception("Failed to take Discord bot offline")
         if "already" in str(e).lower():
-            return {"status": "info", "message": str(e)}
-        return {"status": "error", "message": str(e)}
+            return {"status": "info", "message": "Discord bot is already offline"}
+        return {"status": "error", "message": "Failed to take Discord bot offline"}
 
 
 @router.post("/sign-off", response_model=StandardResponse)

--- a/apps/discordsh/notification-bot/notification_bot/api/discord/commands/bot_online.py
+++ b/apps/discordsh/notification-bot/notification_bot/api/discord/commands/bot_online.py
@@ -1,9 +1,12 @@
 """
 Bot online command module - Manual Dishka resolution
 """
+import logging
 from fastapi import APIRouter, Request
 from ....api.discord.discord_service import DiscordBotService
 from ....models.responses import StandardResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -20,6 +23,7 @@ async def bring_bot_online(request: Request) -> StandardResponse:
             await discord_bot.bring_online()
             return {"status": "success", "message": "Discord bot is coming online"}
     except Exception as e:
+        logger.exception("Failed to bring Discord bot online")
         if "already" in str(e).lower():
-            return {"status": "info", "message": str(e)}
-        return {"status": "error", "message": str(e)}
+            return {"status": "info", "message": "Discord bot is already online"}
+        return {"status": "error", "message": "Failed to bring Discord bot online"}


### PR DESCRIPTION
## Summary
- Replace raw exception text (`str(e)`) in `bot_offline.py` and `bot_online.py` API responses with generic safe messages
- Add `logger.exception()` calls to log full exception details server-side for debugging
- Prevents potential information disclosure through error responses (CWE-209)

## Changes
- `bot_offline.py`: Added logging, replaced `str(e)` with `"Discord bot is already offline"` / `"Failed to take Discord bot offline"`
- `bot_online.py`: Added logging, replaced `str(e)` with `"Discord bot is already online"` / `"Failed to bring Discord bot online"`

## Test plan
- [ ] Verify `/bot-offline` returns generic error message when bot fails to stop
- [ ] Verify `/bot-offline` returns "already offline" info when bot is already stopped
- [ ] Verify `/bot-online` returns generic error message when bot fails to start
- [ ] Verify `/bot-online` returns "already online" info when bot is already running
- [ ] Confirm exception details appear in server logs (not in API response)