### PR TITLE
chore(kube): update kbve to v1.0.20 with health probes

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -7,6 +7,11 @@ metadata:
         app: kbve
 spec:
     replicas: 1
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
     selector:
         matchLabels:
             app: kbve
@@ -16,15 +21,32 @@ spec:
                 rollout-restart: '2026-01-31T17:38:01Z'
             labels:
                 app: kbve
-                version: '1.0.19'
+                version: '1.0.20'
         spec:
             containers:
                 - name: kbve
-                  image: ghcr.io/kbve/kbve.com:1.0.19
+                  image: ghcr.io/kbve/kbve:1.0.20
                   imagePullPolicy: Always
                   ports:
-                      - containerPort: 4321
+                      - name: http
+                        containerPort: 4321
                         protocol: TCP
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: http
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /health
+                          port: http
+                      initialDelaySeconds: 10
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3
                   env:
                       - name: PORT
                         value: '4321'


### PR DESCRIPTION
## Summary

- Fix image name from `ghcr.io/kbve/kbve.com` → `ghcr.io/kbve/kbve` (matches what CI builds)
- Bump deployment to `v1.0.20` (image confirmed published on GHCR + Docker Hub)
- Add liveness + readiness probes using existing `/health` endpoint
- Add rolling update strategy (`maxSurge: 1`, `maxUnavailable: 0`) for zero-downtime deploys

## Context

Follow-up to PR #7633 which added kbve.com to the CI/CD matrix pipeline. The docker image `ghcr.io/kbve/kbve:1.0.20` has been built and pushed successfully. This PR updates the kube deployment to use the correct image name and adds proper health checks.

### Rolling Update Strategy
With `maxSurge: 1, maxUnavailable: 0` and 1 replica:
1. K8s spins up a NEW pod with `kbve:1.0.20`
2. Readiness probe checks `/health` — traffic only routes after probe passes
3. Old pod (`kbve.com:1.0.19`) terminates only after new pod is healthy
4. Zero downtime throughout the process

### Health Probes
- **Liveness**: `GET /health` every 10s (30s initial delay, 3 failures to restart)
- **Readiness**: `GET /health` every 5s (10s initial delay, 3 failures to remove from service)

## Test plan

- [ ] Verify ArgoCD syncs the deployment after merge to main
- [ ] Confirm new pod passes readiness probe and serves traffic
- [ ] Verify old pod terminates cleanly after new pod is ready