### PR TITLE
feat(kilobase): switch CNPG TLS to cert-manager-managed certs

### DIFF
--- a/apps/kube/kilobase/manifests/postgres-cluster.yaml
+++ b/apps/kube/kilobase/manifests/postgres-cluster.yaml
@@ -36,10 +36,15 @@ spec:
         size: 40Gi
         storageClass: longhorn
 
-    # TLS certificates are auto-managed by CNPG operator (default behavior)
-    # Do NOT specify explicit certificate secret names — CNPG treats them as
-    # externally-managed and will NOT auto-renew, causing expiry failures.
-    # Phase 2: migrate to cert-manager-issued certs for external lifecycle management.
+    # TLS certificates issued by cert-manager via Crossplane provider-kubernetes
+    # cert-manager handles renewal (30 days before expiry); CNPG treats these as
+    # externally-managed and will use them without auto-generating its own certs.
+    # Rollback: remove this certificates block to revert to CNPG auto-managed TLS.
+    certificates:
+        serverTLSSecret: supabase-server-tls
+        serverCASecret: internal-ca-key-pair
+        replicationTLSSecret: supabase-replication-tls
+        clientCASecret: internal-ca-key-pair
 
     monitoring:
         enablePodMonitor: true


### PR DESCRIPTION
## Summary
- Switches CNPG `supabase-cluster` to use cert-manager-issued TLS certificates instead of auto-managed certs
- Points `serverTLSSecret` → `supabase-server-tls` and `replicationTLSSecret` → `supabase-replication-tls`
- CA secret uses `internal-ca-key-pair` (same CA chain as cert-manager's internal-ca-issuer)

## Context
This is **PR 3c** — the final step of the Phase 3 cert management externalization:

| PR | Status | Description |
|---|---|---|
| #7704 (3a) | Merged | provider-kubernetes + ProviderConfig + RBAC |
| #7706 (3b) | Merged | cert-manager Certificate Objects via Crossplane |
| #7725 | Merged | RBAC SA name fix |
| This (3c) | Ready | Switch CNPG to cert-manager secrets |

## Verified Prerequisites
- Crossplane Objects: `cnpg-server-certificate` + `cnpg-replication-certificate` — SYNCED+READY
- cert-manager Certificates: `supabase-server-tls` + `supabase-replication-tls` — READY: True
- TLS secrets exist in `kilobase` namespace

## Behavior
- CNPG will detect the `certificates` block and perform a **zero-downtime rolling restart** (one pod at a time across 3 instances)
- cert-manager will auto-renew certs 30 days before expiry (vs CNPG's 7-day default)

## Rollback
Remove the `certificates` block → CNPG reverts to auto-managing its own certs (known-good state from PR #7689).

## Test plan
- [ ] CNPG rolling restart completes without errors
- [ ] `kubectl get cluster supabase-cluster -n kilobase` shows healthy state
- [ ] Database queries continue working throughout restart
- [ ] Server cert is signed by internal-ca-issuer (not CNPG self-managed CA)
- [ ] cert-manager renewal schedule is active (check `kubectl get certificate -n kilobase`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)