### PR TITLE
chore(memes): bump version to 0.1.2

### DIFF
--- a/apps/memes/axum-memes/Cargo.toml
+++ b/apps/memes/axum-memes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-memes"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Patch bump axum-memes from 0.1.1 to 0.1.2
- CI will auto-update kube deployment manifest after image publish

## Test plan
- [ ] CI builds Docker image tagged 0.1.2
- [ ] Kube deployment YAML auto-updated by CI pipeline
- [ ] ArgoCD picks up new image tag