### PR TITLE
feat(crossplane): add CNPG TLS certificates via cert-manager

### DIFF
--- a/apps/kube/crossplane/providers/cnpg-certificates.yaml
+++ b/apps/kube/crossplane/providers/cnpg-certificates.yaml
@@ -1,0 +1,73 @@
+# CNPG TLS certificates managed by cert-manager via Crossplane provider-kubernetes
+# Creates cert-manager Certificate CRDs that issue TLS certs signed by internal-ca-issuer
+# These write to NEW secret names (supabase-server-tls, supabase-replication-tls)
+# to avoid conflicting with CNPG's auto-managed secrets during transition
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+    name: cnpg-server-certificate
+    annotations:
+        argocd.argoproj.io/sync-wave: '15'
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+    forProvider:
+        manifest:
+            apiVersion: cert-manager.io/v1
+            kind: Certificate
+            metadata:
+                name: supabase-server-tls
+                namespace: kilobase
+            spec:
+                secretName: supabase-server-tls
+                duration: 2160h # 90 days
+                renewBefore: 720h # 30 days before expiry
+                issuerRef:
+                    name: internal-ca-issuer
+                    kind: ClusterIssuer
+                commonName: supabase-cluster-rw
+                dnsNames:
+                    - supabase-cluster-rw
+                    - supabase-cluster-rw.kilobase
+                    - supabase-cluster-rw.kilobase.svc
+                    - supabase-cluster-rw.kilobase.svc.cluster.local
+                    - supabase-cluster-r
+                    - supabase-cluster-r.kilobase
+                    - supabase-cluster-r.kilobase.svc
+                    - supabase-cluster-r.kilobase.svc.cluster.local
+                    - supabase-cluster-ro
+                    - supabase-cluster-ro.kilobase
+                    - supabase-cluster-ro.kilobase.svc
+                    - supabase-cluster-ro.kilobase.svc.cluster.local
+                usages:
+                    - server auth
+                    - client auth
+    providerConfigRef:
+        name: kubernetes-provider
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+    name: cnpg-replication-certificate
+    annotations:
+        argocd.argoproj.io/sync-wave: '15'
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+    forProvider:
+        manifest:
+            apiVersion: cert-manager.io/v1
+            kind: Certificate
+            metadata:
+                name: supabase-replication-tls
+                namespace: kilobase
+            spec:
+                secretName: supabase-replication-tls
+                duration: 2160h # 90 days
+                renewBefore: 720h # 30 days before expiry
+                issuerRef:
+                    name: internal-ca-issuer
+                    kind: ClusterIssuer
+                commonName: streaming_replica
+                usages:
+                    - client auth
+    providerConfigRef:
+        name: kubernetes-provider


### PR DESCRIPTION
## Summary
- Adds Crossplane `Object` resources that manage cert-manager `Certificate` CRDs for CNPG TLS
- **Server certificate** (`supabase-server-tls`): 90-day duration, 30-day early renewal, covers all CNPG service DNS names (rw/r/ro)
- **Replication certificate** (`supabase-replication-tls`): 90-day duration, 30-day early renewal, CN=streaming_replica

## Context
This is **PR 3b** of the Phase 3 cert management externalization plan.

- **PR 3a** (merged): Installed `provider-kubernetes` v1.2.1 + ProviderConfig + RBAC
- **PR 3b** (this): Creates cert-manager Certificates via Crossplane Objects — writes to NEW secret names to avoid disrupting CNPG's current auto-managed certs
- **PR 3c** (next): Switches CNPG `postgres-cluster.yaml` to reference these cert-manager-managed secrets

## Key Design Decisions
- Uses `internal-ca-issuer` (same CA chain as CNPG's internal certs)
- New secret names (`supabase-server-tls`, `supabase-replication-tls`) — does NOT touch CNPG's existing auto-managed secrets
- `SkipDryRunOnMissingResource=true` for ArgoCD compatibility (Object CRD may not exist until provider starts)

## Verification
After ArgoCD sync + provider-kubernetes is HEALTHY:
```bash
kubectl get certificate -n kilobase supabase-server-tls supabase-replication-tls
# Both should show READY: True

kubectl get objects cnpg-server-certificate cnpg-replication-certificate
# Both should show SYNCED+READY
```

## Risk
**Zero disruption** — creates new secrets alongside existing ones. CNPG continues using its auto-managed certs until PR 3c switches over.

## Test plan
- [ ] Crossplane Objects sync successfully (SYNCED+READY)
- [ ] cert-manager issues both Certificates (READY: True)
- [ ] New secrets `supabase-server-tls` and `supabase-replication-tls` exist in `kilobase` namespace
- [ ] Existing CNPG auto-managed certs remain untouched
- [ ] Database continues operating normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)