### PR TITLE
fix(mc): enable Docker build cache for local/test configuration

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -20,6 +20,9 @@ jobs:
               with:
                   submodules: true
 
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
             - name: Rust ToolChain
               uses: dtolnay/rust-toolchain@stable
 

--- a/apps/mc/project.json
+++ b/apps/mc/project.json
@@ -38,7 +38,10 @@
 				"local": {
 					"load": true,
 					"push": false,
-					"tags": ["kbve/mc:latest"]
+					"tags": ["kbve/mc:latest"],
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/mc:buildcache"
+					]
 				},
 				"production": {
 					"load": true,


### PR DESCRIPTION
## Summary
- **Root cause**: The MC Docker image builds twice in CI (test + publish), and the test build (`local` config) had **no `cache-from`** — rebuilding all 9 Dockerfile stages from scratch every time (~30+ min)
- **Fix 1**: Added `cache-from: type=registry,ref=ghcr.io/kbve/mc:buildcache` to the `local` containerx configuration in `apps/mc/project.json` — test builds now pull cached layers from the same registry cache that production writes to
- **Fix 2**: Added `docker/setup-buildx-action@v3` to `docker-test-app.yml` so `cache-from: type=registry` is properly supported during e2e test builds

## How it works
```
Production build (publish_docker) → writes cache → ghcr.io/kbve/mc:buildcache
Test build (test_docker)          → reads cache ← ghcr.io/kbve/mc:buildcache
```
The test build no longer compiles Rust from scratch — it reuses the cached Docker layers from the last successful production build.

## Test plan
- [ ] Verify MC test build pulls cache from registry (look for `importing cache manifest` in Docker build logs)
- [ ] Confirm build time drops significantly from 30+ min baseline
- [ ] Verify production publish build continues to work with cache-to