### PR TITLE
fix(kube): correct mc PVC mount path to /pumpkin/world

### DIFF
--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                         protocol: TCP
                   volumeMounts:
                       - name: world-data
-                        mountPath: /pumpkin/worlds
+                        mountPath: /pumpkin/world
                       - name: mc-config
                         mountPath: /pumpkin/config/configuration.toml
                         subPath: configuration.toml


### PR DESCRIPTION
## Summary
- Fixes PVC volume mount path from `/pumpkin/worlds` to `/pumpkin/world` (no trailing **s**)
- Pumpkin writes world data to `/pumpkin/world/` but the mount pointed to `/pumpkin/worlds/`, causing all world data to be written to ephemeral container storage
- This resulted in world data being **lost on every pod restart** and terrain appearing sparse/empty

## Root cause
The Longhorn PVC was healthy and attached, but mounted at the wrong path. World region files, player data, and `level.dat` were all going to the container filesystem instead of persistent storage.

## Test plan
- [ ] Pod restarts with corrected mount path
- [ ] World data persists across pod restarts
- [ ] Terrain loads and generates properly for connecting players

🤖 Generated with [Claude Code](https://claude.com/claude-code)