### PR TITLE
chore(cryptothrone): replace node:24-alpine with node:24-slim

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_BASE=foundation
 # ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-alpine AS astro-builder
+FROM --platform=linux/amd64 node:24-slim AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 


### PR DESCRIPTION
## Summary
- Replace `node:24-alpine` with `node:24-slim` in the cryptothrone Dockerfile astro-builder stage
- All build stages now use Debian/Ubuntu-based images for consistency (rust:1.90-slim, ubuntu:24.04, scratch+chisel)

## Test plan
- [ ] Docker build succeeds with `node:24-slim` base