### PR TITLE
feat(axum-kbve): foundational Docker build caching

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -19,7 +19,9 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
 
 # Install all dependencies (hoisted mode - all go to root node_modules)
-RUN pnpm install --frozen-lockfile
+# Cache pnpm content-addressable store across builds to skip re-downloading
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
+    pnpm install --frozen-lockfile
 
 # Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
@@ -29,9 +31,10 @@ COPY packages/npm/laser/ packages/npm/laser/
 # Copy astro-kbve source
 COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 
-# Build astro site
+# Build astro site (cache .astro dir for incremental content collection builds)
 WORKDIR /app/apps/kbve/astro-kbve
-RUN rm -rf .astro && npx astro sync && \
+RUN --mount=type=cache,target=/app/apps/kbve/astro-kbve/.astro,id=astro-cache \
+    npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build
 
 # ============================================================================
@@ -73,7 +76,8 @@ RUN apt-get update && \
         pkg-config \
         libssl-dev \
         protobuf-compiler \
-        libprotobuf-dev && \
+        libprotobuf-dev \
+        mold && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add x86_64-unknown-linux-gnu && \
@@ -141,6 +145,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # all inline Rust stages and use the pre-built GHCR image instead.
 # ============================================================================
 FROM ${BUILD_BASE} AS builder
+
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
 # Astro build output (precompressed) -> placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/kbve/axum-kbve/templates/dist

--- a/apps/kbve/axum-kbve/Dockerfile.base
+++ b/apps/kbve/axum-kbve/Dockerfile.base
@@ -20,7 +20,8 @@ RUN apt-get update && \
         pkg-config \
         libssl-dev \
         protobuf-compiler \
-        libprotobuf-dev && \
+        libprotobuf-dev \
+        mold && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add x86_64-unknown-linux-gnu && \
@@ -75,6 +76,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Only axum-kbve needs recompilation downstream.
 # ============================================================================
 FROM deps AS foundation
+
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
 # Restore real workspace manifest (chef cook may strip lints/metadata)
 COPY apps/kbve/axum-kbve/Cargo.workspace.toml Cargo.toml

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -88,6 +88,12 @@
 						"./kbve.sh -nx axum-kbve:containerx --configuration=production",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && docker tag kbve/kbve:latest ghcr.io/kbve/kbve:latest && docker tag kbve/kbve:latest ghcr.io/kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION and ghcr.io/kbve/kbve:$VERSION\""
 					]
+				},
+				"ci": {
+					"commands": [
+						"./kbve.sh -nx axum-kbve:containerx --configuration=ci",
+						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
+					]
 				}
 			}
 		},
@@ -117,11 +123,25 @@
 						"BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest"
 					],
 					"cache-from": [
+						"type=gha",
 						"type=registry,ref=ghcr.io/kbve/kbve:buildcache"
 					],
 					"cache-to": [
 						"type=registry,ref=ghcr.io/kbve/kbve:buildcache,mode=max"
 					]
+				},
+				"ci": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/kbve:latest"],
+					"build-args": [
+						"BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest"
+					],
+					"cache-from": [
+						"type=gha",
+						"type=registry,ref=ghcr.io/kbve/kbve:buildcache"
+					],
+					"cache-to": ["type=gha,mode=max"]
 				}
 			}
 		},


### PR DESCRIPTION
## Summary
- **GHA cache fallback**: Add `type=gha` as primary `cache-from` source in production config (lower latency than registry, fallback when GHCR cache is cold)
- **CI configuration**: Add `ci` config to `containerx`/`container` targets — populates GHA cache during e2e test phase, production publish reads from it (mirrors mc project pattern)
- **pnpm store cache mount**: `--mount=type=cache` on pnpm store in Astro builder — skips re-downloading packages every build (~30-60s savings)
- **Astro build cache mount**: `--mount=type=cache` on `.astro` directory for incremental content collection builds (~10-20s savings)
- **mold linker**: Install mold in both `Dockerfile` and `Dockerfile.base`, set `RUSTFLAGS="-C link-arg=-fuse-ld=mold"` for faster ELF linking (~5-15s savings)

## Files changed
| File | Change |
|------|--------|
| `apps/kbve/axum-kbve/project.json` | GHA cache-from, ci configuration for containerx + container |
| `apps/kbve/axum-kbve/Dockerfile` | pnpm/astro cache mounts, mold install + RUSTFLAGS |
| `apps/kbve/axum-kbve/Dockerfile.base` | mold install + RUSTFLAGS in foundation stage |

## Test plan
- [ ] Verify `pnpm nx run axum-kbve:container --configuration=local` builds successfully with mold + cache mounts
- [ ] After CI run, check logs for GHA cache import and `CACHED` on pnpm install layer
- [ ] Compare total CI build time before/after