### PR TITLE
feat(discordsh): redesign nav bar with icon row, logo header, and unified tooltip

### DIFF
--- a/apps/discordsh/astro-discordsh/src/components/header/Header.astro
+++ b/apps/discordsh/astro-discordsh/src/components/header/Header.astro
@@ -3,97 +3,105 @@ import config from 'virtual:starlight/user-config';
 
 import LanguageSelect from 'virtual:starlight/components/LanguageSelect';
 import Search from 'virtual:starlight/components/Search';
-import SiteTitle from 'virtual:starlight/components/SiteTitle';
 import SocialIcons from 'virtual:starlight/components/SocialIcons';
 import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 import NavBar from '../navigation/NavBar.astro';
 
 const shouldRenderSearch =
-  config.pagefind ||
-  config.components.Search !== '@astrojs/starlight/components/Search.astro';
+	config.pagefind ||
+	config.components.Search !== '@astrojs/starlight/components/Search.astro';
 ---
 
 <div class="header">
-  <div class="title-wrapper sl-flex">
-    <SiteTitle />
-  </div>
-  <div class="nav-center">
-    <NavBar />
-  </div>
-  <div class="sl-hidden md:sl-flex print:hidden right-group">
-    <div class="sl-flex social-icons">
-      <SocialIcons />
-    </div>
-    {shouldRenderSearch && <Search />}
-    <ThemeSelect />
-    <LanguageSelect />
-  </div>
+	<div class="title-wrapper sl-flex">
+		<a
+			href="/"
+			class="inline-flex items-center no-underline"
+			data-astro-prefetch>
+			<img
+				src="/images/discord-sh-text.webp"
+				alt="Discord.sh"
+				class="h-7 w-auto object-contain"
+			/>
+		</a>
+	</div>
+	<div class="nav-center">
+		<NavBar />
+	</div>
+	<div class="sl-hidden md:sl-flex print:hidden right-group">
+		<div class="sl-flex social-icons">
+			<SocialIcons />
+		</div>
+		{shouldRenderSearch && <Search />}
+		<ThemeSelect />
+		<LanguageSelect />
+	</div>
 </div>
 
 <style>
-  @layer starlight.core {
-    .header {
-      display: flex;
-      gap: var(--sl-nav-gap);
-      justify-content: space-between;
-      align-items: center;
-      height: 100%;
-    }
+	@layer starlight.core {
+		.header {
+			display: flex;
+			gap: var(--sl-nav-gap);
+			justify-content: space-between;
+			align-items: center;
+			height: 100%;
+		}
 
-    .title-wrapper {
-      overflow: clip;
-      padding: 0.25rem;
-      margin: -0.25rem;
-      min-width: 0;
-    }
+		.title-wrapper {
+			overflow: clip;
+			padding: 0.25rem;
+			margin: -0.25rem;
+			min-width: 0;
+		}
 
-    .nav-center {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
+		.nav-center {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
 
-    .right-group,
-    .social-icons {
-      gap: 1rem;
-      align-items: center;
-    }
-    .social-icons::after {
-      content: '';
-      height: 2rem;
-      border-inline-end: 1px solid var(--sl-color-gray-5);
-    }
+		.right-group,
+		.social-icons {
+			gap: 1rem;
+			align-items: center;
+		}
+		.social-icons::after {
+			content: '';
+			height: 2rem;
+			border-inline-end: 1px solid var(--sl-color-gray-5);
+		}
 
-    @media (min-width: 50rem) {
-      :global(:root[data-has-sidebar]) {
-        --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
-      }
-      :global(:root:not([data-has-toc])) {
-        --__toc-width: 0rem;
-      }
-      .header {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-content: center;
-      }
-      .title-wrapper {
-        justify-self: start;
-      }
-      .nav-center {
-        justify-self: center;
-      }
-      .right-group {
-        justify-self: end;
-      }
-      .right-group :global(site-search) {
-        min-width: 14rem;
-      }
-    }
+		@media (min-width: 50rem) {
+			:global(:root[data-has-sidebar]) {
+				--__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+			}
+			:global(:root:not([data-has-toc])) {
+				--__toc-width: 0rem;
+			}
+			.header {
+				display: grid;
+				grid-template-columns: auto 1fr auto;
+				align-content: center;
+			}
+			.title-wrapper {
+				justify-self: start;
+			}
+			.nav-center {
+				justify-self: center;
+			}
+			.right-group {
+				justify-self: end;
+			}
+			.right-group :global(site-search) {
+				min-width: 14rem;
+			}
+		}
 
-    @media (max-width: 49.99rem) {
-      .nav-center {
-        margin-left: auto;
-      }
-    }
-  }
+		@media (max-width: 49.99rem) {
+			.nav-center {
+				margin-left: auto;
+			}
+		}
+	}
 </style>

--- a/apps/discordsh/astro-discordsh/src/components/navigation/NavBar.astro
+++ b/apps/discordsh/astro-discordsh/src/components/navigation/NavBar.astro
@@ -5,149 +5,347 @@ const currentPath = Astro.url.pathname;
 ---
 
 <nav class="nav-bar not-content flex items-center gap-1">
-  {/* Desktop nav links */}
-  <div class="desktop-links">
-    <a href="/" class:list={['nav-link', { active: currentPath === '/' || currentPath === '' }]} data-astro-prefetch title="Home">
-      <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
-    </a>
-    <a href="/guides/getting-started" class:list={['nav-link', { active: currentPath.startsWith('/guides') || currentPath.startsWith('/reference') }]} data-astro-prefetch title="Docs">
-      <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
-    </a>
-    <a href="/dashboard" class:list={['nav-link', { active: currentPath.startsWith('/dashboard') }]} data-astro-prefetch title="Dashboard">
-      <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
-    </a>
-  </div>
+	{/* Desktop nav links — uniform icon row */}
+	<div class="desktop-links">
+		<a
+			href="/"
+			class:list={[
+				'nav-link',
+				{ active: currentPath === '/' || currentPath === '' },
+			]}
+			data-astro-prefetch
+			data-tooltip-id="home">
+			<svg
+				class="nav-icon"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round">
+				<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z">
+				</path><polyline points="9 22 9 12 15 12 15 22"></polyline>
+			</svg>
+		</a>
+		<a
+			href="/guides/getting-started"
+			class:list={[
+				'nav-link',
+				{
+					active:
+						currentPath.startsWith('/guides') ||
+						currentPath.startsWith('/reference'),
+				},
+			]}
+			data-astro-prefetch
+			data-tooltip-id="docs">
+			<svg
+				class="nav-icon"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round">
+				<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path
+					d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z">
+				</path>
+			</svg>
+		</a>
+		<a
+			href="/dashboard"
+			class:list={[
+				'nav-link',
+				{ active: currentPath.startsWith('/dashboard') },
+			]}
+			data-astro-prefetch
+			data-tooltip-id="dashboard">
+			<svg
+				class="nav-icon"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round">
+				<rect x="3" y="3" width="7" height="7"></rect><rect
+					x="14"
+					y="3"
+					width="7"
+					height="7">
+				</rect><rect x="14" y="14" width="7" height="7"></rect><rect
+					x="3"
+					y="14"
+					width="7"
+					height="7">
+				</rect>
+			</svg>
+		</a>
 
-  {/* Desktop auth container — skeleton until React hydrates */}
-  <div id="nav-auth-desktop" class="desktop-auth">
-    <div class="auth-skeleton">
-      <div class="honeycomb"><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
-    </div>
-  </div>
+		{
+			/* Auth icon slot — static login icon with skeleton z-overlay, no tooltip (has dropdown) */
+		}
+		<div id="nav-auth-desktop" class="nav-link nav-auth-icon">
+			<svg
+				class="nav-icon auth-login-icon"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round">
+				<path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4">
+				</path><polyline points="10 17 15 12 10 7"></polyline><line
+					x1="15"
+					y1="12"
+					x2="3"
+					y2="12">
+				</line>
+			</svg>
+			<div class="auth-skeleton">
+				<div class="skeleton-pulse"></div>
+			</div>
+		</div>
+	</div>
 
-  {/* Mobile hamburger */}
-  <button id="nav-hamburger" type="button" class="hamburger-btn" aria-label="Open menu">
-    <svg class="hamburger-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <line x1="3" y1="12" x2="21" y2="12"></line>
-      <line x1="3" y1="6" x2="21" y2="6"></line>
-      <line x1="3" y1="18" x2="21" y2="18"></line>
-    </svg>
-  </button>
+	{/* Single shared tooltip — positioned via $activeTooltip nanostore */}
+	<div id="nav-tooltip" class="nav-tooltip" aria-hidden="true">
+		<span id="nav-tooltip-text"></span>
+	</div>
 
-  {/* React handles: auth state, portals, drawer, modal */}
-  <ReactNavBar client:only="react" currentPath={currentPath} />
+	{/* Mobile hamburger */}
+	<button
+		id="nav-hamburger"
+		type="button"
+		class="hamburger-btn"
+		aria-label="Open menu">
+		<svg
+			class="hamburger-icon"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round">
+			<line x1="3" y1="12" x2="21" y2="12"></line>
+			<line x1="3" y1="6" x2="21" y2="6"></line>
+			<line x1="3" y1="18" x2="21" y2="18"></line>
+		</svg>
+	</button>
+
+	{/* React handles: auth state, portals, drawer, modal */}
+	<ReactNavBar client:only="react" currentPath={currentPath} />
 </nav>
 
+<script>
+	import { $activeTooltip, openTooltip, closeTooltip } from '@kbve/droid';
+
+	const LABELS: Record<string, string> = {
+		home: 'Home',
+		docs: 'Docs',
+		dashboard: 'Dashboard',
+	};
+
+	function setup() {
+		const tooltip = document.getElementById('nav-tooltip');
+		const text = document.getElementById('nav-tooltip-text');
+		if (!tooltip || !text) return;
+
+		// Attach hover listeners to each nav icon with a tooltip ID
+		document
+			.querySelectorAll<HTMLElement>('[data-tooltip-id]')
+			.forEach((el) => {
+				el.addEventListener('mouseenter', () => {
+					const id = el.dataset.tooltipId;
+					if (id) openTooltip(id);
+				});
+				el.addEventListener('mouseleave', () => closeTooltip());
+			});
+
+		// Subscribe to the shared store — position and show the single tooltip element
+		$activeTooltip.subscribe((id) => {
+			if (!id || !LABELS[id]) {
+				tooltip.style.opacity = '0';
+				tooltip.style.pointerEvents = 'none';
+				return;
+			}
+
+			const trigger = document.querySelector<HTMLElement>(
+				`[data-tooltip-id="${id}"]`,
+			);
+			if (!trigger) return;
+
+			const rect = trigger.getBoundingClientRect();
+			text.textContent = LABELS[id];
+			tooltip.style.opacity = '1';
+			tooltip.style.left = `${rect.left + rect.width / 2}px`;
+			tooltip.style.top = `${rect.bottom + 6}px`;
+		});
+	}
+
+	// Run on initial load and after view transitions
+	setup();
+	document.addEventListener('astro:after-swap', setup);
+</script>
+
 <style>
-  .nav-bar {
-    gap: 0.25rem;
-  }
+	.nav-bar {
+		gap: 0.25rem;
+	}
 
-  .desktop-links {
-    display: none;
-    align-items: center;
-    gap: 0.125rem;
-  }
+	.desktop-links {
+		display: none;
+		align-items: center;
+		gap: 0.25rem;
+	}
 
-  .desktop-auth {
-    display: none;
-    align-items: center;
-    justify-content: center;
-    margin-left: 0.25rem;
-    min-width: 5.5rem;
-    height: 1.75rem;
-    position: relative;
-    border-radius: 999px;
-    background-color: rgba(12, 15, 20, 0.6);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-  }
+	/* Auth icon slot */
+	.nav-auth-icon {
+		position: relative;
+		cursor: pointer;
+	}
 
-  .auth-skeleton {
-    position: absolute;
-    inset: 0;
-    z-index: 2;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 1;
-    transition: opacity 2s ease-in-out;
-    pointer-events: none;
-  }
+	.auth-login-icon {
+		transition: opacity 300ms ease;
+	}
 
-  .desktop-auth:has([data-auth-ready]) .auth-skeleton {
-    opacity: 0;
-  }
+	/* Hide login icon when React renders the avatar */
+	.nav-auth-icon:has([data-auth-avatar]) .auth-login-icon {
+		opacity: 0;
+		pointer-events: none;
+	}
 
-  .hamburger-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2.25rem;
-    height: 2.25rem;
-    border-radius: 0.375rem;
-    border: none;
-    background: none;
-    color: var(--sl-color-gray-2, #a1a1aa);
-    cursor: pointer;
-    transition: color 150ms ease;
-  }
-  .hamburger-btn:hover {
-    color: var(--sl-color-white, #e2e8f0);
-  }
-  .hamburger-icon {
-    width: 1.25rem;
-    height: 1.25rem;
-  }
+	.auth-skeleton {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 1;
+		transition: opacity 2s ease-in-out;
+		pointer-events: none;
+	}
 
-  @media (min-width: 768px) {
-    .desktop-links {
-      display: flex;
-    }
-    .desktop-auth {
-      display: flex;
-    }
-    .hamburger-btn {
-      display: none;
-    }
-  }
+	.nav-auth-icon:has([data-auth-ready]) .auth-skeleton {
+		opacity: 0;
+	}
 
-  .nav-icon {
-    width: 1rem;
-    height: 1rem;
-    flex-shrink: 0;
-    opacity: 0.8;
-  }
+	.skeleton-pulse {
+		width: 0.75rem;
+		height: 0.75rem;
+		border-radius: 50%;
+		background: var(--sl-color-accent);
+		animation: skeleton-pulse 1.5s ease-in-out infinite;
+	}
 
-  .nav-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 0.375rem;
-    color: var(--sl-color-gray-2, #94a3b8);
-    text-decoration: none;
-    transition: background-color 150ms ease, color 150ms ease;
-  }
+	@keyframes skeleton-pulse {
+		0%,
+		100% {
+			opacity: 0.2;
+			transform: scale(0.7);
+		}
+		50% {
+			opacity: 0.7;
+			transform: scale(1);
+		}
+	}
 
-  .nav-link:hover {
-    background-color: var(--sl-color-gray-6, rgba(148, 163, 184, 0.1));
-    color: var(--sl-color-white, #e2e8f0);
-  }
+	/* Shared tooltip — single element, positioned via JS */
+	.nav-tooltip {
+		position: fixed;
+		z-index: 50;
+		transform: translateX(-50%);
+		padding: 0.25rem 0.625rem;
+		border-radius: 0.375rem;
+		background: var(--sl-color-bg-nav, #18181b);
+		border: 1px solid var(--sl-color-hairline, #27272a);
+		color: var(--sl-color-white, #e2e8f0);
+		font-size: 0.6875rem;
+		font-weight: 500;
+		letter-spacing: 0.01em;
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 150ms ease;
+		white-space: nowrap;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+	}
 
-  .nav-link.active {
-    background-color: var(--sl-color-accent-low);
-    color: var(--sl-color-accent);
-  }
+	.hamburger-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.25rem;
+		height: 2.25rem;
+		border-radius: 0.375rem;
+		border: none;
+		background: none;
+		color: var(--sl-color-gray-2, #a1a1aa);
+		cursor: pointer;
+		transition: color 150ms ease;
+	}
+	.hamburger-btn:hover {
+		color: var(--sl-color-white, #e2e8f0);
+	}
+	.hamburger-icon {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
 
-  .nav-link:hover .nav-icon,
-  .nav-link.active .nav-icon {
-    opacity: 1;
-  }
+	@media (min-width: 768px) {
+		.desktop-links {
+			display: flex;
+		}
+		.hamburger-btn {
+			display: none;
+		}
+	}
 
-  @media (max-width: 767px) {
-    .nav-bar {
-      gap: 0.5rem;
-    }
-  }
+	.nav-icon {
+		width: 1rem;
+		height: 1rem;
+		flex-shrink: 0;
+		opacity: 0.8;
+	}
+
+	.nav-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		border-radius: 0.375rem;
+		color: var(--sl-color-gray-2, #94a3b8);
+		text-decoration: none;
+		transition:
+			background-color 150ms ease,
+			color 150ms ease,
+			transform 200ms ease,
+			box-shadow 200ms ease;
+	}
+
+	.nav-link:hover {
+		background-color: var(--sl-color-gray-6, rgba(148, 163, 184, 0.1));
+		color: var(--sl-color-white, #e2e8f0);
+		transform: scale(1.1);
+		box-shadow: 0 2px 8px rgba(139, 92, 246, 0.15);
+	}
+
+	.nav-link.active {
+		background-color: var(--sl-color-accent-low);
+		color: var(--sl-color-accent);
+		box-shadow: 0 0 0 1px
+			color-mix(in srgb, var(--sl-color-accent) 30%, transparent);
+	}
+
+	.nav-link:hover .nav-icon,
+	.nav-link.active .nav-icon {
+		opacity: 1;
+	}
+
+	@media (max-width: 767px) {
+		.nav-bar {
+			gap: 0.5rem;
+		}
+	}
 </style>

--- a/apps/discordsh/astro-discordsh/src/components/navigation/ReactNavBar.tsx
+++ b/apps/discordsh/astro-discordsh/src/components/navigation/ReactNavBar.tsx
@@ -81,7 +81,8 @@ const styles = {
 	} as React.CSSProperties,
 
 	avatarRing: {
-		boxShadow: '0 0 0 2px color-mix(in srgb, var(--sl-color-accent) 25%, transparent)',
+		boxShadow:
+			'0 0 0 2px color-mix(in srgb, var(--sl-color-accent) 25%, transparent)',
 	} as React.CSSProperties,
 
 	userMenu: {
@@ -109,8 +110,7 @@ export default function ReactNavBar({
 	const modalId = useStore($modalId);
 	const modalOpen = modalId === SIGNIN_MODAL;
 
-	const { signInWithOAuth, loading: authLoading } =
-		useAuthBridge(authBridge);
+	const { signInWithOAuth, loading: authLoading } = useAuthBridge(authBridge);
 	const busy = authLoading;
 
 	const currentPath = useStore($currentPath);
@@ -196,8 +196,7 @@ export default function ReactNavBar({
 				className={`${cls} flex items-center justify-center`}
 				style={{
 					backgroundColor: 'var(--sl-color-accent-low)',
-				}}
-			>
+				}}>
 				<User
 					size={large ? 18 : ICON_SIZE}
 					style={{
@@ -214,64 +213,53 @@ export default function ReactNavBar({
 		return (
 			<div
 				data-auth-ready
-				className="absolute inset-0 z-[1] flex items-center justify-center"
-			>
+				className="absolute inset-0 z-[1] flex items-center justify-center">
 				{auth.tone === 'auth' ? (
-					<div className="group relative flex items-center">
-						<button
-							ref={avatarBtnRef}
-							type="button"
-							onClick={() => {
-								if (!avatarBtnRef.current) return;
-								const r =
-									avatarBtnRef.current.getBoundingClientRect();
-								setMenuPos({
-									top: r.bottom + 8,
-									right: window.innerWidth - r.right,
-								});
-								setMenuOpen((v) => !v);
-							}}
-							className="flex items-center gap-1.5 rounded-full px-2 py-0.5 transition-colors duration-150 hover:bg-white/5 focus:outline-none"
-							aria-label="User menu"
-							aria-expanded={menuOpen}
-							aria-haspopup="true"
-						>
-							<Avatar />
-							<span
-								className="text-xs font-medium max-w-[4rem] truncate"
+					<button
+						ref={avatarBtnRef}
+						type="button"
+						onClick={() => {
+							if (!avatarBtnRef.current) return;
+							const r =
+								avatarBtnRef.current.getBoundingClientRect();
+							setMenuPos({
+								top: r.bottom + 8,
+								right: window.innerWidth - r.right,
+							});
+							setMenuOpen((v) => !v);
+						}}
+						className="flex items-center justify-center w-full h-full rounded-[0.375rem] transition-colors duration-150 focus:outline-none"
+						aria-label="User menu"
+						aria-expanded={menuOpen}
+						aria-haspopup="true"
+						data-auth-avatar="">
+						{auth.avatar ? (
+							<img
+								src={auth.avatar}
+								alt={auth.name}
+								className="rounded-full"
 								style={{
-									color: slVar(
-										'--sl-color-white',
-										'#e2e8f0',
-									),
+									width: '1.25rem',
+									height: '1.25rem',
+									...styles.avatarRing,
 								}}
-							>
-								{auth.name}
-							</span>
-						</button>
-					</div>
+							/>
+						) : (
+							<User
+								size={ICON_SIZE}
+								style={{
+									color: 'var(--sl-color-text-accent)',
+								}}
+							/>
+						)}
+					</button>
 				) : (
 					<button
 						type="button"
 						onClick={() => openModal(SIGNIN_MODAL)}
-						className="inline-flex items-center gap-1.5 rounded-full font-medium px-3 text-xs transition-colors duration-150 h-7 whitespace-nowrap"
-						style={styles.accentBtn}
-						onMouseEnter={(e) => {
-							Object.assign(
-								e.currentTarget.style,
-								styles.accentBtnHover,
-							);
-						}}
-						onMouseLeave={(e) => {
-							Object.assign(
-								e.currentTarget.style,
-								styles.accentBtn,
-							);
-						}}
-					>
-						<LogIn size={14} />
-						Sign In
-					</button>
+						className="absolute inset-0 rounded-[0.375rem] focus:outline-none"
+						aria-label="Sign in"
+					/>
 				)}
 			</div>
 		);
@@ -302,8 +290,7 @@ export default function ReactNavBar({
 						className="text-sm font-medium"
 						style={{
 							color: slVar('--sl-color-white', '#e2e8f0'),
-						}}
-					>
+						}}>
 						{auth.name}
 					</span>
 					<a
@@ -321,8 +308,7 @@ export default function ReactNavBar({
 								'--sl-color-gray-2',
 								'#a1a1aa',
 							);
-						}}
-					>
+						}}>
 						<LogOut size={ICON_SIZE} />
 						Sign out
 					</a>
@@ -337,8 +323,7 @@ export default function ReactNavBar({
 				className="inline-flex items-center gap-1.5 w-full px-4 py-3 text-sm font-medium transition-colors duration-150"
 				style={{
 					color: 'var(--sl-color-text-accent)',
-				}}
-			>
+				}}>
 				<LogIn size={ICON_SIZE} />
 				Sign In
 			</button>
@@ -359,8 +344,7 @@ export default function ReactNavBar({
 						)}
 						role="dialog"
 						aria-modal="true"
-						aria-label="Navigation menu"
-					>
+						aria-label="Navigation menu">
 						<div
 							className="absolute inset-0 bg-black/50 backdrop-blur-sm"
 							onClick={doCloseDrawer}
@@ -373,14 +357,12 @@ export default function ReactNavBar({
 									? 'translate-x-0'
 									: 'translate-x-full',
 							)}
-							style={styles.surface}
-						>
+							style={styles.surface}>
 							<div
 								className="flex items-center justify-between px-4 py-3"
 								style={{
 									borderBottom: `1px solid ${slVar('--sl-color-hairline', '#27272a')}`,
-								}}
-							>
+								}}>
 								<span
 									className="text-sm font-semibold"
 									style={{
@@ -388,8 +370,7 @@ export default function ReactNavBar({
 											'--sl-color-white',
 											'#e2e8f0',
 										),
-									}}
-								>
+									}}>
 									Discord.sh
 								</span>
 								<button
@@ -402,8 +383,7 @@ export default function ReactNavBar({
 											'--sl-color-gray-3',
 											'#71717a',
 										),
-									}}
-								>
+									}}>
 									<X size={ICON_SIZE} />
 								</button>
 							</div>
@@ -445,8 +425,7 @@ export default function ReactNavBar({
 															'--sl-color-gray-2',
 															'#a1a1aa',
 														);
-											}}
-										>
+											}}>
 											<item.icon size={ICON_SIZE} />
 											{item.label}
 										</a>
@@ -458,8 +437,7 @@ export default function ReactNavBar({
 								style={{
 									borderTop: `1px solid ${slVar('--sl-color-hairline', '#27272a')}`,
 								}}
-								className="py-2"
-							>
+								className="py-2">
 								<DrawerAuth />
 							</div>
 						</div>
@@ -479,8 +457,7 @@ export default function ReactNavBar({
 							top: menuPos.top,
 							right: menuPos.right,
 						}}
-						role="menu"
-					>
+						role="menu">
 						<div className="flex items-center gap-2.5 px-3 pb-2.5 mb-1">
 							<Avatar large />
 							<div className="min-w-0">
@@ -491,14 +468,12 @@ export default function ReactNavBar({
 											'--sl-color-white',
 											'#e2e8f0',
 										),
-									}}
-								>
+									}}>
 									{auth.name}
 								</div>
 								<div
 									className="text-xs truncate"
-									style={{ color: '#7e8590' }}
-								>
+									style={{ color: '#7e8590' }}>
 									Online
 								</div>
 							</div>
@@ -524,8 +499,7 @@ export default function ReactNavBar({
 											'transparent';
 										e.currentTarget.style.color = '#7e8590';
 									}}
-									role="menuitem"
-								>
+									role="menuitem">
 									<item.icon size={ICON_SIZE} />
 									{item.label}
 								</a>
@@ -553,8 +527,7 @@ export default function ReactNavBar({
 									e.currentTarget.style.color =
 										'var(--sl-color-text-accent)';
 								}}
-								role="menuitem"
-							>
+								role="menuitem">
 								<LogOut size={ICON_SIZE} />
 								Sign Out
 							</a>
@@ -574,12 +547,10 @@ export default function ReactNavBar({
 						onClick={(e) => {
 							if (e.target === e.currentTarget && !busy)
 								closeModal(SIGNIN_MODAL);
-						}}
-					>
+						}}>
 						<div
 							className="w-full max-w-sm rounded-xl shadow-2xl p-5"
-							style={styles.surface}
-						>
+							style={styles.surface}>
 							<div className="flex items-center justify-between mb-4">
 								<h2
 									className="text-base font-semibold"
@@ -588,8 +559,7 @@ export default function ReactNavBar({
 											'--sl-color-white',
 											'#e2e8f0',
 										),
-									}}
-								>
+									}}>
 									Sign in to Discord.sh
 								</h2>
 								<button
@@ -603,8 +573,7 @@ export default function ReactNavBar({
 									onClick={() =>
 										!busy && closeModal(SIGNIN_MODAL)
 									}
-									aria-label="Close"
-								>
+									aria-label="Close">
 									<X size={ICON_SIZE} />
 								</button>
 							</div>
@@ -614,10 +583,8 @@ export default function ReactNavBar({
 									className="mb-3 text-xs rounded-md px-3 py-2"
 									style={{
 										color: '#fca5a5',
-										backgroundColor:
-											'rgba(239,68,68,0.1)',
-									}}
-								>
+										backgroundColor: 'rgba(239,68,68,0.1)',
+									}}>
 									{auth.error}
 								</div>
 							)}
@@ -639,8 +606,7 @@ export default function ReactNavBar({
 									onMouseLeave={(e) => {
 										e.currentTarget.style.backgroundColor =
 											'#5865F2';
-									}}
-								>
+									}}>
 									<DiscordIcon className="w-5 h-5" />
 									Continue with Discord
 								</button>
@@ -661,8 +627,7 @@ export default function ReactNavBar({
 									onMouseLeave={(e) => {
 										e.currentTarget.style.backgroundColor =
 											'#24292f';
-									}}
-								>
+									}}>
 									<GitHubIcon className="w-5 h-5" />
 									Continue with GitHub
 								</button>
@@ -683,8 +648,7 @@ export default function ReactNavBar({
 									onMouseLeave={(e) => {
 										e.currentTarget.style.backgroundColor =
 											'#9146FF';
-									}}
-								>
+									}}>
 									<TwitchIcon className="w-5 h-5" />
 									Continue with Twitch
 								</button>
@@ -697,8 +661,7 @@ export default function ReactNavBar({
 										'--sl-color-gray-3',
 										'#71717a',
 									),
-								}}
-							>
+								}}>
 								Your session syncs automatically across all
 								tabs.
 							</p>


### PR DESCRIPTION
## Summary
- Replace `<SiteTitle />` with Discord.sh logo image in header using Tailwind inline classes
- Redesign navigation as uniform 4-icon row: Home | Docs | Dashboard | Auth (login/avatar)
- Add POC-inspired hover effects: `scale(1.1)`, subtle violet glow shadow, smooth transitions
- Simplify desktop auth to avatar-only display (no username) with static login icon fallback and pulsing skeleton z-overlay that crossfades on auth load via `data-auth-ready` / `data-auth-avatar` CSS selectors
- Add single shared tooltip element positioned via `$activeTooltip` nanostore event bus from `@kbve/droid`, with view transition support (`astro:after-swap`)

## Test plan
- [x] `astro-discordsh:build` passes
- [x] `astro-discordsh:check` passes (0 errors, 0 warnings)
- [x] Dev server renders correctly at localhost:4321
- [ ] Verify logo displays in header on desktop and mobile
- [ ] Verify 4 uniform nav icons render on desktop, hamburger on mobile
- [ ] Hover tooltips appear below Home, Docs, Dashboard icons
- [ ] Auth icon shows pulsing skeleton → crossfades to avatar on login
- [ ] Guest click on auth icon opens sign-in modal
- [ ] Authenticated click opens user menu dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)