### PR TITLE
feat(cryptothrone): add OpenFret, TryMelo.ai, and KBVE backlinks to footer

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/starlight/Footer.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/starlight/Footer.astro
@@ -32,7 +32,11 @@ const currentYear = new Date().getFullYear();
 
 		<nav class="ct-footer__col">
 			<h6 class="ct-footer__title">Kingdom</h6>
-			<a href="https://kbve.com">KBVE.com</a>
+			<a
+				href="https://kbve.com"
+				title="KBVE — Open-source software, game development, and cloud infrastructure">
+				KBVE.com
+			</a>
 			<a
 				href="https://openfret.com/"
 				title="OpenFret — Guitar gear tracker, practice analytics, and the Guitar Quest RPG learning game">


### PR DESCRIPTION
## Summary
- Add OpenFret and TryMelo.ai links to the footer Kingdom column with descriptive title attributes
- Add title attribute to existing KBVE.com backlink for SEO

## Test plan
- [ ] Footer renders with OpenFret, TryMelo.ai, and KBVE links in the Kingdom column
- [ ] Title tooltips appear on hover for all three links