### PR TITLE
fix(discordsh): fix equip bug and add unequip dual-dropdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "askama",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.24"
+version = "1.0.28"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.27"
+version = "0.1.28"
 edition = "2024"
 publish = false
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -88,7 +88,7 @@ fn validate_action(
                 }
             }
         }
-        GameAction::Equip(_) => {
+        GameAction::Equip(_) | GameAction::Unequip(_) => {
             // Allowed anytime except GameOver (already checked above)
         }
         GameAction::Explore => {
@@ -212,6 +212,10 @@ pub fn apply_action(
         }
         GameAction::Equip(ref gear_id) => {
             let msg = apply_equip(session, gear_id, actor)?;
+            vec![msg]
+        }
+        GameAction::Unequip(ref slot_str) => {
+            let msg = apply_unequip(session, slot_str, actor)?;
             vec![msg]
         }
         GameAction::UseItem(ref item_id, target_opt) => {
@@ -2000,6 +2004,42 @@ fn apply_equip(
     }
 
     Ok(format!("Equipped {}!", gear_name))
+}
+
+// ── Unequip gear ────────────────────────────────────────────────────
+
+fn apply_unequip(
+    session: &mut SessionState,
+    slot_str: &str,
+    actor: serenity::UserId,
+) -> Result<String, String> {
+    let player = session.player_mut(actor);
+
+    match slot_str {
+        "weapon" => {
+            let old_id = player.weapon.take().ok_or("No weapon equipped.")?;
+            let name = content::find_gear(&old_id)
+                .map(|g| g.name.to_owned())
+                .unwrap_or_else(|| old_id.clone());
+            add_item_to_inventory(&mut player.inventory, &old_id);
+            Ok(format!("Unequipped {}.", name))
+        }
+        "armor" => {
+            let old_id = player.armor_gear.take().ok_or("No armor equipped.")?;
+            let gear = content::find_gear(&old_id);
+            let name = gear
+                .map(|g| g.name.to_owned())
+                .unwrap_or_else(|| old_id.clone());
+            if let Some(g) = gear {
+                player.armor -= g.bonus_armor;
+                player.max_hp -= g.bonus_hp;
+                player.hp = player.hp.min(player.max_hp);
+            }
+            add_item_to_inventory(&mut player.inventory, &old_id);
+            Ok(format!("Unequipped {}.", name))
+        }
+        _ => Err("Invalid equipment slot.".to_owned()),
+    }
 }
 
 // ── Heal ally (Cleric) ──────────────────────────────────────────────
@@ -4924,6 +4964,112 @@ mod tests {
             old_sword_qty, 1,
             "Old weapon (rusty_sword) should be returned to inventory"
         );
+    }
+
+    #[test]
+    fn test_unequip_weapon() {
+        let mut session = test_session();
+        session.phase = GamePhase::Exploring;
+
+        // Give and equip a weapon
+        add_item_to_inventory(&mut session.player_mut(OWNER).inventory, "rusty_sword");
+        let equip = apply_action(
+            &mut session,
+            GameAction::Equip("rusty_sword".to_owned()),
+            OWNER,
+        );
+        assert!(equip.is_ok());
+        assert_eq!(session.player(OWNER).weapon.as_deref(), Some("rusty_sword"));
+
+        // Unequip weapon
+        let result = apply_action(
+            &mut session,
+            GameAction::Unequip("weapon".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        assert!(
+            session.player(OWNER).weapon.is_none(),
+            "Weapon slot should be empty after unequip"
+        );
+
+        // Weapon should be back in inventory
+        let qty = session
+            .player(OWNER)
+            .inventory
+            .iter()
+            .find(|s| s.item_id == "rusty_sword")
+            .map(|s| s.qty)
+            .unwrap_or(0);
+        assert_eq!(qty, 1, "Unequipped weapon should return to inventory");
+    }
+
+    #[test]
+    fn test_unequip_armor() {
+        let mut session = test_session();
+        session.phase = GamePhase::Exploring;
+
+        // Give and equip armor
+        add_item_to_inventory(&mut session.player_mut(OWNER).inventory, "leather_vest");
+        let base_armor = session.player(OWNER).armor;
+        let equip = apply_action(
+            &mut session,
+            GameAction::Equip("leather_vest".to_owned()),
+            OWNER,
+        );
+        assert!(equip.is_ok());
+        assert!(session.player(OWNER).armor > base_armor);
+
+        let armor_while_equipped = session.player(OWNER).armor;
+
+        // Unequip armor
+        let result = apply_action(&mut session, GameAction::Unequip("armor".to_owned()), OWNER);
+        assert!(result.is_ok());
+        assert!(
+            session.player(OWNER).armor_gear.is_none(),
+            "Armor slot should be empty after unequip"
+        );
+        assert!(
+            session.player(OWNER).armor < armor_while_equipped,
+            "Armor stat should decrease after unequipping"
+        );
+
+        // Armor should be back in inventory
+        let qty = session
+            .player(OWNER)
+            .inventory
+            .iter()
+            .find(|s| s.item_id == "leather_vest")
+            .map(|s| s.qty)
+            .unwrap_or(0);
+        assert_eq!(qty, 1, "Unequipped armor should return to inventory");
+    }
+
+    #[test]
+    fn test_unequip_empty_slot_fails() {
+        let mut session = test_session();
+        session.phase = GamePhase::Exploring;
+
+        // No weapon equipped — unequip should fail
+        let result = apply_action(
+            &mut session,
+            GameAction::Unequip("weapon".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_err());
+
+        // No armor equipped — unequip should fail
+        let result = apply_action(&mut session, GameAction::Unequip("armor".to_owned()), OWNER);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unequip_invalid_slot_fails() {
+        let mut session = test_session();
+        session.phase = GamePhase::Exploring;
+
+        let result = apply_action(&mut session, GameAction::Unequip("ring".to_owned()), OWNER);
+        assert!(result.is_err());
     }
 
     // ── Group 4: Combat Mechanic Tests ──────────────────────────────

--- a/apps/discordsh/axum-discordsh/src/discord/game/render.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/render.rs
@@ -447,6 +447,38 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
 /// Build the direction navigation buttons row.
 /// Each direction is Primary if the current tile has that exit, otherwise disabled Secondary.
 /// The Map button toggles the map overlay.
+/// Build an unequip select menu from currently equipped weapon/armor.
+fn build_unequip_menu(owner: &PlayerState, sid: &str, rows: &mut Vec<serenity::CreateActionRow>) {
+    let mut options = Vec::new();
+
+    if let Some(ref weapon_id) = owner.weapon {
+        if let Some(gear) = super::content::find_gear(weapon_id) {
+            options.push(serenity::CreateSelectMenuOption::new(
+                format!("{} {} [Weapon]", gear.emoji, gear.name),
+                "weapon",
+            ));
+        }
+    }
+
+    if let Some(ref armor_id) = owner.armor_gear {
+        if let Some(gear) = super::content::find_gear(armor_id) {
+            options.push(serenity::CreateSelectMenuOption::new(
+                format!("{} {} [Armor]", gear.emoji, gear.name),
+                "armor",
+            ));
+        }
+    }
+
+    if !options.is_empty() {
+        let menu = serenity::CreateSelectMenu::new(
+            format!("dng|{sid}|unequip"),
+            serenity::CreateSelectMenuKind::String { options },
+        )
+        .placeholder("Unequip gear...");
+        rows.push(serenity::CreateActionRow::SelectMenu(menu));
+    }
+}
+
 fn direction_buttons(session: &SessionState) -> serenity::CreateActionRow {
     let sid = &session.short_id;
     let current_tile = session.map.tiles.get(&session.map.position);
@@ -581,6 +613,9 @@ pub fn render_components(session: &SessionState) -> Vec<serenity::CreateActionRo
                 rows.push(serenity::CreateActionRow::SelectMenu(menu));
             }
         }
+
+        // Gear unequip select menu
+        build_unequip_menu(owner, sid, &mut rows);
 
         return rows;
     }
@@ -810,6 +845,11 @@ pub fn render_components(session: &SessionState) -> Vec<serenity::CreateActionRo
             .placeholder("Equip gear...");
             rows.push(serenity::CreateActionRow::SelectMenu(menu));
         }
+    }
+
+    // Gear unequip select menu
+    if !game_over {
+        build_unequip_menu(owner, sid, &mut rows);
     }
 
     // Cleric heal target menu (show if any party Cleric has heals remaining)

--- a/apps/discordsh/axum-discordsh/src/discord/game/router.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/router.rs
@@ -89,12 +89,31 @@ pub async fn handle_game_component(
             return send_ephemeral(component, ctx, "Invalid select menu interaction.").await;
         }
     } else if action_str == "equip" {
-        // Equip gear — gear_id from parts[3]
-        let gear_id = parts.get(3).unwrap_or(&"");
-        if gear_id.is_empty() {
-            return send_ephemeral(component, ctx, "No gear specified.").await;
+        // Equip gear — gear_id from select menu value
+        if let serenity::ComponentInteractionDataKind::StringSelect { values } =
+            &component.data.kind
+        {
+            if let Some(gear_id) = values.first() {
+                GameAction::Equip(gear_id.to_owned())
+            } else {
+                return send_ephemeral(component, ctx, "No gear selected.").await;
+            }
+        } else {
+            return send_ephemeral(component, ctx, "Invalid select menu interaction.").await;
         }
-        GameAction::Equip(gear_id.to_string())
+    } else if action_str == "unequip" {
+        // Unequip gear — slot from select menu value
+        if let serenity::ComponentInteractionDataKind::StringSelect { values } =
+            &component.data.kind
+        {
+            if let Some(slot_str) = values.first() {
+                GameAction::Unequip(slot_str.to_owned())
+            } else {
+                return send_ephemeral(component, ctx, "No slot selected.").await;
+            }
+        } else {
+            return send_ephemeral(component, ctx, "Invalid select menu interaction.").await;
+        }
     } else if action_str == "heal" {
         // Cleric heal ally — user_id from parts[3]
         let uid_str = parts.get(3).unwrap_or(&"0");
@@ -469,5 +488,37 @@ mod tests {
         let parts: Vec<&str> = value.split('|').collect();
         let target: Option<u8> = parts.get(1).and_then(|s| s.parse().ok());
         assert_eq!(target, Some(0));
+    }
+
+    #[test]
+    fn test_equip_unequip_not_in_parse_action() {
+        // equip and unequip are select-menu actions handled before parse_action,
+        // so they must NOT be recognized by parse_action (avoids double dispatch)
+        assert!(parse_action("equip").is_none());
+        assert!(parse_action("unequip").is_none());
+    }
+
+    #[test]
+    fn test_equip_action_from_select_value() {
+        // Simulate the corrected equip flow: gear_id comes from select menu value
+        let select_value = "rusty_sword";
+        let action = GameAction::Equip(select_value.to_owned());
+        assert_eq!(action, GameAction::Equip("rusty_sword".to_owned()));
+
+        let select_value = "leather_vest";
+        let action = GameAction::Equip(select_value.to_owned());
+        assert_eq!(action, GameAction::Equip("leather_vest".to_owned()));
+    }
+
+    #[test]
+    fn test_unequip_action_from_select_value() {
+        // Unequip values are slot strings ("weapon" or "armor")
+        let select_value = "weapon";
+        let action = GameAction::Unequip(select_value.to_owned());
+        assert_eq!(action, GameAction::Unequip("weapon".to_owned()));
+
+        let select_value = "armor";
+        let action = GameAction::Unequip(select_value.to_owned());
+        assert_eq!(action, GameAction::Unequip("armor".to_owned()));
     }
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/types.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/types.rs
@@ -567,6 +567,7 @@ pub enum GameAction {
     StoryChoice(usize),
     HealAlly(serenity::UserId),
     Equip(String),
+    Unequip(String),
     Move(Direction),
     ViewMap,
     ViewInventory,


### PR DESCRIPTION
## Summary

- **Fixed equip bug**: The equip handler was reading `gear_id` from `custom_id` parts (`parts[3]`) instead of the Discord select menu `values` array, causing "No gear specified" errors whenever players tried to equip gear from the dropdown
- **Added unequip system**: New `Unequip(String)` action with full stat reversal (armor/HP bonuses removed), inventory return, and slot validation
- **Dual-dropdown UI**: Inventory view now shows both an equip dropdown (gear from inventory) and an unequip dropdown (currently equipped weapon/armor) — appears in all non-game-over phases
- **7 new unit tests**: Router parsing, equip/unequip action construction, weapon/armor unequip logic, empty slot and invalid slot error paths
- **Version bump**: 0.1.27 → 0.1.28

## Files changed

| File | Change |
|------|--------|
| `router.rs` | Fix equip to use select menu values; add unequip handler; 3 tests |
| `types.rs` | Add `Unequip(String)` variant to `GameAction` |
| `logic.rs` | Add `apply_unequip()` with stat reversal; phase check; 4 tests |
| `render.rs` | Add `build_unequip_menu()` helper; wire into both render paths |
| `Cargo.toml` | Bump to 0.1.28 |

## Test plan

- [x] All 395 tests pass (`cargo test -p axum-discordsh`)
- [ ] Docker e2e tests pass
- [ ] Manual test: equip gear from dropdown no longer shows "No gear specified"
- [ ] Manual test: unequip dropdown appears when gear is equipped
- [ ] Manual test: unequipping armor correctly reverses stat bonuses