### PR TITLE
fix(droid): fix e2e worker init and add initTimeout

### DIFF
--- a/packages/npm/droid-e2e/e2e/worker-init.spec.ts
+++ b/packages/npm/droid-e2e/e2e/worker-init.spec.ts
@@ -12,9 +12,13 @@ test.describe('Worker Initialization', () => {
 		page.on('pageerror', (err) => errors.push(err.message));
 
 		// Wait for initialization to complete
-		await expect(page.getByTestId('worker-initialized')).toHaveAttribute('data-value', 'true', {
-			timeout: 10_000,
-		});
+		await expect(page.getByTestId('worker-initialized')).toHaveAttribute(
+			'data-value',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
 
 		// Filter out expected warnings (e.g., missing Supabase config)
 		const criticalErrors = errors.filter(
@@ -24,24 +28,85 @@ test.describe('Worker Initialization', () => {
 	});
 
 	test('event bus is available after init', async ({ page }) => {
-		await expect(page.getByTestId('worker-has-events')).toHaveAttribute('data-value', 'true', {
-			timeout: 10_000,
-		});
+		await expect(page.getByTestId('worker-has-events')).toHaveAttribute(
+			'data-value',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
 	});
 
 	test('uiux system is available after init', async ({ page }) => {
-		await expect(page.getByTestId('worker-has-uiux')).toHaveAttribute('data-value', 'true', {
-			timeout: 10_000,
-		});
+		await expect(page.getByTestId('worker-has-uiux')).toHaveAttribute(
+			'data-value',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
 	});
 
 	test('no worker error is displayed', async ({ page }) => {
 		// Wait for init to settle
-		await expect(page.getByTestId('worker-initialized')).toHaveAttribute('data-value', 'true', {
-			timeout: 10_000,
-		});
+		await expect(page.getByTestId('worker-initialized')).toHaveAttribute(
+			'data-value',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
 
 		// Verify no error element is visible
 		await expect(page.getByTestId('worker-error')).not.toBeVisible();
+	});
+
+	test('API worker is available after init', async ({ page }) => {
+		await expect(page.getByTestId('worker-has-api')).toHaveAttribute(
+			'data-value',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
+	});
+
+	test('WebSocket worker is available after init', async ({ page }) => {
+		await expect(page.getByTestId('worker-has-ws')).toHaveAttribute(
+			'data-value',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
+	});
+
+	test('all workers initialize simultaneously', async ({ page }) => {
+		// All subsystems should be ready once initialized is true
+		await expect(page.getByTestId('worker-initialized')).toHaveAttribute(
+			'data-value',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
+
+		// Verify all subsystems are available
+		await expect(page.getByTestId('worker-has-api')).toHaveAttribute(
+			'data-value',
+			'true',
+		);
+		await expect(page.getByTestId('worker-has-uiux')).toHaveAttribute(
+			'data-value',
+			'true',
+		);
+		await expect(page.getByTestId('worker-has-ws')).toHaveAttribute(
+			'data-value',
+			'true',
+		);
+		await expect(page.getByTestId('worker-has-events')).toHaveAttribute(
+			'data-value',
+			'true',
+		);
 	});
 });

--- a/packages/npm/droid-e2e/src/app/WorkerTest.tsx
+++ b/packages/npm/droid-e2e/src/app/WorkerTest.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { droid } from '@kbve/droid';
+import { droid, workerURLs } from '@kbve/droid';
 
 interface WorkerStatus {
 	initialized: boolean;
@@ -25,7 +25,7 @@ export function WorkerTest() {
 
 		async function init() {
 			try {
-				const result = await droid();
+				const result = await droid({ workerURLs, initTimeout: 10_000 });
 				if (cancelled) return;
 
 				const kbve = (window as any).kbve;
@@ -53,18 +53,30 @@ export function WorkerTest() {
 	}, []);
 
 	return (
-		<div data-testid="worker-test" style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+		<div
+			data-testid="worker-test"
+			style={{
+				border: '1px solid #ccc',
+				padding: '1rem',
+				marginBottom: '1rem',
+			}}>
 			<h2>Worker Initialization</h2>
 
-			<div data-testid="worker-initialized" data-value={String(status.initialized)}>
+			<div
+				data-testid="worker-initialized"
+				data-value={String(status.initialized)}>
 				Initialized: {status.initialized ? 'Yes' : 'No'}
 			</div>
 
-			<div data-testid="worker-has-api" data-value={String(status.hasApi)}>
+			<div
+				data-testid="worker-has-api"
+				data-value={String(status.hasApi)}>
 				API Worker: {status.hasApi ? 'Ready' : 'Not loaded'}
 			</div>
 
-			<div data-testid="worker-has-uiux" data-value={String(status.hasUiux)}>
+			<div
+				data-testid="worker-has-uiux"
+				data-value={String(status.hasUiux)}>
 				UIUX: {status.hasUiux ? 'Ready' : 'Not loaded'}
 			</div>
 
@@ -72,7 +84,9 @@ export function WorkerTest() {
 				WebSocket Worker: {status.hasWs ? 'Ready' : 'Not loaded'}
 			</div>
 
-			<div data-testid="worker-has-events" data-value={String(status.hasEvents)}>
+			<div
+				data-testid="worker-has-events"
+				data-value={String(status.hasEvents)}>
 				Event Bus: {status.hasEvents ? 'Ready' : 'Not loaded'}
 			</div>
 

--- a/packages/npm/droid/src/lib/droid.ts
+++ b/packages/npm/droid/src/lib/droid.ts
@@ -7,17 +7,36 @@ export async function droid(opts?: {
 	};
 	i18nPath?: string;
 	dataPath?: string;
+	/** Maximum time (ms) to wait for worker initialization before rejecting. Default: no timeout. */
+	initTimeout?: number;
 }): Promise<{ initialized: boolean }> {
 	console.log('[DROID]: droid<T>');
 
 	const { main } = await import('./workers/main.js');
 
-	await main({
+	const initPromise = main({
 		workerURLs: opts?.workerURLs,
 		workerRefs: opts?.workerRefs,
 		i18nPath: opts?.i18nPath,
 		dataPath: opts?.dataPath,
 	});
+
+	if (opts?.initTimeout && opts.initTimeout > 0) {
+		const timeout = new Promise<never>((_, reject) =>
+			setTimeout(
+				() =>
+					reject(
+						new Error(
+							`[DROID] Worker init timed out after ${opts.initTimeout}ms`,
+						),
+					),
+				opts.initTimeout,
+			),
+		);
+		await Promise.race([initPromise, timeout]);
+	} else {
+		await initPromise;
+	}
 
 	console.log('[DROID]: droid<T> => await WorkerRefs + URLs');
 


### PR DESCRIPTION
## Summary
- Add `initTimeout` option to `droid()` — wraps `main()` in `Promise.race` so worker init fails fast instead of hanging indefinitely when workers can't load
- Pass `workerURLs` from `@kbve/droid` to `WorkerTest.tsx` so the Vite dev server resolves worker modules via `?worker&url` imports (root cause of the 4 failing tests)
- Add 3 new e2e tests: API worker availability, WebSocket worker availability, and all-workers simultaneous init check (34 → 37 tests)

## Test plan
- [x] `nx build droid` — passes
- [x] `nx lint droid` — passes
- [x] `nx e2e droid-e2e` — 37/37 passed (was 30/34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)