### PR TITLE
fix(kube): add TLS cert for cryptothrone.com via cert-manager

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -56,6 +56,18 @@ spec:
                           metadata:
                               annotations:
                                   cert-manager.io/http01-ingress-path-type: 'Prefix'
+
+            # --- Solver 5: CRYPTOTHRONE.COM domains ---
+            - selector:
+                  dnsZones:
+                      - cryptothrone.com
+              http01:
+                  ingress:
+                      ingressClassName: nginx
+                      ingressTemplate:
+                          metadata:
+                              annotations:
+                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -76,7 +88,7 @@ spec:
                       apiTokenSecretRef:
                           name: cloudflare-api-token-secret
                           key: api-token
-                          
+
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/apps/kube/cryptothrone/manifest/cryptothrone-ingress.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-ingress.yaml
@@ -4,11 +4,28 @@ metadata:
     name: cryptothrone-ingress
     namespace: cryptothrone
     annotations:
-        kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/rewrite-target: /
+        nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+        cert-manager.io/cluster-issuer: 'letsencrypt-http'
 spec:
+    ingressClassName: nginx
+    tls:
+        - hosts:
+              - cryptothrone.com
+              - www.cryptothrone.com
+          secretName: cryptothrone-tls
     rules:
         - host: cryptothrone.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: cryptothrone-service
+                            port:
+                                number: 4321
+        - host: www.cryptothrone.com
           http:
               paths:
                   - path: /


### PR DESCRIPTION
## Summary
- Add `cryptothrone.com` as HTTP-01 ACME solver in the `letsencrypt-http` ClusterIssuer
- Update cryptothrone ingress with TLS termination, `ssl-redirect`, and `www.cryptothrone.com` subdomain routing
- Replace deprecated `kubernetes.io/ingress.class` annotation with `spec.ingressClassName: nginx`

## Changes
- `apps/kube/cert-manager/manifests/cluster-issuer.yaml` — add Solver 5 for `cryptothrone.com` dnsZone
- `apps/kube/cryptothrone/manifest/cryptothrone-ingress.yaml` — add TLS section, cert-manager annotation, www host rule

## Test plan
- [ ] Verify cert-manager issues a certificate for `cryptothrone.com` after ArgoCD sync
- [ ] Confirm `https://cryptothrone.com` serves valid Let's Encrypt cert
- [ ] Confirm `https://www.cryptothrone.com` routes correctly