### PR TITLE
feat(kube): restrict MC RCON access to kilobase namespace

### DIFF
--- a/apps/kube/mc/manifest/networkpolicy.yaml
+++ b/apps/kube/mc/manifest/networkpolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: mc-rcon-restrict
+    namespace: mc
+    labels:
+        app: mc
+spec:
+    podSelector:
+        matchLabels:
+            app: mc
+    policyTypes:
+        - Ingress
+    ingress:
+        # Allow game, bedrock, and resource-pack traffic from anywhere
+        - ports:
+              - port: 25565
+                protocol: TCP
+              - port: 19132
+                protocol: UDP
+              - port: 8080
+                protocol: TCP
+        # Allow RCON only from kilobase and mc namespaces
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: kilobase
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: mc
+          ports:
+              - port: 25575
+                protocol: TCP


### PR DESCRIPTION
## Summary
- Adds a `NetworkPolicy` to the MC Kubernetes manifests that restricts RCON (port 25575) access to only the `kilobase` and `mc` namespaces
- Game (25565/TCP), Bedrock (19132/UDP), and Resource Pack (8080/TCP) ports remain unrestricted
- RCON is accessible internally at `mc-service.mc.svc.cluster.local:25575`

## Test plan
- [ ] Verify RCON connection succeeds from a pod in the `kilobase` namespace
- [ ] Verify RCON connection is denied from pods in other namespaces
- [ ] Verify game/bedrock/resource-pack traffic is unaffected