### PR TITLE
fix(axum-kbve): restore Dockerfile Astro build to 8192MB heap

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -32,11 +32,10 @@ COPY packages/npm/laser/ packages/npm/laser/
 COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 
 # Build astro site (cache .astro dir for incremental content collection builds)
-# Memory capped at 4096MB to stay within CI runner limits inside buildkit
 WORKDIR /app/apps/kbve/astro-kbve
 RUN --mount=type=cache,target=/app/apps/kbve/astro-kbve/.astro,id=astro-cache \
     npx astro sync && \
-    UV_THREADPOOL_SIZE=2 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets


### PR DESCRIPTION
## Summary
- Restores `UV_THREADPOOL_SIZE=4` and `--max-old-space-size=8192` in the Dockerfile Astro build stage
- The 4096MB cap was a workaround for ubuntu-latest runners; now that axum-kbve-e2e runs on `arc-runner-set` (24Gi RAM), full heap is supported

## Test plan
- [ ] CI builds axum-kbve Docker image successfully on arc-runner-set