### PR TITLE
chore(mc): bump plugin to 0.1.2, version logging, debug mode

### DIFF
--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -26,6 +26,11 @@ spec:
                   image: ghcr.io/kbve/mc:0.1.1
                   imagePullPolicy: Always
                   command: ['/bin/pumpkin']
+                  env:
+                      - name: RUST_LOG
+                        value: 'debug'
+                      - name: RUST_BACKTRACE
+                        value: '1'
                   ports:
                       - name: java
                         containerPort: 25565

--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbve-mc-plugin"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.89"
 

--- a/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
+++ b/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
@@ -530,7 +530,8 @@ async fn serve_resource_pack() {
 impl KbveMcPlugin {
     #[pumpkin_api_macros::plugin_method]
     async fn on_load(&mut self, context: Arc<Context>) -> Result<(), String> {
-        eprintln!("[kbve-mc-plugin] on_load START");
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+        eprintln!("[kbve-mc-plugin] on_load START (v{VERSION})");
 
         // Register event handlers
         context


### PR DESCRIPTION
## Summary
- Bump kbve-mc-plugin version from 0.1.1 to 0.1.2
- Plugin startup log now shows actual version: `[kbve-mc-plugin] on_load START (v0.1.2)`
- Add `RUST_LOG=debug` and `RUST_BACKTRACE=1` env vars to K8s deployment for better failure visibility

## Test plan
- [ ] Verify plugin loads and logs show `v0.1.2`
- [ ] Check pod logs have debug-level output
- [ ] Confirm no regression in server startup