### PR TITLE
feat(kube): restore rentearth to postgrest and gotrue

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -45,7 +45,7 @@ spec:
                       - name: GOTRUE_SITE_URL
                         value: 'https://kbve.com'
                       - name: GOTRUE_URI_ALLOW_LIST
-                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**'
+                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**'
                       - name: GOTRUE_DISABLE_SIGNUP
                         value: 'false'
 

--- a/apps/kube/postgrest/manifests/postgrest-deployment.yaml
+++ b/apps/kube/postgrest/manifests/postgrest-deployment.yaml
@@ -35,7 +35,7 @@ spec:
 
                       # PostgREST configuration
                       - name: PGRST_DB_SCHEMAS
-                        value: 'public,storage,graphql_public,tracker,profile'
+                        value: 'public,storage,graphql_public,tracker,profile,rentearth'
                       - name: PGRST_DB_ANON_ROLE
                         value: 'anon'
                       - name: PGRST_DB_USE_LEGACY_GUCS


### PR DESCRIPTION
## Summary
- Re-add `rentearth` schema to PostgREST `PGRST_DB_SCHEMAS` configuration
- Re-add `rentearth.com` and `*.rentearth.com` to GoTrue `GOTRUE_URI_ALLOW_LIST`
- These were removed in #7172 and now need to be restored

## Test plan
- [ ] Verify PostgREST can serve the `rentearth` schema tables after deployment
- [ ] Verify GoTrue accepts auth callbacks from `rentearth.com` origins