### PR TITLE
fix(fudster): resolve flake8 lint errors

### DIFF
--- a/packages/python/fudster/fudster/api/clients/coindesk_client.py
+++ b/packages/python/fudster/fudster/api/clients/coindesk_client.py
@@ -5,6 +5,7 @@ import logging
 
 logger = logging.getLogger("uvicorn")
 
+
 class CoinDeskClient(APIConnector):
     """
     A client for fetching Bitcoin price data from the CoinDesk API.

--- a/packages/python/fudster/fudster/api/clients/groq_client.py
+++ b/packages/python/fudster/fudster/api/clients/groq_client.py
@@ -7,6 +7,7 @@ import logging
 
 logger = logging.getLogger("uvicorn")
 
+
 class GroqClient(APIConnector):
     def __init__(self, api_key: str = None):
         super().__init__("https://rust.kbve.com/api/v1")
@@ -31,7 +32,10 @@ class GroqClient(APIConnector):
             raise
         return groq_response
 
-    async def groq_process_pathways(self, pathways: dict, pathway: str, payload: AiGroqPayload, max_calls: int = 5) -> GroqResponse:
+    async def groq_process_pathways(
+        self, pathways: dict, pathway: str,
+        payload: AiGroqPayload, max_calls: int = 5
+    ) -> GroqResponse:
         current_pathway = pathway
         for _ in range(max_calls):
             if current_pathway not in pathways:

--- a/packages/python/fudster/fudster/api/clients/websocket_echo_client.py
+++ b/packages/python/fudster/fudster/api/clients/websocket_echo_client.py
@@ -1,5 +1,6 @@
 from ..api_connector import APIConnector
 
+
 class WebsocketEchoClient(APIConnector):
     """
     A client for interacting with a WebSocket echo server.

--- a/packages/python/fudster/fudster/api/utils/dynamic_endpoint_utils.py
+++ b/packages/python/fudster/fudster/api/utils/dynamic_endpoint_utils.py
@@ -1,6 +1,7 @@
 import importlib
 from fastapi import FastAPI, HTTPException
 
+
 class DynamicEndpoint:
     def __init__(self, app: FastAPI):
         self.app = app

--- a/packages/python/fudster/fudster/api/utils/image_utils.py
+++ b/packages/python/fudster/fudster/api/utils/image_utils.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     cv2 = None
 
+
 class ImageUtility:
     def __init__(self, cache_dir="image_cache", timeout=10):
         self.cache_dir = cache_dir

--- a/packages/python/fudster/fudster/api/utils/kr_decorator.py
+++ b/packages/python/fudster/fudster/api/utils/kr_decorator.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from typing import Type, Callable
 
+
 class KRDecorator:
     def __init__(self, app: FastAPI):
         self.app = app

--- a/packages/python/fudster/fudster/apps/chrome_client.py
+++ b/packages/python/fudster/fudster/apps/chrome_client.py
@@ -49,7 +49,8 @@ class ChromeClient:
             for job_listing in section.find_all("div", class_="opening"):
                 job_title = job_listing.find("a").get_text(strip=True) if job_listing.find("a") else "No Title"
                 job_link = job_listing.find("a")["href"] if job_listing.find("a") else ""
-                location = job_listing.find("span", class_="location").get_text(strip=True) if job_listing.find("span", class_="location") else "No Location"
+                loc_span = job_listing.find("span", class_="location")
+                location = loc_span.get_text(strip=True) if loc_span else "No Location"
 
                 job_data.append({
                     "department": department_name,

--- a/packages/python/fudster/fudster/apps/discord_client.py
+++ b/packages/python/fudster/fudster/apps/discord_client.py
@@ -7,6 +7,7 @@ from .chrome_client import ChromeClient
 
 logger = logging.getLogger("uvicorn")
 
+
 class DiscordClient:
     def __init__(self, headless=True, display=":1"):
         self.headless = headless
@@ -19,10 +20,16 @@ class DiscordClient:
         """
         passkey = passkey or os.getenv("DISCORD_PASSKEY")
         if not passkey:
-            raise ValueError("Passkey not provided. Set it as an argument or in the DISCORD_PASSKEY environment variable.")
+            raise ValueError(
+                "Passkey not provided. Set it as an argument "
+                "or in the DISCORD_PASSKEY environment variable."
+            )
 
         if not re.match(r"^[A-Za-z0-9_\-\.]+$", passkey):
-            raise ValueError("Invalid token format. Discord tokens should be alphanumeric with optional underscores, hyphens, or dots.")
+            raise ValueError(
+                "Invalid token format. Discord tokens should be "
+                "alphanumeric with optional underscores, hyphens, or dots."
+            )
 
         for attempt in range(retries):
             try:
@@ -33,9 +40,9 @@ class DiscordClient:
                 await self.chrome_client.perform_task_with_chrome(discord_url)
 
                 logger.info("Injecting passkey into localStorage")
-                self.chrome_client.sb.execute_script(f'''
-                window.localStorage.setItem('token', '{passkey}');
-                ''')
+                js = "window.localStorage.setItem('token', '"
+                js += passkey + "')"
+                self.chrome_client.sb.execute_script(js)
 
                 logger.info("Refreshing the page to apply the token")
                 self.chrome_client.sb.refresh()

--- a/packages/python/fudster/fudster/apps/novnc_client.py
+++ b/packages/python/fudster/fudster/apps/novnc_client.py
@@ -10,6 +10,7 @@ except ImportError:
     websockets = None
     websocketproxy = None
 
+
 class NoVNCClient:
     def __init__(self, logger=None):
         self.logger = logger if logger else getLogger("uvicorn")
@@ -19,7 +20,7 @@ class NoVNCClient:
             raise ImportError("websockets and websockify are required. Install with: pip install fudster[vnc]")
 
         await websocket.accept()
-        uri = f"ws://{target_host}:{target_port}"
+        uri = "ws://{}:{}".format(target_host, target_port)
         await self.start_websockify_server(target_host, target_port)
 
         while True:

--- a/packages/python/fudster/fudster/apps/screen_client.py
+++ b/packages/python/fudster/fudster/apps/screen_client.py
@@ -4,6 +4,8 @@ import random
 import math
 import tempfile
 
+from ..api.utils import ImageUtility
+
 logger = logging.getLogger("uvicorn")
 
 try:
@@ -16,8 +18,6 @@ except ImportError:
     cv2 = None
     np = None
     SystemCursor = None
-
-from ..api.utils import ImageUtility
 
 
 class ScreenClient:
@@ -69,7 +69,10 @@ class ScreenClient:
                 cursor = SystemCursor()
                 cursor.click_on([click_x, click_y])
 
-                logger.info(f"Clicked at position: ({click_x}, {click_y}) with offset ({random_offset_x}, {random_offset_y})")
+                logger.info(
+                    f"Clicked at position: ({click_x}, {click_y}) "
+                    f"with offset ({random_offset_x}, {random_offset_y})"
+                )
                 return "Click successful"
             else:
                 error_msg = "Image not found with sufficient confidence."

--- a/packages/python/fudster/fudster/models/coindesk.py
+++ b/packages/python/fudster/fudster/models/coindesk.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel, Field
 
+
 class TimeInfo(BaseModel):
     updated: str
     updatedISO: str
     updateduk: str
+
 
 class CurrencyInfo(BaseModel):
     code: str
@@ -12,10 +14,12 @@ class CurrencyInfo(BaseModel):
     description: str
     rate_float: float
 
+
 class BitcoinPriceIndex(BaseModel):
     USD: CurrencyInfo
     GBP: CurrencyInfo
     EUR: CurrencyInfo
+
 
 class CoinDeskAPIResponse(BaseModel):
     time: TimeInfo

--- a/packages/python/fudster/fudster/models/groq.py
+++ b/packages/python/fudster/fudster/models/groq.py
@@ -2,16 +2,19 @@ from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime
 
+
 class AiGroqPayload(BaseModel):
     message: str
     model: str
     system: str
+
 
 class GroqChoice(BaseModel):
     text: str
     index: int
     logprobs: Optional[dict] = None
     finish_reason: Optional[str] = None
+
 
 class GroqUsage(BaseModel):
     prompt_tokens: int

--- a/packages/python/fudster/fudster/models/poem.py
+++ b/packages/python/fudster/fudster/models/poem.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import List
 
+
 class PoemDB(BaseModel):
     title: str
     author: str

--- a/packages/python/fudster/fudster/models/rsps.py
+++ b/packages/python/fudster/fudster/models/rsps.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 from pydantic import BaseModel, Field
 
+
 # Models for /stats endpoint
 class Stat(BaseModel):
     stat: str
@@ -9,8 +10,10 @@ class Stat(BaseModel):
     xp: int
     xp_gained: Union[int, str] = Field(alias='xp gained')
 
+
 class GameStat(BaseModel):
     stats: List[Stat]
+
 
 # Models for /events endpoint
 class WorldPoint(BaseModel):
@@ -20,6 +23,7 @@ class WorldPoint(BaseModel):
     regionID: int = Field(alias='regionID')
     regionX: int = Field(alias='regionX')
     regionY: int = Field(alias='regionY')
+
 
 class Camera(BaseModel):
     yaw: int
@@ -31,9 +35,11 @@ class Camera(BaseModel):
     y2: int
     z2: int
 
+
 class Mouse(BaseModel):
     x: int
     y: int
+
 
 class GameEvent(BaseModel):
     animation: int
@@ -50,10 +56,12 @@ class GameEvent(BaseModel):
     camera: Camera
     mouse: Mouse
 
+
 # Model for /inv endpoint
 class InventoryItem(BaseModel):
     id: int
     quantity: int
+
 
 class GameInventory(BaseModel):
     items: List[InventoryItem]

--- a/packages/python/fudster/fudster/models/rss.py
+++ b/packages/python/fudster/fudster/models/rss.py
@@ -1,11 +1,13 @@
 from pydantic import BaseModel
 from typing import List, Optional
 
+
 class RssItem(BaseModel):
     title: Optional[str]
     link: Optional[str]
     description: Optional[str]
     pubDate: Optional[str]
+
 
 class RssFeed(BaseModel):
     title: Optional[str]

--- a/packages/python/fudster/tests/test_hello.py
+++ b/packages/python/fudster/tests/test_hello.py
@@ -5,9 +5,8 @@ from fudster import (
     KBVELoginModel, HandshakeModel, model_map,
     Routes, CORS, WS, RuneLiteClient,
     APIConnector,
-    RssItem, RssFeed, PoemDB, CoinDeskAPIResponse,
-    AiGroqPayload, GroqResponse,
-    GameEvent, GameStat, GameInventory,
+    RssItem, RssFeed, PoemDB,
+    AiGroqPayload,
     CoinDeskClient, PoetryDBClient, GroqClient, WebsocketEchoClient,
     RSSUtility, KRDecorator, DynamicEndpoint,
 )


### PR DESCRIPTION
## Summary
- Fix E302 (missing blank lines before class definitions) across 13 files
- Fix E501 (line too long >120 chars) in groq_client, chrome_client, discord_client, screen_client
- Fix E702/E231 (semicolon/colon in f-strings confusing flake8) in discord_client, novnc_client
- Fix E402 (import not at top of file) in screen_client
- Fix F401 (unused imports) in test_hello.py — removed CoinDeskAPIResponse, GroqResponse, GameEvent, GameStat, GameInventory

## Test plan
- [x] `flake8 packages/python/fudster/ --max-line-length 120` returns 0 errors