### PR TITLE
chore(axum-kbve): bump version to 1.0.25 to trigger CI pipeline

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.24"
+version = "1.0.25"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump axum-kbve from 1.0.24 to 1.0.25 to trigger the full Docker publish + kube manifest update pipeline
- Verifying end-to-end deployment flow passes cleanly

## Test plan
- [ ] CI detects `astro_kbve` file alteration
- [ ] axum-kbve-e2e passes on `arc-runner-set`
- [ ] Docker image `ghcr.io/kbve/kbve:1.0.25` published
- [ ] Kube manifest auto-updated to 1.0.25