### PR TITLE
fix(kube): explicitly request shared IP for mc-service

### DIFF
--- a/apps/kube/mc/manifest/service.yaml
+++ b/apps/kube/mc/manifest/service.yaml
@@ -7,6 +7,7 @@ metadata:
         app: mc
     annotations:
         metallb.io/allow-shared-ip: 'shared-public-ip'
+        metallb.io/loadBalancerIPs: '142.132.206.74'
 spec:
     type: LoadBalancer
     externalTrafficPolicy: Local


### PR DESCRIPTION
## Summary
- Add `metallb.io/loadBalancerIPs:  annotation to `mc-service`

## Context
After #7286 (annotation prefix) and #7288 (externalTrafficPolicy), MetalLB still fails with `"no available IPs"`. The auto-assignment path doesn't re-evaluate sharing for an already-exhausted pool. Explicitly requesting the IP via `loadBalancerIPs` bypasses auto-assignment and directly invokes the sharing path.

## Test plan
- [ ] After merge, verify `mc-service` gets external IP 
- [ ] Confirm ArgoCD mc app transitions to `Healthy`