### PR TITLE
fix(kube): fix broken TLS certs across 3 ingresses + cryptothrone www removal

### DIFF
--- a/apps/kube/cryptothrone/manifest/cryptothrone-ingress.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-ingress.yaml
@@ -12,20 +12,9 @@ spec:
     tls:
         - hosts:
               - cryptothrone.com
-              - www.cryptothrone.com
           secretName: cryptothrone-tls
     rules:
         - host: cryptothrone.com
-          http:
-              paths:
-                  - path: /
-                    pathType: Prefix
-                    backend:
-                        service:
-                            name: cryptothrone-service
-                            port:
-                                number: 4321
-        - host: www.cryptothrone.com
           http:
               paths:
                   - path: /


### PR DESCRIPTION
## Summary
- **cryptothrone.com**: Removed `www.cryptothrone.com` from ingress (no DNS record, blocking cert issuance)
- **api.kbve.com + supabase.kbve.com**: Changed `letsencrypt-prod` → `letsencrypt-http` (issuer doesn't exist)
- **discord.sh**: Changed `letsencrypt-prod` → `letsencrypt-http`
- **notification.kbve.com**: Changed `letsencrypt-prod` → `letsencrypt-http`

## Root cause
`letsencrypt-prod` ClusterIssuer does not exist. The only production issuer is `letsencrypt-http`. Three ingresses referenced the non-existent issuer, preventing cert-manager from issuing/renewing certificates.

## Affected certificates (all currently READY: False)
| Certificate | Namespace | Domains |
|---|---|---|
| kilobase-api-tls | kilobase | api.kbve.com, supabase.kbve.com |
| discordsh-tls | discordsh | discord.sh |
| notification-bot-tls | discord | notification.kbve.com |
| cryptothrone-tls | cryptothrone | cryptothrone.com (was blocked by www) |

## Test plan
- [ ] After ArgoCD sync, `kubectl get certificate -A` shows all four certs READY: True
- [ ] `curl -I https://api.kbve.com` returns 200 (not 526)
- [ ] `curl -I https://discord.sh` returns valid response
- [ ] `curl -I https://cryptothrone.com` returns 200
- [ ] `kubectl get challenges -A` shows no stuck challenges