### PR TITLE
feat(crossplane): add provider-kubernetes for in-cluster resource management

### DIFF
--- a/apps/kube/crossplane/providers/kubernetes-provider-config.yaml
+++ b/apps/kube/crossplane/providers/kubernetes-provider-config.yaml
@@ -1,0 +1,11 @@
+# ProviderConfig for provider-kubernetes: in-cluster ServiceAccount auth
+# No kubeconfig needed — uses the provider pod's injected identity
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+    name: kubernetes-provider
+    annotations:
+        argocd.argoproj.io/sync-wave: '5'
+spec:
+    credentials:
+        source: InjectedIdentity

--- a/apps/kube/crossplane/providers/kubernetes-rbac.yaml
+++ b/apps/kube/crossplane/providers/kubernetes-rbac.yaml
@@ -1,0 +1,39 @@
+# RBAC for provider-kubernetes to manage cert-manager Certificates and Secrets
+# The provider SA needs permissions to create/update Certificate CRDs and
+# the resulting TLS secrets in target namespaces (kilobase, etc.)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: crossplane-cert-manager-access
+    labels:
+        app.kubernetes.io/name: crossplane
+        app.kubernetes.io/component: provider-kubernetes
+        app.kubernetes.io/managed-by: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '1'
+rules:
+    - apiGroups: ['cert-manager.io']
+      resources: ['certificates', 'certificates/status']
+      verbs: ['create', 'get', 'list', 'watch', 'update', 'delete', 'patch']
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['create', 'get', 'list', 'watch', 'update', 'delete', 'patch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: crossplane-cert-manager-access
+    labels:
+        app.kubernetes.io/name: crossplane
+        app.kubernetes.io/component: provider-kubernetes
+        app.kubernetes.io/managed-by: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '1'
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: crossplane-cert-manager-access
+subjects:
+    - kind: ServiceAccount
+      name: crossplane-contrib-provider-kubernetes
+      namespace: crossplane-system

--- a/apps/kube/crossplane/providers/provider-kubernetes.yaml
+++ b/apps/kube/crossplane/providers/provider-kubernetes.yaml
@@ -1,0 +1,10 @@
+# provider-kubernetes: manages in-cluster Kubernetes resources via Crossplane
+# Used for cert-manager Certificate lifecycle management (CNPG TLS, etc.)
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+    name: crossplane-contrib-provider-kubernetes
+    annotations:
+        argocd.argoproj.io/sync-wave: '0'
+spec:
+    package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.2.1


### PR DESCRIPTION
## Summary
- Installs Crossplane `provider-kubernetes` v1.2.1 for managing in-cluster Kubernetes resources via Crossplane Objects
- Adds `ProviderConfig` with `InjectedIdentity` auth (uses the provider pod's ServiceAccount — no kubeconfig needed)
- Adds RBAC (ClusterRole + ClusterRoleBinding) granting the provider SA permissions to manage cert-manager Certificate CRDs and Secrets

## Context
This is **PR 3a** of the Phase 3 cert management externalization plan. It lays the foundation for PR 3b (CNPG TLS via cert-manager + Crossplane Objects) and PR 3c (switching CNPG to cert-manager-managed secrets).

## Files Added
- `apps/kube/crossplane/providers/provider-kubernetes.yaml` — Provider CRD (sync-wave 0)
- `apps/kube/crossplane/providers/kubernetes-provider-config.yaml` — ProviderConfig (sync-wave 5)
- `apps/kube/crossplane/providers/kubernetes-rbac.yaml` — ClusterRole + ClusterRoleBinding (sync-wave 1)

## Verification
After ArgoCD sync:
- `kubectl get providers` — `crossplane-contrib-provider-kubernetes` should be HEALTHY
- `kubectl get providerconfig kubernetes-provider` — should exist
- Provider-kubernetes pod running in `crossplane-system`

## Risk
**Zero disruption** — purely additive. No existing resources are modified.

## Test plan
- [ ] ArgoCD syncs the 3 new resources without errors
- [ ] provider-kubernetes pod starts and becomes HEALTHY
- [ ] ProviderConfig `kubernetes-provider` is created
- [ ] RBAC bindings are in place for cert-manager access

🤖 Generated with [Claude Code](https://claude.com/claude-code)