### PR TITLE
refactor(mc): extract item registry macros

### DIFF
--- a/apps/mc/plugins/kbve-mc-plugin/src/macros.rs
+++ b/apps/mc/plugins/kbve-mc-plugin/src/macros.rs
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------
+// ins_item! — insert a single ItemDef into a DashMap with optional fields
+// ---------------------------------------------------------------------------
+
+macro_rules! ins_item {
+    ($map:expr, $key:literal, {
+        base: $base:literal,
+        model: $model:literal,
+        name: $name:literal,
+        color: $color:expr
+        $(, particle: ($particle:expr, $count:expr))?
+        $(, max_damage: $max_damage:expr)?
+        $(, potion: { color: $potion_color:expr, effects: $effects:expr })?
+        $(,)?
+    }) => {{
+        $map.insert(
+            $key,
+            $crate::ItemDef {
+                base_item_key: $base,
+                model: $model,
+                display_name: $name,
+                message_color: $color,
+                particle: ins_item!(@opt_particle $(($particle, $count))?),
+                max_damage: ins_item!(@opt_val $($max_damage)?),
+                potion: ins_item!(@opt_potion $(($potion_color, $effects))?),
+            },
+        );
+    }};
+
+    // Internal helpers for optional fields
+    (@opt_particle ($particle:expr, $count:expr)) => { Some(($particle, $count)) };
+    (@opt_particle) => { None };
+
+    (@opt_val $v:expr) => { Some($v) };
+    (@opt_val) => { None };
+
+    (@opt_potion ($color:expr, $effects:expr)) => {
+        Some($crate::PotionEffects { custom_color: $color, effects: $effects })
+    };
+    (@opt_potion) => { None };
+}
+
+// ---------------------------------------------------------------------------
+// item_registry! — define all items in a single compact block
+// ---------------------------------------------------------------------------
+
+macro_rules! item_registry {
+    ($map:expr; $(
+        $key:literal => {
+            base: $base:literal,
+            model: $model:literal,
+            name: $name:literal,
+            color: $color:expr
+            $(, particle: ($particle:expr, $count:expr))?
+            $(, max_damage: $max_damage:expr)?
+            $(, potion: { color: $potion_color:expr, effects: $effects:expr })?
+            $(,)?
+        }
+    ),* $(,)?) => {{
+        $(
+            ins_item!($map, $key, {
+                base: $base,
+                model: $model,
+                name: $name,
+                color: $color
+                $(, particle: ($particle, $count))?
+                $(, max_damage: $max_damage)?
+                $(, potion: { color: $potion_color, effects: $effects })?
+            });
+        )*
+    }};
+}


### PR DESCRIPTION
## Summary
- Adds `ins_item!` and `item_registry!` macros in new `macros.rs` module
- Converts all 20 `map.insert()` item definitions to use the macro DSL
- Net reduction of ~120 lines; each item is now 4-8 lines instead of 12-16
- Zero behavior change — same items, same fields, same compile output

## Test plan
- [x] `cargo check` passes clean (zero errors, zero warnings on plugin crate)
- [x] `rustfmt --check` passes (lint-staged hook)
- [ ] Docker dev build succeeds
- [ ] Items still appear in-game via `/kbve give`

🤖 Generated with [Claude Code](https://claude.com/claude-code)