### PR TITLE
feat(cryptothrone): scaffold axum-cryptothrone with game data API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-cryptothrone"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "askama",
+ "axum 0.8.8",
+ "axum-extra",
+ "dotenvy",
+ "http-body-util",
+ "jedi",
+ "kbve",
+ "num_cpus",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tikv-jemallocator",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "axum-discordsh"
 version = "0.1.26"
 dependencies = [
@@ -1068,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "axum-memes"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "askama",
@@ -4792,7 +4818,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "irc-gateway"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 	'apps/irc/irc-gateway',
 	'apps/discordsh/axum-discordsh',
 	'apps/kbve/axum-kbve',
+	'apps/cryptothrone/axum-cryptothrone',
 ]
 
 [profile.dev]

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "axum-cryptothrone"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+thiserror = "2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.6.8", features = [
+    "compression-full",
+    "limit",
+    "trace",
+    "fs",
+    "cors",
+    "set-header"
+] }
+tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+axum = { version = "0.8.5", features = ["ws", "macros"] }
+axum-extra = { version = "0.12.1", features = ["cookie"] }
+askama = "0.15.4"
+socket2 = "0.6.1"
+num_cpus = "1.17.0"
+dotenvy = "0.15"
+
+# Workspace path dependencies
+jedi = { path = "../../../packages/rust/jedi" }
+kbve = { path = "../../../packages/rust/kbve" }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
+
+[dev-dependencies]
+serial_test = "3"
+http-body-util = "0.1"
+
+[features]
+default = []
+jemalloc = ["dep:tikv-jemallocator"]
+
+[package.metadata.askama]
+dirs = ["templates"]

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml
@@ -1,0 +1,14 @@
+[workspace]
+resolver = "2"
+members = [
+    "apps/cryptothrone/axum-cryptothrone",
+    "packages/rust/jedi",
+    "packages/rust/kbve",
+]
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -1,0 +1,204 @@
+# ============================================================================
+# [STAGE A] - Build Astro Static Site
+# ============================================================================
+FROM --platform=linux/amd64 node:24-alpine AS astro-builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy root dependency and config files (layer-cached separately from source)
+COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
+
+# Install all dependencies (hoisted mode - all go to root node_modules)
+RUN pnpm install --frozen-lockfile
+
+# Copy workspace package sources (TypeScript path aliases resolve to these)
+COPY packages/npm/astro/ packages/npm/astro/
+COPY packages/npm/droid/ packages/npm/droid/
+COPY packages/npm/laser/ packages/npm/laser/
+
+# Copy astro-cryptothrone source
+COPY apps/cryptothrone/astro-cryptothrone/ apps/cryptothrone/astro-cryptothrone/
+
+# Build astro site
+WORKDIR /app/apps/cryptothrone/astro-cryptothrone
+RUN rm -rf .astro && npx astro sync && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+
+# ============================================================================
+# [STAGE B] - Precompress Static Assets
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS astro-precompressor
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gzip brotli && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=astro-builder /app/dist/apps/astro-cryptothrone /static
+
+WORKDIR /static
+RUN find . -type f \( \
+        -name "*.css" -o \
+        -name "*.js" -o \
+        -name "*.json" -o \
+        -name "*.svg" -o \
+        -name "*.xml" -o \
+        -name "*.txt" -o \
+        -name "*.html" \
+    \) ! -path "*/askama/*" -exec sh -c ' \
+        gzip -9 -k "$1" && \
+        brotli --best --keep "$1" \
+    ' _ {} \; && \
+    echo "Precompression complete (brotli-11 + gzip-9)"
+
+# ============================================================================
+# [STAGE C] - Rust Base Image
+# ============================================================================
+FROM --platform=linux/amd64 rust:1.90-slim AS rust-base
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        protobuf-compiler \
+        libprotobuf-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-gnu && \
+    cargo install cargo-chef --locked
+
+WORKDIR /app
+
+# ============================================================================
+# [STAGE D] - Cargo Chef Planner
+# ============================================================================
+FROM rust-base AS planner
+
+# Minimal workspace with only cryptothrone's actual dependencies
+COPY apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+# Copy only the 3 crates we need
+COPY apps/cryptothrone/axum-cryptothrone/Cargo.toml apps/cryptothrone/axum-cryptothrone/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+
+# Create stubs for cargo chef
+RUN mkdir -p apps/cryptothrone/axum-cryptothrone/src && echo "fn main() {}" > apps/cryptothrone/axum-cryptothrone/src/main.rs && \
+    mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
+
+# Copy proto files (needed for jedi build.rs)
+COPY packages/data/proto packages/data/proto
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ============================================================================
+# [STAGE E] - Cargo Chef Builder (Cache Dependencies)
+# ============================================================================
+FROM rust-base AS builder-deps
+
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
+COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
+
+# Copy proto files
+COPY packages/data/proto packages/data/proto
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo chef cook --release --recipe-path recipe.json -p axum-cryptothrone
+
+# ============================================================================
+# [STAGE F] - Build Application
+# ============================================================================
+FROM rust-base AS builder
+
+# Copy cached dependencies
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+# Copy Astro build output (precompressed)
+COPY --from=astro-precompressor /static /app/apps/cryptothrone/axum-cryptothrone/templates/dist
+
+# Use the same minimal workspace
+COPY --from=planner /app/Cargo.toml ./
+COPY Cargo.lock ./
+
+# Copy only the 3 crates (full source)
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+COPY apps/cryptothrone/axum-cryptothrone apps/cryptothrone/axum-cryptothrone
+COPY packages/data/proto packages/data/proto
+
+# Copy Askama templates
+COPY apps/cryptothrone/axum-cryptothrone/templates/askama /app/apps/cryptothrone/axum-cryptothrone/templates/askama
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p axum-cryptothrone && \
+    strip target/release/axum-cryptothrone
+
+# ============================================================================
+# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
+
+RUN apt-get update && apt-get install -y wget ca-certificates
+
+WORKDIR /tmp
+
+RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
+    tar -xvf go1.23.4.linux-amd64.tar.gz && \
+    mv go /usr/local
+
+RUN GOBIN=/usr/local/bin/ /usr/local/go/bin/go install github.com/canonical/chisel/cmd/chisel@latest
+
+WORKDIR /rootfs
+RUN chisel cut --release ubuntu-24.04 --root /rootfs \
+        base-files_base \
+        base-files_release-info \
+        ca-certificates_data \
+        libgcc-s1_libs \
+        libc6_libs \
+        libstdc++6_libs \
+        openssl_config
+
+# ============================================================================
+# [STAGE H] - Jemalloc
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc-dev && \
+    apt-get autoremove -y && \
+    apt-get purge -y --auto-remove && \
+    rm -rf /var/lib/apt/lists/*
+
+# ============================================================================
+# [STAGE Z] - Runtime Image (Scratch + Chisel + Jemalloc)
+# ============================================================================
+FROM --platform=linux/amd64 scratch AS runtime
+
+COPY --from=chisel-builder /rootfs /
+
+COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/axum-cryptothrone /app/axum-cryptothrone
+
+COPY --from=builder /app/apps/cryptothrone/axum-cryptothrone/templates/dist /app/templates/dist
+COPY --from=builder /app/apps/cryptothrone/axum-cryptothrone/templates/askama /app/templates/askama
+
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
+ENV HTTP_HOST=0.0.0.0
+ENV HTTP_PORT=4321
+ENV RUST_LOG=info
+
+EXPOSE 4321
+
+ENTRYPOINT ["/app/axum-cryptothrone"]

--- a/apps/cryptothrone/axum-cryptothrone/askama.toml
+++ b/apps/cryptothrone/axum-cryptothrone/askama.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["templates"]

--- a/apps/cryptothrone/axum-cryptothrone/project.json
+++ b/apps/cryptothrone/axum-cryptothrone/project.json
@@ -1,0 +1,140 @@
+{
+	"name": "axum-cryptothrone",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/cryptothrone/axum-cryptothrone/src",
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"./kbve.sh -nx astro-cryptothrone:build",
+					"STATIC_DIR=./dist/apps/astro-cryptothrone STATIC_PRECOMPRESSED=false cargo run -p axum-cryptothrone"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-cryptothrone"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-cryptothrone"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-cryptothrone"
+			}
+		},
+		"run": {
+			"executor": "@monodon/rust:run",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/axum-cryptothrone"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"nx test axum-cryptothrone",
+					"nx e2e astro-cryptothrone-e2e"
+				],
+				"parallel": false
+			}
+		},
+		"container-prep": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"./kbve.sh -nx astro-cryptothrone:build",
+					"rm -rf ./apps/cryptothrone/axum-cryptothrone/dist/",
+					"mkdir -p ./apps/cryptothrone/axum-cryptothrone/dist/",
+					"cp -a ./dist/apps/astro-cryptothrone/. ./apps/cryptothrone/axum-cryptothrone/dist/"
+				],
+				"parallel": false
+			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container-prep"],
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx axum-cryptothrone:containerx",
+						"VERSION=$(grep '^version' apps/cryptothrone/axum-cryptothrone/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/cryptothrone:latest kbve/cryptothrone:$VERSION && echo \"Tagged kbve/cryptothrone:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx axum-cryptothrone:containerx --configuration=production",
+						"VERSION=$(grep '^version' apps/cryptothrone/axum-cryptothrone/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/cryptothrone:latest kbve/cryptothrone:$VERSION && docker tag kbve/cryptothrone:latest ghcr.io/kbve/cryptothrone:$VERSION && echo \"Tagged kbve/cryptothrone:$VERSION and ghcr.io/kbve/cryptothrone:$VERSION\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/cryptothrone/axum-cryptothrone/Dockerfile",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/cryptothrone:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"metadata": {
+						"images": [
+							"ghcr.io/kbve/cryptothrone",
+							"kbve/cryptothrone"
+						],
+						"tags": ["latest"]
+					},
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/cryptothrone:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/cryptothrone:buildcache,mode=max"
+					]
+				}
+			}
+		}
+	},
+	"tags": []
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/astro/askama.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/astro/askama.rs
@@ -1,0 +1,66 @@
+use askama::Template;
+use axum::{
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+};
+
+#[derive(Template)]
+#[template(path = "askama/index.html")]
+pub struct AstroTemplate<'a> {
+    pub content: &'a str,
+    pub path: &'a str,
+    pub title: &'a str,
+    pub description: &'a str,
+    pub canonical_url: &'a str,
+    pub og_image: &'a str,
+}
+
+impl<'a> AstroTemplate<'a> {
+    pub fn new(
+        content: &'a str,
+        path: &'a str,
+        title: &'a str,
+        description: &'a str,
+        canonical_url: &'a str,
+        og_image: &'a str,
+    ) -> Self {
+        Self {
+            content,
+            path,
+            title,
+            description,
+            canonical_url,
+            og_image,
+        }
+    }
+}
+
+pub struct TemplateResponse<T: Template>(pub T);
+
+impl<T: Template> IntoResponse for TemplateResponse<T> {
+    fn into_response(self) -> Response {
+        match self.0.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(err) => {
+                tracing::error!(error = %err, "template rendering failed");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to render template",
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+pub async fn fallback_handler() -> Response {
+    let template = AstroTemplate::new(
+        "<h1>Page Not Found</h1><p>The requested page does not exist.</p>",
+        "/404",
+        "404 - Not Found",
+        "Page not found",
+        "https://cryptothrone.com/404",
+        "",
+    );
+    (StatusCode::NOT_FOUND, TemplateResponse(template)).into_response()
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/astro/mod.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/astro/mod.rs
@@ -1,0 +1,138 @@
+pub mod askama;
+
+use axum::{
+    Router,
+    http::{StatusCode, header},
+    response::IntoResponse,
+};
+use std::convert::Infallible;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower_http::services::ServeDir;
+
+pub struct StaticConfig {
+    pub base_dir: PathBuf,
+    pub precompressed: bool,
+}
+
+impl StaticConfig {
+    pub fn from_env() -> Self {
+        let base_dir = std::env::var("STATIC_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("templates/dist"));
+        let precompressed = std::env::var("STATIC_PRECOMPRESSED")
+            .map(|v| v != "0" && v.to_lowercase() != "false")
+            .unwrap_or(true);
+        Self {
+            base_dir,
+            precompressed,
+        }
+    }
+}
+
+pub fn build_static_router(config: &StaticConfig) -> Router {
+    let base = &config.base_dir;
+    let precompressed = config.precompressed;
+
+    let not_found_html = Arc::new(
+        std::fs::read_to_string(base.join("404.html"))
+            .unwrap_or_else(|_| "<html><body><h1>404 - Not Found</h1></body></html>".to_string()),
+    );
+
+    let serve_dir = |path: PathBuf| {
+        let svc = ServeDir::new(path);
+        if precompressed {
+            svc.precompressed_br().precompressed_gzip()
+        } else {
+            svc
+        }
+    };
+
+    let astro_service = serve_dir(base.join("_astro"));
+    let assets_service = serve_dir(base.join("assets"));
+    let chunks_service = serve_dir(base.join("chunks"));
+    let pagefind_service = serve_dir(base.join("pagefind"));
+    let images_service = ServeDir::new(base.join("images"));
+
+    let not_found_svc = {
+        let html = not_found_html.clone();
+        tower::service_fn(move |_req: axum::extract::Request| {
+            let html = html.clone();
+            async move {
+                Ok::<_, Infallible>(
+                    (
+                        StatusCode::NOT_FOUND,
+                        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+                        (*html).clone(),
+                    )
+                        .into_response(),
+                )
+            }
+        })
+    };
+
+    let fallback_svc = {
+        let svc = ServeDir::new(base)
+            .append_index_html_on_directories(true)
+            .fallback(not_found_svc);
+        if precompressed {
+            svc.precompressed_br().precompressed_gzip()
+        } else {
+            svc
+        }
+    };
+
+    Router::new()
+        .nest_service("/_astro", astro_service)
+        .nest_service("/assets", assets_service)
+        .nest_service("/chunks", chunks_service)
+        .nest_service("/images", images_service)
+        .nest_service("/pagefind", pagefind_service)
+        .fallback_service(fallback_svc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_static_config_defaults() {
+        std::env::remove_var("STATIC_DIR");
+        std::env::remove_var("STATIC_PRECOMPRESSED");
+
+        let config = StaticConfig::from_env();
+        assert_eq!(config.base_dir, PathBuf::from("templates/dist"));
+        assert!(config.precompressed);
+    }
+
+    #[test]
+    #[serial]
+    fn test_static_config_custom_dir() {
+        std::env::set_var("STATIC_DIR", "/tmp/my-static");
+        std::env::remove_var("STATIC_PRECOMPRESSED");
+
+        let config = StaticConfig::from_env();
+        assert_eq!(config.base_dir, PathBuf::from("/tmp/my-static"));
+        assert!(config.precompressed);
+
+        std::env::remove_var("STATIC_DIR");
+    }
+
+    #[test]
+    #[serial]
+    fn test_static_config_precompressed_false() {
+        std::env::remove_var("STATIC_DIR");
+        std::env::set_var("STATIC_PRECOMPRESSED", "false");
+
+        let config = StaticConfig::from_env();
+        assert!(!config.precompressed);
+
+        std::env::set_var("STATIC_PRECOMPRESSED", "0");
+        let config = StaticConfig::from_env();
+        assert!(!config.precompressed);
+
+        std::env::remove_var("STATIC_PRECOMPRESSED");
+    }
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/game/data.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/game/data.rs
@@ -1,0 +1,171 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use super::models::{DialogueNode, DialogueOption, ItemData, NPCData};
+
+static ITEMS: LazyLock<Vec<ItemData>> = LazyLock::new(|| {
+    vec![
+        ItemData {
+            id: "health_potion".into(),
+            name: "Health Potion".into(),
+            item_type: "consumable".into(),
+            img: "/assets/items/health_potion.png".into(),
+            description: "Restores 25 HP.".into(),
+            bonuses: HashMap::from([("hp".into(), 25.0)]),
+            durability: 1,
+            weight: 0.5,
+            actions: vec!["use".into(), "drop".into(), "inspect".into()],
+        },
+        ItemData {
+            id: "mana_potion".into(),
+            name: "Mana Potion".into(),
+            item_type: "consumable".into(),
+            img: "/assets/items/mana_potion.png".into(),
+            description: "Restores 20 MP.".into(),
+            bonuses: HashMap::from([("mp".into(), 20.0)]),
+            durability: 1,
+            weight: 0.5,
+            actions: vec!["use".into(), "drop".into(), "inspect".into()],
+        },
+        ItemData {
+            id: "iron_sword".into(),
+            name: "Iron Sword".into(),
+            item_type: "weapon".into(),
+            img: "/assets/items/iron_sword.png".into(),
+            description: "A sturdy iron sword.".into(),
+            bonuses: HashMap::from([("attack".into(), 5.0)]),
+            durability: 100,
+            weight: 3.0,
+            actions: vec!["equip".into(), "drop".into(), "inspect".into()],
+        },
+        ItemData {
+            id: "salmon".into(),
+            name: "Salmon".into(),
+            item_type: "consumable".into(),
+            img: "/assets/items/salmon.png".into(),
+            description: "A fresh salmon. Restores 10 HP.".into(),
+            bonuses: HashMap::from([("hp".into(), 10.0)]),
+            durability: 1,
+            weight: 1.0,
+            actions: vec!["use".into(), "drop".into(), "inspect".into()],
+        },
+        ItemData {
+            id: "blue_shark".into(),
+            name: "Blue Shark".into(),
+            item_type: "consumable".into(),
+            img: "/assets/items/blue_shark.png".into(),
+            description: "A rare blue shark. Restores 30 HP.".into(),
+            bonuses: HashMap::from([("hp".into(), 30.0)]),
+            durability: 1,
+            weight: 2.0,
+            actions: vec!["use".into(), "drop".into(), "inspect".into()],
+        },
+    ]
+});
+
+static NPCS: LazyLock<Vec<NPCData>> = LazyLock::new(|| {
+    vec![
+        NPCData {
+            id: "npc_barkeep".into(),
+            name: "Evee The BarKeep".into(),
+            avatar: "/assets/npc/barkeep.webp".into(),
+            slug: "npc/barkeep".into(),
+            actions: vec!["talk".into(), "trade".into(), "steal".into()],
+        },
+        NPCData {
+            id: "npc_monk".into(),
+            name: "Elder Monk".into(),
+            avatar: "/assets/entity/monks.png".into(),
+            slug: "npc/monk".into(),
+            actions: vec!["talk".into(), "inspect".into()],
+        },
+    ]
+});
+
+static DIALOGUES: LazyLock<HashMap<String, DialogueNode>> = LazyLock::new(|| {
+    HashMap::from([
+        (
+            "dlg_barkeep_greeting".into(),
+            DialogueNode {
+                id: "dlg_barkeep_greeting".into(),
+                title: "Greeting".into(),
+                message: "Welcome to the tavern, traveler! What can I get you today?".into(),
+                player_response: None,
+                background_image: Some("/assets/background/animebar.webp".into()),
+                options: Some(vec![
+                    DialogueOption {
+                        id: "opt_about".into(),
+                        title: "Tell me about Cloud City".into(),
+                        next_dialogue_id: "dlg_barkeep_about".into(),
+                    },
+                    DialogueOption {
+                        id: "opt_trade".into(),
+                        title: "What do you have for sale?".into(),
+                        next_dialogue_id: "dlg_barkeep_trade".into(),
+                    },
+                ]),
+            },
+        ),
+        (
+            "dlg_barkeep_about".into(),
+            DialogueNode {
+                id: "dlg_barkeep_about".into(),
+                title: "About Cloud City".into(),
+                message: "Cloud City floats above the old kingdoms. Beware the birds — they are not what they seem. The tombstone near the plaza holds secrets of Samson the Great.".into(),
+                player_response: Some("Tell me about Cloud City.".into()),
+                background_image: Some("/assets/background/animebar.webp".into()),
+                options: Some(vec![DialogueOption {
+                    id: "opt_back".into(),
+                    title: "Thanks for the info".into(),
+                    next_dialogue_id: "dlg_barkeep_greeting".into(),
+                }]),
+            },
+        ),
+        (
+            "dlg_barkeep_trade".into(),
+            DialogueNode {
+                id: "dlg_barkeep_trade".into(),
+                title: "Trade".into(),
+                message: "I've got potions, fresh fish, and the occasional rare item. Check back often — my stock changes with the tides.".into(),
+                player_response: Some("What do you have for sale?".into()),
+                background_image: Some("/assets/background/animebar.webp".into()),
+                options: Some(vec![DialogueOption {
+                    id: "opt_back2".into(),
+                    title: "I'll think about it".into(),
+                    next_dialogue_id: "dlg_barkeep_greeting".into(),
+                }]),
+            },
+        ),
+        (
+            "dlg_monk_greeting".into(),
+            DialogueNode {
+                id: "dlg_monk_greeting".into(),
+                title: "Meditation".into(),
+                message: "Peace, traveler. The path to the throne is long. Patience and wisdom will serve you well.".into(),
+                player_response: None,
+                background_image: None,
+                options: None,
+            },
+        ),
+    ])
+});
+
+pub fn all_items() -> &'static [ItemData] {
+    &ITEMS
+}
+
+pub fn item_by_id(id: &str) -> Option<&'static ItemData> {
+    ITEMS.iter().find(|item| item.id == id)
+}
+
+pub fn all_npcs() -> &'static [NPCData] {
+    &NPCS
+}
+
+pub fn npc_by_id(id: &str) -> Option<&'static NPCData> {
+    NPCS.iter().find(|npc| npc.id == id)
+}
+
+pub fn dialogue_by_id(id: &str) -> Option<&'static DialogueNode> {
+    DIALOGUES.get(id)
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/game/mod.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/game/mod.rs
@@ -1,0 +1,3 @@
+pub mod data;
+pub mod models;
+pub mod routes;

--- a/apps/cryptothrone/axum-cryptothrone/src/game/models.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/game/models.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemData {
+    pub id: String,
+    pub name: String,
+    pub item_type: String,
+    pub img: String,
+    pub description: String,
+    pub bonuses: HashMap<String, f64>,
+    pub durability: u32,
+    pub weight: f64,
+    pub actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NPCData {
+    pub id: String,
+    pub name: String,
+    pub avatar: String,
+    pub slug: String,
+    pub actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DialogueOption {
+    pub id: String,
+    pub title: String,
+    pub next_dialogue_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DialogueNode {
+    pub id: String,
+    pub title: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub player_response: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<DialogueOption>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpeedResponse {
+    pub time_ms: u64,
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/game/routes.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/game/routes.rs
@@ -1,0 +1,47 @@
+use axum::{Json, Router, extract::Path, http::StatusCode, response::IntoResponse, routing::get};
+
+use super::data;
+use super::models::{ItemData, NPCData, SpeedResponse};
+
+async fn list_items() -> Json<Vec<ItemData>> {
+    Json(data::all_items().to_vec())
+}
+
+async fn get_item(Path(id): Path<String>) -> impl IntoResponse {
+    match data::item_by_id(&id) {
+        Some(item) => Ok(Json(item.clone())),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+async fn list_npcs() -> Json<Vec<NPCData>> {
+    Json(data::all_npcs().to_vec())
+}
+
+async fn get_npc(Path(id): Path<String>) -> impl IntoResponse {
+    match data::npc_by_id(&id) {
+        Some(npc) => Ok(Json(npc.clone())),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+async fn get_dialogue(Path(id): Path<String>) -> impl IntoResponse {
+    match data::dialogue_by_id(&id) {
+        Some(dialogue) => Ok(Json(dialogue.clone())),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+async fn speed() -> Json<SpeedResponse> {
+    Json(SpeedResponse { time_ms: 0 })
+}
+
+pub fn game_router() -> Router {
+    Router::new()
+        .route("/api/v1/items", get(list_items))
+        .route("/api/v1/items/{id}", get(get_item))
+        .route("/api/v1/npcs", get(list_npcs))
+        .route("/api/v1/npcs/{id}", get(get_npc))
+        .route("/api/v1/dialogues/{id}", get(get_dialogue))
+        .route("/api/v1/speed", get(speed))
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/main.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/main.rs
@@ -1,0 +1,42 @@
+mod astro;
+mod game;
+mod transport;
+
+use tracing::info;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[cfg(feature = "jemalloc")]
+mod allocator {
+    #[cfg(not(target_env = "msvc"))]
+    use tikv_jemallocator::Jemalloc;
+    #[cfg(not(target_env = "msvc"))]
+    #[global_allocator]
+    static GLOBAL: Jemalloc = Jemalloc;
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                format!("{}=info,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
+            }),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    info!("CryptoThrone v{}", env!("CARGO_PKG_VERSION"));
+
+    let http = tokio::spawn(transport::https::serve());
+
+    tokio::select! {
+        _ = http => {},
+        _ = tokio::signal::ctrl_c() => {
+            info!("shutdown signal received");
+        }
+    }
+
+    Ok(())
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -1,0 +1,432 @@
+use anyhow::Result;
+use std::{net::SocketAddr, time::Duration};
+
+use axum::{
+    Router,
+    extract::Request,
+    http::{HeaderName, HeaderValue, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use tokio::net::TcpListener;
+use tower_http::set_header::SetResponseHeaderLayer;
+use tracing::info;
+
+pub async fn serve() -> Result<()> {
+    let host = std::env::var("HTTP_HOST").unwrap_or_else(|_| "0.0.0.0".into());
+    let port: u16 = std::env::var("HTTP_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4321);
+    let addr: SocketAddr = format!("{host}:{port}").parse()?;
+
+    let listener = tuned_listener(addr)?;
+
+    info!("HTTP listening on http://{addr}");
+
+    let app = router();
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    Ok(())
+}
+
+fn router() -> Router {
+    let max_inflight: usize = num_cpus::get().max(1) * 1024;
+
+    let static_config = crate::astro::StaticConfig::from_env();
+
+    let middleware = tower::ServiceBuilder::new()
+        .layer(
+            tower_http::trace::TraceLayer::new_for_http().make_span_with(
+                tower_http::trace::DefaultMakeSpan::new().level(tracing::Level::INFO),
+            ),
+        )
+        .layer(tower_http::cors::CorsLayer::permissive())
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("referrer-policy"),
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
+        .layer(axum::error_handling::HandleErrorLayer::new(
+            |err: tower::BoxError| async move {
+                if err.is::<tower::timeout::error::Elapsed>() {
+                    (axum::http::StatusCode::REQUEST_TIMEOUT, "request timed out")
+                } else if err.is::<tower::load_shed::error::Overloaded>() {
+                    (
+                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                        "service overloaded",
+                    )
+                } else {
+                    tracing::warn!(error = %err, "middleware error");
+                    (
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "internal server error",
+                    )
+                }
+            },
+        ))
+        .timeout(Duration::from_secs(10))
+        .concurrency_limit(max_inflight)
+        .load_shed()
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(1024 * 1024));
+
+    let static_router = crate::astro::build_static_router(&static_config)
+        .layer(axum::middleware::from_fn(fix_ts_mime))
+        .layer(axum::middleware::from_fn(cache_headers));
+
+    let dynamic_router = Router::new()
+        .route("/health", get(health))
+        .merge(crate::game::routes::game_router());
+
+    static_router.merge(dynamic_router).layer(middleware)
+}
+
+async fn health() -> impl IntoResponse {
+    "OK"
+}
+
+async fn cache_headers(request: Request, next: Next) -> Response {
+    let path = request.uri().path().to_owned();
+    let mut response = next.run(request).await;
+
+    let cache_value = if path.starts_with("/_astro/") {
+        "public, max-age=31536000, immutable"
+    } else if path.starts_with("/pagefind/") || path.starts_with("/images/") {
+        "public, max-age=86400"
+    } else if path.ends_with(".html") || path == "/" || !path.contains('.') {
+        "public, max-age=86400"
+    } else {
+        "public, max-age=86400"
+    };
+
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static(cache_value));
+
+    response
+}
+
+async fn fix_ts_mime(request: Request, next: Next) -> Response {
+    let is_ts = request.uri().path().ends_with(".ts");
+    let mut response = next.run(request).await;
+    if is_ts {
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        );
+    }
+    response
+}
+
+fn tuned_listener(addr: SocketAddr) -> Result<TcpListener> {
+    use socket2::{Domain, Protocol, Socket, Type};
+
+    let domain = match addr {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+
+    socket.set_reuse_address(true)?;
+    socket.set_keepalive(true)?;
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        use socket2::TcpKeepalive;
+        let ka = TcpKeepalive::new()
+            .with_time(Duration::from_secs(30))
+            .with_interval(Duration::from_secs(10));
+        let _ = socket.set_tcp_keepalive(&ka);
+    }
+
+    socket.bind(&addr.into())?;
+    socket.listen(1024)?;
+
+    let std_listener = std::net::TcpListener::from(socket);
+    std_listener.set_nonblocking(true)?;
+    Ok(TcpListener::from_std(std_listener)?)
+}
+
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn test_router() -> Router {
+        let middleware = tower::ServiceBuilder::new()
+            .layer(SetResponseHeaderLayer::overriding(
+                header::X_CONTENT_TYPE_OPTIONS,
+                HeaderValue::from_static("nosniff"),
+            ))
+            .layer(SetResponseHeaderLayer::overriding(
+                header::X_FRAME_OPTIONS,
+                HeaderValue::from_static("DENY"),
+            ))
+            .layer(SetResponseHeaderLayer::overriding(
+                HeaderName::from_static("referrer-policy"),
+                HeaderValue::from_static("strict-origin-when-cross-origin"),
+            ));
+
+        Router::new()
+            .route("/health", get(health))
+            .merge(crate::game::routes::game_router())
+            .layer(middleware)
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"OK");
+    }
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_astro_path() {
+        let app = Router::new()
+            .route("/_astro/{*path}", get(|| async { "asset" }))
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/_astro/bundle.abc123.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let cc = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("immutable"));
+        assert!(cc.contains("31536000"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_html_page() {
+        let app = Router::new()
+            .route("/", get(|| async { "page" }))
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let cc = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("86400"));
+    }
+
+    #[tokio::test]
+    async fn test_fix_ts_mime_rewrites() {
+        let app = Router::new()
+            .route("/worker.ts", get(|| async { "code" }))
+            .layer(axum::middleware::from_fn(fix_ts_mime));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/worker.ts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/javascript; charset=utf-8"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_items_endpoint() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/items")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let items: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(items.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_item_by_id() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/items/health_potion")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let item: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(item["name"], "Health Potion");
+    }
+
+    #[tokio::test]
+    async fn test_item_not_found() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/items/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_npcs_endpoint() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/npcs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let npcs: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(npcs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_npc_by_id() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/npcs/npc_barkeep")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let npc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(npc["name"], "Evee The BarKeep");
+    }
+
+    #[tokio::test]
+    async fn test_dialogue_by_id() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/dialogues/dlg_barkeep_greeting")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let dialogue: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(dialogue["title"], "Greeting");
+        assert!(dialogue["options"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_speed_endpoint() {
+        let app = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/speed")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let speed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(speed["time_ms"], 0);
+    }
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/mod.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/mod.rs
@@ -1,0 +1,1 @@
+pub mod https;

--- a/apps/cryptothrone/axum-cryptothrone/templates/askama/index.html
+++ b/apps/cryptothrone/axum-cryptothrone/templates/askama/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ title }} - CryptoThrone</title>
+    <meta name="description" content="{{ description }}" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href="{{ canonical_url }}" />
+    <meta property="og:title" content="{{ title }} - CryptoThrone" />
+    <meta property="og:description" content="{{ description }}" />
+    <meta property="og:url" content="{{ canonical_url }}" />
+    <meta property="og:site_name" content="CryptoThrone" />
+    <meta property="og:type" content="website" />
+    {% if !og_image.is_empty() %}
+    <meta property="og:image" content="{{ og_image }}" />
+    {% endif %}
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="{{ title }} - CryptoThrone" />
+    <meta name="twitter:description" content="{{ description }}" />
+</head>
+<body>
+    {{ content|safe }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Scaffolds `axum-cryptothrone` Axum web server following the `axum-memes` pattern
- Serves precompressed Astro static builds with brotli/gzip support
- Provides REST JSON endpoints for game data (items, NPCs, dialogues) using in-memory mock data via `LazyLock`
- Includes full middleware stack (CORS, security headers, timeouts, load shedding, body limits)
- Multi-stage Dockerfile (Astro build → precompress → cargo-chef → chisel runtime)
- 15 unit tests covering all endpoints and middleware

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/health` | Health check |
| GET | `/api/v1/items` | List all items |
| GET | `/api/v1/items/{id}` | Get item by ID |
| GET | `/api/v1/npcs` | List all NPCs |
| GET | `/api/v1/npcs/{id}` | Get NPC by ID |
| GET | `/api/v1/dialogues/{id}` | Get dialogue node by ID |
| GET | `/api/v1/speed` | Speed check |

## Test plan
- [x] `cargo test -p axum-cryptothrone` — 15/15 pass
- [x] `cargo clippy -p axum-cryptothrone` — clean (minor dead_code warnings for askama infra, matches axum-memes)
- [x] `cargo build -p axum-cryptothrone` — compiles clean
- [ ] Manual: `STATIC_DIR=./dist/apps/astro-cryptothrone STATIC_PRECOMPRESSED=false cargo run -p axum-cryptothrone`
- [ ] Docker build verification