### PR TITLE
feat(ci): harden CodeQL with PR gates, scheduled scans, and dependency review

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -7,8 +7,11 @@ on:
             - main
     pull_request:
         branches:
+            - dev
             - staging
             - main
+    schedule:
+        - cron: '30 6 * * 1'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +44,7 @@ jobs:
               uses: github/codeql-action/init@v4
               with:
                   languages: ${{ matrix.language }}
+                  queries: security-and-quality
 
             - name: Auto-build
               uses: github/codeql-action/autobuild@v4
@@ -49,3 +53,22 @@ jobs:
               uses: github/codeql-action/analyze@v4
               with:
                   category: /language:${{ matrix.language }}
+
+    dependency-review:
+        name: Dependency Review
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+        timeout-minutes: 10
+        permissions:
+            contents: read
+            pull-requests: write
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Dependency Review
+              uses: actions/dependency-review-action@v4
+              with:
+                  fail-on-severity: high
+                  comment-summary-in-pr: always


### PR DESCRIPTION
## Summary
- **PR gate for dev**: Added `dev` to `pull_request` trigger branches — PRs are now scanned *before* merge instead of only after
- **Scheduled scanning**: Weekly cron (Mondays 06:30 UTC) catches newly disclosed CVEs and updated CodeQL rules against existing code
- **Query suite upgrade**: Changed from `default` to `security-and-quality` for broader coverage (code quality + correctness on top of security)
- **Dependency review**: New `dependency-review` job using `actions/dependency-review-action@v4` blocks PRs that introduce dependencies with high-severity vulnerabilities, with summary comments posted on the PR

## Test plan
- [ ] Verify all three CodeQL matrix jobs (javascript-typescript, python, rust) run on this PR
- [ ] Verify the new Dependency Review job runs and posts a comment summary
- [ ] Confirm `security-and-quality` queries produce results in the Security tab