### PR TITLE
chore(n8n): bump resource limits for production workloads

### DIFF
--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -91,11 +91,11 @@ spec:
                                 key: auth-token
                   resources:
                       requests:
-                          memory: '512Mi'
-                          cpu: '500m'
+                          memory: '2Gi'
+                          cpu: '2000m'
                       limits:
-                          memory: '1024Mi'
-                          cpu: '1000m'
+                          memory: '8Gi'
+                          cpu: '4000m'
                   livenessProbe:
                       httpGet:
                           path: /healthz
@@ -132,11 +132,11 @@ spec:
                         value: '5'
                   resources:
                       requests:
-                          memory: '256Mi'
-                          cpu: '250m'
-                      limits:
                           memory: '512Mi'
                           cpu: '500m'
+                      limits:
+                          memory: '1Gi'
+                          cpu: '1000m'
                   livenessProbe:
                       httpGet:
                           path: /healthz


### PR DESCRIPTION
## Summary
- n8n main container: 2Gi/2CPU requests, 8Gi/4CPU limits (burst headroom for AI/large-data workflows)
- Task runner sidecar: 512Mi/500m requests, 1Gi/1CPU limits
- Aligns with n8n recommended minimums (2GB RAM, 2 CPU cores)

## Test plan
- [ ] Verify pod schedules with new resource requests
- [ ] Monitor memory under active workflow load