### PR TITLE
feat(memes): favicon, robots.txt fix, and Askama OG tags

### DIFF
--- a/apps/memes/astro-memes/astro.config.mjs
+++ b/apps/memes/astro-memes/astro.config.mjs
@@ -9,6 +9,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Meme.sh',
+      favicon: '/favicon.svg',
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/kbve/kbve' },
         { icon: 'discord', label: 'Discord', href: 'https://kbve.com/discord' },

--- a/apps/memes/astro-memes/public/favicon.svg
+++ b/apps/memes/astro-memes/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0ea5e9"/>
+  <text x="16" y="23" text-anchor="middle" font-size="20" font-family="system-ui,sans-serif" fill="white" font-weight="bold">M</text>
+</svg>

--- a/apps/memes/astro-memes/public/robots.txt
+++ b/apps/memes/astro-memes/public/robots.txt
@@ -1,4 +1,5 @@
 User-Agent: *
 Allow: /
 
-Sitemap: https://meme.sh/sitemap.xml
+Sitemap: https://meme.sh/sitemap-index.xml
+Sitemap: https://meme.sh/sitemap-0.xml

--- a/apps/memes/axum-memes/src/astro/askama.rs
+++ b/apps/memes/axum-memes/src/astro/askama.rs
@@ -11,6 +11,8 @@ pub struct AstroTemplate<'a> {
     pub path: &'a str,
     pub title: &'a str,
     pub description: &'a str,
+    pub canonical_url: &'a str,
+    pub og_image: &'a str,
 }
 
 impl<'a> AstroTemplate<'a> {
@@ -19,8 +21,10 @@ impl<'a> AstroTemplate<'a> {
         path: &'a str,
         title: &'a str,
         description: &'a str,
+        canonical_url: &'a str,
+        og_image: &'a str,
     ) -> Self {
-        Self { content, path, title, description }
+        Self { content, path, title, description, canonical_url, og_image }
     }
 }
 
@@ -44,6 +48,8 @@ pub async fn fallback_handler() -> Response {
         "/404",
         "404 - Not Found",
         "Page not found",
+        "https://meme.sh/404",
+        "",
     );
     (StatusCode::NOT_FOUND, TemplateResponse(template)).into_response()
 }

--- a/apps/memes/axum-memes/templates/askama/index.html
+++ b/apps/memes/axum-memes/templates/askama/index.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ title }} - Meme.sh</title>
     <meta name="description" content="{{ description }}" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href="{{ canonical_url }}" />
+    <meta property="og:title" content="{{ title }} - Meme.sh" />
+    <meta property="og:description" content="{{ description }}" />
+    <meta property="og:url" content="{{ canonical_url }}" />
+    <meta property="og:site_name" content="Meme.sh" />
+    <meta property="og:type" content="website" />
+    {% if !og_image.is_empty() %}
+    <meta property="og:image" content="{{ og_image }}" />
+    {% endif %}
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="{{ title }} - Meme.sh" />
+    <meta name="twitter:description" content="{{ description }}" />
 </head>
 <body>
     {{ content|safe }}


### PR DESCRIPTION
## Summary
- Add SVG favicon (cyan "M" on rounded rect) and register it in Starlight config
- Fix `robots.txt` sitemap URL from `sitemap.xml` to `sitemap-index.xml` (matching Starlight's actual output), add `sitemap-0.xml` as second entry
- Add favicon link, canonical URL, and Open Graph meta tags to the Askama server-side template
- Expand `AstroTemplate` struct with `canonical_url` and `og_image` fields

**Note:** Starlight already generates OG tags (`og:title`, `og:description`, `og:url`, `og:site_name`, `og:type`, `twitter:card`, `canonical`) automatically from page frontmatter, so no Head component override was needed for the Astro side.

Closes #7514

## Test plan
- [ ] `npx nx build astro-memes` passes (8 pages, zero errors)
- [ ] `cargo check -p axum-memes` passes
- [ ] Built HTML contains `og:title`, `og:description`, `favicon.svg` link
- [ ] `robots.txt` references `sitemap-index.xml`
- [ ] Existing e2e smoke tests pass (sitemap, security headers, routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)