### PR TITLE
feat(memes): feed UI — comments, share, view tracking, report, profile

### DIFF
--- a/apps/memes/astro-memes/src/components/feed/CommentItem.tsx
+++ b/apps/memes/astro-memes/src/components/feed/CommentItem.tsx
@@ -1,0 +1,254 @@
+import { useState, useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $auth, openModal, addToast } from '@kbve/astro';
+import { User, Trash2, ChevronDown } from 'lucide-react';
+import {
+	fetchReplies,
+	createComment,
+	type FeedComment,
+} from '../../lib/memeService';
+
+interface CommentItemProps {
+	comment: FeedComment;
+	memeId: string;
+	currentUserId: string | null;
+	onDelete: (commentId: string) => void;
+	depth?: number;
+}
+
+export default function CommentItem({
+	comment,
+	memeId,
+	currentUserId,
+	onDelete,
+	depth = 0,
+}: CommentItemProps) {
+	const auth = useStore($auth);
+	const isAuthor = currentUserId === comment.author_id;
+
+	const [showReplies, setShowReplies] = useState(false);
+	const [replies, setReplies] = useState<FeedComment[]>([]);
+	const [replyCursor, setReplyCursor] = useState<string | null>(null);
+	const [hasMoreReplies, setHasMoreReplies] = useState(true);
+	const [loadingReplies, setLoadingReplies] = useState(false);
+
+	const [showReplyInput, setShowReplyInput] = useState(false);
+	const [replyText, setReplyText] = useState('');
+	const [submittingReply, setSubmittingReply] = useState(false);
+
+	const loadReplies = useCallback(async () => {
+		if (loadingReplies) return;
+		setLoadingReplies(true);
+		try {
+			const page = await fetchReplies(comment.id, {
+				limit: 10,
+				cursor: replyCursor,
+			});
+			setReplies((prev) => [...prev, ...page.replies]);
+			setReplyCursor(page.nextCursor);
+			setHasMoreReplies(page.hasMore);
+		} catch {
+			addToast({
+				id: `reply-err-${Date.now()}`,
+				message: 'Failed to load replies.',
+				severity: 'error',
+				duration: 4000,
+			});
+		} finally {
+			setLoadingReplies(false);
+		}
+	}, [comment.id, replyCursor, loadingReplies]);
+
+	const toggleReplies = useCallback(() => {
+		if (!showReplies && replies.length === 0) loadReplies();
+		setShowReplies((v) => !v);
+	}, [showReplies, replies.length, loadReplies]);
+
+	const handleReplySubmit = useCallback(async () => {
+		if (!replyText.trim() || submittingReply) return;
+		if (auth.tone !== 'auth') {
+			openModal('signin');
+			return;
+		}
+
+		setSubmittingReply(true);
+		const body = replyText.trim();
+		setReplyText('');
+
+		try {
+			const replyId = await createComment(memeId, body, comment.id);
+			const optimistic: FeedComment = {
+				id: replyId,
+				author_id: auth.id,
+				body,
+				parent_id: comment.id,
+				reaction_count: 0,
+				reply_count: 0,
+				created_at: new Date().toISOString(),
+				author_name: auth.name || null,
+				author_avatar: auth.avatar || null,
+			};
+			setReplies((prev) => [...prev, optimistic]);
+			if (!showReplies) setShowReplies(true);
+		} catch {
+			setReplyText(body);
+			addToast({
+				id: `reply-post-err-${Date.now()}`,
+				message: 'Failed to post reply.',
+				severity: 'error',
+				duration: 4000,
+			});
+		} finally {
+			setSubmittingReply(false);
+		}
+	}, [replyText, submittingReply, auth, memeId, comment.id, showReplies]);
+
+	const timeAgo = formatTimeAgo(comment.created_at);
+
+	return (
+		<div className="py-2.5" style={depth > 0 ? { paddingLeft: 32 } : undefined}>
+			<div className="flex gap-2.5">
+				{/* Avatar */}
+				{comment.author_avatar ? (
+					<img
+						src={comment.author_avatar}
+						alt=""
+						className="w-7 h-7 rounded-full flex-shrink-0"
+					/>
+				) : (
+					<div
+						className="w-7 h-7 rounded-full flex-shrink-0 flex items-center justify-center"
+						style={{
+							backgroundColor: 'var(--sl-color-accent-low, #164e63)',
+						}}>
+						<User
+							size={14}
+							style={{ color: 'var(--sl-color-text-accent, #22d3ee)' }}
+						/>
+					</div>
+				)}
+
+				<div className="flex-1 min-w-0">
+					<div className="flex items-center gap-1.5">
+						<span
+							className="text-xs font-semibold"
+							style={{ color: 'var(--sl-color-white, #e2e8f0)' }}>
+							{comment.author_name || 'Anonymous'}
+						</span>
+						<span
+							className="text-[10px]"
+							style={{ color: 'var(--sl-color-gray-3, #71717a)' }}>
+							{timeAgo}
+						</span>
+					</div>
+
+					<p
+						className="text-sm mt-0.5 break-words"
+						style={{ color: 'var(--sl-color-gray-2, #a1a1aa)' }}>
+						{comment.body}
+					</p>
+
+					<div className="flex items-center gap-3 mt-1">
+						{depth === 0 && (
+							<button
+								type="button"
+								onClick={() => setShowReplyInput((v) => !v)}
+								className="text-[11px] font-medium"
+								style={{
+									color: 'var(--sl-color-text-accent, #22d3ee)',
+								}}>
+								Reply
+							</button>
+						)}
+						{comment.reply_count > 0 && depth === 0 && (
+							<button
+								type="button"
+								onClick={toggleReplies}
+								className="text-[11px] font-medium flex items-center gap-0.5"
+								style={{
+									color: 'var(--sl-color-text-accent, #22d3ee)',
+								}}>
+								<ChevronDown
+									size={12}
+									className={
+										showReplies
+											? 'rotate-180 transition-transform'
+											: 'transition-transform'
+									}
+								/>
+								{comment.reply_count}{' '}
+								{comment.reply_count === 1 ? 'reply' : 'replies'}
+							</button>
+						)}
+						{isAuthor && (
+							<button
+								type="button"
+								onClick={() => onDelete(comment.id)}
+								className="text-[11px] font-medium flex items-center gap-0.5"
+								style={{ color: '#ef4444' }}>
+								<Trash2 size={12} />
+							</button>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{/* Reply input */}
+			{showReplyInput && depth === 0 && (
+				<div className="flex items-end gap-2 mt-2 ml-9">
+					<input
+						value={replyText}
+						onChange={(e) => setReplyText(e.target.value.slice(0, 500))}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter') handleReplySubmit();
+						}}
+						placeholder="Write a reply..."
+						disabled={submittingReply}
+						className="flex-1 rounded-lg px-3 py-1.5 text-xs outline-none"
+						style={{
+							backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
+							color: 'var(--sl-color-white, #e2e8f0)',
+							border: '1px solid var(--sl-color-hairline, #27272a)',
+						}}
+					/>
+				</div>
+			)}
+
+			{/* Nested replies */}
+			{showReplies &&
+				replies.map((r) => (
+					<CommentItem
+						key={r.id}
+						comment={r}
+						memeId={memeId}
+						currentUserId={currentUserId}
+						onDelete={onDelete}
+						depth={1}
+					/>
+				))}
+			{showReplies && hasMoreReplies && (
+				<button
+					type="button"
+					onClick={loadReplies}
+					disabled={loadingReplies}
+					className="text-[11px] ml-9 mt-1"
+					style={{ color: 'var(--sl-color-text-accent, #22d3ee)' }}>
+					{loadingReplies ? 'Loading...' : 'Load more replies'}
+				</button>
+			)}
+		</div>
+	);
+}
+
+function formatTimeAgo(iso: string): string {
+	const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+	if (seconds < 60) return 'just now';
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	const days = Math.floor(hours / 24);
+	if (days < 30) return `${days}d`;
+	const months = Math.floor(days / 30);
+	return `${months}mo`;
+}

--- a/apps/memes/astro-memes/src/components/feed/CommentsDrawer.tsx
+++ b/apps/memes/astro-memes/src/components/feed/CommentsDrawer.tsx
@@ -1,0 +1,354 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useStore } from '@nanostores/react';
+import { $auth, openModal, addToast } from '@kbve/astro';
+import { X, Send } from 'lucide-react';
+import CommentItem from './CommentItem';
+import {
+	fetchComments,
+	createComment,
+	deleteComment,
+	type FeedComment,
+} from '../../lib/memeService';
+
+interface CommentsDrawerProps {
+	memeId: string;
+	commentCount: number;
+	onClose: () => void;
+	onCommentCountChange: (memeId: string, delta: number) => void;
+}
+
+export default function CommentsDrawer({
+	memeId,
+	commentCount,
+	onClose,
+	onCommentCountChange,
+}: CommentsDrawerProps) {
+	const auth = useStore($auth);
+
+	const [comments, setComments] = useState<FeedComment[]>([]);
+	const [cursor, setCursor] = useState<string | null>(null);
+	const [hasMore, setHasMore] = useState(true);
+	const [loading, setLoading] = useState(true);
+
+	const [newText, setNewText] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+
+	const [visible, setVisible] = useState(false);
+
+	const listRef = useRef<HTMLDivElement>(null);
+	const sentinelRef = useRef<HTMLDivElement>(null);
+
+	// Animate in + lock body scroll
+	useEffect(() => {
+		const prev = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		requestAnimationFrame(() =>
+			requestAnimationFrame(() => setVisible(true)),
+		);
+		return () => {
+			document.body.style.overflow = prev;
+		};
+	}, []);
+
+	// Fetch initial comments
+	useEffect(() => {
+		let cancelled = false;
+		async function load() {
+			try {
+				const page = await fetchComments(memeId, { limit: 20 });
+				if (cancelled) return;
+				setComments(page.comments);
+				setCursor(page.nextCursor);
+				setHasMore(page.hasMore);
+			} catch {
+				if (!cancelled) {
+					addToast({
+						id: `cmt-load-err-${Date.now()}`,
+						message: 'Failed to load comments.',
+						severity: 'error',
+						duration: 4000,
+					});
+				}
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		}
+		load();
+		return () => {
+			cancelled = true;
+		};
+	}, [memeId]);
+
+	// Infinite scroll for more comments
+	useEffect(() => {
+		if (!sentinelRef.current || !hasMore || loading) return;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting && hasMore) loadMore();
+			},
+			{ root: listRef.current, rootMargin: '100px' },
+		);
+
+		observer.observe(sentinelRef.current);
+		return () => observer.disconnect();
+	}, [hasMore, cursor, loading]);
+
+	const loadMore = useCallback(async () => {
+		if (!hasMore) return;
+		try {
+			const page = await fetchComments(memeId, {
+				limit: 20,
+				cursor,
+			});
+			setComments((prev) => [...prev, ...page.comments]);
+			setCursor(page.nextCursor);
+			setHasMore(page.hasMore);
+		} catch {
+			addToast({
+				id: `cmt-more-err-${Date.now()}`,
+				message: 'Failed to load more comments.',
+				severity: 'error',
+				duration: 4000,
+			});
+		}
+	}, [memeId, hasMore, cursor]);
+
+	// Close with animation
+	const handleClose = useCallback(() => {
+		setVisible(false);
+		setTimeout(onClose, 300);
+	}, [onClose]);
+
+	// Submit new comment
+	const handleSubmit = useCallback(async () => {
+		if (!newText.trim() || submitting) return;
+		if (auth.tone !== 'auth') {
+			openModal('signin');
+			return;
+		}
+
+		setSubmitting(true);
+		const body = newText.trim();
+		setNewText('');
+
+		try {
+			const commentId = await createComment(memeId, body);
+			const optimistic: FeedComment = {
+				id: commentId,
+				author_id: auth.id,
+				body,
+				parent_id: null,
+				reaction_count: 0,
+				reply_count: 0,
+				created_at: new Date().toISOString(),
+				author_name: auth.name || null,
+				author_avatar: auth.avatar || null,
+			};
+			setComments((prev) => [optimistic, ...prev]);
+			onCommentCountChange(memeId, 1);
+		} catch {
+			setNewText(body);
+			addToast({
+				id: `cmt-post-err-${Date.now()}`,
+				message: 'Failed to post comment.',
+				severity: 'error',
+				duration: 4000,
+			});
+		} finally {
+			setSubmitting(false);
+		}
+	}, [newText, submitting, auth, memeId, onCommentCountChange]);
+
+	// Delete handler
+	const handleDelete = useCallback(
+		(commentId: string) => {
+			setComments((prev) => prev.filter((c) => c.id !== commentId));
+			onCommentCountChange(memeId, -1);
+			deleteComment(commentId).catch(() => {
+				addToast({
+					id: `cmt-del-err-${Date.now()}`,
+					message: 'Failed to delete comment.',
+					severity: 'error',
+					duration: 4000,
+				});
+			});
+		},
+		[memeId, onCommentCountChange],
+	);
+
+	return createPortal(
+		<div
+			className={`fixed inset-0 z-50 transition-opacity duration-300 ${visible ? 'opacity-100' : 'opacity-0'}`}
+			role="dialog"
+			aria-modal="true"
+			aria-label="Comments">
+			{/* Backdrop */}
+			<div
+				className="absolute inset-0 bg-black/50"
+				onClick={handleClose}
+			/>
+
+			{/* Bottom sheet */}
+			<div
+				className={`absolute bottom-0 left-0 right-0 flex flex-col rounded-t-2xl transition-transform duration-300 ease-out ${visible ? 'translate-y-0' : 'translate-y-full'}`}
+				style={{
+					height: '70dvh',
+					backgroundColor: 'var(--sl-color-bg-nav, #18181b)',
+					color: 'var(--sl-color-white, #e2e8f0)',
+				}}>
+				{/* Header */}
+				<div
+					className="flex items-center justify-between px-4 py-3 flex-shrink-0"
+					style={{
+						borderBottom:
+							'1px solid var(--sl-color-hairline, #27272a)',
+					}}>
+					<h3 className="text-sm font-semibold">
+						{commentCount}{' '}
+						{commentCount === 1 ? 'Comment' : 'Comments'}
+					</h3>
+					<button
+						type="button"
+						onClick={handleClose}
+						aria-label="Close comments"
+						className="w-8 h-8 flex items-center justify-center rounded-md"
+						style={{ color: 'var(--sl-color-gray-3, #71717a)' }}>
+						<X size={16} />
+					</button>
+				</div>
+
+				{/* Scrollable comment list */}
+				<div
+					ref={listRef}
+					className="flex-1 overflow-y-auto px-4 py-2">
+					{loading ? (
+						<div className="flex flex-col gap-4 py-4">
+							{[1, 2, 3].map((i) => (
+								<div
+									key={i}
+									className="flex gap-2.5 animate-pulse">
+									<div
+										className="w-7 h-7 rounded-full flex-shrink-0"
+										style={{
+											backgroundColor:
+												'var(--sl-color-gray-5, #3f3f46)',
+										}}
+									/>
+									<div className="flex-1 space-y-2">
+										<div
+											className="h-3 w-24 rounded"
+											style={{
+												backgroundColor:
+													'var(--sl-color-gray-5, #3f3f46)',
+											}}
+										/>
+										<div
+											className="h-3 w-full rounded"
+											style={{
+												backgroundColor:
+													'var(--sl-color-gray-5, #3f3f46)',
+											}}
+										/>
+									</div>
+								</div>
+							))}
+						</div>
+					) : comments.length === 0 ? (
+						<p
+							className="text-center text-sm py-8"
+							style={{
+								color: 'var(--sl-color-gray-3, #71717a)',
+							}}>
+							No comments yet. Be the first!
+						</p>
+					) : (
+						<>
+							{comments.map((c) => (
+								<CommentItem
+									key={c.id}
+									comment={c}
+									memeId={memeId}
+									currentUserId={
+										auth.tone === 'auth'
+											? auth.id
+											: null
+									}
+									onDelete={handleDelete}
+								/>
+							))}
+							{hasMore && (
+								<div
+									ref={sentinelRef}
+									style={{ height: 1 }}
+									aria-hidden
+								/>
+							)}
+						</>
+					)}
+				</div>
+
+				{/* Input area */}
+				<div
+					className="px-4 py-3 flex-shrink-0"
+					style={{
+						borderTop:
+							'1px solid var(--sl-color-hairline, #27272a)',
+					}}>
+					{auth.tone === 'auth' ? (
+						<div className="flex items-end gap-2">
+							<textarea
+								value={newText}
+								onChange={(e) =>
+									setNewText(e.target.value.slice(0, 500))
+								}
+								onKeyDown={(e) => {
+									if (e.key === 'Enter' && !e.shiftKey) {
+										e.preventDefault();
+										handleSubmit();
+									}
+								}}
+								placeholder="Add a comment..."
+								rows={1}
+								disabled={submitting}
+								className="flex-1 resize-none rounded-lg px-3 py-2 text-sm outline-none"
+								style={{
+									backgroundColor:
+										'var(--sl-color-gray-6, #1c1c1e)',
+									color: 'var(--sl-color-white, #e2e8f0)',
+									border: '1px solid var(--sl-color-hairline, #27272a)',
+								}}
+							/>
+							<button
+								type="button"
+								onClick={handleSubmit}
+								disabled={!newText.trim() || submitting}
+								className="w-9 h-9 flex items-center justify-center rounded-lg transition-colors disabled:opacity-40"
+								style={{
+									backgroundColor:
+										'var(--sl-color-accent, #0ea5e9)',
+									color: '#fff',
+								}}>
+								<Send size={16} />
+							</button>
+						</div>
+					) : (
+						<button
+							type="button"
+							onClick={() => openModal('signin')}
+							className="w-full text-center text-sm py-2 rounded-lg transition-colors"
+							style={{
+								backgroundColor:
+									'var(--sl-color-accent-low, #164e63)',
+								color: 'var(--sl-color-text-accent, #22d3ee)',
+							}}>
+							Sign in to comment
+						</button>
+					)}
+				</div>
+			</div>
+		</div>,
+		document.body,
+	);
+}

--- a/apps/memes/astro-memes/src/components/feed/MemeCard.tsx
+++ b/apps/memes/astro-memes/src/components/feed/MemeCard.tsx
@@ -10,16 +10,34 @@ interface MemeCardProps {
 	onReact: (memeId: string, reaction: number) => void;
 	onSave: (memeId: string) => void;
 	onUnsave: (memeId: string) => void;
+	onComment: (memeId: string) => void;
+	onShare: (memeId: string) => void;
+	onReport: (memeId: string) => void;
 	lazy?: boolean;
 }
 
 const MemeCard = forwardRef<HTMLDivElement, MemeCardProps>(
-	({ meme, userReaction, isSaved, onReact, onSave, onUnsave, lazy }, ref) => {
+	(
+		{
+			meme,
+			userReaction,
+			isSaved,
+			onReact,
+			onSave,
+			onUnsave,
+			onComment,
+			onShare,
+			onReport,
+			lazy,
+		},
+		ref,
+	) => {
 		const isVideo = meme.format === 3 || meme.format === 2;
 
 		return (
 			<div
 				ref={ref}
+				data-meme-id={meme.id}
 				className="relative flex items-center justify-center"
 				style={{
 					height: '100dvh',
@@ -66,12 +84,37 @@ const MemeCard = forwardRef<HTMLDivElement, MemeCardProps>(
 					)}
 
 					<div className="flex items-center gap-2">
-						{meme.author_avatar ? (
-							<img
-								src={meme.author_avatar}
-								alt={meme.author_name || ''}
-								className="w-7 h-7 rounded-full"
-							/>
+						{meme.author_name ? (
+							<a
+								href={`https://kbve.com/@${meme.author_name}`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center gap-2 group">
+								{meme.author_avatar ? (
+									<img
+										src={meme.author_avatar}
+										alt={meme.author_name}
+										className="w-7 h-7 rounded-full transition-shadow group-hover:shadow-[0_0_0_2px_var(--sl-color-accent,#0ea5e9)]"
+									/>
+								) : (
+									<div
+										className="w-7 h-7 rounded-full flex items-center justify-center"
+										style={{
+											backgroundColor:
+												'var(--sl-color-accent-low, #164e63)',
+										}}>
+										<User
+											size={14}
+											style={{
+												color: 'var(--sl-color-text-accent, #22d3ee)',
+											}}
+										/>
+									</div>
+								)}
+								<span className="text-white/80 text-sm font-medium group-hover:text-white transition-colors">
+									@{meme.author_name}
+								</span>
+							</a>
 						) : (
 							<div
 								className="w-7 h-7 rounded-full flex items-center justify-center"
@@ -86,11 +129,6 @@ const MemeCard = forwardRef<HTMLDivElement, MemeCardProps>(
 									}}
 								/>
 							</div>
-						)}
-						{meme.author_name && (
-							<span className="text-white/80 text-sm font-medium">
-								@{meme.author_name}
-							</span>
 						)}
 					</div>
 
@@ -118,11 +156,16 @@ const MemeCard = forwardRef<HTMLDivElement, MemeCardProps>(
 						memeId={meme.id}
 						reactionCount={meme.reaction_count}
 						saveCount={meme.save_count}
+						commentCount={meme.comment_count}
+						shareCount={meme.share_count}
 						userReaction={userReaction}
 						isSaved={isSaved}
 						onReact={onReact}
 						onSave={onSave}
 						onUnsave={onUnsave}
+						onComment={onComment}
+						onShare={onShare}
+						onReport={onReport}
 					/>
 				</div>
 			</div>

--- a/apps/memes/astro-memes/src/components/feed/ReactionBar.tsx
+++ b/apps/memes/astro-memes/src/components/feed/ReactionBar.tsx
@@ -1,7 +1,13 @@
 import { useCallback } from 'react';
 import { useStore } from '@nanostores/react';
 import { $auth, openModal } from '@kbve/astro';
-import { Bookmark, BookmarkCheck } from 'lucide-react';
+import {
+	Bookmark,
+	BookmarkCheck,
+	MessageCircle,
+	Share2,
+	MoreHorizontal,
+} from 'lucide-react';
 import { REACTIONS } from '../../lib/memeService';
 
 const SIGNIN_MODAL = 'signin';
@@ -10,22 +16,32 @@ interface ReactionBarProps {
 	memeId: string;
 	reactionCount: number;
 	saveCount: number;
+	commentCount: number;
+	shareCount: number;
 	userReaction: number | null;
 	isSaved: boolean;
 	onReact: (memeId: string, reaction: number) => void;
 	onSave: (memeId: string) => void;
 	onUnsave: (memeId: string) => void;
+	onComment: (memeId: string) => void;
+	onShare: (memeId: string) => void;
+	onReport: (memeId: string) => void;
 }
 
 export default function ReactionBar({
 	memeId,
 	reactionCount,
 	saveCount,
+	commentCount,
+	shareCount,
 	userReaction,
 	isSaved,
 	onReact,
 	onSave,
 	onUnsave,
+	onComment,
+	onShare,
+	onReport,
 }: ReactionBarProps) {
 	const auth = useStore($auth);
 
@@ -118,6 +134,45 @@ export default function ReactionBar({
 				<span className="text-[10px] text-white/60">
 					{formatCount(saveCount)}
 				</span>
+			</button>
+
+			{/* Divider */}
+			<div className="w-6 h-px bg-white/10" />
+
+			{/* Comment */}
+			<button
+				type="button"
+				onClick={() => onComment(memeId)}
+				className="flex flex-col items-center gap-0.5 transition-transform duration-150 active:scale-110"
+				aria-label="Comments"
+				title="Comments">
+				<MessageCircle size={22} className="text-white/70" />
+				<span className="text-[10px] text-white/60">
+					{formatCount(commentCount)}
+				</span>
+			</button>
+
+			{/* Share */}
+			<button
+				type="button"
+				onClick={() => onShare(memeId)}
+				className="flex flex-col items-center gap-0.5 transition-transform duration-150 active:scale-110"
+				aria-label="Share"
+				title="Share">
+				<Share2 size={22} className="text-white/70" />
+				<span className="text-[10px] text-white/60">
+					{formatCount(shareCount)}
+				</span>
+			</button>
+
+			{/* More / Report */}
+			<button
+				type="button"
+				onClick={() => onReport(memeId)}
+				className="flex flex-col items-center gap-0.5 transition-transform duration-150 active:scale-110"
+				aria-label="More options"
+				title="More">
+				<MoreHorizontal size={22} className="text-white/70" />
 			</button>
 		</div>
 	);

--- a/apps/memes/astro-memes/src/components/feed/ReportModal.tsx
+++ b/apps/memes/astro-memes/src/components/feed/ReportModal.tsx
@@ -1,0 +1,187 @@
+import { useState, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Flag } from 'lucide-react';
+import { addToast } from '@kbve/astro';
+import { reportMeme, REPORT_REASONS } from '../../lib/memeService';
+
+interface ReportModalProps {
+	memeId: string;
+	onClose: () => void;
+}
+
+export default function ReportModal({ memeId, onClose }: ReportModalProps) {
+	const [reason, setReason] = useState<number | null>(null);
+	const [detail, setDetail] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+	const [submitted, setSubmitted] = useState(false);
+
+	// Escape key
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose();
+		};
+		document.addEventListener('keydown', handler);
+		return () => document.removeEventListener('keydown', handler);
+	}, [onClose]);
+
+	// Lock body scroll
+	useEffect(() => {
+		const prev = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = prev;
+		};
+	}, []);
+
+	const handleSubmit = useCallback(async () => {
+		if (reason === null || submitting) return;
+		setSubmitting(true);
+		try {
+			const result = await reportMeme(
+				memeId,
+				reason,
+				detail.trim() || undefined,
+			);
+			if (result.alreadyReported) {
+				addToast({
+					id: `report-dup-${Date.now()}`,
+					message: 'You have already reported this meme.',
+					severity: 'info',
+					duration: 4000,
+				});
+			} else {
+				addToast({
+					id: `report-ok-${Date.now()}`,
+					message: 'Report submitted. Thank you.',
+					severity: 'success',
+					duration: 4000,
+				});
+			}
+			setSubmitted(true);
+			setTimeout(onClose, 1500);
+		} catch {
+			addToast({
+				id: `report-err-${Date.now()}`,
+				message: 'Failed to submit report.',
+				severity: 'error',
+				duration: 4000,
+			});
+		} finally {
+			setSubmitting(false);
+		}
+	}, [reason, detail, submitting, memeId, onClose]);
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Report meme"
+			onClick={(e) => {
+				if (e.target === e.currentTarget && !submitting) onClose();
+			}}>
+			<div
+				className="w-full max-w-sm rounded-xl shadow-2xl p-5"
+				style={{
+					backgroundColor: 'var(--sl-color-bg-nav, #18181b)',
+					color: 'var(--sl-color-white, #e2e8f0)',
+				}}>
+				{/* Header */}
+				<div className="flex items-center justify-between mb-4">
+					<h2 className="text-base font-semibold flex items-center gap-2">
+						<Flag size={16} /> Report Meme
+					</h2>
+					<button
+						type="button"
+						onClick={onClose}
+						aria-label="Close"
+						className="w-8 h-8 flex items-center justify-center rounded-md"
+						style={{
+							color: 'var(--sl-color-gray-3, #71717a)',
+						}}>
+						<X size={16} />
+					</button>
+				</div>
+
+				{submitted ? (
+					<p
+						className="text-sm text-center py-4"
+						style={{
+							color: 'var(--sl-color-gray-2, #a1a1aa)',
+						}}>
+						Thank you for your report.
+					</p>
+				) : (
+					<>
+						{/* Reason selection */}
+						<fieldset className="flex flex-col gap-2 mb-4">
+							<legend
+								className="text-xs font-medium mb-2"
+								style={{
+									color: 'var(--sl-color-gray-2, #a1a1aa)',
+								}}>
+								Why are you reporting this meme?
+							</legend>
+							{REPORT_REASONS.map((r) => (
+								<label
+									key={r.key}
+									className="flex items-center gap-2 cursor-pointer text-sm">
+									<input
+										type="radio"
+										name="report-reason"
+										checked={reason === r.key}
+										onChange={() => setReason(r.key)}
+										className="accent-[var(--sl-color-accent,#0ea5e9)]"
+									/>
+									<span
+										style={{
+											color:
+												reason === r.key
+													? 'var(--sl-color-white, #e2e8f0)'
+													: 'var(--sl-color-gray-2, #a1a1aa)',
+										}}>
+										{r.label}
+									</span>
+								</label>
+							))}
+						</fieldset>
+
+						{/* Detail textarea */}
+						<textarea
+							value={detail}
+							onChange={(e) =>
+								setDetail(e.target.value.slice(0, 2000))
+							}
+							placeholder="Additional details (optional)"
+							rows={3}
+							className="w-full resize-none rounded-lg px-3 py-2 text-sm mb-4 outline-none"
+							style={{
+								backgroundColor:
+									'var(--sl-color-gray-6, #1c1c1e)',
+								color: 'var(--sl-color-white, #e2e8f0)',
+								border: '1px solid var(--sl-color-hairline, #27272a)',
+							}}
+						/>
+
+						<div className="flex justify-end">
+							<button
+								type="button"
+								onClick={handleSubmit}
+								disabled={reason === null || submitting}
+								className="px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-40"
+								style={{
+									backgroundColor: '#ef4444',
+									color: '#fff',
+								}}>
+								{submitting
+									? 'Submitting...'
+									: 'Submit Report'}
+							</button>
+						</div>
+					</>
+				)}
+			</div>
+		</div>,
+		document.body,
+	);
+}

--- a/apps/memes/astro-memes/src/components/profile/ProfilePage.tsx
+++ b/apps/memes/astro-memes/src/components/profile/ProfilePage.tsx
@@ -1,0 +1,451 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $auth, openModal, addToast } from '@kbve/astro';
+import { User, Edit3, Save, ExternalLink } from 'lucide-react';
+import {
+	getProfile,
+	updateProfile,
+	getUserMemes,
+	type UserProfile,
+	type FeedMeme,
+} from '../../lib/memeService';
+
+const SIGNIN_MODAL = 'signin';
+
+export default function ProfilePage() {
+	const auth = useStore($auth);
+
+	const [profile, setProfile] = useState<UserProfile | null>(null);
+	const [memes, setMemes] = useState<FeedMeme[]>([]);
+	const [memesCursor, setMemesCursor] = useState<string | null>(null);
+	const [hasMoreMemes, setHasMoreMemes] = useState(true);
+	const [loading, setLoading] = useState(true);
+	const [loadingMemes, setLoadingMemes] = useState(false);
+
+	const [editing, setEditing] = useState(false);
+	const [editName, setEditName] = useState('');
+	const [editBio, setEditBio] = useState('');
+	const [saving, setSaving] = useState(false);
+
+	// Fetch profile + memes on auth
+	useEffect(() => {
+		if (auth.tone !== 'auth') {
+			setLoading(false);
+			return;
+		}
+
+		let cancelled = false;
+
+		async function load() {
+			try {
+				const [prof, memesPage] = await Promise.all([
+					getProfile(auth.id),
+					getUserMemes(auth.id, { limit: 12 }),
+				]);
+				if (cancelled) return;
+				setProfile(prof);
+				setMemes(memesPage.memes);
+				setMemesCursor(memesPage.nextCursor);
+				setHasMoreMemes(memesPage.hasMore);
+				if (prof) {
+					setEditName(prof.display_name || '');
+					setEditBio(prof.bio || '');
+				}
+			} catch {
+				if (!cancelled) {
+					addToast({
+						id: `profile-err-${Date.now()}`,
+						message: 'Failed to load profile.',
+						severity: 'error',
+						duration: 4000,
+					});
+				}
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		}
+
+		load();
+		return () => {
+			cancelled = true;
+		};
+	}, [auth.tone, auth.id]);
+
+	const loadMoreMemes = useCallback(async () => {
+		if (loadingMemes || !hasMoreMemes || auth.tone !== 'auth') return;
+		setLoadingMemes(true);
+		try {
+			const page = await getUserMemes(auth.id, {
+				limit: 12,
+				cursor: memesCursor,
+			});
+			setMemes((prev) => [...prev, ...page.memes]);
+			setMemesCursor(page.nextCursor);
+			setHasMoreMemes(page.hasMore);
+		} catch {
+			addToast({
+				id: `memes-more-err-${Date.now()}`,
+				message: 'Failed to load more memes.',
+				severity: 'error',
+				duration: 4000,
+			});
+		} finally {
+			setLoadingMemes(false);
+		}
+	}, [loadingMemes, hasMoreMemes, memesCursor, auth]);
+
+	const handleSaveProfile = useCallback(async () => {
+		if (saving) return;
+		setSaving(true);
+		try {
+			await updateProfile({
+				display_name: editName.trim() || undefined,
+				bio: editBio.trim() || undefined,
+			});
+			setProfile((prev) =>
+				prev
+					? {
+							...prev,
+							display_name: editName.trim() || prev.display_name,
+							bio: editBio.trim() || prev.bio,
+						}
+					: prev,
+			);
+			setEditing(false);
+			addToast({
+				id: `profile-saved-${Date.now()}`,
+				message: 'Profile updated.',
+				severity: 'success',
+				duration: 3000,
+			});
+		} catch {
+			addToast({
+				id: `profile-save-err-${Date.now()}`,
+				message: 'Failed to save profile.',
+				severity: 'error',
+				duration: 4000,
+			});
+		} finally {
+			setSaving(false);
+		}
+	}, [saving, editName, editBio]);
+
+	// ── Not authenticated ───────────────────────────────────────────
+	if (auth.tone === 'loading' || loading) {
+		return (
+			<div
+				className="flex items-center justify-center"
+				style={{
+					height: '100dvh',
+					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+					color: 'var(--sl-color-gray-3, #71717a)',
+				}}>
+				<p className="text-sm">Loading...</p>
+			</div>
+		);
+	}
+
+	if (auth.tone !== 'auth') {
+		return (
+			<div
+				className="flex flex-col items-center justify-center gap-4"
+				style={{
+					height: '100dvh',
+					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+					color: 'var(--sl-color-gray-2, #a1a1aa)',
+				}}>
+				<User
+					size={48}
+					style={{ color: 'var(--sl-color-gray-3, #71717a)' }}
+				/>
+				<p className="text-sm">Sign in to view your profile</p>
+				<button
+					type="button"
+					onClick={() => openModal(SIGNIN_MODAL)}
+					className="text-sm px-4 py-2 rounded-lg transition-colors"
+					style={{
+						backgroundColor: 'var(--sl-color-accent, #0ea5e9)',
+						color: '#fff',
+					}}>
+					Sign In
+				</button>
+			</div>
+		);
+	}
+
+	// ── Authenticated ───────────────────────────────────────────────
+	return (
+		<div
+			className="min-h-screen pb-12"
+			style={{
+				backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+				color: 'var(--sl-color-white, #e2e8f0)',
+			}}>
+			<div className="max-w-2xl mx-auto px-4 pt-20">
+				{/* Profile header */}
+				<div className="flex items-start gap-4 mb-6">
+					{/* Avatar */}
+					{profile?.avatar_url || auth.avatar ? (
+						<img
+							src={profile?.avatar_url || auth.avatar}
+							alt=""
+							className="w-20 h-20 rounded-full flex-shrink-0"
+						/>
+					) : (
+						<div
+							className="w-20 h-20 rounded-full flex-shrink-0 flex items-center justify-center"
+							style={{
+								backgroundColor:
+									'var(--sl-color-accent-low, #164e63)',
+							}}>
+							<User
+								size={32}
+								style={{
+									color: 'var(--sl-color-text-accent, #22d3ee)',
+								}}
+							/>
+						</div>
+					)}
+
+					<div className="flex-1 min-w-0">
+						{editing ? (
+							<div className="space-y-3">
+								<input
+									value={editName}
+									onChange={(e) =>
+										setEditName(
+											e.target.value.slice(0, 50),
+										)
+									}
+									placeholder="Display name"
+									className="w-full rounded-lg px-3 py-2 text-sm outline-none"
+									style={{
+										backgroundColor:
+											'var(--sl-color-gray-6, #1c1c1e)',
+										color: 'var(--sl-color-white, #e2e8f0)',
+										border: '1px solid var(--sl-color-hairline, #27272a)',
+									}}
+								/>
+								<textarea
+									value={editBio}
+									onChange={(e) =>
+										setEditBio(
+											e.target.value.slice(0, 200),
+										)
+									}
+									placeholder="Bio"
+									rows={3}
+									className="w-full resize-none rounded-lg px-3 py-2 text-sm outline-none"
+									style={{
+										backgroundColor:
+											'var(--sl-color-gray-6, #1c1c1e)',
+										color: 'var(--sl-color-white, #e2e8f0)',
+										border: '1px solid var(--sl-color-hairline, #27272a)',
+									}}
+								/>
+								<div className="flex gap-2">
+									<button
+										type="button"
+										onClick={handleSaveProfile}
+										disabled={saving}
+										className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors disabled:opacity-40"
+										style={{
+											backgroundColor:
+												'var(--sl-color-accent, #0ea5e9)',
+											color: '#fff',
+										}}>
+										<Save size={14} />
+										{saving ? 'Saving...' : 'Save'}
+									</button>
+									<button
+										type="button"
+										onClick={() => {
+											setEditing(false);
+											setEditName(
+												profile?.display_name || '',
+											);
+											setEditBio(profile?.bio || '');
+										}}
+										className="px-3 py-1.5 rounded-lg text-sm"
+										style={{
+											color: 'var(--sl-color-gray-2, #a1a1aa)',
+										}}>
+										Cancel
+									</button>
+								</div>
+							</div>
+						) : (
+							<>
+								<div className="flex items-center gap-2">
+									<h1 className="text-xl font-bold truncate">
+										{profile?.display_name ||
+											auth.name ||
+											'User'}
+									</h1>
+									<button
+										type="button"
+										onClick={() => setEditing(true)}
+										className="flex-shrink-0"
+										style={{
+											color: 'var(--sl-color-text-accent, #22d3ee)',
+										}}>
+										<Edit3 size={16} />
+									</button>
+								</div>
+								{profile?.bio && (
+									<p
+										className="text-sm mt-1"
+										style={{
+											color: 'var(--sl-color-gray-2, #a1a1aa)',
+										}}>
+										{profile.bio}
+									</p>
+								)}
+								{profile?.display_name && (
+									<a
+										href={`https://kbve.com/@${profile.display_name}`}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="inline-flex items-center gap-1 text-xs mt-2 transition-colors hover:opacity-80"
+										style={{
+											color: 'var(--sl-color-text-accent, #22d3ee)',
+										}}>
+										<ExternalLink size={12} />
+										kbve.com/@{profile.display_name}
+									</a>
+								)}
+							</>
+						)}
+					</div>
+				</div>
+
+				{/* Stats row */}
+				{profile && (
+					<div
+						className="flex gap-6 mb-8 pb-4"
+						style={{
+							borderBottom:
+								'1px solid var(--sl-color-hairline, #27272a)',
+						}}>
+						<Stat
+							label="Memes"
+							value={profile.total_memes}
+						/>
+						<Stat
+							label="Followers"
+							value={profile.follower_count}
+						/>
+						<Stat
+							label="Following"
+							value={profile.following_count}
+						/>
+						<Stat
+							label="Reactions"
+							value={profile.total_reactions_received}
+						/>
+						<Stat
+							label="Views"
+							value={profile.total_views_received}
+						/>
+					</div>
+				)}
+
+				{/* User's memes grid */}
+				<h2
+					className="text-sm font-semibold mb-4"
+					style={{
+						color: 'var(--sl-color-gray-2, #a1a1aa)',
+					}}>
+					Your Memes
+				</h2>
+
+				{memes.length === 0 ? (
+					<p
+						className="text-sm text-center py-8"
+						style={{
+							color: 'var(--sl-color-gray-3, #71717a)',
+						}}>
+						You haven't posted any memes yet.
+					</p>
+				) : (
+					<>
+						<div className="grid grid-cols-3 gap-1">
+							{memes.map((meme) => (
+								<div
+									key={meme.id}
+									className="aspect-square relative overflow-hidden rounded"
+									style={{
+										backgroundColor:
+											'var(--sl-color-gray-6, #1c1c1e)',
+									}}>
+									<img
+										src={
+											meme.thumbnail_url ||
+											meme.asset_url
+										}
+										alt={meme.title || 'Meme'}
+										className="w-full h-full object-cover"
+										loading="lazy"
+									/>
+									<div
+										className="absolute bottom-0 left-0 right-0 px-1.5 py-1 text-[10px] flex items-center gap-2"
+										style={{
+											background:
+												'linear-gradient(transparent, rgba(0,0,0,0.7))',
+											color: 'rgba(255,255,255,0.8)',
+										}}>
+										<span>
+											{formatCount(meme.view_count)} views
+										</span>
+										<span>
+											{formatCount(meme.reaction_count)}{' '}
+											reactions
+										</span>
+									</div>
+								</div>
+							))}
+						</div>
+
+						{hasMoreMemes && (
+							<div className="flex justify-center mt-4">
+								<button
+									type="button"
+									onClick={loadMoreMemes}
+									disabled={loadingMemes}
+									className="text-sm px-4 py-2 rounded-lg transition-colors disabled:opacity-40"
+									style={{
+										backgroundColor:
+											'var(--sl-color-accent-low, #164e63)',
+										color: 'var(--sl-color-text-accent, #22d3ee)',
+									}}>
+									{loadingMemes
+										? 'Loading...'
+										: 'Load More'}
+								</button>
+							</div>
+						)}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+	return (
+		<div className="text-center">
+			<div className="text-base font-bold">{formatCount(value)}</div>
+			<div
+				className="text-[11px]"
+				style={{ color: 'var(--sl-color-gray-3, #71717a)' }}>
+				{label}
+			</div>
+		</div>
+	);
+}
+
+function formatCount(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return String(n);
+}

--- a/apps/memes/astro-memes/src/pages/profile.astro
+++ b/apps/memes/astro-memes/src/pages/profile.astro
@@ -1,0 +1,12 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ReactNavBar from '../components/navigation/ReactNavBar';
+import ProfilePage from '../components/profile/ProfilePage';
+import { OverlayShell } from '../components/overlay/OverlayShell';
+---
+
+<Layout title="Profile | Meme.sh" description="Your profile on Meme.sh">
+  <ReactNavBar client:only="react" currentPath="/profile" />
+  <ProfilePage client:only="react" />
+  <OverlayShell client:only="react" />
+</Layout>


### PR DESCRIPTION
## Summary

- **ReactionBar**: Added comment (MessageCircle), share (Share2), and report (MoreHorizontal) buttons below the existing save button
- **MemeCard**: Author names/avatars now link to `kbve.com/@username`, added `data-meme-id` attribute for view tracking
- **View tracking**: IntersectionObserver fires `trackView()` once per meme when 50% visible (fire-and-forget)
- **Share**: Web Share API with clipboard fallback, optimistic share_count increment, toast notification
- **CommentsDrawer**: Bottom sheet (70dvh) with paginated comment list, threaded replies (1 level), auth-gated input, optimistic create/delete
- **ReportModal**: Centered modal with 7 reason radio buttons, optional detail textarea, duplicate detection
- **ProfilePage**: Personal profile page at `/profile` with stats, inline edit (display_name + bio), user memes grid

## Files changed (3 modified, 5 new)

| File | Change |
|------|--------|
| `ReactionBar.tsx` | +comment, share, report buttons & props |
| `MemeCard.tsx` | +data-meme-id, author links to kbve.com/@name, pass-through props |
| `ReactMemeContent.tsx` | +view tracking, share handler, comment/report overlay wiring |
| `CommentsDrawer.tsx` | **New** — bottom sheet with comment list + input |
| `CommentItem.tsx` | **New** — single comment with nested replies |
| `ReportModal.tsx` | **New** — report dialog with reason selection |
| `ProfilePage.tsx` | **New** — personal profile with stats + edit + memes grid |
| `profile.astro` | **New** — Astro page for /profile route |

## Design decisions

- All new overlays use `createPortal(jsx, document.body)` matching the existing NavBar pattern
- Comment browsing, view tracking, and sharing work without auth; writing comments, reporting, and editing profile require auth
- Comments have max 1 level of nesting (no recursive threading)
- State for `commentsMemeId` and `reportMemeId` is local React state in ReactMemeContent (not nanostores)
- Public profiles link to `kbve.com/@username`; the `/profile` page is personal-only (logged-in user)

## Test plan

- [ ] Navigate to /feed, verify comment/share/report buttons appear in the sidebar
- [ ] Click share button → verify link copied toast or native share sheet
- [ ] Click comment button → verify bottom sheet slides up, shows "No comments yet"
- [ ] Sign in → post a comment → verify it appears optimistically
- [ ] Click MoreHorizontal → verify report modal opens (when authed)
- [ ] Select a report reason and submit → verify toast feedback
- [ ] Click author name → verify opens kbve.com/@username in new tab
- [ ] Scroll through feed → verify network tab shows `feed.view` calls (once per meme)
- [ ] Navigate to /profile → verify profile loads with stats and edit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)