### PR TITLE
feat(astro-memes): bento grid feed, lucide icons, meme page

### DIFF
--- a/apps/memes/astro-memes/src/components/feed/BentoFeed.tsx
+++ b/apps/memes/astro-memes/src/components/feed/BentoFeed.tsx
@@ -1,0 +1,159 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import BentoMemeCard from './BentoMemeCard';
+import MemeLightbox from './MemeLightbox';
+import type { FeedMeme } from '../../lib/memeService';
+
+interface BentoFeedProps {
+	memes: FeedMeme[];
+	hasMore: boolean;
+	loadingMore: boolean;
+	userReactions: Map<string, number>;
+	userSaves: Set<string>;
+	onReact: (memeId: string, reaction: number) => void;
+	onSave: (memeId: string) => void;
+	onUnsave: (memeId: string) => void;
+	onComment: (memeId: string) => void;
+	onShare: (memeId: string) => void;
+	onReport: (memeId: string) => void;
+	onLoadMore: () => void;
+}
+
+export default function BentoFeed({
+	memes,
+	hasMore,
+	loadingMore,
+	userReactions,
+	userSaves,
+	onReact,
+	onSave,
+	onUnsave,
+	onComment,
+	onShare,
+	onReport,
+	onLoadMore,
+}: BentoFeedProps) {
+	const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+	const sentinelRef = useRef<HTMLDivElement>(null);
+
+	// Infinite scroll sentinel
+	useEffect(() => {
+		if (!sentinelRef.current || !hasMore) return;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting && hasMore && !loadingMore) {
+					onLoadMore();
+				}
+			},
+			{ rootMargin: '400px' },
+		);
+
+		observer.observe(sentinelRef.current);
+		return () => observer.disconnect();
+	}, [hasMore, loadingMore, onLoadMore]);
+
+	const handleExpand = useCallback(
+		(meme: FeedMeme) => {
+			const idx = memes.findIndex((m) => m.id === meme.id);
+			setExpandedIndex(idx >= 0 ? idx : null);
+		},
+		[memes],
+	);
+
+	const handlePrev = useCallback(() => {
+		setExpandedIndex((i) => (i !== null && i > 0 ? i - 1 : i));
+	}, []);
+
+	const handleNext = useCallback(() => {
+		setExpandedIndex((i) =>
+			i !== null && i < memes.length - 1 ? i + 1 : i,
+		);
+	}, [memes.length]);
+
+	const expandedMeme = expandedIndex !== null ? memes[expandedIndex] : null;
+
+	return (
+		<>
+			<div
+				className="w-full min-h-screen px-4 py-6"
+				style={{
+					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+				}}>
+				{/* Bento grid */}
+				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 max-w-7xl mx-auto">
+					{memes.map((meme, i) => (
+						<BentoMemeCard
+							key={meme.id}
+							meme={meme}
+							featured={i % 7 === 3}
+							onExpand={handleExpand}
+						/>
+					))}
+				</div>
+
+				{/* Sentinel */}
+				{hasMore && (
+					<div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
+				)}
+
+				{/* Loading more */}
+				{loadingMore && (
+					<div className="flex justify-center py-8">
+						<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 max-w-7xl mx-auto w-full">
+							{[...Array(4)].map((_, i) => (
+								<div
+									key={i}
+									className="aspect-[4/3] rounded-xl animate-pulse"
+									style={{
+										backgroundColor:
+											'var(--sl-color-gray-6, #1c1c1e)',
+									}}
+								/>
+							))}
+						</div>
+					</div>
+				)}
+
+				{/* End of feed */}
+				{!hasMore && memes.length > 0 && (
+					<div className="flex items-center justify-center py-12">
+						<p
+							className="text-sm"
+							style={{
+								color: 'var(--sl-color-gray-3, #71717a)',
+							}}>
+							You've seen them all — for now.
+						</p>
+					</div>
+				)}
+			</div>
+
+			{/* Lightbox */}
+			{expandedMeme && (
+				<MemeLightbox
+					meme={expandedMeme}
+					userReaction={userReactions.get(expandedMeme.id) ?? null}
+					isSaved={userSaves.has(expandedMeme.id)}
+					onReact={onReact}
+					onSave={onSave}
+					onUnsave={onUnsave}
+					onComment={onComment}
+					onShare={onShare}
+					onReport={onReport}
+					onClose={() => setExpandedIndex(null)}
+					onPrev={
+						expandedIndex !== null && expandedIndex > 0
+							? handlePrev
+							: null
+					}
+					onNext={
+						expandedIndex !== null &&
+						expandedIndex < memes.length - 1
+							? handleNext
+							: null
+					}
+				/>
+			)}
+		</>
+	);
+}

--- a/apps/memes/astro-memes/src/components/feed/BentoMemeCard.tsx
+++ b/apps/memes/astro-memes/src/components/feed/BentoMemeCard.tsx
@@ -1,0 +1,124 @@
+import { ExternalLink, Eye, Flame } from 'lucide-react';
+import type { FeedMeme } from '../../lib/memeService';
+
+interface BentoMemeCardProps {
+	meme: FeedMeme;
+	featured?: boolean;
+	onExpand: (meme: FeedMeme) => void;
+}
+
+export default function BentoMemeCard({
+	meme,
+	featured,
+	onExpand,
+}: BentoMemeCardProps) {
+	const isVideo = meme.format === 2 || meme.format === 3;
+
+	return (
+		<button
+			type="button"
+			onClick={() => onExpand(meme)}
+			className={`group relative overflow-hidden rounded-xl transition-shadow duration-200 hover:shadow-lg hover:shadow-black/30 focus:outline-none ${
+				featured ? 'md:col-span-2' : ''
+			}`}
+			style={{
+				border: '1px solid var(--sl-color-hairline, rgba(255,255,255,0.06))',
+				backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
+			}}>
+			{/* Thumbnail */}
+			<div
+				className={`w-full ${featured ? 'aspect-video' : 'aspect-[4/3]'}`}>
+				{isVideo ? (
+					<video
+						src={meme.asset_url}
+						className="w-full h-full object-cover"
+						muted
+						playsInline
+						preload="metadata"
+					/>
+				) : (
+					<img
+						src={meme.thumbnail_url || meme.asset_url}
+						alt={meme.title || 'Meme'}
+						className="w-full h-full object-cover select-none"
+						loading="lazy"
+						draggable={false}
+					/>
+				)}
+			</div>
+
+			{/* Hover overlay */}
+			<div className="absolute inset-0 flex flex-col justify-end opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+				{/* Gradient */}
+				<div
+					className="absolute inset-0"
+					style={{
+						background:
+							'linear-gradient(transparent 30%, rgba(0,0,0,0.75))',
+					}}
+				/>
+
+				{/* Content */}
+				<div className="relative p-3">
+					{meme.title && (
+						<h3 className="text-white text-sm font-semibold leading-tight line-clamp-2 mb-1.5">
+							{meme.title}
+						</h3>
+					)}
+
+					{meme.author_name && (
+						<p className="text-white/60 text-xs mb-2">
+							@{meme.author_name}
+						</p>
+					)}
+
+					{/* Stats row */}
+					<div className="flex items-center gap-3 text-white/50 text-xs">
+						<span className="inline-flex items-center gap-1">
+							<Eye size={12} />
+							{formatCount(meme.view_count)}
+						</span>
+						<span className="inline-flex items-center gap-1">
+							<Flame size={12} />
+							{formatCount(meme.reaction_count)}
+						</span>
+					</div>
+				</div>
+			</div>
+
+			{/* Share button — always visible top-right */}
+			<a
+				href={`/meme?id=${meme.id}`}
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={(e) => e.stopPropagation()}
+				className="absolute top-2 right-2 p-1.5 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 backdrop-blur-sm"
+				style={{
+					backgroundColor: 'rgba(0,0,0,0.4)',
+				}}
+				title="Open in new tab"
+				aria-label="Open meme in new tab">
+				<ExternalLink size={14} className="text-white/80" />
+			</a>
+
+			{/* Tags — bottom-left, visible without hover */}
+			{meme.tags.length > 0 && (
+				<div className="absolute bottom-2 left-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+					{meme.tags.slice(0, 2).map((tag) => (
+						<span
+							key={tag}
+							className="text-[10px] px-1.5 py-0.5 rounded-full bg-white/10 text-white/50 backdrop-blur-sm">
+							#{tag}
+						</span>
+					))}
+				</div>
+			)}
+		</button>
+	);
+}
+
+function formatCount(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return String(n);
+}

--- a/apps/memes/astro-memes/src/components/feed/FeedSkeleton.tsx
+++ b/apps/memes/astro-memes/src/components/feed/FeedSkeleton.tsx
@@ -1,4 +1,38 @@
-export default function FeedSkeleton() {
+interface FeedSkeletonProps {
+	variant?: 'mobile' | 'desktop';
+}
+
+export default function FeedSkeleton({
+	variant = 'mobile',
+}: FeedSkeletonProps) {
+	if (variant === 'desktop') {
+		return (
+			<div
+				className="w-full min-h-screen px-4 py-6"
+				style={{
+					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+				}}>
+				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 max-w-7xl mx-auto">
+					{[...Array(8)].map((_, i) => (
+						<div
+							key={i}
+							className={`rounded-xl animate-pulse ${
+								i % 7 === 3
+									? 'md:col-span-2 aspect-video'
+									: 'aspect-[4/3]'
+							}`}
+							style={{
+								backgroundColor:
+									'var(--sl-color-gray-6, #1c1c1e)',
+								border: '1px solid rgba(255,255,255,0.04)',
+							}}
+						/>
+					))}
+				</div>
+			</div>
+		);
+	}
+
 	return (
 		<div
 			className="relative flex flex-col items-center justify-center gap-6"
@@ -53,8 +87,7 @@ export default function FeedSkeleton() {
 						key={i}
 						className="w-10 h-10 rounded-full animate-pulse"
 						style={{
-							backgroundColor:
-								'var(--sl-color-gray-6, #1c1c1e)',
+							backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
 						}}
 					/>
 				))}

--- a/apps/memes/astro-memes/src/components/feed/MemeLightbox.tsx
+++ b/apps/memes/astro-memes/src/components/feed/MemeLightbox.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useCallback } from 'react';
+import { X, ChevronLeft, ChevronRight, ExternalLink, User } from 'lucide-react';
+import ReactionBar from './ReactionBar';
+import type { FeedMeme } from '../../lib/memeService';
+
+interface MemeLightboxProps {
+	meme: FeedMeme;
+	userReaction: number | null;
+	isSaved: boolean;
+	onReact: (memeId: string, reaction: number) => void;
+	onSave: (memeId: string) => void;
+	onUnsave: (memeId: string) => void;
+	onComment: (memeId: string) => void;
+	onShare: (memeId: string) => void;
+	onReport: (memeId: string) => void;
+	onClose: () => void;
+	onPrev: (() => void) | null;
+	onNext: (() => void) | null;
+}
+
+export default function MemeLightbox({
+	meme,
+	userReaction,
+	isSaved,
+	onReact,
+	onSave,
+	onUnsave,
+	onComment,
+	onShare,
+	onReport,
+	onClose,
+	onPrev,
+	onNext,
+}: MemeLightboxProps) {
+	const isVideo = meme.format === 2 || meme.format === 3;
+
+	const handleKeyDown = useCallback(
+		(e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose();
+			else if (e.key === 'ArrowLeft' && onPrev) onPrev();
+			else if (e.key === 'ArrowRight' && onNext) onNext();
+		},
+		[onClose, onPrev, onNext],
+	);
+
+	useEffect(() => {
+		document.body.style.overflow = 'hidden';
+		window.addEventListener('keydown', handleKeyDown);
+		return () => {
+			document.body.style.overflow = '';
+			window.removeEventListener('keydown', handleKeyDown);
+		};
+	}, [handleKeyDown]);
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center"
+			role="dialog"
+			aria-modal="true"
+			aria-label={meme.title || 'Meme viewer'}>
+			{/* Backdrop */}
+			<div
+				className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+				onClick={onClose}
+			/>
+
+			{/* Close button */}
+			<button
+				type="button"
+				onClick={onClose}
+				className="absolute top-4 right-4 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
+				style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+				aria-label="Close">
+				<X size={20} className="text-white" />
+			</button>
+
+			{/* Open in new tab */}
+			<a
+				href={`/meme?id=${meme.id}`}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="absolute top-4 right-16 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
+				style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+				title="Open in new tab"
+				aria-label="Open meme in new tab">
+				<ExternalLink size={18} className="text-white/80" />
+			</a>
+
+			{/* Prev arrow */}
+			{onPrev && (
+				<button
+					type="button"
+					onClick={onPrev}
+					className="absolute left-4 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
+					style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+					aria-label="Previous meme">
+					<ChevronLeft size={24} className="text-white" />
+				</button>
+			)}
+
+			{/* Next arrow */}
+			{onNext && (
+				<button
+					type="button"
+					onClick={onNext}
+					className="absolute right-4 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
+					style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+					aria-label="Next meme">
+					<ChevronRight size={24} className="text-white" />
+				</button>
+			)}
+
+			{/* Content area */}
+			<div className="relative flex items-start gap-4 max-w-5xl w-full mx-4 max-h-[90vh]">
+				{/* Main image + info */}
+				<div className="flex-1 min-w-0 flex flex-col items-center">
+					{/* Meme asset */}
+					<div className="max-h-[75vh] flex items-center justify-center w-full">
+						{isVideo ? (
+							<video
+								src={meme.asset_url}
+								className="max-w-full max-h-[75vh] object-contain rounded-xl"
+								style={{
+									border: '1px solid rgba(255,255,255,0.06)',
+								}}
+								autoPlay
+								loop
+								muted
+								playsInline
+							/>
+						) : (
+							<img
+								src={meme.asset_url}
+								alt={meme.title || 'Meme'}
+								className="max-w-full max-h-[75vh] object-contain rounded-xl select-none"
+								style={{
+									border: '1px solid rgba(255,255,255,0.06)',
+								}}
+								draggable={false}
+							/>
+						)}
+					</div>
+
+					{/* Info below image */}
+					<div className="w-full mt-3 px-2">
+						{meme.title && (
+							<h2
+								className="text-base font-semibold leading-tight mb-2 line-clamp-2"
+								style={{
+									color: 'var(--sl-color-white, #e2e8f0)',
+								}}>
+								{meme.title}
+							</h2>
+						)}
+
+						<div className="flex items-center gap-2.5">
+							{meme.author_name ? (
+								<a
+									href={`https://kbve.com/@${meme.author_name}`}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-2 group">
+									{meme.author_avatar ? (
+										<img
+											src={meme.author_avatar}
+											alt={meme.author_name}
+											className="w-7 h-7 rounded-full"
+										/>
+									) : (
+										<div
+											className="w-7 h-7 rounded-full flex items-center justify-center"
+											style={{
+												backgroundColor:
+													'var(--sl-color-accent-low, #164e63)',
+											}}>
+											<User
+												size={14}
+												style={{
+													color: 'var(--sl-color-text-accent, #22d3ee)',
+												}}
+											/>
+										</div>
+									)}
+									<span
+										className="text-sm font-medium group-hover:underline"
+										style={{
+											color: 'var(--sl-color-gray-2, #a1a1aa)',
+										}}>
+										@{meme.author_name}
+									</span>
+								</a>
+							) : (
+								<div
+									className="w-7 h-7 rounded-full flex items-center justify-center"
+									style={{
+										backgroundColor:
+											'var(--sl-color-accent-low, #164e63)',
+									}}>
+									<User
+										size={14}
+										style={{
+											color: 'var(--sl-color-text-accent, #22d3ee)',
+										}}
+									/>
+								</div>
+							)}
+						</div>
+
+						{meme.tags.length > 0 && (
+							<div className="flex flex-wrap gap-1.5 mt-2">
+								{meme.tags.slice(0, 5).map((tag) => (
+									<span
+										key={tag}
+										className="text-[11px] px-2 py-0.5 rounded-full bg-white/10 text-white/50">
+										#{tag}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Reaction bar — right side */}
+				<div className="flex-shrink-0 pt-4">
+					<ReactionBar
+						memeId={meme.id}
+						reactionCount={meme.reaction_count}
+						saveCount={meme.save_count}
+						commentCount={meme.comment_count}
+						shareCount={meme.share_count}
+						userReaction={userReaction}
+						isSaved={isSaved}
+						onReact={onReact}
+						onSave={onSave}
+						onUnsave={onUnsave}
+						onComment={onComment}
+						onShare={onShare}
+						onReport={onReport}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/memes/astro-memes/src/components/feed/ReactMemeContent.tsx
+++ b/apps/memes/astro-memes/src/components/feed/ReactMemeContent.tsx
@@ -9,6 +9,7 @@ import {
 import { useStore } from '@nanostores/react';
 import { $auth, openModal, addToast } from '@kbve/astro';
 import MemeCard from './MemeCard';
+import BentoFeed from './BentoFeed';
 import FeedSkeleton from './FeedSkeleton';
 import CommentsDrawer from './CommentsDrawer';
 import ReportModal from './ReportModal';
@@ -134,6 +135,9 @@ export default function ReactMemeContent() {
 	);
 	const [userSaves, setUserSaves] = useState<Set<string>>(new Set());
 
+	// Viewport detection for responsive layout
+	const [isDesktop, setIsDesktop] = useState(false);
+
 	// Overlay state
 	const [commentsMemeId, setCommentsMemeId] = useState<string | null>(null);
 	const [reportMemeId, setReportMemeId] = useState<string | null>(null);
@@ -150,6 +154,15 @@ export default function ReactMemeContent() {
 			(_, i) => cardRefs.current[i] ?? createRef<HTMLDivElement>(),
 		);
 	}
+
+	// ── Viewport detection ───────────────────────────────────────────
+	useEffect(() => {
+		const mq = window.matchMedia('(min-width: 768px)');
+		setIsDesktop(mq.matches);
+		const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+		mq.addEventListener('change', handler);
+		return () => mq.removeEventListener('change', handler);
+	}, []);
 
 	// ── Initial load ──────────────────────────────────────────────────
 	useEffect(() => {
@@ -298,8 +311,7 @@ export default function ReactMemeContent() {
 			(entries) => {
 				for (const entry of entries) {
 					if (!entry.isIntersecting) continue;
-					const memeId =
-						entry.target.getAttribute('data-meme-id');
+					const memeId = entry.target.getAttribute('data-meme-id');
 					if (memeId && !viewedRef.current.has(memeId)) {
 						viewedRef.current.add(memeId);
 						trackView(memeId).catch(() => {});
@@ -373,9 +385,7 @@ export default function ReactMemeContent() {
 		setUserSaves((s) => new Set(s).add(memeId));
 		setMemes((list) =>
 			list.map((m) =>
-				m.id === memeId
-					? { ...m, save_count: m.save_count + 1 }
-					: m,
+				m.id === memeId ? { ...m, save_count: m.save_count + 1 } : m,
 			),
 		);
 
@@ -403,9 +413,7 @@ export default function ReactMemeContent() {
 		});
 		setMemes((list) =>
 			list.map((m) =>
-				m.id === memeId
-					? { ...m, save_count: m.save_count - 1 }
-					: m,
+				m.id === memeId ? { ...m, save_count: m.save_count - 1 } : m,
 			),
 		);
 
@@ -425,7 +433,7 @@ export default function ReactMemeContent() {
 	const handleShare = useCallback(
 		async (memeId: string) => {
 			const meme = memes.find((m) => m.id === memeId);
-			const url = `${window.location.origin}/meme/${memeId}`;
+			const url = `${window.location.origin}/meme?id=${memeId}`;
 			const title = meme?.title || 'Check out this meme on Meme.sh';
 
 			// Optimistic increment
@@ -509,63 +517,81 @@ export default function ReactMemeContent() {
 
 	// ── Render ───────────────────────────────────────────────────────
 
-	if (loading) return <FeedSkeleton />;
+	if (loading)
+		return <FeedSkeleton variant={isDesktop ? 'desktop' : 'mobile'} />;
 
 	return (
 		<>
-			<div
-				ref={scrollRef}
-				className="w-full"
-				style={{
-					height: '100dvh',
-					overflowY: 'scroll',
-					scrollSnapType: 'y mandatory',
-					WebkitOverflowScrolling: 'touch',
-					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
-				}}>
-				{memes.map((meme, i) => (
-					<MemeCard
-						key={meme.id}
-						ref={cardRefs.current[i]}
-						meme={meme}
-						userReaction={userReactions.get(meme.id) ?? null}
-						isSaved={userSaves.has(meme.id)}
-						onReact={handleReact}
-						onSave={handleSave}
-						onUnsave={handleUnsave}
-						onComment={handleComment}
-						onShare={handleShare}
-						onReport={handleReport}
-						lazy={i > 1}
-					/>
-				))}
+			{isDesktop ? (
+				<BentoFeed
+					memes={memes}
+					hasMore={hasMore}
+					loadingMore={loadingMore}
+					userReactions={userReactions}
+					userSaves={userSaves}
+					onReact={handleReact}
+					onSave={handleSave}
+					onUnsave={handleUnsave}
+					onComment={handleComment}
+					onShare={handleShare}
+					onReport={handleReport}
+					onLoadMore={loadMore}
+				/>
+			) : (
+				<div
+					ref={scrollRef}
+					className="w-full"
+					style={{
+						height: '100dvh',
+						overflowY: 'scroll',
+						scrollSnapType: 'y mandatory',
+						WebkitOverflowScrolling: 'touch',
+						backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+					}}>
+					{memes.map((meme, i) => (
+						<MemeCard
+							key={meme.id}
+							ref={cardRefs.current[i]}
+							meme={meme}
+							userReaction={userReactions.get(meme.id) ?? null}
+							isSaved={userSaves.has(meme.id)}
+							onReact={handleReact}
+							onSave={handleSave}
+							onUnsave={handleUnsave}
+							onComment={handleComment}
+							onShare={handleShare}
+							onReport={handleReport}
+							lazy={i > 1}
+						/>
+					))}
 
-				{/* Sentinel for infinite scroll */}
-				{hasMore && (
-					<div
-						ref={sentinelRef}
-						style={{ height: 1 }}
-						aria-hidden
-					/>
-				)}
+					{/* Sentinel for infinite scroll */}
+					{hasMore && (
+						<div
+							ref={sentinelRef}
+							style={{ height: 1 }}
+							aria-hidden
+						/>
+					)}
 
-				{loadingMore && <FeedSkeleton />}
+					{loadingMore && <FeedSkeleton variant="mobile" />}
 
-				{!hasMore && memes.length > 0 && (
-					<div
-						className="flex items-center justify-center py-8"
-						style={{
-							height: '30dvh',
-							scrollSnapAlign: 'start',
-							backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
-							color: 'var(--sl-color-gray-3, #71717a)',
-						}}>
-						<p className="text-sm">
-							You've seen them all — for now.
-						</p>
-					</div>
-				)}
-			</div>
+					{!hasMore && memes.length > 0 && (
+						<div
+							className="flex items-center justify-center py-8"
+							style={{
+								height: '30dvh',
+								scrollSnapAlign: 'start',
+								backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+								color: 'var(--sl-color-gray-3, #71717a)',
+							}}>
+							<p className="text-sm">
+								You've seen them all — for now.
+							</p>
+						</div>
+					)}
+				</div>
+			)}
 
 			{/* Comments drawer */}
 			{commentsMemeId && (

--- a/apps/memes/astro-memes/src/components/feed/ReactionBar.tsx
+++ b/apps/memes/astro-memes/src/components/feed/ReactionBar.tsx
@@ -2,15 +2,31 @@ import { useCallback } from 'react';
 import { useStore } from '@nanostores/react';
 import { $auth, openModal } from '@kbve/astro';
 import {
+	ThumbsUp,
+	ThumbsDown,
+	Flame,
+	Skull,
+	Frown,
+	ShieldAlert,
 	Bookmark,
 	BookmarkCheck,
 	MessageCircle,
 	Share2,
 	MoreHorizontal,
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { REACTIONS } from '../../lib/memeService';
 
 const SIGNIN_MODAL = 'signin';
+
+const ICON_MAP: Record<string, LucideIcon> = {
+	ThumbsUp,
+	ThumbsDown,
+	Flame,
+	Skull,
+	Frown,
+	ShieldAlert,
+};
 
 interface ReactionBarProps {
 	memeId: string;
@@ -74,10 +90,13 @@ export default function ReactionBar({
 	);
 
 	return (
-		<div className="flex flex-col items-center gap-2.5 rounded-2xl p-2.5 backdrop-blur-md"
+		<div
+			className="flex flex-col items-center gap-2.5 rounded-2xl p-2.5 backdrop-blur-md"
 			style={{ backgroundColor: 'rgba(0,0,0,0.35)' }}>
 			{visibleReactions.map((r) => {
 				const isActive = userReaction === r.key;
+				const Icon = ICON_MAP[r.icon];
+				if (!Icon) return null;
 				return (
 					<button
 						key={r.key}
@@ -86,13 +105,21 @@ export default function ReactionBar({
 						className="flex flex-col items-center gap-0.5 transition-transform duration-150 active:scale-110"
 						aria-label={r.label}
 						title={r.label}>
-						<span
-							className="text-[26px] leading-none select-none transition-opacity"
-							style={{
-								opacity: isActive ? 1 : 0.6,
-							}}>
-							{r.emoji}
-						</span>
+						<Icon
+							size={22}
+							className={
+								isActive
+									? 'transition-colors'
+									: 'text-white/60 transition-colors'
+							}
+							style={
+								isActive
+									? {
+											color: 'var(--sl-color-text-accent, #22d3ee)',
+										}
+									: undefined
+							}
+						/>
 						{isActive && (
 							<span
 								className="text-[10px] font-bold"

--- a/apps/memes/astro-memes/src/components/meme/MemePage.tsx
+++ b/apps/memes/astro-memes/src/components/meme/MemePage.tsx
@@ -1,0 +1,393 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import { $auth, openModal, addToast } from '@kbve/astro';
+import { ArrowLeft, User } from 'lucide-react';
+import ReactionBar from '../feed/ReactionBar';
+import {
+	fetchMemeById,
+	reactToMeme,
+	removeReaction,
+	saveMeme,
+	unsaveMeme,
+	getUserReactions,
+	getUserSaves,
+	trackView,
+	trackShare,
+} from '../../lib/memeService';
+import type { FeedMeme } from '../../lib/memeService';
+
+const SIGNIN_MODAL = 'signin';
+
+export default function MemePage() {
+	const auth = useStore($auth);
+
+	const [meme, setMeme] = useState<FeedMeme | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(false);
+	const [userReaction, setUserReaction] = useState<number | null>(null);
+	const [isSaved, setIsSaved] = useState(false);
+	// Extract meme ID from query params
+	const memeId =
+		typeof window !== 'undefined'
+			? new URLSearchParams(window.location.search).get('id')
+			: null;
+
+	// Fetch meme
+	useEffect(() => {
+		if (!memeId) {
+			setError(true);
+			setLoading(false);
+			return;
+		}
+
+		let cancelled = false;
+
+		(async () => {
+			try {
+				const data = await fetchMemeById(memeId);
+				if (cancelled) return;
+				if (data) {
+					setMeme(data);
+					document.title = `${data.title || 'Meme'} — Meme.sh`;
+					trackView(memeId).catch(() => {});
+				} else {
+					setError(true);
+				}
+			} catch {
+				if (!cancelled) setError(true);
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [memeId]);
+
+	// Fetch user reaction / save state
+	useEffect(() => {
+		if (auth.tone !== 'auth' || !meme) return;
+
+		Promise.all([getUserReactions([meme.id]), getUserSaves([meme.id])])
+			.then(([reactions, saves]) => {
+				setUserReaction(reactions.get(meme.id) ?? null);
+				setIsSaved(saves.has(meme.id));
+			})
+			.catch(() => {});
+	}, [auth.tone, meme?.id]);
+
+	// Handlers
+	const handleReact = useCallback(
+		(id: string, reaction: number) => {
+			const prev = userReaction;
+			const toggling = prev === reaction;
+
+			setUserReaction(toggling ? null : reaction);
+			setMeme((m) =>
+				m
+					? {
+							...m,
+							reaction_count:
+								m.reaction_count +
+								(toggling ? -1 : prev === null ? 1 : 0),
+						}
+					: m,
+			);
+
+			const promise = toggling
+				? removeReaction(id)
+				: reactToMeme(id, reaction);
+			promise.catch(() => {
+				setUserReaction(prev);
+				setMeme((m) =>
+					m
+						? {
+								...m,
+								reaction_count:
+									m.reaction_count +
+									(toggling ? 1 : prev === null ? -1 : 0),
+							}
+						: m,
+				);
+			});
+		},
+		[userReaction],
+	);
+
+	const handleSave = useCallback((id: string) => {
+		setIsSaved(true);
+		setMeme((m) => (m ? { ...m, save_count: m.save_count + 1 } : m));
+
+		saveMeme(id).catch(() => {
+			setIsSaved(false);
+			setMeme((m) => (m ? { ...m, save_count: m.save_count - 1 } : m));
+		});
+	}, []);
+
+	const handleUnsave = useCallback((id: string) => {
+		setIsSaved(false);
+		setMeme((m) => (m ? { ...m, save_count: m.save_count - 1 } : m));
+
+		unsaveMeme(id).catch(() => {
+			setIsSaved(true);
+			setMeme((m) => (m ? { ...m, save_count: m.save_count + 1 } : m));
+		});
+	}, []);
+
+	const handleShare = useCallback(async (id: string) => {
+		const url = window.location.href;
+
+		setMeme((m) => (m ? { ...m, share_count: m.share_count + 1 } : m));
+
+		try {
+			if (navigator.share) {
+				await navigator.share({
+					title: 'Check out this meme on Meme.sh',
+					url,
+				});
+			} else {
+				await navigator.clipboard.writeText(url);
+				addToast({
+					id: `share-copy-${Date.now()}`,
+					message: 'Link copied!',
+					severity: 'success',
+					duration: 3000,
+				});
+			}
+		} catch {
+			setMeme((m) => (m ? { ...m, share_count: m.share_count - 1 } : m));
+			return;
+		}
+
+		trackShare(id).catch(() => {});
+	}, []);
+
+	const handleComment = useCallback((_id: string) => {
+		// Comments drawer not yet integrated on standalone meme page
+	}, []);
+
+	const handleReport = useCallback(
+		(_id: string) => {
+			if (auth.tone !== 'auth') {
+				openModal(SIGNIN_MODAL);
+				return;
+			}
+			addToast({
+				id: `report-${Date.now()}`,
+				message: 'Report feature coming soon.',
+				severity: 'info',
+				duration: 3000,
+			});
+		},
+		[auth.tone],
+	);
+
+	// Loading state
+	if (loading) {
+		return (
+			<div
+				className="flex items-center justify-center"
+				style={{
+					minHeight: '100dvh',
+					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+				}}>
+				<div
+					className="w-16 h-16 rounded-xl animate-pulse"
+					style={{
+						backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
+					}}
+				/>
+			</div>
+		);
+	}
+
+	// Error / not found
+	if (error || !meme) {
+		return (
+			<div
+				className="flex flex-col items-center justify-center gap-4"
+				style={{
+					minHeight: '100dvh',
+					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+				}}>
+				<p
+					className="text-lg font-medium"
+					style={{
+						color: 'var(--sl-color-white, #e2e8f0)',
+					}}>
+					Meme not found
+				</p>
+				<a
+					href="/feed"
+					className="inline-flex items-center gap-2 text-sm px-4 py-2 rounded-lg transition-colors hover:opacity-80"
+					style={{
+						backgroundColor: 'var(--sl-color-accent-low, #164e63)',
+						color: 'var(--sl-color-text-accent, #22d3ee)',
+					}}>
+					<ArrowLeft size={16} />
+					Back to feed
+				</a>
+			</div>
+		);
+	}
+
+	const isVideo = meme.format === 2 || meme.format === 3;
+
+	return (
+		<div
+			className="flex flex-col items-center px-4 py-8"
+			style={{
+				minHeight: '100dvh',
+				backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
+			}}>
+			{/* Back link */}
+			<div className="w-full max-w-3xl mb-6">
+				<a
+					href="/feed"
+					className="inline-flex items-center gap-2 text-sm transition-opacity hover:opacity-70"
+					style={{
+						color: 'var(--sl-color-gray-2, #a1a1aa)',
+					}}>
+					<ArrowLeft size={16} />
+					Back to feed
+				</a>
+			</div>
+
+			{/* Content */}
+			<div className="flex flex-col md:flex-row items-start gap-6 max-w-3xl w-full">
+				{/* Meme asset */}
+				<div className="flex-1 min-w-0 flex flex-col items-center w-full">
+					<div className="w-full flex items-center justify-center">
+						{isVideo ? (
+							<video
+								src={meme.asset_url}
+								className="max-w-full max-h-[70vh] object-contain rounded-xl"
+								style={{
+									border: '1px solid var(--sl-color-hairline, rgba(255,255,255,0.06))',
+								}}
+								autoPlay
+								loop
+								muted
+								playsInline
+							/>
+						) : (
+							<img
+								src={meme.asset_url}
+								alt={meme.title || 'Meme'}
+								className="max-w-full max-h-[70vh] object-contain rounded-xl select-none"
+								style={{
+									border: '1px solid var(--sl-color-hairline, rgba(255,255,255,0.06))',
+								}}
+								draggable={false}
+							/>
+						)}
+					</div>
+
+					{/* Info */}
+					<div className="w-full mt-4">
+						{meme.title && (
+							<h1
+								className="text-xl font-bold leading-tight mb-3"
+								style={{
+									color: 'var(--sl-color-white, #e2e8f0)',
+								}}>
+								{meme.title}
+							</h1>
+						)}
+
+						<div className="flex items-center gap-2.5 mb-3">
+							{meme.author_name ? (
+								<a
+									href={`https://kbve.com/@${meme.author_name}`}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-2 group">
+									{meme.author_avatar ? (
+										<img
+											src={meme.author_avatar}
+											alt={meme.author_name}
+											className="w-8 h-8 rounded-full"
+										/>
+									) : (
+										<div
+											className="w-8 h-8 rounded-full flex items-center justify-center"
+											style={{
+												backgroundColor:
+													'var(--sl-color-accent-low, #164e63)',
+											}}>
+											<User
+												size={16}
+												style={{
+													color: 'var(--sl-color-text-accent, #22d3ee)',
+												}}
+											/>
+										</div>
+									)}
+									<span
+										className="text-sm font-medium group-hover:underline"
+										style={{
+											color: 'var(--sl-color-gray-2, #a1a1aa)',
+										}}>
+										@{meme.author_name}
+									</span>
+								</a>
+							) : (
+								<div
+									className="w-8 h-8 rounded-full flex items-center justify-center"
+									style={{
+										backgroundColor:
+											'var(--sl-color-accent-low, #164e63)',
+									}}>
+									<User
+										size={16}
+										style={{
+											color: 'var(--sl-color-text-accent, #22d3ee)',
+										}}
+									/>
+								</div>
+							)}
+						</div>
+
+						{meme.tags.length > 0 && (
+							<div className="flex flex-wrap gap-1.5">
+								{meme.tags.map((tag) => (
+									<span
+										key={tag}
+										className="text-xs px-2.5 py-1 rounded-full"
+										style={{
+											backgroundColor:
+												'var(--sl-color-gray-6, #1c1c1e)',
+											color: 'var(--sl-color-gray-2, #a1a1aa)',
+											border: '1px solid var(--sl-color-hairline, rgba(255,255,255,0.06))',
+										}}>
+										#{tag}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Reaction bar */}
+				<div className="flex-shrink-0 md:sticky md:top-8">
+					<ReactionBar
+						memeId={meme.id}
+						reactionCount={meme.reaction_count}
+						saveCount={meme.save_count}
+						commentCount={meme.comment_count}
+						shareCount={meme.share_count}
+						userReaction={userReaction}
+						isSaved={isSaved}
+						onReact={handleReact}
+						onSave={handleSave}
+						onUnsave={handleUnsave}
+						onComment={handleComment}
+						onShare={handleShare}
+						onReport={handleReport}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/memes/astro-memes/src/lib/memeService.ts
+++ b/apps/memes/astro-memes/src/lib/memeService.ts
@@ -78,14 +78,20 @@ export interface UserProfile {
 }
 
 /** Reaction types matching ReactionType enum (1-indexed, 0 = unspecified) */
-export const REACTIONS = [
-	{ key: 1, emoji: '👍', label: 'Like' },
-	{ key: 2, emoji: '👎', label: 'Dislike' },
-	{ key: 3, emoji: '🔥', label: 'Fire' },
-	{ key: 4, emoji: '💀', label: 'Skull' },
-	{ key: 5, emoji: '😢', label: 'Cry' },
-	{ key: 6, emoji: '🧢', label: 'Cap' },
-] as const;
+export interface Reaction {
+	key: number;
+	icon: string;
+	label: string;
+}
+
+export const REACTIONS: Reaction[] = [
+	{ key: 1, icon: 'ThumbsUp', label: 'Like' },
+	{ key: 2, icon: 'ThumbsDown', label: 'Dislike' },
+	{ key: 3, icon: 'Flame', label: 'Fire' },
+	{ key: 4, icon: 'Skull', label: 'Skull' },
+	{ key: 5, icon: 'Frown', label: 'Cry' },
+	{ key: 6, icon: 'ShieldAlert', label: 'Cap' },
+];
 
 /** Report reasons matching ReportReason enum (1-7) */
 export const REPORT_REASONS = [
@@ -167,9 +173,7 @@ interface EdgeReportResponse {
 
 // ── Feed ─────────────────────────────────────────────────────────────────
 
-export async function fetchFeed(
-	params: FeedParams = {},
-): Promise<FeedPage> {
+export async function fetchFeed(params: FeedParams = {}): Promise<FeedPage> {
 	const data = await callEdge<EdgeFeedResponse>('meme', {
 		command: 'feed.list',
 		limit: params.limit ?? 5,
@@ -196,6 +200,19 @@ export async function trackShare(memeId: string): Promise<void> {
 		command: 'feed.share',
 		meme_id: memeId,
 	});
+}
+
+export async function fetchMemeById(id: string): Promise<FeedMeme | null> {
+	try {
+		const data = await callEdge<EdgeFeedResponse>('meme', {
+			command: 'feed.list',
+			limit: 1,
+			meme_id: id,
+		});
+		return data.memes[0] ?? null;
+	} catch {
+		return null;
+	}
 }
 
 // ── Reactions ────────────────────────────────────────────────────────────
@@ -251,9 +268,7 @@ export async function getUserReactions(
 	return map;
 }
 
-export async function getUserSaves(
-	memeIds: string[],
-): Promise<Set<string>> {
+export async function getUserSaves(memeIds: string[]): Promise<Set<string>> {
 	const data = await callEdge<EdgeUserSavesResponse>('meme', {
 		command: 'user.saves',
 		meme_ids: memeIds,
@@ -311,9 +326,7 @@ export async function deleteComment(commentId: string): Promise<void> {
 
 // ── Profiles ─────────────────────────────────────────────────────────────
 
-export async function getProfile(
-	userId: string,
-): Promise<UserProfile | null> {
+export async function getProfile(userId: string): Promise<UserProfile | null> {
 	const data = await callEdge<EdgeProfileResponse>('meme', {
 		command: 'profile.get',
 		user_id: userId,

--- a/apps/memes/astro-memes/src/pages/meme.astro
+++ b/apps/memes/astro-memes/src/pages/meme.astro
@@ -1,0 +1,55 @@
+---
+// Dedicated meme page — renders a single meme by ?id= query param
+// Uses client:only to avoid SSR (no adapter configured)
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Meme — Meme.sh</title>
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="description" content="View and share memes on Meme.sh" />
+		<style>
+			* {
+				margin: 0;
+				padding: 0;
+				box-sizing: border-box;
+			}
+			:root {
+				--sl-color-bg: #0a0a0a;
+				--sl-color-white: #e2e8f0;
+				--sl-color-gray-2: #a1a1aa;
+				--sl-color-gray-3: #71717a;
+				--sl-color-gray-6: #1c1c1e;
+				--sl-color-text-accent: #22d3ee;
+				--sl-color-accent-low: #164e63;
+				--sl-color-hairline: rgba(255, 255, 255, 0.06);
+			}
+			body {
+				font-family:
+					system-ui,
+					-apple-system,
+					'Segoe UI',
+					Roboto,
+					sans-serif;
+				background-color: var(--sl-color-bg);
+				color: var(--sl-color-white);
+				min-height: 100dvh;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="meme-root"></div>
+
+		<script>
+			import { createElement } from 'react';
+			import { createRoot } from 'react-dom/client';
+			import MemePage from '../components/meme/MemePage';
+
+			const root = createRoot(document.getElementById('meme-root')!);
+			root.render(createElement(MemePage));
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
## Summary
- **Responsive bento grid**: Desktop (md+) shows a multi-column bento grid with auto-featured cards spanning 2 columns; mobile preserves the existing full-screen scroll-snap feed
- **Lucide icons replace emojis**: All reaction emojis removed in favor of lucide-react icons (ThumbsUp, ThumbsDown, Flame, Skull, Frown, ShieldAlert) via string-mapped ICON_MAP
- **Lightbox overlay**: Clicking a bento card expands it in a backdrop-blurred overlay with keyboard navigation (Escape, ArrowLeft/Right), reaction bar, and share link
- **Dedicated meme page**: New `/meme?id=xxx` route for sharing/linking individual memes with full meme viewer, reaction bar, and author info
- **FeedSkeleton variant**: Desktop skeleton renders a bento grid placeholder matching the layout

Closes #7548

## Test plan
- [ ] Verify mobile feed remains full-screen scroll-snap at < 768px
- [ ] Verify desktop feed renders bento grid at >= 768px with featured cards
- [ ] Click a bento card and verify lightbox opens with keyboard nav
- [ ] Verify share button opens `/meme?id=xxx` in new tab
- [ ] Verify `/meme?id=xxx` loads and displays the meme with reactions
- [ ] Verify all reactions use lucide icons (no emojis anywhere)
- [ ] Run `npx nx build astro-memes` — should pass with 0 errors