### PR TITLE
test(crossplane): add S3 healthcheck bucket to verify AWS integration

### DIFF
--- a/apps/kube/crossplane/providers/healthcheck-bucket.yaml
+++ b/apps/kube/crossplane/providers/healthcheck-bucket.yaml
@@ -1,0 +1,20 @@
+# Healthcheck: temporary S3 bucket to verify Crossplane AWS integration
+# Delete this resource (and the bucket) after confirming Crossplane works
+apiVersion: s3.aws.m.upbound.io/v1beta1
+kind: Bucket
+metadata:
+    name: kbve-crossplane-healthcheck
+    namespace: crossplane-system
+    annotations:
+        argocd.argoproj.io/sync-wave: '10'
+spec:
+    deletionPolicy: Delete
+    forProvider:
+        region: us-east-2
+        tags:
+            Environment: test
+            ManagedBy: crossplane
+            Purpose: healthcheck
+    providerConfigRef:
+        name: default
+        kind: ClusterProviderConfig


### PR DESCRIPTION
## Summary
- Add temporary `Bucket` managed resource (`kbve-crossplane-healthcheck`) to verify Crossplane can create S3 buckets in `us-east-2`
- Uses `deletionPolicy: Delete` — removing this file in a follow-up PR will also delete the AWS bucket
- Tagged with `Purpose: healthcheck` for easy identification

## Verification steps
After ArgoCD syncs:
1. `kubectl get bucket -n crossplane-system` — should show `SYNCED: True`, `READY: True`
2. Confirm bucket exists in AWS S3 console (`kbve-crossplane-healthcheck` in `us-east-2`)
3. Once verified, a follow-up PR removes `healthcheck-bucket.yaml` to clean up

## Test plan
- [ ] ArgoCD syncs the Bucket resource
- [ ] Crossplane reconciles and creates the S3 bucket in AWS
- [ ] Bucket shows `SYNCED: True` and `READY: True`
- [ ] Follow-up PR removes the file, ArgoCD prunes it, Crossplane deletes the AWS bucket