### PR TITLE
test(axum-discordsh): add 16 tests for serde, DamageReduction, gear, roster + e2e spec

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/game/content.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/content.rs
@@ -2584,4 +2584,117 @@ mod tests {
             );
         }
     }
+
+    // ── New gear item validation tests ─────────────────────────────
+
+    #[test]
+    fn new_gear_items_all_exist() {
+        let new_ids = [
+            "iron_mace",
+            "glass_stiletto",
+            "excalibur",
+            "void_scythe",
+            "shadow_cloak",
+            "runeguard_plate",
+            "dragon_scale",
+        ];
+        for id in &new_ids {
+            assert!(
+                find_gear(id).is_some(),
+                "gear '{}' should exist in registry",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn legendary_gear_stats_correct() {
+        let excalibur = find_gear("excalibur").unwrap();
+        assert_eq!(excalibur.rarity, ItemRarity::Legendary);
+        assert_eq!(excalibur.slot, EquipSlot::Weapon);
+        assert_eq!(excalibur.bonus_damage, 6);
+        assert_eq!(excalibur.bonus_hp, 5);
+        assert_eq!(
+            excalibur.special,
+            Some(GearSpecial::CritBonus { percent: 10 })
+        );
+
+        let void_scythe = find_gear("void_scythe").unwrap();
+        assert_eq!(void_scythe.rarity, ItemRarity::Legendary);
+        assert_eq!(void_scythe.bonus_damage, 7);
+        assert_eq!(
+            void_scythe.special,
+            Some(GearSpecial::LifeSteal { percent: 15 })
+        );
+
+        let dragon_scale = find_gear("dragon_scale").unwrap();
+        assert_eq!(dragon_scale.rarity, ItemRarity::Legendary);
+        assert_eq!(dragon_scale.slot, EquipSlot::Armor);
+        assert_eq!(dragon_scale.bonus_armor, 8);
+        assert_eq!(dragon_scale.bonus_hp, 15);
+        assert_eq!(
+            dragon_scale.special,
+            Some(GearSpecial::DamageReduction { percent: 10 })
+        );
+    }
+
+    #[test]
+    fn gear_loot_tables_reference_valid_gear() {
+        // Every gear_id in loot tables must exist in the gear registry
+        let tables = gear_loot_tables();
+        for table in tables {
+            for entry in table.entries {
+                assert!(
+                    find_gear(entry.gear_id).is_some(),
+                    "gear loot table '{}' references non-existent gear '{}'",
+                    table.id,
+                    entry.gear_id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn gear_registry_unique_ids() {
+        let registry = gear_registry();
+        let mut seen = std::collections::HashSet::new();
+        for gear in registry {
+            assert!(
+                seen.insert(gear.id),
+                "duplicate gear id '{}' in registry",
+                gear.id
+            );
+        }
+    }
+
+    #[test]
+    fn gear_rarity_distribution() {
+        let registry = gear_registry();
+        let common = registry
+            .iter()
+            .filter(|g| g.rarity == ItemRarity::Common)
+            .count();
+        let uncommon = registry
+            .iter()
+            .filter(|g| g.rarity == ItemRarity::Uncommon)
+            .count();
+        let rare = registry
+            .iter()
+            .filter(|g| g.rarity == ItemRarity::Rare)
+            .count();
+        let epic = registry
+            .iter()
+            .filter(|g| g.rarity == ItemRarity::Epic)
+            .count();
+        let legendary = registry
+            .iter()
+            .filter(|g| g.rarity == ItemRarity::Legendary)
+            .count();
+
+        assert!(common >= 2, "should have at least 2 Common gear");
+        assert!(uncommon >= 2, "should have at least 2 Uncommon gear");
+        assert!(rare >= 2, "should have at least 2 Rare gear");
+        assert!(epic >= 1, "should have at least 1 Epic gear");
+        assert!(legendary >= 3, "should have at least 3 Legendary gear");
+    }
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -6741,4 +6741,92 @@ mod tests {
             2
         );
     }
+
+    // ── DamageReduction gear tests ──────────────────────────────────
+
+    #[test]
+    fn test_damage_reduction_reduces_single_target_damage() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+
+        // Equip dragon_scale (10% DamageReduction)
+        session.player_mut(OWNER).armor_gear = Some("dragon_scale".to_owned());
+        // Set armor to 0 so we isolate DamageReduction
+        session.player_mut(OWNER).armor = 0;
+
+        let hp_before = session.player(OWNER).hp;
+
+        // Enemy deals 20 damage
+        let mut enemy = test_enemy();
+        enemy.intent = Intent::Attack { dmg: 20 };
+        session.enemies = vec![enemy];
+
+        // Process enemy turn
+        let _ = single_enemy_turn(&mut session, 0, OWNER);
+
+        let hp_after = session.player(OWNER).hp;
+        let damage_taken = hp_before - hp_after;
+
+        // 20 base - 0 armor = 20, then 10% DR: ceil(20 * 0.9) = 18
+        assert_eq!(damage_taken, 18, "10% DR should reduce 20 damage to 18");
+    }
+
+    #[test]
+    fn test_damage_reduction_minimum_one_damage() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+
+        session.player_mut(OWNER).armor_gear = Some("dragon_scale".to_owned());
+        // High armor so raw damage is 1
+        session.player_mut(OWNER).armor = 100;
+
+        let hp_before = session.player(OWNER).hp;
+
+        let mut enemy = test_enemy();
+        enemy.intent = Intent::Attack { dmg: 10 };
+        session.enemies = vec![enemy];
+
+        let _ = single_enemy_turn(&mut session, 0, OWNER);
+
+        let hp_after = session.player(OWNER).hp;
+        let damage_taken = hp_before - hp_after;
+
+        // (10 - 100).max(1) = 1, then ceil(1 * 0.9) = 1, max(1) = 1
+        assert_eq!(damage_taken, 1, "DR should never reduce below 1 damage");
+    }
+
+    #[test]
+    fn test_damage_reduction_aoe_attack() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+
+        // Add a second player to verify AoE applies DR per-player
+        let p2 = serenity::UserId::new(2);
+        let mut player2 = PlayerState::default();
+        player2.armor = 0;
+        player2.armor_gear = Some("dragon_scale".to_owned()); // 10% DR
+        session.players.insert(p2, player2);
+        session.party.push(p2);
+
+        // Owner has no DR
+        session.player_mut(OWNER).armor = 0;
+        session.player_mut(OWNER).armor_gear = None;
+
+        let hp_owner_before = session.player(OWNER).hp;
+        let hp_p2_before = session.player(p2).hp;
+
+        let mut enemy = test_enemy();
+        enemy.intent = Intent::AoeAttack { dmg: 20 };
+        session.enemies = vec![enemy];
+
+        let _ = single_enemy_turn(&mut session, 0, OWNER);
+
+        let owner_dmg = hp_owner_before - session.player(OWNER).hp;
+        let p2_dmg = hp_p2_before - session.player(p2).hp;
+
+        // Owner: no DR, 0 armor → takes full 20
+        assert_eq!(owner_dmg, 20, "Owner without DR should take full damage");
+        // P2: 10% DR → ceil(20 * 0.9) = 18
+        assert_eq!(p2_dmg, 18, "P2 with DR should take reduced damage");
+    }
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/render.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/render.rs
@@ -1841,4 +1841,110 @@ mod tests {
             "game over should NOT have Inv button"
         );
     }
+
+    // ── Roster / embed field format tests ───────────────────────────
+
+    /// Build roster parts the same way render_embed does, for testing.
+    fn build_roster_parts(session: &SessionState) -> Vec<String> {
+        session
+            .roster()
+            .iter()
+            .enumerate()
+            .map(|(i, (_, player))| match &player.member_status {
+                MemberStatusTag::Member { username } => {
+                    format!(
+                        "[{}] {} — [kbve.com/@{}](https://kbve.com/@{})",
+                        i + 1,
+                        player.name,
+                        username,
+                        username
+                    )
+                }
+                MemberStatusTag::Guest => format!("[{}] {} (Guest)", i + 1, player.name),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn roster_field_member_has_clickable_link() {
+        let mut session = test_session();
+        session.player_mut(OWNER).name = "Fudster".to_owned();
+        session.player_mut(OWNER).member_status = MemberStatusTag::Member {
+            username: "fudster".to_owned(),
+        };
+
+        let parts = build_roster_parts(&session);
+        assert_eq!(parts.len(), 1);
+        assert!(
+            parts[0].contains("[kbve.com/@fudster](https://kbve.com/@fudster)"),
+            "member should have markdown link, got: {}",
+            parts[0]
+        );
+        assert!(parts[0].starts_with("[1]"), "should start with [1]");
+        assert!(parts[0].contains("Fudster"), "should contain player name");
+    }
+
+    #[test]
+    fn roster_field_guest_no_link() {
+        let mut session = test_session();
+        session.player_mut(OWNER).name = "RandomGuy".to_owned();
+        session.player_mut(OWNER).member_status = MemberStatusTag::Guest;
+
+        let parts = build_roster_parts(&session);
+        assert_eq!(parts.len(), 1);
+        assert!(
+            parts[0].contains("(Guest)"),
+            "guest should show (Guest), got: {}",
+            parts[0]
+        );
+        assert!(
+            !parts[0].contains("kbve.com"),
+            "guest should not have kbve link"
+        );
+    }
+
+    #[test]
+    fn roster_field_party_ordering_and_mixed_status() {
+        let mut session = test_session();
+        session.player_mut(OWNER).name = "Leader".to_owned();
+        session.player_mut(OWNER).member_status = MemberStatusTag::Member {
+            username: "leader".to_owned(),
+        };
+
+        // Add party member (guest)
+        let p2 = serenity::UserId::new(2);
+        let mut player2 = PlayerState::default();
+        player2.name = "GuestBob".to_owned();
+        player2.member_status = MemberStatusTag::Guest;
+        session.players.insert(p2, player2);
+        session.party.push(p2);
+
+        // Add party member (member)
+        let p3 = serenity::UserId::new(3);
+        let mut player3 = PlayerState::default();
+        player3.name = "MemberAlice".to_owned();
+        player3.member_status = MemberStatusTag::Member {
+            username: "alice".to_owned(),
+        };
+        session.players.insert(p3, player3);
+        session.party.push(p3);
+
+        let parts = build_roster_parts(&session);
+        assert_eq!(parts.len(), 3);
+
+        // Owner is always [1]
+        assert!(parts[0].starts_with("[1]"));
+        assert!(parts[0].contains("Leader"));
+        assert!(parts[0].contains("kbve.com/@leader"));
+
+        // Second player is [2] guest
+        assert!(parts[1].starts_with("[2]"));
+        assert!(parts[1].contains("GuestBob"));
+        assert!(parts[1].contains("(Guest)"));
+
+        // Third player is [3] member
+        assert!(parts[2].starts_with("[3]"));
+        assert!(parts[2].contains("MemberAlice"));
+        assert!(parts[2].contains("kbve.com/@alice"));
+    }
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/types.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/types.rs
@@ -1091,4 +1091,229 @@ mod tests {
         };
         assert!(!session.show_inventory);
     }
+
+    // ── Serde serialization tests ──────────────────────────────────
+
+    #[test]
+    fn serde_session_state_round_trip() {
+        use std::time::Instant;
+        let owner = serenity::UserId::new(42);
+        let mut players = HashMap::new();
+        let mut player = PlayerState::default();
+        player.name = "TestHero".to_owned();
+        player.gold = 100;
+        player.weapon = Some("rusty_sword".to_owned());
+        player.armor_gear = Some("leather_vest".to_owned());
+        player.effects.push(EffectInstance {
+            kind: EffectKind::Poison,
+            stacks: 2,
+            turns_left: 3,
+        });
+        player.inventory.push(ItemStack {
+            item_id: "potion".to_owned(),
+            qty: 5,
+        });
+        players.insert(owner, player);
+
+        let session = SessionState {
+            id: uuid::Uuid::new_v4(),
+            short_id: "serde123".to_owned(),
+            owner,
+            party: Vec::new(),
+            mode: SessionMode::Solo,
+            phase: GamePhase::Combat,
+            channel_id: serenity::ChannelId::new(999),
+            message_id: serenity::MessageId::new(888),
+            created_at: Instant::now(),
+            last_action_at: Instant::now(),
+            turn: 7,
+            players,
+            enemies: vec![EnemyState {
+                name: "Goblin".to_owned(),
+                level: 3,
+                hp: 30,
+                max_hp: 40,
+                armor: 2,
+                effects: Vec::new(),
+                intent: Intent::HeavyAttack { dmg: 12 },
+                charged: false,
+                loot_table_id: "skeleton",
+                enraged: false,
+                index: 0,
+                first_strike: false,
+            }],
+            room: super::super::content::generate_room(5),
+            log: vec!["Turn begins.".to_owned(), "Goblin attacks!".to_owned()],
+            show_items: true,
+            pending_actions: HashMap::new(),
+            map: test_map_default(),
+            show_map: false,
+            show_inventory: true,
+            pending_destination: Some(MapPos::new(1, 0)),
+            enemies_had_first_strike: false,
+        };
+
+        let json = serde_json::to_string(&session).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Core fields present
+        assert_eq!(val["short_id"], "serde123");
+        assert_eq!(val["turn"], 7);
+        assert_eq!(val["mode"], "Solo");
+        assert_eq!(val["phase"], "Combat");
+        assert_eq!(val["show_inventory"], true);
+
+        // Players map uses string keys
+        let players_obj = val["players"].as_object().unwrap();
+        assert_eq!(players_obj.len(), 1);
+        assert!(players_obj.contains_key("42"));
+        let p = &players_obj["42"];
+        assert_eq!(p["name"], "TestHero");
+        assert_eq!(p["gold"], 100);
+        assert_eq!(p["weapon"], "rusty_sword");
+        assert_eq!(p["inventory"][0]["item_id"], "potion");
+        assert_eq!(p["inventory"][0]["qty"], 5);
+        assert_eq!(p["effects"][0]["kind"], "Poison");
+
+        // Enemies
+        assert_eq!(val["enemies"][0]["name"], "Goblin");
+        assert_eq!(val["enemies"][0]["hp"], 30);
+
+        // Skipped fields should be absent
+        assert!(val.get("created_at").is_none());
+        assert!(val.get("last_action_at").is_none());
+        assert!(val.get("pending_actions").is_none());
+        assert!(val.get("pending_destination").is_none());
+
+        // Tiles serialized as array
+        assert!(val["map"]["tiles"].is_array());
+
+        // Log preserved
+        assert_eq!(val["log"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn serde_gear_special_all_variants() {
+        let variants = vec![
+            GearSpecial::LifeSteal { percent: 20 },
+            GearSpecial::Thorns { damage: 5 },
+            GearSpecial::CritBonus { percent: 15 },
+            GearSpecial::DamageReduction { percent: 10 },
+        ];
+
+        for variant in &variants {
+            let json = serde_json::to_string(variant).unwrap();
+            let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+            // Each variant serializes as an object with the variant name as key
+            assert!(
+                val.is_object(),
+                "GearSpecial variant should be an object: {json}"
+            );
+        }
+
+        // Verify specific field values
+        let dr_json = serde_json::to_string(&GearSpecial::DamageReduction { percent: 10 }).unwrap();
+        let dr_val: serde_json::Value = serde_json::from_str(&dr_json).unwrap();
+        assert_eq!(dr_val["DamageReduction"]["percent"], 10);
+    }
+
+    #[test]
+    fn serde_game_phase_variants() {
+        let phases = vec![
+            GamePhase::Exploring,
+            GamePhase::Combat,
+            GamePhase::Looting,
+            GamePhase::Event,
+            GamePhase::Rest,
+            GamePhase::Merchant,
+            GamePhase::GameOver(GameOverReason::Victory),
+            GamePhase::GameOver(GameOverReason::Defeated),
+        ];
+
+        for phase in &phases {
+            let json = serde_json::to_string(phase).unwrap();
+            // Should not panic and produce valid JSON
+            let _: serde_json::Value = serde_json::from_str(&json).unwrap();
+        }
+
+        // Simple variants serialize as strings
+        let json = serde_json::to_string(&GamePhase::Exploring).unwrap();
+        assert_eq!(json, "\"Exploring\"");
+
+        // Nested variants serialize with data
+        let json = serde_json::to_string(&GamePhase::GameOver(GameOverReason::Victory)).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["GameOver"], "Victory");
+    }
+
+    #[test]
+    fn serde_map_tiles_serialized_as_array() {
+        let mut tiles = HashMap::new();
+        tiles.insert(
+            MapPos::new(0, 0),
+            MapTile {
+                pos: MapPos::new(0, 0),
+                room_type: RoomType::UndergroundCity,
+                name: "City".to_owned(),
+                description: "A city.".to_owned(),
+                exits: vec![Direction::North],
+                visited: true,
+                cleared: true,
+            },
+        );
+        tiles.insert(
+            MapPos::new(1, 0),
+            MapTile {
+                pos: MapPos::new(1, 0),
+                room_type: RoomType::Combat,
+                name: "Arena".to_owned(),
+                description: "A fight.".to_owned(),
+                exits: vec![Direction::West, Direction::East],
+                visited: false,
+                cleared: false,
+            },
+        );
+
+        let map = MapState {
+            seed: 42,
+            position: MapPos::new(0, 0),
+            tiles,
+            tiles_visited: 1,
+            boss_positions: vec![MapPos::new(5, 5)],
+        };
+
+        let json = serde_json::to_string(&map).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // tiles is an array, not an object
+        let tiles_arr = val["tiles"].as_array().unwrap();
+        assert_eq!(tiles_arr.len(), 2);
+
+        // Each tile has its pos embedded
+        let names: Vec<&str> = tiles_arr
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"City"));
+        assert!(names.contains(&"Arena"));
+
+        // boss_positions serializes normally
+        assert_eq!(val["boss_positions"][0]["x"], 5);
+        assert_eq!(val["boss_positions"][0]["y"], 5);
+    }
+
+    #[test]
+    fn serde_member_status_tag_variants() {
+        let member = MemberStatusTag::Member {
+            username: "fudster".to_owned(),
+        };
+        let guest = MemberStatusTag::Guest;
+
+        let member_json = serde_json::to_string(&member).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&member_json).unwrap();
+        assert_eq!(val["Member"]["username"], "fudster");
+
+        let guest_json = serde_json::to_string(&guest).unwrap();
+        assert_eq!(guest_json, "\"Guest\"");
+    }
 }

--- a/apps/discordsh/discordsh-e2e/e2e/session-api.spec.ts
+++ b/apps/discordsh/discordsh-e2e/e2e/session-api.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Session API: JSON Endpoint', () => {
+	test('GET /api/session/{id} returns 404 JSON for missing session', async ({
+		request,
+	}) => {
+		const response = await request.get('/api/session/deadbeef');
+		expect(response.status()).toBe(404);
+
+		const contentType = response.headers()['content-type'] ?? '';
+		expect(contentType).toContain('application/json');
+
+		const json = await response.json();
+		expect(json.error).toBe('session not found');
+	});
+
+	test('GET /api/session/{id} 404 response has correct structure', async ({
+		request,
+	}) => {
+		const response = await request.get('/api/session/00000000');
+		expect(response.status()).toBe(404);
+
+		const json = await response.json();
+		expect(Object.keys(json)).toEqual(['error']);
+		expect(typeof json.error).toBe('string');
+	});
+
+	test('GET /api/session/ without ID returns 404', async ({ request }) => {
+		const response = await request.get('/api/session/');
+		// Axum should 404 or 405 on missing path segment
+		expect(response.status()).toBeGreaterThanOrEqual(400);
+	});
+
+	test('API 404 includes security headers', async ({ request }) => {
+		const response = await request.get('/api/session/nonexistent');
+		const headers = response.headers();
+		expect(headers['x-content-type-options']).toBe('nosniff');
+		expect(headers['x-frame-options']).toBe('DENY');
+	});
+});
+
+test.describe('Session Viewer: HTML Page', () => {
+	test('GET /session/{id} returns 404 for missing session', async ({
+		request,
+	}) => {
+		const response = await request.get('/session/deadbeef');
+		expect(response.status()).toBe(404);
+	});
+
+	test('/session/{id} 404 returns plain text, not JSON', async ({
+		request,
+	}) => {
+		const response = await request.get('/session/deadbeef');
+		expect(response.status()).toBe(404);
+
+		const body = await response.text();
+		expect(body).toContain('Session not found');
+
+		// Should NOT be JSON
+		const contentType = response.headers()['content-type'] ?? '';
+		expect(contentType).not.toContain('application/json');
+	});
+
+	test('/session/ without ID returns 404', async ({ request }) => {
+		const response = await request.get('/session/');
+		expect(response.status()).toBeGreaterThanOrEqual(400);
+	});
+
+	test('session viewer 404 includes security headers', async ({
+		request,
+	}) => {
+		const response = await request.get('/session/nonexistent');
+		const headers = response.headers();
+		expect(headers['x-content-type-options']).toBe('nosniff');
+		expect(headers['x-frame-options']).toBe('DENY');
+		expect(headers['referrer-policy']).toBe(
+			'strict-origin-when-cross-origin',
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Cherry-picked test commit from #7715 (feat commit already merged via #7699)
- Adds 16 unit tests: serde round-trip, DamageReduction combat, gear validation, embed roster format
- Adds Playwright e2e spec for `/api/session/{id}` and `/session/{id}` viewer endpoints

## Test additions
- **content.rs**: gear item validation, loot table integrity, unique IDs, rarity distribution
- **logic.rs**: DamageReduction combat tests (single-target, AoE, minimum damage)
- **render.rs**: embed roster format tests (member links, guest format, party order)
- **types.rs**: serde round-trip tests (SessionState JSON structure, enum variants)
- **session-api.spec.ts**: e2e tests for session JSON API + HTML viewer + security headers

Closes #7715

## Test plan
- [x] `cargo check -p axum-discordsh` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)