### PR TITLE
feat(data): add player, container, and transfer SQL for MC persistence

### DIFF
--- a/packages/data/sql/schema/mc/mc_container.sql
+++ b/packages/data/sql/schema/mc/mc_container.sql
@@ -1,0 +1,288 @@
+-- ============================================================
+-- MC CONTAINER — Persist container state from MC server
+--
+-- Stores the latest state of world containers (chests, barrels,
+-- shulker boxes, furnaces, etc.) per server.
+--
+-- Called exclusively by the MC server via service_role.
+-- Requires: mc schema (created by mc_auth.sql)
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- TABLE: mc.container
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS mc.container (
+    -- Composite PK: one state per container per server
+    container_id TEXT NOT NULL,
+    server_id    TEXT NOT NULL,
+
+    -- Container metadata
+    container_type INTEGER NOT NULL DEFAULT 0,   -- McContainerType enum
+    world          TEXT,                          -- Dimension / world name
+    pos_x          INTEGER,                      -- Block position X
+    pos_y          INTEGER,                      -- Block position Y
+    pos_z          INTEGER,                      -- Block position Z
+    custom_name    TEXT,                          -- Custom container name if renamed
+
+    -- Slot data as JSONB array of McSlot
+    slots JSONB NOT NULL DEFAULT '[]'::JSONB,
+
+    -- Timestamps
+    captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (container_id, server_id),
+
+    CONSTRAINT container_type_range_chk
+        CHECK (container_type >= 0 AND container_type <= 13)
+);
+
+-- Spatial lookup: find containers in a world at or near a position
+CREATE INDEX IF NOT EXISTS idx_mc_container_world_pos
+    ON mc.container (server_id, world, pos_x, pos_y, pos_z)
+    WHERE world IS NOT NULL AND pos_x IS NOT NULL;
+
+COMMENT ON TABLE mc.container IS
+    'Latest container state (chests, barrels, etc.) per container per server.';
+
+-- ===========================================
+-- RLS
+-- ===========================================
+
+ALTER TABLE mc.container ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON mc.container;
+
+CREATE POLICY "service_role_full_access"
+    ON mc.container
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- ===========================================
+-- TRIGGER: auto-update updated_at
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.trg_container_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.trg_container_updated_at()
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.trg_container_updated_at()
+    TO service_role;
+ALTER FUNCTION mc.trg_container_updated_at() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_mc_container_updated_at ON mc.container;
+
+CREATE TRIGGER trg_mc_container_updated_at
+BEFORE UPDATE ON mc.container
+FOR EACH ROW
+EXECUTE FUNCTION mc.trg_container_updated_at();
+
+-- ===========================================
+-- SERVICE FUNCTION: Save container state
+--
+-- Accepts container JSONB + server_id.
+-- Upserts: creates on first save, updates on subsequent.
+-- Returns the container_id on success.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.service_save_container(
+    p_container JSONB,
+    p_server_id TEXT
+)
+RETURNS TEXT  -- returns container_id
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_container_id TEXT;
+    v_position     JSONB;
+BEGIN
+    v_container_id := p_container->>'container_id';
+
+    IF v_container_id IS NULL OR v_container_id = '' THEN
+        RAISE EXCEPTION 'container_id is required in container'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF p_server_id IS NULL OR p_server_id = '' THEN
+        RAISE EXCEPTION 'server_id is required'
+            USING ERRCODE = '22023';
+    END IF;
+
+    v_position := p_container->'position';
+
+    INSERT INTO mc.container (
+        container_id, server_id, container_type,
+        world, pos_x, pos_y, pos_z,
+        custom_name, slots, captured_at
+    )
+    VALUES (
+        v_container_id,
+        p_server_id,
+        COALESCE((p_container->>'type')::INTEGER, 0),
+        COALESCE(p_container->>'world', v_position->>'world'),
+        (v_position->>'x')::INTEGER,
+        (v_position->>'y')::INTEGER,
+        (v_position->>'z')::INTEGER,
+        p_container->>'custom_name',
+        COALESCE(p_container->'slots', '[]'::JSONB),
+        COALESCE((p_container->>'captured_at')::TIMESTAMPTZ, NOW())
+    )
+    ON CONFLICT (container_id, server_id) DO UPDATE SET
+        container_type = EXCLUDED.container_type,
+        world          = EXCLUDED.world,
+        pos_x          = EXCLUDED.pos_x,
+        pos_y          = EXCLUDED.pos_y,
+        pos_z          = EXCLUDED.pos_z,
+        custom_name    = EXCLUDED.custom_name,
+        slots          = EXCLUDED.slots,
+        captured_at    = EXCLUDED.captured_at;
+
+    RETURN v_container_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.service_save_container(JSONB, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_save_container(JSONB, TEXT)
+    TO service_role;
+ALTER FUNCTION mc.service_save_container(JSONB, TEXT) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Load container state
+--
+-- Returns the latest state for a container on a specific server.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.service_load_container(
+    p_container_id TEXT,
+    p_server_id    TEXT
+)
+RETURNS TABLE (
+    container_id   TEXT,
+    server_id      TEXT,
+    container_type INTEGER,
+    world          TEXT,
+    pos_x          INTEGER,
+    pos_y          INTEGER,
+    pos_z          INTEGER,
+    custom_name    TEXT,
+    slots          JSONB,
+    captured_at    TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.container_id,
+        c.server_id,
+        c.container_type,
+        c.world,
+        c.pos_x,
+        c.pos_y,
+        c.pos_z,
+        c.custom_name,
+        c.slots,
+        c.captured_at
+    FROM mc.container AS c
+    WHERE c.container_id = p_container_id
+      AND c.server_id = p_server_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.service_load_container(TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_load_container(TEXT, TEXT)
+    TO service_role;
+ALTER FUNCTION mc.service_load_container(TEXT, TEXT) OWNER TO service_role;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'mc' AND table_name = 'container'
+    ) THEN
+        RAISE EXCEPTION 'mc.container table creation failed';
+    END IF;
+
+    PERFORM 'mc.service_save_container(jsonb, text)'::regprocedure;
+    PERFORM 'mc.service_load_container(text, text)'::regprocedure;
+
+    IF NOT has_function_privilege('service_role', 'mc.service_save_container(jsonb, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have execute on mc.service_save_container';
+    END IF;
+
+    IF NOT has_function_privilege('service_role', 'mc.service_load_container(text, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have execute on mc.service_load_container';
+    END IF;
+
+    IF has_function_privilege('anon', 'mc.service_save_container(jsonb, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_save_container';
+    END IF;
+
+    IF has_function_privilege('anon', 'mc.service_load_container(text, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_load_container';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'mc.service_save_container(jsonb, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_save_container';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'mc.service_load_container(text, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_load_container';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_save_container(jsonb, text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_save_container must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_load_container(text, text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_load_container must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.trg_container_updated_at()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.trg_container_updated_at must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'mc.container setup and verification completed successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/packages/data/sql/schema/mc/mc_player.sql
+++ b/packages/data/sql/schema/mc/mc_player.sql
@@ -1,0 +1,375 @@
+-- ============================================================
+-- MC PLAYER — Persist player state snapshots from MC server
+--
+-- Stores the latest full snapshot per player per server.
+-- Complex nested data (inventory, ender chest) stored as JSONB;
+-- scalar state (health, food, xp, position) as typed columns
+-- for queryability.
+--
+-- Called exclusively by the MC server via service_role.
+-- Requires: mc schema (created by mc_auth.sql)
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- TABLE: mc.player
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS mc.player (
+    -- Composite PK: one snapshot per player per server
+    player_uuid TEXT NOT NULL,
+    server_id   TEXT NOT NULL,
+
+    -- Identity
+    player_name TEXT NOT NULL,
+    user_id     UUID                      -- Supabase user_id if linked (nullable)
+                    REFERENCES auth.users(id)
+                    ON DELETE SET NULL,
+
+    -- Position
+    pos_x       DOUBLE PRECISION NOT NULL DEFAULT 0,
+    pos_y       DOUBLE PRECISION NOT NULL DEFAULT 0,
+    pos_z       DOUBLE PRECISION NOT NULL DEFAULT 0,
+    pos_yaw     REAL NOT NULL DEFAULT 0,
+    pos_pitch   REAL NOT NULL DEFAULT 0,
+    world       TEXT NOT NULL DEFAULT 'minecraft:overworld',
+
+    -- State
+    game_mode   INTEGER NOT NULL DEFAULT 0,    -- McGameMode enum
+    health      REAL NOT NULL DEFAULT 20.0,
+    food_level  INTEGER NOT NULL DEFAULT 20,
+    saturation  REAL NOT NULL DEFAULT 5.0,
+    xp_level    INTEGER NOT NULL DEFAULT 0,
+    xp_points   INTEGER NOT NULL DEFAULT 0,
+
+    -- Complex nested data as JSONB
+    inventory   JSONB NOT NULL DEFAULT '[]'::JSONB,   -- McSlot array
+    ender_chest JSONB NOT NULL DEFAULT '[]'::JSONB,   -- McSlot array
+    selected_slot INTEGER NOT NULL DEFAULT 0,
+
+    -- Timestamps
+    captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (player_uuid, server_id),
+
+    -- MC UUID format: 32 lowercase hex characters (no dashes)
+    CONSTRAINT player_uuid_format_chk
+        CHECK (player_uuid ~ '^[a-f0-9]{32}$'),
+
+    CONSTRAINT health_range_chk
+        CHECK (health >= 0 AND health <= 20),
+
+    CONSTRAINT food_level_range_chk
+        CHECK (food_level >= 0 AND food_level <= 20),
+
+    CONSTRAINT game_mode_range_chk
+        CHECK (game_mode >= 0 AND game_mode <= 3),
+
+    CONSTRAINT selected_slot_range_chk
+        CHECK (selected_slot >= 0 AND selected_slot <= 8)
+);
+
+-- Fast lookup by user_id for "which servers has this user played on?"
+CREATE INDEX IF NOT EXISTS idx_mc_player_user_id
+    ON mc.player (user_id)
+    WHERE user_id IS NOT NULL;
+
+-- Fast lookup by server for "all players on server X"
+CREATE INDEX IF NOT EXISTS idx_mc_player_server_id
+    ON mc.player (server_id);
+
+COMMENT ON TABLE mc.player IS
+    'Latest player state snapshot per player per server, persisted from MC server.';
+
+-- ===========================================
+-- RLS
+-- ===========================================
+
+ALTER TABLE mc.player ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON mc.player;
+
+CREATE POLICY "service_role_full_access"
+    ON mc.player
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- ===========================================
+-- TRIGGER: auto-update updated_at
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.trg_player_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.trg_player_updated_at()
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.trg_player_updated_at()
+    TO service_role;
+ALTER FUNCTION mc.trg_player_updated_at() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_mc_player_updated_at ON mc.player;
+
+CREATE TRIGGER trg_mc_player_updated_at
+BEFORE UPDATE ON mc.player
+FOR EACH ROW
+EXECUTE FUNCTION mc.trg_player_updated_at();
+
+-- ===========================================
+-- SERVICE FUNCTION: Save player snapshot
+--
+-- Accepts the full snapshot as JSONB, decomposes into columns.
+-- Upserts: creates on first save, updates on subsequent saves.
+-- Returns the player_uuid on success.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.service_save_player(
+    p_snapshot JSONB
+)
+RETURNS TEXT  -- returns player_uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_player_uuid TEXT;
+    v_server_id   TEXT;
+    v_position    JSONB;
+BEGIN
+    v_player_uuid := mc.normalize_mc_uuid(p_snapshot->>'player_uuid');
+    v_server_id   := p_snapshot->>'server_id';
+
+    IF v_server_id IS NULL OR v_server_id = '' THEN
+        RAISE EXCEPTION 'server_id is required in snapshot'
+            USING ERRCODE = '22023';
+    END IF;
+
+    v_position := p_snapshot->'position';
+
+    INSERT INTO mc.player (
+        player_uuid, server_id, player_name, user_id,
+        pos_x, pos_y, pos_z, pos_yaw, pos_pitch, world,
+        game_mode, health, food_level, saturation,
+        xp_level, xp_points,
+        inventory, ender_chest, selected_slot,
+        captured_at
+    )
+    VALUES (
+        v_player_uuid,
+        v_server_id,
+        COALESCE(p_snapshot->>'player_name', ''),
+        CASE WHEN p_snapshot->>'user_id' IS NOT NULL
+             THEN (p_snapshot->>'user_id')::UUID
+             ELSE NULL
+        END,
+        COALESCE((v_position->>'x')::DOUBLE PRECISION, 0),
+        COALESCE((v_position->>'y')::DOUBLE PRECISION, 0),
+        COALESCE((v_position->>'z')::DOUBLE PRECISION, 0),
+        COALESCE((v_position->>'yaw')::REAL, 0),
+        COALESCE((v_position->>'pitch')::REAL, 0),
+        COALESCE(v_position->>'world', 'minecraft:overworld'),
+        COALESCE((p_snapshot->>'game_mode')::INTEGER, 0),
+        COALESCE((p_snapshot->>'health')::REAL, 20.0),
+        COALESCE((p_snapshot->>'food_level')::INTEGER, 20),
+        COALESCE((p_snapshot->>'saturation')::REAL, 5.0),
+        COALESCE((p_snapshot->>'experience_level')::INTEGER, 0),
+        COALESCE((p_snapshot->>'experience_points')::INTEGER, 0),
+        COALESCE(p_snapshot->'inventory'->'slots', '[]'::JSONB),
+        COALESCE(p_snapshot->'ender_chest', '[]'::JSONB),
+        COALESCE((p_snapshot->'inventory'->>'selected_slot')::INTEGER, 0),
+        COALESCE((p_snapshot->>'captured_at')::TIMESTAMPTZ, NOW())
+    )
+    ON CONFLICT (player_uuid, server_id) DO UPDATE SET
+        player_name   = EXCLUDED.player_name,
+        user_id       = EXCLUDED.user_id,
+        pos_x         = EXCLUDED.pos_x,
+        pos_y         = EXCLUDED.pos_y,
+        pos_z         = EXCLUDED.pos_z,
+        pos_yaw       = EXCLUDED.pos_yaw,
+        pos_pitch     = EXCLUDED.pos_pitch,
+        world         = EXCLUDED.world,
+        game_mode     = EXCLUDED.game_mode,
+        health        = EXCLUDED.health,
+        food_level    = EXCLUDED.food_level,
+        saturation    = EXCLUDED.saturation,
+        xp_level      = EXCLUDED.xp_level,
+        xp_points     = EXCLUDED.xp_points,
+        inventory     = EXCLUDED.inventory,
+        ender_chest   = EXCLUDED.ender_chest,
+        selected_slot = EXCLUDED.selected_slot,
+        captured_at   = EXCLUDED.captured_at;
+
+    RETURN v_player_uuid;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.service_save_player(JSONB)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_save_player(JSONB)
+    TO service_role;
+ALTER FUNCTION mc.service_save_player(JSONB) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Load player snapshot
+--
+-- Returns the latest snapshot for a player on a specific server.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.service_load_player(
+    p_player_uuid TEXT,
+    p_server_id   TEXT
+)
+RETURNS TABLE (
+    player_uuid   TEXT,
+    server_id     TEXT,
+    player_name   TEXT,
+    user_id       UUID,
+    pos_x         DOUBLE PRECISION,
+    pos_y         DOUBLE PRECISION,
+    pos_z         DOUBLE PRECISION,
+    pos_yaw       REAL,
+    pos_pitch     REAL,
+    world         TEXT,
+    game_mode     INTEGER,
+    health        REAL,
+    food_level    INTEGER,
+    saturation    REAL,
+    xp_level      INTEGER,
+    xp_points     INTEGER,
+    inventory     JSONB,
+    ender_chest   JSONB,
+    selected_slot INTEGER,
+    captured_at   TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_player_uuid TEXT;
+BEGIN
+    v_player_uuid := mc.normalize_mc_uuid(p_player_uuid);
+
+    RETURN QUERY
+    SELECT
+        p.player_uuid,
+        p.server_id,
+        p.player_name,
+        p.user_id,
+        p.pos_x,
+        p.pos_y,
+        p.pos_z,
+        p.pos_yaw,
+        p.pos_pitch,
+        p.world,
+        p.game_mode,
+        p.health,
+        p.food_level,
+        p.saturation,
+        p.xp_level,
+        p.xp_points,
+        p.inventory,
+        p.ender_chest,
+        p.selected_slot,
+        p.captured_at
+    FROM mc.player AS p
+    WHERE p.player_uuid = v_player_uuid
+      AND p.server_id = p_server_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.service_load_player(TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_load_player(TEXT, TEXT)
+    TO service_role;
+ALTER FUNCTION mc.service_load_player(TEXT, TEXT) OWNER TO service_role;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify table exists
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'mc' AND table_name = 'player'
+    ) THEN
+        RAISE EXCEPTION 'mc.player table creation failed';
+    END IF;
+
+    -- Verify functions exist
+    PERFORM 'mc.service_save_player(jsonb)'::regprocedure;
+    PERFORM 'mc.service_load_player(text, text)'::regprocedure;
+
+    -- Verify service_role can execute
+    IF NOT has_function_privilege('service_role', 'mc.service_save_player(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have execute on mc.service_save_player';
+    END IF;
+
+    IF NOT has_function_privilege('service_role', 'mc.service_load_player(text, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have execute on mc.service_load_player';
+    END IF;
+
+    -- Verify anon CANNOT execute
+    IF has_function_privilege('anon', 'mc.service_save_player(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_save_player';
+    END IF;
+
+    IF has_function_privilege('anon', 'mc.service_load_player(text, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_load_player';
+    END IF;
+
+    -- Verify authenticated CANNOT execute
+    IF has_function_privilege('authenticated', 'mc.service_save_player(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_save_player';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'mc.service_load_player(text, text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_load_player';
+    END IF;
+
+    -- Verify ownership
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_save_player(jsonb)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_save_player must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_load_player(text, text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_load_player must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.trg_player_updated_at()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.trg_player_updated_at must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'mc.player setup and verification completed successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/packages/data/sql/schema/mc/mc_transfer.sql
+++ b/packages/data/sql/schema/mc/mc_transfer.sql
@@ -1,0 +1,302 @@
+-- ============================================================
+-- MC TRANSFER — Append-only item transfer ledger
+--
+-- Records every item movement event (player↔player,
+-- player↔container, pickup, drop, craft, smelt, trade).
+-- Designed for auditability and rollback investigations.
+--
+-- This is an INSERT-heavy, append-only table.
+-- Rows are never updated or deleted by the application.
+--
+-- Called exclusively by the MC server via service_role.
+-- Requires: mc schema (created by mc_auth.sql)
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- TABLE: mc.transfer
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS mc.transfer (
+    -- ULID primary key (time-sortable, globally unique)
+    transfer_id TEXT PRIMARY KEY,
+
+    -- Transfer metadata
+    transfer_type INTEGER NOT NULL DEFAULT 0,   -- McTransferType enum
+    server_id     TEXT NOT NULL,
+    world         TEXT,
+
+    -- The item that was moved (full McItemStack as JSONB)
+    item JSONB NOT NULL,
+
+    -- Source
+    source_player_uuid   TEXT,
+    source_container_id  TEXT,
+    source_slot          INTEGER,
+
+    -- Destination
+    dest_player_uuid     TEXT,
+    dest_container_id    TEXT,
+    dest_slot            INTEGER,
+
+    -- Timestamp from the MC server
+    transferred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- DB insert timestamp
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT transfer_type_range_chk
+        CHECK (transfer_type >= 0 AND transfer_type <= 9),
+
+    -- At least one source must be set
+    CONSTRAINT source_required_chk
+        CHECK (source_player_uuid IS NOT NULL OR source_container_id IS NOT NULL),
+
+    -- At least one destination must be set
+    CONSTRAINT dest_required_chk
+        CHECK (dest_player_uuid IS NOT NULL OR dest_container_id IS NOT NULL)
+);
+
+-- Primary query pattern: "all transfers for player X, newest first"
+CREATE INDEX IF NOT EXISTS idx_mc_transfer_source_player
+    ON mc.transfer (source_player_uuid, transferred_at DESC)
+    WHERE source_player_uuid IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mc_transfer_dest_player
+    ON mc.transfer (dest_player_uuid, transferred_at DESC)
+    WHERE dest_player_uuid IS NOT NULL;
+
+-- Server + time range for server-wide audits
+CREATE INDEX IF NOT EXISTS idx_mc_transfer_server_time
+    ON mc.transfer (server_id, transferred_at DESC);
+
+-- Container audit trail
+CREATE INDEX IF NOT EXISTS idx_mc_transfer_source_container
+    ON mc.transfer (source_container_id, transferred_at DESC)
+    WHERE source_container_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mc_transfer_dest_container
+    ON mc.transfer (dest_container_id, transferred_at DESC)
+    WHERE dest_container_id IS NOT NULL;
+
+COMMENT ON TABLE mc.transfer IS
+    'Append-only item transfer ledger recording all item movements in the MC server.';
+
+-- ===========================================
+-- RLS
+-- ===========================================
+
+ALTER TABLE mc.transfer ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON mc.transfer;
+
+CREATE POLICY "service_role_full_access"
+    ON mc.transfer
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- ===========================================
+-- SERVICE FUNCTION: Record batch of transfers
+--
+-- Accepts a JSONB array of transfer objects.
+-- Inserts all transfers in a single batch.
+-- Returns the count of inserted rows.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.service_record_transfers(
+    p_batch JSONB
+)
+RETURNS INTEGER  -- count of inserted rows
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    IF p_batch IS NULL OR jsonb_typeof(p_batch) <> 'array' THEN
+        RAISE EXCEPTION 'p_batch must be a JSONB array'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF jsonb_array_length(p_batch) = 0 THEN
+        RETURN 0;
+    END IF;
+
+    -- Limit batch size to prevent abuse
+    IF jsonb_array_length(p_batch) > 1000 THEN
+        RAISE EXCEPTION 'Batch size exceeds limit of 1000 transfers'
+            USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO mc.transfer (
+        transfer_id, transfer_type, server_id, world,
+        item,
+        source_player_uuid, source_container_id, source_slot,
+        dest_player_uuid, dest_container_id, dest_slot,
+        transferred_at
+    )
+    SELECT
+        t->>'transfer_id',
+        COALESCE((t->>'type')::INTEGER, 0),
+        t->>'server_id',
+        t->>'world',
+        COALESCE(t->'item', '{}'::JSONB),
+        t->>'source_player_uuid',
+        t->>'source_container_id',
+        (t->>'source_slot')::INTEGER,
+        t->>'dest_player_uuid',
+        t->>'dest_container_id',
+        (t->>'dest_slot')::INTEGER,
+        COALESCE((t->>'timestamp')::TIMESTAMPTZ, NOW())
+    FROM jsonb_array_elements(p_batch) AS t;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.service_record_transfers(JSONB)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_record_transfers(JSONB)
+    TO service_role;
+ALTER FUNCTION mc.service_record_transfers(JSONB) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Get transfer history for a player
+--
+-- Returns transfers where the player is source or destination.
+-- Supports optional server_id filter, time-range filter, and pagination.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION mc.service_get_transfer_history(
+    p_player_uuid TEXT,
+    p_server_id   TEXT    DEFAULT NULL,
+    p_since       TEXT    DEFAULT NULL,
+    p_limit       INTEGER DEFAULT 50,
+    p_offset      INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+    transfer_id          TEXT,
+    transfer_type        INTEGER,
+    server_id            TEXT,
+    world                TEXT,
+    item                 JSONB,
+    source_player_uuid   TEXT,
+    source_container_id  TEXT,
+    source_slot          INTEGER,
+    dest_player_uuid     TEXT,
+    dest_container_id    TEXT,
+    dest_slot            INTEGER,
+    transferred_at       TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_player_uuid TEXT;
+    v_since       TIMESTAMPTZ;
+    v_limit       INTEGER;
+BEGIN
+    v_player_uuid := mc.normalize_mc_uuid(p_player_uuid);
+    v_since := CASE WHEN p_since IS NOT NULL THEN p_since::TIMESTAMPTZ ELSE NULL END;
+    v_limit := LEAST(GREATEST(p_limit, 1), 500);  -- clamp 1..500
+
+    RETURN QUERY
+    SELECT
+        t.transfer_id,
+        t.transfer_type,
+        t.server_id,
+        t.world,
+        t.item,
+        t.source_player_uuid,
+        t.source_container_id,
+        t.source_slot,
+        t.dest_player_uuid,
+        t.dest_container_id,
+        t.dest_slot,
+        t.transferred_at
+    FROM mc.transfer AS t
+    WHERE (t.source_player_uuid = v_player_uuid
+        OR t.dest_player_uuid = v_player_uuid)
+      AND (p_server_id IS NULL OR t.server_id = p_server_id)
+      AND (v_since IS NULL OR t.transferred_at >= v_since)
+    ORDER BY t.transferred_at DESC
+    LIMIT v_limit
+    OFFSET GREATEST(p_offset, 0);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mc.service_get_transfer_history(TEXT, TEXT, TEXT, INTEGER, INTEGER)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_get_transfer_history(TEXT, TEXT, TEXT, INTEGER, INTEGER)
+    TO service_role;
+ALTER FUNCTION mc.service_get_transfer_history(TEXT, TEXT, TEXT, INTEGER, INTEGER) OWNER TO service_role;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'mc' AND table_name = 'transfer'
+    ) THEN
+        RAISE EXCEPTION 'mc.transfer table creation failed';
+    END IF;
+
+    PERFORM 'mc.service_record_transfers(jsonb)'::regprocedure;
+    PERFORM 'mc.service_get_transfer_history(text, text, text, integer, integer)'::regprocedure;
+
+    IF NOT has_function_privilege('service_role', 'mc.service_record_transfers(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have execute on mc.service_record_transfers';
+    END IF;
+
+    IF NOT has_function_privilege('service_role', 'mc.service_get_transfer_history(text, text, text, integer, integer)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have execute on mc.service_get_transfer_history';
+    END IF;
+
+    IF has_function_privilege('anon', 'mc.service_record_transfers(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_record_transfers';
+    END IF;
+
+    IF has_function_privilege('anon', 'mc.service_get_transfer_history(text, text, text, integer, integer)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on mc.service_get_transfer_history';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'mc.service_record_transfers(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_record_transfers';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'mc.service_get_transfer_history(text, text, text, integer, integer)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_get_transfer_history';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_record_transfers(jsonb)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_record_transfers must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'mc.service_get_transfer_history(text, text, text, integer, integer)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'mc.service_get_transfer_history must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'mc.transfer setup and verification completed successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds `mc.player` table + `service_save_player` / `service_load_player` RPCs for player snapshot persistence
- Adds `mc.container` table + `service_save_container` / `service_load_container` RPCs for world container state
- Adds `mc.transfer` append-only ledger + `service_record_transfers` / `service_get_transfer_history` RPCs for item movement auditing

These 6 RPCs complete the SQL backend for the mc/ edge function modules added in #7388.

## Design
- **mc.player**: Typed columns for queryable state (position, health, xp, game_mode), JSONB for nested inventory/ender chest. Composite PK `(player_uuid, server_id)` — one snapshot per player per server.
- **mc.container**: Typed columns for block position + type, JSONB for slot data. Composite PK `(container_id, server_id)`. Spatial index for world lookups.
- **mc.transfer**: Append-only ledger. ULID PK. Batch insert capped at 1000, history query capped at 500 results. Partial indexes on source/dest player and container for efficient audit queries.

## Security
- All functions: `SECURITY DEFINER`, `SET search_path = ''`, owned by `service_role`
- All functions: `REVOKE ALL FROM PUBLIC, anon, authenticated`
- All tables: RLS enabled, `service_role` full access only
- Each file ends with a verification block checking function existence, privileges, and ownership

## Execution order
1. `mc_auth.sql` (creates mc schema + grants) — already applied
2. `mc_player.sql`
3. `mc_container.sql`
4. `mc_transfer.sql`

## RPC ↔ Edge Function mapping
| SQL RPC | Edge Command | 
|---------|-------------|
| `service_save_player(jsonb)` | `player.save` |
| `service_load_player(text, text)` | `player.load` |
| `service_save_container(jsonb, text)` | `container.save` |
| `service_load_container(text, text)` | `container.load` |
| `service_record_transfers(jsonb)` | `transfer.record` |
| `service_get_transfer_history(text, text, text, int, int)` | `transfer.history` |

## Test plan
- [ ] Run `mc_player.sql` against Supabase — verify table, indexes, RLS, functions, verification block passes
- [ ] Run `mc_container.sql` — same checks
- [ ] Run `mc_transfer.sql` — same checks
- [ ] Test `service_save_player` with a sample JSONB snapshot, then `service_load_player` returns it
- [ ] Test `service_record_transfers` with a batch of 3 transfers, then `service_get_transfer_history` returns them
- [ ] Verify anon/authenticated cannot call any of the 6 functions directly