### PR TITLE
chore(axum-kbve): bump version to 1.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.22"
+version = "1.0.23"
 dependencies = [
  "anyhow",
  "askama",
@@ -11384,9 +11384,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.4+spec-1.1.0"
+version = "1.0.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
+checksum = "8825697d11e3935e3ab440a9d672022e540d016ff2f193de4295d11d18244774"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -11717,7 +11717,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.0.4+spec-1.1.0",
+ "toml 1.0.5+spec-1.1.0",
 ]
 
 [[package]]

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.22"
+version = "1.0.23"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps axum-kbve version from 1.0.22 → 1.0.23 to trigger a CI build that validates the Alpine → Debian slim fix from PR #7681

## Test plan
- [ ] CI Docker e2e test (`axum-kbve-e2e`) passes without exit code 130

🤖 Generated with [Claude Code](https://claude.com/claude-code)