### PR TITLE
fix(kbve.sh): init submodules in new worktrees

### DIFF
--- a/kbve.sh
+++ b/kbve.sh
@@ -224,6 +224,12 @@ atomic_function() {
     echo "Branch: $branch_name (based on dev)"
     git worktree add "$worktree_dir" -b "$branch_name" "origin/dev"
 
+    # Initialize submodules in the worktree
+    if [ -f "$worktree_dir/.gitmodules" ]; then
+        echo "Initializing submodules in worktree..."
+        git -C "$worktree_dir" submodule update --init --recursive
+    fi
+
     # Copy .env if it exists in the main repo
     if [ -f "$main_repo/.env" ]; then
         echo "Copying .env from main repo..."
@@ -321,6 +327,12 @@ create_worktree() {
     echo "Creating worktree at: $worktree_dir"
     echo "Branch: $branch_name (based on $base_branch)"
     git worktree add "$worktree_dir" -b "$branch_name" "origin/$base_branch"
+
+    # Initialize submodules in the worktree
+    if [ -f "$worktree_dir/.gitmodules" ]; then
+        echo "Initializing submodules in worktree..."
+        git -C "$worktree_dir" submodule update --init --recursive
+    fi
 
     # Copy .env if it exists in the main repo (gitignored, won't be in worktree)
     if [ -f "$main_repo/.env" ]; then


### PR DESCRIPTION
## Summary
- Patches `create_worktree()` and `atomic_function()` in `kbve.sh` to run `git submodule update --init --recursive` after worktree creation
- Only runs if `.gitmodules` exists in the worktree (no-op for repos without submodules)
- Fixes missing submodules (e.g. `apps/mc/pumpkin`) in new worktrees

## Test plan
- [ ] `./kbve.sh -worktree test-sub` creates worktree with submodules initialized
- [ ] `./kbve.sh -atomic test-sub` creates atomic worktree with submodules initialized
- [ ] Repos without `.gitmodules` skip the step cleanly