### PR TITLE
feat(q): implement P3 improvements from v3 audit

### DIFF
--- a/packages/rust/q/src/core/bridge.rs
+++ b/packages/rust/q/src/core/bridge.rs
@@ -150,6 +150,21 @@ impl EventBridge {
     }
 
     #[func]
+    pub fn get_all_entity_ids(&self) -> Array<GString> {
+        let ids = CHANNELS.entity_store.all_entity_ids();
+        let mut arr = Array::new();
+        for id in ids {
+            arr.push(&GString::from(id.to_string()));
+        }
+        arr
+    }
+
+    #[func]
+    pub fn despawn_all(&self) {
+        CHANNELS.entity_store.despawn_all();
+    }
+
+    #[func]
     pub fn shutdown(&self) {
         CHANNELS.shutdown_flag.store(true, Ordering::Relaxed);
         let _ = CHANNELS.req_tx.send(GameRequest::Shutdown);

--- a/packages/rust/q/src/data/abstract_data_map.rs
+++ b/packages/rust/q/src/data/abstract_data_map.rs
@@ -71,16 +71,11 @@ pub trait AbstractDataMap: Serialize + for<'de> Deserialize<'de> + Sized {
     }
 
     fn from_load_gfile_json(file_path: &str) -> Option<Self> {
-        godot_print!("[AbstractDataMap] Attempting to open file: {}", file_path);
-
         let file = GFile::open(file_path, ModeFlags::READ);
 
         match file {
             Ok(mut file) => {
-                godot_print!("[AbstractDataMap] File opened successfully.");
-
                 if let Ok(json_string) = file.read_gstring_line() {
-                    godot_print!("[AbstractDataMap] Successfully read JSON file.");
                     return Self::from_json(&json_string.to_string());
                 } else {
                     godot_error!("[AbstractDataMap] ERROR: Failed to read JSON string.");

--- a/packages/rust/q/src/data/user_data.rs
+++ b/packages/rust/q/src/data/user_data.rs
@@ -1,4 +1,5 @@
 use crate::data::abstract_data_map::AbstractDataMap;
+use crate::debug_print;
 use dashmap::DashMap;
 use godot::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -97,14 +98,14 @@ impl UserDataCache {
         self.save_user_data(&default_data);
         self.save_to_file(file_path, &default_data);
 
-        godot_print!("[UserDataCache] New user data saved successfully.");
+        debug_print!("[UserDataCache] New user data saved successfully.");
 
         default_data
     }
 
     pub fn save_to_file(&self, file_path: &str, user_data: &UserData) {
         if user_data.to_save_gfile_json(file_path) {
-            godot_print!("[UserDataCache] Successfully saved user settings.");
+            debug_print!("[UserDataCache] Successfully saved user settings.");
         } else {
             godot_error!(
                 "[UserDataCache] ERROR: Failed to save user settings to `{}`!",
@@ -114,10 +115,10 @@ impl UserDataCache {
     }
 
     pub fn load_from_file(&mut self, file_path: &str) -> Option<UserData> {
-        godot_print!("[UserDataCache] Attempting to load file: {}", file_path);
+        debug_print!("[UserDataCache] Loading file: {}", file_path);
 
         if let Some(user_data) = UserData::from_load_gfile_json(file_path) {
-            godot_print!("[UserDataCache] Successfully loaded user settings.");
+            debug_print!("[UserDataCache] Settings loaded.");
             self.save_user_data(&user_data);
             Some(user_data)
         } else {
@@ -130,10 +131,9 @@ impl UserDataCache {
     }
 
     pub fn save_user_data(&mut self, user_data: &UserData) {
-        godot_print!("[UserDataCache] Storing user data in cache...");
         let new_map = user_data.to_variant_map();
         self.map = new_map;
-        godot_print!("[UserDataCache] User data successfully cached.");
+        debug_print!("[UserDataCache] User data cached.");
     }
 
     pub fn load_user_data(&self) -> Option<UserData> {

--- a/packages/rust/q/src/entity/npc_entity.rs
+++ b/packages/rust/q/src/entity/npc_entity.rs
@@ -1,5 +1,6 @@
 use crate::data::abstract_data_map::AbstractDataMap;
 use crate::data::npc_data::{NPCData, NPCState};
+use crate::debug_print;
 use godot::classes::Sprite2D;
 use godot::prelude::*;
 
@@ -32,11 +33,10 @@ impl INode for NPCEntity {
     }
 
     fn ready(&mut self) {
-        godot_print!("[NPCEntity] Ready! Initializing NPCEntity...");
+        debug_print!("[NPCEntity] Initializing...");
 
         if let Some(sprite) = self.base().try_get_node_as::<Sprite2D>("Sprite2D") {
             self.sprite = Some(sprite);
-            godot_print!("[NPCEntity] Sprite2D found and cached by name.");
         } else {
             godot_warn!("[NPCEntity] Base could not be cast to Node.");
         }
@@ -81,12 +81,12 @@ impl NPCEntity {
     }
 
     fn handle_attack(&mut self) {
-        godot_print!("[NPCEntity] Attacking...");
+        debug_print!("[NPCEntity] Attacking...");
         self.data.set_velocity(Vector2::ZERO);
     }
 
     fn handle_defend(&mut self) {
-        godot_print!("[NPCEntity] Defending...");
+        debug_print!("[NPCEntity] Defending...");
         self.data.set_velocity(Vector2::ZERO);
     }
 
@@ -123,13 +123,13 @@ impl NPCEntity {
 
     #[func]
     fn save_npc_data(&self, file_path: GString) -> bool {
-        godot_print!("Saving NPC data to {}", file_path);
+        debug_print!("Saving NPC data to {}", file_path);
         self.data.to_save_gfile_json(&file_path.to_string())
     }
 
     #[func]
     fn load_npc_data(&mut self, file_path: GString) -> bool {
-        godot_print!("Loading NPC data from {}", file_path);
+        debug_print!("Loading NPC data from {}", file_path);
         if let Some(loaded_data) = NPCData::from_load_gfile_json(&file_path.to_string()) {
             self.data = loaded_data;
             true

--- a/packages/rust/q/src/entity/player_entity.rs
+++ b/packages/rust/q/src/entity/player_entity.rs
@@ -1,5 +1,6 @@
 use crate::data::abstract_data_map::AbstractDataMap;
 use crate::data::player_data::PlayerData;
+use crate::debug_print;
 use godot::classes::{Input, Sprite2D};
 use godot::prelude::*;
 
@@ -26,11 +27,10 @@ impl INode for PlayerEntity {
     }
 
     fn ready(&mut self) {
-        godot_print!("[PlayerEntity] Ready! Initializing PlayerEntity...");
+        debug_print!("[PlayerEntity] Initializing...");
 
         if let Some(sprite) = self.base().try_get_node_as::<Sprite2D>("Sprite2D") {
             self.sprite = Some(sprite);
-            godot_print!("[PlayerEntity] Sprite2D found and cached by name.");
         } else {
             godot_warn!("[PlayerEntity] Base could not be cast to Node.");
         }
@@ -93,13 +93,13 @@ impl PlayerEntity {
 
     #[func]
     fn save_player_data(&self, file_path: GString) -> bool {
-        godot_print!("Saving player data to {}", file_path);
+        debug_print!("Saving player data to {}", file_path);
         self.data.to_save_gfile_json(&file_path.to_string())
     }
 
     #[func]
     fn load_player_data(&mut self, file_path: GString) -> bool {
-        godot_print!("Loading player data from {}", file_path);
+        debug_print!("Loading player data from {}", file_path);
         if let Some(loaded_data) = PlayerData::from_load_gfile_json(&file_path.to_string()) {
             self.data = loaded_data;
             true

--- a/packages/rust/q/src/extensions/ui_extension.rs
+++ b/packages/rust/q/src/extensions/ui_extension.rs
@@ -1,3 +1,4 @@
+use crate::impl_node_ext_common;
 use godot::classes::control::LayoutPreset;
 use godot::classes::{Button, CanvasLayer, Control};
 use godot::prelude::*;
@@ -12,16 +13,7 @@ pub trait ControlExt {
     fn with_custom_minimum_size(self, size: Vector2) -> Self;
 }
 
-impl ControlExt for Gd<Control> {
-    fn with_name(mut self, name: &str) -> Self {
-        self.set_name(name);
-        self
-    }
-
-    fn with_cache(self, prefix: &str, key: &GString) -> Self {
-        self.with_name(&format!("{}_{}", prefix, key))
-    }
-
+impl_node_ext_common!(ControlExt, Control {
     fn with_anchors_preset(mut self, preset: LayoutPreset) -> Self {
         self.set_anchors_preset(preset);
         self
@@ -36,7 +28,7 @@ impl ControlExt for Gd<Control> {
         self.set_custom_minimum_size(size);
         self
     }
-}
+});
 
 //  Button Extension
 
@@ -50,16 +42,7 @@ pub trait ButtonExt {
     fn with_callback(self, parent: &Gd<Node>, signal_name: &str, params: &[Variant]) -> Self;
 }
 
-impl ButtonExt for Gd<Button> {
-    fn with_name(mut self, name: &str) -> Self {
-        self.set_name(name);
-        self
-    }
-
-    fn with_cache(self, prefix: &str, key: &GString) -> Self {
-        self.with_name(&format!("{}_{}", prefix, key))
-    }
-
+impl_node_ext_common!(ButtonExt, Button {
     fn with_text(mut self, text: &GString) -> Self {
         self.set_text(text);
         self
@@ -98,7 +81,7 @@ impl ButtonExt for Gd<Button> {
         self.connect("pressed", &parent.callable(signal_name).bind(params));
         self
     }
-}
+});
 
 //  Canvas
 
@@ -113,16 +96,7 @@ pub trait CanvasLayerExt {
     fn with_fixed_position(self, offset: Vector2, scale: Vector2) -> Self;
 }
 
-impl CanvasLayerExt for Gd<CanvasLayer> {
-    fn with_name(mut self, name: &str) -> Self {
-        self.set_name(name);
-        self
-    }
-
-    fn with_cache(self, prefix: &str, key: &GString) -> Self {
-        self.with_name(&format!("{}_{}", prefix, key))
-    }
-
+impl_node_ext_common!(CanvasLayerExt, CanvasLayer {
     fn with_follow_viewport(mut self, enabled: bool) -> Self {
         self.set_follow_viewport(enabled);
         self
@@ -151,4 +125,4 @@ impl CanvasLayerExt for Gd<CanvasLayer> {
     fn with_fixed_position(self, offset: Vector2, scale: Vector2) -> Self {
         self.with_offset(offset).with_scale(scale)
     }
-}
+});

--- a/packages/rust/q/src/macros.rs
+++ b/packages/rust/q/src/macros.rs
@@ -1,4 +1,30 @@
 #[macro_export]
+macro_rules! debug_print {
+    ($($arg:tt)*) => {
+        #[cfg(debug_assertions)]
+        godot_print!($($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! impl_node_ext_common {
+    ($trait_name:ident, $gd_type:ty { $($extra:tt)* }) => {
+        impl $trait_name for Gd<$gd_type> {
+            fn with_name(mut self, name: &str) -> Self {
+                self.set_name(name);
+                self
+            }
+
+            fn with_cache(self, prefix: &str, key: &GString) -> Self {
+                self.with_name(&format!("{}_{}", prefix, key))
+            }
+
+            $($extra)*
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! connect_signal {
     ($obj:expr, $signal:expr, $method:expr) => {{
         let callable = $obj.base().callable($method);
@@ -16,7 +42,7 @@ macro_rules! find_game_manager {
                 let game_manager: Gd<GameManager> = parent.cast::<GameManager>();
                 if game_manager.clone().upcast::<Node>().is_instance_valid() {
                     $self.game_manager = Some(game_manager);
-                    godot_print!(
+                    debug_print!(
                         "[{}:{}] [{}] Successfully linked with GameManager.",
                         file!(),
                         line!(),

--- a/packages/rust/q/src/manager/browser_manager.rs
+++ b/packages/rust/q/src/manager/browser_manager.rs
@@ -1,3 +1,4 @@
+use crate::debug_print;
 use crate::find_game_manager;
 use crate::manager::game_manager::GameManager;
 use godot::classes::{CanvasLayer, ICanvasLayer, IControl};

--- a/packages/rust/q/src/manager/entity_manager.rs
+++ b/packages/rust/q/src/manager/entity_manager.rs
@@ -1,3 +1,4 @@
+use crate::debug_print;
 use dashmap::DashMap;
 use godot::prelude::*;
 
@@ -16,7 +17,7 @@ pub struct EntityManager {
 #[godot_api]
 impl INode for EntityManager {
     fn init(base: Base<Node>) -> Self {
-        godot_print!("[EntityManager] Initializing...");
+        debug_print!("[EntityManager] Initializing...");
 
         EntityManager {
             base,
@@ -27,7 +28,7 @@ impl INode for EntityManager {
     }
 
     fn ready(&mut self) {
-        godot_print!("[EntityManager] Ready!");
+        debug_print!("[EntityManager] Ready.");
     }
 }
 
@@ -35,7 +36,7 @@ impl INode for EntityManager {
 impl EntityManager {
     #[func]
     pub fn set_local_player(&mut self, player: Gd<PlayerEntity>) {
-        godot_print!("[EntityManager] Setting local player.");
+        debug_print!("[EntityManager] Setting local player.");
         self.local_player = Some(player.clone());
         self.base_mut().add_child(&player.upcast::<Node>());
     }

--- a/packages/rust/q/src/manager/game_manager.rs
+++ b/packages/rust/q/src/manager/game_manager.rs
@@ -1,3 +1,4 @@
+use crate::debug_print;
 use godot::classes::ICanvasLayer;
 use godot::prelude::*;
 
@@ -27,7 +28,7 @@ pub struct GameManager {
 #[godot_api]
 impl INode for GameManager {
     fn init(base: Base<Self::Base>) -> Self {
-        godot_print!("[GameManager] Initializing...");
+        debug_print!("[GameManager] Initializing...");
 
         let user_data_cache = Some(UserDataCache::new());
 
@@ -53,7 +54,7 @@ impl INode for GameManager {
     }
 
     fn ready(&mut self) {
-        godot_print!("[GameManager] Ready! Adding children...");
+        debug_print!("[GameManager] Ready! Adding children...");
 
         let cache_manager = self.cache_manager.clone();
         let clock_master = self.clock_master.clone();
@@ -74,7 +75,7 @@ impl INode for GameManager {
             base.add_child(&event_bridge.upcast::<Node>());
         }
 
-        godot_print!("[GameManager] All children added successfully.");
+        debug_print!("[GameManager] All children added successfully.");
     }
 }
 
@@ -122,37 +123,24 @@ impl GameManager {
 
     #[func]
     pub fn load_user_settings(&mut self) {
-        godot_print!("[GameManager] Calling Load User Settings...");
-
-        if self.user_data_cache.is_none() {
-            godot_error!("[GameManager] ERROR: user_data_cache is None!");
-        } else {
-            godot_print!("[GameManager] user_data_cache is initialized.");
-        }
-
         let Some(user_data_cache) = self.user_data_cache.as_mut() else {
             godot_error!("[GameManager] ERROR: user_data_cache is None!");
             return;
         };
 
-        godot_print!("[GameManager] Successfully accessed user_data_cache.");
-
         let file_path = "user://settings.json";
-        godot_print!("[GameManager] Attempting to load file: {}", file_path);
+        debug_print!("[GameManager] Loading settings from: {}", file_path);
 
         match user_data_cache.load_from_file(file_path) {
             Some(data) => {
-                godot_print!("[GameManager] Successfully loaded settings file.");
+                debug_print!("[GameManager] Settings loaded successfully.");
                 drop(data);
             }
             None => {
                 godot_warn!("[GameManager] Settings file not found. Creating default settings...");
                 user_data_cache.save_new_user_data(file_path);
-                godot_print!("[GameManager] Default settings created and saved.");
             }
         }
-
-        godot_print!("[GameManager] User settings loaded successfully.");
     }
 
     #[func]
@@ -171,7 +159,7 @@ impl GameManager {
 
         user_data_cache.save_to_file(file_path, &user_data);
 
-        godot_print!("[GameManager] User settings saved.");
+        debug_print!("[GameManager] User settings saved.");
     }
 
     #[func]
@@ -182,13 +170,13 @@ impl GameManager {
         user_data_cache.insert(&key_str, value.clone());
         self.save_user_settings();
 
-        godot_print!("[GameManager] Updated Setting: {} -> {:?}", key_str, value);
+        debug_print!("[GameManager] Updated setting: {} -> {:?}", key_str, value);
     }
 
     #[func]
     fn start_game(&mut self) {
         self.base_mut().emit_signal("game_started", &[]);
-        godot_print!("[GameManager] Game Started!");
+        debug_print!("[GameManager] Game Started!");
     }
 
     #[func]
@@ -197,7 +185,7 @@ impl GameManager {
         if let Some(mut scene_tree) = self.base().get_tree() {
             scene_tree.set_pause(true);
         }
-        godot_print!("[GameManager] Game Paused.");
+        debug_print!("[GameManager] Game Paused.");
     }
 
     #[func]
@@ -206,13 +194,13 @@ impl GameManager {
         if let Some(mut scene_tree) = self.base().get_tree() {
             scene_tree.set_pause(false);
         }
-        godot_print!("[GameManager] Game Resumed.");
+        debug_print!("[GameManager] Game Resumed.");
     }
 
     #[func]
     fn exit_game(&mut self) {
         self.base_mut().emit_signal("game_exited", &[]);
-        godot_print!("[GameManager] Exiting Game...");
+        debug_print!("[GameManager] Exiting Game...");
 
         if let Some(mut scene_tree) = self.base().get_tree() {
             scene_tree.quit();

--- a/packages/rust/q/src/manager/gui_manager.rs
+++ b/packages/rust/q/src/manager/gui_manager.rs
@@ -3,6 +3,7 @@ use godot::classes::{CanvasLayer, ICanvasLayer, InputEvent, InputEventKey, Windo
 use godot::global::Key;
 use godot::prelude::*;
 
+use crate::debug_print;
 use crate::find_game_manager;
 use crate::manager::game_manager::GameManager;
 

--- a/packages/rust/q/src/manager/music_manager.rs
+++ b/packages/rust/q/src/manager/music_manager.rs
@@ -1,5 +1,6 @@
-use crate::manager::game_manager::GameManager;
-use godot::classes::{AudioStream, AudioStreamPlayer, Timer};
+use crate::debug_print;
+use dashmap::DashMap;
+use godot::classes::{AudioStream, AudioStreamPlayer};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -10,10 +11,20 @@ pub struct MusicManager {
     secondary_audio: Option<Gd<AudioStreamPlayer>>,
     effects: Option<Gd<AudioStreamPlayer>>,
     sfx: Option<Gd<AudioStreamPlayer>>,
-    game_manager: Option<Gd<GameManager>>,
+    audio_cache: DashMap<String, Gd<AudioStream>>,
     global_music_volume: f32,
     global_effects_volume: f32,
     global_sfx_volume: f32,
+    blend_state: Option<BlendState>,
+}
+
+struct BlendState {
+    active_name: StringName,
+    idle_name: StringName,
+    start_volume: f32,
+    target_volume: f32,
+    duration: f32,
+    elapsed: f32,
 }
 
 #[godot_api]
@@ -25,29 +36,15 @@ impl INode for MusicManager {
             secondary_audio: None,
             effects: None,
             sfx: None,
-            game_manager: None,
+            audio_cache: DashMap::new(),
             global_music_volume: 0.0,
             global_effects_volume: 0.0,
             global_sfx_volume: 0.0,
+            blend_state: None,
         }
     }
 
     fn ready(&mut self) {
-        godot_print!("[MusicManager] Ready! Searching for GameManager...");
-
-        if let Some(parent) = self.base().get_parent() {
-            let game_manager = parent.cast::<GameManager>();
-
-            if game_manager.clone().upcast::<Node>().is_instance_valid() {
-                godot_print!("[MusicManager] GameManager found! Linking...");
-                self.game_manager = Some(game_manager);
-            } else {
-                godot_warn!("[MusicManager] Parent is not a GameManager!");
-            }
-        } else {
-            godot_warn!("[MusicManager] Parent Node not found!");
-        }
-
         self.audio = self.get_or_create_audio_player("PrimaryAudioPlayer");
         self.secondary_audio = self.get_or_create_audio_player("SecondaryAudioPlayer");
         self.effects = self.get_or_create_audio_player("EffectsAudioPlayer");
@@ -58,6 +55,43 @@ impl INode for MusicManager {
 
         let sfx_callable = self.base().callable("play_sfx");
         self.base_mut().connect("sfx_play_requested", &sfx_callable);
+    }
+
+    fn process(&mut self, delta: f64) {
+        let blend_done = if let Some(ref mut blend) = self.blend_state {
+            blend.elapsed += delta as f32;
+            let t = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
+
+            let active_vol = blend.start_volume + (-80.0 - blend.start_volume) * t;
+            let idle_vol = -80.0 + (blend.target_volume - (-80.0)) * t;
+
+            let active_name = blend.active_name.clone();
+            let idle_name = blend.idle_name.clone();
+
+            {
+                let base = self.base_mut();
+                let mut active_player = base.get_node_as::<AudioStreamPlayer>(active_name.arg());
+                active_player.set_volume_db(active_vol);
+
+                let mut idle_player = base.get_node_as::<AudioStreamPlayer>(idle_name.arg());
+                idle_player.set_volume_db(idle_vol);
+            }
+
+            if t >= 1.0 {
+                let base = self.base_mut();
+                let mut active_player = base.get_node_as::<AudioStreamPlayer>(active_name.arg());
+                active_player.stop();
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        if blend_done {
+            self.blend_state = None;
+        }
     }
 }
 
@@ -78,12 +112,9 @@ impl MusicManager {
     #[signal]
     fn sfx_play_requested(sfx_path: GString);
 
-    //  [INTERNAL]
-    fn internal_get_or_create_audio_cache(&mut self, audio_path: &str) -> Option<Gd<AudioStream>> {
-        let game_manager = self.game_manager.as_ref()?.bind();
-        let cache_manager = game_manager.internal_get_cache_manager().bind();
-        if let Some(audio) = cache_manager.internal_audio_cache().get(audio_path) {
-            return Some(audio);
+    fn get_or_cache_audio(&self, audio_path: &str) -> Option<Gd<AudioStream>> {
+        if let Some(cached) = self.audio_cache.get(audio_path) {
+            return Some(cached.value().clone());
         }
 
         let audio_stream: Gd<AudioStream> = load::<AudioStream>(audio_path);
@@ -92,9 +123,8 @@ impl MusicManager {
             return None;
         }
 
-        cache_manager
-            .internal_audio_cache()
-            .insert(audio_path, audio_stream.clone());
+        self.audio_cache
+            .insert(audio_path.to_string(), audio_stream.clone());
 
         Some(audio_stream)
     }
@@ -114,7 +144,7 @@ impl MusicManager {
     #[func]
     pub fn set_global_music_volume(&mut self, volume_db: f32) {
         self.global_music_volume = volume_db.clamp(-80.0, 0.0);
-        godot_print!(
+        debug_print!(
             "Global music volume set to: {} dB",
             self.global_music_volume
         );
@@ -127,7 +157,7 @@ impl MusicManager {
     #[func]
     pub fn set_global_effects_volume(&mut self, volume_db: f32) {
         self.global_effects_volume = volume_db.clamp(-80.0, 0.0);
-        godot_print!(
+        debug_print!(
             "Global effects volume set to: {} dB",
             self.global_effects_volume
         );
@@ -140,7 +170,7 @@ impl MusicManager {
     #[func]
     pub fn set_global_sfx_volume(&mut self, volume_db: f32) {
         self.global_sfx_volume = volume_db.clamp(-80.0, 0.0);
-        godot_print!("Global SFX volume set to: {} dB", self.global_sfx_volume);
+        debug_print!("Global SFX volume set to: {} dB", self.global_sfx_volume);
         let volume_variant = self.global_sfx_volume.to_variant();
         self.base_mut()
             .emit_signal("global_sfx_volume_changed", &[volume_variant]);
@@ -149,7 +179,7 @@ impl MusicManager {
     #[func]
     pub fn play_effect(&mut self, effect_path: GString) {
         let effect_path = effect_path.to_string();
-        let audio_stream = self.get_or_cache_effect(&effect_path);
+        let audio_stream = self.get_or_cache_audio(&effect_path);
         if let Some(effects_player) = self.effects.as_mut() {
             if let Some(audio_stream) = audio_stream {
                 if effects_player.is_playing() {
@@ -168,7 +198,7 @@ impl MusicManager {
     #[func]
     pub fn play_sfx(&mut self, sfx_path: GString) {
         let sfx_path = sfx_path.to_string();
-        let audio_stream = self.get_or_cache_sfx(&sfx_path);
+        let audio_stream = self.get_or_cache_audio(&sfx_path);
         if let Some(sfx_player) = self.sfx.as_mut() {
             if let Some(audio_stream) = audio_stream {
                 if sfx_player.is_playing() {
@@ -184,18 +214,10 @@ impl MusicManager {
         }
     }
 
-    fn get_or_cache_sfx(&mut self, sfx_path: &str) -> Option<Gd<AudioStream>> {
-        self.internal_get_or_create_audio_cache(sfx_path)
-    }
-
-    fn get_or_cache_effect(&mut self, effect_path: &str) -> Option<Gd<AudioStream>> {
-        self.internal_get_or_create_audio_cache(effect_path)
-    }
-
     #[func]
     pub fn adjust_sfx_volume(&mut self, volume_db: f32) {
         self.global_sfx_volume = volume_db.clamp(-80.0, 0.0);
-        godot_print!("SFX volume adjusted to: {} dB", self.global_sfx_volume);
+        debug_print!("SFX volume adjusted to: {} dB", self.global_sfx_volume);
 
         if let Some(sfx_player) = self.sfx.as_mut() {
             sfx_player.set_volume_db(self.global_sfx_volume);
@@ -209,7 +231,7 @@ impl MusicManager {
     #[func]
     pub fn adjust_music_volume(&mut self, volume_db: f32) {
         self.global_music_volume = volume_db.clamp(-80.0, 0.0);
-        godot_print!("Music volume adjusted to: {} dB", self.global_music_volume);
+        debug_print!("Music volume adjusted to: {} dB", self.global_music_volume);
 
         if let Some(audio) = self.audio.as_mut() {
             audio.set_volume_db(self.global_music_volume);
@@ -227,7 +249,7 @@ impl MusicManager {
     #[func]
     pub fn adjust_effects_volume(&mut self, volume_db: f32) {
         self.global_effects_volume = volume_db.clamp(-80.0, 0.0);
-        godot_print!(
+        debug_print!(
             "Effects volume adjusted to: {} dB",
             self.global_effects_volume
         );
@@ -279,37 +301,6 @@ impl MusicManager {
     }
 
     #[func]
-    pub fn on_fade_complete(&mut self) {
-        let (primary_name, secondary_name, primary_is_playing) =
-            match (&self.audio, &self.secondary_audio) {
-                (Some(primary), Some(secondary)) => (
-                    primary.get_name(),
-                    secondary.get_name(),
-                    primary.is_playing(),
-                ),
-                _ => {
-                    return;
-                }
-            };
-
-        let (active_name, idle_name) = if primary_is_playing {
-            (primary_name, secondary_name)
-        } else {
-            (secondary_name, primary_name)
-        };
-
-        let mut active_player = self
-            .base_mut()
-            .get_node_as::<AudioStreamPlayer>(active_name.arg());
-        active_player.stop();
-
-        let mut idle_player = self
-            .base_mut()
-            .get_node_as::<AudioStreamPlayer>(idle_name.arg());
-        idle_player.set_volume_db(self.global_music_volume);
-    }
-
-    #[func]
     pub fn blend_music(&mut self, next_track_path: GString, blend_duration: f32) {
         let (primary_name, secondary_name, primary_is_playing) =
             match (&self.audio, &self.secondary_audio) {
@@ -324,10 +315,10 @@ impl MusicManager {
                 }
             };
 
-        let idle_name = if primary_is_playing {
-            secondary_name
+        let (active_name, idle_name) = if primary_is_playing {
+            (primary_name.clone(), secondary_name.clone())
         } else {
-            primary_name
+            (secondary_name.clone(), primary_name.clone())
         };
 
         let audio_stream: Gd<AudioStream> = load::<AudioStream>(&next_track_path);
@@ -346,24 +337,13 @@ impl MusicManager {
             }
         }
 
-        {
-            let mut base = self.base_mut();
-            let mut fade_timer = base
-                .try_get_node_as::<Timer>("fade_timer")
-                .unwrap_or_else(|| {
-                    let mut new_timer = Timer::new_alloc();
-                    new_timer.set_name("fade_timer");
-                    new_timer.set_one_shot(true);
-                    base.add_child(&new_timer);
-                    new_timer
-                });
-
-            fade_timer.set_wait_time(blend_duration as f64);
-            fade_timer.start();
-
-            if !fade_timer.is_connected("timeout", &base.callable("on_fade_complete")) {
-                fade_timer.connect("timeout", &base.callable("on_fade_complete"));
-            }
-        }
+        self.blend_state = Some(BlendState {
+            active_name: active_name.into(),
+            idle_name: idle_name.into(),
+            start_volume: self.global_music_volume,
+            target_volume: self.global_music_volume,
+            duration: blend_duration,
+            elapsed: 0.0,
+        });
     }
 }


### PR DESCRIPTION
## Summary
- **P3 4.1 - Reduce logging verbosity**: Added `debug_print!` macro (`#[cfg(debug_assertions)]` guard) and replaced ~50 `godot_print!` calls across 10 files. Warnings/errors remain always-visible.
- **P3 4.6 - UI extension macro dedup**: Added `impl_node_ext_common!` macro that generates `with_name`/`with_cache` for ControlExt, ButtonExt, and CanvasLayerExt, eliminating 6 duplicate method implementations.
- **P3 5.2 - Entity query API**: Added `entities_with_state(mask)`, `get_all_transforms()`, `despawn_all()` to EntityStore. Exposed `get_all_entity_ids()` and `despawn_all()` as `#[func]` on EventBridge. Added 3 new tests.
- **P3 3.5 - Decouple MusicManager**: Removed `game_manager: Option<Gd<GameManager>>` field and parent-cast coupling. MusicManager now uses its own `DashMap<String, Gd<AudioStream>>` for audio caching.
- **P3 3.6 - Real blend_music interpolation**: Replaced timer-based hard crossfade with `BlendState` struct tracked in `process()`. Volumes interpolate linearly each frame: active fades from current to -80dB, idle fades from -80dB to target.

## Files changed (13)
- `src/macros.rs` — `debug_print!`, `impl_node_ext_common!` macros
- `src/manager/music_manager.rs` — Full rewrite: local cache, blend interpolation, GameManager decoupled
- `src/manager/game_manager.rs` — debug_print, removed redundant load_user_settings checks
- `src/core/ecs.rs` — `entities_with_state`, `get_all_transforms`, `despawn_all` + 3 tests
- `src/core/bridge.rs` — `get_all_entity_ids`, `despawn_all` funcs
- `src/extensions/ui_extension.rs` — Uses `impl_node_ext_common!` macro
- `src/data/user_data.rs`, `src/data/abstract_data_map.rs` — debug_print
- `src/entity/player_entity.rs`, `src/entity/npc_entity.rs` — debug_print
- `src/manager/entity_manager.rs`, `src/manager/gui_manager.rs`, `src/manager/browser_manager.rs` — debug_print import

## Test plan
- [x] All 16 unit tests pass (`cargo test` — 16 passed, 0 failed)
- [x] `rustfmt --check` passes (verified by pre-commit hook)
- [ ] Verify `debug_print!` calls only appear in debug builds
- [ ] Verify `blend_music` smoothly interpolates volume over duration
- [ ] Verify MusicManager works without being a child of GameManager