### PR TITLE
chore(kube): switch edge functions to pre-built Docker image

### DIFF
--- a/apps/kube/functions/manifests/functions-deployment.yaml
+++ b/apps/kube/functions/manifests/functions-deployment.yaml
@@ -12,48 +12,13 @@ spec:
         metadata:
             labels:
                 app: functions
+            annotations:
+                rollout-restart: '2026-02-28T00:00:00Z'
         spec:
-            initContainers:
-                - name: setup-functions
-                  image: busybox:latest
-                  command:
-                      - sh
-                      - -c
-                      - |
-                          echo "Setting up Edge Functions directory structure..."
-                          mkdir -p /home/deno/functions/main
-                          mkdir -p /home/deno/functions/vault-reader
-                          mkdir -p /home/deno/functions/_shared
-
-                          if [ -f /config/main-index.ts ]; then
-                            cp /config/main-index.ts /home/deno/functions/main/index.ts
-                            echo "Copied main function"
-                          fi
-
-                          if [ -f /config/vault-reader-index.ts ]; then
-                            cp /config/vault-reader-index.ts /home/deno/functions/vault-reader/index.ts
-                            echo "Copied vault-reader function"
-                          fi
-
-                          if [ -f /config/shared-cors.ts ]; then
-                            cp /config/shared-cors.ts /home/deno/functions/_shared/cors.ts
-                            echo "Copied shared CORS configuration"
-                          fi
-
-                          echo "Functions setup complete. Directory structure:"
-                          ls -la /home/deno/functions/
-                          ls -la /home/deno/functions/main/
-                          ls -la /home/deno/functions/vault-reader/
-                          ls -la /home/deno/functions/_shared/
-                  volumeMounts:
-                      - name: functions-config
-                        mountPath: /config
-                      - name: functions-dir
-                        mountPath: /home/deno/functions
             containers:
                 - name: edge-functions
-                  image: supabase/edge-runtime:v1.69.6
-                  imagePullPolicy: IfNotPresent
+                  image: ghcr.io/kbve/edge:latest
+                  imagePullPolicy: Always
                   command:
                       - 'edge-runtime'
                       - 'start'
@@ -89,11 +54,6 @@ spec:
                                 key: secret-key
                       - name: VERIFY_JWT
                         value: 'true'
-                      - name: RELEASE_TRIGGER
-                        value: '2025-09-03-004'
-                  volumeMounts:
-                      - name: functions-dir
-                        mountPath: /home/deno/functions
                   resources:
                       requests:
                           memory: '256Mi'
@@ -101,9 +61,3 @@ spec:
                       limits:
                           memory: '512Mi'
                           cpu: '500m'
-            volumes:
-                - name: functions-config
-                  configMap:
-                      name: custom-functions
-                - name: functions-dir
-                  emptyDir: {}

--- a/apps/kube/functions/manifests/kustomization.yaml
+++ b/apps/kube/functions/manifests/kustomization.yaml
@@ -4,16 +4,6 @@ kind: Kustomization
 namespace: kilobase
 
 resources:
-  - functions-deployment.yaml
-  - functions-service.yaml
-  - functions-externalsecret.yaml
-
-configMapGenerator:
-  - name: custom-functions
-    files:
-      - main-index.ts=custom-functions/main/index.ts
-      - vault-reader-index.ts=custom-functions/vault-reader/index.ts
-      - shared-cors.ts=custom-functions/_shared/cors.ts
-
-generatorOptions:
-  disableNameSuffixHash: true
+    - functions-deployment.yaml
+    - functions-service.yaml
+    - functions-externalsecret.yaml


### PR DESCRIPTION
## Summary
- Replace the init container + ConfigMap approach in the edge functions Kubernetes deployment with the pre-built `ghcr.io/kbve/edge:latest` Docker image
- All edge functions (main router, vault-reader, user-vault, mc, discordsh) are baked into the Docker image at build time
- Set `imagePullPolicy: Always` so Kubernetes pulls the latest image on each rollout
- Remove unused `configMapGenerator` from kustomization since functions are no longer loaded via ConfigMap

## Context
The CI/CD pipeline for the edge Docker image is fully configured:
- File alteration detection watches `apps/kbve/edge/functions/**`, `Dockerfile`, `project.json`
- Docker build matrix includes edge with `kbve/edge` image
- E2E test matrix runs `pnpm nx e2e edge` (41 tests passing)
- Publish workflow pushes to both Docker Hub (`kbve/edge:latest`) and GHCR (`ghcr.io/kbve/edge:latest`)

The next `dev → main` merge that includes edge function changes will trigger the full pipeline: build → e2e test → publish to Docker Hub/GHCR.

## Test plan
- [x] Docker image builds locally (`pnpm nx run edge:container`)
- [x] All 41 e2e tests pass (`pnpm nx e2e edge`)
- [ ] CI pipeline triggers edge Docker build on merge to main
- [ ] Edge Docker image published to Docker Hub and GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)