### PR TITLE
chore(discordsh): bump axum-discordsh to 0.1.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.26"
+version = "0.1.27"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump `axum-discordsh` version from `0.1.26` to `0.1.27` after inventory card feature merge

## Test plan
- [x] `cargo check -p axum-discordsh` passes