### PR TITLE
feat(discordsh): Tier 1 dungeon improvements — equip UI, heal targeting, combat mechanics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 publish = false
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/types.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/types.rs
@@ -220,6 +220,8 @@ pub struct PlayerState {
     pub armor_gear: Option<String>,
     pub defending: bool,
     pub stunned_turns: u8,
+    pub first_attack_in_combat: bool,
+    pub heals_used_this_combat: u8,
     pub lifetime_kills: u32,
     pub lifetime_gold_earned: u32,
     pub lifetime_rooms_cleared: u32,
@@ -249,6 +251,8 @@ impl Default for PlayerState {
             armor_gear: None,
             defending: false,
             stunned_turns: 0,
+            first_attack_in_combat: true,
+            heals_used_this_combat: 0,
             lifetime_kills: 0,
             lifetime_gold_earned: 0,
             lifetime_rooms_cleared: 0,
@@ -501,7 +505,9 @@ impl SessionState {
     /// Check if all alive players have submitted pending actions.
     pub fn all_actions_submitted(&self) -> bool {
         let alive = self.alive_player_ids();
-        alive.iter().all(|uid| self.pending_actions.contains_key(uid))
+        alive
+            .iter()
+            .all(|uid| self.pending_actions.contains_key(uid))
     }
 }
 


### PR DESCRIPTION
## Summary

Implements all 4 Tier 1 critical missing features from #7459:

- **Gear equip UI**: Players can now equip dropped gear items via a select menu during gameplay
- **Cleric heal target UI**: Clerics see a target select menu during combat to heal specific party members
- **Rogue first-attack guaranteed crit**: Rogues always crit on their first attack each combat, resets on new room
- **Cleric per-combat heal limit**: Clerics can heal once per combat (resets on new room)

## Changes

- `types.rs`: Added `first_attack_in_combat` and `heals_used_this_combat` fields to `PlayerState`
- `logic.rs`: Rogue crit logic in `resolve_player_attack()`, heal limit in `apply_heal_ally()`, combat state reset in `advance_room()`
- `render.rs`: Gear equip select menu + Cleric heal target select menu in `render_components()`
- `Cargo.toml`: Version bump 0.1.18 → 0.1.19

## Test plan

- [x] `cargo build -p axum-discordsh` — compiles clean
- [x] `cargo test -p axum-discordsh` — 154 tests pass (3 new)
- [x] `rustfmt --check` — passes pre-commit hook