### PR TITLE
fix(kube): grant rentearth and mc cross-namespace access to kilobase secrets

### DIFF
--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -53,6 +53,12 @@ subjects:
     - kind: ServiceAccount
       name: irc-gateway-external-secrets
       namespace: irc
+    - kind: ServiceAccount
+      name: rentearth-external-secrets
+      namespace: rentearth
+    - kind: ServiceAccount
+      name: mc-external-secrets
+      namespace: mc
 ---
 # Additional role for reading services/endpoints if needed
 apiVersion: rbac.authorization.k8s.io/v1

--- a/apps/kube/mc/manifest/mc-externalsecret.yaml
+++ b/apps/kube/mc/manifest/mc-externalsecret.yaml
@@ -1,0 +1,58 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-remote-secret-store
+    namespace: mc
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: mc-external-secrets
+                    namespace: mc
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: mc-supabase-secrets
+    namespace: mc
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                jwt-secret: '{{ .jwtsecret }}'
+                anon-key: '{{ .anonkey }}'
+                service-role-key: '{{ .servicekey }}'
+                db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
+    data:
+        - secretKey: jwtsecret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-jwt
+              property: service-key
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password

--- a/apps/kube/mc/manifest/mc-serviceaccount.yaml
+++ b/apps/kube/mc/manifest/mc-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: mc-external-secrets
+    namespace: mc


### PR DESCRIPTION
## Summary
- Add `rentearth-external-secrets` ServiceAccount to kilobase secrets-reader RoleBinding
- Add `mc-external-secrets` ServiceAccount to kilobase secrets-reader RoleBinding
- Create mc ExternalSecret infrastructure (ServiceAccount, SecretStore, ExternalSecret) to pull supabase credentials into the mc namespace

## Test plan
- [ ] ArgoCD syncs kilobase RBAC with new subjects
- [ ] Rentearth ExternalSecret resolves and creates `supabase-shared` secret in rentearth namespace
- [ ] MC ExternalSecret resolves and creates `supabase-shared` secret in mc namespace