### PR TITLE
feat(astro-kbve): MC players page with panic-safe RCON

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -114,6 +114,11 @@ export default defineConfig({
 					autogenerate: { directory: 'memes' },
 				},
 				{
+					label: 'Minecraft',
+					collapsed: false,
+					autogenerate: { directory: 'mc' },
+				},
+				{
 					label: 'Gaming',
 					collapsed: true,
 					autogenerate: { directory: 'gaming' },

--- a/apps/kbve/astro-kbve/src/components/mc/McPlayerList.tsx
+++ b/apps/kbve/astro-kbve/src/components/mc/McPlayerList.tsx
@@ -1,0 +1,263 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface McPlayer {
+	name: string;
+	uuid: string | null;
+	skin_url: string | null;
+}
+
+interface McPlayerListData {
+	online: number;
+	max: number;
+	players: McPlayer[];
+	cached_at: number;
+}
+
+interface McPlayerListProps {
+	apiBaseUrl?: string;
+	refreshInterval?: number;
+}
+
+const styles = {
+	container: {
+		borderRadius: '0.5rem',
+		border: '1px solid var(--sl-color-gray-5)',
+		background: 'var(--sl-color-bg-nav)',
+		padding: '1rem',
+	} as React.CSSProperties,
+	header: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		marginBottom: '0.75rem',
+		paddingBottom: '0.5rem',
+		borderBottom: '1px solid var(--sl-color-gray-6)',
+	} as React.CSSProperties,
+	title: {
+		margin: 0,
+		fontSize: '1rem',
+		fontWeight: 600,
+		color: 'var(--sl-color-white)',
+	} as React.CSSProperties,
+	badge: {
+		fontSize: '0.75rem',
+		padding: '0.125rem 0.5rem',
+		borderRadius: '9999px',
+		fontWeight: 600,
+	} as React.CSSProperties,
+	badgeOnline: {
+		background: 'rgba(34, 197, 94, 0.15)',
+		color: 'rgb(34, 197, 94)',
+	} as React.CSSProperties,
+	badgeOffline: {
+		background: 'rgba(156, 163, 175, 0.15)',
+		color: 'var(--sl-color-gray-3)',
+	} as React.CSSProperties,
+	playerGrid: {
+		display: 'grid',
+		gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+		gap: '0.5rem',
+	} as React.CSSProperties,
+	playerCard: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.625rem',
+		padding: '0.5rem',
+		borderRadius: '0.375rem',
+		background: 'var(--sl-color-bg)',
+		border: '1px solid var(--sl-color-gray-6)',
+	} as React.CSSProperties,
+	avatar: {
+		width: '32px',
+		height: '32px',
+		borderRadius: '4px',
+		imageRendering: 'pixelated' as const,
+		flexShrink: 0,
+		background: 'var(--sl-color-gray-6)',
+	} as React.CSSProperties,
+	playerName: {
+		fontSize: '0.875rem',
+		fontWeight: 500,
+		color: 'var(--sl-color-white)',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap' as const,
+	} as React.CSSProperties,
+	empty: {
+		textAlign: 'center' as const,
+		padding: '2rem 1rem',
+		color: 'var(--sl-color-gray-3)',
+		fontSize: '0.875rem',
+	} as React.CSSProperties,
+	loading: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '0.5rem',
+		padding: '2rem',
+		color: 'var(--sl-color-gray-3)',
+		fontSize: '0.875rem',
+	} as React.CSSProperties,
+	error: {
+		padding: '1rem',
+		borderRadius: '0.375rem',
+		background: 'rgba(239, 68, 68, 0.1)',
+		border: '1px solid rgba(239, 68, 68, 0.3)',
+		color: 'rgb(239, 68, 68)',
+		fontSize: '0.875rem',
+		textAlign: 'center' as const,
+	} as React.CSSProperties,
+	footer: {
+		marginTop: '0.5rem',
+		paddingTop: '0.5rem',
+		borderTop: '1px solid var(--sl-color-gray-6)',
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		fontSize: '0.7rem',
+		color: 'var(--sl-color-gray-4)',
+	} as React.CSSProperties,
+	retryBtn: {
+		cursor: 'pointer',
+		background: 'none',
+		border: '1px solid rgba(239, 68, 68, 0.5)',
+		borderRadius: '0.25rem',
+		color: 'rgb(239, 68, 68)',
+		padding: '0.25rem 0.75rem',
+		fontSize: '0.75rem',
+		marginTop: '0.5rem',
+	} as React.CSSProperties,
+};
+
+function craftHeadUrl(uuid: string | null): string {
+	if (!uuid) return '';
+	const cleanUuid = uuid.replace(/-/g, '');
+	return `https://mc-heads.net/avatar/${cleanUuid}/32`;
+}
+
+function formatCachedAt(epoch: number): string {
+	if (!epoch) return '';
+	const diff = Math.floor(Date.now() / 1000) - epoch;
+	if (diff < 5) return 'just now';
+	if (diff < 60) return `${diff}s ago`;
+	if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+	return `${Math.floor(diff / 3600)}h ago`;
+}
+
+export default function McPlayerList({
+	apiBaseUrl = '',
+	refreshInterval = 20000,
+}: McPlayerListProps) {
+	const [data, setData] = useState<McPlayerListData | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchPlayers = useCallback(async () => {
+		try {
+			const resp = await fetch(`${apiBaseUrl}/api/v1/mc/players`);
+			if (!resp.ok) {
+				throw new Error(
+					resp.status === 503
+						? 'MC server not connected'
+						: `Failed to fetch: ${resp.status}`,
+				);
+			}
+			const json: McPlayerListData = await resp.json();
+			setData(json);
+			setError(null);
+		} catch (err) {
+			setError(
+				err instanceof Error ? err.message : 'Failed to fetch players',
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, [apiBaseUrl]);
+
+	useEffect(() => {
+		fetchPlayers();
+		if (refreshInterval > 0) {
+			const interval = setInterval(fetchPlayers, refreshInterval);
+			return () => clearInterval(interval);
+		}
+	}, [fetchPlayers, refreshInterval]);
+
+	if (loading) {
+		return (
+			<div style={{ ...styles.container, ...styles.loading }}>
+				Loading player data...
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div style={styles.container}>
+				<div style={styles.error}>
+					{error}
+					<br />
+					<button
+						type="button"
+						style={styles.retryBtn}
+						onClick={() => {
+							setLoading(true);
+							fetchPlayers();
+						}}>
+						Retry
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	if (!data) return null;
+
+	const isOnline = data.online > 0;
+
+	return (
+		<div style={styles.container}>
+			<div style={styles.header}>
+				<h3 style={styles.title}>mc.kbve.com</h3>
+				<span
+					style={{
+						...styles.badge,
+						...(isOnline
+							? styles.badgeOnline
+							: styles.badgeOffline),
+					}}>
+					{data.online} / {data.max} online
+				</span>
+			</div>
+
+			{data.players.length === 0 ? (
+				<div style={styles.empty}>
+					No players online right now. Connect at{' '}
+					<strong>mc.kbve.com</strong>
+				</div>
+			) : (
+				<div style={styles.playerGrid}>
+					{data.players.map((player) => (
+						<div key={player.name} style={styles.playerCard}>
+							{player.uuid ? (
+								<img
+									src={craftHeadUrl(player.uuid)}
+									alt={player.name}
+									style={styles.avatar}
+									loading="lazy"
+								/>
+							) : (
+								<div style={styles.avatar} />
+							)}
+							<span style={styles.playerName}>{player.name}</span>
+						</div>
+					))}
+				</div>
+			)}
+
+			<div style={styles.footer}>
+				<span>Updated {formatCachedAt(data.cached_at)}</span>
+				<span>Auto-refreshes every {refreshInterval / 1000}s</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/mc/players.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/players.mdx
@@ -1,0 +1,26 @@
+---
+title: Minecraft Players
+description: |
+  Live view of online players on the KBVE Minecraft server.
+  Connect at mc.kbve.com to join the adventure.
+sidebar:
+  label: Players
+  order: 1000
+tags:
+  - gaming
+  - minecraft
+---
+
+import McPlayerList from '@/components/mc/McPlayerList.tsx';
+
+## Online Players
+
+See who is currently playing on **mc.kbve.com** — data refreshes automatically.
+
+<McPlayerList client:load />
+
+## How to Connect
+
+1. Open Minecraft **Java Edition** and go to **Multiplayer**
+2. Add a server with the address **mc.kbve.com**
+3. Join and start playing

--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -119,10 +119,17 @@ pub fn init_mc_service() -> bool {
         return false;
     }
 
-    // Spawn background refresh task
+    // Spawn background refresh task with panic recovery
     tokio::spawn(async move {
         loop {
-            svc.refresh_player_list().await;
+            let svc_ref = svc.clone();
+            let result = tokio::task::spawn(async move {
+                svc_ref.refresh_player_list().await;
+            })
+            .await;
+            if let Err(e) = result {
+                warn!("MC refresh task recovered from panic: {e}");
+            }
             tokio::time::sleep(REFRESH_INTERVAL).await;
         }
     });
@@ -198,7 +205,7 @@ impl McService {
 
         // Check cache
         {
-            let mut cache = self.uuid_cache.lock().unwrap();
+            let mut cache = self.uuid_cache.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(entry) = cache.get(&lower) {
                 if !entry.is_expired() {
                     return Some(entry.value.clone());
@@ -218,7 +225,7 @@ impl McService {
 
         // Store in cache
         {
-            let mut cache = self.uuid_cache.lock().unwrap();
+            let mut cache = self.uuid_cache.lock().unwrap_or_else(|e| e.into_inner());
             cache.put(lower, TimedEntry::new(uuid.clone(), UUID_TTL));
         }
 
@@ -229,7 +236,7 @@ impl McService {
     async fn resolve_skin(&self, uuid: &str) -> Option<String> {
         // Check cache
         {
-            let mut cache = self.texture_cache.lock().unwrap();
+            let mut cache = self.texture_cache.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(entry) = cache.get(uuid) {
                 if !entry.is_expired() {
                     return entry.value.clone();
@@ -242,7 +249,7 @@ impl McService {
         let resp = self.http.get(&url).send().await.ok()?;
         if !resp.status().is_success() {
             // Cache the miss to avoid hammering Mojang
-            let mut cache = self.texture_cache.lock().unwrap();
+            let mut cache = self.texture_cache.lock().unwrap_or_else(|e| e.into_inner());
             cache.put(uuid.to_string(), TimedEntry::new(None, TEXTURE_TTL));
             return None;
         }
@@ -252,7 +259,7 @@ impl McService {
 
         // Store in cache
         {
-            let mut cache = self.texture_cache.lock().unwrap();
+            let mut cache = self.texture_cache.lock().unwrap_or_else(|e| e.into_inner());
             cache.put(
                 uuid.to_string(),
                 TimedEntry::new(skin_url.clone(), TEXTURE_TTL),


### PR DESCRIPTION
## Summary
- Fixes panic safety in MC RCON background task: uses `tokio::task::spawn` for panic isolation, `unwrap_or_else(|e| e.into_inner())` for poisoned mutex recovery
- Adds `McPlayerList` React component (`src/components/mc/McPlayerList.tsx`) with auto-refresh, Starlight theme, and mc-heads.net avatar rendering
- Adds `mc/players.mdx` page at `kbve.com/mc/players` with live player list
- Adds Minecraft sidebar section to Starlight config

## Test plan
- [x] `cargo check -p axum-kbve` passes clean
- [x] All 4 MC unit tests pass
- [x] ESLint + Prettier pass on component (lint-staged)
- [ ] Verify `kbve.com/mc/players` renders the player list
- [ ] Verify component handles 503 (MC not configured) gracefully with retry button
- [ ] Verify background task survives RCON connection failures without crashing