### PR TITLE
fix(edge-e2e): update auth tests for generic error messages

### DIFF
--- a/apps/kbve/edge-e2e/e2e/auth.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/auth.spec.ts
@@ -15,7 +15,7 @@ describe('JWT Authentication', () => {
 		});
 		expect(res.status).toBe(401);
 		const body = await res.json();
-		expect(body.msg).toContain('Missing authorization header');
+		expect(body.msg).toContain('Authentication failed');
 	});
 
 	it('should reject requests with a malformed Authorization header', async () => {
@@ -29,7 +29,7 @@ describe('JWT Authentication', () => {
 		});
 		expect(res.status).toBe(401);
 		const body = await res.json();
-		expect(body.msg).toContain("not 'Bearer {token}'");
+		expect(body.msg).toContain('Authentication failed');
 	});
 
 	it('should reject a JWT signed with the wrong secret', async () => {


### PR DESCRIPTION
## Summary
- Auth tests expected specific error strings (`Missing authorization header`, `not 'Bearer {token}'`) that were replaced with generic `Authentication failed` in the CodeQL security fix (PR #7516)
- Updated both assertions to match the new generic responses

## Test plan
- [ ] `auth.spec.ts` — all 6 tests pass
- [ ] Full e2e suite — 71 tests pass