### PR TITLE
feat(q): implement P4 improvements from v3 audit

### DIFF
--- a/packages/rust/q/Cargo.toml
+++ b/packages/rust/q/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 rand = "0.10.0"
 godot = { version = "0.3.5", features = ["experimental-wasm", "experimental-threads"] }
 dashmap = "6.1.0"
-crossbeam-channel = "0.5"
+crossbeam-channel = "0.5.15"
 ulid = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -32,13 +32,13 @@ bitflags = { version = "2.9.0", features = ["serde"] }
 objc2 = "0.6.3"
 wry = { version = "0.53.5", features = ["transparent", "devtools"] }
 raw-window-handle = "0.6.2"
-http = "1.1.0"
+http = "1.4.0"
 infer = "0.19.0"
 tokio = { version = "1.49", features = ["full", "rt-multi-thread"] }
 
 
 [target."cfg(target_os = \"windows\")".dependencies]
-windows = { version = "0.62", features = [
+windows = { version = "0.62.2", features = [
     "Data_Xml_Dom",
     "Win32_Security",
     "Win32_System_Threading",
@@ -46,7 +46,15 @@ windows = { version = "0.62", features = [
 ] }
 wry = { version = "0.53.5", features = ["transparent", "devtools"] }
 raw-window-handle = "0.6.2"
-http = "1.1.0"
+http = "1.4.0"
+infer = "0.19.0"
+tokio = { version = "1.49", features = ["full", "rt-multi-thread"] }
+
+
+[target."cfg(target_os = \"linux\")".dependencies]
+wry = { version = "0.53.5", features = ["transparent", "devtools"] }
+raw-window-handle = "0.6.2"
+http = "1.4.0"
 infer = "0.19.0"
 tokio = { version = "1.49", features = ["full", "rt-multi-thread"] }
 

--- a/packages/rust/q/src/manager/browser_manager.rs
+++ b/packages/rust/q/src/manager/browser_manager.rs
@@ -4,7 +4,7 @@ use crate::manager::game_manager::GameManager;
 use godot::classes::{CanvasLayer, ICanvasLayer, IControl};
 use godot::prelude::*;
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 use crate::platform::browser::GodotBrowser;
 
 #[derive(GodotClass)]
@@ -14,7 +14,7 @@ pub struct BrowserManager {
 
     game_manager: Option<Gd<GameManager>>,
 
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
     browser: Option<Gd<GodotBrowser>>,
 }
 
@@ -23,7 +23,7 @@ impl ICanvasLayer for BrowserManager {
     fn init(base: Base<Self::Base>) -> Self {
         Self {
             base,
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
             browser: Some(Gd::from_init_fn(GodotBrowser::init)),
 
             game_manager: None,
@@ -32,7 +32,7 @@ impl ICanvasLayer for BrowserManager {
 
     fn ready(&mut self) {
         find_game_manager!(self);
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
         {
             // use raw_window_handle::HasWindowHandle;
             let browser_clone = self.browser.clone();
@@ -93,7 +93,7 @@ impl BrowserManager {
     pub fn on_window_resize(&self) {
         godot_print!("[BrowserManager] Browser Event Trigger...");
 
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
         {
             if let Some(ref browser) = self.browser {
                 godot_print!("[BrowserManager] Resizing browser after window resize event.");
@@ -104,10 +104,12 @@ impl BrowserManager {
 
     #[func]
     pub fn open_url(&self, url: GString) {
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
         {
             if let Some(ref browser) = self.browser {
-                godot_print!("[BrowserManager] Opening URL: {} called...", url);
+                browser.bind().open_url(url.clone());
+            } else {
+                godot_warn!("[BrowserManager] Browser not initialized. Cannot open URL.");
             }
         }
 

--- a/packages/rust/q/src/platform/linux.rs
+++ b/packages/rust/q/src/platform/linux.rs
@@ -1,0 +1,37 @@
+#[cfg(target_os = "linux")]
+use std::ffi::c_void;
+#[cfg(target_os = "linux")]
+use std::ptr::NonNull;
+
+#[cfg(target_os = "linux")]
+use godot::classes::DisplayServer;
+#[cfg(target_os = "linux")]
+use godot::classes::display_server::HandleType;
+#[cfg(target_os = "linux")]
+use godot::prelude::*;
+
+#[cfg(target_os = "linux")]
+use raw_window_handle::{
+    HandleError, HasWindowHandle, RawWindowHandle, WindowHandle, XlibWindowHandle,
+};
+
+#[cfg(target_os = "linux")]
+pub struct LinuxWryBrowserOptions;
+
+#[cfg(target_os = "linux")]
+impl HasWindowHandle for LinuxWryBrowserOptions {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        let display_server = DisplayServer::singleton();
+        let window_handle = display_server.window_get_native_handle(HandleType::WINDOW_HANDLE);
+
+        if window_handle == 0 {
+            godot_error!("[LinuxWryBrowserOptions] Invalid window handle (0)");
+            return Err(HandleError::Unavailable);
+        }
+
+        unsafe {
+            let xlib_handle = XlibWindowHandle::new(window_handle as u32);
+            Ok(WindowHandle::borrow_raw(RawWindowHandle::Xlib(xlib_handle)))
+        }
+    }
+}

--- a/packages/rust/q/src/platform/mod.rs
+++ b/packages/rust/q/src/platform/mod.rs
@@ -4,5 +4,8 @@ pub mod macos;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(target_os = "linux")]
+pub mod linux;
+
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 pub mod browser;


### PR DESCRIPTION
## Summary
- **2.2**: Wire `get_res_response` as custom protocol handler (`res://`) in the WebView builder; fix panicking `.expect()` on unknown MIME types with `application/octet-stream` fallback
- **2.3**: Implement `open_url` navigation on `GodotBrowser` and `BrowserManager` — actually navigates the WebView instead of just logging
- **5.5**: Add Linux platform support — new `linux.rs` with X11 `XlibWindowHandle` for Wry, updated cfg gates across `browser.rs`, `browser_manager.rs`, `mod.rs`, and `Cargo.toml`
- **Section 6**: Bump `http` 1.1.0 → 1.4.0, `windows` 0.62 → 0.62.2, pin `crossbeam-channel` to 0.5.15. Note: `godot` 0.3→0.4 and `wry` 0.53→0.54 are breaking minor bumps that need separate investigation

## Test plan
- [x] All 16 unit tests pass (`cargo test`)
- [x] `rustfmt --check` passes
- [ ] Verify `open_url` navigates WebView on macOS/Windows
- [ ] Verify `res://` custom protocol serves local files
- [ ] Test Linux build with X11 (requires Linux environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)