### PR TITLE
feat(mc): add /api/players JSON endpoint

### DIFF
--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbve-mc-plugin"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.89"
 

--- a/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
+++ b/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
@@ -1461,6 +1461,7 @@ async fn serve_web() {
             get(web::mojang_profile_proxy),
         )
         .route("/api/mojang/session/{uuid}", get(web::mojang_session_proxy))
+        .route("/api/players", get(web::players_api_handler))
         .merge(static_router);
 
     let listener = match tokio::net::TcpListener::bind("0.0.0.0:8080").await {

--- a/apps/mc/plugins/kbve-mc-plugin/src/web.rs
+++ b/apps/mc/plugins/kbve-mc-plugin/src/web.rs
@@ -80,6 +80,27 @@ pub async fn players_handler() -> impl IntoResponse {
 }
 
 // ---------------------------------------------------------------------------
+// JSON API: active players
+// ---------------------------------------------------------------------------
+
+/// GET /api/players → JSON list of online player names
+pub async fn players_api_handler() -> impl IntoResponse {
+    let names: Vec<String> = ONLINE_PLAYERS
+        .iter()
+        .map(|entry| entry.key().clone())
+        .collect();
+    let body = serde_json::json!({
+        "online": names.len(),
+        "players": names,
+    });
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        body.to_string(),
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Mojang API proxy (browser CORS workaround)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/players` returning `{ "online": N, "players": ["name1", ...] }` as JSON
- Reads directly from the existing in-memory `ONLINE_PLAYERS` DashMap — zero I/O, no database queries
- Bump plugin version to 0.1.7

## Test plan
- [ ] `curl http://localhost:8080/api/players` returns valid JSON with online count and player names
- [ ] Verify response updates as players join/leave
- [ ] Docker build (`--no-cache` for plugin stage) includes the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)