### PR TITLE
feat(discordsh): edge functions with hCaptcha, vote wiring, and submit form

### DIFF
--- a/apps/discordsh/astro-discordsh/src/components/servers/ReactSubmitForm.tsx
+++ b/apps/discordsh/astro-discordsh/src/components/servers/ReactSubmitForm.tsx
@@ -1,0 +1,352 @@
+import { useState, useCallback, type FormEvent } from 'react';
+import { CATEGORIES } from '@/lib/servers/types';
+import { submitServer } from '@/lib/servers/discordshEdge';
+import { useHCaptcha } from '@/lib/servers/useHCaptcha';
+
+const slVar = (name: string, fallback: string) =>
+	`var(--sl-color-${name}, ${fallback})`;
+
+const inputStyle: React.CSSProperties = {
+	width: '100%',
+	padding: '0.625rem 0.75rem',
+	borderRadius: '0.5rem',
+	border: `1px solid var(--sl-color-gray-5, #374151)`,
+	backgroundColor: 'var(--sl-color-gray-6, #111827)',
+	color: 'var(--sl-color-text, #e5e7eb)',
+	fontSize: '0.875rem',
+	boxSizing: 'border-box',
+};
+
+const labelStyle: React.CSSProperties = {
+	display: 'block',
+	fontSize: '0.8125rem',
+	fontWeight: 600,
+	color: 'var(--sl-color-text, #e5e7eb)',
+	marginBottom: '0.375rem',
+};
+
+const hintStyle: React.CSSProperties = {
+	fontSize: '0.75rem',
+	color: 'var(--sl-color-gray-3, #9ca3af)',
+	marginTop: '0.25rem',
+};
+
+export function ReactSubmitForm() {
+	const [serverId, setServerId] = useState('');
+	const [name, setName] = useState('');
+	const [summary, setSummary] = useState('');
+	const [inviteCode, setInviteCode] = useState('');
+	const [description, setDescription] = useState('');
+	const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
+	const [tagsInput, setTagsInput] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+	const [result, setResult] = useState<{
+		success: boolean;
+		message: string;
+	} | null>(null);
+
+	const {
+		containerRef: captchaRef,
+		execute: executeCaptcha,
+		reset: resetCaptcha,
+	} = useHCaptcha();
+
+	const toggleCategory = useCallback((catValue: number) => {
+		setSelectedCategories((prev) => {
+			if (prev.includes(catValue)) {
+				return prev.filter((c) => c !== catValue);
+			}
+			if (prev.length >= 3) return prev;
+			return [...prev, catValue];
+		});
+	}, []);
+
+	const handleSubmit = useCallback(
+		async (e: FormEvent) => {
+			e.preventDefault();
+			setResult(null);
+			setSubmitting(true);
+
+			try {
+				const captchaToken = await executeCaptcha();
+
+				const tags = tagsInput
+					.split(',')
+					.map((t) => t.trim().toLowerCase())
+					.filter((t) => t.length > 0)
+					.slice(0, 10);
+
+				const res = await submitServer({
+					server_id: serverId.trim(),
+					name: name.trim(),
+					summary: summary.trim(),
+					invite_code: inviteCode.trim(),
+					captcha_token: captchaToken,
+					description: description.trim() || undefined,
+					categories:
+						selectedCategories.length > 0
+							? selectedCategories
+							: undefined,
+					tags: tags.length > 0 ? tags : undefined,
+				});
+
+				setResult({
+					success: res.success,
+					message:
+						res.message ??
+						(res.success
+							? 'Server submitted for review!'
+							: 'Submission failed.'),
+				});
+
+				if (res.success) {
+					setServerId('');
+					setName('');
+					setSummary('');
+					setInviteCode('');
+					setDescription('');
+					setSelectedCategories([]);
+					setTagsInput('');
+				}
+			} catch (err: unknown) {
+				const msg =
+					err instanceof Error ? err.message : 'Unexpected error';
+				setResult({ success: false, message: msg });
+			} finally {
+				setSubmitting(false);
+				resetCaptcha();
+			}
+		},
+		[
+			serverId,
+			name,
+			summary,
+			inviteCode,
+			description,
+			selectedCategories,
+			tagsInput,
+			executeCaptcha,
+			resetCaptcha,
+		],
+	);
+
+	return (
+		<form
+			onSubmit={handleSubmit}
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '1.25rem',
+			}}>
+			{/* Invisible hCaptcha */}
+			<div ref={captchaRef} style={{ display: 'none' }} />
+
+			{/* Result message */}
+			{result && (
+				<div
+					style={{
+						padding: '0.75rem 1rem',
+						borderRadius: '0.5rem',
+						border: `1px solid ${result.success ? '#22c55e' : '#ef4444'}`,
+						backgroundColor: result.success
+							? 'rgba(34, 197, 94, 0.1)'
+							: 'rgba(239, 68, 68, 0.1)',
+						color: result.success ? '#4ade80' : '#f87171',
+						fontSize: '0.875rem',
+					}}>
+					{result.message}
+				</div>
+			)}
+
+			{/* Server ID */}
+			<div>
+				<label style={labelStyle}>Discord Server ID</label>
+				<input
+					type="text"
+					value={serverId}
+					onChange={(e) => setServerId(e.target.value)}
+					placeholder="e.g. 123456789012345678"
+					required
+					pattern="\d{17,20}"
+					style={inputStyle}
+				/>
+				<p style={hintStyle}>
+					Right-click your server name in Discord, select "Copy Server
+					ID". Must be 17-20 digits.
+				</p>
+			</div>
+
+			{/* Server Name */}
+			<div>
+				<label style={labelStyle}>Server Name</label>
+				<input
+					type="text"
+					value={name}
+					onChange={(e) => setName(e.target.value)}
+					placeholder="My Awesome Server"
+					required
+					maxLength={100}
+					style={inputStyle}
+				/>
+			</div>
+
+			{/* Summary */}
+			<div>
+				<label style={labelStyle}>Summary</label>
+				<input
+					type="text"
+					value={summary}
+					onChange={(e) => setSummary(e.target.value)}
+					placeholder="A short description of your server"
+					required
+					maxLength={200}
+					style={inputStyle}
+				/>
+				<p style={hintStyle}>{summary.length}/200 characters</p>
+			</div>
+
+			{/* Invite Code */}
+			<div>
+				<label style={labelStyle}>Invite Code</label>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.5rem',
+					}}>
+					<span
+						style={{
+							color: slVar('gray-3', '#9ca3af'),
+							fontSize: '0.875rem',
+							whiteSpace: 'nowrap',
+						}}>
+						discord.gg/
+					</span>
+					<input
+						type="text"
+						value={inviteCode}
+						onChange={(e) => setInviteCode(e.target.value)}
+						placeholder="your-invite"
+						required
+						pattern="[a-zA-Z0-9_-]{2,32}"
+						maxLength={32}
+						style={inputStyle}
+					/>
+				</div>
+				<p style={hintStyle}>
+					Create a permanent invite link in your server settings.
+				</p>
+			</div>
+
+			{/* Description (optional) */}
+			<div>
+				<label style={labelStyle}>
+					Description{' '}
+					<span
+						style={{
+							fontWeight: 400,
+							color: slVar('gray-3', '#9ca3af'),
+						}}>
+						(optional)
+					</span>
+				</label>
+				<textarea
+					value={description}
+					onChange={(e) => setDescription(e.target.value)}
+					placeholder="Tell people more about your server..."
+					maxLength={2000}
+					rows={4}
+					style={{ ...inputStyle, resize: 'vertical' }}
+				/>
+				<p style={hintStyle}>{description.length}/2000 characters</p>
+			</div>
+
+			{/* Categories */}
+			<div>
+				<label style={labelStyle}>
+					Categories{' '}
+					<span
+						style={{
+							fontWeight: 400,
+							color: slVar('gray-3', '#9ca3af'),
+						}}>
+						(up to 3)
+					</span>
+				</label>
+				<div
+					style={{
+						display: 'flex',
+						flexWrap: 'wrap',
+						gap: '0.5rem',
+					}}>
+					{CATEGORIES.map((cat, idx) => {
+						const catValue = idx + 1;
+						const selected = selectedCategories.includes(catValue);
+						return (
+							<button
+								key={cat.id}
+								type="button"
+								onClick={() => toggleCategory(catValue)}
+								style={{
+									padding: '0.375rem 0.75rem',
+									borderRadius: '9999px',
+									border: `1px solid ${selected ? 'var(--sl-color-accent, #8b5cf6)' : 'var(--sl-color-gray-5, #374151)'}`,
+									backgroundColor: selected
+										? 'var(--sl-color-accent-low, #1e1033)'
+										: 'transparent',
+									color: selected
+										? 'var(--sl-color-accent, #8b5cf6)'
+										: 'var(--sl-color-gray-3, #9ca3af)',
+									fontSize: '0.8125rem',
+									cursor: 'pointer',
+									transition: 'all 0.15s',
+								}}>
+								{cat.label}
+							</button>
+						);
+					})}
+				</div>
+			</div>
+
+			{/* Tags (optional) */}
+			<div>
+				<label style={labelStyle}>
+					Tags{' '}
+					<span
+						style={{
+							fontWeight: 400,
+							color: slVar('gray-3', '#9ca3af'),
+						}}>
+						(optional, comma-separated, max 10)
+					</span>
+				</label>
+				<input
+					type="text"
+					value={tagsInput}
+					onChange={(e) => setTagsInput(e.target.value)}
+					placeholder="e.g. competitive, friendly, 18+"
+					style={inputStyle}
+				/>
+			</div>
+
+			{/* Submit button */}
+			<button
+				type="submit"
+				disabled={submitting}
+				style={{
+					padding: '0.75rem 1.5rem',
+					borderRadius: '0.5rem',
+					border: 'none',
+					backgroundColor: 'var(--sl-color-accent, #8b5cf6)',
+					color: '#fff',
+					fontSize: '0.9375rem',
+					fontWeight: 600,
+					cursor: submitting ? 'default' : 'pointer',
+					opacity: submitting ? 0.6 : 1,
+					transition: 'opacity 0.15s',
+				}}>
+				{submitting ? 'Submitting...' : 'Submit Server'}
+			</button>
+		</form>
+	);
+}

--- a/apps/discordsh/astro-discordsh/src/lib/servers/discordshEdge.ts
+++ b/apps/discordsh/astro-discordsh/src/lib/servers/discordshEdge.ts
@@ -1,0 +1,56 @@
+import { authBridge } from '../supa';
+
+const EDGE_URL = 'https://supabase.kbve.com/functions/v1/discordsh';
+
+interface EdgeResponse {
+	success: boolean;
+	error?: string;
+	[key: string]: unknown;
+}
+
+async function callEdge(
+	command: string,
+	payload: Record<string, unknown>,
+): Promise<EdgeResponse> {
+	const session = await authBridge.getSession();
+	if (!session?.access_token) {
+		return { success: false, error: 'Not authenticated. Please sign in.' };
+	}
+
+	const res = await fetch(EDGE_URL, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${session.access_token}`,
+		},
+		body: JSON.stringify({ command, ...payload }),
+	});
+
+	const data = await res.json();
+	return data as EdgeResponse;
+}
+
+export async function castVote(
+	serverId: string,
+	captchaToken: string,
+): Promise<{ success: boolean; vote_id?: string; message?: string }> {
+	return callEdge('vote.cast', {
+		server_id: serverId,
+		captcha_token: captchaToken,
+	});
+}
+
+export async function submitServer(params: {
+	server_id: string;
+	name: string;
+	summary: string;
+	invite_code: string;
+	captcha_token: string;
+	description?: string;
+	icon_url?: string;
+	banner_url?: string;
+	categories?: number[];
+	tags?: string[];
+}): Promise<{ success: boolean; server_id?: string; message?: string }> {
+	return callEdge('server.submit', params);
+}

--- a/apps/discordsh/astro-discordsh/src/lib/servers/index.ts
+++ b/apps/discordsh/astro-discordsh/src/lib/servers/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './serverService';
+export * from './discordshEdge';

--- a/apps/discordsh/astro-discordsh/src/lib/servers/useHCaptcha.ts
+++ b/apps/discordsh/astro-discordsh/src/lib/servers/useHCaptcha.ts
@@ -1,0 +1,95 @@
+import { useRef, useCallback, useEffect, useState } from 'react';
+
+export const HCAPTCHA_SITEKEY = 'e19cf4a6-2168-49a2-88fe-716e97569e88';
+const HCAPTCHA_SCRIPT_URL = 'https://js.hcaptcha.com/1/api.js';
+
+declare global {
+	interface Window {
+		hcaptcha?: {
+			render: (
+				container: HTMLElement,
+				opts: Record<string, unknown>,
+			) => string;
+			execute: (
+				widgetId: string,
+				opts?: { async: boolean },
+			) => Promise<{ response: string }>;
+			reset: (widgetId: string) => void;
+			remove: (widgetId: string) => void;
+		};
+	}
+}
+
+let scriptLoaded = false;
+let scriptPromise: Promise<void> | null = null;
+
+function loadScript(): Promise<void> {
+	if (scriptLoaded) return Promise.resolve();
+	if (scriptPromise) return scriptPromise;
+
+	scriptPromise = new Promise<void>((resolve, reject) => {
+		if (document.querySelector(`script[src="${HCAPTCHA_SCRIPT_URL}"]`)) {
+			scriptLoaded = true;
+			resolve();
+			return;
+		}
+		const script = document.createElement('script');
+		script.src = `${HCAPTCHA_SCRIPT_URL}?render=explicit`;
+		script.async = true;
+		script.onload = () => {
+			scriptLoaded = true;
+			resolve();
+		};
+		script.onerror = () => reject(new Error('Failed to load hCaptcha'));
+		document.head.appendChild(script);
+	});
+
+	return scriptPromise;
+}
+
+export function useHCaptcha() {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const widgetIdRef = useRef<string | null>(null);
+	const [ready, setReady] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		loadScript().then(() => {
+			if (cancelled || !containerRef.current || !window.hcaptcha) return;
+
+			const id = window.hcaptcha.render(containerRef.current, {
+				sitekey: HCAPTCHA_SITEKEY,
+				size: 'invisible',
+			});
+			widgetIdRef.current = id;
+			setReady(true);
+		});
+
+		return () => {
+			cancelled = true;
+			if (widgetIdRef.current !== null && window.hcaptcha) {
+				window.hcaptcha.remove(widgetIdRef.current);
+				widgetIdRef.current = null;
+			}
+		};
+	}, []);
+
+	const execute = useCallback(async (): Promise<string> => {
+		if (!window.hcaptcha || widgetIdRef.current === null) {
+			throw new Error('hCaptcha not ready');
+		}
+		const result = await window.hcaptcha.execute(widgetIdRef.current, {
+			async: true,
+		});
+		return result.response;
+	}, []);
+
+	const reset = useCallback(() => {
+		if (window.hcaptcha && widgetIdRef.current !== null) {
+			window.hcaptcha.reset(widgetIdRef.current);
+		}
+	}, []);
+
+	return { containerRef, ready, execute, reset };
+}

--- a/apps/discordsh/astro-discordsh/src/pages/servers/submit.astro
+++ b/apps/discordsh/astro-discordsh/src/pages/servers/submit.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import { ReactSubmitForm } from '../../components/servers/ReactSubmitForm';
 ---
 
 <Layout
@@ -8,16 +9,20 @@ import Layout from '../../layouts/Layout.astro';
 	<main class="submit-page">
 		<header class="submit-header">
 			<h1>Submit Your Server</h1>
-			<p>Server submission is coming soon. Check back shortly!</p>
-		</header>
-		<div class="submit-placeholder">
 			<p>
-				We're building a seamless submission flow. Once ready, you'll be
-				able to add your server with a Discord invite link and have it
-				listed in our directory.
+				Add your Discord server to the directory. Submissions are
+				reviewed before going live.
 			</p>
-			<a href="/servers/" class="back-link">Browse Servers</a>
+		</header>
+		<div class="submit-form-wrapper">
+			<ReactSubmitForm client:visible />
 		</div>
+		<noscript>
+			<div class="submit-placeholder">
+				<p>JavaScript is required to submit a server.</p>
+				<a href="/servers/" class="back-link">Browse Servers</a>
+			</div>
+		</noscript>
 	</main>
 </Layout>
 
@@ -40,6 +45,12 @@ import Layout from '../../layouts/Layout.astro';
 		font-size: 1rem;
 		color: var(--sl-color-gray-3, #9ca3af);
 		margin: 0;
+	}
+	.submit-form-wrapper {
+		padding: 1.5rem;
+		border-radius: 0.75rem;
+		border: 1px solid var(--sl-color-gray-5, #374151);
+		background: var(--sl-color-gray-7, #1f2937);
 	}
 	.submit-placeholder {
 		padding: 1.5rem;

--- a/apps/kbve/edge/functions/discordsh/_shared.ts
+++ b/apps/kbve/edge/functions/discordsh/_shared.ts
@@ -1,0 +1,137 @@
+// Re-export all shared utilities from the centralized module
+export {
+	type JwtClaims,
+	parseJwt,
+	extractToken,
+	jsonResponse,
+	createUserClient,
+	createServiceClient,
+	requireUserToken,
+	requireServiceRole,
+} from '../_shared/supabase.ts';
+
+import { jsonResponse } from '../_shared/supabase.ts';
+
+// ---------------------------------------------------------------------------
+// Discordsh-specific request type
+// ---------------------------------------------------------------------------
+
+export interface DiscordshRequest {
+	token: string;
+	claims: import('../_shared/supabase.ts').JwtClaims;
+	body: Record<string, unknown>;
+	action: string;
+}
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+// Discord snowflake: 17-20 digit string (matches SQL CHECK: ^\d{17,20}$)
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
+export function validateSnowflake(
+	id: unknown,
+	field = 'server_id',
+): Response | null {
+	if (!id || typeof id !== 'string') {
+		return jsonResponse({ error: `${field} is required` }, 400);
+	}
+	if (!SNOWFLAKE_RE.test(id)) {
+		return jsonResponse(
+			{ error: `${field} must be a Discord snowflake (17-20 digits)` },
+			400,
+		);
+	}
+	return null;
+}
+
+export function requireNonEmpty(
+	value: unknown,
+	field: string,
+): Response | null {
+	if (!value || (typeof value === 'string' && value.trim() === '')) {
+		return jsonResponse({ error: `${field} is required` }, 400);
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// hCaptcha verification
+// ---------------------------------------------------------------------------
+
+const HCAPTCHA_SECRET = Deno.env.get('HCAPTCHA_SECRET');
+const HCAPTCHA_VERIFY_URL = 'https://api.hcaptcha.com/siteverify';
+
+interface HCaptchaResult {
+	success: boolean;
+	challenge_ts?: string;
+	hostname?: string;
+	'error-codes'?: string[];
+}
+
+/**
+ * Verify an hCaptcha token server-side.
+ * Returns null on success, or a Response on failure.
+ * Matches the guard pattern used by requireUserToken / validateSnowflake.
+ */
+export async function verifyCaptcha(
+	captchaToken: unknown,
+): Promise<Response | null> {
+	if (!HCAPTCHA_SECRET) {
+		console.error('HCAPTCHA_SECRET not configured');
+		return jsonResponse(
+			{ error: 'Captcha verification is not configured' },
+			500,
+		);
+	}
+
+	if (
+		!captchaToken ||
+		typeof captchaToken !== 'string' ||
+		captchaToken.trim() === ''
+	) {
+		return jsonResponse({ error: 'captcha_token is required' }, 400);
+	}
+
+	try {
+		const params = new URLSearchParams();
+		params.set('response', captchaToken);
+		params.set('secret', HCAPTCHA_SECRET);
+
+		const res = await fetch(HCAPTCHA_VERIFY_URL, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: params.toString(),
+		});
+
+		if (!res.ok) {
+			console.error('hCaptcha API error:', res.status);
+			return jsonResponse(
+				{ error: 'Captcha verification service unavailable' },
+				502,
+			);
+		}
+
+		const result: HCaptchaResult = await res.json();
+
+		if (!result.success) {
+			console.warn(
+				'hCaptcha verification failed:',
+				result['error-codes'],
+			);
+			return jsonResponse(
+				{ error: 'Captcha verification failed. Please try again.' },
+				400,
+			);
+		}
+
+		return null;
+	} catch (err) {
+		console.error('hCaptcha verification error:', err);
+		return jsonResponse(
+			{ error: 'Captcha verification failed unexpectedly' },
+			500,
+		);
+	}
+}

--- a/apps/kbve/edge/functions/discordsh/index.ts
+++ b/apps/kbve/edge/functions/discordsh/index.ts
@@ -1,0 +1,96 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { corsHeaders } from '../_shared/cors.ts';
+import { extractToken, parseJwt, jsonResponse } from './_shared.ts';
+import { handleVote, VOTE_ACTIONS } from './vote.ts';
+import { handleServer, SERVER_ACTIONS } from './server.ts';
+
+// ---------------------------------------------------------------------------
+// Discordsh Edge Function — Unified Router
+//
+// Command format: "module.action"
+//   vote:    cast
+//   server:  submit
+// ---------------------------------------------------------------------------
+
+const MODULES: Record<
+	string,
+	{
+		handler: (
+			req: import('./_shared.ts').DiscordshRequest,
+		) => Promise<Response>;
+		actions: string[];
+	}
+> = {
+	vote: { handler: handleVote, actions: VOTE_ACTIONS },
+	server: { handler: handleServer, actions: SERVER_ACTIONS },
+};
+
+function buildHelpText(): string {
+	const commands: string[] = [];
+	for (const [mod, { actions }] of Object.entries(MODULES)) {
+		for (const action of actions) {
+			commands.push(`${mod}.${action}`);
+		}
+	}
+	return commands.join(', ');
+}
+
+serve(async (req) => {
+	if (req.method === 'OPTIONS') {
+		return new Response('ok', { headers: corsHeaders });
+	}
+
+	if (req.method !== 'POST') {
+		return jsonResponse({ error: 'Only POST method is allowed' }, 405);
+	}
+
+	try {
+		const token = extractToken(req);
+		const claims = await parseJwt(token);
+		const body = await req.json();
+		const { command } = body;
+
+		if (!command || typeof command !== 'string') {
+			return jsonResponse(
+				{
+					error: `command is required (format: "module.action"). Available: ${buildHelpText()}`,
+				},
+				400,
+			);
+		}
+
+		const dotIndex = command.indexOf('.');
+		if (dotIndex === -1) {
+			return jsonResponse(
+				{
+					error: `Invalid command format. Use "module.action" (e.g. "vote.cast"). Available: ${buildHelpText()}`,
+				},
+				400,
+			);
+		}
+
+		const moduleName = command.slice(0, dotIndex);
+		const action = command.slice(dotIndex + 1);
+
+		const mod = MODULES[moduleName];
+		if (!mod) {
+			return jsonResponse(
+				{
+					error: `Unknown module: ${moduleName}. Available modules: ${Object.keys(MODULES).join(', ')}`,
+				},
+				400,
+			);
+		}
+
+		return mod.handler({ token, claims, body, action });
+	} catch (err) {
+		console.error('discordsh error:', err);
+		const message =
+			err instanceof Error ? err.message : 'Internal server error';
+		const status =
+			message.includes('authorization') || message.includes('JWT')
+				? 401
+				: 500;
+		return jsonResponse({ error: message }, status);
+	}
+});

--- a/apps/kbve/edge/functions/discordsh/server.ts
+++ b/apps/kbve/edge/functions/discordsh/server.ts
@@ -1,0 +1,128 @@
+import {
+	type DiscordshRequest,
+	jsonResponse,
+	createUserClient,
+	requireUserToken,
+	validateSnowflake,
+	requireNonEmpty,
+	verifyCaptcha,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Discordsh Server Module
+//
+// Actions:
+//   submit — Authenticated user submits a server for review (hCaptcha required)
+// ---------------------------------------------------------------------------
+
+type Handler = (req: DiscordshRequest) => Promise<Response>;
+
+const INVITE_CODE_RE = /^[a-zA-Z0-9_-]{2,32}$/;
+
+const handlers: Record<string, Handler> = {
+	async submit({ claims, token, body }) {
+		const denied = requireUserToken(claims);
+		if (denied) return denied;
+
+		const {
+			server_id,
+			name,
+			summary,
+			invite_code,
+			captcha_token,
+			description,
+			icon_url,
+			banner_url,
+			categories,
+			tags,
+		} = body;
+
+		const idErr = validateSnowflake(server_id, 'server_id');
+		if (idErr) return idErr;
+
+		const nameErr = requireNonEmpty(name, 'name');
+		if (nameErr) return nameErr;
+
+		const summaryErr = requireNonEmpty(summary, 'summary');
+		if (summaryErr) return summaryErr;
+
+		if (
+			!invite_code ||
+			typeof invite_code !== 'string' ||
+			!INVITE_CODE_RE.test(invite_code)
+		) {
+			return jsonResponse(
+				{ error: 'invite_code must be 2-32 alphanumeric characters' },
+				400,
+			);
+		}
+
+		const captchaErr = await verifyCaptcha(captcha_token);
+		if (captchaErr) return captchaErr;
+
+		const rpcArgs: Record<string, unknown> = {
+			p_server_id: server_id as string,
+			p_name: name as string,
+			p_summary: summary as string,
+			p_invite_code: invite_code as string,
+		};
+
+		if (description && typeof description === 'string') {
+			rpcArgs.p_description = description;
+		}
+		if (icon_url && typeof icon_url === 'string') {
+			rpcArgs.p_icon_url = icon_url;
+		}
+		if (banner_url && typeof banner_url === 'string') {
+			rpcArgs.p_banner_url = banner_url;
+		}
+		if (Array.isArray(categories)) {
+			rpcArgs.p_categories = categories;
+		}
+		if (Array.isArray(tags)) {
+			rpcArgs.p_tags = tags;
+		}
+
+		const supabase = createUserClient(token);
+		const { data, error } = await supabase.rpc(
+			'proxy_submit_server',
+			rpcArgs,
+		);
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		const row = Array.isArray(data) ? data[0] : data;
+		if (!row) {
+			return jsonResponse(
+				{ success: false, error: 'No response from database' },
+				500,
+			);
+		}
+
+		return jsonResponse(
+			{
+				success: row.success,
+				server_id: row.server_id,
+				message: row.message,
+			},
+			row.success ? 200 : 400,
+		);
+	},
+};
+
+export const SERVER_ACTIONS = Object.keys(handlers);
+
+export async function handleServer(req: DiscordshRequest): Promise<Response> {
+	const handler = handlers[req.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown server action: ${req.action}. Use: ${SERVER_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(req);
+}

--- a/apps/kbve/edge/functions/discordsh/vote.ts
+++ b/apps/kbve/edge/functions/discordsh/vote.ts
@@ -1,0 +1,73 @@
+import {
+	type DiscordshRequest,
+	jsonResponse,
+	createUserClient,
+	requireUserToken,
+	validateSnowflake,
+	verifyCaptcha,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Discordsh Vote Module
+//
+// Actions:
+//   cast — Authenticated user votes for a server (hCaptcha required)
+// ---------------------------------------------------------------------------
+
+type Handler = (req: DiscordshRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async cast({ claims, token, body }) {
+		const denied = requireUserToken(claims);
+		if (denied) return denied;
+
+		const { server_id, captcha_token } = body;
+
+		const idErr = validateSnowflake(server_id, 'server_id');
+		if (idErr) return idErr;
+
+		const captchaErr = await verifyCaptcha(captcha_token);
+		if (captchaErr) return captchaErr;
+
+		const supabase = createUserClient(token);
+		const { data, error } = await supabase.rpc('proxy_cast_vote', {
+			p_server_id: server_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		const row = Array.isArray(data) ? data[0] : data;
+		if (!row) {
+			return jsonResponse(
+				{ success: false, error: 'No response from database' },
+				500,
+			);
+		}
+
+		return jsonResponse(
+			{
+				success: row.success,
+				vote_id: row.vote_id,
+				message: row.message,
+			},
+			row.success ? 200 : 400,
+		);
+	},
+};
+
+export const VOTE_ACTIONS = Object.keys(handlers);
+
+export async function handleVote(req: DiscordshRequest): Promise<Response> {
+	const handler = handlers[req.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown vote action: ${req.action}. Use: ${VOTE_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(req);
+}

--- a/apps/kube/functions/manifests/functions-deployment.yaml
+++ b/apps/kube/functions/manifests/functions-deployment.yaml
@@ -1,104 +1,109 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: functions
-  namespace: kilobase
+    name: functions
+    namespace: kilobase
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: functions
-  template:
-    metadata:
-      labels:
-        app: functions
-    spec:
-      initContainers:
-      - name: setup-functions
-        image: busybox:latest
-        command: 
-          - sh
-          - -c
-          - |
-            echo "Setting up Edge Functions directory structure..."
-            mkdir -p /home/deno/functions/main
-            mkdir -p /home/deno/functions/vault-reader
-            mkdir -p /home/deno/functions/_shared
-            
-            if [ -f /config/main-index.ts ]; then
-              cp /config/main-index.ts /home/deno/functions/main/index.ts
-              echo "Copied main function"
-            fi
-            
-            if [ -f /config/vault-reader-index.ts ]; then
-              cp /config/vault-reader-index.ts /home/deno/functions/vault-reader/index.ts
-              echo "Copied vault-reader function"
-            fi
-            
-            if [ -f /config/shared-cors.ts ]; then
-              cp /config/shared-cors.ts /home/deno/functions/_shared/cors.ts
-              echo "Copied shared CORS configuration"
-            fi
-            
-            echo "Functions setup complete. Directory structure:"
-            ls -la /home/deno/functions/
-            ls -la /home/deno/functions/main/
-            ls -la /home/deno/functions/vault-reader/
-            ls -la /home/deno/functions/_shared/
-        volumeMounts:
-        - name: functions-config
-          mountPath: /config
-        - name: functions-dir
-          mountPath: /home/deno/functions
-      containers:
-      - name: edge-functions
-        image: supabase/edge-runtime:v1.69.6
-        imagePullPolicy: IfNotPresent
-        command:
-          - "edge-runtime"
-          - "start"
-          - "--main-service"
-          - "/home/deno/functions/main"
-        env:
-        - name: JWT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: jwt-secret
-        - name: SUPABASE_URL
-          value: "http://kong:8000"
-        - name: SUPABASE_ANON_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: anon-key
-        - name: SUPABASE_SERVICE_ROLE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: service-role-key
-        - name: SUPABASE_DB_URL
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: db-url
-        - name: VERIFY_JWT
-          value: "true"
-        - name: RELEASE_TRIGGER
-          value: "2025-09-03-004"
-        volumeMounts:
-        - name: functions-dir
-          mountPath: /home/deno/functions
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
-      volumes:
-      - name: functions-config
-        configMap:
-          name: custom-functions
-      - name: functions-dir
-        emptyDir: {}
+    replicas: 1
+    selector:
+        matchLabels:
+            app: functions
+    template:
+        metadata:
+            labels:
+                app: functions
+        spec:
+            initContainers:
+                - name: setup-functions
+                  image: busybox:latest
+                  command:
+                      - sh
+                      - -c
+                      - |
+                          echo "Setting up Edge Functions directory structure..."
+                          mkdir -p /home/deno/functions/main
+                          mkdir -p /home/deno/functions/vault-reader
+                          mkdir -p /home/deno/functions/_shared
+
+                          if [ -f /config/main-index.ts ]; then
+                            cp /config/main-index.ts /home/deno/functions/main/index.ts
+                            echo "Copied main function"
+                          fi
+
+                          if [ -f /config/vault-reader-index.ts ]; then
+                            cp /config/vault-reader-index.ts /home/deno/functions/vault-reader/index.ts
+                            echo "Copied vault-reader function"
+                          fi
+
+                          if [ -f /config/shared-cors.ts ]; then
+                            cp /config/shared-cors.ts /home/deno/functions/_shared/cors.ts
+                            echo "Copied shared CORS configuration"
+                          fi
+
+                          echo "Functions setup complete. Directory structure:"
+                          ls -la /home/deno/functions/
+                          ls -la /home/deno/functions/main/
+                          ls -la /home/deno/functions/vault-reader/
+                          ls -la /home/deno/functions/_shared/
+                  volumeMounts:
+                      - name: functions-config
+                        mountPath: /config
+                      - name: functions-dir
+                        mountPath: /home/deno/functions
+            containers:
+                - name: edge-functions
+                  image: supabase/edge-runtime:v1.69.6
+                  imagePullPolicy: IfNotPresent
+                  command:
+                      - 'edge-runtime'
+                      - 'start'
+                      - '--main-service'
+                      - '/home/deno/functions/main'
+                  env:
+                      - name: JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: jwt-secret
+                      - name: SUPABASE_URL
+                        value: 'http://kong:8000'
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: anon-key
+                      - name: SUPABASE_SERVICE_ROLE_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: service-role-key
+                      - name: SUPABASE_DB_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url
+                      - name: HCAPTCHA_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: hcaptcha-config
+                                key: secret-key
+                      - name: VERIFY_JWT
+                        value: 'true'
+                      - name: RELEASE_TRIGGER
+                        value: '2025-09-03-004'
+                  volumeMounts:
+                      - name: functions-dir
+                        mountPath: /home/deno/functions
+                  resources:
+                      requests:
+                          memory: '256Mi'
+                          cpu: '100m'
+                      limits:
+                          memory: '512Mi'
+                          cpu: '500m'
+            volumes:
+                - name: functions-config
+                  configMap:
+                      name: custom-functions
+                - name: functions-dir
+                  emptyDir: {}

--- a/apps/kube/postgrest/manifests/postgrest-deployment.yaml
+++ b/apps/kube/postgrest/manifests/postgrest-deployment.yaml
@@ -35,7 +35,7 @@ spec:
 
                       # PostgREST configuration
                       - name: PGRST_DB_SCHEMAS
-                        value: 'public,storage,graphql_public,tracker,profile,rentearth,mc,meme'
+                        value: 'public,storage,graphql_public,tracker,profile,rentearth,mc,meme,discordsh'
                       - name: PGRST_DB_ANON_ROLE
                         value: 'anon'
                       - name: PGRST_DB_USE_LEGACY_GUCS


### PR DESCRIPTION
## Summary

- **Edge function module** (`apps/kbve/edge/functions/discordsh/`): Deno-based edge functions following the MC module pattern
  - `vote.cast`: hCaptcha verification → `proxy_cast_vote` RPC (12h cooldown + 50/day cap enforced by SQL)
  - `server.submit`: hCaptcha verification → `proxy_submit_server` RPC (max 5 pending per user)
  - Shared `verifyCaptcha()` utility calls `https://api.hcaptcha.com/siteverify` with `HCAPTCHA_SECRET` env var
- **Infrastructure**: Add `discordsh` to PostgREST `PGRST_DB_SCHEMAS`, add `HCAPTCHA_SECRET` env var to edge functions deployment
- **Frontend service layer**: `discordshEdge.ts` (edge function client), `useHCaptcha.ts` hook (script-tag API, no npm dependency)
- **Vote wiring**: `ReactServerCard` now supports async voting with loading state; `ReactServerGrid` renders invisible hCaptcha and wires votes through edge function
- **Submit form**: `ReactSubmitForm` with server ID, name, summary, invite code, description, categories (up to 3), tags, and invisible hCaptcha

## Test plan

- [ ] `pnpm nx run edge:container` builds Docker image with discordsh module included
- [ ] `pnpm nx run astro-discordsh:build` passes (8 pages)
- [ ] PostgREST restart with `discordsh` in schemas exposes proxy functions via `.rpc()`
- [ ] Vote button triggers hCaptcha → edge function → SQL proxy → vote_count increment
- [ ] Submit form validates fields → hCaptcha → edge function → SQL proxy → pending server row
- [ ] Rate limits: 12h per-server cooldown, 50/day global vote cap, max 5 pending submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)