### PR TITLE
refactor(laser): route bitecs and rapier through @kbve/laser, fix protoc lint

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/runner/ecs.ts
+++ b/apps/kbve/astro-kbve/src/arcade/runner/ecs.ts
@@ -5,7 +5,7 @@ import {
 	addComponent,
 	hasComponent,
 	query,
-} from 'bitecs';
+} from '@kbve/laser';
 
 // ============================================================================
 // Components (bitecs 0.4+ - plain arrays/objects stored in world)

--- a/apps/kbve/astro-kbve/src/arcade/runner/systems/RapierPhysicsSystem.ts
+++ b/apps/kbve/astro-kbve/src/arcade/runner/systems/RapierPhysicsSystem.ts
@@ -5,7 +5,7 @@
 // Uses dynamic bodies with real gravity (matches official Phaser Rapier examples)
 // ============================================================================
 
-import { RAPIER, createRapierPhysics } from '@phaserjs/rapier-connector';
+import { RAPIER, createRapierPhysics } from '@kbve/laser';
 import { getComponents, getPlatforms, type GameWorld } from '../ecs';
 
 // ============================================================================

--- a/apps/kbve/axum-kbve/build.rs
+++ b/apps/kbve/axum-kbve/build.rs
@@ -1,4 +1,13 @@
 use std::path::Path;
+use std::process::Command;
+
+fn protoc_available() -> bool {
+    Command::new("protoc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Proto file locations
@@ -15,6 +24,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:warning=Proto directory not found, skipping protobuf compilation");
         return Ok(());
     };
+
+    if !protoc_available() {
+        println!("cargo:warning=protoc not found, skipping protobuf compilation");
+        return Ok(());
+    }
 
     let proto_files = vec![
         proto_dir.join("common.proto"),

--- a/packages/npm/laser/package.json
+++ b/packages/npm/laser/package.json
@@ -2,10 +2,22 @@
 	"name": "@kbve/laser",
 	"version": "0.1.0",
 	"description": "Phaser + React Three Fiber integration layer for React 19",
-	"keywords": ["phaser", "react", "r3f", "react-three-fiber", "gamedev", "three.js"],
+	"keywords": [
+		"phaser",
+		"react",
+		"r3f",
+		"react-three-fiber",
+		"gamedev",
+		"three.js"
+	],
 	"homepage": "https://kbve.com/application/javascript/",
-	"bugs": { "url": "https://github.com/KBVE/kbve/issues" },
-	"repository": { "type": "git", "url": "git+https://github.com/KBVE/kbve.git" },
+	"bugs": {
+		"url": "https://github.com/KBVE/kbve/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/KBVE/kbve.git"
+	},
 	"author": "KBVE <hello@kbve.com>",
 	"license": "MIT",
 	"type": "module",
@@ -30,13 +42,29 @@
 		"phaser": ">=3.80.0",
 		"three": ">=0.160.0",
 		"@react-three/fiber": ">=9.0.0",
-		"@react-three/drei": ">=10.0.0"
+		"@react-three/drei": ">=10.0.0",
+		"bitecs": ">=0.4.0",
+		"@phaserjs/rapier-connector": ">=1.0.0"
 	},
 	"peerDependenciesMeta": {
-		"phaser": { "optional": true },
-		"three": { "optional": true },
-		"@react-three/fiber": { "optional": true },
-		"@react-three/drei": { "optional": true }
+		"phaser": {
+			"optional": true
+		},
+		"three": {
+			"optional": true
+		},
+		"@react-three/fiber": {
+			"optional": true
+		},
+		"@react-three/drei": {
+			"optional": true
+		},
+		"bitecs": {
+			"optional": true
+		},
+		"@phaserjs/rapier-connector": {
+			"optional": true
+		}
 	},
 	"dependencies": {},
 	"publishConfig": {

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -18,3 +18,16 @@ export { usePhaserEvent } from './lib/phaser/use-phaser-event';
 export { Stage } from './lib/r3f/components/Stage';
 export type { StageProps } from './lib/r3f/components/Stage';
 export { useGameLoop } from './lib/r3f/hooks/use-game-loop';
+
+// ECS (bitecs)
+export {
+	createWorld,
+	addEntity,
+	removeEntity,
+	addComponent,
+	hasComponent,
+	query,
+} from './lib/ecs/bitecs';
+
+// Physics (Rapier)
+export { RAPIER, createRapierPhysics } from './lib/physics/rapier';

--- a/packages/npm/laser/src/lib/ecs/bitecs.ts
+++ b/packages/npm/laser/src/lib/ecs/bitecs.ts
@@ -1,0 +1,8 @@
+export {
+	createWorld,
+	addEntity,
+	removeEntity,
+	addComponent,
+	hasComponent,
+	query,
+} from 'bitecs';

--- a/packages/npm/laser/src/lib/physics/rapier.ts
+++ b/packages/npm/laser/src/lib/physics/rapier.ts
@@ -1,0 +1,1 @@
+export { RAPIER, createRapierPhysics } from '@phaserjs/rapier-connector';

--- a/packages/npm/laser/vite.config.ts
+++ b/packages/npm/laser/vite.config.ts
@@ -39,6 +39,8 @@ export default defineConfig({
 				'three',
 				'@react-three/fiber',
 				'@react-three/drei',
+				'bitecs',
+				'@phaserjs/rapier-connector',
 			],
 			output: {
 				globals: {


### PR DESCRIPTION
## Summary
- Adds `bitecs` and `@phaserjs/rapier-connector` as optional peer dependencies of `@kbve/laser`
- Creates re-export modules (`lib/ecs/bitecs.ts`, `lib/physics/rapier.ts`) in laser
- Updates astro-kbve arcade runner to import from `@kbve/laser` instead of direct package imports
- Fixes `axum-kbve` CI lint failure by adding `protoc` availability check in `build.rs`

## Changes

| File | Change |
|------|--------|
| `packages/npm/laser/package.json` | Added bitecs + rapier-connector as optional peer deps |
| `packages/npm/laser/vite.config.ts` | Added both to rollup externals |
| `packages/npm/laser/src/index.ts` | Added ECS + Physics re-exports |
| `packages/npm/laser/src/lib/ecs/bitecs.ts` | New: re-exports bitecs symbols |
| `packages/npm/laser/src/lib/physics/rapier.ts` | New: re-exports RAPIER + createRapierPhysics |
| `apps/kbve/astro-kbve/src/arcade/runner/ecs.ts` | `bitecs` -> `@kbve/laser` |
| `apps/kbve/astro-kbve/src/arcade/runner/systems/RapierPhysicsSystem.ts` | `@phaserjs/rapier-connector` -> `@kbve/laser` |
| `apps/kbve/axum-kbve/build.rs` | Added protoc check to skip proto compilation when unavailable |

## Test plan
- [ ] `nx build laser` — laser package builds with new re-exports
- [ ] `nx run axum-kbve:lint` — clippy passes without protoc installed
- [ ] Astro arcade runner still resolves imports via @kbve/laser

🤖 Generated with [Claude Code](https://claude.com/claude-code)