### PR TITLE
ci: rename atomic-branch label to atomic

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -262,7 +262,7 @@ jobs:
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           issue_number: pr.data.number,
-                          labels: ['atomic-branch', 'auto-pr']
+                          labels: ['atomic', 'auto-pr']
                         });
 
                         console.log(`Created PR #${pr.data.number}: ${pr.data.html_url}`);

--- a/.github/workflows/utils-update-kube-manifest.yml
+++ b/.github/workflows/utils-update-kube-manifest.yml
@@ -137,4 +137,4 @@ jobs:
                     --head "$BRANCH_NAME" \
                     --title "Atomic: kube ${APP_NAME} v${NEW_VER}" \
                     --body-file /tmp/pr-body.md \
-                    --label "atomic-branch,auto-pr"
+                    --label "atomic,auto-pr"


### PR DESCRIPTION
## Summary
- Renames `atomic-branch` label to `atomic` in `ci-atom.yml` and `utils-update-kube-manifest.yml`
- Label already renamed on GitHub, duplicate `atom-branch` deleted
- Also cleaned up unused `development` and `production` labels

## Test plan
- [ ] Verify atomic PRs created by `ci-atom.yml` get the `atomic` label
- [ ] Verify kube manifest PRs get the `atomic` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)