### PR TITLE
fix(devops): update marked version specifier to ^17.0.3

### DIFF
--- a/packages/npm/devops/package.json
+++ b/packages/npm/devops/package.json
@@ -38,7 +38,7 @@
 		"@bufbuild/protobuf": "^2.11.0",
 		"axios": "^1.6.7",
 		"jsdom": "^22.1.0",
-		"marked": "^13.0.0",
+		"marked": "^17.0.3",
 		"dompurify": "^3.1.5"
 	},
 	"engines": {


### PR DESCRIPTION
## Summary
- Updates `marked` version specifier in `packages/npm/devops/package.json` from `^13.0.0` to `^17.0.3`
- The root `package.json` was bumped to `^17.0.3` in #7615, but the devops package still had the old specifier
- This caused `@nx/dependency-checks` lint error: installed version 17.0.4 didn't match `^13.0.0`

## Test plan
- [x] `nx run devops:lint` passes (0 errors, 30 warnings)