### PR TITLE
feat(kube): add cryptothrone to root kustomization

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -50,6 +50,7 @@ resources:
     - memes/application.yaml
     - n8n/application.yaml
     - rentearth/application.yaml
+    - cryptothrone/application.yaml
     # GitHub Actions Runner Controller (ARC)
     # Consolidated: controller includes helm chart + sealed secret + RBAC
     # Consolidated: runners includes helm chart + ExternalSecret/SecretStore


### PR DESCRIPTION
## Summary
- Register `cryptothrone/application.yaml` in the root `apps/kube/kustomization.yaml`
- This ensures ArgoCD picks up the cryptothrone deployment (manifests added in #7644)

## Test plan
- [ ] Verify `kustomize build apps/kube/` includes the cryptothrone Application resource
- [ ] Confirm ArgoCD syncs the new Application after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)