### PR TITLE
fix(ci): decouple test_docker from build_base_images dependency

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -372,9 +372,9 @@ jobs:
                 ]
 
     test_docker:
-        needs: ['generate_e2e_docker_matrix', 'build_base_images']
+        needs: ['generate_e2e_docker_matrix']
         name: Test Docker Apps
-        if: ${{ always() && !cancelled() && !failure() && needs.generate_e2e_docker_matrix.outputs.matrix != 'null' }}
+        if: ${{ needs.generate_e2e_docker_matrix.outputs.matrix != 'null' }}
         permissions:
             contents: read
         strategy:

--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -1,1 +1,1 @@
-version = "0.1.6"
+version = "0.1.7"


### PR DESCRIPTION
## Summary
- **Root cause**: `test_docker` had `needs: ['generate_e2e_docker_matrix', 'build_base_images']` — a Trivy CVE failure on `discordsh-build-base` blocked ALL Docker tests, including unrelated projects like edge
- **Fix**: Remove `build_base_images` from `test_docker` needs. Tests run independently. The existing collect/filter pattern handles the rest — only projects whose e2e tests pass get published
- Bumps edge to `0.1.7` to trigger pipeline test

## How it works now
- `build_base_images` — runs independently (builds base images if needed)
- `test_docker` — runs independently (e2e tests all Docker apps)
- `collect_docker_results` — filters by `test-passed-docker-*` artifacts
- `publish_docker` — only publishes apps whose tests passed
- If a project's Docker build fails in testing (because its base image wasn't ready), that project's test fails, no artifact is created, and it's excluded from publishing — without blocking other projects

## Test plan
- [ ] Merge to main → edge tests run regardless of build_base_images status
- [ ] Edge publishes as `ghcr.io/kbve/edge:0.1.7`
- [ ] Kube manifest auto-updates