### PR TITLE
feat(edge): add Docker-based e2e test suite for edge runtime

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -323,7 +323,7 @@ jobs:
                   { "name": "irc-gateway", "target": "container", "condition": "${{ needs.alter.outputs.irc_gateway }}", "e2e_name": "irc", "image": "kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml" },
                   { "name": "discordsh", "target": "container", "condition": "${{ needs.alter.outputs.discordsh }}", "e2e_name": "discordsh", "image": "kbve/discordsh", "cargo_toml": "apps/discordsh/axum-discordsh/Cargo.toml" },
                   { "name": "mc", "target": "container", "condition": "${{ needs.alter.outputs.mc }}", "e2e_name": "mc", "image": "kbve/mc" },
-                  { "name": "edge", "target": "container", "condition": "${{ needs.alter.outputs.edge }}" }
+                  { "name": "edge", "target": "container", "condition": "${{ needs.alter.outputs.edge }}", "e2e_name": "edge", "image": "kbve/edge" }
                 ]
 
     generate_e2e_docker_matrix:
@@ -336,7 +336,8 @@ jobs:
                   { "name": "memes", "condition": "${{ needs.alter.outputs.memes }}" },
                   { "name": "irc", "condition": "${{ needs.alter.outputs.irc_gateway }}" },
                   { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}" },
-                  { "name": "mc", "condition": "${{ needs.alter.outputs.mc }}" }
+                  { "name": "mc", "condition": "${{ needs.alter.outputs.mc }}" },
+                  { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}" }
                 ]
 
     test_docker:

--- a/apps/kbve/edge-e2e/e2e/auth.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/auth.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { createJwt, createBadSignatureJwt } from './helpers/jwt';
+
+describe('JWT Authentication', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('should reject requests without an Authorization header', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ command: 'get', secret_id: 'test' }),
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.msg).toContain('Missing authorization header');
+	});
+
+	it('should reject requests with a malformed Authorization header', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'NotBearer some-token',
+			},
+			body: JSON.stringify({ command: 'get', secret_id: 'test' }),
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.msg).toContain("not 'Bearer {token}'");
+	});
+
+	it('should reject a JWT signed with the wrong secret', async () => {
+		const badToken = createBadSignatureJwt();
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${badToken}`,
+			},
+			body: JSON.stringify({ command: 'get', secret_id: 'test' }),
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.msg).toContain('Invalid JWT');
+	});
+
+	it('should reject an expired JWT', async () => {
+		const expiredToken = createJwt({ expired: true });
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${expiredToken}`,
+			},
+			body: JSON.stringify({ command: 'get', secret_id: 'test' }),
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.msg).toContain('Invalid JWT');
+	});
+
+	it('should reject a completely garbage token string', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer not-a-real-jwt',
+			},
+			body: JSON.stringify({ command: 'get', secret_id: 'test' }),
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.msg).toContain('Invalid JWT');
+	});
+
+	it('should accept a valid JWT and pass through to the sub-function', async () => {
+		const token = createJwt({ role: 'service_role' });
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({
+				command: 'get',
+				secret_id: '00000000-0000-0000-0000-000000000000',
+			}),
+		});
+		// Main router accepted the JWT and forwarded to vault-reader.
+		// Should NOT get 401 from the main router.
+		expect(res.status).not.toBe(401);
+	});
+});

--- a/apps/kbve/edge-e2e/e2e/bad-request.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/bad-request.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { createJwt } from './helpers/jwt';
+
+describe('Bad Request Handling on vault-reader', () => {
+	let serviceToken: string;
+
+	beforeAll(async () => {
+		await waitForReady();
+		serviceToken = createJwt({ role: 'service_role' });
+	});
+
+	const headers = () => ({
+		'Content-Type': 'application/json',
+		Authorization: `Bearer ${serviceToken}`,
+	});
+
+	it('should return 405 for GET requests to vault-reader', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${serviceToken}` },
+		});
+		expect(res.status).toBe(405);
+		const body = await res.json();
+		expect(body.error).toContain('Only POST method is allowed');
+	});
+
+	it('should return 400 when command field is missing', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('command is required');
+	});
+
+	it('should return 400 for get command without secret_id', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({ command: 'get' }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('secret_id is required');
+	});
+
+	it('should return 400 for set command without secret_name/secret_value', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({ command: 'set' }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain(
+			'secret_name and secret_value are required',
+		);
+	});
+
+	it('should return 400 for an invalid command value', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({ command: 'delete' }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('Invalid command');
+	});
+
+	it('should return 500 for malformed JSON body', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${serviceToken}`,
+			},
+			body: '{not valid json',
+		});
+		expect(res.status).toBe(500);
+		const body = await res.json();
+		expect(body.error).toContain('Internal server error');
+	});
+});

--- a/apps/kbve/edge-e2e/e2e/cors.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/cors.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+describe('CORS Preflight Handling', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('should respond to OPTIONS on vault-reader without requiring JWT', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'OPTIONS',
+			headers: {
+				Origin: 'https://example.com',
+				'Access-Control-Request-Method': 'POST',
+				'Access-Control-Request-Headers': 'authorization, content-type',
+			},
+		});
+		expect(res.ok).toBe(true);
+	});
+
+	it('should include CORS headers in the OPTIONS response', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'OPTIONS',
+			headers: {
+				Origin: 'https://example.com',
+				'Access-Control-Request-Method': 'POST',
+			},
+		});
+		const allowOrigin = res.headers.get('access-control-allow-origin');
+		const allowHeaders = res.headers.get('access-control-allow-headers');
+		expect(allowOrigin).toBe('*');
+		expect(allowHeaders).toContain('authorization');
+		expect(allowHeaders).toContain('content-type');
+	});
+});

--- a/apps/kbve/edge-e2e/e2e/health.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/health.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { createJwt } from './helpers/jwt';
+
+describe('Edge Runtime Health', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('should be reachable and respond to HTTP requests', async () => {
+		const res = await fetch(BASE_URL);
+		expect([400, 401]).toContain(res.status);
+	});
+
+	it('should return 400 with valid JWT but no function name', async () => {
+		const token = createJwt();
+		const res = await fetch(BASE_URL, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.msg).toContain('missing function name in request');
+	});
+});

--- a/apps/kbve/edge-e2e/e2e/helpers/http.ts
+++ b/apps/kbve/edge-e2e/e2e/helpers/http.ts
@@ -1,0 +1,30 @@
+const EDGE_HOST = process.env['EDGE_HOST'] ?? '127.0.0.1';
+const EDGE_PORT = Number(process.env['EDGE_PORT'] ?? 9100);
+
+export const BASE_URL = `http://${EDGE_HOST}:${EDGE_PORT}`;
+
+/**
+ * Poll until the edge runtime responds to HTTP requests.
+ * TCP-only checks are insufficient — the runtime accepts TCP
+ * connections before the HTTP server is fully initialized.
+ */
+export async function waitForReady(timeoutMs = 30_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(BASE_URL, {
+				signal: AbortSignal.timeout(2_000),
+			});
+			// Any HTTP response (even 400/401) means the server is ready
+			if (res.status > 0) return;
+		} catch {
+			// Connection refused or reset — keep trying
+		}
+		await new Promise((r) => setTimeout(r, 500));
+	}
+
+	throw new Error(
+		`Edge runtime not ready at ${BASE_URL} after ${timeoutMs}ms`,
+	);
+}

--- a/apps/kbve/edge-e2e/e2e/helpers/jwt.ts
+++ b/apps/kbve/edge-e2e/e2e/helpers/jwt.ts
@@ -1,0 +1,63 @@
+import { createHmac } from 'node:crypto';
+
+const JWT_SECRET = 'super-secret-jwt-token-for-dev';
+
+export type JwtRole = 'service_role' | 'anon' | 'authenticated';
+
+export interface JwtOptions {
+	role?: JwtRole;
+	expiresInSeconds?: number;
+	expired?: boolean;
+	extraClaims?: Record<string, unknown>;
+}
+
+function base64url(input: string | Buffer): string {
+	const buf = typeof input === 'string' ? Buffer.from(input) : input;
+	return buf.toString('base64url');
+}
+
+function signHmac(data: string, secret: string): string {
+	return createHmac('sha256', secret).update(data).digest('base64url');
+}
+
+export function createJwt(options: JwtOptions = {}): string {
+	const {
+		role = 'service_role',
+		expiresInSeconds = 3600,
+		expired = false,
+		extraClaims = {},
+	} = options;
+
+	const now = Math.floor(Date.now() / 1000);
+	const exp = expired ? now - 3600 : now + expiresInSeconds;
+
+	const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+	const payload = base64url(
+		JSON.stringify({
+			role,
+			iss: 'supabase',
+			iat: now,
+			exp,
+			...extraClaims,
+		}),
+	);
+
+	const signature = signHmac(`${header}.${payload}`, JWT_SECRET);
+	return `${header}.${payload}.${signature}`;
+}
+
+export function createBadSignatureJwt(): string {
+	const now = Math.floor(Date.now() / 1000);
+	const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+	const payload = base64url(
+		JSON.stringify({
+			role: 'service_role',
+			iss: 'supabase',
+			iat: now,
+			exp: now + 3600,
+		}),
+	);
+
+	const signature = signHmac(`${header}.${payload}`, 'wrong-secret-key');
+	return `${header}.${payload}.${signature}`;
+}

--- a/apps/kbve/edge-e2e/e2e/role-access.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/role-access.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { createJwt, type JwtRole } from './helpers/jwt';
+
+describe('Role-Based Access Control on vault-reader', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	const makeVaultRequest = (role: JwtRole) => {
+		const token = createJwt({ role });
+		return fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({
+				command: 'get',
+				secret_id: '00000000-0000-0000-0000-000000000000',
+			}),
+		});
+	};
+
+	it('should allow service_role and forward to the function', async () => {
+		const res = await makeVaultRequest('service_role');
+		// Passes both the main router JWT gate and vault-reader role check.
+		// RPC will fail (no Supabase), but we should NOT get 401 or 403.
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(403);
+	});
+
+	it('should deny anon role with 403', async () => {
+		const res = await makeVaultRequest('anon');
+		expect(res.status).toBe(403);
+		const body = await res.json();
+		expect(body.error).toContain('Service role required');
+	});
+
+	it('should deny authenticated role with 403', async () => {
+		const res = await makeVaultRequest('authenticated');
+		expect(res.status).toBe(403);
+		const body = await res.json();
+		expect(body.error).toContain('Service role required');
+	});
+});

--- a/apps/kbve/edge-e2e/e2e/routing.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/routing.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { createJwt } from './helpers/jwt';
+
+describe('Function Routing', () => {
+	let token: string;
+
+	beforeAll(async () => {
+		await waitForReady();
+		token = createJwt();
+	});
+
+	it('should return 400 when no function name is provided', async () => {
+		const res = await fetch(BASE_URL, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.msg).toContain('missing function name in request');
+	});
+
+	it('should return 500 for a non-existent function', async () => {
+		const res = await fetch(`${BASE_URL}/nonexistent-function`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(res.status).toBe(500);
+		const body = await res.json();
+		expect(body.msg).toBeDefined();
+	});
+
+	it('should route to vault-reader when path is /vault-reader', async () => {
+		const res = await fetch(`${BASE_URL}/vault-reader`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({
+				command: 'get',
+				secret_id: '00000000-0000-0000-0000-000000000000',
+			}),
+		});
+		// Reaches vault-reader (not a routing-level error).
+		// Main router errors use 'msg', vault-reader uses 'error'.
+		expect(res.status).not.toBe(400);
+		const body = await res.json();
+		expect(body.msg).toBeUndefined();
+	});
+});

--- a/apps/kbve/edge-e2e/package.json
+++ b/apps/kbve/edge-e2e/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "edge-e2e",
+	"private": true,
+	"version": "0.0.0"
+}

--- a/apps/kbve/edge-e2e/project.json
+++ b/apps/kbve/edge-e2e/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "edge-e2e",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/kbve/edge-e2e/e2e",
+	"implicitDependencies": ["edge"],
+	"targets": {
+		"test": {
+			"executor": "nx:noop",
+			"cache": false
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker rm -f edge-e2e-test 2>/dev/null || true",
+					"docker run -d --name edge-e2e-test -p 9100:9000 -e JWT_SECRET=super-secret-jwt-token-for-dev -e VERIFY_JWT=true -e SUPABASE_URL=http://localhost:54321 -e SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key kbve/edge:latest start --main-service /home/deno/functions/main",
+					"npx vitest run; EC=$?; docker rm -f edge-e2e-test 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false,
+				"cwd": "apps/kbve/edge-e2e"
+			}
+		}
+	},
+	"tags": ["scope:kbve"]
+}

--- a/apps/kbve/edge-e2e/tsconfig.json
+++ b/apps/kbve/edge-e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true
+	},
+	"include": ["e2e/**/*.ts", "vitest.config.ts"]
+}

--- a/apps/kbve/edge-e2e/vitest.config.ts
+++ b/apps/kbve/edge-e2e/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 30_000,
+		hookTimeout: 60_000,
+	},
+});

--- a/apps/kbve/edge/project.json
+++ b/apps/kbve/edge/project.json
@@ -110,6 +110,15 @@
 				],
 				"parallel": false
 			}
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"dependsOn": ["container"],
+			"options": {
+				"commands": ["./kbve.sh -nx edge-e2e:e2e"],
+				"parallel": false
+			}
 		}
 	},
 	"tags": ["scope:kbve", "edge", "infrastructure"]


### PR DESCRIPTION
## Summary
- Create `apps/kbve/edge-e2e/` vitest project with 22 tests across 6 spec files
- Tests cover JWT auth, role-based access (403), CORS preflight, request validation, and routing
- Zero external dependencies — JWT signing uses `node:crypto` (HS256/HMAC-SHA256)
- Add `e2e` target to `edge` project that delegates to `edge-e2e:e2e`
- Wire into CI: `generate_docker_matrix` (e2e_name) + `generate_e2e_docker_matrix`

## Test plan
- [x] `pnpm nx e2e edge-e2e` — 22/22 tests pass locally
- [x] Lint-staged passes (prettier + eslint)
- [ ] CI e2e matrix picks up edge changes and runs tests