### PR TITLE
fix(devops-e2e): fix stale import and escape assertions

### DIFF
--- a/packages/npm/devops-e2e/src/import.spec.ts
+++ b/packages/npm/devops-e2e/src/import.spec.ts
@@ -6,9 +6,6 @@ describe('ESM Import', () => {
 	it('should export all expected functions from the barrel', async () => {
 		const devops = await import('@kbve/devops');
 
-		// Core
-		expect(typeof devops.devops).toBe('function');
-
 		// Sanitization
 		expect(typeof devops._isULID).toBe('function');
 		expect(typeof devops.markdownToJsonSafeString).toBe('function');

--- a/packages/npm/devops-e2e/src/sanitization.spec.ts
+++ b/packages/npm/devops-e2e/src/sanitization.spec.ts
@@ -103,8 +103,12 @@ describe('Sanitization Integration', () => {
 	describe('_md_safe_row', () => {
 		it('escapes markdown special characters', () => {
 			const result = _md_safe_row('hello | world * [test]');
-			expect(result).not.toContain('|');
-			expect(result).not.toContain('*');
+			// The function escapes | to \| and * to \* — check for unescaped chars
+			expect(result).toContain('\\|');
+			expect(result).toContain('\\*');
+			expect(result).toContain('\\[');
+			expect(result).not.toMatch(/(?<!\\)\|/);
+			expect(result).not.toMatch(/(?<!\\)\*/);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Remove `devops.devops` barrel export assertion — the placeholder function was intentionally deleted in #6983 but the E2E test was never updated
- Fix `_md_safe_row` test to use lookbehind regex (`(?<!\\)\|`) instead of `.not.toContain('|')`, which false-positives on backslash-escaped substrings like `\|`

## Test plan
- [x] `nx test devops-e2e` — 20/20 pass
- [x] `nx test devops` — 106/106 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)