### PR TITLE
fix(ci): remove invalid continue-on-error from reusable workflow calls

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -174,7 +174,6 @@ jobs:
         if: ${{ needs.generate_npm_matrix.outputs.matrix != 'null' }}
         permissions:
             contents: read
-        continue-on-error: true
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.generate_npm_matrix.outputs.matrix) }}
@@ -256,7 +255,6 @@ jobs:
         if: ${{ needs.generate_crates_matrix.outputs.matrix != 'null' }}
         permissions:
             contents: read
-        continue-on-error: true
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.generate_crates_matrix.outputs.matrix) }}
@@ -346,7 +344,6 @@ jobs:
         if: ${{ needs.generate_e2e_docker_matrix.outputs.matrix != 'null' }}
         permissions:
             contents: read
-        continue-on-error: true
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.generate_e2e_docker_matrix.outputs.matrix) }}
@@ -575,7 +572,6 @@ jobs:
         if: ${{ needs.generate_python_matrix.outputs.matrix != 'null' }}
         permissions:
             contents: read
-        continue-on-error: true
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.generate_python_matrix.outputs.matrix) }}


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from 4 reusable workflow call jobs (`test_npm`, `test_crates`, `test_docker`, `test_python`)
- This property is not supported on job-level `uses:` (reusable workflow calls) — GitHub Actions requires `runs-on` for jobs with `continue-on-error`
- The `always()` guards on collector jobs already ensure they run regardless of upstream test failures, making `continue-on-error` redundant

## Test plan
- [ ] Verify workflow file passes GitHub Actions validation (no more schema errors)
- [ ] Confirm collector jobs still run when a test job fails (via `always()` guard)
- [ ] Confirm passing projects still publish while failing ones are blocked