### PR TITLE
feat(irc): wire Supabase auth into IRC web chat

### DIFF
--- a/apps/irc/astro-irc/src/components/chat/ReactChatRoom.tsx
+++ b/apps/irc/astro-irc/src/components/chat/ReactChatRoom.tsx
@@ -342,6 +342,7 @@ const UserList: React.FC = () => {
 
 interface StatusBarProps {
 	wsUrl: string;
+	token: string;
 	onToggleSidebar: () => void;
 	onToggleUsers: () => void;
 	sidebarOpen: boolean;
@@ -350,6 +351,7 @@ interface StatusBarProps {
 
 const StatusBar: React.FC<StatusBarProps> = ({
 	wsUrl,
+	token,
 	onToggleSidebar,
 	onToggleUsers,
 	sidebarOpen,
@@ -363,9 +365,9 @@ const StatusBar: React.FC<StatusBarProps> = ({
 		if (status === 'connected') {
 			disconnect();
 		} else {
-			connect(wsUrl);
+			connect(wsUrl, token);
 		}
-	}, [status, wsUrl]);
+	}, [status, wsUrl, token]);
 
 	return (
 		<div className="flex items-center gap-3 px-3 py-2 border-b border-[var(--sl-color-border)] bg-[var(--sl-color-bg-accent)]/50">
@@ -454,6 +456,57 @@ const StatusBar: React.FC<StatusBarProps> = ({
 	);
 };
 
+type OAuthProvider = 'github' | 'discord' | 'twitch';
+
+const PROVIDERS: { id: OAuthProvider; label: string }[] = [
+	{ id: 'github', label: 'GitHub' },
+	{ id: 'discord', label: 'Discord' },
+	{ id: 'twitch', label: 'Twitch' },
+];
+
+const LoginPrompt: React.FC = () => {
+	const [loading, setLoading] = useState(false);
+
+	const handleLogin = useCallback(async (provider: OAuthProvider) => {
+		setLoading(true);
+		try {
+			const { authBridge } = await import('../../lib/supa');
+			await authBridge.signInWithOAuth(provider);
+		} catch {
+			setLoading(false);
+		}
+	}, []);
+
+	return (
+		<div className="flex flex-col items-center justify-center gap-6 p-8 text-center h-full">
+			<div>
+				<h2 className="text-xl font-bold text-[var(--sl-color-text)] mb-2">
+					Sign in to chat
+				</h2>
+				<p className="text-sm text-[var(--sl-color-gray-3)]">
+					You need a valid account to join the IRC chat.
+				</p>
+			</div>
+			<div className="flex flex-col gap-3 w-full max-w-xs">
+				{PROVIDERS.map(({ id, label }) => (
+					<button
+						key={id}
+						onClick={() => handleLogin(id)}
+						disabled={loading}
+						className={cn(
+							'w-full px-4 py-3 rounded-lg text-sm font-medium transition-colors',
+							'bg-[var(--sl-color-accent)] text-white',
+							'hover:opacity-90',
+							loading && 'opacity-50 cursor-not-allowed',
+						)}>
+						{loading ? 'Redirecting...' : `Sign in with ${label}`}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+};
+
 export interface ReactChatRoomProps {
 	wsUrl?: string;
 }
@@ -463,6 +516,47 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 }) => {
 	const [sidebarOpen, setSidebarOpen] = useState(false);
 	const [usersOpen, setUsersOpen] = useState(false);
+	const [authState, setAuthState] = useState<'loading' | 'auth' | 'anon'>(
+		'loading',
+	);
+	const [token, setToken] = useState('');
+
+	// Check for existing Supabase session on mount
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const { authBridge } = await import('../../lib/supa');
+				const session = await authBridge.getSession();
+				if (cancelled) return;
+				if (session?.access_token) {
+					setToken(session.access_token);
+					setAuthState('auth');
+				} else {
+					setAuthState('anon');
+				}
+			} catch {
+				if (!cancelled) setAuthState('anon');
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	// Graceful disconnect on unmount or page unload
+	useEffect(() => {
+		const handleUnload = () => {
+			if ($connectionStatus.get() === 'connected') {
+				disconnect();
+			}
+		};
+		window.addEventListener('beforeunload', handleUnload);
+		return () => {
+			window.removeEventListener('beforeunload', handleUnload);
+			handleUnload();
+		};
+	}, []);
 
 	const toggleSidebar = useCallback(() => {
 		setSidebarOpen((prev) => !prev);
@@ -475,6 +569,42 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 	}, []);
 
 	const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+
+	if (authState === 'loading') {
+		return (
+			<div
+				className={cn(
+					'flex flex-col items-center justify-center',
+					'w-full h-full',
+					'rounded-xl overflow-hidden',
+					'border border-[var(--sl-color-border)]',
+					'border-t-2 border-t-[var(--sl-color-accent)]',
+					'bg-[var(--sl-color-bg)]',
+					'shadow-lg shadow-black/10',
+				)}>
+				<span className="text-sm text-[var(--sl-color-gray-3)]">
+					Loading...
+				</span>
+			</div>
+		);
+	}
+
+	if (authState === 'anon') {
+		return (
+			<div
+				className={cn(
+					'flex flex-col',
+					'w-full h-full',
+					'rounded-xl overflow-hidden',
+					'border border-[var(--sl-color-border)]',
+					'border-t-2 border-t-[var(--sl-color-accent)]',
+					'bg-[var(--sl-color-bg)]',
+					'shadow-lg shadow-black/10',
+				)}>
+				<LoginPrompt />
+			</div>
+		);
+	}
 
 	return (
 		<div
@@ -489,6 +619,7 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 			)}>
 			<StatusBar
 				wsUrl={wsUrl}
+				token={token}
 				onToggleSidebar={toggleSidebar}
 				onToggleUsers={toggleUsers}
 				sidebarOpen={sidebarOpen}

--- a/apps/irc/astro-irc/src/components/chat/service.ts
+++ b/apps/irc/astro-irc/src/components/chat/service.ts
@@ -1,22 +1,26 @@
 import { atom, computed } from 'nanostores';
 
 export interface ChatMessage {
-  id: string;
-  nick: string;
-  content: string;
-  channel: string;
-  timestamp: number;
-  type: 'message' | 'join' | 'part' | 'system';
+	id: string;
+	nick: string;
+	content: string;
+	channel: string;
+	timestamp: number;
+	type: 'message' | 'join' | 'part' | 'system';
 }
 
 export interface ChannelState {
-  name: string;
-  topic: string;
-  users: string[];
-  unread: number;
+	name: string;
+	topic: string;
+	users: string[];
+	unread: number;
 }
 
-export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+export type ConnectionStatus =
+	| 'disconnected'
+	| 'connecting'
+	| 'connected'
+	| 'error';
 
 export const $connectionStatus = atom<ConnectionStatus>('disconnected');
 export const $activeChannel = atom<string>('#general');
@@ -27,318 +31,341 @@ export const $error = atom<string>('');
 const $messageStore = atom<Map<string, ChatMessage[]>>(new Map());
 
 export const $activeMessages = computed(
-  [$messageStore, $activeChannel],
-  (store, channel) => store.get(channel) ?? [],
+	[$messageStore, $activeChannel],
+	(store, channel) => store.get(channel) ?? [],
 );
 
 export const $channelList = computed([$channels], (channels) =>
-  Array.from(channels.values()).sort((a, b) => a.name.localeCompare(b.name)),
+	Array.from(channels.values()).sort((a, b) => a.name.localeCompare(b.name)),
 );
 
 export const $activeUsers = computed(
-  [$channels, $activeChannel],
-  (channels, active) => channels.get(active)?.users ?? [],
+	[$channels, $activeChannel],
+	(channels, active) => channels.get(active)?.users ?? [],
 );
 
 type MessageListener = (msg: ChatMessage) => void;
 const listeners = new Set<MessageListener>();
 
 export function onMessage(fn: MessageListener): () => void {
-  listeners.add(fn);
-  return () => listeners.delete(fn);
+	listeners.add(fn);
+	return () => listeners.delete(fn);
 }
 
 const MAX_MESSAGES_PER_CHANNEL = 500;
 
 function pushMessage(msg: ChatMessage): void {
-  const store = new Map($messageStore.get());
-  const msgs = store.get(msg.channel) ?? [];
-  const updated = [...msgs, msg].slice(-MAX_MESSAGES_PER_CHANNEL);
-  store.set(msg.channel, updated);
-  $messageStore.set(store);
+	const store = new Map($messageStore.get());
+	const msgs = store.get(msg.channel) ?? [];
+	const updated = [...msgs, msg].slice(-MAX_MESSAGES_PER_CHANNEL);
+	store.set(msg.channel, updated);
+	$messageStore.set(store);
 
-  for (const fn of listeners) fn(msg);
+	for (const fn of listeners) fn(msg);
 
-  if (msg.channel !== $activeChannel.get() && msg.type === 'message') {
-    const channels = new Map($channels.get());
-    const ch = channels.get(msg.channel);
-    if (ch) {
-      channels.set(msg.channel, { ...ch, unread: ch.unread + 1 });
-      $channels.set(channels);
-    }
-  }
+	if (msg.channel !== $activeChannel.get() && msg.type === 'message') {
+		const channels = new Map($channels.get());
+		const ch = channels.get(msg.channel);
+		if (ch) {
+			channels.set(msg.channel, { ...ch, unread: ch.unread + 1 });
+			$channels.set(channels);
+		}
+	}
 }
 
 function makeId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function systemMessage(channel: string, content: string): void {
-  pushMessage({
-    id: makeId(),
-    nick: '',
-    content,
-    channel,
-    timestamp: Date.now(),
-    type: 'system',
-  });
+	pushMessage({
+		id: makeId(),
+		nick: '',
+		content,
+		channel,
+		timestamp: Date.now(),
+		type: 'system',
+	});
 }
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
-export async function connect(wsUrl: string): Promise<void> {
-  if ($connectionStatus.get() === 'connected') return;
+export async function connect(wsUrl: string, token?: string): Promise<void> {
+	if ($connectionStatus.get() === 'connected') return;
 
-  $connectionStatus.set('connecting');
-  $error.set('');
+	$connectionStatus.set('connecting');
+	$error.set('');
 
-  try {
-    const kbve = (window as any).kbve;
-    if (!kbve?.ws) {
-      throw new Error('Droid WebSocket worker not initialized');
-    }
+	try {
+		const kbve = (window as any).kbve;
+		if (!kbve?.ws) {
+			throw new Error('Droid WebSocket worker not initialized');
+		}
 
-    await kbve.ws.connect(wsUrl);
+		const url = token
+			? `${wsUrl}${wsUrl.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`
+			: wsUrl;
 
-    kbve.ws.onStatus((status: string) => {
-      if (status === 'connected') {
-        $connectionStatus.set('connected');
-        systemMessage($activeChannel.get(), 'Connected to IRC');
-      } else if (status === 'disconnected' || status === 'error') {
-        $connectionStatus.set(status as ConnectionStatus);
-      }
-    });
+		await kbve.ws.connect(url);
 
-    kbve.ws.onMessage((data: ArrayBuffer | Uint8Array | string) => {
-      const text = typeof data === 'string' ? data : decoder.decode(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
-      handleIncoming(text);
-    });
-  } catch (err: any) {
-    $connectionStatus.set('error');
-    $error.set(err.message ?? 'Connection failed');
-  }
+		kbve.ws.onStatus((status: string) => {
+			if (status === 'connected') {
+				$connectionStatus.set('connected');
+				systemMessage($activeChannel.get(), 'Connected to IRC');
+			} else if (status === 'disconnected' || status === 'error') {
+				$connectionStatus.set(status as ConnectionStatus);
+			}
+		});
+
+		kbve.ws.onMessage((data: ArrayBuffer | Uint8Array | string) => {
+			const text =
+				typeof data === 'string'
+					? data
+					: decoder.decode(
+							data instanceof ArrayBuffer
+								? new Uint8Array(data)
+								: data,
+						);
+			handleIncoming(text);
+		});
+	} catch (err: any) {
+		$connectionStatus.set('error');
+		$error.set(err.message ?? 'Connection failed');
+	}
 }
 
 export async function disconnect(): Promise<void> {
-  try {
-    const kbve = (window as any).kbve;
-    if (kbve?.ws) await kbve.ws.close();
-  } finally {
-    $connectionStatus.set('disconnected');
-    systemMessage($activeChannel.get(), 'Disconnected from IRC');
-  }
+	try {
+		const kbve = (window as any).kbve;
+		if (kbve?.ws) await kbve.ws.close();
+	} finally {
+		$connectionStatus.set('disconnected');
+		systemMessage($activeChannel.get(), 'Disconnected from IRC');
+	}
 }
 
 export async function sendMessage(content: string): Promise<void> {
-  const channel = $activeChannel.get();
-  const nick = $nick.get();
+	const channel = $activeChannel.get();
+	const nick = $nick.get();
 
-  if (!content.trim()) return;
+	if (!content.trim()) return;
 
-  const kbve = (window as any).kbve;
-  if (!kbve?.ws) return;
+	const kbve = (window as any).kbve;
+	if (!kbve?.ws) return;
 
-  const raw = `PRIVMSG ${channel} :${content}\r\n`;
-  await kbve.ws.send(encoder.encode(raw));
+	const raw = `PRIVMSG ${channel} :${content}\r\n`;
+	await kbve.ws.send(encoder.encode(raw));
 
-  pushMessage({
-    id: makeId(),
-    nick,
-    content,
-    channel,
-    timestamp: Date.now(),
-    type: 'message',
-  });
+	pushMessage({
+		id: makeId(),
+		nick,
+		content,
+		channel,
+		timestamp: Date.now(),
+		type: 'message',
+	});
 }
 
 export function switchChannel(channel: string): void {
-  $activeChannel.set(channel);
+	$activeChannel.set(channel);
 
-  const channels = new Map($channels.get());
-  const ch = channels.get(channel);
-  if (ch) {
-    channels.set(channel, { ...ch, unread: 0 });
-    $channels.set(channels);
-  }
+	const channels = new Map($channels.get());
+	const ch = channels.get(channel);
+	if (ch) {
+		channels.set(channel, { ...ch, unread: 0 });
+		$channels.set(channels);
+	}
 }
 
 export function joinChannel(channel: string): void {
-  const kbve = (window as any).kbve;
-  if (!kbve?.ws) return;
+	const kbve = (window as any).kbve;
+	if (!kbve?.ws) return;
 
-  const raw = `JOIN ${channel}\r\n`;
-  kbve.ws.send(encoder.encode(raw));
+	const raw = `JOIN ${channel}\r\n`;
+	kbve.ws.send(encoder.encode(raw));
 
-  const channels = new Map($channels.get());
-  if (!channels.has(channel)) {
-    channels.set(channel, { name: channel, topic: '', users: [], unread: 0 });
-    $channels.set(channels);
-  }
-  switchChannel(channel);
+	const channels = new Map($channels.get());
+	if (!channels.has(channel)) {
+		channels.set(channel, {
+			name: channel,
+			topic: '',
+			users: [],
+			unread: 0,
+		});
+		$channels.set(channels);
+	}
+	switchChannel(channel);
 }
 
 export function partChannel(channel: string): void {
-  const kbve = (window as any).kbve;
-  if (!kbve?.ws) return;
+	const kbve = (window as any).kbve;
+	if (!kbve?.ws) return;
 
-  const raw = `PART ${channel}\r\n`;
-  kbve.ws.send(encoder.encode(raw));
+	const raw = `PART ${channel}\r\n`;
+	kbve.ws.send(encoder.encode(raw));
 
-  const channels = new Map($channels.get());
-  channels.delete(channel);
-  $channels.set(channels);
+	const channels = new Map($channels.get());
+	channels.delete(channel);
+	$channels.set(channels);
 
-  const remaining = Array.from(channels.keys());
-  if (remaining.length > 0) {
-    switchChannel(remaining[0]);
-  }
+	const remaining = Array.from(channels.keys());
+	if (remaining.length > 0) {
+		switchChannel(remaining[0]);
+	}
 }
 
 function handleIncoming(raw: string): void {
-  const lines = raw.split('\r\n').filter(Boolean);
+	const lines = raw.split('\r\n').filter(Boolean);
 
-  for (const line of lines) {
-    if (line.startsWith('PING')) {
-      const kbve = (window as any).kbve;
-      if (kbve?.ws) {
-        kbve.ws.send(encoder.encode(`PONG ${line.slice(5)}\r\n`));
-      }
-      continue;
-    }
+	for (const line of lines) {
+		if (line.startsWith('PING')) {
+			const kbve = (window as any).kbve;
+			if (kbve?.ws) {
+				kbve.ws.send(encoder.encode(`PONG ${line.slice(5)}\r\n`));
+			}
+			continue;
+		}
 
-    const parsed = parseIrcLine(line);
-    if (!parsed) continue;
+		const parsed = parseIrcLine(line);
+		if (!parsed) continue;
 
-    switch (parsed.command) {
-      case 'PRIVMSG': {
-        const channel = parsed.params[0];
-        const content = parsed.trailing ?? '';
-        pushMessage({
-          id: makeId(),
-          nick: parsed.nick,
-          content,
-          channel,
-          timestamp: Date.now(),
-          type: 'message',
-        });
-        break;
-      }
+		switch (parsed.command) {
+			case 'PRIVMSG': {
+				const channel = parsed.params[0];
+				const content = parsed.trailing ?? '';
+				pushMessage({
+					id: makeId(),
+					nick: parsed.nick,
+					content,
+					channel,
+					timestamp: Date.now(),
+					type: 'message',
+				});
+				break;
+			}
 
-      case 'JOIN': {
-        const channel = parsed.params[0] || parsed.trailing || '';
-        const channels = new Map($channels.get());
-        const ch = channels.get(channel);
-        if (ch && !ch.users.includes(parsed.nick)) {
-          channels.set(channel, { ...ch, users: [...ch.users, parsed.nick] });
-          $channels.set(channels);
-        }
-        pushMessage({
-          id: makeId(),
-          nick: parsed.nick,
-          content: `${parsed.nick} joined ${channel}`,
-          channel,
-          timestamp: Date.now(),
-          type: 'join',
-        });
-        break;
-      }
+			case 'JOIN': {
+				const channel = parsed.params[0] || parsed.trailing || '';
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch && !ch.users.includes(parsed.nick)) {
+					channels.set(channel, {
+						...ch,
+						users: [...ch.users, parsed.nick],
+					});
+					$channels.set(channels);
+				}
+				pushMessage({
+					id: makeId(),
+					nick: parsed.nick,
+					content: `${parsed.nick} joined ${channel}`,
+					channel,
+					timestamp: Date.now(),
+					type: 'join',
+				});
+				break;
+			}
 
-      case 'PART': {
-        const channel = parsed.params[0];
-        const channels = new Map($channels.get());
-        const ch = channels.get(channel);
-        if (ch) {
-          channels.set(channel, {
-            ...ch,
-            users: ch.users.filter((u) => u !== parsed.nick),
-          });
-          $channels.set(channels);
-        }
-        pushMessage({
-          id: makeId(),
-          nick: parsed.nick,
-          content: `${parsed.nick} left ${channel}`,
-          channel,
-          timestamp: Date.now(),
-          type: 'part',
-        });
-        break;
-      }
+			case 'PART': {
+				const channel = parsed.params[0];
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch) {
+					channels.set(channel, {
+						...ch,
+						users: ch.users.filter((u) => u !== parsed.nick),
+					});
+					$channels.set(channels);
+				}
+				pushMessage({
+					id: makeId(),
+					nick: parsed.nick,
+					content: `${parsed.nick} left ${channel}`,
+					channel,
+					timestamp: Date.now(),
+					type: 'part',
+				});
+				break;
+			}
 
-      case '332': {
-        const channel = parsed.params[1];
-        const topic = parsed.trailing ?? '';
-        const channels = new Map($channels.get());
-        const ch = channels.get(channel);
-        if (ch) {
-          channels.set(channel, { ...ch, topic });
-          $channels.set(channels);
-        }
-        break;
-      }
+			case '332': {
+				const channel = parsed.params[1];
+				const topic = parsed.trailing ?? '';
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch) {
+					channels.set(channel, { ...ch, topic });
+					$channels.set(channels);
+				}
+				break;
+			}
 
-      case '353': {
-        const channel = parsed.params[2];
-        const nicks = (parsed.trailing ?? '').split(' ').filter(Boolean);
-        const channels = new Map($channels.get());
-        const ch = channels.get(channel);
-        if (ch) {
-          const uniqueUsers = Array.from(new Set([...ch.users, ...nicks]));
-          channels.set(channel, { ...ch, users: uniqueUsers });
-          $channels.set(channels);
-        }
-        break;
-      }
+			case '353': {
+				const channel = parsed.params[2];
+				const nicks = (parsed.trailing ?? '')
+					.split(' ')
+					.filter(Boolean);
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch) {
+					const uniqueUsers = Array.from(
+						new Set([...ch.users, ...nicks]),
+					);
+					channels.set(channel, { ...ch, users: uniqueUsers });
+					$channels.set(channels);
+				}
+				break;
+			}
 
-      case '001': {
-        if (parsed.params[0]) {
-          $nick.set(parsed.params[0]);
-        }
-        systemMessage(
-          $activeChannel.get(),
-          parsed.trailing ?? 'Welcome to IRC',
-        );
-        break;
-      }
+			case '001': {
+				if (parsed.params[0]) {
+					$nick.set(parsed.params[0]);
+				}
+				systemMessage(
+					$activeChannel.get(),
+					parsed.trailing ?? 'Welcome to IRC',
+				);
+				break;
+			}
 
-      default:
-        break;
-    }
-  }
+			default:
+				break;
+		}
+	}
 }
 
 interface ParsedIrcMessage {
-  nick: string;
-  command: string;
-  params: string[];
-  trailing?: string;
+	nick: string;
+	command: string;
+	params: string[];
+	trailing?: string;
 }
 
 function parseIrcLine(line: string): ParsedIrcMessage | null {
-  let nick = '';
-  let rest = line;
+	let nick = '';
+	let rest = line;
 
-  if (rest.startsWith(':')) {
-    const spaceIdx = rest.indexOf(' ');
-    if (spaceIdx === -1) return null;
-    const prefix = rest.slice(1, spaceIdx);
-    nick = prefix.split('!')[0];
-    rest = rest.slice(spaceIdx + 1);
-  }
+	if (rest.startsWith(':')) {
+		const spaceIdx = rest.indexOf(' ');
+		if (spaceIdx === -1) return null;
+		const prefix = rest.slice(1, spaceIdx);
+		nick = prefix.split('!')[0];
+		rest = rest.slice(spaceIdx + 1);
+	}
 
-  let trailing: string | undefined;
-  const trailIdx = rest.indexOf(' :');
-  if (trailIdx !== -1) {
-    trailing = rest.slice(trailIdx + 2);
-    rest = rest.slice(0, trailIdx);
-  }
+	let trailing: string | undefined;
+	const trailIdx = rest.indexOf(' :');
+	if (trailIdx !== -1) {
+		trailing = rest.slice(trailIdx + 2);
+		rest = rest.slice(0, trailIdx);
+	}
 
-  const parts = rest.split(' ').filter(Boolean);
-  if (parts.length === 0) return null;
+	const parts = rest.split(' ').filter(Boolean);
+	if (parts.length === 0) return null;
 
-  const command = parts[0];
-  const params = parts.slice(1);
+	const command = parts[0];
+	const params = parts.slice(1);
 
-  return { nick, command, params, trailing };
+	return { nick, command, params, trailing };
 }

--- a/apps/irc/astro-irc/src/pages/auth/callback.astro
+++ b/apps/irc/astro-irc/src/pages/auth/callback.astro
@@ -4,83 +4,99 @@
 
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Authenticating...</title>
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        font-family: system-ui, -apple-system, sans-serif;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
-      }
-      .container {
-        text-align: center;
-        color: white;
-      }
-      .spinner {
-        width: 50px;
-        height: 50px;
-        margin: 0 auto 20px;
-        border: 4px solid rgba(255, 255, 255, 0.3);
-        border-top-color: white;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-      }
-      @keyframes spin {
-        to { transform: rotate(360deg); }
-      }
-      .message {
-        font-size: 18px;
-        margin-bottom: 10px;
-      }
-      .sub-message {
-        font-size: 14px;
-        opacity: 0.8;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="spinner"></div>
-      <div class="message">Completing sign-in...</div>
-      <div class="sub-message">Please wait</div>
-    </div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Authenticating...</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 100vh;
+				background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
+			}
+			.container {
+				text-align: center;
+				color: white;
+			}
+			.spinner {
+				width: 50px;
+				height: 50px;
+				margin: 0 auto 20px;
+				border: 4px solid rgba(255, 255, 255, 0.3);
+				border-top-color: white;
+				border-radius: 50%;
+				animation: spin 1s linear infinite;
+			}
+			@keyframes spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			.message {
+				font-size: 18px;
+				margin-bottom: 10px;
+			}
+			.sub-message {
+				font-size: 14px;
+				opacity: 0.8;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<div class="spinner"></div>
+			<div class="message">Completing sign-in...</div>
+			<div class="sub-message">Please wait</div>
+		</div>
 
-    <script>
-      import { authBridge, initSupa, getSupa } from '../../lib/supa';
+		<script>
+			import { authBridge, initSupa, getSupa } from '../../lib/supa';
 
-      (async () => {
-        try {
-          const session = await authBridge.handleCallback();
+			(async () => {
+				try {
+					const session = await authBridge.handleCallback();
 
-          if (session) {
-            await initSupa();
-            const supa = getSupa();
-            await supa.getSession();
-            await new Promise(resolve => setTimeout(resolve, 500));
-            window.location.href = '/';
-          } else {
-            const messageEl = document.querySelector('.message');
-            const subMessageEl = document.querySelector('.sub-message');
-            if (messageEl) messageEl.textContent = 'Authentication failed';
-            if (subMessageEl) subMessageEl.textContent = 'Redirecting...';
-            setTimeout(() => { window.location.href = '/'; }, 2000);
-          }
-        } catch (error) {
-          console.error('Auth callback error:', error);
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Authentication failed';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting...';
-          setTimeout(() => { window.location.href = '/'; }, 2000);
-        }
-      })();
-    </script>
-  </body>
+					if (session) {
+						await initSupa();
+						const supa = getSupa();
+						await supa.getSession();
+						await new Promise((resolve) =>
+							setTimeout(resolve, 500),
+						);
+						window.location.href = '/chat';
+					} else {
+						const messageEl = document.querySelector('.message');
+						const subMessageEl =
+							document.querySelector('.sub-message');
+						if (messageEl)
+							messageEl.textContent = 'Authentication failed';
+						if (subMessageEl)
+							subMessageEl.textContent = 'Redirecting...';
+						setTimeout(() => {
+							window.location.href = '/auth';
+						}, 2000);
+					}
+				} catch (error) {
+					console.error('Auth callback error:', error);
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Authentication failed';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting...';
+					setTimeout(() => {
+						window.location.href = '/auth';
+					}, 2000);
+				}
+			})();
+		</script>
+	</body>
 </html>

--- a/apps/irc/astro-irc/src/pages/auth/index.astro
+++ b/apps/irc/astro-irc/src/pages/auth/index.astro
@@ -1,7 +1,138 @@
 ---
-// Redirect to home if someone navigates to /auth directly
+// Login page — OAuth provider selection
 ---
 
-<script>
-  window.location.href = '/';
-</script>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Sign In — KBVE Chat</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 100vh;
+				background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
+			}
+			.container {
+				text-align: center;
+				color: white;
+				max-width: 320px;
+				width: 100%;
+				padding: 0 1rem;
+			}
+			h1 {
+				font-size: 24px;
+				margin-bottom: 8px;
+			}
+			.sub {
+				font-size: 14px;
+				opacity: 0.8;
+				margin-bottom: 32px;
+			}
+			.btn {
+				display: block;
+				width: 100%;
+				padding: 14px;
+				margin-bottom: 12px;
+				border: none;
+				border-radius: 8px;
+				font-size: 15px;
+				font-weight: 600;
+				cursor: pointer;
+				transition: opacity 0.2s;
+				background: rgba(255, 255, 255, 0.15);
+				color: white;
+				backdrop-filter: blur(4px);
+				border: 1px solid rgba(255, 255, 255, 0.2);
+			}
+			.btn:hover {
+				opacity: 0.85;
+			}
+			.btn:disabled {
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
+			.back {
+				display: inline-block;
+				margin-top: 16px;
+				color: rgba(255, 255, 255, 0.7);
+				font-size: 13px;
+				text-decoration: none;
+			}
+			.back:hover {
+				color: white;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<h1>Sign In</h1>
+			<p class="sub">Choose a provider to join the chat</p>
+
+			<button class="btn" data-provider="github">
+				Sign in with GitHub
+			</button>
+			<button class="btn" data-provider="discord">
+				Sign in with Discord
+			</button>
+			<button class="btn" data-provider="twitch">
+				Sign in with Twitch
+			</button>
+
+			<a href="/" class="back">Back to home</a>
+		</div>
+
+		<script>
+			import { authBridge } from '../../lib/supa';
+
+			// If already authenticated, go straight to chat
+			(async () => {
+				try {
+					const session = await authBridge.getSession();
+					if (session?.access_token) {
+						window.location.href = '/chat';
+						return;
+					}
+				} catch {
+					// Not logged in — stay on login page
+				}
+
+				document.querySelectorAll('[data-provider]').forEach((btn) => {
+					btn.addEventListener('click', async () => {
+						const provider = (btn as HTMLElement).dataset
+							.provider as 'github' | 'discord' | 'twitch';
+						document
+							.querySelectorAll('.btn')
+							.forEach(
+								(b) =>
+									((b as HTMLButtonElement).disabled = true),
+							);
+						btn.textContent = 'Redirecting...';
+						try {
+							await authBridge.signInWithOAuth(provider);
+						} catch (err) {
+							console.error('OAuth error:', err);
+							btn.textContent = `Sign in with ${provider.charAt(0).toUpperCase() + provider.slice(1)}`;
+							document
+								.querySelectorAll('.btn')
+								.forEach(
+									(b) =>
+										((b as HTMLButtonElement).disabled =
+											false),
+								);
+						}
+					});
+				});
+			})();
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
## Summary
- **service.ts**: `connect()` now accepts an optional JWT token and appends it as `?token=` query param to the WebSocket URL
- **ReactChatRoom.tsx**: Auth gate checks for Supabase session on mount — shows login prompt (GitHub/Discord/Twitch OAuth) if unauthenticated, passes JWT to `connect()`, graceful disconnect on unmount and `beforeunload`
- **auth/callback.astro**: Redirects to `/chat` after successful OAuth (was `/`)
- **auth/index.astro**: Full OAuth login page with provider buttons (was just a redirect to `/`)

## Context
The IRC gateway validates JWTs but the frontend never sent one — every WebSocket connection got 401'd. This wires the existing Supabase AuthBridge into the chat flow so authenticated users can connect.

## Test plan
- [ ] `pnpm nx build astro-irc` compiles (TS check passes for modified files)
- [ ] Existing e2e tests pass (`pnpm nx e2e irc-e2e`)
- [ ] Manual: `/auth` shows OAuth buttons → OAuth → `/auth/callback` → `/chat` → Connect works with JWT
- [ ] Manual: unauthenticated user sees "Sign in to chat" prompt on `/chat`
- [ ] Manual: page unload/navigation gracefully disconnects WebSocket