### PR TITLE
fix(ci): install GTK/webkit2gtk system libs for q crate

### DIFF
--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -17,6 +17,12 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
+            - name: Install system libraries for wry/webkit2gtk
+              run: |
+                  sudo apt-get update -qq
+                  sudo apt-get install -y --no-install-recommends \
+                    pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
+
             - name: Rust ToolChain
               uses: dtolnay/rust-toolchain@stable
               with:

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -80,6 +80,12 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v7
 
+            - name: Install system libraries for wry/webkit2gtk
+              run: |
+                  sudo apt-get update -qq
+                  sudo apt-get install -y --no-install-recommends \
+                    pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
+
             - name: Setup PostgreSQL 17 for pgrx
               run: |
                   sudo install -d /usr/share/postgresql-common/pgdg


### PR DESCRIPTION
## Summary
- Install `libgtk-3-dev`, `libwebkit2gtk-4.1-dev`, and `libayatana-appindicator3-dev` in CI workflows
- Fixes `q:lint` (`cargo clippy`) and `q:test` (`cargo test`) failing on `ubuntu-latest` because `wry` → `webkit2gtk` → `glib-sys` needs `pkg-config` to find `glib-2.0`

## Files changed
- `.github/workflows/utils-ci-lint-test.yml` — added system lib install step before lint/test
- `.github/workflows/rust-test-crate.yml` — added system lib install step before e2e

## Test plan
- [x] Same packages verified working in `Dockerfile.linux-check` (PR #7232)
- [ ] CI `q:lint` passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)