### PR TITLE
feat(memes): full-bleed hero with Bayer dither image cycling

### DIFF
--- a/apps/memes/astro-memes/astro.config.mjs
+++ b/apps/memes/astro-memes/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
       components: {
         Header: './src/components/header/Header.astro',
         Footer: './src/components/starlight/Footer.astro',
+        PageTitle: './src/components/starlight/PageTitle.astro',
       },
       sidebar: [
         {

--- a/apps/memes/astro-memes/src/components/hero/AstroHeroSection.astro
+++ b/apps/memes/astro-memes/src/components/hero/AstroHeroSection.astro
@@ -1,0 +1,226 @@
+---
+// Full-screen magazine hero — 100% static HTML, zero JS.
+// Background image, gradient overlay, animated text, CTAs.
+// HeroScrollFade.tsx hydrates separately to add the scroll-fade effect.
+---
+
+<section
+	id="hero"
+	class="hero-section"
+	style={`background-image: url('https://images.unsplash.com/photo-1443890923422-7819ed4101c0?crop=entropy&dpr=2&fit=crop&fm=jpg&h=700&ixjsv=2.1.0&ixlib=rb-0.3.5&q=50&w=1300');`}>
+	<canvas id="hero-canvas" class="hero-canvas" aria-hidden="true"></canvas>
+	<div class="hero-overlay" aria-hidden="true"></div>
+	<div class="hero-content">
+		<p class="hero-label hero-animate hero-delay-1">
+			Where memes come to life
+		</p>
+		<h1 class="hero-title hero-animate hero-delay-2">Meme.sh</h1>
+		<p class="hero-tagline hero-animate hero-delay-3">
+			Discover, share, and react to the internet's finest memes
+		</p>
+		<div class="hero-actions hero-animate hero-delay-4">
+			<a href="/feed" class="hero-cta-primary">
+				Browse Feed
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="18"
+					height="18"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true">
+					<path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path>
+				</svg>
+			</a>
+			<a href="/auth" class="hero-cta-secondary">Sign In</a>
+		</div>
+	</div>
+</section>
+
+<style>
+	/* ── Layout ─────────────────────────────────────── */
+	.hero-section {
+		position: relative;
+		width: 100%;
+		height: 100vh;
+		background-position: 50% 50%;
+		background-repeat: no-repeat;
+		background-size: cover;
+		backface-visibility: hidden;
+		overflow: hidden;
+		will-change: opacity;
+	}
+
+	@media (min-width: 640px) {
+		.hero-section {
+			background-position: 50% 0;
+		}
+	}
+
+	.hero-canvas {
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+		width: 100%;
+		height: 100%;
+		display: none;
+		image-rendering: -moz-crisp-edges;
+		image-rendering: pixelated;
+		image-rendering: crisp-edges;
+		pointer-events: none;
+	}
+
+	.hero-overlay {
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			135deg,
+			rgba(8, 51, 68, 0.75) 0%,
+			rgba(6, 182, 212, 0.25) 50%,
+			rgba(14, 116, 144, 0.6) 100%
+		);
+		z-index: 1;
+	}
+
+	.hero-content {
+		position: relative;
+		z-index: 2;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		height: 100%;
+		padding: 2rem 2.5rem 4rem;
+		box-sizing: border-box;
+	}
+
+	@media (min-width: 640px) {
+		.hero-content {
+			justify-content: center;
+			padding: 3rem 4rem;
+		}
+	}
+
+	/* ── Typography ─────────────────────────────────── */
+	.hero-label {
+		color: rgba(255, 255, 255, 0.8);
+		font-size: 0.75rem;
+		font-weight: 700;
+		letter-spacing: 0.35em;
+		text-transform: uppercase;
+		margin: 0 0 1rem;
+	}
+
+	.hero-title {
+		color: white;
+		font-size: clamp(3.5rem, 17vw, 10rem);
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		line-height: 1;
+		margin: 0 0 1rem;
+		width: 85%;
+	}
+
+	@media (min-width: 640px) {
+		.hero-title {
+			font-size: clamp(4rem, 10vw, 9rem);
+		}
+	}
+
+	.hero-tagline {
+		color: rgba(255, 255, 255, 0.7);
+		font-size: 1.125rem;
+		line-height: 1.5;
+		margin: 0 0 2rem;
+		max-width: 32rem;
+	}
+
+	/* ── CTAs ────────────────────────────────────────── */
+	.hero-actions {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.hero-cta-primary {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.875rem 2rem;
+		background: rgba(255, 255, 255, 0.9);
+		color: var(--sl-color-accent-high, #0e7490);
+		font-size: 1rem;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		text-decoration: none;
+		border-radius: 0.5rem;
+		transition:
+			background 0.2s,
+			transform 0.2s;
+	}
+
+	.hero-cta-primary:hover {
+		background: white;
+		transform: translateY(-1px);
+	}
+
+	.hero-cta-secondary {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.875rem 2rem;
+		background: rgba(255, 255, 255, 0.12);
+		color: white;
+		font-size: 1rem;
+		font-weight: 600;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		text-decoration: none;
+		border-radius: 0.5rem;
+		border: 1px solid rgba(255, 255, 255, 0.25);
+		backdrop-filter: blur(4px);
+		transition:
+			background 0.2s,
+			transform 0.2s;
+	}
+
+	.hero-cta-secondary:hover {
+		background: rgba(255, 255, 255, 0.2);
+		transform: translateY(-1px);
+	}
+
+	/* ── Fade-in animations ─────────────────────────── */
+	.hero-animate {
+		opacity: 0;
+		transform: translate3d(-12px, 0, 0);
+		animation: heroFadeInLeft 0.75s cubic-bezier(0.2, 0.3, 0.25, 0.9)
+			forwards;
+	}
+
+	.hero-delay-1 {
+		animation-delay: 0.2s;
+	}
+	.hero-delay-2 {
+		animation-delay: 0.4s;
+	}
+	.hero-delay-3 {
+		animation-delay: 0.6s;
+	}
+	.hero-delay-4 {
+		animation-delay: 0.8s;
+	}
+
+	@keyframes heroFadeInLeft {
+		from {
+			opacity: 0;
+			transform: translate3d(-12px, 0, 0);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/apps/memes/astro-memes/src/components/hero/HeroDitherCycle.tsx
+++ b/apps/memes/astro-memes/src/components/hero/HeroDitherCycle.tsx
@@ -1,0 +1,239 @@
+import { useEffect } from 'react';
+
+/**
+ * Unsplash photo IDs to cycle through.
+ * Add/remove IDs here to change the hero image rotation.
+ */
+const UNSPLASH_IDS = [
+	'1443890923422-7819ed4101c0',
+	'1706076463257-20b41d9519f0',
+];
+
+function unsplashUrl(id: string, w = 1400): string {
+	return `https://images.unsplash.com/photo-${id}?auto=format&fit=crop&w=${w}&q=80`;
+}
+
+/**
+ * Bayer 8×8 ordered dither matrix, normalized to [0, 1).
+ * Each value is a threshold — during the dissolve, pixels whose
+ * threshold is below the current progress show the incoming image.
+ */
+const BAYER_8 = [
+	[0, 32, 8, 40, 2, 34, 10, 42],
+	[48, 16, 56, 24, 50, 18, 58, 26],
+	[12, 44, 4, 36, 14, 46, 6, 38],
+	[60, 28, 52, 20, 62, 30, 54, 22],
+	[3, 35, 11, 43, 1, 33, 9, 41],
+	[51, 19, 59, 27, 49, 17, 57, 25],
+	[15, 47, 7, 39, 13, 45, 5, 37],
+	[63, 31, 55, 23, 61, 29, 53, 21],
+].map((row) => row.map((v) => v / 64));
+
+/** Downscale factor — canvas renders at 1/SCALE for pixel dither aesthetic */
+const SCALE = 4;
+/** Milliseconds between image transitions */
+const CYCLE_MS = 8000;
+/** Milliseconds for the dither dissolve animation */
+const DISSOLVE_MS = 2000;
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+	return new Promise((resolve, reject) => {
+		const img = new Image();
+		img.crossOrigin = 'anonymous';
+		img.onload = () => resolve(img);
+		img.onerror = reject;
+		img.src = src;
+	});
+}
+
+/** Draw image to canvas with cover-fit (background-size: cover equivalent) */
+function drawCover(ctx: CanvasRenderingContext2D, img: HTMLImageElement) {
+	const cw = ctx.canvas.width;
+	const ch = ctx.canvas.height;
+	const scale = Math.max(cw / img.naturalWidth, ch / img.naturalHeight);
+	const sw = cw / scale;
+	const sh = ch / scale;
+	ctx.drawImage(
+		img,
+		(img.naturalWidth - sw) / 2,
+		(img.naturalHeight - sh) / 2,
+		sw,
+		sh,
+		0,
+		0,
+		cw,
+		ch,
+	);
+}
+
+function easeInOut(t: number): number {
+	return t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+}
+
+/**
+ * Minimal hydration island — renders nothing to the VDOM (O(1)).
+ * Attaches to the static #hero and #hero-canvas elements to:
+ *   1. Cycle background images with a Bayer ordered-dither dissolve
+ *   2. Fade the hero section on scroll
+ */
+export default function HeroDitherCycle() {
+	useEffect(() => {
+		const hero = document.getElementById('hero');
+		const canvas = document.getElementById(
+			'hero-canvas',
+		) as HTMLCanvasElement | null;
+		if (!hero || !canvas) return;
+
+		const ctx = canvas.getContext('2d', { alpha: false });
+		if (!ctx) return;
+
+		let disposed = false;
+		let rafId = 0;
+		let cycleTimer: ReturnType<typeof setTimeout>;
+		let currentIdx = 0;
+		let currentImg: HTMLImageElement | null = null;
+		const imageCache = new Map<string, HTMLImageElement>();
+
+		function resize() {
+			canvas!.width = Math.ceil(hero!.offsetWidth / SCALE);
+			canvas!.height = Math.ceil(hero!.offsetHeight / SCALE);
+		}
+
+		async function getImage(idx: number): Promise<HTMLImageElement> {
+			const id = UNSPLASH_IDS[idx];
+			let img = imageCache.get(id);
+			if (!img) {
+				img = await loadImage(unsplashUrl(id));
+				imageCache.set(id, img);
+			}
+			return img;
+		}
+
+		function preload(idx: number) {
+			const id = UNSPLASH_IDS[idx];
+			if (!imageCache.has(id)) {
+				loadImage(unsplashUrl(id))
+					.then((img) => imageCache.set(id, img))
+					.catch(() => {});
+			}
+		}
+
+		// ── Initialization ───────────────────────────────
+		async function init() {
+			resize();
+			try {
+				currentImg = await getImage(0);
+				if (disposed) return;
+				drawCover(ctx!, currentImg);
+				// Canvas is ready — show it and hide CSS background
+				canvas!.style.display = 'block';
+				hero!.style.backgroundImage = 'none';
+			} catch {
+				return; // CSS background-image remains as fallback
+			}
+			// Preload remaining images
+			for (let i = 1; i < UNSPLASH_IDS.length; i++) preload(i);
+			scheduleCycle();
+		}
+
+		// ── Cycle timer ──────────────────────────────────
+		function scheduleCycle() {
+			if (disposed || UNSPLASH_IDS.length < 2) return;
+			cycleTimer = setTimeout(() => runTransition(), CYCLE_MS);
+		}
+
+		// ── Dither dissolve transition ───────────────────
+		async function runTransition() {
+			if (disposed) return;
+			const nextIdx = (currentIdx + 1) % UNSPLASH_IDS.length;
+			const w = canvas!.width;
+			const h = canvas!.height;
+
+			// Snapshot current pixels (clone the buffer)
+			const dataA = new Uint32Array(
+				ctx!.getImageData(0, 0, w, h).data.buffer.slice(0),
+			);
+
+			// Get next image
+			let nextImg: HTMLImageElement;
+			try {
+				nextImg = await getImage(nextIdx);
+			} catch {
+				currentIdx = nextIdx;
+				scheduleCycle();
+				return;
+			}
+			if (disposed) return;
+
+			// Draw next image and snapshot its pixels
+			drawCover(ctx!, nextImg);
+			const dataB = new Uint32Array(
+				ctx!.getImageData(0, 0, w, h).data.buffer.slice(0),
+			);
+
+			// Prepare output buffer
+			const outData = ctx!.createImageData(w, h);
+			const out32 = new Uint32Array(outData.data.buffer);
+			const t0 = performance.now();
+
+			function animate(now: number) {
+				if (disposed) return;
+				const raw = Math.min(1, (now - t0) / DISSOLVE_MS);
+				const progress = easeInOut(raw);
+
+				// Bayer ordered-dither blend
+				for (let i = 0, len = out32.length; i < len; i++) {
+					const threshold = BAYER_8[((i / w) | 0) & 7][i % w & 7];
+					out32[i] = progress > threshold ? dataB[i] : dataA[i];
+				}
+				ctx!.putImageData(outData, 0, 0);
+
+				if (raw < 1) {
+					rafId = requestAnimationFrame(animate);
+				} else {
+					currentIdx = nextIdx;
+					currentImg = nextImg;
+					preload((nextIdx + 1) % UNSPLASH_IDS.length);
+					scheduleCycle();
+				}
+			}
+
+			rafId = requestAnimationFrame(animate);
+		}
+
+		init();
+
+		// ── Scroll fade ──────────────────────────────────
+		let ticking = false;
+		const onScroll = () => {
+			if (ticking) return;
+			ticking = true;
+			requestAnimationFrame(() => {
+				const ratio = Math.max(
+					0,
+					1 - window.scrollY / hero!.offsetHeight,
+				);
+				hero!.style.opacity = String(ratio);
+				ticking = false;
+			});
+		};
+		window.addEventListener('scroll', onScroll, { passive: true });
+
+		// ── Resize ───────────────────────────────────────
+		const onResize = () => {
+			resize();
+			if (currentImg) drawCover(ctx!, currentImg);
+		};
+		window.addEventListener('resize', onResize);
+
+		return () => {
+			disposed = true;
+			cancelAnimationFrame(rafId);
+			clearTimeout(cycleTimer);
+			window.removeEventListener('scroll', onScroll);
+			window.removeEventListener('resize', onResize);
+		};
+	}, []);
+
+	return null;
+}

--- a/apps/memes/astro-memes/src/components/starlight/PageTitle.astro
+++ b/apps/memes/astro-memes/src/components/starlight/PageTitle.astro
@@ -1,0 +1,43 @@
+---
+// Custom PageTitle override — skip the h1 on splash pages since
+// those render their own hero/title via custom components.
+// A hidden marker + head-hoisted global CSS hides the parent content-panel
+// before first paint — zero layout shift.
+const route = Astro.locals.starlightRoute;
+const isSplash = route.entry.data.template === 'splash';
+---
+
+{
+	isSplash ? (
+		<span data-splash-no-title aria-hidden="true" style="display:none" />
+	) : (
+		<h1 id="_top">{route.entry.data.title}</h1>
+	)
+}
+
+<style>
+	@layer starlight.core {
+		h1 {
+			margin-top: 1rem;
+			font-size: var(--sl-text-h1);
+			line-height: var(--sl-line-height-headings);
+			font-weight: 600;
+			color: var(--sl-color-white);
+		}
+	}
+</style>
+
+<style is:global>
+	/* Selectors scope to [data-splash-no-title] — no effect on non-splash pages */
+	.content-panel:has([data-splash-no-title]) {
+		display: none !important;
+	}
+	.content-panel:has([data-splash-no-title]) + .content-panel {
+		padding: 0;
+	}
+	.content-panel:has([data-splash-no-title])
+		+ .content-panel
+		> .sl-container {
+		max-width: none;
+	}
+</style>

--- a/apps/memes/astro-memes/src/content/docs/index.mdx
+++ b/apps/memes/astro-memes/src/content/docs/index.mdx
@@ -2,17 +2,14 @@
 title: Meme.sh
 description: Discover the Best Memes
 template: splash
-hero:
-  title: Meme.sh
-  tagline: Discover the Best Memes
-  actions:
-    - text: Browse Feed
-      link: /feed
-      icon: right-arrow
 ---
 
+import AstroHeroSection from '../../components/hero/AstroHeroSection.astro';
+import HeroDitherCycle from '../../components/hero/HeroDitherCycle';
 import ReactMemeContent from '../../components/feed/ReactMemeContent';
 
-<div style="margin-left: calc(-1 * var(--sl-content-pad-x, 1rem)); margin-right: calc(-1 * var(--sl-content-pad-x, 1rem)); margin-top: 2rem;">
+<div class="not-content">
+  <AstroHeroSection />
+  <HeroDitherCycle client:idle />
   <ReactMemeContent client:only="react" />
 </div>


### PR DESCRIPTION
## Summary

- Replace Starlight's default hero with a custom full-viewport magazine-style hero section
- `AstroHeroSection.astro` renders static HTML at build time (zero JS, instant paint) with background image, gradient overlay, animated text, and CTA buttons
- `HeroDitherCycle.tsx` is an O(1) React hydration island (renders null) that cycles unsplash backgrounds using an 8x8 Bayer ordered-dither dissolve on a quarter-resolution canvas with `image-rendering: pixelated`
- `PageTitle.astro` override suppresses Starlight's h1 and content-panel padding on splash pages for true edge-to-edge layout with zero layout shift
- Unsplash image rotation managed via a simple array of photo IDs

## Test plan

- [ ] Verify hero fills full viewport with no side dead space on mobile and desktop
- [ ] Wait ~8s and confirm Bayer dither dissolve transition between images
- [ ] Scroll down and verify hero fades out smoothly
- [ ] Confirm non-splash pages (e.g. guides) still render h1 and normal layout
- [ ] Resize browser and confirm canvas redraws correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)