### PR TITLE
chore(discordsh): bump dashmap from 6 to 6.1

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -32,7 +32,7 @@ serenity = { version = "0.12.5", default-features = false, features = ["client",
 poise = "0.6.1"
 sysinfo = "0.38.2"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
-dashmap = "6"
+dashmap = "6.1"
 uuid = { version = "1", features = ["v4"] }
 rand = "0.8"
 


### PR DESCRIPTION
## Summary
- Bumps `dashmap` dependency from `6` to `6.1` in `axum-discordsh`

## Test plan
- [x] `cargo build` compiles with `dashmap v6.1.0`
- [x] `nx run axum-discordsh:test` — 104 passed, 0 failed