### PR TITLE
fix(mc): clean cargo registry to pass Trivy CVE scan

### DIFF
--- a/apps/mc/Dockerfile.base
+++ b/apps/mc/Dockerfile.base
@@ -12,7 +12,8 @@
 FROM rust:1-alpine3.23 AS chef
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN apk add --no-cache musl-dev git
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --locked \
+    && rm -rf /usr/local/cargo/registry/src /usr/local/cargo/registry/cache
 WORKDIR /pumpkin
 COPY ./apps/mc/pumpkin/rust-toolchain.toml /pumpkin/rust-toolchain.toml
 RUN rustup show active-toolchain || rustup toolchain install


### PR DESCRIPTION
## Summary

- CI Trivy scan fails on `globwalk-0.8.1/Cargo.lock` found in `/usr/local/cargo/registry/src/` — flags CVEs in `crossbeam-utils`, `regex`, and `thread_local`
- `globwalk` is **not our dependency** — it's a transitive dep of `cargo-chef` that gets left behind after `cargo install`
- Fix: clean `registry/src` and `registry/cache` after `cargo install cargo-chef` in `Dockerfile.base`. The `--mount=type=cache` handles registry during actual builds

## Verified locally

- `docker build -f apps/mc/Dockerfile.base` builds successfully
- No `Cargo.lock` files in `/usr/local/cargo/registry/src/` in the built image
- `globwalk` source directory is completely removed

## Test plan

- [x] Dockerfile.base builds without errors
- [x] No globwalk source or Cargo.lock in final image
- [ ] CI Trivy scan passes