### PR TITLE
feat(discordsh): add status embed with interactive buttons (Phase 2)

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/commands/status.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/status.rs
@@ -1,10 +1,27 @@
 use crate::discord::bot::{Context, Error};
+use crate::discord::components::build_status_action_row;
+use crate::discord::embeds::{StatusSnapshot, StatusState, build_status_embed};
 
-/// Shows the current bot status.
+/// Shows the current bot status as a rich embed with interactive buttons.
 #[poise::command(slash_command)]
 pub async fn status(ctx: Context<'_>) -> Result<(), Error> {
-    let version = env!("CARGO_PKG_VERSION");
-    ctx.say(format!("Bot is online. Version: {version}"))
-        .await?;
+    let data = ctx.data();
+
+    let snap = StatusSnapshot {
+        state: StatusState::Online,
+        version: env!("CARGO_PKG_VERSION"),
+        guild_count: ctx.cache().guild_count(),
+        shard_id: Some(ctx.serenity_context().shard_id.0),
+        uptime: data.start_time.elapsed(),
+    };
+
+    let embed = build_status_embed(&snap);
+    let components = vec![build_status_action_row()];
+
+    let reply = poise::CreateReply::default()
+        .embed(embed)
+        .components(components);
+
+    ctx.send(reply).await?;
     Ok(())
 }

--- a/apps/discordsh/axum-discordsh/src/discord/components/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/components/mod.rs
@@ -1,0 +1,3 @@
+mod status_buttons;
+
+pub use status_buttons::{build_status_action_row, handle_status_component};

--- a/apps/discordsh/axum-discordsh/src/discord/components/status_buttons.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/components/status_buttons.rs
@@ -1,0 +1,139 @@
+use poise::serenity_prelude as serenity;
+use tracing::info;
+
+use crate::discord::bot::{Data, Error};
+use crate::discord::embeds::{StatusSnapshot, StatusState, build_status_embed};
+
+// ── Custom ID constants ──────────────────────────────────────────────
+
+pub const ID_STATUS_REFRESH: &str = "status_refresh";
+pub const ID_STATUS_CLEANUP: &str = "status_cleanup";
+pub const ID_STATUS_RESTART: &str = "status_restart";
+
+// ── Button row builder ───────────────────────────────────────────────
+
+/// Build the action row of buttons attached to the `/status` embed.
+pub fn build_status_action_row() -> serenity::CreateActionRow {
+    serenity::CreateActionRow::Buttons(vec![
+        serenity::CreateButton::new(ID_STATUS_REFRESH)
+            .label("Refresh")
+            .style(serenity::ButtonStyle::Primary)
+            .emoji(serenity::ReactionType::Unicode("\u{1F504}".to_owned())),
+        serenity::CreateButton::new(ID_STATUS_CLEANUP)
+            .label("Cleanup")
+            .style(serenity::ButtonStyle::Secondary)
+            .emoji(serenity::ReactionType::Unicode("\u{1F9F9}".to_owned())),
+        serenity::CreateButton::new(ID_STATUS_RESTART)
+            .label("Restart")
+            .style(serenity::ButtonStyle::Danger)
+            .emoji(serenity::ReactionType::Unicode("\u{26A1}".to_owned())),
+    ])
+}
+
+// ── Snapshot helper ──────────────────────────────────────────────────
+
+/// Collect a `StatusSnapshot` from the current serenity cache and bot data.
+///
+/// This is the single bridge between poise `Data` + serenity cache and the
+/// decoupled `StatusSnapshot` the embed builder expects.
+fn collect_snapshot(data: &Data, cache: &serenity::Cache) -> StatusSnapshot {
+    StatusSnapshot {
+        state: StatusState::Online,
+        version: env!("CARGO_PKG_VERSION"),
+        guild_count: cache.guild_count(),
+        shard_id: None,
+        uptime: data.start_time.elapsed(),
+    }
+}
+
+// ── Interaction handler ──────────────────────────────────────────────
+
+/// Handle a component interaction whose `custom_id` starts with `"status_"`.
+///
+/// Returns `Ok(true)` if handled, `Ok(false)` if the custom_id didn't match.
+pub async fn handle_status_component(
+    interaction: &serenity::ComponentInteraction,
+    ctx: &serenity::Context,
+    data: &Data,
+) -> Result<bool, Error> {
+    let custom_id = interaction.data.custom_id.as_str();
+
+    match custom_id {
+        ID_STATUS_REFRESH => {
+            info!(user = %interaction.user.name, "Status refresh button pressed");
+
+            let snap = collect_snapshot(data, &ctx.cache);
+            let embed = build_status_embed(&snap);
+            let components = vec![build_status_action_row()];
+
+            interaction
+                .create_response(
+                    &ctx.http,
+                    serenity::CreateInteractionResponse::UpdateMessage(
+                        serenity::CreateInteractionResponseMessage::new()
+                            .embed(embed)
+                            .components(components),
+                    ),
+                )
+                .await?;
+
+            Ok(true)
+        }
+
+        ID_STATUS_CLEANUP => {
+            info!(user = %interaction.user.name, "Status cleanup button pressed");
+
+            interaction
+                .create_response(
+                    &ctx.http,
+                    serenity::CreateInteractionResponse::Message(
+                        serenity::CreateInteractionResponseMessage::new()
+                            .content("Cleanup is not yet implemented.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await?;
+
+            Ok(true)
+        }
+
+        ID_STATUS_RESTART => {
+            info!(user = %interaction.user.name, "Status restart button pressed");
+
+            let has_permission = if let Some(member) = &interaction.member {
+                member.permissions.is_some_and(|p| p.administrator())
+            } else {
+                false
+            };
+
+            if !has_permission {
+                interaction
+                    .create_response(
+                        &ctx.http,
+                        serenity::CreateInteractionResponse::Message(
+                            serenity::CreateInteractionResponseMessage::new()
+                                .content("You do not have permission to restart the bot.")
+                                .ephemeral(true),
+                        ),
+                    )
+                    .await?;
+                return Ok(true);
+            }
+
+            interaction
+                .create_response(
+                    &ctx.http,
+                    serenity::CreateInteractionResponse::Message(
+                        serenity::CreateInteractionResponseMessage::new()
+                            .content("Restart is not yet implemented.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await?;
+
+            Ok(true)
+        }
+
+        _ => Ok(false),
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/mod.rs
@@ -1,0 +1,5 @@
+mod status_embed;
+mod status_state;
+
+pub use status_embed::{StatusSnapshot, build_status_embed};
+pub use status_state::StatusState;

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/status_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/status_embed.rs
@@ -1,0 +1,93 @@
+use poise::serenity_prelude as serenity;
+use std::time::Duration;
+
+use super::status_state::StatusState;
+
+/// Data bag passed into the embed builder, decoupled from poise's Data struct.
+pub struct StatusSnapshot {
+    pub state: StatusState,
+    pub version: &'static str,
+    pub guild_count: usize,
+    pub shard_id: Option<u32>,
+    pub uptime: Duration,
+}
+
+/// Format a `Duration` into a human-friendly string like "2d 5h 32m 10s".
+fn format_uptime(d: Duration) -> String {
+    let total_secs = d.as_secs();
+    let days = total_secs / 86400;
+    let hours = (total_secs % 86400) / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let seconds = total_secs % 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h {minutes}m {seconds}s")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m {seconds}s")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+/// Build the status embed from a snapshot of bot state.
+///
+/// This function is pure — it takes data and returns a `CreateEmbed`.
+/// No side effects, no async, easy to test.
+pub fn build_status_embed(snap: &StatusSnapshot) -> serenity::CreateEmbed {
+    let state = snap.state;
+
+    let shard_display = match snap.shard_id {
+        Some(id) => format!("Shard {id}"),
+        None => "N/A".to_owned(),
+    };
+
+    serenity::CreateEmbed::new()
+        .title("Bot Status Dashboard")
+        .color(state.color())
+        .thumbnail(state.thumbnail_url())
+        .field(
+            "Status",
+            format!("{} {}", state.emoji(), state.label()),
+            true,
+        )
+        .field("Guilds", snap.guild_count.to_string(), true)
+        .field("Shard", shard_display, true)
+        .field("Uptime", format_uptime(snap.uptime), true)
+        .footer(serenity::CreateEmbedFooter::new(format!(
+            "axum-discordsh v{}",
+            snap.version
+        )))
+        .timestamp(serenity::Timestamp::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_uptime_seconds_only() {
+        assert_eq!(format_uptime(Duration::from_secs(42)), "42s");
+    }
+
+    #[test]
+    fn format_uptime_minutes() {
+        assert_eq!(format_uptime(Duration::from_secs(130)), "2m 10s");
+    }
+
+    #[test]
+    fn format_uptime_hours() {
+        assert_eq!(format_uptime(Duration::from_secs(3661)), "1h 1m 1s");
+    }
+
+    #[test]
+    fn format_uptime_days() {
+        assert_eq!(format_uptime(Duration::from_secs(90061)), "1d 1h 1m 1s");
+    }
+
+    #[test]
+    fn format_uptime_zero() {
+        assert_eq!(format_uptime(Duration::from_secs(0)), "0s");
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/status_state.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/status_state.rs
@@ -1,0 +1,83 @@
+/// Bot lifecycle states with associated display properties.
+///
+/// Ported from notification-bot's `StatusState` enum, simplified
+/// to the five states relevant for the Rust bot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusState {
+    Online,
+    Offline,
+    Starting,
+    Stopping,
+    Error,
+}
+
+impl StatusState {
+    /// Embed sidebar color as a Discord color integer.
+    pub fn color(self) -> u32 {
+        match self {
+            Self::Online => 0x57F287,
+            Self::Offline => 0xED4245,
+            Self::Starting => 0xFEE75C,
+            Self::Stopping => 0xE67E22,
+            Self::Error => 0x992D22,
+        }
+    }
+
+    /// Unicode emoji for inline display.
+    pub fn emoji(self) -> &'static str {
+        match self {
+            Self::Online => "\u{1F7E2}",
+            Self::Offline => "\u{1F534}",
+            Self::Starting => "\u{1F7E1}",
+            Self::Stopping => "\u{1F7E0}",
+            Self::Error => "\u{26A0}\u{FE0F}",
+        }
+    }
+
+    /// Human-readable label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Online => "Online & Ready",
+            Self::Offline => "Offline",
+            Self::Starting => "Starting...",
+            Self::Stopping => "Stopping...",
+            Self::Error => "Error",
+        }
+    }
+
+    /// Thumbnail URL for the status embed.
+    pub fn thumbnail_url(self) -> &'static str {
+        match self {
+            Self::Online => "https://octodex.github.com/images/megacat-2.png",
+            Self::Offline => "https://octodex.github.com/images/deckfailcat.png",
+            Self::Starting => "https://octodex.github.com/images/dunetocat.png",
+            Self::Stopping => "https://octodex.github.com/images/dunetocat.png",
+            Self::Error => "https://octodex.github.com/images/dunetocat.png",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn online_color_is_green() {
+        assert_eq!(StatusState::Online.color(), 0x57F287);
+    }
+
+    #[test]
+    fn all_variants_have_nonempty_properties() {
+        for state in [
+            StatusState::Online,
+            StatusState::Offline,
+            StatusState::Starting,
+            StatusState::Stopping,
+            StatusState::Error,
+        ] {
+            assert!(!state.label().is_empty());
+            assert!(!state.emoji().is_empty());
+            assert!(!state.thumbnail_url().is_empty());
+        }
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/mod.rs
@@ -1,2 +1,4 @@
 pub mod bot;
 pub mod commands;
+pub mod components;
+pub mod embeds;


### PR DESCRIPTION
## Summary
- Port Python notification-bot's `BotStatusView` embed system to Rust
- Add `StatusState` enum (5 variants) with color, emoji, label, thumbnail properties
- Add `StatusSnapshot` + `build_status_embed()` pure function for embed construction
- Add 3 interactive buttons: Refresh (edits embed in-place), Cleanup (stub), Restart (admin-only stub)
- Wire global `event_handler` in poise `FrameworkOptions` for persistent button interactions
- Update `/status` command to send rich embed with button row
- Update `DISCORDSH_PLAN.md` marking Phase 1 and Phase 2 as complete

## Test plan
- [x] `cargo build -p axum-discordsh` — compiles clean
- [x] `cargo test -p axum-discordsh` — 16/16 tests pass (7 new unit tests)
- [x] `cargo clippy -p axum-discordsh` — clean
- [x] `pnpm nx e2e discordsh` — 9/9 e2e tests pass
- [ ] Manual: `/status` shows embed with green sidebar, 4 fields, 3 buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)