### PR TITLE
fix(kube): force MetalLB re-evaluation for mc-service IP allocation

### DIFF
--- a/apps/kube/mc/manifest/service.yaml
+++ b/apps/kube/mc/manifest/service.yaml
@@ -7,6 +7,7 @@ metadata:
         app: mc
     annotations:
         metallb.io/allow-shared-ip: 'shared-public-ip'
+        kbve.com/last-updated: '2026-02-25'
 spec:
     type: LoadBalancer
     externalTrafficPolicy: Local


### PR DESCRIPTION
## Summary
- Add `kbve.com/last-updated` annotation to `mc-service` to force ArgoCD to re-apply the service, triggering a fresh MetalLB reconciliation

## Context
After #7286 and #7288 fixed the annotation prefix and externalTrafficPolicy, MetalLB's controller still has the allocation failure cached. This annotation change creates a diff that forces ArgoCD to re-apply, which triggers MetalLB to re-evaluate with the corrected config.

## Test plan
- [ ] Verify `mc-service` gets external IP assigned after merge
- [ ] Confirm ArgoCD mc app becomes `Healthy`