### PR TITLE
chore(axum-kbve): bump version to 1.0.27

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.26"
+version = "1.0.27"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bumps `axum-kbve` version from `1.0.26` to `1.0.27` to trigger a fresh build

## Test plan
- [ ] CI build triggers successfully for axum-kbve