### PR TITLE
fix(mc): use Docker-baked features.toml for resource pack SHA1

### DIFF
--- a/apps/kube/mc/manifest/deployment.yaml
+++ b/apps/kube/mc/manifest/deployment.yaml
@@ -25,12 +25,13 @@ spec:
                 - name: mc
                   image: ghcr.io/kbve/mc:0.1.4
                   imagePullPolicy: Always
-                  command: ['/bin/pumpkin']
                   env:
                       - name: RUST_LOG
                         value: 'debug'
                       - name: RUST_BACKTRACE
                         value: '1'
+                      - name: RESOURCE_PACK_URL
+                        value: 'https://mc.kbve.com/kbve-resource-pack.zip'
                   ports:
                       - name: java
                         containerPort: 25565
@@ -52,10 +53,6 @@ spec:
                       - name: mc-config
                         mountPath: /pumpkin/config/configuration.toml
                         subPath: configuration.toml
-                        readOnly: true
-                      - name: mc-config
-                        mountPath: /pumpkin/config/features.toml
-                        subPath: features.toml
                         readOnly: true
                   resources:
                       requests:


### PR DESCRIPTION
## Summary
- Remove features.toml ConfigMap mount — it had a hardcoded stale SHA1 that caused missing textures (purple/black blocks) when the resource pack changed
- Remove `command: ['/bin/pumpkin']` override so the Dockerfile's entrypoint runs and templates `RESOURCE_PACK_URL` into the Docker-baked features.toml
- Add `RESOURCE_PACK_URL` env var (`https://mc.kbve.com/kbve-resource-pack.zip`)
- SHA1 is now always correct because it's computed at Docker build time from the actual zip file

## Test plan
- [ ] Deploy and verify resource pack loads (no purple/black textures)
- [ ] Verify custom item models render correctly
- [ ] Verify configuration.toml still applied from ConfigMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)