### PR TITLE
chore(discordsh): bump version to 0.1.10

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump `axum-discordsh` version from `0.1.9` to `0.1.10` to reflect the embed polish, dungeon crawler game upgrade, and membership lookup features merged in PR #7305.

## Test plan
- [x] `cargo test -p axum-discordsh` — 93 tests pass
- [x] `cargo build -p axum-discordsh` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)