### PR TITLE
feat(mc): enable world autosave and features.toml config

### DIFF
--- a/apps/kube/mc/manifest/configmap.yaml
+++ b/apps/kube/mc/manifest/configmap.yaml
@@ -32,3 +32,120 @@ data:
         allow_chat_reports = false
         white_list = false
         enforce_whitelist = false
+    features.toml: |
+        [logging]
+        enabled = true
+        threads = true
+        color = true
+        timestamp = true
+        file = "latest.log"
+
+        [resource_pack]
+        enabled = true
+        url = "https://mc.kbve.com/kbve-resource-pack.zip"
+        sha1 = "b9485038041b202b23d56dc04353f62278f7527a"
+        prompt_message = "KBVE Resource Pack - Custom items and textures"
+        force = true
+
+        [world]
+        lighting = "default"
+        autosave_ticks = 6000
+
+        [world.chunk]
+        type = "anvil"
+        write_in_place = false
+
+        [world.chunk.compression]
+        algorithm = "LZ4"
+        level = 6
+
+        [networking.authentication]
+        enabled = true
+        connect_timeout = 5000
+        read_timeout = 5000
+        prevent_proxy_connections = false
+
+        [networking.authentication.player_profile]
+        allow_banned_players = false
+        allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
+
+        [networking.authentication.textures]
+        enabled = true
+        allowed_url_schemes = ["http", "https"]
+        allowed_url_domains = [".minecraft.net", ".mojang.com"]
+
+        [networking.authentication.textures.types]
+        skin = true
+        cape = true
+        elytra = true
+
+        [networking.query]
+        enabled = true
+        address = "0.0.0.0:25565"
+
+        [networking.rcon]
+        enabled = true
+        address = "0.0.0.0:25575"
+        password = "kbve-rcon"
+        max_connections = 5
+
+        [networking.rcon.logging]
+        logged_successfully = true
+        wrong_password = true
+        commands = true
+        quit = true
+
+        [networking.proxy]
+        enabled = false
+
+        [networking.proxy.velocity]
+        enabled = false
+        secret = ""
+
+        [networking.proxy.bungeecord]
+        enabled = false
+
+        [networking.packet_compression]
+        enabled = true
+        threshold = 256
+        level = 4
+
+        [networking.lan_broadcast]
+        enabled = false
+
+        [commands]
+        use_console = true
+        use_tty = true
+        log_console = true
+        default_op_level = 0
+
+        [chat]
+        format = "<{DISPLAYNAME}> {MESSAGE}"
+
+        [pvp]
+        enabled = true
+        hurt_animation = true
+        protect_creative = true
+        knockback = true
+        swing = true
+
+        [server_links]
+        enabled = true
+        bug_report = "https://github.com/Pumpkin-MC/Pumpkin/issues"
+        support = ""
+        status = ""
+        feedback = ""
+        community = ""
+        website = ""
+        forums = ""
+        news = ""
+        announcements = ""
+
+        [server_links.custom]
+
+        [player_data]
+        save_player_data = true
+        save_player_cron_interval = 300
+
+        [fun]
+        april_fools = true

--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -50,6 +50,10 @@ spec:
                         mountPath: /pumpkin/config/configuration.toml
                         subPath: configuration.toml
                         readOnly: true
+                      - name: mc-config
+                        mountPath: /pumpkin/config/features.toml
+                        subPath: features.toml
+                        readOnly: true
                   resources:
                       requests:
                           memory: '512Mi'

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -69,7 +69,7 @@ RUN apk add --no-cache zip coreutils
 COPY ./data/resource-pack /resource-pack
 RUN cd /resource-pack && zip -r /kbve-resource-pack.zip . -x '.*' -x '__MACOSX/*'
 RUN SHA1=$(sha1sum /kbve-resource-pack.zip | awk '{print $1}') && \
-    printf '[resource_pack]\nenabled = true\nurl = "http://localhost:8080/kbve-resource-pack.zip"\nsha1 = "%s"\nforce = true\nprompt_message = "KBVE Resource Pack - Custom items and textures"\n\n[networking.rcon]\nenabled = true\naddress = "0.0.0.0:25575"\npassword = "kbve-rcon"\nmax_connections = 5\n' "$SHA1" > /features.toml
+    printf '[resource_pack]\nenabled = true\nurl = "http://localhost:8080/kbve-resource-pack.zip"\nsha1 = "%s"\nforce = true\nprompt_message = "KBVE Resource Pack - Custom items and textures"\n\n[world]\nlighting = "default"\nautosave_ticks = 6000\n\n[world.chunk]\ntype = "anvil"\nwrite_in_place = false\n\n[world.chunk.compression]\nalgorithm = "LZ4"\nlevel = 6\n\n[networking.rcon]\nenabled = true\naddress = "0.0.0.0:25575"\npassword = "kbve-rcon"\nmax_connections = 5\n' "$SHA1" > /features.toml
 
 # --- Final image ---
 FROM alpine:3.23


### PR DESCRIPTION
## Summary
- Extends Dockerfile `features.toml` generation to include `[world]` section with `autosave_ticks = 6000` (5 min at 20 TPS)
- Adds complete `features.toml` to K8s ConfigMap as a runtime override (no rebuild needed to tweak settings)
- Mounts `features.toml` from ConfigMap alongside `configuration.toml` in deployment

## Problem
Pumpkin's default `autosave_ticks = 0` means terrain chunks are generated in memory but never saved to disk. The `region/` directory stays empty, causing:
- Terrain regenerated from scratch on every player connection
- Slow/sparse terrain loading experience
- No world persistence across pod restarts

## Changes
- **Dockerfile**: Added `[world]`, `[world.chunk]`, `[world.chunk.compression]` sections to the `printf`-generated `features.toml`
- **ConfigMap**: Full `features.toml` with all sections for runtime overrides
- **Deployment**: Additional volumeMount for `features.toml`

## Test plan
- [ ] ConfigMap override takes effect immediately on pod restart
- [ ] `region/` directory populates with `.mca` files after 5 minutes
- [ ] Terrain persists across disconnects/reconnects
- [ ] Next Docker image build includes autosave in baked config

🤖 Generated with [Claude Code](https://claude.com/claude-code)