### PR TITLE
chore(deps): bump marked from 13.0.3 to 17.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
 		"input-otp": "^1.4.1",
 		"lucide": "^0.575.0",
 		"lucide-react": "^0.575.0",
-		"marked": "^13.0.3",
+		"marked": "^17.0.3",
 		"mermaid": "^11.12.0",
 		"openpgp": "^6.3.0",
 		"phaser": "^3.86.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
                 specifier: ^0.575.0
                 version: 0.575.0(react@19.2.4)
             marked:
-                specifier: ^13.0.3
-                version: 13.0.3
+                specifier: ^17.0.3
+                version: 17.0.4
             mermaid:
                 specifier: ^11.12.0
                 version: 11.12.0
@@ -18273,18 +18273,18 @@ packages:
                 integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
             }
 
-    marked@13.0.3:
-        resolution:
-            {
-                integrity: sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==,
-            }
-        engines: { node: '>= 18' }
-        hasBin: true
-
     marked@16.4.0:
         resolution:
             {
                 integrity: sha512-CTPAcRBq57cn3R8n3hwc2REddc28hjR7RzDXQ+lXLmMJYqn20BaI2cGw6QjgZGIgVfp2Wdfw4aMzgNteQ6qJgQ==,
+            }
+        engines: { node: '>= 20' }
+        hasBin: true
+
+    marked@17.0.4:
+        resolution:
+            {
+                integrity: sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==,
             }
         engines: { node: '>= 20' }
         hasBin: true
@@ -40283,9 +40283,9 @@ snapshots:
 
     markdown-table@3.0.4: {}
 
-    marked@13.0.3: {}
-
     marked@16.4.0: {}
+
+    marked@17.0.4: {}
 
     marky@1.3.0: {}
 


### PR DESCRIPTION
## Summary
- Bumps `marked` from 13.0.3 to 17.0.3
- Only usage is `marked.parse()` in `packages/npm/devops/src/lib/sanitization.ts` — API unchanged across versions

Supersedes #7537 (Dependabot PR).

## Test plan
- [x] `pnpm install` succeeds
- [ ] CI lint + test pass