### PR TITLE
chore(dbmate): add n8n integration test docker compose template

### DIFF
--- a/packages/data/sql/dbmate/README.md
+++ b/packages/data/sql/dbmate/README.md
@@ -124,6 +124,24 @@ dbmate --no-dump-schema --migrations-dir migrations rollback  # test rollback
 docker compose down -v
 ```
 
+### n8n integration test (Postgres + n8n)
+
+Runs both Postgres and n8n to verify the full integration — n8n boots, TypeORM creates tables in the `n8n` schema, and existing schemas are unaffected.
+
+```bash
+cp n8n-docker-compose.yml docker-compose.yml
+docker compose up -d
+# Wait for postgres health check, then apply migrations:
+DATABASE_URL="postgresql://postgres:postgres@localhost:54322/postgres?sslmode=disable&search_path=dbmate,public" \
+  dbmate --no-dump-schema --migrations-dir migrations up
+# Wait ~30s for n8n TypeORM migrations, then verify:
+psql "postgresql://postgres:postgres@localhost:54322/postgres" -c "\dt n8n.*"
+# n8n editor: http://localhost:5678
+docker compose down -v
+```
+
+**When to run this**: After bumping the n8n image version, before updating the kube manifest. Verifies TypeORM migrations still work with the `n8n` custom schema.
+
 ### Production-replica test (CNPG image)
 
 Use `docker-compose.yml` with the production image (`ghcr.io/kbve/postgres:17.4.1.069-kilobase`). Requires `platform: linux/amd64` on ARM Macs (Rosetta via OrbStack/Docker Desktop).
@@ -193,6 +211,7 @@ dbmate/
   .env                    # Connection string (gitignored)
   .gitignore              # Excludes .env, docker-compose.yml, schema dump artifacts
   dev-docker-compose.yml  # Committed template (vanilla postgres:17-alpine)
+  n8n-docker-compose.yml  # Committed template (postgres + n8n for integration testing)
   docker-compose.yml      # Local override (gitignored)
   README.md
   init/                   # Docker entrypoint scripts (run alphabetically on first start)

--- a/packages/data/sql/dbmate/n8n-docker-compose.yml
+++ b/packages/data/sql/dbmate/n8n-docker-compose.yml
@@ -1,0 +1,61 @@
+# Local Postgres + n8n for testing n8n integration.
+#
+# Runs both services together so you can verify:
+#   - n8n boots with DB_POSTGRESDB_SCHEMA=n8n
+#   - TypeORM creates all tables in the n8n schema
+#   - n8n editor is accessible at http://localhost:5678
+#   - Existing schemas (mc, meme, discordsh, osrs) are unaffected
+#
+# Usage:
+#   cp n8n-docker-compose.yml docker-compose.yml
+#   docker compose up -d
+#   # Wait for postgres to be healthy, then apply migrations:
+#   DATABASE_URL="postgresql://postgres:postgres@localhost:54322/postgres?sslmode=disable&search_path=dbmate,public" \
+#     dbmate --no-dump-schema --migrations-dir migrations up
+#   # Wait ~30s for n8n to run TypeORM migrations, then verify:
+#   psql "postgresql://postgres:postgres@localhost:54322/postgres" -c "\dt n8n.*"
+#   # Open n8n editor:
+#   open http://localhost:5678
+#   # Tear down:
+#   docker compose down -v
+
+services:
+    postgres:
+        image: postgres:17-alpine
+        ports:
+            - '54322:5432'
+        environment:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: postgres
+        volumes:
+            - ./init:/docker-entrypoint-initdb.d
+            - pgdata:/var/lib/postgresql/data
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U postgres']
+            interval: 5s
+            timeout: 3s
+            retries: 5
+
+    n8n:
+        image: n8nio/n8n:2.9.4
+        ports:
+            - '5678:5678'
+        environment:
+            - DB_TYPE=postgresdb
+            - DB_POSTGRESDB_HOST=postgres
+            - DB_POSTGRESDB_PORT=5432
+            - DB_POSTGRESDB_DATABASE=postgres
+            - DB_POSTGRESDB_USER=postgres
+            - DB_POSTGRESDB_PASSWORD=postgres
+            - DB_POSTGRESDB_SCHEMA=n8n
+            - DB_POSTGRESDB_POOL_SIZE=5
+            - N8N_PORT=5678
+            - N8N_ENCRYPTION_KEY=local-test-key-do-not-use-in-production-0000
+            - GENERIC_TIMEZONE=UTC
+        depends_on:
+            postgres:
+                condition: service_healthy
+
+volumes:
+    pgdata:


### PR DESCRIPTION
## Summary

- Add `n8n-docker-compose.yml` — committed template that runs postgres + n8n:2.9.4 together for local integration testing
- Update README with n8n integration test section and directory listing

## Usage

```bash
cd packages/data/sql/dbmate
cp n8n-docker-compose.yml docker-compose.yml
docker compose up -d
dbmate up   # apply all migrations including n8n schema
# Wait ~30s, then verify:
psql -c "\dt n8n.*"   # 61 tables created by TypeORM
open http://localhost:5678   # n8n editor
docker compose down -v
```

## When to use

Run this before bumping the n8n image version in `apps/kube/n8n/manifest/n8n-deployment.yaml` to verify TypeORM migrations still work with the custom `n8n` schema.

## Test plan

- [x] Verified locally: n8n 2.9.4 boots, creates 61 tables in `n8n` schema
- [x] Schema isolation: anon=blocked, authenticated=blocked, service_role=allowed
- [x] Existing schemas unaffected: mc(6), meme(14), discordsh(3), osrs(9), vault(2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)