### PR TITLE
fix(ci): handle missing MERGE_HEAD in staging conflict check

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -39,10 +39,10 @@ jobs:
 
                   if git merge --no-commit --no-ff origin/main; then
                     echo "No merge conflicts detected"
-                    git merge --abort
+                    git merge --abort 2>/dev/null || git reset --hard HEAD
                   else
                     echo "Merge conflicts detected! Please resolve before merging."
-                    git merge --abort
+                    git merge --abort 2>/dev/null || git reset --hard HEAD
                     exit 1
                   fi
 


### PR DESCRIPTION
## Summary
- Fix `Validate Staging→Main PR / Lint and Test` failing with `fatal: There is no merge to abort (MERGE_HEAD missing)` (exit code 128)
- When staging already contains main, `git merge --no-commit --no-ff origin/main` returns "Already up to date" without creating a `MERGE_HEAD`. The subsequent `git merge --abort` then fails because there's nothing to abort.
- Fix: fall back to `git reset --hard HEAD` when `git merge --abort` fails, covering both the success (no conflicts) and failure (conflicts) paths.

## Test plan
- [ ] Re-run `Validate Staging→Main PR` on PR #7268 after this merges to dev → staging
- [ ] Verify the conflict check passes when staging is already up to date with main