### PR TITLE
feat(astro-kbve): R3F 3D skin viewer for MC players

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mc/McPlayerList.tsx
+++ b/apps/kbve/astro-kbve/src/components/mc/McPlayerList.tsx
@@ -1,4 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+
+const McSkinViewer = lazy(() => import('./McSkinViewer'));
 
 interface McPlayer {
 	name: string;
@@ -66,6 +68,12 @@ const styles = {
 		borderRadius: '0.375rem',
 		background: 'var(--sl-color-bg)',
 		border: '1px solid var(--sl-color-gray-6)',
+		cursor: 'pointer',
+		transition: 'border-color 0.15s, background 0.15s',
+	} as React.CSSProperties,
+	playerCardHover: {
+		borderColor: 'rgb(34, 197, 94)',
+		background: 'rgba(34, 197, 94, 0.05)',
 	} as React.CSSProperties,
 	avatar: {
 		width: '32px',
@@ -127,6 +135,99 @@ const styles = {
 		fontSize: '0.75rem',
 		marginTop: '0.5rem',
 	} as React.CSSProperties,
+	backdrop: {
+		position: 'fixed' as const,
+		inset: 0,
+		background: 'rgba(0, 0, 0, 0.4)',
+		zIndex: 9998,
+		transition: 'opacity 0.3s ease',
+	} as React.CSSProperties,
+	panel: {
+		position: 'fixed' as const,
+		top: 0,
+		right: 0,
+		width: '360px',
+		maxWidth: '90vw',
+		height: '100vh',
+		background: 'var(--sl-color-bg-nav)',
+		borderLeft: '1px solid var(--sl-color-gray-5)',
+		zIndex: 9999,
+		display: 'flex',
+		flexDirection: 'column' as const,
+		transition: 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+	} as React.CSSProperties,
+	panelHeader: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		padding: '1rem 1.25rem',
+		borderBottom: '1px solid var(--sl-color-gray-6)',
+	} as React.CSSProperties,
+	panelTitle: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.75rem',
+	} as React.CSSProperties,
+	panelPlayerName: {
+		fontSize: '1.125rem',
+		fontWeight: 600,
+		color: 'var(--sl-color-white)',
+	} as React.CSSProperties,
+	panelCloseBtn: {
+		cursor: 'pointer',
+		background: 'none',
+		border: '1px solid var(--sl-color-gray-5)',
+		borderRadius: '0.375rem',
+		color: 'var(--sl-color-gray-3)',
+		padding: '0.25rem 0.5rem',
+		fontSize: '1rem',
+		lineHeight: 1,
+	} as React.CSSProperties,
+	panelBody: {
+		flex: 1,
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: '1rem',
+		overflow: 'hidden',
+	} as React.CSSProperties,
+	panelFooter: {
+		padding: '0.75rem 1.25rem',
+		borderTop: '1px solid var(--sl-color-gray-6)',
+		fontSize: '0.75rem',
+		color: 'var(--sl-color-gray-4)',
+		textAlign: 'center' as const,
+	} as React.CSSProperties,
+	panelUuid: {
+		fontFamily: 'monospace',
+		fontSize: '0.7rem',
+		color: 'var(--sl-color-gray-4)',
+		wordBreak: 'break-all' as const,
+	} as React.CSSProperties,
+	panelOnlineBadge: {
+		display: 'inline-block',
+		width: '8px',
+		height: '8px',
+		borderRadius: '50%',
+		background: 'rgb(34, 197, 94)',
+		flexShrink: 0,
+	} as React.CSSProperties,
+	skinLoading: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		width: '100%',
+		height: '300px',
+		color: 'var(--sl-color-gray-3)',
+		fontSize: '0.875rem',
+	} as React.CSSProperties,
+	noSkinMsg: {
+		textAlign: 'center' as const,
+		padding: '2rem',
+		color: 'var(--sl-color-gray-3)',
+		fontSize: '0.875rem',
+	} as React.CSSProperties,
 };
 
 function craftHeadUrl(uuid: string | null): string {
@@ -144,6 +245,130 @@ function formatCachedAt(epoch: number): string {
 	return `${Math.floor(diff / 3600)}h ago`;
 }
 
+function PlayerCard({
+	player,
+	onSelect,
+}: {
+	player: McPlayer;
+	onSelect: (p: McPlayer) => void;
+}) {
+	const [hovered, setHovered] = useState(false);
+
+	return (
+		<div
+			style={{
+				...styles.playerCard,
+				...(hovered ? styles.playerCardHover : {}),
+			}}
+			onClick={() => onSelect(player)}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}>
+			{player.uuid ? (
+				<img
+					src={craftHeadUrl(player.uuid)}
+					alt={player.name}
+					style={styles.avatar}
+					loading="lazy"
+				/>
+			) : (
+				<div style={styles.avatar} />
+			)}
+			<span style={styles.playerName}>{player.name}</span>
+		</div>
+	);
+}
+
+function PlayerPanel({
+	player,
+	visible,
+	onClose,
+}: {
+	player: McPlayer;
+	visible: boolean;
+	onClose: () => void;
+}) {
+	useEffect(() => {
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose();
+		};
+		if (visible) {
+			document.addEventListener('keydown', handleKey);
+			return () => document.removeEventListener('keydown', handleKey);
+		}
+	}, [visible, onClose]);
+
+	return (
+		<>
+			<div
+				style={{
+					...styles.backdrop,
+					opacity: visible ? 1 : 0,
+					pointerEvents: visible ? 'auto' : 'none',
+				}}
+				onClick={onClose}
+			/>
+			<div
+				style={{
+					...styles.panel,
+					transform: visible ? 'translateX(0)' : 'translateX(100%)',
+				}}>
+				<div style={styles.panelHeader}>
+					<div style={styles.panelTitle}>
+						{player.uuid && (
+							<img
+								src={craftHeadUrl(player.uuid)}
+								alt={player.name}
+								style={{
+									...styles.avatar,
+									width: '24px',
+									height: '24px',
+								}}
+							/>
+						)}
+						<span style={styles.panelPlayerName}>
+							{player.name}
+						</span>
+						<span style={styles.panelOnlineBadge} />
+					</div>
+					<button
+						type="button"
+						style={styles.panelCloseBtn}
+						onClick={onClose}>
+						&#x2715;
+					</button>
+				</div>
+
+				<div style={styles.panelBody}>
+					{player.uuid ? (
+						<Suspense
+							fallback={
+								<div style={styles.skinLoading}>
+									Loading 3D model...
+								</div>
+							}>
+							<McSkinViewer
+								uuid={player.uuid}
+								width={320}
+								height={420}
+							/>
+						</Suspense>
+					) : (
+						<div style={styles.noSkinMsg}>
+							No skin data available for this player.
+						</div>
+					)}
+				</div>
+
+				<div style={styles.panelFooter}>
+					{player.uuid && (
+						<span style={styles.panelUuid}>{player.uuid}</span>
+					)}
+				</div>
+			</div>
+		</>
+	);
+}
+
 export default function McPlayerList({
 	apiBaseUrl = '',
 	refreshInterval = 20000,
@@ -151,6 +376,8 @@ export default function McPlayerList({
 	const [data, setData] = useState<McPlayerListData | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [selectedPlayer, setSelectedPlayer] = useState<McPlayer | null>(null);
+	const [panelVisible, setPanelVisible] = useState(false);
 
 	const fetchPlayers = useCallback(async () => {
 		try {
@@ -181,6 +408,16 @@ export default function McPlayerList({
 			return () => clearInterval(interval);
 		}
 	}, [fetchPlayers, refreshInterval]);
+
+	const openPanel = useCallback((player: McPlayer) => {
+		setSelectedPlayer(player);
+		requestAnimationFrame(() => setPanelVisible(true));
+	}, []);
+
+	const closePanel = useCallback(() => {
+		setPanelVisible(false);
+		setTimeout(() => setSelectedPlayer(null), 300);
+	}, []);
 
 	if (loading) {
 		return (
@@ -237,19 +474,11 @@ export default function McPlayerList({
 			) : (
 				<div style={styles.playerGrid}>
 					{data.players.map((player) => (
-						<div key={player.name} style={styles.playerCard}>
-							{player.uuid ? (
-								<img
-									src={craftHeadUrl(player.uuid)}
-									alt={player.name}
-									style={styles.avatar}
-									loading="lazy"
-								/>
-							) : (
-								<div style={styles.avatar} />
-							)}
-							<span style={styles.playerName}>{player.name}</span>
-						</div>
+						<PlayerCard
+							key={player.name}
+							player={player}
+							onSelect={openPanel}
+						/>
 					))}
 				</div>
 			)}
@@ -258,6 +487,14 @@ export default function McPlayerList({
 				<span>Updated {formatCachedAt(data.cached_at)}</span>
 				<span>Auto-refreshes every {refreshInterval / 1000}s</span>
 			</div>
+
+			{selectedPlayer && (
+				<PlayerPanel
+					player={selectedPlayer}
+					visible={panelVisible}
+					onClose={closePanel}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/mc/McSkinViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/mc/McSkinViewer.tsx
@@ -1,0 +1,250 @@
+import { useRef, useMemo, useState, useEffect } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import * as THREE from 'three';
+
+interface McSkinViewerProps {
+	uuid: string;
+	width?: number;
+	height?: number;
+}
+
+const SKIN_W = 64;
+const SKIN_H = 64;
+const S = 1 / 16; // Scale: 32px total height → 2 units
+
+// Pixel regions for each body part face: [x1, y1, x2, y2]
+// Face order: [+X(left), -X(right), +Y(top), -Y(bottom), +Z(back), -Z(front)]
+type FaceUVs = [number, number, number, number][];
+
+const HEAD_UVS: FaceUVs = [
+	[16, 8, 24, 16],
+	[0, 8, 8, 16],
+	[8, 0, 16, 8],
+	[16, 0, 24, 8],
+	[24, 8, 32, 16],
+	[8, 8, 16, 16],
+];
+
+const BODY_UVS: FaceUVs = [
+	[28, 20, 32, 32],
+	[16, 20, 20, 32],
+	[20, 16, 28, 20],
+	[28, 16, 36, 20],
+	[32, 20, 40, 32],
+	[20, 20, 28, 32],
+];
+
+const R_ARM_UVS: FaceUVs = [
+	[48, 20, 52, 32],
+	[40, 20, 44, 32],
+	[44, 16, 48, 20],
+	[48, 16, 52, 20],
+	[52, 20, 56, 32],
+	[44, 20, 48, 32],
+];
+
+const L_ARM_UVS: FaceUVs = [
+	[40, 52, 44, 64],
+	[32, 52, 36, 64],
+	[36, 48, 40, 52],
+	[40, 48, 44, 52],
+	[44, 52, 48, 64],
+	[36, 52, 40, 64],
+];
+
+const R_LEG_UVS: FaceUVs = [
+	[8, 20, 12, 32],
+	[0, 20, 4, 32],
+	[4, 16, 8, 20],
+	[8, 16, 12, 20],
+	[12, 20, 16, 32],
+	[4, 20, 8, 32],
+];
+
+const L_LEG_UVS: FaceUVs = [
+	[24, 52, 28, 64],
+	[16, 52, 20, 64],
+	[20, 48, 24, 52],
+	[24, 48, 28, 52],
+	[28, 52, 32, 64],
+	[20, 52, 24, 64],
+];
+
+// Faces 0 (+X/left) and 5 (-Z/front) need horizontal UV flip
+// due to Three.js BoxGeometry vertex winding vs MC skin convention
+const FLIP_U = [true, false, false, false, false, true];
+
+function applyUVs(geometry: THREE.BoxGeometry, faceUVs: FaceUVs): void {
+	const uv = geometry.getAttribute('uv');
+	const uvArray = uv.array as Float32Array;
+
+	for (let face = 0; face < 6; face++) {
+		const [px1, py1, px2, py2] = faceUVs[face];
+		let u1 = px1 / SKIN_W;
+		let u2 = px2 / SKIN_W;
+		const v1 = 1 - py2 / SKIN_H;
+		const v2 = 1 - py1 / SKIN_H;
+
+		if (FLIP_U[face]) {
+			const tmp = u1;
+			u1 = u2;
+			u2 = tmp;
+		}
+
+		const offset = face * 8;
+		uvArray[offset + 0] = u1;
+		uvArray[offset + 1] = v2;
+		uvArray[offset + 2] = u2;
+		uvArray[offset + 3] = v2;
+		uvArray[offset + 4] = u1;
+		uvArray[offset + 5] = v1;
+		uvArray[offset + 6] = u2;
+		uvArray[offset + 7] = v1;
+	}
+
+	uv.needsUpdate = true;
+}
+
+function SkinModel({ texture }: { texture: THREE.Texture }) {
+	const groupRef = useRef<THREE.Group>(null);
+
+	const geometries = useMemo(() => {
+		const head = new THREE.BoxGeometry(8 * S, 8 * S, 8 * S);
+		applyUVs(head, HEAD_UVS);
+
+		const body = new THREE.BoxGeometry(8 * S, 12 * S, 4 * S);
+		applyUVs(body, BODY_UVS);
+
+		const rArm = new THREE.BoxGeometry(4 * S, 12 * S, 4 * S);
+		applyUVs(rArm, R_ARM_UVS);
+
+		const lArm = new THREE.BoxGeometry(4 * S, 12 * S, 4 * S);
+		applyUVs(lArm, L_ARM_UVS);
+
+		const rLeg = new THREE.BoxGeometry(4 * S, 12 * S, 4 * S);
+		applyUVs(rLeg, R_LEG_UVS);
+
+		const lLeg = new THREE.BoxGeometry(4 * S, 12 * S, 4 * S);
+		applyUVs(lLeg, L_LEG_UVS);
+
+		return { head, body, rArm, lArm, rLeg, lLeg };
+	}, []);
+
+	const material = useMemo(() => {
+		return new THREE.MeshStandardMaterial({
+			map: texture,
+			side: THREE.FrontSide,
+			alphaTest: 0.1,
+		});
+	}, [texture]);
+
+	useFrame((_, delta) => {
+		if (groupRef.current) {
+			groupRef.current.rotation.y += delta * 0.4;
+		}
+	});
+
+	return (
+		<group ref={groupRef} position={[0, -1, 0]}>
+			<mesh
+				geometry={geometries.head}
+				material={material}
+				position={[0, 28 * S, 0]}
+			/>
+			<mesh
+				geometry={geometries.body}
+				material={material}
+				position={[0, 18 * S, 0]}
+			/>
+			<mesh
+				geometry={geometries.rArm}
+				material={material}
+				position={[-6 * S, 18 * S, 0]}
+			/>
+			<mesh
+				geometry={geometries.lArm}
+				material={material}
+				position={[6 * S, 18 * S, 0]}
+			/>
+			<mesh
+				geometry={geometries.rLeg}
+				material={material}
+				position={[-2 * S, 6 * S, 0]}
+			/>
+			<mesh
+				geometry={geometries.lLeg}
+				material={material}
+				position={[2 * S, 6 * S, 0]}
+			/>
+		</group>
+	);
+}
+
+function FallbackCube() {
+	const ref = useRef<THREE.Mesh>(null);
+	useFrame((_, delta) => {
+		if (ref.current) ref.current.rotation.y += delta * 0.5;
+	});
+	return (
+		<mesh ref={ref}>
+			<boxGeometry args={[0.5, 0.5, 0.5]} />
+			<meshStandardMaterial color="#4a5568" wireframe />
+		</mesh>
+	);
+}
+
+function SkinScene({ uuid }: { uuid: string }) {
+	const [texture, setTexture] = useState<THREE.Texture | null>(null);
+	const [failed, setFailed] = useState(false);
+
+	useEffect(() => {
+		setTexture(null);
+		setFailed(false);
+
+		const cleanUuid = uuid.replace(/-/g, '');
+		const url = `https://crafatar.com/skins/${cleanUuid}`;
+		const loader = new THREE.TextureLoader();
+		loader.setCrossOrigin('anonymous');
+		loader.load(
+			url,
+			(tex) => {
+				tex.magFilter = THREE.NearestFilter;
+				tex.minFilter = THREE.NearestFilter;
+				tex.generateMipmaps = false;
+				setTexture(tex);
+			},
+			undefined,
+			() => setFailed(true),
+		);
+	}, [uuid]);
+
+	if (failed) return <FallbackCube />;
+	if (!texture) return <FallbackCube />;
+	return <SkinModel texture={texture} />;
+}
+
+export default function McSkinViewer({
+	uuid,
+	width = 300,
+	height = 400,
+}: McSkinViewerProps) {
+	return (
+		<div style={{ width, height }}>
+			<Canvas
+				camera={{ position: [0, 0.2, 2.8], fov: 45 }}
+				style={{ background: 'transparent' }}>
+				<ambientLight intensity={1.8} />
+				<directionalLight position={[5, 8, 5]} intensity={1.2} />
+				<directionalLight position={[-3, 4, -3]} intensity={0.5} />
+				<SkinScene uuid={uuid} />
+				<OrbitControls
+					enablePan={false}
+					enableZoom={false}
+					minPolarAngle={Math.PI / 6}
+					maxPolarAngle={(Math.PI * 5) / 6}
+				/>
+			</Canvas>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Add `McSkinViewer` R3F component that renders Minecraft player skins as interactive 3D models using UV-mapped BoxGeometry (head, body, arms, legs) with pixelated nearest-neighbor filtering
- Update `McPlayerList` with clickable player cards that open a slide-in off-canvas panel from the right showing the 3D skin viewer
- Panel features: auto-rotation, orbit controls (drag to rotate), close via button/backdrop/Escape key, lazy-loaded R3F Canvas via `React.lazy`

## Test plan
- [ ] Verify `McPlayerList` renders player cards with hover highlight effect
- [ ] Click a player card and confirm the off-canvas panel slides in from the right
- [ ] Confirm 3D skin model loads from crafatar.com and auto-rotates
- [ ] Drag the 3D model to verify orbit controls work
- [ ] Close panel via X button, backdrop click, and Escape key
- [ ] Verify graceful fallback (wireframe cube) when skin texture fails to load
- [ ] Test on mobile viewport — panel should max at 90vw

🤖 Generated with [Claude Code](https://claude.com/claude-code)