### PR TITLE
feat(axum-discordsh): clickable links, gear expansion, JSON API + session viewer

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -33,7 +33,7 @@ poise = "0.6.1"
 sysinfo = "0.38.2"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 dashmap = "6.1"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 rand = "0.10"
 rand_chacha = "0.10"
 

--- a/apps/discordsh/axum-discordsh/src/astro/askama.rs
+++ b/apps/discordsh/axum-discordsh/src/astro/askama.rs
@@ -29,17 +29,18 @@ impl<'a> AstroTemplate<'a> {
         }
     }
 
-    pub fn with_og(
-        mut self,
-        og_type: &'a str,
-        og_url: &'a str,
-        og_image: &'a str,
-    ) -> Self {
+    pub fn with_og(mut self, og_type: &'a str, og_url: &'a str, og_image: &'a str) -> Self {
         self.og_type = og_type;
         self.og_url = og_url;
         self.og_image = og_image;
         self
     }
+}
+
+#[derive(Template)]
+#[template(path = "askama/session.html")]
+pub struct SessionViewerTemplate<'a> {
+    pub short_id: &'a str,
 }
 
 pub struct TemplateResponse<T: Template>(pub T);

--- a/apps/discordsh/axum-discordsh/src/discord/game/card.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/card.rs
@@ -756,6 +756,7 @@ fn build_equip_slot_display(gear_id: Option<&str>) -> EquipSlotDisplay {
                 Some(GearSpecial::LifeSteal { percent }) => format!("{}% Lifesteal", percent),
                 Some(GearSpecial::Thorns { damage }) => format!("{} Thorns", damage),
                 Some(GearSpecial::CritBonus { percent }) => format!("+{}% Crit", percent),
+                Some(GearSpecial::DamageReduction { percent }) => format!("-{}% Dmg", percent),
                 None => String::new(),
             };
             EquipSlotDisplay {

--- a/apps/discordsh/axum-discordsh/src/discord/game/content.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/content.rs
@@ -404,6 +404,84 @@ pub fn gear_registry() -> &'static [GearDef] {
             bonus_hp: 10,
             special: None,
         },
+        // ── New gear ──────────────────────────────────────────
+        GearDef {
+            id: "iron_mace",
+            name: "Iron Mace",
+            emoji: "\u{1F528}",
+            slot: EquipSlot::Weapon,
+            rarity: ItemRarity::Uncommon,
+            bonus_damage: 3,
+            bonus_armor: 0,
+            bonus_hp: 0,
+            special: None,
+        },
+        GearDef {
+            id: "glass_stiletto",
+            name: "Glass Stiletto",
+            emoji: "\u{1F52A}",
+            slot: EquipSlot::Weapon,
+            rarity: ItemRarity::Rare,
+            bonus_damage: 3,
+            bonus_armor: 0,
+            bonus_hp: 0,
+            special: Some(GearSpecial::CritBonus { percent: 15 }),
+        },
+        GearDef {
+            id: "excalibur",
+            name: "Excalibur",
+            emoji: "\u{2694}",
+            slot: EquipSlot::Weapon,
+            rarity: ItemRarity::Legendary,
+            bonus_damage: 6,
+            bonus_armor: 0,
+            bonus_hp: 5,
+            special: Some(GearSpecial::CritBonus { percent: 10 }),
+        },
+        GearDef {
+            id: "void_scythe",
+            name: "Void Scythe",
+            emoji: "\u{1F300}",
+            slot: EquipSlot::Weapon,
+            rarity: ItemRarity::Legendary,
+            bonus_damage: 7,
+            bonus_armor: 0,
+            bonus_hp: 0,
+            special: Some(GearSpecial::LifeSteal { percent: 15 }),
+        },
+        GearDef {
+            id: "shadow_cloak",
+            name: "Shadow Cloak",
+            emoji: "\u{1F9E5}",
+            slot: EquipSlot::Armor,
+            rarity: ItemRarity::Uncommon,
+            bonus_damage: 1,
+            bonus_armor: 3,
+            bonus_hp: 0,
+            special: None,
+        },
+        GearDef {
+            id: "runeguard_plate",
+            name: "Runeguard Plate",
+            emoji: "\u{1F6E1}",
+            slot: EquipSlot::Armor,
+            rarity: ItemRarity::Rare,
+            bonus_damage: 0,
+            bonus_armor: 5,
+            bonus_hp: 5,
+            special: Some(GearSpecial::Thorns { damage: 2 }),
+        },
+        GearDef {
+            id: "dragon_scale",
+            name: "Dragon Scale",
+            emoji: "\u{1F409}",
+            slot: EquipSlot::Armor,
+            rarity: ItemRarity::Legendary,
+            bonus_damage: 0,
+            bonus_armor: 8,
+            bonus_hp: 15,
+            special: Some(GearSpecial::DamageReduction { percent: 10 }),
+        },
     ];
     GEAR
 }
@@ -553,6 +631,14 @@ fn gear_loot_tables() -> &'static [GearLootTable] {
                     gear_id: "chain_mail",
                     weight: 4,
                 },
+                GearLootEntry {
+                    gear_id: "iron_mace",
+                    weight: 3,
+                },
+                GearLootEntry {
+                    gear_id: "shadow_cloak",
+                    weight: 3,
+                },
             ],
             drop_chance: 0.15,
         },
@@ -567,6 +653,14 @@ fn gear_loot_tables() -> &'static [GearLootTable] {
                     gear_id: "spiked_plate",
                     weight: 3,
                 },
+                GearLootEntry {
+                    gear_id: "glass_stiletto",
+                    weight: 2,
+                },
+                GearLootEntry {
+                    gear_id: "runeguard_plate",
+                    weight: 2,
+                },
             ],
             drop_chance: 0.20,
         },
@@ -580,6 +674,18 @@ fn gear_loot_tables() -> &'static [GearLootTable] {
                 GearLootEntry {
                     gear_id: "crystal_armor",
                     weight: 3,
+                },
+                GearLootEntry {
+                    gear_id: "excalibur",
+                    weight: 1,
+                },
+                GearLootEntry {
+                    gear_id: "void_scythe",
+                    weight: 1,
+                },
+                GearLootEntry {
+                    gear_id: "dragon_scale",
+                    weight: 1,
                 },
             ],
             drop_chance: 0.50,
@@ -1953,7 +2059,7 @@ mod tests {
 
     #[test]
     fn gear_registry_test() {
-        assert_eq!(gear_registry().len(), 8);
+        assert_eq!(gear_registry().len(), 15);
         // Verify a weapon and an armor piece exist
         let sword = find_gear("rusty_sword").unwrap();
         assert_eq!(sword.slot, EquipSlot::Weapon);

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -1277,7 +1277,23 @@ fn single_enemy_turn(
 
     // Apply damage to player
     match action {
-        EnemyAction::DealDamage { dmg, msg } => {
+        EnemyAction::DealDamage { mut dmg, msg } => {
+            // DamageReduction from armor gear
+            let dr_pct = session
+                .player(target)
+                .armor_gear
+                .as_ref()
+                .and_then(|id| content::find_gear(id))
+                .and_then(|g| match &g.special {
+                    Some(GearSpecial::DamageReduction { percent }) => Some(*percent as f32 / 100.0),
+                    _ => None,
+                })
+                .unwrap_or(0.0);
+            if dr_pct > 0.0 {
+                dmg = ((dmg as f32) * (1.0 - dr_pct)).ceil() as i32;
+                dmg = dmg.max(1);
+            }
+
             let player = session.player_mut(target);
             player.hp -= dmg;
             logs.push(msg);
@@ -1339,6 +1355,23 @@ fn single_enemy_turn(
                 let mut actual = (dmg - p_armor).max(1);
                 if p_shielded || p_defending {
                     actual /= 2;
+                }
+
+                // DamageReduction from armor gear
+                let dr_pct = player
+                    .armor_gear
+                    .as_ref()
+                    .and_then(|id| content::find_gear(id))
+                    .and_then(|g| match &g.special {
+                        Some(GearSpecial::DamageReduction { percent }) => {
+                            Some(*percent as f32 / 100.0)
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or(0.0);
+                if dr_pct > 0.0 {
+                    actual = ((actual as f32) * (1.0 - dr_pct)).ceil() as i32;
+                    actual = actual.max(1);
                 }
 
                 let player = session.player_mut(uid);

--- a/apps/discordsh/axum-discordsh/src/discord/game/render.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/render.rs
@@ -413,28 +413,31 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
         embed = embed.field(label, log_display, false);
     }
 
-    // Footer — party roster with membership badges
+    // Party roster — embed field supports markdown links (footer does not)
     let roster_parts: Vec<String> = session
         .roster()
         .iter()
         .enumerate()
-        .map(|(i, (_, player))| {
-            let badge = match &player.member_status {
-                MemberStatusTag::Member { username } => {
-                    format!("{} -- kbve.com/@{}", player.name, username)
-                }
-                MemberStatusTag::Guest => format!("{} (Guest)", player.name),
-            };
-            format!("[{}] {}", i + 1, badge)
+        .map(|(i, (_, player))| match &player.member_status {
+            MemberStatusTag::Member { username } => {
+                format!(
+                    "[{}] {} — [kbve.com/@{}](https://kbve.com/@{})",
+                    i + 1,
+                    player.name,
+                    username,
+                    username
+                )
+            }
+            MemberStatusTag::Guest => format!("[{}] {} (Guest)", i + 1, player.name),
         })
         .collect();
-    let footer_text = format!(
-        "Turn {}  //  Session {}\n{}",
-        session.turn,
-        session.short_id,
-        roster_parts.join("  |  ")
-    );
-    embed = embed.footer(serenity::CreateEmbedFooter::new(footer_text));
+    embed = embed.field("\u{2014} Party \u{2014}", roster_parts.join("\n"), false);
+
+    // Footer — turn/session only
+    embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
+        "Turn {}  //  Session {}",
+        session.turn, session.short_id
+    )));
 
     embed
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/types.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/types.rs
@@ -4,10 +4,11 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use poise::serenity_prelude as serenity;
+use serde::ser::SerializeMap;
 
 // ── Map types ──────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 pub struct MapPos {
     pub x: i16,
     pub y: i16,
@@ -51,7 +52,7 @@ impl MapPos {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum Direction {
     North,
     South,
@@ -116,7 +117,7 @@ impl Direction {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct MapTile {
     pub pos: MapPos,
     pub room_type: RoomType,
@@ -127,13 +128,41 @@ pub struct MapTile {
     pub cleared: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct MapState {
     pub seed: u64,
     pub position: MapPos,
+    #[serde(serialize_with = "serialize_tiles")]
     pub tiles: HashMap<MapPos, MapTile>,
     pub tiles_visited: u32,
     pub boss_positions: Vec<MapPos>,
+}
+
+// ── Serde helpers ──────────────────────────────────────────────────
+
+/// Serialize `HashMap<MapPos, MapTile>` as a flat `Vec<MapTile>`.
+fn serialize_tiles<S: serde::Serializer>(
+    tiles: &HashMap<MapPos, MapTile>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeSeq;
+    let mut seq = s.serialize_seq(Some(tiles.len()))?;
+    for tile in tiles.values() {
+        seq.serialize_element(tile)?;
+    }
+    seq.end()
+}
+
+/// Serialize `HashMap<UserId, PlayerState>` with string keys.
+fn serialize_players<S: serde::Serializer>(
+    players: &HashMap<serenity::UserId, PlayerState>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    let mut map = s.serialize_map(Some(players.len()))?;
+    for (uid, player) in players {
+        map.serialize_entry(&uid.get().to_string(), player)?;
+    }
+    map.end()
 }
 
 // ── Short session ID ────────────────────────────────────────────────
@@ -151,7 +180,7 @@ pub fn new_short_sid() -> (uuid::Uuid, ShortSid) {
 
 // ── Game phase ──────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum GamePhase {
     Exploring,
     Combat,
@@ -167,7 +196,7 @@ pub enum GamePhase {
     GameOver(GameOverReason),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum GameOverReason {
     Defeated,
     Escaped,
@@ -177,7 +206,7 @@ pub enum GameOverReason {
 
 // ── Room types ──────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum RoomType {
     Combat,
     Treasure,
@@ -192,7 +221,7 @@ pub enum RoomType {
 
 // ── Effects ─────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum EffectKind {
     Poison,
     Burning,
@@ -204,7 +233,7 @@ pub enum EffectKind {
     Thorns,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct EffectInstance {
     pub kind: EffectKind,
     pub stacks: u8,
@@ -213,7 +242,7 @@ pub struct EffectInstance {
 
 // ── Enemy intent (telegraph) ────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum Intent {
     Attack {
         dmg: i32,
@@ -245,7 +274,7 @@ pub const MAX_INVENTORY_SLOTS: usize = 16;
 
 pub type ItemId = String;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum UseEffect {
     Heal {
         amount: i32,
@@ -268,7 +297,7 @@ pub enum UseEffect {
 
 // ── Item rarity ────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 pub enum ItemRarity {
     Common,
     Uncommon,
@@ -288,7 +317,7 @@ pub struct ItemDef {
     pub use_effect: Option<UseEffect>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ItemStack {
     pub item_id: ItemId,
     pub qty: u16,
@@ -296,17 +325,18 @@ pub struct ItemStack {
 
 // ── Equipment / Gear ────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum EquipSlot {
     Weapon,
     Armor,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum GearSpecial {
     LifeSteal { percent: u8 },
     Thorns { damage: i32 },
     CritBonus { percent: u8 },
+    DamageReduction { percent: u8 },
 }
 
 #[derive(Debug, Clone)]
@@ -324,7 +354,7 @@ pub struct GearDef {
 
 // ── Player class ────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum ClassType {
     Warrior,
     Rogue,
@@ -351,7 +381,7 @@ impl ClassType {
 
 // ── Player state ────────────────────────────────────────────────────
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct PlayerState {
     pub name: String,
     pub hp: i32,
@@ -442,7 +472,7 @@ impl PlayerState {
 
 // ── Enemy state ─────────────────────────────────────────────────────
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct EnemyState {
     pub name: String,
     pub level: u8,
@@ -460,14 +490,14 @@ pub struct EnemyState {
 
 // ── Room state ──────────────────────────────────────────────────────
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum RoomModifier {
     Fog { accuracy_penalty: f32 },
     Blessing { heal_bonus: i32 },
     Cursed { dmg_multiplier: f32 },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum Hazard {
     Spikes {
         dmg: i32,
@@ -479,26 +509,26 @@ pub enum Hazard {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct MerchantOffer {
     pub item_id: ItemId,
     pub price: i32,
     pub is_gear: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct StoryChoice {
     pub label: String,
     pub description: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct StoryEvent {
     pub prompt: String,
     pub choices: Vec<StoryChoice>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct StoryOutcome {
     pub log_message: String,
     pub hp_change: i32,
@@ -507,7 +537,7 @@ pub struct StoryOutcome {
     pub effect_gain: Option<(EffectKind, u8, u8)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct RoomState {
     pub index: u32,
     pub room_type: RoomType,
@@ -545,7 +575,7 @@ pub enum GameAction {
 
 // ── Session mode ────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum SessionMode {
     Solo,
     Party,
@@ -554,7 +584,7 @@ pub enum SessionMode {
 // ── Member status tag ────────────────────────────────────────────────
 
 /// Lightweight membership tag stored in the session.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum MemberStatusTag {
     Member { username: String },
     Guest,
@@ -562,7 +592,7 @@ pub enum MemberStatusTag {
 
 // ── Session state ───────────────────────────────────────────────────
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SessionState {
     pub id: uuid::Uuid,
     pub short_id: ShortSid,
@@ -572,18 +602,23 @@ pub struct SessionState {
     pub phase: GamePhase,
     pub channel_id: serenity::ChannelId,
     pub message_id: serenity::MessageId,
+    #[serde(skip)]
     pub created_at: Instant,
+    #[serde(skip)]
     pub last_action_at: Instant,
     pub turn: u32,
+    #[serde(serialize_with = "serialize_players")]
     pub players: HashMap<serenity::UserId, PlayerState>,
     pub enemies: Vec<EnemyState>,
     pub room: RoomState,
     pub log: Vec<String>,
     pub show_items: bool,
+    #[serde(skip)]
     pub pending_actions: HashMap<serenity::UserId, GameAction>,
     pub map: MapState,
     pub show_map: bool,
     pub show_inventory: bool,
+    #[serde(skip)]
     pub pending_destination: Option<MapPos>,
     pub enemies_had_first_strike: bool,
 }

--- a/apps/discordsh/axum-discordsh/src/transport/api.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/api.rs
@@ -1,0 +1,220 @@
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+
+use crate::astro::askama::{SessionViewerTemplate, TemplateResponse};
+
+use super::HttpState;
+
+pub fn router() -> Router<HttpState> {
+    Router::new()
+        .route("/api/session/{session_id}", get(session_json))
+        .route("/session/{session_id}", get(session_page))
+}
+
+/// JSON snapshot of a live game session.
+async fn session_json(State(state): State<HttpState>, Path(session_id): Path<String>) -> Response {
+    let handle = match state.app.sessions.get(&session_id) {
+        Some(h) => h,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "session not found" })),
+            )
+                .into_response();
+        }
+    };
+
+    let snapshot = handle.lock().await.clone();
+
+    let mut resp = Json(snapshot).into_response();
+    resp.headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+    resp
+}
+
+/// Server-rendered session viewer page.
+async fn session_page(State(state): State<HttpState>, Path(session_id): Path<String>) -> Response {
+    if state.app.sessions.get(&session_id).is_none() {
+        return (StatusCode::NOT_FOUND, "Session not found").into_response();
+    }
+
+    let template = SessionViewerTemplate {
+        short_id: &session_id,
+    };
+    TemplateResponse(template).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use http_body_util::BodyExt;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    use crate::health::HealthMonitor;
+
+    fn test_router() -> (Router, Arc<crate::state::AppState>) {
+        let health_monitor = Arc::new(HealthMonitor::new());
+        let app_state = Arc::new(crate::state::AppState::new(health_monitor, None));
+        let state = HttpState {
+            app: Arc::clone(&app_state),
+        };
+        let r = router().with_state(state);
+        (r, app_state)
+    }
+
+    #[tokio::test]
+    async fn session_json_404_for_missing() {
+        let (app, _) = test_router();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/session/deadbeef")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "session not found");
+    }
+
+    #[tokio::test]
+    async fn session_page_404_for_missing() {
+        let (app, _) = test_router();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/session/deadbeef")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn session_json_returns_snapshot() {
+        use crate::discord::game::types::*;
+        use poise::serenity_prelude as serenity;
+        use std::collections::HashMap;
+        use std::time::Instant;
+
+        let (app, state) = test_router();
+
+        // Create a session
+        let owner = serenity::UserId::new(42);
+        let mut players = HashMap::new();
+        players.insert(owner, PlayerState::default());
+        let session = SessionState {
+            id: uuid::Uuid::new_v4(),
+            short_id: "abc12345".to_owned(),
+            owner,
+            party: Vec::new(),
+            mode: SessionMode::Solo,
+            phase: GamePhase::Exploring,
+            channel_id: serenity::ChannelId::new(1),
+            message_id: serenity::MessageId::new(1),
+            created_at: Instant::now(),
+            last_action_at: Instant::now(),
+            turn: 1,
+            players,
+            enemies: Vec::new(),
+            room: crate::discord::game::content::generate_room(0),
+            log: vec!["Adventure begins!".to_owned()],
+            show_items: false,
+            pending_actions: HashMap::new(),
+            map: test_map_default(),
+            show_map: false,
+            show_inventory: false,
+            pending_destination: None,
+            enemies_had_first_strike: false,
+        };
+        state.sessions.create(session);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/session/abc12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-cache"
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["short_id"], "abc12345");
+        assert_eq!(json["turn"], 1);
+        assert!(json["players"].is_object());
+    }
+
+    #[tokio::test]
+    async fn session_page_renders_for_existing() {
+        use crate::discord::game::types::*;
+        use poise::serenity_prelude as serenity;
+        use std::collections::HashMap;
+        use std::time::Instant;
+
+        let (app, state) = test_router();
+
+        let owner = serenity::UserId::new(42);
+        let mut players = HashMap::new();
+        players.insert(owner, PlayerState::default());
+        let session = SessionState {
+            id: uuid::Uuid::new_v4(),
+            short_id: "page1234".to_owned(),
+            owner,
+            party: Vec::new(),
+            mode: SessionMode::Solo,
+            phase: GamePhase::Exploring,
+            channel_id: serenity::ChannelId::new(1),
+            message_id: serenity::MessageId::new(1),
+            created_at: Instant::now(),
+            last_action_at: Instant::now(),
+            turn: 1,
+            players,
+            enemies: Vec::new(),
+            room: crate::discord::game::content::generate_room(0),
+            log: Vec::new(),
+            show_items: false,
+            pending_actions: HashMap::new(),
+            map: test_map_default(),
+            show_map: false,
+            show_inventory: false,
+            pending_destination: None,
+            enemies_had_first_strike: false,
+        };
+        state.sessions.create(session);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/session/page1234")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let html = String::from_utf8_lossy(&body);
+        assert!(html.contains("page1234"));
+        assert!(html.contains("Session Viewer"));
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/transport/https.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/https.rs
@@ -93,6 +93,7 @@ fn router(state: HttpState) -> Router {
         .layer(axum::middleware::from_fn(cache_headers));
 
     let svg_router = super::svg::router().with_state(state.clone());
+    let api_router = super::api::router().with_state(state.clone());
 
     let dynamic_router = Router::new()
         .route("/health", get(health))
@@ -105,6 +106,7 @@ fn router(state: HttpState) -> Router {
 
     static_router
         .merge(svg_router)
+        .merge(api_router)
         .merge(dynamic_router)
         .layer(middleware)
 }

--- a/apps/discordsh/axum-discordsh/src/transport/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/mod.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod https;
 pub mod svg;
 

--- a/apps/discordsh/axum-discordsh/templates/askama/session.html
+++ b/apps/discordsh/axum-discordsh/templates/askama/session.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session {{ short_id }} - Discord.sh</title>
+    <meta name="description" content="Live dungeon session {{ short_id }} on Discord.sh" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://discord.sh/session/{{ short_id }}" />
+    <meta property="og:title" content="Session {{ short_id }} — Discord.sh Dungeon" />
+    <meta property="og:description" content="Live dungeon crawl session on Discord.sh" />
+    <meta property="og:image" content="https://discord.sh/svg/game/png/{{ short_id }}" />
+    <meta property="og:site_name" content="Discord.sh" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Session {{ short_id }} — Discord.sh Dungeon" />
+    <meta name="twitter:description" content="Live dungeon crawl session on Discord.sh" />
+    <meta name="twitter:image" content="https://discord.sh/svg/game/png/{{ short_id }}" />
+
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            background: #0d1117;
+            color: #c9d1d9;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+            min-height: 100vh;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+        h1 {
+            color: #58a6ff;
+            font-size: 1.5rem;
+            margin-bottom: 1.5rem;
+        }
+        h1 span { color: #8b949e; font-weight: normal; }
+        .cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 1.5rem;
+            margin-bottom: 2rem;
+        }
+        .cards img {
+            width: 100%;
+            border-radius: 8px;
+            border: 1px solid #30363d;
+        }
+        #session-data {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 8px;
+            padding: 1.5rem;
+        }
+        #session-data h2 {
+            color: #58a6ff;
+            font-size: 1.1rem;
+            margin-bottom: 1rem;
+        }
+        .info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+        }
+        .info-card {
+            background: #0d1117;
+            border: 1px solid #30363d;
+            border-radius: 6px;
+            padding: 1rem;
+        }
+        .info-card .label { color: #8b949e; font-size: 0.85rem; }
+        .info-card .value { color: #c9d1d9; font-size: 1.1rem; margin-top: 0.25rem; }
+        .player-list { list-style: none; padding: 0; }
+        .player-list li {
+            padding: 0.5rem 0;
+            border-bottom: 1px solid #21262d;
+        }
+        .player-list li:last-child { border-bottom: none; }
+        .hp-bar {
+            display: inline-block;
+            background: #21262d;
+            border-radius: 3px;
+            width: 100px;
+            height: 8px;
+            margin-left: 0.5rem;
+            vertical-align: middle;
+        }
+        .hp-bar-fill {
+            display: block;
+            background: #3fb950;
+            border-radius: 3px;
+            height: 100%;
+        }
+        .dead { color: #f85149; }
+        .log-list {
+            list-style: none;
+            padding: 0;
+            max-height: 300px;
+            overflow-y: auto;
+            font-size: 0.9rem;
+        }
+        .log-list li {
+            padding: 0.25rem 0;
+            border-bottom: 1px solid #21262d;
+        }
+        .loading { color: #8b949e; font-style: italic; }
+        .error { color: #f85149; }
+        a { color: #58a6ff; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Session Viewer <span>// {{ short_id }}</span></h1>
+
+        <div class="cards">
+            <img src="/svg/game/png/{{ short_id }}" alt="Game Card" loading="lazy" />
+            <img src="/svg/map/png/{{ short_id }}" alt="Map Card" loading="lazy" />
+            <img src="/svg/inventory/png/{{ short_id }}" alt="Inventory Card" loading="lazy" />
+        </div>
+
+        <div id="session-data">
+            <p class="loading">Loading session data...</p>
+        </div>
+    </div>
+
+    <script>
+    (function() {
+        var sid = '{{ short_id }}';
+        var container = document.getElementById('session-data');
+
+        fetch('/api/session/' + sid)
+            .then(function(r) {
+                if (!r.ok) throw new Error('Session not found');
+                return r.json();
+            })
+            .then(function(d) {
+                var players = Object.entries(d.players || {});
+                var playerHtml = players.map(function(entry) {
+                    var p = entry[1];
+                    var pct = p.max_hp > 0 ? Math.max(0, (p.hp / p.max_hp) * 100) : 0;
+                    var cls = p.alive ? '' : ' class="dead"';
+                    var status = p.alive ? p.hp + '/' + p.max_hp : 'Dead';
+                    return '<li' + cls + '>'
+                        + '<strong>' + esc(p.name) + '</strong> '
+                        + '<span>Lv.' + p.level + ' ' + esc(p.class) + '</span> '
+                        + status
+                        + '<span class="hp-bar"><span class="hp-bar-fill" style="width:' + pct + '%"></span></span>'
+                        + '</li>';
+                }).join('');
+
+                var logHtml = (d.log || []).slice(-20).map(function(l) {
+                    return '<li>' + esc(l) + '</li>';
+                }).join('');
+
+                var enemies = (d.enemies || []).map(function(e) {
+                    return esc(e.name) + ' (HP: ' + e.hp + '/' + e.max_hp + ')';
+                }).join(', ') || 'None';
+
+                container.innerHTML =
+                    '<h2>Session Info</h2>'
+                    + '<div class="info-grid">'
+                    + '<div class="info-card"><div class="label">Phase</div><div class="value">' + esc(JSON.stringify(d.phase)) + '</div></div>'
+                    + '<div class="info-card"><div class="label">Turn</div><div class="value">' + d.turn + '</div></div>'
+                    + '<div class="info-card"><div class="label">Mode</div><div class="value">' + esc(d.mode) + '</div></div>'
+                    + '<div class="info-card"><div class="label">Room</div><div class="value">' + esc(d.room.name) + '</div></div>'
+                    + '<div class="info-card"><div class="label">Enemies</div><div class="value">' + enemies + '</div></div>'
+                    + '<div class="info-card"><div class="label">Tiles Visited</div><div class="value">' + d.map.tiles_visited + '</div></div>'
+                    + '</div>'
+                    + '<h2 style="margin-top:1.5rem">Party</h2>'
+                    + '<ul class="player-list">' + playerHtml + '</ul>'
+                    + '<h2 style="margin-top:1.5rem">Combat Log</h2>'
+                    + '<ul class="log-list">' + logHtml + '</ul>';
+            })
+            .catch(function(err) {
+                container.innerHTML = '<p class="error">' + esc(err.message) + '</p>';
+            });
+
+        function esc(s) {
+            if (s == null) return '';
+            var d = document.createElement('div');
+            d.textContent = String(s);
+            return d.innerHTML;
+        }
+    })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **Clickable profile links**: Move player roster from embed footer (plain text) to embed field where `[text](url)` markdown links are clickable
- **Gear expansion**: Add 7 new gear items including Legendary tier (Excalibur, Void Scythe, Dragon Scale) and new `DamageReduction` gear special
- **JSON API**: Add `/api/session/{id}` endpoint returning full session state as JSON with `Cache-Control: no-cache`
- **Session viewer**: Add `/session/{id}` page via Askama template with game/map/inventory card images, OG metadata for social sharing, and inline JS that fetches session JSON
- **Serde serialization**: Add `serde::Serialize` to all game types with custom serializers for `HashMap<UserId, _>` and `HashMap<MapPos, _>`

## New Gear Items
| Name | Slot | Rarity | Special |
|---|---|---|---|
| Iron Mace | Weapon | Uncommon | — |
| Glass Stiletto | Weapon | Rare | +15% Crit |
| Excalibur | Weapon | Legendary | +10% Crit |
| Void Scythe | Weapon | Legendary | 15% Lifesteal |
| Shadow Cloak | Armor | Uncommon | — |
| Runeguard Plate | Armor | Rare | 2 Thorns |
| Dragon Scale | Armor | Legendary | 10% DmgReduction |

## Files Changed
- `Cargo.toml` — enable `serde` feature on `uuid`
- `types.rs` — `serde::Serialize` on all types, `DamageReduction` variant, custom serializers
- `content.rs` — 7 new gear items, updated loot tables (skeleton, wraith, boss)
- `logic.rs` — `DamageReduction` in single-target + AoE enemy damage calc
- `card.rs` — `DamageReduction` match arm in gear display
- `render.rs` — roster in embed field with clickable links, simplified footer
- `askama.rs` — `SessionViewerTemplate` struct
- `transport/api.rs` — **new** JSON + page endpoints with tests
- `transport/mod.rs` — `pub mod api;`
- `transport/https.rs` — merge API router
- `templates/askama/session.html` — **new** session viewer HTML template

## Test plan
- [x] `cargo build -p axum-discordsh` compiles
- [x] `cargo test -p axum-discordsh` — 372 tests pass
- [ ] Manual: dungeon embed shows clickable profile links
- [ ] Manual: `curl /api/session/{sid}` returns valid JSON
- [ ] Manual: `/session/{sid}` renders viewer page with cards
- [ ] Manual: boss drops Legendary gear
- [ ] Manual: Dragon Scale reduces enemy damage by 10%