### PR TITLE
feat(meme): wire 12 new RPCs to edge function handlers

### DIFF
--- a/apps/kbve/edge/functions/meme/comment.ts
+++ b/apps/kbve/edge/functions/meme/comment.ts
@@ -1,0 +1,173 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	requireAuthenticated,
+	validateMemeId,
+	validateCommentBody,
+	validateLimit,
+	validateCursor,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Comment Module
+//
+// Actions:
+//   list    -- Fetch top-level comments for a meme (anonymous OK)
+//   replies -- Fetch replies to a comment (anonymous OK)
+//   create  -- Post a comment or reply (auth required)
+//   delete  -- Delete own comment (auth required)
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async list({ body }) {
+		const { meme_id, limit, cursor } = body;
+
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const { value: safeLimit, error: limitErr } = validateLimit(limit);
+		if (limitErr) return limitErr;
+
+		const cursorErr = validateCursor(cursor);
+		if (cursorErr) return cursorErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_fetch_comments', {
+			p_meme_id: meme_id as string,
+			p_limit: safeLimit,
+			p_cursor: (cursor as string) ?? null,
+		});
+
+		if (error) {
+			return jsonResponse({ error: error.message }, 400);
+		}
+
+		const comments = Array.isArray(data) ? data : [];
+		const hasMore = comments.length === safeLimit;
+		const nextCursor =
+			hasMore && comments.length > 0
+				? comments[comments.length - 1].id
+				: null;
+
+		return jsonResponse({ comments, nextCursor, hasMore });
+	},
+
+	async replies({ body }) {
+		const { parent_id, limit, cursor } = body;
+
+		const parentErr = validateMemeId(parent_id, 'parent_id');
+		if (parentErr) return parentErr;
+
+		const { value: safeLimit, error: limitErr } = validateLimit(limit);
+		if (limitErr) return limitErr;
+
+		const cursorErr = validateCursor(cursor);
+		if (cursorErr) return cursorErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_fetch_replies', {
+			p_parent_id: parent_id as string,
+			p_limit: safeLimit,
+			p_cursor: (cursor as string) ?? null,
+		});
+
+		if (error) {
+			return jsonResponse({ error: error.message }, 400);
+		}
+
+		const replies = Array.isArray(data) ? data : [];
+		const hasMore = replies.length === safeLimit;
+		const nextCursor =
+			hasMore && replies.length > 0
+				? replies[replies.length - 1].id
+				: null;
+
+		return jsonResponse({ replies, nextCursor, hasMore });
+	},
+
+	async create({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_id, body: commentBody, parent_id } = body;
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const bodyErr = validateCommentBody(commentBody);
+		if (bodyErr) return bodyErr;
+
+		if (parent_id !== undefined && parent_id !== null) {
+			const parentErr = validateMemeId(parent_id, 'parent_id');
+			if (parentErr) return parentErr;
+		}
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_create_comment', {
+			p_user_id: userId,
+			p_meme_id: meme_id as string,
+			p_body: (commentBody as string).trim(),
+			p_parent_id: (parent_id as string) ?? null,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true, comment_id: data });
+	},
+
+	async delete({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { comment_id } = body;
+		const idErr = validateMemeId(comment_id, 'comment_id');
+		if (idErr) return idErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_delete_comment', {
+			p_user_id: userId,
+			p_comment_id: comment_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		if (!data) {
+			return jsonResponse(
+				{
+					success: false,
+					error: 'Comment not found or not yours',
+				},
+				404,
+			);
+		}
+
+		return jsonResponse({ success: true });
+	},
+};
+
+export const COMMENT_ACTIONS = Object.keys(handlers);
+
+export async function handleComment(
+	memeReq: MemeRequest,
+): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown comment action: ${memeReq.action}. Use: ${COMMENT_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/apps/kbve/edge/functions/meme/feed.ts
+++ b/apps/kbve/edge/functions/meme/feed.ts
@@ -10,7 +10,9 @@ import {
 // Meme Feed Module
 //
 // Actions:
-//   list  -- Fetch published memes feed with keyset pagination
+//   list   -- Fetch published memes feed with keyset pagination
+//   view   -- Increment view count on a published meme (anonymous OK)
+//   share  -- Increment share count on a published meme (anonymous OK)
 // ---------------------------------------------------------------------------
 
 type Handler = (memeReq: MemeRequest) => Promise<Response>;
@@ -65,6 +67,40 @@ const handlers: Record<string, Handler> = {
 				: null;
 
 		return jsonResponse({ memes, nextCursor, hasMore });
+	},
+
+	async view({ body }) {
+		const { meme_id } = body;
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const supabase = createServiceClient();
+		const { error } = await supabase.rpc('service_increment_view', {
+			p_meme_id: meme_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true });
+	},
+
+	async share({ body }) {
+		const { meme_id } = body;
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const supabase = createServiceClient();
+		const { error } = await supabase.rpc('service_increment_share', {
+			p_meme_id: meme_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true });
 	},
 };
 

--- a/apps/kbve/edge/functions/meme/follow.ts
+++ b/apps/kbve/edge/functions/meme/follow.ts
@@ -1,0 +1,90 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	requireAuthenticated,
+	validateUserId,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Follow Module
+//
+// Actions:
+//   add    -- Follow a user (auth required)
+//   remove -- Unfollow a user (auth required)
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async add({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { following_id } = body;
+		const idErr = validateUserId(following_id, 'following_id');
+		if (idErr) return idErr;
+
+		// Prevent self-follow at edge layer (CHECK constraint is backup)
+		if (following_id === userId) {
+			return jsonResponse(
+				{ error: 'You cannot follow yourself' },
+				400,
+			);
+		}
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_follow', {
+			p_follower_id: userId,
+			p_following_id: following_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true, is_new: data });
+	},
+
+	async remove({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { following_id } = body;
+		const idErr = validateUserId(following_id, 'following_id');
+		if (idErr) return idErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_unfollow', {
+			p_follower_id: userId,
+			p_following_id: following_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true, was_following: data });
+	},
+};
+
+export const FOLLOW_ACTIONS = Object.keys(handlers);
+
+export async function handleFollow(
+	memeReq: MemeRequest,
+): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown follow action: ${memeReq.action}. Use: ${FOLLOW_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/apps/kbve/edge/functions/meme/index.ts
+++ b/apps/kbve/edge/functions/meme/index.ts
@@ -11,15 +11,23 @@ import { handleFeed, FEED_ACTIONS } from './feed.ts';
 import { handleReaction, REACTION_ACTIONS } from './reaction.ts';
 import { handleSave, SAVE_ACTIONS } from './save.ts';
 import { handleUser, USER_ACTIONS } from './user.ts';
+import { handleComment, COMMENT_ACTIONS } from './comment.ts';
+import { handleProfile, PROFILE_ACTIONS } from './profile.ts';
+import { handleFollow, FOLLOW_ACTIONS } from './follow.ts';
+import { handleReport, REPORT_ACTIONS } from './report.ts';
 
 // ---------------------------------------------------------------------------
 // Meme Edge Function — Unified Router
 //
 // Command format: "module.action"
-//   feed:     list
+//   feed:     list, view, share
 //   reaction: add, remove
 //   save:     add, remove
 //   user:     reactions, saves
+//   comment:  list, replies, create, delete
+//   profile:  get, update, memes
+//   follow:   add, remove
+//   report:   create
 // ---------------------------------------------------------------------------
 
 const MODULES: Record<
@@ -33,6 +41,10 @@ const MODULES: Record<
 	reaction: { handler: handleReaction, actions: REACTION_ACTIONS },
 	save: { handler: handleSave, actions: SAVE_ACTIONS },
 	user: { handler: handleUser, actions: USER_ACTIONS },
+	comment: { handler: handleComment, actions: COMMENT_ACTIONS },
+	profile: { handler: handleProfile, actions: PROFILE_ACTIONS },
+	follow: { handler: handleFollow, actions: FOLLOW_ACTIONS },
+	report: { handler: handleReport, actions: REPORT_ACTIONS },
 };
 
 function buildHelpText(): string {

--- a/apps/kbve/edge/functions/meme/profile.ts
+++ b/apps/kbve/edge/functions/meme/profile.ts
@@ -1,0 +1,167 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	requireAuthenticated,
+	validateUserId,
+	validateLimit,
+	validateCursor,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Profile Module
+//
+// Actions:
+//   get    -- Fetch public user profile (anonymous OK)
+//   update -- Update own profile (auth required)
+//   memes  -- Fetch user's published memes (anonymous OK)
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async get({ body }) {
+		const { user_id } = body;
+
+		const idErr = validateUserId(user_id);
+		if (idErr) return idErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_get_profile', {
+			p_user_id: user_id as string,
+		});
+
+		if (error) {
+			return jsonResponse({ error: error.message }, 400);
+		}
+
+		const rows = Array.isArray(data) ? data : [];
+		return jsonResponse({ profile: rows[0] ?? null });
+	},
+
+	async update({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { display_name, avatar_url, bio } = body;
+
+		// At least one field must be provided
+		if (
+			display_name === undefined &&
+			avatar_url === undefined &&
+			bio === undefined
+		) {
+			return jsonResponse(
+				{
+					error: 'At least one of display_name, avatar_url, or bio must be provided',
+				},
+				400,
+			);
+		}
+
+		// Validate display_name if provided
+		if (display_name !== undefined && display_name !== null) {
+			if (
+				typeof display_name !== 'string' ||
+				display_name.trim().length < 1 ||
+				display_name.trim().length > 50
+			) {
+				return jsonResponse(
+					{
+						error: 'display_name must be between 1 and 50 characters',
+					},
+					400,
+				);
+			}
+		}
+
+		// Validate avatar_url if provided
+		if (avatar_url !== undefined && avatar_url !== null) {
+			if (
+				typeof avatar_url !== 'string' ||
+				!avatar_url.startsWith('https://')
+			) {
+				return jsonResponse(
+					{ error: 'avatar_url must be a valid HTTPS URL' },
+					400,
+				);
+			}
+		}
+
+		// Validate bio if provided
+		if (bio !== undefined && bio !== null) {
+			if (typeof bio !== 'string' || bio.length > 500) {
+				return jsonResponse(
+					{ error: 'bio must be at most 500 characters' },
+					400,
+				);
+			}
+		}
+
+		const supabase = createServiceClient();
+		const { error } = await supabase.rpc('service_upsert_profile', {
+			p_user_id: userId,
+			p_display_name: (display_name as string) ?? null,
+			p_avatar_url: (avatar_url as string) ?? null,
+			p_bio: (bio as string) ?? null,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		return jsonResponse({ success: true });
+	},
+
+	async memes({ body }) {
+		const { user_id, limit, cursor } = body;
+
+		const idErr = validateUserId(user_id);
+		if (idErr) return idErr;
+
+		const { value: safeLimit, error: limitErr } = validateLimit(limit);
+		if (limitErr) return limitErr;
+
+		const cursorErr = validateCursor(cursor);
+		if (cursorErr) return cursorErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_get_user_memes', {
+			p_user_id: user_id as string,
+			p_limit: safeLimit,
+			p_cursor: (cursor as string) ?? null,
+		});
+
+		if (error) {
+			return jsonResponse({ error: error.message }, 400);
+		}
+
+		const memes = Array.isArray(data) ? data : [];
+		const hasMore = memes.length === safeLimit;
+		const nextCursor =
+			hasMore && memes.length > 0
+				? memes[memes.length - 1].id
+				: null;
+
+		return jsonResponse({ memes, nextCursor, hasMore });
+	},
+};
+
+export const PROFILE_ACTIONS = Object.keys(handlers);
+
+export async function handleProfile(
+	memeReq: MemeRequest,
+): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown profile action: ${memeReq.action}. Use: ${PROFILE_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/apps/kbve/edge/functions/meme/report.ts
+++ b/apps/kbve/edge/functions/meme/report.ts
@@ -1,0 +1,78 @@
+import {
+	type MemeRequest,
+	jsonResponse,
+	createServiceClient,
+	requireAuthenticated,
+	validateMemeId,
+	validateReportReason,
+	validateReportDetail,
+} from './_shared.ts';
+
+// ---------------------------------------------------------------------------
+// Meme Report Module
+//
+// Actions:
+//   create -- Submit a content report on a meme (auth required)
+// ---------------------------------------------------------------------------
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+	async create({ claims, body }) {
+		const denied = requireAuthenticated(claims);
+		if (denied) return denied;
+
+		const userId = claims.sub;
+
+		const { meme_id, reason, detail } = body;
+
+		const memeErr = validateMemeId(meme_id);
+		if (memeErr) return memeErr;
+
+		const reasonErr = validateReportReason(reason);
+		if (reasonErr) return reasonErr;
+
+		const detailErr = validateReportDetail(detail);
+		if (detailErr) return detailErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc('service_report_meme', {
+			p_reporter_id: userId,
+			p_meme_id: meme_id as string,
+			p_reason: Number(reason),
+			p_detail: (detail as string) ?? null,
+		});
+
+		if (error) {
+			return jsonResponse({ success: false, error: error.message }, 400);
+		}
+
+		// NULL means user already has an open report for this meme
+		if (data === null) {
+			return jsonResponse({
+				success: true,
+				report_id: null,
+				already_reported: true,
+			});
+		}
+
+		return jsonResponse({ success: true, report_id: data });
+	},
+};
+
+export const REPORT_ACTIONS = Object.keys(handlers);
+
+export async function handleReport(
+	memeReq: MemeRequest,
+): Promise<Response> {
+	const handler = handlers[memeReq.action];
+	if (!handler) {
+		return jsonResponse(
+			{
+				error: `Unknown report action: ${memeReq.action}. Use: ${REPORT_ACTIONS.join(', ')}`,
+			},
+			400,
+		);
+	}
+	return handler(memeReq);
+}

--- a/apps/memes/astro-memes/src/lib/memeService.ts
+++ b/apps/memes/astro-memes/src/lib/memeService.ts
@@ -40,6 +40,43 @@ export interface FeedParams {
 	tag?: string | null;
 }
 
+export interface FeedComment {
+	id: string;
+	author_id: string;
+	body: string;
+	parent_id: string | null;
+	reaction_count: number;
+	reply_count: number;
+	created_at: string;
+	author_name: string | null;
+	author_avatar: string | null;
+}
+
+export interface CommentPage {
+	comments: FeedComment[];
+	nextCursor: string | null;
+	hasMore: boolean;
+}
+
+export interface ReplyPage {
+	replies: FeedComment[];
+	nextCursor: string | null;
+	hasMore: boolean;
+}
+
+export interface UserProfile {
+	user_id: string;
+	display_name: string | null;
+	avatar_url: string | null;
+	bio: string | null;
+	total_memes: number;
+	total_reactions_received: number;
+	total_views_received: number;
+	follower_count: number;
+	following_count: number;
+	joined_at: string;
+}
+
 /** Reaction types matching ReactionType enum (1-indexed, 0 = unspecified) */
 export const REACTIONS = [
 	{ key: 1, emoji: '👍', label: 'Like' },
@@ -50,7 +87,18 @@ export const REACTIONS = [
 	{ key: 6, emoji: '🧢', label: 'Cap' },
 ] as const;
 
-// ── Edge function command helper ─────────────────────────────────────────
+/** Report reasons matching ReportReason enum (1-7) */
+export const REPORT_REASONS = [
+	{ key: 1, label: 'Spam' },
+	{ key: 2, label: 'NSFW' },
+	{ key: 3, label: 'Hate Speech' },
+	{ key: 4, label: 'Harassment' },
+	{ key: 5, label: 'Copyright' },
+	{ key: 6, label: 'Misinformation' },
+	{ key: 7, label: 'Other' },
+] as const;
+
+// ── Edge function response types ─────────────────────────────────────────
 
 interface EdgeFeedResponse {
 	memes: FeedMeme[];
@@ -77,7 +125,47 @@ interface EdgeUserSavesResponse {
 	saves: string[];
 }
 
-// ── Service Functions ────────────────────────────────────────────────────
+interface EdgeCommentListResponse {
+	comments: FeedComment[];
+	nextCursor: string | null;
+	hasMore: boolean;
+}
+
+interface EdgeReplyListResponse {
+	replies: FeedComment[];
+	nextCursor: string | null;
+	hasMore: boolean;
+}
+
+interface EdgeCommentCreateResponse {
+	success: boolean;
+	comment_id?: string;
+	error?: string;
+}
+
+interface EdgeProfileResponse {
+	profile: UserProfile | null;
+}
+
+interface EdgeProfileMemesResponse {
+	memes: FeedMeme[];
+	nextCursor: string | null;
+	hasMore: boolean;
+}
+
+interface EdgeFollowResponse {
+	success: boolean;
+	is_new?: boolean;
+	error?: string;
+}
+
+interface EdgeReportResponse {
+	success: boolean;
+	report_id: string | null;
+	already_reported?: boolean;
+}
+
+// ── Feed ─────────────────────────────────────────────────────────────────
 
 export async function fetchFeed(
 	params: FeedParams = {},
@@ -95,6 +183,22 @@ export async function fetchFeed(
 		hasMore: data.hasMore,
 	};
 }
+
+export async function trackView(memeId: string): Promise<void> {
+	await callEdge<EdgeBoolResponse>('meme', {
+		command: 'feed.view',
+		meme_id: memeId,
+	});
+}
+
+export async function trackShare(memeId: string): Promise<void> {
+	await callEdge<EdgeBoolResponse>('meme', {
+		command: 'feed.share',
+		meme_id: memeId,
+	});
+}
+
+// ── Reactions ────────────────────────────────────────────────────────────
 
 export async function reactToMeme(
 	memeId: string,
@@ -114,6 +218,8 @@ export async function removeReaction(memeId: string): Promise<void> {
 	});
 }
 
+// ── Saves ────────────────────────────────────────────────────────────────
+
 export async function saveMeme(memeId: string): Promise<void> {
 	await callEdge<EdgeBoolResponse>('meme', {
 		command: 'save.add',
@@ -127,6 +233,8 @@ export async function unsaveMeme(memeId: string): Promise<void> {
 		meme_id: memeId,
 	});
 }
+
+// ── User State ───────────────────────────────────────────────────────────
 
 export async function getUserReactions(
 	memeIds: string[],
@@ -152,4 +260,122 @@ export async function getUserSaves(
 	});
 
 	return new Set(data.saves);
+}
+
+// ── Comments ─────────────────────────────────────────────────────────────
+
+export async function fetchComments(
+	memeId: string,
+	params: { limit?: number; cursor?: string | null } = {},
+): Promise<CommentPage> {
+	return callEdge<EdgeCommentListResponse>('meme', {
+		command: 'comment.list',
+		meme_id: memeId,
+		limit: params.limit ?? 20,
+		cursor: params.cursor ?? null,
+	});
+}
+
+export async function fetchReplies(
+	parentId: string,
+	params: { limit?: number; cursor?: string | null } = {},
+): Promise<ReplyPage> {
+	return callEdge<EdgeReplyListResponse>('meme', {
+		command: 'comment.replies',
+		parent_id: parentId,
+		limit: params.limit ?? 20,
+		cursor: params.cursor ?? null,
+	});
+}
+
+export async function createComment(
+	memeId: string,
+	body: string,
+	parentId?: string | null,
+): Promise<string> {
+	const data = await callEdge<EdgeCommentCreateResponse>('meme', {
+		command: 'comment.create',
+		meme_id: memeId,
+		body,
+		parent_id: parentId ?? null,
+	});
+	return data.comment_id!;
+}
+
+export async function deleteComment(commentId: string): Promise<void> {
+	await callEdge<EdgeBoolResponse>('meme', {
+		command: 'comment.delete',
+		comment_id: commentId,
+	});
+}
+
+// ── Profiles ─────────────────────────────────────────────────────────────
+
+export async function getProfile(
+	userId: string,
+): Promise<UserProfile | null> {
+	const data = await callEdge<EdgeProfileResponse>('meme', {
+		command: 'profile.get',
+		user_id: userId,
+	});
+	return data.profile;
+}
+
+export async function updateProfile(fields: {
+	display_name?: string;
+	avatar_url?: string;
+	bio?: string;
+}): Promise<void> {
+	await callEdge<EdgeBoolResponse>('meme', {
+		command: 'profile.update',
+		...fields,
+	});
+}
+
+export async function getUserMemes(
+	userId: string,
+	params: { limit?: number; cursor?: string | null } = {},
+): Promise<FeedPage> {
+	return callEdge<EdgeProfileMemesResponse>('meme', {
+		command: 'profile.memes',
+		user_id: userId,
+		limit: params.limit ?? 20,
+		cursor: params.cursor ?? null,
+	});
+}
+
+// ── Follows ──────────────────────────────────────────────────────────────
+
+export async function followUser(userId: string): Promise<boolean> {
+	const data = await callEdge<EdgeFollowResponse>('meme', {
+		command: 'follow.add',
+		following_id: userId,
+	});
+	return data.is_new ?? true;
+}
+
+export async function unfollowUser(userId: string): Promise<void> {
+	await callEdge<EdgeBoolResponse>('meme', {
+		command: 'follow.remove',
+		following_id: userId,
+	});
+}
+
+// ── Reports ──────────────────────────────────────────────────────────────
+
+export async function reportMeme(
+	memeId: string,
+	reason: number,
+	detail?: string,
+): Promise<{ reportId: string | null; alreadyReported: boolean }> {
+	const data = await callEdge<EdgeReportResponse>('meme', {
+		command: 'report.create',
+		meme_id: memeId,
+		reason,
+		detail: detail ?? null,
+	});
+	return {
+		reportId: data.report_id,
+		alreadyReported: data.already_reported ?? false,
+	};
 }


### PR DESCRIPTION
## Summary

Wires all 12 new service-role RPCs (from PR #7451) to Deno edge function handlers and updates the Astro frontend service layer. Closes #7460.

**4 new modules created:**
- `comment.ts` — `comment.list` (anon), `comment.replies` (anon), `comment.create` (auth), `comment.delete` (auth)
- `profile.ts` — `profile.get` (anon), `profile.update` (auth, own only), `profile.memes` (anon)
- `follow.ts` — `follow.add` (auth, self-follow rejected), `follow.remove` (auth)
- `report.ts` — `report.create` (auth, duplicate detection)

**2 existing modules extended:**
- `feed.ts` — added `feed.view` (anon) and `feed.share` (anon) for counter tracking
- `index.ts` — registered all 4 new modules in MODULES router map

**Validators added to `_shared.ts`:**
- `validateUserId` (UUID format), `validateCommentBody` (1-500 chars), `validateReportReason` (1-7), `validateReportDetail` (max 2000), `validateLimit` (1-50), `validateCursor` (ULID)

**Frontend (`memeService.ts`) updated with 12 new functions:**
- `trackView`, `trackShare`, `fetchComments`, `fetchReplies`, `createComment`, `deleteComment`, `getProfile`, `updateProfile`, `getUserMemes`, `followUser`, `unfollowUser`, `reportMeme`

Total edge function commands: **7 → 19**

## Test plan
- [ ] Deploy edge functions to Supabase
- [ ] Test anonymous: `comment.list`, `comment.replies`, `profile.get`, `profile.memes`, `feed.view`, `feed.share`
- [ ] Test authenticated: `comment.create`, `comment.delete`, `profile.update`, `follow.add`, `follow.remove`, `report.create`
- [ ] Verify self-follow returns 400 error
- [ ] Verify duplicate report returns `already_reported: true`
- [ ] Verify comment parent validation (wrong meme → error from RPC)