### PR TITLE
fix(q): remove cfg-gated browser field init that fails on Linux

### DIFF
--- a/packages/rust/q/src/manager/browser_manager.rs
+++ b/packages/rust/q/src/manager/browser_manager.rs
@@ -23,10 +23,7 @@ impl ICanvasLayer for BrowserManager {
         Self {
             base,
             #[cfg(any(target_os = "macos", target_os = "windows"))]
-            browser: Some(Gd::from_init_fn(|base| GodotBrowser::init(base))),
-
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-            browser: None,
+            browser: Some(Gd::from_init_fn(GodotBrowser::init)),
 
             game_manager: None,
         }


### PR DESCRIPTION
## Summary
- Remove `#[cfg(not(...))] browser: None` from `BrowserManager::init()` that tries to set a non-existent field on Linux (E0560)
- The `browser` field is only defined on macOS/Windows via `#[cfg(any(target_os = "macos", target_os = "windows"))]`, so the fallback init branch was invalid on Linux where the field doesn't exist

## Test plan
- [x] `cargo check -p q` passes on macOS
- [x] `rustfmt --check` passes
- [ ] CI lint (`cargo clippy -p q` on Ubuntu) should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)