### PR TITLE
fix(ci): add GHCR login to docker e2e tests and order base image builds

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -378,11 +378,12 @@ jobs:
                 ]
 
     test_docker:
-        needs: ['generate_e2e_docker_matrix']
+        needs: ['generate_e2e_docker_matrix', 'build_base_images']
         name: Test Docker Apps
-        if: ${{ needs.generate_e2e_docker_matrix.outputs.matrix != 'null' }}
+        if: ${{ always() && needs.generate_e2e_docker_matrix.outputs.matrix != 'null' && !failure() && !cancelled() }}
         permissions:
             contents: read
+            packages: read
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.generate_e2e_docker_matrix.outputs.matrix) }}

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -11,7 +11,6 @@ on:
                 required: false
                 type: string
                 default: 'ubuntu-latest'
-
 jobs:
     test:
         name: Test ${{ inputs.project }} Docker App
@@ -19,6 +18,7 @@ jobs:
         timeout-minutes: 60
         permissions:
             contents: read
+            packages: read
 
         steps:
             - name: Checkout the monorepo
@@ -53,6 +53,13 @@ jobs:
               uses: docker/setup-buildx-action@v3
               with:
                   driver-opts: network=host
+
+            - name: Login to GHCR
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ github.token }}
 
             - name: Rust ToolChain
               uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Add GHCR login (`docker/login-action`) to `docker-test-app.yml` using `github.token` so BuildKit can pull base images and registry caches from `ghcr.io`
- Add `packages: read` permission to both `docker-test-app.yml` and `test_docker` job
- Make `test_docker` depend on `build_base_images` so pre-built foundation images are available before e2e tests attempt to pull them
- Use `always() && !failure() && !cancelled()` condition so tests still run when `build_base_images` is skipped (no base changes)

## Root cause
`axum-kbve:container:ci` uses `BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest` but the `docker-test-app.yml` workflow never logged into GHCR. BuildKit couldn't authenticate to pull the base image or registry build caches, causing the build to stall and get killed with exit code 130 (SIGINT).

## Test plan
- [ ] `axum-kbve:container:ci` succeeds with GHCR base image pull
- [ ] Other docker e2e tests (herbmail, memes, etc.) unaffected
- [ ] `test_docker` still runs when `build_base_images` is skipped