### PR TITLE
chore(cryptothrone): bump to 0.1.1

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Cargo.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-cryptothrone"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps `axum-cryptothrone` from `0.1.0` → `0.1.1` to trigger the full CI pipeline: build → e2e → Docker publish → kube manifest update.

## Test plan
- [ ] Verify cryptothrone Docker image `ghcr.io/kbve/cryptothrone:0.1.1` is published
- [ ] Verify "Update Kube Manifests" job runs for cryptothrone and updates deployment to 0.1.1