### PR TITLE
feat(memes): add meme feed to landing page

### DIFF
--- a/apps/memes/astro-memes/src/content/docs/index.mdx
+++ b/apps/memes/astro-memes/src/content/docs/index.mdx
@@ -6,7 +6,13 @@ hero:
   title: Meme.sh
   tagline: Discover the Best Memes
   actions:
-    - text: Get Started
-      link: /guides/getting-started/
+    - text: Browse Feed
+      link: /feed
       icon: right-arrow
 ---
+
+import ReactMemeContent from '../../components/feed/ReactMemeContent';
+
+<div style="margin-left: calc(-1 * var(--sl-content-pad-x, 1rem)); margin-right: calc(-1 * var(--sl-content-pad-x, 1rem)); margin-top: 2rem;">
+  <ReactMemeContent client:only="react" />
+</div>


### PR DESCRIPTION
## Summary
- Import `ReactMemeContent` onto the index.mdx splash page so visitors see memes immediately
- Updated hero CTA from "Get Started" → "Browse Feed" linking to `/feed`
- Full-width wrapper breaks out of Starlight content padding for edge-to-edge meme cards

## Test plan
- [ ] Build passes (`npx nx build astro-memes`)
- [ ] Landing page shows hero + meme feed below
- [ ] Feed infinite scroll, reactions, and comments work on index page
- [ ] Mobile layout is responsive