### PR TITLE
fix(husky): auto-format Rust and add Python lint-staged hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,11 @@
 			"prettier --write"
 		],
 		"*.rs": [
-			"rustfmt --check"
+			"rustfmt"
+		],
+		"*.py": [
+			"autopep8 --in-place",
+			"flake8 --max-line-length 120"
 		]
 	},
 	"nx": {


### PR DESCRIPTION
## Summary
- Changed Rust `rustfmt --check` to `rustfmt` (auto-format) — consistent with how eslint/prettier hooks work
- Added Python hooks: `autopep8 --in-place` + `flake8 --max-line-length 120` — matches existing project tooling

## Test plan
- [ ] Stage a `.rs` file, commit — rustfmt auto-formats instead of failing
- [ ] Stage a `.py` file, commit — autopep8 formats, flake8 lints
- [ ] Existing TS/JS/Astro/JSON hooks unchanged