### PR TITLE
fix(docker): run axum containers as non-root user

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -164,7 +164,10 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         libgcc-s1_libs \
         libc6_libs \
         libstdc++6_libs \
-        openssl_config
+        openssl_config && \
+    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
+    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
+    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
 
 # ============================================================================
 # [STAGE H] - Jemalloc
@@ -188,10 +191,10 @@ COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-
 
 WORKDIR /app
 
-COPY --from=builder /app/target/release/axum-cryptothrone /app/axum-cryptothrone
+COPY --from=builder --chown=10001:10001 /app/target/release/axum-cryptothrone /app/axum-cryptothrone
 
-COPY --from=builder /app/apps/cryptothrone/axum-cryptothrone/templates/dist /app/templates/dist
-COPY --from=builder /app/apps/cryptothrone/axum-cryptothrone/templates/askama /app/templates/askama
+COPY --from=builder --chown=10001:10001 /app/apps/cryptothrone/axum-cryptothrone/templates/dist /app/templates/dist
+COPY --from=builder --chown=10001:10001 /app/apps/cryptothrone/axum-cryptothrone/templates/askama /app/templates/askama
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
@@ -200,5 +203,7 @@ ENV HTTP_PORT=4321
 ENV RUST_LOG=info
 
 EXPOSE 4321
+
+USER 10001:10001
 
 ENTRYPOINT ["/app/axum-cryptothrone"]

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -182,7 +182,10 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         libgcc-s1_libs \
         libc6_libs \
         libstdc++6_libs \
-        openssl_config
+        openssl_config && \
+    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
+    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
+    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
 
 # ============================================================================
 # [STAGE E] - Jemalloc
@@ -217,14 +220,14 @@ COPY --from=libpq-runtime /usr/lib/x86_64-linux-gnu/libpq.so.5* /usr/lib/x86_64-
 
 WORKDIR /app
 
-COPY --from=builder /app/target/release/axum-discordsh /app/axum-discordsh
+COPY --from=builder --chown=10001:10001 /app/target/release/axum-discordsh /app/axum-discordsh
 
-COPY --from=builder /app/apps/discordsh/axum-discordsh/templates/dist /app/templates/dist
-COPY --from=builder /app/apps/discordsh/axum-discordsh/templates/askama /app/templates/askama
+COPY --from=builder --chown=10001:10001 /app/apps/discordsh/axum-discordsh/templates/dist /app/templates/dist
+COPY --from=builder --chown=10001:10001 /app/apps/discordsh/axum-discordsh/templates/askama /app/templates/askama
 
 # Game card fonts (SVG → PNG rendering via resvg)
-COPY apps/discordsh/axum-discordsh/alagard.ttf /app/alagard.ttf
-COPY apps/discordsh/axum-discordsh/NotoSansSymbols-Regular.ttf /app/NotoSansSymbols-Regular.ttf
+COPY --chown=10001:10001 apps/discordsh/axum-discordsh/alagard.ttf /app/alagard.ttf
+COPY --chown=10001:10001 apps/discordsh/axum-discordsh/NotoSansSymbols-Regular.ttf /app/NotoSansSymbols-Regular.ttf
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
@@ -235,5 +238,7 @@ ENV FONT_PATH=/app/alagard.ttf
 ENV SYMBOL_FONT_PATH=/app/NotoSansSymbols-Regular.ttf
 
 EXPOSE 4321
+
+USER 10001:10001
 
 ENTRYPOINT ["/app/axum-discordsh"]

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -163,7 +163,10 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         libgcc-s1_libs \
         libc6_libs \
         libstdc++6_libs \
-        openssl_config
+        openssl_config && \
+    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
+    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
+    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
 
 # ============================================================================
 # [STAGE H] - Jemalloc
@@ -187,10 +190,10 @@ COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-
 
 WORKDIR /app
 
-COPY --from=builder /app/target/release/axum-herbmail /app/axum-herbmail
+COPY --from=builder --chown=10001:10001 /app/target/release/axum-herbmail /app/axum-herbmail
 
-COPY --from=builder /app/apps/herbmail/axum-herbmail/templates/dist /app/templates/dist
-COPY --from=builder /app/apps/herbmail/axum-herbmail/templates/askama /app/templates/askama
+COPY --from=builder --chown=10001:10001 /app/apps/herbmail/axum-herbmail/templates/dist /app/templates/dist
+COPY --from=builder --chown=10001:10001 /app/apps/herbmail/axum-herbmail/templates/askama /app/templates/askama
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
@@ -199,5 +202,7 @@ ENV HTTP_PORT=4321
 ENV RUST_LOG=info
 
 EXPOSE 4321
+
+USER 10001:10001
 
 ENTRYPOINT ["/app/axum-herbmail"]

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -160,7 +160,10 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         libgcc-s1_libs \
         libc6_libs \
         libstdc++6_libs \
-        openssl_config
+        openssl_config && \
+    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
+    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
+    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
 
 # ============================================================================
 # [STAGE H] - Jemalloc
@@ -184,9 +187,9 @@ COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-
 
 WORKDIR /app
 
-COPY --from=builder /app/target/release/irc-gateway /app/irc-gateway
+COPY --from=builder --chown=10001:10001 /app/target/release/irc-gateway /app/irc-gateway
 
-COPY --from=builder /app/apps/irc/irc-gateway/templates/dist /app/templates/dist
+COPY --from=builder --chown=10001:10001 /app/apps/irc/irc-gateway/templates/dist /app/templates/dist
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
@@ -196,5 +199,7 @@ ENV RUST_LOG=info
 
 EXPOSE 4321
 EXPOSE 6667
+
+USER 10001:10001
 
 ENTRYPOINT ["/app/irc-gateway"]

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -163,7 +163,10 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         libgcc-s1_libs \
         libc6_libs \
         libstdc++6_libs \
-        openssl_config
+        openssl_config && \
+    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
+    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
+    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
 
 # ============================================================================
 # [STAGE H] - Jemalloc
@@ -187,10 +190,10 @@ COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-
 
 WORKDIR /app
 
-COPY --from=builder /app/target/release/axum-memes /app/axum-memes
+COPY --from=builder --chown=10001:10001 /app/target/release/axum-memes /app/axum-memes
 
-COPY --from=builder /app/apps/memes/axum-memes/templates/dist /app/templates/dist
-COPY --from=builder /app/apps/memes/axum-memes/templates/askama /app/templates/askama
+COPY --from=builder --chown=10001:10001 /app/apps/memes/axum-memes/templates/dist /app/templates/dist
+COPY --from=builder --chown=10001:10001 /app/apps/memes/axum-memes/templates/askama /app/templates/askama
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
@@ -199,5 +202,7 @@ ENV HTTP_PORT=4321
 ENV RUST_LOG=info
 
 EXPOSE 4321
+
+USER 10001:10001
 
 ENTRYPOINT ["/app/axum-memes"]


### PR DESCRIPTION
## Summary
- Inject non-root `appuser` (UID 10001) into chisel rootfs `passwd`/`group` for all scratch-based axum Dockerfiles
- Add `--chown=10001:10001` to all `COPY` directives in runtime stages
- Add `USER 10001:10001` before `ENTRYPOINT` to drop root privileges

## Affected Dockerfiles
- `apps/herbmail/axum-herbmail/Dockerfile`
- `apps/memes/axum-memes/Dockerfile`
- `apps/discordsh/axum-discordsh/Dockerfile`
- `apps/cryptothrone/axum-cryptothrone/Dockerfile`
- `apps/irc/irc-gateway/Dockerfile`

## Test plan
- [ ] Verify each container builds successfully
- [ ] Confirm `whoami` / `id` inside running container shows UID 10001
- [ ] Validate application starts and serves requests as non-root