### PR TITLE
fix(discordsh): resolve toast race condition between Astro islands

### DIFF
--- a/apps/discordsh/discordsh-e2e/e2e/toast-welcome.spec.ts
+++ b/apps/discordsh/discordsh-e2e/e2e/toast-welcome.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+// This test requires the full production stack (workers + Supabase gateway).
+// Run via the Docker playwright config: e2e:docker target.
+
+test.describe('Toast: Welcome Toast', () => {
+	test('welcome toast appears on page load', async ({ page }) => {
+		await page.goto('/');
+
+		// Wait for droid to initialize (workers must be served by the container)
+		await page.waitForFunction(() => !!(window as any).kbve?.events, null, {
+			timeout: 20_000,
+		});
+
+		// The welcome toast fires as "Welcome!" (anon) or "Welcome back, {name}" (auth).
+		// ToastContainer renders each toast inside a role="alert" element.
+		const toast = page.locator('role=alert').first();
+		await expect(toast).toBeVisible({ timeout: 15_000 });
+		await expect(toast).toContainText(/Welcome/);
+	});
+
+	test('welcome toast auto-dismisses', async ({ page }) => {
+		await page.goto('/');
+
+		await page.waitForFunction(() => !!(window as any).kbve?.events, null, {
+			timeout: 20_000,
+		});
+
+		const toast = page.locator('role=alert').first();
+		await expect(toast).toBeVisible({ timeout: 15_000 });
+
+		// The welcome toast duration is 3000–4000ms plus 200ms transition.
+		await expect(toast).not.toBeVisible({ timeout: 6_000 });
+	});
+});

--- a/apps/discordsh/discordsh-e2e/e2e/toast.spec.ts
+++ b/apps/discordsh/discordsh-e2e/e2e/toast.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Toast: Queue Drain (race condition fix)', () => {
+	test('toast queued before island mount is displayed', async ({ page }) => {
+		// Seed the window-level queue BEFORE the page runs any JS,
+		// simulating DroidProvider calling addToast() before ToastContainer mounts.
+		await page.addInitScript(() => {
+			(window as any).__kbveToastQueue = [
+				{
+					id: 'e2e-race-test',
+					message: 'Race condition toast',
+					severity: 'info',
+					duration: 30_000,
+				},
+			];
+		});
+
+		await page.goto('/');
+
+		const toast = page.locator('role=alert', {
+			hasText: 'Race condition toast',
+		});
+		await expect(toast).toBeVisible({ timeout: 15_000 });
+	});
+
+	test('multiple queued toasts are all drained', async ({ page }) => {
+		await page.addInitScript(() => {
+			(window as any).__kbveToastQueue = [
+				{
+					id: 'e2e-drain-1',
+					message: 'First queued',
+					severity: 'info',
+					duration: 30_000,
+				},
+				{
+					id: 'e2e-drain-2',
+					message: 'Second queued',
+					severity: 'success',
+					duration: 30_000,
+				},
+			];
+		});
+
+		await page.goto('/');
+
+		await expect(
+			page.locator('role=alert', { hasText: 'First queued' }),
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.locator('role=alert', { hasText: 'Second queued' }),
+		).toBeVisible({ timeout: 15_000 });
+	});
+
+	test('queue is cleared after drain', async ({ page }) => {
+		await page.addInitScript(() => {
+			(window as any).__kbveToastQueue = [
+				{
+					id: 'e2e-clear-test',
+					message: 'Should clear',
+					severity: 'info',
+					duration: 30_000,
+				},
+			];
+		});
+
+		await page.goto('/');
+
+		// Wait for the toast to appear (confirms drain happened)
+		await expect(
+			page.locator('role=alert', { hasText: 'Should clear' }),
+		).toBeVisible({ timeout: 15_000 });
+
+		// Queue should be empty after drain
+		const queueLength = await page.evaluate(
+			() => (window as any).__kbveToastQueue?.length ?? -1,
+		);
+		expect(queueLength).toBe(0);
+	});
+});

--- a/apps/discordsh/discordsh-e2e/playwright.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'dev',
+			testIgnore: /toast-welcome/,
 			use: {
 				...devices['Desktop Chrome'],
 				baseURL,

--- a/packages/npm/droid/src/index.ts
+++ b/packages/npm/droid/src/index.ts
@@ -1,3 +1,5 @@
+export type { KBVEGlobal } from './types';
+
 export * from './lib/droid';
 export * from './lib/types/bento';
 export * from './lib/types/event-types';

--- a/packages/npm/droid/src/lib/state/toasts.ts
+++ b/packages/npm/droid/src/lib/state/toasts.ts
@@ -4,8 +4,14 @@ import type { ToastPayload } from '../types/ui-event-types';
 
 export const $toasts = map<Record<string, ToastPayload>>({});
 
+function getToastQueue(): ToastPayload[] {
+	if (!window.__kbveToastQueue) window.__kbveToastQueue = [];
+	return window.__kbveToastQueue;
+}
+
 export function addToast(payload: ToastPayload): void {
 	$toasts.set({ ...$toasts.get(), [payload.id]: payload });
+	getToastQueue().push(payload);
 	DroidEvents.emit('toast-added', payload);
 }
 
@@ -13,5 +19,10 @@ export function removeToast(id: string): void {
 	const current = { ...$toasts.get() };
 	delete current[id];
 	$toasts.set(current);
+
+	const q = getToastQueue();
+	const idx = q.findIndex((t) => t.id === id);
+	if (idx !== -1) q.splice(idx, 1);
+
 	DroidEvents.emit('toast-removed', { id });
 }

--- a/packages/npm/droid/src/types.ts
+++ b/packages/npm/droid/src/types.ts
@@ -2,21 +2,23 @@ import type { DroidEvents } from './lib/workers/events';
 import type { FlexDataAPI } from './lib/workers/data';
 import type { ModManager } from './lib/types/modules';
 import type { SupabaseGateway } from './lib/gateway/SupabaseGateway';
+import type { ToastPayload } from './lib/types/ui-event-types';
 
 export interface KBVEGlobal {
-  api?: unknown;
-  i18n?: unknown;
-  uiux?: Record<string, unknown>;
-  ws?: unknown;
-  data?: FlexDataAPI;
-  mod?: ModManager;
-  events: typeof DroidEvents;
-  gateway?: SupabaseGateway;
-  [key: string]: unknown;
+	api?: unknown;
+	i18n?: unknown;
+	uiux?: Record<string, unknown>;
+	ws?: unknown;
+	data?: FlexDataAPI;
+	mod?: ModManager;
+	events: typeof DroidEvents;
+	gateway?: SupabaseGateway;
+	[key: string]: unknown;
 }
 
 declare global {
-  interface Window {
-    kbve: KBVEGlobal;
-  }
+	interface Window {
+		kbve: KBVEGlobal;
+		__kbveToastQueue?: ToastPayload[];
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes toast notifications being silently lost when `DroidProvider` fires `addToast()` before `ToastContainer` mounts its `CustomEvent` listener (separate Astro islands, no mount-order guarantee)
- Buffers toasts in `window.__kbveToastQueue`; `ToastContainer` drains the queue on mount
- Adds e2e tests for queue drain (dev) and welcome toast lifecycle (docker-only)

## Test plan
- [ ] `droid:build` and `astro:build` pass
- [ ] `discordsh-e2e:e2e` queue drain tests pass (dev config)
- [ ] `discordsh-e2e:e2e:docker` welcome toast tests pass (docker config)
- [ ] Manual: load app, welcome toast appears on first page load