### PR TITLE
fix(astro): inline overlay styles with Starlight CSS variables

### DIFF
--- a/packages/npm/astro/src/react/TooltipOverlay.tsx
+++ b/packages/npm/astro/src/react/TooltipOverlay.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { useTooltip } from '../hooks/useTooltip';
-import { cn } from '../utils/cn';
 
 export interface TooltipOverlayProps {
 	id: string;
@@ -39,23 +38,42 @@ export function TooltipOverlay({
 		});
 	}, [open, anchorId]);
 
+	const visible = open && pos;
+
+	const tooltipStyle: CSSProperties = {
+		position: 'absolute',
+		zIndex: 9997,
+		paddingInline: 12,
+		paddingBlock: 8,
+		borderRadius: 8,
+		backgroundColor: 'var(--sl-color-gray-5, #27272a)',
+		color: 'var(--sl-color-text, #e4e4e7)',
+		fontSize: 'var(--sl-text-sm, 0.875rem)',
+		boxShadow: 'var(--sl-shadow-md, 0 4px 6px -1px rgba(0,0,0,0.3))',
+		transform: 'translateX(-50%)',
+		transition: 'opacity 150ms ease',
+		...(visible
+			? {
+					opacity: 1,
+					visibility: 'visible' as const,
+					top: pos.top,
+					left: pos.left,
+				}
+			: {
+					opacity: 0,
+					visibility: 'hidden' as const,
+					pointerEvents: 'none' as const,
+					top: -9999,
+					left: -9999,
+				}),
+	};
+
 	return createPortal(
 		<div
 			role="tooltip"
 			aria-hidden={!open}
-			className={cn(
-				'absolute z-[9997] px-3 py-2 rounded-lg bg-zinc-800 text-zinc-200 text-sm shadow-lg',
-				'transform -translate-x-1/2 transition-opacity duration-150',
-				open && pos
-					? 'opacity-100 visible'
-					: 'opacity-0 invisible pointer-events-none',
-				className,
-			)}
-			style={
-				open && pos
-					? { top: pos.top, left: pos.left }
-					: { top: -9999, left: -9999 }
-			}>
+			className={className}
+			style={tooltipStyle}>
 			{children ?? content ?? null}
 		</div>,
 		document.body,


### PR DESCRIPTION
## Summary
- **Root cause**: `ToastContainer`, `ModalOverlay`, and `TooltipOverlay` used Tailwind utility classes, but the host app's `content` array only scans `./src/**` — `@kbve/astro` package sources were never included, so none of the classes were compiled into CSS
- Replaces all Tailwind classes in the three overlay components with inline `CSSProperties` using `var(--sl-color-*, fallback)` Starlight tokens, ensuring styles render correctly regardless of Tailwind content scanning
- Components now automatically adapt to light/dark Starlight themes via CSS custom properties with hardcoded fallbacks for non-Starlight contexts

## Test plan
- [x] `astro:build` passes (includes `droid:build` dependency)
- [ ] `pnpm nx dev astro-discordsh` — verify toast appears on page load
- [ ] Verify modal and tooltip overlays render with correct colors
- [ ] Toggle light/dark theme — overlays should adapt via Starlight variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)