### PR TITLE
feat(edge): guild-vault edge function for Discord guild token management

### DIFF
--- a/apps/kbve/edge/functions/guild-vault/_shared.ts
+++ b/apps/kbve/edge/functions/guild-vault/_shared.ts
@@ -1,0 +1,278 @@
+// Re-export shared utilities from the centralized module
+export {
+  createServiceClient,
+  extractToken,
+  jsonResponse,
+  type JwtClaims,
+  parseJwt,
+  requireUserToken,
+} from "../_shared/supabase.ts";
+
+import { jsonResponse } from "../_shared/supabase.ts";
+
+// ---------------------------------------------------------------------------
+// Guild-vault-specific request type
+// ---------------------------------------------------------------------------
+
+export interface GuildVaultRequest {
+  token: string;
+  claims: import("../_shared/supabase.ts").JwtClaims;
+  body: Record<string, unknown>;
+  action: string;
+  userId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Validators (guard pattern: return Response on failure, null on success)
+// ---------------------------------------------------------------------------
+
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+const TOKEN_NAME_RE = /^[a-z0-9_-]{3,64}$/;
+const SERVICE_RE = /^[a-z0-9_]{2,32}$/;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function validateSnowflake(
+  id: unknown,
+  field = "server_id",
+): Response | null {
+  if (!id || typeof id !== "string") {
+    return jsonResponse({ error: `${field} is required` }, 400);
+  }
+  if (!SNOWFLAKE_RE.test(id)) {
+    return jsonResponse(
+      { error: `${field} must be a Discord snowflake (17-20 digits)` },
+      400,
+    );
+  }
+  return null;
+}
+
+export function validateTokenName(name: unknown): Response | null {
+  if (!name || typeof name !== "string") {
+    return jsonResponse(
+      { error: "token_name is required (3-64 chars, lowercase a-z0-9_-)" },
+      400,
+    );
+  }
+  if (!TOKEN_NAME_RE.test(name)) {
+    return jsonResponse(
+      { error: "token_name must be 3-64 lowercase chars: a-z, 0-9, _, -" },
+      400,
+    );
+  }
+  return null;
+}
+
+export function validateService(service: unknown): Response | null {
+  if (!service || typeof service !== "string") {
+    return jsonResponse(
+      { error: "service is required (2-32 chars, lowercase a-z0-9_)" },
+      400,
+    );
+  }
+  if (!SERVICE_RE.test(service)) {
+    return jsonResponse(
+      { error: "service must be 2-32 lowercase chars: a-z, 0-9, _" },
+      400,
+    );
+  }
+  return null;
+}
+
+export function validateTokenValue(value: unknown): Response | null {
+  if (!value || typeof value !== "string") {
+    return jsonResponse({ error: "token_value is required" }, 400);
+  }
+  if (value.length < 10 || value.length > 8000) {
+    return jsonResponse(
+      { error: "token_value must be 10-8000 characters" },
+      400,
+    );
+  }
+  return null;
+}
+
+export function validateDescription(desc: unknown): Response | null {
+  if (desc === undefined || desc === null) return null;
+  if (typeof desc !== "string") {
+    return jsonResponse({ error: "description must be a string" }, 400);
+  }
+  if (desc.length > 500) {
+    return jsonResponse(
+      { error: "description must be at most 500 characters" },
+      400,
+    );
+  }
+  return null;
+}
+
+export function validateUuid(
+  id: unknown,
+  field = "token_id",
+): Response | null {
+  if (!id || typeof id !== "string") {
+    return jsonResponse({ error: `${field} (UUID) is required` }, 400);
+  }
+  if (!UUID_RE.test(id)) {
+    return jsonResponse({ error: `${field} must be a valid UUID` }, 400);
+  }
+  return null;
+}
+
+export function validateProviderToken(token: unknown): Response | null {
+  if (!token || typeof token !== "string" || token.trim() === "") {
+    return jsonResponse(
+      { error: "provider_token is required (Discord access token)" },
+      400,
+    );
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Discord API guild ownership verification (cached)
+// ---------------------------------------------------------------------------
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+const OWNERSHIP_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface OwnershipCacheEntry {
+  owned: boolean;
+  timestamp: number;
+}
+
+interface DiscordGuild {
+  id: string;
+  owner: boolean;
+}
+
+const ownershipCache = new Map<string, OwnershipCacheEntry>();
+
+function getCacheKey(userId: string, serverId: string): string {
+  return `${userId}:${serverId}`;
+}
+
+function getCachedOwnership(
+  userId: string,
+  serverId: string,
+): boolean | null {
+  const key = getCacheKey(userId, serverId);
+  const entry = ownershipCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > OWNERSHIP_CACHE_TTL_MS) {
+    ownershipCache.delete(key);
+    return null;
+  }
+  return entry.owned;
+}
+
+function setCachedOwnership(
+  userId: string,
+  serverId: string,
+  owned: boolean,
+): void {
+  ownershipCache.set(getCacheKey(userId, serverId), {
+    owned,
+    timestamp: Date.now(),
+  });
+
+  // Lazy eviction: prune expired entries if cache grows large
+  if (ownershipCache.size > 1000) {
+    const now = Date.now();
+    for (const [k, v] of ownershipCache) {
+      if (now - v.timestamp > OWNERSHIP_CACHE_TTL_MS) {
+        ownershipCache.delete(k);
+      }
+    }
+  }
+}
+
+/**
+ * Invalidate cached ownership for a user+server pair.
+ * Called on RPC failures to detect ownership transfers.
+ */
+export function invalidateOwnershipCache(
+  userId: string,
+  serverId: string,
+): void {
+  ownershipCache.delete(getCacheKey(userId, serverId));
+}
+
+/**
+ * Verify that the user owns the specified Discord guild via Discord API.
+ * Results are cached for 5 minutes to reduce API calls.
+ *
+ * Returns null on success (user is owner), or a Response on failure.
+ * Follows the guard pattern used by validateSnowflake, verifyCaptcha, etc.
+ */
+export async function verifyGuildOwnership(
+  userId: string,
+  serverId: string,
+  providerToken: string,
+): Promise<Response | null> {
+  // Check cache first
+  const cached = getCachedOwnership(userId, serverId);
+  if (cached === true) return null;
+  if (cached === false) {
+    return jsonResponse(
+      { error: "You are not the owner of this Discord server" },
+      403,
+    );
+  }
+
+  // Call Discord API
+  try {
+    const res = await fetch(`${DISCORD_API_BASE}/users/@me/guilds`, {
+      headers: { Authorization: `Bearer ${providerToken}` },
+    });
+
+    if (res.status === 401) {
+      return jsonResponse(
+        { error: "Discord token expired or invalid. Please re-authenticate." },
+        401,
+      );
+    }
+
+    if (res.status === 429) {
+      console.warn(
+        "Discord API rate limited. Retry after:",
+        res.headers.get("retry-after"),
+      );
+      return jsonResponse(
+        { error: "Discord API rate limited. Please try again later." },
+        429,
+      );
+    }
+
+    if (!res.ok) {
+      console.error(`Discord API error: ${res.status} ${res.statusText}`);
+      return jsonResponse(
+        { error: "Failed to verify Discord guild ownership" },
+        502,
+      );
+    }
+
+    const guilds: DiscordGuild[] = await res.json();
+    const guild = guilds.find((g) => g.id === serverId);
+    const isOwner = guild?.owner === true;
+
+    // Cache both positive and negative results
+    setCachedOwnership(userId, serverId, isOwner);
+
+    if (!isOwner) {
+      return jsonResponse(
+        { error: "You are not the owner of this Discord server" },
+        403,
+      );
+    }
+
+    return null;
+  } catch (err) {
+    console.error("Discord guild ownership verification error:", err);
+    return jsonResponse(
+      { error: "Failed to verify Discord guild ownership" },
+      502,
+    );
+  }
+}

--- a/apps/kbve/edge/functions/guild-vault/index.ts
+++ b/apps/kbve/edge/functions/guild-vault/index.ts
@@ -1,0 +1,123 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import {
+  extractToken,
+  type GuildVaultRequest,
+  jsonResponse,
+  parseJwt,
+  requireUserToken,
+} from "./_shared.ts";
+import { handleTokens, TOKEN_ACTIONS } from "./tokens.ts";
+
+// ---------------------------------------------------------------------------
+// Guild Vault Edge Function — Router
+//
+// Auth: authenticated user only (no service_role dual-auth).
+// Discord API ownership verification happens per-action in tokens.ts.
+//
+// Command format: "tokens.action"
+//   tokens: set_token, list_tokens, delete_token, toggle_token
+//
+// Deliberately omits get_token — decrypted secrets are bot-only.
+// ---------------------------------------------------------------------------
+
+const MODULES: Record<
+  string,
+  {
+    handler: (req: GuildVaultRequest) => Promise<Response>;
+    actions: string[];
+  }
+> = {
+  tokens: { handler: handleTokens, actions: TOKEN_ACTIONS },
+};
+
+function buildHelpText(): string {
+  const commands: string[] = [];
+  for (const [mod, { actions }] of Object.entries(MODULES)) {
+    for (const action of actions) {
+      commands.push(`${mod}.${action}`);
+    }
+  }
+  return commands.join(", ");
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+  }
+
+  try {
+    const token = extractToken(req);
+    const claims = await parseJwt(token);
+
+    // Guild vault: authenticated users only (no service_role)
+    const denied = requireUserToken(claims);
+    if (denied) return denied;
+
+    const sub = claims.sub;
+    if (!sub || typeof sub !== "string") {
+      return jsonResponse({ error: "JWT is missing sub claim" }, 401);
+    }
+
+    const body = await req.json();
+    const { command } = body;
+
+    if (!command || typeof command !== "string") {
+      return jsonResponse(
+        {
+          error:
+            `command is required (format: "module.action"). Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const dotIndex = command.indexOf(".");
+    if (dotIndex === -1) {
+      return jsonResponse(
+        {
+          error:
+            `Invalid command format. Use "module.action". Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const moduleName = command.slice(0, dotIndex);
+    const action = command.slice(dotIndex + 1);
+
+    const mod = MODULES[moduleName];
+    if (!mod) {
+      return jsonResponse(
+        {
+          error: `Unknown module: ${moduleName}. Available: ${
+            Object.keys(MODULES).join(", ")
+          }`,
+        },
+        400,
+      );
+    }
+
+    return mod.handler({
+      token,
+      claims,
+      body,
+      action,
+      userId: sub,
+    });
+  } catch (err) {
+    console.error("guild-vault error:", err);
+    const message = err instanceof Error
+      ? err.message
+      : "Internal server error";
+    const status = message.includes("authorization") ||
+        message.includes("JWT")
+      ? 401
+      : 500;
+    return jsonResponse({ error: message }, status);
+  }
+});

--- a/apps/kbve/edge/functions/guild-vault/tokens.ts
+++ b/apps/kbve/edge/functions/guild-vault/tokens.ts
@@ -1,0 +1,244 @@
+import {
+  createServiceClient,
+  type GuildVaultRequest,
+  invalidateOwnershipCache,
+  jsonResponse,
+  validateDescription,
+  validateProviderToken,
+  validateService,
+  validateSnowflake,
+  validateTokenName,
+  validateTokenValue,
+  validateUuid,
+  verifyGuildOwnership,
+} from "./_shared.ts";
+
+// ---------------------------------------------------------------------------
+// Guild token CRUD handlers — all use service client + Discord ownership
+//
+// Deliberately omits get_token — decrypted tokens are bot-only, never
+// exposed through the edge function layer.
+// ---------------------------------------------------------------------------
+
+type Handler = (req: GuildVaultRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+  async set_token({ userId, body }) {
+    const {
+      server_id,
+      token_name,
+      service,
+      token_value,
+      description,
+      provider_token,
+    } = body;
+
+    const ptErr = validateProviderToken(provider_token);
+    if (ptErr) return ptErr;
+
+    const sidErr = validateSnowflake(server_id, "server_id");
+    if (sidErr) return sidErr;
+
+    const tnErr = validateTokenName(token_name);
+    if (tnErr) return tnErr;
+
+    const svcErr = validateService(service);
+    if (svcErr) return svcErr;
+
+    const tvErr = validateTokenValue(token_value);
+    if (tvErr) return tvErr;
+
+    const descErr = validateDescription(description);
+    if (descErr) return descErr;
+
+    // Discord API ownership verification (cached 5 min)
+    const ownerErr = await verifyGuildOwnership(
+      userId,
+      server_id as string,
+      provider_token as string,
+    );
+    if (ownerErr) return ownerErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_set_guild_token", {
+      p_owner_id: userId,
+      p_server_id: server_id as string,
+      p_service: service as string,
+      p_token_name: token_name as string,
+      p_token_value: token_value as string,
+      p_description: (description as string) || null,
+    });
+
+    if (error) {
+      invalidateOwnershipCache(userId, server_id as string);
+      return jsonResponse({ error: error.message }, 400);
+    }
+
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) {
+      return jsonResponse(
+        { success: false, error: "No response from database" },
+        500,
+      );
+    }
+
+    return jsonResponse(
+      { success: row.success, token_id: row.token_id, message: row.message },
+      row.success ? 200 : 400,
+    );
+  },
+
+  async list_tokens({ userId, body }) {
+    const { server_id, provider_token } = body;
+
+    const ptErr = validateProviderToken(provider_token);
+    if (ptErr) return ptErr;
+
+    const sidErr = validateSnowflake(server_id, "server_id");
+    if (sidErr) return sidErr;
+
+    const ownerErr = await verifyGuildOwnership(
+      userId,
+      server_id as string,
+      provider_token as string,
+    );
+    if (ownerErr) return ownerErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_list_guild_tokens", {
+      p_owner_id: userId,
+      p_server_id: server_id as string,
+    });
+
+    if (error) {
+      invalidateOwnershipCache(userId, server_id as string);
+      return jsonResponse({ error: error.message }, 400);
+    }
+
+    const tokens = Array.isArray(data) ? data : [];
+    return jsonResponse({ success: true, tokens, count: tokens.length });
+  },
+
+  async delete_token({ userId, body }) {
+    const { server_id, token_id, provider_token } = body;
+
+    const ptErr = validateProviderToken(provider_token);
+    if (ptErr) return ptErr;
+
+    const sidErr = validateSnowflake(server_id, "server_id");
+    if (sidErr) return sidErr;
+
+    const tidErr = validateUuid(token_id, "token_id");
+    if (tidErr) return tidErr;
+
+    const ownerErr = await verifyGuildOwnership(
+      userId,
+      server_id as string,
+      provider_token as string,
+    );
+    if (ownerErr) return ownerErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc(
+      "service_delete_guild_token",
+      {
+        p_owner_id: userId,
+        p_server_id: server_id as string,
+        p_token_id: token_id as string,
+      },
+    );
+
+    if (error) {
+      invalidateOwnershipCache(userId, server_id as string);
+      return jsonResponse({ error: error.message }, 400);
+    }
+
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) {
+      return jsonResponse(
+        { success: false, error: "No response from database" },
+        500,
+      );
+    }
+
+    return jsonResponse(
+      { success: row.success, message: row.message },
+      row.success ? 200 : 400,
+    );
+  },
+
+  async toggle_token({ userId, body }) {
+    const { server_id, token_id, is_active, provider_token } = body;
+
+    const ptErr = validateProviderToken(provider_token);
+    if (ptErr) return ptErr;
+
+    const sidErr = validateSnowflake(server_id, "server_id");
+    if (sidErr) return sidErr;
+
+    const tidErr = validateUuid(token_id, "token_id");
+    if (tidErr) return tidErr;
+
+    if (typeof is_active !== "boolean") {
+      return jsonResponse(
+        { error: "is_active (boolean) is required" },
+        400,
+      );
+    }
+
+    const ownerErr = await verifyGuildOwnership(
+      userId,
+      server_id as string,
+      provider_token as string,
+    );
+    if (ownerErr) return ownerErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc(
+      "service_toggle_guild_token_status",
+      {
+        p_owner_id: userId,
+        p_server_id: server_id as string,
+        p_token_id: token_id as string,
+        p_is_active: is_active,
+      },
+    );
+
+    if (error) {
+      invalidateOwnershipCache(userId, server_id as string);
+      return jsonResponse({ error: error.message }, 400);
+    }
+
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) {
+      return jsonResponse(
+        { success: false, error: "No response from database" },
+        500,
+      );
+    }
+
+    return jsonResponse(
+      { success: row.success, message: row.message },
+      row.success ? 200 : 400,
+    );
+  },
+};
+
+export const TOKEN_ACTIONS = Object.keys(handlers);
+
+export async function handleTokens(
+  req: GuildVaultRequest,
+): Promise<Response> {
+  const handler = handlers[req.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown token action: ${req.action}. Use: ${
+          TOKEN_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(req);
+}


### PR DESCRIPTION
## Summary

Implements the edge function layer for the guild vault system (Issue #7497, closes #7515).

- **4 actions**: `set_token`, `list_tokens`, `delete_token`, `toggle_token`
- **Discord API ownership verification** with 5-minute in-memory cache
- **`get_token` deliberately omitted** — decrypted secrets are bot-only, never exposed via edge function
- Follows existing modular router pattern (`user-vault`, `discordsh`)

### 5-Layer Security Model

1. Supabase JWT verification (authenticated users only, no service_role dual-auth)
2. Discord API guild ownership check (`GET /users/@me/guilds`, `owner: true`)
3. Database `verify_guild_owner()` (checks `discordsh.servers.owner_id` + rejects banned servers)
4. `auth.role()` runtime guard in every RPC
5. `REVOKE ALL` from PUBLIC/anon/authenticated on table + functions

### Files Added
- `apps/kbve/edge/functions/guild-vault/_shared.ts` — Types, validators, Discord API verification with cache
- `apps/kbve/edge/functions/guild-vault/tokens.ts` — 4 token CRUD handlers
- `apps/kbve/edge/functions/guild-vault/index.ts` — Router

### Dependencies
- Database layer: PRs #7507 (guild vault schema) and #7524 (security hardening) — both merged
- Migration `20260302000000_discordsh_guild_vault` — applied in production

## Test plan
- [ ] Deploy to staging environment
- [ ] Test `tokens.set_token` with valid Discord guild owner — expect success
- [ ] Test `tokens.list_tokens` — returns metadata only (no secrets)
- [ ] Test `tokens.toggle_token` — disable/enable
- [ ] Test `tokens.delete_token` — removes vault secret
- [ ] Test with non-owner Discord user — expect 403
- [ ] Test with expired Discord token — expect 401
- [ ] Test with missing `provider_token` — expect 400
- [ ] Verify cache works (second request within 5 min skips Discord API call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)