### PR TITLE
fix(cryptothrone): full-bleed game canvas, re-render fix, bundle splitting

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
+++ b/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
@@ -32,8 +32,16 @@ export default defineConfig({
 	vite: {
 		plugins: [tailwindcss()],
 		build: {
+			chunkSizeWarningLimit: 1200,
 			rollupOptions: {
 				external: ['fsevents'],
+				output: {
+					manualChunks(id) {
+						if (id.includes('node_modules/phaser')) return 'phaser';
+						if (id.includes('node_modules/grid-engine'))
+							return 'grid-engine';
+					},
+				},
 			},
 		},
 		optimizeDeps: {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -1,11 +1,11 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useMemo, memo } from 'react';
 import Phaser from 'phaser';
 import GridEngine from 'grid-engine';
 import { PhaserGame } from '@kbve/laser';
 import type { PhaserGameRef } from '@kbve/laser';
 import { PreloaderScene } from './scenes/PreloaderScene';
 import { CloudCityScene } from './scenes/CloudCityScene';
-import { GameStoreProvider, useGameStore } from './store/GameStoreContext';
+import { GameStoreProvider, useGameDispatch } from './store/GameStoreContext';
 import { useEventBridge } from './store/useEventBridge';
 import { CharacterDialog } from './ui/CharacterDialog';
 import { NotificationToast } from './ui/NotificationToast';
@@ -14,40 +14,55 @@ import { ActionMenu } from './ui/ActionMenu';
 import { DialogueModal } from './ui/DialogueModal';
 import { DiceRollModal } from './ui/DiceRollModal';
 
-function GameWindowInner() {
+/**
+ * Isolated Phaser canvas — never re-renders when game store changes.
+ * Config and onReady are memoized so the PhaserGame useEffect dependency
+ * array stays referentially stable across React re-renders.
+ */
+const PhaserCanvas = memo(function PhaserCanvas() {
 	const gameRef = useRef<PhaserGameRef>(null);
-	const { dispatch } = useGameStore();
-	useEventBridge(dispatch);
+
+	const config = useMemo(
+		() => ({
+			width: 800,
+			height: 600,
+			scenes: [PreloaderScene, CloudCityScene],
+			backgroundColor: '#1a1a2e',
+			plugins: {
+				scene: [
+					{
+						key: 'gridEngine',
+						plugin: GridEngine,
+						mapping: 'gridEngine',
+					},
+				],
+			},
+			scale: {
+				mode: Phaser.Scale.FIT,
+				autoCenter: Phaser.Scale.CENTER_BOTH,
+			},
+		}),
+		[],
+	);
 
 	const handleReady = useCallback((game: Phaser.Game) => {
 		console.log('[CryptoThrone] Game ready', game.config.gameTitle);
 	}, []);
 
+	return <PhaserGame ref={gameRef} config={config} onReady={handleReady} />;
+});
+
+/**
+ * Event bridge + UI overlays.
+ * Uses dispatch-only hook so this wrapper never re-renders on state changes.
+ * Each child subscribes to its own state slice independently.
+ */
+function GameUI() {
+	const dispatch = useGameDispatch();
+	useEventBridge(dispatch);
+
 	return (
 		<>
-			<PhaserGame
-				ref={gameRef}
-				config={{
-					width: 800,
-					height: 600,
-					scenes: [PreloaderScene, CloudCityScene],
-					backgroundColor: '#1a1a2e',
-					plugins: {
-						scene: [
-							{
-								key: 'gridEngine',
-								plugin: GridEngine,
-								mapping: 'gridEngine',
-							},
-						],
-					},
-					scale: {
-						mode: Phaser.Scale.FIT,
-						autoCenter: Phaser.Scale.CENTER_BOTH,
-					},
-				}}
-				onReady={handleReady}
-			/>
 			<StickySidebar />
 			<ActionMenu />
 			<DialogueModal />
@@ -62,7 +77,8 @@ export default function GameWindow() {
 	return (
 		<GameStoreProvider>
 			<div className="relative flex justify-center items-center w-full">
-				<GameWindowInner />
+				<PhaserCanvas />
+				<GameUI />
 			</div>
 		</GameStoreProvider>
 	);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindowLoader.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindowLoader.tsx
@@ -6,7 +6,7 @@ export default function GameWindowLoader() {
 	return (
 		<Suspense
 			fallback={
-				<div className="flex justify-center items-center w-full h-[600px] bg-[#1a1a2e] text-white">
+				<div className="flex justify-center items-center w-full h-full bg-[#1a1a2e] text-white">
 					Loading game…
 				</div>
 			}>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/GameStoreContext.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/GameStoreContext.tsx
@@ -2,6 +2,8 @@ import {
 	createContext,
 	useContext,
 	useReducer,
+	useCallback,
+	useMemo,
 	type Dispatch,
 	type ReactNode,
 } from 'react';
@@ -12,25 +14,49 @@ import {
 	type GameAction,
 } from './game-store';
 
-interface GameStoreContextValue {
-	state: GameState;
-	dispatch: Dispatch<GameAction>;
-}
-
-const GameStoreContext = createContext<GameStoreContextValue | null>(null);
+/**
+ * Two separate contexts so components that only need dispatch (event bridge,
+ * action handlers) never re-render when state changes.
+ */
+const StateContext = createContext<GameState | null>(null);
+const DispatchContext = createContext<Dispatch<GameAction> | null>(null);
 
 export function GameStoreProvider({ children }: { children: ReactNode }) {
 	const [state, dispatch] = useReducer(gameReducer, initialGameState);
 	return (
-		<GameStoreContext.Provider value={{ state, dispatch }}>
-			{children}
-		</GameStoreContext.Provider>
+		<DispatchContext.Provider value={dispatch}>
+			<StateContext.Provider value={state}>
+				{children}
+			</StateContext.Provider>
+		</DispatchContext.Provider>
 	);
 }
 
-export function useGameStore(): GameStoreContextValue {
-	const ctx = useContext(GameStoreContext);
-	if (!ctx)
+/** Full store access — use only when you need both state and dispatch. */
+export function useGameStore() {
+	const state = useContext(StateContext);
+	const dispatch = useContext(DispatchContext);
+	if (!state || !dispatch)
 		throw new Error('useGameStore must be used within GameStoreProvider');
-	return ctx;
+	return { state, dispatch };
+}
+
+/** Dispatch-only hook — never triggers re-renders. */
+export function useGameDispatch(): Dispatch<GameAction> {
+	const dispatch = useContext(DispatchContext);
+	if (!dispatch)
+		throw new Error(
+			'useGameDispatch must be used within GameStoreProvider',
+		);
+	return dispatch;
+}
+
+/** Select a slice of state — combine with memo to skip irrelevant updates. */
+export function useGameSelector<T>(selector: (state: GameState) => T): T {
+	const state = useContext(StateContext);
+	if (!state)
+		throw new Error(
+			'useGameSelector must be used within GameStoreProvider',
+		);
+	return selector(state);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ActionMenu.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ActionMenu.tsx
@@ -1,11 +1,11 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useGameStore } from '../store/GameStoreContext';
+import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 import { getNPCById, getDialogueById } from '../data/npcs';
 import type { NPCAction } from '../types';
 
 export function ActionMenu() {
-	const { state, dispatch } = useGameStore();
-	const npc = state.npcInteraction;
+	const npc = useGameSelector((s) => s.npcInteraction);
+	const dispatch = useGameDispatch();
 	const menuRef = useRef<HTMLDivElement>(null);
 	const [position, setPosition] = useState({ x: 0, y: 0 });
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CharacterDialog.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CharacterDialog.tsx
@@ -1,8 +1,8 @@
-import { useGameStore } from '../store/GameStoreContext';
+import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 
 export function CharacterDialog() {
-	const { state, dispatch } = useGameStore();
-	const modal = state.activeModal;
+	const modal = useGameSelector((s) => s.activeModal);
+	const dispatch = useGameDispatch();
 
 	if (!modal) return null;
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DialogueModal.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DialogueModal.tsx
@@ -1,12 +1,12 @@
 import { useState, useCallback } from 'react';
-import { useGameStore } from '../store/GameStoreContext';
+import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 import { getDialogueById } from '../data/npcs';
 import { TypewriterText } from './TypewriterText';
 import type { DialogueOption } from '../types';
 
 export function DialogueModal() {
-	const { state, dispatch } = useGameStore();
-	const dialogue = state.dialogue;
+	const dialogue = useGameSelector((s) => s.dialogue);
+	const dispatch = useGameDispatch();
 
 	const [playerTypingDone, setPlayerTypingDone] = useState(false);
 	const [npcTypingDone, setNpcTypingDone] = useState(false);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useGameStore } from '../store/GameStoreContext';
+import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 
 function rollDie(): number {
 	return Math.floor(Math.random() * 6) + 1;
@@ -15,8 +15,8 @@ const DICE_FACES: Record<number, string> = {
 };
 
 export function DiceRollModal() {
-	const { state, dispatch } = useGameStore();
-	const diceRoll = state.diceRoll;
+	const diceRoll = useGameSelector((s) => s.diceRoll);
+	const dispatch = useGameDispatch();
 	const [rolling, setRolling] = useState(false);
 
 	const handleRoll = useCallback(() => {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/NotificationToast.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/NotificationToast.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useGameStore } from '../store/GameStoreContext';
+import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 
 const BORDER_COLORS: Record<string, string> = {
 	danger: 'border-red-500',
@@ -9,8 +9,8 @@ const BORDER_COLORS: Record<string, string> = {
 };
 
 export function NotificationToast() {
-	const { state, dispatch } = useGameStore();
-	const { notifications } = state;
+	const notifications = useGameSelector((s) => s.notifications);
+	const dispatch = useGameDispatch();
 
 	useEffect(() => {
 		if (notifications.length === 0) return;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
@@ -1,12 +1,13 @@
-import { useGameStore } from '../store/GameStoreContext';
+import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 import { StatsSection } from './StatsSection';
 import { ToggleButton } from './ToggleButton';
 import { InventoryGrid } from './InventoryGrid';
 import { getItemById } from '../data/items';
 
 export function StickySidebar() {
-	const { state, dispatch } = useGameStore();
-	const { player, settings } = state;
+	const player = useGameSelector((s) => s.player);
+	const settings = useGameSelector((s) => s.settings);
+	const dispatch = useGameDispatch();
 
 	return (
 		<div className="fixed top-24 left-3 w-[350px] p-4 bg-zinc-800 text-yellow-400 border border-yellow-300 rounded-lg z-20 transition duration-500 opacity-50 hover:opacity-100 max-h-[80vh] overflow-y-auto">

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/game/play.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/game/play.mdx
@@ -3,9 +3,12 @@ title: Play CryptoThrone
 description: Launch the CryptoThrone game.
 template: splash
 hero:
-  tagline: ''
+  title: ' '
+  tagline: ' '
 ---
 
 import GameWindowLoader from '../../../components/game/GameWindowLoader';
 
-<GameWindowLoader client:only="react" />
+<div class="game-fullscreen">
+  <GameWindowLoader client:only="react" />
+</div>

--- a/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
+++ b/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
@@ -1,1 +1,27 @@
 @import 'tailwindcss';
+
+/* ── Game full-bleed layout ── */
+
+/* Lock body scroll when the game overlay is active */
+body:has(.game-fullscreen) {
+	overflow: hidden;
+}
+
+/* Full-viewport game overlay — covers Starlight header/hero */
+.game-fullscreen {
+	position: fixed;
+	inset: 0;
+	z-index: 50;
+	background: #1a1a2e;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+}
+
+/* Let the Phaser canvas fill the viewport while keeping aspect ratio */
+.game-fullscreen canvas {
+	max-width: 100vw;
+	max-height: 100vh;
+	object-fit: contain;
+}


### PR DESCRIPTION
## Summary
- Fix Phaser game resetting on UI button clicks (Settings, etc.) by isolating `PhaserCanvas` in a `memo`'d component with `useMemo`'d config — store dispatches no longer destroy/recreate the game instance
- Split `GameStoreContext` into stable `DispatchContext` + `StateContext` so event bridge never re-renders on state changes
- Each UI overlay (`StickySidebar`, `ActionMenu`, `DiceRollModal`, etc.) now subscribes to only its own state slice via `useGameSelector`
- Split the 3.3 MB monolith bundle into 3 independently cacheable chunks: `phaser.js` (1.5 MB), `grid-engine.js` (297 kB), `GameWindow.js` (1.6 MB)
- Full-viewport game overlay (`.game-fullscreen` CSS) replacing the enclosed Starlight layout
- Hide Starlight hero `<h1>` on the game page

## Test plan
- [ ] Open `/game/play/` — game fills the full viewport
- [ ] Click Settings toggle — game canvas should NOT reset
- [ ] Open dialogue/dice roll — only relevant UI re-renders
- [ ] Verify network tab shows separate phaser/grid-engine chunks
- [ ] Returning visits serve phaser/grid-engine from browser cache