### PR TITLE
fix(ci): restore Astro heap size and fix cryptothrone e2e locator

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/smoke.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/smoke.spec.ts
@@ -14,7 +14,7 @@ test.describe('astro-cryptothrone smoke tests', () => {
 
 	test('homepage hero has Play Now link', async ({ page }) => {
 		await page.goto('/');
-		const playLink = page.locator('a[href="/game/play/"]');
+		const playLink = page.locator('a[href="/game/play/"]').first();
 		await expect(playLink).toBeVisible();
 	});
 

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -35,7 +35,7 @@ COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 WORKDIR /app/apps/kbve/astro-kbve
 RUN --mount=type=cache,target=/app/apps/kbve/astro-kbve/.astro,id=astro-cache \
     npx astro sync && \
-    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets


### PR DESCRIPTION
## Summary
- Restore `--max-old-space-size=8192` in Dockerfile — the 4096 reduction caused `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` during Astro static site generation
- With `params: "forward"` already merged (#7673), CI now uses the pre-built base image so Rust stages don't compete for memory — 8GB heap is safe
- Fix cryptothrone `smoke.spec.ts` strict mode violation: `page.locator('a[href="/game/play/"]')` resolved to 2 elements (hero button + sidebar nav link), added `.first()` to target the hero link

## Test plan
- [ ] CI `axum-kbve-e2e` Docker test passes without OOM
- [ ] CI `cryptothrone` Docker test passes (Play Now locator resolves correctly)