### PR TITLE
feat(cryptothrone): custom landing page with hero and feature grid

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/landing/CryptoThroneHero.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/landing/CryptoThroneHero.astro
@@ -1,0 +1,153 @@
+---
+interface Props {
+	title?: string;
+	tagline?: string;
+	playLink?: string;
+	guidesLink?: string;
+}
+
+const {
+	title = 'CryptoThrone',
+	tagline = 'Explore cloud cities, battle bird monsters, and claim the throne.',
+	playLink = '/game/play/',
+	guidesLink = '/guides/getting-started/',
+} = Astro.props;
+---
+
+<section class="ct-hero">
+	<div class="ct-hero__overlay"></div>
+	<div class="ct-hero__content">
+		<h1 class="ct-hero__title">{title}</h1>
+		<p class="ct-hero__tagline">{tagline}</p>
+		<div class="ct-hero__actions">
+			<a href={playLink} class="ct-btn ct-btn--primary">Play Now</a>
+			<a href={guidesLink} class="ct-btn ct-btn--ghost">View Guides</a>
+		</div>
+	</div>
+	<div class="ct-hero__scroll-hint" aria-hidden="true">
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2">
+			<path d="M12 5v14M5 12l7 7 7-7"></path>
+		</svg>
+	</div>
+</section>
+
+<style>
+	.ct-hero {
+		position: relative;
+		min-height: 80vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: url('/assets/background/chip-background.webp') center /
+			cover no-repeat;
+		overflow: hidden;
+	}
+
+	.ct-hero__overlay {
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			180deg,
+			rgba(26, 26, 46, 0.85) 0%,
+			rgba(26, 26, 46, 0.6) 50%,
+			rgba(26, 26, 46, 0.9) 100%
+		);
+	}
+
+	.ct-hero__content {
+		position: relative;
+		z-index: 1;
+		text-align: center;
+		padding: 2rem;
+		max-width: 700px;
+	}
+
+	.ct-hero__title {
+		font-size: clamp(2.5rem, 6vw, 4.5rem);
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		background: linear-gradient(135deg, #fbbf24, #f59e0b, #d97706);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+		margin: 0 0 1rem;
+		line-height: 1.1;
+	}
+
+	.ct-hero__tagline {
+		font-size: clamp(1rem, 2vw, 1.25rem);
+		color: #d1d5db;
+		margin: 0 0 2.5rem;
+		line-height: 1.6;
+	}
+
+	.ct-hero__actions {
+		display: flex;
+		gap: 1rem;
+		justify-content: center;
+		flex-wrap: wrap;
+	}
+
+	.ct-btn {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.75rem 2rem;
+		border-radius: 0.5rem;
+		font-weight: 600;
+		font-size: 1rem;
+		text-decoration: none;
+		transition: all 0.2s ease;
+	}
+
+	.ct-btn--primary {
+		background: linear-gradient(135deg, #f59e0b, #d97706);
+		color: #1a1a2e;
+	}
+
+	.ct-btn--primary:hover {
+		transform: translateY(-2px);
+		box-shadow: 0 8px 24px rgba(245, 158, 11, 0.3);
+	}
+
+	.ct-btn--ghost {
+		border: 1px solid rgba(251, 191, 36, 0.4);
+		color: #fbbf24;
+		background: transparent;
+	}
+
+	.ct-btn--ghost:hover {
+		background: rgba(251, 191, 36, 0.1);
+		border-color: #fbbf24;
+	}
+
+	.ct-hero__scroll-hint {
+		position: absolute;
+		bottom: 2rem;
+		left: 50%;
+		transform: translateX(-50%);
+		color: rgba(251, 191, 36, 0.5);
+		animation: bounce 2s infinite;
+	}
+
+	@keyframes bounce {
+		0%,
+		20%,
+		50%,
+		80%,
+		100% {
+			transform: translateX(-50%) translateY(0);
+		}
+		40% {
+			transform: translateX(-50%) translateY(-8px);
+		}
+		60% {
+			transform: translateX(-50%) translateY(-4px);
+		}
+	}
+</style>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureCard.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureCard.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+	title: string;
+	description: string;
+	icon: string;
+}
+
+const { title, description, icon } = Astro.props;
+---
+
+<div class="ct-card">
+	<div class="ct-card__icon">{icon}</div>
+	<h3 class="ct-card__title">{title}</h3>
+	<p class="ct-card__desc">{description}</p>
+</div>
+
+<style>
+	.ct-card {
+		background: rgba(39, 39, 42, 0.6);
+		border: 1px solid rgba(251, 191, 36, 0.15);
+		border-radius: 0.75rem;
+		padding: 1.5rem;
+		transition: all 0.3s ease;
+	}
+
+	.ct-card:hover {
+		border-color: rgba(251, 191, 36, 0.4);
+		transform: translateY(-4px);
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+	}
+
+	.ct-card__icon {
+		font-size: 2rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.ct-card__title {
+		font-size: 1.125rem;
+		font-weight: 700;
+		color: #fbbf24;
+		margin: 0 0 0.5rem;
+	}
+
+	.ct-card__desc {
+		font-size: 0.875rem;
+		color: #9ca3af;
+		line-height: 1.6;
+		margin: 0;
+	}
+</style>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureGrid.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureGrid.astro
@@ -1,0 +1,79 @@
+---
+import FeatureCard from './FeatureCard.astro';
+
+const features = [
+	{
+		icon: '\u2694\uFE0F',
+		title: 'Real-Time Combat',
+		description:
+			'Battle bird monsters and hostile NPCs with dice-based mechanics and strategic encounters.',
+	},
+	{
+		icon: '\uD83C\uDFD9\uFE0F',
+		title: 'Cloud Cities',
+		description:
+			'Explore sprawling tile-based worlds built with GridEngine and richly layered tilesets.',
+	},
+	{
+		icon: '\uD83C\uDFB2',
+		title: 'Dice Rolls',
+		description:
+			'Steal, negotiate, and gamble your way through encounters with animated dice mechanics.',
+	},
+	{
+		icon: '\uD83D\uDEE1\uFE0F',
+		title: 'Inventory & Equipment',
+		description:
+			'Collect loot, manage your backpack, and equip gear to strengthen your character.',
+	},
+	{
+		icon: '\uD83D\uDCAC',
+		title: 'NPC Dialogue',
+		description:
+			'Engage in branching conversations with typewriter-style text and meaningful choices.',
+	},
+	{
+		icon: '\u26A1',
+		title: 'Phaser + React',
+		description:
+			'Built on Phaser 3 with a React overlay — buttery smooth rendering meets modern UI.',
+	},
+];
+---
+
+<section class="ct-features">
+	<h2 class="ct-features__heading">Features</h2>
+	<div class="ct-features__grid">
+		{
+			features.map((f) => (
+				<FeatureCard
+					title={f.title}
+					description={f.description}
+					icon={f.icon}
+				/>
+			))
+		}
+	</div>
+</section>
+
+<style>
+	.ct-features {
+		max-width: 900px;
+		margin: 0 auto;
+		padding: 4rem 1.5rem;
+	}
+
+	.ct-features__heading {
+		font-size: 1.75rem;
+		font-weight: 700;
+		color: #fbbf24;
+		text-align: center;
+		margin: 0 0 2.5rem;
+	}
+
+	.ct-features__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+		gap: 1.25rem;
+	}
+</style>

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/index.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/index.mdx
@@ -3,13 +3,12 @@ title: CryptoThrone
 description: A 2D tile-based RPG built with Phaser, GridEngine, and React.
 template: splash
 hero:
-  tagline: Explore cloud cities, battle bird monsters, and claim the throne.
-  actions:
-    - text: Play Now
-      link: /game/play/
-      icon: right-arrow
-      variant: primary
-    - text: View Guides
-      link: /guides/getting-started/
-      variant: minimal
+  title: ' '
+  tagline: ' '
 ---
+
+import CryptoThroneHero from '../../components/landing/CryptoThroneHero.astro';
+import FeatureGrid from '../../components/landing/FeatureGrid.astro';
+
+<CryptoThroneHero />
+<FeatureGrid />


### PR DESCRIPTION
## Summary
- Replace default Starlight hero on CryptoThrone index page with a custom `CryptoThroneHero` component featuring gradient title, `chip-background.webp` backdrop, and CTA buttons
- Add a `FeatureGrid` with six cards highlighting game mechanics (combat, cloud cities, dice rolls, inventory, NPC dialogue, tech stack)
- New reusable `FeatureCard` component with hover effects and gold accent theming

## Test plan
- [ ] `npx nx build astro-cryptothrone` passes (verified locally — 4 pages generated)
- [ ] Index page renders custom hero with background image and feature grid
- [ ] Play Now / View Guides links navigate correctly
- [ ] Feature cards display icons, titles, and descriptions