### PR TITLE
fix(memes): GHCR tagging and bump to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "axum-memes"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/memes/axum-memes/Cargo.toml
+++ b/apps/memes/axum-memes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-memes"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 

--- a/apps/memes/axum-memes/project.json
+++ b/apps/memes/axum-memes/project.json
@@ -93,7 +93,7 @@
         "production": {
           "commands": [
             "./kbve.sh -nx axum-memes:containerx --configuration=production",
-            "VERSION=$(grep '^version' apps/memes/axum-memes/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/memes:latest kbve/memes:$VERSION && docker tag ghcr.io/kbve/memes:latest ghcr.io/kbve/memes:$VERSION && echo \"Tagged kbve/memes:$VERSION\""
+            "VERSION=$(grep '^version' apps/memes/axum-memes/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/memes:latest kbve/memes:$VERSION && docker tag kbve/memes:latest ghcr.io/kbve/memes:$VERSION && echo \"Tagged kbve/memes:$VERSION and ghcr.io/kbve/memes:$VERSION\""
           ]
         }
       }


### PR DESCRIPTION
## Summary
- **Fixed GHCR publish bug**: The production tagging command was sourcing `ghcr.io/kbve/memes:$VERSION` from `ghcr.io/kbve/memes:latest`, which doesn't exist locally after `containerx` build. Changed to source from `kbve/memes:latest` (the actual build output). This is why GHCR was stuck at `0.1.0` while Docker Hub had `0.1.2`.
- **Bumped version to 0.1.3** to trigger the full publish pipeline and verify the fix end-to-end.
- **Version-only GHCR tags** — no `:latest` pushed to GHCR, only `ghcr.io/kbve/memes:0.1.3`.

## Root cause
```bash
# Before (broken) — ghcr.io/kbve/memes:latest doesn't exist locally
docker tag ghcr.io/kbve/memes:latest ghcr.io/kbve/memes:$VERSION

# After (fixed) — kbve/memes:latest is the actual containerx build output
docker tag kbve/memes:latest ghcr.io/kbve/memes:$VERSION
```

## Test plan
- [ ] CI publishes `kbve/memes:0.1.3` to Docker Hub
- [ ] CI publishes `ghcr.io/kbve/memes:0.1.3` to GHCR
- [ ] Verify both registries have the new tag after merge