### PR TITLE
fix(ci): set Docker build context to repo root for MC builds

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -306,7 +306,7 @@ jobs:
             - name: Build MC dev image
               uses: docker/build-push-action@v6
               with:
-                  context: apps/mc
+                  context: .
                   file: apps/mc/Dockerfile.dev
                   push: false
                   load: true

--- a/.github/workflows/ci-docker-smoke-test.yml
+++ b/.github/workflows/ci-docker-smoke-test.yml
@@ -90,7 +90,7 @@ jobs:
                 include:
                     - name: mc
                       dockerfile: apps/mc/Dockerfile
-                      context: apps/mc
+                      context: .
                       cache_scope: smoke-mc
                       submodules: true
                     - name: herbmail

--- a/.github/workflows/ci-mc-headless-e2e.yml
+++ b/.github/workflows/ci-mc-headless-e2e.yml
@@ -51,7 +51,7 @@ jobs:
             - name: Build MC dev image
               uses: docker/build-push-action@v6
               with:
-                  context: apps/mc
+                  context: .
                   file: apps/mc/Dockerfile.dev
                   push: false
                   load: true


### PR DESCRIPTION
## Summary
- Fix MC Docker build failure (`entrypoint.dev.sh: not found`) by changing `context: apps/mc` to `context: .` in three CI workflows
- Both `Dockerfile` and `Dockerfile.dev` use repo-root-relative COPY paths (`./apps/mc/...`, `package.json`, `./packages/npm/...`) which require the repo root as build context

## Changes
- `.github/workflows/ci-dev.yml` — `context: .`
- `.github/workflows/ci-mc-headless-e2e.yml` — `context: .`
- `.github/workflows/ci-docker-smoke-test.yml` — `context: .`

## Test plan
- [ ] ci-dev MC Docker build passes (no more `entrypoint.dev.sh: not found`)
- [ ] ci-docker-smoke-test MC build passes