### PR TITLE
fix(data): harden mc.auth with bcrypt, TTL, lockout, unlink

### DIFF
--- a/packages/data/sql/schema/mc/mc_auth.sql
+++ b/packages/data/sql/schema/mc/mc_auth.sql
@@ -3,11 +3,18 @@
 -- with in-game verification code flow.
 --
 -- Flow:
---   1. Authenticated user calls proxy_request_mc_link(mc_uuid)
---   2. System generates a 6-digit verification code, inserts pending row
+--   1. Authenticated user calls proxy_request_link(mc_uuid)
+--   2. System generates a 6-digit code, stores bcrypt hash, returns plaintext
 --   3. Player joins the MC server and enters /verify <code>
---   4. MC server (service_role) calls service_verify_mc_link(mc_uuid, code)
---   5. On match: status is flipped to VERIFIED, code is cleared
+--   4. MC server (service_role) calls service_verify_link(mc_uuid, code)
+--   5. On match: status is flipped to VERIFIED, hash is cleared
+--
+-- Security:
+--   - Verification codes are bcrypt-hashed (pgcrypto), never stored plaintext
+--   - 10-minute code TTL (code_expires_at)
+--   - Max 5 attempts per code; 15-minute lockout after exceeded (locked_until)
+--   - Verified links cannot be overwritten; must explicitly unlink first
+--   - Advisory locks serialize concurrent requests per mc_uuid
 --
 -- Status bitflags:
 --   0x0000  UNVERIFIED (pending)
@@ -17,6 +24,9 @@
 -- ============================================================
 
 BEGIN;
+
+-- pgcrypto for bcrypt hashing of verification codes
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- ===========================================
 -- SCHEMA
@@ -50,15 +60,21 @@ CREATE TABLE IF NOT EXISTS mc.auth (
         REFERENCES auth.users(id)
         ON DELETE CASCADE,
 
-    -- Minecraft UUID (dashed or undashed, stored undashed lowercase 32 hex chars)
+    -- Minecraft UUID (stored undashed lowercase 32 hex chars)
     mc_uuid TEXT NOT NULL,
 
     -- Bitwise status flags (see header)
     status INTEGER NOT NULL DEFAULT 0,
 
-    -- Verification code: 0 = no pending verification / already verified
-    -- Non-zero 6-digit integer = pending in-game verification
-    verification_code INTEGER NOT NULL DEFAULT 0,
+    -- Bcrypt hash of the 6-digit verification code (NULL = no pending verification)
+    verification_code_hash TEXT,
+
+    -- Code TTL: code is invalid after this timestamp
+    code_expires_at TIMESTAMPTZ,
+
+    -- Brute-force protection
+    verify_attempts INTEGER NOT NULL DEFAULT 0,
+    locked_until TIMESTAMPTZ,
 
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -67,9 +83,13 @@ CREATE TABLE IF NOT EXISTS mc.auth (
     CONSTRAINT mc_uuid_format_chk
         CHECK (mc_uuid ~ '^[a-f0-9]{32}$'),
 
-    -- Verification code is either 0 (none) or a 6-digit number
-    CONSTRAINT verification_code_range_chk
-        CHECK (verification_code = 0 OR verification_code BETWEEN 100000 AND 999999)
+    -- If there's a hash, there must be an expiry
+    CONSTRAINT code_expires_chk
+        CHECK (verification_code_hash IS NULL OR code_expires_at IS NOT NULL),
+
+    -- Attempts counter must be non-negative
+    CONSTRAINT verify_attempts_chk
+        CHECK (verify_attempts >= 0)
 );
 
 -- One MC UUID can only be linked to one Supabase user
@@ -79,7 +99,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_auth_mc_uuid
 -- Fast lookup of pending verifications by MC UUID
 CREATE INDEX IF NOT EXISTS idx_mc_auth_pending_verification
     ON mc.auth (mc_uuid)
-    WHERE verification_code != 0;
+    WHERE verification_code_hash IS NOT NULL;
 
 COMMENT ON TABLE mc.auth IS
     'Links Supabase auth.users to Minecraft player UUIDs with in-game verification.';
@@ -89,8 +109,14 @@ COMMENT ON COLUMN mc.auth.mc_uuid IS
     'Minecraft player UUID, stored as 32 lowercase hex chars (no dashes).';
 COMMENT ON COLUMN mc.auth.status IS
     'Bitwise status flags: 0x0=unverified, 0x1=verified, 0x2=suspended, 0x4=banned.';
-COMMENT ON COLUMN mc.auth.verification_code IS
-    '6-digit code for in-game verification. 0 = no pending verification.';
+COMMENT ON COLUMN mc.auth.verification_code_hash IS
+    'Bcrypt hash of 6-digit verification code. NULL = no pending verification.';
+COMMENT ON COLUMN mc.auth.code_expires_at IS
+    'Verification code expiry. Code is invalid after this timestamp.';
+COMMENT ON COLUMN mc.auth.verify_attempts IS
+    'Failed verification attempts for current code. Resets on new code or successful verify.';
+COMMENT ON COLUMN mc.auth.locked_until IS
+    'Temporary lockout timestamp after too many failed attempts. NULL = not locked.';
 
 -- ===========================================
 -- RLS (LOCKED DOWN)
@@ -181,33 +207,73 @@ GRANT EXECUTE ON FUNCTION mc.normalize_mc_uuid(TEXT)
 
 -- ===========================================
 -- SERVICE FUNCTION: Request MC link (creates pending verification)
+--
+-- Generates a 6-digit code, stores its bcrypt hash, sets 10-min TTL.
+-- Blocks if user already has a VERIFIED link (must unlink first).
+-- Raises clean exception if MC UUID is already linked to another user.
 -- ===========================================
 
 CREATE OR REPLACE FUNCTION mc.service_request_link(
     p_user_id UUID,
     p_mc_uuid TEXT
 )
-RETURNS INTEGER  -- returns the generated verification code
+RETURNS INTEGER  -- returns the generated verification code (plaintext, not stored)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-    v_mc_uuid TEXT;
-    v_code    INTEGER;
+    v_mc_uuid      TEXT;
+    v_code         INTEGER;
+    v_existing_status INTEGER;
 BEGIN
     v_mc_uuid := mc.normalize_mc_uuid(p_mc_uuid);
+
+    -- Serialize on mc_uuid to prevent race conditions
+    PERFORM pg_advisory_xact_lock(hashtext(v_mc_uuid));
+
+    -- Block re-linking if user already has a VERIFIED link
+    SELECT status INTO v_existing_status
+    FROM mc.auth
+    WHERE user_id = p_user_id;
+
+    IF v_existing_status IS NOT NULL AND (v_existing_status & 1) = 1 THEN
+        RAISE EXCEPTION 'Account already has a verified Minecraft link. Unlink first.'
+            USING ERRCODE = '23505';
+    END IF;
+
+    -- Block if MC UUID is already linked to a different user
+    IF EXISTS (
+        SELECT 1 FROM mc.auth
+        WHERE mc_uuid = v_mc_uuid
+          AND user_id <> p_user_id
+    ) THEN
+        RAISE EXCEPTION 'Minecraft UUID already linked to another account'
+            USING ERRCODE = '23505';
+    END IF;
 
     -- Generate a random 6-digit code
     v_code := floor(random() * 900000 + 100000)::INTEGER;
 
-    -- Upsert: if user already has a row, reset to pending with new code
-    INSERT INTO mc.auth (user_id, mc_uuid, status, verification_code)
-    VALUES (p_user_id, v_mc_uuid, 0, v_code)
+    -- Upsert: if user already has an unverified row, reset with new hashed code
+    INSERT INTO mc.auth (
+        user_id, mc_uuid, status,
+        verification_code_hash, code_expires_at,
+        verify_attempts, locked_until
+    )
+    VALUES (
+        p_user_id, v_mc_uuid, 0,
+        crypt(v_code::TEXT, gen_salt('bf')),
+        NOW() + INTERVAL '10 minutes',
+        0, NULL
+    )
     ON CONFLICT (user_id) DO UPDATE SET
-        mc_uuid           = EXCLUDED.mc_uuid,
-        status            = 0,
-        verification_code = EXCLUDED.verification_code;
+        mc_uuid                = EXCLUDED.mc_uuid,
+        status                 = 0,
+        verification_code_hash = EXCLUDED.verification_code_hash,
+        code_expires_at        = EXCLUDED.code_expires_at,
+        verify_attempts        = 0,
+        locked_until           = NULL;
 
     RETURN v_code;
 END;
@@ -221,6 +287,10 @@ ALTER FUNCTION mc.service_request_link(UUID, TEXT) OWNER TO service_role;
 
 -- ===========================================
 -- SERVICE FUNCTION: Verify MC link (called by MC server)
+--
+-- Checks: not expired, not locked, increments attempts on failure,
+-- locks for 15 min after 5 failed attempts.
+-- Matches code via bcrypt comparison (never sees plaintext in DB).
 -- ===========================================
 
 CREATE OR REPLACE FUNCTION mc.service_verify_link(
@@ -233,30 +303,73 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-    v_mc_uuid TEXT;
-    v_user_id UUID;
+    v_mc_uuid  TEXT;
+    v_user_id  UUID;
+    v_hash     TEXT;
+    v_expires  TIMESTAMPTZ;
+    v_attempts INTEGER;
+    v_locked   TIMESTAMPTZ;
 BEGIN
     v_mc_uuid := mc.normalize_mc_uuid(p_mc_uuid);
 
-    -- Find pending row matching this MC UUID and code
-    SELECT user_id INTO v_user_id
+    -- Lock the row for update to prevent concurrent verify races
+    SELECT user_id, verification_code_hash, code_expires_at, verify_attempts, locked_until
+    INTO v_user_id, v_hash, v_expires, v_attempts, v_locked
     FROM mc.auth
-    WHERE mc_uuid           = v_mc_uuid
-      AND verification_code = p_code
-      AND verification_code != 0
-      AND (status & 6) = 0;  -- not suspended (0x2) or banned (0x4)
+    WHERE mc_uuid = v_mc_uuid
+      AND verification_code_hash IS NOT NULL
+      AND (status & 6) = 0  -- not suspended (0x2) or banned (0x4)
+    FOR UPDATE;
 
+    -- No pending verification for this MC UUID
     IF v_user_id IS NULL THEN
         RETURN NULL;
     END IF;
 
-    -- Mark as verified: set bit 0x1, clear verification code
-    UPDATE mc.auth
-    SET status            = (status | 1),
-        verification_code = 0
-    WHERE user_id = v_user_id;
+    -- Check lockout
+    IF v_locked IS NOT NULL AND v_locked > NOW() THEN
+        RETURN NULL;
+    END IF;
 
-    RETURN v_user_id;
+    -- Check expiry
+    IF v_expires IS NOT NULL AND v_expires < NOW() THEN
+        -- Expired: clear the hash
+        UPDATE mc.auth
+        SET verification_code_hash = NULL,
+            code_expires_at        = NULL,
+            verify_attempts        = 0,
+            locked_until           = NULL
+        WHERE user_id = v_user_id;
+        RETURN NULL;
+    END IF;
+
+    -- Compare code against stored bcrypt hash
+    IF v_hash = crypt(p_code::TEXT, v_hash) THEN
+        -- Correct code: mark as verified, clear hash and attempts
+        UPDATE mc.auth
+        SET status                 = (status | 1),
+            verification_code_hash = NULL,
+            code_expires_at        = NULL,
+            verify_attempts        = 0,
+            locked_until           = NULL
+        WHERE user_id = v_user_id;
+
+        RETURN v_user_id;
+    END IF;
+
+    -- Wrong code: increment attempts, lock after 5
+    IF v_attempts + 1 >= 5 THEN
+        UPDATE mc.auth
+        SET verify_attempts = verify_attempts + 1,
+            locked_until    = NOW() + INTERVAL '15 minutes'
+        WHERE user_id = v_user_id;
+    ELSE
+        UPDATE mc.auth
+        SET verify_attempts = verify_attempts + 1
+        WHERE user_id = v_user_id;
+    END IF;
+
+    RETURN NULL;
 END;
 $$;
 
@@ -265,6 +378,30 @@ REVOKE ALL ON FUNCTION mc.service_verify_link(TEXT, INTEGER)
 GRANT EXECUTE ON FUNCTION mc.service_verify_link(TEXT, INTEGER)
     TO service_role;
 ALTER FUNCTION mc.service_verify_link(TEXT, INTEGER) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Unlink MC account
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.service_unlink(
+    p_user_id UUID
+)
+RETURNS BOOLEAN  -- true if a row was deleted
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    DELETE FROM mc.auth WHERE user_id = p_user_id;
+    RETURN FOUND;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.service_unlink(UUID)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_unlink(UUID)
+    TO service_role;
+ALTER FUNCTION mc.service_unlink(UUID) OWNER TO service_role;
 
 -- ===========================================
 -- SERVICE FUNCTION: Lookup user_id by MC UUID
@@ -314,7 +451,7 @@ ALTER FUNCTION mc.service_get_user_by_mc_uuid(TEXT) OWNER TO service_role;
 CREATE OR REPLACE FUNCTION mc.proxy_request_link(
     p_mc_uuid TEXT
 )
-RETURNS INTEGER  -- returns verification code
+RETURNS INTEGER  -- returns verification code (plaintext, for display to user)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
@@ -342,6 +479,7 @@ ALTER FUNCTION mc.proxy_request_link(TEXT) OWNER TO service_role;
 
 -- ===========================================
 -- PROXY FUNCTION: Authenticated user checks own link status
+-- (Never exposes verification_code_hash)
 -- ===========================================
 
 CREATE OR REPLACE FUNCTION mc.proxy_get_link_status()
@@ -349,6 +487,7 @@ RETURNS TABLE (
     mc_uuid      TEXT,
     status       INTEGER,
     is_verified  BOOLEAN,
+    is_pending   BOOLEAN,
     created_at   TIMESTAMPTZ,
     updated_at   TIMESTAMPTZ
 )
@@ -370,6 +509,9 @@ BEGIN
         a.mc_uuid,
         a.status,
         (a.status & 1) = 1,
+        a.verification_code_hash IS NOT NULL
+            AND a.code_expires_at > NOW()
+            AND (a.locked_until IS NULL OR a.locked_until <= NOW()),
         a.created_at,
         a.updated_at
     FROM mc.auth AS a
@@ -382,6 +524,35 @@ REVOKE ALL ON FUNCTION mc.proxy_get_link_status()
 GRANT EXECUTE ON FUNCTION mc.proxy_get_link_status()
     TO authenticated, service_role;
 ALTER FUNCTION mc.proxy_get_link_status() OWNER TO service_role;
+
+-- ===========================================
+-- PROXY FUNCTION: Authenticated user unlinks MC account
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.proxy_unlink()
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_user_id UUID;
+BEGIN
+    v_user_id := auth.uid();
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated'
+            USING ERRCODE = '28000';
+    END IF;
+
+    RETURN mc.service_unlink(v_user_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.proxy_unlink()
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION mc.proxy_unlink()
+    TO authenticated, service_role;
+ALTER FUNCTION mc.proxy_unlink() OWNER TO service_role;
 
 -- ===========================================
 -- VERIFICATION
@@ -408,22 +579,87 @@ BEGIN
         RAISE EXCEPTION 'mc.auth setup failed — schema: %, table: %', schema_ok, table_ok;
     END IF;
 
+    -- Verify pgcrypto extension is available
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto'
+    ) THEN
+        RAISE EXCEPTION 'pgcrypto extension is required but not installed';
+    END IF;
+
     -- Verify service functions exist
     PERFORM 'mc.service_request_link(uuid, text)'::regprocedure;
     PERFORM 'mc.service_verify_link(text, integer)'::regprocedure;
     PERFORM 'mc.service_get_user_by_mc_uuid(text)'::regprocedure;
+    PERFORM 'mc.service_unlink(uuid)'::regprocedure;
 
     -- Verify proxy functions exist
     PERFORM 'mc.proxy_request_link(text)'::regprocedure;
     PERFORM 'mc.proxy_get_link_status()'::regprocedure;
+    PERFORM 'mc.proxy_unlink()'::regprocedure;
 
-    -- Verify service_role can execute
+    -- Verify service_role can execute service functions
     IF NOT has_function_privilege('service_role', 'mc.service_request_link(uuid, text)', 'EXECUTE') THEN
         RAISE EXCEPTION 'service_role must have execute on mc.service_request_link';
     END IF;
 
     IF NOT has_function_privilege('service_role', 'mc.service_verify_link(text, integer)', 'EXECUTE') THEN
         RAISE EXCEPTION 'service_role must have execute on mc.service_verify_link';
+    END IF;
+
+    IF NOT has_function_privilege('service_role', 'mc.service_unlink(uuid)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have execute on mc.service_unlink';
+    END IF;
+
+    -- Verify anon CANNOT execute service functions
+    IF has_function_privilege('anon', 'mc.service_request_link(uuid, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_request_link';
+    END IF;
+
+    IF has_function_privilege('anon', 'mc.service_verify_link(text, integer)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_verify_link';
+    END IF;
+
+    IF has_function_privilege('anon', 'mc.service_unlink(uuid)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_unlink';
+    END IF;
+
+    -- Verify authenticated CANNOT execute service functions directly
+    IF has_function_privilege('authenticated', 'mc.service_request_link(uuid, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_request_link';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'mc.service_verify_link(text, integer)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_verify_link';
+    END IF;
+
+    -- Verify proxy functions are callable by authenticated
+    IF NOT has_function_privilege('authenticated', 'mc.proxy_request_link(text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_request_link';
+    END IF;
+
+    IF NOT has_function_privilege('authenticated', 'mc.proxy_get_link_status()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_get_link_status';
+    END IF;
+
+    IF NOT has_function_privilege('authenticated', 'mc.proxy_unlink()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_unlink';
+    END IF;
+
+    -- Verify service function ownership
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_request_link(uuid, text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_request_link must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_verify_link(text, integer)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_verify_link must be owned by service_role';
     END IF;
 
     RAISE NOTICE 'mc.auth schema setup and verification completed successfully.';


### PR DESCRIPTION
## Summary
- **Bcrypt-hashed codes**: Verification codes stored as bcrypt hashes via pgcrypto, never plaintext. If DB is leaked, pending codes are not claimable.
- **10-minute TTL**: `code_expires_at` enforced in `service_verify_link`; expired codes are auto-cleared.
- **Brute-force lockout**: `verify_attempts` counter + `locked_until` — 5 failed attempts triggers 15-minute lockout.
- **Explicit unlink flow**: Verified links cannot be overwritten via re-request. New `service_unlink()` / `proxy_unlink()` functions required first.
- **Clean UUID conflict**: Raises `'Minecraft UUID already linked to another account'` instead of ambiguous unique violation.
- **Advisory lock**: `pg_advisory_xact_lock(hashtext(mc_uuid))` serializes concurrent link requests per UUID.
- **FOR UPDATE row lock**: Prevents concurrent verify races on the same row.
- **Expanded verification block**: Checks pgcrypto installed, anon/authenticated denied service functions, function ownership validated.

## Test plan
- [ ] Run SQL against Supabase — verify schema, functions, and pgcrypto extension create cleanly
- [ ] Request link → verify with correct code within 10 min → confirm VERIFIED status
- [ ] Request link → wait 10+ min → verify → confirm code expired and cleared
- [ ] Request link → fail 5 times → confirm 15-min lockout
- [ ] Attempt re-link while verified → confirm clean exception
- [ ] Attempt to link UUID already owned by another user → confirm clean exception
- [ ] Call `proxy_unlink()` → confirm row deleted, can re-link