### PR TITLE
feat(meme-types): proto-to-zod codegen pipeline

### DIFF
--- a/packages/npm/meme-types/codegen/proto-to-zod.ts
+++ b/packages/npm/meme-types/codegen/proto-to-zod.ts
@@ -1,0 +1,322 @@
+/**
+ * proto-to-zod.ts — Generates Zod schemas from meme.proto
+ *
+ * Usage: ts-node --esm packages/npm/meme-types/codegen/proto-to-zod.ts
+ *
+ * Reads packages/data/proto/meme/meme.proto and outputs
+ * packages/npm/meme-types/src/generated/meme.zod.ts
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const PROTO_PATH = resolve('packages/data/proto/meme/meme.proto');
+const OUTPUT_PATH = resolve(
+	'packages/npm/meme-types/src/generated/meme.zod.ts',
+);
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface ProtoEnum {
+	name: string;
+	values: string[];
+}
+
+interface ProtoField {
+	name: string;
+	type: string;
+	repeated: boolean;
+	optional: boolean;
+}
+
+interface ProtoMessage {
+	name: string;
+	fields: ProtoField[];
+}
+
+// ── Parse ───────────────────────────────────────────────────────────────────
+
+function parseProto(source: string): {
+	enums: ProtoEnum[];
+	messages: ProtoMessage[];
+} {
+	const enums: ProtoEnum[] = [];
+	const messages: ProtoMessage[] = [];
+
+	const lines = source.split('\n');
+	let i = 0;
+
+	while (i < lines.length) {
+		const line = lines[i].trim();
+
+		// Skip empty, comments, syntax, package, import, service/rpc blocks
+		if (
+			!line ||
+			line.startsWith('//') ||
+			line.startsWith('syntax') ||
+			line.startsWith('package') ||
+			line.startsWith('import')
+		) {
+			i++;
+			continue;
+		}
+
+		// Service block — skip entirely
+		if (line.startsWith('service ')) {
+			let depth = 0;
+			for (; i < lines.length; i++) {
+				const l = lines[i];
+				depth += (l.match(/{/g) || []).length;
+				depth -= (l.match(/}/g) || []).length;
+				if (depth <= 0 && l.includes('}')) {
+					i++;
+					break;
+				}
+			}
+			continue;
+		}
+
+		// Enum block
+		const enumMatch = line.match(/^enum\s+(\w+)\s*\{/);
+		if (enumMatch) {
+			const name = enumMatch[1];
+			const values: string[] = [];
+			i++;
+			while (i < lines.length) {
+				const eLine = lines[i].trim();
+				if (eLine === '}') {
+					i++;
+					break;
+				}
+				// Match: ENUM_VALUE = 0; // optional comment
+				const valueMatch = eLine.match(/^(\w+)\s*=\s*\d+\s*;/);
+				if (valueMatch) {
+					values.push(valueMatch[1]);
+				}
+				i++;
+			}
+			enums.push({ name, values });
+			continue;
+		}
+
+		// Message block
+		const msgMatch = line.match(/^message\s+(\w+)\s*\{/);
+		if (msgMatch) {
+			const name = msgMatch[1];
+			const fields: ProtoField[] = [];
+			i++;
+			while (i < lines.length) {
+				const mLine = lines[i].trim();
+				if (mLine === '}') {
+					i++;
+					break;
+				}
+
+				// Skip comments and empty lines inside message
+				if (!mLine || mLine.startsWith('//')) {
+					i++;
+					continue;
+				}
+
+				// Parse field: [optional|repeated] type name = N;
+				const fieldMatch = mLine.match(
+					/^(optional\s+|repeated\s+)?(\S+)\s+(\w+)\s*=\s*\d+\s*;/,
+				);
+				if (fieldMatch) {
+					const modifier = (fieldMatch[1] || '').trim();
+					const type = fieldMatch[2];
+					const fieldName = fieldMatch[3];
+					fields.push({
+						name: fieldName,
+						type,
+						repeated: modifier === 'repeated',
+						optional: modifier === 'optional',
+					});
+				}
+				i++;
+			}
+			messages.push({ name, fields });
+			continue;
+		}
+
+		i++;
+	}
+
+	return { enums, messages };
+}
+
+// ── Topological Sort ────────────────────────────────────────────────────────
+
+function topoSort(
+	messages: ProtoMessage[],
+	enumNames: Set<string>,
+): ProtoMessage[] {
+	const msgIndex = new Map<string, number>();
+	messages.forEach((m, idx) => msgIndex.set(m.name, idx));
+
+	// Build adjacency: message depends on other messages it references
+	const deps = new Map<string, Set<string>>();
+	for (const m of messages) {
+		const s = new Set<string>();
+		for (const f of m.fields) {
+			const t = f.type;
+			if (msgIndex.has(t) && t !== m.name) {
+				s.add(t);
+			}
+		}
+		deps.set(m.name, s);
+	}
+
+	// Kahn's algorithm
+	const inDegree = new Map<string, number>();
+	for (const m of messages) inDegree.set(m.name, 0);
+	for (const [, d] of deps) {
+		for (const dep of d) {
+			inDegree.set(dep, (inDegree.get(dep) || 0) + 1);
+		}
+	}
+
+	// Note: inDegree counts how many messages DEPEND ON this message,
+	// but for topo sort we need how many deps each message HAS.
+	// Let me redo this correctly.
+	const inDeg = new Map<string, number>();
+	for (const m of messages) inDeg.set(m.name, deps.get(m.name)!.size);
+
+	const queue: string[] = [];
+	for (const [name, deg] of inDeg) {
+		if (deg === 0) queue.push(name);
+	}
+
+	const sorted: string[] = [];
+	while (queue.length > 0) {
+		const curr = queue.shift()!;
+		sorted.push(curr);
+		// Find messages that depend on curr and decrement their in-degree
+		for (const [name, d] of deps) {
+			if (d.has(curr)) {
+				d.delete(curr);
+				inDeg.set(name, inDeg.get(name)! - 1);
+				if (inDeg.get(name) === 0) {
+					queue.push(name);
+				}
+			}
+		}
+	}
+
+	return sorted.map((name) => messages[msgIndex.get(name)!]);
+}
+
+// ── Type Mapping ────────────────────────────────────────────────────────────
+
+function mapType(
+	protoType: string,
+	enumNames: Set<string>,
+	msgNames: Set<string>,
+): string {
+	switch (protoType) {
+		case 'string':
+			return 'z.string()';
+		case 'int32':
+			return 'z.number().int()';
+		case 'int64':
+			return 'z.number()';
+		case 'float':
+			return 'z.number()';
+		case 'double':
+			return 'z.number()';
+		case 'bool':
+			return 'z.boolean()';
+		case 'kbve.common.Result':
+			return 'ResultSchema';
+		default:
+			if (enumNames.has(protoType)) return `${protoType}Schema`;
+			if (msgNames.has(protoType)) return `${protoType}Schema`;
+			return `z.unknown() /* unmapped: ${protoType} */`;
+	}
+}
+
+// ── Emit ────────────────────────────────────────────────────────────────────
+
+function emit(enums: ProtoEnum[], messages: ProtoMessage[]): string {
+	const enumNames = new Set(enums.map((e) => e.name));
+	const msgNames = new Set(messages.map((m) => m.name));
+	const sorted = topoSort(messages, enumNames);
+
+	const lines: string[] = [];
+
+	lines.push('// AUTO-GENERATED from meme.proto — DO NOT EDIT');
+	lines.push(`// Source: packages/data/proto/meme/meme.proto`);
+	lines.push('');
+	lines.push("import { z } from 'zod';");
+	lines.push('');
+	lines.push("import { ResultSchema } from '../common.zod';");
+	lines.push('');
+
+	// Enums
+	lines.push(
+		'// ─────────────────────────────────────────────────────────────────────────',
+	);
+	lines.push('// Enums');
+	lines.push(
+		'// ─────────────────────────────────────────────────────────────────────────',
+	);
+	lines.push('');
+
+	for (const e of enums) {
+		const valuesName = `${e.name}Values`;
+		lines.push(`export const ${valuesName} = [`);
+		for (const v of e.values) {
+			lines.push(`\t'${v}',`);
+		}
+		lines.push('] as const;');
+		lines.push(`export const ${e.name}Schema = z.enum(${valuesName});`);
+		lines.push(`export type ${e.name} = z.infer<typeof ${e.name}Schema>;`);
+		lines.push('');
+	}
+
+	// Messages
+	lines.push(
+		'// ─────────────────────────────────────────────────────────────────────────',
+	);
+	lines.push('// Messages');
+	lines.push(
+		'// ─────────────────────────────────────────────────────────────────────────',
+	);
+	lines.push('');
+
+	for (const m of sorted) {
+		lines.push(`export const ${m.name}Schema = z.object({`);
+		for (const f of m.fields) {
+			const base = mapType(f.type, enumNames, msgNames);
+			let zodExpr: string;
+			if (f.repeated) {
+				zodExpr = `z.array(${base})`;
+			} else if (f.optional) {
+				zodExpr = `${base}.optional()`;
+			} else {
+				zodExpr = base;
+			}
+			lines.push(`\t${f.name}: ${zodExpr},`);
+		}
+		lines.push('});');
+		lines.push(`export type ${m.name} = z.infer<typeof ${m.name}Schema>;`);
+		lines.push('');
+	}
+
+	return lines.join('\n');
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+const source = readFileSync(PROTO_PATH, 'utf-8');
+const { enums, messages } = parseProto(source);
+const output = emit(enums, messages);
+
+mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+writeFileSync(OUTPUT_PATH, output, 'utf-8');
+
+console.log(
+	`Generated ${OUTPUT_PATH} (${enums.length} enums, ${messages.length} messages)`,
+);

--- a/packages/npm/meme-types/package.json
+++ b/packages/npm/meme-types/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "@kbve/meme-types",
+	"version": "0.0.1",
+	"description": "Zod schemas auto-generated from meme.proto",
+	"author": "KBVE <hello@kbve.com>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./meme-types.es.js",
+	"module": "./meme-types.es.js",
+	"types": "./index.d.ts",
+	"exports": {
+		".": {
+			"import": "./meme-types.es.js",
+			"types": "./index.d.ts"
+		}
+	},
+	"dependencies": {
+		"zod": "^3.23.8"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/npm/meme-types/project.json
+++ b/packages/npm/meme-types/project.json
@@ -1,0 +1,46 @@
+{
+	"name": "meme-types",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/npm/meme-types/src",
+	"projectType": "library",
+	"tags": [],
+	"targets": {
+		"proto": {
+			"executor": "nx:run-commands",
+			"inputs": [
+				"{workspaceRoot}/packages/data/proto/meme/meme.proto",
+				"{workspaceRoot}/packages/data/proto/kbve/common.proto",
+				"{projectRoot}/codegen/proto-to-zod.ts"
+			],
+			"outputs": ["{projectRoot}/src/generated/meme.zod.ts"],
+			"options": {
+				"command": "ts-node --esm packages/npm/meme-types/codegen/proto-to-zod.ts"
+			},
+			"cache": true
+		},
+		"build": {
+			"executor": "@nx/vite:build",
+			"dependsOn": ["proto"],
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/packages/npm/meme-types",
+				"main": "packages/npm/meme-types/src/index.ts",
+				"tsConfig": "packages/npm/meme-types/tsconfig.lib.json",
+				"configFile": "packages/npm/meme-types/vite.config.ts"
+			}
+		},
+		"sync": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["build"],
+			"options": {
+				"commands": ["nx build astro", "nx build astro-memes"],
+				"parallel": false
+			}
+		},
+		"nx-release-publish": {
+			"options": {
+				"packageRoot": "dist/packages/npm/meme-types"
+			}
+		}
+	}
+}

--- a/packages/npm/meme-types/src/common.zod.ts
+++ b/packages/npm/meme-types/src/common.zod.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const ResultSchema = z.object({
+	success: z.boolean(),
+	message: z.string(),
+	code: z.number().int(),
+});
+export type Result = z.infer<typeof ResultSchema>;

--- a/packages/npm/meme-types/src/generated/meme.zod.ts
+++ b/packages/npm/meme-types/src/generated/meme.zod.ts
@@ -1,0 +1,765 @@
+// AUTO-GENERATED from meme.proto — DO NOT EDIT
+// Source: packages/data/proto/meme/meme.proto
+
+import { z } from 'zod';
+
+import { ResultSchema } from '../common.zod';
+
+// ─────────────────────────────────────────────────────────────────────────
+// Enums
+// ─────────────────────────────────────────────────────────────────────────
+
+export const MemeFormatValues = [
+	'MEME_FORMAT_UNSPECIFIED',
+	'MEME_FORMAT_IMAGE',
+	'MEME_FORMAT_GIF',
+	'MEME_FORMAT_VIDEO',
+	'MEME_FORMAT_WEBP_ANIM',
+] as const;
+export const MemeFormatSchema = z.enum(MemeFormatValues);
+export type MemeFormat = z.infer<typeof MemeFormatSchema>;
+
+export const MemeStatusValues = [
+	'MEME_STATUS_UNSPECIFIED',
+	'MEME_STATUS_DRAFT',
+	'MEME_STATUS_PENDING',
+	'MEME_STATUS_PUBLISHED',
+	'MEME_STATUS_REJECTED',
+	'MEME_STATUS_ARCHIVED',
+	'MEME_STATUS_FLAGGED',
+	'MEME_STATUS_BANNED',
+] as const;
+export const MemeStatusSchema = z.enum(MemeStatusValues);
+export type MemeStatus = z.infer<typeof MemeStatusSchema>;
+
+export const ReactionTypeValues = [
+	'REACTION_UNSPECIFIED',
+	'REACTION_LIKE',
+	'REACTION_DISLIKE',
+	'REACTION_FIRE',
+	'REACTION_SKULL',
+	'REACTION_CRY',
+	'REACTION_CAP',
+] as const;
+export const ReactionTypeSchema = z.enum(ReactionTypeValues);
+export type ReactionType = z.infer<typeof ReactionTypeSchema>;
+
+export const MemeRarityValues = [
+	'MEME_RARITY_UNSPECIFIED',
+	'MEME_RARITY_COMMON',
+	'MEME_RARITY_UNCOMMON',
+	'MEME_RARITY_RARE',
+	'MEME_RARITY_EPIC',
+	'MEME_RARITY_LEGENDARY',
+	'MEME_RARITY_MYTHIC',
+] as const;
+export const MemeRaritySchema = z.enum(MemeRarityValues);
+export type MemeRarity = z.infer<typeof MemeRaritySchema>;
+
+export const MemeElementValues = [
+	'MEME_ELEMENT_UNSPECIFIED',
+	'MEME_ELEMENT_DANK',
+	'MEME_ELEMENT_WHOLESOME',
+	'MEME_ELEMENT_CURSED',
+	'MEME_ELEMENT_DEEP_FRIED',
+	'MEME_ELEMENT_SURREAL',
+	'MEME_ELEMENT_META',
+	'MEME_ELEMENT_EDGY',
+	'MEME_ELEMENT_NOSTALGIC',
+] as const;
+export const MemeElementSchema = z.enum(MemeElementValues);
+export type MemeElement = z.infer<typeof MemeElementSchema>;
+
+export const AbilityTriggerValues = [
+	'ABILITY_TRIGGER_UNSPECIFIED',
+	'ABILITY_TRIGGER_ON_PLAY',
+	'ABILITY_TRIGGER_ON_ATTACK',
+	'ABILITY_TRIGGER_ON_DEFEND',
+	'ABILITY_TRIGGER_ON_DEATH',
+	'ABILITY_TRIGGER_PASSIVE',
+	'ABILITY_TRIGGER_ON_TURN_START',
+	'ABILITY_TRIGGER_ON_TURN_END',
+] as const;
+export const AbilityTriggerSchema = z.enum(AbilityTriggerValues);
+export type AbilityTrigger = z.infer<typeof AbilityTriggerSchema>;
+
+export const AbilityEffectValues = [
+	'ABILITY_EFFECT_UNSPECIFIED',
+	'ABILITY_EFFECT_DAMAGE',
+	'ABILITY_EFFECT_HEAL',
+	'ABILITY_EFFECT_BUFF_ATK',
+	'ABILITY_EFFECT_BUFF_DEF',
+	'ABILITY_EFFECT_DEBUFF_ATK',
+	'ABILITY_EFFECT_DEBUFF_DEF',
+	'ABILITY_EFFECT_DRAW',
+	'ABILITY_EFFECT_STUN',
+	'ABILITY_EFFECT_SHIELD',
+	'ABILITY_EFFECT_ELEMENT_SHIFT',
+] as const;
+export const AbilityEffectSchema = z.enum(AbilityEffectValues);
+export type AbilityEffect = z.infer<typeof AbilityEffectSchema>;
+
+export const FeedSortValues = [
+	'FEED_SORT_UNSPECIFIED',
+	'FEED_SORT_HOT',
+	'FEED_SORT_NEW',
+	'FEED_SORT_TOP',
+	'FEED_SORT_RANDOM',
+	'FEED_SORT_RISING',
+] as const;
+export const FeedSortSchema = z.enum(FeedSortValues);
+export type FeedSort = z.infer<typeof FeedSortSchema>;
+
+export const FeedTimeWindowValues = [
+	'FEED_TIME_UNSPECIFIED',
+	'FEED_TIME_HOUR',
+	'FEED_TIME_DAY',
+	'FEED_TIME_WEEK',
+	'FEED_TIME_MONTH',
+	'FEED_TIME_ALL',
+] as const;
+export const FeedTimeWindowSchema = z.enum(FeedTimeWindowValues);
+export type FeedTimeWindow = z.infer<typeof FeedTimeWindowSchema>;
+
+export const ReportReasonValues = [
+	'REPORT_REASON_UNSPECIFIED',
+	'REPORT_REASON_SPAM',
+	'REPORT_REASON_NSFW',
+	'REPORT_REASON_HATE_SPEECH',
+	'REPORT_REASON_HARASSMENT',
+	'REPORT_REASON_COPYRIGHT',
+	'REPORT_REASON_MISINFORMATION',
+	'REPORT_REASON_OTHER',
+] as const;
+export const ReportReasonSchema = z.enum(ReportReasonValues);
+export type ReportReason = z.infer<typeof ReportReasonSchema>;
+
+export const BattleStatusValues = [
+	'BATTLE_STATUS_UNSPECIFIED',
+	'BATTLE_STATUS_WAITING',
+	'BATTLE_STATUS_IN_PROGRESS',
+	'BATTLE_STATUS_COMPLETED',
+	'BATTLE_STATUS_ABANDONED',
+	'BATTLE_STATUS_DRAW',
+] as const;
+export const BattleStatusSchema = z.enum(BattleStatusValues);
+export type BattleStatus = z.infer<typeof BattleStatusSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Messages
+// ─────────────────────────────────────────────────────────────────────────
+
+export const MemeCaptionSchema = z.object({
+	text: z.string(),
+	position_x: z.number(),
+	position_y: z.number(),
+	font_size: z.number().optional(),
+	font_family: z.string().optional(),
+	color: z.string().optional(),
+	stroke_color: z.string().optional(),
+	stroke_width: z.number().optional(),
+	rotation: z.number().optional(),
+	text_align: z.string().optional(),
+	max_width: z.number().optional(),
+});
+export type MemeCaption = z.infer<typeof MemeCaptionSchema>;
+
+export const TemplateCaptionSlotSchema = z.object({
+	label: z.string(),
+	default_x: z.number(),
+	default_y: z.number(),
+	default_font_size: z.number().optional(),
+	placeholder: z.string().optional(),
+	max_width: z.number().optional(),
+	max_chars: z.number().int().optional(),
+});
+export type TemplateCaptionSlot = z.infer<typeof TemplateCaptionSlotSchema>;
+
+export const CardAbilitySchema = z.object({
+	name: z.string(),
+	description: z.string(),
+	trigger: AbilityTriggerSchema,
+	effect: AbilityEffectSchema,
+	value: z.number().int(),
+	cooldown: z.number().int().optional(),
+	duration: z.number().int().optional(),
+});
+export type CardAbility = z.infer<typeof CardAbilitySchema>;
+
+export const ElementMatchupSchema = z.object({
+	attacker: MemeElementSchema,
+	defender: MemeElementSchema,
+	damage_multiplier: z.number(),
+});
+export type ElementMatchup = z.infer<typeof ElementMatchupSchema>;
+
+export const MemeReactionSchema = z.object({
+	meme_id: z.string(),
+	user_id: z.string(),
+	reaction: ReactionTypeSchema,
+	created_at: z.string(),
+});
+export type MemeReaction = z.infer<typeof MemeReactionSchema>;
+
+export const MemeCommentSchema = z.object({
+	id: z.string(),
+	meme_id: z.string(),
+	author_id: z.string(),
+	body: z.string(),
+	parent_id: z.string().optional(),
+	reaction_count: z.number(),
+	reply_count: z.number().int(),
+	created_at: z.string(),
+	updated_at: z.string().optional(),
+});
+export type MemeComment = z.infer<typeof MemeCommentSchema>;
+
+export const MemeSaveSchema = z.object({
+	meme_id: z.string(),
+	user_id: z.string(),
+	collection_id: z.string().optional(),
+	created_at: z.string(),
+});
+export type MemeSave = z.infer<typeof MemeSaveSchema>;
+
+export const MemeCollectionSchema = z.object({
+	id: z.string(),
+	owner_id: z.string(),
+	name: z.string(),
+	description: z.string().optional(),
+	cover_meme_id: z.string().optional(),
+	is_public: z.boolean(),
+	meme_count: z.number().int(),
+	created_at: z.string(),
+	updated_at: z.string().optional(),
+});
+export type MemeCollection = z.infer<typeof MemeCollectionSchema>;
+
+export const MemePlayerStatsSchema = z.object({
+	user_id: z.string(),
+	total_battles: z.number().int(),
+	wins: z.number().int(),
+	losses: z.number().int(),
+	draws: z.number().int(),
+	elo_rating: z.number().int(),
+	cards_owned: z.number().int(),
+	highest_streak: z.number().int(),
+	rank_title: z.string().optional(),
+});
+export type MemePlayerStats = z.infer<typeof MemePlayerStatsSchema>;
+
+export const MemeFollowSchema = z.object({
+	follower_id: z.string(),
+	following_id: z.string(),
+	created_at: z.string(),
+});
+export type MemeFollow = z.infer<typeof MemeFollowSchema>;
+
+export const DeckCardSchema = z.object({
+	card_id: z.string(),
+	position: z.number().int().optional(),
+});
+export type DeckCard = z.infer<typeof DeckCardSchema>;
+
+export const BattleActionSchema = z.object({
+	turn: z.number().int(),
+	player_id: z.string(),
+	card_id: z.string(),
+	target_card_id: z.string().optional(),
+	ability_name: z.string().optional(),
+	damage_dealt: z.number().int(),
+	healing_done: z.number().int(),
+	effect_applied: z.string().optional(),
+});
+export type BattleAction = z.infer<typeof BattleActionSchema>;
+
+export const MemeReportSchema = z.object({
+	id: z.string(),
+	meme_id: z.string(),
+	reporter_id: z.string(),
+	reason: ReportReasonSchema,
+	detail: z.string().optional(),
+	resolved: z.boolean(),
+	resolved_by: z.string().optional(),
+	resolution_note: z.string().optional(),
+	created_at: z.string(),
+	resolved_at: z.string().optional(),
+});
+export type MemeReport = z.infer<typeof MemeReportSchema>;
+
+export const FeedRequestSchema = z.object({
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+	sort: FeedSortSchema,
+	time_window: FeedTimeWindowSchema.optional(),
+	tag: z.string().optional(),
+	author_id: z.string().optional(),
+	element: MemeElementSchema.optional(),
+	cards_only: z.boolean().optional(),
+});
+export type FeedRequest = z.infer<typeof FeedRequestSchema>;
+
+export const GetMemeRequestSchema = z.object({
+	id: z.string(),
+});
+export type GetMemeRequest = z.infer<typeof GetMemeRequestSchema>;
+
+export const UpdateMemeRequestSchema = z.object({
+	id: z.string(),
+	title: z.string().optional(),
+	tags: z.array(z.string()),
+	alt_text: z.string().optional(),
+	status: MemeStatusSchema.optional(),
+});
+export type UpdateMemeRequest = z.infer<typeof UpdateMemeRequestSchema>;
+
+export const DeleteMemeRequestSchema = z.object({
+	id: z.string(),
+});
+export type DeleteMemeRequest = z.infer<typeof DeleteMemeRequestSchema>;
+
+export const DeleteMemeResponseSchema = z.object({
+	result: ResultSchema,
+});
+export type DeleteMemeResponse = z.infer<typeof DeleteMemeResponseSchema>;
+
+export const ReactRequestSchema = z.object({
+	meme_id: z.string(),
+	reaction: ReactionTypeSchema,
+});
+export type ReactRequest = z.infer<typeof ReactRequestSchema>;
+
+export const ReactResponseSchema = z.object({
+	result: ResultSchema,
+});
+export type ReactResponse = z.infer<typeof ReactResponseSchema>;
+
+export const AddCommentRequestSchema = z.object({
+	meme_id: z.string(),
+	body: z.string(),
+	parent_id: z.string().optional(),
+});
+export type AddCommentRequest = z.infer<typeof AddCommentRequestSchema>;
+
+export const ListCommentsRequestSchema = z.object({
+	meme_id: z.string(),
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+	parent_id: z.string().optional(),
+});
+export type ListCommentsRequest = z.infer<typeof ListCommentsRequestSchema>;
+
+export const SaveMemeRequestSchema = z.object({
+	meme_id: z.string(),
+	collection_id: z.string().optional(),
+});
+export type SaveMemeRequest = z.infer<typeof SaveMemeRequestSchema>;
+
+export const SaveMemeResponseSchema = z.object({
+	result: ResultSchema,
+});
+export type SaveMemeResponse = z.infer<typeof SaveMemeResponseSchema>;
+
+export const UnsaveMemeRequestSchema = z.object({
+	meme_id: z.string(),
+	collection_id: z.string().optional(),
+});
+export type UnsaveMemeRequest = z.infer<typeof UnsaveMemeRequestSchema>;
+
+export const UnsaveMemeResponseSchema = z.object({
+	result: ResultSchema,
+});
+export type UnsaveMemeResponse = z.infer<typeof UnsaveMemeResponseSchema>;
+
+export const CreateCollectionRequestSchema = z.object({
+	name: z.string(),
+	description: z.string().optional(),
+	is_public: z.boolean(),
+});
+export type CreateCollectionRequest = z.infer<
+	typeof CreateCollectionRequestSchema
+>;
+
+export const ListCollectionsRequestSchema = z.object({
+	owner_id: z.string(),
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+});
+export type ListCollectionsRequest = z.infer<
+	typeof ListCollectionsRequestSchema
+>;
+
+export const GetCollectionMemesRequestSchema = z.object({
+	collection_id: z.string(),
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+});
+export type GetCollectionMemesRequest = z.infer<
+	typeof GetCollectionMemesRequestSchema
+>;
+
+export const GetTemplateRequestSchema = z.object({
+	id: z.string(),
+});
+export type GetTemplateRequest = z.infer<typeof GetTemplateRequestSchema>;
+
+export const ListTemplatesRequestSchema = z.object({
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+	search: z.string().optional(),
+});
+export type ListTemplatesRequest = z.infer<typeof ListTemplatesRequestSchema>;
+
+export const GetMemeProfileRequestSchema = z.object({
+	user_id: z.string(),
+});
+export type GetMemeProfileRequest = z.infer<typeof GetMemeProfileRequestSchema>;
+
+export const FollowRequestSchema = z.object({
+	target_user_id: z.string(),
+});
+export type FollowRequest = z.infer<typeof FollowRequestSchema>;
+
+export const FollowResponseSchema = z.object({
+	result: ResultSchema,
+});
+export type FollowResponse = z.infer<typeof FollowResponseSchema>;
+
+export const UnfollowRequestSchema = z.object({
+	target_user_id: z.string(),
+});
+export type UnfollowRequest = z.infer<typeof UnfollowRequestSchema>;
+
+export const UnfollowResponseSchema = z.object({
+	result: ResultSchema,
+});
+export type UnfollowResponse = z.infer<typeof UnfollowResponseSchema>;
+
+export const ListFollowersRequestSchema = z.object({
+	user_id: z.string(),
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+});
+export type ListFollowersRequest = z.infer<typeof ListFollowersRequestSchema>;
+
+export const ListFollowingRequestSchema = z.object({
+	user_id: z.string(),
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+});
+export type ListFollowingRequest = z.infer<typeof ListFollowingRequestSchema>;
+
+export const ReportMemeRequestSchema = z.object({
+	meme_id: z.string(),
+	reason: ReportReasonSchema,
+	detail: z.string().optional(),
+});
+export type ReportMemeRequest = z.infer<typeof ReportMemeRequestSchema>;
+
+export const ReportMemeResponseSchema = z.object({
+	result: ResultSchema,
+});
+export type ReportMemeResponse = z.infer<typeof ReportMemeResponseSchema>;
+
+export const MintCardRequestSchema = z.object({
+	meme_id: z.string(),
+});
+export type MintCardRequest = z.infer<typeof MintCardRequestSchema>;
+
+export const CreateDeckRequestSchema = z.object({
+	name: z.string(),
+	card_ids: z.array(z.string()),
+});
+export type CreateDeckRequest = z.infer<typeof CreateDeckRequestSchema>;
+
+export const UpdateDeckRequestSchema = z.object({
+	deck_id: z.string(),
+	name: z.string().optional(),
+	card_ids: z.array(z.string()),
+	is_active: z.boolean().optional(),
+});
+export type UpdateDeckRequest = z.infer<typeof UpdateDeckRequestSchema>;
+
+export const ListDecksRequestSchema = z.object({
+	owner_id: z.string(),
+});
+export type ListDecksRequest = z.infer<typeof ListDecksRequestSchema>;
+
+export const StartBattleRequestSchema = z.object({
+	deck_id: z.string(),
+});
+export type StartBattleRequest = z.infer<typeof StartBattleRequestSchema>;
+
+export const StartBattleResponseSchema = z.object({
+	result: ResultSchema,
+	battle_id: z.string().optional(),
+	status: BattleStatusSchema.optional(),
+});
+export type StartBattleResponse = z.infer<typeof StartBattleResponseSchema>;
+
+export const GetBattleRequestSchema = z.object({
+	battle_id: z.string(),
+});
+export type GetBattleRequest = z.infer<typeof GetBattleRequestSchema>;
+
+export const ListBattleHistoryRequestSchema = z.object({
+	user_id: z.string(),
+	limit: z.number().int(),
+	cursor: z.string().optional(),
+});
+export type ListBattleHistoryRequest = z.infer<
+	typeof ListBattleHistoryRequestSchema
+>;
+
+export const SubmitMemeRequestSchema = z.object({
+	title: z.string().optional(),
+	template_id: z.string().optional(),
+	format: MemeFormatSchema,
+	asset_url: z.string(),
+	captions: z.array(MemeCaptionSchema),
+	tags: z.array(z.string()),
+	source_url: z.string().optional(),
+	alt_text: z.string().optional(),
+});
+export type SubmitMemeRequest = z.infer<typeof SubmitMemeRequestSchema>;
+
+export const MemeTemplateSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	description: z.string().optional(),
+	image_url: z.string(),
+	thumbnail_url: z.string().optional(),
+	width: z.number().int(),
+	height: z.number().int(),
+	slots: z.array(TemplateCaptionSlotSchema),
+	usage_count: z.number(),
+	tags: z.array(z.string()),
+	created_at: z.string(),
+	updated_at: z.string().optional(),
+});
+export type MemeTemplate = z.infer<typeof MemeTemplateSchema>;
+
+export const MemeCardStatsSchema = z.object({
+	meme_id: z.string(),
+	rarity: MemeRaritySchema,
+	element: MemeElementSchema,
+	attack: z.number().int(),
+	defense: z.number().int(),
+	hp: z.number().int(),
+	energy_cost: z.number().int(),
+	abilities: z.array(CardAbilitySchema),
+	flavor_text: z.string().optional(),
+	level: z.number().int(),
+	xp: z.number(),
+	evolves_from: z.string().optional(),
+	evolves_into: z.string().optional(),
+});
+export type MemeCardStats = z.infer<typeof MemeCardStatsSchema>;
+
+export const AddCommentResponseSchema = z.object({
+	result: ResultSchema,
+	comment: MemeCommentSchema.optional(),
+});
+export type AddCommentResponse = z.infer<typeof AddCommentResponseSchema>;
+
+export const ListCommentsResponseSchema = z.object({
+	comments: z.array(MemeCommentSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type ListCommentsResponse = z.infer<typeof ListCommentsResponseSchema>;
+
+export const CreateCollectionResponseSchema = z.object({
+	result: ResultSchema,
+	collection: MemeCollectionSchema.optional(),
+});
+export type CreateCollectionResponse = z.infer<
+	typeof CreateCollectionResponseSchema
+>;
+
+export const ListCollectionsResponseSchema = z.object({
+	collections: z.array(MemeCollectionSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type ListCollectionsResponse = z.infer<
+	typeof ListCollectionsResponseSchema
+>;
+
+export const MemeUserProfileSchema = z.object({
+	user_id: z.string(),
+	display_name: z.string().optional(),
+	avatar_url: z.string().optional(),
+	bio: z.string().optional(),
+	total_memes: z.number(),
+	total_reactions_received: z.number(),
+	total_views_received: z.number(),
+	follower_count: z.number().int(),
+	following_count: z.number().int(),
+	card_stats: MemePlayerStatsSchema.optional(),
+	joined_at: z.string(),
+	updated_at: z.string().optional(),
+});
+export type MemeUserProfile = z.infer<typeof MemeUserProfileSchema>;
+
+export const MemeDeckSchema = z.object({
+	id: z.string(),
+	owner_id: z.string(),
+	name: z.string(),
+	cards: z.array(DeckCardSchema),
+	is_active: z.boolean(),
+	created_at: z.string(),
+	updated_at: z.string().optional(),
+});
+export type MemeDeck = z.infer<typeof MemeDeckSchema>;
+
+export const BattleResultSchema = z.object({
+	battle_id: z.string(),
+	player_a_id: z.string(),
+	player_b_id: z.string(),
+	status: BattleStatusSchema,
+	winner_id: z.string().optional(),
+	total_turns: z.number().int(),
+	actions: z.array(BattleActionSchema),
+	elo_delta_a: z.number().int(),
+	elo_delta_b: z.number().int(),
+	created_at: z.string(),
+	completed_at: z.string().optional(),
+});
+export type BattleResult = z.infer<typeof BattleResultSchema>;
+
+export const GetTemplateResponseSchema = z.object({
+	found: z.boolean(),
+	template: MemeTemplateSchema.optional(),
+});
+export type GetTemplateResponse = z.infer<typeof GetTemplateResponseSchema>;
+
+export const ListTemplatesResponseSchema = z.object({
+	templates: z.array(MemeTemplateSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type ListTemplatesResponse = z.infer<typeof ListTemplatesResponseSchema>;
+
+export const MemeSchema = z.object({
+	id: z.string(),
+	author_id: z.string(),
+	title: z.string().optional(),
+	template_id: z.string().optional(),
+	format: MemeFormatSchema,
+	status: MemeStatusSchema,
+	asset_url: z.string(),
+	thumbnail_url: z.string().optional(),
+	width: z.number().int().optional(),
+	height: z.number().int().optional(),
+	file_size: z.number().optional(),
+	captions: z.array(MemeCaptionSchema),
+	tags: z.array(z.string()),
+	source_url: z.string().optional(),
+	alt_text: z.string().optional(),
+	view_count: z.number(),
+	reaction_count: z.number(),
+	share_count: z.number(),
+	comment_count: z.number(),
+	save_count: z.number(),
+	created_at: z.string(),
+	updated_at: z.string().optional(),
+	published_at: z.string().optional(),
+	card: MemeCardStatsSchema.optional(),
+	content_hash: z.string().optional(),
+});
+export type Meme = z.infer<typeof MemeSchema>;
+
+export const MintCardResponseSchema = z.object({
+	result: ResultSchema,
+	card: MemeCardStatsSchema.optional(),
+});
+export type MintCardResponse = z.infer<typeof MintCardResponseSchema>;
+
+export const GetMemeProfileResponseSchema = z.object({
+	found: z.boolean(),
+	profile: MemeUserProfileSchema.optional(),
+});
+export type GetMemeProfileResponse = z.infer<
+	typeof GetMemeProfileResponseSchema
+>;
+
+export const ListFollowersResponseSchema = z.object({
+	followers: z.array(MemeUserProfileSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type ListFollowersResponse = z.infer<typeof ListFollowersResponseSchema>;
+
+export const ListFollowingResponseSchema = z.object({
+	following: z.array(MemeUserProfileSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type ListFollowingResponse = z.infer<typeof ListFollowingResponseSchema>;
+
+export const CreateDeckResponseSchema = z.object({
+	result: ResultSchema,
+	deck: MemeDeckSchema.optional(),
+});
+export type CreateDeckResponse = z.infer<typeof CreateDeckResponseSchema>;
+
+export const UpdateDeckResponseSchema = z.object({
+	result: ResultSchema,
+	deck: MemeDeckSchema.optional(),
+});
+export type UpdateDeckResponse = z.infer<typeof UpdateDeckResponseSchema>;
+
+export const ListDecksResponseSchema = z.object({
+	decks: z.array(MemeDeckSchema),
+});
+export type ListDecksResponse = z.infer<typeof ListDecksResponseSchema>;
+
+export const GetBattleResponseSchema = z.object({
+	found: z.boolean(),
+	battle: BattleResultSchema.optional(),
+});
+export type GetBattleResponse = z.infer<typeof GetBattleResponseSchema>;
+
+export const ListBattleHistoryResponseSchema = z.object({
+	battles: z.array(BattleResultSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type ListBattleHistoryResponse = z.infer<
+	typeof ListBattleHistoryResponseSchema
+>;
+
+export const FeedResponseSchema = z.object({
+	memes: z.array(MemeSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type FeedResponse = z.infer<typeof FeedResponseSchema>;
+
+export const SubmitMemeResponseSchema = z.object({
+	result: ResultSchema,
+	meme: MemeSchema.optional(),
+});
+export type SubmitMemeResponse = z.infer<typeof SubmitMemeResponseSchema>;
+
+export const GetMemeResponseSchema = z.object({
+	found: z.boolean(),
+	meme: MemeSchema.optional(),
+});
+export type GetMemeResponse = z.infer<typeof GetMemeResponseSchema>;
+
+export const UpdateMemeResponseSchema = z.object({
+	result: ResultSchema,
+	meme: MemeSchema.optional(),
+});
+export type UpdateMemeResponse = z.infer<typeof UpdateMemeResponseSchema>;
+
+export const GetCollectionMemesResponseSchema = z.object({
+	memes: z.array(MemeSchema),
+	next_cursor: z.string().optional(),
+	has_more: z.boolean(),
+});
+export type GetCollectionMemesResponse = z.infer<
+	typeof GetCollectionMemesResponseSchema
+>;

--- a/packages/npm/meme-types/src/index.ts
+++ b/packages/npm/meme-types/src/index.ts
@@ -1,0 +1,2 @@
+export * from './common.zod';
+export * from './generated/meme.zod';

--- a/packages/npm/meme-types/tsconfig.json
+++ b/packages/npm/meme-types/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "esnext",
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"importHelpers": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"files": [],
+	"include": ["src"],
+	"references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/packages/npm/meme-types/tsconfig.lib.json
+++ b/packages/npm/meme-types/tsconfig.lib.json
@@ -1,0 +1,18 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"],
+		"composite": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": [
+		"vite.config.ts",
+		"vite.config.mts",
+		"vitest.config.ts",
+		"vitest.config.mts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts"
+	]
+}

--- a/packages/npm/meme-types/vite.config.ts
+++ b/packages/npm/meme-types/vite.config.ts
@@ -1,0 +1,33 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import * as path from 'path';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+	root: __dirname,
+	cacheDir: '../../../node_modules/.vite/npm/meme-types',
+
+	plugins: [
+		nxViteTsPaths(),
+		dts({
+			entryRoot: 'src',
+			tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
+			skipDiagnostics: true,
+		}),
+	],
+
+	build: {
+		outDir: '../../../dist/packages/npm/meme-types',
+		reportCompressedSize: true,
+		lib: {
+			entry: path.resolve(__dirname, 'src/index.ts'),
+			name: 'meme-types',
+			fileName: (format) => `meme-types.${format}.js`,
+			formats: ['es'],
+		},
+		rollupOptions: {
+			external: ['zod'],
+		},
+	},
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,7 +19,8 @@
 			"@kbve/devops": ["packages/npm/devops/src/index.ts"],
 			"@kbve/droid": ["packages/npm/droid/src/index.ts"],
 			"@kbve/khashvault": ["packages/npm/khashvault/src/index.ts"],
-			"@kbve/laser": ["packages/npm/laser/src/index.ts"]
+			"@kbve/laser": ["packages/npm/laser/src/index.ts"],
+			"@kbve/meme-types": ["packages/npm/meme-types/src/index.ts"]
 		}
 	},
 	"exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary
- Add `@kbve/meme-types` NX library with auto-generated Zod schemas from `meme.proto`
- Custom `codegen/proto-to-zod.ts` parser (zero new deps) generates 11 enums + 75 message schemas with topological ordering
- NX targets: `proto` (codegen, cached on proto+script inputs), `build` (Vite lib), `sync` (chains proto → build → astro → astro-memes)

## Details
- **Source of truth**: `packages/data/proto/meme/meme.proto` → auto-generated `src/generated/meme.zod.ts`
- **Hand-written**: `src/common.zod.ts` for `kbve.common.Result` (stable, rarely changes)
- **One command**: `pnpm nx sync meme-types` runs full pipeline: proto codegen → build meme-types → build astro → build astro-memes
- **Caching**: NX cache on proto file + codegen script inputs — unchanged steps are instant

## Test plan
- [ ] `pnpm nx proto meme-types` generates `src/generated/meme.zod.ts` with 11 enums + 75 messages
- [ ] `pnpm nx build meme-types` compiles to `dist/packages/npm/meme-types/` with `.es.js` + `.d.ts`
- [ ] `pnpm nx sync meme-types` runs full chain (proto → build → astro → astro-memes)
- [ ] Re-run with no changes hits NX cache on all steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)