### PR TITLE
chore(discordsh,mc): bump versions to retrigger builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "askama",
@@ -2463,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 publish = false
 

--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbve-mc-plugin"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.89"
 


### PR DESCRIPTION
## Summary
- Bump `axum-discordsh` 0.1.10 → 0.1.11
- Bump `kbve-mc-plugin` 0.1.2 → 0.1.3
- Retrigger Docker builds for discordsh and mc after CI pipeline fix

## Test plan
- [ ] CI detects file alterations for discordsh and mc
- [ ] Docker e2e tests run for both projects
- [ ] Docker images publish and kube manifests update