### PR TITLE
feat(memes): service RPCs + edge function module

### DIFF
--- a/apps/kbve/edge/functions/meme/_shared.ts
+++ b/apps/kbve/edge/functions/meme/_shared.ts
@@ -1,0 +1,121 @@
+// Re-export all shared utilities from the centralized module
+export {
+	type JwtClaims,
+	parseJwt,
+	extractToken,
+	jsonResponse,
+	createUserClient,
+	createServiceClient,
+	requireUserToken,
+	requireServiceRole,
+} from '../_shared/supabase.ts';
+
+import { jsonResponse } from '../_shared/supabase.ts';
+import type { JwtClaims } from '../_shared/supabase.ts';
+
+// Meme-specific request type
+export interface MemeRequest {
+	token: string;
+	claims: JwtClaims;
+	body: Record<string, unknown>;
+	action: string;
+}
+
+// ULID format: 26 Crockford Base32 characters
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+export function validateMemeId(
+	id: unknown,
+	field = 'meme_id',
+): Response | null {
+	if (!id || typeof id !== 'string') {
+		return jsonResponse({ error: `${field} is required` }, 400);
+	}
+	if (!ULID_RE.test(id)) {
+		return jsonResponse(
+			{
+				error: `${field} must be a valid ULID (26 chars, Crockford Base32)`,
+			},
+			400,
+		);
+	}
+	return null;
+}
+
+// Reaction type: 1-6 (matching meme_reactions CHECK constraint)
+export function validateReaction(reaction: unknown): Response | null {
+	const num = Number(reaction);
+	if (
+		reaction === undefined ||
+		reaction === null ||
+		!Number.isFinite(num) ||
+		!Number.isInteger(num) ||
+		num < 1 ||
+		num > 6
+	) {
+		return jsonResponse(
+			{ error: 'reaction must be an integer between 1 and 6' },
+			400,
+		);
+	}
+	return null;
+}
+
+// Tag validation: lowercase slug-safe, 1-50 chars
+const TAG_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+export function validateTag(tag: unknown): Response | null {
+	if (tag === undefined || tag === null) return null;
+	if (typeof tag !== 'string' || tag.length < 1 || tag.length > 50) {
+		return jsonResponse(
+			{ error: 'tag must be a string of 1-50 characters' },
+			400,
+		);
+	}
+	if (!TAG_RE.test(tag)) {
+		return jsonResponse(
+			{
+				error: 'tag must be lowercase alphanumeric with hyphens/underscores',
+			},
+			400,
+		);
+	}
+	return null;
+}
+
+// Validate an array of ULID strings (for batch lookups)
+export function validateMemeIdArray(
+	ids: unknown,
+	field = 'meme_ids',
+	maxLength = 50,
+): Response | null {
+	if (!Array.isArray(ids)) {
+		return jsonResponse({ error: `${field} must be an array` }, 400);
+	}
+	if (ids.length === 0) {
+		return jsonResponse({ error: `${field} must not be empty` }, 400);
+	}
+	if (ids.length > maxLength) {
+		return jsonResponse(
+			{ error: `${field} exceeds maximum of ${maxLength} items` },
+			400,
+		);
+	}
+	for (const id of ids) {
+		if (typeof id !== 'string' || !ULID_RE.test(id)) {
+			return jsonResponse(
+				{ error: `Invalid ULID in ${field}: ${id}` },
+				400,
+			);
+		}
+	}
+	return null;
+}
+
+// Require an authenticated user (has sub claim in JWT)
+export function requireAuthenticated(claims: JwtClaims): Response | null {
+	if (!claims.sub) {
+		return jsonResponse({ error: 'Authentication required' }, 401);
+	}
+	return null;
+}

--- a/apps/kbve/edge/functions/meme/feed.ts
+++ b/apps/kbve/edge/functions/meme/feed.ts
@@ -1,0 +1,84 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	validateMemeId,
+	validateTag,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Feed Module
+//
+// Actions:
+//   list  -- Fetch published memes feed with keyset pagination
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async list({ body }) {
+		// No auth check — anonymous browsing allowed
+
+		const { limit, cursor, tag } = body;
+
+		// Validate limit
+		let safeLimit = 20;
+		if (limit !== undefined) {
+			const num = Number(limit);
+			if (!Number.isInteger(num) || num < 1 || num > 50) {
+				return jsonResponse(
+					{ error: 'limit must be an integer between 1 and 50' },
+					400,
+				);
+			}
+			safeLimit = num;
+		}
+
+		// Validate cursor (optional ULID)
+		if (cursor !== undefined && cursor !== null) {
+			const cursorErr = validateMemeId(cursor, 'cursor');
+			if (cursorErr) return cursorErr;
+		}
+
+		// Validate tag (optional)
+		if (tag !== undefined && tag !== null) {
+			const tagErr = validateTag(tag);
+			if (tagErr) return tagErr;
+		}
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_fetch_feed', {
+			p_limit: safeLimit,
+			p_cursor: (cursor as string) ?? null,
+			p_tag: (tag as string) ?? null,
+		});
+
+		if (error) {
+			return jsonResponse({ error: error.message }, 400);
+		}
+
+		const memes = Array.isArray(data) ? data : [];
+		const hasMore = memes.length === safeLimit;
+		const nextCursor =
+			hasMore && memes.length > 0
+				? memes[memes.length - 1].id
+				: null;
+
+		return jsonResponse({ memes, nextCursor, hasMore });
+	},
+};
+
+export const FEED_ACTIONS = Object.keys(handlers);
+
+export async function handleFeed(memeReq: MemeRequest): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown feed action: ${memeReq.action}. Use: ${FEED_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/apps/kbve/edge/functions/meme/index.ts
+++ b/apps/kbve/edge/functions/meme/index.ts
@@ -1,0 +1,115 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { corsHeaders } from '../_shared/cors.ts';
+import {
+	type MemeRequest,
+	type JwtClaims,
+	extractToken,
+	parseJwt,
+	jsonResponse,
+} from './_shared.ts';
+import { handleFeed, FEED_ACTIONS } from './feed.ts';
+import { handleReaction, REACTION_ACTIONS } from './reaction.ts';
+import { handleSave, SAVE_ACTIONS } from './save.ts';
+import { handleUser, USER_ACTIONS } from './user.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Edge Function — Unified Router
+//
+// Command format: "module.action"
+//   feed:     list
+//   reaction: add, remove
+//   save:     add, remove
+//   user:     reactions, saves
+// ---------------------------------------------------------------------------
+
+const MODULES: Record<
+	string,
+	{
+		handler: (memeReq: MemeRequest) => Promise<Response>;
+		actions: string[];
+	}
+> = {
+	feed: { handler: handleFeed, actions: FEED_ACTIONS },
+	reaction: { handler: handleReaction, actions: REACTION_ACTIONS },
+	save: { handler: handleSave, actions: SAVE_ACTIONS },
+	user: { handler: handleUser, actions: USER_ACTIONS },
+};
+
+function buildHelpText(): string {
+	const commands: string[] = [];
+	for (const [mod, { actions }] of Object.entries(MODULES)) {
+		for (const action of actions) {
+			commands.push(`${mod}.${action}`);
+		}
+	}
+	return commands.join(', ');
+}
+
+serve(async (req) => {
+	if (req.method === 'OPTIONS') {
+		return new Response('ok', { headers: corsHeaders });
+	}
+
+	if (req.method !== 'POST') {
+		return jsonResponse({ error: 'Only POST method is allowed' }, 405);
+	}
+
+	try {
+		// Try to parse JWT — anonymous access is allowed for some actions
+		let token = '';
+		let claims: JwtClaims = { role: 'anon' };
+
+		try {
+			token = extractToken(req);
+			claims = await parseJwt(token);
+		} catch {
+			// No token or invalid token — proceed as anonymous
+		}
+
+		const body = await req.json();
+		const { command } = body;
+
+		if (!command || typeof command !== 'string') {
+			return jsonResponse(
+				{
+					error: `command is required (format: "module.action"). Available: ${buildHelpText()}`,
+				},
+				400,
+			);
+		}
+
+		const dotIndex = command.indexOf('.');
+		if (dotIndex === -1) {
+			return jsonResponse(
+				{
+					error: `Invalid command format. Use "module.action" (e.g. "feed.list"). Available: ${buildHelpText()}`,
+				},
+				400,
+			);
+		}
+
+		const moduleName = command.slice(0, dotIndex);
+		const action = command.slice(dotIndex + 1);
+
+		const mod = MODULES[moduleName];
+		if (!mod) {
+			return jsonResponse(
+				{
+					error: `Unknown module: ${moduleName}. Available modules: ${Object.keys(MODULES).join(', ')}`,
+				},
+				400,
+			);
+		}
+
+		return mod.handler({ token, claims, body, action });
+	} catch (err) {
+		console.error('meme error:', err);
+		const message =
+			err instanceof Error ? err.message : 'Internal server error';
+		const status =
+			message.includes('authorization') || message.includes('JWT')
+				? 401
+				: 500;
+		return jsonResponse({ error: message }, status);
+	}
+});

--- a/apps/kbve/edge/functions/meme/reaction.ts
+++ b/apps/kbve/edge/functions/meme/reaction.ts
@@ -1,0 +1,87 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	requireAuthenticated,
+	validateMemeId,
+	validateReaction,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Reaction Module
+//
+// Actions:
+//   add     -- React to a meme (or change existing reaction)
+//   remove  -- Remove reaction from a meme
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async add({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_id, reaction } = body;
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const reactionErr = validateReaction(reaction);
+		if (reactionErr) return reactionErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_react', {
+			p_user_id: userId,
+			p_meme_id: meme_id as string,
+			p_reaction: Number(reaction),
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true, meme_id: data });
+	},
+
+	async remove({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_id } = body;
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_unreact', {
+			p_user_id: userId,
+			p_meme_id: meme_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true, was_reacted: data });
+	},
+};
+
+export const REACTION_ACTIONS = Object.keys(handlers);
+
+export async function handleReaction(
+	memeReq: MemeRequest,
+): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown reaction action: ${memeReq.action}. Use: ${REACTION_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/apps/kbve/edge/functions/meme/save.ts
+++ b/apps/kbve/edge/functions/meme/save.ts
@@ -1,0 +1,80 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	requireAuthenticated,
+	validateMemeId,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Save Module
+//
+// Actions:
+//   add     -- Save/bookmark a meme (to default collection)
+//   remove  -- Unsave/unbookmark a meme
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async add({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_id } = body;
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_save_meme', {
+			p_user_id: userId,
+			p_meme_id: meme_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true, is_new_save: data });
+	},
+
+	async remove({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_id } = body;
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_unsave_meme', {
+			p_user_id: userId,
+			p_meme_id: meme_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true, was_saved: data });
+	},
+};
+
+export const SAVE_ACTIONS = Object.keys(handlers);
+
+export async function handleSave(memeReq: MemeRequest): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown save action: ${memeReq.action}. Use: ${SAVE_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/apps/kbve/edge/functions/meme/user.ts
+++ b/apps/kbve/edge/functions/meme/user.ts
@@ -1,0 +1,90 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	requireAuthenticated,
+	validateMemeIdArray,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme User Module -- Batch state lookups for current user
+//
+// Actions:
+//   reactions  -- Get current user's reactions for a batch of memes
+//   saves      -- Get which memes from a batch the user has saved
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async reactions({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_ids } = body;
+		const idsErr = validateMemeIdArray(meme_ids);
+		if (idsErr) return idsErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc(
+			'service_get_user_reactions',
+			{
+				p_user_id: userId,
+				p_meme_ids: meme_ids as string[],
+			},
+		);
+
+		if (error) {
+			return jsonResponse({ error: error.message }, 400);
+		}
+
+		const reactions = Array.isArray(data) ? data : [];
+		return jsonResponse({ reactions });
+	},
+
+	async saves({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_ids } = body;
+		const idsErr = validateMemeIdArray(meme_ids);
+		if (idsErr) return idsErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc(
+			'service_get_user_saves',
+			{
+				p_user_id: userId,
+				p_meme_ids: meme_ids as string[],
+			},
+		);
+
+		if (error) {
+			return jsonResponse({ error: error.message }, 400);
+		}
+
+		const saves = Array.isArray(data)
+			? data.map((row: { meme_id: string }) => row.meme_id)
+			: [];
+		return jsonResponse({ saves });
+	},
+};
+
+export const USER_ACTIONS = Object.keys(handlers);
+
+export async function handleUser(memeReq: MemeRequest): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown user action: ${memeReq.action}. Use: ${USER_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/packages/data/sql/dbmate/migrations/20260228210000_meme_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260228210000_meme_rpcs.sql
@@ -1,0 +1,416 @@
+-- migrate:up
+
+-- ============================================================
+-- MEME RPC FUNCTIONS
+-- Service-role-only RPC functions for meme feed operations.
+-- Called by Deno edge functions via createServiceClient().
+--
+-- Source of truth: packages/data/sql/schema/meme/meme_rpcs.sql
+-- Depends on: 20260227220000_meme_schema_init (full meme schema)
+-- ============================================================
+
+
+-- ===========================================
+-- RPC: service_fetch_feed
+-- Paginated published meme feed with author info
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_fetch_feed(
+    p_limit  INT  DEFAULT 20,
+    p_cursor TEXT DEFAULT NULL,
+    p_tag    TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    id              TEXT,
+    title           TEXT,
+    format          SMALLINT,
+    asset_url       TEXT,
+    thumbnail_url   TEXT,
+    width           INTEGER,
+    height          INTEGER,
+    tags            TEXT[],
+    view_count      BIGINT,
+    reaction_count  BIGINT,
+    comment_count   BIGINT,
+    save_count      BIGINT,
+    share_count     BIGINT,
+    created_at      TIMESTAMPTZ,
+    author_name     TEXT,
+    author_avatar   TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- Clamp limit to 1-50
+    p_limit := GREATEST(1, LEAST(p_limit, 50));
+
+    RETURN QUERY
+    SELECT
+        m.id,
+        m.title,
+        m.format,
+        m.asset_url,
+        m.thumbnail_url,
+        m.width,
+        m.height,
+        m.tags,
+        m.view_count,
+        m.reaction_count,
+        m.comment_count,
+        m.save_count,
+        m.share_count,
+        m.created_at,
+        p.display_name AS author_name,
+        p.avatar_url   AS author_avatar
+    FROM meme.memes AS m
+    LEFT JOIN meme.meme_user_profiles AS p
+        ON p.user_id = m.author_id
+    WHERE m.status = 3  -- published only
+      AND (p_cursor IS NULL OR m.id < p_cursor)
+      AND (p_tag IS NULL OR p_tag = ANY(m.tags))
+    ORDER BY m.id DESC
+    LIMIT p_limit;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_fetch_feed(INT, TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_fetch_feed(INT, TEXT, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_fetch_feed(INT, TEXT, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_react
+-- Add or change a reaction on a meme
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_react(
+    p_user_id   UUID,
+    p_meme_id   TEXT,
+    p_reaction  SMALLINT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    INSERT INTO meme.meme_reactions (meme_id, user_id, reaction)
+    VALUES (p_meme_id, p_user_id, p_reaction)
+    ON CONFLICT (meme_id, user_id)
+    DO UPDATE SET reaction = EXCLUDED.reaction;
+
+    RETURN p_meme_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_react(UUID, TEXT, SMALLINT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_react(UUID, TEXT, SMALLINT)
+    TO service_role;
+ALTER FUNCTION meme.service_react(UUID, TEXT, SMALLINT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_unreact
+-- Remove a reaction from a meme
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_unreact(
+    p_user_id  UUID,
+    p_meme_id  TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    DELETE FROM meme.meme_reactions
+    WHERE meme_id = p_meme_id AND user_id = p_user_id;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_unreact(UUID, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_unreact(UUID, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_unreact(UUID, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_save_meme
+-- Bookmark a meme to the default saves bucket
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_save_meme(
+    p_user_id  UUID,
+    p_meme_id  TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    INSERT INTO meme.meme_saves (meme_id, user_id, collection_id)
+    VALUES (p_meme_id, p_user_id, NULL)
+    ON CONFLICT (meme_id, user_id, COALESCE(collection_id, '__default__'))
+    DO NOTHING;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_save_meme(UUID, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_save_meme(UUID, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_save_meme(UUID, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_unsave_meme
+-- Remove a meme from default saves
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_unsave_meme(
+    p_user_id  UUID,
+    p_meme_id  TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    DELETE FROM meme.meme_saves
+    WHERE meme_id = p_meme_id
+      AND user_id = p_user_id
+      AND collection_id IS NULL;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_unsave_meme(UUID, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_unsave_meme(UUID, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_unsave_meme(UUID, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_get_user_reactions
+-- Batch lookup of user reactions for given meme IDs
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_get_user_reactions(
+    p_user_id   UUID,
+    p_meme_ids  TEXT[]
+)
+RETURNS TABLE (
+    meme_id   TEXT,
+    reaction  SMALLINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT r.meme_id, r.reaction
+    FROM meme.meme_reactions AS r
+    WHERE r.user_id = p_user_id
+      AND r.meme_id = ANY(p_meme_ids);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_get_user_reactions(UUID, TEXT[])
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_get_user_reactions(UUID, TEXT[])
+    TO service_role;
+ALTER FUNCTION meme.service_get_user_reactions(UUID, TEXT[])
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_get_user_saves
+-- Batch lookup of user saves for given meme IDs
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_get_user_saves(
+    p_user_id   UUID,
+    p_meme_ids  TEXT[]
+)
+RETURNS TABLE (
+    meme_id TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT DISTINCT s.meme_id
+    FROM meme.meme_saves AS s
+    WHERE s.user_id = p_user_id
+      AND s.meme_id = ANY(p_meme_ids);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_get_user_saves(UUID, TEXT[])
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_get_user_saves(UUID, TEXT[])
+    TO service_role;
+ALTER FUNCTION meme.service_get_user_saves(UUID, TEXT[])
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify all 7 functions exist
+    PERFORM 'meme.service_fetch_feed(int,text,text)'::regprocedure;
+    PERFORM 'meme.service_react(uuid,text,smallint)'::regprocedure;
+    PERFORM 'meme.service_unreact(uuid,text)'::regprocedure;
+    PERFORM 'meme.service_save_meme(uuid,text)'::regprocedure;
+    PERFORM 'meme.service_unsave_meme(uuid,text)'::regprocedure;
+    PERFORM 'meme.service_get_user_reactions(uuid,text[])'::regprocedure;
+    PERFORM 'meme.service_get_user_saves(uuid,text[])'::regprocedure;
+
+    -- Verify service_role has EXECUTE on all 7
+    IF NOT has_function_privilege('service_role', 'meme.service_fetch_feed(int,text,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_fetch_feed';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_react(uuid,text,smallint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_react';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_unreact(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_unreact';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_save_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_save_meme';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_unsave_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_unsave_meme';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_get_user_reactions(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_get_user_reactions';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_get_user_saves(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_get_user_saves';
+    END IF;
+
+    -- Verify anon does NOT have EXECUTE on any
+    IF has_function_privilege('anon', 'meme.service_fetch_feed(int,text,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_fetch_feed';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_react(uuid,text,smallint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_react';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_unreact(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_unreact';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_save_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_save_meme';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_unsave_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_unsave_meme';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_get_user_reactions(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_get_user_reactions';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_get_user_saves(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_get_user_saves';
+    END IF;
+
+    -- Verify all owned by service_role
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_fetch_feed(int,text,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_fetch_feed must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_react(uuid,text,smallint)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_react must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_unreact(uuid,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_unreact must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_save_meme(uuid,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_save_meme must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_unsave_meme(uuid,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_unsave_meme must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_get_user_reactions(uuid,text[])'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_get_user_reactions must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_get_user_saves(uuid,text[])'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_get_user_saves must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'meme.rpcs: all 7 service functions verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS meme.service_fetch_feed(INT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS meme.service_react(UUID, TEXT, SMALLINT);
+DROP FUNCTION IF EXISTS meme.service_unreact(UUID, TEXT);
+DROP FUNCTION IF EXISTS meme.service_save_meme(UUID, TEXT);
+DROP FUNCTION IF EXISTS meme.service_unsave_meme(UUID, TEXT);
+DROP FUNCTION IF EXISTS meme.service_get_user_reactions(UUID, TEXT[]);
+DROP FUNCTION IF EXISTS meme.service_get_user_saves(UUID, TEXT[]);

--- a/packages/data/sql/schema/meme/meme_rpcs.sql
+++ b/packages/data/sql/schema/meme/meme_rpcs.sql
@@ -1,0 +1,405 @@
+-- ============================================================
+-- MEME RPC FUNCTIONS
+-- Service-role-only RPC functions for meme feed operations.
+-- Called by Deno edge functions via createServiceClient().
+--
+-- Depends on: meme_core.sql, meme_engagement.sql, meme_social.sql
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- RPC: service_fetch_feed
+-- Paginated published meme feed with author info
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_fetch_feed(
+    p_limit  INT  DEFAULT 20,
+    p_cursor TEXT DEFAULT NULL,
+    p_tag    TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    id              TEXT,
+    title           TEXT,
+    format          SMALLINT,
+    asset_url       TEXT,
+    thumbnail_url   TEXT,
+    width           INTEGER,
+    height          INTEGER,
+    tags            TEXT[],
+    view_count      BIGINT,
+    reaction_count  BIGINT,
+    comment_count   BIGINT,
+    save_count      BIGINT,
+    share_count     BIGINT,
+    created_at      TIMESTAMPTZ,
+    author_name     TEXT,
+    author_avatar   TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- Clamp limit to 1-50
+    p_limit := GREATEST(1, LEAST(p_limit, 50));
+
+    RETURN QUERY
+    SELECT
+        m.id,
+        m.title,
+        m.format,
+        m.asset_url,
+        m.thumbnail_url,
+        m.width,
+        m.height,
+        m.tags,
+        m.view_count,
+        m.reaction_count,
+        m.comment_count,
+        m.save_count,
+        m.share_count,
+        m.created_at,
+        p.display_name AS author_name,
+        p.avatar_url   AS author_avatar
+    FROM meme.memes AS m
+    LEFT JOIN meme.meme_user_profiles AS p
+        ON p.user_id = m.author_id
+    WHERE m.status = 3  -- published only
+      AND (p_cursor IS NULL OR m.id < p_cursor)
+      AND (p_tag IS NULL OR p_tag = ANY(m.tags))
+    ORDER BY m.id DESC
+    LIMIT p_limit;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_fetch_feed(INT, TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_fetch_feed(INT, TEXT, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_fetch_feed(INT, TEXT, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_react
+-- Add or change a reaction on a meme
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_react(
+    p_user_id   UUID,
+    p_meme_id   TEXT,
+    p_reaction  SMALLINT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    INSERT INTO meme.meme_reactions (meme_id, user_id, reaction)
+    VALUES (p_meme_id, p_user_id, p_reaction)
+    ON CONFLICT (meme_id, user_id)
+    DO UPDATE SET reaction = EXCLUDED.reaction;
+
+    RETURN p_meme_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_react(UUID, TEXT, SMALLINT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_react(UUID, TEXT, SMALLINT)
+    TO service_role;
+ALTER FUNCTION meme.service_react(UUID, TEXT, SMALLINT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_unreact
+-- Remove a reaction from a meme
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_unreact(
+    p_user_id  UUID,
+    p_meme_id  TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    DELETE FROM meme.meme_reactions
+    WHERE meme_id = p_meme_id AND user_id = p_user_id;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_unreact(UUID, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_unreact(UUID, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_unreact(UUID, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_save_meme
+-- Bookmark a meme to the default saves bucket
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_save_meme(
+    p_user_id  UUID,
+    p_meme_id  TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    INSERT INTO meme.meme_saves (meme_id, user_id, collection_id)
+    VALUES (p_meme_id, p_user_id, NULL)
+    ON CONFLICT (meme_id, user_id, COALESCE(collection_id, '__default__'))
+    DO NOTHING;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_save_meme(UUID, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_save_meme(UUID, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_save_meme(UUID, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_unsave_meme
+-- Remove a meme from default saves
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_unsave_meme(
+    p_user_id  UUID,
+    p_meme_id  TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    DELETE FROM meme.meme_saves
+    WHERE meme_id = p_meme_id
+      AND user_id = p_user_id
+      AND collection_id IS NULL;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_unsave_meme(UUID, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_unsave_meme(UUID, TEXT)
+    TO service_role;
+ALTER FUNCTION meme.service_unsave_meme(UUID, TEXT)
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_get_user_reactions
+-- Batch lookup of user reactions for given meme IDs
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_get_user_reactions(
+    p_user_id   UUID,
+    p_meme_ids  TEXT[]
+)
+RETURNS TABLE (
+    meme_id   TEXT,
+    reaction  SMALLINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT r.meme_id, r.reaction
+    FROM meme.meme_reactions AS r
+    WHERE r.user_id = p_user_id
+      AND r.meme_id = ANY(p_meme_ids);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_get_user_reactions(UUID, TEXT[])
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_get_user_reactions(UUID, TEXT[])
+    TO service_role;
+ALTER FUNCTION meme.service_get_user_reactions(UUID, TEXT[])
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- RPC: service_get_user_saves
+-- Batch lookup of user saves for given meme IDs
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_get_user_saves(
+    p_user_id   UUID,
+    p_meme_ids  TEXT[]
+)
+RETURNS TABLE (
+    meme_id TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT DISTINCT s.meme_id
+    FROM meme.meme_saves AS s
+    WHERE s.user_id = p_user_id
+      AND s.meme_id = ANY(p_meme_ids);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_get_user_saves(UUID, TEXT[])
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_get_user_saves(UUID, TEXT[])
+    TO service_role;
+ALTER FUNCTION meme.service_get_user_saves(UUID, TEXT[])
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify all 7 functions exist
+    PERFORM 'meme.service_fetch_feed(int,text,text)'::regprocedure;
+    PERFORM 'meme.service_react(uuid,text,smallint)'::regprocedure;
+    PERFORM 'meme.service_unreact(uuid,text)'::regprocedure;
+    PERFORM 'meme.service_save_meme(uuid,text)'::regprocedure;
+    PERFORM 'meme.service_unsave_meme(uuid,text)'::regprocedure;
+    PERFORM 'meme.service_get_user_reactions(uuid,text[])'::regprocedure;
+    PERFORM 'meme.service_get_user_saves(uuid,text[])'::regprocedure;
+
+    -- Verify service_role has EXECUTE on all 7
+    IF NOT has_function_privilege('service_role', 'meme.service_fetch_feed(int,text,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_fetch_feed';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_react(uuid,text,smallint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_react';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_unreact(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_unreact';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_save_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_save_meme';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_unsave_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_unsave_meme';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_get_user_reactions(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_get_user_reactions';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'meme.service_get_user_saves(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on meme.service_get_user_saves';
+    END IF;
+
+    -- Verify anon does NOT have EXECUTE on any
+    IF has_function_privilege('anon', 'meme.service_fetch_feed(int,text,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_fetch_feed';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_react(uuid,text,smallint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_react';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_unreact(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_unreact';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_save_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_save_meme';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_unsave_meme(uuid,text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_unsave_meme';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_get_user_reactions(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_get_user_reactions';
+    END IF;
+    IF has_function_privilege('anon', 'meme.service_get_user_saves(uuid,text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on meme.service_get_user_saves';
+    END IF;
+
+    -- Verify all owned by service_role
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_fetch_feed(int,text,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_fetch_feed must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_react(uuid,text,smallint)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_react must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_unreact(uuid,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_unreact must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_save_meme(uuid,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_save_meme must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_unsave_meme(uuid,text)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_unsave_meme must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_get_user_reactions(uuid,text[])'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_get_user_reactions must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'meme.service_get_user_saves(uuid,text[])'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'meme.service_get_user_saves must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'meme.rpcs: all 7 service functions verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds 7 SQL RPC functions in the `meme` schema, all locked to `service_role` only (SECURITY DEFINER, REVOKE from anon/authenticated)
- Adds Deno edge function module at `functions/meme/` following the MC module pattern
- Architecture: Frontend → Edge Function (JWT auth + validation) → SQL RPC (service_role) → PostgreSQL

## SQL RPCs (`meme_rpcs.sql` + migration `20260228210000`)

| RPC | Purpose | Returns |
|-----|---------|---------|
| `service_fetch_feed` | Paginated published feed with author join | TABLE (meme + author_name/avatar) |
| `service_react` | Upsert reaction (ON CONFLICT UPDATE) | meme_id |
| `service_unreact` | Delete reaction | BOOLEAN |
| `service_save_meme` | Bookmark (ON CONFLICT DO NOTHING) | BOOLEAN |
| `service_unsave_meme` | Remove bookmark | BOOLEAN |
| `service_get_user_reactions` | Batch reaction lookup | TABLE (meme_id, reaction) |
| `service_get_user_saves` | Batch save lookup | TABLE (meme_id) |

All RPCs include verification DO block (existence, permissions, ownership).

## Edge Functions (`functions/meme/`)

| File | Commands |
|------|----------|
| `feed.ts` | `feed.list` (anonymous OK) |
| `reaction.ts` | `reaction.add`, `reaction.remove` |
| `save.ts` | `save.add`, `save.remove` |
| `user.ts` | `user.reactions`, `user.saves` |

- Anonymous feed browsing: JWT parsing is non-throwing, `feed.list` skips auth check
- All write operations require authenticated user (`claims.sub` from JWT)
- Input validation: ULID format, reaction range 1-6, tag format, batch array max 50

## Test plan
- [ ] Apply migration locally with `dbmate up`
- [ ] Verify RPCs exist and permissions are correct (service_role can execute, anon cannot)
- [ ] Test edge function router with `curl -X POST /meme -d '{"command":"feed.list"}'`
- [ ] Test anonymous `feed.list` without Authorization header
- [ ] Test `reaction.add` with user JWT
- [ ] Test validation rejects invalid ULID, out-of-range reaction, oversized batch arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)