### PR TITLE
feat(n8n): add KEDA ScaledObject for worker autoscaling

### DIFF
--- a/apps/kube/n8n/manifest/n8n-keda.yaml
+++ b/apps/kube/n8n/manifest/n8n-keda.yaml
@@ -1,0 +1,40 @@
+# TriggerAuthentication: Redis password for KEDA scaler
+# Reuses the existing ExternalSecret-managed n8n-redis-secret
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+    name: n8n-redis-trigger-auth
+    namespace: n8n
+spec:
+    secretTargetRef:
+        - parameter: password
+          name: n8n-redis-secret
+          key: QUEUE_BULL_REDIS_PASSWORD
+---
+# ScaledObject: Scale n8n-worker based on Bull queue depth in Redis
+# Bull key: n8n-bull:jobs:wait (prefix:queueName:state) in Redis DB 2
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+    name: n8n-worker-scaledobject
+    namespace: n8n
+    labels:
+        app: n8n-worker
+spec:
+    scaleTargetRef:
+        name: n8n-worker
+    pollingInterval: 15
+    cooldownPeriod: 300
+    minReplicaCount: 1
+    maxReplicaCount: 5
+    triggers:
+        - type: redis
+          metadata:
+              address: redis-master.redis.svc.cluster.local:6379
+              listName: 'n8n-bull:jobs:wait'
+              listLength: '5'
+              activationListLength: '1'
+              databaseIndex: '2'
+              enableTLS: 'false'
+          authenticationRef:
+              name: n8n-redis-trigger-auth


### PR DESCRIPTION
## Summary
- Add `TriggerAuthentication` referencing existing `n8n-redis-secret` for KEDA Redis auth
- Add `ScaledObject` targeting `n8n-worker` Deployment based on Bull queue depth (`n8n-bull:jobs:wait` in Redis DB 2)
- Scales 1–5 replicas, polls every 15s, 5min cooldown before scale-down
- Activates scaling when ≥1 job is waiting, targets 5 jobs per replica

## Details
- KEDA operator is already live on the cluster (PR #7605)
- Redis key `n8n-bull:jobs:wait` is a List (Bull's waiting queue), matching KEDA's `redis` (lists) scaler
- `databaseIndex: 2` matches `QUEUE_BULL_REDIS_DB=2` from n8n deployment
- All manifests pass `kubectl apply --dry-run=client`

Closes last open item from #7590 (KEDA-based worker scaling)

## Test plan
- [ ] Verify `TriggerAuthentication` and `ScaledObject` sync via ArgoCD
- [ ] Confirm KEDA operator can reach Redis DB 2 and read queue length
- [ ] Trigger test workflows to queue jobs, observe worker replica scaling
- [ ] Verify scale-down after cooldown period (300s)