### PR TITLE
chore(discordsh): bump axum to 0.8.8 and axum-extra to 0.12.5

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -22,8 +22,8 @@ tower-http = { version = "0.6.8", features = [
 tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-axum = { version = "0.8.5", features = ["ws", "macros"] }
-axum-extra = { version = "0.12.1", features = ["cookie"] }
+axum = { version = "0.8.8", features = ["ws", "macros"] }
+axum-extra = { version = "0.12.5", features = ["cookie"] }
 askama = "0.15.4"
 socket2 = "0.6.1"
 num_cpus = "1.17.0"


### PR DESCRIPTION
## Summary
- Bumps `axum` from `0.8.5` to `0.8.8`
- Bumps `axum-extra` from `0.12.1` to `0.12.5`

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `nx run axum-discordsh:test` — 104 passed, 0 failed