### PR TITLE
chore(axum-kbve): bump version to 1.0.24 to trigger CI pipeline

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.23"
+version = "1.0.24"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump axum-kbve from 1.0.23 to 1.0.24 to trigger a fresh CI build

## Test plan
- [ ] CI pipeline triggers and builds successfully