### PR TITLE
fix(ci): bypass nested Nx for Docker build on arc-runner-set

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.29"
+version = "1.0.30"
 edition = "2021"
 publish = false
 

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -102,7 +102,7 @@
 				"ci": {
 					"commands": [
 						"echo '=== Pre-build diagnostics ===' && df -h 2>/dev/null && echo '--- cgroup memory ---' && cat /sys/fs/cgroup/memory.max 2>/dev/null && cat /sys/fs/cgroup/memory.current 2>/dev/null || true && docker system df 2>/dev/null || true && docker buildx ls 2>/dev/null || true",
-						"BUILDKIT_PROGRESS=plain ./kbve.sh -nx axum-kbve:containerx --configuration=ci",
+						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --build-arg BUILD_BASE=ghcr.io/kbve/kbve-build-base:latest --cache-from type=registry,ref=ghcr.io/kbve/kbve:buildcache --file apps/kbve/axum-kbve/Dockerfile .",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
 					]
 				}


### PR DESCRIPTION
## Summary
- Replace nested `./kbve.sh -nx axum-kbve:containerx --configuration=ci` with direct `docker buildx build` command in container CI config
- The nested Nx invocation (pnpm nx inside pnpm nx) was getting SIGINT (exit 130) on arc-runner-set — every attempt dies at the same point during base image pulls
- Direct docker buildx eliminates the Nx daemon nesting that likely causes the signal handling issue
- Bump version to 1.0.30

## Context
Three consecutive runs all fail with exit 130 at the same point, regardless of buildx driver (docker-container or docker). The cgroup diagnostics show 9.3 GiB used of 24 GiB limit. The common factor is the nested Nx process chain: outer `pnpm nx e2e` → `container:ci` run-commands → inner `pnpm nx containerx:ci`. Bypassing the inner Nx and calling docker directly tests this theory.

## Test plan
- [ ] Merge and verify axum-kbve-e2e CI passes on arc-runner-set