### PR TITLE
feat(axum-kbve): MC RCON player list API with LRU cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "jedi",
  "jsonwebtoken",
  "kbve",
+ "lru 0.16.3",
  "num_cpus",
  "prost",
  "prost-build",
@@ -4156,6 +4157,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -4986,7 +4989,7 @@ dependencies = [
  "dotenvy",
  "jedi",
  "jsonwebtoken",
- "lru",
+ "lru 0.12.5",
  "num-bigint 0.4.6",
  "once_cell",
  "r2d2",
@@ -5197,6 +5200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -39,6 +39,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 dashmap = { version = "6.1", features = ["rayon"] }
 rayon = "1.10"
 regex = "1.11"
+lru = "0.16"
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi" }

--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -1,0 +1,520 @@
+// MC RCON client with LRU-cached player list and Mojang profile enrichment.
+//
+// Background task polls RCON `list` every 15s, resolves UUIDs + textures
+// via Mojang API, and stores results for instant API responses.
+
+use lru::LruCache;
+use serde::Serialize;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tracing::{debug, warn};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const REFRESH_INTERVAL: Duration = Duration::from_secs(15);
+const UUID_CACHE_CAP: usize = 500;
+const TEXTURE_CACHE_CAP: usize = 500;
+const UUID_TTL: Duration = Duration::from_secs(86400); // 24h
+const TEXTURE_TTL: Duration = Duration::from_secs(3600); // 1h
+const RCON_TIMEOUT: Duration = Duration::from_secs(5);
+
+const MOJANG_API: &str = "https://api.mojang.com/users/profiles/minecraft";
+const MOJANG_SESSION: &str = "https://sessionserver.mojang.com/session/minecraft/profile";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize)]
+pub struct McPlayer {
+    pub name: String,
+    pub uuid: Option<String>,
+    pub skin_url: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct McPlayerList {
+    pub online: usize,
+    pub max: usize,
+    pub players: Vec<McPlayer>,
+    pub cached_at: u64,
+}
+
+struct TimedEntry<T> {
+    value: T,
+    inserted: Instant,
+    ttl: Duration,
+}
+
+impl<T> TimedEntry<T> {
+    fn new(value: T, ttl: Duration) -> Self {
+        Self {
+            value,
+            inserted: Instant::now(),
+            ttl,
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.inserted.elapsed() > self.ttl
+    }
+}
+
+pub struct McService {
+    rcon_host: String,
+    rcon_port: u16,
+    rcon_password: String,
+    http: reqwest::Client,
+    // Cached player list (refreshed by background task)
+    player_list: Arc<tokio::sync::RwLock<Option<McPlayerList>>>,
+    // LRU caches for Mojang lookups
+    uuid_cache: Arc<Mutex<LruCache<String, TimedEntry<String>>>>,
+    texture_cache: Arc<Mutex<LruCache<String, TimedEntry<Option<String>>>>>,
+}
+
+// ---------------------------------------------------------------------------
+// Global singleton (same pattern as osrs.rs, discord.rs)
+// ---------------------------------------------------------------------------
+
+static MC_SERVICE: OnceLock<Arc<McService>> = OnceLock::new();
+
+pub fn get_mc_service() -> Option<&'static Arc<McService>> {
+    MC_SERVICE.get()
+}
+
+pub fn init_mc_service() -> bool {
+    let host = match std::env::var("MC_RCON_HOST") {
+        Ok(h) => h,
+        Err(_) => return false,
+    };
+    let port: u16 = std::env::var("MC_RCON_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(25575);
+    let password = std::env::var("MC_RCON_PASSWORD").unwrap_or_default();
+
+    let svc = Arc::new(McService {
+        rcon_host: host,
+        rcon_port: port,
+        rcon_password: password,
+        http: reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap_or_default(),
+        player_list: Arc::new(tokio::sync::RwLock::new(None)),
+        uuid_cache: Arc::new(Mutex::new(LruCache::new(
+            NonZeroUsize::new(UUID_CACHE_CAP).unwrap(),
+        ))),
+        texture_cache: Arc::new(Mutex::new(LruCache::new(
+            NonZeroUsize::new(TEXTURE_CACHE_CAP).unwrap(),
+        ))),
+    });
+
+    if MC_SERVICE.set(svc.clone()).is_err() {
+        return false;
+    }
+
+    // Spawn background refresh task
+    tokio::spawn(async move {
+        loop {
+            svc.refresh_player_list().await;
+            tokio::time::sleep(REFRESH_INTERVAL).await;
+        }
+    });
+
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+impl McService {
+    pub async fn get_players(&self) -> McPlayerList {
+        self.player_list
+            .read()
+            .await
+            .clone()
+            .unwrap_or(McPlayerList {
+                online: 0,
+                max: 0,
+                players: vec![],
+                cached_at: now_epoch(),
+            })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background refresh
+// ---------------------------------------------------------------------------
+
+impl McService {
+    async fn refresh_player_list(&self) {
+        let rcon_result = self.rcon_list().await;
+
+        let (names, max) = match rcon_result {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(error = %e, "RCON list failed");
+                return;
+            }
+        };
+
+        let mut players = Vec::with_capacity(names.len());
+
+        for name in &names {
+            let uuid = self.resolve_uuid(name).await;
+            let skin_url = if let Some(ref uuid) = uuid {
+                self.resolve_skin(uuid).await
+            } else {
+                None
+            };
+            players.push(McPlayer {
+                name: name.clone(),
+                uuid,
+                skin_url,
+            });
+        }
+
+        let list = McPlayerList {
+            online: players.len(),
+            max,
+            players,
+            cached_at: now_epoch(),
+        };
+
+        *self.player_list.write().await = Some(list);
+        debug!("MC player list refreshed ({} players)", names.len());
+    }
+
+    /// Resolve player name → UUID via LRU cache or Mojang API.
+    async fn resolve_uuid(&self, name: &str) -> Option<String> {
+        let lower = name.to_lowercase();
+
+        // Check cache
+        {
+            let mut cache = self.uuid_cache.lock().unwrap();
+            if let Some(entry) = cache.get(&lower) {
+                if !entry.is_expired() {
+                    return Some(entry.value.clone());
+                }
+                // Expired — will re-fetch below
+            }
+        }
+
+        // Fetch from Mojang
+        let url = format!("{MOJANG_API}/{name}");
+        let resp = self.http.get(&url).send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        let body: serde_json::Value = resp.json().await.ok()?;
+        let uuid = body.get("id")?.as_str()?.to_string();
+
+        // Store in cache
+        {
+            let mut cache = self.uuid_cache.lock().unwrap();
+            cache.put(lower, TimedEntry::new(uuid.clone(), UUID_TTL));
+        }
+
+        Some(uuid)
+    }
+
+    /// Resolve UUID → skin texture URL via LRU cache or Mojang session API.
+    async fn resolve_skin(&self, uuid: &str) -> Option<String> {
+        // Check cache
+        {
+            let mut cache = self.texture_cache.lock().unwrap();
+            if let Some(entry) = cache.get(uuid) {
+                if !entry.is_expired() {
+                    return entry.value.clone();
+                }
+            }
+        }
+
+        // Fetch from Mojang session server
+        let url = format!("{MOJANG_SESSION}/{uuid}");
+        let resp = self.http.get(&url).send().await.ok()?;
+        if !resp.status().is_success() {
+            // Cache the miss to avoid hammering Mojang
+            let mut cache = self.texture_cache.lock().unwrap();
+            cache.put(uuid.to_string(), TimedEntry::new(None, TEXTURE_TTL));
+            return None;
+        }
+
+        let body: serde_json::Value = resp.json().await.ok()?;
+        let skin_url = extract_skin_url(&body);
+
+        // Store in cache
+        {
+            let mut cache = self.texture_cache.lock().unwrap();
+            cache.put(
+                uuid.to_string(),
+                TimedEntry::new(skin_url.clone(), TEXTURE_TTL),
+            );
+        }
+
+        skin_url
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RCON protocol (Minecraft/Source RCON — simple length-prefixed TCP packets)
+// ---------------------------------------------------------------------------
+
+// Packet types
+const RCON_AUTH: i32 = 3;
+const RCON_EXEC: i32 = 2;
+
+impl McService {
+    /// Connect to RCON, authenticate, run `list`, return (player_names, max_players).
+    async fn rcon_list(&self) -> anyhow::Result<(Vec<String>, usize)> {
+        let addr = format!("{}:{}", self.rcon_host, self.rcon_port);
+        let mut stream = tokio::time::timeout(RCON_TIMEOUT, TcpStream::connect(&addr)).await??;
+
+        // Authenticate
+        rcon_send(&mut stream, 1, RCON_AUTH, &self.rcon_password).await?;
+        let (req_id, _, _) = rcon_recv(&mut stream).await?;
+        if req_id == -1 {
+            anyhow::bail!("RCON authentication failed");
+        }
+
+        // Send `list` command
+        rcon_send(&mut stream, 2, RCON_EXEC, "list").await?;
+        let (_, _, body) = rcon_recv(&mut stream).await?;
+
+        parse_list_response(&body)
+    }
+}
+
+/// Send an RCON packet: [length:4][req_id:4][type:4][body + \0][pad \0]
+async fn rcon_send(
+    stream: &mut TcpStream,
+    req_id: i32,
+    ptype: i32,
+    body: &str,
+) -> anyhow::Result<()> {
+    let body_bytes = body.as_bytes();
+    let length = 4 + 4 + body_bytes.len() as i32 + 2; // req_id + type + body + 2 nulls
+
+    stream.write_all(&length.to_le_bytes()).await?;
+    stream.write_all(&req_id.to_le_bytes()).await?;
+    stream.write_all(&ptype.to_le_bytes()).await?;
+    stream.write_all(body_bytes).await?;
+    stream.write_all(&[0, 0]).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Read an RCON response packet, returns (req_id, type, body).
+async fn rcon_recv(stream: &mut TcpStream) -> anyhow::Result<(i32, i32, String)> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await?;
+    let length = i32::from_le_bytes(len_buf) as usize;
+
+    if length < 10 || length > 4096 {
+        anyhow::bail!("RCON packet length out of range: {length}");
+    }
+
+    let mut payload = vec![0u8; length];
+    stream.read_exact(&mut payload).await?;
+
+    let req_id = i32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+    let ptype = i32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
+    // Body is everything after the 8-byte header, minus 2 trailing nulls
+    let body_end = length.saturating_sub(2);
+    let body = String::from_utf8_lossy(&payload[8..body_end]).to_string();
+
+    Ok((req_id, ptype, body))
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/// Parse Minecraft `list` response:
+/// "There are N of a max of M players online: name1, name2, ..."
+/// or "There are 0 of a max of M players online:"
+fn parse_list_response(response: &str) -> anyhow::Result<(Vec<String>, usize)> {
+    // Find "max of N" to extract max players
+    let max = response
+        .split("max of ")
+        .nth(1)
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0);
+
+    // Find player names after the colon
+    let names = if let Some(after_colon) = response.split(':').nth(1) {
+        let trimmed = after_colon.trim();
+        if trimmed.is_empty() {
+            vec![]
+        } else {
+            trimmed
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        }
+    } else {
+        vec![]
+    };
+
+    Ok((names, max))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract skin URL from Mojang session profile response.
+/// The `properties` array contains a base64-encoded JSON with texture URLs.
+fn extract_skin_url(profile: &serde_json::Value) -> Option<String> {
+    let properties = profile.get("properties")?.as_array()?;
+    let textures_prop = properties.iter().find(|p| {
+        p.get("name")
+            .and_then(|n| n.as_str())
+            .map_or(false, |n| n == "textures")
+    })?;
+    let b64 = textures_prop.get("value")?.as_str()?;
+
+    let decoded = base64_decode(b64)?;
+    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+
+    json.get("textures")?
+        .get("SKIN")?
+        .get("url")?
+        .as_str()
+        .map(String::from)
+}
+
+/// Minimal base64 decode (standard alphabet, with padding).
+fn base64_decode(input: &str) -> Option<Vec<u8>> {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+
+    for &b in input.as_bytes() {
+        let val = if b == b'=' {
+            continue;
+        } else if let Some(pos) = TABLE.iter().position(|&c| c == b) {
+            pos as u32
+        } else if b == b'\n' || b == b'\r' || b == b' ' {
+            continue;
+        } else {
+            return None;
+        };
+
+        buf = (buf << 6) | val;
+        bits += 6;
+
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+            buf &= (1 << bits) - 1;
+        }
+    }
+
+    Some(out)
+}
+
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_list_with_players() {
+        let resp = "There are 3 of a max of 20 players online: Alice, Bob, Charlie";
+        let (names, max) = parse_list_response(resp).unwrap();
+        assert_eq!(max, 20);
+        assert_eq!(names, vec!["Alice", "Bob", "Charlie"]);
+    }
+
+    #[test]
+    fn test_parse_list_empty() {
+        let resp = "There are 0 of a max of 20 players online:";
+        let (names, max) = parse_list_response(resp).unwrap();
+        assert_eq!(max, 20);
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn test_base64_decode() {
+        let encoded = "SGVsbG8gV29ybGQ=";
+        let decoded = base64_decode(encoded).unwrap();
+        assert_eq!(&decoded, b"Hello World");
+    }
+
+    #[test]
+    fn test_extract_skin_url() {
+        let texture_json =
+            r#"{"textures":{"SKIN":{"url":"https://textures.minecraft.net/texture/abc123"}}}"#;
+        let b64 = {
+            const TABLE: &[u8; 64] =
+                b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            let input = texture_json.as_bytes();
+            let mut out = String::new();
+            let mut i = 0;
+            while i < input.len() {
+                let b0 = input[i] as u32;
+                let b1 = if i + 1 < input.len() {
+                    input[i + 1] as u32
+                } else {
+                    0
+                };
+                let b2 = if i + 2 < input.len() {
+                    input[i + 2] as u32
+                } else {
+                    0
+                };
+                let triple = (b0 << 16) | (b1 << 8) | b2;
+                out.push(TABLE[((triple >> 18) & 0x3F) as usize] as char);
+                out.push(TABLE[((triple >> 12) & 0x3F) as usize] as char);
+                if i + 1 < input.len() {
+                    out.push(TABLE[((triple >> 6) & 0x3F) as usize] as char);
+                } else {
+                    out.push('=');
+                }
+                if i + 2 < input.len() {
+                    out.push(TABLE[(triple & 0x3F) as usize] as char);
+                } else {
+                    out.push('=');
+                }
+                i += 3;
+            }
+            out
+        };
+
+        let profile = serde_json::json!({
+            "id": "abc",
+            "name": "Test",
+            "properties": [
+                {
+                    "name": "textures",
+                    "value": b64
+                }
+            ]
+        });
+
+        let url = extract_skin_url(&profile).unwrap();
+        assert_eq!(url, "https://textures.minecraft.net/texture/abc123");
+    }
+}

--- a/apps/kbve/axum-kbve/src/db/mod.rs
+++ b/apps/kbve/axum-kbve/src/db/mod.rs
@@ -2,6 +2,7 @@
 
 mod cache;
 mod discord;
+pub mod mc;
 mod osrs;
 mod profile;
 mod rentearth;
@@ -10,6 +11,7 @@ mod twitch;
 
 pub use cache::{ProfileCache, get_profile_cache, init_profile_cache};
 pub use discord::{DiscordClient, get_discord_client, get_role_names, init_discord_client};
+pub use mc::{get_mc_service, init_mc_service};
 pub use osrs::{get_osrs_cache, init_osrs_cache};
 pub use profile::{UserProfile, get_profile_service, init_profile_service, validate_username};
 pub use rentearth::{get_rentearth_service, init_rentearth_service};

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -69,6 +69,13 @@ async fn main() -> anyhow::Result<()> {
     let _osrs_cache = db::init_osrs_cache().await;
     info!("OSRS cache actor started");
 
+    // Initialize MC RCON service (optional - for player list API)
+    if db::init_mc_service() {
+        info!("MC RCON service initialized - player API enabled");
+    } else {
+        info!("MC RCON not configured - player API disabled");
+    }
+
     // Initialize JWT cache for authenticated endpoints
     if let (Ok(supabase_url), Ok(supabase_anon_key)) = (
         std::env::var("SUPABASE_URL"),

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -22,9 +22,9 @@ use crate::astro::askama::{
 };
 use crate::auth::{extract_bearer_token, get_jwt_cache};
 use crate::db::{
-    DiscordClient, UserProfile, get_discord_client, get_osrs_cache, get_profile_cache,
-    get_profile_service, get_rentearth_service, get_role_names, get_twitch_client,
-    validate_username,
+    DiscordClient, UserProfile, get_discord_client, get_mc_service, get_osrs_cache,
+    get_profile_cache, get_profile_service, get_rentearth_service, get_role_names,
+    get_twitch_client, validate_username,
 };
 
 #[derive(Clone)]
@@ -145,6 +145,7 @@ fn router(state: AppState) -> Router {
         .route("/health.html", get(health_html))
         .route("/api/status", get(api_status))
         .route("/api/v1/osrs/{item_id}", get(osrs_api_handler))
+        .route("/api/v1/mc/players", get(mc_players_handler))
         .route("/api/v1/profile/me", get(profile_me_handler))
         .route("/api/v1/profile/username", post(set_username_handler))
         .route("/api/v1/profile/{username}", get(profile_api_handler))
@@ -956,6 +957,41 @@ async fn osrs_api_handler(Path(item_id): Path<String>) -> impl IntoResponse {
         )
             .into_response(),
     }
+}
+
+// ---------------------------------------------------------------------------
+// MC API handlers
+// ---------------------------------------------------------------------------
+
+/// MC players API endpoint - returns online player list with UUIDs and skin URLs.
+/// GET /api/v1/mc/players
+///
+/// Data is LRU-cached and refreshed every 15s via RCON background task.
+async fn mc_players_handler() -> impl IntoResponse {
+    let svc = match get_mc_service() {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({
+                    "error": "MC player service not configured"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let players = svc.get_players().await;
+
+    (
+        StatusCode::OK,
+        [(
+            header::CACHE_CONTROL,
+            "public, max-age=10, stale-while-revalidate=10",
+        )],
+        Json(json!(players)),
+    )
+        .into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -1,75 +1,81 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kbve-deployment
-  namespace: kbve
-  labels:
-    app: kbve
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: kbve
-  template:
-    metadata:
-      annotations:
-        rollout-restart: "2026-01-31T17:38:01Z"
-      labels:
+    name: kbve-deployment
+    namespace: kbve
+    labels:
         app: kbve
-        version: "1.0.19"
-    spec:
-      containers:
-      - name: kbve
-        image: ghcr.io/kbve/kbve.com:1.0.19
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 4321
-          protocol: TCP
-        env:
-        - name: PORT
-          value: "4321"
-        - name: SUPABASE_URL
-          value: "http://kong.kilobase.svc.cluster.local:8000"
-        - name: SUPABASE_ANON_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: anon-key
-        - name: SUPABASE_SERVICE_ROLE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: service-role-key
-        - name: TWITCH_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: twitch-client-id
-        - name: TWITCH_APP_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: twitch-client-secret
-        resources:
-          requests:
-            memory: "512Mi"
-            cpu: "2000m"
-          limits:
-            memory: "1024Mi"
-            cpu: "4000m"
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: kbve
+    template:
+        metadata:
+            annotations:
+                rollout-restart: '2026-01-31T17:38:01Z'
+            labels:
+                app: kbve
+                version: '1.0.19'
+        spec:
+            containers:
+                - name: kbve
+                  image: ghcr.io/kbve/kbve.com:1.0.19
+                  imagePullPolicy: Always
+                  ports:
+                      - containerPort: 4321
+                        protocol: TCP
+                  env:
+                      - name: PORT
+                        value: '4321'
+                      - name: SUPABASE_URL
+                        value: 'http://kong.kilobase.svc.cluster.local:8000'
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: anon-key
+                      - name: SUPABASE_SERVICE_ROLE_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: service-role-key
+                      - name: TWITCH_CLIENT_ID
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: twitch-client-id
+                      - name: TWITCH_APP_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: twitch-client-secret
+                      - name: MC_RCON_HOST
+                        value: 'mc-service.mc.svc.cluster.local'
+                      - name: MC_RCON_PORT
+                        value: '25575'
+                      - name: MC_RCON_PASSWORD
+                        value: 'kbve-rcon'
+                  resources:
+                      requests:
+                          memory: '512Mi'
+                          cpu: '2000m'
+                      limits:
+                          memory: '1024Mi'
+                          cpu: '4000m'
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: kbve-service
-  namespace: kbve
-  labels:
-    app: kbve
+    name: kbve-service
+    namespace: kbve
+    labels:
+        app: kbve
 spec:
-  type: ClusterIP
-  selector:
-    app: kbve
-  ports:
-  - port: 4321
-    targetPort: 4321
-    protocol: TCP
+    type: ClusterIP
+    selector:
+        app: kbve
+    ports:
+        - port: 4321
+          targetPort: 4321
+          protocol: TCP

--- a/apps/kube/mc/manifest/networkpolicy.yaml
+++ b/apps/kube/mc/manifest/networkpolicy.yaml
@@ -20,11 +20,14 @@ spec:
                 protocol: UDP
               - port: 8080
                 protocol: TCP
-        # Allow RCON only from kilobase and mc namespaces
+        # Allow RCON only from kilobase, kbve, and mc namespaces
         - from:
               - namespaceSelector:
                     matchLabels:
                         kubernetes.io/metadata.name: kilobase
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: kbve
               - namespaceSelector:
                     matchLabels:
                         kubernetes.io/metadata.name: mc


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/mc/players` endpoint to axum-kbve that returns online Minecraft players with UUIDs and skin texture URLs
- Background task polls MC server via RCON every 15s, enriches player data via Mojang API, caches with LRU (uuid: 24h TTL, textures: 1h TTL)
- Custom lightweight RCON protocol implementation (no external crate)
- Updates NetworkPolicy to allow `kbve` namespace to reach MC RCON (port 25575)
- Adds RCON connection env vars (`MC_RCON_HOST`, `MC_RCON_PORT`, `MC_RCON_PASSWORD`) to kbve deployment

## Test plan
- [x] `cargo check -p axum-kbve` passes with zero warnings
- [x] Unit tests pass (RCON response parsing, base64 decode, skin URL extraction)
- [ ] Verify `GET /api/v1/mc/players` returns 503 when RCON env vars are not set
- [ ] Verify player list returns correctly when connected to a Pumpkin server with RCON enabled
- [ ] Verify NetworkPolicy allows RCON from kbve namespace in cluster