### PR TITLE
fix(ci): use PR titles as merge commit headlines for promotion PRs

### DIFF
--- a/.github/scripts/commit-utils.mjs
+++ b/.github/scripts/commit-utils.mjs
@@ -166,3 +166,26 @@ export function formatStagingToMainBody(categories, totalCommits, mergedPRCount)
 	body += `*This PR is automatically maintained by CI • Last updated: ${new Date().toISOString()}*`;
 	return body;
 }
+
+/**
+ * Format a clean merge commit body (no markdown, no checklists).
+ * Used as the `commitBody` when enabling auto-merge via the GitHub GraphQL API,
+ * so that `git log` shows a useful plain-text changelog instead of PR UI elements.
+ *
+ * @param {Record<string, string[]>} categories
+ * @param {number} totalCommits
+ * @param {string} target - Target branch display name (e.g. "staging", "main")
+ * @returns {string}
+ */
+export function formatMergeCommitBody(categories, totalCommits, target) {
+	const s = totalCommits === 1 ? '' : 's';
+	let body = `${totalCommits} commit${s} promoted to ${target}\n\n`;
+
+	for (const [key, label] of Object.entries(CATEGORIES)) {
+		if (categories[key]?.length > 0) {
+			body += `${label}:\n${categories[key].join('\n')}\n\n`;
+		}
+	}
+
+	return body.trim();
+}

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -211,6 +211,62 @@ jobs:
                       console.log(`Updated PR #${prNumber} — ${title}`);
                       return { number: prNumber };
 
+            - name: Enable auto-merge with clean commit title
+              if: fromJson(steps.check_changes.outputs.result).hasChanges == true
+              uses: actions/github-script@v8
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const path = require('path');
+                      const utils = await import(path.resolve('.github/scripts/commit-utils.mjs'));
+                      const prResult = ${{ steps.upsert_pr.outputs.result }};
+                      const prNumber = prResult.number;
+
+                      // Get PR node_id and title
+                      const pr = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: prNumber
+                      });
+
+                      // Generate clean merge commit body (plain text, no markdown UI)
+                      const comparison = await github.rest.repos.compareCommits({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        base: 'staging',
+                        head: 'dev'
+                      });
+                      const rawCommits = comparison.data.commits.map(c => ({
+                        message: c.commit.message,
+                        sha: c.sha
+                      }));
+                      const { categories } = utils.categorizeCommits(rawCommits);
+                      const mergeBody = utils.formatMergeCommitBody(categories, rawCommits.length, 'staging');
+
+                      try {
+                        await github.graphql(`
+                          mutation($prId: ID!, $headline: String!, $body: String!) {
+                            enablePullRequestAutoMerge(input: {
+                              pullRequestId: $prId
+                              commitHeadline: $headline
+                              commitBody: $body
+                              mergeMethod: MERGE
+                            }) {
+                              pullRequest { number }
+                            }
+                          }
+                        `, {
+                          prId: pr.data.node_id,
+                          headline: pr.data.title,
+                          body: mergeBody
+                        });
+                        console.log(`Auto-merge enabled for PR #${prNumber} with title: ${pr.data.title}`);
+                      } catch (error) {
+                        console.log(`Could not enable auto-merge: ${error.message}`);
+                        console.log('Ensure "Allow auto-merge" is enabled in repo settings and branch protection is configured on staging');
+                        console.log('PR will need manual merge — use the PR title as the merge commit message');
+                      }
+
             - name: Summary
               run: |
                   if [[ "${{ fromJson(steps.check_changes.outputs.result).hasChanges }}" == "true" ]]; then

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -185,6 +185,62 @@ jobs:
                       console.log(`Updated PR #${prNumber} — ${title}`);
                       return { number: prNumber };
 
+            - name: Enable auto-merge with clean commit title
+              if: fromJson(steps.check_changes.outputs.result).hasChanges == true
+              uses: actions/github-script@v8
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const path = require('path');
+                      const utils = await import(path.resolve('.github/scripts/commit-utils.mjs'));
+                      const prResult = ${{ steps.upsert_pr.outputs.result }};
+                      const prNumber = prResult.number;
+
+                      // Get PR node_id and title
+                      const pr = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: prNumber
+                      });
+
+                      // Generate clean merge commit body (plain text, no markdown UI)
+                      const comparison = await github.rest.repos.compareCommits({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        base: 'main',
+                        head: 'staging'
+                      });
+                      const rawCommits = comparison.data.commits.map(c => ({
+                        message: c.commit.message,
+                        sha: c.sha
+                      }));
+                      const { categories } = utils.categorizeCommits(rawCommits);
+                      const mergeBody = utils.formatMergeCommitBody(categories, rawCommits.length, 'main');
+
+                      try {
+                        await github.graphql(`
+                          mutation($prId: ID!, $headline: String!, $body: String!) {
+                            enablePullRequestAutoMerge(input: {
+                              pullRequestId: $prId
+                              commitHeadline: $headline
+                              commitBody: $body
+                              mergeMethod: MERGE
+                            }) {
+                              pullRequest { number }
+                            }
+                          }
+                        `, {
+                          prId: pr.data.node_id,
+                          headline: pr.data.title,
+                          body: mergeBody
+                        });
+                        console.log(`Auto-merge enabled for PR #${prNumber} with title: ${pr.data.title}`);
+                      } catch (error) {
+                        console.log(`Could not enable auto-merge: ${error.message}`);
+                        console.log('Ensure "Allow auto-merge" is enabled in repo settings and branch protection is configured on main');
+                        console.log('PR will need manual merge — use the PR title as the merge commit message');
+                      }
+
             - name: Summary
               run: |
                   if [[ "${{ fromJson(steps.check_changes.outputs.result).hasChanges }}" == "true" ]]; then


### PR DESCRIPTION
## Summary
- When staging→main and dev→staging PRs are merged via GitHub, the merge commit title defaults to `Merge pull request #X from KBVE/staging` instead of the descriptive PR title like `Production Release: 3 features, 1 fix → Main`
- Adds an **auto-merge step** to both `ci-staging.yml` and `ci-dev.yml` that calls the GraphQL `enablePullRequestAutoMerge` mutation with the PR title as `commitHeadline`
- Adds `formatMergeCommitBody()` to `commit-utils.mjs` — generates a clean plain-text changelog for the merge commit body (no markdown, no checklists)
- Graceful fallback: if auto-merge isn't available (requires "Allow auto-merge" in repo settings + branch protection), logs a helpful message and the PR can still be merged manually

## Prerequisite
For auto-merge to work, ensure these GitHub repo settings are configured:
1. Settings → General → Pull Requests → **Allow auto-merge** is checked
2. Branch protection rules exist on `main` and `staging` with at least one required status check

## Test plan
- [ ] Verify CI runs the auto-merge step on next staging→main PR creation
- [ ] Confirm merge commit on `main` uses the PR title instead of `Merge pull request #X from...`
- [ ] Verify graceful fallback if auto-merge is not enabled in repo settings