### PR TITLE
fix(ci): stream Nx output to prevent ARC runner inactivity timeout

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -110,7 +110,7 @@ jobs:
             - name: Nx e2e ${{ inputs.project }}
               env:
                   BUILDKIT_PROGRESS: plain
-              run: pnpm nx e2e ${{ inputs.project }} --configuration=ci --no-cloud
+              run: pnpm nx e2e ${{ inputs.project }} --configuration=ci --no-cloud --output-style=stream
 
             - name: Mark test passed
               if: success()

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.30"
+version = "1.0.31"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Add `--output-style=stream` to the Nx e2e command in `docker-test-app.yml`
- Bump axum-kbve to 1.0.31

## Root cause
Nx defaults to `static` output in CI, which **buffers all dependency task output** and only displays it on completion. When the `container` target (Docker build) runs as a dependency of `e2e`, the build output is silenced for 10+ minutes. The ARC runner's inactivity timeout detects no stdout and sends SIGINT (exit 130).

This explains why:
- It fails regardless of buildx driver (docker-container or docker)
- It fails regardless of nested vs direct docker commands
- It always dies during layer downloads (the silent period)
- rentearth works (uses `docker/build-push-action` directly in a GHA step, not through Nx)
- The build works locally (no inactivity timeout)

## Test plan
- [ ] Merge and verify axum-kbve-e2e CI passes on arc-runner-set
- [ ] Verify Docker build output streams in real-time in CI logs