### PR TITLE
fix(ci): move CodeQL Rust analysis to weekly cron only

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -34,7 +34,6 @@ jobs:
                 language:
                     - javascript-typescript
                     - python
-                    - rust
 
         steps:
             - name: Checkout
@@ -60,6 +59,40 @@ jobs:
               uses: github/codeql-action/analyze@v4
               with:
                   category: /language:${{ matrix.language }}
+
+    codeql-rust:
+        name: CodeQL Rust Analysis
+        runs-on: ubuntu-latest
+        if: github.event_name == 'schedule'
+        timeout-minutes: 120
+        permissions:
+            security-events: write
+            contents: read
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  submodules: recursive
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v4
+              with:
+                  languages: rust
+                  queries: security-and-quality
+                  config: |
+                      paths-ignore:
+                          - 'apps/mc/pumpkin'
+                          - 'apps/irc/ergo'
+                          - 'apps/postgres'
+
+            - name: Auto-build
+              uses: github/codeql-action/autobuild@v4
+
+            - name: Run CodeQL Analysis
+              uses: github/codeql-action/analyze@v4
+              with:
+                  category: /language:rust
 
     dependency-review:
         name: Dependency Review


### PR DESCRIPTION
## Summary
- Remove `rust` from the main CodeQL matrix that runs on every push/PR
- Add a dedicated `codeql-rust` job gated with `if: github.event_name == 'schedule'` so it only runs on the existing weekly Monday cron (06:30 UTC)
- JS/TS and Python CodeQL continue running on every push and PR as before
- Gave the Rust job a 120-minute timeout (vs 45 for the others) since Rust compilation is heavy

## Why
Rust CodeQL `autobuild` compiles the entire Rust workspace, which was making CI runs on every push/PR excessively slow. Weekly scans are sufficient for security coverage on the Rust codebase.

## Test plan
- [ ] Verify this PR's CI runs CodeQL for JS/TS and Python but **not** Rust
- [ ] On next Monday cron trigger, confirm `codeql-rust` job runs successfully