### PR TITLE
fix(droid): SharedWorker port cleanup and toast leader-tab decouple

### DIFF
--- a/packages/npm/droid/src/lib/state/welcome-toast.ts
+++ b/packages/npm/droid/src/lib/state/welcome-toast.ts
@@ -40,7 +40,15 @@ export function showWelcomeToast(): void {
 	// Auth still loading — subscribe and wait (10s timeout)
 	const timeoutId = setTimeout(() => {
 		unsub();
-		shown = true;
+		if (!shown) {
+			shown = true;
+			addToast({
+				id: `welcome-${Date.now()}`,
+				message: 'Welcome!',
+				severity: 'info',
+				duration: 3000,
+			});
+		}
 	}, 10_000);
 
 	const unsub = $auth.subscribe(() => {

--- a/packages/npm/droid/src/lib/workers/db-worker.ts
+++ b/packages/npm/droid/src/lib/workers/db-worker.ts
@@ -242,5 +242,8 @@ self.onconnect = (event: MessageEvent) => {
 	ports.add(port);
 	port.start();
 	port.postMessage({ type: isFirst ? 'first-connect' : 'reconnect' });
+	port.addEventListener('message', (e: MessageEvent) => {
+		if (e.data?.type === 'close') ports.delete(port);
+	});
 	expose(storageAPI, port);
 };

--- a/packages/npm/droid/src/lib/workers/main.ts
+++ b/packages/npm/droid/src/lib/workers/main.ts
@@ -60,6 +60,12 @@ function initSharedWorker(
 	const url = opts?.workerURL ?? resolveWorkerURL(name);
 	const worker = new SharedWorker(url, { type: 'module' });
 	worker.port.start();
+
+	// Notify worker to clean up this port on tab close/reload
+	window.addEventListener('beforeunload', () => {
+		worker.port.postMessage({ type: 'close' });
+	});
+
 	return worker;
 }
 
@@ -552,8 +558,9 @@ export async function main(opts?: {
 						timestamp: Date.now(),
 						workersFirst: { db: dbFirst, ws: wsFirst },
 					});
-					showWelcomeToast();
 				}
+
+				showWelcomeToast();
 
 				console.log('[KBVE] Global API ready');
 			} catch (err) {

--- a/packages/npm/droid/src/lib/workers/ws-worker.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.ts
@@ -199,5 +199,8 @@ self.onconnect = (event: MessageEvent) => {
 	ports.add(port);
 	port.start();
 	port.postMessage({ type: isFirst ? 'first-connect' : 'reconnect' });
+	port.addEventListener('message', (e: MessageEvent) => {
+		if (e.data?.type === 'close') ports.delete(port);
+	});
 	expose(wsInstanceAPI, port);
 };


### PR DESCRIPTION
## Summary
- **SharedWorker port cleanup** — workers now listen for `close` messages and remove dead ports from their tracking Set; main thread sends `close` on `beforeunload`
- **Toast decoupled from leader-tab gate** — `showWelcomeToast()` moved outside the `isLeaderTab` block so it fires on every init, not just the first SharedWorker connection
- **Auth timeout fallback** — 10s timeout now shows a "Welcome!" toast instead of silently giving up when auth state stays at `loading`

## Root Cause
Three compounding issues prevented toast display:

1. SharedWorkers tracked ports in a `Set` but never removed dead ones — on page reload, the old port remained so `ports.size > 0`, sending `reconnect` instead of `first-connect`
2. `showWelcomeToast()` was gated behind `isLeaderTab` (requires both workers to report first connection), which was always `false` after any reload
3. The 10s auth timeout just set `shown = true` without calling `tryShow()` or adding any toast

## Changes
| File | Change |
|------|--------|
| `packages/npm/droid/src/lib/workers/db-worker.ts` | Listen for `close` message, remove port from Set |
| `packages/npm/droid/src/lib/workers/ws-worker.ts` | Listen for `close` message, remove port from Set |
| `packages/npm/droid/src/lib/workers/main.ts` | Send `close` on `beforeunload` + move `showWelcomeToast()` outside `isLeaderTab` |
| `packages/npm/droid/src/lib/state/welcome-toast.ts` | 10s timeout shows fallback toast |

## Test plan
- [ ] Fresh browser visit — toast appears immediately
- [ ] Page reload (F5) — toast appears again (port cleanup restores first-connect)
- [ ] Dev mode with HMR — toast appears on initial load
- [ ] Multiple tabs — each tab shows its own welcome toast (module-level `shown` flag is per-tab)
- [ ] `droid:build` passes
- [ ] `astro-discordsh:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)