### PR TITLE
feat(droid,astro): wire toast, tooltip and modal event system

### DIFF
--- a/packages/npm/ASTRO_DROID_PLAN.md
+++ b/packages/npm/ASTRO_DROID_PLAN.md
@@ -1,0 +1,681 @@
+# Toast, Tooltip & Modal Event System Integration
+
+> Connecting UI overlays to the `DroidEventBus` across `@kbve/droid` and `@kbve/astro`.
+
+---
+
+## Problem
+
+The `@kbve/droid` package has a `DroidEventBus` (typed, Zod-validated, dual-dispatch via Map listeners + `window.CustomEvent`) and nanostores-based UI state (`$activeTooltip`, `$modalId`, `toastManager`). These two systems are **completely disconnected**:
+
+- State functions (`openModal`, `addToast`, etc.) mutate nanostores but never emit events.
+- The event bus only has 4 events (`droid-ready`, `droid-mod-ready`, `panel-open`, `panel-close`) — the panel events are defined but never emitted.
+- Toast payloads are `Record<string, any>` — no typing, no validation.
+- Workers have no way to produce toasts, tooltips, or modals — `emitFromWorker` only handles `injectVNode`.
+- `@kbve/astro` re-exports state functions but provides zero rendering components for overlays.
+- Consumers (discord.sh, etc.) must build their own modal/toast/tooltip UI from scratch.
+
+## Goal
+
+Wire the event bus into every UI state change, type all payloads with Zod, bridge worker→main thread for overlay messages, and provide opt-in rendering components — while preserving the `droid → astro` dependency direction and keeping workers off the DOM.
+
+---
+
+## Architecture
+
+```
+Worker Thread                     Main Thread
+┌──────────────────┐  postMsg    ┌──────────────────────────────────────────────┐
+│ Mod Worker       │ ──────────► │ emitFromWorker(msg)                          │
+│                  │             │   │                                          │
+│ Builds typed     │             │   ├─ Zod-validates payload                   │
+│ payload (plain   │             │   ├─ Calls state fn (addToast / openModal)   │
+│ data, no DOM)    │             │   │    ├─ Mutates nanostore (state-first)    │
+│                  │             │   │    └─ DroidEvents.emit() (event-second)  │
+│ Example:         │             │   │         ├─ Map-based listeners           │
+│ { type: 'toast', │             │   │         └─ window.CustomEvent dispatch   │
+│   payload: {     │             │   │                                          │
+│     id, message, │             │   └─ React/Astro components re-render        │
+│     severity }}  │             │       via useStore() / .subscribe()          │
+└──────────────────┘             └──────────────────────────────────────────────┘
+```
+
+### Two layers, one flow
+
+| Layer             | Role                       | Mechanism                                             | Consumers                                                |
+| ----------------- | -------------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| **Nanostores**    | Reactive UI state          | `$toasts`, `$modalId`, `$activeTooltip` atoms/maps    | React (`useStore()`), Astro (`.subscribe()`), vanilla JS |
+| **DroidEventBus** | Cross-cutting notification | `DroidEvents.on()` / `.emit()` + `window.CustomEvent` | Analytics, logging, inter-module coordination, workers   |
+
+**State mutates first, then events emit.** This guarantees any event handler that reads state sees the current value.
+
+### Dependency direction (no circular deps)
+
+```
+@kbve/droid  (schemas, event bus, state, workers, VirtualNode)
+     ↑  one-way dependency
+@kbve/astro  (React hooks, rendering components, Astro wrappers)
+```
+
+Droid never imports from Astro. All type definitions, Zod schemas, nanostores, and event bus logic live in Droid. Astro only consumes and wraps.
+
+### Workers stay off the DOM
+
+Workers produce **serializable descriptors** — typed payloads with optional `VirtualNode` fields. They never touch `document`, `HTMLElement`, or any DOM API. The main thread receives these descriptors via `emitFromWorker`, validates with Zod, and delegates to state functions. Rendering components in Astro handle the final DOM materialization.
+
+When a payload contains a `VirtualNode` (for custom worker-produced content), the React component calls `renderVNode()` from droid inside a `ref`-managed container — converting the descriptor to a real element only on the main thread.
+
+---
+
+## Phase 1: Typed Payloads
+
+**Package:** `@kbve/droid`
+**Depends on:** Nothing (first phase)
+
+### New file: `src/lib/types/ui-event-types.ts`
+
+Define Zod schemas and TypeScript types for all three UI overlay payloads.
+
+```ts
+import { z } from 'zod';
+
+// Recursive VirtualNode schema matching the type in modules.ts.
+// Validates worker-produced descriptors at runtime.
+const VirtualNodeSchema: z.ZodType<any> = z.lazy(() =>
+	z.object({
+		tag: z.string(),
+		id: z.string().optional(),
+		key: z.string().optional(),
+		class: z.string().optional(),
+		attrs: z.record(z.any()).optional(),
+		style: z.record(z.string()).optional(),
+		children: z.array(z.union([z.string(), VirtualNodeSchema])).optional(),
+	}),
+);
+
+// ── Toast ──
+export const ToastSeveritySchema = z.enum([
+	'success',
+	'warning',
+	'error',
+	'info',
+]);
+export type ToastSeverity = z.infer<typeof ToastSeveritySchema>;
+
+export const ToastPayloadSchema = z.object({
+	id: z.string(),
+	message: z.string(),
+	severity: ToastSeveritySchema,
+	duration: z.number().positive().optional(), // ms, default 5000; 0 = persistent
+	vnode: VirtualNodeSchema.optional(), // optional custom content from worker
+});
+export type ToastPayload = z.infer<typeof ToastPayloadSchema>;
+
+// ── Tooltip ──
+export const TooltipPositionSchema = z.enum([
+	'top',
+	'bottom',
+	'left',
+	'right',
+	'auto',
+]);
+export type TooltipPosition = z.infer<typeof TooltipPositionSchema>;
+
+export const TooltipPayloadSchema = z.object({
+	id: z.string(),
+	content: z.union([z.string(), VirtualNodeSchema]).optional(),
+	position: TooltipPositionSchema.optional(),
+	anchor: z.string().optional(), // CSS selector or element ID
+});
+export type TooltipPayload = z.infer<typeof TooltipPayloadSchema>;
+
+// ── Modal ──
+export const ModalPayloadSchema = z.object({
+	id: z.string(),
+	content: VirtualNodeSchema.optional(),
+	title: z.string().optional(),
+	metadata: z.record(z.any()).optional(),
+});
+export type ModalPayload = z.infer<typeof ModalPayloadSchema>;
+
+export { VirtualNodeSchema };
+```
+
+### Modify: `src/lib/types/event-types.ts`
+
+Add 6 new events to `DroidEventSchemas`:
+
+```ts
+import {
+	ToastPayloadSchema,
+	TooltipPayloadSchema,
+	ModalPayloadSchema,
+} from './ui-event-types';
+
+export const DroidEventSchemas = {
+	// existing
+	'droid-ready': DroidReadySchema,
+	'droid-mod-ready': DroidModReadySchema,
+	'panel-open': PanelEventSchema,
+	'panel-close': PanelEventSchema,
+	// new
+	'toast-added': ToastPayloadSchema,
+	'toast-removed': ToastPayloadSchema.pick({ id: true }),
+	'tooltip-opened': TooltipPayloadSchema,
+	'tooltip-closed': TooltipPayloadSchema.pick({ id: true }),
+	'modal-opened': ModalPayloadSchema,
+	'modal-closed': ModalPayloadSchema.pick({ id: true }),
+};
+```
+
+`DroidEventMap` and `EventKey` are derived automatically via the existing mapped type — they pick up the new events with zero additional code.
+
+---
+
+## Phase 2: Wire `emit()` into State Functions
+
+**Package:** `@kbve/droid`
+**Depends on:** Phase 1
+
+### New file: `src/lib/state/toasts.ts`
+
+Dedicated ephemeral toast store. Uses `map()` (NOT `persistentMap`) because toasts should not survive page refresh.
+
+```ts
+import { map } from 'nanostores';
+import { DroidEvents } from '../workers/events';
+import type { ToastPayload } from '../types/ui-event-types';
+
+export const $toasts = map<Record<string, ToastPayload>>({});
+
+export function addToast(payload: ToastPayload): void {
+	$toasts.set({ ...$toasts.get(), [payload.id]: payload });
+	DroidEvents.emit('toast-added', payload);
+}
+
+export function removeToast(id: string): void {
+	const current = { ...$toasts.get() };
+	delete current[id];
+	$toasts.set(current);
+	DroidEvents.emit('toast-removed', { id });
+}
+```
+
+**Import safety:** `state/toasts.ts` → `workers/events.ts` → `types/event-types.ts`. No cycle — `events.ts` never imports from `state/`.
+
+### Modify: `src/lib/state/ui.ts`
+
+Add `DroidEvents.emit()` after every state mutation:
+
+```ts
+import { DroidEvents } from '../workers/events';
+
+export function openTooltip(id: string) {
+	$activeTooltip.set(id);
+	DroidEvents.emit('tooltip-opened', { id });
+}
+
+export function closeTooltip(id?: string) {
+	if (id && $activeTooltip.get() !== id) return;
+	const closedId = $activeTooltip.get();
+	$activeTooltip.set(null);
+	if (closedId) DroidEvents.emit('tooltip-closed', { id: closedId });
+}
+
+export function openModal(id: string) {
+	$modalId.set(id);
+	$drawerOpen.set(false);
+	$activeTooltip.set(null);
+	DroidEvents.emit('modal-opened', { id });
+}
+
+export function closeModal(id?: string) {
+	if (id && $modalId.get() !== id) return;
+	const closedId = $modalId.get();
+	$modalId.set(null);
+	if (closedId) DroidEvents.emit('modal-closed', { id: closedId });
+}
+```
+
+Function signatures are unchanged — existing consumers are unaffected.
+
+### Modify: `src/lib/state/index.ts`
+
+Re-export the new toast module:
+
+```ts
+export { $toasts, addToast, removeToast } from './toasts';
+```
+
+### Modify: `src/lib/workers/main.ts`
+
+Wire the already-defined `panel-open` / `panel-close` events into panel functions:
+
+```ts
+openPanel(id: PanelId, payload?: PanelPayload) {
+  const panels = { ...uiuxState.get().panelManager };
+  panels[id] = { open: true, payload };
+  uiuxState.setKey('panelManager', panels);
+  DroidEvents.emit('panel-open', { id, payload });       // was defined but never fired
+},
+
+closePanel(id: PanelId) {
+  const panels = { ...uiuxState.get().panelManager };
+  panels[id] = { open: false, payload: undefined };
+  uiuxState.setKey('panelManager', panels);
+  DroidEvents.emit('panel-close', { id });                // was defined but never fired
+},
+```
+
+Deprecate the old toast functions on `uiux` (no consumer uses them — confirmed via grep):
+
+```ts
+/** @deprecated Use addToast() from '@kbve/droid' state exports instead */
+addToast(id: string, data: any) {
+  console.warn('[KBVE] uiux.addToast is deprecated. Use addToast() from @kbve/droid.');
+  const toasts = { ...uiuxState.get().toastManager, [id]: data };
+  uiuxState.setKey('toastManager', toasts);
+},
+```
+
+---
+
+## Phase 3: Extend `emitFromWorker` for UI Messages
+
+**Package:** `@kbve/droid`
+**Depends on:** Phases 1, 2
+
+### Modify: `src/lib/workers/main.ts` — `emitFromWorker`
+
+Expand to handle typed UI overlay messages from workers. Every message is Zod-validated before dispatching to state functions (which in turn emit events).
+
+```ts
+import { addToast, removeToast } from '../state/toasts';
+import { openTooltip, closeTooltip, openModal, closeModal } from '../state/ui';
+import {
+  ToastPayloadSchema,
+  TooltipPayloadSchema,
+  ModalPayloadSchema,
+} from '../types/ui-event-types';
+
+emitFromWorker(msg: any) {
+  // Existing: VNode injection (unchanged)
+  if (msg.type === 'injectVNode' && msg.vnode) {
+    dispatchAsync(() => { /* ... existing logic ... */ });
+    return;
+  }
+
+  // Toast
+  if (msg.type === 'toast' && msg.payload) {
+    const parsed = ToastPayloadSchema.safeParse(msg.payload);
+    if (!parsed.success) {
+      console.error('[KBVE] Invalid toast payload from worker:', parsed.error);
+      return;
+    }
+    addToast(parsed.data);
+    return;
+  }
+  if (msg.type === 'toast-remove' && msg.payload?.id) {
+    removeToast(msg.payload.id);
+    return;
+  }
+
+  // Tooltip
+  if (msg.type === 'tooltip-open' && msg.payload) {
+    const parsed = TooltipPayloadSchema.safeParse(msg.payload);
+    if (!parsed.success) {
+      console.error('[KBVE] Invalid tooltip payload from worker:', parsed.error);
+      return;
+    }
+    openTooltip(parsed.data.id);
+    return;
+  }
+  if (msg.type === 'tooltip-close') {
+    closeTooltip(msg.payload?.id);
+    return;
+  }
+
+  // Modal
+  if (msg.type === 'modal-open' && msg.payload) {
+    const parsed = ModalPayloadSchema.safeParse(msg.payload);
+    if (!parsed.success) {
+      console.error('[KBVE] Invalid modal payload from worker:', parsed.error);
+      return;
+    }
+    openModal(parsed.data.id);
+    return;
+  }
+  if (msg.type === 'modal-close') {
+    closeModal(msg.payload?.id);
+    return;
+  }
+
+  console.warn('[KBVE] Unknown worker UI message type:', msg.type);
+},
+```
+
+### Worker-side usage example
+
+Workers call `emitFromWorker` (passed via the mod init context). The main thread validates — workers don't need Zod themselves.
+
+```ts
+// Inside a mod worker's init():
+ctx.emitFromWorker({
+	type: 'toast',
+	payload: {
+		id: `toast-${Date.now()}`,
+		message: 'Data sync complete',
+		severity: 'success',
+		duration: 3000,
+	},
+});
+```
+
+---
+
+## Phase 4: Export from `@kbve/droid`
+
+**Package:** `@kbve/droid`
+**Depends on:** Phases 1–3
+
+### Modify: `src/index.ts`
+
+Add exports for new types, schemas, and the `VirtualNode` type:
+
+```ts
+// UI event types & schemas
+export type {
+	ToastPayload,
+	ToastSeverity,
+	TooltipPayload,
+	TooltipPosition,
+	ModalPayload,
+} from './lib/types/ui-event-types';
+
+export {
+	ToastPayloadSchema,
+	ToastSeveritySchema,
+	TooltipPayloadSchema,
+	TooltipPositionSchema,
+	ModalPayloadSchema,
+	VirtualNodeSchema,
+} from './lib/types/ui-event-types';
+
+// VirtualNode type (not previously exported)
+export type { VirtualNode } from './lib/types/modules';
+```
+
+The `$toasts`, `addToast`, `removeToast` are already available through the existing `export * from './lib/state'` barrel.
+
+---
+
+## Phase 5: React Hooks in `@kbve/astro`
+
+**Package:** `@kbve/astro`
+**Depends on:** Phase 4
+
+### New file: `src/hooks/useToast.ts`
+
+```ts
+import { useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $toasts, addToast, removeToast } from '@kbve/droid';
+import type { ToastPayload, ToastSeverity } from '@kbve/droid';
+
+export function useToast() {
+	const toasts = useStore($toasts);
+
+	const add = useCallback((payload: ToastPayload) => addToast(payload), []);
+	const remove = useCallback((id: string) => removeToast(id), []);
+
+	/** Convenience: auto-generates ID, returns it */
+	const notify = useCallback(
+		(
+			message: string,
+			severity: ToastSeverity = 'info',
+			duration = 5000,
+		): string => {
+			const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+			addToast({ id, message, severity, duration });
+			return id;
+		},
+		[],
+	);
+
+	return { toasts, add, remove, notify };
+}
+```
+
+### New file: `src/hooks/useTooltip.ts`
+
+```ts
+import { useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $activeTooltip, openTooltip, closeTooltip } from '@kbve/droid';
+
+export function useTooltip() {
+	const activeTooltipId = useStore($activeTooltip);
+	const isOpen = useCallback(
+		(id: string) => activeTooltipId === id,
+		[activeTooltipId],
+	);
+	const open = useCallback((id: string) => openTooltip(id), []);
+	const close = useCallback((id?: string) => closeTooltip(id), []);
+
+	return { activeTooltipId, isOpen, open, close };
+}
+```
+
+### New file: `src/hooks/useModal.ts`
+
+```ts
+import { useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $modalId, openModal, closeModal } from '@kbve/droid';
+
+export function useModal() {
+	const modalId = useStore($modalId);
+	const isOpen = useCallback((id: string) => modalId === id, [modalId]);
+	const open = useCallback((id: string) => openModal(id), []);
+	const close = useCallback((id?: string) => closeModal(id), []);
+
+	return { modalId, isOpen, open, close };
+}
+```
+
+### Modify: `src/index.ts`
+
+```ts
+// Hooks
+export { useToast } from './hooks/useToast';
+export { useTooltip } from './hooks/useTooltip';
+export { useModal } from './hooks/useModal';
+
+// Pass-through from @kbve/droid
+export {
+	$toasts,
+	addToast,
+	removeToast,
+	ToastPayloadSchema,
+	ToastSeveritySchema,
+	TooltipPayloadSchema,
+	ModalPayloadSchema,
+} from '@kbve/droid';
+export type {
+	ToastPayload,
+	ToastSeverity,
+	TooltipPayload,
+	TooltipPosition,
+	ModalPayload,
+	VirtualNode,
+} from '@kbve/droid';
+```
+
+### Modify: `package.json`
+
+Add `@nanostores/react` as optional peer dependency:
+
+```json
+"peerDependencies": {
+  "@nanostores/react": ">=0.7.0"
+},
+"peerDependenciesMeta": {
+  "@nanostores/react": { "optional": true }
+}
+```
+
+---
+
+## Phase 6: Rendering Components in `@kbve/astro`
+
+**Package:** `@kbve/astro`
+**Depends on:** Phase 5
+
+### Design principle
+
+React JSX for component chrome (backdrop, close button, positioning, animations). `renderVNode()` via dynamic import for worker-produced `VirtualNode` content, materialized inside a `ref`-managed container `<div>`. This keeps SSR-safe (no droid import at module scope in components that might SSR).
+
+### New file: `src/react/ToastContainer.tsx`
+
+Renders active toasts from `$toasts` state. Features:
+
+- Severity-based styling (success/warning/error/info color classes)
+- Auto-dismiss via `setTimeout` based on `duration` (default 5000ms)
+- Configurable position (`top-right`, `bottom-center`, etc.)
+- Max visible limit
+- Dismiss button
+- `VNodeSlot` sub-component for worker-produced custom content
+- `role="alert"` accessibility
+
+### New file: `src/react/ModalOverlay.tsx`
+
+Renders when `$modalId` matches a given `id` prop. Features:
+
+- `createPortal` to `document.body`
+- Backdrop with click-to-close (configurable)
+- Escape key handler
+- Body scroll lock
+- `role="dialog"` + `aria-modal="true"` accessibility
+- Accepts React `children` (preferred) or `VirtualNode` vnode prop
+- `VNodeSlot` for worker-produced content
+
+### New file: `src/react/TooltipOverlay.tsx`
+
+Global tooltip renderer for event/worker-driven tooltips. Features:
+
+- `createPortal` to `document.body`
+- Anchor-based positioning (reads `getBoundingClientRect` of anchor element)
+- `role="tooltip"` accessibility
+- Accepts React `children` or plain `content` string
+
+**Note:** This is a complement to, not a replacement for, anchor-specific tooltips like `SocialTooltip.astro` which uses `.subscribe()` directly. `TooltipOverlay` is for cases where tooltip content comes from the event system or workers.
+
+### New file: `src/components/ToastContainer.astro`
+
+Astro wrapper:
+
+```astro
+---
+import { ToastContainer as ReactToastContainer } from '../react/ToastContainer';
+const { position = 'top-right', maxVisible = 5, className } = Astro.props;
+---
+
+<ReactToastContainer
+	client:only="react"
+	position={position}
+	maxVisible={maxVisible}
+	className={className}
+/>
+```
+
+### Modify: `src/index.ts`
+
+```ts
+export { ToastContainer } from './react/ToastContainer';
+export { ModalOverlay } from './react/ModalOverlay';
+export { TooltipOverlay } from './react/TooltipOverlay';
+```
+
+### Modify: `package.json` exports
+
+```json
+"./components/ToastContainer.astro": "./components/ToastContainer.astro"
+```
+
+---
+
+## Backward Compatibility
+
+| Consumer                                  | Current usage                                                       | Impact                                                                                                                                           |
+| ----------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SocialTooltip.astro` (discord.sh)        | `$activeTooltip.subscribe()`, `openTooltip(id)`, `closeTooltip(id)` | **None.** Function signatures unchanged. Now also emits events (additive).                                                                       |
+| `ReactNavBar.tsx` (discord.sh)            | `useStore($modalId)`, `openModal('signin')`, `closeModal()`         | **None.** Same signatures, same nanostore. `ModalOverlay` component is opt-in.                                                                   |
+| `window.kbve.uiux.addToast`               | Direct call on global object                                        | **Deprecated.** Logs console warning. Old `toastManager` persistentMap field retained. New `$toasts` store is the source of truth for rendering. |
+| Vanilla JS `window.CustomEvent` listeners | `window.addEventListener('droid-ready', ...)`                       | **Enhanced.** 6 new event types available to listen for.                                                                                         |
+
+---
+
+## File Summary
+
+### New files (9)
+
+| Package | Path                                  | Purpose                                                                            |
+| ------- | ------------------------------------- | ---------------------------------------------------------------------------------- |
+| `droid` | `src/lib/types/ui-event-types.ts`     | Zod schemas: `ToastPayload`, `TooltipPayload`, `ModalPayload`, `VirtualNodeSchema` |
+| `droid` | `src/lib/state/toasts.ts`             | `$toasts` nanostore + `addToast`/`removeToast` with event emission                 |
+| `astro` | `src/hooks/useToast.ts`               | React hook wrapping toast state                                                    |
+| `astro` | `src/hooks/useTooltip.ts`             | React hook wrapping tooltip state                                                  |
+| `astro` | `src/hooks/useModal.ts`               | React hook wrapping modal state                                                    |
+| `astro` | `src/react/ToastContainer.tsx`        | Toast rendering with auto-dismiss, severity styles, VNode support                  |
+| `astro` | `src/react/ModalOverlay.tsx`          | Modal rendering with portal, backdrop, scroll lock, VNode support                  |
+| `astro` | `src/react/TooltipOverlay.tsx`        | Global tooltip rendering with anchor positioning                                   |
+| `astro` | `src/components/ToastContainer.astro` | Astro wrapper for `ToastContainer`                                                 |
+
+### Modified files (7)
+
+| Package | Path                           | Change                                                                                    |
+| ------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `droid` | `src/lib/types/event-types.ts` | Add 6 event entries to `DroidEventSchemas`                                                |
+| `droid` | `src/lib/state/ui.ts`          | Add `DroidEvents.emit()` to tooltip/modal functions                                       |
+| `droid` | `src/lib/state/index.ts`       | Re-export `$toasts`, `addToast`, `removeToast`                                            |
+| `droid` | `src/lib/workers/main.ts`      | Extend `emitFromWorker` with UI message types; wire panel events; deprecate old toast fns |
+| `droid` | `src/index.ts`                 | Export new types, schemas, `VirtualNode`                                                  |
+| `astro` | `src/index.ts`                 | Export hooks, components, pass-through types                                              |
+| `astro` | `package.json`                 | Add `@nanostores/react` optional peer; add `ToastContainer.astro` export                  |
+
+---
+
+## Phase Dependency Graph
+
+```
+Phase 1 ─── Typed Payloads (Zod schemas + TS types)
+   │
+   └──► Phase 2 ─── Wire emit() into state functions
+           │
+           └──► Phase 3 ─── Extend emitFromWorker (worker→main bridge)
+                   │
+                   └──► Phase 4 ─── Export from @kbve/droid index
+                           │
+                           └──► Phase 5 ─── React hooks in @kbve/astro
+                                   │
+                                   └──► Phase 6 ─── Rendering components
+```
+
+Phases 1–4: purely `@kbve/droid`.
+Phases 5–6: purely `@kbve/astro`.
+No phase introduces a circular dependency.
+
+---
+
+## Verification
+
+1. **Build droid:** `pnpm nx run droid:build` — compiles with new types/schemas/state
+2. **Build astro:** `pnpm nx run astro:build` — compiles with new hooks/components
+3. **Run droid tests:** `pnpm nx run droid:test` — existing tests pass
+4. **No circular deps:** Verify no file in `packages/npm/droid/src/` imports from `@kbve/astro`
+5. **Manual smoke test (browser console):**
+    - `window.kbve.events.on('toast-added', (p) => console.log('toast!', p))` — register listener
+    - Import and call `addToast({ id: 'test', message: 'Hello', severity: 'info' })` — listener fires
+    - `window.kbve.events.on('modal-opened', (p) => console.log('modal!', p))` — register listener
+    - Call `openModal('test')` — listener fires, `$modalId.get()` returns `'test'`
+6. **Worker integration test:** From a mod worker, call `ctx.emitFromWorker({ type: 'toast', payload: { id: 'w1', message: 'From worker', severity: 'success' } })` — toast appears in `$toasts` on main thread

--- a/packages/npm/astro/package.json
+++ b/packages/npm/astro/package.json
@@ -2,10 +2,21 @@
 	"name": "@kbve/astro",
 	"version": "0.1.0",
 	"description": "Unified Astro component library with React support and @kbve/droid integration",
-	"keywords": ["astro", "react", "droid", "workers", "components"],
+	"keywords": [
+		"astro",
+		"react",
+		"droid",
+		"workers",
+		"components"
+	],
 	"homepage": "https://kbve.com/application/javascript/",
-	"bugs": { "url": "https://github.com/KBVE/kbve/issues" },
-	"repository": { "type": "git", "url": "git+https://github.com/KBVE/kbve.git" },
+	"bugs": {
+		"url": "https://github.com/KBVE/kbve/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/KBVE/kbve.git"
+	},
 	"author": "KBVE <hello@kbve.com>",
 	"license": "MIT",
 	"type": "module",
@@ -24,7 +35,8 @@
 		"./components/AskamaHero.astro": "./components/AskamaHero.astro",
 		"./components/AskamaAlert.astro": "./components/AskamaAlert.astro",
 		"./components/AskamaSection.astro": "./components/AskamaSection.astro",
-		"./components/AskamaStat.astro": "./components/AskamaStat.astro"
+		"./components/AskamaStat.astro": "./components/AskamaStat.astro",
+		"./components/ToastContainer.astro": "./components/ToastContainer.astro"
 	},
 	"files": [
 		"astro.es.js",
@@ -37,10 +49,16 @@
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0",
 		"astro": ">=4.0.0",
-		"@kbve/droid": ">=0.1.0"
+		"@kbve/droid": ">=0.1.0",
+		"@nanostores/react": ">=0.7.0"
 	},
 	"peerDependenciesMeta": {
-		"astro": { "optional": true }
+		"astro": {
+			"optional": true
+		},
+		"@nanostores/react": {
+			"optional": true
+		}
 	},
 	"dependencies": {
 		"clsx": "^2.1.1",

--- a/packages/npm/astro/src/components/ToastContainer.astro
+++ b/packages/npm/astro/src/components/ToastContainer.astro
@@ -1,0 +1,28 @@
+---
+import { ToastContainer as ReactToastContainer } from '../react/ToastContainer';
+
+interface Props {
+	position?:
+		| 'top-right'
+		| 'top-left'
+		| 'bottom-right'
+		| 'bottom-left'
+		| 'top-center'
+		| 'bottom-center';
+	maxVisible?: number;
+	class?: string;
+}
+
+const {
+	position = 'top-right',
+	maxVisible = 5,
+	class: className,
+} = Astro.props;
+---
+
+<ReactToastContainer
+	client:only="react"
+	position={position}
+	maxVisible={maxVisible}
+	className={className}
+/>

--- a/packages/npm/astro/src/hooks/useModal.ts
+++ b/packages/npm/astro/src/hooks/useModal.ts
@@ -1,0 +1,13 @@
+import { useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $modalId, openModal, closeModal } from '@kbve/droid';
+
+export function useModal() {
+	const modalId = useStore($modalId);
+
+	const isOpen = useCallback((id: string) => modalId === id, [modalId]);
+	const open = useCallback((id: string) => openModal(id), []);
+	const close = useCallback((id?: string) => closeModal(id), []);
+
+	return { modalId, isOpen, open, close };
+}

--- a/packages/npm/astro/src/hooks/useToast.ts
+++ b/packages/npm/astro/src/hooks/useToast.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $toasts, addToast, removeToast } from '@kbve/droid';
+import type { ToastPayload, ToastSeverity } from '@kbve/droid';
+
+export function useToast() {
+	const toasts = useStore($toasts);
+
+	const add = useCallback((payload: ToastPayload) => addToast(payload), []);
+	const remove = useCallback((id: string) => removeToast(id), []);
+
+	const notify = useCallback(
+		(
+			message: string,
+			severity: ToastSeverity = 'info',
+			duration = 5000,
+		): string => {
+			const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+			addToast({ id, message, severity, duration });
+			return id;
+		},
+		[],
+	);
+
+	return { toasts, add, remove, notify };
+}

--- a/packages/npm/astro/src/hooks/useTooltip.ts
+++ b/packages/npm/astro/src/hooks/useTooltip.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $activeTooltip, openTooltip, closeTooltip } from '@kbve/droid';
+
+export function useTooltip() {
+	const activeTooltipId = useStore($activeTooltip);
+
+	const isOpen = useCallback(
+		(id: string) => activeTooltipId === id,
+		[activeTooltipId],
+	);
+	const open = useCallback((id: string) => openTooltip(id), []);
+	const close = useCallback((id?: string) => closeTooltip(id), []);
+
+	return { activeTooltipId, isOpen, open, close };
+}

--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -2,10 +2,19 @@
 export { useDroid } from './hooks/useDroid';
 export type { DroidState } from './hooks/useDroid';
 export { useDroidEvents } from './hooks/useDroidEvents';
+export { useToast } from './hooks/useToast';
+export { useTooltip } from './hooks/useTooltip';
+export { useModal } from './hooks/useModal';
 
 // React components
 export { DroidProvider, useDroidContext } from './react/DroidProvider';
 export { DroidStatus } from './react/DroidStatus';
+export { ToastContainer } from './react/ToastContainer';
+export type { ToastContainerProps } from './react/ToastContainer';
+export { ModalOverlay } from './react/ModalOverlay';
+export type { ModalOverlayProps } from './react/ModalOverlay';
+export { TooltipOverlay } from './react/TooltipOverlay';
+export type { TooltipOverlayProps } from './react/TooltipOverlay';
 
 // Auth
 export { AuthBridge, useAuthBridge, bootAuth, IDBStorage } from './auth';
@@ -24,6 +33,9 @@ export {
 	$drawerOpen,
 	$modalId,
 	$activeTooltip,
+	$toasts,
+	addToast,
+	removeToast,
 	openDrawer,
 	closeDrawer,
 	openModal,
@@ -32,6 +44,23 @@ export {
 	closeTooltip,
 } from '@kbve/droid';
 export type { AuthTone, AuthState } from '@kbve/droid';
+
+// Types (pass-through from @kbve/droid)
+export type {
+	ToastPayload,
+	ToastSeverity,
+	TooltipPayload,
+	TooltipPosition,
+	ModalPayload,
+	VirtualNode,
+} from '@kbve/droid';
+export {
+	ToastPayloadSchema,
+	ToastSeveritySchema,
+	TooltipPayloadSchema,
+	TooltipPositionSchema,
+	ModalPayloadSchema,
+} from '@kbve/droid';
 
 // Gateway (pass-through from @kbve/droid)
 export { SupabaseGateway } from '@kbve/droid';

--- a/packages/npm/astro/src/react/ModalOverlay.tsx
+++ b/packages/npm/astro/src/react/ModalOverlay.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useModal } from '../hooks/useModal';
+import { cn } from '../utils/cn';
+
+export interface ModalOverlayProps {
+	id: string;
+	title?: string;
+	children?: React.ReactNode;
+	vnode?: any;
+	className?: string;
+	closeOnBackdrop?: boolean;
+}
+
+export function ModalOverlay({
+	id,
+	title,
+	children,
+	vnode,
+	className,
+	closeOnBackdrop = true,
+}: ModalOverlayProps) {
+	const { isOpen, close } = useModal();
+	const vnodeRef = useRef<HTMLDivElement>(null);
+	const open = isOpen(id);
+
+	// Render VNode if provided and no children
+	useEffect(() => {
+		if (!open || !vnode || children || !vnodeRef.current) return;
+		let cancelled = false;
+		import('@kbve/droid').then((mod) => {
+			if (cancelled || !vnodeRef.current) return;
+			const renderVNode = (mod as any).renderVNode;
+			if (typeof renderVNode === 'function') {
+				vnodeRef.current.innerHTML = '';
+				vnodeRef.current.appendChild(renderVNode(vnode));
+			}
+		});
+		return () => {
+			cancelled = true;
+			if (vnodeRef.current) vnodeRef.current.innerHTML = '';
+		};
+	}, [open, vnode, children]);
+
+	// Escape key handler
+	useEffect(() => {
+		if (!open) return;
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') close(id);
+		};
+		document.addEventListener('keydown', handler);
+		return () => document.removeEventListener('keydown', handler);
+	}, [open, id, close]);
+
+	// Lock body scroll
+	useEffect(() => {
+		if (!open) return;
+		const prev = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = prev;
+		};
+	}, [open]);
+
+	if (!open) return null;
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-[9998] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-label={title ?? 'Modal'}
+			onClick={(e) => {
+				if (closeOnBackdrop && e.target === e.currentTarget) close(id);
+			}}>
+			<div
+				className={cn(
+					'w-full max-w-lg rounded-xl shadow-2xl p-6 bg-zinc-900 text-zinc-100',
+					className,
+				)}>
+				{title && (
+					<div className="flex items-center justify-between mb-4">
+						<h2 className="text-lg font-semibold">{title}</h2>
+						<button
+							type="button"
+							onClick={() => close(id)}
+							className="text-zinc-400 hover:text-white transition-colors"
+							aria-label="Close">
+							&times;
+						</button>
+					</div>
+				)}
+				{children ?? <div ref={vnodeRef} />}
+			</div>
+		</div>,
+		document.body,
+	);
+}

--- a/packages/npm/astro/src/react/ToastContainer.tsx
+++ b/packages/npm/astro/src/react/ToastContainer.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useToast } from '../hooks/useToast';
+import { cn } from '../utils/cn';
+import type { ToastPayload } from '@kbve/droid';
+
+const SEVERITY_STYLES: Record<string, string> = {
+	success: 'border-l-4 border-green-500 bg-green-900/20 text-green-200',
+	warning: 'border-l-4 border-yellow-500 bg-yellow-900/20 text-yellow-200',
+	error: 'border-l-4 border-red-500 bg-red-900/20 text-red-200',
+	info: 'border-l-4 border-blue-500 bg-blue-900/20 text-blue-200',
+};
+
+const DEFAULT_DURATION = 5000;
+
+function VNodeSlot({ vnode }: { vnode: any }) {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!ref.current) return;
+		let cancelled = false;
+		import('@kbve/droid').then((mod) => {
+			if (cancelled || !ref.current) return;
+			// Access renderVNode from the workers/tools module via the droid entry
+			const renderVNode = (mod as any).renderVNode;
+			if (typeof renderVNode === 'function') {
+				ref.current.innerHTML = '';
+				ref.current.appendChild(renderVNode(vnode));
+			}
+		});
+		return () => {
+			cancelled = true;
+			if (ref.current) ref.current.innerHTML = '';
+		};
+	}, [vnode]);
+
+	return <div ref={ref} />;
+}
+
+function ToastItem({
+	toast,
+	onDismiss,
+}: {
+	toast: ToastPayload;
+	onDismiss: (id: string) => void;
+}) {
+	useEffect(() => {
+		const duration = toast.duration ?? DEFAULT_DURATION;
+		if (duration <= 0) return;
+		const timer = setTimeout(() => onDismiss(toast.id), duration);
+		return () => clearTimeout(timer);
+	}, [toast.id, toast.duration, onDismiss]);
+
+	return (
+		<div
+			role="alert"
+			className={cn(
+				'rounded-lg px-4 py-3 shadow-lg backdrop-blur-md',
+				SEVERITY_STYLES[toast.severity] ?? SEVERITY_STYLES.info,
+			)}>
+			<div className="flex items-start justify-between gap-2">
+				<div className="flex-1">
+					<p className="text-sm font-medium">{toast.message}</p>
+					{toast.vnode && <VNodeSlot vnode={toast.vnode} />}
+				</div>
+				<button
+					type="button"
+					onClick={() => onDismiss(toast.id)}
+					className="text-current opacity-60 hover:opacity-100 transition-opacity"
+					aria-label="Dismiss">
+					&times;
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export interface ToastContainerProps {
+	className?: string;
+	position?:
+		| 'top-right'
+		| 'top-left'
+		| 'bottom-right'
+		| 'bottom-left'
+		| 'top-center'
+		| 'bottom-center';
+	maxVisible?: number;
+}
+
+const POSITION_CLASSES: Record<string, string> = {
+	'top-right': 'top-4 right-4',
+	'top-left': 'top-4 left-4',
+	'bottom-right': 'bottom-4 right-4',
+	'bottom-left': 'bottom-4 left-4',
+	'top-center': 'top-4 left-1/2 -translate-x-1/2',
+	'bottom-center': 'bottom-4 left-1/2 -translate-x-1/2',
+};
+
+export function ToastContainer({
+	className,
+	position = 'top-right',
+	maxVisible = 5,
+}: ToastContainerProps) {
+	const { toasts, remove } = useToast();
+	const entries = Object.values(toasts).slice(0, maxVisible);
+
+	const handleDismiss = useCallback((id: string) => remove(id), [remove]);
+
+	if (entries.length === 0) return null;
+
+	return (
+		<div
+			className={cn(
+				'fixed z-[9999] flex flex-col gap-2 w-80 pointer-events-none',
+				POSITION_CLASSES[position],
+				className,
+			)}>
+			{entries.map((toast) => (
+				<div key={toast.id} className="pointer-events-auto">
+					<ToastItem toast={toast} onDismiss={handleDismiss} />
+				</div>
+			))}
+		</div>
+	);
+}

--- a/packages/npm/astro/src/react/TooltipOverlay.tsx
+++ b/packages/npm/astro/src/react/TooltipOverlay.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTooltip } from '../hooks/useTooltip';
+import { cn } from '../utils/cn';
+
+export interface TooltipOverlayProps {
+	id: string;
+	content?: string;
+	anchorId?: string;
+	className?: string;
+	children?: React.ReactNode;
+}
+
+export function TooltipOverlay({
+	id,
+	content,
+	anchorId,
+	className,
+	children,
+}: TooltipOverlayProps) {
+	const { isOpen } = useTooltip();
+	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+	const open = isOpen(id);
+
+	useEffect(() => {
+		if (!open || !anchorId) {
+			setPos(null);
+			return;
+		}
+		const anchor = document.getElementById(anchorId);
+		if (!anchor) {
+			setPos(null);
+			return;
+		}
+		const rect = anchor.getBoundingClientRect();
+		setPos({
+			top: rect.bottom + 8 + window.scrollY,
+			left: rect.left + rect.width / 2 + window.scrollX,
+		});
+	}, [open, anchorId]);
+
+	if (!open) return null;
+
+	return createPortal(
+		<div
+			role="tooltip"
+			className={cn(
+				'absolute z-[9997] px-3 py-2 rounded-lg bg-zinc-800 text-zinc-200 text-sm shadow-lg',
+				'transform -translate-x-1/2',
+				className,
+			)}
+			style={pos ? { top: pos.top, left: pos.left } : undefined}>
+			{children ?? content ?? null}
+		</div>,
+		document.body,
+	);
+}

--- a/packages/npm/droid/src/index.ts
+++ b/packages/npm/droid/src/index.ts
@@ -2,10 +2,13 @@ export * from './lib/droid';
 export * from './lib/types/bento';
 export * from './lib/types/event-types';
 export * from './lib/types/panel-types';
+export * from './lib/types/ui-event-types';
 export * from './lib/workers/events';
 export * from './lib/mod/mod-urls';
 export * from './lib/gateway';
 export * from './lib/state';
+
+export type { VirtualNode } from './lib/types/modules';
 
 // Vite ?worker&url imports — bundles each worker as JS and returns the URL string
 import canvasWorkerUrl from './lib/workers/canvas-worker?worker&url';

--- a/packages/npm/droid/src/lib/state/index.ts
+++ b/packages/npm/droid/src/lib/state/index.ts
@@ -19,3 +19,5 @@ export {
 	openModal,
 	closeModal,
 } from './ui';
+
+export { $toasts, addToast, removeToast } from './toasts';

--- a/packages/npm/droid/src/lib/state/toasts.ts
+++ b/packages/npm/droid/src/lib/state/toasts.ts
@@ -1,0 +1,17 @@
+import { map } from 'nanostores';
+import { DroidEvents } from '../workers/events';
+import type { ToastPayload } from '../types/ui-event-types';
+
+export const $toasts = map<Record<string, ToastPayload>>({});
+
+export function addToast(payload: ToastPayload): void {
+	$toasts.set({ ...$toasts.get(), [payload.id]: payload });
+	DroidEvents.emit('toast-added', payload);
+}
+
+export function removeToast(id: string): void {
+	const current = { ...$toasts.get() };
+	delete current[id];
+	$toasts.set(current);
+	DroidEvents.emit('toast-removed', { id });
+}

--- a/packages/npm/droid/src/lib/state/ui.ts
+++ b/packages/npm/droid/src/lib/state/ui.ts
@@ -1,4 +1,5 @@
 import { atom } from 'nanostores';
+import { DroidEvents } from '../workers/events';
 
 export const $activeTooltip = atom<string | null>(null);
 export const $drawerOpen = atom(false);
@@ -6,11 +7,16 @@ export const $modalId = atom<string | null>(null);
 
 export function openTooltip(id: string) {
 	$activeTooltip.set(id);
+	DroidEvents.emit('tooltip-opened', { id });
 }
 
 export function closeTooltip(id?: string) {
 	if (id && $activeTooltip.get() !== id) return;
+	const closedId = $activeTooltip.get();
 	$activeTooltip.set(null);
+	if (closedId) {
+		DroidEvents.emit('tooltip-closed', { id: closedId });
+	}
 }
 
 export function openDrawer() {
@@ -26,9 +32,14 @@ export function openModal(id: string) {
 	$modalId.set(id);
 	$drawerOpen.set(false);
 	$activeTooltip.set(null);
+	DroidEvents.emit('modal-opened', { id });
 }
 
 export function closeModal(id?: string) {
 	if (id && $modalId.get() !== id) return;
+	const closedId = $modalId.get();
 	$modalId.set(null);
+	if (closedId) {
+		DroidEvents.emit('modal-closed', { id: closedId });
+	}
 }

--- a/packages/npm/droid/src/lib/types/event-types.ts
+++ b/packages/npm/droid/src/lib/types/event-types.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 import { PanelIdSchema } from './panel-types';
+import {
+	ToastPayloadSchema,
+	TooltipPayloadSchema,
+	ModalPayloadSchema,
+} from './ui-event-types';
 
 export const ModMetaSchema = z.object({
 	name: z.string(),
@@ -21,15 +26,25 @@ export const DroidReadySchema = z.object({
 });
 
 export const DroidEventSchemas = {
-	'droid-ready': DroidReadySchema, 
+	'droid-ready': DroidReadySchema,
 	'droid-mod-ready': DroidModReadySchema,
 	'panel-open': PanelEventSchema,
 	'panel-close': PanelEventSchema,
+	'toast-added': ToastPayloadSchema,
+	'toast-removed': ToastPayloadSchema.pick({ id: true }),
+	'tooltip-opened': TooltipPayloadSchema,
+	'tooltip-closed': TooltipPayloadSchema.pick({ id: true }),
+	'modal-opened': ModalPayloadSchema,
+	'modal-closed': ModalPayloadSchema.pick({ id: true }),
 };
 
 export type DroidEventMap = {
-	[K in keyof typeof DroidEventSchemas]: z.infer<(typeof DroidEventSchemas)[K]>;
+	[K in keyof typeof DroidEventSchemas]: z.infer<
+		(typeof DroidEventSchemas)[K]
+	>;
 };
 
 export type EventKey = keyof DroidEventMap;
-export type EventHandler<K extends EventKey> = (payload: DroidEventMap[K]) => void;
+export type EventHandler<K extends EventKey> = (
+	payload: DroidEventMap[K],
+) => void;

--- a/packages/npm/droid/src/lib/types/ui-event-types.ts
+++ b/packages/npm/droid/src/lib/types/ui-event-types.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+// Recursive VirtualNode schema matching the type in modules.ts.
+// Validates worker-produced descriptors at runtime.
+const VirtualNodeSchema: z.ZodType<any> = z.lazy(() =>
+	z.object({
+		tag: z.string(),
+		id: z.string().optional(),
+		key: z.string().optional(),
+		class: z.string().optional(),
+		attrs: z.record(z.any()).optional(),
+		style: z.record(z.string()).optional(),
+		children: z.array(z.union([z.string(), VirtualNodeSchema])).optional(),
+	}),
+);
+
+// ── Toast ──
+
+export const ToastSeveritySchema = z.enum([
+	'success',
+	'warning',
+	'error',
+	'info',
+]);
+export type ToastSeverity = z.infer<typeof ToastSeveritySchema>;
+
+export const ToastPayloadSchema = z.object({
+	id: z.string(),
+	message: z.string(),
+	severity: ToastSeveritySchema,
+	duration: z.number().positive().optional(),
+	vnode: VirtualNodeSchema.optional(),
+});
+export type ToastPayload = z.infer<typeof ToastPayloadSchema>;
+
+// ── Tooltip ──
+
+export const TooltipPositionSchema = z.enum([
+	'top',
+	'bottom',
+	'left',
+	'right',
+	'auto',
+]);
+export type TooltipPosition = z.infer<typeof TooltipPositionSchema>;
+
+export const TooltipPayloadSchema = z.object({
+	id: z.string(),
+	content: z.union([z.string(), VirtualNodeSchema]).optional(),
+	position: TooltipPositionSchema.optional(),
+	anchor: z.string().optional(),
+});
+export type TooltipPayload = z.infer<typeof TooltipPayloadSchema>;
+
+// ── Modal ──
+
+export const ModalPayloadSchema = z.object({
+	id: z.string(),
+	content: VirtualNodeSchema.optional(),
+	title: z.string().optional(),
+	metadata: z.record(z.any()).optional(),
+});
+export type ModalPayload = z.infer<typeof ModalPayloadSchema>;
+
+export { VirtualNodeSchema };

--- a/packages/npm/droid/src/lib/workers/main.ts
+++ b/packages/npm/droid/src/lib/workers/main.ts
@@ -10,6 +10,16 @@ import { scopeData } from './data';
 import { dispatchAsync, renderVNode } from './tools';
 import type { PanelPayload, PanelId } from '../types/panel-types';
 import { DroidEvents } from './events';
+import {
+	addToast as _addToast,
+	removeToast as _removeToast,
+} from '../state/toasts';
+import { openTooltip, closeTooltip, openModal, closeModal } from '../state/ui';
+import {
+	ToastPayloadSchema,
+	TooltipPayloadSchema,
+	ModalPayloadSchema,
+} from '../types/ui-event-types';
 import { SupabaseGateway } from '../gateway/SupabaseGateway';
 import type { GatewayConfig } from '../gateway/types';
 
@@ -84,7 +94,9 @@ async function initCanvasComlink(opts?: {
 	return wrap<CanvasWorkerAPI>(worker);
 }
 
-async function finalize(api: Remote<LocalStorageAPI>): Promise<Remote<LocalStorageAPI>> {
+async function finalize(
+	api: Remote<LocalStorageAPI>,
+): Promise<Remote<LocalStorageAPI>> {
 	const version = await api.getVersion();
 	if (version !== EXPECTED_DB_VERSION) {
 		await initializeWorkerDatabase(api, {
@@ -135,12 +147,14 @@ export const uiux = {
 		const panels = { ...uiuxState.get().panelManager };
 		panels[id] = { open: true, payload };
 		uiuxState.setKey('panelManager', panels);
+		DroidEvents.emit('panel-open', { id, payload });
 	},
 
 	closePanel(id: PanelId) {
 		const panels = { ...uiuxState.get().panelManager };
 		panels[id] = { open: false, payload: undefined };
 		uiuxState.setKey('panelManager', panels);
+		DroidEvents.emit('panel-close', { id });
 	},
 
 	togglePanel(id: PanelId, payload?: PanelPayload) {
@@ -148,18 +162,31 @@ export const uiux = {
 		const isOpen = panels[id]?.open ?? false;
 		panels[id] = { open: !isOpen, payload: !isOpen ? payload : undefined };
 		uiuxState.setKey('panelManager', panels);
+		if (!isOpen) {
+			DroidEvents.emit('panel-open', { id, payload });
+		} else {
+			DroidEvents.emit('panel-close', { id });
+		}
 	},
 
 	setTheme(theme: 'light' | 'dark' | 'auto') {
 		uiuxState.setKey('themeManager', { theme });
 	},
 
+	/** @deprecated Use addToast() from '@kbve/droid' state exports instead. */
 	addToast(id: string, data: any) {
+		console.warn(
+			'[KBVE] uiux.addToast is deprecated. Use addToast() from @kbve/droid.',
+		);
 		const toasts = { ...uiuxState.get().toastManager, [id]: data };
 		uiuxState.setKey('toastManager', toasts);
 	},
 
+	/** @deprecated Use removeToast() from '@kbve/droid' state exports instead. */
 	removeToast(id: string) {
+		console.warn(
+			'[KBVE] uiux.removeToast is deprecated. Use removeToast() from @kbve/droid.',
+		);
 		const toasts = { ...uiuxState.get().toastManager };
 		delete toasts[id];
 		uiuxState.setKey('toastManager', toasts);
@@ -171,7 +198,9 @@ export const uiux = {
 		mode: 'static' | 'animated' | 'dynamic' = 'animated',
 	) {
 		const offscreen = canvasEl.transferControlToOffscreen();
-		await (window.kbve?.uiux as Record<string, any>)?.['worker']?.bindCanvas(panelId, offscreen, mode);
+		await (window.kbve?.uiux as Record<string, any>)?.[
+			'worker'
+		]?.bindCanvas(panelId, offscreen, mode);
 	},
 
 	closeAllPanels() {
@@ -183,11 +212,14 @@ export const uiux = {
 	},
 
 	emitFromWorker(msg: any) {
+		// Existing: VNode injection
 		if (msg.type === 'injectVNode' && msg.vnode) {
 			dispatchAsync(() => {
 				const target = document.getElementById('bento-grid-inject');
 				if (!target) {
-					console.warn('[KBVE] No injection target found: #bento-grid-inject');
+					console.warn(
+						'[KBVE] No injection target found: #bento-grid-inject',
+					);
 					return;
 				}
 
@@ -200,7 +232,64 @@ export const uiux = {
 
 				target.appendChild(el);
 			});
+			return;
 		}
+
+		// Toast from worker
+		if (msg.type === 'toast' && msg.payload) {
+			const parsed = ToastPayloadSchema.safeParse(msg.payload);
+			if (!parsed.success) {
+				console.error(
+					'[KBVE] Invalid toast payload from worker:',
+					parsed.error,
+				);
+				return;
+			}
+			_addToast(parsed.data);
+			return;
+		}
+		if (msg.type === 'toast-remove' && msg.payload?.id) {
+			_removeToast(msg.payload.id);
+			return;
+		}
+
+		// Tooltip from worker
+		if (msg.type === 'tooltip-open' && msg.payload) {
+			const parsed = TooltipPayloadSchema.safeParse(msg.payload);
+			if (!parsed.success) {
+				console.error(
+					'[KBVE] Invalid tooltip payload from worker:',
+					parsed.error,
+				);
+				return;
+			}
+			openTooltip(parsed.data.id);
+			return;
+		}
+		if (msg.type === 'tooltip-close') {
+			closeTooltip(msg.payload?.id);
+			return;
+		}
+
+		// Modal from worker
+		if (msg.type === 'modal-open' && msg.payload) {
+			const parsed = ModalPayloadSchema.safeParse(msg.payload);
+			if (!parsed.success) {
+				console.error(
+					'[KBVE] Invalid modal payload from worker:',
+					parsed.error,
+				);
+				return;
+			}
+			openModal(parsed.data.id);
+			return;
+		}
+		if (msg.type === 'modal-close') {
+			closeModal(msg.payload?.id);
+			return;
+		}
+
+		console.warn('[KBVE] Unknown worker UI message type:', msg.type);
 	},
 };
 
@@ -330,9 +419,10 @@ export async function main(opts?: {
 			});
 
 			const api = await initStorageComlink({
-				workerURL: typeof opts?.workerURLs?.['dbWorker'] === 'string'
-					? opts.workerURLs['dbWorker']
-					: undefined,
+				workerURL:
+					typeof opts?.workerURLs?.['dbWorker'] === 'string'
+						? opts.workerURLs['dbWorker']
+						: undefined,
 				workerRef: opts?.workerRefs?.dbWorker,
 			});
 


### PR DESCRIPTION
## Summary
- Connect `DroidEventBus` to UI state for toasts, tooltips, and modals with Zod-validated typed payloads
- Add worker→main thread bridge so workers can produce toast/tooltip/modal overlays via `emitFromWorker`
- Provide `useToast`, `useTooltip`, `useModal` React hooks and `ToastContainer`, `ModalOverlay`, `TooltipOverlay` rendering components in `@kbve/astro`
- Wire previously-orphaned `panel-open`/`panel-close` events into panel functions
- No circular dependencies — all schemas/state/events in droid, all UI in astro

## Test plan
- [x] `droid:build` passes
- [x] `astro:build` passes
- [x] `droid:test` — 5/5 tests pass
- [x] Zero `@kbve/astro` imports in droid source (no circular deps)
- [ ] CI lint + test on this PR