### PR TITLE
feat(memes): polish UI — auth page, feed cards, navigation

### DIFF
--- a/apps/memes/astro-memes/src/components/auth/SignInPage.tsx
+++ b/apps/memes/astro-memes/src/components/auth/SignInPage.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	$auth,
+	useAuthBridge,
+	addToast,
+	DiscordIcon,
+	GitHubIcon,
+	TwitchIcon,
+} from '@kbve/astro';
+import type { OAuthProvider } from '@kbve/astro';
+import { authBridge, initSupa } from '../../lib/supa';
+
+export default function SignInPage() {
+	const auth = useStore($auth);
+	const { signInWithOAuth, loading } = useAuthBridge(authBridge);
+	const [ready, setReady] = useState(false);
+
+	useEffect(() => {
+		initSupa().catch(() => {});
+		setReady(true);
+	}, []);
+
+	const handleOAuth = async (provider: OAuthProvider) => {
+		try {
+			await signInWithOAuth(provider);
+			addToast({
+				id: `auth-ok-${Date.now()}`,
+				message: 'Signed in successfully!',
+				severity: 'success',
+				duration: 4000,
+			});
+		} catch {
+			// useAuthBridge tracks the error
+		}
+	};
+
+	if (!ready) {
+		return (
+			<div className="flex items-center justify-center min-h-[60vh]">
+				<div
+					className="w-10 h-10 rounded-full animate-pulse"
+					style={{ backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)' }}
+				/>
+			</div>
+		);
+	}
+
+	if (auth.tone === 'auth') {
+		return (
+			<div className="flex items-center justify-center min-h-[60vh] px-4">
+				<div
+					className="w-full max-w-sm rounded-2xl p-8 text-center"
+					style={{
+						backgroundColor: 'var(--sl-color-bg-nav, #18181b)',
+						border: '1px solid var(--sl-color-hairline, #27272a)',
+					}}>
+					<div
+						className="w-16 h-16 rounded-full mx-auto mb-4 overflow-hidden"
+						style={{
+							boxShadow: '0 0 0 3px var(--sl-color-accent, #0ea5e9)',
+						}}>
+						{auth.avatar ? (
+							<img
+								src={auth.avatar}
+								alt={auth.name}
+								className="w-full h-full object-cover"
+							/>
+						) : (
+							<div
+								className="w-full h-full flex items-center justify-center text-2xl font-bold"
+								style={{
+									backgroundColor: 'var(--sl-color-accent-low, #164e63)',
+									color: 'var(--sl-color-text-accent, #22d3ee)',
+								}}>
+								{auth.name?.charAt(0).toUpperCase() || '?'}
+							</div>
+						)}
+					</div>
+					<h2
+						className="text-lg font-semibold mb-1"
+						style={{ color: 'var(--sl-color-white, #e2e8f0)' }}>
+						Welcome back, {auth.name}
+					</h2>
+					<p
+						className="text-sm mb-6"
+						style={{ color: 'var(--sl-color-gray-2, #a1a1aa)' }}>
+						You&apos;re already signed in.
+					</p>
+					<div className="flex flex-col gap-2">
+						<a
+							href="/profile"
+							className="inline-flex items-center justify-center rounded-lg text-sm font-medium px-4 py-2.5 transition-colors"
+							style={{
+								backgroundColor: 'var(--sl-color-accent, #0ea5e9)',
+								color: '#fff',
+							}}>
+							Go to Profile
+						</a>
+						<a
+							href="/feed"
+							className="inline-flex items-center justify-center rounded-lg text-sm font-medium px-4 py-2.5 transition-colors"
+							style={{
+								backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
+								color: 'var(--sl-color-white, #e2e8f0)',
+							}}>
+							Browse Feed
+						</a>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex items-center justify-center min-h-[60vh] px-4">
+			<div
+				className="w-full max-w-sm rounded-2xl p-8"
+				style={{
+					backgroundColor: 'var(--sl-color-bg-nav, #18181b)',
+					border: '1px solid var(--sl-color-hairline, #27272a)',
+				}}>
+				<div className="text-center mb-6">
+					<h2
+						className="text-xl font-semibold mb-1"
+						style={{ color: 'var(--sl-color-white, #e2e8f0)' }}>
+						Sign in to Meme.sh
+					</h2>
+					<p
+						className="text-sm"
+						style={{ color: 'var(--sl-color-gray-2, #a1a1aa)' }}>
+						Choose a provider to get started
+					</p>
+				</div>
+
+				{auth.error && (
+					<div
+						className="mb-4 text-xs rounded-lg px-3 py-2"
+						style={{
+							color: '#fca5a5',
+							backgroundColor: 'rgba(239,68,68,0.1)',
+						}}>
+						{auth.error}
+					</div>
+				)}
+
+				<div className="flex flex-col gap-3">
+					<button
+						type="button"
+						onClick={() => handleOAuth('discord')}
+						disabled={loading}
+						className="w-full inline-flex items-center justify-center gap-2.5 rounded-lg text-sm font-medium px-4 py-3 transition-colors disabled:opacity-60"
+						style={{ backgroundColor: '#5865F2', color: '#fff' }}
+						onMouseEnter={(e) => {
+							e.currentTarget.style.backgroundColor = '#4752C4';
+						}}
+						onMouseLeave={(e) => {
+							e.currentTarget.style.backgroundColor = '#5865F2';
+						}}>
+						<DiscordIcon className="w-5 h-5" />
+						Continue with Discord
+					</button>
+
+					<button
+						type="button"
+						onClick={() => handleOAuth('github')}
+						disabled={loading}
+						className="w-full inline-flex items-center justify-center gap-2.5 rounded-lg text-sm font-medium px-4 py-3 transition-colors disabled:opacity-60"
+						style={{ backgroundColor: '#24292f', color: '#fff' }}
+						onMouseEnter={(e) => {
+							e.currentTarget.style.backgroundColor = '#1b1f23';
+						}}
+						onMouseLeave={(e) => {
+							e.currentTarget.style.backgroundColor = '#24292f';
+						}}>
+						<GitHubIcon className="w-5 h-5" />
+						Continue with GitHub
+					</button>
+
+					<button
+						type="button"
+						onClick={() => handleOAuth('twitch')}
+						disabled={loading}
+						className="w-full inline-flex items-center justify-center gap-2.5 rounded-lg text-sm font-medium px-4 py-3 transition-colors disabled:opacity-60"
+						style={{ backgroundColor: '#9146FF', color: '#fff' }}
+						onMouseEnter={(e) => {
+							e.currentTarget.style.backgroundColor = '#7B2FFF';
+						}}
+						onMouseLeave={(e) => {
+							e.currentTarget.style.backgroundColor = '#9146FF';
+						}}>
+						<TwitchIcon className="w-5 h-5" />
+						Continue with Twitch
+					</button>
+				</div>
+
+				<p
+					className="mt-5 text-[11px] text-center"
+					style={{ color: 'var(--sl-color-gray-3, #71717a)' }}>
+					Your session syncs automatically across all tabs.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/memes/astro-memes/src/components/feed/FeedSkeleton.tsx
+++ b/apps/memes/astro-memes/src/components/feed/FeedSkeleton.tsx
@@ -1,48 +1,53 @@
 export default function FeedSkeleton() {
 	return (
 		<div
-			className="flex flex-col items-center justify-center gap-6"
+			className="relative flex flex-col items-center justify-center gap-6"
 			style={{
 				height: '100dvh',
 				backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
 			}}>
-			{/* Image placeholder */}
+			{/* Image placeholder — matches constrained card layout */}
 			<div
-				className="w-3/4 max-w-md rounded-xl animate-pulse"
+				className="w-[85%] max-w-lg rounded-xl animate-pulse"
 				style={{
 					height: '55%',
 					backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
+					border: '1px solid rgba(255,255,255,0.04)',
 				}}
 			/>
 
-			{/* Title bar */}
-			<div className="w-3/4 max-w-md flex flex-col gap-2">
-				<div
-					className="h-4 w-3/4 rounded animate-pulse"
-					style={{
-						backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
-					}}
-				/>
-				<div className="flex items-center gap-2">
+			{/* Bottom info bar */}
+			<div className="absolute bottom-0 left-0 right-0 p-4 pb-6">
+				<div className="flex flex-col gap-2.5 max-w-lg">
 					<div
-						className="w-6 h-6 rounded-full animate-pulse"
+						className="h-4 w-3/4 rounded animate-pulse"
 						style={{
-							backgroundColor:
-								'var(--sl-color-gray-6, #1c1c1e)',
+							backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
 						}}
 					/>
-					<div
-						className="h-3 w-20 rounded animate-pulse"
-						style={{
-							backgroundColor:
-								'var(--sl-color-gray-6, #1c1c1e)',
-						}}
-					/>
+					<div className="flex items-center gap-2">
+						<div
+							className="w-8 h-8 rounded-full animate-pulse"
+							style={{
+								backgroundColor:
+									'var(--sl-color-gray-6, #1c1c1e)',
+							}}
+						/>
+						<div
+							className="h-3 w-20 rounded animate-pulse"
+							style={{
+								backgroundColor:
+									'var(--sl-color-gray-6, #1c1c1e)',
+							}}
+						/>
+					</div>
 				</div>
 			</div>
 
-			{/* Right-side reaction placeholder */}
-			<div className="absolute right-4 bottom-1/4 flex flex-col gap-4">
+			{/* Right-side reaction bar placeholder */}
+			<div
+				className="absolute right-3 bottom-28 flex flex-col items-center gap-2.5 rounded-2xl p-2.5"
+				style={{ backgroundColor: 'rgba(255,255,255,0.03)' }}>
 				{[...Array(4)].map((_, i) => (
 					<div
 						key={i}

--- a/apps/memes/astro-memes/src/components/feed/MemeCard.tsx
+++ b/apps/memes/astro-memes/src/components/feed/MemeCard.tsx
@@ -45,113 +45,114 @@ const MemeCard = forwardRef<HTMLDivElement, MemeCardProps>(
 					scrollSnapStop: 'always',
 					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
 				}}>
-				{/* Meme asset */}
-				{isVideo ? (
-					<video
-						src={meme.asset_url}
-						className="max-w-full max-h-full object-contain"
-						autoPlay
-						loop
-						muted
-						playsInline
-					/>
-				) : (
-					<img
-						src={meme.thumbnail_url || meme.asset_url}
-						alt={meme.title || 'Meme'}
-						className="max-w-full max-h-full object-contain select-none"
-						loading={lazy ? 'lazy' : 'eager'}
-						draggable={false}
-					/>
-				)}
-
-				{/* Bottom gradient overlay */}
-				<div
-					className="absolute bottom-0 left-0 right-0 pointer-events-none"
-					style={{
-						height: '40%',
-						background:
-							'linear-gradient(transparent, rgba(0,0,0,0.75))',
-					}}
-				/>
-
-				{/* Title + Author */}
-				<div className="absolute bottom-0 left-0 right-16 p-4 pb-6">
-					{meme.title && (
-						<h2 className="text-white text-base font-semibold leading-tight mb-2 drop-shadow-md line-clamp-2">
-							{meme.title}
-						</h2>
-					)}
-
-					<div className="flex items-center gap-2">
-						{meme.author_name ? (
-							<a
-								href={`https://kbve.com/@${meme.author_name}`}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="flex items-center gap-2 group">
-								{meme.author_avatar ? (
-									<img
-										src={meme.author_avatar}
-										alt={meme.author_name}
-										className="w-7 h-7 rounded-full transition-shadow group-hover:shadow-[0_0_0_2px_var(--sl-color-accent,#0ea5e9)]"
-									/>
-								) : (
-									<div
-										className="w-7 h-7 rounded-full flex items-center justify-center"
-										style={{
-											backgroundColor:
-												'var(--sl-color-accent-low, #164e63)',
-										}}>
-										<User
-											size={14}
-											style={{
-												color: 'var(--sl-color-text-accent, #22d3ee)',
-											}}
-										/>
-									</div>
-								)}
-								<span className="text-white/80 text-sm font-medium group-hover:text-white transition-colors">
-									@{meme.author_name}
-								</span>
-							</a>
-						) : (
-							<div
-								className="w-7 h-7 rounded-full flex items-center justify-center"
-								style={{
-									backgroundColor:
-										'var(--sl-color-accent-low, #164e63)',
-								}}>
-								<User
-									size={14}
-									style={{
-										color: 'var(--sl-color-text-accent, #22d3ee)',
-									}}
-								/>
-							</div>
-						)}
-					</div>
-
-					{/* Tags */}
-					{meme.tags.length > 0 && (
-						<div className="flex flex-wrap gap-1.5 mt-2">
-							{meme.tags.slice(0, 3).map((tag) => (
-								<span
-									key={tag}
-									className="text-[11px] px-2 py-0.5 rounded-full"
-									style={{
-										backgroundColor: 'rgba(255,255,255,0.1)',
-										color: 'rgba(255,255,255,0.6)',
-									}}>
-									#{tag}
-								</span>
-							))}
-						</div>
+				{/* Meme asset — constrained with rounded corners */}
+				<div className="relative flex items-center justify-center w-full px-4"
+					style={{ maxHeight: '82dvh' }}>
+					{isVideo ? (
+						<video
+							src={meme.asset_url}
+							className="max-w-full max-h-full object-contain rounded-xl"
+							style={{
+								border: '1px solid rgba(255,255,255,0.06)',
+							}}
+							autoPlay
+							loop
+							muted
+							playsInline
+						/>
+					) : (
+						<img
+							src={meme.thumbnail_url || meme.asset_url}
+							alt={meme.title || 'Meme'}
+							className="max-w-full max-h-full object-contain select-none rounded-xl"
+							style={{
+								border: '1px solid rgba(255,255,255,0.06)',
+							}}
+							loading={lazy ? 'lazy' : 'eager'}
+							draggable={false}
+						/>
 					)}
 				</div>
 
-				{/* Reaction bar — right side */}
-				<div className="absolute right-3 bottom-24">
+				{/* Bottom info card — frosted glass */}
+				<div
+					className="absolute bottom-0 left-0 right-0 px-4 pb-5 pt-10 pointer-events-none"
+					style={{
+						background: 'linear-gradient(transparent, rgba(0,0,0,0.7) 40%)',
+					}}>
+					<div className="pointer-events-auto max-w-lg">
+						{meme.title && (
+							<h2 className="text-white text-base font-semibold leading-tight mb-2 drop-shadow-md line-clamp-2">
+								{meme.title}
+							</h2>
+						)}
+
+						<div className="flex items-center gap-2.5">
+							{meme.author_name ? (
+								<a
+									href={`https://kbve.com/@${meme.author_name}`}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-2 group">
+									{meme.author_avatar ? (
+										<img
+											src={meme.author_avatar}
+											alt={meme.author_name}
+											className="w-8 h-8 rounded-full transition-shadow group-hover:shadow-[0_0_0_2px_var(--sl-color-accent,#0ea5e9)]"
+										/>
+									) : (
+										<div
+											className="w-8 h-8 rounded-full flex items-center justify-center"
+											style={{
+												backgroundColor:
+													'var(--sl-color-accent-low, #164e63)',
+											}}>
+											<User
+												size={15}
+												style={{
+													color: 'var(--sl-color-text-accent, #22d3ee)',
+												}}
+											/>
+										</div>
+									)}
+									<span className="text-white/80 text-sm font-medium group-hover:text-white transition-colors">
+										@{meme.author_name}
+									</span>
+								</a>
+							) : (
+								<div
+									className="w-8 h-8 rounded-full flex items-center justify-center"
+									style={{
+										backgroundColor:
+											'var(--sl-color-accent-low, #164e63)',
+									}}>
+									<User
+										size={15}
+										style={{
+											color: 'var(--sl-color-text-accent, #22d3ee)',
+										}}
+									/>
+								</div>
+							)}
+						</div>
+
+						{/* Tags */}
+						{meme.tags.length > 0 && (
+							<div className="flex flex-wrap gap-1.5 mt-2.5">
+								{meme.tags.slice(0, 3).map((tag) => (
+									<span
+										key={tag}
+										className="text-[11px] px-2.5 py-0.5 rounded-full bg-white/10 text-white/60 backdrop-blur-sm">
+										#{tag}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Reaction bar — right side with glass pill */}
+				<div className="absolute right-3 bottom-28">
 					<ReactionBar
 						memeId={meme.id}
 						reactionCount={meme.reaction_count}

--- a/apps/memes/astro-memes/src/components/feed/ReactionBar.tsx
+++ b/apps/memes/astro-memes/src/components/feed/ReactionBar.tsx
@@ -74,7 +74,8 @@ export default function ReactionBar({
 	);
 
 	return (
-		<div className="flex flex-col items-center gap-3">
+		<div className="flex flex-col items-center gap-2.5 rounded-2xl p-2.5 backdrop-blur-md"
+			style={{ backgroundColor: 'rgba(0,0,0,0.35)' }}>
 			{visibleReactions.map((r) => {
 				const isActive = userReaction === r.key;
 				return (
@@ -86,10 +87,9 @@ export default function ReactionBar({
 						aria-label={r.label}
 						title={r.label}>
 						<span
-							className="text-2xl leading-none select-none"
+							className="text-[26px] leading-none select-none transition-opacity"
 							style={{
-								filter: isActive ? 'none' : 'grayscale(0.5)',
-								opacity: isActive ? 1 : 0.7,
+								opacity: isActive ? 1 : 0.6,
 							}}>
 							{r.emoji}
 						</span>
@@ -110,9 +110,6 @@ export default function ReactionBar({
 			<span className="text-xs font-medium text-white/60">
 				{formatCount(reactionCount)}
 			</span>
-
-			{/* Divider */}
-			<div className="w-6 h-px bg-white/10" />
 
 			{/* Save / Bookmark */}
 			<button
@@ -136,9 +133,6 @@ export default function ReactionBar({
 				</span>
 			</button>
 
-			{/* Divider */}
-			<div className="w-6 h-px bg-white/10" />
-
 			{/* Comment */}
 			<button
 				type="button"
@@ -146,7 +140,7 @@ export default function ReactionBar({
 				className="flex flex-col items-center gap-0.5 transition-transform duration-150 active:scale-110"
 				aria-label="Comments"
 				title="Comments">
-				<MessageCircle size={22} className="text-white/70" />
+				<MessageCircle size={24} className="text-white/70" />
 				<span className="text-[10px] text-white/60">
 					{formatCount(commentCount)}
 				</span>
@@ -159,7 +153,7 @@ export default function ReactionBar({
 				className="flex flex-col items-center gap-0.5 transition-transform duration-150 active:scale-110"
 				aria-label="Share"
 				title="Share">
-				<Share2 size={22} className="text-white/70" />
+				<Share2 size={24} className="text-white/70" />
 				<span className="text-[10px] text-white/60">
 					{formatCount(shareCount)}
 				</span>
@@ -172,7 +166,7 @@ export default function ReactionBar({
 				className="flex flex-col items-center gap-0.5 transition-transform duration-150 active:scale-110"
 				aria-label="More options"
 				title="More">
-				<MoreHorizontal size={22} className="text-white/70" />
+				<MoreHorizontal size={24} className="text-white/70" />
 			</button>
 		</div>
 	);

--- a/apps/memes/astro-memes/src/components/navigation/NavBar.astro
+++ b/apps/memes/astro-memes/src/components/navigation/NavBar.astro
@@ -13,8 +13,8 @@ const currentPath = Astro.url.pathname;
     <a href="/guides/getting-started" class:list={['nav-link', { active: currentPath.startsWith('/guides') || currentPath.startsWith('/reference') }]} data-astro-prefetch title="Docs">
       <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
     </a>
-    <a href="/dashboard" class:list={['nav-link', { active: currentPath.startsWith('/dashboard') }]} data-astro-prefetch title="Dashboard">
-      <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
+    <a href="/feed" class:list={['nav-link', { active: currentPath.startsWith('/feed') }]} data-astro-prefetch title="Feed">
+      <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0011 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 11-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 002.5 2.5z"></path></svg>
     </a>
   </div>
 

--- a/apps/memes/astro-memes/src/components/navigation/ReactNavBar.tsx
+++ b/apps/memes/astro-memes/src/components/navigation/ReactNavBar.tsx
@@ -23,13 +23,11 @@ import { authBridge, initSupa } from '../../lib/supa';
 import {
 	Home,
 	BookOpen,
-	LayoutDashboard,
 	Flame,
 	LogIn,
 	LogOut,
 	X,
 	User,
-	Settings,
 	UserCircle,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -47,13 +45,10 @@ const NAV_ITEMS: NavItem[] = [
 	{ label: 'Home', href: '/', icon: Home },
 	{ label: 'Feed', href: '/feed', icon: Flame },
 	{ label: 'Docs', href: '/guides/getting-started', icon: BookOpen },
-	{ label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
 ];
 
 const USER_MENU_ITEMS: NavItem[] = [
 	{ label: 'Profile', href: '/profile', icon: UserCircle },
-	{ label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
-	{ label: 'Settings', href: '/settings', icon: Settings },
 ];
 
 function isActive(href: string, path: string): boolean {

--- a/apps/memes/astro-memes/src/content/docs/auth.mdx
+++ b/apps/memes/astro-memes/src/content/docs/auth.mdx
@@ -1,0 +1,14 @@
+---
+title: Sign In
+description: Sign in to Meme.sh with your favorite provider
+template: splash
+hero:
+  title: Sign In
+  tagline: Sign in to Meme.sh
+---
+
+import SignInPage from '../../components/auth/SignInPage';
+
+<div style="margin-left: calc(-1 * var(--sl-content-pad-x, 1rem)); margin-right: calc(-1 * var(--sl-content-pad-x, 1rem)); margin-top: 2rem;">
+  <SignInPage client:only="react" />
+</div>

--- a/apps/memes/astro-memes/src/pages/auth/index.astro
+++ b/apps/memes/astro-memes/src/pages/auth/index.astro
@@ -1,7 +1,0 @@
----
-// Redirect to home if someone navigates to /auth
----
-
-<script>
-  window.location.href = '/';
-</script>


### PR DESCRIPTION
## Summary
- Replace bare `/auth` redirect with a proper sign-in page (centered card with Discord/GitHub/Twitch OAuth buttons, shows "welcome back" if already signed in)
- Improve feed card layout: constrained image (~82vh) with rounded corners and subtle border, shorter frosted-glass gradient overlay, better tag pills with `backdrop-blur-sm`
- Add glass-morphism background (`backdrop-blur-md bg-black/35 rounded-2xl`) to ReactionBar so buttons are visible on any image background
- Remove grayscale filter on inactive reactions — use opacity only for cleaner look
- Update FeedSkeleton to match the revised card layout (constrained image, bottom info bar, glass pill for reactions)
- Replace dead `/dashboard` desktop nav link with `/feed` (Flame icon)
- Remove dead `/dashboard` and `/settings` entries from mobile drawer and user menu dropdown

## Test plan
- [ ] Navigate to `/auth` — sign-in card with 3 OAuth buttons renders in Starlight layout
- [ ] If signed in, `/auth` shows "Welcome back" with links to Profile and Feed
- [ ] Feed cards have breathing room — image doesn't fill entire viewport
- [ ] Reaction bar has glass pill background, readable on light and dark images
- [ ] Desktop nav: Home, Feed, Docs (no Dashboard)
- [ ] Mobile drawer: Home, Feed, Docs (no Dashboard)
- [ ] User menu: Profile only (no Dashboard/Settings links that 404)
- [ ] `npx nx build astro-memes` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)