### PR TITLE
ci(kbve.com): add axum-kbve to CI/CD matrix pipeline

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -356,7 +356,8 @@ jobs:
                   { "name": "discordsh", "target": "container", "condition": "${{ needs.alter.outputs.discordsh }}", "e2e_name": "discordsh", "image": "kbve/discordsh", "cargo_toml": "apps/discordsh/axum-discordsh/Cargo.toml" },
                   { "name": "mc", "target": "container", "condition": "${{ needs.alter.outputs.mc }}", "e2e_name": "mc", "image": "kbve/mc" },
                   { "name": "edge", "target": "container", "condition": "${{ needs.alter.outputs.edge }}", "e2e_name": "edge", "image": "kbve/edge", "cargo_toml": "apps/kbve/edge/version.toml" },
-                  { "name": "cryptothrone", "target": "container", "condition": "${{ needs.alter.outputs.cryptothrone }}", "e2e_name": "cryptothrone", "image": "kbve/cryptothrone", "cargo_toml": "apps/cryptothrone/axum-cryptothrone/Cargo.toml" }
+                  { "name": "cryptothrone", "target": "container", "condition": "${{ needs.alter.outputs.cryptothrone }}", "e2e_name": "cryptothrone", "image": "kbve/cryptothrone", "cargo_toml": "apps/cryptothrone/axum-cryptothrone/Cargo.toml" },
+                  { "name": "axum-kbve", "target": "container", "condition": "${{ needs.alter.outputs.astro_kbve }}", "e2e_name": "axum-kbve-e2e", "image": "kbve/kbve", "cargo_toml": "apps/kbve/axum-kbve/Cargo.toml" }
                 ]
 
     generate_e2e_docker_matrix:
@@ -371,7 +372,8 @@ jobs:
                   { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}" },
                   { "name": "mc", "condition": "${{ needs.alter.outputs.mc }}" },
                   { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}" },
-                  { "name": "cryptothrone", "condition": "${{ needs.alter.outputs.cryptothrone }}" }
+                  { "name": "cryptothrone", "condition": "${{ needs.alter.outputs.cryptothrone }}" },
+                  { "name": "axum-kbve-e2e", "condition": "${{ needs.alter.outputs.astro_kbve }}" }
                 ]
 
     test_docker:
@@ -468,7 +470,8 @@ jobs:
                   { "name": "irc-gateway", "condition": "${{ needs.alter.outputs.irc_gateway }}", "e2e_name": "irc", "image_name": "ghcr.io/kbve/irc-gateway", "cargo_toml": "apps/irc/irc-gateway/Cargo.toml", "deployment_yaml": "apps/kube/irc/manifests/irc-gateway-deployment.yaml" },
                   { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}", "e2e_name": "discordsh", "image_name": "ghcr.io/kbve/discordsh", "cargo_toml": "apps/discordsh/axum-discordsh/Cargo.toml", "deployment_yaml": "apps/kube/discordsh/manifest/deployment.yaml" },
                   { "name": "mc", "condition": "${{ needs.alter.outputs.mc }}", "e2e_name": "mc", "image_name": "ghcr.io/kbve/mc", "cargo_toml": "apps/mc/plugins/kbve-mc-plugin/Cargo.toml", "deployment_yaml": "apps/kube/mc/manifest/deployment.yaml" },
-                  { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}", "e2e_name": "edge", "image_name": "ghcr.io/kbve/edge", "cargo_toml": "apps/kbve/edge/version.toml", "deployment_yaml": "apps/kube/functions/manifests/functions-deployment.yaml" }
+                  { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}", "e2e_name": "edge", "image_name": "ghcr.io/kbve/edge", "cargo_toml": "apps/kbve/edge/version.toml", "deployment_yaml": "apps/kube/functions/manifests/functions-deployment.yaml" },
+                  { "name": "axum-kbve", "condition": "${{ needs.alter.outputs.astro_kbve }}", "e2e_name": "axum-kbve-e2e", "image_name": "ghcr.io/kbve/kbve", "cargo_toml": "apps/kbve/axum-kbve/Cargo.toml", "deployment_yaml": "apps/kube/kbve/manifest/kbve-deployment.yaml" }
                 ]
 
     collect_kube_results:

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -216,6 +216,12 @@ jobs:
                           - 'packages/khashvault/package.json'
                       devops:
                           - 'packages/npm/devops/package.json'
+                      astro_kbve:
+                          - 'apps/kbve/astro-kbve/**'
+                          - 'apps/kbve/axum-kbve/**'
+                          - 'packages/npm/astro/**'
+                          - 'packages/npm/droid/**'
+                          - 'packages/npm/laser/**'
                       cryptothrone:
                           - 'apps/cryptothrone/**'
                       laser:

--- a/apps/kbve/axum-kbve-e2e/project.json
+++ b/apps/kbve/axum-kbve-e2e/project.json
@@ -10,6 +10,7 @@
 		},
 		"e2e": {
 			"executor": "nx:run-commands",
+			"dependsOn": ["axum-kbve:container"],
 			"cache": false,
 			"options": {
 				"commands": [
@@ -19,6 +20,9 @@
 				],
 				"parallel": false,
 				"cwd": "apps/kbve/axum-kbve-e2e"
+			},
+			"configurations": {
+				"ci": {}
 			}
 		}
 	},

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.0"
+version = "1.0.20"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- Add kbve.com (axum-kbve) to the docker build, e2e test, and kube manifest update matrices
- Add missing `astro_kbve` file alteration pattern (was declared as output but had no file glob)
- Bump `axum-kbve` version from `0.1.0` to `1.0.20` (version source for kube manifest updater)
- Make `axum-kbve-e2e` CI-ready with `dependsOn` container build and `ci` configuration

## Details

kbve.com was the only docker-deployed app not in the automated CI matrix pipeline. This PR wires it in so file changes trigger: e2e test → docker publish → kube manifest update PR.

**Note:** The kube deployment YAML (`apps/kube/kbve/manifest/kbve-deployment.yaml`) still references the old image name `ghcr.io/kbve/kbve.com:1.0.19`. A follow-up PR will update the image name to `ghcr.io/kbve/kbve:1.0.20` after confirming the container builds and publishes successfully.

## Test plan

- [ ] Verify CI detects `astro_kbve` file changes and populates matrices
- [ ] Confirm docker image `ghcr.io/kbve/kbve:1.0.20` builds and publishes
- [ ] Follow-up: update kube deployment image name after image is confirmed on GHCR