### PR TITLE
chore(cryptothrone): bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "axum-cryptothrone"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-cryptothrone"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump `axum-cryptothrone` from `0.1.1` to `0.1.2`
- Sync `Cargo.lock`

## Test plan
- [ ] CI builds Docker image and pushes `ghcr.io/kbve/cryptothrone:0.1.2`
- [ ] Verify automated kube manifest PR is created to update deployment image tag