### PR TITLE
fix(kube): route MC traffic through ingress-nginx TCP/UDP proxy

### DIFF
--- a/apps/kube/ingress/manifests/values.yaml
+++ b/apps/kube/ingress/manifests/values.yaml
@@ -88,5 +88,7 @@ defaultBackend:
 tcp:
     6667: 'irc/ergo-irc-service:6667'
     6697: 'irc/ergo-irc-service:6697'
+    25565: 'mc/mc-service:25565'
 
-udp: {}
+udp:
+    19132: 'mc/mc-service:19132'

--- a/apps/kube/mc/manifest/ingress.yaml
+++ b/apps/kube/mc/manifest/ingress.yaml
@@ -23,6 +23,6 @@ spec:
                     pathType: Prefix
                     backend:
                         service:
-                            name: mc-internal-service
+                            name: mc-service
                             port:
                                 number: 8080

--- a/apps/kube/mc/manifest/service.yaml
+++ b/apps/kube/mc/manifest/service.yaml
@@ -5,12 +5,8 @@ metadata:
     namespace: mc
     labels:
         app: mc
-    annotations:
-        metallb.io/allow-shared-ip: 'shared-public-ip'
-        kbve.com/last-updated: '2026-02-25'
 spec:
-    type: LoadBalancer
-    externalTrafficPolicy: Local
+    type: ClusterIP
     selector:
         app: mc
     ports:
@@ -22,19 +18,6 @@ spec:
           port: 19132
           targetPort: 19132
           protocol: UDP
----
-apiVersion: v1
-kind: Service
-metadata:
-    name: mc-internal-service
-    namespace: mc
-    labels:
-        app: mc
-spec:
-    type: ClusterIP
-    selector:
-        app: mc
-    ports:
         - name: resource-pack
           port: 8080
           targetPort: 8080

--- a/apps/kube/metallb/manifests/ip-pool.yaml
+++ b/apps/kube/metallb/manifests/ip-pool.yaml
@@ -3,8 +3,6 @@ kind: IPAddressPool
 metadata:
     name: public-ip-pool
     namespace: metallb-system
-    annotations:
-        kbve.com/last-updated: '2026-02-25'
 spec:
     addresses:
         - 142.132.206.74/32


### PR DESCRIPTION
## Summary
- Replace MC's LoadBalancer service with a single ClusterIP service
- Route game traffic (25565/TCP, 19132/UDP) through ingress-nginx's TCP/UDP proxy
- Same pattern already used for IRC (6667, 6697)

## Why
MetalLB cannot share an IP between services with different pod selectors when using `externalTrafficPolicy: Local`. This caused the persistent `"no available IPs"` allocation failure and ArgoCD `Progressing` loop.

## Changes
| File | Change |
|------|--------|
| `apps/kube/mc/manifest/service.yaml` | Merge two services into one ClusterIP, drop MetalLB annotations |
| `apps/kube/ingress/manifests/values.yaml` | Add `25565` TCP and `19132` UDP proxy entries |
| `apps/kube/mc/manifest/ingress.yaml` | Update backend ref from `mc-internal-service` to `mc-service` |
| `apps/kube/metallb/manifests/ip-pool.yaml` | Revert temporary annotation |

## Test plan
- [ ] After merge, verify ingress-nginx controller picks up ports 25565 and 19132
- [ ] Test Minecraft Java connectivity on `142.132.206.74:25565`
- [ ] Test Bedrock connectivity on `142.132.206.74:19132`
- [ ] Verify `mc.kbve.com` resource pack endpoint still works via ingress
- [ ] Confirm ArgoCD mc app becomes `Healthy`