### PR TITLE
fix(ci): queue commits instead of canceling runs

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
     group: atom-${{ github.ref_name }}
-    cancel-in-progress: true
+    cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: false
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Change `cancel-in-progress` from `true` to `false` on **ci-dev** and **ci-atom** workflows
- With the concurrency group + `cancel-in-progress: false`, GitHub Actions queues at most **one** pending run per group — rapid commits behave as:
  - **A** runs
  - **B**, **C** pushed while A runs → superseded in the queue (never start)
  - **D** (latest) runs after A completes
- Stops wasting CI minutes by killing nearly-complete runs on every push

## Unchanged
- **ci-main** and **ci-security** — already `false`
- **ci-mc-headless-e2e** — manual dispatch, canceling makes sense if re-triggered with different params
- **ci-docker-smoke-test** — cron-only, rarely relevant

## Test plan
- [ ] Push multiple commits to a dev PR in quick succession
- [ ] Verify the first run completes, intermediate commits are skipped, and only the latest queued commit runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)