### PR TITLE
fix(mc-e2e): disable auto-inferred vitest test target

### DIFF
--- a/apps/mc/mc-e2e/project.json
+++ b/apps/mc/mc-e2e/project.json
@@ -5,6 +5,10 @@
 	"sourceRoot": "apps/mc/mc-e2e/e2e",
 	"implicitDependencies": ["mc"],
 	"targets": {
+		"test": {
+			"executor": "nx:noop",
+			"cache": false
+		},
 		"e2e": {
 			"executor": "nx:run-commands",
 			"cache": false,


### PR DESCRIPTION
## Summary
- The `@nx/vitest` plugin auto-infers a bare `test` target from `vitest.config.ts`, which `nx affected --target=test` picks up in CI (`utils-ci-lint-test.yml`)
- This runs vitest without the Docker container, so the MC server (port 25565) and resource pack HTTP server (port 8080) are never started, causing all 4 tests to fail
- Added an explicit `nx:noop` test target to override the inference — the proper e2e pipeline (`nx e2e mc` → Docker build → container start → vitest) remains unchanged

## Test plan
- [ ] Verify `nx affected --target=test` no longer runs bare vitest for `mc-e2e`
- [ ] Verify `nx e2e mc` still builds the Docker image, starts the container, and runs all 4 vitest specs