### PR TITLE
feat(discordsh): add real-time health monitoring with sysinfo (Phase 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,10 +251,10 @@ dependencies = [
  "image",
  "log",
  "objc2 0.6.3",
- "objc2-app-kit 0.3.2",
+ "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.2",
+ "objc2-foundation 0.3.1",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
@@ -943,6 +943,7 @@ dependencies = [
  "serenity",
  "serial_test",
  "socket2 0.6.2",
+ "sysinfo 0.38.2",
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
@@ -3667,9 +3668,9 @@ dependencies = [
  "glutin_wgl_sys",
  "libloading",
  "objc2 0.6.3",
- "objc2-app-kit 0.3.2",
+ "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation 0.3.1",
  "once_cell",
  "raw-window-handle",
  "wayland-sys",
@@ -5575,15 +5576,15 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
  "bitflags 2.11.0",
  "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.2",
+ "objc2-foundation 0.3.1",
 ]
 
 [[package]]
@@ -5624,9 +5625,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
@@ -5635,9 +5636,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-graphics"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
@@ -5700,9 +5701,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
  "bitflags 2.11.0",
  "objc2 0.6.3",
@@ -5710,10 +5711,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
+name = "objc2-io-kit"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
  "bitflags 2.11.0",
  "objc2 0.6.3",
@@ -5768,15 +5779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-system-configuration"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
-dependencies = [
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-ui-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5799,14 +5801,14 @@ dependencies = [
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+checksum = "25b1312ad7bc8a0e92adae17aa10f90aae1fb618832f9b993b022b591027daed"
 dependencies = [
  "bitflags 2.11.0",
  "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation 0.3.1",
 ]
 
 [[package]]
@@ -5835,16 +5837,16 @@ dependencies = [
 
 [[package]]
 name = "objc2-web-kit"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
+checksum = "91672909de8b1ce1c2252e95bbee8c1649c9ad9d14b9248b3d7b4c47903c47ad"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
  "objc2 0.6.3",
- "objc2-app-kit 0.3.2",
+ "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation 0.3.1",
 ]
 
 [[package]]
@@ -6245,7 +6247,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
- "sysinfo",
+ "sysinfo 0.34.2",
  "tempfile",
  "thiserror 2.0.18",
  "winapi",
@@ -10384,6 +10386,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11887,7 +11903,7 @@ dependencies = [
  "log",
  "ndk-context",
  "objc2 0.6.3",
- "objc2-foundation 0.3.2",
+ "objc2-foundation 0.3.1",
  "url",
  "web-sys",
 ]
@@ -12118,13 +12134,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
 dependencies = [
- "libc",
  "libredox",
- "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -12914,10 +12928,10 @@ dependencies = [
  "libc",
  "ndk",
  "objc2 0.6.3",
- "objc2-app-kit 0.3.2",
+ "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "objc2-ui-kit 0.3.2",
+ "objc2-foundation 0.3.1",
+ "objc2-ui-kit 0.3.1",
  "objc2-web-kit",
  "once_cell",
  "percent-encoding",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -30,6 +30,7 @@ num_cpus = "1.17.0"
 dotenvy = "0.15"
 serenity = { version = "0.12.5", default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"] }
 poise = "0.6.1"
+sysinfo = "0.38.2"
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi" }

--- a/apps/discordsh/axum-discordsh/src/astro/askama.rs
+++ b/apps/discordsh/axum-discordsh/src/astro/askama.rs
@@ -14,13 +14,13 @@ pub struct AstroTemplate<'a> {
 }
 
 impl<'a> AstroTemplate<'a> {
-    pub fn new(
-        content: &'a str,
-        path: &'a str,
-        title: &'a str,
-        description: &'a str,
-    ) -> Self {
-        Self { content, path, title, description }
+    pub fn new(content: &'a str, path: &'a str, title: &'a str, description: &'a str) -> Self {
+        Self {
+            content,
+            path,
+            title,
+            description,
+        }
     }
 }
 
@@ -32,7 +32,11 @@ impl<T: Template> IntoResponse for TemplateResponse<T> {
             Ok(html) => Html(html).into_response(),
             Err(err) => {
                 tracing::error!(error = %err, "template rendering failed");
-                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to render template").into_response()
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to render template",
+                )
+                    .into_response()
             }
         }
     }

--- a/apps/discordsh/axum-discordsh/src/astro/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/astro/mod.rs
@@ -1,9 +1,9 @@
 pub mod askama;
 
 use axum::{
-    http::{header, StatusCode},
-    response::IntoResponse,
     Router,
+    http::{StatusCode, header},
+    response::IntoResponse,
 };
 use std::convert::Infallible;
 use std::path::PathBuf;
@@ -23,7 +23,10 @@ impl StaticConfig {
         let precompressed = std::env::var("STATIC_PRECOMPRESSED")
             .map(|v| v != "0" && v.to_lowercase() != "false")
             .unwrap_or(true);
-        Self { base_dir, precompressed }
+        Self {
+            base_dir,
+            precompressed,
+        }
     }
 }
 
@@ -33,9 +36,8 @@ pub fn build_static_router(config: &StaticConfig) -> Router {
 
     // Read Astro's 404.html at startup for the not-found fallback
     let not_found_html = Arc::new(
-        std::fs::read_to_string(base.join("404.html")).unwrap_or_else(|_| {
-            "<html><body><h1>404 - Not Found</h1></body></html>".to_string()
-        }),
+        std::fs::read_to_string(base.join("404.html"))
+            .unwrap_or_else(|_| "<html><body><h1>404 - Not Found</h1></body></html>".to_string()),
     );
 
     let serve_dir = |path: PathBuf| {

--- a/apps/discordsh/axum-discordsh/src/discord/commands/health.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/health.rs
@@ -1,8 +1,59 @@
 use crate::discord::bot::{Context, Error};
+use poise::serenity_prelude as serenity;
 
-/// Reports system health information.
+/// Reports detailed system health information.
 #[poise::command(slash_command)]
 pub async fn health(ctx: Context<'_>) -> Result<(), Error> {
-    ctx.say("System health: OK").await?;
+    let data = ctx.data();
+
+    let snap = match data.health_monitor.snapshot().await {
+        Some(s) => s,
+        None => {
+            ctx.say("Health data is not yet available. Please try again in a moment.")
+                .await?;
+            return Ok(());
+        }
+    };
+
+    let color = snap.health_status.color_override().unwrap_or(0x57F287);
+
+    let embed = serenity::CreateEmbed::new()
+        .title("System Health Report")
+        .color(color)
+        .field(
+            "Health Status",
+            format!("{} {:?}", snap.health_status.emoji(), snap.health_status),
+            false,
+        )
+        .field(
+            "Process Memory",
+            format!(
+                "{:.1}MB ({:.1}%)\n{}",
+                snap.memory_usage_mb,
+                snap.memory_percent,
+                snap.memory_bar(10)
+            ),
+            true,
+        )
+        .field(
+            "System Memory",
+            format!(
+                "{:.1}GB total, {:.1}% used",
+                snap.system_memory_total_gb, snap.system_memory_used_percent
+            ),
+            true,
+        )
+        .field("CPU", format!("{:.1}%", snap.cpu_percent), true)
+        .field("Threads", snap.thread_count.to_string(), true)
+        .field("PID", snap.pid.to_string(), true)
+        .field("Uptime", &snap.uptime_formatted, true)
+        .footer(serenity::CreateEmbedFooter::new(format!(
+            "axum-discordsh v{}",
+            env!("CARGO_PKG_VERSION")
+        )))
+        .timestamp(serenity::Timestamp::now());
+
+    let reply = poise::CreateReply::default().embed(embed);
+    ctx.send(reply).await?;
     Ok(())
 }

--- a/apps/discordsh/axum-discordsh/src/discord/commands/status.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/status.rs
@@ -6,6 +6,7 @@ use crate::discord::embeds::{StatusSnapshot, StatusState, build_status_embed};
 #[poise::command(slash_command)]
 pub async fn status(ctx: Context<'_>) -> Result<(), Error> {
     let data = ctx.data();
+    let health = data.health_monitor.snapshot().await;
 
     let snap = StatusSnapshot {
         state: StatusState::Online,
@@ -13,6 +14,7 @@ pub async fn status(ctx: Context<'_>) -> Result<(), Error> {
         guild_count: ctx.cache().guild_count(),
         shard_id: Some(ctx.serenity_context().shard_id.0),
         uptime: data.start_time.elapsed(),
+        health,
     };
 
     let embed = build_status_embed(&snap);

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/status_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/status_embed.rs
@@ -2,6 +2,7 @@ use poise::serenity_prelude as serenity;
 use std::time::Duration;
 
 use super::status_state::StatusState;
+use crate::health::HealthSnapshot;
 
 /// Data bag passed into the embed builder, decoupled from poise's Data struct.
 pub struct StatusSnapshot {
@@ -10,6 +11,7 @@ pub struct StatusSnapshot {
     pub guild_count: usize,
     pub shard_id: Option<u32>,
     pub uptime: Duration,
+    pub health: Option<HealthSnapshot>,
 }
 
 /// Format a `Duration` into a human-friendly string like "2d 5h 32m 10s".
@@ -38,14 +40,21 @@ fn format_uptime(d: Duration) -> String {
 pub fn build_status_embed(snap: &StatusSnapshot) -> serenity::CreateEmbed {
     let state = snap.state;
 
+    // Health-based color override: CRITICAL → red, WARNING → orange
+    let color = snap
+        .health
+        .as_ref()
+        .and_then(|h| h.health_status.color_override())
+        .unwrap_or_else(|| state.color());
+
     let shard_display = match snap.shard_id {
         Some(id) => format!("Shard {id}"),
         None => "N/A".to_owned(),
     };
 
-    serenity::CreateEmbed::new()
+    let mut embed = serenity::CreateEmbed::new()
         .title("Bot Status Dashboard")
-        .color(state.color())
+        .color(color)
         .thumbnail(state.thumbnail_url())
         .field(
             "Status",
@@ -54,7 +63,34 @@ pub fn build_status_embed(snap: &StatusSnapshot) -> serenity::CreateEmbed {
         )
         .field("Guilds", snap.guild_count.to_string(), true)
         .field("Shard", shard_display, true)
-        .field("Uptime", format_uptime(snap.uptime), true)
+        .field("Uptime", format_uptime(snap.uptime), true);
+
+    if let Some(ref health) = snap.health {
+        embed = embed
+            .field(
+                "Memory",
+                format!(
+                    "{:.1}MB ({:.1}%)\n{}",
+                    health.memory_usage_mb,
+                    health.memory_percent,
+                    health.memory_bar(10)
+                ),
+                true,
+            )
+            .field("CPU", format!("{:.1}%", health.cpu_percent), true)
+            .field("Threads", health.thread_count.to_string(), true)
+            .field(
+                "Health",
+                format!(
+                    "{} {:?}",
+                    health.health_status.emoji(),
+                    health.health_status
+                ),
+                true,
+            );
+    }
+
+    embed
         .footer(serenity::CreateEmbedFooter::new(format!(
             "axum-discordsh v{}",
             snap.version

--- a/apps/discordsh/axum-discordsh/src/health/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/health/mod.rs
@@ -1,0 +1,294 @@
+use serde::Serialize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use sysinfo::{ProcessesToUpdate, System};
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+// ── Health status ────────────────────────────────────────────────────
+
+/// Health assessment based on memory and CPU thresholds.
+///
+/// Thresholds match the Python notification-bot:
+/// - HEALTHY: memory ≤ 70% AND CPU ≤ 70%
+/// - WARNING: either > 70% but neither > 90%
+/// - CRITICAL: either > 90%
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HealthStatus {
+    Healthy,
+    Warning,
+    Critical,
+}
+
+impl HealthStatus {
+    pub fn from_usage(memory_percent: f64, cpu_percent: f64) -> Self {
+        if memory_percent > 90.0 || cpu_percent > 90.0 {
+            Self::Critical
+        } else if memory_percent > 70.0 || cpu_percent > 70.0 {
+            Self::Warning
+        } else {
+            Self::Healthy
+        }
+    }
+
+    /// Discord embed color override.
+    /// Returns `None` for Healthy (caller should use the normal state color).
+    pub fn color_override(self) -> Option<u32> {
+        match self {
+            Self::Healthy => None,
+            Self::Warning => Some(0xE67E22),
+            Self::Critical => Some(0xED4245),
+        }
+    }
+
+    pub fn emoji(self) -> &'static str {
+        match self {
+            Self::Healthy => "\u{1F7E2}",
+            Self::Warning => "\u{1F7E1}",
+            Self::Critical => "\u{1F534}",
+        }
+    }
+}
+
+// ── Health snapshot ──────────────────────────────────────────────────
+
+/// Serializable snapshot of health metrics.
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthSnapshot {
+    pub memory_usage_mb: f64,
+    pub memory_percent: f64,
+    pub system_memory_total_gb: f64,
+    pub system_memory_used_percent: f64,
+    pub cpu_percent: f64,
+    pub thread_count: usize,
+    pub pid: u32,
+    pub uptime_seconds: u64,
+    pub uptime_formatted: String,
+    pub health_status: HealthStatus,
+}
+
+impl HealthSnapshot {
+    /// Generate a Discord-friendly memory bar using emoji squares.
+    pub fn memory_bar(&self, width: usize) -> String {
+        let filled = ((self.memory_percent / 100.0) * width as f64).round() as usize;
+        let filled = filled.min(width);
+
+        let (fill, empty) = if self.memory_percent > 90.0 {
+            ("\u{1F7E5}", "\u{2B1B}") // red / black
+        } else if self.memory_percent > 70.0 {
+            ("\u{1F7E7}", "\u{2B1B}") // orange / black
+        } else {
+            ("\u{1F7E9}", "\u{2B1B}") // green / black
+        };
+
+        format!("{}{}", fill.repeat(filled), empty.repeat(width - filled))
+    }
+}
+
+// ── Health monitor ───────────────────────────────────────────────────
+
+/// Background health monitor that periodically collects system metrics.
+///
+/// Owns a persistent `sysinfo::System` for accurate CPU delta measurement
+/// and exposes the latest `HealthSnapshot` via an `Arc<RwLock<>>`.
+pub struct HealthMonitor {
+    sys: RwLock<System>,
+    snapshot: RwLock<Option<HealthSnapshot>>,
+    start_time: Instant,
+    pid: sysinfo::Pid,
+}
+
+impl HealthMonitor {
+    /// Create a new monitor. Call `spawn_background_task()` to start collection.
+    pub fn new() -> Self {
+        let pid = sysinfo::get_current_pid().expect("failed to get current PID");
+        let mut sys = System::new();
+        // Prime the CPU measurement so the first real refresh has a delta.
+        sys.refresh_cpu_usage();
+
+        Self {
+            sys: RwLock::new(sys),
+            snapshot: RwLock::new(None),
+            start_time: Instant::now(),
+            pid,
+        }
+    }
+
+    /// Spawn the background refresh task onto the tokio runtime.
+    pub fn spawn_background_task(self: &Arc<Self>) {
+        let monitor = Arc::clone(self);
+        tokio::spawn(async move {
+            monitor.background_loop().await;
+        });
+    }
+
+    /// Read the latest cached snapshot. Returns `None` only before the
+    /// first refresh cycle completes (~1s after startup).
+    pub async fn snapshot(&self) -> Option<HealthSnapshot> {
+        self.snapshot.read().await.clone()
+    }
+
+    /// Force an immediate metric refresh (used by the Refresh button).
+    pub async fn force_refresh(&self) {
+        let snap = self.collect_inner().await;
+        *self.snapshot.write().await = Some(snap);
+    }
+
+    /// Background loop: 1s warmup for CPU delta, then 60s periodic refreshes.
+    async fn background_loop(&self) {
+        // Wait 1s so the primed CPU refresh has a meaningful time delta.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let snap = self.collect_inner().await;
+        *self.snapshot.write().await = Some(snap);
+        info!("Initial health snapshot collected");
+
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        interval.tick().await; // skip the immediate first tick
+
+        loop {
+            interval.tick().await;
+            let snap = self.collect_inner().await;
+            *self.snapshot.write().await = Some(snap);
+        }
+    }
+
+    /// Refresh the persistent System and extract a snapshot.
+    async fn collect_inner(&self) -> HealthSnapshot {
+        let mut sys = self.sys.write().await;
+        sys.refresh_cpu_usage();
+        sys.refresh_memory();
+        sys.refresh_processes(ProcessesToUpdate::Some(&[self.pid]), false);
+        self.extract_from(&sys)
+    }
+
+    /// Extract metrics from the System without holding any lock.
+    fn extract_from(&self, sys: &System) -> HealthSnapshot {
+        let total_mem = sys.total_memory();
+        let used_mem = sys.used_memory();
+
+        let (proc_mem_bytes, thread_count) = match sys.process(self.pid) {
+            Some(proc) => {
+                let threads = {
+                    #[cfg(target_os = "linux")]
+                    {
+                        proc.tasks().map_or(0, |t| t.len())
+                    }
+                    #[cfg(not(target_os = "linux"))]
+                    {
+                        let _ = proc;
+                        0usize
+                    }
+                };
+                (proc.memory(), threads)
+            }
+            None => {
+                warn!("Could not find own process in sysinfo");
+                (0, 0)
+            }
+        };
+
+        let memory_usage_mb = proc_mem_bytes as f64 / 1_048_576.0;
+        let memory_percent = if total_mem > 0 {
+            (proc_mem_bytes as f64 / total_mem as f64) * 100.0
+        } else {
+            0.0
+        };
+        let system_memory_total_gb = total_mem as f64 / 1_073_741_824.0;
+        let system_memory_used_percent = if total_mem > 0 {
+            (used_mem as f64 / total_mem as f64) * 100.0
+        } else {
+            0.0
+        };
+        let cpu_percent = sys.global_cpu_usage() as f64;
+
+        let uptime_secs = self.start_time.elapsed().as_secs();
+        let health_status = HealthStatus::from_usage(memory_percent, cpu_percent);
+
+        HealthSnapshot {
+            memory_usage_mb: round2(memory_usage_mb),
+            memory_percent: round2(memory_percent),
+            system_memory_total_gb: round2(system_memory_total_gb),
+            system_memory_used_percent: round2(system_memory_used_percent),
+            cpu_percent: round2(cpu_percent),
+            thread_count,
+            pid: self.pid.as_u32(),
+            uptime_seconds: uptime_secs,
+            uptime_formatted: format_uptime_secs(uptime_secs),
+            health_status,
+        }
+    }
+}
+
+/// Round to 2 decimal places.
+fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}
+
+fn format_uptime_secs(total_secs: u64) -> String {
+    let days = total_secs / 86400;
+    let hours = (total_secs % 86400) / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let seconds = total_secs % 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h {minutes}m {seconds}s")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m {seconds}s")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_status_healthy() {
+        assert_eq!(HealthStatus::from_usage(50.0, 60.0), HealthStatus::Healthy);
+        assert_eq!(HealthStatus::from_usage(70.0, 70.0), HealthStatus::Healthy);
+    }
+
+    #[test]
+    fn health_status_warning() {
+        assert_eq!(HealthStatus::from_usage(71.0, 50.0), HealthStatus::Warning);
+        assert_eq!(HealthStatus::from_usage(50.0, 71.0), HealthStatus::Warning);
+    }
+
+    #[test]
+    fn health_status_critical() {
+        assert_eq!(HealthStatus::from_usage(91.0, 50.0), HealthStatus::Critical);
+        assert_eq!(HealthStatus::from_usage(50.0, 91.0), HealthStatus::Critical);
+    }
+
+    #[test]
+    fn memory_bar_low_usage() {
+        let snap = HealthSnapshot {
+            memory_usage_mb: 10.0,
+            memory_percent: 30.0,
+            system_memory_total_gb: 16.0,
+            system_memory_used_percent: 50.0,
+            cpu_percent: 5.0,
+            thread_count: 1,
+            pid: 1,
+            uptime_seconds: 60,
+            uptime_formatted: "1m 0s".into(),
+            health_status: HealthStatus::Healthy,
+        };
+        let bar = snap.memory_bar(10);
+        // 30% of 10 = 3 filled
+        assert!(bar.contains("\u{1F7E9}")); // green squares
+        assert!(bar.contains("\u{2B1B}")); // black squares
+    }
+
+    #[test]
+    fn round2_precision() {
+        assert_eq!(round2(3.14159), 3.14);
+        assert_eq!(round2(0.0), 0.0);
+        assert_eq!(round2(99.999), 100.0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HealthMonitor` module with background 60s polling for CPU, memory, threads, and process metrics via `sysinfo` 0.38.2
- Wire shared `Arc<HealthMonitor>` into both Discord bot (`Data`) and Axum HTTP server (`HttpState`)
- `/health` slash command now shows rich embed with health thresholds (Healthy/Warning/Critical), memory bar, CPU, threads, PID, and uptime
- `/status` embed gains conditional health fields (Memory, CPU, Threads, Health) when data is available
- HTTP `/health` endpoint returns JSON with full system metrics instead of plain "OK"
- Refresh button calls `force_refresh()` for immediate metric update before re-rendering

## Test plan
- [x] `cargo build -p axum-discordsh` — zero errors
- [x] `cargo clippy -p axum-discordsh` — clean (only pre-existing warnings in other modules)
- [x] `cargo test -p axum-discordsh` — 21/21 pass (5 new health tests + 16 existing)
- [x] `rustfmt --check` — clean, passes pre-commit hook
- [ ] `pnpm nx e2e discordsh` — Docker build (requires OrbStack running)
- [ ] Manual: `/status` shows Memory, CPU, Threads, Health fields
- [ ] Manual: `/health` shows detailed health embed with thresholds
- [ ] Manual: Refresh button triggers `force_refresh()` and updates embed
- [ ] Manual: `curl localhost:4321/health` returns JSON with `status: "ok"` and health metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)