### PR TITLE
chore(axum-kbve): bump to 1.0.22 to trigger CI publish pipeline

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.21"
+version = "1.0.22"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps axum-kbve version from `1.0.21` → `1.0.22`
- The RCON fix (1.0.21) went through CI but docker publish was skipped due to the `download-artifact@v8` bug (fixed in #7647)
- This version bump triggers `astro_kbve` file alteration detection so the full pipeline runs with the corrected artifact handling

## Expected pipeline flow
1. File alteration detects `apps/kbve/axum-kbve/Cargo.toml` change → `astro_kbve=true`
2. Docker matrix includes `axum-kbve` → container builds
3. E2e matrix runs `axum-kbve-e2e` → test passes → uploads `test-passed-docker-axum-kbve-e2e` artifact
4. Collect step downloads artifact into subdirectory (with `merge-multiple: false`) → filters match
5. Publish pushes `ghcr.io/kbve/kbve:1.0.22` + `:latest`
6. Kube update creates PR bumping `kbve-deployment.yaml` image tag to `1.0.22`