### PR TITLE
perf(kube): bump mc CPU to 2 cores for terrain generation

### DIFF
--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -55,10 +55,10 @@ spec:
                   resources:
                       requests:
                           memory: '512Mi'
-                          cpu: '250m'
+                          cpu: '500m'
                       limits:
                           memory: '2Gi'
-                          cpu: '1000m'
+                          cpu: '2000m'
                   livenessProbe:
                       tcpSocket:
                           port: java


### PR DESCRIPTION
## Summary
- Bumps CPU limit from 1 core to 2 cores (`1000m` → `2000m`)
- Bumps CPU request from 250m to 500m

## Problem
Pumpkin's terrain chunk generation is CPU-bound. With a 1-core limit, initial terrain loading hangs on "loading terrain" for extended periods when generating new chunks.

## Test plan
- [ ] Pod restarts with new resource limits
- [ ] Initial terrain loads noticeably faster on connect
- [ ] No OOM or scheduling issues with the higher request

🤖 Generated with [Claude Code](https://claude.com/claude-code)