### PR TITLE
feat(discordsh): bump axum-discordsh to 0.1.8; fix ci-dev permissions

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -224,6 +224,8 @@ jobs:
     alter:
         name: 'Dev File Alterations'
         if: github.repository == 'kbve/kbve'
+        permissions:
+            contents: read
         uses: KBVE/kbve/.github/workflows/utils-file-alterations.yml@main
         with:
             branch: 'dev'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps `axum-discordsh` from `0.1.7` to `0.1.8` to retrigger the discordsh pipeline after the failed ci-main run caused by missing permissions
- Fixes `ci-dev.yml`: adds `permissions: { contents: read }` to the `alter` job, which had the same `permissions: {}` inheritance issue as ci-main
- `ci-staging.yml` was audited and is already fine — all its jobs have explicit permissions

## Test plan
- [ ] ci-dev workflow passes validation
- [ ] discordsh pipeline triggers on next main merge