### PR TITLE
fix(kilobase): remove explicit certificates block to restore CNPG auto-renewal

### DIFF
--- a/apps/kube/kilobase/manifests/postgres-cluster.yaml
+++ b/apps/kube/kilobase/manifests/postgres-cluster.yaml
@@ -36,17 +36,10 @@ spec:
         size: 40Gi
         storageClass: longhorn
 
-    # Certificate configuration
-    # Certificates are auto-renewed by CNPG operator
-    # These settings ensure longer validity and earlier renewal
-    certificates:
-        # Server certificate for TLS connections
-        serverTLSSecret: supabase-cluster-server
-        serverCASecret: supabase-cluster-ca
-        # Replication certificate for streaming replication
-        replicationTLSSecret: supabase-cluster-replication
-        # Client CA for client certificate authentication
-        clientCASecret: supabase-cluster-ca
+    # TLS certificates are auto-managed by CNPG operator (default behavior)
+    # Do NOT specify explicit certificate secret names — CNPG treats them as
+    # externally-managed and will NOT auto-renew, causing expiry failures.
+    # Phase 2: migrate to cert-manager-issued certs for external lifecycle management.
 
     monitoring:
         enablePodMonitor: true
@@ -104,47 +97,45 @@ spec:
             supautils.reserved_roles: 'supabase_admin, supabase_auth_admin, supabase_storage_admin, supabase_read_only_user, supabase_realtime_admin, supabase_replication_admin, dashboard_user, pgbouncer, service_role*, authenticator*, authenticated*, anon*'
 
         pg_hba:
-          # ripped from supabase/posgres/ansible/files/postgresql_config/pg_hba.conf
-          - local all  supabase_admin       scram-sha-256
-          - local all  all                  peer map=supabase_map
-          - host  all  all  127.0.0.1/32    trust
-          - host  all  all  ::1/128         trust
-          - host  all  all  10.0.0.0/8      scram-sha-256
-          - host  all  all  172.16.0.0/12   scram-sha-256
-          - host  all  all  192.168.0.0/16  scram-sha-256
-          - host  all  all  0.0.0.0/0       scram-sha-256
-          - host  all  all  ::0/0           scram-sha-256
-        
-        pg_ident:
-          # ripped from supabase/posgres/ansible/files/postgresql_config/pg_ident.conf
-          - supabase_map  postgres   postgres
-          - supabase_map  gotrue     supabase_auth_admin
-          - supabase_map  postgrest  authenticator
-          - supabase_map  adminapi   postgres
-        # ripped from supabase/posgres/ansible/files/postgresql_config/postgresql.conf
-        
-        shared_preload_libraries:
-          [
-            pg_stat_statements,
-            pg_stat_monitor,
-            pgaudit,
-            plpgsql,
-            plpgsql_check,
-            pg_cron,
-            pg_net,
-            # orioledb,
-            # timescaledb,
-            auto_explain,
-            pg_tle,
-            supautils,
-            pgsodium,
-            supabase_vault,
-            plan_filter,
-            # Kilobase
-            kilobase,
-            pg_failover_slots
-          ]
+            # ripped from supabase/posgres/ansible/files/postgresql_config/pg_hba.conf
+            - local all  supabase_admin       scram-sha-256
+            - local all  all                  peer map=supabase_map
+            - host  all  all  127.0.0.1/32    trust
+            - host  all  all  ::1/128         trust
+            - host  all  all  10.0.0.0/8      scram-sha-256
+            - host  all  all  172.16.0.0/12   scram-sha-256
+            - host  all  all  192.168.0.0/16  scram-sha-256
+            - host  all  all  0.0.0.0/0       scram-sha-256
+            - host  all  all  ::0/0           scram-sha-256
 
+        pg_ident:
+            # ripped from supabase/posgres/ansible/files/postgresql_config/pg_ident.conf
+            - supabase_map  postgres   postgres
+            - supabase_map  gotrue     supabase_auth_admin
+            - supabase_map  postgrest  authenticator
+            - supabase_map  adminapi   postgres
+        # ripped from supabase/posgres/ansible/files/postgresql_config/postgresql.conf
+
+        shared_preload_libraries: [
+                pg_stat_statements,
+                pg_stat_monitor,
+                pgaudit,
+                plpgsql,
+                plpgsql_check,
+                pg_cron,
+                pg_net,
+                # orioledb,
+                # timescaledb,
+                auto_explain,
+                pg_tle,
+                supautils,
+                pgsodium,
+                supabase_vault,
+                plan_filter,
+                # Kilobase
+                kilobase,
+                pg_failover_slots,
+            ]
 
     env:
         - name: JWT_SECRET
@@ -164,20 +155,20 @@ spec:
               serverName: kilobase-postgres-backup
 
     bootstrap:
-      recovery:
-        source: kilobase-postgres-backup
+        recovery:
+            source: kilobase-postgres-backup
 
     externalClusters:
-      - name: kilobase-postgres-backup
-        barmanObjectStore:
-          destinationPath: s3://kilobase/barman/backup
-          serverName: kilobase-postgres-backup
-          s3Credentials:
-            accessKeyId:
-              name: kilobase-s3-secret
-              key: keyId
-            secretAccessKey:
-              name: kilobase-s3-secret
-              key: accessKey
-          wal:
-            compression: gzip
+        - name: kilobase-postgres-backup
+          barmanObjectStore:
+              destinationPath: s3://kilobase/barman/backup
+              serverName: kilobase-postgres-backup
+              s3Credentials:
+                  accessKeyId:
+                      name: kilobase-s3-secret
+                      key: keyId
+                  secretAccessKey:
+                      name: kilobase-s3-secret
+                      key: accessKey
+              wal:
+                  compression: gzip


### PR DESCRIPTION
## Summary
- Removes the explicit `certificates` block from the CNPG Cluster CR
- CNPG treated explicitly-named secrets as externally-managed, preventing auto-renewal
- When the CA expired (Feb 24, 2026), the operator entered a crash loop — couldn't sign new certs against the expired CA

## Root cause
The `certificates` block in `postgres-cluster.yaml` specified explicit secret names:
```yaml
certificates:
    serverTLSSecret: supabase-cluster-server
    serverCASecret: supabase-cluster-ca
    replicationTLSSecret: supabase-cluster-replication
    clientCASecret: supabase-cluster-ca
```
CNPG treats these as "externally-managed" — it uses them but won't regenerate them. When the 90-day CA expired, the operator couldn't renew server certs (x509 verification failed) and entered a permanent error loop.

## Emergency fix already applied
The cluster was patched live via `kubectl patch` to remove the `certificates` block. CNPG regenerated all 3 secrets immediately and the cluster returned to "Cluster in healthy state". This PR makes the repo match the live state.

## New cert validity
| Secret | Valid From | Valid Until |
|---|---|---|
| supabase-cluster-ca | Mar 6, 2026 | Jun 4, 2026 |
| supabase-cluster-server | Mar 6, 2026 | Jun 4, 2026 |
| supabase-cluster-replication | Mar 6, 2026 | Jun 4, 2026 |

## Test plan
- [x] Database serving queries (verified: auth.users count = 20)
- [x] Cluster phase: "Cluster in healthy state"
- [x] All 3 pods Running (2/2)
- [x] Poolers now running (were stuck waiting for missing pooler secret)
- [ ] ArgoCD sync shows no drift after merge