### PR TITLE
fix(droid,astro): toast visibility for anon users and cross-island event bridge

### DIFF
--- a/packages/npm/droid/src/lib/state/welcome-toast.ts
+++ b/packages/npm/droid/src/lib/state/welcome-toast.ts
@@ -18,7 +18,17 @@ export function showWelcomeToast(): void {
 			});
 			return true;
 		}
-		if (auth.tone === 'anon' || auth.tone === 'error') {
+		if (auth.tone === 'anon') {
+			shown = true;
+			addToast({
+				id: `welcome-${Date.now()}`,
+				message: 'Welcome!',
+				severity: 'info',
+				duration: 3000,
+			});
+			return true;
+		}
+		if (auth.tone === 'error') {
 			shown = true;
 			return true;
 		}


### PR DESCRIPTION
## Summary
- **Welcome toast now fires for anonymous users** — previously `showWelcomeToast()` silently skipped when `auth.tone === 'anon'`, meaning the only toast trigger never produced visible output for unauthenticated visitors
- **Added CustomEvent bridge in ToastContainer** — listens for `toast-added` / `toast-removed` window events to sync toast state across Astro islands, handling the case where Vite bundles duplicate nanostores modules

## Root Cause
1. `showWelcomeToast()` in `welcome-toast.ts` was auth-gated: only `auth.tone === 'auth'` produced a toast. Anonymous users (`'anon'`) got `shown = true` with no toast added
2. `DroidProvider` and `OverlayShell` are separate `client:only="react"` Astro islands — if nanostores `$toasts` is duplicated across bundles, `addToast()` in one island doesn't trigger `useStore($toasts)` in the other

## Changes
| File | Change |
|------|--------|
| `packages/npm/droid/src/lib/state/welcome-toast.ts` | Show "Welcome!" info toast (3s) for anon users |
| `packages/npm/astro/src/react/ToastContainer.tsx` | Add `$toasts` import + CustomEvent bridge effect |

## Test plan
- [ ] Visit discord.sh as anonymous user — should see "Welcome!" info toast in top-right
- [ ] Visit as authenticated user — should see "Welcome back, {name}" success toast
- [ ] Verify toast auto-dismisses after duration
- [ ] Verify dismiss button works
- [ ] `droid:build` passes
- [ ] `astro-discordsh:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)