### PR TITLE
feat(axum-kbve): JWT-gated Grafana reverse proxy

### DIFF
--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -88,6 +88,13 @@ async fn main() -> anyhow::Result<()> {
         warn!("JWT cache not initialized - SUPABASE_URL or SUPABASE_ANON_KEY not set");
     }
 
+    // Initialize Grafana reverse proxy (optional - for /dashboard/grafana)
+    if transport::proxy::init_grafana_proxy() {
+        info!("Grafana proxy initialized - /dashboard/grafana enabled");
+    } else {
+        info!("Grafana proxy not configured (GRAFANA_UPSTREAM_URL not set)");
+    }
+
     // Shared application state
     let state = transport::https::AppState::new();
 

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -8,7 +8,7 @@ use axum::{
     http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header},
     middleware::Next,
     response::{IntoResponse, Redirect, Response},
-    routing::{get, post},
+    routing::{any, get, post},
 };
 use serde::Serialize;
 use serde_json::json;
@@ -162,7 +162,20 @@ fn router(state: AppState) -> Router {
         )
         .with_state(state);
 
-    static_router.merge(public_router).layer(middleware)
+    let main_app = static_router.merge(public_router).layer(middleware);
+
+    // Grafana proxy routes bypass global middleware (no 10s timeout, no 1MB body limit)
+    let proxy_router = Router::new()
+        .route(
+            "/dashboard/grafana/{*path}",
+            any(super::proxy::grafana_proxy_handler),
+        )
+        .route(
+            "/dashboard/grafana",
+            any(super::proxy::grafana_proxy_handler),
+        );
+
+    proxy_router.merge(main_app)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kbve/axum-kbve/src/transport/mod.rs
+++ b/apps/kbve/axum-kbve/src/transport/mod.rs
@@ -1,1 +1,2 @@
 pub mod https;
+pub mod proxy;

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -1,0 +1,213 @@
+use std::sync::OnceLock;
+
+use axum::{
+    body::Body,
+    extract::{Path, Request},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use reqwest::Client;
+use serde_json::json;
+use tracing::{debug, warn};
+
+use crate::auth::{extract_bearer_token, get_jwt_cache};
+
+// ---------------------------------------------------------------------------
+// GrafanaProxy singleton
+// ---------------------------------------------------------------------------
+
+struct GrafanaProxy {
+    client: Client,
+    upstream: String,
+}
+
+static GRAFANA_PROXY: OnceLock<GrafanaProxy> = OnceLock::new();
+
+pub fn init_grafana_proxy() -> bool {
+    let upstream = match std::env::var("GRAFANA_UPSTREAM_URL") {
+        Ok(u) => u.trim_end_matches('/').to_string(),
+        Err(_) => return false,
+    };
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("failed to build reqwest client for grafana proxy");
+
+    GRAFANA_PROXY.set(GrafanaProxy { client, upstream }).is_ok()
+}
+
+fn get_grafana_proxy() -> Option<&'static GrafanaProxy> {
+    GRAFANA_PROXY.get()
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+pub async fn grafana_proxy_handler(
+    path: Option<Path<String>>,
+    req: Request<Body>,
+) -> impl IntoResponse {
+    // --- JWT auth gate ---
+    let auth_header = match req.headers().get(header::AUTHORIZATION) {
+        Some(h) => match h.to_str() {
+            Ok(s) => s.to_string(),
+            Err(_) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    axum::Json(json!({"error": "Invalid Authorization header encoding"})),
+                )
+                    .into_response();
+            }
+        },
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                axum::Json(json!({
+                    "error": "Missing Authorization header",
+                    "hint": "Include 'Authorization: Bearer <token>' header"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let token = match extract_bearer_token(&auth_header) {
+        Some(t) => t.to_string(),
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                axum::Json(json!({"error": "Invalid Authorization header format"})),
+            )
+                .into_response();
+        }
+    };
+
+    let jwt_cache = match get_jwt_cache() {
+        Some(c) => c,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({"error": "JWT validation not configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(e) = jwt_cache.verify_and_cache(&token).await {
+        warn!("Grafana proxy JWT rejected: {e}");
+        return (
+            StatusCode::UNAUTHORIZED,
+            axum::Json(json!({"error": "Invalid or expired token"})),
+        )
+            .into_response();
+    }
+
+    // --- Proxy ---
+    let proxy = match get_grafana_proxy() {
+        Some(p) => p,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({"error": "Grafana proxy not configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    let suffix = path.map(|Path(p)| p).unwrap_or_default();
+    let query = req
+        .uri()
+        .query()
+        .map(|q| format!("?{q}"))
+        .unwrap_or_default();
+    let upstream_url = format!("{}/{}{}", proxy.upstream, suffix, query);
+
+    let method = req.method().clone();
+    let mut headers = req.headers().clone();
+    headers.remove(header::HOST);
+    headers.remove(header::AUTHORIZATION);
+
+    let body_bytes = match axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                axum::Json(json!({"error": "Request body too large"})),
+            )
+                .into_response();
+        }
+    };
+
+    debug!(%upstream_url, %method, "proxying to grafana");
+
+    let upstream_req = proxy
+        .client
+        .request(method, &upstream_url)
+        .headers(reqwest_headers(&headers))
+        .body(body_bytes);
+
+    let upstream_resp = match upstream_req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Grafana upstream error: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(json!({"error": "Grafana upstream unreachable"})),
+            )
+                .into_response();
+        }
+    };
+
+    let status = StatusCode::from_u16(upstream_resp.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+    let mut resp_headers = HeaderMap::new();
+    for (k, v) in upstream_resp.headers() {
+        if let Ok(name) = axum::http::HeaderName::from_bytes(k.as_str().as_bytes()) {
+            if let Ok(val) = HeaderValue::from_bytes(v.as_bytes()) {
+                resp_headers.insert(name, val);
+            }
+        }
+    }
+
+    let resp_body = match upstream_resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("Grafana upstream body read error: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(json!({"error": "Failed to read upstream response"})),
+            )
+                .into_response();
+        }
+    };
+
+    let mut response = Response::builder().status(status);
+    if let Some(h) = response.headers_mut() {
+        *h = resp_headers;
+    }
+    response
+        .body(Body::from(resp_body))
+        .unwrap_or_else(|_| {
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .unwrap()
+        })
+        .into_response()
+}
+
+// Convert axum HeaderMap to reqwest HeaderMap
+fn reqwest_headers(headers: &HeaderMap) -> reqwest::header::HeaderMap {
+    let mut out = reqwest::header::HeaderMap::new();
+    for (k, v) in headers {
+        if let Ok(name) = reqwest::header::HeaderName::from_bytes(k.as_str().as_bytes()) {
+            if let Ok(val) = reqwest::header::HeaderValue::from_bytes(v.as_bytes()) {
+                out.insert(name, val);
+            }
+        }
+    }
+    out
+}

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -78,6 +78,8 @@ spec:
                         value: '25575'
                       - name: MC_RCON_PASSWORD
                         value: 'kbve-rcon'
+                      - name: GRAFANA_UPSTREAM_URL
+                        value: 'http://monitoring-grafana.monitoring.svc.cluster.local:80'
                   resources:
                       requests:
                           memory: '512Mi'

--- a/apps/kube/monitoring/manifests/values.yaml
+++ b/apps/kube/monitoring/manifests/values.yaml
@@ -1,16 +1,16 @@
 grafana:
     ingress:
-        enabled: true
-        ingressClassName: nginx
-        annotations:
-            cert-manager.io/cluster-issuer: letsencrypt-http
-            nginx.ingress.kubernetes.io/backend-protocol: 'HTTP'
-        hosts:
-            - grafana.kbve.com
-        tls:
-            - hosts:
-                  - grafana.kbve.com
-              secretName: grafana-tls
+        enabled: false
+
+    grafana.ini:
+        server:
+            root_url: 'https://kbve.com/dashboard/grafana'
+            serve_from_sub_path: true
+        auth.anonymous:
+            enabled: true
+            org_role: Viewer
+        auth:
+            disable_login_form: true
 
     admin:
         existingSecret: grafana-admin
@@ -31,7 +31,7 @@ grafana:
                       path: /var/lib/grafana/dashboards/default
 
     dashboardsConfigMaps:
-        default: "grafana-dashboards"
+        default: 'grafana-dashboards'
 
 prometheus-node-exporter:
     tolerations:
@@ -40,22 +40,22 @@ prometheus-node-exporter:
           effect: NoSchedule
         - operator: Exists
           effect: NoSchedule
-        - operator: Exists 
+        - operator: Exists
           effect: NoExecute
     podAnnotations:
         pod-security.kubernetes.io/enforce: privileged
         pod-security.kubernetes.io/audit: privileged
         pod-security.kubernetes.io/warn: privileged
-    
+
     hostNetwork: true
     hostPID: true
-    
+
     securityContext:
         fsGroup: 65534
         runAsGroup: 65534
         runAsNonRoot: true
         runAsUser: 65534
-    
+
     containerSecurityContext:
         allowPrivilegeEscalation: false
         capabilities:


### PR DESCRIPTION
## Summary
- Adds a reverse proxy at `/dashboard/grafana/*` that forwards requests to the internal Grafana service
- Requires valid JWT authentication before proxying (uses existing Supabase JWT validation)
- Removes `grafana.kbve.com` public ingress — all Grafana access now goes through `kbve.com/dashboard/grafana`
- Configures Grafana for sub-path serving (`serve_from_sub_path: true`) and anonymous viewer auth (JWT gate handles access control)

## Changes
- **New**: `src/transport/proxy.rs` — GrafanaProxy singleton + JWT-gated handler
- **Modified**: `src/transport/mod.rs` — register proxy module
- **Modified**: `src/transport/https.rs` — mount proxy routes before global middleware (bypasses 10s timeout + 1MB body limit)
- **Modified**: `src/main.rs` — init GrafanaProxy on startup
- **Modified**: `kbve-deployment.yaml` — add `GRAFANA_UPSTREAM_URL` env var
- **Modified**: `values.yaml` — disable ingress, add sub-path + anonymous auth config

## Test plan
- [ ] Build compiles locally (`cargo check -p axum-kbve` passes)
- [ ] Set `GRAFANA_UPSTREAM_URL=http://localhost:3000` locally — verify 401 without JWT, proxy attempt with JWT
- [ ] After deploy: verify `kbve.com/dashboard/grafana` loads with valid JWT
- [ ] Verify `grafana.kbve.com` no longer resolves after ingress removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)