### PR TITLE
feat(kube): add Kubernetes manifests for MC server

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -41,6 +41,7 @@ resources:
     - clickhouse-operator/application.yaml
     - clickhouse/application.yaml
 
+    - mc/application.yaml
     - cityvote/application.yaml
     - herbmail/application.yaml
     - memes/application.yaml

--- a/apps/kube/mc/application.yaml
+++ b/apps/kube/mc/application.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: mc
+    namespace: argocd
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: main
+        path: apps/kube/mc/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: mc
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - PrunePropagationPolicy=foreground
+            - PruneLast=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m
+    revisionHistoryLimit: 3

--- a/apps/kube/mc/manifest/configmap.yaml
+++ b/apps/kube/mc/manifest/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: mc-config
+    namespace: mc
+    labels:
+        app: mc
+data:
+    configuration.toml: |
+        java_edition = true
+        java_edition_address = "0.0.0.0:25565"
+        bedrock_edition = true
+        bedrock_edition_address = "0.0.0.0:19132"
+        max_players = 1000
+        view_distance = 16
+        simulation_distance = 10
+        default_difficulty = "Normal"
+        op_permission_level = 4
+        allow_nether = true
+        allow_end = true
+        hardcore = false
+        online_mode = true
+        encryption = true
+        motd = "KBVE Minecraft Server - Powered by Pumpkin"
+        tps = 20.0
+        default_gamemode = "Survival"
+        force_gamemode = false
+        scrub_ips = true
+        use_favicon = true
+        favicon_path = "server_icon.png"
+        default_level_name = "world"
+        allow_chat_reports = false
+        white_list = false
+        enforce_whitelist = false

--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: mc
+    namespace: mc
+    labels:
+        app: mc
+spec:
+    replicas: 1
+    strategy:
+        type: Recreate
+    selector:
+        matchLabels:
+            app: mc
+    template:
+        metadata:
+            labels:
+                app: mc
+        spec:
+            securityContext:
+                runAsUser: 2613
+                runAsGroup: 2613
+                fsGroup: 2613
+            containers:
+                - name: mc
+                  image: ghcr.io/kbve/mc:latest
+                  imagePullPolicy: Always
+                  ports:
+                      - name: java
+                        containerPort: 25565
+                        protocol: TCP
+                      - name: bedrock
+                        containerPort: 19132
+                        protocol: UDP
+                      - name: resource-pack
+                        containerPort: 8080
+                        protocol: TCP
+                      - name: rcon
+                        containerPort: 25575
+                        protocol: TCP
+                  volumeMounts:
+                      - name: world-data
+                        mountPath: /pumpkin/worlds
+                      - name: mc-config
+                        mountPath: /pumpkin/config/configuration.toml
+                        subPath: configuration.toml
+                        readOnly: true
+                  resources:
+                      requests:
+                          memory: '512Mi'
+                          cpu: '250m'
+                      limits:
+                          memory: '2Gi'
+                          cpu: '1000m'
+                  livenessProbe:
+                      tcpSocket:
+                          port: java
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  readinessProbe:
+                      tcpSocket:
+                          port: java
+                      initialDelaySeconds: 10
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3
+            volumes:
+                - name: world-data
+                  persistentVolumeClaim:
+                      claimName: mc-world-data
+                - name: mc-config
+                  configMap:
+                      name: mc-config

--- a/apps/kube/mc/manifest/namespace.yaml
+++ b/apps/kube/mc/manifest/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: mc
+    labels:
+        name: mc

--- a/apps/kube/mc/manifest/pvc.yaml
+++ b/apps/kube/mc/manifest/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: mc-world-data
+    namespace: mc
+    labels:
+        app: mc
+spec:
+    accessModes:
+        - ReadWriteOnce
+    storageClassName: longhorn
+    resources:
+        requests:
+            storage: 10Gi

--- a/apps/kube/mc/manifest/service.yaml
+++ b/apps/kube/mc/manifest/service.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: mc-service
+    namespace: mc
+    labels:
+        app: mc
+spec:
+    type: LoadBalancer
+    selector:
+        app: mc
+    ports:
+        - name: java
+          port: 25565
+          targetPort: 25565
+          protocol: TCP
+        - name: bedrock
+          port: 19132
+          targetPort: 19132
+          protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: mc-internal-service
+    namespace: mc
+    labels:
+        app: mc
+spec:
+    type: ClusterIP
+    selector:
+        app: mc
+    ports:
+        - name: resource-pack
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+        - name: rcon
+          port: 25575
+          targetPort: 25575
+          protocol: TCP


### PR DESCRIPTION
## Summary
- Adds `apps/kube/mc/` with ArgoCD-managed Kubernetes manifests for the Pumpkin MC server
- LoadBalancer service (MetalLB) exposes Java (25565 TCP) and Bedrock (19132 UDP) for player access
- Internal ClusterIP for RCON (25575) and resource pack HTTP (8080)
- 10Gi Longhorn PVC for world data persistence
- ConfigMap for server configuration (mirrors `apps/mc/data/config/configuration.toml`)
- Registered in root `kustomization.yaml` for ArgoCD auto-sync

## Test plan
- [ ] Verify ArgoCD picks up the `mc` application after merge to `main`
- [ ] Confirm MetalLB assigns an external IP to `mc-service`
- [ ] Test player connection to `<external-ip>:25565`
- [ ] Validate world data persists across pod restarts