### PR TITLE
fix(crossplane): replace deletionPolicy with managementPolicies

### DIFF
--- a/apps/kube/crossplane/providers/healthcheck-bucket.yaml
+++ b/apps/kube/crossplane/providers/healthcheck-bucket.yaml
@@ -8,7 +8,8 @@ metadata:
     annotations:
         argocd.argoproj.io/sync-wave: '10'
 spec:
-    deletionPolicy: Delete
+    managementPolicies:
+        - '*'
     forProvider:
         region: us-east-2
         tags:


### PR DESCRIPTION
## Summary
- Fix `healthcheck-bucket.yaml` — replace `deletionPolicy: Delete` with `managementPolicies: ['*']`
- Crossplane 2.x removed `deletionPolicy` from namespaced managed resources (`.m.upbound.io` API group)
- `managementPolicies: ['*']` grants full lifecycle control (Create, Delete, Observe, Update, LateInitialize)

## Root cause
The `deletionPolicy` field exists in Crossplane 1.x cluster-scoped MRs but was removed from Crossplane 2.x namespaced MRs. The `s3.aws.m.upbound.io/v1beta1` Bucket CRD doesn't include it in the schema, causing ArgoCD sync failure.

## Reference
- For future "orphan on delete" behavior, use: `managementPolicies: [Observe, Create, Update, LateInitialize]`

## Test plan
- [ ] ArgoCD syncs without schema errors
- [ ] Bucket shows `SYNCED: True`, `READY: True`
- [ ] S3 bucket `kbve-crossplane-healthcheck` created in `us-east-2`