### PR TITLE
chore(discordsh): bump axum-discordsh to 0.1.17

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump `axum-discordsh` version from `0.1.16` to `0.1.17` for release of party stats, flee rework, and underground city features (#7391)

## Test plan
- [x] `cargo check -p axum-discordsh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)