### PR TITLE
feat(meme): service-role-only admin.create endpoint

### DIFF
--- a/apps/kbve/edge-e2e/e2e/meme.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/meme.spec.ts
@@ -96,6 +96,7 @@ describe('Meme — Smoke Tests', () => {
 		expect(body.error).toContain('profile');
 		expect(body.error).toContain('follow');
 		expect(body.error).toContain('report');
+		expect(body.error).toContain('admin');
 	});
 
 	it('should return 500 for malformed JSON body', async () => {
@@ -131,5 +132,92 @@ describe('Meme — Smoke Tests', () => {
 		});
 		expect(res.status).not.toBe(401);
 		expect(res.status).not.toBe(405);
+	});
+
+	// -- Admin module (service_role only) --
+
+	it('should reject admin.create without service_role', async () => {
+		const anonToken = createJwt({ role: 'authenticated', extraClaims: { sub: '00000000-0000-0000-0000-000000000001' } });
+		const res = await fetch(`${BASE_URL}/meme`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${anonToken}`,
+			},
+			body: JSON.stringify({ command: 'admin.create', asset_url: 'https://example.com/meme.png' }),
+		});
+		expect(res.status).toBe(403);
+		const body = await res.json();
+		expect(body.error).toContain('service_role');
+	});
+
+	it('should reject admin.create with missing asset_url', async () => {
+		const res = await fetch(`${BASE_URL}/meme`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({
+				command: 'admin.create',
+				author_id: '00000000-0000-0000-0000-000000000001',
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('asset_url');
+	});
+
+	it('should reject admin.create with missing author_id', async () => {
+		const res = await fetch(`${BASE_URL}/meme`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({
+				command: 'admin.create',
+				asset_url: 'https://example.com/meme.png',
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('author_id');
+	});
+
+	it('should reject admin.create with non-HTTPS asset_url', async () => {
+		const res = await fetch(`${BASE_URL}/meme`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({
+				command: 'admin.create',
+				author_id: '00000000-0000-0000-0000-000000000001',
+				asset_url: 'http://example.com/meme.png',
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('HTTPS');
+	});
+
+	it('should reject admin.create with invalid format', async () => {
+		const res = await fetch(`${BASE_URL}/meme`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({
+				command: 'admin.create',
+				author_id: '00000000-0000-0000-0000-000000000001',
+				asset_url: 'https://example.com/meme.png',
+				format: 99,
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('format');
+	});
+
+	it('should return 400 for unknown admin action', async () => {
+		const res = await fetch(`${BASE_URL}/meme`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({ command: 'admin.nonexistent' }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('Unknown admin action');
 	});
 });

--- a/apps/kbve/edge/functions/meme/admin.ts
+++ b/apps/kbve/edge/functions/meme/admin.ts
@@ -1,0 +1,244 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  type MemeRequest,
+  requireServiceRole,
+  validateTag,
+} from "./_shared.ts";
+
+// ---------------------------------------------------------------------------
+// Meme Admin Module — service_role only
+//
+// Actions:
+//   create  -- Insert a new meme (URL reference + metadata)
+// ---------------------------------------------------------------------------
+
+const HTTPS_RE = /^https:\/\/.+/;
+const HEX_RE = /^[a-f0-9]+$/;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type Handler = (memeReq: MemeRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+  async create({ claims, body }) {
+    // Gate: service_role only
+    const roleErr = requireServiceRole(claims);
+    if (roleErr) return roleErr;
+
+    const {
+      author_id,
+      asset_url,
+      title,
+      format,
+      thumbnail_url,
+      width,
+      height,
+      file_size,
+      tags,
+      source_url,
+      alt_text,
+      content_hash,
+      status,
+    } = body;
+
+    // --- Belt: edge-level validation ---
+
+    // author_id: required UUID
+    if (!author_id || typeof author_id !== "string") {
+      return jsonResponse({ error: "author_id is required" }, 400);
+    }
+    if (!UUID_RE.test(author_id)) {
+      return jsonResponse({ error: "author_id must be a valid UUID" }, 400);
+    }
+
+    // asset_url: required HTTPS URL
+    if (!asset_url || typeof asset_url !== "string") {
+      return jsonResponse({ error: "asset_url is required" }, 400);
+    }
+    if (
+      !HTTPS_RE.test(asset_url) ||
+      asset_url.length > 2048
+    ) {
+      return jsonResponse(
+        { error: "asset_url must be a valid HTTPS URL (max 2048 chars)" },
+        400,
+      );
+    }
+
+    // title: optional, max 200 chars
+    if (title !== undefined && title !== null) {
+      if (typeof title !== "string" || title.length > 200) {
+        return jsonResponse(
+          { error: "title must be a string of at most 200 characters" },
+          400,
+        );
+      }
+    }
+
+    // format: optional, 0-4
+    const safeFormat = format !== undefined ? Number(format) : 0;
+    if (
+      !Number.isInteger(safeFormat) || safeFormat < 0 || safeFormat > 4
+    ) {
+      return jsonResponse(
+        {
+          error:
+            "format must be 0 (unspecified), 1 (image), 2 (gif), 3 (video), or 4 (webp_anim)",
+        },
+        400,
+      );
+    }
+
+    // thumbnail_url: optional HTTPS
+    if (thumbnail_url !== undefined && thumbnail_url !== null) {
+      if (
+        typeof thumbnail_url !== "string" ||
+        !HTTPS_RE.test(thumbnail_url) ||
+        thumbnail_url.length > 2048
+      ) {
+        return jsonResponse(
+          { error: "thumbnail_url must be a valid HTTPS URL" },
+          400,
+        );
+      }
+    }
+
+    // source_url: optional HTTPS
+    if (source_url !== undefined && source_url !== null) {
+      if (
+        typeof source_url !== "string" ||
+        !HTTPS_RE.test(source_url) ||
+        source_url.length > 2048
+      ) {
+        return jsonResponse(
+          { error: "source_url must be a valid HTTPS URL" },
+          400,
+        );
+      }
+    }
+
+    // width/height: optional positive integers
+    const safeWidth = width !== undefined ? Number(width) : null;
+    if (
+      safeWidth !== null && (!Number.isInteger(safeWidth) || safeWidth <= 0)
+    ) {
+      return jsonResponse({ error: "width must be a positive integer" }, 400);
+    }
+
+    const safeHeight = height !== undefined ? Number(height) : null;
+    if (
+      safeHeight !== null && (!Number.isInteger(safeHeight) || safeHeight <= 0)
+    ) {
+      return jsonResponse({ error: "height must be a positive integer" }, 400);
+    }
+
+    // file_size: optional positive integer
+    const safeFileSize = file_size !== undefined ? Number(file_size) : null;
+    if (
+      safeFileSize !== null &&
+      (!Number.isInteger(safeFileSize) || safeFileSize <= 0)
+    ) {
+      return jsonResponse(
+        { error: "file_size must be a positive integer" },
+        400,
+      );
+    }
+
+    // tags: optional array of slug-safe strings
+    if (tags !== undefined && tags !== null) {
+      if (!Array.isArray(tags)) {
+        return jsonResponse({ error: "tags must be an array" }, 400);
+      }
+      if (tags.length > 20) {
+        return jsonResponse({ error: "tags exceeds maximum of 20" }, 400);
+      }
+      for (const tag of tags) {
+        const tagErr = validateTag(tag);
+        if (tagErr) return tagErr;
+      }
+    }
+
+    // alt_text: optional, max 500 chars
+    if (alt_text !== undefined && alt_text !== null) {
+      if (typeof alt_text !== "string" || alt_text.length > 500) {
+        return jsonResponse(
+          { error: "alt_text must be a string of at most 500 characters" },
+          400,
+        );
+      }
+    }
+
+    // content_hash: optional hex string
+    if (content_hash !== undefined && content_hash !== null) {
+      if (
+        typeof content_hash !== "string" ||
+        content_hash.length > 128 ||
+        !HEX_RE.test(content_hash)
+      ) {
+        return jsonResponse(
+          { error: "content_hash must be lowercase hex, max 128 chars" },
+          400,
+        );
+      }
+    }
+
+    // status: optional, 1 (draft), 2 (pending), or 3 (published)
+    const safeStatus = status !== undefined ? Number(status) : 1;
+    if (
+      !Number.isInteger(safeStatus) ||
+      ![1, 2, 3].includes(safeStatus)
+    ) {
+      return jsonResponse(
+        { error: "status must be 1 (draft), 2 (pending), or 3 (published)" },
+        400,
+      );
+    }
+
+    // --- Suspenders: let the DB RPC + table constraints do their job ---
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_create_meme", {
+      p_author_id: author_id as string,
+      p_asset_url: asset_url as string,
+      p_title: (title as string) ?? null,
+      p_format: safeFormat,
+      p_thumbnail_url: (thumbnail_url as string) ?? null,
+      p_width: safeWidth,
+      p_height: safeHeight,
+      p_file_size: safeFileSize,
+      p_tags: (tags as string[]) ?? [],
+      p_source_url: (source_url as string) ?? null,
+      p_alt_text: (alt_text as string) ?? null,
+      p_content_hash: (content_hash as string) ?? null,
+      p_status: safeStatus,
+    });
+
+    if (error) {
+      console.error("service_create_meme error:", error);
+      return jsonResponse({ error: error.message }, 400);
+    }
+
+    return jsonResponse({
+      success: true,
+      meme_id: data,
+    });
+  },
+};
+
+export const ADMIN_ACTIONS = Object.keys(handlers);
+
+export async function handleAdmin(memeReq: MemeRequest): Promise<Response> {
+  const handler = handlers[memeReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown admin action: ${memeReq.action}. Use: ${
+          ADMIN_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(memeReq);
+}

--- a/apps/kbve/edge/functions/meme/index.ts
+++ b/apps/kbve/edge/functions/meme/index.ts
@@ -15,6 +15,7 @@ import { COMMENT_ACTIONS, handleComment } from "./comment.ts";
 import { handleProfile, PROFILE_ACTIONS } from "./profile.ts";
 import { FOLLOW_ACTIONS, handleFollow } from "./follow.ts";
 import { handleReport, REPORT_ACTIONS } from "./report.ts";
+import { ADMIN_ACTIONS, handleAdmin } from "./admin.ts";
 
 // ---------------------------------------------------------------------------
 // Meme Edge Function — Unified Router
@@ -28,6 +29,7 @@ import { handleReport, REPORT_ACTIONS } from "./report.ts";
 //   profile:  get, update, memes
 //   follow:   add, remove
 //   report:   create
+//   admin:    create              (service_role only)
 // ---------------------------------------------------------------------------
 
 const MODULES: Record<
@@ -45,6 +47,7 @@ const MODULES: Record<
   profile: { handler: handleProfile, actions: PROFILE_ACTIONS },
   follow: { handler: handleFollow, actions: FOLLOW_ACTIONS },
   report: { handler: handleReport, actions: REPORT_ACTIONS },
+  admin: { handler: handleAdmin, actions: ADMIN_ACTIONS },
 };
 
 function buildHelpText(): string {

--- a/packages/data/sql/dbmate/migrations/20260303210000_meme_create_rpc.sql
+++ b/packages/data/sql/dbmate/migrations/20260303210000_meme_create_rpc.sql
@@ -1,0 +1,102 @@
+-- migrate:up
+-- ===========================================
+-- RPC: service_create_meme
+-- Service-role-only: insert a new meme (URL reference + metadata)
+-- Belt: validates all fields at RPC level
+-- Suspenders: table constraints + triggers catch anything missed
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_create_meme(
+    p_author_id       UUID,
+    p_asset_url       TEXT,
+    p_title           TEXT       DEFAULT NULL,
+    p_format          SMALLINT   DEFAULT 0,
+    p_thumbnail_url   TEXT       DEFAULT NULL,
+    p_width           INTEGER    DEFAULT NULL,
+    p_height          INTEGER    DEFAULT NULL,
+    p_file_size       BIGINT     DEFAULT NULL,
+    p_tags            TEXT[]     DEFAULT '{}',
+    p_source_url      TEXT       DEFAULT NULL,
+    p_alt_text        TEXT       DEFAULT NULL,
+    p_content_hash    TEXT       DEFAULT NULL,
+    p_status          SMALLINT   DEFAULT 1
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_meme_id TEXT;
+BEGIN
+    -- Belt: validate at RPC level before hitting table constraints
+
+    IF p_author_id IS NULL THEN
+        RAISE EXCEPTION 'author_id is required';
+    END IF;
+
+    IF p_asset_url IS NULL OR btrim(p_asset_url) = '' THEN
+        RAISE EXCEPTION 'asset_url is required';
+    END IF;
+    IF NOT meme.is_safe_url(p_asset_url) THEN
+        RAISE EXCEPTION 'asset_url must be a valid HTTPS URL (max 2048 chars)';
+    END IF;
+
+    IF p_thumbnail_url IS NOT NULL AND NOT meme.is_safe_url(p_thumbnail_url) THEN
+        RAISE EXCEPTION 'thumbnail_url must be a valid HTTPS URL';
+    END IF;
+    IF p_source_url IS NOT NULL AND NOT meme.is_safe_url(p_source_url) THEN
+        RAISE EXCEPTION 'source_url must be a valid HTTPS URL';
+    END IF;
+
+    IF p_title IS NOT NULL AND (char_length(p_title) > 200 OR NOT meme.is_safe_text(p_title)) THEN
+        RAISE EXCEPTION 'title must be <= 200 chars with no control characters';
+    END IF;
+
+    IF p_alt_text IS NOT NULL AND (char_length(p_alt_text) > 500 OR NOT meme.is_safe_text(p_alt_text)) THEN
+        RAISE EXCEPTION 'alt_text must be <= 500 chars with no control characters';
+    END IF;
+
+    IF p_format < 0 OR p_format > 4 THEN
+        RAISE EXCEPTION 'format must be between 0 and 4';
+    END IF;
+
+    IF p_status NOT IN (1, 2, 3) THEN
+        RAISE EXCEPTION 'status must be 1 (draft), 2 (pending), or 3 (published)';
+    END IF;
+
+    IF NOT meme.are_valid_tags(p_tags) THEN
+        RAISE EXCEPTION 'tags must be <= 20 lowercase slug-safe strings (1-50 chars each)';
+    END IF;
+
+    IF p_content_hash IS NOT NULL AND (char_length(p_content_hash) > 128 OR p_content_hash !~ '^[a-f0-9]+$') THEN
+        RAISE EXCEPTION 'content_hash must be lowercase hex, max 128 chars';
+    END IF;
+
+    -- Suspenders: INSERT — table constraints + triggers catch anything we missed
+    INSERT INTO meme.memes (
+        author_id, asset_url, title, format, status,
+        thumbnail_url, width, height, file_size,
+        tags, source_url, alt_text, content_hash,
+        published_at
+    ) VALUES (
+        p_author_id, p_asset_url, p_title, p_format, p_status,
+        p_thumbnail_url, p_width, p_height, p_file_size,
+        p_tags, p_source_url, p_alt_text, p_content_hash,
+        CASE WHEN p_status = 3 THEN NOW() ELSE NULL END
+    )
+    RETURNING id INTO v_meme_id;
+
+    RETURN v_meme_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_create_meme(UUID, TEXT, TEXT, SMALLINT, TEXT, INTEGER, INTEGER, BIGINT, TEXT[], TEXT, TEXT, TEXT, SMALLINT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_create_meme(UUID, TEXT, TEXT, SMALLINT, TEXT, INTEGER, INTEGER, BIGINT, TEXT[], TEXT, TEXT, TEXT, SMALLINT)
+    TO service_role;
+ALTER FUNCTION meme.service_create_meme(UUID, TEXT, TEXT, SMALLINT, TEXT, INTEGER, INTEGER, BIGINT, TEXT[], TEXT, TEXT, TEXT, SMALLINT)
+    OWNER TO service_role;
+
+-- migrate:down
+DROP FUNCTION IF EXISTS meme.service_create_meme(UUID, TEXT, TEXT, SMALLINT, TEXT, INTEGER, INTEGER, BIGINT, TEXT[], TEXT, TEXT, TEXT, SMALLINT);

--- a/packages/data/sql/schema/meme/meme_rpcs.sql
+++ b/packages/data/sql/schema/meme/meme_rpcs.sql
@@ -789,6 +789,106 @@ ALTER FUNCTION meme.service_report_meme(UUID, TEXT, SMALLINT, TEXT)
 
 
 -- ===========================================
+-- RPC: service_create_meme
+-- Service-role-only: insert a new meme (URL reference + metadata)
+-- Belt: validates all fields at RPC level
+-- Suspenders: table constraints + triggers catch anything missed
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION meme.service_create_meme(
+    p_author_id       UUID,
+    p_asset_url       TEXT,
+    p_title           TEXT       DEFAULT NULL,
+    p_format          SMALLINT   DEFAULT 0,
+    p_thumbnail_url   TEXT       DEFAULT NULL,
+    p_width           INTEGER    DEFAULT NULL,
+    p_height          INTEGER    DEFAULT NULL,
+    p_file_size       BIGINT     DEFAULT NULL,
+    p_tags            TEXT[]     DEFAULT '{}',
+    p_source_url      TEXT       DEFAULT NULL,
+    p_alt_text        TEXT       DEFAULT NULL,
+    p_content_hash    TEXT       DEFAULT NULL,
+    p_status          SMALLINT   DEFAULT 1
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_meme_id TEXT;
+BEGIN
+    -- Belt: validate at RPC level before hitting table constraints
+
+    IF p_author_id IS NULL THEN
+        RAISE EXCEPTION 'author_id is required';
+    END IF;
+
+    IF p_asset_url IS NULL OR btrim(p_asset_url) = '' THEN
+        RAISE EXCEPTION 'asset_url is required';
+    END IF;
+    IF NOT meme.is_safe_url(p_asset_url) THEN
+        RAISE EXCEPTION 'asset_url must be a valid HTTPS URL (max 2048 chars)';
+    END IF;
+
+    IF p_thumbnail_url IS NOT NULL AND NOT meme.is_safe_url(p_thumbnail_url) THEN
+        RAISE EXCEPTION 'thumbnail_url must be a valid HTTPS URL';
+    END IF;
+    IF p_source_url IS NOT NULL AND NOT meme.is_safe_url(p_source_url) THEN
+        RAISE EXCEPTION 'source_url must be a valid HTTPS URL';
+    END IF;
+
+    IF p_title IS NOT NULL AND (char_length(p_title) > 200 OR NOT meme.is_safe_text(p_title)) THEN
+        RAISE EXCEPTION 'title must be <= 200 chars with no control characters';
+    END IF;
+
+    IF p_alt_text IS NOT NULL AND (char_length(p_alt_text) > 500 OR NOT meme.is_safe_text(p_alt_text)) THEN
+        RAISE EXCEPTION 'alt_text must be <= 500 chars with no control characters';
+    END IF;
+
+    IF p_format < 0 OR p_format > 4 THEN
+        RAISE EXCEPTION 'format must be between 0 and 4';
+    END IF;
+
+    IF p_status NOT IN (1, 2, 3) THEN
+        RAISE EXCEPTION 'status must be 1 (draft), 2 (pending), or 3 (published)';
+    END IF;
+
+    IF NOT meme.are_valid_tags(p_tags) THEN
+        RAISE EXCEPTION 'tags must be <= 20 lowercase slug-safe strings (1-50 chars each)';
+    END IF;
+
+    IF p_content_hash IS NOT NULL AND (char_length(p_content_hash) > 128 OR p_content_hash !~ '^[a-f0-9]+$') THEN
+        RAISE EXCEPTION 'content_hash must be lowercase hex, max 128 chars';
+    END IF;
+
+    -- Suspenders: INSERT — table constraints + triggers catch anything we missed
+    INSERT INTO meme.memes (
+        author_id, asset_url, title, format, status,
+        thumbnail_url, width, height, file_size,
+        tags, source_url, alt_text, content_hash,
+        published_at
+    ) VALUES (
+        p_author_id, p_asset_url, p_title, p_format, p_status,
+        p_thumbnail_url, p_width, p_height, p_file_size,
+        p_tags, p_source_url, p_alt_text, p_content_hash,
+        CASE WHEN p_status = 3 THEN NOW() ELSE NULL END
+    )
+    RETURNING id INTO v_meme_id;
+
+    RETURN v_meme_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION meme.service_create_meme(UUID, TEXT, TEXT, SMALLINT, TEXT, INTEGER, INTEGER, BIGINT, TEXT[], TEXT, TEXT, TEXT, SMALLINT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION meme.service_create_meme(UUID, TEXT, TEXT, SMALLINT, TEXT, INTEGER, INTEGER, BIGINT, TEXT[], TEXT, TEXT, TEXT, SMALLINT)
+    TO service_role;
+ALTER FUNCTION meme.service_create_meme(UUID, TEXT, TEXT, SMALLINT, TEXT, INTEGER, INTEGER, BIGINT, TEXT[], TEXT, TEXT, TEXT, SMALLINT)
+    OWNER TO service_role;
+
+
+-- ===========================================
 -- VERIFICATION
 -- ===========================================
 
@@ -813,7 +913,8 @@ DECLARE
         'meme.service_get_user_memes(uuid,int,text)',
         'meme.service_follow(uuid,uuid)',
         'meme.service_unfollow(uuid,uuid)',
-        'meme.service_report_meme(uuid,text,smallint,text)'
+        'meme.service_report_meme(uuid,text,smallint,text)',
+        'meme.service_create_meme(uuid,text,text,smallint,text,integer,integer,bigint,text[],text,text,text,smallint)'
     ];
     v_fn TEXT;
 BEGIN
@@ -843,7 +944,7 @@ BEGIN
         END IF;
     END LOOP;
 
-    RAISE NOTICE 'meme.rpcs: all 19 service functions verified successfully.';
+    RAISE NOTICE 'meme.rpcs: all 20 service functions verified successfully.';
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
## Summary
- Add `admin.create` command to the meme edge function — **service_role only**
- Stores meme URL reference + metadata (title, format, tags, dimensions, etc.) — no media blobs
- Belt-and-suspenders validation: edge function validates all fields, DB RPC validates again, table constraints + triggers are the final backstop

## Changes
- **Schema source** (`sql/schema/meme/meme_rpcs.sql`): Add `service_create_meme` RPC with full input validation, REVOKE/GRANT/OWNER pattern, verification block updated to 20 functions
- **Migration** (`20260303210000_meme_create_rpc.sql`): Derived from schema source
- **Edge function** (`functions/meme/admin.ts`): Service-role gate, input validation, calls RPC
- **Router** (`functions/meme/index.ts`): Wire `admin` module
- **E2E tests** (`meme.spec.ts`): 6 new tests — auth rejection, missing fields, non-HTTPS URL, invalid format, unknown action, module discovery

## Test plan
- [ ] `admin.create` with authenticated token returns 403
- [ ] `admin.create` with service_role + valid payload returns success + ULID
- [ ] Missing `asset_url` or `author_id` returns 400
- [ ] Non-HTTPS `asset_url` returns 400
- [ ] Invalid format (>4) returns 400
- [ ] DB migration applies cleanly on production