### PR TITLE
fix(irc-gateway): enable rust_crypto for jsonwebtoken v10 CryptoProvider

### DIFF
--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "irc-gateway"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Enable `rust_crypto` feature on `jsonwebtoken = "10.3.0"` in irc-gateway's Cargo.toml
- jsonwebtoken v10 requires an explicit crypto provider; without it, JWT decode panics at runtime with `Could not automatically determine the process-level CryptoProvider`
- This caused all 4 authenticated e2e tests to fail with `socket hang up` (server panicked on first JWT validation)

## Test plan
- [x] `cargo build -p irc-gateway` compiles cleanly
- [x] Manual: `/health` returns 200
- [x] Manual: `/api/v1/status` with valid JWT returns 200 (no panic)
- [ ] CI: `irc-e2e:e2e` — 27/27 tests pass (4 previously failing auth tests now work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)