### PR TITLE
fix(astro-kbve): add @kbve/laser tsconfig path for dev resolution

### DIFF
--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -9,7 +9,8 @@
 		"paths": {
 			"@/*": ["src/*"],
 			"@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
-			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"]
+			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
+			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"]
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `@kbve/laser` path mapping to `apps/kbve/astro-kbve/tsconfig.json`
- Fixes Vite resolution error during `astro dev` where `@kbve/laser` could not be found
- Matches existing pattern used for `@kbve/astro` and `@kbve/droid`

## Context
PR #7517 moved `bitecs` and `@phaserjs/rapier-connector` imports to go through `@kbve/laser`, but the tsconfig path mapping was missing. The `package.json` exports point to `laser.es.js` (a build artifact), so without the tsconfig path pointing to `src/index.ts`, Vite can't resolve the package during development.

## Test plan
- [x] `astro dev` starts without `@kbve/laser` resolution errors
- [ ] CI passes