### PR TITLE
fix(mc-e2e): project-relative vitest paths and resource pack test

### DIFF
--- a/apps/mc/mc-e2e/e2e/resource-pack.spec.ts
+++ b/apps/mc/mc-e2e/e2e/resource-pack.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+const MC_HOST = process.env['MC_HOST'] ?? '127.0.0.1';
+const PACK_PORT = Number(process.env['MC_PACK_PORT'] ?? 8080);
+const PACK_PATH = '/kbve-resource-pack.zip';
+
+describe('MC Resource Pack HTTP Server', () => {
+	it('should serve the resource pack as a ZIP file', async () => {
+		const url = `http://${MC_HOST}:${PACK_PORT}${PACK_PATH}`;
+		const res = await fetch(url);
+
+		expect(res.ok).toBe(true);
+		expect(res.status).toBe(200);
+
+		const contentType = res.headers.get('content-type');
+		expect(contentType).toContain('application/zip');
+
+		const body = await res.arrayBuffer();
+		expect(body.byteLength).toBeGreaterThan(0);
+
+		// Validate ZIP magic bytes (PK\x03\x04)
+		const header = new Uint8Array(body, 0, 4);
+		expect(header[0]).toBe(0x50); // P
+		expect(header[1]).toBe(0x4b); // K
+		expect(header[2]).toBe(0x03);
+		expect(header[3]).toBe(0x04);
+	});
+
+	it('should return 404 for unknown paths', async () => {
+		const url = `http://${MC_HOST}:${PACK_PORT}/nonexistent`;
+		const res = await fetch(url);
+
+		expect(res.ok).toBe(false);
+	});
+});

--- a/apps/mc/mc-e2e/project.json
+++ b/apps/mc/mc-e2e/project.json
@@ -11,10 +11,11 @@
 			"options": {
 				"commands": [
 					"docker rm -f mc-e2e-test 2>/dev/null || true",
-					"docker run -d --name mc-e2e-test -p 25565:25565 kbve/mc:local",
-					"npx vitest run --config apps/mc/mc-e2e/vitest.config.ts; EC=$?; docker rm -f mc-e2e-test 2>/dev/null || true; exit $EC"
+					"docker run -d --name mc-e2e-test -p 25565:25565 -p 8080:8080 kbve/mc:local",
+					"npx vitest run; EC=$?; docker rm -f mc-e2e-test 2>/dev/null || true; exit $EC"
 				],
-				"parallel": false
+				"parallel": false,
+				"cwd": "apps/mc/mc-e2e"
 			}
 		}
 	},

--- a/apps/mc/mc-e2e/vitest.config.ts
+++ b/apps/mc/mc-e2e/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['apps/mc/mc-e2e/e2e/**/*.spec.ts'],
+		include: ['e2e/**/*.spec.ts'],
 		testTimeout: 30_000,
 		hookTimeout: 60_000,
 	},


### PR DESCRIPTION
## Summary
- Fix `mc-e2e:test` failing with "No test files found" by changing vitest include path from monorepo-root-relative (`apps/mc/mc-e2e/e2e/**/*.spec.ts`) to project-relative (`e2e/**/*.spec.ts`)
- Add `cwd` to the `e2e` target so both inferred and explicit targets resolve paths consistently
- Expose port 8080 in the Docker run command for the resource pack HTTP server
- Add `resource-pack.spec.ts` e2e test validating the plugin's HTTP endpoint serves a valid ZIP at `:8080/kbve-resource-pack.zip`

## Test plan
- [x] `npx vitest run` from `apps/mc/mc-e2e/` discovers all 3 test files (was 0 before fix)
- [x] All 4 tests pass locally (health, status, resource-pack serve, resource-pack 404)
- [ ] CI runs `nx run mc-e2e:test` without "No test files found" error
- [ ] Full e2e target (`mc-e2e:e2e`) with Docker still works end-to-end