### PR TITLE
feat(discordsh): Docker build base image for cached foundation builds

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -318,7 +318,8 @@ jobs:
         with:
             items: |
                 [
-                  { "name": "mc", "target": "base", "condition": "${{ needs.alter.outputs.mc_base }}", "image": "ghcr.io/kbve/mc-rust-base" }
+                  { "name": "mc", "target": "base", "condition": "${{ needs.alter.outputs.mc_base }}", "image": "ghcr.io/kbve/mc-rust-base" },
+                  { "name": "discordsh", "target": "base", "condition": "${{ needs.alter.outputs.discordsh_base }}", "image": "ghcr.io/kbve/discordsh-build-base" }
                 ]
 
     build_base_images:

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -109,6 +109,9 @@ on:
             mc_base:
                 description: 'MC base image dependencies changed'
                 value: ${{ jobs.alter.outputs.mc_base }}
+            discordsh_base:
+                description: 'Discordsh build base image dependencies changed'
+                value: ${{ jobs.alter.outputs.discordsh_base }}
             edge:
                 description: 'Edge functions changed'
                 value: ${{ jobs.alter.outputs.edge }}
@@ -151,6 +154,7 @@ jobs:
             mc_server: ${{ steps.delta.outputs.mc_server_any_changed }}
             mc_plugin: ${{ steps.delta.outputs.mc_plugin_any_changed }}
             mc_base: ${{ steps.delta.outputs.mc_base_any_changed }}
+            discordsh_base: ${{ steps.delta.outputs.discordsh_base_any_changed }}
             edge: ${{ steps.delta.outputs.edge_any_changed }}
 
         steps:
@@ -241,6 +245,16 @@ jobs:
                           - 'apps/mc/pumpkin/pumpkin-protocol/**'
                           - 'apps/mc/pumpkin/pumpkin-inventory/**'
                           - 'apps/mc/Dockerfile.base'
+                      discordsh_base:
+                          - 'packages/rust/kbve/Cargo.toml'
+                          - 'packages/rust/kbve/src/**'
+                          - 'packages/rust/jedi/Cargo.toml'
+                          - 'packages/rust/jedi/src/**'
+                          - 'packages/data/proto/**'
+                          - 'apps/discordsh/axum-discordsh/Cargo.toml'
+                          - 'apps/discordsh/axum-discordsh/Cargo.workspace.toml'
+                          - 'apps/discordsh/axum-discordsh/Dockerfile.base'
+                          - 'Cargo.lock'
                       edge:
                           - 'apps/kbve/edge/functions/**'
                           - 'apps/kbve/edge/Dockerfile'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.23"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 publish = false
 

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -1,3 +1,6 @@
+# Pre-built Rust build base image (override with --build-arg BUILD_BASE=...)
+ARG BUILD_BASE=ghcr.io/kbve/discordsh-build-base:latest
+
 # ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
@@ -52,109 +55,13 @@ RUN find . -type f \( \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# [STAGE C] - Rust Base Image
-# ============================================================================
-FROM --platform=linux/amd64 rust:1.90-slim AS rust-base
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        libpq-dev \
-        protobuf-compiler \
-        libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# ============================================================================
-# [STAGE D] - Cargo Chef Planner
-# ============================================================================
-FROM rust-base AS planner
-
-# Minimal workspace with only discordsh's actual dependencies
-COPY apps/discordsh/axum-discordsh/Cargo.workspace.toml Cargo.toml
-COPY Cargo.lock ./
-
-# Copy only the 3 crates we need
-COPY apps/discordsh/axum-discordsh/Cargo.toml apps/discordsh/axum-discordsh/Cargo.toml
-COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
-COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
-
-# Proto files (needed for jedi build.rs during chef prepare)
-COPY packages/data/proto packages/data/proto
-
-# Create stubs for cargo chef
-RUN mkdir -p apps/discordsh/axum-discordsh/src && echo "fn main() {}" > apps/discordsh/axum-discordsh/src/main.rs && \
-    mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
-    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
-
-RUN cargo chef prepare --recipe-path recipe.json
-
-# ============================================================================
-# [STAGE E] - Cargo Chef Cook (Cache External Dependencies)
-# ============================================================================
-FROM rust-base AS builder-deps
-
-COPY --from=planner /app/recipe.json recipe.json
-COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
-COPY --from=planner /app/apps apps
-COPY --from=planner /app/packages packages
-
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo chef cook --release --recipe-path recipe.json -p axum-discordsh
-
-# ============================================================================
-# [STAGE E2] - Foundation Layer (Compile kbve + jedi from real source)
+# [STAGE C] - Build Application
 #
-# This layer is cached when only axum-discordsh application code changes,
-# avoiding expensive recompilation of foundation crates (~60% of build time).
+# Uses pre-built base image with Rust toolchain + all external deps +
+# foundation crates (kbve + jedi) already compiled in release mode.
+# Only axum-discordsh needs recompilation here.
 # ============================================================================
-FROM rust-base AS builder-foundation
-
-# Cached deps from chef cook
-COPY --from=builder-deps /app/target target
-COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
-
-# Workspace + lockfile
-COPY --from=planner /app/Cargo.toml ./
-COPY Cargo.lock ./
-
-# App Cargo.toml (workspace resolution) + stub main
-COPY apps/discordsh/axum-discordsh/Cargo.toml apps/discordsh/axum-discordsh/Cargo.toml
-RUN mkdir -p apps/discordsh/axum-discordsh/src && \
-    echo "fn main() {}" > apps/discordsh/axum-discordsh/src/main.rs
-
-# Proto files (jedi build.rs generates protobuf code)
-COPY packages/data/proto packages/data/proto
-
-# Foundation crate source (changes less frequently than app code)
-COPY packages/rust/jedi packages/rust/jedi
-COPY packages/rust/kbve packages/rust/kbve
-
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p kbve -p jedi
-
-# ============================================================================
-# [STAGE F] - Build Application
-#
-# Only axum-discordsh needs recompilation here; kbve + jedi are pre-built
-# in the foundation layer above.
-# ============================================================================
-FROM rust-base AS builder
-
-# Pre-built foundation (kbve + jedi + all external deps)
-COPY --from=builder-foundation /app/target target
-COPY --from=builder-foundation /usr/local/cargo /usr/local/cargo
-
-# Workspace + lockfile
-COPY --from=planner /app/Cargo.toml ./
-COPY Cargo.lock ./
+FROM ${BUILD_BASE} AS builder
 
 # Astro build output (precompressed) → placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/discordsh/axum-discordsh/templates/dist
@@ -173,7 +80,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     strip target/release/axum-discordsh
 
 # ============================================================================
-# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
+# [STAGE D] - Chisel Ubuntu Base (Minimal Runtime)
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
 
@@ -198,7 +105,7 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         openssl_config
 
 # ============================================================================
-# [STAGE H] - Jemalloc
+# [STAGE E] - Jemalloc
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
 
@@ -209,7 +116,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # ============================================================================
-# [STAGE I] - libpq runtime (needed by diesel postgres)
+# [STAGE F] - libpq runtime (needed by diesel postgres)
 # ============================================================================
 FROM --platform=linux/amd64 ubuntu:24.04 AS libpq-runtime
 

--- a/apps/discordsh/axum-discordsh/Dockerfile.base
+++ b/apps/discordsh/axum-discordsh/Dockerfile.base
@@ -1,0 +1,97 @@
+# Dockerfile.base — Pre-built Rust base image for discordsh builds
+# Bakes Rust toolchain + cargo-chef + third-party deps + foundation crates (kbve + jedi).
+# Only needs rebuilding when Cargo.toml/Cargo.lock or foundation source changes.
+#
+# Build:
+#   docker build -f apps/discordsh/axum-discordsh/Dockerfile.base -t ghcr.io/kbve/discordsh-build-base:latest .
+#
+# Usage in Dockerfile:
+#   ARG BUILD_BASE=ghcr.io/kbve/discordsh-build-base:latest
+#   FROM ${BUILD_BASE} AS foundation
+
+# ============================================================================
+# [STAGE 1] - Rust Toolchain + cargo-chef (NO source code)
+# ============================================================================
+FROM --platform=linux/amd64 rust:1.90-slim AS chef
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        libpq-dev \
+        protobuf-compiler \
+        libprotobuf-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-gnu && \
+    cargo install cargo-chef --locked && \
+    rm -rf /usr/local/cargo/registry/src /usr/local/cargo/registry/cache
+
+WORKDIR /app
+
+# ============================================================================
+# [STAGE 2] - Cargo Chef Planner (needs Cargo.tomls to generate recipe)
+# ============================================================================
+FROM chef AS planner
+
+# Minimal workspace with only discordsh's actual dependencies
+COPY apps/discordsh/axum-discordsh/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+# Copy only the 3 crate manifests
+COPY apps/discordsh/axum-discordsh/Cargo.toml apps/discordsh/axum-discordsh/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+
+# Proto files (needed for jedi build.rs during chef prepare)
+COPY packages/data/proto packages/data/proto
+
+# Create stubs for cargo chef
+RUN mkdir -p apps/discordsh/axum-discordsh/src && echo "fn main() {}" > apps/discordsh/axum-discordsh/src/main.rs && \
+    mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ============================================================================
+# [STAGE 3] - Cargo Chef Cook (cache all external dependencies)
+# ============================================================================
+FROM chef AS deps
+
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
+COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo chef cook --release --recipe-path recipe.json -p axum-discordsh
+
+# ============================================================================
+# [STAGE 4] - Foundation (compile kbve + jedi from real source)
+#
+# This is the FINAL stage — downstream Dockerfiles inherit from here.
+# External deps are pre-compiled; kbve + jedi are built from source.
+# Only axum-discordsh needs recompilation downstream.
+# ============================================================================
+FROM deps AS foundation
+
+# Restore real workspace manifest (chef cook may strip lints/metadata)
+COPY apps/discordsh/axum-discordsh/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+# App Cargo.toml (workspace resolution) + stub main
+COPY apps/discordsh/axum-discordsh/Cargo.toml apps/discordsh/axum-discordsh/Cargo.toml
+RUN mkdir -p apps/discordsh/axum-discordsh/src && \
+    echo "fn main() {}" > apps/discordsh/axum-discordsh/src/main.rs
+
+# Proto files (jedi build.rs generates protobuf code)
+COPY packages/data/proto packages/data/proto
+
+# Foundation crate source (changes less frequently than app code)
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p kbve -p jedi

--- a/apps/discordsh/axum-discordsh/project.json
+++ b/apps/discordsh/axum-discordsh/project.json
@@ -1,134 +1,189 @@
 {
-  "name": "axum-discordsh",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/discordsh/axum-discordsh/src",
-  "targets": {
-    "dev": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "./kbve.sh -nx astro-discordsh:build",
-          "STATIC_DIR=./dist/apps/astro-discordsh STATIC_PRECOMPRESSED=false cargo run -p axum-discordsh"
-        ],
-        "parallel": false
-      }
-    },
-    "build": {
-      "executor": "@monodon/rust:build",
-      "outputs": ["{options.target-dir}"],
-      "options": {
-        "target-dir": "dist/target/axum-discordsh"
-      },
-      "configurations": {
-        "production": {
-          "release": true
-        }
-      }
-    },
-    "test": {
-      "executor": "@monodon/rust:test",
-      "outputs": ["{options.target-dir}"],
-      "options": {
-        "target-dir": "dist/target/axum-discordsh"
-      },
-      "configurations": {
-        "production": {
-          "release": true
-        }
-      }
-    },
-    "lint": {
-      "executor": "@monodon/rust:lint",
-      "outputs": ["{options.target-dir}"],
-      "options": {
-        "target-dir": "dist/target/axum-discordsh"
-      }
-    },
-    "run": {
-      "executor": "@monodon/rust:run",
-      "outputs": ["{options.target-dir}"],
-      "options": {
-        "target-dir": "dist/target/axum-discordsh"
-      },
-      "configurations": {
-        "production": {
-          "release": true
-        }
-      }
-    },
-    "e2e": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": ["nx test axum-discordsh", "nx e2e discordsh-e2e"],
-        "parallel": false
-      }
-    },
-    "container-prep": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "./kbve.sh -nx astro-discordsh:build",
-          "rm -rf ./apps/discordsh/axum-discordsh/dist/",
-          "mkdir -p ./apps/discordsh/axum-discordsh/dist/",
-          "cp -a ./dist/apps/astro-discordsh/. ./apps/discordsh/axum-discordsh/dist/"
-        ],
-        "parallel": false
-      }
-    },
-    "container": {
-      "executor": "nx:run-commands",
-      "dependsOn": ["container-prep"],
-      "defaultConfiguration": "local",
-      "options": {
-        "parallel": false
-      },
-      "configurations": {
-        "local": {
-          "commands": [
-            "./kbve.sh -nx axum-discordsh:containerx",
-            "VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION\""
-          ]
-        },
-        "production": {
-          "commands": [
-            "./kbve.sh -nx axum-discordsh:containerx --configuration=production",
-            "VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && docker tag kbve/discordsh:latest ghcr.io/kbve/discordsh:latest && docker tag kbve/discordsh:latest ghcr.io/kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION and ghcr.io/kbve/discordsh:$VERSION\""
-          ]
-        }
-      }
-    },
-    "containerx": {
-      "executor": "@nx-tools/nx-container:build",
-      "defaultConfiguration": "local",
-      "options": {
-        "engine": "docker",
-        "context": ".",
-        "file": "apps/discordsh/axum-discordsh/Dockerfile",
-        "load": true
-      },
-      "configurations": {
-        "local": {
-          "load": true,
-          "push": false,
-          "tags": ["kbve/discordsh:latest"]
-        },
-        "production": {
-          "load": true,
-          "push": false,
-          "metadata": {
-            "images": ["ghcr.io/kbve/discordsh", "kbve/discordsh"],
-            "tags": ["latest"]
-          },
-          "cache-from": [
-            "type=registry,ref=ghcr.io/kbve/discordsh:buildcache"
-          ],
-          "cache-to": [
-            "type=registry,ref=ghcr.io/kbve/discordsh:buildcache,mode=max"
-          ]
-        }
-      }
-    }
-  },
-  "tags": []
+	"name": "axum-discordsh",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/discordsh/axum-discordsh/src",
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"./kbve.sh -nx astro-discordsh:build",
+					"STATIC_DIR=./dist/apps/astro-discordsh STATIC_PRECOMPRESSED=false cargo run -p axum-discordsh"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-discordsh"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-discordsh"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-discordsh"
+			}
+		},
+		"run": {
+			"executor": "@monodon/rust:run",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-discordsh"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx test axum-discordsh", "nx e2e discordsh-e2e"],
+				"parallel": false
+			}
+		},
+		"container-prep": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"./kbve.sh -nx astro-discordsh:build",
+					"rm -rf ./apps/discordsh/axum-discordsh/dist/",
+					"mkdir -p ./apps/discordsh/axum-discordsh/dist/",
+					"cp -a ./dist/apps/astro-discordsh/. ./apps/discordsh/axum-discordsh/dist/"
+				],
+				"parallel": false
+			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container-prep"],
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx axum-discordsh:containerx",
+						"VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx axum-discordsh:containerx --configuration=production",
+						"VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/discordsh:latest kbve/discordsh:$VERSION && docker tag kbve/discordsh:latest ghcr.io/kbve/discordsh:latest && docker tag kbve/discordsh:latest ghcr.io/kbve/discordsh:$VERSION && echo \"Tagged kbve/discordsh:$VERSION and ghcr.io/kbve/discordsh:$VERSION\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/discordsh/axum-discordsh/Dockerfile",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/discordsh:latest"],
+					"build-args": [
+						"BUILD_BASE=ghcr.io/kbve/discordsh-build-base:latest"
+					]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"metadata": {
+						"images": ["ghcr.io/kbve/discordsh", "kbve/discordsh"],
+						"tags": ["latest"]
+					},
+					"build-args": [
+						"BUILD_BASE=ghcr.io/kbve/discordsh-build-base:latest"
+					],
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/discordsh:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/discordsh:buildcache,mode=max"
+					]
+				}
+			}
+		},
+		"basex": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/discordsh/axum-discordsh/Dockerfile.base",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["ghcr.io/kbve/discordsh-build-base:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"tags": ["ghcr.io/kbve/discordsh-build-base:latest"],
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/discordsh-build-base:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/discordsh-build-base:buildcache,mode=max"
+					]
+				}
+			}
+		},
+		"base": {
+			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx axum-discordsh:basex",
+						"VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag ghcr.io/kbve/discordsh-build-base:latest ghcr.io/kbve/discordsh-build-base:$VERSION && echo \"Tagged ghcr.io/kbve/discordsh-build-base:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx axum-discordsh:basex --configuration=production",
+						"VERSION=$(grep '^version' apps/discordsh/axum-discordsh/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag ghcr.io/kbve/discordsh-build-base:latest ghcr.io/kbve/discordsh-build-base:$VERSION && echo \"Tagged ghcr.io/kbve/discordsh-build-base:$VERSION\""
+					]
+				}
+			}
+		}
+	},
+	"tags": []
 }

--- a/apps/discordsh/project.json
+++ b/apps/discordsh/project.json
@@ -1,32 +1,48 @@
 {
-  "name": "discordsh",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/discordsh",
-  "targets": {
-    "e2e": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx test axum-discordsh",
-          "nx container axum-discordsh",
-          "nx e2e:docker discordsh-e2e"
-        ],
-        "parallel": false
-      }
-    },
-    "container": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": ["nx container axum-discordsh"],
-        "parallel": false
-      },
-      "configurations": {
-        "production": {
-          "commands": ["nx container axum-discordsh --configuration=production"]
-        }
-      }
-    }
-  },
-  "tags": []
+	"name": "discordsh",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/discordsh",
+	"targets": {
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"nx test axum-discordsh",
+					"nx container axum-discordsh",
+					"nx e2e:docker discordsh-e2e"
+				],
+				"parallel": false
+			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx container axum-discordsh"],
+				"parallel": false
+			},
+			"configurations": {
+				"production": {
+					"commands": [
+						"nx container axum-discordsh --configuration=production"
+					]
+				}
+			}
+		},
+		"base": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx base axum-discordsh"],
+				"parallel": false
+			},
+			"configurations": {
+				"production": {
+					"commands": [
+						"nx base axum-discordsh --configuration=production"
+					]
+				}
+			}
+		}
+	},
+	"tags": []
 }


### PR DESCRIPTION
## Summary

- Extract Rust toolchain + cargo-chef + foundation crates (kbve + jedi) into `Dockerfile.base` → `ghcr.io/kbve/discordsh-build-base`
- Main Dockerfile uses `ARG BUILD_BASE` to pull pre-built base, eliminating ~60% of build time when only app code changes
- Add `discordsh_base` file alteration trigger in CI so the base image only rebuilds when foundation deps change (Cargo.toml, kbve/jedi source, proto files)

## Changes

| File | Change |
|------|--------|
| `Dockerfile.base` (new) | 4-stage pipeline: chef → planner → deps → foundation |
| `Dockerfile` | Simplified from 9 stages to 6 — stages C/D/E/E2 replaced by single `FROM ${BUILD_BASE}` |
| `axum-discordsh/project.json` | Add `basex`/`base` Nx targets with GHCR cache-from/to |
| `discordsh/project.json` | Add `base` target delegation |
| `utils-file-alterations.yml` | Add `discordsh_base` trigger for kbve/jedi/proto/Cargo changes |
| `ci-main.yml` | Add discordsh-build-base to base Docker images matrix |
| `Cargo.toml` | Bump to v0.1.25 |

## Test plan

- [x] All 233 tests pass (`cargo test -p axum-discordsh`)
- [ ] Build base image locally: `nx base discordsh`
- [ ] Build app image with base: `nx container discordsh`
- [ ] Verify CI triggers base image rebuild on kbve/jedi changes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)