### PR TITLE
feat(kube): add KEDA event-driven autoscaler operator

### DIFF
--- a/apps/kube/keda/application.yaml
+++ b/apps/kube/keda/application.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: keda
+    namespace: argocd
+spec:
+    project: default
+    sources:
+        - repoURL: https://kedacore.github.io/charts
+          targetRevision: 2.19.0
+          chart: keda
+          helm:
+              releaseName: keda
+              valueFiles:
+                  - $values/apps/kube/keda/manifests/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: keda
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m

--- a/apps/kube/keda/manifests/values.yaml
+++ b/apps/kube/keda/manifests/values.yaml
@@ -1,0 +1,67 @@
+operator:
+    replicaCount: 1
+
+metricsServer:
+    replicaCount: 1
+
+resources:
+    operator:
+        requests:
+            cpu: 100m
+            memory: 128Mi
+        limits:
+            cpu: 500m
+            memory: 512Mi
+    metricServer:
+        requests:
+            cpu: 100m
+            memory: 128Mi
+        limits:
+            cpu: 500m
+            memory: 512Mi
+
+logging:
+    operator:
+        level: info
+    metricServer:
+        level: '0'
+
+prometheus:
+    operator:
+        enabled: true
+        podMonitor:
+            enabled: true
+            namespace: monitoring
+            labels:
+                release: prometheus
+    metricServer:
+        enabled: true
+        podMonitor:
+            enabled: true
+            namespace: monitoring
+            labels:
+                release: prometheus
+
+podSecurityContext:
+    operator:
+        runAsNonRoot: true
+    metricServer:
+        runAsNonRoot: true
+
+securityContext:
+    operator:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+            drop:
+                - ALL
+    metricServer:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+            drop:
+                - ALL
+
+nodeSelector: {}
+affinity: {}
+tolerations: []

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
     - ingress/application.yaml
     - cert-manager/application.yaml
     - sealed-secrets/application.yaml
+    - keda/application.yaml
     - external-secrets/application.yaml
     - monitoring/application.yaml
     - redis/application.yaml


### PR DESCRIPTION
Ref #7590

## Summary
- Deploys **KEDA 2.19.0** (latest stable) as an ArgoCD-managed Helm chart
- Follows the CNPG multi-source pattern: vendor Helm chart + repo-hosted values override
- Added to root `kustomization.yaml` alongside other platform operators
- Deploys to `keda` namespace

## What KEDA enables
KEDA extends Kubernetes autoscaling beyond CPU/memory to support event-driven triggers:

| Trigger | Use case |
|---|---|
| Redis list length | n8n-worker queue scaling (#7590) |
| Kafka lag | Analytics processors |
| Prometheus query | Custom metric-based scaling |
| Cron schedule | Time-based scaling |

## Files
- `apps/kube/keda/application.yaml` — ArgoCD Application (Helm chart pinned to 2.19.0)
- `apps/kube/keda/manifests/values.yaml` — Helm values (resources, security, monitoring)
- `apps/kube/kustomization.yaml` — Added `keda/application.yaml` to resources

## Configuration highlights
- Operator + metrics server: 100m/128Mi requests, 500m/512Mi limits
- PodMonitor enabled for Prometheus scraping
- Security: non-root, read-only root filesystem, all capabilities dropped
- Retry: 3 attempts with exponential backoff

## Next steps (after merge + deploy)
1. Verify KEDA pods healthy: `kubectl get pods -n keda`
2. Verify CRDs registered: `kubectl get crd | grep keda`
3. Create `ScaledObject` for n8n-worker targeting Redis Bull queue depth

## Test plan
- [x] `kubectl apply --dry-run=client` passes for application.yaml
- [ ] CI passes
- [ ] After deploy: KEDA operator + metrics server running