### PR TITLE
feat(n8n): activate ArgoCD deployment and cross-namespace RBAC

### DIFF
--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -59,6 +59,9 @@ subjects:
     - kind: ServiceAccount
       name: mc-external-secrets
       namespace: mc
+    - kind: ServiceAccount
+      name: n8n-external-secrets
+      namespace: n8n
 ---
 # Additional role for reading services/endpoints if needed
 apiVersion: rbac.authorization.k8s.io/v1

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -45,6 +45,7 @@ resources:
     - cityvote/application.yaml
     - herbmail/application.yaml
     - memes/application.yaml
+    - n8n/application.yaml
     - rentearth/application.yaml
     # GitHub Actions Runner Controller (ARC)
     # Consolidated: controller includes helm chart + sealed secret + RBAC


### PR DESCRIPTION
## Summary
- Adds `n8n-external-secrets` ServiceAccount to kilobase `cross-namespace-rbac.yaml` so ExternalSecrets can pull the `supabase-postgres` password
- Adds `n8n/application.yaml` to root `kustomization.yaml` so ArgoCD syncs the n8n deployment

## Pre-requisites (all complete)
- [x] n8n kube manifests merged (#7553)
- [x] n8n schema migration merged (#7553) and applied to production
- [x] Sealed encryption key merged (#7555)
- [x] License key, ingress, basic auth merged (#7556)
- [x] DNS record for `n8n.kbve.com` (needed before merge)

## What happens on merge
ArgoCD will sync `apps/kube/n8n/manifest/` → creates namespace, deployment, service, ingress, ExternalSecrets, RBAC, SealedSecrets. n8n boots and TypeORM creates its tables in the `n8n` schema.

## Test plan
- [ ] Verify `n8n.kbve.com` DNS resolves
- [ ] ArgoCD sync completes without errors
- [ ] n8n pod is Running and healthy
- [ ] `\dt n8n.*` shows TypeORM tables
- [ ] `n8n.kbve.com/webhook` is accessible (no auth)
- [ ] `n8n.kbve.com/` prompts for basic auth