### PR TITLE
fix(axum-kbve): add apt-get upgrade to Dockerfile.base for Trivy

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile.base
+++ b/apps/kbve/axum-kbve/Dockerfile.base
@@ -15,6 +15,7 @@
 FROM --platform=linux/amd64 rust:1.90-slim AS chef
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         pkg-config \
         libssl-dev \


### PR DESCRIPTION
## Summary
- Adds `apt-get upgrade -y` to the `chef` stage in `Dockerfile.base` to patch Debian OS packages
- Fixes Trivy scan failure (79 HIGH/CRITICAL Debian vulnerabilities with available fixes)
- Matches the existing pattern in `apps/discordsh/axum-discordsh/Dockerfile.base`

## Context
The `utils-publish-docker-image.yml` Trivy step scans `ghcr.io/kbve/kbve-build-base:latest` with `exit-code: 1`, `severity: CRITICAL,HIGH`, `ignore-unfixed: true`. The `rust:1.90-slim` base ships Debian 13.1 packages with known CVEs that need patching via `apt-get upgrade`.

## Test plan
- [ ] Rebuild base image and verify Trivy scan passes
- [ ] Verify downstream `Dockerfile` (inline foundation stages) still builds