### PR TITLE
chore(discordsh): clean up compiler warnings v0.1.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 publish = false
 

--- a/apps/discordsh/axum-discordsh/src/astro/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/astro/mod.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub mod askama;
 
 use axum::{

--- a/apps/discordsh/axum-discordsh/src/discord/components/status_buttons.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/components/status_buttons.rs
@@ -1,5 +1,5 @@
 use poise::serenity_prelude as serenity;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use crate::discord::bot::{Data, Error};
 use crate::discord::embeds::{StatusSnapshot, StatusState, build_status_embed};

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/status_state.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/status_state.rs
@@ -3,6 +3,7 @@
 /// Ported from notification-bot's `StatusState` enum, simplified
 /// to the five states relevant for the Rust bot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum StatusState {
     Online,
     Offline,

--- a/apps/discordsh/axum-discordsh/src/discord/game/card.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/card.rs
@@ -65,7 +65,6 @@ pub struct EnemyPanel {
     pub y_hp_bar: u32,
     pub y_hp_text: u32,
     pub y_def: u32,
-    pub y_intent: u32,
     pub y_intent_box: u32,
     pub y_intent_text: u32,
     pub y_effects: u32,
@@ -96,6 +95,7 @@ pub struct GameCardTemplate {
     // Enemies (conditional, multi-enemy)
     pub has_enemy: bool,
     pub enemies: Vec<EnemyPanel>,
+    #[allow(dead_code)] // used in tests but not in the SVG template
     pub enemy_count: usize,
 
     // Room
@@ -435,7 +435,6 @@ impl GameCardTemplate {
                         y_hp_bar,
                         y_hp_text,
                         y_def,
-                        y_intent,
                         y_intent_box: y_intent - 4,
                         y_intent_text: y_intent + 8,
                         y_effects,
@@ -501,7 +500,6 @@ pub struct MapCardTemplate {
     pub tiles: Vec<MapTileDisplay>,
     pub player_x: i32,
     pub player_y: i32,
-    pub grid_size: i32,
     pub tiles_explored: u32,
     pub depth: u32,
 }
@@ -606,7 +604,6 @@ pub fn build_map_card(session: &SessionState) -> MapCardTemplate {
         tiles,
         player_x: pos.x as i32,
         player_y: pos.y as i32,
-        grid_size: 7,
         tiles_explored: session.map.tiles_visited,
         depth: pos.depth(),
     }

--- a/apps/discordsh/axum-discordsh/src/discord/game/content.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/content.rs
@@ -877,6 +877,8 @@ pub fn class_starting_stats(class: &ClassType) -> (i32, i32, i32, f32, i32) {
 // ── Room generation ─────────────────────────────────────────────────
 
 /// Weighted random room type. Boss guaranteed every 7th room, room 0 always Combat.
+/// (Legacy linear room gen — kept for test helpers.)
+#[allow(dead_code)]
 fn room_type_for_index(index: u32, rng: &mut impl Rng) -> RoomType {
     if index > 0 && index % 7 == 6 {
         return RoomType::Boss;
@@ -950,6 +952,8 @@ fn generate_hazards(index: u32, room_type: &RoomType, rng: &mut impl Rng) -> Vec
 }
 
 /// Generate a room for the given index with randomized content.
+/// (Legacy linear room gen — kept for test helpers.)
+#[allow(dead_code)]
 pub fn generate_room(index: u32) -> RoomState {
     let mut rng = rand::rng();
     let room_type = room_type_for_index(index, &mut rng);

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -933,7 +933,6 @@ fn single_enemy_turn(
             msg: String,
         },
         HealEnemy {
-            amount: i32,
             msg: String,
         },
     }
@@ -1030,7 +1029,7 @@ fn single_enemy_turn(
             let heal = *amount;
             enemy.hp = (enemy.hp + heal).min(enemy_max_hp);
             let msg = format!("{} heals for {}!", enemy.name, heal);
-            EnemyAction::HealEnemy { amount: heal, msg }
+            EnemyAction::HealEnemy { msg }
         }
     };
 
@@ -1108,7 +1107,7 @@ fn single_enemy_turn(
             }
             // No thorns reflect for AoE
         }
-        EnemyAction::HealEnemy { amount: _, msg } => {
+        EnemyAction::HealEnemy { msg } => {
             logs.push(msg);
         }
     }
@@ -4272,12 +4271,6 @@ mod tests {
         let mut tiles_visited = 0u32;
         let mut total_iterations = 0;
         let max_iterations = 500;
-        let directions = [
-            Direction::North,
-            Direction::East,
-            Direction::South,
-            Direction::West,
-        ];
         let mut dir_idx = 0;
 
         while total_iterations < max_iterations {
@@ -4633,7 +4626,6 @@ mod tests {
         session.player_mut(OWNER).accuracy = 1.0;
 
         // Attack WITHOUT sharpened first to get baseline
-        let hp_before_no_sharp = session.enemies[0].hp;
         let _ = apply_action(&mut session, GameAction::Attack, OWNER);
         if session.enemies.is_empty() {
             // Enemy died from first attack, re-add for sharpened test


### PR DESCRIPTION
## Summary
- Remove unused struct fields (`grid_size`, `y_intent`, `HealEnemy.amount`), unused imports, and dead test variables
- Suppress `dead_code` warnings for legacy room generation functions kept for test helpers and scaffolding modules
- Bump version to v0.1.23

## Test plan
- [x] `cargo check` — zero warnings
- [x] `cargo test` — all 223 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)