### PR TITLE
feat(cryptothrone): not-content wrappers, Starlight CSS variables, bump 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "axum-cryptothrone"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "askama",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.23"
+version = "1.0.24"
 dependencies = [
  "anyhow",
  "askama",
@@ -11384,9 +11384,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.5+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8825697d11e3935e3ab440a9d672022e540d016ff2f193de4295d11d18244774"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -11717,7 +11717,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.0.5+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
 ]
 
 [[package]]

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindowLoader.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindowLoader.tsx
@@ -6,7 +6,9 @@ export default function GameWindowLoader() {
 	return (
 		<Suspense
 			fallback={
-				<div className="flex justify-center items-center w-full h-full bg-[#1a1a2e] text-white">
+				<div
+					className="flex justify-center items-center w-full h-full text-white"
+					style={{ background: 'var(--ct-bg-deep, #1a1a2e)' }}>
 					Loading game…
 				</div>
 			}>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/landing/CryptoThroneHero.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/landing/CryptoThroneHero.astro
@@ -72,7 +72,12 @@ const {
 		font-size: clamp(2.5rem, 6vw, 4.5rem);
 		font-weight: 800;
 		letter-spacing: -0.02em;
-		background: linear-gradient(135deg, #fbbf24, #f59e0b, #d97706);
+		background: linear-gradient(
+			135deg,
+			var(--ct-accent),
+			var(--ct-accent-mid),
+			var(--ct-accent-dark)
+		);
 		-webkit-background-clip: text;
 		-webkit-text-fill-color: transparent;
 		background-clip: text;
@@ -82,7 +87,7 @@ const {
 
 	.ct-hero__tagline {
 		font-size: clamp(1rem, 2vw, 1.25rem);
-		color: #d1d5db;
+		color: var(--sl-color-gray-2, #d1d5db);
 		margin: 0 0 2.5rem;
 		line-height: 1.6;
 	}
@@ -106,8 +111,12 @@ const {
 	}
 
 	.ct-btn--primary {
-		background: linear-gradient(135deg, #f59e0b, #d97706);
-		color: #1a1a2e;
+		background: linear-gradient(
+			135deg,
+			var(--ct-accent-mid),
+			var(--ct-accent-dark)
+		);
+		color: var(--ct-bg-deep);
 	}
 
 	.ct-btn--primary:hover {
@@ -116,14 +125,14 @@ const {
 	}
 
 	.ct-btn--ghost {
-		border: 1px solid rgba(251, 191, 36, 0.4);
-		color: #fbbf24;
+		border: 1px solid color-mix(in srgb, var(--ct-accent) 40%, transparent);
+		color: var(--ct-accent);
 		background: transparent;
 	}
 
 	.ct-btn--ghost:hover {
-		background: rgba(251, 191, 36, 0.1);
-		border-color: #fbbf24;
+		background: color-mix(in srgb, var(--ct-accent) 10%, transparent);
+		border-color: var(--ct-accent);
 	}
 
 	.ct-hero__scroll-hint {
@@ -131,7 +140,7 @@ const {
 		bottom: 2rem;
 		left: 50%;
 		transform: translateX(-50%);
-		color: rgba(251, 191, 36, 0.5);
+		color: color-mix(in srgb, var(--ct-accent) 50%, transparent);
 		animation: bounce 2s infinite;
 	}
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureCard.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureCard.astro
@@ -16,15 +16,19 @@ const { title, description, icon } = Astro.props;
 
 <style>
 	.ct-card {
-		background: rgba(39, 39, 42, 0.6);
-		border: 1px solid rgba(251, 191, 36, 0.15);
+		background: color-mix(
+			in srgb,
+			var(--sl-color-gray-6, #27272a) 60%,
+			transparent
+		);
+		border: 1px solid color-mix(in srgb, var(--ct-accent) 15%, transparent);
 		border-radius: 0.75rem;
 		padding: 1.5rem;
 		transition: all 0.3s ease;
 	}
 
 	.ct-card:hover {
-		border-color: rgba(251, 191, 36, 0.4);
+		border-color: color-mix(in srgb, var(--ct-accent) 40%, transparent);
 		transform: translateY(-4px);
 		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 	}
@@ -37,13 +41,13 @@ const { title, description, icon } = Astro.props;
 	.ct-card__title {
 		font-size: 1.125rem;
 		font-weight: 700;
-		color: #fbbf24;
+		color: var(--ct-accent);
 		margin: 0 0 0.5rem;
 	}
 
 	.ct-card__desc {
 		font-size: 0.875rem;
-		color: #9ca3af;
+		color: var(--sl-color-gray-3, #9ca3af);
 		line-height: 1.6;
 		margin: 0;
 	}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureGrid.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/landing/FeatureGrid.astro
@@ -66,7 +66,7 @@ const features = [
 	.ct-features__heading {
 		font-size: 1.75rem;
 		font-weight: 700;
-		color: #fbbf24;
+		color: var(--ct-accent);
 		text-align: center;
 		margin: 0 0 2.5rem;
 	}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/starlight/Footer.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/starlight/Footer.astro
@@ -113,11 +113,12 @@ const currentYear = new Date().getFullYear();
 	.ct-footer {
 		margin-top: 2.5rem;
 		padding: 0 1.5rem;
-		border-top: 1px solid rgba(251, 191, 36, 0.15);
+		border-top: 1px solid
+			color-mix(in srgb, var(--ct-accent) 15%, transparent);
 		background: linear-gradient(
 			180deg,
 			transparent 0%,
-			rgba(26, 26, 46, 0.4) 100%
+			color-mix(in srgb, var(--ct-bg-deep) 40%, transparent) 100%
 		);
 	}
 
@@ -152,7 +153,11 @@ const currentYear = new Date().getFullYear();
 	.ct-footer__logo-text {
 		font-size: 1.25rem;
 		font-weight: 800;
-		background: linear-gradient(135deg, #fbbf24, #d97706);
+		background: linear-gradient(
+			135deg,
+			var(--ct-accent),
+			var(--ct-accent-dark)
+		);
 		-webkit-background-clip: text;
 		-webkit-text-fill-color: transparent;
 		background-clip: text;
@@ -177,7 +182,7 @@ const currentYear = new Date().getFullYear();
 		font-weight: 700;
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
-		color: #fbbf24;
+		color: var(--ct-accent);
 		margin-bottom: 0.25rem;
 	}
 
@@ -189,7 +194,7 @@ const currentYear = new Date().getFullYear();
 	}
 
 	.ct-footer__col a:hover {
-		color: #fbbf24;
+		color: var(--ct-accent);
 	}
 
 	/* Bottom bar */
@@ -200,7 +205,8 @@ const currentYear = new Date().getFullYear();
 		max-width: 72rem;
 		margin: 0 auto;
 		padding: 1.25rem 0;
-		border-top: 1px solid rgba(251, 191, 36, 0.1);
+		border-top: 1px solid
+			color-mix(in srgb, var(--ct-accent) 10%, transparent);
 	}
 
 	.ct-footer__bottom span {
@@ -216,7 +222,7 @@ const currentYear = new Date().getFullYear();
 	}
 
 	.ct-footer__bottom a:hover {
-		color: #fbbf24;
+		color: var(--ct-accent);
 	}
 
 	/* Social badges */
@@ -234,15 +240,15 @@ const currentYear = new Date().getFullYear();
 		height: 2rem;
 		border-radius: 0.5rem;
 		color: var(--sl-color-gray-2, #a1a1aa);
-		background: rgba(251, 191, 36, 0.08);
-		border: 1px solid rgba(251, 191, 36, 0.15);
+		background: color-mix(in srgb, var(--ct-accent) 8%, transparent);
+		border: 1px solid color-mix(in srgb, var(--ct-accent) 15%, transparent);
 		transition: all 200ms ease;
 	}
 
 	.ct-footer__badge:hover {
-		color: #fbbf24;
-		border-color: rgba(251, 191, 36, 0.4);
-		background: rgba(251, 191, 36, 0.15);
+		color: var(--ct-accent);
+		border-color: color-mix(in srgb, var(--ct-accent) 40%, transparent);
+		background: color-mix(in srgb, var(--ct-accent) 15%, transparent);
 		transform: translateY(-2px);
 	}
 

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/game/play.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/game/play.mdx
@@ -9,6 +9,6 @@ hero:
 
 import GameWindowLoader from '../../../components/game/GameWindowLoader';
 
-<div class="game-fullscreen">
+<div class="game-fullscreen not-content">
   <GameWindowLoader client:only="react" />
 </div>

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/index.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/index.mdx
@@ -10,5 +10,7 @@ hero:
 import CryptoThroneHero from '../../components/landing/CryptoThroneHero.astro';
 import FeatureGrid from '../../components/landing/FeatureGrid.astro';
 
-<CryptoThroneHero />
-<FeatureGrid />
+<div class="not-content">
+  <CryptoThroneHero />
+  <FeatureGrid />
+</div>

--- a/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
+++ b/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
@@ -1,5 +1,13 @@
 @import 'tailwindcss';
 
+/* ── CryptoThrone theme tokens ── */
+:root {
+	--ct-accent: #fbbf24;
+	--ct-accent-mid: #f59e0b;
+	--ct-accent-dark: #d97706;
+	--ct-bg-deep: #1a1a2e;
+}
+
 /* ── Game full-bleed layout ── */
 
 /* Lock body scroll and hide footer when the game overlay is active */
@@ -17,7 +25,7 @@ body:has(.game-fullscreen) .ct-footer {
 	position: fixed;
 	inset: 0;
 	z-index: 50;
-	background: #1a1a2e;
+	background: var(--ct-bg-deep);
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-cryptothrone"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Wrap game (`play.mdx`) and landing page (`index.mdx`) content with `not-content` class to prevent Starlight from applying content typography styles to custom components
- Introduce `--ct-accent`, `--ct-accent-mid`, `--ct-accent-dark`, and `--ct-bg-deep` CSS custom properties in `global.css` for centralized theme control
- Replace hardcoded hex colors (`#fbbf24`, `#d97706`, `#1a1a2e`, etc.) with Starlight CSS variables (`--sl-color-gray-*`) and CryptoThrone theme tokens across hero, feature cards, feature grid, footer, and game loader components
- Bump `axum-cryptothrone` to 0.1.3

## Test plan
- [x] Astro build succeeds (`nx build astro-cryptothrone`)
- [x] Docker image builds successfully
- [x] All 8 Docker e2e tests pass (smoke, sidebar, search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)