### PR TITLE
feat(droid,astro): dual-path canvas/DOM overlay rendering

### DIFF
--- a/packages/npm/astro-e2e/e2e/provider-edge-cases.spec.ts
+++ b/packages/npm/astro-e2e/e2e/provider-edge-cases.spec.ts
@@ -3,29 +3,29 @@ import { test, expect } from '@playwright/test';
 test.describe('Multiple context consumers', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/edge-cases');
-		await page.getByTestId('multi-consumer-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('multi-consumer-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 	});
 
 	test('all three consumers render', async ({ page }) => {
-		await expect(page.getByTestId('consumer-a')).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByTestId('consumer-a')).toBeVisible({
+			timeout: 10_000,
+		});
 		await expect(page.getByTestId('consumer-b')).toBeVisible();
 		await expect(page.getByTestId('consumer-c')).toBeVisible();
 	});
 
 	test('all consumers reflect same initialized state', async ({ page }) => {
-		await expect(page.getByTestId('consumer-a-initialized')).toHaveAttribute(
-			'data-value',
-			'true',
-			{ timeout: 10_000 },
-		);
-		await expect(page.getByTestId('consumer-b-initialized')).toHaveAttribute(
-			'data-value',
-			'true',
-		);
-		await expect(page.getByTestId('consumer-c-initialized')).toHaveAttribute(
-			'data-value',
-			'true',
-		);
+		await expect(
+			page.getByTestId('consumer-a-initialized'),
+		).toHaveAttribute('data-value', 'true', { timeout: 10_000 });
+		await expect(
+			page.getByTestId('consumer-b-initialized'),
+		).toHaveAttribute('data-value', 'true');
+		await expect(
+			page.getByTestId('consumer-c-initialized'),
+		).toHaveAttribute('data-value', 'true');
 	});
 
 	test('all consumers reflect same event bus state', async ({ page }) => {
@@ -45,18 +45,18 @@ test.describe('Multiple context consumers', () => {
 	});
 
 	test('deeply nested consumer receives context', async ({ page }) => {
-		await expect(page.getByTestId('deep-consumer-initialized')).toHaveAttribute(
-			'data-value',
-			'true',
-			{ timeout: 10_000 },
-		);
+		await expect(
+			page.getByTestId('deep-consumer-initialized'),
+		).toHaveAttribute('data-value', 'true', { timeout: 10_000 });
 	});
 });
 
 test.describe('Provider re-initialization on navigation', () => {
 	test('navigating away and back resets provider state', async ({ page }) => {
 		await page.goto('/provider');
-		await page.getByTestId('provider-status-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('provider-status-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		// Wait for initialization
 		await expect(page.getByTestId('droid-initialized')).toHaveAttribute(
@@ -71,7 +71,9 @@ test.describe('Provider re-initialization on navigation', () => {
 
 		// Navigate back to provider
 		await page.getByTestId('nav-provider').click();
-		await page.getByTestId('provider-status-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('provider-status-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		// Should re-initialize successfully
 		await expect(page.getByTestId('droid-initialized')).toHaveAttribute(
@@ -86,9 +88,13 @@ test.describe('Provider re-initialization on navigation', () => {
 		);
 	});
 
-	test('navigating between provider and events preserves independent state', async ({ page }) => {
+	test('navigating between provider and events preserves independent state', async ({
+		page,
+	}) => {
 		await page.goto('/provider');
-		await page.getByTestId('provider-status-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('provider-status-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		await expect(page.getByTestId('droid-initialized')).toHaveAttribute(
 			'data-value',
@@ -98,18 +104,29 @@ test.describe('Provider re-initialization on navigation', () => {
 
 		// Navigate to events page
 		await page.getByTestId('nav-events').click();
-		await page.getByTestId('event-hook-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('event-hook-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
-		// Events page should start clean
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '0');
+		// Clear any events captured during navigation (droid-ready fires on astro:page-load)
+		await page.getByTestId('clear-logs').click();
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 
 		// Emit an event on events page
 		await page.getByTestId('emit-ready').click();
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '1');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'1',
+		);
 
 		// Navigate back to provider
 		await page.getByTestId('nav-provider').click();
-		await page.getByTestId('provider-status-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('provider-status-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		// Provider should still be functional
 		await expect(page.getByTestId('droid-initialized')).toHaveAttribute(
@@ -121,14 +138,18 @@ test.describe('Provider re-initialization on navigation', () => {
 });
 
 test.describe('Cross-page navigation', () => {
-	test('navigating through all pages works without errors', async ({ page }) => {
+	test('navigating through all pages works without errors', async ({
+		page,
+	}) => {
 		// Start at home
 		await page.goto('/');
 		await page.getByTestId('menu-view').waitFor({ state: 'visible' });
 
 		// Go to provider
 		await page.getByTestId('nav-provider').click();
-		await page.getByTestId('provider-status-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('provider-status-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 		await expect(page.getByTestId('droid-initialized')).toHaveAttribute(
 			'data-value',
 			'true',
@@ -137,11 +158,15 @@ test.describe('Cross-page navigation', () => {
 
 		// Go to events
 		await page.getByTestId('nav-events').click();
-		await page.getByTestId('event-hook-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('event-hook-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		// Go to edge cases
 		await page.getByTestId('nav-edge-cases').click();
-		await page.getByTestId('rapid-fire-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('rapid-fire-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		// Go back to home
 		await page.getByTestId('nav-home').click();
@@ -159,7 +184,9 @@ test.describe('Cross-page navigation', () => {
 		await page.getByTestId('nav-home').click();
 
 		// Should eventually settle on home without console errors
-		await page.getByTestId('menu-view').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('menu-view')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 	});
 
 	test('no console errors during full page lifecycle', async ({ page }) => {
@@ -167,13 +194,19 @@ test.describe('Cross-page navigation', () => {
 		page.on('pageerror', (err) => errors.push(err.message));
 
 		await page.goto('/edge-cases');
-		await page.getByTestId('rapid-fire-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('rapid-fire-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		// Interact with the page
 		await page.getByTestId('emit-burst').click();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '20', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'20',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		await page.getByTestId('clear-rapid').click();
 

--- a/packages/npm/astro/package.json
+++ b/packages/npm/astro/package.json
@@ -36,7 +36,8 @@
 		"./components/AskamaAlert.astro": "./components/AskamaAlert.astro",
 		"./components/AskamaSection.astro": "./components/AskamaSection.astro",
 		"./components/AskamaStat.astro": "./components/AskamaStat.astro",
-		"./components/ToastContainer.astro": "./components/ToastContainer.astro"
+		"./components/ToastContainer.astro": "./components/ToastContainer.astro",
+		"./components/CanvasOverlay.astro": "./components/CanvasOverlay.astro"
 	},
 	"files": [
 		"astro.es.js",

--- a/packages/npm/astro/project.json
+++ b/packages/npm/astro/project.json
@@ -28,6 +28,13 @@
 				"packageRoot": "dist/packages/npm/astro"
 			}
 		},
+		"test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx e2e astro-e2e"],
+				"parallel": false
+			}
+		},
 		"e2e": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/packages/npm/astro/src/components/CanvasOverlay.astro
+++ b/packages/npm/astro/src/components/CanvasOverlay.astro
@@ -1,0 +1,5 @@
+---
+import { CanvasOverlay as ReactCanvasOverlay } from '../react/CanvasOverlay';
+---
+
+<ReactCanvasOverlay client:only="react" />

--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -62,6 +62,14 @@ export {
 	ModalPayloadSchema,
 } from '@kbve/droid';
 
+// Canvas overlay
+export { CanvasOverlay } from './react/CanvasOverlay';
+export type { CanvasOverlayProps } from './react/CanvasOverlay';
+
+// Overlay manager (pass-through from @kbve/droid)
+export { OverlayManager } from '@kbve/droid';
+export type { RenderPath } from '@kbve/droid';
+
 // Gateway (pass-through from @kbve/droid)
 export { SupabaseGateway } from '@kbve/droid';
 

--- a/packages/npm/astro/src/react/CanvasOverlay.tsx
+++ b/packages/npm/astro/src/react/CanvasOverlay.tsx
@@ -1,0 +1,53 @@
+import { useRef, useEffect } from 'react';
+import type { OverlayManager } from '@kbve/droid';
+
+export interface CanvasOverlayProps {
+	overlayManager: OverlayManager;
+	dbGet: (key: string) => Promise<string | null>;
+	zIndex?: number;
+}
+
+export function CanvasOverlay({
+	overlayManager,
+	dbGet,
+	zIndex = 9999,
+}: CanvasOverlayProps) {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		if (!canvas) return;
+
+		// Size to viewport
+		const resize = () => {
+			canvas.width = window.innerWidth;
+			canvas.height = window.innerHeight;
+		};
+		resize();
+		window.addEventListener('resize', resize);
+
+		// Transfer to worker
+		void overlayManager.bindCanvas(canvas, dbGet);
+
+		return () => {
+			window.removeEventListener('resize', resize);
+			void overlayManager.destroy();
+		};
+	}, [overlayManager, dbGet]);
+
+	return (
+		<canvas
+			ref={canvasRef}
+			style={{
+				position: 'fixed',
+				top: 0,
+				left: 0,
+				width: '100vw',
+				height: '100vh',
+				pointerEvents: 'none',
+				zIndex,
+			}}
+			aria-hidden="true"
+		/>
+	);
+}

--- a/packages/npm/droid/src/index.ts
+++ b/packages/npm/droid/src/index.ts
@@ -10,6 +10,16 @@ export * from './lib/state';
 
 export type { VirtualNode } from './lib/types/modules';
 
+// Worker-side validation
+export { validateUIMessage } from './lib/workers/validate';
+export type {
+	ValidatedWorkerMessage,
+	UIMessageType,
+} from './lib/workers/validate';
+
+// Canvas UI renderer (for direct worker usage)
+export { CanvasUIRenderer } from './lib/workers/canvas-ui-renderer';
+
 // Vite ?worker&url imports — bundles each worker as JS and returns the URL string
 import canvasWorkerUrl from './lib/workers/canvas-worker?worker&url';
 import dbWorkerUrl from './lib/workers/db-worker?worker&url';

--- a/packages/npm/droid/src/lib/state/index.ts
+++ b/packages/npm/droid/src/lib/state/index.ts
@@ -21,3 +21,12 @@ export {
 } from './ui';
 
 export { $toasts, addToast, removeToast } from './toasts';
+
+export {
+	syncThemeToDexie,
+	broadcastThemeChange,
+	observeThemeChanges,
+} from './theme-sync';
+
+export { OverlayManager } from './overlay-manager';
+export type { RenderPath } from './overlay-manager';

--- a/packages/npm/droid/src/lib/state/overlay-manager.ts
+++ b/packages/npm/droid/src/lib/state/overlay-manager.ts
@@ -1,0 +1,125 @@
+import type { Remote } from 'comlink';
+import type { CanvasWorkerAPI } from '../workers/canvas-worker';
+import { addToast, removeToast } from './toasts';
+import { openTooltip, closeTooltip, openModal, closeModal } from './ui';
+import type {
+	ToastPayload,
+	TooltipPayload,
+	ModalPayload,
+} from '../types/ui-event-types';
+
+export type RenderPath = 'dom' | 'canvas' | 'auto';
+
+interface OverlayManagerConfig {
+	preferredPath: RenderPath;
+	canvasWorker?: Remote<CanvasWorkerAPI>;
+}
+
+/**
+ * Unified overlay manager that routes to DOM or Canvas rendering.
+ *
+ * - 'dom': Uses nanostores → React components (Phases 1–6)
+ * - 'canvas': Uses CanvasUIRenderer in canvas-worker (Phase 9)
+ * - 'auto': Uses canvas if OffscreenCanvas is available AND a canvas worker
+ *           is bound, otherwise falls back to DOM
+ */
+export class OverlayManager {
+	private path: RenderPath;
+	private canvasWorker: Remote<CanvasWorkerAPI> | null;
+	private canvasBound = false;
+
+	constructor(config: OverlayManagerConfig) {
+		this.path = config.preferredPath;
+		this.canvasWorker = config.canvasWorker ?? null;
+	}
+
+	private get effectivePath(): 'dom' | 'canvas' {
+		if (this.path === 'canvas' && this.canvasBound && this.canvasWorker) {
+			return 'canvas';
+		}
+		if (this.path === 'auto' && this.canvasBound && this.canvasWorker) {
+			return 'canvas';
+		}
+		return 'dom';
+	}
+
+	/**
+	 * Bind a <canvas> element for off-thread overlay rendering.
+	 * Must be called before canvas path can be used.
+	 */
+	async bindCanvas(
+		canvasEl: HTMLCanvasElement,
+		dbGet: (key: string) => Promise<string | null>,
+	): Promise<void> {
+		if (!this.canvasWorker) {
+			console.warn('[OverlayManager] No canvas worker available');
+			return;
+		}
+		const offscreen = canvasEl.transferControlToOffscreen();
+		await (this.canvasWorker as any).bindUICanvas(offscreen, dbGet);
+		this.canvasBound = true;
+	}
+
+	// ── Toast ──
+
+	toast(payload: ToastPayload): void {
+		if (this.effectivePath === 'canvas') {
+			void (this.canvasWorker as any)?.addCanvasToast(payload);
+		}
+		// Always update DOM state (nanostores) so event listeners and
+		// any DOM-rendered components stay in sync
+		addToast(payload);
+	}
+
+	dismissToast(id: string): void {
+		if (this.effectivePath === 'canvas') {
+			void (this.canvasWorker as any)?.removeCanvasToast(id);
+		}
+		removeToast(id);
+	}
+
+	// ── Tooltip ──
+
+	showTooltip(payload: TooltipPayload): void {
+		if (this.effectivePath === 'canvas') {
+			void (this.canvasWorker as any)?.showCanvasTooltip(payload);
+		}
+		openTooltip(payload.id);
+	}
+
+	hideTooltip(id?: string): void {
+		if (this.effectivePath === 'canvas') {
+			void (this.canvasWorker as any)?.showCanvasTooltip(null);
+		}
+		closeTooltip(id);
+	}
+
+	// ── Modal ──
+
+	showModal(payload: ModalPayload): void {
+		if (this.effectivePath === 'canvas') {
+			void (this.canvasWorker as any)?.showCanvasModal(payload);
+		}
+		openModal(payload.id);
+	}
+
+	hideModal(id?: string): void {
+		if (this.effectivePath === 'canvas') {
+			void (this.canvasWorker as any)?.showCanvasModal(null);
+		}
+		closeModal(id);
+	}
+
+	/** Switch rendering path at runtime */
+	setPath(path: RenderPath): void {
+		this.path = path;
+	}
+
+	/** Unbind canvas and clean up */
+	async destroy(): Promise<void> {
+		if (this.canvasBound && this.canvasWorker) {
+			await (this.canvasWorker as any).unbindUICanvas();
+			this.canvasBound = false;
+		}
+	}
+}

--- a/packages/npm/droid/src/lib/state/theme-sync.ts
+++ b/packages/npm/droid/src/lib/state/theme-sync.ts
@@ -1,0 +1,75 @@
+import type { Remote } from 'comlink';
+import type { LocalStorageAPI } from '../workers/db-worker';
+
+const THEME_VARS = [
+	'accent',
+	'accent-low',
+	'accent-high',
+	'bg',
+	'bg-accent',
+	'text',
+	'text-accent',
+	'border',
+	'white',
+	'black',
+] as const;
+
+/**
+ * Read resolved CSS custom property values from the document root
+ * and persist them to Dexie so workers can access theme colors.
+ */
+export async function syncThemeToDexie(
+	api: Remote<LocalStorageAPI>,
+): Promise<void> {
+	const root = document.documentElement;
+	const styles = getComputedStyle(root);
+	const mode = root.dataset['theme'] ?? 'dark';
+
+	await api.dbSet('theme:mode', mode);
+
+	for (const name of THEME_VARS) {
+		const value = styles.getPropertyValue(`--sl-color-${name}`).trim();
+		if (value) {
+			await api.dbSet(`theme:${name}`, value);
+		}
+	}
+}
+
+/**
+ * Broadcast a theme-sync event so workers re-read colors from Dexie.
+ */
+export function broadcastThemeChange(): void {
+	try {
+		const bc = new BroadcastChannel('kbve_theme');
+		bc.postMessage({ type: 'theme-sync', timestamp: Date.now() });
+		bc.close();
+	} catch {
+		// BroadcastChannel not available — workers won't get live updates
+	}
+}
+
+/**
+ * Observe theme attribute changes and auto-sync.
+ * Call once from main() after Dexie is initialized.
+ */
+export function observeThemeChanges(api: Remote<LocalStorageAPI>): void {
+	const observer = new MutationObserver(async (mutations) => {
+		for (const mutation of mutations) {
+			if (
+				mutation.type === 'attributes' &&
+				mutation.attributeName === 'data-theme'
+			) {
+				await syncThemeToDexie(api);
+				broadcastThemeChange();
+			}
+		}
+	});
+
+	observer.observe(document.documentElement, {
+		attributes: true,
+		attributeFilter: ['data-theme'],
+	});
+
+	// Initial sync
+	void syncThemeToDexie(api);
+}

--- a/packages/npm/droid/src/lib/workers/canvas-ui-renderer.ts
+++ b/packages/npm/droid/src/lib/workers/canvas-ui-renderer.ts
@@ -1,0 +1,266 @@
+import type {
+	ToastPayload,
+	TooltipPayload,
+	ModalPayload,
+} from '../types/ui-event-types';
+
+interface ThemeColors {
+	accent: string;
+	accentLow: string;
+	accentHigh: string;
+	bg: string;
+	bgAccent: string;
+	text: string;
+	textAccent: string;
+	border: string;
+	white: string;
+	black: string;
+	mode: 'light' | 'dark';
+}
+
+const SEVERITY_COLORS: Record<
+	string,
+	{ bg: string; border: string; text: string }
+> = {
+	success: { bg: '#065f46', border: '#10b981', text: '#d1fae5' },
+	warning: { bg: '#78350f', border: '#f59e0b', text: '#fef3c7' },
+	error: { bg: '#7f1d1d', border: '#ef4444', text: '#fee2e2' },
+	info: { bg: '#1e3a5f', border: '#3b82f6', text: '#dbeafe' },
+};
+
+interface ActiveToast extends ToastPayload {
+	createdAt: number;
+	opacity: number;
+	y: number;
+	targetY: number;
+}
+
+export class CanvasUIRenderer {
+	private ctx: OffscreenCanvasRenderingContext2D | null = null;
+	private canvas: OffscreenCanvas | null = null;
+	private toasts: ActiveToast[] = [];
+	private tooltip: TooltipPayload | null = null;
+	private modal: ModalPayload | null = null;
+	private theme: ThemeColors = {
+		accent: '#8b5cf6',
+		accentLow: '#1e1033',
+		accentHigh: '#c4b5fd',
+		bg: '#0a0a0a',
+		bgAccent: '#3b1f6e',
+		text: '#e0e0e0',
+		textAccent: '#a78bfa',
+		border: '#4c1d95',
+		white: '#ffffff',
+		black: '#000000',
+		mode: 'dark',
+	};
+	private animFrame: number | null = null;
+	private dbGet: ((key: string) => Promise<string | null>) | null = null;
+
+	async bind(
+		canvas: OffscreenCanvas,
+		dbGet: (key: string) => Promise<string | null>,
+	): Promise<void> {
+		this.canvas = canvas;
+		this.ctx = canvas.getContext('2d');
+		this.dbGet = dbGet;
+		await this.refreshTheme();
+		this.startLoop();
+	}
+
+	async refreshTheme(): Promise<void> {
+		if (!this.dbGet) return;
+		this.theme = {
+			accent: (await this.dbGet('theme:accent')) ?? '#8b5cf6',
+			accentLow: (await this.dbGet('theme:accent-low')) ?? '#1e1033',
+			accentHigh: (await this.dbGet('theme:accent-high')) ?? '#c4b5fd',
+			bg: (await this.dbGet('theme:bg')) ?? '#0a0a0a',
+			bgAccent: (await this.dbGet('theme:bg-accent')) ?? '#3b1f6e',
+			text: (await this.dbGet('theme:text')) ?? '#e0e0e0',
+			textAccent: (await this.dbGet('theme:text-accent')) ?? '#a78bfa',
+			border: (await this.dbGet('theme:border')) ?? '#4c1d95',
+			white: (await this.dbGet('theme:white')) ?? '#ffffff',
+			black: (await this.dbGet('theme:black')) ?? '#000000',
+			mode:
+				((await this.dbGet('theme:mode')) as 'light' | 'dark') ??
+				'dark',
+		};
+	}
+
+	addToast(payload: ToastPayload): void {
+		const yOffset = 20 + this.toasts.length * 80;
+		this.toasts.push({
+			...payload,
+			createdAt: Date.now(),
+			opacity: 0,
+			y: yOffset - 20,
+			targetY: yOffset,
+		});
+	}
+
+	removeToast(id: string): void {
+		const idx = this.toasts.findIndex((t) => t.id === id);
+		if (idx !== -1) this.toasts.splice(idx, 1);
+		this.recalcPositions();
+	}
+
+	showTooltip(payload: TooltipPayload | null): void {
+		this.tooltip = payload;
+	}
+
+	showModal(payload: ModalPayload | null): void {
+		this.modal = payload;
+	}
+
+	private recalcPositions(): void {
+		this.toasts.forEach((t, i) => {
+			t.targetY = 20 + i * 80;
+		});
+	}
+
+	private startLoop(): void {
+		const draw = () => {
+			this.render();
+			this.animFrame = requestAnimationFrame(draw);
+		};
+		draw();
+	}
+
+	private render(): void {
+		if (!this.ctx || !this.canvas) return;
+		const { width, height } = this.canvas;
+		this.ctx.clearRect(0, 0, width, height);
+
+		// Auto-dismiss expired toasts
+		const now = Date.now();
+		this.toasts = this.toasts.filter((t) => {
+			if (
+				t.duration &&
+				t.duration > 0 &&
+				now - t.createdAt > t.duration
+			) {
+				return false;
+			}
+			return true;
+		});
+		this.recalcPositions();
+
+		// Animate toasts
+		for (const toast of this.toasts) {
+			if (toast.opacity < 1)
+				toast.opacity = Math.min(1, toast.opacity + 0.05);
+			toast.y += (toast.targetY - toast.y) * 0.15;
+			this.drawToast(toast, width);
+		}
+
+		// Draw modal backdrop + content
+		if (this.modal) {
+			this.drawModal(width, height);
+		}
+	}
+
+	private drawToast(toast: ActiveToast, canvasWidth: number): void {
+		if (!this.ctx) return;
+		const ctx = this.ctx;
+		const w = 320;
+		const h = 64;
+		const x = canvasWidth - w - 20;
+		const y = toast.y;
+		const colors =
+			SEVERITY_COLORS[toast.severity] ?? SEVERITY_COLORS['info'];
+
+		ctx.globalAlpha = toast.opacity;
+
+		// Background
+		ctx.fillStyle = colors.bg;
+		this.roundRect(ctx, x, y, w, h, 8);
+		ctx.fill();
+
+		// Border
+		ctx.strokeStyle = colors.border;
+		ctx.lineWidth = 1.5;
+		this.roundRect(ctx, x, y, w, h, 8);
+		ctx.stroke();
+
+		// Text
+		ctx.fillStyle = colors.text;
+		ctx.font = '14px system-ui, -apple-system, sans-serif';
+		ctx.fillText(toast.message, x + 12, y + 24, w - 24);
+
+		// Severity label
+		ctx.font = 'bold 10px system-ui, sans-serif';
+		ctx.fillStyle = colors.border;
+		ctx.fillText(toast.severity.toUpperCase(), x + 12, y + 48);
+
+		ctx.globalAlpha = 1;
+	}
+
+	private drawModal(canvasWidth: number, canvasHeight: number): void {
+		if (!this.ctx || !this.modal) return;
+		const ctx = this.ctx;
+
+		// Backdrop
+		ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+		ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+		// Modal box
+		const w = Math.min(500, canvasWidth - 40);
+		const h = 300;
+		const x = (canvasWidth - w) / 2;
+		const y = (canvasHeight - h) / 2;
+
+		ctx.fillStyle = this.theme.bg;
+		this.roundRect(ctx, x, y, w, h, 12);
+		ctx.fill();
+
+		ctx.strokeStyle = this.theme.border;
+		ctx.lineWidth = 1;
+		this.roundRect(ctx, x, y, w, h, 12);
+		ctx.stroke();
+
+		// Title
+		if (this.modal.title) {
+			ctx.fillStyle = this.theme.text;
+			ctx.font = 'bold 18px system-ui, sans-serif';
+			ctx.fillText(this.modal.title, x + 20, y + 36, w - 40);
+		}
+
+		// ID label
+		ctx.fillStyle = this.theme.textAccent;
+		ctx.font = '12px system-ui, sans-serif';
+		ctx.fillText(this.modal.id, x + 20, y + 60, w - 40);
+	}
+
+	private roundRect(
+		ctx: OffscreenCanvasRenderingContext2D,
+		x: number,
+		y: number,
+		w: number,
+		h: number,
+		r: number,
+	): void {
+		ctx.beginPath();
+		ctx.moveTo(x + r, y);
+		ctx.lineTo(x + w - r, y);
+		ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+		ctx.lineTo(x + w, y + h - r);
+		ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+		ctx.lineTo(x + r, y + h);
+		ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+		ctx.lineTo(x, y + r);
+		ctx.quadraticCurveTo(x, y, x + r, y);
+		ctx.closePath();
+	}
+
+	unbind(): void {
+		if (this.animFrame !== null) {
+			cancelAnimationFrame(this.animFrame);
+			this.animFrame = null;
+		}
+		this.ctx = null;
+		this.canvas = null;
+		this.toasts = [];
+		this.tooltip = null;
+		this.modal = null;
+	}
+}

--- a/packages/npm/droid/src/lib/workers/main.ts
+++ b/packages/npm/droid/src/lib/workers/main.ts
@@ -22,6 +22,8 @@ import {
 } from '../types/ui-event-types';
 import { SupabaseGateway } from '../gateway/SupabaseGateway';
 import type { GatewayConfig } from '../gateway/types';
+import { observeThemeChanges } from '../state/theme-sync';
+import { OverlayManager } from '../state/overlay-manager';
 
 const EXPECTED_DB_VERSION = '1.0.3';
 let initialized = false;
@@ -462,6 +464,11 @@ export async function main(opts?: {
 				gateway = new SupabaseGateway(opts.gateway);
 			}
 
+			const overlay = new OverlayManager({
+				preferredPath: 'auto',
+				canvasWorker: canvas,
+			});
+
 			window.kbve = {
 				...(window.kbve || {}),
 				api,
@@ -471,8 +478,12 @@ export async function main(opts?: {
 				data,
 				mod,
 				events,
+				overlay,
 				...(gateway ? { gateway } : {}),
 			};
+
+			// Sync theme CSS vars to Dexie for worker access
+			observeThemeChanges(api);
 
 			await i18n.ready;
 

--- a/packages/npm/droid/src/lib/workers/validate.ts
+++ b/packages/npm/droid/src/lib/workers/validate.ts
@@ -1,0 +1,61 @@
+import {
+	ToastPayloadSchema,
+	TooltipPayloadSchema,
+	ModalPayloadSchema,
+} from '../types/ui-event-types';
+import type { z } from 'zod';
+
+export type UIMessageType =
+	| 'toast'
+	| 'toast-remove'
+	| 'tooltip-open'
+	| 'tooltip-close'
+	| 'modal-open'
+	| 'modal-close';
+
+const SCHEMAS: Partial<Record<UIMessageType, z.ZodType<any>>> = {
+	toast: ToastPayloadSchema,
+	'tooltip-open': TooltipPayloadSchema,
+	'modal-open': ModalPayloadSchema,
+};
+
+export interface ValidatedWorkerMessage {
+	type: UIMessageType;
+	payload: any;
+}
+
+/**
+ * Validate a UI message payload BEFORE postMessage to main thread.
+ * Returns the validated message or throws with a descriptive error.
+ *
+ * Usage (inside worker):
+ *   const msg = validateUIMessage('toast', rawPayload);
+ *   emitFromWorker(msg); // guaranteed valid
+ */
+export function validateUIMessage(
+	type: UIMessageType,
+	payload: unknown,
+): ValidatedWorkerMessage {
+	const schema = SCHEMAS[type];
+	if (schema) {
+		const result = schema.safeParse(payload);
+		if (!result.success) {
+			throw new Error(
+				`[KBVE Worker] Invalid ${type} payload: ${result.error.message}`,
+			);
+		}
+		return { type, payload: result.data };
+	}
+	// Types without full schemas (toast-remove, tooltip-close, modal-close)
+	// only require an id field
+	if (
+		type === 'toast-remove' ||
+		type === 'tooltip-close' ||
+		type === 'modal-close'
+	) {
+		if (!payload || typeof (payload as any).id !== 'string') {
+			throw new Error(`[KBVE Worker] ${type} requires { id: string }`);
+		}
+	}
+	return { type, payload };
+}


### PR DESCRIPTION
## Summary
- Add worker-side Zod validation (`validate.ts`) so payloads are checked before `postMessage`
- Add Dexie theme bridge (`theme-sync.ts`) — resolves `--sl-color-*` CSS vars via `getComputedStyle`, persists to Dexie, broadcasts changes via `BroadcastChannel` so canvas workers can read theme colors
- Add `CanvasUIRenderer` for off-thread toast/modal/tooltip rendering on `OffscreenCanvas`
- Add `OverlayManager` dual-path router (`dom` / `canvas` / `auto`) — always keeps nanostores in sync regardless of render path
- Add `CanvasOverlay` React + Astro components (transparent fixed canvas with `pointer-events: none`)
- Update `ASTRO_DROID_PLAN.md` with Phases 7–12 architecture
- Fix `astro:test` target to delegate to `astro-e2e` Playwright suite instead of failing on empty vitest
- Fix e2e navigation test for `droid-ready` event firing on `astro:page-load`

## Test plan
- [x] `droid:build` passes
- [x] `astro:build` passes
- [x] `droid:test` — 5/5 pass
- [x] `astro-e2e:e2e` — 54/54 pass
- [x] No circular deps (zero `@kbve/astro` imports in droid)