### PR TITLE
fix(cryptothrone): use toBeAttached for sidebar nav e2e tests

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/smoke.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/smoke.spec.ts
@@ -37,8 +37,8 @@ test.describe('sidebar navigation', () => {
 	test('sidebar contains Game section with Play link', async ({ page }) => {
 		await page.goto('/guides/getting-started/');
 		const sidebar = page.locator('nav[aria-label="Main"]');
-		await expect(sidebar).toBeVisible();
-		await expect(sidebar.locator('a[href="/game/play/"]')).toBeVisible();
+		await expect(sidebar).toBeAttached();
+		await expect(sidebar.locator('a[href="/game/play/"]')).toBeAttached();
 	});
 
 	test('sidebar contains Guides section', async ({ page }) => {
@@ -46,7 +46,7 @@ test.describe('sidebar navigation', () => {
 		const sidebar = page.locator('nav[aria-label="Main"]');
 		await expect(
 			sidebar.locator('a[href="/guides/getting-started/"]'),
-		).toBeVisible();
+		).toBeAttached();
 	});
 });
 


### PR DESCRIPTION
## Summary
- Sidebar navigation tests fail in Docker because Starlight hides the `nav[aria-label="Main"]` via CSS at certain viewports
- The element exists in the DOM but has `hidden` visibility, causing `toBeVisible()` to timeout
- Switch to `toBeAttached()` which verifies DOM presence regardless of CSS visibility state

## Test plan
- [ ] `nx e2e:docker astro-cryptothrone-e2e` passes (8/8 tests)