### PR TITLE
fix(axum-kbve): resolve all 82 clippy warnings

### DIFF
--- a/apps/kbve/axum-kbve/src/astro/askama.rs
+++ b/apps/kbve/axum-kbve/src/astro/askama.rs
@@ -53,6 +53,7 @@ pub struct ErrorTemplate {
 }
 
 /// RentEarth character summary for template display
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct RentEarthCharacterDisplay {
     pub id: String,
@@ -85,9 +86,13 @@ pub struct ProfileTemplate {
     pub discord_username: Option<String>,
     pub discord_avatar: Option<String>,
     pub discord_is_guild_member: Option<bool>,
+    #[allow(dead_code)]
     pub discord_id: Option<String>,
+    #[allow(dead_code)]
     pub discord_guild_nickname: Option<String>,
+    #[allow(dead_code)]
     pub discord_joined_at: Option<String>,
+    #[allow(dead_code)]
     pub discord_is_boosting: Option<bool>,
     pub discord_role_count: usize,
     pub discord_role_names: Vec<String>,
@@ -101,6 +106,7 @@ pub struct ProfileTemplate {
     // RentEarth fields
     pub rentearth_characters: Vec<RentEarthCharacterDisplay>,
     pub rentearth_total_playtime_hours: Option<i64>,
+    #[allow(dead_code)]
     pub rentearth_last_activity: Option<String>,
 }
 

--- a/apps/kbve/axum-kbve/src/auth/mod.rs
+++ b/apps/kbve/axum-kbve/src/auth/mod.rs
@@ -2,12 +2,13 @@
 
 pub mod jwt_cache;
 
-pub use jwt_cache::{JwtCache, JwtCacheError, TokenInfo, get_jwt_cache, init_jwt_cache};
+pub use jwt_cache::{JwtCacheError, get_jwt_cache, init_jwt_cache};
 
 use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation, decode};
 use serde::{Deserialize, Serialize};
 
 /// JWT Claims from Supabase
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claims {
     /// Subject (user ID as UUID)
@@ -33,6 +34,7 @@ pub struct Claims {
 }
 
 /// Authenticated user information
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct AuthUser {
     pub id: String,
@@ -51,6 +53,7 @@ impl From<Claims> for AuthUser {
 }
 
 /// Authentication errors
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum AuthError {
     MissingToken,
@@ -73,6 +76,7 @@ impl std::fmt::Display for AuthError {
 impl std::error::Error for AuthError {}
 
 /// Validate a JWT token using the Supabase JWT secret
+#[allow(dead_code)]
 pub fn validate_token(token: &str, jwt_secret: &str) -> Result<TokenData<Claims>, AuthError> {
     let key = DecodingKey::from_secret(jwt_secret.as_bytes());
 
@@ -94,6 +98,7 @@ pub fn extract_bearer_token(auth_header: &str) -> Option<&str> {
 }
 
 /// Check if a token is expired (with optional grace period in seconds)
+#[allow(dead_code)]
 pub fn is_token_expired(claims: &Claims, grace_seconds: i64) -> bool {
     let now = chrono::Utc::now().timestamp();
     claims.exp + grace_seconds < now

--- a/apps/kbve/axum-kbve/src/db/discord.rs
+++ b/apps/kbve/axum-kbve/src/db/discord.rs
@@ -248,6 +248,7 @@ impl DiscordClient {
 
     /// Get user by ID (doesn't require guild membership)
     /// GET /users/{user.id}
+    #[allow(dead_code)]
     pub async fn get_user(&self, user_id: &str) -> Result<Option<DiscordUser>, String> {
         let url = format!("{}/users/{}", DISCORD_API_BASE, user_id);
 
@@ -456,6 +457,7 @@ pub fn get_role_names(role_ids: &[String]) -> Vec<String> {
 }
 
 /// Get the cached role map (for debugging/inspection)
+#[allow(dead_code)]
 pub fn get_cached_roles() -> Option<&'static std::collections::HashMap<String, String>> {
     GUILD_ROLES_CACHE.get()
 }

--- a/apps/kbve/axum-kbve/src/db/mod.rs
+++ b/apps/kbve/axum-kbve/src/db/mod.rs
@@ -8,18 +8,9 @@ mod rentearth;
 mod supabase;
 mod twitch;
 
-pub use cache::{CacheStats, ProfileCache, get_profile_cache, init_profile_cache};
-pub use discord::{
-    DiscordClient, DiscordGuildMember, get_discord_client, get_role_names, init_discord_client,
-};
-pub use osrs::{
-    OSRSCache, OSRSCacheStats, OSRSItem, OSRSItemWithPrice, OSRSPrice, encode_icon_url,
-    get_osrs_cache, init_osrs_cache, item_name_to_url, normalize_item_name,
-};
+pub use cache::{ProfileCache, get_profile_cache, init_profile_cache};
+pub use discord::{DiscordClient, get_discord_client, get_role_names, init_discord_client};
+pub use osrs::{get_osrs_cache, init_osrs_cache};
 pub use profile::{UserProfile, get_profile_service, init_profile_service, validate_username};
-pub use rentearth::{
-    RentEarthAppearance, RentEarthCharacterFull, RentEarthCharacterSummary, RentEarthCoreStats,
-    RentEarthDerivedStats, RentEarthPosition, RentEarthProfile, RentEarthService,
-    get_rentearth_service, init_rentearth_service,
-};
-pub use twitch::{TwitchClient, get_twitch_client, init_twitch_client};
+pub use rentearth::{get_rentearth_service, init_rentearth_service};
+pub use twitch::{get_twitch_client, init_twitch_client};

--- a/apps/kbve/axum-kbve/src/db/osrs.rs
+++ b/apps/kbve/axum-kbve/src/db/osrs.rs
@@ -93,6 +93,7 @@ pub fn item_name_to_url(name: &str) -> String {
 /// "Dragon hunter crossbow.png" -> "Dragon_hunter_crossbow.png"
 /// Note: OSRS Wiki uses underscores for spaces in image URLs
 #[inline]
+#[allow(dead_code)]
 pub fn encode_icon_url(icon: &str) -> String {
     icon.replace(' ', "_")
 }
@@ -134,6 +135,7 @@ pub struct OSRSPrice {
 pub struct OSRSItemWithPrice {
     pub item: Arc<OSRSItem>,
     pub price: OSRSPrice,
+    #[allow(dead_code)]
     pub canonical_url: String,
 }
 
@@ -150,11 +152,12 @@ pub enum OSRSCacheCommand {
         reply: oneshot::Sender<Option<OSRSItemWithPrice>>,
     },
     /// Get cache statistics
+    #[allow(dead_code)]
     Stats {
         reply: oneshot::Sender<OSRSCacheStats>,
     },
     /// Force refresh prices now
-    RefreshPrices,
+    RefreshPrices, // used by price_refresh_loop
 }
 
 /// Cache statistics
@@ -210,6 +213,7 @@ impl OSRSCache {
     }
 
     /// Get cache statistics
+    #[allow(dead_code)]
     pub async fn stats(&self) -> Option<OSRSCacheStats> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let cmd = OSRSCacheCommand::Stats { reply: reply_tx };
@@ -222,6 +226,7 @@ impl OSRSCache {
     }
 
     /// Force a price refresh
+    #[allow(dead_code)]
     pub async fn refresh_prices(&self) {
         let _ = self.tx.send(OSRSCacheCommand::RefreshPrices).await;
     }

--- a/apps/kbve/axum-kbve/src/db/supabase.rs
+++ b/apps/kbve/axum-kbve/src/db/supabase.rs
@@ -7,8 +7,10 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct SupabaseConfig {
     pub url: String,
+    #[allow(dead_code)]
     pub anon_key: String,
     pub service_role_key: Option<String>,
+    #[allow(dead_code)]
     pub jwt_secret: Option<String>,
 }
 
@@ -39,6 +41,7 @@ impl SupabaseConfig {
     }
 
     /// Get the REST API base URL
+    #[allow(dead_code)]
     pub fn rest_url(&self) -> String {
         format!("{}/rest/v1", self.url)
     }
@@ -49,6 +52,7 @@ impl SupabaseConfig {
     }
 
     /// Get the auth API base URL
+    #[allow(dead_code)]
     pub fn auth_url(&self) -> String {
         format!("{}/auth/v1", self.url)
     }
@@ -83,6 +87,7 @@ impl SupabaseClient {
     }
 
     /// Build headers for read operations (using anon key)
+    #[allow(dead_code)]
     pub fn read_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -97,6 +102,7 @@ impl SupabaseClient {
     }
 
     /// Build headers for read operations with a specific schema
+    #[allow(dead_code)]
     pub fn read_headers_with_schema(&self, schema: &str) -> HeaderMap {
         let mut headers = self.read_headers();
         headers.insert("Accept-Profile", HeaderValue::from_str(schema).unwrap());
@@ -136,6 +142,7 @@ impl SupabaseClient {
 
     /// Build headers for RPC calls using a user's JWT token
     /// This allows auth.uid() to work in the RPC function
+    #[allow(dead_code)]
     pub fn rpc_headers_with_user_token(&self, schema: &str, user_token: &str) -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(

--- a/apps/kbve/axum-kbve/src/db/twitch.rs
+++ b/apps/kbve/axum-kbve/src/db/twitch.rs
@@ -19,6 +19,7 @@ const TOKEN_REFRESH_BUFFER_SECS: u64 = 3600;
 struct TokenResponse {
     access_token: String,
     expires_in: u64,
+    #[allow(dead_code)]
     token_type: String,
 }
 
@@ -211,6 +212,7 @@ impl TwitchClient {
     }
 
     /// Get user by ID
+    #[allow(dead_code)]
     pub async fn get_user_by_id(&self, user_id: &str) -> Result<Option<TwitchUser>, String> {
         let token = self.get_token().await?;
         let url = format!("{}/users?id={}", TWITCH_API_BASE, user_id);
@@ -251,6 +253,7 @@ impl TwitchClient {
     }
 
     /// Check if a user is currently live streaming
+    #[allow(dead_code)]
     pub async fn get_stream_by_user_id(
         &self,
         user_id: &str,

--- a/apps/kbve/axum-kbve/src/proto/mod.rs
+++ b/apps/kbve/axum-kbve/src/proto/mod.rs
@@ -1,27 +1,34 @@
 // Auto-generated protobuf modules via prost-build
 // Source: packages/data/proto/kbve/*.proto
 
+#[allow(dead_code, clippy::enum_variant_names)]
 pub mod kbve {
+    #[allow(dead_code)]
     pub mod common {
         include!(concat!(env!("OUT_DIR"), "/kbve.common.rs"));
     }
 
+    #[allow(dead_code, clippy::enum_variant_names)]
     pub mod enums {
         include!(concat!(env!("OUT_DIR"), "/kbve.enums.rs"));
     }
 
+    #[allow(dead_code)]
     pub mod snapshot {
         include!(concat!(env!("OUT_DIR"), "/kbve.snapshot.rs"));
     }
 
+    #[allow(dead_code)]
     pub mod pool {
         include!(concat!(env!("OUT_DIR"), "/kbve.pool.rs"));
     }
 
+    #[allow(dead_code, clippy::enum_variant_names)]
     pub mod schema {
         include!(concat!(env!("OUT_DIR"), "/kbve.schema.rs"));
     }
 
+    #[allow(dead_code)]
     pub mod osrs {
         include!(concat!(env!("OUT_DIR"), "/kbve.osrs.rs"));
     }

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -1347,9 +1347,7 @@ async fn set_username_handler(
             );
 
             // Determine appropriate status code based on error
-            let status = if e.contains("already taken") {
-                StatusCode::CONFLICT
-            } else if e.contains("already have") {
+            let status = if e.contains("already taken") || e.contains("already have") {
                 StatusCode::CONFLICT
             } else if e.contains("Invalid") {
                 StatusCode::BAD_REQUEST
@@ -1372,6 +1370,7 @@ async fn set_username_handler(
 // Utility helpers
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 fn format_duration(d: Duration) -> String {
     let secs = d.as_secs();
     let hours = secs / 3600;


### PR DESCRIPTION
## Summary
- Resolved all 82 clippy warnings in axum-kbve (down to zero)
- Replaced deprecated `insecure_disable_signature_validation()` with `jsonwebtoken::dangerous::insecure_decode()`
- Boxed `UserProfile` in `CacheCommand::Set` to fix large enum variant (872 bytes)
- Merged identical if blocks in set_username error handling
- Removed unused re-exports from `db/mod.rs`
- Suppressed `clippy::enum_variant_names` on prost-generated proto modules
- Added `#[allow(dead_code)]` for ported API surface not yet called at runtime

## Test plan
- [x] `cargo clippy -p axum-kbve -- -W clippy::all` — zero warnings
- [x] `cargo test -p axum-kbve` — 15 tests pass
- [x] rustfmt passes pre-commit hook

## Notes
- **astro-kbve:check** has 97 pre-existing TypeScript errors across 37 files (arcade, workers, components) — unrelated to this PR
- **astro-kbve:lint** target does not exist in project.json; `check` is available instead
- `jedi` (58 warnings) and `kbve` (128 warnings) library crates have pre-existing warnings — not addressed here