### PR TITLE
chore(axum-kbve): bump version to 1.0.26 to trigger CI pipeline

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.25"
+version = "1.0.26"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump axum-kbve from 1.0.25 to 1.0.26
- Triggers file alteration detection so the full pipeline runs after dev→main merge
- This ensures `docker-test-app.yml@main` has the `runner` input when the e2e runs on `arc-runner-set`

## Test plan
- [ ] Merge to dev, then merge dev→main (PR #7711)
- [ ] axum-kbve-e2e runs on `arc-runner-set` (not ubuntu-latest)
- [ ] Docker image `ghcr.io/kbve/kbve:1.0.26` published
- [ ] Kube manifest auto-updated to 1.0.26