### PR TITLE
feat(discordsh): ExpandButton with React Spring hover animation

### DIFF
--- a/apps/discordsh/astro-discordsh/src/components/servers/ExpandButton.tsx
+++ b/apps/discordsh/astro-discordsh/src/components/servers/ExpandButton.tsx
@@ -1,0 +1,160 @@
+import { useState, type ReactNode, type CSSProperties } from 'react';
+import { useSpring, animated } from 'react-spring';
+
+interface ExpandButtonProps {
+	/** Icon element shown in both collapsed and expanded state */
+	icon: ReactNode;
+	/** Text label revealed on hover */
+	label: string;
+	/** Optional secondary text (e.g. vote count) always visible below icon */
+	badge?: string;
+	/** Click handler (button mode) */
+	onClick?: () => void;
+	/** Link href (anchor mode — renders <a> instead of <button>) */
+	href?: string;
+	target?: string;
+	rel?: string;
+	disabled?: boolean;
+	ariaLabel?: string;
+	/** Accent color for hover state */
+	accentColor?: string;
+	/** Additional style overrides for the outer element */
+	style?: CSSProperties;
+}
+
+const slVar = (name: string, fallback: string) =>
+	`var(--sl-color-${name}, ${fallback})`;
+
+export function ExpandButton({
+	icon,
+	label,
+	badge,
+	onClick,
+	href,
+	target,
+	rel,
+	disabled = false,
+	ariaLabel,
+	accentColor = slVar('accent', '#8b5cf6'),
+	style,
+}: ExpandButtonProps) {
+	const [hovered, setHovered] = useState(false);
+
+	// Spring for expanding the label width
+	const expand = useSpring({
+		maxWidth: hovered ? 120 : 0,
+		opacity: hovered ? 1 : 0,
+		config: { tension: 260, friction: 24 },
+	});
+
+	// Spring for the shine sweep
+	const shine = useSpring({
+		x: hovered ? 200 : -100,
+		config: { tension: 180, friction: 28 },
+	});
+
+	// Spring for background + border transitions
+	const bg = useSpring({
+		borderColor: hovered ? accentColor : slVar('gray-5', '#374151'),
+		backgroundColor: hovered
+			? slVar('accent-low', '#1e1033')
+			: 'transparent',
+		config: { tension: 200, friction: 26 },
+	});
+
+	const baseStyle: CSSProperties = {
+		display: 'inline-flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '0.25rem',
+		padding: '0.375rem 0.5rem',
+		borderRadius: '0.5rem',
+		borderWidth: 1,
+		borderStyle: 'solid',
+		color: hovered ? accentColor : slVar('gray-3', '#9ca3af'),
+		cursor: disabled ? 'default' : 'pointer',
+		opacity: disabled ? 0.6 : 1,
+		position: 'relative',
+		overflow: 'hidden',
+		fontSize: '0.75rem',
+		fontWeight: 600,
+		lineHeight: 1,
+		textDecoration: 'none',
+		transition: 'color 0.15s',
+		...style,
+	};
+
+	const inner = (
+		<>
+			{/* Shine sweep overlay */}
+			<animated.span
+				aria-hidden
+				style={{
+					position: 'absolute',
+					top: '-50%',
+					right: 0,
+					width: '0.5rem',
+					height: '200%',
+					background: 'rgba(255,255,255,0.10)',
+					transform: shine.x.to(
+						(v) => `translateX(${v}%) rotate(12deg)`,
+					),
+					pointerEvents: 'none',
+				}}
+			/>
+			{/* Icon (always visible) */}
+			{icon}
+			{/* Expanding label */}
+			<animated.span
+				style={{
+					display: 'inline-block',
+					maxWidth: expand.maxWidth,
+					opacity: expand.opacity,
+					overflow: 'hidden',
+					whiteSpace: 'nowrap',
+				}}>
+				{label}
+			</animated.span>
+			{/* Optional always-visible badge (e.g. vote count) */}
+			{badge != null && <span>{badge}</span>}
+		</>
+	);
+
+	const handlers = {
+		onMouseEnter: () => !disabled && setHovered(true),
+		onMouseLeave: () => setHovered(false),
+	};
+
+	if (href) {
+		return (
+			<animated.a
+				href={href}
+				target={target}
+				rel={rel}
+				aria-label={ariaLabel}
+				style={{
+					...baseStyle,
+					borderColor: bg.borderColor,
+					backgroundColor: bg.backgroundColor,
+				}}
+				{...handlers}>
+				{inner}
+			</animated.a>
+		);
+	}
+
+	return (
+		<animated.button
+			onClick={onClick}
+			disabled={disabled}
+			aria-label={ariaLabel}
+			style={{
+				...baseStyle,
+				borderColor: bg.borderColor,
+				backgroundColor: bg.backgroundColor,
+			}}
+			{...handlers}>
+			{inner}
+		</animated.button>
+	);
+}

--- a/apps/discordsh/astro-discordsh/src/components/servers/ReactServerCard.tsx
+++ b/apps/discordsh/astro-discordsh/src/components/servers/ReactServerCard.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { ArrowBigUp, Users, ExternalLink } from 'lucide-react';
 import type { ServerCard } from '@/lib/servers/types';
 import { CATEGORY_MAP, buildInviteUrl, formatMemberCount } from '@/lib/servers';
+import { ExpandButton } from './ExpandButton';
 
 interface Props {
 	server: ServerCard;
@@ -184,68 +185,28 @@ export function ReactServerCard({ server, onVote }: Props) {
 					gap: '0.375rem',
 					minWidth: '3.5rem',
 				}}>
-				<button
+				<ExpandButton
+					icon={
+						<ArrowBigUp
+							size={18}
+							fill={voted ? 'currentColor' : 'none'}
+						/>
+					}
+					label="Vote"
+					badge={String(server.vote_count + (voted ? 1 : 0))}
 					onClick={handleVote}
 					disabled={voted || voting}
-					aria-label={`Vote for ${server.name}`}
-					style={{
-						display: 'flex',
-						flexDirection: 'column',
-						alignItems: 'center',
-						justifyContent: 'center',
-						padding: '0.375rem 0.5rem',
-						borderRadius: '0.5rem',
-						border: voted
-							? `1px solid ${slVar('accent', '#8b5cf6')}`
-							: `1px solid ${slVar('gray-5', '#374151')}`,
-						backgroundColor: voted
-							? slVar('accent-low', '#1e1033')
-							: 'transparent',
-						color: voted
-							? slVar('accent', '#8b5cf6')
-							: slVar('gray-3', '#9ca3af'),
-						cursor: voted || voting ? 'default' : 'pointer',
-						opacity: voting ? 0.6 : 1,
-						transition: 'all 0.15s',
-						fontSize: '0.75rem',
-						fontWeight: 600,
-						lineHeight: 1,
-					}}>
-					<ArrowBigUp
-						size={18}
-						fill={voted ? 'currentColor' : 'none'}
-					/>
-					<span>{server.vote_count + (voted ? 1 : 0)}</span>
-				</button>
+					ariaLabel={`Vote for ${server.name}`}
+				/>
 
-				<a
+				<ExpandButton
+					icon={<ExternalLink size={16} />}
+					label="Join"
 					href={buildInviteUrl(server.invite_code)}
 					target="_blank"
 					rel="noopener noreferrer"
-					aria-label={`Join ${server.name}`}
-					style={{
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'center',
-						padding: '0.25rem',
-						borderRadius: '0.375rem',
-						color: slVar('gray-3', '#9ca3af'),
-						transition: 'color 0.15s',
-					}}
-					onMouseEnter={(e) => {
-						e.currentTarget.style.color = slVar(
-							'accent',
-							'#8b5cf6',
-						);
-					}}
-					onMouseLeave={(e) => {
-						e.currentTarget.style.color = slVar(
-							'gray-3',
-							'#9ca3af',
-						);
-					}}>
-					<ExternalLink size={16} />
-				</a>
+					ariaLabel={`Join ${server.name}`}
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Create `ExpandButton` component using `react-spring` for spring-animated hover effects
- Buttons render as compact icons at rest, expand with label text + shine sweep on hover
- Apply to vote (`ArrowBigUp` → "Vote") and invite (`ExternalLink` → "Join") buttons on server cards

## Test plan
- [x] `npx astro build` passes — ExpandButton bundled into ReactServerGrid chunk
- [ ] Visual verification: hover vote/invite buttons to see spring expand + shine sweep
- [ ] Buttons revert to icon-only on mouse leave