### PR TITLE
fix(ci): reduce Astro build memory and forward CI config to e2e

### DIFF
--- a/apps/kbve/axum-kbve-e2e/project.json
+++ b/apps/kbve/axum-kbve-e2e/project.json
@@ -10,7 +10,13 @@
 		},
 		"e2e": {
 			"executor": "nx:run-commands",
-			"dependsOn": ["axum-kbve:container"],
+			"dependsOn": [
+				{
+					"target": "container",
+					"projects": ["axum-kbve"],
+					"params": "forward"
+				}
+			],
 			"cache": false,
 			"options": {
 				"commands": [

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -35,7 +35,7 @@ COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 WORKDIR /app/apps/kbve/astro-kbve
 RUN --mount=type=cache,target=/app/apps/kbve/astro-kbve/.astro,id=astro-cache \
     npx astro sync && \
-    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets


### PR DESCRIPTION
## Summary
- Reduce `--max-old-space-size` from 8192 to 4096 in Dockerfile STAGE A (Astro build) — 8GB exceeds GitHub Actions runner memory (7GB), causing SIGINT/exit code 130 during static route generation
- Forward CI configuration from `axum-kbve-e2e:e2e` → `axum-kbve:container` via `params: "forward"` so the Docker build uses the pre-built base image (`ghcr.io/kbve/kbve-build-base:latest`) and GHA cache instead of building all Rust stages inline

## Test plan
- [ ] Verify CI `axum-kbve-e2e` Docker test passes without exit code 130
- [ ] Verify local `pnpm nx e2e axum-kbve-e2e` still uses `local` configuration (no regression)