### PR TITLE
chore(discordsh): bump axum-discordsh version to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps `axum-discordsh` package version from `0.1.8` to `0.1.9`
- Updates `Cargo.lock` accordingly

## Test plan
- [x] `cargo check -p axum-discordsh` passes
- [x] `cargo test -p axum-discordsh` — 71 tests pass