### PR TITLE
fix(ci): prevent skip propagation on publish_docker and update_kube_manifests

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -435,7 +435,7 @@ jobs:
     publish_docker:
         needs: ['collect_docker_results']
         name: Publish Docker Images
-        if: ${{ needs.collect_docker_results.outputs.publish_matrix != 'null' }}
+        if: ${{ always() && !cancelled() && needs.collect_docker_results.outputs.publish_matrix != 'null' }}
         permissions:
             contents: read
             packages: write
@@ -519,7 +519,7 @@ jobs:
     update_kube_manifests:
         needs: ['collect_kube_results']
         name: Update Kube Manifests
-        if: ${{ needs.collect_kube_results.outputs.matrix != 'null' }}
+        if: ${{ always() && !cancelled() && needs.collect_kube_results.outputs.matrix != 'null' }}
         permissions:
             contents: write
             pull-requests: write


### PR DESCRIPTION
## Summary
- Add `always() && !cancelled()` to `publish_docker` and `update_kube_manifests` job conditions in `ci-main.yml`

## Root cause
When `build_base_images` is skipped (no mc changes), GitHub Actions propagates the skip through the dependency chain. The intermediate jobs (`test_docker`, `collect_docker_results`, `collect_kube_results`) survive via their existing `always()` conditions, but `publish_docker` and `update_kube_manifests` lack it and get silently skipped — even when their collect jobs produce valid, non-null matrices.

```
build_base_images → SKIPPED (no mc changes)
    ↓
test_docker → SUCCESS (via always())
    ↓
collect_docker_results → SUCCESS (via always())
    ↓
publish_docker → SKIPPED (no always(), skip propagates)
    ↓
update_kube_manifests → SKIPPED (same issue)
```

This only happens when memes/discordsh/edge change **without** mc changes. When mc is in the matrix, `build_base_images` runs and the chain stays clean.

## Test plan
- [ ] Merge to dev, then main — verify `Publish Docker Images` runs for memes 0.1.3
- [ ] Verify `Update Kube Manifests` creates an atomic PR for memes deployment
- [ ] Verify `ghcr.io/kbve/memes:0.1.3` appears on GHCR after publish