### PR TITLE
fix(irc): replace nginx permanent-redirect with static redirect page

### DIFF
--- a/apps/kube/irc/manifests/irc-domain-redirect.yaml
+++ b/apps/kube/irc/manifests/irc-domain-redirect.yaml
@@ -5,7 +5,6 @@ metadata:
     namespace: irc
     annotations:
         cert-manager.io/cluster-issuer: letsencrypt-http
-        nginx.ingress.kubernetes.io/permanent-redirect: 'https://chat.kbve.com$request_uri'
 spec:
     ingressClassName: nginx
     tls:
@@ -20,6 +19,6 @@ spec:
                     pathType: Prefix
                     backend:
                         service:
-                            name: irc-gateway-service
+                            name: irc-redirect-service
                             port:
-                                number: 4321
+                                number: 80

--- a/apps/kube/irc/manifests/irc-redirect-configmap.yaml
+++ b/apps/kube/irc/manifests/irc-redirect-configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: irc-redirect-html
+    namespace: irc
+data:
+    index.html: |
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0;url=https://chat.kbve.com">
+          <title>Redirecting to KBVE Chat</title>
+        </head>
+        <body>
+          <p>Redirecting to <a href="https://chat.kbve.com">chat.kbve.com</a>...</p>
+          <script>window.location.replace("https://chat.kbve.com" + window.location.pathname + window.location.search);</script>
+        </body>
+        </html>

--- a/apps/kube/irc/manifests/irc-redirect-deployment.yaml
+++ b/apps/kube/irc/manifests/irc-redirect-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: irc-redirect
+    namespace: irc
+    labels:
+        app: irc-redirect
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: irc-redirect
+    template:
+        metadata:
+            labels:
+                app: irc-redirect
+        spec:
+            containers:
+                - name: nginx
+                  image: nginx:1.27-alpine
+                  ports:
+                      - containerPort: 80
+                        protocol: TCP
+                        name: http
+                  volumeMounts:
+                      - name: html
+                        mountPath: /usr/share/nginx/html
+                        readOnly: true
+                  resources:
+                      requests:
+                          memory: '16Mi'
+                          cpu: '10m'
+                      limits:
+                          memory: '32Mi'
+                          cpu: '50m'
+                  livenessProbe:
+                      httpGet:
+                          path: /
+                          port: 80
+                      initialDelaySeconds: 5
+                      periodSeconds: 30
+                  readinessProbe:
+                      httpGet:
+                          path: /
+                          port: 80
+                      initialDelaySeconds: 2
+                      periodSeconds: 10
+            volumes:
+                - name: html
+                  configMap:
+                      name: irc-redirect-html
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: irc-redirect-service
+    namespace: irc
+    labels:
+        app: irc-redirect
+spec:
+    type: ClusterIP
+    selector:
+        app: irc-redirect
+    ports:
+        - port: 80
+          targetPort: 80
+          protocol: TCP
+          name: http


### PR DESCRIPTION
## Summary
- The `irc-domain-redirect` ingress was stuck without an ADDRESS due to the `permanent-redirect` annotation, causing ArgoCD to report **Progressing** indefinitely
- Replaced with a tiny `nginx:1.27-alpine` container serving a static HTML page with meta refresh + JS redirect from `irc.kbve.com` to `chat.kbve.com`
- Ingress now points to the new `irc-redirect-service` backend so the ingress controller assigns an ADDRESS properly

## Test plan
- [ ] Verify ArgoCD syncs the new resources (ConfigMap, Deployment, Service, updated Ingress)
- [ ] Confirm ArgoCD IRC application health transitions from Progressing to Healthy
- [ ] Verify `irc.kbve.com` redirects to `chat.kbve.com` in a browser
- [ ] Confirm `chat.kbve.com` continues to work as before