### PR TITLE
feat(crossplane): deploy Crossplane operator via ArgoCD

### DIFF
--- a/apps/kube/crossplane/application.yaml
+++ b/apps/kube/crossplane/application.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: crossplane
+    namespace: argocd
+spec:
+    project: default
+    sources:
+        - repoURL: https://charts.crossplane.io/stable
+          targetRevision: 2.2.0
+          chart: crossplane
+          helm:
+              releaseName: crossplane
+              valueFiles:
+                  - $values/apps/kube/crossplane/manifests/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: crossplane-system
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m

--- a/apps/kube/crossplane/manifests/values.yaml
+++ b/apps/kube/crossplane/manifests/values.yaml
@@ -1,0 +1,44 @@
+replicas: 1
+
+resourcesCrossplane:
+    requests:
+        cpu: 100m
+        memory: 256Mi
+    limits:
+        cpu: 500m
+        memory: 1Gi
+
+resourcesRBACManager:
+    requests:
+        cpu: 100m
+        memory: 256Mi
+    limits:
+        cpu: 100m
+        memory: 512Mi
+
+securityContextCrossplane:
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+
+securityContextRBACManager:
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+
+podSecurityContextCrossplane:
+    runAsNonRoot: true
+
+podSecurityContextRBACManager:
+    runAsNonRoot: true
+
+metrics:
+    enabled: true
+
+rbacManager:
+    deploy: true
+
+webhooks:
+    enabled: true

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
     - cert-manager/application.yaml
     - sealed-secrets/application.yaml
     - keda/application.yaml
+    - crossplane/application.yaml
     - external-secrets/application.yaml
     - monitoring/application.yaml
     - redis/application.yaml


### PR DESCRIPTION
## Summary
- Deploy Crossplane 2.2.0 operator via ArgoCD Helm multi-source pattern (same as KEDA/CNPG)
- Namespace: `crossplane-system`, with RBAC manager, webhooks, and metrics enabled
- Security hardened: non-root (UID 65532), read-only rootfs, no privilege escalation
- Added to root `kustomization.yaml` after KEDA, before external-secrets

## Context
Crossplane will manage cloud infrastructure declaratively via K8s CRDs — starting with S3 buckets for CNPG backups. This PR deploys only the operator; provider-aws and S3 bucket resources come in follow-up PRs.

Crossplane self-manages its CRDs at runtime (no separate CRD install needed).

## Test plan
- [x] `kubectl apply --dry-run=client` passes
- [ ] ArgoCD syncs and deploys crossplane + rbac-manager pods
- [ ] `kubectl get crds | grep crossplane` shows core CRDs registered
- [ ] Ready for provider-aws installation in follow-up PR