### PR TITLE
fix(ci): add KBVE Studio link to auto-maintained PR body

### DIFF
--- a/.github/scripts/commit-utils.mjs
+++ b/.github/scripts/commit-utils.mjs
@@ -120,7 +120,7 @@ export function formatDevToMainBody(categories, totalCommits) {
 		}
 	}
 
-	body += `---\n*This PR is automatically maintained by CI*`;
+	body += `---\n*This PR is automatically maintained by CI — [KBVE Studio](https://kbve.com)*`;
 	return body;
 }
 

--- a/packages/npm/devops/src/lib/client/github/pulls.ts
+++ b/packages/npm/devops/src/lib/client/github/pulls.ts
@@ -378,6 +378,6 @@ export function _$gha_formatDevBody(
 		}
 	}
 
-	body += `---\n*This PR is automatically maintained by CI*`;
+	body += `---\n*This PR is automatically maintained by CI — [KBVE Studio](https://kbve.com)*`;
 	return body;
 }


### PR DESCRIPTION
## Summary
- Add a [KBVE Studio](https://kbve.com) backlink to the CI-generated PR body text
- Updated in both mirror locations:
  - `.github/scripts/commit-utils.mjs` (zero-dep GHA shim)
  - `packages/npm/devops/src/lib/client/github/pulls.ts` (source of truth)

**Before:** `*This PR is automatically maintained by CI*`
**After:** `*This PR is automatically maintained by CI — [KBVE Studio](https://kbve.com)*`

## Test plan
- [ ] Merge to dev, then observe the next auto-generated Dev→Main PR body includes the link