### PR TITLE
feat(data): add meme.sh SQL schema for Supabase

### DIFF
--- a/packages/data/sql/schema/meme/meme_cards.sql
+++ b/packages/data/sql/schema/meme/meme_cards.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS meme.meme_card_stats (
 
     -- JSONB array of CardAbility objects
     abilities       JSONB NOT NULL DEFAULT '[]'::jsonb,
-    flavor_text     TEXT,
+    flavor_text     TEXT CHECK (flavor_text IS NULL OR (char_length(flavor_text) <= 300 AND meme.is_safe_text(flavor_text))),
 
     -- Evolution / leveling
     level           INTEGER NOT NULL DEFAULT 1 CHECK (level BETWEEN 1 AND 100),
@@ -81,7 +81,7 @@ GRANT SELECT ON meme.meme_card_stats TO anon, authenticated;
 CREATE TABLE IF NOT EXISTS meme.meme_decks (
     id          TEXT PRIMARY KEY DEFAULT gen_ulid(),
     owner_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-    name        TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 50),
+    name        TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 50 AND meme.is_safe_text(name)),
     is_active   BOOLEAN NOT NULL DEFAULT false,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at  TIMESTAMPTZ
@@ -201,7 +201,7 @@ CREATE TABLE IF NOT EXISTS meme.meme_player_stats (
     elo_rating      INTEGER NOT NULL DEFAULT 1000,
     cards_owned     INTEGER NOT NULL DEFAULT 0 CHECK (cards_owned >= 0),
     highest_streak  INTEGER NOT NULL DEFAULT 0 CHECK (highest_streak >= 0),
-    rank_title      TEXT
+    rank_title      TEXT CHECK (rank_title IS NULL OR (char_length(rank_title) <= 50 AND meme.is_safe_text(rank_title)))
 );
 
 COMMENT ON TABLE meme.meme_player_stats IS 'Card game player statistics and ELO ratings';

--- a/packages/data/sql/schema/meme/meme_engagement.sql
+++ b/packages/data/sql/schema/meme/meme_engagement.sql
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS meme.meme_comments (
     id              TEXT PRIMARY KEY DEFAULT gen_ulid(),
     meme_id         TEXT NOT NULL REFERENCES meme.memes(id) ON DELETE CASCADE,
     author_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-    body            TEXT NOT NULL CHECK (char_length(body) BETWEEN 1 AND 500),
+    body            TEXT NOT NULL CHECK (char_length(body) BETWEEN 1 AND 500 AND meme.is_safe_text(body)),
     parent_id       TEXT REFERENCES meme.meme_comments(id) ON DELETE CASCADE,
     reaction_count  BIGINT NOT NULL DEFAULT 0 CHECK (reaction_count >= 0),
     reply_count     INTEGER NOT NULL DEFAULT 0 CHECK (reply_count >= 0),

--- a/packages/data/sql/schema/meme/meme_moderation.sql
+++ b/packages/data/sql/schema/meme/meme_moderation.sql
@@ -18,11 +18,11 @@ CREATE TABLE IF NOT EXISTS meme.meme_reports (
 
     -- ReportReason enum (1-7)
     reason          SMALLINT NOT NULL CHECK (reason BETWEEN 1 AND 7),
-    detail          TEXT,
+    detail          TEXT CHECK (detail IS NULL OR (char_length(detail) <= 2000 AND meme.is_safe_text(detail))),
 
     resolved        BOOLEAN NOT NULL DEFAULT false,
     resolved_by     UUID REFERENCES auth.users(id) ON DELETE SET NULL,
-    resolution_note TEXT,
+    resolution_note TEXT CHECK (resolution_note IS NULL OR (char_length(resolution_note) <= 2000 AND meme.is_safe_text(resolution_note))),
 
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     resolved_at     TIMESTAMPTZ

--- a/packages/data/sql/schema/meme/meme_social.sql
+++ b/packages/data/sql/schema/meme/meme_social.sql
@@ -13,9 +13,9 @@ BEGIN;
 
 CREATE TABLE IF NOT EXISTS meme.meme_user_profiles (
     user_id                     UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
-    display_name                TEXT,
-    avatar_url                  TEXT,
-    bio                         TEXT CHECK (bio IS NULL OR char_length(bio) <= 500),
+    display_name                TEXT CHECK (display_name IS NULL OR (char_length(display_name) BETWEEN 1 AND 50 AND meme.is_safe_text(display_name))),
+    avatar_url                  TEXT CHECK (meme.is_safe_url(avatar_url)),
+    bio                         TEXT CHECK (bio IS NULL OR (char_length(bio) <= 500 AND meme.is_safe_text(bio))),
 
     -- Aggregate stats (denormalized)
     total_memes                 BIGINT NOT NULL DEFAULT 0 CHECK (total_memes >= 0),
@@ -148,8 +148,8 @@ GRANT SELECT, INSERT, DELETE ON meme.meme_follows TO authenticated;
 CREATE TABLE IF NOT EXISTS meme.meme_collections (
     id              TEXT PRIMARY KEY DEFAULT gen_ulid(),
     owner_id        UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-    name            TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 100),
-    description     TEXT,
+    name            TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 100 AND meme.is_safe_text(name)),
+    description     TEXT CHECK (description IS NULL OR (char_length(description) <= 1000 AND meme.is_safe_text(description))),
     cover_meme_id   TEXT REFERENCES meme.memes(id) ON DELETE SET NULL,
     is_public       BOOLEAN NOT NULL DEFAULT false,
     meme_count      INTEGER NOT NULL DEFAULT 0 CHECK (meme_count >= 0),


### PR DESCRIPTION
## Summary
- Adds 14 PostgreSQL tables across 5 SQL migration files under `packages/data/sql/schema/meme/`, mapping 1:1 to the `meme.proto` schema merged in #7373
- **meme_core.sql**: Schema setup, shared `update_updated_at_column()` trigger, `meme_templates` (reusable base images with caption slots), `memes` (core entity with feed-optimized partial indexes)
- **meme_engagement.sql**: `meme_reactions` (one per user per meme, 6 types), `meme_comments` (threaded with reply_count), counter triggers for denormalized counts
- **meme_social.sql**: `meme_user_profiles` (aggregated stats), `meme_follows` (social graph with counter triggers), `meme_collections` (curated folders), `meme_saves` (bookmarks with COALESCE unique index for nullable collection_id)
- **meme_moderation.sql**: `meme_reports` (content reports with one-open-per-user-per-meme constraint, moderation queue index)
- **meme_cards.sql**: `meme_card_stats` (battle stats for minted memes), `meme_decks` (one active per player), `meme_deck_cards` (join table), `meme_player_stats` (ELO leaderboard), `battle_results` (match records with JSONB replay log)

All tables include RLS policies (`service_role_full_access`, scoped anon/authenticated access), verification DO blocks, and follow existing conventions from `tracker.sql` and `username.sql`.

## Test plan
- [ ] Review SQL syntax and verify all FK references are correct
- [ ] Run each file in order against a Supabase instance (meme_core first, then the rest in any order)
- [ ] Verify RLS policies by testing as anon, authenticated, and service_role
- [ ] Confirm counter triggers fire correctly on INSERT/DELETE
- [ ] Validate verification DO blocks pass without exceptions