### PR TITLE
fix(kube): annotate MetalLB IP pool to force controller re-evaluation

### DIFF
--- a/apps/kube/metallb/manifests/ip-pool.yaml
+++ b/apps/kube/metallb/manifests/ip-pool.yaml
@@ -1,14 +1,16 @@
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
-  name: public-ip-pool
-  namespace: metallb-system
+    name: public-ip-pool
+    namespace: metallb-system
+    annotations:
+        kbve.com/last-updated: '2026-02-25'
 spec:
-  addresses:
-    - 142.132.206.74/32
+    addresses:
+        - 142.132.206.74/32
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
-  name: public-l2
-  namespace: metallb-system
+    name: public-l2
+    namespace: metallb-system


### PR DESCRIPTION
## Summary
- Add `kbve.com/last-updated` annotation to the MetalLB `IPAddressPool` to force the controller to re-process all service allocations

## Context
After #7286 (annotation prefix) and #7288 (externalTrafficPolicy), MetalLB's controller still has the allocation failure cached. Modifying the IPAddressPool triggers a full re-evaluation of all LoadBalancer services against the corrected shared-ip config.

## Test plan
- [ ] Verify MetalLB re-evaluates and assigns `mc-service` a shared IP
- [ ] Confirm ArgoCD mc app becomes `Healthy`