### PR TITLE
feat(memes): add toast system, inline nav, and 3-column footer

### DIFF
--- a/apps/memes/astro-memes/src/components/header/Header.astro
+++ b/apps/memes/astro-memes/src/components/header/Header.astro
@@ -9,91 +9,77 @@ import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 import NavBar from '../navigation/NavBar.astro';
 
 const shouldRenderSearch =
-  config.pagefind ||
-  config.components.Search !== '@astrojs/starlight/components/Search.astro';
+	config.pagefind ||
+	config.components.Search !== '@astrojs/starlight/components/Search.astro';
 ---
 
 <div class="header">
-  <div class="title-wrapper sl-flex">
-    <SiteTitle />
-  </div>
-  <div class="nav-center">
-    <NavBar />
-  </div>
-  <div class="sl-hidden md:sl-flex print:hidden right-group">
-    <div class="sl-flex social-icons">
-      <SocialIcons />
-    </div>
-    {shouldRenderSearch && <Search />}
-    <ThemeSelect />
-    <LanguageSelect />
-  </div>
+	<div class="title-wrapper sl-flex">
+		<SiteTitle />
+		<NavBar />
+	</div>
+	<div class="sl-hidden md:sl-flex print:hidden right-group">
+		<div class="sl-flex social-icons">
+			<SocialIcons />
+		</div>
+		{shouldRenderSearch && <Search />}
+		<ThemeSelect />
+		<LanguageSelect />
+	</div>
 </div>
 
 <style>
-  @layer starlight.core {
-    .header {
-      display: flex;
-      gap: var(--sl-nav-gap);
-      justify-content: space-between;
-      align-items: center;
-      height: 100%;
-    }
+	@layer starlight.core {
+		.header {
+			display: flex;
+			gap: var(--sl-nav-gap);
+			justify-content: space-between;
+			align-items: center;
+			height: 100%;
+		}
 
-    .title-wrapper {
-      overflow: clip;
-      padding: 0.25rem;
-      margin: -0.25rem;
-      min-width: 0;
-    }
+		.title-wrapper {
+			overflow: clip;
+			padding: 0.25rem;
+			margin: -0.25rem;
+			min-width: 0;
+			display: flex;
+			align-items: center;
+			gap: 0.25rem;
+		}
 
-    .nav-center {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
+		.right-group,
+		.social-icons {
+			gap: 1rem;
+			align-items: center;
+		}
+		.social-icons::after {
+			content: '';
+			height: 2rem;
+			border-inline-end: 1px solid var(--sl-color-gray-5);
+		}
 
-    .right-group,
-    .social-icons {
-      gap: 1rem;
-      align-items: center;
-    }
-    .social-icons::after {
-      content: '';
-      height: 2rem;
-      border-inline-end: 1px solid var(--sl-color-gray-5);
-    }
-
-    @media (min-width: 50rem) {
-      :global(:root[data-has-sidebar]) {
-        --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
-      }
-      :global(:root:not([data-has-toc])) {
-        --__toc-width: 0rem;
-      }
-      .header {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-content: center;
-      }
-      .title-wrapper {
-        justify-self: start;
-      }
-      .nav-center {
-        justify-self: center;
-      }
-      .right-group {
-        justify-self: end;
-      }
-      .right-group :global(site-search) {
-        min-width: 14rem;
-      }
-    }
-
-    @media (max-width: 49.99rem) {
-      .nav-center {
-        margin-left: auto;
-      }
-    }
-  }
+		@media (min-width: 50rem) {
+			:global(:root[data-has-sidebar]) {
+				--__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+			}
+			:global(:root:not([data-has-toc])) {
+				--__toc-width: 0rem;
+			}
+			.header {
+				display: grid;
+				grid-template-columns: 1fr auto;
+				align-content: center;
+			}
+			.title-wrapper {
+				justify-self: start;
+			}
+			.right-group {
+				justify-self: end;
+			}
+			.right-group :global(site-search) {
+				min-width: 14rem;
+			}
+		}
+	}
 </style>

--- a/apps/memes/astro-memes/src/components/navigation/ReactNavBar.tsx
+++ b/apps/memes/astro-memes/src/components/navigation/ReactNavBar.tsx
@@ -13,6 +13,7 @@ import {
 	closeModal,
 	useAuthBridge,
 	cn,
+	addToast,
 	DiscordIcon,
 	GitHubIcon,
 	TwitchIcon,
@@ -81,7 +82,8 @@ const styles = {
 	} as React.CSSProperties,
 
 	avatarRing: {
-		boxShadow: '0 0 0 2px color-mix(in srgb, var(--sl-color-accent) 25%, transparent)',
+		boxShadow:
+			'0 0 0 2px color-mix(in srgb, var(--sl-color-accent) 25%, transparent)',
 	} as React.CSSProperties,
 
 	userMenu: {
@@ -109,8 +111,7 @@ export default function ReactNavBar({
 	const modalId = useStore($modalId);
 	const modalOpen = modalId === SIGNIN_MODAL;
 
-	const { signInWithOAuth, loading: authLoading } =
-		useAuthBridge(authBridge);
+	const { signInWithOAuth, loading: authLoading } = useAuthBridge(authBridge);
 	const busy = authLoading;
 
 	const currentPath = useStore($currentPath);
@@ -171,6 +172,12 @@ export default function ReactNavBar({
 			try {
 				await signInWithOAuth(p);
 				closeModal(SIGNIN_MODAL);
+				addToast({
+					id: `auth-ok-${Date.now()}`,
+					message: 'Signed in successfully!',
+					severity: 'success',
+					duration: 4000,
+				});
 			} catch {
 				// useAuthBridge tracks the error
 			}
@@ -196,8 +203,7 @@ export default function ReactNavBar({
 				className={`${cls} flex items-center justify-center`}
 				style={{
 					backgroundColor: 'var(--sl-color-accent-low)',
-				}}
-			>
+				}}>
 				<User
 					size={large ? 18 : ICON_SIZE}
 					style={{
@@ -214,8 +220,7 @@ export default function ReactNavBar({
 		return (
 			<div
 				data-auth-ready
-				className="absolute inset-0 z-[1] flex items-center justify-center"
-			>
+				className="absolute inset-0 z-[1] flex items-center justify-center">
 				{auth.tone === 'auth' ? (
 					<div className="group relative flex items-center">
 						<button
@@ -234,18 +239,13 @@ export default function ReactNavBar({
 							className="flex items-center gap-1.5 rounded-full px-2 py-0.5 transition-colors duration-150 hover:bg-white/5 focus:outline-none"
 							aria-label="User menu"
 							aria-expanded={menuOpen}
-							aria-haspopup="true"
-						>
+							aria-haspopup="true">
 							<Avatar />
 							<span
 								className="text-xs font-medium max-w-[4rem] truncate"
 								style={{
-									color: slVar(
-										'--sl-color-white',
-										'#e2e8f0',
-									),
-								}}
-							>
+									color: slVar('--sl-color-white', '#e2e8f0'),
+								}}>
 								{auth.name}
 							</span>
 						</button>
@@ -267,8 +267,7 @@ export default function ReactNavBar({
 								e.currentTarget.style,
 								styles.accentBtn,
 							);
-						}}
-					>
+						}}>
 						<LogIn size={14} />
 						Sign In
 					</button>
@@ -302,8 +301,7 @@ export default function ReactNavBar({
 						className="text-sm font-medium"
 						style={{
 							color: slVar('--sl-color-white', '#e2e8f0'),
-						}}
-					>
+						}}>
 						{auth.name}
 					</span>
 					<a
@@ -321,8 +319,7 @@ export default function ReactNavBar({
 								'--sl-color-gray-2',
 								'#a1a1aa',
 							);
-						}}
-					>
+						}}>
 						<LogOut size={ICON_SIZE} />
 						Sign out
 					</a>
@@ -337,8 +334,7 @@ export default function ReactNavBar({
 				className="inline-flex items-center gap-1.5 w-full px-4 py-3 text-sm font-medium transition-colors duration-150"
 				style={{
 					color: 'var(--sl-color-text-accent)',
-				}}
-			>
+				}}>
 				<LogIn size={ICON_SIZE} />
 				Sign In
 			</button>
@@ -359,8 +355,7 @@ export default function ReactNavBar({
 						)}
 						role="dialog"
 						aria-modal="true"
-						aria-label="Navigation menu"
-					>
+						aria-label="Navigation menu">
 						<div
 							className="absolute inset-0 bg-black/50 backdrop-blur-sm"
 							onClick={doCloseDrawer}
@@ -373,14 +368,12 @@ export default function ReactNavBar({
 									? 'translate-x-0'
 									: 'translate-x-full',
 							)}
-							style={styles.surface}
-						>
+							style={styles.surface}>
 							<div
 								className="flex items-center justify-between px-4 py-3"
 								style={{
 									borderBottom: `1px solid ${slVar('--sl-color-hairline', '#27272a')}`,
-								}}
-							>
+								}}>
 								<span
 									className="text-sm font-semibold"
 									style={{
@@ -388,8 +381,7 @@ export default function ReactNavBar({
 											'--sl-color-white',
 											'#e2e8f0',
 										),
-									}}
-								>
+									}}>
 									Meme.sh
 								</span>
 								<button
@@ -402,8 +394,7 @@ export default function ReactNavBar({
 											'--sl-color-gray-3',
 											'#71717a',
 										),
-									}}
-								>
+									}}>
 									<X size={ICON_SIZE} />
 								</button>
 							</div>
@@ -445,8 +436,7 @@ export default function ReactNavBar({
 															'--sl-color-gray-2',
 															'#a1a1aa',
 														);
-											}}
-										>
+											}}>
 											<item.icon size={ICON_SIZE} />
 											{item.label}
 										</a>
@@ -458,8 +448,7 @@ export default function ReactNavBar({
 								style={{
 									borderTop: `1px solid ${slVar('--sl-color-hairline', '#27272a')}`,
 								}}
-								className="py-2"
-							>
+								className="py-2">
 								<DrawerAuth />
 							</div>
 						</div>
@@ -479,8 +468,7 @@ export default function ReactNavBar({
 							top: menuPos.top,
 							right: menuPos.right,
 						}}
-						role="menu"
-					>
+						role="menu">
 						<div className="flex items-center gap-2.5 px-3 pb-2.5 mb-1">
 							<Avatar large />
 							<div className="min-w-0">
@@ -491,14 +479,12 @@ export default function ReactNavBar({
 											'--sl-color-white',
 											'#e2e8f0',
 										),
-									}}
-								>
+									}}>
 									{auth.name}
 								</div>
 								<div
 									className="text-xs truncate"
-									style={{ color: '#7e8590' }}
-								>
+									style={{ color: '#7e8590' }}>
 									Online
 								</div>
 							</div>
@@ -524,8 +510,7 @@ export default function ReactNavBar({
 											'transparent';
 										e.currentTarget.style.color = '#7e8590';
 									}}
-									role="menuitem"
-								>
+									role="menuitem">
 									<item.icon size={ICON_SIZE} />
 									{item.label}
 								</a>
@@ -553,8 +538,7 @@ export default function ReactNavBar({
 									e.currentTarget.style.color =
 										'var(--sl-color-text-accent)';
 								}}
-								role="menuitem"
-							>
+								role="menuitem">
 								<LogOut size={ICON_SIZE} />
 								Sign Out
 							</a>
@@ -574,12 +558,10 @@ export default function ReactNavBar({
 						onClick={(e) => {
 							if (e.target === e.currentTarget && !busy)
 								closeModal(SIGNIN_MODAL);
-						}}
-					>
+						}}>
 						<div
 							className="w-full max-w-sm rounded-xl shadow-2xl p-5"
-							style={styles.surface}
-						>
+							style={styles.surface}>
 							<div className="flex items-center justify-between mb-4">
 								<h2
 									className="text-base font-semibold"
@@ -588,8 +570,7 @@ export default function ReactNavBar({
 											'--sl-color-white',
 											'#e2e8f0',
 										),
-									}}
-								>
+									}}>
 									Sign in to Meme.sh
 								</h2>
 								<button
@@ -603,8 +584,7 @@ export default function ReactNavBar({
 									onClick={() =>
 										!busy && closeModal(SIGNIN_MODAL)
 									}
-									aria-label="Close"
-								>
+									aria-label="Close">
 									<X size={ICON_SIZE} />
 								</button>
 							</div>
@@ -614,10 +594,8 @@ export default function ReactNavBar({
 									className="mb-3 text-xs rounded-md px-3 py-2"
 									style={{
 										color: '#fca5a5',
-										backgroundColor:
-											'rgba(239,68,68,0.1)',
-									}}
-								>
+										backgroundColor: 'rgba(239,68,68,0.1)',
+									}}>
 									{auth.error}
 								</div>
 							)}
@@ -639,8 +617,7 @@ export default function ReactNavBar({
 									onMouseLeave={(e) => {
 										e.currentTarget.style.backgroundColor =
 											'#5865F2';
-									}}
-								>
+									}}>
 									<DiscordIcon className="w-5 h-5" />
 									Continue with Discord
 								</button>
@@ -661,8 +638,7 @@ export default function ReactNavBar({
 									onMouseLeave={(e) => {
 										e.currentTarget.style.backgroundColor =
 											'#24292f';
-									}}
-								>
+									}}>
 									<GitHubIcon className="w-5 h-5" />
 									Continue with GitHub
 								</button>
@@ -683,8 +659,7 @@ export default function ReactNavBar({
 									onMouseLeave={(e) => {
 										e.currentTarget.style.backgroundColor =
 											'#9146FF';
-									}}
-								>
+									}}>
 									<TwitchIcon className="w-5 h-5" />
 									Continue with Twitch
 								</button>
@@ -697,8 +672,7 @@ export default function ReactNavBar({
 										'--sl-color-gray-3',
 										'#71717a',
 									),
-								}}
-							>
+								}}>
 								Your session syncs automatically across all
 								tabs.
 							</p>

--- a/apps/memes/astro-memes/src/components/overlay/OverlayShell.tsx
+++ b/apps/memes/astro-memes/src/components/overlay/OverlayShell.tsx
@@ -1,0 +1,11 @@
+import { ToastContainer, ModalOverlay, TooltipOverlay } from '@kbve/astro';
+
+export function OverlayShell() {
+	return (
+		<>
+			<ToastContainer position="bottom-right" maxVisible={5} />
+			<ModalOverlay id="generic" title="Notice" />
+			<TooltipOverlay id="react-tooltip" />
+		</>
+	);
+}

--- a/apps/memes/astro-memes/src/components/starlight/Footer.astro
+++ b/apps/memes/astro-memes/src/components/starlight/Footer.astro
@@ -2,358 +2,434 @@
 import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Footer.astro';
 import { DroidProvider } from '@kbve/astro';
+import { OverlayShell } from '../overlay/OverlayShell';
 import { workerURLs } from '../../lib/workers';
 
 const siteName = 'Meme.sh';
-const siteDescription = 'Meme sharing platform powered by KBVE. Discover, create, and share.';
+const siteDescription =
+	'Meme sharing platform powered by KBVE. Discover, create, and share.';
 
 const socialLinks = [
-  { name: 'GitHub', href: 'https://github.com/kbve', icon: 'github' },
-  { name: 'Discord', href: 'https://kbve.com/discord', icon: 'discord' },
+	{ name: 'GitHub', href: 'https://github.com/kbve', icon: 'github' },
+	{ name: 'Discord', href: 'https://kbve.com/discord', icon: 'discord' },
+];
+
+const productLinks = [
+	{ href: '/', label: 'Feed' },
+	{ href: '/dashboard', label: 'Dashboard' },
+	{ href: '/guides/getting-started/', label: 'Getting Started' },
 ];
 
 const resourceLinks = [
-  { href: '/guides/getting-started/', label: 'Documentation' },
-  { href: 'https://kbve.com', label: 'KBVE.com' },
-  { href: 'https://github.com/kbve/kbve', label: 'GitHub' },
+	{ href: '/guides/getting-started/', label: 'Documentation' },
+	{ href: 'https://kbve.com', label: 'KBVE.com' },
+	{ href: 'https://github.com/kbve/kbve', label: 'GitHub' },
 ];
 
 const legalLinks = [
-  { href: 'https://kbve.com/legal/privacy/', label: 'Privacy' },
-  { href: 'https://kbve.com/legal/tos/', label: 'Terms' },
-  { href: 'https://kbve.com/legal/', label: 'Legal' },
+	{ href: 'https://kbve.com/legal/privacy/', label: 'Privacy' },
+	{ href: 'https://kbve.com/legal/tos/', label: 'Terms' },
+	{ href: 'https://kbve.com/legal/', label: 'Legal' },
 ];
 ---
 
 <DroidProvider client:only="react" workerURLs={workerURLs} />
+<OverlayShell client:only="react" />
 <Default {...Astro.props}><slot /></Default>
 
 <footer class="kf-footer">
-  <div class="kf-hexgrid" aria-hidden="true">
-    {Array.from({ length: 4 }).map((_, row) =>
-      Array.from({ length: 13 }).map((_, i) => (
-        <div class="kf-hex" style={`--row: ${row}; --col: ${i - 6};`}></div>
-      ))
-    )}
-  </div>
+	<div class="kf-hexgrid" aria-hidden="true">
+		{
+			Array.from({ length: 4 }).map((_, row) =>
+				Array.from({ length: 13 }).map((_, i) => (
+					<div
+						class="kf-hex"
+						style={`--row: ${row}; --col: ${i - 6};`}
+					/>
+				)),
+			)
+		}
+	</div>
 
-  <div class="kf-container">
-    <div class="kf-grid">
-      <div class="kf-brand">
-        <div class="kf-logo-group">
-          <div class="kf-logo-wrapper">
-            <svg viewBox="0 0 76 76" class="kf-logo-svg" xmlns="http://www.w3.org/2000/svg">
-              <path
-                fill="currentColor"
-                d="M 19.3919,37.5442C 19.6211,31.4744 22.697,25.8757 28.3209,22.1759C 28.3375,22.1822 28.4831,22.1291 28.4166,22.255C 27.9707,22.668 19.9618,32.1286 27.3341,39.5966C 27.3341,39.5966 31.2074,43.3197 34.2103,39.7866C 34.2103,39.7866 37.1747,35.9499 34.173,30.134C 34.173,30.134 33.4135,28.2344 30.6765,27.057L 32.8808,24.6247C 32.8808,24.6247 34.7436,25.424 36.1859,27.5916C 36.1859,27.5916 36.2626,25.3093 34.5143,22.8771L 37.9323,19L 41.3153,22.8411C 41.3153,22.8411 39.7596,25.0452 39.645,27.6276C 39.645,27.6276 40.7072,25.8795 42.9887,24.6247L 45.1531,27.057C 45.1531,27.057 43.0717,27.7423 41.6775,30.1087C 40.4786,32.3015 39.5556,36.9906 41.7314,39.867C 41.7314,39.867 44.1662,43.3197 48.45,39.663C 48.45,39.663 56.3257,32.6062 47.6423,22.4039C 47.6423,22.4039 47.168,21.9846 47.7007,22.2127C 51.5385,25.0066 56.1339,28.6918 56.6082,37.8876C 56.4214,49.0393 48.9535,57 38.0487,57C 27.3715,57 19.0713,48.0899 19.3919,37.5442 Z"
-              />
-            </svg>
-          </div>
-          <span class="kf-logo-text">{siteName}</span>
-        </div>
-        <p class="kf-description">{siteDescription}</p>
-        <div class="kf-social">
-          {socialLinks.map(({ name, href, icon }) => (
-            <a href={href} target="_blank" rel="noopener noreferrer" class="kf-social-link" aria-label={name}>
-              {icon === 'github' && (
-                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
-                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                </svg>
-              )}
-              {icon === 'discord' && (
-                <svg viewBox="0 0 24 24" fill="currentColor" class="kf-social-icon">
-                  <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/>
-                </svg>
-              )}
-            </a>
-          ))}
-        </div>
-      </div>
+	<div class="kf-container">
+		<div class="kf-grid">
+			<div class="kf-brand">
+				<div class="kf-logo-group">
+					<div class="kf-logo-wrapper">
+						<svg
+							viewBox="0 0 76 76"
+							class="kf-logo-svg"
+							xmlns="http://www.w3.org/2000/svg">
+							<path
+								fill="currentColor"
+								d="M 19.3919,37.5442C 19.6211,31.4744 22.697,25.8757 28.3209,22.1759C 28.3375,22.1822 28.4831,22.1291 28.4166,22.255C 27.9707,22.668 19.9618,32.1286 27.3341,39.5966C 27.3341,39.5966 31.2074,43.3197 34.2103,39.7866C 34.2103,39.7866 37.1747,35.9499 34.173,30.134C 34.173,30.134 33.4135,28.2344 30.6765,27.057L 32.8808,24.6247C 32.8808,24.6247 34.7436,25.424 36.1859,27.5916C 36.1859,27.5916 36.2626,25.3093 34.5143,22.8771L 37.9323,19L 41.3153,22.8411C 41.3153,22.8411 39.7596,25.0452 39.645,27.6276C 39.645,27.6276 40.7072,25.8795 42.9887,24.6247L 45.1531,27.057C 45.1531,27.057 43.0717,27.7423 41.6775,30.1087C 40.4786,32.3015 39.5556,36.9906 41.7314,39.867C 41.7314,39.867 44.1662,43.3197 48.45,39.663C 48.45,39.663 56.3257,32.6062 47.6423,22.4039C 47.6423,22.4039 47.168,21.9846 47.7007,22.2127C 51.5385,25.0066 56.1339,28.6918 56.6082,37.8876C 56.4214,49.0393 48.9535,57 38.0487,57C 27.3715,57 19.0713,48.0899 19.3919,37.5442 Z">
+							</path>
+						</svg>
+					</div>
+					<span class="kf-logo-text">{siteName}</span>
+				</div>
+				<p class="kf-description">{siteDescription}</p>
+				<div class="kf-social">
+					{
+						socialLinks.map(({ name, href, icon }) => (
+							<a
+								href={href}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="kf-social-link"
+								aria-label={name}>
+								{icon === 'github' && (
+									<svg
+										viewBox="0 0 24 24"
+										fill="currentColor"
+										class="kf-social-icon">
+										<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+									</svg>
+								)}
+								{icon === 'discord' && (
+									<svg
+										viewBox="0 0 24 24"
+										fill="currentColor"
+										class="kf-social-icon">
+										<path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+									</svg>
+								)}
+							</a>
+						))
+					}
+				</div>
+			</div>
 
-      <nav class="kf-nav" aria-labelledby="resources-heading">
-        <h3 id="resources-heading" class="kf-nav-title">Resources</h3>
-        <ul class="kf-nav-list">
-          {resourceLinks.map((link) => (
-            <li>
-              <a href={link.href} class="kf-nav-link">{link.label}</a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-    </div>
+			<nav class="kf-nav" aria-labelledby="product-heading">
+				<h3 id="product-heading" class="kf-nav-title">Product</h3>
+				<ul class="kf-nav-list">
+					{
+						productLinks.map((link) => (
+							<li>
+								<a href={link.href} class="kf-nav-link">
+									{link.label}
+								</a>
+							</li>
+						))
+					}
+				</ul>
+			</nav>
 
-    <div class="kf-bottom">
-      <div class="kf-bottom-content">
-        <p class="kf-copyright">&copy; {new Date().getFullYear()} KBVE. All rights reserved.</p>
-        <nav class="kf-legal" aria-label="Legal">
-          {legalLinks.map((link) => (
-            <a href={link.href} class="kf-legal-link">{link.label}</a>
-          ))}
-        </nav>
-      </div>
-    </div>
-  </div>
+			<nav class="kf-nav" aria-labelledby="resources-heading">
+				<h3 id="resources-heading" class="kf-nav-title">Resources</h3>
+				<ul class="kf-nav-list">
+					{
+						resourceLinks.map((link) => (
+							<li>
+								<a href={link.href} class="kf-nav-link">
+									{link.label}
+								</a>
+							</li>
+						))
+					}
+				</ul>
+			</nav>
+		</div>
+
+		<div class="kf-bottom">
+			<div class="kf-bottom-content">
+				<p class="kf-copyright">
+					&copy; {new Date().getFullYear()} KBVE. All rights reserved.
+				</p>
+				<nav class="kf-legal" aria-label="Legal">
+					{
+						legalLinks.map((link) => (
+							<a href={link.href} class="kf-legal-link">
+								{link.label}
+							</a>
+						))
+					}
+				</nav>
+			</div>
+		</div>
+	</div>
 </footer>
 
 <style>
-  .kf-footer {
-    margin-top: auto;
-    background: var(--sl-color-bg);
-    border-top: 1px solid var(--sl-color-border);
-    position: relative;
-    overflow: hidden;
-  }
+	.kf-footer {
+		margin-top: auto;
+		background: var(--sl-color-bg);
+		border-top: 1px solid var(--sl-color-border);
+		position: relative;
+		overflow: hidden;
+	}
 
-  .kf-hexgrid {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    overflow: hidden;
-  }
+	.kf-hexgrid {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		overflow: hidden;
+	}
 
-  .kf-hex {
-    --hex-size: 44px;
-    --hex-width: var(--hex-size);
-    --hex-height: calc(var(--hex-size) * 1.1547);
-    --hex-horiz: calc(var(--hex-width) * 0.75);
-    --hex-vert: calc(var(--hex-height) * 0.5);
+	.kf-hex {
+		--hex-size: 44px;
+		--hex-width: var(--hex-size);
+		--hex-height: calc(var(--hex-size) * 1.1547);
+		--hex-horiz: calc(var(--hex-width) * 0.75);
+		--hex-vert: calc(var(--hex-height) * 0.5);
 
-    position: absolute;
-    width: var(--hex-width);
-    height: var(--hex-height);
-    background: var(--sl-color-accent);
-    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+		position: absolute;
+		width: var(--hex-width);
+		height: var(--hex-height);
+		background: var(--sl-color-accent);
+		clip-path: polygon(
+			50% 0%,
+			100% 25%,
+			100% 75%,
+			50% 100%,
+			0% 75%,
+			0% 25%
+		);
 
-    left: calc(50% + (var(--col) * var(--hex-horiz)) - (var(--hex-width) * 0.5));
-    bottom: calc(var(--row) * var(--hex-vert) + 8px);
+		left: calc(
+			50% + (var(--col) * var(--hex-horiz)) - (var(--hex-width) * 0.5)
+		);
+		bottom: calc(var(--row) * var(--hex-vert) + 8px);
 
-    --dist-from-center: max(var(--col), calc(-1 * var(--col)));
-    --delay: calc(2s + (var(--row) * 0.4s) + (var(--dist-from-center) * 0.2s));
-    --drift-x: calc(var(--col) * 25px);
-    --drift-y: calc(-120px - (var(--row) * 30px));
-    --rotation: calc(var(--col) * 12deg);
+		--dist-from-center: max(var(--col), calc(-1 * var(--col)));
+		--delay: calc(
+			2s + (var(--row) * 0.4s) + (var(--dist-from-center) * 0.2s)
+		);
+		--drift-x: calc(var(--col) * 25px);
+		--drift-y: calc(-120px - (var(--row) * 30px));
+		--rotation: calc(var(--col) * 12deg);
 
-    opacity: 0.15;
-    animation: kf-hex-dissolve 14s ease-in-out infinite;
-    animation-delay: var(--delay);
-  }
+		opacity: 0.15;
+		animation: kf-hex-dissolve 14s ease-in-out infinite;
+		animation-delay: var(--delay);
+	}
 
-  .kf-hex[style*="--row: 1"],
-  .kf-hex[style*="--row: 3"] {
-    transform: translateX(calc(var(--hex-horiz) * 0.5));
-  }
+	.kf-hex[style*='--row: 1'],
+	.kf-hex[style*='--row: 3'] {
+		transform: translateX(calc(var(--hex-horiz) * 0.5));
+	}
 
-  .kf-hex[style*="--row: 0"],
-  .kf-hex[style*="--row: 2"] {
-    transform: translateX(0);
-  }
+	.kf-hex[style*='--row: 0'],
+	.kf-hex[style*='--row: 2'] {
+		transform: translateX(0);
+	}
 
-  @keyframes kf-hex-dissolve {
-    0%, 20% {
-      opacity: 0.15;
-      transform: translateX(var(--row-offset, 0)) translateY(0) rotate(0deg) scale(1);
-    }
-    35% {
-      opacity: 0.12;
-      transform: translateX(var(--row-offset, 0)) translateY(-8px) rotate(0deg) scale(1);
-    }
-    55% {
-      opacity: 0.08;
-      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.4))
-                 translateY(calc(var(--drift-y) * 0.4))
-                 rotate(calc(var(--rotation) * 0.3))
-                 scale(0.9);
-    }
-    75% {
-      opacity: 0.03;
-      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x) * 0.8))
-                 translateY(calc(var(--drift-y) * 0.7))
-                 rotate(calc(var(--rotation) * 0.7))
-                 scale(0.7);
-    }
-    90%, 100% {
-      opacity: 0;
-      transform: translateX(calc(var(--row-offset, 0) + var(--drift-x)))
-                 translateY(var(--drift-y))
-                 rotate(var(--rotation))
-                 scale(0.4);
-    }
-  }
+	@keyframes kf-hex-dissolve {
+		0%,
+		20% {
+			opacity: 0.15;
+			transform: translateX(var(--row-offset, 0)) translateY(0)
+				rotate(0deg) scale(1);
+		}
+		35% {
+			opacity: 0.12;
+			transform: translateX(var(--row-offset, 0)) translateY(-8px)
+				rotate(0deg) scale(1);
+		}
+		55% {
+			opacity: 0.08;
+			transform: translateX(
+					calc(var(--row-offset, 0) + var(--drift-x) * 0.4)
+				)
+				translateY(calc(var(--drift-y) * 0.4))
+				rotate(calc(var(--rotation) * 0.3)) scale(0.9);
+		}
+		75% {
+			opacity: 0.03;
+			transform: translateX(
+					calc(var(--row-offset, 0) + var(--drift-x) * 0.8)
+				)
+				translateY(calc(var(--drift-y) * 0.7))
+				rotate(calc(var(--rotation) * 0.7)) scale(0.7);
+		}
+		90%,
+		100% {
+			opacity: 0;
+			transform: translateX(calc(var(--row-offset, 0) + var(--drift-x)))
+				translateY(var(--drift-y)) rotate(var(--rotation)) scale(0.4);
+		}
+	}
 
-  @media (prefers-reduced-motion: reduce) {
-    .kf-hex {
-      animation: none;
-      opacity: 0.08;
-    }
-  }
+	@media (prefers-reduced-motion: reduce) {
+		.kf-hex {
+			animation: none;
+			opacity: 0.08;
+		}
+	}
 
-  @media (max-width: 768px) {
-    .kf-hex { --hex-size: 36px; }
-  }
+	@media (max-width: 768px) {
+		.kf-hex {
+			--hex-size: 36px;
+		}
+	}
 
-  @media (max-width: 480px) {
-    .kf-hex { --hex-size: 28px; }
-  }
+	@media (max-width: 480px) {
+		.kf-hex {
+			--hex-size: 28px;
+		}
+	}
 
-  .kf-container {
-    max-width: 72rem;
-    margin: 0 auto;
-    padding: 2rem 1.5rem;
-    position: relative;
-    z-index: 1;
-  }
+	.kf-container {
+		max-width: 72rem;
+		margin: 0 auto;
+		padding: 2rem 1.5rem;
+		position: relative;
+		z-index: 1;
+	}
 
-  .kf-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 2rem;
-  }
+	.kf-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 2rem;
+	}
 
-  @media (min-width: 640px) {
-    .kf-grid { grid-template-columns: 2fr 1fr; }
-  }
+	@media (min-width: 640px) {
+		.kf-grid {
+			grid-template-columns: 2fr 1fr 1fr;
+		}
+	}
 
-  .kf-brand {
-    grid-column: 1;
-  }
+	.kf-brand {
+		grid-column: 1;
+	}
 
-  .kf-logo-group {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
+	.kf-logo-group {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 1rem;
+	}
 
-  .kf-logo-wrapper {
-    width: 2.5rem;
-    height: 2.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--sl-color-accent-low);
-    border-radius: 0.5rem;
-    border: 1px solid var(--sl-color-border);
-  }
+	.kf-logo-wrapper {
+		width: 2.5rem;
+		height: 2.5rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--sl-color-accent-low);
+		border-radius: 0.5rem;
+		border: 1px solid var(--sl-color-border);
+	}
 
-  .kf-logo-svg {
-    width: 1.5rem;
-    height: 1.5rem;
-    color: var(--sl-color-accent);
-  }
+	.kf-logo-svg {
+		width: 1.5rem;
+		height: 1.5rem;
+		color: var(--sl-color-accent);
+	}
 
-  .kf-logo-text {
-    font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    color: var(--sl-color-text);
-  }
+	.kf-logo-text {
+		font-size: 1.25rem;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		color: var(--sl-color-text);
+	}
 
-  .kf-description {
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: var(--sl-color-gray-2);
-    max-width: 20rem;
-    margin-bottom: 1rem;
-  }
+	.kf-description {
+		font-size: 0.875rem;
+		line-height: 1.6;
+		color: var(--sl-color-gray-2);
+		max-width: 20rem;
+		margin-bottom: 1rem;
+	}
 
-  .kf-social {
-    display: flex;
-    gap: 0.75rem;
-  }
+	.kf-social {
+		display: flex;
+		gap: 0.75rem;
+	}
 
-  .kf-social-link {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    color: var(--sl-color-gray-2);
-    background: var(--sl-color-accent-low);
-    border: 1px solid var(--sl-color-border);
-    border-radius: 0.375rem;
-    transition: all 0.2s ease;
-  }
+	.kf-social-link {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		color: var(--sl-color-gray-2);
+		background: var(--sl-color-accent-low);
+		border: 1px solid var(--sl-color-border);
+		border-radius: 0.375rem;
+		transition: all 0.2s ease;
+	}
 
-  .kf-social-link:hover {
-    color: var(--sl-color-accent);
-    border-color: var(--sl-color-accent);
-    transform: translateY(-2px);
-  }
+	.kf-social-link:hover {
+		color: var(--sl-color-accent);
+		border-color: var(--sl-color-accent);
+		transform: translateY(-2px);
+	}
 
-  .kf-social-icon {
-    width: 1rem;
-    height: 1rem;
-  }
+	.kf-social-icon {
+		width: 1rem;
+		height: 1rem;
+	}
 
-  .kf-nav-title {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--sl-color-accent);
-    margin-bottom: 1rem;
-  }
+	.kf-nav-title {
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sl-color-accent);
+		margin-bottom: 1rem;
+	}
 
-  .kf-nav-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
+	.kf-nav-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
 
-  .kf-nav-link {
-    font-size: 0.875rem;
-    color: var(--sl-color-gray-2);
-    text-decoration: none;
-    transition: color 0.2s ease;
-    display: inline-block;
-  }
+	.kf-nav-link {
+		font-size: 0.875rem;
+		color: var(--sl-color-gray-2);
+		text-decoration: none;
+		transition: color 0.2s ease;
+		display: inline-block;
+	}
 
-  .kf-nav-link:hover {
-    color: var(--sl-color-accent);
-  }
+	.kf-nav-link:hover {
+		color: var(--sl-color-accent);
+	}
 
-  .kf-bottom {
-    margin-top: 2rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--sl-color-border);
-  }
+	.kf-bottom {
+		margin-top: 2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--sl-color-border);
+	}
 
-  .kf-bottom-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-  }
+	.kf-bottom-content {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+	}
 
-  @media (min-width: 640px) {
-    .kf-bottom-content {
-      flex-direction: row;
-      justify-content: space-between;
-    }
-  }
+	@media (min-width: 640px) {
+		.kf-bottom-content {
+			flex-direction: row;
+			justify-content: space-between;
+		}
+	}
 
-  .kf-copyright {
-    font-size: 0.75rem;
-    color: var(--sl-color-gray-3);
-    margin: 0;
-  }
+	.kf-copyright {
+		font-size: 0.75rem;
+		color: var(--sl-color-gray-3);
+		margin: 0;
+	}
 
-  .kf-legal {
-    display: flex;
-    gap: 1.5rem;
-  }
+	.kf-legal {
+		display: flex;
+		gap: 1.5rem;
+	}
 
-  .kf-legal-link {
-    font-size: 0.75rem;
-    color: var(--sl-color-gray-3);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+	.kf-legal-link {
+		font-size: 0.75rem;
+		color: var(--sl-color-gray-3);
+		text-decoration: none;
+		transition: color 0.2s ease;
+	}
 
-  .kf-legal-link:hover {
-    color: var(--sl-color-accent);
-  }
+	.kf-legal-link:hover {
+		color: var(--sl-color-accent);
+	}
 </style>


### PR DESCRIPTION
## Summary
- Wire up `OverlayShell` (ToastContainer + ModalOverlay + TooltipOverlay) following the discordsh pattern
- Restructure header to inline brand + nav icons: `<Meme.sh> { Home · Docs · Dashboard · Auth · ☰ }` on the left
- Add "Product" link column to footer for a full 3-column grid (Brand | Product | Resources)
- Fire success toast on OAuth sign-in

## Test plan
- [ ] Build passes (`pnpm nx build astro-memes`)
- [ ] Desktop: brand text and nav icons sit flush together on the left
- [ ] Mobile: hamburger opens drawer, nav items work
- [ ] Footer: 3 columns (Brand | Product | Resources) + legal bar
- [ ] Toast: bottom-right notification appears on successful OAuth sign-in