### PR TITLE
feat(dashboard): add edge function health dashboard page

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroEdgeDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroEdgeDashboard.astro
@@ -1,0 +1,34 @@
+---
+import ReactEdgeDashboard from './ReactEdgeDashboard';
+---
+
+<section
+	id="edge-dashboard-wrapper"
+	class="edge-dashboard-wrapper"
+	aria-label="Edge function health dashboard">
+	<div id="dashboard-content" class="dashboard-content">
+		<ReactEdgeDashboard client:only="react" />
+	</div>
+</section>
+
+<style>
+	.edge-dashboard-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100vw;
+		margin-left: calc(-50vw + 50%);
+	}
+
+	.dashboard-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.dashboard-content {
+			padding: 2rem 1.5rem;
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeDashboard.tsx
@@ -1,0 +1,481 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { SUPABASE_URL } from '@/lib/supa';
+import {
+	Activity,
+	CheckCircle,
+	XCircle,
+	RefreshCw,
+	Loader2,
+	AlertCircle,
+	Clock,
+	Zap,
+} from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EDGE_CACHE_KEY = 'cache:edge:health';
+const CACHE_TTL_MS = 30 * 1000; // 30 seconds
+const FETCH_TIMEOUT_MS = 10_000;
+
+const EDGE_FUNCTIONS = [
+	{ name: 'health', label: 'Health', description: 'Core health check' },
+	{ name: 'meme', label: 'Meme', description: 'Meme feed and reactions' },
+	{ name: 'mc', label: 'Minecraft', description: 'MC data operations' },
+	{
+		name: 'discordsh',
+		label: 'Discord',
+		description: 'Discord server integration',
+	},
+	{
+		name: 'user-vault',
+		label: 'User Vault',
+		description: 'User API token management',
+	},
+	{
+		name: 'guild-vault',
+		label: 'Guild Vault',
+		description: 'Guild token management',
+	},
+	{
+		name: 'vault-reader',
+		label: 'Vault Reader',
+		description: 'System secret access',
+	},
+] as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FunctionHealth {
+	name: string;
+	label: string;
+	description: string;
+	status: 'ok' | 'error' | 'pending';
+	version?: string;
+	latencyMs?: number;
+	timestamp?: string;
+	error?: string;
+}
+
+interface CachedHealth {
+	functions: FunctionHealth[];
+	cached_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+function getCachedHealth(): CachedHealth | null {
+	try {
+		const raw = localStorage.getItem(EDGE_CACHE_KEY);
+		if (!raw) return null;
+		const cached: CachedHealth = JSON.parse(raw);
+		if (Date.now() - cached.cached_at > CACHE_TTL_MS) return null;
+		return cached;
+	} catch {
+		return null;
+	}
+}
+
+function setCachedHealth(data: CachedHealth): void {
+	try {
+		localStorage.setItem(EDGE_CACHE_KEY, JSON.stringify(data));
+	} catch {
+		/* quota exceeded */
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+async function checkFunctionHealth(
+	fn: (typeof EDGE_FUNCTIONS)[number],
+): Promise<FunctionHealth> {
+	const url = `${SUPABASE_URL}/functions/v1/${fn.name}`;
+	const start = performance.now();
+
+	try {
+		const controller = new AbortController();
+		const timeout = setTimeout(
+			() => controller.abort(),
+			FETCH_TIMEOUT_MS,
+		);
+
+		// Health endpoint is a simple GET, other functions expect POST
+		// We use OPTIONS (preflight) for non-health functions to avoid
+		// triggering auth errors — a 200 on OPTIONS means the function
+		// is deployed and responding.
+		const method = fn.name === 'health' ? 'GET' : 'OPTIONS';
+
+		const resp = await fetch(url, {
+			method,
+			signal: controller.signal,
+		});
+		clearTimeout(timeout);
+
+		const latencyMs = Math.round(performance.now() - start);
+
+		if (fn.name === 'health' && resp.ok) {
+			const data = await resp.json();
+			return {
+				...fn,
+				status: 'ok',
+				version: data.version,
+				timestamp: data.timestamp,
+				latencyMs,
+			};
+		}
+
+		// For non-health functions, OPTIONS returning 200 means alive
+		if (method === 'OPTIONS' && resp.ok) {
+			return {
+				...fn,
+				status: 'ok',
+				latencyMs,
+			};
+		}
+
+		return {
+			...fn,
+			status: 'error',
+			latencyMs,
+			error: `HTTP ${resp.status}`,
+		};
+	} catch (e: unknown) {
+		const latencyMs = Math.round(performance.now() - start);
+		return {
+			...fn,
+			status: 'error',
+			latencyMs,
+			error:
+				e instanceof Error
+					? e.name === 'AbortError'
+						? 'Timeout'
+						: e.message
+					: 'Unknown error',
+		};
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatusCard({ fn }: { fn: FunctionHealth }) {
+	const statusColor =
+		fn.status === 'ok'
+			? '#22c55e'
+			: fn.status === 'error'
+				? '#ef4444'
+				: 'var(--sl-color-gray-3, #8b949e)';
+
+	const StatusIcon =
+		fn.status === 'ok'
+			? CheckCircle
+			: fn.status === 'error'
+				? XCircle
+				: Loader2;
+
+	return (
+		<div style={styles.statusCard}>
+			<div style={styles.cardHeader}>
+				<StatusIcon size={18} style={{ color: statusColor }} />
+				<span style={styles.cardLabel}>{fn.label}</span>
+				{fn.latencyMs != null && (
+					<span style={styles.latencyBadge}>{fn.latencyMs}ms</span>
+				)}
+			</div>
+			<div style={styles.cardDescription}>{fn.description}</div>
+			{fn.version && (
+				<div style={styles.cardMeta}>
+					<Zap size={12} />
+					<span>v{fn.version}</span>
+				</div>
+			)}
+			{fn.timestamp && (
+				<div style={styles.cardMeta}>
+					<Clock size={12} />
+					<span>
+						{new Date(fn.timestamp).toLocaleTimeString([], {
+							hour: '2-digit',
+							minute: '2-digit',
+							second: '2-digit',
+						})}
+					</span>
+				</div>
+			)}
+			{fn.error && <div style={styles.cardError}>{fn.error}</div>}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function ReactEdgeDashboard() {
+	const [functions, setFunctions] = useState<FunctionHealth[]>(
+		EDGE_FUNCTIONS.map((fn) => ({ ...fn, status: 'pending' as const })),
+	);
+	const [fromCache, setFromCache] = useState(false);
+	const [refreshing, setRefreshing] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [lastChecked, setLastChecked] = useState<Date | null>(null);
+
+	const fetchHealth = useCallback(async (skipCache = false) => {
+		if (!skipCache) {
+			const cached = getCachedHealth();
+			if (cached) {
+				setFunctions(cached.functions);
+				setFromCache(true);
+				setLastChecked(new Date(cached.cached_at));
+				return;
+			}
+		}
+
+		setRefreshing(true);
+		setError(null);
+		setFromCache(false);
+
+		try {
+			const results = await Promise.all(
+				EDGE_FUNCTIONS.map(checkFunctionHealth),
+			);
+			setFunctions(results);
+			setLastChecked(new Date());
+
+			setCachedHealth({
+				functions: results,
+				cached_at: Date.now(),
+			});
+		} catch (e: unknown) {
+			setError(
+				e instanceof Error
+					? e.message
+					: 'Failed to check edge function health',
+			);
+		} finally {
+			setRefreshing(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		fetchHealth();
+	}, [fetchHealth]);
+
+	const handleRefresh = () => {
+		if (!refreshing) fetchHealth(true);
+	};
+
+	const okCount = functions.filter((f) => f.status === 'ok').length;
+	const errorCount = functions.filter((f) => f.status === 'error').length;
+	const totalCount = functions.length;
+
+	return (
+		<div className="not-content" style={styles.dashboard}>
+			{/* Header */}
+			<header style={styles.header}>
+				<div>
+					<h1 style={styles.title}>Edge Functions</h1>
+					{fromCache && (
+						<span style={styles.cacheBadge}>cached</span>
+					)}
+				</div>
+				<button
+					onClick={handleRefresh}
+					disabled={refreshing}
+					style={styles.refreshButton}
+					title="Refresh health checks">
+					<RefreshCw
+						size={18}
+						style={
+							refreshing
+								? { animation: 'spin 1s linear infinite' }
+								: undefined
+						}
+					/>
+				</button>
+			</header>
+
+			{/* Summary bar */}
+			<div style={styles.summaryBar}>
+				<div style={styles.summaryItem}>
+					<Activity size={16} />
+					<span>
+						{okCount}/{totalCount} operational
+					</span>
+				</div>
+				{errorCount > 0 && (
+					<div style={{ ...styles.summaryItem, color: '#fca5a5' }}>
+						<XCircle size={16} />
+						<span>
+							{errorCount} {errorCount === 1 ? 'issue' : 'issues'}
+						</span>
+					</div>
+				)}
+				{lastChecked && (
+					<div style={styles.summaryItem}>
+						<Clock size={16} />
+						<span>
+							{lastChecked.toLocaleTimeString([], {
+								hour: '2-digit',
+								minute: '2-digit',
+								second: '2-digit',
+							})}
+						</span>
+					</div>
+				)}
+			</div>
+
+			{/* Error banner */}
+			{error && (
+				<div style={styles.errorBanner}>
+					<AlertCircle size={16} />
+					<span>{error}</span>
+				</div>
+			)}
+
+			{/* Status cards grid */}
+			<div style={styles.statusGrid}>
+				{functions.map((fn) => (
+					<StatusCard key={fn.name} fn={fn} />
+				))}
+			</div>
+
+			<style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles: Record<string, React.CSSProperties> = {
+	dashboard: {
+		display: 'flex',
+		flexDirection: 'column',
+		gap: '1.5rem',
+	},
+	header: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+	},
+	title: {
+		color: 'var(--sl-color-text, #e6edf3)',
+		margin: 0,
+		fontSize: '1.75rem',
+		fontWeight: 700,
+		display: 'inline',
+	},
+	cacheBadge: {
+		marginLeft: '0.75rem',
+		padding: '2px 8px',
+		borderRadius: '4px',
+		background: 'var(--sl-color-gray-6, #1c1c1c)',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		fontSize: '0.7rem',
+		fontWeight: 500,
+		textTransform: 'uppercase' as const,
+		letterSpacing: '0.05em',
+	},
+	refreshButton: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		width: '36px',
+		height: '36px',
+		borderRadius: '8px',
+		border: '1px solid var(--sl-color-gray-5, #262626)',
+		background: 'var(--sl-color-bg-nav, #111)',
+		color: 'var(--sl-color-text, #e6edf3)',
+		cursor: 'pointer',
+		transition: 'border-color 0.2s',
+	},
+	summaryBar: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '1.5rem',
+		padding: '0.75rem 1rem',
+		borderRadius: '8px',
+		background: 'var(--sl-color-bg-nav, #111)',
+		border: '1px solid var(--sl-color-gray-5, #262626)',
+		fontSize: '0.875rem',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		flexWrap: 'wrap',
+	},
+	summaryItem: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+	},
+	errorBanner: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		padding: '0.75rem 1rem',
+		borderRadius: '8px',
+		background: 'rgba(239,68,68,0.1)',
+		border: '1px solid rgba(239,68,68,0.3)',
+		color: '#fca5a5',
+		fontSize: '0.875rem',
+	},
+	statusGrid: {
+		display: 'grid',
+		gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+		gap: '1rem',
+	},
+	statusCard: {
+		display: 'flex',
+		flexDirection: 'column',
+		gap: '0.5rem',
+		padding: '1.25rem',
+		borderRadius: '12px',
+		border: '1px solid var(--sl-color-gray-5, #262626)',
+		background: 'var(--sl-color-bg-nav, #111)',
+	},
+	cardHeader: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+	},
+	cardLabel: {
+		color: 'var(--sl-color-text, #e6edf3)',
+		fontWeight: 600,
+		fontSize: '1rem',
+		flex: 1,
+	},
+	latencyBadge: {
+		padding: '2px 6px',
+		borderRadius: '4px',
+		background: 'var(--sl-color-gray-6, #1c1c1c)',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		fontSize: '0.7rem',
+		fontWeight: 500,
+		fontVariantNumeric: 'tabular-nums',
+	},
+	cardDescription: {
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		fontSize: '0.8rem',
+	},
+	cardMeta: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		color: 'var(--sl-color-gray-4, #6b7280)',
+		fontSize: '0.75rem',
+	},
+	cardError: {
+		color: '#fca5a5',
+		fontSize: '0.75rem',
+		padding: '4px 8px',
+		borderRadius: '4px',
+		background: 'rgba(239,68,68,0.1)',
+	},
+};

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/edge/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/edge/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Edge Functions
+description: KBVE Edge Function Health Dashboard
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: Edge Functions
+    order: 2
+unsplash: 1558494949-ef010cbdcc31
+img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - edge
+---
+
+import AstroEdgeDashboard from '@/components/dashboard/AstroEdgeDashboard.astro';
+
+<AstroEdgeDashboard />


### PR DESCRIPTION
## Summary
- Adds `/dashboard/edge/` page to the Starlight docs site
- Displays real-time health status of all 7 Supabase edge functions
- No authentication required — uses `GET /functions/v1/health` for the health endpoint and `OPTIONS` preflight for other functions to detect availability
- Shows status (ok/error), latency (ms), version, and timestamp for each function
- Summary bar with operational count and last-checked time
- 30-second localStorage cache to reduce API calls
- Follows existing Grafana dashboard patterns (same component architecture, styling, design tokens)

### Functions Monitored
| Function | Method | What it checks |
|----------|--------|----------------|
| Health | GET | Full health response (status, version, timestamp) |
| Meme | OPTIONS | Function deployed and responding |
| Minecraft | OPTIONS | Function deployed and responding |
| Discord | OPTIONS | Function deployed and responding |
| User Vault | OPTIONS | Function deployed and responding |
| Guild Vault | OPTIONS | Function deployed and responding |
| Vault Reader | OPTIONS | Function deployed and responding |

### Files Added
- `apps/kbve/astro-kbve/src/content/docs/dashboard/edge/index.mdx`
- `apps/kbve/astro-kbve/src/components/dashboard/AstroEdgeDashboard.astro`
- `apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeDashboard.tsx`

## Test plan
- [ ] Page renders at `/dashboard/edge/`
- [ ] Health function shows version and timestamp
- [ ] All functions show ok/error status with latency
- [ ] Refresh button triggers new health checks
- [ ] Cache badge appears when viewing cached results
- [ ] Summary bar shows X/7 operational

🤖 Generated with [Claude Code](https://claude.com/claude-code)