### PR TITLE
feat(cryptothrone): integrate into general CI docker matrix

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -355,7 +355,8 @@ jobs:
                   { "name": "irc-gateway", "target": "container", "condition": "${{ needs.alter.outputs.irc_gateway }}", "e2e_name": "irc", "image": "kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml" },
                   { "name": "discordsh", "target": "container", "condition": "${{ needs.alter.outputs.discordsh }}", "e2e_name": "discordsh", "image": "kbve/discordsh", "cargo_toml": "apps/discordsh/axum-discordsh/Cargo.toml" },
                   { "name": "mc", "target": "container", "condition": "${{ needs.alter.outputs.mc }}", "e2e_name": "mc", "image": "kbve/mc" },
-                  { "name": "edge", "target": "container", "condition": "${{ needs.alter.outputs.edge }}", "e2e_name": "edge", "image": "kbve/edge", "cargo_toml": "apps/kbve/edge/version.toml" }
+                  { "name": "edge", "target": "container", "condition": "${{ needs.alter.outputs.edge }}", "e2e_name": "edge", "image": "kbve/edge", "cargo_toml": "apps/kbve/edge/version.toml" },
+                  { "name": "cryptothrone", "target": "container", "condition": "${{ needs.alter.outputs.cryptothrone }}", "e2e_name": "cryptothrone", "image": "kbve/cryptothrone", "cargo_toml": "apps/cryptothrone/axum-cryptothrone/Cargo.toml" }
                 ]
 
     generate_e2e_docker_matrix:
@@ -369,7 +370,8 @@ jobs:
                   { "name": "irc", "condition": "${{ needs.alter.outputs.irc_gateway }}" },
                   { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}" },
                   { "name": "mc", "condition": "${{ needs.alter.outputs.mc }}" },
-                  { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}" }
+                  { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}" },
+                  { "name": "cryptothrone", "condition": "${{ needs.alter.outputs.cryptothrone }}" }
                 ]
 
     test_docker:
@@ -534,73 +536,6 @@ jobs:
             image_name: ${{ matrix.image_name }}
             cargo_toml: ${{ matrix.cargo_toml }}
             deployment_yaml: ${{ matrix.deployment_yaml }}
-
-    #   ! Everything below this line will be removed and replaced with the matrix setup.
-
-    #   [CryptoThrone]
-    cryptothrone_build_process:
-        needs: ['deploy', 'alter', 'globals']
-        name: CryptoThrone Build and Deployment
-        if: needs.alter.outputs.cryptothrone == 'true'
-        runs-on: 'ubuntu-latest'
-        timeout-minutes: 30
-        permissions:
-            contents: read
-            id-token: write
-        steps:
-            - name: Checkout the monorepo using git
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-
-            - name: Setup Node v24
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 9
-                  run_install: false
-
-            - name: Get pnpm Store
-              id: pnpm-store
-              shell: bash
-              run: |
-                  echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm Cache
-              uses: actions/cache@v5
-              with:
-                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install pnpm dependencies
-              shell: bash
-              run: |
-                  pnpm install
-
-            - name: Build CryptoThrone.com
-              shell: bash
-              run: |
-                  pnpm nx build cryptothrone.com
-            - name: CryptoThrone.com -> Deployment
-              uses: dobbelina/copy_file_to_another_repo_action@main
-              env:
-                  API_TOKEN_GITHUB: ${{ secrets.UNITY_PAT }}
-              with:
-                  source_file: 'dist/apps/cryptothrone.com/'
-                  destination_repo: 'KBVE/cryptothrone.com'
-                  destination_folder: '/docs'
-                  destination_branch: 'main'
-                  destination_branch_create: 'patch-cryptothrone-deploy-${{ needs.globals.outputs.sha256head }}'
-                  user_email: '5599058+h0lybyte@users.noreply.github.com'
-                  user_name: 'h0lybyte'
-                  commit_message: ${{ github.event.head_commit.message }}
-                  rsync_option: '-avrh --delete'
 
     ## Python
     generate_python_matrix:

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -217,7 +217,7 @@ jobs:
                       devops:
                           - 'packages/npm/devops/package.json'
                       cryptothrone:
-                          - 'apps/cryptothrone.com/src/**'
+                          - 'apps/cryptothrone/**'
                       laser:
                           - 'packages/npm/laser/package.json'
                       asteroids:

--- a/apps/cryptothrone/astro-cryptothrone-e2e/playwright.docker.config.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/playwright.docker.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const workspaceRoot = resolve(__dirname, '../../..');
+const port = 4321;
+const baseURL = `http://localhost:${port}`;
+
+const cargoToml = readFileSync(
+	resolve(workspaceRoot, 'apps/cryptothrone/axum-cryptothrone/Cargo.toml'),
+	'utf-8',
+);
+const version = cargoToml.match(/^version\s*=\s*"(.+)"/m)?.[1] ?? '0.1.0';
+
+const killPort = `lsof -ti:${port} | xargs kill -9 2>/dev/null; sleep 1;`;
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'docker',
+			use: {
+				...devices['Desktop Chrome'],
+				baseURL,
+			},
+		},
+	],
+	webServer: {
+		command: `${killPort} docker run --rm --name cryptothrone-e2e-test -p ${port}:${port} kbve/cryptothrone:${version}`,
+		url: `${baseURL}/`,
+		reuseExistingServer: false,
+		timeout: 30_000,
+	},
+});

--- a/apps/cryptothrone/astro-cryptothrone-e2e/project.json
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/project.json
@@ -12,6 +12,13 @@
 				"config": "apps/cryptothrone/astro-cryptothrone-e2e/playwright.config.ts"
 			}
 		},
+		"e2e:docker": {
+			"executor": "@nx/playwright:playwright",
+			"cache": false,
+			"options": {
+				"config": "apps/cryptothrone/astro-cryptothrone-e2e/playwright.docker.config.ts"
+			}
+		},
 		"e2e:preview": {
 			"executor": "@nx/playwright:playwright",
 			"cache": false,

--- a/apps/cryptothrone/project.json
+++ b/apps/cryptothrone/project.json
@@ -1,0 +1,34 @@
+{
+	"name": "cryptothrone",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/cryptothrone",
+	"targets": {
+		"e2e": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"nx test axum-cryptothrone",
+					"nx container axum-cryptothrone",
+					"nx e2e:docker astro-cryptothrone-e2e"
+				],
+				"parallel": false
+			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx container axum-cryptothrone"],
+				"parallel": false
+			},
+			"configurations": {
+				"production": {
+					"commands": [
+						"nx container axum-cryptothrone --configuration=production"
+					]
+				}
+			}
+		}
+	},
+	"tags": []
+}


### PR DESCRIPTION
## Summary
- Adds cryptothrone to the general CI docker build + e2e test + publish matrices
- Creates umbrella `cryptothrone` Nx project (orchestrates: test → container → docker e2e)
- Adds `e2e:docker` target to `astro-cryptothrone-e2e` with `playwright.docker.config.ts`
- Updates file alteration detection from `apps/cryptothrone.com/src/**` to `apps/cryptothrone/**`
- Removes legacy `cryptothrone_build_process` job (was GitHub Pages deploy for static site)

Docker images will publish to:
- Docker Hub: `kbve/cryptothrone`
- GHCR: `ghcr.io/kbve/cryptothrone`

## Test plan
- [x] `nx show project cryptothrone` resolves with `e2e` + `container` targets
- [x] `nx show project astro-cryptothrone-e2e` shows `e2e`, `e2e:docker`, `e2e:preview`
- [ ] CI matrix picks up cryptothrone on file changes