### PR TITLE
feat(mc): integrate Askama + Axum static site serving with live players page

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -1,9 +1,65 @@
+# ============================================================================
+# [STAGE A] - Build Astro Static Site
+# ============================================================================
+FROM node:24-alpine AS astro-builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy root dependency and config files (layer-cached separately from source)
+COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+
+# Install all dependencies (hoisted mode - all go to root node_modules)
+RUN pnpm install --frozen-lockfile
+
+# Copy workspace package sources (TypeScript path aliases resolve to these)
+COPY packages/npm/astro/ packages/npm/astro/
+COPY packages/npm/droid/ packages/npm/droid/
+
+# Copy astro-mc source
+COPY apps/mc/astro-mc/ apps/mc/astro-mc/
+
+# Build astro site
+WORKDIR /app/apps/mc/astro-mc
+RUN rm -rf .astro && npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+
+# ============================================================================
+# [STAGE B] - Precompress Static Assets
+# ============================================================================
+FROM ubuntu:24.04 AS astro-precompressor
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gzip brotli && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=astro-builder /app/dist/apps/astro-mc /static
+
+WORKDIR /static
+RUN find . -type f \( \
+        -name "*.css" -o \
+        -name "*.js" -o \
+        -name "*.json" -o \
+        -name "*.svg" -o \
+        -name "*.xml" -o \
+        -name "*.txt" -o \
+        -name "*.html" \
+    \) ! -path "*/askama/*" -exec sh -c ' \
+        gzip -9 -k "$1" && \
+        brotli --best --keep "$1" \
+    ' _ {} \; && \
+    echo "Precompression complete (brotli-11 + gzip-9)"
+
+# ============================================================================
+# Rust build stages (Pumpkin server + plugin)
+# ============================================================================
 FROM rust:1-alpine3.23 AS chef
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN apk add --no-cache musl-dev git
 RUN cargo install cargo-chef --locked
 WORKDIR /pumpkin
-COPY ./pumpkin /pumpkin
+COPY ./apps/mc/pumpkin /pumpkin
 RUN rustup show active-toolchain || rustup toolchain install
 RUN rustup component add rustfmt
 
@@ -22,38 +78,40 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
 #     cargo-chef cook strips workspace.lints, so restore the real manifests.
 #     Full workspace build ensures feature unification is correct.
 FROM deps AS foundation
-COPY ./pumpkin/Cargo.toml /pumpkin/Cargo.toml
-COPY ./pumpkin/Cargo.lock /pumpkin/Cargo.lock
-COPY ./pumpkin/pumpkin-nbt /pumpkin/pumpkin-nbt
-COPY ./pumpkin/pumpkin-api-macros /pumpkin/pumpkin-api-macros
-COPY ./pumpkin/pumpkin-util /pumpkin/pumpkin-util
-COPY ./pumpkin/pumpkin-data /pumpkin/pumpkin-data
-COPY ./pumpkin/pumpkin-macros /pumpkin/pumpkin-macros
-COPY ./pumpkin/pumpkin-config /pumpkin/pumpkin-config
+COPY ./apps/mc/pumpkin/Cargo.toml /pumpkin/Cargo.toml
+COPY ./apps/mc/pumpkin/Cargo.lock /pumpkin/Cargo.lock
+COPY ./apps/mc/pumpkin/pumpkin-nbt /pumpkin/pumpkin-nbt
+COPY ./apps/mc/pumpkin/pumpkin-api-macros /pumpkin/pumpkin-api-macros
+COPY ./apps/mc/pumpkin/pumpkin-util /pumpkin/pumpkin-util
+COPY ./apps/mc/pumpkin/pumpkin-data /pumpkin/pumpkin-data
+COPY ./apps/mc/pumpkin/pumpkin-macros /pumpkin/pumpkin-macros
+COPY ./apps/mc/pumpkin/pumpkin-config /pumpkin/pumpkin-config
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release
 
 # --- Core: engine crates (protocol, world, inventory) ---
 FROM foundation AS core
-COPY ./pumpkin/pumpkin-world /pumpkin/pumpkin-world
-COPY ./pumpkin/pumpkin-protocol /pumpkin/pumpkin-protocol
-COPY ./pumpkin/pumpkin-inventory /pumpkin/pumpkin-inventory
+COPY ./apps/mc/pumpkin/pumpkin-world /pumpkin/pumpkin-world
+COPY ./apps/mc/pumpkin/pumpkin-protocol /pumpkin/pumpkin-protocol
+COPY ./apps/mc/pumpkin/pumpkin-inventory /pumpkin/pumpkin-inventory
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release
 
 # --- Pumpkin: build server (parallel with plugin) ---
 FROM core AS builder
-COPY ./pumpkin/pumpkin /pumpkin/pumpkin
+COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release && cp target/release/pumpkin ./pumpkin.release
 
 # --- Plugin: build (parallel with pumpkin, reuses all pre-compiled crates) ---
 FROM core AS plugin-builder
-COPY ./pumpkin/pumpkin /pumpkin/pumpkin
-COPY ./plugins /plugins
+COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
+COPY ./apps/mc/plugins /plugins
+# Inject Astro-built players page as Askama template (compiled into the .so)
+COPY --from=astro-builder /app/dist/apps/astro-mc/players/index.html /plugins/kbve-mc-plugin/templates/askama/players.html
 ENV CARGO_TARGET_DIR=/pumpkin/target
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
@@ -66,7 +124,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
 # --- Resource pack ---
 FROM alpine:3.23 AS pack-builder
 RUN apk add --no-cache zip coreutils
-COPY ./data/resource-pack /resource-pack
+COPY ./apps/mc/data/resource-pack /resource-pack
 RUN cd /resource-pack && zip -r /kbve-resource-pack.zip . -x '.*' -x '__MACOSX/*'
 RUN SHA1=$(sha1sum /kbve-resource-pack.zip | awk '{print $1}') && \
     printf '[resource_pack]\nenabled = true\nurl = "http://localhost:8080/kbve-resource-pack.zip"\nsha1 = "%s"\nforce = true\nprompt_message = "KBVE Resource Pack - Custom items and textures"\n\n[world]\nlighting = "default"\nautosave_ticks = 6000\n\n[world.chunk]\ntype = "anvil"\nwrite_in_place = false\n\n[world.chunk.compression]\nalgorithm = "LZ4"\nlevel = 6\n\n[networking.rcon]\nenabled = true\naddress = "0.0.0.0:25575"\npassword = "kbve-rcon"\nmax_connections = 5\n' "$SHA1" > /features.toml
@@ -80,15 +138,18 @@ COPY --from=plugin-builder /built-plugins/ /pumpkin/plugins/
 WORKDIR /pumpkin
 
 # Bake in custom server config and icon
-COPY ./data/config/configuration.toml /pumpkin/config/configuration.toml
-COPY ./data/server_icon.png /pumpkin/server_icon.png
+COPY ./apps/mc/data/config/configuration.toml /pumpkin/config/configuration.toml
+COPY ./apps/mc/data/server_icon.png /pumpkin/server_icon.png
 
 # Resource pack: zip served by axum, config for Pumpkin
 COPY --from=pack-builder /kbve-resource-pack.zip /pumpkin/resource-pack.zip
 COPY --from=pack-builder /features.toml /pumpkin/config/features.toml
 
+# Static Astro site: served by plugin's axum server
+COPY --from=astro-precompressor /static /pumpkin/web
+
 # Entrypoint: templates RESOURCE_PACK_URL env var into features.toml at startup
-COPY ./entrypoint.sh /entrypoint.sh
+COPY ./apps/mc/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 RUN apk add --no-cache libgcc && chown -R 2613:2613 .

--- a/apps/mc/Dockerfile.dev
+++ b/apps/mc/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Dockerfile.dev — release builds with dev tooling (logging, RCON, volumes)
 # Usage:
-#   docker build -f Dockerfile.dev -t kbve-mc:dev .
+#   docker build -f apps/mc/Dockerfile.dev -t kbve-mc:dev .
 #   docker run -p 25565:25565 -p 8080:8080 -p 25575:25575 \
 #     -v $PWD/logs:/pumpkin/logs \
 #     -v $PWD/world:/pumpkin/world kbve-mc:dev
@@ -10,14 +10,63 @@
 #
 # Granular cargo-chef layers cache deps aggressively — only the crate
 # you actually changed triggers a recompile:
-#   docker build -f Dockerfile.dev -t kbve-mc:dev .
+#   docker build -f apps/mc/Dockerfile.dev -t kbve-mc:dev .
 
+# ============================================================================
+# [STAGE A] - Build Astro Static Site
+# ============================================================================
+FROM node:24-alpine AS astro-builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+RUN pnpm install --frozen-lockfile
+
+COPY packages/npm/astro/ packages/npm/astro/
+COPY packages/npm/droid/ packages/npm/droid/
+COPY apps/mc/astro-mc/ apps/mc/astro-mc/
+
+WORKDIR /app/apps/mc/astro-mc
+RUN rm -rf .astro && npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+
+# ============================================================================
+# [STAGE B] - Precompress Static Assets
+# ============================================================================
+FROM ubuntu:24.04 AS astro-precompressor
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gzip brotli && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=astro-builder /app/dist/apps/astro-mc /static
+
+WORKDIR /static
+RUN find . -type f \( \
+        -name "*.css" -o \
+        -name "*.js" -o \
+        -name "*.json" -o \
+        -name "*.svg" -o \
+        -name "*.xml" -o \
+        -name "*.txt" -o \
+        -name "*.html" \
+    \) ! -path "*/askama/*" -exec sh -c ' \
+        gzip -9 -k "$1" && \
+        brotli --best --keep "$1" \
+    ' _ {} \; && \
+    echo "Precompression complete (brotli-11 + gzip-9)"
+
+# ============================================================================
+# Rust build stages (Pumpkin server + plugin)
+# ============================================================================
 FROM rust:1-alpine3.23 AS chef
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN apk add --no-cache musl-dev git
 RUN cargo install cargo-chef --locked
 WORKDIR /pumpkin
-COPY ./pumpkin /pumpkin
+COPY ./apps/mc/pumpkin /pumpkin
 RUN rustup show active-toolchain || rustup toolchain install
 RUN rustup component add rustfmt
 
@@ -36,38 +85,40 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
 #     cargo-chef cook strips workspace.lints, so restore the real manifests.
 #     Full workspace build ensures feature unification is correct.
 FROM deps AS foundation
-COPY ./pumpkin/Cargo.toml /pumpkin/Cargo.toml
-COPY ./pumpkin/Cargo.lock /pumpkin/Cargo.lock
-COPY ./pumpkin/pumpkin-nbt /pumpkin/pumpkin-nbt
-COPY ./pumpkin/pumpkin-api-macros /pumpkin/pumpkin-api-macros
-COPY ./pumpkin/pumpkin-util /pumpkin/pumpkin-util
-COPY ./pumpkin/pumpkin-data /pumpkin/pumpkin-data
-COPY ./pumpkin/pumpkin-macros /pumpkin/pumpkin-macros
-COPY ./pumpkin/pumpkin-config /pumpkin/pumpkin-config
+COPY ./apps/mc/pumpkin/Cargo.toml /pumpkin/Cargo.toml
+COPY ./apps/mc/pumpkin/Cargo.lock /pumpkin/Cargo.lock
+COPY ./apps/mc/pumpkin/pumpkin-nbt /pumpkin/pumpkin-nbt
+COPY ./apps/mc/pumpkin/pumpkin-api-macros /pumpkin/pumpkin-api-macros
+COPY ./apps/mc/pumpkin/pumpkin-util /pumpkin/pumpkin-util
+COPY ./apps/mc/pumpkin/pumpkin-data /pumpkin/pumpkin-data
+COPY ./apps/mc/pumpkin/pumpkin-macros /pumpkin/pumpkin-macros
+COPY ./apps/mc/pumpkin/pumpkin-config /pumpkin/pumpkin-config
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release
 
 # --- Core: engine crates (protocol, world, inventory) ---
 FROM foundation AS core
-COPY ./pumpkin/pumpkin-world /pumpkin/pumpkin-world
-COPY ./pumpkin/pumpkin-protocol /pumpkin/pumpkin-protocol
-COPY ./pumpkin/pumpkin-inventory /pumpkin/pumpkin-inventory
+COPY ./apps/mc/pumpkin/pumpkin-world /pumpkin/pumpkin-world
+COPY ./apps/mc/pumpkin/pumpkin-protocol /pumpkin/pumpkin-protocol
+COPY ./apps/mc/pumpkin/pumpkin-inventory /pumpkin/pumpkin-inventory
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release
 
 # --- Pumpkin: build server (parallel with plugin) ---
 FROM core AS builder
-COPY ./pumpkin/pumpkin /pumpkin/pumpkin
+COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release && cp target/release/pumpkin /pumpkin.bin
 
 # --- Plugin: build (parallel with pumpkin, reuses all pre-compiled crates) ---
 FROM core AS plugin-builder
-COPY ./pumpkin/pumpkin /pumpkin/pumpkin
-COPY ./plugins /plugins
+COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
+COPY ./apps/mc/plugins /plugins
+# Inject Astro-built players page as Askama template (compiled into the .so)
+COPY --from=astro-builder /app/dist/apps/astro-mc/players/index.html /plugins/kbve-mc-plugin/templates/askama/players.html
 ENV CARGO_TARGET_DIR=/pumpkin/target
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
@@ -80,7 +131,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
 # --- Resource pack (fast, runs in parallel with rust builds) ---
 FROM alpine:3.23 AS pack-builder
 RUN apk add --no-cache zip coreutils
-COPY ./data/resource-pack /resource-pack
+COPY ./apps/mc/data/resource-pack /resource-pack
 RUN cd /resource-pack && zip -r /kbve-resource-pack.zip . -x '.*' -x '__MACOSX/*'
 RUN SHA1=$(sha1sum /kbve-resource-pack.zip | awk '{print $1}') && \
     printf '[resource_pack]\nenabled = true\nurl = "http://localhost:8080/kbve-resource-pack.zip"\nsha1 = "%s"\nforce = true\nprompt_message = "KBVE Resource Pack - Custom items and textures"\n\n[world]\nlighting = "default"\nautosave_ticks = 6000\n\n[world.chunk]\ntype = "anvil"\nwrite_in_place = false\n\n[world.chunk.compression]\nalgorithm = "LZ4"\nlevel = 6\n\n[networking.rcon]\nenabled = true\naddress = "0.0.0.0:25575"\npassword = "kbve-rcon"\nmax_connections = 5\n' "$SHA1" > /features.toml
@@ -93,13 +144,16 @@ COPY --from=plugin-builder /built-plugins/ /pumpkin/plugins/
 
 WORKDIR /pumpkin
 
-COPY ./data/config/configuration.toml /pumpkin/config/configuration.toml
-COPY ./data/server_icon.png /pumpkin/server_icon.png
+COPY ./apps/mc/data/config/configuration.toml /pumpkin/config/configuration.toml
+COPY ./apps/mc/data/server_icon.png /pumpkin/server_icon.png
 
 COPY --from=pack-builder /kbve-resource-pack.zip /pumpkin/resource-pack.zip
 COPY --from=pack-builder /features.toml /pumpkin/config/features.toml
 
-COPY ./entrypoint.dev.sh /entrypoint.sh
+# Static Astro site: served by plugin's axum server
+COPY --from=astro-precompressor /static /pumpkin/web
+
+COPY ./apps/mc/entrypoint.dev.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Create mountable directories (logs + world persistence)

--- a/apps/mc/astro-mc/astro.config.mjs
+++ b/apps/mc/astro-mc/astro.config.mjs
@@ -23,6 +23,12 @@ export default defineConfig({
       },
       sidebar: [
         {
+          label: 'Server',
+          items: [
+            { label: 'Live Players', slug: 'players' },
+          ],
+        },
+        {
           label: 'Guides',
           autogenerate: { directory: 'guides' },
         },

--- a/apps/mc/astro-mc/src/components/providers/AskamaMCPlayersProvider.astro
+++ b/apps/mc/astro-mc/src/components/providers/AskamaMCPlayersProvider.astro
@@ -1,0 +1,136 @@
+---
+// AskamaMCPlayersProvider.astro
+// Outputs Askama template placeholders that get filled by the Axum backend
+// at request time with live player data from the Pumpkin server.
+//
+// Astro builds this as literal text → Askama compiles it → Axum renders it.
+
+const playerCount = `{{ player_count }}`;
+const maxPlayers = `{{ max_players }}`;
+
+const playerListBlock = `{% if player_count > 0 %}
+<ul class="player-list" role="list">
+    {% for player in players %}
+    <li class="player-card">
+        <span class="player-name">{{ player }}</span>
+    </li>
+    {% endfor %}
+</ul>
+{% else %}
+<p class="no-players">No players are currently online.</p>
+{% endif %}`;
+
+const serverStatusBlock = `{% if server_online %}
+<span class="status-dot online"></span> Online
+{% else %}
+<span class="status-dot offline"></span> Offline
+{% endif %}`;
+---
+
+<div class="mc-players-panel">
+	<div class="server-header">
+		<div class="server-status">
+			<Fragment set:html={serverStatusBlock} />
+		</div>
+		<div class="player-counter">
+			<span class="count"><Fragment set:html={playerCount} /></span>
+			<span class="separator">/</span>
+			<span class="max"><Fragment set:html={maxPlayers} /></span>
+			<span class="label">players</span>
+		</div>
+	</div>
+
+	<Fragment set:html={playerListBlock} />
+</div>
+
+<style>
+	.mc-players-panel {
+		padding: 1.5rem;
+		border-radius: 0.75rem;
+		border: 1px solid var(--sl-color-hairline, #27272a);
+		background: var(--sl-color-bg-nav, rgba(0, 0, 0, 0.1));
+	}
+
+	.server-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1.25rem;
+		padding-bottom: 1rem;
+		border-bottom: 1px solid var(--sl-color-hairline, #27272a);
+	}
+
+	.server-status {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-weight: 600;
+		font-size: 0.875rem;
+	}
+
+	.status-dot {
+		display: inline-block;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+	}
+
+	.status-dot.online {
+		background: #10b981;
+		box-shadow: 0 0 6px #10b981;
+	}
+
+	.status-dot.offline {
+		background: #ef4444;
+		box-shadow: 0 0 6px #ef4444;
+	}
+
+	.player-counter {
+		display: flex;
+		align-items: baseline;
+		gap: 0.25rem;
+		font-size: 0.875rem;
+		color: var(--sl-color-gray-2, #a1a1aa);
+	}
+
+	.player-counter .count {
+		font-size: 1.25rem;
+		font-weight: 700;
+		color: var(--sl-color-accent, #10b981);
+	}
+
+	.player-counter .label {
+		margin-left: 0.25rem;
+	}
+
+	.player-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+		gap: 0.5rem;
+	}
+
+	.player-card {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: 0.375rem;
+		background: var(--sl-color-bg, rgba(0, 0, 0, 0.15));
+		border: 1px solid var(--sl-color-hairline, #27272a);
+	}
+
+	.player-name {
+		font-size: 0.8125rem;
+		font-weight: 500;
+	}
+
+	.no-players {
+		text-align: center;
+		color: var(--sl-color-gray-3, #71717a);
+		font-size: 0.875rem;
+		padding: 1rem 0;
+	}
+</style>

--- a/apps/mc/astro-mc/src/content/docs/players.mdx
+++ b/apps/mc/astro-mc/src/content/docs/players.mdx
@@ -1,0 +1,12 @@
+---
+title: Live Players
+description: See who's currently online on the KBVE Minecraft server.
+---
+
+import AskamaMCPlayersProvider from '../../components/providers/AskamaMCPlayersProvider.astro';
+
+## Server Status
+
+Live view of players currently connected to the KBVE Minecraft server.
+
+<AskamaMCPlayersProvider />

--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.lock
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.lock
@@ -29,6 +29,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +56,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "askama"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
+dependencies = [
+ "askama_macros",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
+dependencies = [
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow",
 ]
 
 [[package]]
@@ -144,6 +211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +244,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +283,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -267,8 +366,12 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
+ "brotli",
  "compression-core",
  "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -834,6 +937,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
@@ -958,6 +1073,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -1161,6 +1282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1305,7 @@ dependencies = [
 name = "kbve-mc-plugin"
 version = "0.1.5"
 dependencies = [
+ "askama",
  "axum",
  "dashmap",
  "pumpkin",
@@ -1184,6 +1316,8 @@ dependencies = [
  "pumpkin-util",
  "pumpkin-world",
  "tokio",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]
@@ -1311,6 +1445,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1574,6 +1718,12 @@ dependencies = [
  "der 0.8.0",
  "spki 0.8.0-rc.4",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -2545,6 +2695,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2817,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3068,6 +3251,9 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -3251,3 +3437,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
@@ -19,4 +19,10 @@ pumpkin-protocol = { path = "../../pumpkin/pumpkin-protocol" }
 pumpkin-world = { path = "../../pumpkin/pumpkin-world" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 axum = "0.8"
+askama = "0.15.4"
+tower-http = { version = "0.6.8", features = ["fs", "compression-full", "set-header"] }
+tower = { version = "0.5.3", features = ["util"] }
 dashmap = "6"
+
+[package.metadata.askama]
+dirs = ["templates"]

--- a/apps/mc/plugins/kbve-mc-plugin/askama.toml
+++ b/apps/mc/plugins/kbve-mc-plugin/askama.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["templates"]

--- a/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
+++ b/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[macro_use]
 mod macros;
+mod web;
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
@@ -20,6 +21,7 @@ use pumpkin::plugin::player::player_death::PlayerDeathEvent;
 use pumpkin::plugin::player::player_interact_entity_event::PlayerInteractEntityEvent;
 use pumpkin::plugin::player::player_interact_event::PlayerInteractEvent;
 use pumpkin::plugin::player::player_join::PlayerJoinEvent;
+use pumpkin::plugin::player::player_leave::PlayerLeaveEvent;
 use pumpkin::plugin::player::player_respawn::PlayerRespawnEvent;
 use pumpkin::plugin::{BoxFuture, EventHandler, EventPriority};
 use pumpkin::server::Server;
@@ -124,6 +126,13 @@ impl EventHandler<PlayerJoinEvent> for WelcomeHandler {
             let handler_start = Instant::now();
 
             info!("Sending welcome to {name} ({uuid})");
+
+            // Track player for web dashboard
+            web::ONLINE_PLAYERS.insert(name.clone(), ());
+            debug!(
+                "ONLINE_PLAYERS += {name} (total: {})",
+                web::ONLINE_PLAYERS.len()
+            );
 
             // Capture BEFORE the sleep — spawn_java_player runs concurrently and
             // sets has_played_before = true at world/mod.rs:1881 during the delay.
@@ -342,6 +351,30 @@ impl EventHandler<PlayerJoinEvent> for WelcomeHandler {
             info!(
                 "WelcomeHandler for {name} completed in {:.1?}",
                 handler_start.elapsed()
+            );
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Leave handler (fires on player disconnect — removes from ONLINE_PLAYERS)
+// ---------------------------------------------------------------------------
+
+struct LeaveHandler;
+
+impl EventHandler<PlayerLeaveEvent> for LeaveHandler {
+    fn handle<'a>(
+        &'a self,
+        _server: &'a Arc<Server>,
+        event: &'a PlayerLeaveEvent,
+    ) -> BoxFuture<'a, ()> {
+        let player = Arc::clone(&event.player);
+        Box::pin(async move {
+            let name = &player.gameprofile.name;
+            web::ONLINE_PLAYERS.remove(name);
+            info!(
+                "Player left: {name} (online: {})",
+                web::ONLINE_PLAYERS.len()
             );
         })
     }
@@ -1376,10 +1409,10 @@ impl EventHandler<PlayerInteractEvent> for OrbitalStrikeHandler {
 }
 
 // ---------------------------------------------------------------------------
-// Axum resource pack server
+// Axum web server (resource pack + static Astro site)
 // ---------------------------------------------------------------------------
 
-async fn serve_resource_pack() {
+async fn serve_web() {
     use axum::Router;
     use axum::http::header;
     use axum::response::IntoResponse;
@@ -1405,7 +1438,25 @@ async fn serve_resource_pack() {
         }
     }
 
-    let app = Router::new().route("/kbve-resource-pack.zip", get(pack_handler));
+    // Build the static Astro file router
+    let static_dir = web::static_dir();
+    let static_router = if static_dir.exists() {
+        info!("Static site directory: {}", static_dir.display());
+        web::build_static_router(&static_dir)
+    } else {
+        info!(
+            "Static site directory not found: {} (web UI disabled)",
+            static_dir.display()
+        );
+        Router::new()
+    };
+
+    // Explicit routes take priority, Astro static files are the fallback
+    let app = Router::new()
+        .route("/kbve-resource-pack.zip", get(pack_handler))
+        .route("/players", get(web::players_handler))
+        .route("/players/", get(web::players_handler))
+        .merge(static_router);
 
     let listener = match tokio::net::TcpListener::bind("0.0.0.0:8080").await {
         Ok(l) => l,
@@ -1415,7 +1466,7 @@ async fn serve_resource_pack() {
         }
     };
 
-    info!("Resource pack server listening on :8080");
+    info!("Web server listening on :8080");
     if let Err(e) = axum::serve(listener, app).await {
         info!("Axum server error: {e}");
     }
@@ -1457,6 +1508,9 @@ impl KbveMcPlugin {
         context
             .register_event(Arc::new(OrbitalStrikeHandler), EventPriority::Normal, false)
             .await;
+        context
+            .register_event(Arc::new(LeaveHandler), EventPriority::Normal, false)
+            .await;
         info!("Event handlers registered");
 
         // Register /kbve command permission (Allow = all players can use it)
@@ -1491,9 +1545,9 @@ impl KbveMcPlugin {
             ITEM_REGISTRY.iter().map(|e| *e.key()).collect::<Vec<_>>()
         );
 
-        // Spawn resource pack HTTP server (runs in background on GLOBAL_RUNTIME)
-        GLOBAL_RUNTIME.spawn(serve_resource_pack());
-        info!("Resource pack server spawned");
+        // Spawn web server: resource pack + static Astro site (background on GLOBAL_RUNTIME)
+        GLOBAL_RUNTIME.spawn(serve_web());
+        info!("Web server spawned");
 
         info!("on_load END ({:.1?})", load_start.elapsed());
         Ok(())

--- a/apps/mc/plugins/kbve-mc-plugin/src/web.rs
+++ b/apps/mc/plugins/kbve-mc-plugin/src/web.rs
@@ -1,0 +1,160 @@
+use askama::Template;
+use axum::{
+    Router,
+    http::{StatusCode, header},
+    response::{Html, IntoResponse, Response},
+};
+use dashmap::DashMap;
+use std::convert::Infallible;
+use std::path::PathBuf;
+use std::sync::{Arc, LazyLock};
+use tower_http::services::ServeDir;
+
+// ---------------------------------------------------------------------------
+// Shared player tracking (written by event handlers, read by web handlers)
+// ---------------------------------------------------------------------------
+
+/// Online players: name → () (name is unique in Minecraft)
+pub static ONLINE_PLAYERS: LazyLock<DashMap<String, ()>> = LazyLock::new(DashMap::new);
+
+// ---------------------------------------------------------------------------
+// Askama templates
+// ---------------------------------------------------------------------------
+
+#[derive(Template)]
+#[template(path = "askama/index.html")]
+pub struct AstroTemplate<'a> {
+    pub content: &'a str,
+    pub title: &'a str,
+    pub description: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "askama/players.html")]
+pub struct PlayersTemplate {
+    pub player_count: usize,
+    pub max_players: usize,
+    pub players: Vec<String>,
+    pub server_online: bool,
+}
+
+pub struct TemplateResponse<T: Template>(pub T);
+
+impl<T: Template> IntoResponse for TemplateResponse<T> {
+    fn into_response(self) -> Response {
+        match self.0.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(_err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to render template",
+            )
+                .into_response(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+pub async fn players_handler() -> impl IntoResponse {
+    let players: Vec<String> = ONLINE_PLAYERS
+        .iter()
+        .map(|entry| entry.key().clone())
+        .collect();
+    let player_count = players.len();
+    let max_players = std::env::var("MAX_PLAYERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1000u32) as usize;
+
+    let template = PlayersTemplate {
+        player_count,
+        max_players,
+        players,
+        server_online: true,
+    };
+
+    TemplateResponse(template)
+}
+
+// ---------------------------------------------------------------------------
+// Static file serving
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STATIC_DIR: &str = "/pumpkin/web";
+
+pub fn static_dir() -> PathBuf {
+    std::env::var("STATIC_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_STATIC_DIR))
+}
+
+pub fn build_static_router(base: &PathBuf) -> Router {
+    let precompressed = std::env::var("STATIC_PRECOMPRESSED")
+        .map(|v| v != "0" && v.to_lowercase() != "false")
+        .unwrap_or(true);
+
+    // Read Astro's 404.html at startup for the not-found fallback
+    let not_found_html = Arc::new(
+        std::fs::read_to_string(base.join("404.html"))
+            .unwrap_or_else(|_| "<html><body><h1>404 - Not Found</h1></body></html>".to_string()),
+    );
+
+    let serve_dir = |path: PathBuf| {
+        let svc = ServeDir::new(path);
+        if precompressed {
+            svc.precompressed_br().precompressed_gzip()
+        } else {
+            svc
+        }
+    };
+
+    // Content-hashed asset directories
+    let astro_service = serve_dir(base.join("_astro"));
+    let assets_service = serve_dir(base.join("assets"));
+    let chunks_service = serve_dir(base.join("chunks"));
+    let pagefind_service = serve_dir(base.join("pagefind"));
+
+    // Images are already compressed formats — skip precompression
+    let images_service = ServeDir::new(base.join("images"));
+
+    // 404 service: returns Astro's 404.html with proper status code
+    let not_found_svc = {
+        let html = not_found_html.clone();
+        tower::service_fn(move |_req: axum::extract::Request| {
+            let html = html.clone();
+            async move {
+                Ok::<_, Infallible>(
+                    (
+                        StatusCode::NOT_FOUND,
+                        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+                        (*html).clone(),
+                    )
+                        .into_response(),
+                )
+            }
+        })
+    };
+
+    // Root fallback: serves pages (/auth → /auth/index.html),
+    // falls back to Astro's 404.html for unknown routes
+    let fallback_svc = {
+        let svc = ServeDir::new(base)
+            .append_index_html_on_directories(true)
+            .fallback(not_found_svc);
+        if precompressed {
+            svc.precompressed_br().precompressed_gzip()
+        } else {
+            svc
+        }
+    };
+
+    Router::new()
+        .nest_service("/_astro", astro_service)
+        .nest_service("/assets", assets_service)
+        .nest_service("/chunks", chunks_service)
+        .nest_service("/images", images_service)
+        .nest_service("/pagefind", pagefind_service)
+        .fallback_service(fallback_svc)
+}

--- a/apps/mc/plugins/kbve-mc-plugin/templates/askama/index.html
+++ b/apps/mc/plugins/kbve-mc-plugin/templates/askama/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ title }} - KBVE MC</title>
+    <meta name="description" content="{{ description }}" />
+</head>
+<body>
+    {{ content|safe }}
+</body>
+</html>

--- a/apps/mc/plugins/kbve-mc-plugin/templates/askama/players.html
+++ b/apps/mc/plugins/kbve-mc-plugin/templates/askama/players.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Live Players - KBVE MC</title>
+</head>
+<body>
+    <!-- Placeholder: replaced by Astro build output in Docker -->
+    <h1>Server Status</h1>
+    <p>{{ player_count }} / {{ max_players }} players</p>
+    {% if server_online %}
+    <span>Online</span>
+    {% else %}
+    <span>Offline</span>
+    {% endif %}
+    {% if player_count > 0 %}
+    <ul>
+        {% for player in players %}
+        <li>{{ player }}</li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p>No players are currently online.</p>
+    {% endif %}
+</body>
+</html>

--- a/apps/mc/project.json
+++ b/apps/mc/project.json
@@ -36,7 +36,7 @@
 			"defaultConfiguration": "local",
 			"options": {
 				"engine": "docker",
-				"context": "apps/mc",
+				"context": ".",
 				"file": "apps/mc/Dockerfile",
 				"load": true
 			},
@@ -98,7 +98,7 @@
 			"defaultConfiguration": "local",
 			"options": {
 				"engine": "docker",
-				"context": "apps/mc",
+				"context": ".",
 				"file": "apps/mc/Dockerfile.dev",
 				"load": true
 			},


### PR DESCRIPTION
## Summary
- Integrate Askama templating + static Astro site serving into the MC plugin's Axum server on `:8080`
- Add live `/players` page that renders online player data from the Pumpkin server via Askama templates
- Expand Docker build context to repo root to support Astro build inside Dockerfile

## Changes
- **Plugin deps**: Added `askama 0.15.4`, `tower-http 0.6.8`, `tower 0.5.3`
- **web.rs**: Static file router (ServeDir + precompressed br/gz), `PlayersTemplate`, `ONLINE_PLAYERS` tracking, `/players` route handler
- **lib.rs**: `LeaveHandler` for player disconnect tracking, `ONLINE_PLAYERS` insert on join, `/players` + `/players/` routes wired in `serve_web()`
- **Astro**: `AskamaMCPlayersProvider.astro` outputs Askama `{{ }}` / `{% %}` placeholders via `set:html`, `players.mdx` content page, sidebar entry
- **Docker**: Both Dockerfiles expanded to repo-root context with Astro build + precompress stages, Astro-built players page copied as Askama template before Rust build
- **project.json**: containerx context changed from `apps/mc` to `.`

## Test plan
- [x] `cargo check` passes locally
- [x] `nx container-dev mc` builds successfully (full Docker pipeline)
- [x] `curl http://localhost:8080/` returns Astro Starlight homepage
- [x] `curl http://localhost:8080/players` returns Askama-rendered live players page (shows Online, 0/1000 players, "No players currently online")
- [x] `curl http://localhost:8080/kbve-resource-pack.zip` still serves the resource pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)