### PR TITLE
feat(kbve): scaffold astro-kbve and astro-kbve-e2e

### DIFF
--- a/apps/kbve/astro-kbve-e2e/e2e/smoke.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('astro-kbve smoke tests', () => {
+	test('homepage loads with 200', async ({ page }) => {
+		const response = await page.goto('/');
+		expect(response?.status()).toBe(200);
+	});
+
+	test('homepage has correct title', async ({ page }) => {
+		await page.goto('/');
+		await expect(page).toHaveTitle(/KBVE/);
+	});
+
+	test('guides page loads', async ({ page }) => {
+		const response = await page.goto('/guides/');
+		expect(response?.status()).toBe(200);
+	});
+});

--- a/apps/kbve/astro-kbve-e2e/playwright.config.ts
+++ b/apps/kbve/astro-kbve-e2e/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+import { resolve } from 'path';
+
+const workspaceRoot = resolve(__dirname, '../../..');
+const port = 4321;
+const baseURL = `http://localhost:${port}`;
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'dev',
+			use: {
+				...devices['Desktop Chrome'],
+				baseURL,
+			},
+		},
+	],
+	webServer: {
+		command: './kbve.sh -nx astro-kbve:dev',
+		cwd: workspaceRoot,
+		url: baseURL,
+		reuseExistingServer: !process.env['CI'],
+		timeout: process.env['CI'] ? 600_000 : 120_000,
+	},
+});

--- a/apps/kbve/astro-kbve-e2e/playwright.docker.config.ts
+++ b/apps/kbve/astro-kbve-e2e/playwright.docker.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const port = 4323;
+const baseURL = `http://localhost:${port}`;
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'docker',
+			use: {
+				...devices['Desktop Chrome'],
+				baseURL,
+			},
+		},
+	],
+});

--- a/apps/kbve/astro-kbve-e2e/playwright.preview.config.ts
+++ b/apps/kbve/astro-kbve-e2e/playwright.preview.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+import { resolve } from 'path';
+
+const workspaceRoot = resolve(__dirname, '../../..');
+const port = 4322;
+const baseURL = `http://localhost:${port}`;
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'preview',
+			use: {
+				...devices['Desktop Chrome'],
+				baseURL,
+			},
+		},
+	],
+	webServer: {
+		command: `pnpm nx run astro-kbve:preview -- --port ${port}`,
+		cwd: workspaceRoot,
+		url: baseURL,
+		reuseExistingServer: false,
+		timeout: process.env['CI'] ? 600_000 : 120_000,
+	},
+});

--- a/apps/kbve/astro-kbve-e2e/project.json
+++ b/apps/kbve/astro-kbve-e2e/project.json
@@ -1,0 +1,32 @@
+{
+	"name": "astro-kbve-e2e",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/kbve/astro-kbve-e2e/e2e",
+	"implicitDependencies": ["astro-kbve"],
+	"targets": {
+		"e2e": {
+			"executor": "@nx/playwright:playwright",
+			"cache": false,
+			"options": {
+				"config": "apps/kbve/astro-kbve-e2e/playwright.config.ts"
+			}
+		},
+		"e2e:preview": {
+			"executor": "@nx/playwright:playwright",
+			"cache": false,
+			"dependsOn": ["astro-kbve:build"],
+			"options": {
+				"config": "apps/kbve/astro-kbve-e2e/playwright.preview.config.ts"
+			}
+		},
+		"e2e:docker": {
+			"executor": "@nx/playwright:playwright",
+			"cache": false,
+			"options": {
+				"config": "apps/kbve/astro-kbve-e2e/playwright.docker.config.ts"
+			}
+		}
+	},
+	"tags": []
+}

--- a/apps/kbve/astro-kbve-e2e/tsconfig.json
+++ b/apps/kbve/astro-kbve-e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"include": ["e2e/**/*.ts", "*.config.ts"]
+}

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -1,0 +1,83 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+import starlightSiteGraph from 'starlight-site-graph';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
+import worker from '@astropub/worker';
+import mermaid from 'astro-mermaid';
+
+export default defineConfig({
+	site: 'https://kbve.com',
+	output: 'static',
+	trailingSlash: 'always',
+	outDir: '../../../dist/apps/astro-kbve',
+	image: {
+		domains: ['images.unsplash.com'],
+	},
+	prefetch: true,
+	integrations: [
+		worker(),
+		mermaid({
+			theme: 'forest',
+		}),
+		starlight({
+			title: 'KBVE',
+			defaultLocale: 'root',
+			locales: {
+				root: { label: 'English', lang: 'en' },
+			},
+			editLink: {
+				baseUrl:
+					'https://github.com/kbve/kbve/edit/dev/apps/kbve/astro-kbve',
+			},
+			expressiveCode: true,
+			customCss: ['./src/styles/global.css'],
+			social: [
+				{
+					icon: 'github',
+					label: 'GitHub',
+					href: 'https://github.com/kbve/kbve',
+				},
+				{
+					icon: 'discord',
+					label: 'Discord',
+					href: 'https://kbve.com/discord/',
+				},
+			],
+			components: {
+				SiteTitle: './src/components/navigation/SiteTitle.astro',
+				PageSidebar: './src/components/pagesidebar/PageSidebar.astro',
+				Footer: './src/components/footer/AstroFooter.astro',
+			},
+			plugins: [
+				starlightSiteGraph({
+					graphConfig: {
+						depth: 2,
+						renderArrows: true,
+					},
+					overridePageSidebar: false,
+				}),
+			],
+			sidebar: [
+				{
+					label: 'Guides',
+					autogenerate: { directory: 'guides' },
+				},
+			],
+		}),
+		react(),
+		sitemap({ i18n: { defaultLocale: 'en' } }),
+	],
+	vite: {
+		plugins: [tailwindcss()],
+		build: {
+			rollupOptions: {
+				external: ['fsevents'],
+			},
+		},
+		optimizeDeps: {
+			exclude: ['fsevents'],
+		},
+	},
+});

--- a/apps/kbve/astro-kbve/buf.gen.yaml
+++ b/apps/kbve/astro-kbve/buf.gen.yaml
@@ -1,0 +1,16 @@
+version: v2
+plugins:
+    - remote: buf.build/community/stephenh-ts-proto
+      out: src/generated/proto
+      opt:
+          - useZod=true
+          - esModuleInterop=true
+          - importSuffix=.js
+          - outputServices=false
+          - oneof=unions
+          - enumsAsLiterals=true
+          - stringEnums=true
+          - useOptionals=messages
+          - useExactTypes=true
+          - exportCommonSymbols=true
+          - removeEnumPrefix=true

--- a/apps/kbve/astro-kbve/postcss.config.cjs
+++ b/apps/kbve/astro-kbve/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+	plugins: [
+		require('@tailwindcss/postcss'),
+		require('cssnano'),
+	],
+};

--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -1,0 +1,99 @@
+{
+	"name": "astro-kbve",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/kbve/astro-kbve/src",
+	"tags": [],
+	"targets": {
+		"proto": {
+			"executor": "nx:run-commands",
+			"inputs": ["{workspaceRoot}/packages/data/proto/kbve/*.proto"],
+			"outputs": ["{projectRoot}/src/generated/proto"],
+			"options": {
+				"command": "buf generate packages/data/proto --template apps/kbve/astro-kbve/buf.gen.yaml --path kbve/",
+				"cwd": "{workspaceRoot}"
+			},
+			"cache": true
+		},
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/astro-kbve",
+				"commands": [
+					"rm -rf .astro",
+					"nx exec -- astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=8192\" nx exec -- astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"dependsOn": ["proto"],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/astro-kbve",
+				"commands": [
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=8192\" nx exec -- astro build"
+				],
+				"parallel": false
+			}
+		},
+		"build:osrs": {
+			"dependsOn": ["proto"],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/astro-kbve",
+				"commands": [
+					"node scripts/generate-osrs-items.mjs",
+					"nx exec -- astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=8192\" nx exec -- astro build"
+				],
+				"parallel": false
+			}
+		},
+		"preview": {
+			"dependsOn": [
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/astro-kbve",
+				"commands": ["nx exec -- astro preview"],
+				"parallel": false
+			}
+		},
+		"check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/astro-kbve",
+				"commands": ["nx exec -- astro check"],
+				"parallel": false
+			}
+		},
+		"sync": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/astro-kbve",
+				"commands": ["nx exec -- astro sync"],
+				"parallel": false
+			}
+		},
+		"proto:lint": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "buf lint packages/data/proto",
+				"cwd": "{workspaceRoot}"
+			}
+		},
+		"proto:clean": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "rm -rf apps/kbve/astro-kbve/src/generated/proto && mkdir -p apps/kbve/astro-kbve/src/generated/proto",
+				"cwd": "{workspaceRoot}"
+			}
+		}
+	}
+}

--- a/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
@@ -1,0 +1,10 @@
+---
+/**
+ * Custom Footer override for Starlight.
+ * TODO: Port full implementation from ~/kbve.com/website/astro/src/components/footer/AstroFooter.astro
+ */
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/Footer.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>

--- a/apps/kbve/astro-kbve/src/components/navigation/SiteTitle.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/SiteTitle.astro
@@ -1,0 +1,11 @@
+---
+/**
+ * Custom SiteTitle override for Starlight.
+ * TODO: Port full implementation from ~/kbve.com/website/astro/src/components/navigation/SiteTitle.astro
+ */
+import type { Props } from '@astrojs/starlight/props';
+---
+
+<a href="/" class="site-title sl-flex">
+	<span>KBVE</span>
+</a>

--- a/apps/kbve/astro-kbve/src/components/pagesidebar/PageSidebar.astro
+++ b/apps/kbve/astro-kbve/src/components/pagesidebar/PageSidebar.astro
@@ -1,0 +1,10 @@
+---
+/**
+ * Custom PageSidebar override for Starlight.
+ * TODO: Port full implementation from ~/kbve.com/website/astro/src/components/pagesidebar/PageSidebar.astro
+ */
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageSidebar.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -1,0 +1,10 @@
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+	docs: defineCollection({
+		loader: docsLoader(),
+		schema: docsSchema(),
+	}),
+};

--- a/apps/kbve/astro-kbve/src/content/docs/guides/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/guides/index.mdx
@@ -1,0 +1,8 @@
+---
+title: Guides
+description: Getting started guides for KBVE platform.
+---
+
+# Guides
+
+Welcome to the KBVE guides section. Content will be migrated from the existing kbve.com repository.

--- a/apps/kbve/astro-kbve/src/content/docs/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/index.mdx
@@ -1,0 +1,17 @@
+---
+title: KBVE
+description: Knowledge Base Virtual Engine — guides, tools, gaming, and more.
+template: splash
+hero:
+  tagline: Knowledge Base Virtual Engine
+  actions:
+    - text: Get Started
+      link: /guides/
+      icon: right-arrow
+      variant: primary
+    - text: View on GitHub
+      link: https://github.com/kbve/kbve
+      icon: external
+---
+
+Welcome to KBVE — your hub for guides, applications, gaming resources, and developer tools.

--- a/apps/kbve/astro-kbve/src/env.d.ts
+++ b/apps/kbve/astro-kbve/src/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference path=".astro/types.d.ts" />
+/// <reference types="astro/client" />

--- a/apps/kbve/astro-kbve/src/styles/global.css
+++ b/apps/kbve/astro-kbve/src/styles/global.css
@@ -1,0 +1,41 @@
+@layer base, starlight, theme, components, utilities, galaxy, my-overrides;
+
+@import '@astrojs/starlight-tailwind';
+@import 'tailwindcss/theme' layer(theme);
+@import 'tailwindcss/utilities' layer(utilities);
+
+:root {
+	--sl-color-accent-low: #1a3a4a;
+	--sl-color-accent: #06b6d4;
+	--sl-color-accent-high: #a5f3fc;
+}
+
+:root[data-theme='dark'] {
+	--sl-color-accent-low: #083344;
+	--sl-color-accent: #06b6d4;
+	--sl-color-accent-high: #a5f3fc;
+}
+
+@layer utilities {
+	.focus-ring {
+		@apply focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2;
+	}
+}
+
+@layer my-overrides {
+	a.sl-link-button {
+		text-decoration: none;
+	}
+
+	.sl-markdown-content a {
+		color: var(--sl-color-accent);
+	}
+
+	.sl-markdown-content a:hover {
+		color: var(--sl-color-accent-high);
+	}
+}
+
+@view-transition {
+	navigation: auto;
+}

--- a/apps/kbve/astro-kbve/tailwind.config.mjs
+++ b/apps/kbve/astro-kbve/tailwind.config.mjs
@@ -1,0 +1,39 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+	content: [
+		'./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
+	],
+	theme: {
+		extend: {
+			colors: {
+				purple: {
+					50: '#faf5ff',
+					100: '#f3e8ff',
+					200: '#e9d5ff',
+					300: '#d8b4fe',
+					400: '#c084fc',
+					500: '#a855f7',
+					600: '#9333ea',
+					700: '#7e22ce',
+					800: '#6b21a8',
+					900: '#581c87',
+					950: '#3b0764',
+				},
+				primary: {
+					50: '#faf5ff',
+					100: '#f3e8ff',
+					200: '#e9d5ff',
+					300: '#d8b4fe',
+					400: '#c084fc',
+					500: '#a855f7',
+					600: '#9333ea',
+					700: '#7e22ce',
+					800: '#6b21a8',
+					900: '#581c87',
+					950: '#3b0764',
+				},
+			},
+		},
+	},
+	plugins: [],
+};

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "astro/tsconfigs/strict",
+	"include": [".astro/types.d.ts", "**/*"],
+	"exclude": ["dist"],
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "react",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"],
+			"@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
+			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"]
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Scaffolds `astro-kbve` (Astro 5 + Starlight + React 19) under `apps/kbve/astro-kbve/`
- Scaffolds `astro-kbve-e2e` (Playwright) under `apps/kbve/astro-kbve-e2e/`
- Phase 1 of KBVE_PLAN.md — project boots clean with `nx run astro-kbve:dev`

## What's included

**astro-kbve:**
- `project.json` with Nx targets: dev, build, build:osrs, preview, check, sync, proto, proto:lint, proto:clean
- `astro.config.mjs` — Starlight + React + Tailwind + mermaid + site-graph + worker + sitemap
- `tsconfig.json` — strict mode, react-jsx, path aliases (@kbve/astro, @kbve/droid)
- `tailwind.config.mjs` — purple theme
- `postcss.config.cjs`, `buf.gen.yaml` (ts-proto + Zod)
- `content.config.ts` with Starlight docsLoader/docsSchema
- Starlight component override stubs (SiteTitle, PageSidebar, Footer)
- Minimal homepage + guides page
- Global CSS with Tailwind layers, cyan/teal accent theme, view transitions

**astro-kbve-e2e:**
- `project.json` with e2e, e2e:preview, e2e:docker targets
- Playwright configs for dev (4321), preview (4322), and docker (4323) modes
- Smoke tests: homepage 200, title check, guides page load

## Test plan
- [x] `astro sync` completes without errors
- [x] Dev server boots clean (astro v5.17.2, ready in ~1s)
- [x] Homepage returns HTTP 200, contains "KBVE"
- [x] Guides page returns HTTP 200
- [x] All 3 Playwright smoke tests pass
- [x] Nx project graph recognizes both projects