### PR TITLE
fix(kube): set mc namespace PodSecurity to privileged for hostPort

### DIFF
--- a/apps/kube/mc/manifest/namespace.yaml
+++ b/apps/kube/mc/manifest/namespace.yaml
@@ -4,3 +4,4 @@ metadata:
     name: mc
     labels:
         name: mc
+        pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
## Summary
- Sets `pod-security.kubernetes.io/enforce: privileged` on the `mc` namespace to allow `hostPort` usage
- The MC pod is currently **DOWN** because `hostPort` in the deployment violates the default PodSecurity `baseline` policy
- This unblocks the pod from starting and restores direct game traffic on ports 25565/TCP and 19132/UDP

## Context
The nginx TCP/UDP proxy approach added latency to game traffic, making it unsuitable for Minecraft. Direct `hostPort` binding bypasses the proxy entirely but requires the namespace to allow privileged pod security.

## Test plan
- [ ] ArgoCD syncs the namespace label change
- [ ] MC pod starts successfully with hostPort
- [ ] Players can connect to mc.kbve.com:25565

🤖 Generated with [Claude Code](https://claude.com/claude-code)