### PR TITLE
feat(q): implement P2 improvements from v3 audit

### DIFF
--- a/packages/rust/q/src/core/bridge.rs
+++ b/packages/rust/q/src/core/bridge.rs
@@ -1,7 +1,9 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use godot::prelude::*;
+use serde_json::Value;
 
 use crate::core::actor::Actor;
 use crate::core::ecs::EntityStore;
@@ -11,17 +13,20 @@ struct Channels {
     req_tx: Sender<GameRequest>,
     evt_rx: Receiver<GameEvent>,
     entity_store: Arc<EntityStore>,
+    shutdown_flag: Arc<AtomicBool>,
 }
 
 static CHANNELS: LazyLock<Channels> = LazyLock::new(|| {
     let (req_tx, req_rx) = unbounded();
     let (evt_tx, evt_rx) = unbounded();
     let entity_store = Arc::new(EntityStore::new());
-    Actor::spawn(entity_store.clone(), req_rx, evt_tx);
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    Actor::spawn(entity_store.clone(), req_rx, evt_tx, shutdown_flag.clone());
     Channels {
         req_tx,
         evt_rx,
         entity_store,
+        shutdown_flag,
     }
 });
 
@@ -66,44 +71,88 @@ impl EventBridge {
     pub fn send_request(&self, request_type: GString, payload: GString) {
         let request_str = request_type.to_string();
         let payload_str = payload.to_string();
-        let request = match request_str.as_str() {
+        let request = if let Ok(json) = serde_json::from_str::<Value>(&payload_str) {
+            Self::parse_json_request(&request_str, &json, &payload_str)
+        } else {
+            Self::parse_csv_request(&request_str, &payload_str)
+        };
+        let _ = CHANNELS.req_tx.send(request);
+    }
+
+    fn parse_json_request(request_type: &str, json: &Value, raw: &str) -> GameRequest {
+        match request_type {
             "spawn_entity" => {
-                let parts: Vec<&str> = payload_str.split(',').collect();
-                if parts.len() == 2 {
-                    if let (Ok(x), Ok(y)) = (parts[0].trim().parse(), parts[1].trim().parse()) {
-                        GameRequest::SpawnEntity { x, y }
-                    } else {
-                        GameRequest::Custom(request_str.clone(), payload_str)
-                    }
+                let x = json["x"].as_f64().map(|v| v as f32);
+                let y = json["y"].as_f64().map(|v| v as f32);
+                if let (Some(x), Some(y)) = (x, y) {
+                    GameRequest::SpawnEntity { x, y }
                 } else {
-                    GameRequest::Custom(request_str.clone(), payload_str)
+                    GameRequest::Custom(request_type.to_string(), raw.to_string())
                 }
             }
-            "despawn_entity" => GameRequest::DespawnEntity { id: payload_str },
+            "despawn_entity" => {
+                let id = json["id"]
+                    .as_str()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| raw.to_string());
+                GameRequest::DespawnEntity { id }
+            }
             "update_position" => {
-                let parts: Vec<&str> = payload_str.split(',').collect();
+                let id = json["id"].as_str().map(|s| s.to_string());
+                let x = json["x"].as_f64().map(|v| v as f32);
+                let y = json["y"].as_f64().map(|v| v as f32);
+                if let (Some(id), Some(x), Some(y)) = (id, x, y) {
+                    GameRequest::UpdatePosition { id, x, y }
+                } else {
+                    GameRequest::Custom(request_type.to_string(), raw.to_string())
+                }
+            }
+            "shutdown" => GameRequest::Shutdown,
+            _ => GameRequest::Custom(request_type.to_string(), raw.to_string()),
+        }
+    }
+
+    fn parse_csv_request(request_type: &str, payload: &str) -> GameRequest {
+        match request_type {
+            "spawn_entity" => {
+                let parts: Vec<&str> = payload.split(',').collect();
+                if parts.len() == 2 {
+                    if let (Ok(x), Ok(y)) = (parts[0].trim().parse(), parts[1].trim().parse()) {
+                        return GameRequest::SpawnEntity { x, y };
+                    }
+                }
+                GameRequest::Custom(request_type.to_string(), payload.to_string())
+            }
+            "despawn_entity" => GameRequest::DespawnEntity {
+                id: payload.to_string(),
+            },
+            "update_position" => {
+                let parts: Vec<&str> = payload.split(',').collect();
                 if parts.len() == 3 {
                     if let (Ok(x), Ok(y)) = (parts[1].trim().parse(), parts[2].trim().parse()) {
-                        GameRequest::UpdatePosition {
+                        return GameRequest::UpdatePosition {
                             id: parts[0].trim().to_string(),
                             x,
                             y,
-                        }
-                    } else {
-                        GameRequest::Custom(request_str, payload_str)
+                        };
                     }
-                } else {
-                    GameRequest::Custom(request_str, payload_str)
                 }
+                GameRequest::Custom(request_type.to_string(), payload.to_string())
             }
-            _ => GameRequest::Custom(request_str, payload_str),
-        };
-        let _ = CHANNELS.req_tx.send(request);
+            "shutdown" => GameRequest::Shutdown,
+            _ => GameRequest::Custom(request_type.to_string(), payload.to_string()),
+        }
     }
 
     #[func]
     pub fn get_entity_count(&self) -> i64 {
         CHANNELS.entity_store.entity_count() as i64
+    }
+
+    #[func]
+    pub fn shutdown(&self) {
+        CHANNELS.shutdown_flag.store(true, Ordering::Relaxed);
+        let _ = CHANNELS.req_tx.send(GameRequest::Shutdown);
     }
 
     fn emit_event(&mut self, event: GameEvent) {

--- a/packages/rust/q/src/core/ecs.rs
+++ b/packages/rust/q/src/core/ecs.rs
@@ -90,4 +90,189 @@ impl EntityStore {
             .map(|entry| *entry.key())
             .collect()
     }
+
+    pub fn all_entity_ids(&self) -> Vec<EntityId> {
+        self.transforms.iter().map(|entry| *entry.key()).collect()
+    }
+}
+
+impl Default for EntityStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_transform(x: f32, y: f32) -> Transform {
+        Transform { q: 0, r: 0, x, y }
+    }
+
+    fn test_stats() -> EntityStats {
+        EntityStats {
+            hp: 100.0,
+            max_hp: 100.0,
+            attack: 10.0,
+            defense: 5.0,
+            speed: 1.0,
+        }
+    }
+
+    #[test]
+    fn spawn_and_count() {
+        let store = EntityStore::new();
+        assert_eq!(store.entity_count(), 0);
+
+        store.spawn(test_transform(1.0, 2.0), test_stats());
+        assert_eq!(store.entity_count(), 1);
+
+        store.spawn(test_transform(3.0, 4.0), test_stats());
+        assert_eq!(store.entity_count(), 2);
+    }
+
+    #[test]
+    fn despawn_removes_all_components() {
+        let store = EntityStore::new();
+        let id = store.spawn(test_transform(1.0, 2.0), test_stats());
+        store.set_state(&id, 42);
+
+        assert!(store.get_transform(&id).is_some());
+        assert!(store.get_stats(&id).is_some());
+        assert!(store.get_state(&id).is_some());
+
+        store.despawn(&id);
+
+        assert!(store.get_transform(&id).is_none());
+        assert!(store.get_stats(&id).is_none());
+        assert!(store.get_state(&id).is_none());
+        assert_eq!(store.entity_count(), 0);
+    }
+
+    #[test]
+    fn update_transform_preserves_entity() {
+        let store = EntityStore::new();
+        let id = store.spawn(test_transform(1.0, 2.0), test_stats());
+
+        let new_transform = Transform {
+            q: 5,
+            r: 10,
+            x: 99.0,
+            y: 88.0,
+        };
+        store.update_transform(&id, new_transform);
+
+        let t = store.get_transform(&id).unwrap();
+        assert_eq!(t.q, 5);
+        assert_eq!(t.r, 10);
+        assert_eq!(t.x, 99.0);
+        assert_eq!(t.y, 88.0);
+        assert_eq!(store.entity_count(), 1);
+    }
+
+    #[test]
+    fn update_stats() {
+        let store = EntityStore::new();
+        let id = store.spawn(test_transform(0.0, 0.0), test_stats());
+
+        let new_stats = EntityStats {
+            hp: 50.0,
+            max_hp: 200.0,
+            attack: 25.0,
+            defense: 15.0,
+            speed: 3.0,
+        };
+        store.update_stats(&id, new_stats);
+
+        let s = store.get_stats(&id).unwrap();
+        assert_eq!(s.hp, 50.0);
+        assert_eq!(s.max_hp, 200.0);
+        assert_eq!(s.attack, 25.0);
+    }
+
+    #[test]
+    fn state_management() {
+        let store = EntityStore::new();
+        let id = store.spawn(test_transform(0.0, 0.0), test_stats());
+
+        assert_eq!(store.get_state(&id), Some(0));
+
+        store.set_state(&id, 0b00000101);
+        assert_eq!(store.get_state(&id), Some(0b00000101));
+    }
+
+    #[test]
+    fn entities_in_range_filters_correctly() {
+        let store = EntityStore::new();
+
+        let t_in = Transform {
+            q: 5,
+            r: 5,
+            x: 0.0,
+            y: 0.0,
+        };
+        let t_out = Transform {
+            q: 100,
+            r: 100,
+            x: 0.0,
+            y: 0.0,
+        };
+
+        let id_in = store.spawn(t_in, test_stats());
+        let _id_out = store.spawn(t_out, test_stats());
+
+        let results = store.entities_in_range((5, 5), 2);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], id_in);
+    }
+
+    #[test]
+    fn all_entity_ids() {
+        let store = EntityStore::new();
+        let id1 = store.spawn(test_transform(0.0, 0.0), test_stats());
+        let id2 = store.spawn(test_transform(1.0, 1.0), test_stats());
+
+        let ids = store.all_entity_ids();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&id1));
+        assert!(ids.contains(&id2));
+    }
+
+    #[test]
+    fn default_impl() {
+        let store = EntityStore::default();
+        assert_eq!(store.entity_count(), 0);
+    }
+
+    #[test]
+    fn transform_serde_roundtrip() {
+        let t = Transform {
+            q: 3,
+            r: 7,
+            x: 1.5,
+            y: 2.5,
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let t2: Transform = serde_json::from_str(&json).unwrap();
+        assert_eq!(t.q, t2.q);
+        assert_eq!(t.r, t2.r);
+        assert_eq!(t.x, t2.x);
+        assert_eq!(t.y, t2.y);
+    }
+
+    #[test]
+    fn entity_stats_serde_roundtrip() {
+        let s = EntityStats {
+            hp: 75.0,
+            max_hp: 100.0,
+            attack: 12.0,
+            defense: 8.0,
+            speed: 2.5,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let s2: EntityStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(s.hp, s2.hp);
+        assert_eq!(s.speed, s2.speed);
+    }
 }

--- a/packages/rust/q/src/core/event.rs
+++ b/packages/rust/q/src/core/event.rs
@@ -4,6 +4,7 @@ pub enum GameRequest {
     DespawnEntity { id: String },
     UpdatePosition { id: String, x: f32, y: f32 },
     Custom(String, String),
+    Shutdown,
 }
 
 #[derive(Debug, Clone)]
@@ -13,4 +14,61 @@ pub enum GameEvent {
     PositionUpdated { id: String, x: f32, y: f32 },
     Custom(String, String),
     Error(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn game_request_variants() {
+        let spawn = GameRequest::SpawnEntity { x: 1.0, y: 2.0 };
+        assert!(matches!(spawn, GameRequest::SpawnEntity { x, y } if x == 1.0 && y == 2.0));
+
+        let despawn = GameRequest::DespawnEntity {
+            id: "abc".to_string(),
+        };
+        assert!(matches!(despawn, GameRequest::DespawnEntity { ref id } if id == "abc"));
+
+        let update = GameRequest::UpdatePosition {
+            id: "xyz".to_string(),
+            x: 5.0,
+            y: 10.0,
+        };
+        assert!(
+            matches!(update, GameRequest::UpdatePosition { ref id, x, y } if id == "xyz" && x == 5.0 && y == 10.0)
+        );
+
+        let custom = GameRequest::Custom("type".to_string(), "data".to_string());
+        assert!(matches!(custom, GameRequest::Custom(ref t, ref d) if t == "type" && d == "data"));
+
+        let shutdown = GameRequest::Shutdown;
+        assert!(matches!(shutdown, GameRequest::Shutdown));
+    }
+
+    #[test]
+    fn game_event_variants() {
+        let spawned = GameEvent::EntitySpawned {
+            id: "e1".to_string(),
+            x: 1.0,
+            y: 2.0,
+        };
+        assert!(matches!(spawned, GameEvent::EntitySpawned { ref id, .. } if id == "e1"));
+
+        let error = GameEvent::Error("oops".to_string());
+        assert!(matches!(error, GameEvent::Error(ref msg) if msg == "oops"));
+    }
+
+    #[test]
+    fn clone_preserves_data() {
+        let original = GameRequest::UpdatePosition {
+            id: "test".to_string(),
+            x: 3.0,
+            y: 4.0,
+        };
+        let cloned = original.clone();
+        assert!(
+            matches!(cloned, GameRequest::UpdatePosition { ref id, x, y } if id == "test" && x == 3.0 && y == 4.0)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- **P2 3.2 - Actor graceful shutdown**: Added `AtomicBool` shutdown flag and `Shutdown` request variant to enable clean actor thread termination from GDScript via `EventBridge.shutdown()`
- **P2 5.1 - Unit tests**: Added 13 tests across `ecs.rs` and `event.rs` covering spawn/despawn, transforms, stats, state management, range queries, serde roundtrips, and all event/request variants
- **P2 3.4 - Structured request payloads**: Refactored `send_request` to parse JSON payloads first (`{"x":1.0,"y":2.0}`) with CSV fallback for backward compatibility. Also added `all_entity_ids()`, `Default` impl to `EntityStore`, and cleaned unused `JoinHandle` import

## Files changed
- `packages/rust/q/src/core/actor.rs` — shutdown flag param, tick returns bool, Shutdown match arm
- `packages/rust/q/src/core/bridge.rs` — JSON/CSV dual parser, shutdown func, cleanup
- `packages/rust/q/src/core/ecs.rs` — `all_entity_ids()`, `Default` impl, 10 tests
- `packages/rust/q/src/core/event.rs` — `Shutdown` variant, 3 tests

## Test plan
- [x] All 13 unit tests pass (`cargo test` — 13 passed, 0 failed)
- [x] `rustfmt --check` passes (verified by pre-commit hook)
- [ ] Verify JSON payloads work from GDScript: `bridge.send_request("spawn_entity", '{"x":5.0,"y":10.0}')`
- [ ] Verify CSV payloads still work: `bridge.send_request("spawn_entity", "5.0,10.0")`
- [ ] Verify `bridge.shutdown()` cleanly stops the actor thread