### PR TITLE
fix(data): align meme proto and SQL schema 1:1

### DIFF
--- a/packages/data/proto/meme/meme.proto
+++ b/packages/data/proto/meme/meme.proto
@@ -241,6 +241,7 @@ message CardAbility {
 }
 
 message MemeCardStats {
+  string meme_id = 13;         // ULID FK → Meme.id (the minted meme)
   MemeRarity rarity = 1;
   MemeElement element = 2;
   int32 attack = 3;            // 0–999
@@ -340,6 +341,7 @@ message MemeUserProfile {
 
 // Card game player statistics
 message MemePlayerStats {
+  string user_id = 9;           // UUID FK → auth.users.id
   int32 total_battles = 1;
   int32 wins = 2;
   int32 losses = 3;
@@ -364,11 +366,17 @@ message MemeFollow {
 // Card Deck - A player's battle deck
 // =============================================================================
 
+// A card slot within a deck (maps 1:1 to meme.meme_deck_cards join table)
+message DeckCard {
+  string card_id = 1;         // ULID FK → Meme.id (with card stats)
+  optional int32 position = 2; // Ordering position within the deck
+}
+
 message MemeDeck {
   string id = 1;              // ULID
   string owner_id = 2;        // User UUID
   string name = 3;            // Deck name, e.g. "Cursed Rush"
-  repeated string card_ids = 4; // ULID references to Meme entities (with card stats)
+  repeated DeckCard cards = 4; // Cards in this deck (replaces flat card_ids)
   bool is_active = 5;         // Currently selected deck for matchmaking
   string created_at = 6;
   optional string updated_at = 7;

--- a/packages/data/sql/schema/meme/meme_cards.sql
+++ b/packages/data/sql/schema/meme/meme_cards.sql
@@ -234,7 +234,7 @@ GRANT SELECT ON meme.meme_player_stats TO anon, authenticated;
 -- ===========================================
 
 CREATE TABLE IF NOT EXISTS meme.battle_results (
-    id              TEXT PRIMARY KEY DEFAULT gen_ulid(),
+    battle_id       TEXT PRIMARY KEY DEFAULT gen_ulid(),
     player_a_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     player_b_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
 


### PR DESCRIPTION
## Summary
- Reconciles 4 mismatches found between `meme.proto` (source of truth) and the SQL schema so the two are field-for-field identical
- **MemeCardStats**: adds `string meme_id = 13` — the SQL table uses `meme_id` as its PK (1:1 link to the parent meme), but the proto was missing this field since it was embedded inside `Meme`
- **MemePlayerStats**: adds `string user_id = 9` — same pattern; SQL PK is `user_id`, proto was embedded inside `MemeUserProfile`
- **MemeDeck**: replaces `repeated string card_ids = 4` with `repeated DeckCard cards = 4`, adding a new `DeckCard` message with `card_id` + `position` fields — matches the normalized `meme.meme_deck_cards` join table which has a `position` column that had no proto representation
- **battle_results**: renames SQL column `id` → `battle_id` to match `BattleResult.battle_id` in proto

## Test plan
- [ ] Verify proto compiles cleanly with `protoc`
- [ ] Confirm SQL `battle_id` rename does not break any downstream references (fresh schema, no migrations needed)
- [ ] Cross-reference all 13 proto messages against SQL tables — should now be 1:1

Generated with [Claude Code](https://claude.com/claude-code)