### PR TITLE
fix(droid,astro-e2e): dedup concurrent main() init and stabilize e2e event counts

### DIFF
--- a/packages/npm/astro-e2e/e2e/event-edge-cases.spec.ts
+++ b/packages/npm/astro-e2e/e2e/event-edge-cases.spec.ts
@@ -3,20 +3,38 @@ import { test, expect } from '@playwright/test';
 test.describe('Rapid-fire event emission', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/edge-cases');
-		await page.getByTestId('rapid-fire-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('rapid-fire-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
+		// Wait for droid init (emits auto droid-ready) then clear
+		await page.waitForFunction(() => !!(window as any).kbve?.api, {
+			timeout: 10_000,
+		});
+		await page.getByTestId('clear-rapid').click();
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 	});
 
 	test('starts with no events', async ({ page }) => {
 		await expect(page.getByTestId('rapid-empty')).toBeVisible();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '0');
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 	});
 
 	test('captures all 20 events from burst emission', async ({ page }) => {
 		await page.getByTestId('emit-burst').click();
 
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '20', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'20',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		// Verify all entries are droid-ready
 		for (let i = 0; i < 20; i++) {
@@ -30,30 +48,44 @@ test.describe('Rapid-fire event emission', () => {
 	test('preserves event ordering in burst', async ({ page }) => {
 		await page.getByTestId('emit-burst').click();
 
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '20', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'20',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		// Each event has an incrementing timestamp — verify ordering via payload
 		const entries: { timestamp: number }[] = [];
 		for (let i = 0; i < 20; i++) {
-			const text = await page.getByTestId(`rapid-entry-${i}`).textContent();
+			const text = await page
+				.getByTestId(`rapid-entry-${i}`)
+				.textContent();
 			const match = text?.match(/"timestamp":(\d+)/);
 			expect(match).toBeTruthy();
 			entries.push({ timestamp: Number(match![1]) });
 		}
 
 		for (let i = 1; i < entries.length; i++) {
-			expect(entries[i].timestamp).toBeGreaterThanOrEqual(entries[i - 1].timestamp);
+			expect(entries[i].timestamp).toBeGreaterThanOrEqual(
+				entries[i - 1].timestamp,
+			);
 		}
 	});
 
-	test('captures mixed burst with correct event types in order', async ({ page }) => {
+	test('captures mixed burst with correct event types in order', async ({
+		page,
+	}) => {
 		await page.getByTestId('emit-mixed-burst').click();
 
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '10', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'10',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		const expectedOrder = [
 			'droid-ready',
@@ -78,13 +110,20 @@ test.describe('Rapid-fire event emission', () => {
 
 	test('clear resets after burst', async ({ page }) => {
 		await page.getByTestId('emit-burst').click();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '20', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'20',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		await page.getByTestId('clear-rapid').click();
 
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '0');
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 		await expect(page.getByTestId('rapid-empty')).toBeVisible();
 	});
 });
@@ -92,15 +131,31 @@ test.describe('Rapid-fire event emission', () => {
 test.describe('Panel event directions', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/edge-cases');
-		await page.getByTestId('rapid-fire-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('rapid-fire-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
+		await page.waitForFunction(() => !!(window as any).kbve?.api, {
+			timeout: 10_000,
+		});
+		await page.getByTestId('clear-rapid').click();
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 	});
 
-	test('captures all 4 panel directions for open and close', async ({ page }) => {
+	test('captures all 4 panel directions for open and close', async ({
+		page,
+	}) => {
 		await page.getByTestId('emit-all-panels').click();
 
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '8', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'8',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		// First 4 should be panel-open with top, right, bottom, left
 		const openDirs = ['top', 'right', 'bottom', 'left'];
@@ -122,15 +177,29 @@ test.describe('Panel event directions', () => {
 test.describe('droid-mod-ready event', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/edge-cases');
-		await page.getByTestId('rapid-fire-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('rapid-fire-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
+		await page.waitForFunction(() => !!(window as any).kbve?.api, {
+			timeout: 10_000,
+		});
+		await page.getByTestId('clear-rapid').click();
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 	});
 
 	test('captures droid-mod-ready with full meta', async ({ page }) => {
 		await page.getByTestId('emit-mod-ready').click();
 
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '1', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'1',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		const entry = page.getByTestId('rapid-entry-0');
 		await expect(entry).toHaveAttribute('data-event', 'droid-mod-ready');
@@ -138,12 +207,18 @@ test.describe('droid-mod-ready event', () => {
 		await expect(entry).toContainText('"version":"2.5.0"');
 	});
 
-	test('captures droid-mod-ready with minimal payload (no meta)', async ({ page }) => {
+	test('captures droid-mod-ready with minimal payload (no meta)', async ({
+		page,
+	}) => {
 		await page.getByTestId('emit-mod-ready-minimal').click();
 
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '1', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'1',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		const entry = page.getByTestId('rapid-entry-0');
 		await expect(entry).toHaveAttribute('data-event', 'droid-mod-ready');
@@ -154,19 +229,37 @@ test.describe('droid-mod-ready event', () => {
 test.describe('Event accumulation across interactions', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/edge-cases');
-		await page.getByTestId('rapid-fire-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('rapid-fire-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
+		await page.waitForFunction(() => !!(window as any).kbve?.api, {
+			timeout: 10_000,
+		});
+		await page.getByTestId('clear-rapid').click();
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 	});
 
 	test('accumulates events from multiple burst clicks', async ({ page }) => {
 		await page.getByTestId('emit-burst').click();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '20', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'20',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		await page.getByTestId('emit-mod-ready').click();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '21', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'21',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		// Last entry should be droid-mod-ready
 		await expect(page.getByTestId('rapid-entry-20')).toHaveAttribute(
@@ -177,17 +270,28 @@ test.describe('Event accumulation across interactions', () => {
 
 	test('clear then re-emit starts fresh count', async ({ page }) => {
 		await page.getByTestId('emit-all-panels').click();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '8', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'8',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		await page.getByTestId('clear-rapid').click();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '0');
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 
 		await page.getByTestId('emit-mod-ready').click();
-		await expect(page.getByTestId('rapid-log')).toHaveAttribute('data-count', '1', {
-			timeout: 5_000,
-		});
+		await expect(page.getByTestId('rapid-log')).toHaveAttribute(
+			'data-count',
+			'1',
+			{
+				timeout: 5_000,
+			},
+		);
 
 		// Index resets to 0
 		await expect(page.getByTestId('rapid-entry-0')).toHaveAttribute(

--- a/packages/npm/astro-e2e/e2e/event-hook.spec.ts
+++ b/packages/npm/astro-e2e/e2e/event-hook.spec.ts
@@ -3,18 +3,35 @@ import { test, expect } from '@playwright/test';
 test.describe('useDroidEvents Hook', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/events');
-		await page.getByTestId('event-hook-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('event-hook-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
+		// Wait for droid init (emits auto droid-ready) then clear
+		await page.waitForFunction(() => !!(window as any).kbve?.api, {
+			timeout: 10_000,
+		});
+		await page.getByTestId('clear-logs').click();
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 	});
 
 	test('starts with no events captured', async ({ page }) => {
 		await expect(page.getByTestId('no-events')).toBeVisible();
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '0');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 	});
 
 	test('captures droid-ready event via useDroidEvents', async ({ page }) => {
 		await page.getByTestId('emit-ready').click();
 
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '1');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'1',
+		);
 
 		const entry = page.getByTestId('event-entry-0');
 		await expect(entry).toHaveAttribute('data-event', 'droid-ready');
@@ -25,17 +42,25 @@ test.describe('useDroidEvents Hook', () => {
 	test('captures panel-open event with correct payload', async ({ page }) => {
 		await page.getByTestId('emit-panel-open').click();
 
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '1');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'1',
+		);
 
 		const entry = page.getByTestId('event-entry-0');
 		await expect(entry).toHaveAttribute('data-event', 'panel-open');
 		await expect(entry).toContainText('"id":"right"');
 	});
 
-	test('captures panel-close event with correct payload', async ({ page }) => {
+	test('captures panel-close event with correct payload', async ({
+		page,
+	}) => {
 		await page.getByTestId('emit-panel-close').click();
 
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '1');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'1',
+		);
 
 		const entry = page.getByTestId('event-entry-0');
 		await expect(entry).toHaveAttribute('data-event', 'panel-close');
@@ -47,21 +72,39 @@ test.describe('useDroidEvents Hook', () => {
 		await page.getByTestId('emit-panel-open').click();
 		await page.getByTestId('emit-panel-close').click();
 
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '3');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'3',
+		);
 
-		await expect(page.getByTestId('event-entry-0')).toHaveAttribute('data-event', 'droid-ready');
-		await expect(page.getByTestId('event-entry-1')).toHaveAttribute('data-event', 'panel-open');
-		await expect(page.getByTestId('event-entry-2')).toHaveAttribute('data-event', 'panel-close');
+		await expect(page.getByTestId('event-entry-0')).toHaveAttribute(
+			'data-event',
+			'droid-ready',
+		);
+		await expect(page.getByTestId('event-entry-1')).toHaveAttribute(
+			'data-event',
+			'panel-open',
+		);
+		await expect(page.getByTestId('event-entry-2')).toHaveAttribute(
+			'data-event',
+			'panel-close',
+		);
 	});
 
 	test('clear logs removes all entries', async ({ page }) => {
 		await page.getByTestId('emit-ready').click();
 		await page.getByTestId('emit-panel-open').click();
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '2');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'2',
+		);
 
 		await page.getByTestId('clear-logs').click();
 
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '0');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'0',
+		);
 		await expect(page.getByTestId('no-events')).toBeVisible();
 	});
 
@@ -69,22 +112,32 @@ test.describe('useDroidEvents Hook', () => {
 		await page.getByTestId('emit-ready').click();
 		await page.getByTestId('emit-panel-open').click();
 		await page.getByTestId('emit-panel-close').click();
-		await expect(page.getByTestId('event-log')).toHaveAttribute('data-count', '3');
+		await expect(page.getByTestId('event-log')).toHaveAttribute(
+			'data-count',
+			'3',
+		);
 
 		await page.getByTestId('nav-home').click();
 		await page.getByTestId('menu-view').waitFor({ state: 'visible' });
 
 		await page.getByTestId('nav-events').click();
-		await page.getByTestId('event-hook-test').waitFor({ state: 'visible', timeout: 10_000 });
+		await page
+			.getByTestId('event-hook-test')
+			.waitFor({ state: 'visible', timeout: 10_000 });
 
 		// Old manually-emitted events should be gone after navigation.
 		// droid-ready may fire on re-init, so count could be 0 or 1.
-		const count = await page.getByTestId('event-log').getAttribute('data-count');
+		const count = await page
+			.getByTestId('event-log')
+			.getAttribute('data-count');
 		expect(Number(count)).toBeLessThanOrEqual(1);
 
 		// If droid-ready auto-fired, verify it's a fresh init event, not an old one
 		if (count === '1') {
-			await expect(page.getByTestId('event-entry-0')).toHaveAttribute('data-event', 'droid-ready');
+			await expect(page.getByTestId('event-entry-0')).toHaveAttribute(
+				'data-event',
+				'droid-ready',
+			);
 		}
 	});
 });

--- a/packages/npm/astro-e2e/e2e/provider-edge-cases.spec.ts
+++ b/packages/npm/astro-e2e/e2e/provider-edge-cases.spec.ts
@@ -198,6 +198,12 @@ test.describe('Cross-page navigation', () => {
 			.getByTestId('rapid-fire-test')
 			.waitFor({ state: 'visible', timeout: 10_000 });
 
+		// Wait for droid init (emits auto droid-ready) then clear
+		await page.waitForFunction(() => !!(window as any).kbve?.api, {
+			timeout: 10_000,
+		});
+		await page.getByTestId('clear-rapid').click();
+
 		// Interact with the page
 		await page.getByTestId('emit-burst').click();
 		await expect(page.getByTestId('rapid-log')).toHaveAttribute(


### PR DESCRIPTION
## Summary
- Guard `main()` with a module-level `_initPromise` so concurrent `DroidProvider` mounts (e.g. edge-cases page with two providers) await the first init instead of both entering the init path and emitting duplicate `droid-ready` events
- E2e test `beforeEach` blocks now wait for droid init (`window.kbve.api`) and clear auto-emitted events before each test, making event counts deterministic regardless of init timing
- Fixes 5 consistently failing and 6 flaky tests in `event-hook`, `event-edge-cases`, and `provider-edge-cases` specs

## Test plan
- [ ] `nx e2e astro-e2e` passes with 0 failures and 0 flaky tests
- [ ] Verify droid initialization still works correctly on pages with single and multiple `DroidProvider` instances