### PR TITLE
feat(n8n): add kubernetes manifests and database schema for n8n integration

### DIFF
--- a/apps/kube/n8n/application.yaml
+++ b/apps/kube/n8n/application.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: n8n
+    namespace: argocd
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: HEAD
+        path: apps/kube/n8n/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: n8n
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+            allowEmpty: false
+        syncOptions:
+            - CreateNamespace=true
+            - PrunePropagationPolicy=foreground
+            - PruneLast=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m
+    revisionHistoryLimit: 3

--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: n8n
+    namespace: n8n
+    labels:
+        app: n8n
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: n8n
+    template:
+        metadata:
+            labels:
+                app: n8n
+        spec:
+            serviceAccountName: n8n-sa
+            containers:
+                - name: n8n
+                  image: n8nio/n8n:2.9.4
+                  imagePullPolicy: IfNotPresent
+                  ports:
+                      - name: http
+                        containerPort: 5678
+                        protocol: TCP
+                  envFrom:
+                      - secretRef:
+                            name: n8n-redis-secret
+                  env:
+                      # PostgreSQL (shared supabase database, dedicated n8n schema)
+                      - name: DB_TYPE
+                        value: 'postgresdb'
+                      - name: DB_POSTGRESDB_HOST
+                        value: 'supabase-cluster-rw.kilobase.svc.cluster.local'
+                      - name: DB_POSTGRESDB_PORT
+                        value: '5432'
+                      - name: DB_POSTGRESDB_DATABASE
+                        value: 'supabase'
+                      - name: DB_POSTGRESDB_USER
+                        value: 'postgres'
+                      - name: DB_POSTGRESDB_SCHEMA
+                        value: 'n8n'
+                      - name: DB_POSTGRESDB_POOL_SIZE
+                        value: '10'
+                      - name: DB_POSTGRESDB_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: n8n-supabase-shared
+                                key: db-password
+                      # Redis (queue-based execution)
+                      - name: EXECUTIONS_MODE
+                        value: 'queue'
+                      - name: QUEUE_BULL_REDIS_HOST
+                        value: 'redis-master.redis.svc.cluster.local'
+                      - name: QUEUE_BULL_REDIS_PORT
+                        value: '6379'
+                      # n8n configuration
+                      - name: N8N_PORT
+                        value: '5678'
+                      - name: GENERIC_TIMEZONE
+                        value: 'UTC'
+                      - name: N8N_ENCRYPTION_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: n8n-encryption-secret
+                                key: encryption-key
+                  resources:
+                      requests:
+                          memory: '512Mi'
+                          cpu: '500m'
+                      limits:
+                          memory: '1024Mi'
+                          cpu: '1000m'
+                  livenessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: http
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: http
+                      initialDelaySeconds: 10
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3

--- a/apps/kube/n8n/manifest/n8n-externalsecret.yaml
+++ b/apps/kube/n8n/manifest/n8n-externalsecret.yaml
@@ -1,0 +1,103 @@
+# ServiceAccount for ExternalSecrets cross-namespace access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: n8n-external-secrets
+    namespace: n8n
+---
+# SecretStore: Redis namespace (for redis-auth password)
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: n8n-redis-secret-store
+    namespace: n8n
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: redis
+            auth:
+                serviceAccount:
+                    name: n8n-external-secrets
+                    namespace: n8n
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: Pull Redis password
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: n8n-redis-secrets
+    namespace: n8n
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: n8n-redis-secret-store
+        kind: SecretStore
+    target:
+        name: n8n-redis-secret
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                REDIS_PASSWORD: '{{ .redispassword }}'
+    data:
+        - secretKey: redispassword
+          remoteRef:
+              key: redis-auth
+              property: redis-password
+---
+# SecretStore: Kilobase namespace (for supabase-postgres password)
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: n8n-supabase-secret-store
+    namespace: n8n
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: n8n-external-secrets
+                    namespace: n8n
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: Pull Supabase PostgreSQL password
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: n8n-supabase-secrets
+    namespace: n8n
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: n8n-supabase-secret-store
+        kind: SecretStore
+    target:
+        name: n8n-supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                db-password: '{{ .dbpassword }}'
+    data:
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password
+---
+# TODO: Create n8n-encryption-secret SealedSecret via kubeseal before deployment:
+#   echo -n "$(openssl rand -hex 32)" | kubectl create secret generic n8n-encryption-secret \
+#     --namespace=n8n --from-file=encryption-key=/dev/stdin --dry-run=client -o yaml \
+#     | kubeseal --format yaml > n8n-encryption-sealedsecret.yaml

--- a/apps/kube/n8n/manifest/n8n-service.yaml
+++ b/apps/kube/n8n/manifest/n8n-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: n8n
+    namespace: n8n
+    labels:
+        app: n8n
+spec:
+    type: ClusterIP
+    selector:
+        app: n8n
+    ports:
+        - name: http
+          port: 5678
+          targetPort: 5678
+          protocol: TCP

--- a/apps/kube/n8n/manifest/rbac.yaml
+++ b/apps/kube/n8n/manifest/rbac.yaml
@@ -1,0 +1,85 @@
+# ServiceAccount used by the n8n Deployment pod
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: n8n-sa
+    namespace: n8n
+---
+# Role: Allow n8n ExternalSecrets SA to read redis-auth secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: n8n-redis-access
+    namespace: redis
+rules:
+    - apiGroups: ['']
+      resources: ['services', 'endpoints']
+      verbs: ['get', 'list']
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['redis-auth']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: n8n-redis-access-binding
+    namespace: redis
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: n8n-redis-access
+subjects:
+    - kind: ServiceAccount
+      name: n8n-external-secrets
+      namespace: n8n
+---
+# Role: Allow n8n ExternalSecrets SA to read supabase-postgres secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: n8n-supabase-access
+    namespace: kilobase
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-postgres']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: n8n-supabase-access-binding
+    namespace: kilobase
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: n8n-supabase-access
+subjects:
+    - kind: ServiceAccount
+      name: n8n-external-secrets
+      namespace: n8n
+---
+# NetworkPolicy: Allow n8n pods to reach Redis on port 6379
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: allow-n8n-to-redis
+    namespace: redis
+spec:
+    podSelector:
+        matchLabels:
+            app.kubernetes.io/name: redis
+    policyTypes:
+        - Ingress
+    ingress:
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        name: n8n
+              - podSelector:
+                    matchLabels:
+                        app: n8n
+          ports:
+              - protocol: TCP
+                port: 6379

--- a/packages/data/sql/dbmate/README.md
+++ b/packages/data/sql/dbmate/README.md
@@ -4,17 +4,18 @@ Manages PostgreSQL schema migrations for the KBVE Supabase cluster (`supabase-cl
 
 ## Applied Migrations
 
-| Version | Name | Schema | Objects |
-|---------|------|--------|---------|
-| `20260227210000` | `mc_schema_init` | `mc` | 6 tables, 28 functions |
-| `20260227215000` | `gen_ulid` | `public` | 1 function (`gen_ulid()`) |
-| `20260227220000` | `meme_schema_init` | `meme` | 14 tables, 18 functions |
-| `20260228000000` | `discordsh_schema_init` | `discordsh` | 2 tables, 13 functions |
-| `20260228210000` | `meme_rpcs` | `meme` | +7 service RPC functions |
-| `20260228220000` | `osrs_schema_init` | `osrs` | 9 tables, 11 functions |
-| `20260228230000` | `discordsh_update_server` | `discordsh` | +2 functions, removes direct UPDATE |
-| `20260301210000` | `meme_rpcs_v2` | `meme` | +12 service RPC functions |
-| `20260302000000` | `discordsh_guild_vault` | `discordsh` | 1 table, 7 functions (guild token vault) |
+| Version          | Name                      | Schema      | Objects                                  |
+| ---------------- | ------------------------- | ----------- | ---------------------------------------- |
+| `20260227210000` | `mc_schema_init`          | `mc`        | 6 tables, 28 functions                   |
+| `20260227215000` | `gen_ulid`                | `public`    | 1 function (`gen_ulid()`)                |
+| `20260227220000` | `meme_schema_init`        | `meme`      | 14 tables, 18 functions                  |
+| `20260228000000` | `discordsh_schema_init`   | `discordsh` | 2 tables, 13 functions                   |
+| `20260228210000` | `meme_rpcs`               | `meme`      | +7 service RPC functions                 |
+| `20260228220000` | `osrs_schema_init`        | `osrs`      | 9 tables, 11 functions                   |
+| `20260228230000` | `discordsh_update_server` | `discordsh` | +2 functions, removes direct UPDATE      |
+| `20260301210000` | `meme_rpcs_v2`            | `meme`      | +12 service RPC functions                |
+| `20260302000000` | `discordsh_guild_vault`   | `discordsh` | 1 table, 7 functions (guild token vault) |
+| `20260302100000` | `n8n_schema_init`         | `n8n`       | Schema creation for n8n workflow engine  |
 
 Migration state is tracked in `dbmate.schema_migrations` (not `public`) to isolate it from PostgREST/RPC.
 
@@ -52,6 +53,14 @@ Migration state is tracked in `dbmate.schema_migrations` (not `public`) to isola
 - **Access**: service_role only (data ingestion from OSRS APIs)
 - **Extensions**: `pg_trgm` for fuzzy item name search via `service_search_items()`
 
+### `n8n` — n8n workflow engine
+
+Schema container only — n8n TypeORM manages its own 23 tables (workflows, executions, credentials, webhooks, users, etc.) within this schema. We create the schema and grants; n8n handles all DDL on boot.
+
+- **Source**: `../schema/n8n/`
+- **Access**: postgres (superuser) + service_role (read); anon/authenticated blocked entirely
+- **Integration**: n8n workflows call KBVE service functions directly via SQL (no HTTP hop)
+
 ### `public` — Shared utilities
 
 `gen_ulid()` function for ULID primary key generation. Available to all roles.
@@ -64,7 +73,7 @@ All schemas follow the **belt-and-suspenders** pattern:
 2. **RLS on every table**: `service_role_full_access` policy, restrictive policies for other roles
 3. **Function lockdown**: Every function gets `REVOKE ALL FROM PUBLIC, anon, authenticated` + `GRANT EXECUTE TO service_role` + `OWNER TO service_role`
 4. **SECURITY DEFINER + SET search_path = ''**: On all service/proxy functions and sensitive triggers
-5. **Service/proxy pattern**: `service_*` functions take explicit `user_id` (service_role only); `proxy_*` functions derive identity from `auth.uid()` (authenticated users)
+5. **Service/proxy pattern**: `service_*` functions take explicit `user_id` (service*role only); `proxy*\*`functions derive identity from`auth.uid()` (authenticated users)
 6. **ALTER DEFAULT PRIVILEGES**: Both `IN SCHEMA` and `FOR ROLE postgres IN SCHEMA` variants ensure future objects get correct grants
 7. **Verification DO blocks**: Each migration validates function existence, privilege grants, ownership, and negative checks (anon must NOT have EXECUTE)
 
@@ -99,6 +108,8 @@ schema/
   osrs/                  # OSRS item database
     osrs_core.sql          # 9 tables, triggers, RLS
     osrs_rpcs.sql          # 4 service functions
+  n8n/                   # n8n workflow engine
+    n8n_init.sql           # Schema creation + grants (n8n TypeORM manages tables)
 ```
 
 ## Local Testing
@@ -134,7 +145,7 @@ DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/supabase?sslmode=di
   dbmate --no-dump-schema --migrations-dir migrations up
 
 # 3. Verify
-psql "postgresql://postgres:postgres@127.0.0.1:54322/supabase" -c "\dt mc.*; \dt meme.*; \dt discordsh.*; \dt osrs.*"
+psql "postgresql://postgres:postgres@127.0.0.1:54322/supabase" -c "\dt mc.*; \dt meme.*; \dt discordsh.*; \dt osrs.*; \dn n8n"
 ```
 
 **Tip**: The port-forward can be flaky — if `dbmate status` fails with "connection refused", kill the port-forward (`kill $(lsof -ti:54322)`) and restart it. Avoid making test psql queries before running dbmate, as the port-forward may drop after the first connection.
@@ -188,6 +199,7 @@ dbmate/
     00-roles.sql            # Supabase-compatible roles (service_role, anon, authenticated, etc.)
     01-auth-stub.sql        # Minimal auth.users + auth.uid() + auth.jwt() + auth.role()
     02-extensions-stub.sql  # extensions schema + pgcrypto + vault schema stub
+    03-n8n-stub.sql         # n8n schema stub (TypeORM manages tables)
     pgsodium_getkey.sh      # Dummy key for production image testing
   migrations/
     20260227210000_mc_schema_init.sql
@@ -199,6 +211,7 @@ dbmate/
     20260228230000_discordsh_update_server.sql
     20260301210000_meme_rpcs_v2.sql
     20260302000000_discordsh_guild_vault.sql
+    20260302100000_n8n_schema_init.sql
 ```
 
 ## Important Notes

--- a/packages/data/sql/dbmate/init/03-n8n-stub.sql
+++ b/packages/data/sql/dbmate/init/03-n8n-stub.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- n8n schema stub for local migration testing.
+--
+-- In production, this is created by dbmate migration
+-- 20260302100000_n8n_schema_init.sql. This stub exists so
+-- the n8n schema is available in local docker compose before
+-- migrations run (same pattern as 01-auth-stub.sql and
+-- 02-extensions-stub.sql).
+--
+-- n8n TypeORM manages its own 23 tables within this schema.
+-- We only create the schema and grants here.
+-- ============================================================
+
+CREATE SCHEMA IF NOT EXISTS n8n;
+
+-- Grant access
+GRANT ALL ON SCHEMA n8n TO postgres;
+GRANT USAGE ON SCHEMA n8n TO service_role;
+
+-- Future tables created by n8n are readable by service_role
+ALTER DEFAULT PRIVILEGES IN SCHEMA n8n
+    GRANT SELECT ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA n8n
+    GRANT USAGE ON SEQUENCES TO service_role;
+
+-- Isolation: block anon/authenticated
+REVOKE ALL ON SCHEMA n8n FROM PUBLIC;

--- a/packages/data/sql/dbmate/migrations/20260302100000_n8n_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260302100000_n8n_schema_init.sql
@@ -1,0 +1,87 @@
+-- migrate:up
+
+-- ============================================================
+-- N8N SCHEMA INITIALIZATION
+--
+-- Creates a dedicated PostgreSQL schema for the n8n workflow
+-- engine. n8n connects to the shared supabase database with
+-- DB_POSTGRESDB_SCHEMA=n8n, and TypeORM manages all 23 tables
+-- within this schema automatically on first boot.
+--
+-- We ONLY create the schema and grants here. n8n owns its own
+-- table lifecycle (creation, migration, indexing).
+--
+-- Upgrade process:
+--   1. Pin n8n image version in apps/kube/n8n/manifest/
+--   2. Bump version locally in docker compose
+--   3. docker compose up → n8n auto-migrates its own tables
+--   4. Verify clean → update kube manifest → ArgoCD syncs
+--
+-- Depends on: 00-roles.sql (service_role must exist)
+-- ============================================================
+
+-- ===========================================
+-- SCHEMA
+-- ===========================================
+
+CREATE SCHEMA IF NOT EXISTS n8n;
+
+COMMENT ON SCHEMA n8n IS
+    'n8n workflow engine schema. Tables managed by n8n TypeORM, not dbmate.';
+
+-- ===========================================
+-- GRANTS
+-- ===========================================
+
+-- postgres is superuser (implicit full access), but explicit for clarity
+GRANT ALL ON SCHEMA n8n TO postgres;
+
+-- service_role needs access for cross-schema RPC calls from n8n workflows
+GRANT USAGE ON SCHEMA n8n TO service_role;
+
+-- Ensure future tables/sequences created by n8n are accessible to service_role
+ALTER DEFAULT PRIVILEGES IN SCHEMA n8n
+    GRANT SELECT ON TABLES TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA n8n
+    GRANT USAGE ON SEQUENCES TO service_role;
+
+-- ===========================================
+-- ISOLATION: Block anon/authenticated from n8n internals
+-- ===========================================
+
+REVOKE ALL ON SCHEMA n8n FROM PUBLIC;
+REVOKE ALL ON SCHEMA n8n FROM anon;
+REVOKE ALL ON SCHEMA n8n FROM authenticated;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    -- Verify schema exists
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.schemata
+        WHERE schema_name = 'n8n'
+    ) THEN
+        RAISE EXCEPTION 'n8n schema creation failed';
+    END IF;
+
+    -- Verify anon cannot access n8n schema
+    IF has_schema_privilege('anon', 'n8n', 'USAGE') THEN
+        RAISE EXCEPTION 'anon must NOT have USAGE on n8n schema';
+    END IF;
+
+    -- Verify authenticated cannot access n8n schema
+    IF has_schema_privilege('authenticated', 'n8n', 'USAGE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have USAGE on n8n schema';
+    END IF;
+
+    RAISE NOTICE 'n8n_init.sql: n8n schema created and verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+-- migrate:down
+
+DROP SCHEMA IF EXISTS n8n CASCADE;

--- a/packages/data/sql/schema/n8n/n8n_init.sql
+++ b/packages/data/sql/schema/n8n/n8n_init.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- N8N SCHEMA INITIALIZATION
+--
+-- Creates a dedicated PostgreSQL schema for the n8n workflow
+-- engine. n8n connects to the shared supabase database with
+-- DB_POSTGRESDB_SCHEMA=n8n, and TypeORM manages all 23 tables
+-- within this schema automatically on first boot.
+--
+-- We ONLY create the schema and grants here. n8n owns its own
+-- table lifecycle (creation, migration, indexing).
+--
+-- Upgrade process:
+--   1. Pin n8n image version in apps/kube/n8n/manifest/
+--   2. Bump version locally in docker compose
+--   3. docker compose up → n8n auto-migrates its own tables
+--   4. Verify clean → update kube manifest → ArgoCD syncs
+--
+-- Depends on: 00-roles.sql (service_role must exist)
+-- ============================================================
+
+-- ===========================================
+-- SCHEMA
+-- ===========================================
+
+CREATE SCHEMA IF NOT EXISTS n8n;
+
+COMMENT ON SCHEMA n8n IS
+    'n8n workflow engine schema. Tables managed by n8n TypeORM, not dbmate.';
+
+-- ===========================================
+-- GRANTS
+-- ===========================================
+
+-- postgres is superuser (implicit full access), but explicit for clarity
+GRANT ALL ON SCHEMA n8n TO postgres;
+
+-- service_role needs access for cross-schema RPC calls from n8n workflows
+GRANT USAGE ON SCHEMA n8n TO service_role;
+
+-- Ensure future tables/sequences created by n8n are accessible to service_role
+ALTER DEFAULT PRIVILEGES IN SCHEMA n8n
+    GRANT SELECT ON TABLES TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA n8n
+    GRANT USAGE ON SEQUENCES TO service_role;
+
+-- ===========================================
+-- ISOLATION: Block anon/authenticated from n8n internals
+-- ===========================================
+
+REVOKE ALL ON SCHEMA n8n FROM PUBLIC;
+REVOKE ALL ON SCHEMA n8n FROM anon;
+REVOKE ALL ON SCHEMA n8n FROM authenticated;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    -- Verify schema exists
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.schemata
+        WHERE schema_name = 'n8n'
+    ) THEN
+        RAISE EXCEPTION 'n8n schema creation failed';
+    END IF;
+
+    -- Verify anon cannot access n8n schema
+    IF has_schema_privilege('anon', 'n8n', 'USAGE') THEN
+        RAISE EXCEPTION 'anon must NOT have USAGE on n8n schema';
+    END IF;
+
+    -- Verify authenticated cannot access n8n schema
+    IF has_schema_privilege('authenticated', 'n8n', 'USAGE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have USAGE on n8n schema';
+    END IF;
+
+    RAISE NOTICE 'n8n_init.sql: n8n schema created and verified successfully.';
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

- Add `apps/kube/n8n/` with ArgoCD Application, Deployment (pinned `n8nio/n8n:2.9.4`), Service, ExternalSecrets, RBAC, and NetworkPolicy — **not yet added to root kustomization.yaml**
- Add dbmate migration `20260302100000_n8n_schema_init` creating dedicated `n8n` schema with isolation grants (anon/authenticated blocked)
- Add source-of-truth `schema/n8n/n8n_init.sql` and local init stub `03-n8n-stub.sql`
- n8n shares the `supabase` database via `DB_POSTGRESDB_SCHEMA=n8n`; TypeORM manages its own 23 tables within that schema
- Redis queue mode connects to existing `redis-master.redis.svc.cluster.local`

## Activation steps (future, not part of this PR)

1. Create `n8n-encryption-secret` SealedSecret via `kubeseal`
2. Add `- n8n/application.yaml` to `apps/kube/kustomization.yaml`
3. ArgoCD syncs → n8n boots → TypeORM creates tables in `n8n` schema

## Test plan

- [x] `docker compose down -v && docker compose up -d` — fresh postgres
- [x] `dbmate up` — all 10 migrations apply clean (no errors)
- [x] `dbmate rollback` — n8n schema drops, prior 9 migrations intact
- [x] `dbmate up` — re-applies cleanly
- [x] Privilege checks: anon=false, authenticated=false, service_role=true
- [ ] Root `kustomization.yaml` NOT modified (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)