### PR TITLE
feat(discordsh): per-player identity and JRPG party combat

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/game/card.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/card.rs
@@ -58,6 +58,11 @@ pub struct GameCardTemplate {
     // Room
     pub room_badges: Vec<RoomBadge>,
     pub turn: u32,
+
+    // Party indicator
+    pub is_party_mode: bool,
+    pub party_count: usize,
+    pub party_alive: usize,
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -281,6 +286,10 @@ impl GameCardTemplate {
 
             room_badges: build_room_badges(session),
             turn: session.turn,
+
+            is_party_mode: session.mode == SessionMode::Party,
+            party_count: session.players.len(),
+            party_alive: session.players.values().filter(|p| p.alive).count(),
         }
     }
 }
@@ -345,7 +354,6 @@ mod tests {
             room: super::super::content::generate_room(0),
             log: Vec::new(),
             show_items: false,
-            member_status: None,
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/session.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/session.rs
@@ -126,7 +126,6 @@ mod tests {
             room: content::generate_room(0),
             log: Vec::new(),
             show_items: false,
-            member_status: None,
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/transport/svg.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/svg.rs
@@ -213,7 +213,6 @@ mod tests {
             room: content::generate_room(0),
             log: vec!["Test session".to_owned()],
             show_items: false,
-            member_status: None,
         };
         state.app.sessions.create(session);
         short_id

--- a/apps/discordsh/axum-discordsh/templates/game/card.svg
+++ b/apps/discordsh/axum-discordsh/templates/game/card.svg
@@ -87,4 +87,9 @@
 
   <!-- Phase label -->
   <text x="20" y="392" font-family="Alagard, sans-serif" font-size="10" fill="#555555">{{ phase_label }}</text>
+
+  {% if is_party_mode %}
+  <!-- Party indicator -->
+  <text x="400" y="392" text-anchor="middle" font-family="Alagard, sans-serif" font-size="10" fill="#9b59b6">Party {{ party_alive }}/{{ party_count }}</text>
+  {% endif %}
 </svg>


### PR DESCRIPTION
## Summary
- **Per-player identity**: Moved `member_status` from `SessionState` to `PlayerState` so each party member carries their own Member/Guest tag. `/join` now performs a membership lookup and stores the result on the joining player.
- **Numbered roster footer**: Footer shows all players with identity — e.g., `[1] h0lybyte — kbve.com/@h0lybyte | [2] SomeUser (Guest)`.
- **Unified party stats**: In party mode, all players get equal detail in the embed (HP bar, DEF, gold, effects, defeated status).
- **JRPG enemy targeting**: `pick_enemy_target()` gives 50% chance to hit the acting player and 50% to hit a random alive party member. Combat messages now name the target (e.g., "Skeleton attacks Bob for 8 damage!").
- **SVG party indicator**: Card shows "Party X/Y" alive count in party mode.

## Files changed (8)
- `types.rs` — `member_status` on `PlayerState`, `roster()` method, new tests
- `dungeon.rs` — membership lookup on `/join` with lock drop/re-acquire pattern
- `render.rs` — unified roster display + numbered footer
- `logic.rs` — `pick_enemy_target()`, personalized attack/death messages, 3 new tests
- `card.rs` — party indicator fields (`is_party_mode`, `party_count`, `party_alive`)
- `card.svg` — party alive indicator
- `session.rs`, `svg.rs` — removed stale `member_status` from test helpers

## Test plan
- [x] `cargo build -p axum-discordsh` — clean compile
- [x] `cargo test -p axum-discordsh` — 120 tests pass (4 new)
- [x] `grep session.member_status` — zero hits (fully migrated)
- [ ] Manual test: start solo session, verify footer shows `[1] Name (Guest)`
- [ ] Manual test: start party session, have member join, verify both appear in footer and stats
- [ ] Manual test: in party combat, verify enemy attacks different players

🤖 Generated with [Claude Code](https://claude.com/claude-code)