### PR TITLE
feat(kube): expose mc and meme schemas via PostgREST

### DIFF
--- a/apps/kube/postgrest/manifests/postgrest-deployment.yaml
+++ b/apps/kube/postgrest/manifests/postgrest-deployment.yaml
@@ -35,7 +35,7 @@ spec:
 
                       # PostgREST configuration
                       - name: PGRST_DB_SCHEMAS
-                        value: 'public,storage,graphql_public,tracker,profile,rentearth'
+                        value: 'public,storage,graphql_public,tracker,profile,rentearth,mc,meme'
                       - name: PGRST_DB_ANON_ROLE
                         value: 'anon'
                       - name: PGRST_DB_USE_LEGACY_GUCS


### PR DESCRIPTION
## Summary
- Add `mc` and `meme` to `PGRST_DB_SCHEMAS` in the PostgREST deployment
- Enables `.rpc()` calls to functions in the `mc.*` and `meme.*` schemas from edge functions and Supabase clients

## Test plan
- [ ] After ArgoCD sync, verify PostgREST restarts with updated schema list
- [ ] Confirm `supabase.schema('mc').rpc('service_save_player', ...)` resolves
- [ ] Confirm `supabase.schema('meme').rpc(...)` resolves once meme migration is applied