### PR TITLE
fix(mc): prevent item duplication on player rejoin

### DIFF
--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.lock
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.lock
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "kbve-mc-plugin"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "axum",
  "dashmap",

--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbve-mc-plugin"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.89"
 


### PR DESCRIPTION
## Summary
- Scan player inventory for existing custom item models (by `ItemModel` data component) before auto-giving on join
- Skip items already present in inventory — prevents duplication on rejoin
- Overflow items are no longer dropped on ground (prevents entity spam that was causing slow ticks)
- Bumps kbve-mc-plugin to v0.1.5

## Test plan
- [ ] Join server with empty inventory — should receive all 20 custom items
- [ ] Disconnect and rejoin — should receive 0 items (all already present)
- [ ] Consume a potion and rejoin — should receive only that one potion back
- [ ] Join with full inventory — items that don't fit are silently skipped (no ground drops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)