### PR TITLE
fix(n8n): fix Redis auth and ingress service name

### DIFF
--- a/apps/kube/n8n/manifest/n8n-externalsecret.yaml
+++ b/apps/kube/n8n/manifest/n8n-externalsecret.yaml
@@ -44,7 +44,7 @@ spec:
         template:
             engineVersion: v2
             data:
-                REDIS_PASSWORD: '{{ .redispassword }}'
+                QUEUE_BULL_REDIS_PASSWORD: '{{ .redispassword }}'
     data:
         - secretKey: redispassword
           remoteRef:

--- a/apps/kube/n8n/manifest/n8n-ingress.yaml
+++ b/apps/kube/n8n/manifest/n8n-ingress.yaml
@@ -31,14 +31,14 @@ spec:
                     pathType: Prefix
                     backend:
                         service:
-                            name: n8n-service
+                            name: n8n
                             port:
                                 number: 5678
                   - path: /webhook-test
                     pathType: Prefix
                     backend:
                         service:
-                            name: n8n-service
+                            name: n8n
                             port:
                                 number: 5678
 ---
@@ -70,6 +70,6 @@ spec:
                     pathType: Prefix
                     backend:
                         service:
-                            name: n8n-service
+                            name: n8n
                             port:
                                 number: 5678


### PR DESCRIPTION
## Summary
- **Redis auth**: ExternalSecret was creating `REDIS_PASSWORD` env var but n8n expects `QUEUE_BULL_REDIS_PASSWORD` — caused `NOAUTH Authentication required` crash
- **Ingress service name**: All three ingress paths referenced `n8n-service` but the actual Service is named `n8n` — caused 503 errors

## Root cause
n8n pod was in CrashLoopBackOff with two sequential failures:
1. DB auth failure (postgres user had no password set in CNPG — fixed manually via `ALTER USER`)
2. Redis auth failure (wrong env var name in ExternalSecret template)

## Test plan
- [ ] ArgoCD syncs the changes
- [ ] n8n pod starts and stays Running
- [ ] `n8n.kbve.com/webhook` returns n8n response (not 503)
- [ ] `n8n.kbve.com/` prompts for basic auth then loads editor