### PR TITLE
chore(deps-dev): bump @testing-library/react from 16.1.0 to 16.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@tailwindcss/postcss": "^4.1.3",
 		"@tailwindcss/typography": "^0.5.15",
 		"@tailwindcss/vite": "^4.1.3",
-		"@testing-library/react": "16.1.0",
+		"@testing-library/react": "16.3.2",
 		"@types/dompurify": "^3.0.5",
 		"@types/node": "18.19.17",
 		"@types/react": "19.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,8 +333,8 @@ importers:
                 specifier: ^4.1.3
                 version: 4.1.3(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))
             '@testing-library/react':
-                specifier: 16.1.0
-                version: 16.1.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+                specifier: 16.3.2
+                version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
             '@types/dompurify':
                 specifier: ^3.0.5
                 version: 3.2.0
@@ -8046,10 +8046,10 @@ packages:
             }
         engines: { node: '>=18' }
 
-    '@testing-library/react@16.1.0':
+    '@testing-library/react@16.3.2':
         resolution:
             {
-                integrity: sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==,
+                integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==,
             }
         engines: { node: '>=18' }
         peerDependencies:
@@ -33011,7 +33011,7 @@ snapshots:
             lz-string: 1.5.0
             pretty-format: 27.5.1
 
-    '@testing-library/react@16.1.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
         dependencies:
             '@babel/runtime': 7.27.6
             '@testing-library/dom': 10.4.0


### PR DESCRIPTION
## Summary
- Bumps `@testing-library/react` from 16.1.0 to 16.3.2
- Key changes: React v19 `onCaughtError` type fix, React error handler support

Supersedes #7540 (Dependabot PR).

## Test plan
- [x] `pnpm install` succeeds
- [ ] CI lint + test pass