### PR TITLE
fix(discordsh): load system fonts as fallback for SVG text rendering

### DIFF
--- a/apps/discordsh/axum-discordsh/src/state.rs
+++ b/apps/discordsh/axum-discordsh/src/state.rs
@@ -60,14 +60,21 @@ pub struct AppState {
 impl AppState {
     pub fn new(health_monitor: Arc<HealthMonitor>, tracker: Option<ShardTracker>) -> Self {
         let mut fontdb = FontDb::new();
+
+        // Load system fonts first as baseline fallback (sans-serif, etc.)
+        fontdb.load_system_fonts();
+
+        // Load custom game font on top
         let font_path = std::env::var("FONT_PATH").unwrap_or_else(|_| "alagard.ttf".to_owned());
         if let Err(e) = fontdb.load_font_file(&font_path) {
             tracing::warn!(
                 error = %e,
                 path = %font_path,
-                "Failed to load game font; SVG text may render incorrectly"
+                "Failed to load game font; falling back to system fonts"
             );
         }
+
+        tracing::info!(fonts = fontdb.len(), "Font database initialized");
 
         Self {
             health_monitor,

--- a/packages/rust/kbve/src/entity/images/renderer.rs
+++ b/packages/rust/kbve/src/entity/images/renderer.rs
@@ -53,6 +53,16 @@ impl FontDb {
         }
     }
 
+    /// Return the number of loaded font faces.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Return `true` if no fonts are loaded.
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+
     /// Access the inner font database arc for embedding into Options.
     pub fn database_arc(&self) -> Arc<usvg::fontdb::Database> {
         self.inner.clone()


### PR DESCRIPTION
## Summary
- When the custom `alagard.ttf` font file is missing, the `FontDb` was completely empty, causing resvg to silently skip all `<text>` SVG elements — cards rendered shapes/colors but no text
- Now loads system fonts as a baseline fallback **before** attempting the custom font, so `font-family="Alagard, sans-serif"` falls through to a real sans-serif font
- Adds `FontDb::len()` / `is_empty()` methods and startup log showing font count for easier debugging

## Test plan
- [ ] Cards render with text when `alagard.ttf` is present (custom font)
- [ ] Cards render with text when `alagard.ttf` is missing (system font fallback)
- [ ] Startup logs show `Font database initialized` with font count

🤖 Generated with [Claude Code](https://claude.com/claude-code)