### PR TITLE
fix(irc): exclude only ergo submodule from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,6 @@ target
 # Large / irrelevant app directories not needed by any Dockerfile
 apps/mc/pumpkin
 apps/postgres
-apps/irc
+apps/irc/ergo
 apps/godot
 apps/unity


### PR DESCRIPTION
## Summary
- The root `.dockerignore` had a blanket `apps/irc` exclusion that blocked the irc-gateway Docker build from finding `apps/irc/astro-irc/` and `apps/irc/irc-gateway/` in the build context
- Narrowed the exclusion to `apps/irc/ergo` (the Ergo IRC submodule) so the Dockerfile `COPY` commands succeed
- This was the sole cause of the `irc:e2e` CI failure on main — steps 1-2 (Rust tests + Playwright e2e) passed; only the Docker image build (step 4) failed

## Test plan
- [ ] CI-Dev passes (`.dockerignore` change triggers `irc_gateway` file alteration)
- [ ] After merge to main, `Test Docker Apps (irc)` job succeeds — Docker image builds and e2e:docker tests pass