### PR TITLE
chore(discordsh): bump axum-discordsh to v0.1.18

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump axum-discordsh version from 0.1.17 to 0.1.18 to trigger CI build after #7452 bug fixes merged without the bump.

## Test plan
- [x] Version-only change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)