### PR TITLE
fix(mc): add skin texture proxy for CORS bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
+++ b/apps/mc/plugins/kbve-mc-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbve-mc-plugin"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.89"
 

--- a/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
+++ b/apps/mc/plugins/kbve-mc-plugin/src/lib.rs
@@ -1461,6 +1461,7 @@ async fn serve_web() {
             get(web::mojang_profile_proxy),
         )
         .route("/api/mojang/session/{uuid}", get(web::mojang_session_proxy))
+        .route("/api/textures/{hash}", get(web::skin_texture_proxy))
         .route("/api/players", get(web::players_api_handler))
         .merge(static_router);
 


### PR DESCRIPTION
## Summary
- Add `/api/textures/{hash}` proxy in the Rust plugin to fetch skin PNGs from `textures.minecraft.net` server-side
- Update `mojang.ts` to use proxy first, with direct fetch as fallback
- Fixes CORS error: `Fetch API cannot load http://textures.minecraft.net/texture/... due to access control checks`

## Changes
- **`web.rs`**: New `skin_texture_proxy()` handler — validates hex hash, fetches via `ureq`, returns PNG with 24h cache header
- **`lib.rs`**: Register `/api/textures/{hash}` route
- **`mojang.ts`**: Extract texture hash from URL, fetch via `/api/textures/{hash}` proxy first, fall back to direct `textures.minecraft.net`
- **`Cargo.toml`**: Version bump `0.1.7` → `0.1.8`

## Test plan
- [ ] Deploy to MC server
- [ ] Visit https://mc.kbve.com/players
- [ ] Verify player skins load (2D avatars + 3D panel)
- [ ] Check Network tab: `/api/textures/...` returns 200 with `image/png`