### PR TITLE
fix(ci): download-artifact@v8 merge-multiple breaking docker publish

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -407,6 +407,7 @@ jobs:
               with:
                   pattern: test-passed-docker-*
                   path: ./test-results
+                  merge-multiple: false
               continue-on-error: true
 
             - name: Build filtered publish matrix
@@ -492,6 +493,7 @@ jobs:
               with:
                   pattern: test-passed-docker-*
                   path: ./test-results
+                  merge-multiple: false
               continue-on-error: true
 
             - name: Build filtered kube matrix


### PR DESCRIPTION
## Summary
- `download-artifact@v8` changed default behavior: it now merges all artifacts into a flat directory instead of preserving artifact name subdirectories
- This broke the docker publish and kube manifest update pipelines for **all projects** — the collect steps rely on directory names matching `test-passed-docker-<e2e-name>` to identify which tests passed
- Without `merge-multiple: false`, the directory contains just `test-result.txt` instead of subdirectories, so the jq filter produces a null matrix and publish/kube jobs are skipped

## Evidence from CI run 22752360497
```
PASSED entries:
test-result.txt          <-- should be "axum-kbve-e2e"
```
Expected with `merge-multiple: false`:
```
test-results/
  test-passed-docker-axum-kbve-e2e/
    test-result.txt
```

## Fix
Add `merge-multiple: false` to both `download-artifact@v8` steps in `collect_docker_results` and `collect_kube_results`.

## Test plan
- [ ] After merge to main, trigger a CI run with file changes matching any docker matrix entry
- [ ] Verify "Publish Docker Images" and "Update Kube Manifests" jobs run instead of being skipped