### PR TITLE
fix(n8n): basic auth on root page only, SPA paths open

### DIFF
--- a/apps/kube/n8n/manifest/n8n-ingress.yaml
+++ b/apps/kube/n8n/manifest/n8n-ingress.yaml
@@ -91,6 +91,13 @@ spec:
                             name: n8n
                             port:
                                 number: 5678
+                  - path: /favicon.ico
+                    pathType: Exact
+                    backend:
+                        service:
+                            name: n8n
+                            port:
+                                number: 5678
 ---
 # --- Editor ingress (basic auth on root page only) ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary
Routes all SPA paths through an open ingress (no auth) so basic auth only triggers on the initial HTML page load. This prevents the infinite re-prompt issue.

**Open ingress (no auth):** `/webhook`, `/webhook-test`, `/rest`, `/assets`, `/static`, `/healthz`, `/icons`, `/types`
**Basic auth ingress:** `/` (catches the initial page load only)

## How it works
1. User visits `n8n.kbve.com/` → NGINX basic auth prompt (root path)
2. n8n serves the SPA HTML → browser renders
3. SPA calls `/rest/*`, loads `/assets/*` → these match the open ingress (more specific path = higher priority), no auth
4. n8n's own 401 on `/rest/login` is handled by the SPA's login form, NOT interpreted as a basic auth failure

## Test plan
- [ ] `n8n.kbve.com/` prompts for basic auth once
- [ ] After entering creds, editor loads without re-prompting
- [ ] No 401 errors in browser console for `/rest/*` or `/assets/*`
- [ ] `n8n.kbve.com/webhook` accessible without auth
- [ ] n8n login form appears after basic auth (double layer)