### PR TITLE
fix(ci): switch Astro Docker build from Alpine to Debian slim

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_BASE=foundation
 # ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-alpine AS astro-builder
+FROM --platform=linux/amd64 node:24-slim AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 


### PR DESCRIPTION
## Summary
- Switch `node:24-alpine` to `node:24-slim` in Dockerfile STAGE A (Astro build)
- Alpine's musl libc mishandles V8's large heap reservations (`MAP_NORESERVE` not supported), causing SIGINT (exit code 130) during static route generation — even with `--max-old-space-size=8192` and the pre-built Rust base image (no memory competition)
- The HOST Astro build (Debian/glibc) succeeds with identical settings; only the Docker build (Alpine/musl) fails
- Only affects the build stage — the final runtime image (scratch + chisel) is unchanged

## Test plan
- [ ] CI `axum-kbve-e2e` Docker test completes the Astro build without exit code 130
- [ ] Docker image size is comparable (STAGE A output is copied, not the base image)