### PR TITLE
feat(sql): harden osrs/discordsh schemas + proxy_update_server

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260228230000_discordsh_update_server.sql
+++ b/packages/data/sql/dbmate/migrations/20260228230000_discordsh_update_server.sql
@@ -1,0 +1,301 @@
+-- migrate:up
+
+-- ============================================================
+-- DISCORDSH — Add service_update_server + proxy_update_server
+--
+-- Replaces direct authenticated UPDATE access with gated proxy
+-- function. Fixes CHECK constraint permission issue where
+-- authenticated users couldn't call validation functions
+-- (is_safe_text, is_safe_url, etc.) during direct UPDATE.
+--
+-- Changes:
+--   1. Adds service_update_server (service_role only)
+--   2. Adds proxy_update_server (authenticated, derives auth.uid())
+--   3. Drops authenticated_update_own RLS policy on servers
+--   4. Revokes UPDATE from authenticated on servers
+--
+-- Source of truth:
+--   packages/data/sql/schema/discordsh/discordsh_servers.sql
+-- Depends on: 20260228000000_discordsh_schema_init
+-- ============================================================
+
+
+-- ===========================================
+-- SERVICE FUNCTION: Update server (internal, service_role only)
+--
+-- Validates ownership, enforces advisory lock, updates only
+-- allowed display fields. Server-managed columns (status,
+-- counters, owner_id, bumped_at, is_online) are untouched.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_update_server(
+    p_owner_id    UUID,
+    p_server_id   TEXT,
+    p_name        TEXT,
+    p_summary     TEXT,
+    p_invite_code TEXT,
+    p_description TEXT DEFAULT NULL,
+    p_icon_url    TEXT DEFAULT NULL,
+    p_banner_url  TEXT DEFAULT NULL,
+    p_categories  SMALLINT[] DEFAULT '{}',
+    p_tags        TEXT[] DEFAULT '{}'
+)
+RETURNS TABLE(success BOOLEAN, server_id TEXT, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_current_owner UUID;
+BEGIN
+    -- Validate server_id format (Discord snowflake)
+    IF p_server_id IS NULL OR p_server_id !~ '^\d{17,20}$' THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid server ID format.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Validate invite_code format
+    IF p_invite_code IS NULL OR p_invite_code !~ '^[a-zA-Z0-9_-]{2,32}$' THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid invite code format.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Validate required text fields
+    IF p_name IS NULL OR char_length(p_name) NOT BETWEEN 1 AND 100 THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Name must be 1-100 characters.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF p_summary IS NULL OR char_length(p_summary) NOT BETWEEN 1 AND 200 THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Summary must be 1-200 characters.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF p_description IS NOT NULL AND char_length(p_description) > 2000 THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Description must be 2000 characters or fewer.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Text safety validation
+    IF NOT discordsh.is_safe_text(p_name) OR NOT discordsh.is_safe_text(p_summary) THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Text contains invalid characters.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF p_description IS NOT NULL AND NOT discordsh.is_safe_text(p_description) THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Description contains invalid characters.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- URL validation
+    IF NOT discordsh.is_safe_url(p_icon_url) THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid icon URL.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF NOT discordsh.is_safe_url(p_banner_url) THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid banner URL.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Category/tag validation
+    IF NOT discordsh.are_valid_categories(p_categories) THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid categories.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF NOT discordsh.are_valid_tags(p_tags) THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid tags.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Advisory lock on server to prevent concurrent updates
+    PERFORM pg_advisory_xact_lock(hashtext('update:' || p_server_id));
+
+    -- Verify server exists and check ownership
+    SELECT s.owner_id INTO v_current_owner
+    FROM discordsh.servers s
+    WHERE s.server_id = p_server_id;
+
+    IF v_current_owner IS NULL THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Server not found.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF v_current_owner <> p_owner_id THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Not the server owner.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Update display fields only (status, counters, owner_id, bumped_at, is_online untouched)
+    UPDATE discordsh.servers s
+    SET name        = p_name,
+        summary     = p_summary,
+        invite_code = p_invite_code,
+        description = p_description,
+        icon_url    = p_icon_url,
+        banner_url  = p_banner_url,
+        categories  = p_categories,
+        tags        = p_tags
+    WHERE s.server_id = p_server_id;
+
+    RETURN QUERY SELECT true, p_server_id, 'Server updated.'::TEXT;
+
+EXCEPTION
+    WHEN check_violation THEN
+        RETURN QUERY SELECT false, NULL::TEXT,
+            ('Validation failed: ' || SQLERRM)::TEXT;
+    WHEN unique_violation THEN
+        RETURN QUERY SELECT false, NULL::TEXT,
+            'Invite code already in use by another server.'::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_update_server IS
+    'Internal: update server display fields with full validation. Verifies ownership. Called by proxy_update_server.';
+
+REVOKE ALL ON FUNCTION discordsh.service_update_server(UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[])
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_update_server(UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[])
+    TO service_role;
+ALTER FUNCTION discordsh.service_update_server(UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[])
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- PROXY FUNCTION: Update server (public, authenticated only)
+--
+-- Derives user identity from JWT via auth.uid().
+-- Prevents ownership spoofing — always uses caller's identity.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.proxy_update_server(
+    p_server_id   TEXT,
+    p_name        TEXT,
+    p_summary     TEXT,
+    p_invite_code TEXT,
+    p_description TEXT DEFAULT NULL,
+    p_icon_url    TEXT DEFAULT NULL,
+    p_banner_url  TEXT DEFAULT NULL,
+    p_categories  SMALLINT[] DEFAULT '{}',
+    p_tags        TEXT[] DEFAULT '{}'
+)
+RETURNS TABLE(success BOOLEAN, server_id TEXT, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_uid UUID;
+BEGIN
+    v_uid := auth.uid();
+    IF v_uid IS NULL THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Not authenticated.'::TEXT;
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT * FROM discordsh.service_update_server(
+        v_uid, p_server_id, p_name, p_summary, p_invite_code,
+        p_description, p_icon_url, p_banner_url, p_categories, p_tags
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.proxy_update_server IS
+    'Public: update server display fields. Derives owner from JWT. Validates inputs and ownership.';
+
+REVOKE ALL ON FUNCTION discordsh.proxy_update_server(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[])
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION discordsh.proxy_update_server(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[])
+    TO authenticated, service_role;
+ALTER FUNCTION discordsh.proxy_update_server(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[])
+    OWNER TO service_role;
+
+
+-- ===========================================
+-- REMOVE DIRECT UPDATE ACCESS
+--
+-- Drop the authenticated_update_own RLS policy and revoke
+-- UPDATE from authenticated. All updates now go through
+-- proxy_update_server.
+-- ===========================================
+
+DROP POLICY IF EXISTS "authenticated_update_own" ON discordsh.servers;
+REVOKE UPDATE ON discordsh.servers FROM authenticated;
+
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify new functions exist
+    PERFORM 'discordsh.service_update_server(uuid, text, text, text, text, text, text, text, smallint[], text[])'::regprocedure;
+    PERFORM 'discordsh.proxy_update_server(text, text, text, text, text, text, text, smallint[], text[])'::regprocedure;
+
+    -- Verify service_role has EXECUTE on both
+    IF NOT has_function_privilege('service_role', 'discordsh.service_update_server(uuid, text, text, text, text, text, text, text, smallint[], text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on discordsh.service_update_server';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'discordsh.proxy_update_server(text, text, text, text, text, text, text, smallint[], text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on discordsh.proxy_update_server';
+    END IF;
+
+    -- Verify authenticated CAN execute proxy but NOT service
+    IF NOT has_function_privilege('authenticated', 'discordsh.proxy_update_server(text, text, text, text, text, text, text, smallint[], text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have EXECUTE on discordsh.proxy_update_server';
+    END IF;
+    IF has_function_privilege('authenticated', 'discordsh.service_update_server(uuid, text, text, text, text, text, text, text, smallint[], text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have EXECUTE on discordsh.service_update_server';
+    END IF;
+
+    -- Verify anon CANNOT execute either
+    IF has_function_privilege('anon', 'discordsh.proxy_update_server(text, text, text, text, text, text, text, smallint[], text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on discordsh.proxy_update_server';
+    END IF;
+    IF has_function_privilege('anon', 'discordsh.service_update_server(uuid, text, text, text, text, text, text, text, smallint[], text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on discordsh.service_update_server';
+    END IF;
+
+    -- Verify ownership
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.service_update_server(uuid, text, text, text, text, text, text, text, smallint[], text[])'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.service_update_server must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.proxy_update_server(text, text, text, text, text, text, text, smallint[], text[])'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.proxy_update_server must be owned by service_role';
+    END IF;
+
+    -- Verify authenticated does NOT have UPDATE on servers table
+    IF has_table_privilege('authenticated', 'discordsh.servers', 'UPDATE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have UPDATE on discordsh.servers — use proxy_update_server';
+    END IF;
+
+    RAISE NOTICE 'discordsh_update_server: service + proxy functions verified, direct UPDATE removed.';
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS discordsh.proxy_update_server(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[]);
+DROP FUNCTION IF EXISTS discordsh.service_update_server(UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, SMALLINT[], TEXT[]);
+
+-- Restore the original authenticated UPDATE access
+GRANT UPDATE ON discordsh.servers TO authenticated;
+
+CREATE POLICY "authenticated_update_own" ON discordsh.servers
+    FOR UPDATE TO authenticated
+    USING (owner_id = auth.uid())
+    WITH CHECK (owner_id = auth.uid());

--- a/packages/data/sql/schema/osrs/osrs_core.sql
+++ b/packages/data/sql/schema/osrs/osrs_core.sql
@@ -1,0 +1,581 @@
+-- ============================================================
+-- OSRS CORE — Item catalog with equipment, drops, recipes, prices
+--
+-- Creates the osrs schema, all 9 tables, trigger functions,
+-- indexes, and RLS policies. Service-role-only data store —
+-- no anon/authenticated access at all.
+--
+-- Tables: items, equipment, bonuses, requirements,
+--         drop_sources, recipes, recipe_materials,
+--         prices, price_latest
+--
+-- Security:
+--   - service_role has full access via RLS bypass
+--   - anon/authenticated have NO schema usage, NO table access
+--   - All trigger functions: REVOKE from PUBLIC, owned by service_role
+--   - All SECURITY DEFINER functions: search_path=''
+--
+-- Prerequisite: pg_trgm extension (for fuzzy item name search)
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- EXTENSION: pg_trgm (fuzzy text search)
+-- ===========================================
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- ===========================================
+-- SCHEMA + PERMISSIONS
+-- ===========================================
+
+CREATE SCHEMA IF NOT EXISTS osrs;
+ALTER SCHEMA osrs OWNER TO postgres;
+
+GRANT USAGE ON SCHEMA osrs TO service_role;
+REVOKE ALL ON SCHEMA osrs FROM PUBLIC;
+REVOKE ALL ON SCHEMA osrs FROM anon, authenticated;
+
+GRANT ALL ON ALL TABLES    IN SCHEMA osrs TO service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA osrs TO service_role;
+GRANT ALL ON ALL FUNCTIONS IN SCHEMA osrs TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA osrs
+    GRANT ALL ON TABLES    TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA osrs
+    GRANT ALL ON SEQUENCES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA osrs
+    GRANT ALL ON FUNCTIONS TO service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA osrs
+    GRANT ALL ON TABLES    TO service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA osrs
+    GRANT ALL ON SEQUENCES TO service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA osrs
+    GRANT ALL ON FUNCTIONS TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA osrs
+    REVOKE ALL ON TABLES    FROM PUBLIC, anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA osrs
+    REVOKE ALL ON SEQUENCES FROM PUBLIC, anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA osrs
+    REVOKE ALL ON FUNCTIONS FROM PUBLIC, anon, authenticated;
+
+-- ===========================================
+-- TABLE: osrs.items
+-- Core item catalog — every OSRS item has an entry here.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.items (
+    item_id    BIGINT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    slug       TEXT NOT NULL,
+    examine    TEXT NOT NULL DEFAULT '',
+    members    BOOLEAN NOT NULL DEFAULT false,
+    icon       TEXT NOT NULL DEFAULT '',
+    value      INTEGER NOT NULL DEFAULT 0,
+    lowalch    INTEGER,
+    highalch   INTEGER,
+    ge_limit   INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT items_slug_unique UNIQUE (slug)
+);
+
+COMMENT ON TABLE osrs.items IS 'Core OSRS item catalog. Every item has an entry here.';
+COMMENT ON COLUMN osrs.items.item_id IS 'OSRS item ID (from game data)';
+COMMENT ON COLUMN osrs.items.slug IS 'URL-safe slug derived from item name';
+COMMENT ON COLUMN osrs.items.ge_limit IS 'Grand Exchange buy limit per 4-hour window';
+
+CREATE INDEX IF NOT EXISTS idx_osrs_items_name_trgm
+    ON osrs.items USING GIN (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_osrs_items_slug
+    ON osrs.items (slug);
+CREATE INDEX IF NOT EXISTS idx_osrs_items_members
+    ON osrs.items (members);
+
+ALTER TABLE osrs.items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.items;
+CREATE POLICY "service_role_full_access" ON osrs.items
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Global revoke after first table creation
+REVOKE ALL ON ALL TABLES IN SCHEMA osrs FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA osrs FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA osrs FROM PUBLIC, anon, authenticated;
+
+-- ===========================================
+-- TABLE: osrs.equipment
+-- Equipment stats for wearable/wieldable items.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.equipment (
+    item_id      BIGINT PRIMARY KEY REFERENCES osrs.items(item_id) ON DELETE CASCADE,
+    slot         TEXT,
+    weapon_type  TEXT,
+    weight       REAL,
+    attack_speed INTEGER,
+    attack_range INTEGER,
+    tradeable    BOOLEAN,
+    degradable   BOOLEAN,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.equipment IS 'Equipment metadata for wearable/wieldable items';
+COMMENT ON COLUMN osrs.equipment.slot IS 'Equipment slot: head, cape, neck, ammo, weapon, body, shield, legs, hands, feet, ring, 2h';
+
+ALTER TABLE osrs.equipment ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.equipment;
+CREATE POLICY "service_role_full_access" ON osrs.equipment
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TABLE: osrs.bonuses
+-- Combat bonuses for equipment items.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.bonuses (
+    item_id         BIGINT PRIMARY KEY REFERENCES osrs.equipment(item_id) ON DELETE CASCADE,
+    attack_stab     INTEGER NOT NULL DEFAULT 0,
+    attack_slash    INTEGER NOT NULL DEFAULT 0,
+    attack_crush    INTEGER NOT NULL DEFAULT 0,
+    attack_magic    INTEGER NOT NULL DEFAULT 0,
+    attack_ranged   INTEGER NOT NULL DEFAULT 0,
+    defence_stab    INTEGER NOT NULL DEFAULT 0,
+    defence_slash   INTEGER NOT NULL DEFAULT 0,
+    defence_crush   INTEGER NOT NULL DEFAULT 0,
+    defence_magic   INTEGER NOT NULL DEFAULT 0,
+    defence_ranged  INTEGER NOT NULL DEFAULT 0,
+    melee_strength  INTEGER NOT NULL DEFAULT 0,
+    ranged_strength INTEGER NOT NULL DEFAULT 0,
+    magic_damage    INTEGER NOT NULL DEFAULT 0,
+    prayer          INTEGER NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.bonuses IS 'Combat bonuses for equipment. 1:1 with osrs.equipment.';
+
+ALTER TABLE osrs.bonuses ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.bonuses;
+CREATE POLICY "service_role_full_access" ON osrs.bonuses
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TABLE: osrs.requirements
+-- Skill/quest requirements to equip items.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.requirements (
+    item_id      BIGINT PRIMARY KEY REFERENCES osrs.equipment(item_id) ON DELETE CASCADE,
+    attack       INTEGER,
+    strength     INTEGER,
+    defence      INTEGER,
+    ranged       INTEGER,
+    prayer       INTEGER,
+    magic        INTEGER,
+    runecraft    INTEGER,
+    hitpoints    INTEGER,
+    crafting     INTEGER,
+    mining       INTEGER,
+    smithing     INTEGER,
+    fishing      INTEGER,
+    cooking      INTEGER,
+    firemaking   INTEGER,
+    woodcutting  INTEGER,
+    agility      INTEGER,
+    herblore     INTEGER,
+    thieving     INTEGER,
+    fletching    INTEGER,
+    slayer       INTEGER,
+    farming      INTEGER,
+    construction INTEGER,
+    hunter       INTEGER,
+    quest        TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.requirements IS 'Skill/quest requirements to equip an item. 1:1 with osrs.equipment.';
+
+ALTER TABLE osrs.requirements ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.requirements;
+CREATE POLICY "service_role_full_access" ON osrs.requirements
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TABLE: osrs.drop_sources
+-- NPC/activity drop sources for items.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.drop_sources (
+    id           BIGSERIAL PRIMARY KEY,
+    item_id      BIGINT NOT NULL REFERENCES osrs.items(item_id) ON DELETE CASCADE,
+    source       TEXT NOT NULL,
+    combat_level INTEGER,
+    quantity     TEXT,
+    rarity       TEXT,
+    drop_rate    TEXT,
+    members_only BOOLEAN,
+    wilderness   BOOLEAN,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.drop_sources IS 'NPC/activity drop sources. Many-to-one with osrs.items.';
+
+CREATE INDEX IF NOT EXISTS idx_osrs_drop_sources_item
+    ON osrs.drop_sources (item_id);
+CREATE INDEX IF NOT EXISTS idx_osrs_drop_sources_source
+    ON osrs.drop_sources (source);
+
+ALTER TABLE osrs.drop_sources ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.drop_sources;
+CREATE POLICY "service_role_full_access" ON osrs.drop_sources
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TABLE: osrs.recipes
+-- Crafting/processing recipes that produce items.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.recipes (
+    id        BIGSERIAL PRIMARY KEY,
+    item_id   BIGINT NOT NULL REFERENCES osrs.items(item_id) ON DELETE CASCADE,
+    skill     TEXT,
+    level     INTEGER,
+    xp        REAL,
+    facility  TEXT,
+    ticks     INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.recipes IS 'Crafting/processing recipes. Many-to-one with osrs.items.';
+
+CREATE INDEX IF NOT EXISTS idx_osrs_recipes_item
+    ON osrs.recipes (item_id);
+CREATE INDEX IF NOT EXISTS idx_osrs_recipes_skill
+    ON osrs.recipes (skill);
+
+ALTER TABLE osrs.recipes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.recipes;
+CREATE POLICY "service_role_full_access" ON osrs.recipes
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TABLE: osrs.recipe_materials
+-- Input materials for recipes.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.recipe_materials (
+    id               BIGSERIAL PRIMARY KEY,
+    recipe_id        BIGINT NOT NULL REFERENCES osrs.recipes(id) ON DELETE CASCADE,
+    material_item_id INTEGER,
+    item_name        TEXT NOT NULL,
+    quantity         INTEGER NOT NULL DEFAULT 1,
+    consumed         BOOLEAN NOT NULL DEFAULT true,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.recipe_materials IS 'Input materials for recipes. Many-to-one with osrs.recipes.';
+
+CREATE INDEX IF NOT EXISTS idx_osrs_recipe_materials_recipe
+    ON osrs.recipe_materials (recipe_id);
+
+ALTER TABLE osrs.recipe_materials ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.recipe_materials;
+CREATE POLICY "service_role_full_access" ON osrs.recipe_materials
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TABLE: osrs.prices
+-- Historical GE price snapshots.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.prices (
+    id          BIGSERIAL PRIMARY KEY,
+    item_id     BIGINT NOT NULL REFERENCES osrs.items(item_id) ON DELETE CASCADE,
+    high_price  BIGINT,
+    high_time   BIGINT,
+    low_price   BIGINT,
+    low_time    BIGINT,
+    captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.prices IS 'Historical GE price snapshots. Many-to-one with osrs.items.';
+
+CREATE INDEX IF NOT EXISTS idx_osrs_prices_item_time
+    ON osrs.prices (item_id, captured_at DESC);
+
+ALTER TABLE osrs.prices ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.prices;
+CREATE POLICY "service_role_full_access" ON osrs.prices
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TABLE: osrs.price_latest
+-- Latest GE prices (one row per item, upserted).
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS osrs.price_latest (
+    item_id    BIGINT PRIMARY KEY REFERENCES osrs.items(item_id) ON DELETE CASCADE,
+    high_price BIGINT,
+    high_time  BIGINT,
+    low_price  BIGINT,
+    low_time   BIGINT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE osrs.price_latest IS 'Latest GE prices. 1:1 with osrs.items, upserted on each price fetch.';
+
+ALTER TABLE osrs.price_latest ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON osrs.price_latest;
+CREATE POLICY "service_role_full_access" ON osrs.price_latest
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- TRIGGER FUNCTIONS: updated_at
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION osrs.trg_items_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION osrs.trg_equipment_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION osrs.trg_bonuses_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION osrs.trg_requirements_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION osrs.trg_drop_sources_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION osrs.trg_recipes_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION osrs.trg_price_latest_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+-- Trigger function permissions
+REVOKE ALL ON FUNCTION osrs.trg_items_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION osrs.trg_equipment_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION osrs.trg_bonuses_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION osrs.trg_requirements_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION osrs.trg_drop_sources_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION osrs.trg_recipes_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION osrs.trg_price_latest_updated_at() FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION osrs.trg_items_updated_at() TO service_role;
+GRANT EXECUTE ON FUNCTION osrs.trg_equipment_updated_at() TO service_role;
+GRANT EXECUTE ON FUNCTION osrs.trg_bonuses_updated_at() TO service_role;
+GRANT EXECUTE ON FUNCTION osrs.trg_requirements_updated_at() TO service_role;
+GRANT EXECUTE ON FUNCTION osrs.trg_drop_sources_updated_at() TO service_role;
+GRANT EXECUTE ON FUNCTION osrs.trg_recipes_updated_at() TO service_role;
+GRANT EXECUTE ON FUNCTION osrs.trg_price_latest_updated_at() TO service_role;
+
+ALTER FUNCTION osrs.trg_items_updated_at() OWNER TO service_role;
+ALTER FUNCTION osrs.trg_equipment_updated_at() OWNER TO service_role;
+ALTER FUNCTION osrs.trg_bonuses_updated_at() OWNER TO service_role;
+ALTER FUNCTION osrs.trg_requirements_updated_at() OWNER TO service_role;
+ALTER FUNCTION osrs.trg_drop_sources_updated_at() OWNER TO service_role;
+ALTER FUNCTION osrs.trg_recipes_updated_at() OWNER TO service_role;
+ALTER FUNCTION osrs.trg_price_latest_updated_at() OWNER TO service_role;
+
+-- ===========================================
+-- TRIGGERS
+-- ===========================================
+
+DROP TRIGGER IF EXISTS trg_osrs_items_updated_at ON osrs.items;
+CREATE TRIGGER trg_osrs_items_updated_at
+    BEFORE UPDATE ON osrs.items
+    FOR EACH ROW EXECUTE FUNCTION osrs.trg_items_updated_at();
+
+DROP TRIGGER IF EXISTS trg_osrs_equipment_updated_at ON osrs.equipment;
+CREATE TRIGGER trg_osrs_equipment_updated_at
+    BEFORE UPDATE ON osrs.equipment
+    FOR EACH ROW EXECUTE FUNCTION osrs.trg_equipment_updated_at();
+
+DROP TRIGGER IF EXISTS trg_osrs_bonuses_updated_at ON osrs.bonuses;
+CREATE TRIGGER trg_osrs_bonuses_updated_at
+    BEFORE UPDATE ON osrs.bonuses
+    FOR EACH ROW EXECUTE FUNCTION osrs.trg_bonuses_updated_at();
+
+DROP TRIGGER IF EXISTS trg_osrs_requirements_updated_at ON osrs.requirements;
+CREATE TRIGGER trg_osrs_requirements_updated_at
+    BEFORE UPDATE ON osrs.requirements
+    FOR EACH ROW EXECUTE FUNCTION osrs.trg_requirements_updated_at();
+
+DROP TRIGGER IF EXISTS trg_osrs_drop_sources_updated_at ON osrs.drop_sources;
+CREATE TRIGGER trg_osrs_drop_sources_updated_at
+    BEFORE UPDATE ON osrs.drop_sources
+    FOR EACH ROW EXECUTE FUNCTION osrs.trg_drop_sources_updated_at();
+
+DROP TRIGGER IF EXISTS trg_osrs_recipes_updated_at ON osrs.recipes;
+CREATE TRIGGER trg_osrs_recipes_updated_at
+    BEFORE UPDATE ON osrs.recipes
+    FOR EACH ROW EXECUTE FUNCTION osrs.trg_recipes_updated_at();
+
+DROP TRIGGER IF EXISTS trg_osrs_price_latest_updated_at ON osrs.price_latest;
+CREATE TRIGGER trg_osrs_price_latest_updated_at
+    BEFORE UPDATE ON osrs.price_latest
+    FOR EACH ROW EXECUTE FUNCTION osrs.trg_price_latest_updated_at();
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify schema exists
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.schemata
+        WHERE schema_name = 'osrs'
+    ) THEN
+        RAISE EXCEPTION 'osrs schema creation failed';
+    END IF;
+
+    -- Verify all 9 tables exist
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'items') THEN
+        RAISE EXCEPTION 'osrs.items table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'equipment') THEN
+        RAISE EXCEPTION 'osrs.equipment table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'bonuses') THEN
+        RAISE EXCEPTION 'osrs.bonuses table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'requirements') THEN
+        RAISE EXCEPTION 'osrs.requirements table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'drop_sources') THEN
+        RAISE EXCEPTION 'osrs.drop_sources table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'recipes') THEN
+        RAISE EXCEPTION 'osrs.recipes table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'recipe_materials') THEN
+        RAISE EXCEPTION 'osrs.recipe_materials table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'prices') THEN
+        RAISE EXCEPTION 'osrs.prices table creation failed';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'osrs' AND table_name = 'price_latest') THEN
+        RAISE EXCEPTION 'osrs.price_latest table creation failed';
+    END IF;
+
+    -- Verify all 7 trigger functions exist
+    PERFORM 'osrs.trg_items_updated_at()'::regprocedure;
+    PERFORM 'osrs.trg_equipment_updated_at()'::regprocedure;
+    PERFORM 'osrs.trg_bonuses_updated_at()'::regprocedure;
+    PERFORM 'osrs.trg_requirements_updated_at()'::regprocedure;
+    PERFORM 'osrs.trg_drop_sources_updated_at()'::regprocedure;
+    PERFORM 'osrs.trg_recipes_updated_at()'::regprocedure;
+    PERFORM 'osrs.trg_price_latest_updated_at()'::regprocedure;
+
+    -- Verify anon has NO access
+    IF has_schema_privilege('anon', 'osrs', 'USAGE') THEN
+        RAISE EXCEPTION 'anon must NOT have USAGE on osrs schema';
+    END IF;
+    IF has_schema_privilege('authenticated', 'osrs', 'USAGE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have USAGE on osrs schema';
+    END IF;
+
+    -- Verify service_role has access
+    IF NOT has_schema_privilege('service_role', 'osrs', 'USAGE') THEN
+        RAISE EXCEPTION 'service_role must have USAGE on osrs schema';
+    END IF;
+
+    -- Verify trigger function ownership
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'osrs.trg_items_updated_at()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'osrs.trg_items_updated_at must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'osrs.trg_equipment_updated_at()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'osrs.trg_equipment_updated_at must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'osrs_core.sql: schema, 9 tables, 7 trigger functions verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/packages/data/sql/schema/osrs/osrs_rpcs.sql
+++ b/packages/data/sql/schema/osrs/osrs_rpcs.sql
@@ -1,0 +1,604 @@
+-- ============================================================
+-- OSRS RPC FUNCTIONS
+-- Service-role-only RPC functions for OSRS item data operations.
+-- Called by Deno edge functions or axum services via service_role.
+--
+-- Functions:
+--   service_upsert_item(JSONB)         — Upsert item with all nested data
+--   service_save_prices(JSONB)         — Bulk upsert GE prices
+--   service_get_item(BIGINT)           — Get full item as JSONB
+--   service_search_items(TEXT, INTEGER) — Fuzzy search by name (pg_trgm)
+--
+-- Security:
+--   - All functions: SECURITY DEFINER, search_path='', service_role only
+--   - anon/authenticated have NO execute permissions
+--
+-- Depends on: osrs_core.sql (all 9 tables)
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- RPC: service_upsert_item
+-- Upsert a full item with all nested data
+-- (equipment, bonuses, requirements, drops, recipes)
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION osrs.service_upsert_item(p_data JSONB)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_item_id  BIGINT;
+    v_equip    JSONB;
+    v_bonuses  JSONB;
+    v_reqs     JSONB;
+    v_drops    JSONB;
+    v_recipes  JSONB;
+    v_recipe   JSONB;
+    v_recipe_id BIGINT;
+    v_mats     JSONB;
+BEGIN
+    v_item_id := (p_data->>'id')::BIGINT;
+    IF v_item_id IS NULL THEN
+        RAISE EXCEPTION 'id is required in item data' USING ERRCODE = '22023';
+    END IF;
+
+    -- Upsert core item
+    INSERT INTO osrs.items (
+        item_id, name, slug, examine, members, icon, value, lowalch, highalch, ge_limit
+    )
+    VALUES (
+        v_item_id,
+        COALESCE(p_data->>'name', ''),
+        COALESCE(p_data->>'slug', ''),
+        COALESCE(p_data->>'examine', ''),
+        COALESCE((p_data->>'members')::BOOLEAN, false),
+        COALESCE(p_data->>'icon', ''),
+        COALESCE((p_data->>'value')::INTEGER, 0),
+        (p_data->>'lowalch')::INTEGER,
+        (p_data->>'highalch')::INTEGER,
+        (p_data->>'ge_limit')::INTEGER
+    )
+    ON CONFLICT (item_id) DO UPDATE SET
+        name     = EXCLUDED.name,
+        slug     = EXCLUDED.slug,
+        examine  = EXCLUDED.examine,
+        members  = EXCLUDED.members,
+        icon     = EXCLUDED.icon,
+        value    = EXCLUDED.value,
+        lowalch  = EXCLUDED.lowalch,
+        highalch = EXCLUDED.highalch,
+        ge_limit = EXCLUDED.ge_limit;
+
+    -- Equipment
+    v_equip := p_data->'equipment';
+    IF v_equip IS NOT NULL AND jsonb_typeof(v_equip) = 'object' THEN
+        INSERT INTO osrs.equipment (
+            item_id, slot, weapon_type, weight, attack_speed, attack_range, tradeable, degradable
+        )
+        VALUES (
+            v_item_id,
+            v_equip->>'slot',
+            v_equip->>'weapon_type',
+            (v_equip->>'weight')::REAL,
+            (v_equip->>'attack_speed')::INTEGER,
+            (v_equip->>'attack_range')::INTEGER,
+            (v_equip->>'tradeable')::BOOLEAN,
+            (v_equip->>'degradable')::BOOLEAN
+        )
+        ON CONFLICT (item_id) DO UPDATE SET
+            slot         = EXCLUDED.slot,
+            weapon_type  = EXCLUDED.weapon_type,
+            weight       = EXCLUDED.weight,
+            attack_speed = EXCLUDED.attack_speed,
+            attack_range = EXCLUDED.attack_range,
+            tradeable    = EXCLUDED.tradeable,
+            degradable   = EXCLUDED.degradable;
+
+        -- Bonuses (nested under equipment)
+        v_bonuses := v_equip->'bonuses';
+        IF v_bonuses IS NOT NULL AND jsonb_typeof(v_bonuses) = 'object' THEN
+            INSERT INTO osrs.bonuses (
+                item_id,
+                attack_stab, attack_slash, attack_crush, attack_magic, attack_ranged,
+                defence_stab, defence_slash, defence_crush, defence_magic, defence_ranged,
+                melee_strength, ranged_strength, magic_damage, prayer
+            )
+            VALUES (
+                v_item_id,
+                COALESCE((v_bonuses->>'attack_stab')::INTEGER, 0),
+                COALESCE((v_bonuses->>'attack_slash')::INTEGER, 0),
+                COALESCE((v_bonuses->>'attack_crush')::INTEGER, 0),
+                COALESCE((v_bonuses->>'attack_magic')::INTEGER, 0),
+                COALESCE((v_bonuses->>'attack_ranged')::INTEGER, 0),
+                COALESCE((v_bonuses->>'defence_stab')::INTEGER, 0),
+                COALESCE((v_bonuses->>'defence_slash')::INTEGER, 0),
+                COALESCE((v_bonuses->>'defence_crush')::INTEGER, 0),
+                COALESCE((v_bonuses->>'defence_magic')::INTEGER, 0),
+                COALESCE((v_bonuses->>'defence_ranged')::INTEGER, 0),
+                COALESCE((v_bonuses->>'melee_strength')::INTEGER, 0),
+                COALESCE((v_bonuses->>'ranged_strength')::INTEGER, 0),
+                COALESCE((v_bonuses->>'magic_damage')::INTEGER, 0),
+                COALESCE((v_bonuses->>'prayer')::INTEGER, 0)
+            )
+            ON CONFLICT (item_id) DO UPDATE SET
+                attack_stab     = EXCLUDED.attack_stab,
+                attack_slash    = EXCLUDED.attack_slash,
+                attack_crush    = EXCLUDED.attack_crush,
+                attack_magic    = EXCLUDED.attack_magic,
+                attack_ranged   = EXCLUDED.attack_ranged,
+                defence_stab    = EXCLUDED.defence_stab,
+                defence_slash   = EXCLUDED.defence_slash,
+                defence_crush   = EXCLUDED.defence_crush,
+                defence_magic   = EXCLUDED.defence_magic,
+                defence_ranged  = EXCLUDED.defence_ranged,
+                melee_strength  = EXCLUDED.melee_strength,
+                ranged_strength = EXCLUDED.ranged_strength,
+                magic_damage    = EXCLUDED.magic_damage,
+                prayer          = EXCLUDED.prayer;
+        END IF;
+
+        -- Requirements (nested under equipment)
+        v_reqs := v_equip->'requirements';
+        IF v_reqs IS NOT NULL AND jsonb_typeof(v_reqs) = 'object' THEN
+            INSERT INTO osrs.requirements (
+                item_id,
+                attack, strength, defence, ranged, prayer, magic,
+                runecraft, hitpoints, crafting, mining, smithing,
+                fishing, cooking, firemaking, woodcutting,
+                agility, herblore, thieving, fletching,
+                slayer, farming, construction, hunter, quest
+            )
+            VALUES (
+                v_item_id,
+                (v_reqs->>'attack')::INTEGER,
+                (v_reqs->>'strength')::INTEGER,
+                (v_reqs->>'defence')::INTEGER,
+                (v_reqs->>'ranged')::INTEGER,
+                (v_reqs->>'prayer')::INTEGER,
+                (v_reqs->>'magic')::INTEGER,
+                (v_reqs->>'runecraft')::INTEGER,
+                (v_reqs->>'hitpoints')::INTEGER,
+                (v_reqs->>'crafting')::INTEGER,
+                (v_reqs->>'mining')::INTEGER,
+                (v_reqs->>'smithing')::INTEGER,
+                (v_reqs->>'fishing')::INTEGER,
+                (v_reqs->>'cooking')::INTEGER,
+                (v_reqs->>'firemaking')::INTEGER,
+                (v_reqs->>'woodcutting')::INTEGER,
+                (v_reqs->>'agility')::INTEGER,
+                (v_reqs->>'herblore')::INTEGER,
+                (v_reqs->>'thieving')::INTEGER,
+                (v_reqs->>'fletching')::INTEGER,
+                (v_reqs->>'slayer')::INTEGER,
+                (v_reqs->>'farming')::INTEGER,
+                (v_reqs->>'construction')::INTEGER,
+                (v_reqs->>'hunter')::INTEGER,
+                v_reqs->>'quest'
+            )
+            ON CONFLICT (item_id) DO UPDATE SET
+                attack       = EXCLUDED.attack,
+                strength     = EXCLUDED.strength,
+                defence      = EXCLUDED.defence,
+                ranged       = EXCLUDED.ranged,
+                prayer       = EXCLUDED.prayer,
+                magic        = EXCLUDED.magic,
+                runecraft    = EXCLUDED.runecraft,
+                hitpoints    = EXCLUDED.hitpoints,
+                crafting     = EXCLUDED.crafting,
+                mining       = EXCLUDED.mining,
+                smithing     = EXCLUDED.smithing,
+                fishing      = EXCLUDED.fishing,
+                cooking      = EXCLUDED.cooking,
+                firemaking   = EXCLUDED.firemaking,
+                woodcutting  = EXCLUDED.woodcutting,
+                agility      = EXCLUDED.agility,
+                herblore     = EXCLUDED.herblore,
+                thieving     = EXCLUDED.thieving,
+                fletching    = EXCLUDED.fletching,
+                slayer       = EXCLUDED.slayer,
+                farming      = EXCLUDED.farming,
+                construction = EXCLUDED.construction,
+                hunter       = EXCLUDED.hunter,
+                quest        = EXCLUDED.quest;
+        END IF;
+    END IF;
+
+    -- Drop sources (replace all for this item)
+    v_drops := p_data->'drop_sources';
+    IF v_drops IS NOT NULL AND jsonb_typeof(v_drops) = 'array' AND jsonb_array_length(v_drops) > 0 THEN
+        DELETE FROM osrs.drop_sources WHERE item_id = v_item_id;
+        INSERT INTO osrs.drop_sources (
+            item_id, source, combat_level, quantity, rarity, drop_rate, members_only, wilderness
+        )
+        SELECT
+            v_item_id,
+            d->>'source',
+            (d->>'combat_level')::INTEGER,
+            d->>'quantity',
+            d->>'rarity',
+            d->>'drop_rate',
+            (d->>'members_only')::BOOLEAN,
+            (d->>'wilderness')::BOOLEAN
+        FROM jsonb_array_elements(v_drops) AS d;
+    END IF;
+
+    -- Recipes (replace all for this item)
+    v_recipes := p_data->'recipes';
+    IF v_recipes IS NOT NULL AND jsonb_typeof(v_recipes) = 'array' AND jsonb_array_length(v_recipes) > 0 THEN
+        DELETE FROM osrs.recipes WHERE item_id = v_item_id;
+        FOR v_recipe IN SELECT * FROM jsonb_array_elements(v_recipes)
+        LOOP
+            INSERT INTO osrs.recipes (item_id, skill, level, xp, facility, ticks)
+            VALUES (
+                v_item_id,
+                v_recipe->>'skill',
+                (v_recipe->>'level')::INTEGER,
+                (v_recipe->>'xp')::REAL,
+                v_recipe->>'facility',
+                (v_recipe->>'ticks')::INTEGER
+            )
+            RETURNING id INTO v_recipe_id;
+
+            v_mats := v_recipe->'materials';
+            IF v_mats IS NOT NULL AND jsonb_typeof(v_mats) = 'array' AND jsonb_array_length(v_mats) > 0 THEN
+                INSERT INTO osrs.recipe_materials (
+                    recipe_id, material_item_id, item_name, quantity, consumed
+                )
+                SELECT
+                    v_recipe_id,
+                    (m->>'item_id')::INTEGER,
+                    COALESCE(m->>'item_name', ''),
+                    COALESCE((m->>'quantity')::INTEGER, 1),
+                    COALESCE((m->>'consumed')::BOOLEAN, true)
+                FROM jsonb_array_elements(v_mats) AS m;
+            END IF;
+        END LOOP;
+    END IF;
+
+    RETURN v_item_id;
+END;
+$$;
+
+COMMENT ON FUNCTION osrs.service_upsert_item IS
+    'Upsert a full item with equipment, bonuses, requirements, drop sources, and recipes from JSONB.';
+
+REVOKE ALL ON FUNCTION osrs.service_upsert_item(JSONB) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION osrs.service_upsert_item(JSONB) TO service_role;
+ALTER FUNCTION osrs.service_upsert_item(JSONB) OWNER TO service_role;
+
+-- ===========================================
+-- RPC: service_save_prices
+-- Bulk upsert GE prices (historical + latest)
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION osrs.service_save_prices(p_prices JSONB)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    IF p_prices IS NULL OR jsonb_typeof(p_prices) <> 'array' THEN
+        RAISE EXCEPTION 'p_prices must be a JSONB array' USING ERRCODE = '22023';
+    END IF;
+    IF jsonb_array_length(p_prices) = 0 THEN
+        RETURN 0;
+    END IF;
+    IF jsonb_array_length(p_prices) > 5000 THEN
+        RAISE EXCEPTION 'Batch size exceeds limit of 5000 prices' USING ERRCODE = '22023';
+    END IF;
+
+    -- Insert into historical prices
+    INSERT INTO osrs.prices (item_id, high_price, high_time, low_price, low_time)
+    SELECT
+        (p->>'item_id')::BIGINT,
+        (p->>'high_price')::BIGINT,
+        (p->>'high_time')::BIGINT,
+        (p->>'low_price')::BIGINT,
+        (p->>'low_time')::BIGINT
+    FROM jsonb_array_elements(p_prices) AS p
+    WHERE (p->>'item_id')::BIGINT IS NOT NULL;
+
+    -- Upsert latest prices
+    INSERT INTO osrs.price_latest (item_id, high_price, high_time, low_price, low_time)
+    SELECT
+        (p->>'item_id')::BIGINT,
+        (p->>'high_price')::BIGINT,
+        (p->>'high_time')::BIGINT,
+        (p->>'low_price')::BIGINT,
+        (p->>'low_time')::BIGINT
+    FROM jsonb_array_elements(p_prices) AS p
+    WHERE (p->>'item_id')::BIGINT IS NOT NULL
+    ON CONFLICT (item_id) DO UPDATE SET
+        high_price = EXCLUDED.high_price,
+        high_time  = EXCLUDED.high_time,
+        low_price  = EXCLUDED.low_price,
+        low_time   = EXCLUDED.low_time;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION osrs.service_save_prices IS
+    'Bulk upsert GE prices into historical + latest tables. Max 5000 per batch.';
+
+REVOKE ALL ON FUNCTION osrs.service_save_prices(JSONB) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION osrs.service_save_prices(JSONB) TO service_role;
+ALTER FUNCTION osrs.service_save_prices(JSONB) OWNER TO service_role;
+
+-- ===========================================
+-- RPC: service_get_item
+-- Get a full item with all nested data as JSONB
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION osrs.service_get_item(p_item_id BIGINT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_result  JSONB;
+    v_equip   JSONB;
+    v_bonuses JSONB;
+    v_reqs    JSONB;
+    v_drops   JSONB;
+    v_recipes JSONB;
+    v_price   JSONB;
+BEGIN
+    -- Core item
+    SELECT jsonb_build_object(
+        'id', i.item_id, 'name', i.name, 'slug', i.slug,
+        'examine', i.examine, 'members', i.members, 'icon', i.icon,
+        'value', i.value, 'lowalch', i.lowalch, 'highalch', i.highalch,
+        'ge_limit', i.ge_limit
+    )
+    INTO v_result
+    FROM osrs.items i
+    WHERE i.item_id = p_item_id;
+
+    IF v_result IS NULL THEN RETURN NULL; END IF;
+
+    -- Equipment
+    SELECT jsonb_build_object(
+        'slot', e.slot, 'weapon_type', e.weapon_type, 'weight', e.weight,
+        'attack_speed', e.attack_speed, 'attack_range', e.attack_range,
+        'tradeable', e.tradeable, 'degradable', e.degradable
+    )
+    INTO v_equip
+    FROM osrs.equipment e
+    WHERE e.item_id = p_item_id;
+
+    IF v_equip IS NOT NULL THEN
+        -- Bonuses
+        SELECT jsonb_build_object(
+            'attack_stab', b.attack_stab, 'attack_slash', b.attack_slash,
+            'attack_crush', b.attack_crush, 'attack_magic', b.attack_magic,
+            'attack_ranged', b.attack_ranged, 'defence_stab', b.defence_stab,
+            'defence_slash', b.defence_slash, 'defence_crush', b.defence_crush,
+            'defence_magic', b.defence_magic, 'defence_ranged', b.defence_ranged,
+            'melee_strength', b.melee_strength, 'ranged_strength', b.ranged_strength,
+            'magic_damage', b.magic_damage, 'prayer', b.prayer
+        )
+        INTO v_bonuses
+        FROM osrs.bonuses b
+        WHERE b.item_id = p_item_id;
+
+        IF v_bonuses IS NOT NULL THEN
+            v_equip := v_equip || jsonb_build_object('bonuses', v_bonuses);
+        END IF;
+
+        -- Requirements
+        SELECT jsonb_strip_nulls(jsonb_build_object(
+            'attack', r.attack, 'strength', r.strength, 'defence', r.defence,
+            'ranged', r.ranged, 'prayer', r.prayer, 'magic', r.magic,
+            'runecraft', r.runecraft, 'hitpoints', r.hitpoints,
+            'crafting', r.crafting, 'mining', r.mining, 'smithing', r.smithing,
+            'fishing', r.fishing, 'cooking', r.cooking, 'firemaking', r.firemaking,
+            'woodcutting', r.woodcutting, 'agility', r.agility, 'herblore', r.herblore,
+            'thieving', r.thieving, 'fletching', r.fletching, 'slayer', r.slayer,
+            'farming', r.farming, 'construction', r.construction,
+            'hunter', r.hunter, 'quest', r.quest
+        ))
+        INTO v_reqs
+        FROM osrs.requirements r
+        WHERE r.item_id = p_item_id;
+
+        IF v_reqs IS NOT NULL THEN
+            v_equip := v_equip || jsonb_build_object('requirements', v_reqs);
+        END IF;
+
+        v_result := v_result || jsonb_build_object('equipment', v_equip);
+    END IF;
+
+    -- Drop sources
+    SELECT jsonb_agg(jsonb_build_object(
+        'source', d.source, 'combat_level', d.combat_level,
+        'quantity', d.quantity, 'rarity', d.rarity,
+        'drop_rate', d.drop_rate, 'members_only', d.members_only,
+        'wilderness', d.wilderness
+    ))
+    INTO v_drops
+    FROM osrs.drop_sources d
+    WHERE d.item_id = p_item_id;
+
+    IF v_drops IS NOT NULL THEN
+        v_result := v_result || jsonb_build_object('drop_sources', v_drops);
+    END IF;
+
+    -- Recipes with materials
+    SELECT jsonb_agg(jsonb_build_object(
+        'skill', rec.skill, 'level', rec.level, 'xp', rec.xp,
+        'facility', rec.facility, 'ticks', rec.ticks,
+        'materials', COALESCE(
+            (SELECT jsonb_agg(jsonb_build_object(
+                'item_id', rm.material_item_id, 'item_name', rm.item_name,
+                'quantity', rm.quantity, 'consumed', rm.consumed
+            ))
+            FROM osrs.recipe_materials rm WHERE rm.recipe_id = rec.id),
+            '[]'::JSONB
+        )
+    ))
+    INTO v_recipes
+    FROM osrs.recipes rec
+    WHERE rec.item_id = p_item_id;
+
+    IF v_recipes IS NOT NULL THEN
+        v_result := v_result || jsonb_build_object('recipes', v_recipes);
+    END IF;
+
+    -- Latest price
+    SELECT jsonb_build_object(
+        'high_price', pl.high_price, 'high_time', pl.high_time,
+        'low_price', pl.low_price, 'low_time', pl.low_time
+    )
+    INTO v_price
+    FROM osrs.price_latest pl
+    WHERE pl.item_id = p_item_id;
+
+    IF v_price IS NOT NULL THEN
+        v_result := v_result || jsonb_build_object('price', v_price);
+    END IF;
+
+    RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION osrs.service_get_item IS
+    'Get a full item with equipment, bonuses, requirements, drops, recipes, and latest price as JSONB.';
+
+REVOKE ALL ON FUNCTION osrs.service_get_item(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION osrs.service_get_item(BIGINT) TO service_role;
+ALTER FUNCTION osrs.service_get_item(BIGINT) OWNER TO service_role;
+
+-- ===========================================
+-- RPC: service_search_items
+-- Fuzzy search items by name using pg_trgm
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION osrs.service_search_items(
+    p_query TEXT,
+    p_limit INTEGER DEFAULT 20
+)
+RETURNS TABLE (
+    item_id    BIGINT,
+    name       TEXT,
+    slug       TEXT,
+    members    BOOLEAN,
+    icon       TEXT,
+    similarity REAL
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_limit INTEGER;
+BEGIN
+    IF p_query IS NULL OR p_query = '' THEN
+        RAISE EXCEPTION 'search query cannot be empty' USING ERRCODE = '22023';
+    END IF;
+
+    v_limit := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
+
+    RETURN QUERY
+    SELECT i.item_id, i.name, i.slug, i.members, i.icon,
+           similarity(i.name, p_query) AS sim
+    FROM osrs.items i
+    WHERE i.name % p_query
+    ORDER BY sim DESC, i.name
+    LIMIT v_limit;
+END;
+$$;
+
+COMMENT ON FUNCTION osrs.service_search_items IS
+    'Fuzzy search items by name using pg_trgm. Returns up to p_limit results sorted by similarity.';
+
+REVOKE ALL ON FUNCTION osrs.service_search_items(TEXT, INTEGER) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION osrs.service_search_items(TEXT, INTEGER) TO service_role;
+ALTER FUNCTION osrs.service_search_items(TEXT, INTEGER) OWNER TO service_role;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify all 4 service functions exist
+    PERFORM 'osrs.service_upsert_item(jsonb)'::regprocedure;
+    PERFORM 'osrs.service_save_prices(jsonb)'::regprocedure;
+    PERFORM 'osrs.service_get_item(bigint)'::regprocedure;
+    PERFORM 'osrs.service_search_items(text,integer)'::regprocedure;
+
+    -- Verify service_role has EXECUTE on all 4
+    IF NOT has_function_privilege('service_role', 'osrs.service_upsert_item(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on osrs.service_upsert_item';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'osrs.service_save_prices(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on osrs.service_save_prices';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'osrs.service_get_item(bigint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on osrs.service_get_item';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'osrs.service_search_items(text,integer)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must have EXECUTE on osrs.service_search_items';
+    END IF;
+
+    -- Verify anon does NOT have EXECUTE on any
+    IF has_function_privilege('anon', 'osrs.service_upsert_item(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on osrs.service_upsert_item';
+    END IF;
+    IF has_function_privilege('anon', 'osrs.service_save_prices(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on osrs.service_save_prices';
+    END IF;
+    IF has_function_privilege('anon', 'osrs.service_get_item(bigint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on osrs.service_get_item';
+    END IF;
+    IF has_function_privilege('anon', 'osrs.service_search_items(text,integer)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have EXECUTE on osrs.service_search_items';
+    END IF;
+
+    -- Verify all owned by service_role
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'osrs.service_upsert_item(jsonb)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'osrs.service_upsert_item must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'osrs.service_save_prices(jsonb)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'osrs.service_save_prices must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'osrs.service_get_item(bigint)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'osrs.service_get_item must be owned by service_role';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'osrs.service_search_items(text,integer)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'osrs.service_search_items must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'osrs_rpcs.sql: all 4 service functions verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Create OSRS source-of-truth files (`osrs_core.sql`, `osrs_rpcs.sql`) under `packages/data/sql/schema/osrs/`
- Regenerate OSRS migration with full security hardening: COMMENT ON, individual REVOKE/GRANT/OWNER, ALTER DEFAULT PRIVILEGES FOR ROLE postgres, verification DO blocks
- Add `service_update_server` + `proxy_update_server` to discordsh via new migration `20260228230000`
- Remove direct `UPDATE` grant from `authenticated` on `discordsh.servers` — fixes CHECK constraint permission bug where authenticated users couldn't call validation functions (`is_safe_text`, `is_safe_url`, etc.) during direct UPDATE
- All authenticated writes now gated through proxy functions (submit + update + vote)

## Changes
| File | Change |
|------|--------|
| `schema/osrs/osrs_core.sql` | **New** — source of truth for 9 tables, 7 triggers, RLS, verification |
| `schema/osrs/osrs_rpcs.sql` | **New** — source of truth for 4 service functions, verification |
| `migrations/20260228220000_osrs_schema_init.sql` | **Updated** — regenerated from source with full hardening |
| `migrations/20260228230000_discordsh_update_server.sql` | **New** — adds update functions, removes direct UPDATE |
| `schema/discordsh/discordsh_servers.sql` | **Updated** — reflects proxy_update_server, SELECT-only for authenticated |

## Test plan
- [x] All 7 migrations apply cleanly on local postgres:17-alpine
- [x] Full rollback (all 7) succeeds
- [x] Re-apply succeeds (idempotent)
- [x] OSRS: 9 tables, 11 functions verified
- [x] Discordsh: 15 functions, authenticated has SELECT only (no UPDATE/INSERT)
- [x] Verification DO blocks pass in all migrations
- [ ] Production deployment via kubectl port-forward + dbmate up

🤖 Generated with [Claude Code](https://claude.com/claude-code)