### PR TITLE
feat(osrs): expand proto as source of truth + proto-aligned Zod schema

### DIFF
--- a/apps/kbve/astro-kbve/buf.gen.yaml
+++ b/apps/kbve/astro-kbve/buf.gen.yaml
@@ -1,9 +1,9 @@
 version: v2
 plugins:
+    # TypeScript interfaces (snake_case field names)
     - remote: buf.build/community/stephenh-ts-proto
       out: apps/kbve/astro-kbve/src/generated/proto
       opt:
-          - useZod=true
           - esModuleInterop=true
           - importSuffix=.js
           - outputServices=false
@@ -14,3 +14,7 @@ plugins:
           - useExactTypes=true
           - exportCommonSymbols=true
           - removeEnumPrefix=true
+          - snakeToCamel=false
+    # JSON Schema generation (uncomment when codegen pipeline is automated)
+    # - remote: buf.build/bufbuild/protoschema-jsonschema
+    #   out: apps/kbve/astro-kbve/src/generated/jsonschema

--- a/apps/kbve/astro-kbve/src/data/schema/osrs/generated.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/osrs/generated.ts
@@ -1,0 +1,780 @@
+/**
+ * Proto-Aligned OSRS Zod Schema
+ *
+ * This file mirrors the structure defined in packages/data/proto/kbve/osrs.proto
+ * and serves as the Zod validation layer for OSRS item frontmatter in Astro
+ * content collections.
+ *
+ * Proto is the single source of truth for the data model. This Zod schema
+ * validates MDX frontmatter against that model. Where field names differ
+ * between proto and MDX convention, the MDX name is used with a comment
+ * noting the proto field name.
+ *
+ * Proto message → Zod schema mapping:
+ *   OSRSAttackBonus      → OSRSAttackBonusSchema
+ *   OSRSDefenceBonus     → OSRSDefenceBonusSchema
+ *   OSRSOtherBonus       → OSRSOtherBonusSchema
+ *   OSRSRequirements     → OSRSRequirementsSchema
+ *   OSRSEquipment        → OSRSEquipmentSchema
+ *   OSRSSpecialAttack    → OSRSSpecialAttackSchema
+ *   OSRSSetBonus         → OSRSSetBonusSchema
+ *   OSRSDropSource       → OSRSDropSourceSchema
+ *   OSRSRecipeMaterial   → OSRSMaterialSchema
+ *   OSRSRecipe           → OSRSRecipeSchema
+ *   OSRSEffect           → (inline in OSRSPotionSchema.effects)
+ *   OSRSConsumable       → OSRSPotionSchema        (renamed for MDX compat)
+ *   OSRSFood             → OSRSFoodSchema
+ *   OSRSCookingBurnRate  → (inline in OSRSCookingSchema.burn_rates)
+ *   OSRSCooking          → OSRSCookingSchema
+ *   OSRSShopSource       → OSRSShopSourceSchema
+ *   OSRSSkillingSource   → OSRSSkillingSourceSchema
+ *   OSRSTreasureTrail    → OSRSTreasureTrailSchema
+ *   OSRSRelatedItem      → OSRSRelatedItemSchema
+ *   OSRSItemProperties   → OSRSItemPropertiesSchema
+ *   OSRSMeta             → OSRSMetaSchema
+ *   OSRSPrice            → OSRSPriceSchema
+ *   OSRSItem             → OSRSExtendedSchema
+ *
+ * Field name differences (proto → MDX):
+ *   ge_limit     → limit
+ *   drop_sources → drop_table (supports both array and object format)
+ *   consumable   → potion
+ *
+ * Future: proto → JSON Schema → Zod codegen pipeline
+ *   buf.gen.yaml has a commented-out protoschema-jsonschema plugin.
+ *   Once json-schema-to-zod supports Draft 2020-12 + protobuf patterns,
+ *   this file can be fully generated with a thin refinement layer.
+ */
+
+import { z } from 'astro:content';
+
+// ============================================================================
+// SEO / Meta — proto: OSRSMeta
+// ============================================================================
+
+export const OSRSHeadTagSchema = z.object({
+	tag: z.enum([
+		'meta',
+		'link',
+		'script',
+		'style',
+		'title',
+		'base',
+		'noscript',
+		'template',
+	]),
+	attrs: z.record(z.union([z.string(), z.boolean()])).optional(),
+	content: z.string().optional(),
+});
+
+export type OSRSHeadTag = z.infer<typeof OSRSHeadTagSchema>;
+
+export const OSRSMetaSchema = z.object({
+	description: z.string().max(160).optional(), // proto: description
+	keywords: z.array(z.string()).optional(), // proto: keywords
+	og_image: z.string().optional(), // proto: og_image
+	og_image_alt: z.string().optional(),
+	og_type: z.enum(['article', 'website', 'product']).optional(),
+	twitter_card: z.enum(['summary', 'summary_large_image']).optional(),
+	head: z.array(OSRSHeadTagSchema).optional(),
+	noindex: z.boolean().optional(),
+	canonical: z.string().url().optional(), // proto: canonical
+});
+
+export type OSRSMeta = z.infer<typeof OSRSMetaSchema>;
+
+// ============================================================================
+// Item Properties — proto: OSRSItemProperties
+// ============================================================================
+
+export const OSRSItemPropertiesSchema = z.object({
+	release_date: z.string().optional(),
+	update: z.string().optional(),
+	tradeable: z.boolean().optional(),
+	tradeable_ge: z.boolean().optional(),
+	stackable: z.boolean().optional(),
+	noteable: z.boolean().optional(),
+	equipable: z.boolean().optional(),
+	edible: z.boolean().optional(),
+	quest_item: z.boolean().optional(),
+	quest: z.string().optional(),
+	options: z.array(z.string()).optional(),
+	bankable: z.boolean().optional(),
+	placeholder: z.boolean().optional(),
+	weight: z.number().optional(),
+	league_region: z.string().optional(), // MDX-only, not in proto
+});
+
+export type OSRSItemProperties = z.infer<typeof OSRSItemPropertiesSchema>;
+
+// ============================================================================
+// Equipment Slots — proto: OSRSSlot enum
+// ============================================================================
+
+export const OSRSEquipmentSlots = [
+	'head',
+	'cape',
+	'neck',
+	'ammo',
+	'weapon',
+	'body',
+	'shield',
+	'legs',
+	'hands',
+	'feet',
+	'ring',
+	'2h',
+] as const;
+
+export type OSRSEquipmentSlot = (typeof OSRSEquipmentSlots)[number];
+
+export const OSRSEquipmentSlotSchema = z.enum(OSRSEquipmentSlots);
+
+// ============================================================================
+// Weapon Types — proto: OSRSWeaponType enum
+// ============================================================================
+
+export const OSRSWeaponTypes = [
+	'unarmed',
+	'axe',
+	'blunt',
+	'bow',
+	'bulwark',
+	'chinchompa',
+	'claw',
+	'crossbow',
+	'gun',
+	'pickaxe',
+	'polearm',
+	'polestaff',
+	'powered-staff',
+	'salamander',
+	'scythe',
+	'slash-sword',
+	'spear',
+	'spiked',
+	'stab-sword',
+	'staff',
+	'thrown',
+	'two-handed-sword',
+	'whip',
+] as const;
+
+export type OSRSWeaponType = (typeof OSRSWeaponTypes)[number];
+
+export const OSRSWeaponTypeSchema = z.enum(OSRSWeaponTypes);
+
+// ============================================================================
+// Combat Styles (frontend-only, not in proto)
+// ============================================================================
+
+export const OSRSCombatStyles = [
+	'stab',
+	'slash',
+	'crush',
+	'magic',
+	'ranged',
+	'defensive',
+	'controlled',
+	'accurate',
+	'aggressive',
+	'rapid',
+	'longrange',
+] as const;
+
+export type OSRSCombatStyle = (typeof OSRSCombatStyles)[number];
+
+export const OSRSCombatStyleSchema = z.enum(OSRSCombatStyles);
+
+// ============================================================================
+// Stat Bonuses — proto: OSRSAttackBonus, OSRSDefenceBonus, OSRSOtherBonus
+// ============================================================================
+
+export const OSRSAttackBonusSchema = z.object({
+	stab: z.number().optional(),
+	slash: z.number().optional(),
+	crush: z.number().optional(),
+	magic: z.number().optional(),
+	ranged: z.number().optional(),
+});
+
+export type OSRSAttackBonus = z.infer<typeof OSRSAttackBonusSchema>;
+
+export const OSRSDefenceBonusSchema = z.object({
+	stab: z.number().optional(),
+	slash: z.number().optional(),
+	crush: z.number().optional(),
+	magic: z.number().optional(),
+	ranged: z.number().optional(),
+});
+
+export type OSRSDefenceBonus = z.infer<typeof OSRSDefenceBonusSchema>;
+
+export const OSRSOtherBonusSchema = z.object({
+	melee_strength: z.number().optional(),
+	ranged_strength: z.number().optional(),
+	magic_damage: z.number().optional(),
+	prayer: z.number().optional(),
+});
+
+export type OSRSOtherBonus = z.infer<typeof OSRSOtherBonusSchema>;
+
+// ============================================================================
+// Skill Requirements — proto: OSRSRequirements
+// ============================================================================
+
+export const OSRSSkills = [
+	'attack',
+	'strength',
+	'defence',
+	'ranged',
+	'prayer',
+	'magic',
+	'runecraft',
+	'hitpoints',
+	'crafting',
+	'mining',
+	'smithing',
+	'fishing',
+	'cooking',
+	'firemaking',
+	'woodcutting',
+	'agility',
+	'herblore',
+	'thieving',
+	'fletching',
+	'slayer',
+	'farming',
+	'construction',
+	'hunter',
+] as const;
+
+export type OSRSSkill = (typeof OSRSSkills)[number];
+
+export const OSRSRequirementsSchema = z.object({
+	attack: z.number().min(1).max(99).optional(),
+	strength: z.number().min(1).max(99).optional(),
+	defence: z.number().min(1).max(99).optional(),
+	ranged: z.number().min(1).max(99).optional(),
+	prayer: z.number().min(1).max(99).optional(),
+	magic: z.number().min(1).max(99).optional(),
+	runecraft: z.number().min(1).max(99).optional(),
+	hitpoints: z.number().min(1).max(99).optional(),
+	crafting: z.number().min(1).max(99).optional(),
+	mining: z.number().min(1).max(99).optional(),
+	smithing: z.number().min(1).max(99).optional(),
+	fishing: z.number().min(1).max(99).optional(),
+	cooking: z.number().min(1).max(99).optional(),
+	firemaking: z.number().min(1).max(99).optional(),
+	woodcutting: z.number().min(1).max(99).optional(),
+	agility: z.number().min(1).max(99).optional(),
+	herblore: z.number().min(1).max(99).optional(),
+	thieving: z.number().min(1).max(99).optional(),
+	fletching: z.number().min(1).max(99).optional(),
+	slayer: z.number().min(1).max(99).optional(),
+	farming: z.number().min(1).max(99).optional(),
+	construction: z.number().min(1).max(99).optional(),
+	hunter: z.number().min(1).max(99).optional(),
+	quest: z.string().optional(),
+});
+
+export type OSRSRequirements = z.infer<typeof OSRSRequirementsSchema>;
+
+// ============================================================================
+// Equipment — proto: OSRSEquipment
+// ============================================================================
+
+export const OSRSEquipmentSchema = z
+	.object({
+		slot: z.string().nullable().optional(), // proto: OSRSSlot enum
+		weapon_type: z.string().nullable().optional(), // proto: OSRSWeaponType enum
+		weight: z.number().nullable().optional(),
+		attack_speed: z.number().min(1).max(10).nullable().optional(),
+		attack_range: z.number().min(1).max(10).nullable().optional(),
+		tradeable: z.boolean().nullable().optional(),
+		degradable: z.boolean().nullable().optional(),
+		degrade_hours: z.number().nullable().optional(),
+		requirements: OSRSRequirementsSchema.nullable().optional(),
+		attack_bonus: OSRSAttackBonusSchema.nullable().optional(),
+		defence_bonus: OSRSDefenceBonusSchema.nullable().optional(),
+		other_bonus: OSRSOtherBonusSchema.nullable().optional(),
+	})
+	.passthrough();
+
+export type OSRSEquipment = z.infer<typeof OSRSEquipmentSchema>;
+
+// ============================================================================
+// Special Attack — proto: OSRSSpecialAttack
+// ============================================================================
+
+export const OSRSSpecialAttackSchema = z
+	.object({
+		name: z.string().optional(),
+		energy: z.number().min(0).max(100).optional(),
+		description: z.string().optional(),
+		accuracy_modifier: z.number().optional(),
+		damage_modifier: z.number().optional(),
+		heals: z.boolean().optional(),
+		drains_defence: z.boolean().optional(),
+		drains_stats: z.boolean().optional(),
+		freezes: z.boolean().optional(),
+		freeze_duration: z.number().optional(),
+	})
+	.passthrough();
+
+export type OSRSSpecialAttack = z.infer<typeof OSRSSpecialAttackSchema>;
+
+// ============================================================================
+// Set Bonus — proto: OSRSSetBonus
+// ============================================================================
+
+export const OSRSSetBonusSchema = z.object({
+	set_name: z.string().optional(),
+	pieces_required: z.number().min(2).max(5).optional(),
+	description: z.string().optional(),
+	pieces: z.array(z.number()).optional(),
+});
+
+export type OSRSSetBonus = z.infer<typeof OSRSSetBonusSchema>;
+
+// ============================================================================
+// Drop Sources — proto: OSRSDropSource
+// ============================================================================
+
+export const OSRSDropRarities = [
+	'always',
+	'common',
+	'uncommon',
+	'rare',
+	'very-rare',
+	'varies',
+] as const;
+
+export type OSRSDropRarity = (typeof OSRSDropRarities)[number];
+
+export const OSRSDropSourceSchema = z
+	.object({
+		source: z.string(), // proto: source
+		source_id: z.number().nullable().optional(), // MDX-only
+		combat_level: z.number().nullable().optional(),
+		quantity: z.string().nullable().optional(),
+		rarity: z.string().nullable().optional(), // proto: OSRSRarity enum
+		drop_rate: z.string().nullable().optional(),
+		drop_rate_decimal: z.number().nullable().optional(), // MDX-only
+		members_only: z.boolean().nullable().optional(),
+		wilderness: z.boolean().nullable().optional(),
+	})
+	.passthrough();
+
+export type OSRSDropSource = z.infer<typeof OSRSDropSourceSchema>;
+
+/**
+ * Drop table — proto uses flat `repeated OSRSDropSource drop_sources`,
+ * but MDX frontmatter supports both object format and array format.
+ * MDX field name: drop_table (proto: drop_sources)
+ */
+export const OSRSDropTableSchema = z.union([
+	z.object({
+		sources: z.array(OSRSDropSourceSchema).optional(),
+		primary_source: z.string().optional(),
+		best_drop_rate: z.string().optional(),
+	}),
+	z.array(OSRSDropSourceSchema),
+]);
+
+export type OSRSDropTable = z.infer<typeof OSRSDropTableSchema>;
+
+// ============================================================================
+// Shop Sources — proto: OSRSShopSource
+// ============================================================================
+
+export const OSRSShopSourceSchema = z.object({
+	shop_name: z.string(),
+	location: z.string().optional(),
+	price: z.union([z.number(), z.string()]).optional(),
+	stock: z.union([z.number(), z.string()]).optional(),
+	members_only: z.boolean().optional(), // MDX-only
+	currency: z.string().optional(),
+});
+
+export type OSRSShopSource = z.infer<typeof OSRSShopSourceSchema>;
+
+// ============================================================================
+// Skilling Sources — proto: OSRSSkillingSource
+// ============================================================================
+
+export const OSRSSkillingSourceSchema = z.object({
+	skill: z.string().transform((s) => s.toLowerCase()),
+	level: z.number().min(1).max(99),
+	xp: z.number().optional(),
+	location: z.string().optional(),
+	method: z.string().optional(),
+	catch_rate: z.number().optional(),
+	success_rate: z.number().optional(),
+	tool: z.string().optional(),
+	bait: z.string().optional(),
+	members_only: z.boolean().optional(),
+});
+
+export type OSRSSkillingSource = z.infer<typeof OSRSSkillingSourceSchema>;
+
+// ============================================================================
+// Recipes — proto: OSRSRecipe, OSRSRecipeMaterial
+// ============================================================================
+
+export const OSRSCreationSkills = [
+	'herblore',
+	'crafting',
+	'smithing',
+	'fletching',
+	'cooking',
+	'construction',
+	'runecraft',
+	'magic',
+	'firemaking',
+] as const;
+
+export type OSRSCreationSkill = (typeof OSRSCreationSkills)[number];
+
+/** proto: OSRSRecipeMaterial */
+export const OSRSMaterialSchema = z.object({
+	item_id: z.number().optional(),
+	item_name: z.string(),
+	quantity: z.number().default(1),
+	consumed: z.boolean().default(true),
+});
+
+export type OSRSMaterial = z.infer<typeof OSRSMaterialSchema>;
+
+const lowercaseSkill = z
+	.string()
+	.transform((s) => s.toLowerCase())
+	.nullable()
+	.optional();
+
+export const OSRSRecipeSchema = z
+	.object({
+		skill: lowercaseSkill,
+		level: z.number().min(0).max(99).nullable().optional(),
+		xp: z.number().nullable().optional(),
+		materials: z.array(OSRSMaterialSchema).nullable().optional(),
+		tools: z.array(z.string()).nullable().optional(), // MDX-only
+		facility: z.string().nullable().optional(),
+		ticks: z.number().nullable().optional(),
+		quest_required: z.string().nullable().optional(), // MDX-only
+		members_only: z.boolean().nullable().optional(), // MDX-only
+		output_quantity: z.number().nullable().optional(), // MDX-only
+	})
+	.passthrough();
+
+export type OSRSRecipe = z.infer<typeof OSRSRecipeSchema>;
+
+// ============================================================================
+// Consumables — proto: OSRSConsumable → MDX: potion
+// ============================================================================
+
+/** proto: OSRSConsumable (renamed to potion for MDX backwards compat) */
+export const OSRSPotionSchema = z
+	.object({
+		doses: z.number().min(0).max(4).nullable().optional(),
+		herblore_level: z.number().min(1).max(99).nullable().optional(),
+		herblore_xp: z.number().nullable().optional(),
+		effects: z
+			.array(
+				z
+					.object({
+						stat: z
+							.string()
+							.transform((s) => s.toLowerCase())
+							.nullable()
+							.optional(),
+						boost_type: z.string().nullable().optional(),
+						boost_value: z.number().nullable().optional(),
+						boost_formula: z.string().nullable().optional(),
+						duration: z.number().nullable().optional(),
+					})
+					.passthrough(),
+			)
+			.nullable()
+			.optional(),
+	})
+	.passthrough();
+
+export type OSRSPotion = z.infer<typeof OSRSPotionSchema>;
+
+// ============================================================================
+// Food — proto: OSRSFood
+// ============================================================================
+
+export const OSRSFoodSchema = z
+	.object({
+		heals: z.number().nullable().optional(),
+		heals_formula: z.string().nullable().optional(),
+		overheal: z.boolean().nullable().optional(),
+		cooking_level: z.number().min(1).max(99).nullable().optional(),
+		cooking_xp: z.number().nullable().optional(), // MDX-only
+		burn_level: z.number().nullable().optional(), // MDX-only
+	})
+	.passthrough();
+
+export type OSRSFood = z.infer<typeof OSRSFoodSchema>;
+
+// ============================================================================
+// Cooking — proto: OSRSCooking, OSRSCookingBurnRate
+// ============================================================================
+
+export const OSRSCookingSchema = z
+	.object({
+		level: z.number().min(0).max(99).nullable().optional(), // proto: cooking_level
+		xp: z.number().nullable().optional(), // proto: cooking_xp
+		stop_burn_level: z.number().nullable().optional(),
+		stop_burn_level_gauntlets: z.number().nullable().optional(),
+		stop_burn_level_hosidius: z.number().nullable().optional(),
+		burn_rates: z
+			.array(
+				z
+					.object({
+						level: z.number().nullable().optional(),
+						fire_rate: z.number().nullable().optional(), // proto: fire_success
+						range_rate: z.number().nullable().optional(), // proto: range_success
+						gauntlets_rate: z.number().nullable().optional(), // proto: gauntlets_success
+					})
+					.passthrough(),
+			)
+			.nullable()
+			.optional(),
+		raw_item_id: z.number().nullable().optional(),
+		raw_item_name: z.string().nullable().optional(),
+		ticks: z.number().nullable().optional(),
+		burnt_item_id: z.number().nullable().optional(),
+	})
+	.passthrough();
+
+export type OSRSCooking = z.infer<typeof OSRSCookingSchema>;
+
+// ============================================================================
+// Treasure Trails — proto: OSRSTreasureTrail
+// ============================================================================
+
+export const OSRSTreasureTrailSchema = z.object({
+	tier: z.enum(['beginner', 'easy', 'medium', 'hard', 'elite', 'master']),
+	emotes: z.array(z.string()).optional(),
+	stash_location: z.string().optional(),
+	required_items: z.array(z.string()).optional(),
+	is_reward: z.boolean().optional(),
+	reward_tiers: z
+		.array(
+			z.enum(['beginner', 'easy', 'medium', 'hard', 'elite', 'master']),
+		)
+		.optional(),
+});
+
+export type OSRSTreasureTrail = z.infer<typeof OSRSTreasureTrailSchema>;
+
+// ============================================================================
+// Related Items — proto: OSRSRelatedItem
+// ============================================================================
+
+export const OSRSRelatedItemSchema = z.object({
+	item_id: z.number().optional(),
+	item_name: z.string().optional(),
+	slug: z.string().optional(),
+	relationship: z
+		.enum([
+			'variant',
+			'upgrade',
+			'downgrade',
+			'component',
+			'product',
+			'set-piece',
+			'alternative',
+		])
+		.optional(),
+	description: z.string().optional(), // MDX-only
+});
+
+export type OSRSRelatedItem = z.infer<typeof OSRSRelatedItemSchema>;
+
+// ============================================================================
+// Price — proto: OSRSPrice
+// ============================================================================
+
+export const OSRSPriceSchema = z.object({
+	high_price: z.number().nullable().optional(),
+	high_time: z.number().nullable().optional(),
+	low_price: z.number().nullable().optional(),
+	low_time: z.number().nullable().optional(),
+});
+
+export type OSRSPrice = z.infer<typeof OSRSPriceSchema>;
+
+// ============================================================================
+// Complete OSRS Item — proto: OSRSItem
+// ============================================================================
+
+export const OSRSExtendedSchema = z.object({
+	// Base fields — proto: id, name, slug, examine, members, icon, value
+	id: z.number(),
+	name: z.string(),
+	slug: z.string(),
+	examine: z.string(),
+	members: z.boolean(),
+	icon: z.string(),
+	value: z.number(),
+	lowalch: z.number().nullable(),
+	highalch: z.number().nullable(),
+	limit: z.number().nullable(), // proto: ge_limit
+
+	// SEO / Meta
+	meta: OSRSMetaSchema.optional(),
+
+	// Item properties
+	properties: OSRSItemPropertiesSchema.optional(),
+
+	// Equipment (weapons + armor) — proto: equipment, special_attack, set_bonus
+	equipment: OSRSEquipmentSchema.optional(),
+	special_attack: OSRSSpecialAttackSchema.optional(),
+	set_bonus: OSRSSetBonusSchema.optional(),
+
+	// Consumable data — proto: consumable (→ potion), food, cooking
+	potion: OSRSPotionSchema.optional(), // proto field: consumable
+	food: OSRSFoodSchema.optional(),
+	cooking: OSRSCookingSchema.optional(),
+
+	// Sources — proto: drop_sources (→ drop_table), shops, skilling_source
+	drop_table: OSRSDropTableSchema.optional(), // proto field: drop_sources
+	shops: z.array(OSRSShopSourceSchema).optional(),
+	skilling_source: OSRSSkillingSourceSchema.optional(),
+
+	// Creation — proto: recipes
+	recipes: z.array(OSRSRecipeSchema).optional(),
+
+	// Treasure trails — proto: treasure_trail
+	treasure_trail: OSRSTreasureTrailSchema.optional(),
+
+	// Related items — proto: related_items
+	related_items: z.array(OSRSRelatedItemSchema).optional(),
+
+	// Price (runtime data, not typically in frontmatter)
+	price: OSRSPriceSchema.optional(),
+});
+
+export type OSRSExtended = z.infer<typeof OSRSExtendedSchema>;
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+export function hasEquipment(
+	item: OSRSExtended,
+): item is OSRSExtended & { equipment: OSRSEquipment } {
+	return item.equipment !== undefined;
+}
+
+export function isWeapon(item: OSRSExtended): boolean {
+	return item.equipment?.slot === 'weapon' || item.equipment?.slot === '2h';
+}
+
+export function hasSpecialAttack(
+	item: OSRSExtended,
+): item is OSRSExtended & { special_attack: OSRSSpecialAttack } {
+	return item.special_attack !== undefined;
+}
+
+export function hasSetBonus(
+	item: OSRSExtended,
+): item is OSRSExtended & { set_bonus: OSRSSetBonus } {
+	return item.set_bonus !== undefined;
+}
+
+export function isPotion(
+	item: OSRSExtended,
+): item is OSRSExtended & { potion: OSRSPotion } {
+	return item.potion !== undefined;
+}
+
+export function isFood(
+	item: OSRSExtended,
+): item is OSRSExtended & { food: OSRSFood } {
+	return item.food !== undefined;
+}
+
+export function hasCooking(
+	item: OSRSExtended,
+): item is OSRSExtended & { cooking: OSRSCooking } {
+	return item.cooking !== undefined;
+}
+
+export function hasDropSources(
+	item: OSRSExtended,
+): item is OSRSExtended & { drop_table: OSRSDropTable } {
+	if (item.drop_table === undefined) return false;
+	if (Array.isArray(item.drop_table)) {
+		return item.drop_table.length > 0;
+	}
+	return (item.drop_table.sources?.length ?? 0) > 0;
+}
+
+export function hasShopSources(item: OSRSExtended): boolean {
+	return (item.shops?.length ?? 0) > 0;
+}
+
+export function hasRecipes(item: OSRSExtended): boolean {
+	return (item.recipes?.length ?? 0) > 0;
+}
+
+export function isTreasureTrailItem(
+	item: OSRSExtended,
+): item is OSRSExtended & { treasure_trail: OSRSTreasureTrail } {
+	return item.treasure_trail !== undefined;
+}
+
+export function hasMeta(
+	item: OSRSExtended,
+): item is OSRSExtended & { meta: OSRSMeta } {
+	return item.meta !== undefined;
+}
+
+export function hasProperties(
+	item: OSRSExtended,
+): item is OSRSExtended & { properties: OSRSItemProperties } {
+	return item.properties !== undefined;
+}
+
+export function isTradeable(item: OSRSExtended): boolean {
+	return (
+		item.properties?.tradeable === true ||
+		item.properties?.tradeable_ge === true
+	);
+}
+
+export function isQuestItem(item: OSRSExtended): boolean {
+	return item.properties?.quest_item === true;
+}
+
+export function hasRelatedItems(item: OSRSExtended): boolean {
+	return (item.related_items?.length ?? 0) > 0;
+}
+
+export function generateMetaDescription(item: OSRSExtended): string {
+	const parts: string[] = [item.name];
+
+	if (item.members) {
+		parts.push('(P2P)');
+	}
+
+	if (hasEquipment(item) && item.equipment.slot) {
+		parts.push(`- ${item.equipment.slot} slot equipment`);
+	} else if (isPotion(item)) {
+		parts.push('- potion');
+	} else if (isFood(item)) {
+		parts.push(`- heals ${item.food.heals ?? '?'} HP`);
+	}
+
+	parts.push(`in Old School RuneScape. ${item.examine}`);
+
+	const description = parts.join(' ');
+	return description.length > 160
+		? description.substring(0, 157) + '...'
+		: description;
+}

--- a/apps/kbve/astro-kbve/src/data/schema/osrs/index.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/osrs/index.ts
@@ -1,1 +1,1 @@
-export * from './IOSRSSchema';
+export * from './generated';

--- a/packages/data/proto/kbve/osrs.proto
+++ b/packages/data/proto/kbve/osrs.proto
@@ -134,30 +134,33 @@ enum OSRSRelationship {
 }
 
 // =============================================================================
-// Equipment & Bonuses
+// Equipment & Bonuses (Weapons + Armor)
 // =============================================================================
 
-// 14 combat bonus fields (5 attack, 5 defence, 4 other)
-message OSRSBonuses {
-  // Attack bonuses
-  int32 attack_stab   = 1;
-  int32 attack_slash  = 2;
-  int32 attack_crush  = 3;
-  int32 attack_magic  = 4;
-  int32 attack_ranged = 5;
+// Offensive bonuses — primarily for weapons
+message OSRSAttackBonus {
+  optional int32 stab   = 1;
+  optional int32 slash  = 2;
+  optional int32 crush  = 3;
+  optional int32 magic  = 4;
+  optional int32 ranged = 5;
+}
 
-  // Defence bonuses
-  int32 defence_stab   = 6;
-  int32 defence_slash  = 7;
-  int32 defence_crush  = 8;
-  int32 defence_magic  = 9;
-  int32 defence_ranged = 10;
+// Defensive bonuses — primarily for armor
+message OSRSDefenceBonus {
+  optional int32 stab   = 1;
+  optional int32 slash  = 2;
+  optional int32 crush  = 3;
+  optional int32 magic  = 4;
+  optional int32 ranged = 5;
+}
 
-  // Other bonuses
-  int32 melee_strength  = 11;
-  int32 ranged_strength = 12;
-  int32 magic_damage    = 13;  // Percentage (e.g., 5 = 5%)
-  int32 prayer          = 14;
+// Other bonuses — strength, prayer, magic damage
+message OSRSOtherBonus {
+  optional int32 melee_strength  = 1;
+  optional int32 ranged_strength = 2;
+  optional int32 magic_damage    = 3;  // Percentage (e.g., 5 = 5%)
+  optional int32 prayer          = 4;
 }
 
 // Skill requirements for equipment (all 23 skills + quest)
@@ -188,17 +191,43 @@ message OSRSRequirements {
   optional string quest       = 24;
 }
 
-// Equipment stats for wearable items
+// Equipment stats for wearable/wieldable items (weapons + armor)
 message OSRSEquipment {
-  OSRSSlot slot                  = 1;
-  OSRSWeaponType weapon_type     = 2;
-  optional float weight          = 3;   // kg
-  optional int32 attack_speed    = 4;   // Game ticks (1-10)
-  optional int32 attack_range    = 5;   // Tiles (1-10)
-  optional bool tradeable        = 6;
-  optional bool degradable       = 7;
-  optional OSRSBonuses bonuses   = 8;
-  optional OSRSRequirements requirements = 9;
+  OSRSSlot slot                            = 1;
+  OSRSWeaponType weapon_type               = 2;
+  optional float weight                    = 3;   // kg
+  optional int32 attack_speed              = 4;   // Game ticks (1-10), weapons
+  optional int32 attack_range              = 5;   // Tiles (1-10), weapons
+  optional bool tradeable                  = 6;
+  optional bool degradable                 = 7;
+  optional float degrade_hours             = 8;   // Hours of combat before degrading
+  optional OSRSRequirements requirements   = 9;
+  // Bonus groups — nested to match component access pattern
+  optional OSRSAttackBonus attack_bonus    = 10;  // Weapon offensive stats
+  optional OSRSDefenceBonus defence_bonus  = 11;  // Armor defensive stats
+  optional OSRSOtherBonus other_bonus      = 12;  // Strength, prayer, etc.
+}
+
+// Weapon special attack (e.g., Dragon dagger, AGS, Abyssal whip)
+message OSRSSpecialAttack {
+  optional string name                = 1;
+  optional int32 energy               = 2;   // Percentage 0-100
+  optional string description         = 3;
+  optional float accuracy_modifier    = 4;   // Multiplier (2 = double accuracy)
+  optional float damage_modifier      = 5;   // Multiplier (1.25 = +25% damage)
+  optional bool heals                 = 6;
+  optional bool drains_defence        = 7;
+  optional bool drains_stats          = 8;
+  optional bool freezes               = 9;
+  optional int32 freeze_duration      = 10;  // Ticks
+}
+
+// Armor set bonuses (Barrows, Void, Inquisitor's, etc.)
+message OSRSSetBonus {
+  optional string set_name            = 1;
+  optional int32 pieces_required      = 2;   // Min pieces for bonus (2-5)
+  optional string description         = 3;
+  repeated int32 pieces               = 4;   // Item IDs in the set
 }
 
 // =============================================================================
@@ -239,7 +268,7 @@ message OSRSRecipe {
 }
 
 // =============================================================================
-// Consumables
+// Consumables (Potions + Food)
 // =============================================================================
 
 // Potion/buff effect per dose
@@ -251,12 +280,123 @@ message OSRSEffect {
   optional int32 duration         = 5;   // Ticks
 }
 
-// Consumable item data (potions and food)
+// Potion data (Super combat, Prayer, etc.)
 message OSRSConsumable {
   optional int32 heals            = 1;   // HP healed (food)
   optional int32 doses            = 2;   // Potion doses (0-4)
   optional int32 cooking_level    = 3;   // Required cooking level
   repeated OSRSEffect effects     = 4;   // Potion effects per dose
+}
+
+// Food-specific data (separate from generic consumable)
+message OSRSFood {
+  optional int32 heals            = 1;   // HP healed
+  optional string heals_formula   = 2;   // e.g., "floor(max_hp * 0.06)"
+  optional bool overheal          = 3;   // Can heal above max HP (e.g., Anglerfish)
+  optional int32 cooking_level    = 4;   // Required cooking level
+}
+
+// Cooking burn rate at a specific level
+message OSRSCookingBurnRate {
+  int32 level                     = 1;
+  optional float fire_success     = 2;   // Success rate on fire (0.0-1.0)
+  optional float range_success    = 3;   // Success rate on range
+  optional float gauntlets_success = 4;  // Success rate with cooking gauntlets
+}
+
+// Cooking data (burn rates, stop-burn levels, etc.)
+message OSRSCooking {
+  optional int32 cooking_level    = 1;
+  optional float cooking_xp       = 2;
+  optional int32 stop_burn_level  = 3;   // Level at which burning stops (fire)
+  optional int32 stop_burn_level_gauntlets = 4; // With cooking gauntlets
+  optional int32 stop_burn_level_hosidius  = 5; // With Hosidius range
+  optional int32 raw_item_id      = 6;
+  optional string raw_item_name   = 7;
+  optional int32 burnt_item_id    = 8;
+  optional int32 ticks            = 9;   // Game ticks per cook
+  repeated OSRSCookingBurnRate burn_rates = 10;
+}
+
+// =============================================================================
+// Shops & Obtaining
+// =============================================================================
+
+// Shop purchase source
+message OSRSShopSource {
+  optional string shop_name       = 1;
+  optional string location        = 2;
+  optional string price           = 3;   // String to handle "Free", "N/A"
+  optional int32 stock            = 4;
+  optional string currency        = 5;   // "coins", "tokkul", etc.
+}
+
+// Skilling source (fishing, mining, hunter, etc.)
+message OSRSSkillingSource {
+  optional string skill           = 1;
+  optional int32 level            = 2;
+  optional float xp               = 3;
+  optional string location        = 4;
+  optional string method          = 5;   // e.g., "Net fishing", "Barb-tail harpoon"
+  optional float catch_rate       = 6;
+  optional float success_rate     = 7;
+  optional string tool            = 8;
+  optional string bait            = 9;
+  optional bool members_only      = 10;
+}
+
+// =============================================================================
+// Treasure Trails (Clue Scrolls)
+// =============================================================================
+
+message OSRSTreasureTrail {
+  optional string tier            = 1;   // beginner/easy/medium/hard/elite/master
+  repeated string emotes          = 2;
+  optional string stash_location  = 3;
+  repeated string required_items  = 4;
+  optional bool is_reward         = 5;
+  repeated string reward_tiers    = 6;
+}
+
+// =============================================================================
+// Related Items
+// =============================================================================
+
+message OSRSRelatedItem {
+  optional int32 item_id          = 1;
+  optional string item_name       = 2;
+  optional string relationship    = 3;   // variant/upgrade/downgrade/component/product/set-piece/alternative
+  optional string slug            = 4;
+}
+
+// =============================================================================
+// Item Properties & Metadata
+// =============================================================================
+
+// Wiki infobox properties
+message OSRSItemProperties {
+  optional string release_date    = 1;
+  optional string update          = 2;
+  optional bool tradeable         = 3;
+  optional bool tradeable_ge      = 4;
+  optional bool stackable         = 5;
+  optional bool noteable          = 6;
+  optional bool equipable         = 7;
+  optional bool edible            = 8;
+  optional bool quest_item        = 9;
+  optional string quest           = 10;
+  repeated string options         = 11;  // Right-click options
+  optional bool bankable          = 12;
+  optional bool placeholder       = 13;
+  optional float weight           = 14;  // kg (for non-equipment items)
+}
+
+// SEO and page metadata
+message OSRSMeta {
+  optional string description     = 1;   // Max ~160 chars
+  repeated string keywords        = 2;
+  optional string og_image        = 3;
+  optional string canonical       = 4;
 }
 
 // =============================================================================
@@ -277,6 +417,7 @@ message OSRSPrice {
 
 // Complete OSRS item with all optional nested data
 message OSRSItem {
+  // Base fields (from Wiki API)
   int64 id                            = 1;   // OSRS item ID
   string name                         = 2;
   string slug                         = 3;   // URL-safe slug
@@ -288,12 +429,32 @@ message OSRSItem {
   optional int32 highalch             = 9;
   optional int32 ge_limit             = 10;  // GE buy limit per 4 hours
 
-  // Nested optional data
+  // Equipment (weapons + armor)
   optional OSRSEquipment equipment    = 11;
-  repeated OSRSDropSource drop_sources = 12;
-  repeated OSRSRecipe recipes         = 13;
-  optional OSRSConsumable consumable  = 14;
-  optional OSRSPrice price            = 15;
+  optional OSRSSpecialAttack special_attack = 12;
+  optional OSRSSetBonus set_bonus     = 13;
+
+  // Sources (where to get it)
+  repeated OSRSDropSource drop_sources = 14;
+  repeated OSRSShopSource shops       = 15;
+  optional OSRSSkillingSource skilling_source = 16;
+
+  // Creation (how to make it)
+  repeated OSRSRecipe recipes         = 17;
+
+  // Consumable data
+  optional OSRSConsumable consumable  = 18;
+  optional OSRSFood food              = 19;
+  optional OSRSCooking cooking        = 20;
+
+  // Relationships & classification
+  repeated OSRSRelatedItem related_items = 21;
+  optional OSRSTreasureTrail treasure_trail = 22;
+
+  // Metadata
+  optional OSRSItemProperties properties = 23;
+  optional OSRSMeta meta              = 24;
+  optional OSRSPrice price            = 25;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- **Expand `osrs.proto`** from ~160 to ~520 lines — restructure bonuses into nested messages (`OSRSAttackBonus`, `OSRSDefenceBonus`, `OSRSOtherBonus`), add 12 new messages covering special attacks, set bonuses, food, cooking, shops, skilling sources, treasure trails, related items, item properties, SEO meta, and price data
- **Fix `buf.gen.yaml`** — add `snakeToCamel=false` for snake_case TypeScript interfaces, remove defunct `useZod=true` option
- **Add `generated.ts`** — proto-aligned Zod schema with type guards, replacing hand-written `IOSRSSchema.ts` as the active export. Documents proto ↔ Zod field name mappings (`ge_limit` → `limit`, `drop_sources` → `drop_table`, `consumable` → `potion`)

## Verification

- `astro check` — 0 errors, 0 warnings
- `astro dev` — starts clean, content syncs successfully
- All existing component imports (`@/data/schema`) resolve unchanged

## Follow-up

- Custom proto → descriptor → Zod generator (`@kbve/devops`) to eliminate hand-written Zod drift
- Proto ↔ SQL schema integration
- Delete legacy `IOSRSSchema.ts` once all components verified

## Test plan

- [x] `astro check` passes with 0 errors
- [x] `astro dev` starts and content syncs
- [ ] Spot-check OSRS item pages render correctly
- [ ] Verify no regressions in existing OSRS components

🤖 Generated with [Claude Code](https://claude.com/claude-code)