### PR TITLE
feat(axum-kbve): add Docker base image with foundation cargo chef caching

### DIFF
--- a/.github/workflows/ci-docker-smoke-test.yml
+++ b/.github/workflows/ci-docker-smoke-test.yml
@@ -39,6 +39,7 @@ jobs:
                     apps/mc/Dockerfile \
                     apps/herbmail/axum-herbmail/Dockerfile \
                     apps/memes/axum-memes/Dockerfile \
+                    apps/kbve/axum-kbve/Dockerfile \
                     apps/discordsh/axum-discordsh/Dockerfile \
                     apps/irc/irc-gateway/Dockerfile \
                     apps/discordsh/notification-bot/Dockerfile \
@@ -63,6 +64,7 @@ jobs:
                       apps/mc/Dockerfile
                       apps/herbmail/axum-herbmail/Dockerfile
                       apps/memes/axum-memes/Dockerfile
+                      apps/kbve/axum-kbve/Dockerfile
                       apps/discordsh/axum-discordsh/Dockerfile
                       apps/irc/irc-gateway/Dockerfile
                       apps/discordsh/notification-bot/Dockerfile
@@ -117,6 +119,11 @@ jobs:
                       dockerfile: apps/discordsh/notification-bot/Dockerfile
                       context: apps/discordsh/notification-bot
                       cache_scope: smoke-notification-bot
+                      submodules: false
+                    - name: kbve
+                      dockerfile: apps/kbve/axum-kbve/Dockerfile
+                      context: .
+                      cache_scope: smoke-kbve
                       submodules: false
                     - name: kilobase
                       dockerfile: apps/kbve/kilobase/Dockerfile
@@ -193,6 +200,7 @@ jobs:
                     apps/mc/Dockerfile \
                     apps/herbmail/axum-herbmail/Dockerfile \
                     apps/memes/axum-memes/Dockerfile \
+                    apps/kbve/axum-kbve/Dockerfile \
                     apps/discordsh/axum-discordsh/Dockerfile \
                     apps/irc/irc-gateway/Dockerfile \
                     apps/discordsh/notification-bot/Dockerfile \

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -319,7 +319,8 @@ jobs:
             items: |
                 [
                   { "name": "mc", "target": "base", "condition": "${{ needs.alter.outputs.mc_base }}", "image": "ghcr.io/kbve/mc-rust-base" },
-                  { "name": "discordsh", "target": "base", "condition": "${{ needs.alter.outputs.discordsh_base }}", "image": "ghcr.io/kbve/discordsh-build-base" }
+                  { "name": "discordsh", "target": "base", "condition": "${{ needs.alter.outputs.discordsh_base }}", "image": "ghcr.io/kbve/discordsh-build-base" },
+                  { "name": "axum-kbve", "target": "base", "condition": "${{ needs.alter.outputs.kbve_base }}", "image": "ghcr.io/kbve/kbve-build-base" }
                 ]
 
     build_base_images:

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -112,6 +112,9 @@ on:
             discordsh_base:
                 description: 'Discordsh build base image dependencies changed'
                 value: ${{ jobs.alter.outputs.discordsh_base }}
+            kbve_base:
+                description: 'KBVE build base image dependencies changed'
+                value: ${{ jobs.alter.outputs.kbve_base }}
             edge:
                 description: 'Edge functions changed'
                 value: ${{ jobs.alter.outputs.edge }}
@@ -155,6 +158,7 @@ jobs:
             mc_plugin: ${{ steps.delta.outputs.mc_plugin_any_changed }}
             mc_base: ${{ steps.delta.outputs.mc_base_any_changed }}
             discordsh_base: ${{ steps.delta.outputs.discordsh_base_any_changed }}
+            kbve_base: ${{ steps.delta.outputs.kbve_base_any_changed }}
             edge: ${{ steps.delta.outputs.edge_any_changed }}
 
         steps:
@@ -254,6 +258,16 @@ jobs:
                           - 'apps/discordsh/axum-discordsh/Cargo.toml'
                           - 'apps/discordsh/axum-discordsh/Cargo.workspace.toml'
                           - 'apps/discordsh/axum-discordsh/Dockerfile.base'
+                          - 'Cargo.lock'
+                      kbve_base:
+                          - 'packages/rust/kbve/Cargo.toml'
+                          - 'packages/rust/kbve/src/**'
+                          - 'packages/rust/jedi/Cargo.toml'
+                          - 'packages/rust/jedi/src/**'
+                          - 'packages/data/proto/**'
+                          - 'apps/kbve/axum-kbve/Cargo.toml'
+                          - 'apps/kbve/axum-kbve/Cargo.workspace.toml'
+                          - 'apps/kbve/axum-kbve/Dockerfile.base'
                           - 'Cargo.lock'
                       edge:
                           - 'apps/kbve/edge/functions/**'

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -1,3 +1,11 @@
+# Pre-built Rust build base image (override with --build-arg BUILD_BASE=...)
+#
+# CI mode:   BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest
+#             -> skips inline Rust stages, pulls pre-built foundation from GHCR
+# Local mode: BUILD_BASE=foundation (default)
+#             -> builds everything inline (no external image needed)
+ARG BUILD_BASE=foundation
+
 # ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
@@ -52,8 +60,11 @@ RUN find . -type f \( \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# [STAGE C] - Rust Base Image
+# Inline Rust build stages (used when BUILD_BASE=foundation, i.e. local mode)
+# When BUILD_BASE points to an external image, these stages are skipped entirely.
 # ============================================================================
+
+# [STAGE C] - Rust Base Image
 FROM --platform=linux/amd64 rust:1.90-slim AS rust-base
 
 RUN apt-get update && \
@@ -69,33 +80,25 @@ RUN rustup target add x86_64-unknown-linux-gnu && \
 
 WORKDIR /app
 
-# ============================================================================
 # [STAGE D] - Cargo Chef Planner
-# ============================================================================
 FROM rust-base AS planner
 
-# Minimal workspace with only axum-kbve's actual dependencies
 COPY apps/kbve/axum-kbve/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 
-# Copy only the 3 crates we need
 COPY apps/kbve/axum-kbve/Cargo.toml apps/kbve/axum-kbve/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 
-# Create stubs for cargo chef
+COPY packages/data/proto packages/data/proto
+
 RUN mkdir -p apps/kbve/axum-kbve/src && echo "fn main() {}" > apps/kbve/axum-kbve/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
 
-# Copy proto files (needed for axum-kbve build.rs and jedi build.rs)
-COPY packages/data/proto packages/data/proto
-
 RUN cargo chef prepare --recipe-path recipe.json
 
-# ============================================================================
-# [STAGE E] - Cargo Chef Builder (Cache Dependencies)
-# ============================================================================
+# [STAGE E] - Cargo Chef Cook (Cache External Dependencies)
 FROM rust-base AS builder-deps
 
 COPY --from=planner /app/recipe.json recipe.json
@@ -103,34 +106,51 @@ COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
 COPY --from=planner /app/packages packages
 
-# Copy proto files
-COPY packages/data/proto packages/data/proto
-
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef cook --release --recipe-path recipe.json -p axum-kbve
 
-# ============================================================================
-# [STAGE F] - Build Application
-# ============================================================================
-FROM rust-base AS builder
+# [STAGE E2] - Foundation Layer (Compile kbve + jedi from real source)
+FROM rust-base AS foundation
 
-# Copy cached dependencies
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
 
-# Copy Astro build output (precompressed)
-COPY --from=astro-precompressor /static /app/apps/kbve/axum-kbve/templates/dist
-
-# Use the same minimal workspace
 COPY --from=planner /app/Cargo.toml ./
 COPY Cargo.lock ./
 
-# Copy only the 3 crates (full source)
+COPY apps/kbve/axum-kbve/Cargo.toml apps/kbve/axum-kbve/Cargo.toml
+RUN mkdir -p apps/kbve/axum-kbve/src && \
+    echo "fn main() {}" > apps/kbve/axum-kbve/src/main.rs
+
+COPY packages/data/proto packages/data/proto
+
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
-COPY apps/kbve/axum-kbve apps/kbve/axum-kbve
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p kbve -p jedi
+
+# ============================================================================
+# [STAGE F] - Build Application
+#
+# Uses BUILD_BASE (default: "foundation" = inline stages above).
+# In CI, set BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest to skip
+# all inline Rust stages and use the pre-built GHCR image instead.
+# ============================================================================
+FROM ${BUILD_BASE} AS builder
+
+# Astro build output (precompressed) -> placed into templates/dist
+COPY --from=astro-precompressor /static /app/apps/kbve/axum-kbve/templates/dist
+
+# Foundation crate source (cargo needs source to verify fingerprints)
 COPY packages/data/proto packages/data/proto
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+
+# Application source (most frequently changing — placed last for cache)
+COPY apps/kbve/axum-kbve apps/kbve/axum-kbve
 
 # Copy Askama templates
 COPY apps/kbve/axum-kbve/templates/askama /app/apps/kbve/axum-kbve/templates/askama

--- a/apps/kbve/axum-kbve/Dockerfile.base
+++ b/apps/kbve/axum-kbve/Dockerfile.base
@@ -1,0 +1,96 @@
+# Dockerfile.base — Pre-built Rust base image for axum-kbve builds
+# Bakes Rust toolchain + cargo-chef + third-party deps + foundation crates (kbve + jedi).
+# Only needs rebuilding when Cargo.toml/Cargo.lock or foundation source changes.
+#
+# Build:
+#   docker build -f apps/kbve/axum-kbve/Dockerfile.base -t ghcr.io/kbve/kbve-build-base:latest .
+#
+# Usage in Dockerfile:
+#   ARG BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest
+#   FROM ${BUILD_BASE} AS foundation
+
+# ============================================================================
+# [STAGE 1] - Rust Toolchain + cargo-chef (NO source code)
+# ============================================================================
+FROM --platform=linux/amd64 rust:1.90-slim AS chef
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        protobuf-compiler \
+        libprotobuf-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-gnu && \
+    cargo install cargo-chef --locked && \
+    rm -rf /usr/local/cargo/registry/src /usr/local/cargo/registry/cache
+
+WORKDIR /app
+
+# ============================================================================
+# [STAGE 2] - Cargo Chef Planner (needs Cargo.tomls to generate recipe)
+# ============================================================================
+FROM chef AS planner
+
+# Minimal workspace with only axum-kbve's actual dependencies
+COPY apps/kbve/axum-kbve/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+# Copy only the 3 crate manifests
+COPY apps/kbve/axum-kbve/Cargo.toml apps/kbve/axum-kbve/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+
+# Proto files (needed for jedi build.rs during chef prepare)
+COPY packages/data/proto packages/data/proto
+
+# Create stubs for cargo chef
+RUN mkdir -p apps/kbve/axum-kbve/src && echo "fn main() {}" > apps/kbve/axum-kbve/src/main.rs && \
+    mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ============================================================================
+# [STAGE 3] - Cargo Chef Cook (cache all external dependencies)
+# ============================================================================
+FROM chef AS deps
+
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
+COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo chef cook --release --recipe-path recipe.json -p axum-kbve
+
+# ============================================================================
+# [STAGE 4] - Foundation (compile kbve + jedi from real source)
+#
+# This is the FINAL stage — downstream Dockerfiles inherit from here.
+# External deps are pre-compiled; kbve + jedi are built from source.
+# Only axum-kbve needs recompilation downstream.
+# ============================================================================
+FROM deps AS foundation
+
+# Restore real workspace manifest (chef cook may strip lints/metadata)
+COPY apps/kbve/axum-kbve/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+# App Cargo.toml (workspace resolution) + stub main
+COPY apps/kbve/axum-kbve/Cargo.toml apps/kbve/axum-kbve/Cargo.toml
+RUN mkdir -p apps/kbve/axum-kbve/src && \
+    echo "fn main() {}" > apps/kbve/axum-kbve/src/main.rs
+
+# Proto files (jedi build.rs generates protobuf code)
+COPY packages/data/proto packages/data/proto
+
+# Foundation crate source (changes less frequently than app code)
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p kbve -p jedi

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -86,7 +86,7 @@
 				"production": {
 					"commands": [
 						"./kbve.sh -nx axum-kbve:containerx --configuration=production",
-						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && docker tag ghcr.io/kbve/kbve:latest ghcr.io/kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
+						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && docker tag kbve/kbve:latest ghcr.io/kbve/kbve:latest && docker tag kbve/kbve:latest ghcr.io/kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION and ghcr.io/kbve/kbve:$VERSION\""
 					]
 				}
 			}
@@ -113,11 +113,63 @@
 						"images": ["ghcr.io/kbve/kbve", "kbve/kbve"],
 						"tags": ["latest"]
 					},
+					"build-args": [
+						"BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest"
+					],
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/kbve:buildcache"
 					],
 					"cache-to": [
 						"type=registry,ref=ghcr.io/kbve/kbve:buildcache,mode=max"
+					]
+				}
+			}
+		},
+		"basex": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/kbve/axum-kbve/Dockerfile.base",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["ghcr.io/kbve/kbve-build-base:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"tags": ["ghcr.io/kbve/kbve-build-base:latest"],
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/kbve-build-base:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/kbve-build-base:buildcache,mode=max"
+					]
+				}
+			}
+		},
+		"base": {
+			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx axum-kbve:basex",
+						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag ghcr.io/kbve/kbve-build-base:latest ghcr.io/kbve/kbve-build-base:$VERSION && echo \"Tagged ghcr.io/kbve/kbve-build-base:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx axum-kbve:basex --configuration=production",
+						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag ghcr.io/kbve/kbve-build-base:latest ghcr.io/kbve/kbve-build-base:$VERSION && echo \"Tagged ghcr.io/kbve/kbve-build-base:$VERSION\""
 					]
 				}
 			}


### PR DESCRIPTION
## Summary
- Adds `Dockerfile.base` for axum-kbve following the discordsh two-level build pattern
- Pre-builds Rust toolchain + cargo-chef + foundation crates (kbve + jedi) into `ghcr.io/kbve/kbve-build-base`
- Updates `Dockerfile` with `BUILD_BASE` arg — local mode builds everything inline, CI mode pulls pre-built foundation from GHCR
- Adds `basex`/`base` Nx targets to `project.json`
- Wires up CI: file alteration trigger (`kbve_base`), base image build matrix, docker smoke tests

## Architecture

**Two-level Docker build:**
1. **Dockerfile.base** (foundation) — Rust 1.90 + cargo-chef + external deps + kbve/jedi compiled. Published to `ghcr.io/kbve/kbve-build-base:latest`. Only rebuilds when Cargo.toml/Cargo.lock or foundation source changes.
2. **Dockerfile** (application) — Inherits from foundation via `BUILD_BASE` arg. Only compiles axum-kbve application code. Chisel-sliced Ubuntu 24.04 runtime (scratch + minimal rootfs) with jemalloc.

**Chisel slices (unchanged):**
- `base-files_base`, `base-files_release-info`, `ca-certificates_data`
- `libgcc-s1_libs`, `libc6_libs`, `libstdc++6_libs`, `openssl_config`

## Test plan
- [ ] `nx run axum-kbve:base` — builds foundation image locally
- [ ] `nx run axum-kbve:container` — builds full image locally (inline foundation)
- [ ] CI smoke test passes for kbve Dockerfile
- [ ] Verify chisel rootfs produces minimal runtime image

🤖 Generated with [Claude Code](https://claude.com/claude-code)