### PR TITLE
feat(discordsh): add Embed Dungeon game PoC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,12 +932,14 @@ dependencies = [
  "askama",
  "axum 0.8.8",
  "axum-extra",
+ "dashmap 6.1.0",
  "dotenvy",
  "http-body-util",
  "jedi",
  "kbve",
  "num_cpus",
  "poise",
+ "rand 0.8.5",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -952,6 +954,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/discordsh/DISCORDSH_GAMEIDEA.md
+++ b/apps/discordsh/DISCORDSH_GAMEIDEA.md
@@ -1,0 +1,672 @@
+# Discord Bot Game Idea (Serenity + Poise)
+
+## Project: **Embed Dungeon – “The Glass Catacombs”**
+
+A Discord-native, embed-first mini RPG designed specifically to **stress-test your embed + component system** (buttons, select menus, pagination, message edits, concurrency guards, and state persistence).
+
+---
+
+## 1) Core Pitch
+
+**Embed Dungeon** is a session-based dungeon crawler where a player (or party) advances room-by-room.  
+All UI is a single “game message” that gets **edited** every turn. Players interact through **buttons** and **select menus**.
+
+### Why it’s perfect for embed testing
+
+- Repeated **message embed edits** (the common real-world bot pattern)
+- Multiple interaction types (buttons + selects)
+- **Pagination** for inventory/skills
+- Turn timer / idle expiration for cleanup
+- Concurrency/race-condition challenges (multi-user parties, shared boss)
+
+---
+
+## 2) Gameplay Loop
+
+1. `/dungeon start` → bot creates a new session + sends the “game message” embed
+2. Player chooses actions via buttons:
+    - ⚔ Attack
+    - 🛡 Defend
+    - 🧪 Item
+    - 🧭 Explore (advance / interact)
+    - 🏃 Flee (end session)
+3. Bot updates:
+    - Room description
+    - Enemy state
+    - Player stats
+    - Loot drops
+    - Turn counter
+4. Session ends on victory, defeat, or timeout.
+
+---
+
+## 3) Command Surface (Poise)
+
+### Commands
+
+- `/dungeon start [mode: solo|party]`
+- `/dungeon join` (party mode)
+- `/dungeon leave`
+- `/dungeon status` (re-renders current session embed)
+- `/dungeon end` (owner only)
+- `/dungeon leaderboard` (optional)
+
+### Component Interactions
+
+- Buttons: `dungeon:atk`, `dungeon:def`, `dungeon:item`, `dungeon:explore`, `dungeon:flee`
+- Select menu: `dungeon:item_select` (inventory)
+- Optional select menu: `dungeon:target_select` (if multiple enemies)
+
+---
+
+## 4) Embed UI Spec
+
+### Main Game Embed (single message, edited each turn)
+
+**Embed Title:** `🕯️ The Glass Catacombs — Room {N}: {RoomName}`  
+**Embed Description:** short narrative + current prompt (“What do you do?”)
+
+**Fields (suggested)**
+
+- **Player**
+    - HP: `███░░ 32/50`
+    - Armor: `12`
+    - Gold: `45`
+- **Enemy**
+    - Name + level
+    - HP bar
+    - Intent (telegraphed move): “Charging a heavy strike”
+- **Room**
+    - Hazards / modifiers (“Fog: accuracy -10%”)
+    - Loot potential (“Rare drop chance: 3%”)
+
+**Footer**
+
+- `Turn {t} • Session {short_id} • Expires in {mm:ss}`
+
+**Color**
+
+- Varies by state:
+    - Green (safe)
+    - Orange (combat)
+    - Red (critical HP)
+
+**Optional**
+
+- **Thumbnail:** enemy icon
+- **Image:** room art (even if placeholder)
+
+---
+
+## 5) Components Layout
+
+### Primary Row (Buttons)
+
+- ⚔ Attack
+- 🛡 Defend
+- 🧪 Item
+- 🧭 Explore
+- 🏃 Flee
+
+### Secondary Row (Context Buttons)
+
+Swap these in/out depending on state:
+
+- 🎯 “Aim” (if fog/hard enemy)
+- ✨ “Skill” (if skills exist)
+- 🧱 “Interact” (room objects)
+
+### Item Select Menu (only visible when “Item” pressed)
+
+Menu placeholder: “Choose an item”
+Options show:
+
+- emoji + name
+- remaining quantity
+- effect summary in description
+
+Pagination strategy:
+
+- If > 25 items, show “Page 1/3” and Next/Prev buttons, or split into categories.
+
+---
+
+## 6) Data Model (State)
+
+### Session
+
+- `session_id: Uuid`
+- `channel_id`
+- `message_id` (the game embed message you keep editing)
+- `owner_user_id`
+- `party: Vec<UserId>`
+- `created_at`, `last_action_at`
+- `state: Exploring | Combat | Loot | GameOver`
+
+### PlayerState
+
+- `hp, max_hp`
+- `armor`
+- `inventory: Vec<ItemStack>`
+- `effects: Vec<Effect>`
+- `cooldowns: HashMap<SkillId, turns>`
+
+### EnemyState
+
+- `enemy_id`
+- `hp, max_hp`
+- `intent: Intent` (telegraph for next turn)
+- `effects`
+
+### RoomState
+
+- `room_index`
+- `room_seed`
+- `room_type: Combat | Treasure | Event | Rest`
+- `modifiers: Vec<Modifier>`
+
+---
+
+## 7) Interaction Rules (Important for Testing)
+
+### Session Ownership & Access
+
+- **Solo mode:** only owner can press buttons
+- **Party mode:** party members can act, but:
+    - Implement **turn ownership** (one action per turn)
+    - Or implement **vote-based** action (collect clicks for 10 seconds)
+
+### Concurrency / Race Conditions
+
+You want to test:
+
+- Two interactions arriving nearly simultaneously
+- Multiple users spamming buttons
+
+**Hard requirement:** per-session locking / serialization:
+
+- “first valid interaction wins”
+- others receive ephemeral message: “Turn already taken”
+
+### Timeout & Cleanup
+
+If no actions for `N` minutes:
+
+- disable components
+- edit embed footer: “Session expired”
+- remove session from storage
+
+---
+
+## 8) Content: Rooms & Events (Simple but Enough)
+
+### Room Types
+
+1. **Combat**
+2. **Treasure**
+3. **Trap**
+4. **Merchant**
+5. **Rest Shrine**
+6. **Boss**
+
+### Example Events
+
+- “A mirror whispers your name” → choose:
+    - `Listen` (gain buff)
+    - `Smash` (take damage, get loot)
+- “Rusty chest” → choose:
+    - `Open` (chance trap)
+    - `Inspect` (safer)
+
+These choices are perfect for **dynamic embed field swaps** and component changes.
+
+---
+
+## 9) Minimal Item Set (for inventory testing)
+
+- 🧪 Potion (heal 15)
+- 🧷 Bandage (heal 5, remove bleed)
+- 💣 Bomb (deal 10)
+- 🧿 Ward (reduce next hit by 50%)
+- 🍞 Rations (small heal + buff out of combat)
+
+Give stacks to force:
+
+- select menus
+- pagination
+- conditional enable/disable (no potion left)
+
+---
+
+## 10) Implementation Notes (Serenity + Poise)
+
+### Interaction Handler Shape
+
+- A single `ComponentInteraction` router:
+    - parse `custom_id` like `dungeon:atk:{session_id}`
+    - validate session exists
+    - acquire session lock
+    - apply action
+    - render updated embed + components
+    - edit original message
+
+### Rendering Strategy
+
+Build a pure function:
+
+- `render(session_state) -> (CreateEmbed, Vec<CreateActionRow>)`
+  So you can test rendering without Discord calls.
+
+### Storage Strategy (choose one)
+
+- In-memory `DashMap<SessionId, Session>`
+- Or persistent DB (SQLite/Postgres) if you want resilience
+
+---
+
+## 11) Test Checklist (Embed/System QA)
+
+### Embed
+
+- [ ] Title/description updates correctly
+- [ ] Fields swap between Exploring/Combat/Loot
+- [ ] Footer countdown updates on each action
+- [ ] Colors change on critical HP
+
+### Components
+
+- [ ] Buttons disable when invalid (e.g., Explore during combat)
+- [ ] Item select appears only when needed
+- [ ] Pagination works (over 25 options)
+- [ ] Session expiration disables all components
+
+### Interaction Safety
+
+- [ ] Turn locking works (no double actions)
+- [ ] Only allowed users can act (solo vs party)
+- [ ] Ephemeral errors returned for invalid actions
+
+---
+
+## 12) Optional: “Raid Boss” Add-on (Stress Test Mode)
+
+Add `/raid start` that creates a server-wide boss with one shared embed:
+
+- HP bar updates on every hit
+- leaderboard field updates live
+- test rate limiting + batching edits (e.g., update every 2 seconds)
+
+---
+
+## 13) Deliverable Summary
+
+You end up with:
+
+- A fun mini game
+- A real embed “UI engine”
+- A reusable component router pattern
+- A rendering function you can reuse across other bot features
+
+---
+
+## 14) Next Steps (If You Want Code After This)
+
+If you tell me:
+
+- whether you’re using **DashMap**, **tokio::sync::Mutex**, or a DB
+- whether you want **solo only** first
+  I can produce:
+- Poise command stubs
+- a full component router skeleton
+- a render module layout (`embed.rs`, `components.rs`, `state.rs`)
+- a safe session lock pattern for Serenity interactions
+
+---
+
+# Embed Dungeon (Serenity + Poise) — Helper Spec + Proof-of-Concept Code
+
+> A practical “helper markdown” you can keep in your repo alongside your bot.  
+> Focus: embed rendering, components, interaction routing, session state, locking, and persistence patterns.
+
+---
+
+## Table of Contents
+
+1. Goals & Non-Goals
+2. Architecture Overview
+3. Data Model (Expanded)
+4. Custom ID Scheme
+5. Rendering Model (Embed + Components)
+6. Interaction Routing (Poise + Serenity)
+7. Session Locking & Concurrency
+8. Storage Options (In-Memory + DB Notes)
+9. Proof-of-Concept: Minimal Working Skeleton
+10. Proof-of-Concept: Action Handling + Message Editing
+11. Proof-of-Concept: Inventory Select Menu + Pagination
+12. Proof-of-Concept: Timers / Expiration Cleanup
+13. Testing & QA Checklist
+14. Suggested File Layout
+
+---
+
+## 1) Goals & Non-Goals
+
+### Goals
+
+- Validate **editing a single “game message”** repeatedly (typical Discord UX).
+- Exercise **buttons**, **select menus**, and conditional component visibility.
+- Prove out:
+    - session creation
+    - per-session state
+    - concurrency locks
+    - interaction routing + validation
+    - embed rendering as a pure function
+
+### Non-Goals
+
+- Perfect game balance.
+- Full content pipeline (images, localization).
+- Full persistence on day 1.
+
+---
+
+## 2) Architecture Overview
+
+### Core Loop
+
+1. `/dungeon start` creates `SessionState`
+2. bot sends a message with:
+    - 1 embed (primary UI)
+    - components (action buttons)
+3. user interactions call a single router:
+    - parse `custom_id`
+    - acquire lock
+    - apply action
+    - render updated embed/components
+    - edit original message
+4. session expires after inactivity or game over.
+
+### Recommended Core Abstractions
+
+- `SessionStore`: get/insert/remove sessions
+- `SessionState`: all game state
+- `render(session) -> RenderedMessage`: pure rendering
+- `apply_action(session, action, actor) -> Result<()>`: pure state transform
+
+---
+
+## 3) Data Model (Expanded)
+
+### High-level types
+
+- `SessionId`: `Uuid`
+- `UserId`: Serenity `UserId`
+- `ChannelId`: Serenity `ChannelId`
+- `MessageId`: Serenity `MessageId`
+
+### Expanded enums
+
+- `GamePhase`:
+
+    - `Exploring`
+    - `Combat`
+    - `Looting`
+    - `Event`
+    - `Rest`
+    - `Merchant`
+    - `GameOver { reason: GameOverReason }`
+
+- `GameOverReason`:
+
+    - `Defeated`
+    - `Escaped`
+    - `Victory`
+    - `Expired`
+
+- `RoomType`:
+
+    - `Combat`
+    - `Treasure`
+    - `Trap`
+    - `RestShrine`
+    - `Merchant`
+    - `Boss`
+    - `Story`
+
+- `Intent` (enemy telegraph):
+    - `Attack { dmg: i32 }`
+    - `HeavyAttack { dmg: i32, windup: u8 }`
+    - `Defend { armor: i32 }`
+    - `Debuff { effect: EffectKind }`
+    - `Charge`
+    - `Flee`
+
+### Effects
+
+- `EffectKind`:
+
+    - `Poison`
+    - `Burning`
+    - `Bleed`
+    - `Shielded`
+    - `Focused`
+    - `Weakened`
+    - `Stunned`
+
+- `EffectInstance`:
+    - `kind: EffectKind`
+    - `stacks: u8`
+    - `turns_left: u8`
+
+### Inventory
+
+- `ItemId`: `String` (`"potion_small"`, `"bomb_rusty"`)
+- `ItemRarity`:
+
+    - `Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`
+
+- `ItemKind`:
+
+    - `Consumable`
+    - `Equipment`
+    - `Quest`
+    - `Currency`
+
+- `ItemDef` (static):
+
+    - `id, name, emoji, rarity, kind`
+    - `description`
+    - `max_stack: u16`
+    - `use_effect: Option<UseEffect>`
+
+- `UseEffect`:
+
+    - `Heal { amount: i32 }`
+    - `DamageEnemy { amount: i32 }`
+    - `ApplyEffect { kind: EffectKind, stacks: u8, turns: u8 }`
+    - `RemoveEffect { kind: EffectKind }`
+
+- `ItemStack`:
+    - `item_id: ItemId`
+    - `qty: u16`
+
+### PlayerState (expanded)
+
+- `name: String`
+- `hp, max_hp: i32`
+- `armor: i32`
+- `gold: i32`
+- `effects: Vec<EffectInstance>`
+- `inventory: Vec<ItemStack>`
+- `cooldowns: HashMap<String, u8>`
+- `crit_chance: f32`
+- `accuracy: f32`
+
+### EnemyState (expanded)
+
+- `name: String`
+- `level: u8`
+- `hp, max_hp: i32`
+- `armor: i32`
+- `effects: Vec<EffectInstance>`
+- `intent: Intent`
+- `loot_table_id: String`
+
+### RoomState (expanded)
+
+- `index: u32`
+- `room_type: RoomType`
+- `name: String`
+- `description: String`
+- `modifiers: Vec<RoomModifier>`
+- `hazards: Vec<Hazard>`
+- `seed: u64`
+
+- `RoomModifier`:
+
+    - `Fog { accuracy_penalty: f32 }`
+    - `Blessing { heal_bonus: i32 }`
+    - `Cursed { dmg_taken_multiplier: f32 }`
+
+- `Hazard`:
+    - `Spikes { dmg: i32 }`
+    - `Gas { effect: EffectKind, stacks: u8 }`
+
+### SessionState (expanded)
+
+- `id: SessionId`
+- `owner: UserId`
+- `party: Vec<UserId>`
+- `phase: GamePhase`
+- `channel_id: ChannelId`
+- `message_id: MessageId`
+- `created_at: Instant`
+- `last_action_at: Instant`
+- `turn: u32`
+- `rng_seed: u64`
+- `player: PlayerState` _(solo mode; party can be Vec<PlayerState>)_
+- `enemy: Option<EnemyState>`
+- `room: RoomState`
+- `log: Vec<String>` _(last N events, used for debug embed field / page)_
+
+---
+
+## 4) Custom ID Scheme
+
+You want IDs that are:
+
+- short enough for Discord limits
+- easy to parse
+- include session id
+- include an action code
+- optionally include pagination or target data
+
+### Suggested format
+
+`dng|<sid>|<act>|<arg>`
+
+Where:
+
+- `sid`: a short session id (e.g., first 8 chars of UUID)
+- `act`: `atk`, `def`, `item`, `explore`, `flee`, `invpage`, etc.
+- `arg`: optional, like `p2` or `item:potion_small`
+
+Examples:
+
+- `dng|a1b2c3d4|atk|`
+- `dng|a1b2c3d4|item|`
+- `dng|a1b2c3d4|invpage|next`
+- `dng|a1b2c3d4|useitem|potion_small`
+
+---
+
+## 5) Rendering Model (Embed + Components)
+
+### Pure rendering is critical
+
+Write rendering functions that take `&SessionState` and return:
+
+- `CreateEmbed`
+- `Vec<CreateActionRow>`
+
+So you can test render output without Discord.
+
+### Suggested Embed Layout
+
+- Title: `🕯️ The Glass Catacombs — Room {idx}: {name}`
+- Description: narrative + prompt
+- Fields:
+    - Player stats
+    - Enemy stats (if any)
+    - Room modifiers/hazards
+    - Log (last 3-5 events)
+- Footer:
+    - `Turn {turn} • Session {sid} • Idle {mm:ss} remaining`
+
+---
+
+## 6) Interaction Routing (Poise + Serenity)
+
+### How it typically works
+
+Poise registers slash commands, and you also register an event handler for component interactions.
+
+You can do this either by:
+
+- Poise’s built-in `event_handler`, or
+- Serenity `EventHandler` that delegates to your router.
+
+**Key requirement:** one “router” function that handles all `MessageComponent` interactions.
+
+---
+
+## 7) Session Locking & Concurrency
+
+Discord interactions can arrive concurrently.
+
+### Requirement
+
+Per-session lock so only one action mutates state at a time.
+
+### Recommended pattern
+
+- `DashMap<ShortSid, Arc<tokio::sync::Mutex<SessionState>>>`
+- Lock, validate, mutate, render, edit message, unlock.
+
+Alternative:
+
+- `RwLock` but write lock on every action anyway.
+
+---
+
+## 8) Storage Options
+
+### Option A: In-memory (fastest)
+
+- `DashMap` + periodic cleanup task
+- easiest to implement
+
+### Option B: DB-backed
+
+- store sessions in SQLite/Postgres
+- still use in-memory lock for live session, commit snapshot after action
+
+**Recommendation:** start with A, add B once embed system is proven.
+
+---
+
+## 9) Proof-of-Concept: Minimal Working Skeleton
+
+> The following snippets are “compilable-ish” patterns.  
+> They may require small adjustments based on your exact Poise/Serenity versions.
+
+### Cargo dependencies (conceptual)
+
+```toml
+[dependencies]
+poise = "0.6"
+serenity = { version = "0.12", features = ["client", "gateway", "rustls_backend", "model"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+dashmap = "5"
+uuid = { version = "1", features = ["v4"] }
+```

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -32,6 +32,9 @@ serenity = { version = "0.12.5", default-features = false, features = ["client",
 poise = "0.6.1"
 sysinfo = "0.38.2"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
+dashmap = "6"
+uuid = { version = "1", features = ["v4"] }
+rand = "0.8"
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi" }

--- a/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
@@ -1,0 +1,314 @@
+use std::time::Instant;
+
+use poise::serenity_prelude as serenity;
+
+use crate::discord::bot::{Context, Error};
+use crate::discord::game::{self, content, render, types::*};
+
+/// Dungeon crawler game — stress-test embeds, buttons, and select menus.
+#[poise::command(slash_command, subcommands("start", "join", "leave", "status", "end"))]
+pub async fn dungeon(_ctx: Context<'_>) -> Result<(), Error> {
+    Ok(())
+}
+
+/// Start a new dungeon session.
+#[poise::command(slash_command)]
+async fn start(
+    ctx: Context<'_>,
+    #[description = "Session mode"] mode: Option<String>,
+) -> Result<(), Error> {
+    let user = ctx.author().id;
+    let channel = ctx.channel_id();
+
+    // Check for existing session in this channel
+    if let Some(existing) = ctx.data().app.sessions.find_by_channel(channel) {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(format!(
+                    "There's already an active session in this channel ({}). End it first with `/dungeon end`.",
+                    existing
+                ))
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let session_mode = match mode.as_deref() {
+        Some("party") => SessionMode::Party,
+        _ => SessionMode::Solo,
+    };
+
+    let (id, short_id) = game::new_short_sid();
+    let room = content::generate_room(0);
+
+    // First room is combat — spawn enemy
+    let enemy = if room.room_type == RoomType::Combat {
+        Some(content::spawn_enemy(0))
+    } else {
+        None
+    };
+
+    let phase = if enemy.is_some() {
+        GamePhase::Combat
+    } else {
+        GamePhase::Exploring
+    };
+
+    let player = PlayerState {
+        name: ctx.author().name.clone(),
+        inventory: content::starting_inventory(),
+        ..PlayerState::default()
+    };
+
+    // We need to send the message first to get the MessageId
+    let session_state = SessionState {
+        id,
+        short_id: short_id.clone(),
+        owner: user,
+        party: Vec::new(),
+        mode: session_mode.clone(),
+        phase,
+        channel_id: channel,
+        message_id: serenity::MessageId::new(1), // placeholder, updated below
+        created_at: Instant::now(),
+        last_action_at: Instant::now(),
+        turn: 0,
+        player,
+        enemy,
+        room,
+        log: vec!["You descend into The Glass Catacombs...".to_owned()],
+        show_items: false,
+    };
+
+    let embed = render::render_embed(&session_state);
+    let components = render::render_components(&session_state);
+
+    let mode_label = match session_mode {
+        SessionMode::Solo => "Solo",
+        SessionMode::Party => "Party",
+    };
+
+    let reply = ctx
+        .send(
+            poise::CreateReply::default()
+                .content(format!(
+                    "**Embed Dungeon** started! ({} mode, session `{}`)",
+                    mode_label, short_id
+                ))
+                .embed(embed)
+                .components(components),
+        )
+        .await?;
+
+    // Get the message ID from the reply
+    let msg = reply.message().await?;
+    let mut final_state = session_state;
+    final_state.message_id = msg.id;
+
+    ctx.data().app.sessions.create(final_state);
+
+    Ok(())
+}
+
+/// Join an active party session in this channel.
+#[poise::command(slash_command)]
+async fn join(ctx: Context<'_>) -> Result<(), Error> {
+    let user = ctx.author().id;
+    let channel = ctx.channel_id();
+
+    let sid = match ctx.data().app.sessions.find_by_channel(channel) {
+        Some(s) => s,
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("No active session in this channel.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let handle = match ctx.data().app.sessions.get(&sid) {
+        Some(h) => h,
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("Session not found.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let mut session = handle.lock().await;
+
+    if session.mode != SessionMode::Party {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(
+                    "This is a solo session. Start a party session with `/dungeon start party`.",
+                )
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    if session.owner == user || session.party.contains(&user) {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("You're already in this session.")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    if session.party.len() >= 3 {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("Party is full (max 4 players including owner).")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    session.party.push(user);
+    session
+        .log
+        .push(format!("{} joined the party!", ctx.author().name));
+
+    ctx.send(
+        poise::CreateReply::default()
+            .content(format!("{} joined the dungeon party!", ctx.author().name)),
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Leave the current dungeon session.
+#[poise::command(slash_command)]
+async fn leave(ctx: Context<'_>) -> Result<(), Error> {
+    let user = ctx.author().id;
+
+    let sid = match ctx.data().app.sessions.find_by_user(user) {
+        Some(s) => s,
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("You're not in any active session.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let handle = match ctx.data().app.sessions.get(&sid) {
+        Some(h) => h,
+        None => return Ok(()),
+    };
+
+    let mut session = handle.lock().await;
+
+    if session.owner == user {
+        // Owner leaving ends the session
+        session.phase = GamePhase::GameOver(GameOverReason::Escaped);
+        drop(session);
+        ctx.data().app.sessions.remove(&sid);
+        ctx.send(poise::CreateReply::default().content("Session ended (owner left)."))
+            .await?;
+    } else {
+        session.party.retain(|&id| id != user);
+        session
+            .log
+            .push(format!("{} left the party.", ctx.author().name));
+        ctx.send(
+            poise::CreateReply::default().content(format!("{} left the party.", ctx.author().name)),
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Show the current status of your dungeon session.
+#[poise::command(slash_command)]
+async fn status(ctx: Context<'_>) -> Result<(), Error> {
+    let user = ctx.author().id;
+
+    let sid = match ctx.data().app.sessions.find_by_user(user) {
+        Some(s) => s,
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("You're not in any active session.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let handle = match ctx.data().app.sessions.get(&sid) {
+        Some(h) => h,
+        None => return Ok(()),
+    };
+
+    let session = handle.lock().await;
+    let embed = render::render_embed(&session);
+
+    ctx.send(poise::CreateReply::default().embed(embed).ephemeral(true))
+        .await?;
+
+    Ok(())
+}
+
+/// End the current dungeon session (owner only).
+#[poise::command(slash_command)]
+async fn end(ctx: Context<'_>) -> Result<(), Error> {
+    let user = ctx.author().id;
+
+    let sid = match ctx.data().app.sessions.find_by_user(user) {
+        Some(s) => s,
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("You're not in any active session.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let handle = match ctx.data().app.sessions.get(&sid) {
+        Some(h) => h,
+        None => return Ok(()),
+    };
+
+    let session = handle.lock().await;
+
+    if session.owner != user {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("Only the session owner can end the dungeon.")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    drop(session);
+    ctx.data().app.sessions.remove(&sid);
+
+    ctx.send(poise::CreateReply::default().content(format!("Dungeon session `{}` ended.", sid)))
+        .await?;
+
+    Ok(())
+}

--- a/apps/discordsh/axum-discordsh/src/discord/commands/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/mod.rs
@@ -1,4 +1,5 @@
 mod admin;
+mod dungeon;
 mod health;
 mod ping;
 mod status;
@@ -13,5 +14,6 @@ pub fn all() -> Vec<poise::Command<Data, Error>> {
         health::health(),
         admin::restart(),
         admin::cleanup(),
+        dungeon::dungeon(),
     ]
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/content.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/content.rs
@@ -1,0 +1,256 @@
+use super::types::*;
+
+// ── Item registry ───────────────────────────────────────────────────
+
+/// Static item definitions for the dungeon.
+pub fn item_registry() -> &'static [ItemDef] {
+    static ITEMS: &[ItemDef] = &[
+        ItemDef {
+            id: "potion",
+            name: "Potion",
+            emoji: "\u{1F9EA}",
+            description: "Restores 15 HP",
+            max_stack: 5,
+            use_effect: Some(UseEffect::Heal { amount: 15 }),
+        },
+        ItemDef {
+            id: "bandage",
+            name: "Bandage",
+            emoji: "\u{1F9F7}",
+            description: "Heals 5 HP and removes bleed",
+            max_stack: 5,
+            use_effect: Some(UseEffect::Heal { amount: 5 }),
+        },
+        ItemDef {
+            id: "bomb",
+            name: "Bomb",
+            emoji: "\u{1F4A3}",
+            description: "Deals 10 damage to the enemy",
+            max_stack: 3,
+            use_effect: Some(UseEffect::DamageEnemy { amount: 10 }),
+        },
+        ItemDef {
+            id: "ward",
+            name: "Ward",
+            emoji: "\u{1F9FF}",
+            description: "Grants Shielded for 2 turns",
+            max_stack: 2,
+            use_effect: Some(UseEffect::ApplyEffect {
+                kind: EffectKind::Shielded,
+                stacks: 1,
+                turns: 2,
+            }),
+        },
+        ItemDef {
+            id: "rations",
+            name: "Rations",
+            emoji: "\u{1F35E}",
+            description: "Heals 8 HP (best used out of combat)",
+            max_stack: 3,
+            use_effect: Some(UseEffect::Heal { amount: 8 }),
+        },
+    ];
+    ITEMS
+}
+
+/// Look up an item definition by ID.
+pub fn find_item(id: &str) -> Option<&'static ItemDef> {
+    item_registry().iter().find(|item| item.id == id)
+}
+
+/// Default starting inventory for a new session.
+pub fn starting_inventory() -> Vec<ItemStack> {
+    vec![
+        ItemStack {
+            item_id: "potion".to_owned(),
+            qty: 2,
+        },
+        ItemStack {
+            item_id: "bandage".to_owned(),
+            qty: 1,
+        },
+        ItemStack {
+            item_id: "bomb".to_owned(),
+            qty: 1,
+        },
+    ]
+}
+
+// ── Enemy spawning ──────────────────────────────────────────────────
+
+/// Spawn an enemy scaled to the current room index.
+pub fn spawn_enemy(room_index: u32) -> EnemyState {
+    match room_index {
+        0..=1 => EnemyState {
+            name: "Glass Slime".to_owned(),
+            level: 1,
+            hp: 20,
+            max_hp: 20,
+            armor: 0,
+            effects: Vec::new(),
+            intent: Intent::Attack { dmg: 5 },
+        },
+        2..=3 => EnemyState {
+            name: "Skeleton Guard".to_owned(),
+            level: 2,
+            hp: 30,
+            max_hp: 30,
+            armor: 3,
+            effects: Vec::new(),
+            intent: Intent::Defend { armor: 5 },
+        },
+        4..=5 => EnemyState {
+            name: "Shadow Wraith".to_owned(),
+            level: 3,
+            hp: 25,
+            max_hp: 25,
+            armor: 2,
+            effects: Vec::new(),
+            intent: Intent::HeavyAttack { dmg: 12 },
+        },
+        _ => EnemyState {
+            name: "Glass Golem".to_owned(),
+            level: 5,
+            hp: 60,
+            max_hp: 60,
+            armor: 8,
+            effects: Vec::new(),
+            intent: Intent::Charge,
+        },
+    }
+}
+
+// ── Room generation ─────────────────────────────────────────────────
+
+/// Room type sequence: Combat, Treasure, Combat, Rest, Combat, Combat, Boss, ...
+fn room_type_for_index(index: u32) -> RoomType {
+    match index % 7 {
+        0 => RoomType::Combat,
+        1 => RoomType::Treasure,
+        2 => RoomType::Combat,
+        3 => RoomType::RestShrine,
+        4 => RoomType::Combat,
+        5 => RoomType::Trap,
+        6 => RoomType::Boss,
+        _ => unreachable!(),
+    }
+}
+
+/// Generate a room for the given index.
+pub fn generate_room(index: u32) -> RoomState {
+    let room_type = room_type_for_index(index);
+
+    let (name, description) = match &room_type {
+        RoomType::Combat => (
+            "Shattered Gallery".to_owned(),
+            "Broken mirrors line the walls. Something stirs in the reflections...".to_owned(),
+        ),
+        RoomType::Treasure => (
+            "Crystal Vault".to_owned(),
+            "A small chamber glittering with crystalline formations. A chest sits in the center."
+                .to_owned(),
+        ),
+        RoomType::Trap => (
+            "Cracked Corridor".to_owned(),
+            "The floor is riddled with hairline fractures. Each step could be your last."
+                .to_owned(),
+        ),
+        RoomType::RestShrine => (
+            "Luminous Alcove".to_owned(),
+            "A warm glow emanates from a shrine embedded in the wall. You feel at peace."
+                .to_owned(),
+        ),
+        RoomType::Merchant => (
+            "Wanderer's Nook".to_owned(),
+            "A cloaked figure beckons from behind a makeshift stall.".to_owned(),
+        ),
+        RoomType::Boss => (
+            "The Prismatic Throne".to_owned(),
+            "An enormous chamber. At its center, a creature of living glass awakens.".to_owned(),
+        ),
+        RoomType::Story => (
+            "Whispering Hall".to_owned(),
+            "Voices echo from nowhere. The walls seem to breathe.".to_owned(),
+        ),
+    };
+
+    let modifiers = if index >= 4 && room_type == RoomType::Combat {
+        vec![RoomModifier::Fog {
+            accuracy_penalty: 0.1,
+        }]
+    } else {
+        Vec::new()
+    };
+
+    RoomState {
+        index,
+        room_type,
+        name,
+        description,
+        modifiers,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn item_registry_has_5_items() {
+        assert_eq!(item_registry().len(), 5);
+    }
+
+    #[test]
+    fn find_item_by_id() {
+        let potion = find_item("potion");
+        assert!(potion.is_some());
+        assert_eq!(potion.unwrap().name, "Potion");
+    }
+
+    #[test]
+    fn find_item_missing() {
+        assert!(find_item("nonexistent").is_none());
+    }
+
+    #[test]
+    fn starting_inventory_has_items() {
+        let inv = starting_inventory();
+        assert_eq!(inv.len(), 3);
+        assert_eq!(inv[0].item_id, "potion");
+        assert_eq!(inv[0].qty, 2);
+    }
+
+    #[test]
+    fn enemy_scaling() {
+        let slime = spawn_enemy(0);
+        assert_eq!(slime.name, "Glass Slime");
+        assert_eq!(slime.level, 1);
+
+        let skeleton = spawn_enemy(2);
+        assert_eq!(skeleton.name, "Skeleton Guard");
+        assert_eq!(skeleton.level, 2);
+
+        let wraith = spawn_enemy(4);
+        assert_eq!(wraith.name, "Shadow Wraith");
+
+        let boss = spawn_enemy(7);
+        assert_eq!(boss.name, "Glass Golem");
+        assert_eq!(boss.hp, 60);
+    }
+
+    #[test]
+    fn room_generation_sequence() {
+        assert_eq!(generate_room(0).room_type, RoomType::Combat);
+        assert_eq!(generate_room(1).room_type, RoomType::Treasure);
+        assert_eq!(generate_room(3).room_type, RoomType::RestShrine);
+        assert_eq!(generate_room(5).room_type, RoomType::Trap);
+        assert_eq!(generate_room(6).room_type, RoomType::Boss);
+    }
+
+    #[test]
+    fn fog_modifier_applied_at_room_4() {
+        let room = generate_room(4);
+        assert_eq!(room.modifiers.len(), 1);
+        matches!(&room.modifiers[0], RoomModifier::Fog { .. });
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -1,0 +1,536 @@
+use poise::serenity_prelude as serenity;
+use rand::Rng;
+
+use super::content;
+use super::types::*;
+
+// ── Action validation ───────────────────────────────────────────────
+
+/// Check if the actor is allowed to take actions in this session.
+fn validate_actor(session: &SessionState, actor: serenity::UserId) -> Result<(), String> {
+    if session.owner == actor {
+        return Ok(());
+    }
+    if session.mode == SessionMode::Party && session.party.contains(&actor) {
+        return Ok(());
+    }
+    Err("You are not part of this session.".to_owned())
+}
+
+/// Check if an action is legal for the current game phase.
+fn validate_action(session: &SessionState, action: &GameAction) -> Result<(), String> {
+    if matches!(session.phase, GamePhase::GameOver(_)) {
+        return Err("This session is over.".to_owned());
+    }
+
+    match action {
+        GameAction::Attack | GameAction::Defend => {
+            if session.phase != GamePhase::Combat {
+                return Err("You can only fight during combat.".to_owned());
+            }
+        }
+        GameAction::Explore => {
+            if session.phase == GamePhase::Combat {
+                return Err("You can't explore during combat!".to_owned());
+            }
+        }
+        GameAction::UseItem(_) | GameAction::ToggleItems | GameAction::Flee => {}
+    }
+    Ok(())
+}
+
+// ── Main action dispatcher ──────────────────────────────────────────
+
+/// Apply a game action to the session state.
+///
+/// Returns log entries describing what happened, or an error message.
+pub fn apply_action(
+    session: &mut SessionState,
+    action: GameAction,
+    actor: serenity::UserId,
+) -> Result<Vec<String>, String> {
+    validate_actor(session, actor)?;
+    validate_action(session, &action)?;
+
+    let logs = match action {
+        GameAction::Attack => resolve_combat_turn(session, GameAction::Attack),
+        GameAction::Defend => resolve_combat_turn(session, GameAction::Defend),
+        GameAction::UseItem(ref item_id) => {
+            let msg = apply_item(session, item_id)?;
+            let mut logs = vec![msg];
+            if session.phase == GamePhase::Combat {
+                logs.extend(enemy_turn(session));
+            }
+            logs
+        }
+        GameAction::Explore => advance_room(session),
+        GameAction::Flee => {
+            session.phase = GamePhase::GameOver(GameOverReason::Escaped);
+            vec!["You fled the dungeon!".to_owned()]
+        }
+        GameAction::ToggleItems => {
+            session.show_items = !session.show_items;
+            return Ok(Vec::new());
+        }
+    };
+
+    session.turn += 1;
+    session.last_action_at = std::time::Instant::now();
+
+    // Trim log to last 8 entries
+    for entry in &logs {
+        session.log.push(entry.clone());
+    }
+    if session.log.len() > 8 {
+        let drain = session.log.len() - 8;
+        session.log.drain(..drain);
+    }
+
+    Ok(logs)
+}
+
+// ── Combat resolution ───────────────────────────────────────────────
+
+fn resolve_combat_turn(session: &mut SessionState, player_action: GameAction) -> Vec<String> {
+    let mut logs = Vec::new();
+    let mut rng = rand::thread_rng();
+
+    // Compute accuracy before mutable borrows
+    let accuracy = effective_accuracy(session);
+
+    // Player phase
+    match player_action {
+        GameAction::Attack => {
+            if let Some(ref mut enemy) = session.enemy {
+                let mut dmg = rng.gen_range(6..=12);
+
+                if rng.gen_range(0.0f32..1.0) > accuracy {
+                    logs.push("Your attack missed!".to_owned());
+                } else {
+                    dmg = (dmg - enemy.armor).max(1);
+                    enemy.hp -= dmg;
+                    logs.push(format!("You strike the {} for {} damage!", enemy.name, dmg));
+                }
+            }
+        }
+        GameAction::Defend => {
+            session.player.armor += 3;
+            logs.push("You raise your guard. (+3 armor this turn)".to_owned());
+        }
+        _ => {}
+    }
+
+    // Check enemy death
+    if let Some(ref enemy) = session.enemy
+        && enemy.hp <= 0
+    {
+        let gold = rng.gen_range(5..=15);
+        session.player.gold += gold;
+        logs.push(format!("The {} is defeated! (+{} gold)", enemy.name, gold));
+        session.enemy = None;
+        session.phase = GamePhase::Exploring;
+
+        // Check if this was a boss
+        if session.room.room_type == RoomType::Boss {
+            session.phase = GamePhase::GameOver(GameOverReason::Victory);
+            logs.push("You have conquered The Glass Catacombs!".to_owned());
+        }
+        return logs;
+    }
+
+    // Enemy phase
+    logs.extend(enemy_turn(session));
+
+    // Tick effects
+    logs.extend(tick_effects(&mut session.player.effects));
+
+    // Reset temporary defend bonus
+    if player_action == GameAction::Defend {
+        session.player.armor -= 3;
+    }
+
+    logs
+}
+
+/// Execute the enemy's telegraphed intent.
+fn enemy_turn(session: &mut SessionState) -> Vec<String> {
+    let mut logs = Vec::new();
+    let mut rng = rand::thread_rng();
+
+    if let Some(ref mut enemy) = session.enemy {
+        match &enemy.intent {
+            Intent::Attack { dmg } => {
+                let actual = (*dmg - session.player.armor).max(1);
+                let shielded = session
+                    .player
+                    .effects
+                    .iter()
+                    .any(|e| e.kind == EffectKind::Shielded);
+                let final_dmg = if shielded { actual / 2 } else { actual };
+                session.player.hp -= final_dmg;
+                logs.push(format!("{} attacks for {} damage!", enemy.name, final_dmg));
+            }
+            Intent::HeavyAttack { dmg } => {
+                let actual = (*dmg - session.player.armor).max(1);
+                session.player.hp -= actual;
+                logs.push(format!(
+                    "{} unleashes a devastating blow for {} damage!",
+                    enemy.name, actual
+                ));
+            }
+            Intent::Defend { armor } => {
+                enemy.armor += armor;
+                logs.push(format!(
+                    "{} fortifies its defenses. (+{} armor)",
+                    enemy.name, armor
+                ));
+            }
+            Intent::Charge => {
+                logs.push(format!("{} is charging up...", enemy.name));
+            }
+            Intent::Flee => {
+                logs.push(format!("The {} flees!", enemy.name));
+                session.enemy = None;
+                session.phase = GamePhase::Exploring;
+                return logs;
+            }
+        }
+
+        // Generate new intent
+        if let Some(ref mut enemy) = session.enemy {
+            enemy.intent = match rng.gen_range(0..4) {
+                0 => Intent::Attack {
+                    dmg: 5 + enemy.level as i32,
+                },
+                1 => Intent::HeavyAttack {
+                    dmg: 8 + enemy.level as i32 * 2,
+                },
+                2 => Intent::Defend { armor: 3 },
+                _ => Intent::Attack {
+                    dmg: 4 + enemy.level as i32,
+                },
+            };
+        }
+    }
+
+    // Check player death
+    if session.player.hp <= 0 {
+        session.phase = GamePhase::GameOver(GameOverReason::Defeated);
+        logs.push("You have been defeated...".to_owned());
+    }
+
+    logs
+}
+
+// ── Item usage ──────────────────────────────────────────────────────
+
+fn apply_item(session: &mut SessionState, item_id: &str) -> Result<String, String> {
+    let stack = session
+        .player
+        .inventory
+        .iter_mut()
+        .find(|s| s.item_id == item_id)
+        .ok_or_else(|| "You don't have that item.".to_owned())?;
+
+    if stack.qty == 0 {
+        return Err("No more of that item remaining.".to_owned());
+    }
+
+    let def = content::find_item(item_id).ok_or_else(|| "Unknown item.".to_owned())?;
+
+    let msg = match &def.use_effect {
+        Some(UseEffect::Heal { amount }) => {
+            session.player.hp = (session.player.hp + amount).min(session.player.max_hp);
+            format!("Used {}! Restored {} HP.", def.name, amount)
+        }
+        Some(UseEffect::DamageEnemy { amount }) => {
+            if let Some(ref mut enemy) = session.enemy {
+                enemy.hp -= amount;
+                format!(
+                    "Used {}! Dealt {} damage to {}.",
+                    def.name, amount, enemy.name
+                )
+            } else {
+                return Err("No enemy to target.".to_owned());
+            }
+        }
+        Some(UseEffect::ApplyEffect {
+            kind,
+            stacks,
+            turns,
+        }) => {
+            session.player.effects.push(EffectInstance {
+                kind: kind.clone(),
+                stacks: *stacks,
+                turns_left: *turns,
+            });
+            format!("Used {}! Gained {:?} for {} turns.", def.name, kind, turns)
+        }
+        Some(UseEffect::RemoveEffect { kind }) => {
+            session.player.effects.retain(|e| e.kind != *kind);
+            format!("Used {}! Removed {:?}.", def.name, kind)
+        }
+        None => {
+            return Err("That item has no use effect.".to_owned());
+        }
+    };
+
+    // Handle bandage special: also removes bleed
+    if item_id == "bandage" {
+        session
+            .player
+            .effects
+            .retain(|e| e.kind != EffectKind::Bleed);
+    }
+
+    stack.qty -= 1;
+    session.show_items = false;
+
+    Ok(msg)
+}
+
+// ── Room advancement ────────────────────────────────────────────────
+
+fn advance_room(session: &mut SessionState) -> Vec<String> {
+    let mut logs = Vec::new();
+    let next_index = session.room.index + 1;
+    session.room = content::generate_room(next_index);
+
+    logs.push(format!(
+        "You enter Room {}: {}.",
+        next_index + 1,
+        session.room.name
+    ));
+
+    match session.room.room_type {
+        RoomType::Combat | RoomType::Boss => {
+            let enemy = content::spawn_enemy(next_index);
+            logs.push(format!(
+                "A {} (Lv.{}) blocks your path!",
+                enemy.name, enemy.level
+            ));
+            session.enemy = Some(enemy);
+            session.phase = GamePhase::Combat;
+        }
+        RoomType::Treasure => {
+            let gold = 10 + next_index as i32 * 3;
+            session.player.gold += gold;
+            logs.push(format!("You found a treasure chest! (+{} gold)", gold));
+            session.phase = GamePhase::Exploring;
+        }
+        RoomType::RestShrine => {
+            let heal = 15;
+            session.player.hp = (session.player.hp + heal).min(session.player.max_hp);
+            logs.push(format!("The shrine's warmth restores {} HP.", heal));
+            session.phase = GamePhase::Rest;
+        }
+        RoomType::Trap => {
+            let dmg = 5 + next_index as i32;
+            session.player.hp -= dmg;
+            logs.push(format!("A trap springs! You take {} damage.", dmg));
+            if session.player.hp <= 0 {
+                session.phase = GamePhase::GameOver(GameOverReason::Defeated);
+                logs.push("The trap proved fatal...".to_owned());
+            } else {
+                session.phase = GamePhase::Exploring;
+            }
+        }
+        _ => {
+            session.phase = GamePhase::Exploring;
+        }
+    }
+
+    logs
+}
+
+// ── Effect ticking ──────────────────────────────────────────────────
+
+fn tick_effects(effects: &mut Vec<EffectInstance>) -> Vec<String> {
+    let mut logs = Vec::new();
+
+    for effect in effects.iter_mut() {
+        effect.turns_left = effect.turns_left.saturating_sub(1);
+        if effect.turns_left == 0 {
+            logs.push(format!("{:?} wore off.", effect.kind));
+        }
+    }
+
+    effects.retain(|e| e.turns_left > 0);
+    logs
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn effective_accuracy(session: &SessionState) -> f32 {
+    let mut acc = session.player.accuracy;
+    for modifier in &session.room.modifiers {
+        if let RoomModifier::Fog { accuracy_penalty } = modifier {
+            acc -= accuracy_penalty;
+        }
+    }
+    acc.max(0.1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn test_session() -> SessionState {
+        let (id, short_id) = new_short_sid();
+        let mut player = PlayerState::default();
+        player.inventory = content::starting_inventory();
+
+        SessionState {
+            id,
+            short_id,
+            owner: serenity::UserId::new(1),
+            party: Vec::new(),
+            mode: SessionMode::Solo,
+            phase: GamePhase::Exploring,
+            channel_id: serenity::ChannelId::new(1),
+            message_id: serenity::MessageId::new(1),
+            created_at: Instant::now(),
+            last_action_at: Instant::now(),
+            turn: 0,
+            player,
+            enemy: None,
+            room: content::generate_room(0),
+            log: Vec::new(),
+            show_items: false,
+        }
+    }
+
+    #[test]
+    fn attack_not_allowed_outside_combat() {
+        let mut session = test_session();
+        session.phase = GamePhase::Exploring;
+        let result = apply_action(&mut session, GameAction::Attack, serenity::UserId::new(1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn explore_advances_room() {
+        let mut session = test_session();
+        session.phase = GamePhase::Exploring;
+        let result = apply_action(&mut session, GameAction::Explore, serenity::UserId::new(1));
+        assert!(result.is_ok());
+        assert_eq!(session.room.index, 1);
+    }
+
+    #[test]
+    fn flee_ends_session() {
+        let mut session = test_session();
+        let result = apply_action(&mut session, GameAction::Flee, serenity::UserId::new(1));
+        assert!(result.is_ok());
+        assert_eq!(session.phase, GamePhase::GameOver(GameOverReason::Escaped));
+    }
+
+    #[test]
+    fn wrong_actor_rejected() {
+        let mut session = test_session();
+        let result = apply_action(
+            &mut session,
+            GameAction::Explore,
+            serenity::UserId::new(999),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not part of this session"));
+    }
+
+    #[test]
+    fn party_member_can_act() {
+        let mut session = test_session();
+        session.mode = SessionMode::Party;
+        session.party.push(serenity::UserId::new(42));
+        let result = apply_action(&mut session, GameAction::Explore, serenity::UserId::new(42));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn use_item_heals() {
+        let mut session = test_session();
+        session.player.hp = 30;
+        let result = apply_action(
+            &mut session,
+            GameAction::UseItem("potion".to_owned()),
+            serenity::UserId::new(1),
+        );
+        assert!(result.is_ok());
+        assert_eq!(session.player.hp, 45); // 30 + 15
+    }
+
+    #[test]
+    fn use_item_capped_at_max_hp() {
+        let mut session = test_session();
+        session.player.hp = 48;
+        let _ = apply_action(
+            &mut session,
+            GameAction::UseItem("potion".to_owned()),
+            serenity::UserId::new(1),
+        );
+        assert_eq!(session.player.hp, 50); // capped at max_hp
+    }
+
+    #[test]
+    fn toggle_items_flips_flag() {
+        let mut session = test_session();
+        assert!(!session.show_items);
+        let _ = apply_action(
+            &mut session,
+            GameAction::ToggleItems,
+            serenity::UserId::new(1),
+        );
+        assert!(session.show_items);
+    }
+
+    #[test]
+    fn game_over_blocks_actions() {
+        let mut session = test_session();
+        session.phase = GamePhase::GameOver(GameOverReason::Defeated);
+        let result = apply_action(&mut session, GameAction::Explore, serenity::UserId::new(1));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("over"));
+    }
+
+    #[test]
+    fn tick_effects_removes_expired() {
+        let mut effects = vec![
+            EffectInstance {
+                kind: EffectKind::Poison,
+                stacks: 1,
+                turns_left: 1,
+            },
+            EffectInstance {
+                kind: EffectKind::Shielded,
+                stacks: 1,
+                turns_left: 3,
+            },
+        ];
+        let logs = tick_effects(&mut effects);
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].kind, EffectKind::Shielded);
+        assert_eq!(effects[0].turns_left, 2);
+        assert!(logs.iter().any(|l| l.contains("Poison")));
+    }
+
+    #[test]
+    fn combat_turn_damages_enemy() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+        session.enemy = Some(content::spawn_enemy(0));
+
+        let starting_hp = session.enemy.as_ref().unwrap().hp;
+        // Run multiple attacks to account for possible miss
+        for _ in 0..10 {
+            if session.enemy.is_none() || !matches!(session.phase, GamePhase::Combat) {
+                break;
+            }
+            let _ = apply_action(&mut session, GameAction::Attack, serenity::UserId::new(1));
+        }
+        // Enemy should either be dead or have taken damage
+        if let Some(ref enemy) = session.enemy {
+            assert!(enemy.hp < starting_hp);
+        }
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/game/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/mod.rs
@@ -1,0 +1,9 @@
+pub mod content;
+pub mod logic;
+pub mod render;
+pub mod router;
+pub mod session;
+pub mod types;
+
+pub use session::SessionStore;
+pub use types::*;

--- a/apps/discordsh/axum-discordsh/src/discord/game/render.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/render.rs
@@ -1,0 +1,359 @@
+use poise::serenity_prelude as serenity;
+
+use super::types::*;
+
+// ── Colors ──────────────────────────────────────────────────────────
+
+const COLOR_SAFE: u32 = 0x2ECC71; // green
+const COLOR_COMBAT: u32 = 0xE67E22; // orange
+const COLOR_CRITICAL: u32 = 0xE74C3C; // red
+const COLOR_GAME_OVER: u32 = 0x95A5A6; // grey
+
+fn phase_color(session: &SessionState) -> u32 {
+    if matches!(session.phase, GamePhase::GameOver(_)) {
+        return COLOR_GAME_OVER;
+    }
+    if session.player.hp <= session.player.max_hp / 4 {
+        return COLOR_CRITICAL;
+    }
+    if session.phase == GamePhase::Combat {
+        return COLOR_COMBAT;
+    }
+    COLOR_SAFE
+}
+
+// ── HP bar ──────────────────────────────────────────────────────────
+
+/// Render an HP bar like `[###--] 32/50`.
+pub fn hp_bar(current: i32, max: i32, width: usize) -> String {
+    let current = current.max(0);
+    let ratio = if max > 0 {
+        current as f32 / max as f32
+    } else {
+        0.0
+    };
+    let filled = (ratio * width as f32).round() as usize;
+    let empty = width.saturating_sub(filled);
+
+    format!(
+        "`[{}{}]` {}/{}",
+        "\u{2588}".repeat(filled),
+        "\u{2591}".repeat(empty),
+        current,
+        max
+    )
+}
+
+// ── Intent description ──────────────────────────────────────────────
+
+pub fn intent_description(intent: &Intent) -> String {
+    match intent {
+        Intent::Attack { dmg } => format!("Preparing to attack ({} dmg)", dmg),
+        Intent::HeavyAttack { dmg } => format!("Winding up a heavy blow ({} dmg)", dmg),
+        Intent::Defend { armor } => format!("Bracing for defense (+{} armor)", armor),
+        Intent::Charge => "Charging up something powerful...".to_owned(),
+        Intent::Flee => "Looking for an escape...".to_owned(),
+    }
+}
+
+// ── Embed builder ───────────────────────────────────────────────────
+
+/// Build the main game embed from session state.
+///
+/// Pure function — no async, no side effects.
+pub fn render_embed(session: &SessionState) -> serenity::CreateEmbed {
+    let title = format!(
+        "\u{1F56F}\u{FE0F} The Glass Catacombs \u{2014} Room {}: {}",
+        session.room.index + 1,
+        session.room.name
+    );
+
+    let description = if matches!(session.phase, GamePhase::GameOver(GameOverReason::Victory)) {
+        "You have conquered The Glass Catacombs! Glory awaits.".to_owned()
+    } else if matches!(session.phase, GamePhase::GameOver(GameOverReason::Defeated)) {
+        "Your adventure ends here. The catacombs claim another soul.".to_owned()
+    } else if matches!(session.phase, GamePhase::GameOver(GameOverReason::Escaped)) {
+        "You escaped the dungeon, living to fight another day.".to_owned()
+    } else if matches!(session.phase, GamePhase::GameOver(GameOverReason::Expired)) {
+        "The session has expired due to inactivity.".to_owned()
+    } else {
+        format!("{}\n\n*What do you do?*", session.room.description)
+    };
+
+    let mut embed = serenity::CreateEmbed::new()
+        .title(title)
+        .description(description)
+        .color(phase_color(session));
+
+    // Player stats field
+    let player_field = format!(
+        "HP: {}\nArmor: {}\nGold: {}",
+        hp_bar(session.player.hp, session.player.max_hp, 10),
+        session.player.armor,
+        session.player.gold
+    );
+    embed = embed.field("\u{2694}\u{FE0F} Player", player_field, true);
+
+    // Enemy field (if in combat)
+    if let Some(ref enemy) = session.enemy {
+        let enemy_field = format!(
+            "{} (Lv.{})\nHP: {}\nArmor: {}\nIntent: {}",
+            enemy.name,
+            enemy.level,
+            hp_bar(enemy.hp, enemy.max_hp, 10),
+            enemy.armor,
+            intent_description(&enemy.intent)
+        );
+        embed = embed.field("\u{1F47E} Enemy", enemy_field, true);
+    }
+
+    // Room modifiers
+    if !session.room.modifiers.is_empty() {
+        let mods: Vec<String> = session
+            .room
+            .modifiers
+            .iter()
+            .map(|m| match m {
+                RoomModifier::Fog { accuracy_penalty } => {
+                    format!(
+                        "\u{1F32B}\u{FE0F} Fog: accuracy -{:.0}%",
+                        accuracy_penalty * 100.0
+                    )
+                }
+                RoomModifier::Blessing { heal_bonus } => {
+                    format!("\u{2728} Blessing: +{} heal", heal_bonus)
+                }
+                RoomModifier::Cursed { dmg_multiplier } => {
+                    format!(
+                        "\u{1F480} Cursed: +{:.0}% damage taken",
+                        (dmg_multiplier - 1.0) * 100.0
+                    )
+                }
+            })
+            .collect();
+        embed = embed.field("Room Effects", mods.join("\n"), false);
+    }
+
+    // Combat log (last 5 entries)
+    if !session.log.is_empty() {
+        let log_display: String = session
+            .log
+            .iter()
+            .rev()
+            .take(5)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .map(|s| format!("> {}", s))
+            .collect::<Vec<_>>()
+            .join("\n");
+        embed = embed.field("\u{1F4DC} Log", log_display, false);
+    }
+
+    // Footer
+    embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
+        "Turn {} \u{2022} Session {}",
+        session.turn, session.short_id
+    )));
+
+    embed
+}
+
+// ── Component builders ──────────────────────────────────────────────
+
+/// Build the action rows (buttons + optional item select) for the game message.
+pub fn render_components(session: &SessionState) -> Vec<serenity::CreateActionRow> {
+    let sid = &session.short_id;
+    let game_over = matches!(session.phase, GamePhase::GameOver(_));
+    let in_combat = session.phase == GamePhase::Combat;
+    let exploring = matches!(
+        session.phase,
+        GamePhase::Exploring | GamePhase::Rest | GamePhase::Looting
+    );
+
+    // Primary button row
+    let buttons = vec![
+        serenity::CreateButton::new(format!("dng|{}|atk|", sid))
+            .label("Attack")
+            .style(serenity::ButtonStyle::Danger)
+            .emoji(serenity::ReactionType::Unicode(
+                "\u{2694}\u{FE0F}".to_owned(),
+            ))
+            .disabled(game_over || !in_combat),
+        serenity::CreateButton::new(format!("dng|{}|def|", sid))
+            .label("Defend")
+            .style(serenity::ButtonStyle::Primary)
+            .emoji(serenity::ReactionType::Unicode(
+                "\u{1F6E1}\u{FE0F}".to_owned(),
+            ))
+            .disabled(game_over || !in_combat),
+        serenity::CreateButton::new(format!("dng|{}|item|", sid))
+            .label("Item")
+            .style(serenity::ButtonStyle::Secondary)
+            .emoji(serenity::ReactionType::Unicode("\u{1F9EA}".to_owned()))
+            .disabled(game_over || session.player.inventory.iter().all(|s| s.qty == 0)),
+        serenity::CreateButton::new(format!("dng|{}|explore|", sid))
+            .label("Explore")
+            .style(serenity::ButtonStyle::Success)
+            .emoji(serenity::ReactionType::Unicode("\u{1F9ED}".to_owned()))
+            .disabled(game_over || !exploring),
+        serenity::CreateButton::new(format!("dng|{}|flee|", sid))
+            .label("Flee")
+            .style(serenity::ButtonStyle::Secondary)
+            .emoji(serenity::ReactionType::Unicode("\u{1F3C3}".to_owned()))
+            .disabled(game_over),
+    ];
+
+    let mut rows = vec![serenity::CreateActionRow::Buttons(buttons)];
+
+    // Item select menu (only shown when toggled)
+    if session.show_items && !game_over {
+        let options: Vec<serenity::CreateSelectMenuOption> = session
+            .player
+            .inventory
+            .iter()
+            .filter(|s| s.qty > 0)
+            .filter_map(|s| {
+                super::content::find_item(&s.item_id).map(|def| {
+                    serenity::CreateSelectMenuOption::new(
+                        format!("{} {} (x{})", def.emoji, def.name, s.qty),
+                        format!("{}|{}", s.item_id, s.qty),
+                    )
+                    .description(def.description)
+                })
+            })
+            .collect();
+
+        if !options.is_empty() {
+            let select = serenity::CreateSelectMenu::new(
+                format!("dng|{}|useitem|select", sid),
+                serenity::CreateSelectMenuKind::String { options },
+            )
+            .placeholder("Choose an item to use...");
+
+            rows.push(serenity::CreateActionRow::SelectMenu(select));
+        }
+    }
+
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn test_session() -> SessionState {
+        let (id, short_id) = new_short_sid();
+        SessionState {
+            id,
+            short_id,
+            owner: serenity::UserId::new(1),
+            party: Vec::new(),
+            mode: SessionMode::Solo,
+            phase: GamePhase::Exploring,
+            channel_id: serenity::ChannelId::new(1),
+            message_id: serenity::MessageId::new(1),
+            created_at: Instant::now(),
+            last_action_at: Instant::now(),
+            turn: 0,
+            player: PlayerState::default(),
+            enemy: None,
+            room: super::super::content::generate_room(0),
+            log: Vec::new(),
+            show_items: false,
+        }
+    }
+
+    #[test]
+    fn hp_bar_full() {
+        let bar = hp_bar(50, 50, 10);
+        assert!(bar.contains("50/50"));
+        assert!(bar.contains("\u{2588}\u{2588}\u{2588}"));
+    }
+
+    #[test]
+    fn hp_bar_empty() {
+        let bar = hp_bar(0, 50, 10);
+        assert!(bar.contains("0/50"));
+    }
+
+    #[test]
+    fn hp_bar_negative_clamped() {
+        let bar = hp_bar(-5, 50, 10);
+        assert!(bar.contains("0/50"));
+    }
+
+    #[test]
+    fn intent_descriptions() {
+        assert!(intent_description(&Intent::Attack { dmg: 5 }).contains("5 dmg"));
+        assert!(intent_description(&Intent::Charge).contains("Charging"));
+    }
+
+    #[test]
+    fn render_embed_exploring() {
+        let session = test_session();
+        let _embed = render_embed(&session);
+        // Embed is built without panic — primary assertion
+    }
+
+    #[test]
+    fn render_embed_combat() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+        session.enemy = Some(super::super::content::spawn_enemy(0));
+        let _embed = render_embed(&session);
+    }
+
+    #[test]
+    fn render_embed_game_over() {
+        let mut session = test_session();
+        session.phase = GamePhase::GameOver(GameOverReason::Victory);
+        let _embed = render_embed(&session);
+    }
+
+    #[test]
+    fn render_components_exploring() {
+        let session = test_session();
+        let components = render_components(&session);
+        assert_eq!(components.len(), 1); // just button row, no items
+    }
+
+    #[test]
+    fn render_components_with_items() {
+        let mut session = test_session();
+        session.show_items = true;
+        session.player.inventory = super::super::content::starting_inventory();
+        let components = render_components(&session);
+        assert_eq!(components.len(), 2); // button row + select menu
+    }
+
+    #[test]
+    fn render_components_game_over_disabled() {
+        let mut session = test_session();
+        session.phase = GamePhase::GameOver(GameOverReason::Defeated);
+        let components = render_components(&session);
+        // Only 1 row (no items shown when game over)
+        assert_eq!(components.len(), 1);
+    }
+
+    #[test]
+    fn phase_color_exploring_is_green() {
+        let session = test_session();
+        assert_eq!(phase_color(&session), COLOR_SAFE);
+    }
+
+    #[test]
+    fn phase_color_combat_is_orange() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+        assert_eq!(phase_color(&session), COLOR_COMBAT);
+    }
+
+    #[test]
+    fn phase_color_critical_is_red() {
+        let mut session = test_session();
+        session.player.hp = 5;
+        assert_eq!(phase_color(&session), COLOR_CRITICAL);
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/game/router.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/router.rs
@@ -1,0 +1,151 @@
+use poise::serenity_prelude as serenity;
+use tracing::info;
+
+use crate::discord::bot::{Data, Error};
+
+use super::logic;
+use super::render;
+use super::types::GameAction;
+
+/// Handle a component interaction whose `custom_id` starts with `"dng|"`.
+///
+/// Custom ID format: `dng|<short_sid>|<action>|<arg>`
+pub async fn handle_game_component(
+    component: &serenity::ComponentInteraction,
+    ctx: &serenity::Context,
+    data: &Data,
+) -> Result<(), Error> {
+    let custom_id = &component.data.custom_id;
+    let parts: Vec<&str> = custom_id.split('|').collect();
+
+    if parts.len() < 3 {
+        return send_ephemeral(component, ctx, "Invalid interaction.").await;
+    }
+
+    let sid = parts[1];
+    let action_str = parts[2];
+
+    // Look up session
+    let session_handle = match data.app.sessions.get(sid) {
+        Some(h) => h,
+        None => {
+            return send_ephemeral(component, ctx, "Session not found or expired.").await;
+        }
+    };
+
+    // Try to acquire per-session lock (non-blocking)
+    let mut session = match session_handle.try_lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return send_ephemeral(component, ctx, "Action in progress, try again.").await;
+        }
+    };
+
+    // Handle select menu item usage
+    let action = if action_str == "useitem" {
+        // For select menus, the selected value is in component.data.kind
+        if let serenity::ComponentInteractionDataKind::StringSelect { values } =
+            &component.data.kind
+        {
+            if let Some(value) = values.first() {
+                // Value format: "item_id|qty"
+                let item_id = value.split('|').next().unwrap_or(value);
+                GameAction::UseItem(item_id.to_owned())
+            } else {
+                return send_ephemeral(component, ctx, "No item selected.").await;
+            }
+        } else {
+            return send_ephemeral(component, ctx, "Invalid select menu interaction.").await;
+        }
+    } else {
+        match parse_action(action_str) {
+            Some(a) => a,
+            None => {
+                return send_ephemeral(component, ctx, "Unknown action.").await;
+            }
+        }
+    };
+
+    let actor = component.user.id;
+
+    info!(
+        session = sid,
+        user = %actor,
+        action = ?action,
+        "Game interaction"
+    );
+
+    // Apply action
+    match logic::apply_action(&mut session, action, actor) {
+        Ok(_logs) => {
+            // Render updated embed + components
+            let embed = render::render_embed(&session);
+            let components = render::render_components(&session);
+
+            component
+                .create_response(
+                    &ctx.http,
+                    serenity::CreateInteractionResponse::UpdateMessage(
+                        serenity::CreateInteractionResponseMessage::new()
+                            .embed(embed)
+                            .components(components),
+                    ),
+                )
+                .await?;
+        }
+        Err(msg) => {
+            return send_ephemeral(component, ctx, &msg).await;
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_action(s: &str) -> Option<GameAction> {
+    match s {
+        "atk" => Some(GameAction::Attack),
+        "def" => Some(GameAction::Defend),
+        "item" => Some(GameAction::ToggleItems),
+        "explore" => Some(GameAction::Explore),
+        "flee" => Some(GameAction::Flee),
+        _ => None,
+    }
+}
+
+async fn send_ephemeral(
+    component: &serenity::ComponentInteraction,
+    ctx: &serenity::Context,
+    msg: &str,
+) -> Result<(), Error> {
+    component
+        .create_response(
+            &ctx.http,
+            serenity::CreateInteractionResponse::Message(
+                serenity::CreateInteractionResponseMessage::new()
+                    .content(msg)
+                    .ephemeral(true),
+            ),
+        )
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_action_valid() {
+        assert_eq!(parse_action("atk"), Some(GameAction::Attack));
+        assert_eq!(parse_action("def"), Some(GameAction::Defend));
+        assert_eq!(parse_action("item"), Some(GameAction::ToggleItems));
+        assert_eq!(parse_action("explore"), Some(GameAction::Explore));
+        assert_eq!(parse_action("flee"), Some(GameAction::Flee));
+    }
+
+    #[test]
+    fn parse_action_invalid() {
+        assert!(parse_action("unknown").is_none());
+        assert!(parse_action("").is_none());
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/game/session.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/session.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use poise::serenity_prelude as serenity;
+use tokio::sync::Mutex;
+
+use super::types::{GameOverReason, GamePhase, SessionState, ShortSid};
+
+/// In-memory session store backed by DashMap.
+///
+/// Each session is wrapped in `Arc<Mutex<..>>` so the interaction router
+/// can acquire a per-session lock without blocking the entire store.
+pub struct SessionStore {
+    sessions: DashMap<ShortSid, Arc<Mutex<SessionState>>>,
+}
+
+impl SessionStore {
+    pub fn new() -> Self {
+        Self {
+            sessions: DashMap::new(),
+        }
+    }
+
+    /// Insert a new session and return the shared handle.
+    pub fn create(&self, state: SessionState) -> Arc<Mutex<SessionState>> {
+        let short_id = state.short_id.clone();
+        let handle = Arc::new(Mutex::new(state));
+        self.sessions.insert(short_id, Arc::clone(&handle));
+        handle
+    }
+
+    /// Look up a session by its short ID.
+    pub fn get(&self, short_id: &str) -> Option<Arc<Mutex<SessionState>>> {
+        self.sessions.get(short_id).map(|r| Arc::clone(r.value()))
+    }
+
+    /// Remove a session by short ID.
+    pub fn remove(&self, short_id: &str) {
+        self.sessions.remove(short_id);
+    }
+
+    /// Find an active session in the given channel.
+    pub fn find_by_channel(&self, channel_id: serenity::ChannelId) -> Option<ShortSid> {
+        for entry in self.sessions.iter() {
+            if let Ok(session) = entry.value().try_lock()
+                && session.channel_id == channel_id
+                && !matches!(session.phase, GamePhase::GameOver(_))
+            {
+                return Some(entry.key().clone());
+            }
+        }
+        None
+    }
+
+    /// Find an active session where the user is owner or party member.
+    pub fn find_by_user(&self, user_id: serenity::UserId) -> Option<ShortSid> {
+        for entry in self.sessions.iter() {
+            if let Ok(session) = entry.value().try_lock()
+                && !matches!(session.phase, GamePhase::GameOver(_))
+                && (session.owner == user_id || session.party.contains(&user_id))
+            {
+                return Some(entry.key().clone());
+            }
+        }
+        None
+    }
+
+    /// Remove sessions that have been idle longer than `timeout`.
+    /// Called periodically by a background task.
+    pub fn cleanup_expired(&self, timeout: Duration) {
+        let now = Instant::now();
+        let mut to_remove = Vec::new();
+
+        for entry in self.sessions.iter() {
+            if let Ok(mut session) = entry.value().try_lock()
+                && now.duration_since(session.last_action_at) > timeout
+            {
+                session.phase = GamePhase::GameOver(GameOverReason::Expired);
+                to_remove.push(entry.key().clone());
+            }
+        }
+
+        for sid in to_remove {
+            self.sessions.remove(&sid);
+        }
+    }
+
+    /// Number of active sessions (for diagnostics).
+    #[allow(dead_code)]
+    pub fn count(&self) -> usize {
+        self.sessions.len()
+    }
+}
+
+impl Default for SessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discord::game::{content, types::*};
+
+    fn test_state(short_id: &str, channel: u64, owner: u64) -> SessionState {
+        let mut player = PlayerState::default();
+        player.inventory = content::starting_inventory();
+
+        SessionState {
+            id: uuid::Uuid::new_v4(),
+            short_id: short_id.to_owned(),
+            owner: serenity::UserId::new(owner),
+            party: Vec::new(),
+            mode: SessionMode::Solo,
+            phase: GamePhase::Exploring,
+            channel_id: serenity::ChannelId::new(channel),
+            message_id: serenity::MessageId::new(1),
+            created_at: Instant::now(),
+            last_action_at: Instant::now(),
+            turn: 0,
+            player,
+            enemy: None,
+            room: content::generate_room(0),
+            log: Vec::new(),
+            show_items: false,
+        }
+    }
+
+    #[test]
+    fn create_and_get() {
+        let store = SessionStore::new();
+        let state = test_state("abc12345", 100, 1);
+        store.create(state);
+
+        assert!(store.get("abc12345").is_some());
+        assert!(store.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn remove_session() {
+        let store = SessionStore::new();
+        store.create(test_state("abc12345", 100, 1));
+        assert_eq!(store.count(), 1);
+
+        store.remove("abc12345");
+        assert_eq!(store.count(), 0);
+    }
+
+    #[test]
+    fn find_by_channel() {
+        let store = SessionStore::new();
+        store.create(test_state("abc12345", 100, 1));
+        store.create(test_state("def67890", 200, 2));
+
+        assert_eq!(
+            store.find_by_channel(serenity::ChannelId::new(100)),
+            Some("abc12345".to_owned())
+        );
+        assert!(
+            store
+                .find_by_channel(serenity::ChannelId::new(999))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_by_user() {
+        let store = SessionStore::new();
+        store.create(test_state("abc12345", 100, 42));
+
+        assert_eq!(
+            store.find_by_user(serenity::UserId::new(42)),
+            Some("abc12345".to_owned())
+        );
+        assert!(store.find_by_user(serenity::UserId::new(99)).is_none());
+    }
+
+    #[test]
+    fn cleanup_expired_removes_old() {
+        let store = SessionStore::new();
+        let mut state = test_state("old_one", 100, 1);
+        state.last_action_at = Instant::now() - Duration::from_secs(700);
+        store.create(state);
+        store.create(test_state("new_one", 200, 2));
+
+        assert_eq!(store.count(), 2);
+        store.cleanup_expired(Duration::from_secs(600));
+        assert_eq!(store.count(), 1);
+        assert!(store.get("new_one").is_some());
+        assert!(store.get("old_one").is_none());
+    }
+
+    #[test]
+    fn game_over_sessions_not_found() {
+        let store = SessionStore::new();
+        let mut state = test_state("done", 100, 1);
+        state.phase = GamePhase::GameOver(GameOverReason::Defeated);
+        store.create(state);
+
+        assert!(
+            store
+                .find_by_channel(serenity::ChannelId::new(100))
+                .is_none()
+        );
+        assert!(store.find_by_user(serenity::UserId::new(1)).is_none());
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/game/types.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/types.rs
@@ -1,0 +1,252 @@
+#![allow(dead_code)]
+
+use std::time::Instant;
+
+use poise::serenity_prelude as serenity;
+
+// ── Short session ID ────────────────────────────────────────────────
+
+/// First 8 hex characters of a UUID, used as the session identifier
+/// in custom_id strings (Discord limits custom_id to 100 chars).
+pub type ShortSid = String;
+
+/// Generate a new UUID and return its 8-char hex prefix.
+pub fn new_short_sid() -> (uuid::Uuid, ShortSid) {
+    let id = uuid::Uuid::new_v4();
+    let short = id.simple().to_string()[..8].to_owned();
+    (id, short)
+}
+
+// ── Game phase ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GamePhase {
+    Exploring,
+    Combat,
+    Looting,
+    Event,
+    Rest,
+    Merchant,
+    GameOver(GameOverReason),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GameOverReason {
+    Defeated,
+    Escaped,
+    Victory,
+    Expired,
+}
+
+// ── Room types ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RoomType {
+    Combat,
+    Treasure,
+    Trap,
+    RestShrine,
+    Merchant,
+    Boss,
+    Story,
+}
+
+// ── Enemy intent (telegraph) ────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Intent {
+    Attack { dmg: i32 },
+    HeavyAttack { dmg: i32 },
+    Defend { armor: i32 },
+    Charge,
+    Flee,
+}
+
+// ── Effects ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EffectKind {
+    Poison,
+    Burning,
+    Bleed,
+    Shielded,
+    Weakened,
+    Stunned,
+}
+
+#[derive(Debug, Clone)]
+pub struct EffectInstance {
+    pub kind: EffectKind,
+    pub stacks: u8,
+    pub turns_left: u8,
+}
+
+// ── Items ───────────────────────────────────────────────────────────
+
+pub type ItemId = String;
+
+#[derive(Debug, Clone)]
+pub enum UseEffect {
+    Heal {
+        amount: i32,
+    },
+    DamageEnemy {
+        amount: i32,
+    },
+    ApplyEffect {
+        kind: EffectKind,
+        stacks: u8,
+        turns: u8,
+    },
+    RemoveEffect {
+        kind: EffectKind,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct ItemDef {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub emoji: &'static str,
+    pub description: &'static str,
+    pub max_stack: u16,
+    pub use_effect: Option<UseEffect>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ItemStack {
+    pub item_id: ItemId,
+    pub qty: u16,
+}
+
+// ── Player state ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct PlayerState {
+    pub name: String,
+    pub hp: i32,
+    pub max_hp: i32,
+    pub armor: i32,
+    pub gold: i32,
+    pub effects: Vec<EffectInstance>,
+    pub inventory: Vec<ItemStack>,
+    pub accuracy: f32,
+}
+
+impl Default for PlayerState {
+    fn default() -> Self {
+        Self {
+            name: "Adventurer".to_owned(),
+            hp: 50,
+            max_hp: 50,
+            armor: 5,
+            gold: 0,
+            effects: Vec::new(),
+            inventory: Vec::new(),
+            accuracy: 1.0,
+        }
+    }
+}
+
+// ── Enemy state ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct EnemyState {
+    pub name: String,
+    pub level: u8,
+    pub hp: i32,
+    pub max_hp: i32,
+    pub armor: i32,
+    pub effects: Vec<EffectInstance>,
+    pub intent: Intent,
+}
+
+// ── Room state ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub enum RoomModifier {
+    Fog { accuracy_penalty: f32 },
+    Blessing { heal_bonus: i32 },
+    Cursed { dmg_multiplier: f32 },
+}
+
+#[derive(Debug, Clone)]
+pub struct RoomState {
+    pub index: u32,
+    pub room_type: RoomType,
+    pub name: String,
+    pub description: String,
+    pub modifiers: Vec<RoomModifier>,
+}
+
+// ── Game action ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GameAction {
+    Attack,
+    Defend,
+    UseItem(ItemId),
+    Explore,
+    Flee,
+    ToggleItems,
+}
+
+// ── Session mode ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SessionMode {
+    Solo,
+    Party,
+}
+
+// ── Session state ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct SessionState {
+    pub id: uuid::Uuid,
+    pub short_id: ShortSid,
+    pub owner: serenity::UserId,
+    pub party: Vec<serenity::UserId>,
+    pub mode: SessionMode,
+    pub phase: GamePhase,
+    pub channel_id: serenity::ChannelId,
+    pub message_id: serenity::MessageId,
+    pub created_at: Instant,
+    pub last_action_at: Instant,
+    pub turn: u32,
+    pub player: PlayerState,
+    pub enemy: Option<EnemyState>,
+    pub room: RoomState,
+    pub log: Vec<String>,
+    pub show_items: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_short_sid_is_8_chars() {
+        let (uuid, short) = new_short_sid();
+        assert_eq!(short.len(), 8);
+        assert!(uuid.simple().to_string().starts_with(&short));
+    }
+
+    #[test]
+    fn new_short_sid_unique() {
+        let (_, a) = new_short_sid();
+        let (_, b) = new_short_sid();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn default_player_state() {
+        let p = PlayerState::default();
+        assert_eq!(p.hp, 50);
+        assert_eq!(p.max_hp, 50);
+        assert_eq!(p.armor, 5);
+        assert_eq!(p.gold, 0);
+        assert!(p.inventory.is_empty());
+        assert!(p.effects.is_empty());
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/mod.rs
@@ -2,3 +2,4 @@ pub mod bot;
 pub mod commands;
 pub mod components;
 pub mod embeds;
+pub mod game;

--- a/apps/discordsh/axum-discordsh/src/state.rs
+++ b/apps/discordsh/axum-discordsh/src/state.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use poise::serenity_prelude as serenity;
 use tokio::sync::{Notify, RwLock};
 
+use crate::discord::game::SessionStore;
 use crate::health::HealthMonitor;
 use crate::tracker::ShardTracker;
 
@@ -40,6 +41,10 @@ pub struct AppState {
     /// Serenity HTTP client, stored during bot setup so HTTP endpoints
     /// (e.g. `/cleanup-thread`) can make Discord API calls.
     pub bot_http: RwLock<Option<Arc<serenity::Http>>>,
+
+    // ── Game sessions ────────────────────────────────────────────────
+    /// In-memory store for Embed Dungeon game sessions.
+    pub sessions: Arc<SessionStore>,
 }
 
 impl AppState {
@@ -52,6 +57,7 @@ impl AppState {
             restart_flag: AtomicBool::new(false),
             shard_manager: RwLock::new(None),
             bot_http: RwLock::new(None),
+            sessions: Arc::new(SessionStore::new()),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add **Embed Dungeon — "The Glass Catacombs"** proof-of-concept game to stress-test the Discord bot's embed + component system
- Implement 7 new game modules: types, content, logic, render, router, session store, and module re-exports
- Add `/dungeon start|join|leave|status|end` slash commands with solo + party mode support
- Wire DashMap-backed `SessionStore` with per-session `Mutex` locking into `AppState`
- Add `dng|` component interaction routing in event handler + background session cleanup task
- Include `DISCORDSH_GAMEIDEA.md` design spec document
- 42 new unit tests (71 total), clippy clean, rustfmt clean

## New Files

| File | Purpose |
|------|---------|
| `discord/game/types.rs` | Data model (GamePhase, PlayerState, EnemyState, SessionState, etc.) |
| `discord/game/content.rs` | 5 items, 4 enemy tiers, 7 room types |
| `discord/game/logic.rs` | Combat resolution, item usage, room advancement, effect ticking |
| `discord/game/render.rs` | Pure embed + component builders (HP bars, contextual buttons, select menus) |
| `discord/game/session.rs` | `SessionStore` backed by `DashMap<ShortSid, Arc<Mutex<SessionState>>>` |
| `discord/game/router.rs` | Component interaction router with `try_lock` concurrency |
| `discord/commands/dungeon.rs` | `/dungeon` subcommands via Poise |

## Test plan

- [x] `cargo test -p axum-discordsh` — 71 tests passing
- [x] `cargo clippy -p axum-discordsh` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks pass (rustfmt + prettier)
- [ ] Manual Discord test: `/dungeon start` → interact with buttons → verify embed updates