### PR TITLE
chore(edge): bump version to 0.1.10

### DIFF
--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -1,1 +1,1 @@
-version = "0.1.9"
+version = "0.1.10"


### PR DESCRIPTION
## Summary
- Bumps edge function version from 0.1.9 → 0.1.10 to trigger a deploy with the guild-vault edge function from PR #7690

## Test plan
- [ ] CI build triggers edge function deployment
- [ ] Guild-vault edge function is available at `/functions/v1/guild-vault`

🤖 Generated with [Claude Code](https://claude.com/claude-code)