### PR TITLE
fix(axum-kbve): buffer RCON packets to fix TCP segmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "0.1.0"
+version = "1.0.21"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.20"
+version = "1.0.21"
 edition = "2021"
 publish = false
 

--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -300,6 +300,9 @@ impl McService {
 }
 
 /// Send an RCON packet: [length:4][req_id:4][type:4][body + \0][pad \0]
+///
+/// The entire packet is buffered and sent in a single write to avoid
+/// TCP segmentation issues with RCON servers that expect atomic reads.
 async fn rcon_send(
     stream: &mut TcpStream,
     req_id: i32,
@@ -309,11 +312,14 @@ async fn rcon_send(
     let body_bytes = body.as_bytes();
     let length = 4 + 4 + body_bytes.len() as i32 + 2; // req_id + type + body + 2 nulls
 
-    stream.write_all(&length.to_le_bytes()).await?;
-    stream.write_all(&req_id.to_le_bytes()).await?;
-    stream.write_all(&ptype.to_le_bytes()).await?;
-    stream.write_all(body_bytes).await?;
-    stream.write_all(&[0, 0]).await?;
+    let mut buf = Vec::with_capacity(4 + length as usize);
+    buf.extend_from_slice(&length.to_le_bytes());
+    buf.extend_from_slice(&req_id.to_le_bytes());
+    buf.extend_from_slice(&ptype.to_le_bytes());
+    buf.extend_from_slice(body_bytes);
+    buf.extend_from_slice(&[0, 0]);
+
+    stream.write_all(&buf).await?;
     stream.flush().await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- RCON client was sending packet fields as 5 separate `write_all` calls, causing TCP segmentation
- Pumpkin's RCON server expects the full packet in a single read — fragmented packets trigger "Failed to read packet" errors and `Connection reset by peer (os error 104)` every 15 seconds
- Fix: buffer the entire RCON packet into a `Vec<u8>` and send with a single `write_all` call
- Bumps axum-kbve version to `1.0.21`

## Diagnosis
- Port-forwarded RCON locally and confirmed the protocol works when packets are sent atomically (Python `sendall`)
- The Rust `rcon_send` was doing: `length → req_id → type → body → nulls` as separate writes
- Each `write_all` on an unbuffered `TcpStream` can produce a separate TCP segment
- Pumpkin's RCON reads the full packet in one `read()` call, so partial segments = parse failure

## Test plan
- [x] `cargo check -p axum-kbve` passes
- [ ] After deploy, verify `/api/v1/mc/players` returns player data
- [ ] RCON warnings should stop in kbve pod logs