### PR TITLE
feat(discordsh): party stats, flee rework, underground city

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/game/router.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/router.rs
@@ -179,6 +179,7 @@ fn parse_action(s: &str) -> Option<GameAction> {
         "item" => Some(GameAction::ToggleItems),
         "explore" => Some(GameAction::Explore),
         "flee" => Some(GameAction::Flee),
+        "rest" => Some(GameAction::Rest),
         _ => None,
     }
 }
@@ -212,6 +213,7 @@ mod tests {
         assert_eq!(parse_action("item"), Some(GameAction::ToggleItems));
         assert_eq!(parse_action("explore"), Some(GameAction::Explore));
         assert_eq!(parse_action("flee"), Some(GameAction::Flee));
+        assert_eq!(parse_action("rest"), Some(GameAction::Rest));
     }
 
     #[test]

--- a/apps/discordsh/axum-discordsh/src/discord/game/session.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/session.rs
@@ -107,11 +107,12 @@ mod tests {
     fn test_state(short_id: &str, channel: u64, owner: u64) -> SessionState {
         let mut player = PlayerState::default();
         player.inventory = content::starting_inventory();
+        let owner_id = serenity::UserId::new(owner);
 
         SessionState {
             id: uuid::Uuid::new_v4(),
             short_id: short_id.to_owned(),
-            owner: serenity::UserId::new(owner),
+            owner: owner_id,
             party: Vec::new(),
             mode: SessionMode::Solo,
             phase: GamePhase::Exploring,
@@ -120,7 +121,7 @@ mod tests {
             created_at: Instant::now(),
             last_action_at: Instant::now(),
             turn: 0,
-            player,
+            players: std::collections::HashMap::from([(owner_id, player)]),
             enemy: None,
             room: content::generate_room(0),
             log: Vec::new(),

--- a/apps/discordsh/axum-discordsh/src/transport/svg.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/svg.rs
@@ -195,10 +195,11 @@ mod tests {
 
     fn seed_session(state: &HttpState) -> String {
         let (id, short_id) = new_short_sid();
+        let owner = serenity::UserId::new(1);
         let session = SessionState {
             id,
             short_id: short_id.clone(),
-            owner: serenity::UserId::new(1),
+            owner,
             party: Vec::new(),
             mode: SessionMode::Solo,
             phase: GamePhase::Exploring,
@@ -207,7 +208,7 @@ mod tests {
             created_at: Instant::now(),
             last_action_at: Instant::now(),
             turn: 1,
-            player: PlayerState::default(),
+            players: std::collections::HashMap::from([(owner, PlayerState::default())]),
             enemy: None,
             room: content::generate_room(0),
             log: vec!["Test session".to_owned()],


### PR DESCRIPTION
## Summary
- **Independent party stats**: Each player in a party session gets their own `PlayerState` (HP, inventory, gold, effects) via `HashMap<UserId, PlayerState>` inside the existing `Arc<Mutex<SessionState>>` — no DashMap needed since all inner access is Mutex-guarded
- **Flee rework**: Flee restricted to combat only, base 60% success chance (-5% per room depth, min 30%). Success escapes to a Hallway room; failure triggers a free enemy hit
- **Underground City**: New room type (5% spawn weight) with inn (full heal + clear effects for scaling gold cost) and merchant shop. Purple phase color, dedicated Rest button

## Changes
| File | What changed |
|------|-------------|
| `types.rs` | `players: HashMap` replacing `player`, `alive` field, `City`/`Hallway`/`UndergroundCity`/`Rest` enums, helper methods |
| `logic.rs` | Multi-player dispatch via `actor` param, flee rework, city rest/buy, per-player death tracking |
| `content.rs` | Hallway + city room templates, `generate_hallway_room()`, weight rebalance |
| `render.rs` | Party roster embed field, city purple color, Rest button, flee combat-only |
| `card.rs` | City phase label/colors, `owner_player()` for SVG card data |
| `router.rs` | `"rest"` action parsing |
| `dungeon.rs` | HashMap init on start, player insert on join, player remove on leave |
| `session.rs` + `svg.rs` | Test helpers updated for HashMap |

## Test plan
- [x] `cargo build -p axum-discordsh` — clean (7 pre-existing warnings only)
- [x] `cargo test -p axum-discordsh` — 116 passed, 0 failed
- [ ] Manual Discord test: start solo session, verify explore/combat/flee/city flow
- [ ] Manual Discord test: start party session, verify join/leave with independent HP

🤖 Generated with [Claude Code](https://claude.com/claude-code)