### PR TITLE
chore(edge,memes): bump edge to 0.1.9, axum-memes to 0.1.5

### DIFF
--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -1,1 +1,1 @@
-version = "0.1.8"
+version = "0.1.9"

--- a/apps/memes/axum-memes/Cargo.toml
+++ b/apps/memes/axum-memes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-memes"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps edge functions from 0.1.8 to 0.1.9
- Bumps axum-memes from 0.1.4 to 0.1.5

## Test plan
- [ ] CI passes cleanly