### PR TITLE
feat(irc-gateway): bump tokio-tungstenite 0.26 → 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "axum-memes"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "askama",
@@ -4809,7 +4809,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -11397,18 +11397,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.26.2",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -11847,23 +11835,6 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.2",
- "sha1",
- "thiserror 2.0.18",
  "utf-8",
 ]
 

--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -20,7 +20,7 @@ axum-extra = { version = "0.12.1", features = ["cookie"] }
 socket2 = "0.6.1"
 num_cpus = "1.17.0"
 dotenvy = "0.15"
-tokio-tungstenite = "0.26"
+tokio-tungstenite = "0.28"
 jsonwebtoken = "10.3.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 


### PR DESCRIPTION
## Summary
- Bumps `tokio-tungstenite` from `0.26` to `0.28` in `apps/irc/irc-gateway`
- Also updates underlying `tungstenite` crate from `0.26` to `0.28`
- No API changes required — compiles cleanly with existing WebSocket proxy code

## Test plan
- [x] `cargo check -p irc-gateway` passes with no errors or warnings
- [ ] CI build succeeds