### PR TITLE
fix(kube): update MetalLB shared-ip annotation to metallb.io prefix

### DIFF
--- a/apps/kube/ingress/manifests/values.yaml
+++ b/apps/kube/ingress/manifests/values.yaml
@@ -12,7 +12,7 @@ controller:
         type: LoadBalancer
         externalTrafficPolicy: Local
         annotations:
-            metallb.universe.tf/allow-shared-ip: 'shared-public-ip'
+            metallb.io/allow-shared-ip: 'shared-public-ip'
 
     config:
         enable-real-ip: 'true'

--- a/apps/kube/mc/manifest/service.yaml
+++ b/apps/kube/mc/manifest/service.yaml
@@ -6,7 +6,7 @@ metadata:
     labels:
         app: mc
     annotations:
-        metallb.universe.tf/allow-shared-ip: 'shared-public-ip'
+        metallb.io/allow-shared-ip: 'shared-public-ip'
 spec:
     type: LoadBalancer
     selector:


### PR DESCRIPTION
## Summary
- Update `allow-shared-ip` annotation from legacy `metallb.universe.tf/` prefix to `metallb.io/` on both `mc-service` and `ingress-nginx-controller`
- MetalLB v0.15.2 does not recognize the legacy prefix, causing `mc-service` LoadBalancer to stay in `<pending>` with `"no available IPs"` allocation error
- This made ArgoCD report the mc Application as `Progressing` indefinitely

## Root Cause
MetalLB controller logs showed repeated `"error":"no available IPs","level":"error","msg":"IP allocation failed"` for `mc/mc-service`. The IP pool (`142.132.206.74/32`) was fully assigned to `ingress-nginx-controller`, and MetalLB couldn't share it because the `metallb.universe.tf/allow-shared-ip` annotation is not recognized by v0.15.2 — only `metallb.io/allow-shared-ip` is.

## Files Changed
- `apps/kube/mc/manifest/service.yaml` — annotation prefix update
- `apps/kube/ingress/manifests/values.yaml` — annotation prefix update

## Test plan
- [ ] After merge to main, verify ArgoCD syncs both `mc` and `ingress-nginx` apps
- [ ] Confirm `mc-service` gets external IP `142.132.206.74` assigned
- [ ] Confirm ArgoCD mc app transitions from `Progressing` to `Healthy`
- [ ] Verify ingress-nginx continues to work with the updated annotation