### PR TITLE
fix(kube): bypass entrypoint.sh for read-only ConfigMap mount

### DIFF
--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -25,9 +25,7 @@ spec:
                 - name: mc
                   image: ghcr.io/kbve/mc:0.1.1
                   imagePullPolicy: Always
-                  env:
-                      - name: RESOURCE_PACK_URL
-                        value: 'https://mc.kbve.com/kbve-resource-pack.zip'
+                  command: ['/bin/pumpkin']
                   ports:
                       - name: java
                         containerPort: 25565


### PR DESCRIPTION
## Summary
- Overrides the container command to run `/bin/pumpkin` directly, bypassing `entrypoint.sh`
- Removes the `RESOURCE_PACK_URL` env var (no longer needed since ConfigMap has the production URL)

## Problem
After merging #7296, the pod is crash-looping with:
```
sed: can't move '/pumpkin/config/features.tomlAOmPji' to '/pumpkin/config/features.toml': Resource busy
```
The `entrypoint.sh` runs `sed -i` on `features.toml` to substitute the resource pack URL, but `sed -i` can't write to a ConfigMap subPath mount (bind mount prevents rename).

## Fix
Since the ConfigMap already contains the production resource pack URL (`https://mc.kbve.com/kbve-resource-pack.zip`), the entrypoint substitution is unnecessary. Running pumpkin directly skips the failing sed.

## Test plan
- [ ] Pod starts without crash loop
- [ ] Features.toml is read correctly with autosave enabled
- [ ] Resource pack URL is correct in server config

🤖 Generated with [Claude Code](https://claude.com/claude-code)