### PR TITLE
feat(discordsh): add /restart and /cleanup admin slash commands

### DIFF
--- a/apps/discordsh/DISCORDSH_PLAN.md
+++ b/apps/discordsh/DISCORDSH_PLAN.md
@@ -12,32 +12,39 @@ The Rust bot already has production-grade infrastructure (Axum HTTP server, Dock
 
 ### axum-discordsh (Rust) — What Exists
 
-- **Poise 0.6.1** slash command framework on **Serenity 0.12.5** (Phase 1 complete)
-- Slash commands: `/ping`, `/status` (rich embed + buttons), `/health`
+- **Poise 0.6.1** slash command framework on **Serenity 0.12.5**, Rust edition 2024
+- Slash commands: `/ping`, `/status` (rich embed + buttons), `/health` (rich health embed), `/restart`, `/cleanup`
 - `StatusState` enum with 5 lifecycle states, color/emoji/thumbnail properties
-- Status embed with guild count, shard info, uptime, interactive buttons (Refresh, Cleanup stub, Restart stub)
+- Status embed with guild count, shard info, uptime, health metrics, interactive buttons (Refresh, Cleanup, Restart)
+- `HealthMonitor` with background 60s polling via `sysinfo` 0.38.2 — CPU, memory, threads, process metrics
+- Health thresholds: Healthy (≤70%), Warning (70-90%), Critical (>90%) with color-coded embeds
+- Central `AppState` shared between HTTP server and Discord bot (lifecycle control, shard management)
+- `ShardTracker` backed by Supabase PostgREST for distributed shard management
+- HTTP API: `/health`, `/healthz`, `/bot-restart`, `/sign-off`, `/cleanup-thread`, `/tracker-status`
+- Bot restart loop in `main.rs` with `AtomicBool` restart flag + `ShardManager` shutdown
+- Configurable sharding: single (default), distributed (`SHARD_ID`/`SHARD_COUNT`), auto-scaling (`USE_AUTO_SCALING`)
+- Expanded event handler: Ready (tracker + 30s heartbeat), GuildCreate, GuildDelete, InteractionCreate
 - Global `event_handler` routing component interactions by `custom_id` prefix
 - Token resolution from env or Supabase Vault
-- Axum HTTP server with `/health` endpoint
+- Axum HTTP server with security headers, CORS, compression, load shedding
 - Static file serving (Astro frontend)
-- Security headers, CORS, compression, load shedding
 - Docker multi-stage build with jemalloc
-- Internal crate dependencies: `kbve` (Supabase), `jedi`
+- Internal crate dependencies: `kbve` (Supabase), `jedi`, `reqwest` 0.13.2
 
 ### notification-bot (Python) — What Must Be Migrated
 
-| Feature Area          | Details                                                                                      |
-| --------------------- | -------------------------------------------------------------------------------------------- |
-| **Bot lifecycle**     | Start, stop, restart, force-restart, sign-off via HTTP API                                   |
-| **Slash commands**    | Not yet slash commands — exposed as FastAPI POST endpoints called externally                 |
-| **Status embeds**     | Rich embed with health metrics, shard info, interactive buttons (Refresh, Cleanup, Restart)  |
-| **Health monitoring** | CPU, memory, threads, uptime, process info with HEALTHY/WARNING/CRITICAL thresholds          |
-| **Supabase tracker**  | Distributed shard assignment, heartbeat, cluster status, stale shard cleanup                 |
-| **Supabase vault**    | Secret retrieval via Edge Function (already shared with Rust bot)                            |
-| **User management**   | Discord ID lookup, multi-provider linking (Discord, GitHub, Google), sync from auth metadata |
-| **Thread cleanup**    | Delete old bot messages from a status thread                                                 |
-| **Sharding**          | Auto-sharding and distributed sharding (one shard per container)                             |
-| **DI framework**      | Dishka container with scoped providers                                                       |
+| Feature Area          | Status   | Details                                                                                     |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| **Bot lifecycle**     | ✅ Done  | Start, stop, restart, sign-off via HTTP API + slash commands                                |
+| **Slash commands**    | ✅ Done  | `/ping`, `/status`, `/health`, `/restart`, `/cleanup`                                       |
+| **Status embeds**     | ✅ Done  | Rich embed with health metrics, shard info, interactive buttons (Refresh, Cleanup, Restart) |
+| **Health monitoring** | ✅ Done  | CPU, memory, threads, uptime, process info with HEALTHY/WARNING/CRITICAL thresholds         |
+| **Supabase tracker**  | ✅ Done  | Distributed shard assignment, heartbeat, cluster status, stale shard cleanup                |
+| **Supabase vault**    | ✅ Done  | Secret retrieval via Edge Function (shared with Python bot)                                 |
+| **User management**   | Deferred | Discord ID lookup, multi-provider linking — only needed for user-facing commands            |
+| **Thread cleanup**    | ✅ Done  | Delete old bot messages from a status thread (HTTP + slash command + button)                |
+| **Sharding**          | ✅ Done  | Single, distributed, and auto-scaling modes                                                 |
+| **DI framework**      | N/A      | Rust uses `Arc<AppState>` instead of Dishka DI — simpler, zero-cost                         |
 
 ---
 
@@ -74,12 +81,12 @@ Migrated from Serenity raw `EventHandler` to the **poise 0.6.1** framework (sere
 - Three buttons: **Refresh** (Primary), **Cleanup** (Secondary), **Restart** (Danger)
 - Custom IDs: `status_refresh`, `status_cleanup`, `status_restart`
 - **Refresh** rebuilds the embed and edits in-place via `CreateInteractionResponse::UpdateMessage`
-- **Cleanup** responds with ephemeral stub (actual logic deferred to Phase 4/5)
-- **Restart** checks `member.permissions.administrator()`, rejects non-admins, responds with ephemeral stub
+- **Cleanup** deletes bot's own messages from configured status thread
+- **Restart** checks `member.permissions.administrator()`, rejects non-admins, triggers shard shutdown + restart
 
 **`src/discord/bot.rs`** — Updated:
 
-- `Data { start_time: Instant }` for uptime tracking
+- `Data { app: Arc<AppState> }` wrapping central shared state
 - Global `event_handler` routes component interactions by `custom_id` prefix (`"status_"`)
 - Uses poise's `FrameworkOptions::event_handler` for persistent buttons (survive bot restarts)
 
@@ -88,146 +95,145 @@ Migrated from Serenity raw `EventHandler` to the **poise 0.6.1** framework (sere
 - Builds `StatusSnapshot` from `ctx.data()`, `ctx.cache().guild_count()`, shard ID
 - Sends embed + button row via `poise::CreateReply`
 
-### Deferred to Phase 3+
+### Deferred Items
 
-- CPU/memory/thread metrics (requires `sysinfo` crate — Phase 3)
-- Health thresholds and health-based color override (Phase 3)
-- Actual Cleanup thread deletion logic (Phase 4/5)
-- Actual Restart process signal logic (Phase 4)
-- Shard latency display (Phase 7)
-
----
-
-## Phase 3: Health Monitoring
-
-Port the Python `HealthMonitor` to Rust with lower overhead.
-
-### Dependencies
-
-```toml
-[dependencies]
-sysinfo = "0.35"   # Cross-platform system info (CPU, memory, processes)
-```
-
-### Design
-
-```
-src/health/
-├── mod.rs          # HealthMonitor struct with cached metrics
-└── metrics.rs      # Metric collection and thresholds
-```
-
-- Background `tokio::spawn` task that refreshes metrics on interval (configurable, default 60s)
-- Shared state via `Arc<RwLock<HealthSnapshot>>`
-- Thresholds: HEALTHY (<70%), WARNING (70-90%), CRITICAL (>90%) for memory and CPU
-- Expose via both HTTP `/health` endpoint (JSON) and `/status` slash command (embed)
-
-### HealthSnapshot Fields
-
-```rust
-pub struct HealthSnapshot {
-    pub memory_usage_mb: f64,
-    pub memory_percent: f64,
-    pub cpu_percent: f64,
-    pub uptime_seconds: u64,
-    pub uptime_formatted: String,
-    pub thread_count: usize,
-    pub system_memory_total_gb: f64,
-    pub system_memory_used_percent: f64,
-    pub health_status: HealthStatus, // Healthy | Warning | Critical
-    pub pid: u32,
-    pub timestamp: chrono::DateTime<chrono::Utc>,
-}
-```
+- ~~CPU/memory/thread metrics (requires `sysinfo` crate — Phase 3)~~ ✅ Done
+- ~~Health thresholds and health-based color override (Phase 3)~~ ✅ Done
+- ~~Actual Cleanup thread deletion logic (Phase 4/5)~~ ✅ Done
+- ~~Actual Restart process signal logic (Phase 4)~~ ✅ Done
+- Shard latency display (future enhancement)
 
 ---
 
-## Phase 4: HTTP API Endpoints
+## Phase 3: Health Monitoring ✅
 
-Maintain HTTP API compatibility for external orchestration (Kubernetes probes, CI/CD triggers).
+> **Completed** — PR #7223 merged to `dev`.
 
-### Endpoints to Migrate
+### What Was Built
 
-| Method | Path                 | Purpose                                   | Priority |
-| ------ | -------------------- | ----------------------------------------- | -------- |
-| `GET`  | `/health`            | Full health JSON (already exists, expand) | High     |
-| `GET`  | `/healthz`           | Simple liveness probe (200 OK)            | High     |
-| `POST` | `/bot-online`        | Bring bot online                          | Medium   |
-| `POST` | `/bot-offline`       | Take bot offline                          | Medium   |
-| `POST` | `/bot-restart`       | Restart bot                               | Medium   |
-| `POST` | `/bot-force-restart` | Force restart                             | Medium   |
-| `POST` | `/sign-off`          | Graceful shutdown                         | Medium   |
-| `GET`  | `/tracker-status`    | Cluster/shard status                      | Low      |
-| `POST` | `/cleanup-thread`    | Clean status thread messages              | Low      |
+**`src/health/mod.rs`** — Real-time system metrics with `sysinfo` 0.38.2:
 
-### Implementation
+- `HealthMonitor` struct with persistent `RwLock<System>` for accurate CPU deltas
+- Background `tokio::spawn` task: 1s warmup, then 60s interval refreshes
+- `snapshot()` — read lock, clone cached data (cheap)
+- `force_refresh()` — immediate refresh (wired to Refresh button)
+- `spawn_background_task()` — starts the background polling loop
 
-- Add Axum routes in `src/transport/https.rs` alongside existing static file routes
-- Share bot state via Axum `State` extractor (Arc-wrapped)
-- Return generic error messages (no raw exception text — apply the same security pattern from the Python fix)
-- Use `tracing::error!` for server-side exception logging
+**`HealthSnapshot`** (Clone + Serialize):
 
----
+- `memory_usage_mb`, `memory_percent`, `system_memory_total_gb`, `system_memory_used_percent`
+- `cpu_percent` (global CPU %)
+- `thread_count` (Linux-only via `process.tasks()`, 0 on other platforms)
+- `pid`, `uptime_seconds`, `uptime_formatted`
+- `health_status: HealthStatus` — Healthy/Warning/Critical
+- `memory_bar(width) -> String` — emoji progress bar (green/orange/red based on level)
 
-## Phase 5: Supabase Integration
+**`HealthStatus` enum** — Healthy (≤70%), Warning (70-90%), Critical (>90%):
 
-Expand the existing `kbve` crate's Supabase support.
+- `from_usage(memory_percent, cpu_percent)` — threshold classification
+- `color_override()` — None for Healthy (use state color), orange for Warning, red for Critical
+- `emoji()` — green/yellow/red circle
 
-### Vault (Already Working)
+**Wiring:**
 
-- Token resolution from vault is implemented
-- Extend to support additional secrets as needed
+- `Arc<HealthMonitor>` created in `main.rs`, shared via `AppState`
+- HTTP `/health` returns JSON with full system metrics (`{"status": "ok", "health": {...}}`)
+- `/status` embed gains conditional Memory, CPU, Threads, Health fields
+- `/health` slash command shows rich embed with all metrics + color-coded thresholds
+- Refresh button calls `force_refresh()` before re-rendering
 
-### Tracker (Shard Coordination)
-
-Port the distributed shard tracker for multi-instance deployments:
-
-- Shard assignment via Supabase RPC or direct table operations
-- Heartbeat updates on interval
-- Stale shard cleanup
-- Cluster status queries
-
-### User Management (Future)
-
-Port the user lookup and provider linking functionality:
-
-- Discord ID → user profile lookup via RPC
-- Multi-provider relationship queries
-- Provider sync from auth metadata
-
-This is lower priority — only needed if the bot adds user-facing commands beyond status/health.
+**Tests:** 5 unit tests (health_status thresholds, memory_bar, round2 precision)
 
 ---
 
-## Phase 6: Sharding Support
+## Phase 4: HTTP API Endpoints ✅
 
-### Auto-Sharding (Default)
+> **Completed** — PR #7226 merged to `dev`.
 
-- Serenity's `Client::builder` with default sharding (Discord recommends shard count)
-- Track per-shard metrics (latency, guild count, connection state)
+### What Was Built
 
-### Distributed Sharding (Kubernetes)
+**`src/state.rs`** — Central `AppState` shared between HTTP server and Discord bot:
 
-- Environment variables: `SHARD_ID`, `SHARD_COUNT`, `TOTAL_SHARDS`, `CLUSTER_NAME`
-- One shard per container instance
-- Supabase tracker for shard coordination (Phase 5)
-- Graceful shard handoff on shutdown
+- `health_monitor: Arc<HealthMonitor>` — system metrics
+- `tracker: Option<ShardTracker>` — Supabase shard coordination (optional)
+- `start_time: Instant` — for uptime tracking
+- `shutdown_notify: Notify` — cross-subsystem graceful shutdown
+- `restart_flag: AtomicBool` — HTTP/button → bot restart signal
+- `shard_manager: RwLock<Option<Arc<ShardManager>>>` — lifecycle control
+- `bot_http: RwLock<Option<Arc<Http>>>` — serenity HTTP client for API calls
+
+**`src/transport/https.rs`** — 6 HTTP endpoints:
+
+| Method | Path              | Purpose                                    |
+| ------ | ----------------- | ------------------------------------------ |
+| `GET`  | `/health`         | Full health JSON with system metrics       |
+| `GET`  | `/healthz`        | Simple liveness probe (200 "ok")           |
+| `POST` | `/bot-restart`    | Set restart flag + shutdown shards         |
+| `POST` | `/sign-off`       | Graceful process shutdown                  |
+| `POST` | `/cleanup-thread` | Delete bot messages from DISCORD_THREAD_ID |
+| `GET`  | `/tracker-status` | Query cluster shard status from Supabase   |
+
+**`src/main.rs`** — Bot restart loop:
+
+- HTTP server spawned once, runs for process lifetime
+- Bot runs in a loop; on exit, checks `restart_flag` to restart or break
+- `tokio::select!` handles restart, shutdown notify, and Ctrl+C
+
+**Tests:** 2 new HTTP endpoint tests (healthz, tracker_status)
 
 ---
 
-## Phase 7: Event Handlers
+## Phase 5: Supabase Shard Tracker ✅
 
-Expand beyond the basic `ready` handler:
+> **Completed** — PR #7226 merged to `dev`.
 
-| Event                | Purpose                                              |
-| -------------------- | ---------------------------------------------------- |
-| `ready`              | Log connection, record shard info, send status embed |
-| `shard_ready`        | Per-shard tracking and heartbeat                     |
-| `shard_disconnect`   | Update tracker, log reconnection                     |
-| `shard_resumed`      | Log session resume                                   |
-| `guild_create`       | Track new guild joins                                |
-| `guild_delete`       | Track guild departures                               |
-| `interaction_create` | Handle button/component interactions                 |
+### What Was Built
+
+**`src/tracker/mod.rs`** — `ShardTracker` backed by Supabase PostgREST:
+
+- Uses `tracker.cluster_management` table via `Content-Profile: tracker` header
+- Own `reqwest::Client` (kbve `SupabaseClient` lacks non-default schema support)
+- `from_env()` — optional, reads `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`
+- `record_shard()` — upsert on Ready event
+- `update_heartbeat()` — PATCH every 30s from spawned heartbeat task
+- `cleanup_assignment()` — mark instance inactive on shutdown
+- `get_cluster_status()` — query active shards for `/tracker-status` endpoint
+- `cleanup_stale()` — RPC call to clean stale assignments
+
+All operations are best-effort — errors logged but never crash the bot.
+
+**Tests:** 3 unit tests (ShardRecord deserialization, null handling, from_env safety)
+
+---
+
+## Phase 6: Sharding Support ✅
+
+> **Completed** — PR #7226 merged to `dev`.
+
+Three sharding modes configured via environment variables:
+
+| Mode             | Env Vars                                     | Behavior                                                  |
+| ---------------- | -------------------------------------------- | --------------------------------------------------------- |
+| Single (default) | None                                         | `client.start()` — one shard                              |
+| Distributed      | `SHARD_ID` + `SHARD_COUNT`                   | `client.start_shard(id, count)` — one shard per container |
+| Auto-scaling     | `USE_AUTO_SCALING` + optional `TOTAL_SHARDS` | `client.start_shards(total)` — multiple shards            |
+
+Shard manager stored in `AppState` for HTTP/button-triggered shutdown and restart.
+
+---
+
+## Phase 7: Event Handlers ✅
+
+> **Completed** — PR #7226 merged to `dev`.
+
+Event handler embedded in `bot.rs` (not a separate `events.rs` — kept simple):
+
+| Event               | Behavior                                                    |
+| ------------------- | ----------------------------------------------------------- |
+| `Ready`             | Log shard info, record in tracker, spawn 30s heartbeat task |
+| `GuildCreate`       | Log new guild joins (`is_new` check)                        |
+| `GuildDelete`       | Log guild departures                                        |
+| `InteractionCreate` | Route component interactions by `custom_id` prefix          |
 
 ---
 
@@ -237,33 +243,31 @@ Files marked with ✅ exist and are implemented.
 
 ```
 apps/discordsh/axum-discordsh/src/
-├── main.rs                        ✅ Entry point, tokio runtime
+├── main.rs                        ✅ Entry point, tokio runtime, bot restart loop
+├── state.rs                       ✅ AppState — central shared state (Phase 4)
 ├── discord/
 │   ├── mod.rs                     ✅ Module declarations (bot, commands, embeds, components)
-│   ├── bot.rs                     ✅ Poise framework setup, Data struct, event_handler
+│   ├── bot.rs                     ✅ Poise framework, Data struct, event_handler, sharding
 │   ├── commands/
 │   │   ├── mod.rs                 ✅ Command registration (all())
 │   │   ├── ping.rs                ✅ /ping
 │   │   ├── status.rs              ✅ /status (embed + buttons)
-│   │   ├── health.rs              ✅ /health (text placeholder — Phase 3)
-│   │   └── admin.rs               /restart, /force-restart, /cleanup
+│   │   ├── health.rs              ✅ /health (rich health embed)
+│   │   └── admin.rs               ✅ /restart, /cleanup (admin commands)
 │   ├── embeds/
 │   │   ├── mod.rs                 ✅ Re-exports
 │   │   ├── status_state.rs        ✅ StatusState enum (5 variants)
 │   │   └── status_embed.rs        ✅ StatusSnapshot + build_status_embed()
-│   ├── components/
-│   │   ├── mod.rs                 ✅ Re-exports
-│   │   └── status_buttons.rs      ✅ Button row + interaction handler
-│   └── events.rs                  Shard/guild event handlers (Phase 7)
+│   └── components/
+│       ├── mod.rs                 ✅ Re-exports
+│       └── status_buttons.rs      ✅ Button row + interaction handler (Refresh, Cleanup, Restart)
 ├── health/
-│   ├── mod.rs                     HealthMonitor (Phase 3)
-│   └── metrics.rs                 Metric collection (Phase 3)
+│   └── mod.rs                     ✅ HealthMonitor, HealthSnapshot, HealthStatus (Phase 3)
 ├── tracker/
-│   ├── mod.rs                     Shard tracker — Supabase (Phase 5)
-│   └── shard.rs                   Shard assignment logic (Phase 5)
+│   └── mod.rs                     ✅ ShardTracker, ShardRecord — Supabase PostgREST (Phase 5)
 ├── transport/
 │   ├── mod.rs                     ✅
-│   └── https.rs                   ✅ Axum HTTP server + API routes
+│   └── https.rs                   ✅ Axum HTTP server + 6 API routes (Phase 4)
 └── astro/
     ├── mod.rs                     ✅
     └── askama.rs                  ✅ Static file serving
@@ -280,13 +284,13 @@ apps/discordsh/axum-discordsh/src/
 | 3    | 1     | Add `/status` and `/health` commands (text-only first)    | Low  | ✅ Done |
 | 4    | 2     | Build status embed with `StatusState` and buttons         | Med  | ✅ Done |
 | 5    | 2     | Add interactive button handling (Refresh/Cleanup/Restart) | Med  | ✅ Done |
-| 6    | 3     | Add `sysinfo` dependency, implement HealthMonitor         | Low  | Next    |
-| 7    | 1     | Add admin commands (`/restart`, `/cleanup`)               | Med  | Pending |
-| 8    | 4     | Expand HTTP API endpoints                                 | Low  | Pending |
-| 9    | 5     | Expand Supabase tracker integration                       | Med  | Pending |
-| 10   | 6     | Add distributed sharding support                          | High | Pending |
-| 11   | 7     | Expand event handlers                                     | Low  | Pending |
-| 12   | —     | Integration testing, Docker verification                  | Med  | Pending |
+| 6    | 3     | Add `sysinfo` dependency, implement HealthMonitor         | Low  | ✅ Done |
+| 7    | —     | Add admin commands (`/restart`, `/cleanup`)               | Med  | ✅ Done |
+| 8    | 4     | Central AppState + HTTP API endpoints                     | Low  | ✅ Done |
+| 9    | 5     | Supabase ShardTracker integration                         | Med  | ✅ Done |
+| 10   | 6     | Configurable sharding support                             | High | ✅ Done |
+| 11   | 7     | Expanded event handlers                                   | Low  | ✅ Done |
+| 12   | —     | Integration testing, Docker verification                  | Med  | Next    |
 | 13   | —     | Deprecate notification-bot, update CI                     | Low  | Pending |
 
 ---
@@ -315,3 +319,13 @@ Once the Rust bot reaches feature parity:
 | Response format   | TypedDict + orjson                       | serde + serde_json            |
 | Memory allocator  | Python GC                                | jemalloc (production)         |
 | Token source      | Vault Edge Function or env               | Same (shared vault ID)        |
+| Rust edition      | N/A                                      | 2024                          |
+
+---
+
+## Deferred to Future Work
+
+- **User management** — Discord ID lookup, multi-provider linking (only needed for user-facing commands)
+- **Shard latency display** — Per-shard latency in status embed
+- **`/bot-online` / `/bot-offline`** — Explicit online/offline toggle (bot auto-starts)
+- **Runtime sharding toggle** — Sharding mode set via env vars at startup

--- a/apps/discordsh/axum-discordsh/src/discord/commands/admin.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/admin.rs
@@ -1,0 +1,98 @@
+use std::sync::atomic::Ordering;
+
+use poise::serenity_prelude as serenity;
+use tracing::info;
+
+use crate::discord::bot::{Context, Error};
+
+/// Restart the Discord bot. Requires Administrator permission.
+#[poise::command(slash_command, required_permissions = "ADMINISTRATOR")]
+pub async fn restart(ctx: Context<'_>) -> Result<(), Error> {
+    let data = ctx.data();
+
+    ctx.send(
+        poise::CreateReply::default()
+            .content("Restarting bot...")
+            .ephemeral(true),
+    )
+    .await?;
+
+    info!(user = %ctx.author().name, "Bot restart triggered via /restart command");
+
+    data.app.restart_flag.store(true, Ordering::Relaxed);
+    if let Some(sm) = data.app.shard_manager.read().await.as_ref() {
+        sm.shutdown_all().await;
+    }
+
+    Ok(())
+}
+
+/// Delete old bot messages from the configured status thread. Requires Administrator permission.
+#[poise::command(slash_command, required_permissions = "ADMINISTRATOR")]
+pub async fn cleanup(
+    ctx: Context<'_>,
+    #[description = "Maximum number of messages to scan (default 50, max 100)"] limit: Option<u8>,
+) -> Result<(), Error> {
+    let limit = limit.unwrap_or(50).min(100);
+
+    let thread_id = match std::env::var("DISCORD_THREAD_ID")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+    {
+        Some(id) => serenity::ChannelId::new(id),
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("DISCORD_THREAD_ID is not configured.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    ctx.defer_ephemeral().await?;
+
+    let http = ctx.serenity_context().http.clone();
+
+    let messages = match thread_id
+        .messages(&http, serenity::GetMessages::new().limit(limit))
+        .await
+    {
+        Ok(msgs) => msgs,
+        Err(e) => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content(format!("Failed to fetch messages: {e}"))
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let bot_user_id = http.get_current_user().await.map(|u| u.id).ok();
+    let to_delete: Vec<serenity::MessageId> = messages
+        .iter()
+        .filter(|m| bot_user_id.is_some_and(|id| m.author.id == id))
+        .map(|m| m.id)
+        .collect();
+
+    let count = to_delete.len();
+    if count > 1 {
+        let _ = thread_id.delete_messages(&http, &to_delete).await;
+    } else if count == 1 {
+        let _ = thread_id.delete_message(&http, to_delete[0]).await;
+    }
+
+    info!(user = %ctx.author().name, deleted = count, "Thread cleanup via /cleanup command");
+
+    ctx.send(
+        poise::CreateReply::default()
+            .content(format!("Cleaned up {count} bot message(s)."))
+            .ephemeral(true),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/apps/discordsh/axum-discordsh/src/discord/commands/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/mod.rs
@@ -1,3 +1,4 @@
+mod admin;
 mod health;
 mod ping;
 mod status;
@@ -6,5 +7,11 @@ use crate::discord::bot::{Data, Error};
 
 /// Returns all slash commands for registration with Discord.
 pub fn all() -> Vec<poise::Command<Data, Error>> {
-    vec![ping::ping(), status::status(), health::health()]
+    vec![
+        ping::ping(),
+        status::status(),
+        health::health(),
+        admin::restart(),
+        admin::cleanup(),
+    ]
 }


### PR DESCRIPTION
## Summary

- Add `/restart` and `/cleanup` as native Discord slash commands (both require `ADMINISTRATOR` permission)
- `/restart` sets the restart flag and triggers shard shutdown — same logic as the Restart button and HTTP `/bot-restart` endpoint
- `/cleanup` deletes bot messages from the configured status thread with optional `limit` parameter (default 50, max 100)
- Comprehensively update `DISCORDSH_PLAN.md` to mark all 7 phases complete with actual implementation summaries, updated source layout, and execution table

## Test plan

- [x] `cargo build -p axum-discordsh` — zero errors
- [x] `cargo clippy -p axum-discordsh` — clean
- [x] `cargo test -p axum-discordsh` — all 26 tests pass
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks pass (rustfmt + prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)