### PR TITLE
feat(mc): add stop-dev, restart-dev nx targets

### DIFF
--- a/apps/mc/project.json
+++ b/apps/mc/project.json
@@ -130,7 +130,25 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"mkdir -p apps/mc/logs apps/mc/world && docker run --rm -p 25565:25565 -p 8080:8080 -p 25575:25575 -v $PWD/apps/mc/logs:/pumpkin/logs -v $PWD/apps/mc/world:/pumpkin/world kbve/mc:dev"
+					"docker rm -f kbve-mc-dev 2>/dev/null; mkdir -p apps/mc/logs apps/mc/world && docker run -d --name kbve-mc-dev -p 25565:25565 -p 8080:8080 -p 25575:25575 -e KBVE_TRACE=${KBVE_TRACE:-1} -v $PWD/apps/mc/logs:/pumpkin/logs -v $PWD/apps/mc/world:/pumpkin/world kbve/mc:dev && echo 'Started kbve-mc-dev (detached). Logs: nx stop-dev to stop.'"
+				],
+				"parallel": false
+			}
+		},
+		"stop-dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"docker stop kbve-mc-dev 2>/dev/null && docker rm kbve-mc-dev 2>/dev/null && echo 'Stopped kbve-mc-dev' || echo 'kbve-mc-dev is not running'"
+				],
+				"parallel": false
+			}
+		},
+		"restart-dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"nx stop-dev mc --no-cloud && nx run-dev mc --no-cloud"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
## Summary
- **`run-dev`**: Now uses a named container (`kbve-mc-dev`) in detached mode with world + logs volume mounts and configurable `KBVE_TRACE` level (defaults to 1/DEBUG)
- **`stop-dev`**: Stops and removes the `kbve-mc-dev` container
- **`restart-dev`**: Chains `stop-dev` → `run-dev` for quick iteration cycles
- Added `world/` to `.gitignore` for persistent world data between restarts

### Usage
```bash
# Build the dev image
nx container-dev mc

# Start (detached, named container)
nx run-dev mc

# Check logs
docker logs -f kbve-mc-dev

# Stop
nx stop-dev mc

# Quick restart (stop + start)
nx restart-dev mc

# Override trace level (0=INFO, 1=DEBUG, 2=TRACE)
KBVE_TRACE=2 nx run-dev mc
```

## Test plan
- [ ] `nx run-dev mc` starts a detached named container
- [ ] `nx stop-dev mc` stops it cleanly
- [ ] `nx restart-dev mc` cycles stop → start
- [ ] World data persists in `apps/mc/world/` across restarts
- [ ] Logs persist in `apps/mc/logs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)