### PR TITLE
feat(crossplane): add provider-aws-s3 with ExternalSecret credentials

### DIFF
--- a/apps/kube/crossplane/providers-application.yaml
+++ b/apps/kube/crossplane/providers-application.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: crossplane-providers
+    namespace: argocd
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: main
+        path: apps/kube/crossplane/providers
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: crossplane-system
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - SkipDryRunOnMissingResource=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 10s
+                factor: 2
+                maxDuration: 5m

--- a/apps/kube/crossplane/providers/aws-externalsecret.yaml
+++ b/apps/kube/crossplane/providers/aws-externalsecret.yaml
@@ -1,0 +1,66 @@
+# ServiceAccount for ExternalSecrets cross-namespace access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: crossplane-external-secrets
+    namespace: crossplane-system
+    annotations:
+        argocd.argoproj.io/sync-wave: '1'
+---
+# SecretStore: kilobase namespace (for AWS S3 credentials)
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: crossplane-kilobase-secret-store
+    namespace: crossplane-system
+    annotations:
+        argocd.argoproj.io/sync-wave: '1'
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: crossplane-external-secrets
+                    namespace: crossplane-system
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: Pull AWS credentials from kilobase-s3-secret and
+# reformat into INI format required by Crossplane ProviderConfig
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: crossplane-aws-credentials
+    namespace: crossplane-system
+    annotations:
+        argocd.argoproj.io/sync-wave: '2'
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: crossplane-kilobase-secret-store
+        kind: SecretStore
+    target:
+        name: aws-secret
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                creds: |
+                    [default]
+                    aws_access_key_id = {{ .keyId }}
+                    aws_secret_access_key = {{ .accessKey }}
+    data:
+        - secretKey: keyId
+          remoteRef:
+              key: kilobase-s3-secret
+              property: keyId
+        - secretKey: accessKey
+          remoteRef:
+              key: kilobase-s3-secret
+              property: accessKey

--- a/apps/kube/crossplane/providers/cluster-provider-config.yaml
+++ b/apps/kube/crossplane/providers/cluster-provider-config.yaml
@@ -1,0 +1,16 @@
+# ClusterProviderConfig: shared AWS authentication for all Crossplane AWS providers
+# Depends on provider-aws-s3 being healthy (registers the CRD)
+# sync-wave 5 gives the provider time to start and register CRDs
+apiVersion: aws.m.upbound.io/v1beta1
+kind: ClusterProviderConfig
+metadata:
+    name: default
+    annotations:
+        argocd.argoproj.io/sync-wave: '5'
+spec:
+    credentials:
+        source: Secret
+        secretRef:
+            namespace: crossplane-system
+            name: aws-secret
+            key: creds

--- a/apps/kube/crossplane/providers/provider-aws-s3.yaml
+++ b/apps/kube/crossplane/providers/provider-aws-s3.yaml
@@ -1,0 +1,10 @@
+# Crossplane AWS S3 family provider
+# Auto-installs provider-family-aws as a dependency (shared ClusterProviderConfig CRDs)
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+    name: upbound-provider-aws-s3
+    annotations:
+        argocd.argoproj.io/sync-wave: '0'
+spec:
+    package: xpkg.upbound.io/upbound/provider-aws-s3:v2.4.0

--- a/apps/kube/crossplane/providers/rbac.yaml
+++ b/apps/kube/crossplane/providers/rbac.yaml
@@ -1,0 +1,30 @@
+# Cross-namespace RBAC for Crossplane ExternalSecrets
+# Allows crossplane-external-secrets SA to read kilobase-s3-secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: crossplane-kilobase-access
+    namespace: kilobase
+    annotations:
+        argocd.argoproj.io/sync-wave: '1'
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['kilobase-s3-secret']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: crossplane-kilobase-access-binding
+    namespace: kilobase
+    annotations:
+        argocd.argoproj.io/sync-wave: '1'
+subjects:
+    - kind: ServiceAccount
+      name: crossplane-external-secrets
+      namespace: crossplane-system
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: crossplane-kilobase-access

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
     - sealed-secrets/application.yaml
     - keda/application.yaml
     - crossplane/application.yaml
+    - crossplane/providers-application.yaml
     - external-secrets/application.yaml
     - monitoring/application.yaml
     - redis/application.yaml


### PR DESCRIPTION
## Summary
- Install `provider-aws-s3` v2.4.0 (Upbound family provider) — auto-pulls `provider-family-aws` for shared auth CRDs
- Pull AWS credentials from existing `kilobase-s3-secret` via ExternalSecret cross-namespace access (same pattern as n8n)
- Reformat credentials into INI format required by Crossplane `ClusterProviderConfig`
- Sync-wave ordering ensures provider CRDs register before `ClusterProviderConfig` is applied

## Architecture
```
providers-application.yaml (ArgoCD)
└── providers/
    ├── provider-aws-s3.yaml          [wave 0] Provider CRD
    ├── aws-externalsecret.yaml       [wave 1-2] SA + SecretStore + ExternalSecret
    ├── rbac.yaml                     [wave 1] Cross-namespace Role/RoleBinding
    └── cluster-provider-config.yaml  [wave 5] ClusterProviderConfig (needs provider CRDs)
```

- `SkipDryRunOnMissingResource=true` handles the CRD timing gap
- Retry policy (5 attempts, 10s backoff) covers provider startup time
- Credentials flow: `kilobase-s3-secret` → ExternalSecret → `aws-secret` (INI format) → `ClusterProviderConfig`

## What's Next (follow-up PRs)
- [ ] S3 Bucket managed resource for CNPG backup bucket
- [ ] BucketVersioning, BucketServerSideEncryptionConfiguration, etc.
- [ ] Additional AWS providers as needed (EC2, IAM, etc.)

## Test plan
- [x] All resources except `ClusterProviderConfig` pass `kubectl apply --dry-run=client`
- [x] `ClusterProviderConfig` uses `SkipDryRunOnMissingResource=true` (CRD doesn't exist until provider installs)
- [ ] ArgoCD syncs provider → provider pod starts → CRDs register
- [ ] ExternalSecret syncs `aws-secret` with INI-formatted credentials
- [ ] `ClusterProviderConfig` applies successfully on retry
- [ ] `kubectl get provider` shows `upbound-provider-aws-s3` as HEALTHY