### PR TITLE
feat(kube): restore rentearth k8s deployment manifests

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -45,6 +45,7 @@ resources:
     - cityvote/application.yaml
     - herbmail/application.yaml
     - memes/application.yaml
+    - rentearth/application.yaml
     # GitHub Actions Runner Controller (ARC)
     # Consolidated: controller includes helm chart + sealed secret + RBAC
     # Consolidated: runners includes helm chart + ExternalSecret/SecretStore

--- a/apps/kube/rentearth/application.yaml
+++ b/apps/kube/rentearth/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: rentearth
+    namespace: argocd
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: HEAD
+        path: apps/kube/rentearth/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: rentearth
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - PrunePropagationPolicy=foreground
+            - PruneLast=true
+            - RespectIgnoreDifferences=true
+            - Replace=false

--- a/apps/kube/rentearth/manifest/kustomization.yaml
+++ b/apps/kube/rentearth/manifest/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rentearth
+
+resources:
+    - rentearth-serviceaccount.yaml
+    - rentearth-externalsecret.yaml
+    - rentearth-deployment.yaml
+    - nginx-ingress.yaml

--- a/apps/kube/rentearth/manifest/nginx-ingress.yaml
+++ b/apps/kube/rentearth/manifest/nginx-ingress.yaml
@@ -1,0 +1,141 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: rentearth-ingress
+    namespace: rentearth
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        nginx.ingress.kubernetes.io/websocket-services: rentearth-service
+        nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+        nginx.ingress.kubernetes.io/upstream-hash-by: '$http_upgrade'
+        nginx.ingress.kubernetes.io/proxy-pass-headers: 'Cross-Origin-Opener-Policy,Cross-Origin-Embedder-Policy,Cross-Origin-Resource-Policy'
+spec:
+    rules:
+        - host: rentearth.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: rentearth-service
+                            port:
+                                number: 4321
+        - host: www.rentearth.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: rentearth-service
+                            port:
+                                number: 4321
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: supabase-proxy
+    namespace: rentearth
+spec:
+    type: ExternalName
+    externalName: kong-kong-proxy.kilobase.svc.cluster.local
+    ports:
+        - port: 80
+          targetPort: 80
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: supabase-rentearth-ingress
+    namespace: rentearth
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        nginx.ingress.kubernetes.io/proxy-body-size: '10m'
+        nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
+        nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-buffer-size: '160k'
+        nginx.ingress.kubernetes.io/proxy-buffers-number: '64'
+        nginx.ingress.kubernetes.io/client-header-buffer-size: '160k'
+        nginx.ingress.kubernetes.io/large-client-header-buffers: '64 160k'
+        nginx.ingress.kubernetes.io/client-body-buffer-size: '160k'
+        nginx.ingress.kubernetes.io/enable-cors: 'true'
+        nginx.ingress.kubernetes.io/cors-allow-origin: 'https://rentearth.com,https://*.rentearth.com,http://localhost:4321,http://localhost:3000'
+        nginx.ingress.kubernetes.io/cors-allow-methods: 'GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD'
+        nginx.ingress.kubernetes.io/cors-allow-headers: 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,apikey,x-client-info,x-supabase-api-version,Accept,Accept-Profile,Accept-Version'
+        nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+        nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+        nginx.ingress.kubernetes.io/upstream-hash-by: '$http_upgrade'
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: '3600'
+        nginx.ingress.kubernetes.io/upstream-vhost: 'supabase.kbve.com'
+        nginx.ingress.kubernetes.io/proxy-set-headers: 'rentearth/supabase-proxy-headers'
+spec:
+    rules:
+        - host: supabase.rentearth.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: supabase-proxy
+                            port:
+                                number: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: supabase-proxy-headers
+    namespace: rentearth
+data:
+    Host: 'supabase.kbve.com'
+    X-Forwarded-Host: 'supabase.rentearth.com'
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: irc-proxy
+    namespace: rentearth
+spec:
+    type: ExternalName
+    externalName: ergo-irc-service.irc.svc.cluster.local
+    ports:
+        - port: 8067
+          targetPort: 8067
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: irc-rentearth-ingress
+    namespace: rentearth
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+        nginx.ingress.kubernetes.io/upstream-hash-by: '$http_upgrade'
+        nginx.ingress.kubernetes.io/websocket-services: irc-proxy
+        nginx.ingress.kubernetes.io/enable-cors: 'true'
+        nginx.ingress.kubernetes.io/cors-allow-origin: 'https://rentearth.com,https://*.rentearth.com,http://localhost:4321,http://localhost:3000'
+        nginx.ingress.kubernetes.io/cors-allow-methods: 'GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD'
+        nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+spec:
+    rules:
+        - host: irc.rentearth.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: irc-proxy
+                            port:
+                                number: 8067

--- a/apps/kube/rentearth/manifest/rentearth-deployment.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: rentearth-deployment
+    namespace: rentearth
+    labels:
+        app: rentearth
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: rentearth
+    template:
+        metadata:
+            annotations:
+                rollout-restart: '2026-01-12T02:11:58Z'
+            labels:
+                app: rentearth
+                version: '1.0.18'
+        spec:
+            containers:
+                - name: rentearth
+                  image: ghcr.io/kbve/rentearth:1.0.18
+                  imagePullPolicy: Always
+                  ports:
+                      - containerPort: 4321
+                        protocol: TCP
+                  env:
+                      - name: PORT
+                        value: '4321'
+                      - name: SUPABASE_URL
+                        value: 'http://kong.kilobase.svc.cluster.local:8000'
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: anon-key
+                      - name: SUPABASE_SERVICE_ROLE_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: service-role-key
+                      # IRC configuration - connects to Ergo IRC server in cluster
+                      - name: IRC_ENABLED
+                        value: 'true'
+                      - name: IRC_SERVER
+                        value: 'ergo-irc-service.irc.svc.cluster.local'
+                      - name: IRC_NICKNAME
+                        value: 'RentEarthBot'
+                      - name: IRC_CHANNEL
+                        value: '#general'
+                  resources:
+                      requests:
+                          memory: '512Mi'
+                          cpu: '2000m'
+                      limits:
+                          memory: '1024Mi'
+                          cpu: '4000m'
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: rentearth-service
+    namespace: rentearth
+    labels:
+        app: rentearth
+spec:
+    type: ClusterIP
+    selector:
+        app: rentearth
+    ports:
+        - port: 4321
+          targetPort: 4321
+          protocol: TCP

--- a/apps/kube/rentearth/manifest/rentearth-externalsecret.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-externalsecret.yaml
@@ -1,0 +1,58 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-remote-secret-store
+    namespace: rentearth
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: rentearth-external-secrets
+                    namespace: rentearth
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: rentearth-supabase-secrets
+    namespace: rentearth
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                jwt-secret: '{{ .jwtsecret }}'
+                anon-key: '{{ .anonkey }}'
+                service-role-key: '{{ .servicekey }}'
+                db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
+    data:
+        - secretKey: jwtsecret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-jwt
+              property: service-key
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password

--- a/apps/kube/rentearth/manifest/rentearth-serviceaccount.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: rentearth-external-secrets
+    namespace: rentearth


### PR DESCRIPTION
## Summary
- Restore all 6 rentearth kube manifests removed in #7172 (1:1 copy from `trunk/pre-astro-migration`)
- Add `rentearth/application.yaml` back to root `kustomization.yaml`
- Files restored: ArgoCD application, kustomization, nginx ingress (3 ingresses + supabase proxy + IRC proxy), deployment + service, external secrets, service account

## Test plan
- [ ] Verify ArgoCD picks up the rentearth application after merge
- [ ] Confirm rentearth namespace is created and pods deploy
- [ ] Validate ingress routes for rentearth.com, supabase.rentearth.com, and irc.rentearth.com