### PR TITLE
feat(kube): add cryptothrone Kubernetes deployment

### DIFF
--- a/apps/kube/cryptothrone/application.yaml
+++ b/apps/kube/cryptothrone/application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: cryptothrone
+    namespace: argocd
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: HEAD
+        path: apps/kube/cryptothrone/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: cryptothrone
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - PrunePropagationPolicy=foreground
+            - PruneLast=true
+            - RespectIgnoreDifferences=true
+            - Replace=false

--- a/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: cryptothrone-deployment
+    namespace: cryptothrone
+    labels:
+        app: cryptothrone
+spec:
+    replicas: 1
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
+    selector:
+        matchLabels:
+            app: cryptothrone
+    template:
+        metadata:
+            labels:
+                app: cryptothrone
+                version: '0.1.0'
+        spec:
+            containers:
+                - name: cryptothrone
+                  image: ghcr.io/kbve/cryptothrone:0.1.0
+                  imagePullPolicy: Always
+                  ports:
+                      - name: http
+                        containerPort: 4321
+                        protocol: TCP
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: http
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /health
+                          port: http
+                      initialDelaySeconds: 10
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3
+                  env:
+                      - name: HTTP_PORT
+                        value: '4321'
+                  resources:
+                      requests:
+                          memory: '256Mi'
+                          cpu: '500m'
+                      limits:
+                          memory: '512Mi'
+                          cpu: '2000m'
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: cryptothrone-service
+    namespace: cryptothrone
+    labels:
+        app: cryptothrone
+spec:
+    type: ClusterIP
+    selector:
+        app: cryptothrone
+    ports:
+        - port: 4321
+          targetPort: 4321
+          protocol: TCP

--- a/apps/kube/cryptothrone/manifest/cryptothrone-ingress.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: cryptothrone-ingress
+    namespace: cryptothrone
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+    rules:
+        - host: cryptothrone.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: cryptothrone-service
+                            port:
+                                number: 4321

--- a/apps/kube/cryptothrone/manifest/cryptothrone-serviceaccount.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: cryptothrone-external-secrets
+    namespace: cryptothrone

--- a/apps/kube/cryptothrone/manifest/kustomization.yaml
+++ b/apps/kube/cryptothrone/manifest/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cryptothrone
+
+resources:
+    - cryptothrone-serviceaccount.yaml
+    - cryptothrone-deployment.yaml
+    - cryptothrone-ingress.yaml


### PR DESCRIPTION
## Summary
- Add ArgoCD `Application` for cryptothrone (auto-sync from `apps/kube/cryptothrone/manifest`)
- Add `Deployment` (1 replica, `ghcr.io/kbve/cryptothrone:0.1.0`, port 4321, health probes)
- Add `Service` (ClusterIP), `Ingress` (cryptothrone.com), `ServiceAccount`, `Kustomization`
- Namespace: `cryptothrone` (auto-created by ArgoCD)

## Test plan
- [ ] Verify `kustomize build apps/kube/cryptothrone/manifest` renders valid YAML
- [ ] Apply ArgoCD Application and confirm namespace + deployment sync
- [ ] Verify `/health` probe returns 200 from running container

🤖 Generated with [Claude Code](https://claude.com/claude-code)