### PR TITLE
fix(discordsh): patch linux-libc-dev CVEs in Docker build images

### DIFF
--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -68,6 +68,7 @@ RUN find . -type f \( \
 FROM --platform=linux/amd64 rust:1.90-slim AS rust-base
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         pkg-config \
         libssl-dev \

--- a/apps/discordsh/axum-discordsh/Dockerfile.base
+++ b/apps/discordsh/axum-discordsh/Dockerfile.base
@@ -15,6 +15,7 @@
 FROM --platform=linux/amd64 rust:1.90-slim AS chef
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         pkg-config \
         libssl-dev \


### PR DESCRIPTION
## Summary
- Add `apt-get upgrade -y` to both `Dockerfile` and `Dockerfile.base` before installing build dependencies
- Patches 79 HIGH `linux-libc-dev` kernel CVEs from the `rust:1.90-slim` Debian base layer
- Trivy scan remains fully enforced for all images (no skip, no advisory mode)

## Context
CI run [22551566124](https://github.com/KBVE/kbve/actions/runs/22551566124/job/65322288913) failed Trivy with 79 HIGH findings — all `linux-libc-dev` from the unpatchedDebian layer in `rust:1.90-slim`.

## Test plan
- [ ] Verify discordsh base image publish passes Trivy scan in CI
- [ ] Verify discordsh app image still passes Trivy scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)