### PR TITLE
perf(kube): bump mc resources to 4 CPU cores and 4Gi memory

### DIFF
--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -54,11 +54,11 @@ spec:
                         readOnly: true
                   resources:
                       requests:
-                          memory: '512Mi'
-                          cpu: '500m'
+                          memory: '1Gi'
+                          cpu: '1000m'
                       limits:
-                          memory: '2Gi'
-                          cpu: '2000m'
+                          memory: '4Gi'
+                          cpu: '4000m'
                   livenessProbe:
                       tcpSocket:
                           port: java


### PR DESCRIPTION
Further increase resources for faster chunk generation and smoother terrain loading. Requests: 1 CPU / 1Gi RAM, Limits: 4 CPU / 4Gi RAM.