### PR TITLE
fix(ci): prevent CodeQL Rust analysis cancelation

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: false
 
 permissions: {}
 
@@ -23,7 +23,7 @@ jobs:
     codeql:
         name: CodeQL Analysis
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 45
         permissions:
             security-events: write
             contents: read
@@ -39,12 +39,19 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v6
+              with:
+                  submodules: recursive
 
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v4
               with:
                   languages: ${{ matrix.language }}
                   queries: security-and-quality
+                  config: |
+                      paths-ignore:
+                          - 'apps/mc/pumpkin'
+                          - 'apps/irc/ergo'
+                          - 'apps/postgres'
 
             - name: Auto-build
               uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
## Summary
- **Disable `cancel-in-progress`** — CodeQL Rust analysis was failing with `The operation was canceled` because every new push to `dev` canceled the in-flight security scan
- **Add `submodules: recursive`** to checkout — `kbve-mc-plugin` depends on 7 pumpkin crates via relative paths; without the submodule checkout, CodeQL's Rust extractor can't resolve the dependency graph
- **Exclude third-party submodule paths** (`apps/mc/pumpkin`, `apps/irc/ergo`, `apps/postgres`) from analysis — we don't own this code and it was inflating scan time
- **Bump timeout to 45min** — Rust analysis is slower than JS/Python; 30 min was tight

## Test plan
- [ ] Verify CodeQL Rust analysis completes without cancelation on next push to dev
- [ ] Confirm JS/TS and Python analyses still pass
- [ ] Check that `kbve-mc-plugin` Rust code is included in analysis results