### PR TITLE
feat(ci): add Rust to CodeQL security analysis

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -31,6 +31,7 @@ jobs:
                 language:
                     - javascript-typescript
                     - python
+                    - rust
 
         steps:
             - name: Checkout


### PR DESCRIPTION
## Summary
- Adds `rust` to the CodeQL language matrix in `ci-security.yml`
- The existing workflow only covered `javascript-typescript` and `python`, leaving the Rust workspace (10+ crates) unscanned
- CodeQL's Rust extractor and autobuild will detect the root `Cargo.toml` workspace automatically

## Test plan
- [ ] Verify the new `CodeQL Analysis (rust)` matrix job runs successfully on this PR
- [ ] Confirm existing `javascript-typescript` and `python` jobs are unaffected