### PR TITLE
feat(droid,astro): overlay element pooling, leader tab detection and welcome toast

### DIFF
--- a/packages/npm/ASTRO_DROID_PLAN.md
+++ b/packages/npm/ASTRO_DROID_PLAN.md
@@ -1,0 +1,138 @@
+# ASTRO_DROID_PLAN — Phases 13–15
+
+> Phases 1–12 completed and delivered in prior PRs.
+
+---
+
+## Phase 13: Element Pooling for Overlay Components
+
+**Problem:** All three overlay components return `null` when inactive, causing full React unmount/remount on each show/hide. This creates unnecessary DOM churn.
+
+**Solution:** Keep elements always rendered, toggle visibility via CSS, mutate content in-place.
+
+### 13a — ToastContainer
+
+**File:** `packages/npm/astro/src/react/ToastContainer.tsx`
+
+- Container always renders (no more early `return null`)
+- Pre-render `maxVisible` `PooledToastSlot` elements
+- Each slot receives `toast: ToastPayload | null`
+    - `null` → `opacity-0 invisible max-h-0 overflow-hidden pointer-events-none` + `aria-hidden="true"`
+    - non-null → `opacity-100 visible max-h-40 pointer-events-auto`
+- Slot assignment: `entries[i]` maps to slot `i`, remaining slots get `null`
+- Auto-dismiss timer inside `PooledToastSlot` via `useEffect`
+- `transition-all duration-200` for smooth fade
+
+**Status:** Complete
+
+### 13b — ModalOverlay
+
+**File:** `packages/npm/astro/src/react/ModalOverlay.tsx`
+
+- Portal always exists in `document.body` (removed `if (!open) return null`)
+- When closed: `opacity-0 invisible pointer-events-none` + `aria-hidden="true"` on backdrop
+- When open: `opacity-100 visible pointer-events-auto bg-black/50 backdrop-blur-sm`
+- Content panel: `scale-95` → `scale-100` transition on open
+- Body scroll lock / escape key / backdrop click effects remain guarded by `if (!open)`
+- `transition-all duration-200` on backdrop, `transition-transform duration-200` on panel
+
+**Status:** Complete
+
+### 13c — TooltipOverlay
+
+**File:** `packages/npm/astro/src/react/TooltipOverlay.tsx`
+
+- Portal always exists in `document.body` (removed `if (!open) return null`)
+- When closed: `opacity-0 invisible pointer-events-none` + positioned offscreen (`top: -9999px`)
+- When open: `opacity-100 visible` + positioned via `getBoundingClientRect()`
+- `transition-opacity duration-150`
+
+**Status:** Complete
+
+---
+
+## Phase 14: SharedWorker First-Connection Detection
+
+**Problem:** `db-worker.ts` and `ws-worker.ts` have no port tracking — no way to know if a tab is the first to connect (leader tab) or a subsequent tab joining an existing worker.
+
+**Solution:** Add `ports` Set, emit `first-connect` or `reconnect` message to each connecting port.
+
+### 14a — db-worker.ts
+
+**File:** `packages/npm/droid/src/lib/workers/db-worker.ts`
+
+- Added `const ports = new Set<MessagePort>()`
+- On `self.onconnect`: track port, check `ports.size === 0` before adding, `postMessage({ type: 'first-connect' | 'reconnect' })`
+
+**Status:** Complete
+
+### 14b — ws-worker.ts
+
+**File:** `packages/npm/droid/src/lib/workers/ws-worker.ts`
+
+- Same pattern as 14a
+
+**Status:** Complete
+
+### 14c — main.ts receiver
+
+**File:** `packages/npm/droid/src/lib/workers/main.ts`
+
+- Added `listenFirstConnect(port)` helper — listens for `first-connect`/`reconnect` message with 5s timeout
+- `initStorageComlink()` returns `{ api, isFirstConnection }`
+- `initWsComlink()` returns `{ ws, isFirstConnection }`
+- In `main()`: `const isLeaderTab = dbFirst && wsFirst`
+
+**Status:** Complete
+
+### 14d — New event type
+
+**File:** `packages/npm/droid/src/lib/types/event-types.ts`
+
+- Added `DroidFirstConnectSchema` with `timestamp` and `workersFirst: { db, ws }`
+- Registered `'droid-first-connect'` in `DroidEventSchemas`
+
+**Status:** Complete
+
+---
+
+## Phase 15: Welcome Toast on SharedWorker Init
+
+**Problem:** No user-facing feedback when the droid system initializes and the user is authenticated.
+
+**Solution:** When leader tab is detected (Phase 14) and `$auth.tone === 'auth'`, show "Welcome back, {name}" toast. Anonymous users see nothing.
+
+### 15a — welcome-toast.ts
+
+**File:** `packages/npm/droid/src/lib/state/welcome-toast.ts` (NEW)
+
+- `showWelcomeToast()` with auth-awaiting logic
+- Fast path: auth already resolved → fires immediately
+- Slow path: subscribes to `$auth`, waits for tone change
+- 10s timeout if auth never resolves
+- Module-level `shown` flag prevents duplicate toasts across Astro view transitions
+
+**Status:** Complete
+
+### 15b — Wire into main.ts
+
+**File:** `packages/npm/droid/src/lib/workers/main.ts`
+
+- Import `showWelcomeToast` from `'../state/welcome-toast'`
+- Call after determining `isLeaderTab`:
+    ```ts
+    if (isLeaderTab) {
+      events.emit('droid-first-connect', { ... });
+      showWelcomeToast();
+    }
+    ```
+
+**Status:** Complete
+
+### 15c — Export
+
+**File:** `packages/npm/droid/src/lib/state/index.ts`
+
+- Added `export { showWelcomeToast } from './welcome-toast'`
+
+**Status:** Complete

--- a/packages/npm/astro/src/react/ModalOverlay.tsx
+++ b/packages/npm/astro/src/react/ModalOverlay.tsx
@@ -62,20 +62,26 @@ export function ModalOverlay({
 		};
 	}, [open]);
 
-	if (!open) return null;
-
 	return createPortal(
 		<div
-			className="fixed inset-0 z-[9998] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+			className={cn(
+				'fixed inset-0 z-[9998] flex items-center justify-center p-4 transition-all duration-200',
+				open
+					? 'opacity-100 visible pointer-events-auto bg-black/50 backdrop-blur-sm'
+					: 'opacity-0 invisible pointer-events-none',
+			)}
 			role="dialog"
-			aria-modal="true"
+			aria-modal={open}
+			aria-hidden={!open}
 			aria-label={title ?? 'Modal'}
 			onClick={(e) => {
-				if (closeOnBackdrop && e.target === e.currentTarget) close(id);
+				if (open && closeOnBackdrop && e.target === e.currentTarget)
+					close(id);
 			}}>
 			<div
 				className={cn(
-					'w-full max-w-lg rounded-xl shadow-2xl p-6 bg-zinc-900 text-zinc-100',
+					'w-full max-w-lg rounded-xl shadow-2xl p-6 bg-zinc-900 text-zinc-100 transition-transform duration-200',
+					open ? 'scale-100' : 'scale-95',
 					className,
 				)}>
 				{title && (

--- a/packages/npm/astro/src/react/TooltipOverlay.tsx
+++ b/packages/npm/astro/src/react/TooltipOverlay.tsx
@@ -39,17 +39,23 @@ export function TooltipOverlay({
 		});
 	}, [open, anchorId]);
 
-	if (!open) return null;
-
 	return createPortal(
 		<div
 			role="tooltip"
+			aria-hidden={!open}
 			className={cn(
 				'absolute z-[9997] px-3 py-2 rounded-lg bg-zinc-800 text-zinc-200 text-sm shadow-lg',
-				'transform -translate-x-1/2',
+				'transform -translate-x-1/2 transition-opacity duration-150',
+				open && pos
+					? 'opacity-100 visible'
+					: 'opacity-0 invisible pointer-events-none',
 				className,
 			)}
-			style={pos ? { top: pos.top, left: pos.left } : undefined}>
+			style={
+				open && pos
+					? { top: pos.top, left: pos.left }
+					: { top: -9999, left: -9999 }
+			}>
 			{children ?? content ?? null}
 		</div>,
 		document.body,

--- a/packages/npm/droid/src/lib/state/index.ts
+++ b/packages/npm/droid/src/lib/state/index.ts
@@ -22,6 +22,8 @@ export {
 
 export { $toasts, addToast, removeToast } from './toasts';
 
+export { showWelcomeToast } from './welcome-toast';
+
 export {
 	syncThemeToDexie,
 	broadcastThemeChange,

--- a/packages/npm/droid/src/lib/state/welcome-toast.ts
+++ b/packages/npm/droid/src/lib/state/welcome-toast.ts
@@ -1,0 +1,42 @@
+import { $auth } from './auth';
+import { addToast } from './toasts';
+
+let shown = false;
+
+export function showWelcomeToast(): void {
+	if (shown) return;
+
+	const tryShow = (): boolean => {
+		const auth = $auth.get();
+		if (auth.tone === 'auth' && auth.name) {
+			shown = true;
+			addToast({
+				id: `welcome-${Date.now()}`,
+				message: `Welcome back, ${auth.name}`,
+				severity: 'success',
+				duration: 4000,
+			});
+			return true;
+		}
+		if (auth.tone === 'anon' || auth.tone === 'error') {
+			shown = true;
+			return true;
+		}
+		return false;
+	};
+
+	if (tryShow()) return;
+
+	// Auth still loading — subscribe and wait (10s timeout)
+	const timeoutId = setTimeout(() => {
+		unsub();
+		shown = true;
+	}, 10_000);
+
+	const unsub = $auth.subscribe(() => {
+		if ($auth.get().tone === 'loading') return;
+		clearTimeout(timeoutId);
+		unsub();
+		tryShow();
+	});
+}

--- a/packages/npm/droid/src/lib/types/event-types.ts
+++ b/packages/npm/droid/src/lib/types/event-types.ts
@@ -25,7 +25,16 @@ export const DroidReadySchema = z.object({
 	timestamp: z.number(),
 });
 
+export const DroidFirstConnectSchema = z.object({
+	timestamp: z.number(),
+	workersFirst: z.object({
+		db: z.boolean(),
+		ws: z.boolean(),
+	}),
+});
+
 export const DroidEventSchemas = {
+	'droid-first-connect': DroidFirstConnectSchema,
 	'droid-ready': DroidReadySchema,
 	'droid-mod-ready': DroidModReadySchema,
 	'panel-open': PanelEventSchema,

--- a/packages/npm/droid/src/lib/workers/ws-worker.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.ts
@@ -191,8 +191,13 @@ const wsInstanceAPI = {
 
 export type WSInstance = typeof wsInstanceAPI;
 
+const ports = new Set<MessagePort>();
+
 self.onconnect = (event: MessageEvent) => {
 	const port = event.ports[0];
+	const isFirst = ports.size === 0;
+	ports.add(port);
 	port.start();
+	port.postMessage({ type: isFirst ? 'first-connect' : 'reconnect' });
 	expose(wsInstanceAPI, port);
 };


### PR DESCRIPTION
## Summary

- **Element pooling** for all three overlay components (ToastContainer, ModalOverlay, TooltipOverlay) — DOM elements persist across show/hide cycles using CSS visibility toggling instead of React mount/unmount, eliminating unnecessary DOM churn
- **SharedWorker first-connect detection** — port tracking in db-worker and ws-worker identifies leader tab (first connection) vs subsequent tabs, emits new `droid-first-connect` event
- **Welcome toast** — authenticated users see "Welcome back, {name}" toast on leader tab init, with auth-awaiting logic and session dedup

## Changes

| File | Change |
|------|--------|
| `packages/npm/astro/src/react/ToastContainer.tsx` | Pool `maxVisible` slots, CSS visibility toggle |
| `packages/npm/astro/src/react/ModalOverlay.tsx` | Always-render portal, opacity + scale transitions |
| `packages/npm/astro/src/react/TooltipOverlay.tsx` | Always-render portal, offscreen positioning when hidden |
| `packages/npm/droid/src/lib/workers/db-worker.ts` | Port tracking Set, `first-connect`/`reconnect` signal |
| `packages/npm/droid/src/lib/workers/ws-worker.ts` | Same port tracking pattern |
| `packages/npm/droid/src/lib/workers/main.ts` | `listenFirstConnect()` helper, `isLeaderTab` logic, welcome toast call |
| `packages/npm/droid/src/lib/types/event-types.ts` | `DroidFirstConnectSchema` + event registration |
| `packages/npm/droid/src/lib/state/welcome-toast.ts` | **NEW** — auth-awaiting welcome toast with 10s timeout |
| `packages/npm/droid/src/lib/state/index.ts` | Export `showWelcomeToast` |
| `packages/npm/ASTRO_DROID_PLAN.md` | **NEW** — Phases 13-15 documentation |

## Test plan

- [ ] `droid:build` passes
- [ ] `astro-discordsh:build` passes
- [ ] Open first tab → SharedWorker spins up → authenticated user sees "Welcome back, {name}" toast
- [ ] Open second tab → no welcome toast (not leader tab)
- [ ] Toast/modal/tooltip show/hide → DOM elements persist (no mount/unmount in inspector)
- [ ] Modal open/close → smooth opacity + scale transition
- [ ] Tooltip open/close → smooth opacity transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)