### PR TITLE
fix(repo): graceful deno fmt in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 			"flake8 --max-line-length 120"
 		],
 		"apps/kbve/edge/functions/**/*.ts": [
-			"deno fmt"
+			"./scripts/deno-fmt.sh"
 		]
 	},
 	"nx": {

--- a/scripts/deno-fmt.sh
+++ b/scripts/deno-fmt.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Wrapper for deno fmt that gracefully skips when deno is not installed.
+# Used by lint-staged so local devs without deno aren't blocked.
+if command -v deno >/dev/null 2>&1; then
+  exec deno fmt "$@"
+fi


### PR DESCRIPTION
## Summary
- Wraps `deno fmt` in `scripts/deno-fmt.sh` that checks if deno is installed before running
- Updates lint-staged config in `package.json` to use the wrapper instead of calling `deno fmt` directly
- Prevents `ENOENT` errors in the pre-commit hook for local devs without deno installed
- When deno IS available (CI, devs who have it), formatting runs as before

## Test plan
- [ ] Commit edge function `.ts` files without deno installed — hook passes cleanly
- [ ] Commit edge function `.ts` files with deno installed — `deno fmt` runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)