### PR TITLE
feat(discordsh): integration tests, E2E fix, notification-bot CI deprecation

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -251,7 +251,6 @@ jobs:
             items: |
                 [
                   { "name": "kilobase", "target": "container", "condition": "${{ needs.alter.outputs.kilobase }}" },
-                  { "name": "notification-bot", "target": "container", "condition": "${{ needs.alter.outputs.notification_bot }}" },
                   { "name": "herbmail", "target": "container", "condition": "${{ needs.alter.outputs.herbmail }}", "image": "kbve/herbmail", "cargo_toml": "apps/herbmail/axum-herbmail/Cargo.toml" },
                   { "name": "memes", "target": "container", "condition": "${{ needs.alter.outputs.memes }}", "image": "kbve/memes", "cargo_toml": "apps/memes/axum-memes/Cargo.toml" },
                   { "name": "irc-gateway", "target": "container", "condition": "${{ needs.alter.outputs.irc_gateway }}", "image": "kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml" },

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -33,10 +33,6 @@ on:
             kilobase:
                 description: 'Kilobase package changed'
                 value: ${{ jobs.alter.outputs.kilobase }}
-            # ? Python
-            notification_bot:
-                description: 'Notification Bot'
-                value: ${{ jobs.alter.outputs.notification_bot }}
             # NOTE: Atlas has been migrated into pydesk. Disabled.
             # py_atlas:
             #   description: "Atlas changed"
@@ -136,7 +132,6 @@ jobs:
             devops: ${{ steps.delta.outputs.devops_any_changed }}
             laser: ${{ steps.delta.outputs.laser_any_changed }}
             asteroids: ${{ steps.delta.outputs.asteroids_any_changed }}
-            notification_bot: ${{ steps.delta.outputs.notificationbot_any_changed }}
 
         steps:
             - name: Checkout the repository
@@ -173,8 +168,6 @@ jobs:
                           - 'packages/python/fudster/fudster/**'
                       py_lib_kbve:
                           - 'packages/python/kbve/kbve/**'
-                      notificationbot:
-                          - 'apps/discordsh/notification-bot/README.md'
                       astro_herbmail:
                           - 'apps/herbmail/README.md'
                       herbmail:

--- a/apps/discordsh/discordsh-e2e/e2e/smoke.spec.ts
+++ b/apps/discordsh/discordsh-e2e/e2e/smoke.spec.ts
@@ -21,10 +21,21 @@ test.describe('Smoke: Page Loading', () => {
 });
 
 test.describe('Smoke: Health Endpoint', () => {
-	test('GET /health returns OK', async ({ request }) => {
+	test('GET /health returns JSON with status ok', async ({ request }) => {
 		const response = await request.get('/health');
 		expect(response.status()).toBe(200);
-		expect(await response.text()).toBe('OK');
+
+		const contentType = response.headers()['content-type'] ?? '';
+		expect(contentType).toContain('application/json');
+
+		const json = await response.json();
+		expect(json.status).toBe('ok');
+	});
+
+	test('GET /healthz returns plain text ok', async ({ request }) => {
+		const response = await request.get('/healthz');
+		expect(response.status()).toBe(200);
+		expect(await response.text()).toBe('ok');
 	});
 });
 
@@ -55,8 +66,7 @@ test.describe('Smoke: Cache-Control Headers', () => {
 			if (new URL(resp.url()).pathname.startsWith('/_astro/')) {
 				astroRequests.push({
 					url: resp.url(),
-					cacheControl:
-						resp.headers()['cache-control'] ?? '',
+					cacheControl: resp.headers()['cache-control'] ?? '',
 				});
 			}
 		});
@@ -92,7 +102,10 @@ test.describe('Smoke: Sitemap Routes', () => {
 
 		test.info().annotations.push(
 			{ type: 'core_routes', description: core.join(', ') },
-			{ type: 'sampled_routes', description: sampled.join(', ') || '(none)' },
+			{
+				type: 'sampled_routes',
+				description: sampled.join(', ') || '(none)',
+			},
 			{
 				type: 'seed',
 				description: process.env['GITHUB_RUN_ID'] || '42 (local)',


### PR DESCRIPTION
## Summary

- Fix broken E2E smoke test: `/health` returns JSON, not plain text `"OK"` — now parses JSON and asserts `json.status === "ok"`
- Add `/healthz` plain-text liveness probe E2E test
- Add 3 Rust integration tests for POST endpoints (`/bot-restart`, `/sign-off`, `/cleanup-thread`) — 29 tests total (was 26)
- Remove `notification-bot` from CI Docker build matrix (`ci-main.yml`) and file-alteration triggers (`utils-file-alterations.yml`)
- Mark migration steps 12 and 13 complete in `DISCORDSH_PLAN.md`

## Test plan

- [x] `cargo test -p axum-discordsh` — 29/29 pass
- [x] `cargo clippy -p axum-discordsh` — clean (only pre-existing warnings)
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks pass (rustfmt, eslint, prettier)