### PR TITLE
feat(astro-memes): polish bento grid with react-spring animations

### DIFF
--- a/apps/memes/astro-memes/src/components/feed/BentoFeed.tsx
+++ b/apps/memes/astro-memes/src/components/feed/BentoFeed.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useTrail, config } from '@react-spring/web';
 import BentoMemeCard from './BentoMemeCard';
 import MemeLightbox from './MemeLightbox';
 import type { FeedMeme } from '../../lib/memeService';
@@ -34,6 +35,21 @@ export default function BentoFeed({
 }: BentoFeedProps) {
 	const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
 	const sentinelRef = useRef<HTMLDivElement>(null);
+	const prevCount = useRef(0);
+
+	// Track how many memes were already rendered for entrance animation
+	const animateFrom = useMemo(() => {
+		const from = prevCount.current;
+		prevCount.current = memes.length;
+		return from;
+	}, [memes.length]);
+
+	// Trail animation for staggered card entrance
+	const trail = useTrail(memes.length, {
+		from: { opacity: 0, y: 24 },
+		to: { opacity: 1, y: 0 },
+		config: { ...config.gentle, clamp: true },
+	});
 
 	// Infinite scroll sentinel
 	useEffect(() => {
@@ -75,20 +91,33 @@ export default function BentoFeed({
 	return (
 		<>
 			<div
-				className="w-full min-h-screen px-4 py-6"
+				className="w-full min-h-screen px-4 md:px-6 lg:px-8 py-8"
 				style={{
 					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
 				}}>
 				{/* Bento grid */}
-				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 max-w-7xl mx-auto">
-					{memes.map((meme, i) => (
-						<BentoMemeCard
-							key={meme.id}
-							meme={meme}
-							featured={i % 7 === 3}
-							onExpand={handleExpand}
-						/>
-					))}
+				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 max-w-7xl mx-auto">
+					{trail.map((springStyle, i) => {
+						const meme = memes[i];
+						const shouldAnimate = i >= animateFrom;
+						return (
+							<BentoMemeCard
+								key={meme.id}
+								meme={meme}
+								featured={i % 7 === 3}
+								onExpand={handleExpand}
+								style={
+									shouldAnimate
+										? {
+												opacity:
+													springStyle.opacity.get(),
+												transform: `translateY(${springStyle.y.get()}px)`,
+											}
+										: undefined
+								}
+							/>
+						);
+					})}
 				</div>
 
 				{/* Sentinel */}
@@ -96,29 +125,32 @@ export default function BentoFeed({
 					<div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
 				)}
 
-				{/* Loading more */}
+				{/* Loading more — shimmer skeleton cards */}
 				{loadingMore && (
-					<div className="flex justify-center py-8">
-						<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 max-w-7xl mx-auto w-full">
-							{[...Array(4)].map((_, i) => (
-								<div
-									key={i}
-									className="aspect-[4/3] rounded-xl animate-pulse"
-									style={{
-										backgroundColor:
-											'var(--sl-color-gray-6, #1c1c1e)',
-									}}
-								/>
-							))}
-						</div>
+					<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 max-w-7xl mx-auto mt-4">
+						{[...Array(4)].map((_, i) => (
+							<div
+								key={i}
+								className="aspect-[4/3] rounded-2xl overflow-hidden"
+								style={{
+									background:
+										'linear-gradient(110deg, var(--sl-color-gray-6, #1c1c1e) 30%, var(--sl-color-gray-5, #27272a) 50%, var(--sl-color-gray-6, #1c1c1e) 70%)',
+									backgroundSize: '200% 100%',
+									animation:
+										'shimmer 1.5s ease-in-out infinite',
+									animationDelay: `${i * 100}ms`,
+									border: '1px solid rgba(255,255,255,0.04)',
+								}}
+							/>
+						))}
 					</div>
 				)}
 
 				{/* End of feed */}
 				{!hasMore && memes.length > 0 && (
-					<div className="flex items-center justify-center py-12">
+					<div className="flex items-center justify-center py-16">
 						<p
-							className="text-sm"
+							className="text-sm tracking-wide"
 							style={{
 								color: 'var(--sl-color-gray-3, #71717a)',
 							}}>

--- a/apps/memes/astro-memes/src/components/feed/BentoMemeCard.tsx
+++ b/apps/memes/astro-memes/src/components/feed/BentoMemeCard.tsx
@@ -1,3 +1,5 @@
+import { useState, useCallback } from 'react';
+import { useSpring, animated, config } from '@react-spring/web';
 import { ExternalLink, Eye, Flame } from 'lucide-react';
 import type { FeedMeme } from '../../lib/memeService';
 
@@ -5,29 +7,69 @@ interface BentoMemeCardProps {
 	meme: FeedMeme;
 	featured?: boolean;
 	onExpand: (meme: FeedMeme) => void;
+	style?: React.CSSProperties;
 }
 
 export default function BentoMemeCard({
 	meme,
 	featured,
 	onExpand,
+	style,
 }: BentoMemeCardProps) {
 	const isVideo = meme.format === 2 || meme.format === 3;
+	const [hovered, setHovered] = useState(false);
+	const [imgLoaded, setImgLoaded] = useState(false);
+
+	const hoverSpring = useSpring({
+		scale: hovered ? 1.02 : 1,
+		shadow: hovered ? 20 : 0,
+		overlayOpacity: hovered ? 1 : 0,
+		config: config.gentle,
+	});
+
+	const imgSpring = useSpring({
+		opacity: imgLoaded ? 1 : 0,
+		config: { duration: 300 },
+	});
+
+	const handleMouseEnter = useCallback(() => setHovered(true), []);
+	const handleMouseLeave = useCallback(() => setHovered(false), []);
 
 	return (
-		<button
+		<animated.button
 			type="button"
 			onClick={() => onExpand(meme)}
-			className={`group relative overflow-hidden rounded-xl transition-shadow duration-200 hover:shadow-lg hover:shadow-black/30 focus:outline-none ${
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+			className={`relative overflow-hidden rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/50 ${
 				featured ? 'md:col-span-2' : ''
 			}`}
 			style={{
-				border: '1px solid var(--sl-color-hairline, rgba(255,255,255,0.06))',
+				...style,
+				transform: hoverSpring.scale.to((s) => `scale(${s})`),
+				boxShadow: hoverSpring.shadow.to(
+					(s) =>
+						`0 ${s * 0.5}px ${s}px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.06)`,
+				),
 				backgroundColor: 'var(--sl-color-gray-6, #1c1c1e)',
+				willChange: 'transform',
 			}}>
 			{/* Thumbnail */}
 			<div
 				className={`w-full ${featured ? 'aspect-video' : 'aspect-[4/3]'}`}>
+				{/* Shimmer placeholder */}
+				{!imgLoaded && (
+					<div
+						className="absolute inset-0 overflow-hidden"
+						style={{
+							background:
+								'linear-gradient(110deg, var(--sl-color-gray-6, #1c1c1e) 30%, var(--sl-color-gray-5, #27272a) 50%, var(--sl-color-gray-6, #1c1c1e) 70%)',
+							backgroundSize: '200% 100%',
+							animation: 'shimmer 1.5s ease-in-out infinite',
+						}}
+					/>
+				)}
+
 				{isVideo ? (
 					<video
 						src={meme.asset_url}
@@ -35,85 +77,108 @@ export default function BentoMemeCard({
 						muted
 						playsInline
 						preload="metadata"
+						onLoadedData={() => setImgLoaded(true)}
 					/>
 				) : (
-					<img
+					<animated.img
 						src={meme.thumbnail_url || meme.asset_url}
 						alt={meme.title || 'Meme'}
 						className="w-full h-full object-cover select-none"
 						loading="lazy"
 						draggable={false}
+						onLoad={() => setImgLoaded(true)}
+						style={{ opacity: imgSpring.opacity }}
 					/>
 				)}
 			</div>
 
 			{/* Hover overlay */}
-			<div className="absolute inset-0 flex flex-col justify-end opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+			<animated.div
+				className="absolute inset-0 flex flex-col justify-end"
+				style={{ opacity: hoverSpring.overlayOpacity }}>
 				{/* Gradient */}
 				<div
 					className="absolute inset-0"
 					style={{
 						background:
-							'linear-gradient(transparent 30%, rgba(0,0,0,0.75))',
+							'linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 40%, transparent 70%)',
 					}}
 				/>
 
 				{/* Content */}
-				<div className="relative p-3">
+				<div className="relative p-3.5 pb-3">
 					{meme.title && (
-						<h3 className="text-white text-sm font-semibold leading-tight line-clamp-2 mb-1.5">
+						<h3 className="text-white text-sm font-semibold leading-snug line-clamp-2 mb-1.5 text-left">
 							{meme.title}
 						</h3>
 					)}
 
-					{meme.author_name && (
-						<p className="text-white/60 text-xs mb-2">
-							@{meme.author_name}
-						</p>
-					)}
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-3">
+							{meme.author_name && (
+								<p className="text-white/50 text-xs">
+									@{meme.author_name}
+								</p>
+							)}
+						</div>
 
-					{/* Stats row */}
-					<div className="flex items-center gap-3 text-white/50 text-xs">
-						<span className="inline-flex items-center gap-1">
-							<Eye size={12} />
-							{formatCount(meme.view_count)}
-						</span>
-						<span className="inline-flex items-center gap-1">
-							<Flame size={12} />
-							{formatCount(meme.reaction_count)}
-						</span>
+						{/* Stats */}
+						<div className="flex items-center gap-2.5 text-white/40 text-[11px]">
+							<span className="inline-flex items-center gap-1">
+								<Eye size={11} />
+								{formatCount(meme.view_count)}
+							</span>
+							<span className="inline-flex items-center gap-1">
+								<Flame size={11} />
+								{formatCount(meme.reaction_count)}
+							</span>
+						</div>
 					</div>
 				</div>
-			</div>
+			</animated.div>
 
-			{/* Share button — always visible top-right */}
-			<a
-				href={`/meme?id=${meme.id}`}
-				target="_blank"
-				rel="noopener noreferrer"
-				onClick={(e) => e.stopPropagation()}
-				className="absolute top-2 right-2 p-1.5 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 backdrop-blur-sm"
-				style={{
-					backgroundColor: 'rgba(0,0,0,0.4)',
-				}}
-				title="Open in new tab"
-				aria-label="Open meme in new tab">
-				<ExternalLink size={14} className="text-white/80" />
-			</a>
+			{/* Share button — top-right, visible on hover */}
+			<animated.div
+				className="absolute top-2.5 right-2.5"
+				style={{ opacity: hoverSpring.overlayOpacity }}>
+				<a
+					href={`/meme?id=${meme.id}`}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={(e) => e.stopPropagation()}
+					className="block p-1.5 rounded-lg backdrop-blur-md transition-colors hover:bg-white/20"
+					style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+					title="Open in new tab"
+					aria-label="Open meme in new tab">
+					<ExternalLink size={13} className="text-white/90" />
+				</a>
+			</animated.div>
 
-			{/* Tags — bottom-left, visible without hover */}
+			{/* Tags — bottom-left on hover */}
 			{meme.tags.length > 0 && (
-				<div className="absolute bottom-2 left-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+				<animated.div
+					className="absolute bottom-2.5 left-3 flex gap-1.5"
+					style={{ opacity: hoverSpring.overlayOpacity }}>
 					{meme.tags.slice(0, 2).map((tag) => (
 						<span
 							key={tag}
-							className="text-[10px] px-1.5 py-0.5 rounded-full bg-white/10 text-white/50 backdrop-blur-sm">
+							className="text-[10px] px-2 py-0.5 rounded-full backdrop-blur-md text-white/60"
+							style={{
+								backgroundColor: 'rgba(255,255,255,0.1)',
+							}}>
 							#{tag}
 						</span>
 					))}
-				</div>
+				</animated.div>
 			)}
-		</button>
+
+			<style>{`
+				@keyframes shimmer {
+					0% { background-position: 200% 0; }
+					100% { background-position: -200% 0; }
+				}
+			`}</style>
+		</animated.button>
 	);
 }
 

--- a/apps/memes/astro-memes/src/components/feed/FeedSkeleton.tsx
+++ b/apps/memes/astro-memes/src/components/feed/FeedSkeleton.tsx
@@ -8,27 +8,36 @@ export default function FeedSkeleton({
 	if (variant === 'desktop') {
 		return (
 			<div
-				className="w-full min-h-screen px-4 py-6"
+				className="w-full min-h-screen px-4 md:px-6 lg:px-8 py-8"
 				style={{
 					backgroundColor: 'var(--sl-color-bg, #0a0a0a)',
 				}}>
-				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 max-w-7xl mx-auto">
+				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 max-w-7xl mx-auto">
 					{[...Array(8)].map((_, i) => (
 						<div
 							key={i}
-							className={`rounded-xl animate-pulse ${
+							className={`rounded-2xl overflow-hidden ${
 								i % 7 === 3
 									? 'md:col-span-2 aspect-video'
 									: 'aspect-[4/3]'
 							}`}
 							style={{
-								backgroundColor:
-									'var(--sl-color-gray-6, #1c1c1e)',
+								background:
+									'linear-gradient(110deg, var(--sl-color-gray-6, #1c1c1e) 30%, var(--sl-color-gray-5, #27272a) 50%, var(--sl-color-gray-6, #1c1c1e) 70%)',
+								backgroundSize: '200% 100%',
+								animation: 'shimmer 1.5s ease-in-out infinite',
+								animationDelay: `${i * 80}ms`,
 								border: '1px solid rgba(255,255,255,0.04)',
 							}}
 						/>
 					))}
 				</div>
+				<style>{`
+					@keyframes shimmer {
+						0% { background-position: 200% 0; }
+						100% { background-position: -200% 0; }
+					}
+				`}</style>
 			</div>
 		);
 	}

--- a/apps/memes/astro-memes/src/components/feed/MemeLightbox.tsx
+++ b/apps/memes/astro-memes/src/components/feed/MemeLightbox.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
+import { useSpring, animated, config } from '@react-spring/web';
 import { X, ChevronLeft, ChevronRight, ExternalLink, User } from 'lucide-react';
 import ReactionBar from './ReactionBar';
 import type { FeedMeme } from '../../lib/memeService';
@@ -33,14 +34,42 @@ export default function MemeLightbox({
 	onNext,
 }: MemeLightboxProps) {
 	const isVideo = meme.format === 2 || meme.format === 3;
+	const [closing, setClosing] = useState(false);
+
+	// Backdrop fade
+	const backdropSpring = useSpring({
+		opacity: closing ? 0 : 1,
+		config: { duration: 200 },
+	});
+
+	// Content scale + fade
+	const contentSpring = useSpring({
+		opacity: closing ? 0 : 1,
+		scale: closing ? 0.95 : 1,
+		config: config.stiff,
+	});
+
+	// Animate meme transitions (prev/next navigation)
+	const memeSpring = useSpring({
+		opacity: 1,
+		from: { opacity: 0.6 },
+		reset: true,
+		config: { tension: 300, friction: 28 },
+		key: meme.id,
+	});
+
+	const handleClose = useCallback(() => {
+		setClosing(true);
+		setTimeout(onClose, 180);
+	}, [onClose]);
 
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
-			if (e.key === 'Escape') onClose();
+			if (e.key === 'Escape') handleClose();
 			else if (e.key === 'ArrowLeft' && onPrev) onPrev();
 			else if (e.key === 'ArrowRight' && onNext) onNext();
 		},
-		[onClose, onPrev, onNext],
+		[handleClose, onPrev, onNext],
 	);
 
 	useEffect(() => {
@@ -53,25 +82,26 @@ export default function MemeLightbox({
 	}, [handleKeyDown]);
 
 	return (
-		<div
+		<animated.div
 			className="fixed inset-0 z-50 flex items-center justify-center"
+			style={{ opacity: backdropSpring.opacity }}
 			role="dialog"
 			aria-modal="true"
 			aria-label={meme.title || 'Meme viewer'}>
 			{/* Backdrop */}
 			<div
-				className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-				onClick={onClose}
+				className="absolute inset-0 bg-black/75 backdrop-blur-md"
+				onClick={handleClose}
 			/>
 
 			{/* Close button */}
 			<button
 				type="button"
-				onClick={onClose}
-				className="absolute top-4 right-4 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
-				style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+				onClick={handleClose}
+				className="absolute top-4 right-4 z-10 p-2.5 rounded-full backdrop-blur-md transition-colors hover:bg-white/15"
+				style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
 				aria-label="Close">
-				<X size={20} className="text-white" />
+				<X size={18} className="text-white" />
 			</button>
 
 			{/* Open in new tab */}
@@ -79,11 +109,11 @@ export default function MemeLightbox({
 				href={`/meme?id=${meme.id}`}
 				target="_blank"
 				rel="noopener noreferrer"
-				className="absolute top-4 right-16 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
-				style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+				className="absolute top-4 right-16 z-10 p-2.5 rounded-full backdrop-blur-md transition-colors hover:bg-white/15"
+				style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
 				title="Open in new tab"
 				aria-label="Open meme in new tab">
-				<ExternalLink size={18} className="text-white/80" />
+				<ExternalLink size={16} className="text-white/80" />
 			</a>
 
 			{/* Prev arrow */}
@@ -91,10 +121,10 @@ export default function MemeLightbox({
 				<button
 					type="button"
 					onClick={onPrev}
-					className="absolute left-4 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
-					style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+					className="absolute left-4 z-10 p-2.5 rounded-full backdrop-blur-md transition-colors hover:bg-white/15"
+					style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
 					aria-label="Previous meme">
-					<ChevronLeft size={24} className="text-white" />
+					<ChevronLeft size={22} className="text-white" />
 				</button>
 			)}
 
@@ -103,25 +133,33 @@ export default function MemeLightbox({
 				<button
 					type="button"
 					onClick={onNext}
-					className="absolute right-4 z-10 p-2 rounded-full backdrop-blur-md transition-colors hover:bg-white/10"
-					style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+					className="absolute right-4 z-10 p-2.5 rounded-full backdrop-blur-md transition-colors hover:bg-white/15"
+					style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
 					aria-label="Next meme">
-					<ChevronRight size={24} className="text-white" />
+					<ChevronRight size={22} className="text-white" />
 				</button>
 			)}
 
 			{/* Content area */}
-			<div className="relative flex items-start gap-4 max-w-5xl w-full mx-4 max-h-[90vh]">
+			<animated.div
+				className="relative flex items-start gap-4 max-w-5xl w-full mx-4 max-h-[90vh]"
+				style={{
+					opacity: contentSpring.opacity,
+					transform: contentSpring.scale.to((s) => `scale(${s})`),
+				}}>
 				{/* Main image + info */}
-				<div className="flex-1 min-w-0 flex flex-col items-center">
+				<animated.div
+					className="flex-1 min-w-0 flex flex-col items-center"
+					style={{ opacity: memeSpring.opacity }}>
 					{/* Meme asset */}
 					<div className="max-h-[75vh] flex items-center justify-center w-full">
 						{isVideo ? (
 							<video
 								src={meme.asset_url}
-								className="max-w-full max-h-[75vh] object-contain rounded-xl"
+								className="max-w-full max-h-[75vh] object-contain rounded-2xl"
 								style={{
-									border: '1px solid rgba(255,255,255,0.06)',
+									border: '1px solid rgba(255,255,255,0.08)',
+									boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
 								}}
 								autoPlay
 								loop
@@ -132,9 +170,10 @@ export default function MemeLightbox({
 							<img
 								src={meme.asset_url}
 								alt={meme.title || 'Meme'}
-								className="max-w-full max-h-[75vh] object-contain rounded-xl select-none"
+								className="max-w-full max-h-[75vh] object-contain rounded-2xl select-none"
 								style={{
-									border: '1px solid rgba(255,255,255,0.06)',
+									border: '1px solid rgba(255,255,255,0.08)',
+									boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
 								}}
 								draggable={false}
 							/>
@@ -142,10 +181,10 @@ export default function MemeLightbox({
 					</div>
 
 					{/* Info below image */}
-					<div className="w-full mt-3 px-2">
+					<div className="w-full mt-4 px-2">
 						{meme.title && (
 							<h2
-								className="text-base font-semibold leading-tight mb-2 line-clamp-2"
+								className="text-base font-semibold leading-tight mb-2.5 line-clamp-2"
 								style={{
 									color: 'var(--sl-color-white, #e2e8f0)',
 								}}>
@@ -165,6 +204,10 @@ export default function MemeLightbox({
 											src={meme.author_avatar}
 											alt={meme.author_name}
 											className="w-7 h-7 rounded-full"
+											style={{
+												boxShadow:
+													'0 0 0 2px rgba(255,255,255,0.1)',
+											}}
 										/>
 									) : (
 										<div
@@ -207,18 +250,22 @@ export default function MemeLightbox({
 						</div>
 
 						{meme.tags.length > 0 && (
-							<div className="flex flex-wrap gap-1.5 mt-2">
+							<div className="flex flex-wrap gap-1.5 mt-2.5">
 								{meme.tags.slice(0, 5).map((tag) => (
 									<span
 										key={tag}
-										className="text-[11px] px-2 py-0.5 rounded-full bg-white/10 text-white/50">
+										className="text-[11px] px-2.5 py-0.5 rounded-full text-white/50"
+										style={{
+											backgroundColor:
+												'rgba(255,255,255,0.08)',
+										}}>
 										#{tag}
 									</span>
 								))}
 							</div>
 						)}
 					</div>
-				</div>
+				</animated.div>
 
 				{/* Reaction bar — right side */}
 				<div className="flex-shrink-0 pt-4">
@@ -238,7 +285,7 @@ export default function MemeLightbox({
 						onReport={onReport}
 					/>
 				</div>
-			</div>
-		</div>
+			</animated.div>
+		</animated.div>
 	);
 }


### PR DESCRIPTION
## Summary
- Added `@react-spring/web` animations to the desktop bento grid feed (closes #7548 partially)
- **BentoMemeCard**: spring-based hover scale + dynamic shadow, image fade-in on load, shimmer placeholder while images load, focus-visible accessibility ring
- **BentoFeed**: staggered card entrance via `useTrail` (fade + slide-up), only animates newly loaded batches on infinite scroll
- **MemeLightbox**: animated backdrop fade, content scale-in on open, smooth close animation, crossfade between memes on prev/next navigation
- **FeedSkeleton**: desktop variant uses shimmer gradient with staggered delays instead of flat pulse

## Test plan
- [ ] Desktop (`>=768px`): bento grid cards cascade in with staggered animation on initial load
- [ ] Hover over cards: smooth spring scale + shadow effect
- [ ] Click card: lightbox opens with scale animation, backdrop fades in
- [ ] Navigate prev/next in lightbox: meme crossfades
- [ ] Close lightbox: smooth scale-down + fade-out
- [ ] Infinite scroll: new batch of cards animates in, existing cards stay static
- [ ] Mobile (`<768px`): unchanged vertical scroll-snap feed (no regressions)
- [ ] Loading state: shimmer skeletons with staggered timing