### PR TITLE
feat(n8n): add Prometheus ServiceMonitor and PodMonitor

### DIFF
--- a/apps/kube/n8n/manifest/n8n-servicemonitor.yaml
+++ b/apps/kube/n8n/manifest/n8n-servicemonitor.yaml
@@ -1,0 +1,35 @@
+# ServiceMonitor: scrape n8n main instance metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: n8n-metrics
+    namespace: n8n
+    labels:
+        app: n8n
+        release: prometheus
+spec:
+    selector:
+        matchLabels:
+            app: n8n
+    endpoints:
+        - port: http
+          interval: 30s
+          path: /metrics
+---
+# PodMonitor: scrape n8n-worker metrics (no Service exists for worker)
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+    name: n8n-worker-metrics
+    namespace: n8n
+    labels:
+        app: n8n-worker
+        release: prometheus
+spec:
+    selector:
+        matchLabels:
+            app: n8n-worker
+    podMetricsEndpoints:
+        - port: health
+          interval: 30s
+          path: /metrics


### PR DESCRIPTION
## Summary
- Add `ServiceMonitor` for n8n main instance — scrapes `/metrics` on port `http` (5678)
- Add `PodMonitor` for n8n-worker — scrapes `/metrics` on port `health` (5678, no Service exists for worker)
- Both use `release: prometheus` label for Prometheus operator discovery
- 30s scrape interval, deployed to `n8n` namespace

## Context
n8n already has `N8N_METRICS=true` and `N8N_METRICS_INCLUDE_QUEUE_METRICS=true` enabled (PR #7591), but Prometheus wasn't scraping the endpoint. This completes the observability item (#7) from #7590.

Metrics exposed include queue depth, execution duration, error rates — ready for Grafana dashboards and alerting rules.

## Test plan
- [x] `kubectl apply --dry-run=client` passes
- [ ] ArgoCD syncs ServiceMonitor + PodMonitor
- [ ] `kubectl get servicemonitor,podmonitor -n n8n` shows both resources
- [ ] Prometheus Targets page shows n8n and n8n-worker endpoints as UP
- [ ] Query `n8n_` metrics in Grafana to verify data collection

Closes observability item in #7590