### PR TITLE
fix(kube): use hostPort for MC game traffic instead of nginx proxy

### DIFF
--- a/apps/kube/ingress/manifests/values.yaml
+++ b/apps/kube/ingress/manifests/values.yaml
@@ -88,7 +88,5 @@ defaultBackend:
 tcp:
     6667: 'irc/ergo-irc-service:6667'
     6697: 'irc/ergo-irc-service:6697'
-    25565: 'mc/mc-service:25565'
 
-udp:
-    19132: 'mc/mc-service:19132'
+udp: {}

--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -31,9 +31,11 @@ spec:
                   ports:
                       - name: java
                         containerPort: 25565
+                        hostPort: 25565
                         protocol: TCP
                       - name: bedrock
                         containerPort: 19132
+                        hostPort: 19132
                         protocol: UDP
                       - name: resource-pack
                         containerPort: 8080


### PR DESCRIPTION
## Summary
- Add `hostPort` for Java (25565/TCP) and Bedrock (19132/UDP) on the MC deployment
- Remove MC ports from ingress-nginx TCP/UDP proxy config
- Resource pack (8080) and RCON (25575) remain internal via ClusterIP

## Why
The nginx TCP proxy causes stale connection detection — Pumpkin doesn't see client disconnects promptly, leaving ghost player sessions. `hostPort` binds game ports directly on the host, giving the pod clean unproxied TCP/UDP connections.

## Test plan
- [ ] After merge, verify `mc.kbve.com:25565` is reachable
- [ ] Test connect → disconnect → reconnect cycle (no "already connected" error)
- [ ] Verify resource pack still works via `https://mc.kbve.com`