### PR TITLE
feat(astro-kbve): link Yuki books to documentation pages

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/ReactJayYuki.tsx
+++ b/apps/kbve/astro-kbve/src/components/jay/ReactJayYuki.tsx
@@ -20,6 +20,7 @@ import {
 	type CharacterKeyPoint,
 	type MagicalRune,
 } from './jay_service';
+import { getSkillDocs, type SkillDoc } from './jay_docs';
 
 interface ReactJayYukiProps {
 	width?: number;
@@ -949,6 +950,7 @@ function BookModal({
 }) {
 	const [showDetails, setShowDetails] = useState(false);
 	const [isClosing, setIsClosing] = useState(false);
+	const relatedDocs = skill ? getSkillDocs(skill.id) : [];
 
 	const handleClose = useCallback(() => {
 		setIsClosing(true);
@@ -1149,6 +1151,109 @@ function BookModal({
 					}}>
 					{skill.description}
 				</p>
+
+				{relatedDocs.length > 0 && (
+					<div
+						style={{
+							marginTop: '1rem',
+							paddingTop: '0.75rem',
+							borderTop: '1px solid rgba(139, 119, 101, 0.3)',
+						}}>
+						<div
+							style={{
+								fontSize: '0.75rem',
+								color: '#8b7765',
+								fontFamily: 'Georgia, "Times New Roman", serif',
+								fontStyle: 'italic',
+								marginBottom: '0.5rem',
+							}}>
+							Related scrolls:
+						</div>
+						<div
+							style={{
+								display: 'flex',
+								flexWrap: 'wrap',
+								gap: '0.375rem',
+							}}>
+							{relatedDocs.map((doc) => (
+								<a
+									key={doc.path}
+									href={doc.path}
+									target="_blank"
+									rel="noopener noreferrer"
+									title={doc.description}
+									style={{
+										fontSize: '0.7rem',
+										color: '#6b5344',
+										fontFamily:
+											'Georgia, "Times New Roman", serif',
+										padding: '0.2rem 0.5rem',
+										borderRadius: '0.25rem',
+										border: '1px solid rgba(139, 119, 101, 0.3)',
+										background: 'rgba(139, 119, 101, 0.08)',
+										textDecoration: 'none',
+										transition: 'all 0.2s',
+										cursor: 'pointer',
+									}}
+									onMouseEnter={(e) => {
+										e.currentTarget.style.background =
+											'rgba(139, 119, 101, 0.2)';
+										e.currentTarget.style.borderColor =
+											'rgba(139, 119, 101, 0.5)';
+									}}
+									onMouseLeave={(e) => {
+										e.currentTarget.style.background =
+											'rgba(139, 119, 101, 0.08)';
+										e.currentTarget.style.borderColor =
+											'rgba(139, 119, 101, 0.3)';
+									}}>
+									{doc.title}
+								</a>
+							))}
+						</div>
+					</div>
+				)}
+
+				{skill.link && (
+					<div
+						style={{
+							marginTop: '1rem',
+							textAlign: 'center',
+						}}>
+						<a
+							href={skill.link}
+							target="_blank"
+							rel="noopener noreferrer"
+							style={{
+								display: 'inline-block',
+								padding: '0.4rem 1.25rem',
+								fontSize: '0.85rem',
+								fontFamily: 'Georgia, "Times New Roman", serif',
+								color: '#3d2914',
+								background: 'rgba(139, 119, 101, 0.15)',
+								border: '1px solid rgba(139, 119, 101, 0.4)',
+								borderRadius: '0.25rem',
+								textDecoration: 'none',
+								cursor: 'pointer',
+								transition: 'all 0.2s',
+								fontWeight: 600,
+							}}
+							onMouseEnter={(e) => {
+								e.currentTarget.style.background =
+									'rgba(139, 119, 101, 0.3)';
+								e.currentTarget.style.borderColor =
+									'rgba(139, 119, 101, 0.6)';
+							}}
+							onMouseLeave={(e) => {
+								e.currentTarget.style.background =
+									'rgba(139, 119, 101, 0.15)';
+								e.currentTarget.style.borderColor =
+									'rgba(139, 119, 101, 0.4)';
+							}}>
+							Read More
+						</a>
+					</div>
+				)}
 
 				<div
 					onClick={handleClose}

--- a/apps/kbve/astro-kbve/src/components/jay/jay_docs.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/jay_docs.ts
@@ -1,0 +1,218 @@
+export interface SkillDoc {
+	title: string;
+	path: string;
+	description: string;
+}
+
+export interface SkillDocsEntry {
+	skillId: string;
+	docs: SkillDoc[];
+}
+
+export const skillDocs: SkillDocsEntry[] = [
+	{
+		skillId: 'programming',
+		docs: [
+			{
+				title: 'Programming',
+				path: '/theory/programming/',
+				description: 'Core programming concepts and paradigms',
+			},
+			{
+				title: 'JavaScript',
+				path: '/application/javascript/',
+				description: 'Web development with JS and TypeScript',
+			},
+			{
+				title: 'Python',
+				path: '/application/python/',
+				description: 'Scripting, automation, and data processing',
+			},
+			{
+				title: 'Rust',
+				path: '/application/rust/',
+				description: 'Systems programming and performance',
+			},
+		],
+	},
+	{
+		skillId: 'devops',
+		docs: [
+			{
+				title: 'Docker',
+				path: '/application/docker/',
+				description: 'Containerization and image management',
+			},
+			{
+				title: 'Kubernetes',
+				path: '/application/kubernetes/',
+				description: 'Container orchestration at scale',
+			},
+			{
+				title: 'Terraform',
+				path: '/application/terraform/',
+				description: 'Infrastructure as code',
+			},
+			{
+				title: 'Linux',
+				path: '/application/linux/',
+				description: 'Server administration and shell scripting',
+			},
+		],
+	},
+	{
+		skillId: 'databases',
+		docs: [
+			{
+				title: 'SQL',
+				path: '/application/sql/',
+				description: 'Relational database design and queries',
+			},
+			{
+				title: 'Supabase',
+				path: '/application/supabase/',
+				description: 'Open-source Firebase alternative',
+			},
+			{
+				title: 'Redis',
+				path: '/application/redis/',
+				description: 'In-memory caching and data structures',
+			},
+		],
+	},
+	{
+		skillId: 'gamedev',
+		docs: [
+			{
+				title: 'Unity',
+				path: '/application/unity/',
+				description: 'Cross-platform game engine',
+			},
+			{
+				title: 'Godot',
+				path: '/application/godot/',
+				description: 'Open-source 2D and 3D game engine',
+			},
+			{
+				title: 'Brackeys GameJam',
+				path: '/project/brackeys/',
+				description: 'Game jam projects and prototypes',
+			},
+			{
+				title: 'RareIcon',
+				path: '/project/rareicon/',
+				description: 'Collectible game project',
+			},
+		],
+	},
+	{
+		skillId: 'security',
+		docs: [
+			{
+				title: 'Nmap',
+				path: '/application/nmap/',
+				description: 'Network scanning and reconnaissance',
+			},
+			{
+				title: 'WireGuard',
+				path: '/application/wireguard/',
+				description: 'VPN tunneling and secure networking',
+			},
+			{
+				title: 'Authelia',
+				path: '/application/authelia/',
+				description: 'Authentication and access control',
+			},
+		],
+	},
+	{
+		skillId: 'ml',
+		docs: [
+			{
+				title: 'Machine Learning',
+				path: '/application/ml/',
+				description: 'ML frameworks and AI integration',
+			},
+		],
+	},
+	{
+		skillId: 'leadership',
+		docs: [
+			{
+				title: 'Webmaster',
+				path: '/webmaster/',
+				description: 'Project management and site operations',
+			},
+		],
+	},
+	{
+		skillId: 'communication',
+		docs: [
+			{
+				title: 'Introduction',
+				path: '/guides/intro/',
+				description: 'KBVE services overview and documentation',
+			},
+			{
+				title: 'Getting Started',
+				path: '/guides/getting-started/',
+				description: 'Onboarding guide for new contributors',
+			},
+		],
+	},
+	{
+		skillId: 'problemsolving',
+		docs: [
+			{
+				title: 'Automation',
+				path: '/theory/automation/',
+				description: 'Automating workflows and processes',
+			},
+			{
+				title: 'Technical Specifications',
+				path: '/advanced/technical-specifications/',
+				description: 'Architecture and design decisions',
+			},
+		],
+	},
+	{
+		skillId: 'collaboration',
+		docs: [
+			{
+				title: 'API',
+				path: '/project/api/',
+				description: 'Shared API design and integrations',
+			},
+			{
+				title: 'Git',
+				path: '/application/git/',
+				description: 'Version control and collaboration',
+			},
+		],
+	},
+	{
+		skillId: 'adaptability',
+		docs: [
+			{
+				title: 'First Project Checklist',
+				path: '/guides/first-project-checklist/',
+				description: 'Getting up to speed on new projects',
+			},
+		],
+	},
+	{
+		skillId: 'mentoring',
+		docs: [
+			{
+				title: 'Getting Started',
+				path: '/guides/getting-started/',
+				description: 'Guiding newcomers through the codebase',
+			},
+		],
+	},
+];
+
+export function getSkillDocs(skillId: string): SkillDoc[] {
+	const entry = skillDocs.find((e) => e.skillId === skillId);
+	return entry?.docs ?? [];
+}

--- a/apps/kbve/astro-kbve/src/components/jay/jay_service.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/jay_service.ts
@@ -31,36 +31,42 @@ export const hardSkills: Skill[] = [
 		description:
 			'Full-stack development with TypeScript, Python, Rust, and more',
 		level: 'expert',
+		link: '/theory/programming/',
 	},
 	{
 		id: 'devops',
 		name: 'DevOps & Cloud',
 		description: 'AWS, GCP, Docker, Kubernetes, CI/CD pipelines',
 		level: 'advanced',
+		link: '/application/docker/',
 	},
 	{
 		id: 'databases',
 		name: 'Databases',
 		description: 'PostgreSQL, MongoDB, Redis, Supabase',
 		level: 'advanced',
+		link: '/application/sql/',
 	},
 	{
 		id: 'gamedev',
 		name: 'Game Development',
 		description: 'Unity, Phaser, Godot, and custom engines',
 		level: 'intermediate',
+		link: '/application/unity/',
 	},
 	{
 		id: 'security',
 		name: 'Cybersecurity',
 		description: 'Penetration testing, security audits, CTF competitions',
 		level: 'intermediate',
+		link: '/application/nmap/',
 	},
 	{
 		id: 'ml',
 		name: 'Machine Learning',
 		description: 'TensorFlow, PyTorch, LLM integration',
 		level: 'intermediate',
+		link: '/application/ml/',
 	},
 ];
 
@@ -70,36 +76,42 @@ export const softSkills: Skill[] = [
 		name: 'Leadership',
 		description: 'Team management and project coordination',
 		level: 'advanced',
+		link: '/webmaster/',
 	},
 	{
 		id: 'communication',
 		name: 'Communication',
 		description: 'Technical writing, presentations, and documentation',
 		level: 'advanced',
+		link: '/guides/intro/',
 	},
 	{
 		id: 'problemsolving',
 		name: 'Problem Solving',
 		description: 'Analytical thinking and creative solutions',
 		level: 'expert',
+		link: '/theory/automation/',
 	},
 	{
 		id: 'collaboration',
 		name: 'Collaboration',
 		description: 'Cross-functional teamwork and open source contribution',
 		level: 'advanced',
+		link: '/project/api/',
 	},
 	{
 		id: 'adaptability',
 		name: 'Adaptability',
 		description: 'Quick learner, embraces new technologies',
 		level: 'expert',
+		link: '/guides/first-project-checklist/',
 	},
 	{
 		id: 'mentoring',
 		name: 'Mentoring',
 		description: 'Teaching and guiding junior developers',
 		level: 'intermediate',
+		link: '/guides/getting-started/',
 	},
 ];
 


### PR DESCRIPTION
## Summary
- Add `jay_docs.ts` static mapping that pairs each skill ID with related documentation pages (title, path, description) — covers all 12 skills across hard and soft categories
- Populate `link` fields on all skills in `jay_service.ts` pointing to primary doc pages (e.g., Programming → `/theory/programming/`, DevOps → `/application/docker/`)
- Update `BookModal` in `ReactJayYuki.tsx` to show:
  - **Related scrolls** — tag-style chips linking to related doc pages (e.g., JavaScript, Python, Rust for the Programming skill)
  - **Read More** button — opens the primary documentation page in a new window
  - Both styled to match the existing parchment/book aesthetic (Georgia serif, brown tones)

## Test plan
- [ ] Open a book in the Yuki scene (click bookshelf or skill drawer card)
- [ ] Verify "Related scrolls" chips appear below the description text
- [ ] Click a chip — confirm it opens the correct doc page in a new tab
- [ ] Verify "Read More" button appears and opens the primary doc in a new tab
- [ ] Test with all 6 hard skills and 6 soft skills
- [ ] Confirm modal close still works (X button, click-to-close text, backdrop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)