### PR TITLE
fix(crossplane): mirror internal CA secret into kilobase for CNPG

### DIFF
--- a/apps/kube/crossplane/providers/cnpg-ca-secret.yaml
+++ b/apps/kube/crossplane/providers/cnpg-ca-secret.yaml
@@ -1,0 +1,44 @@
+# Replicate the internal CA certificate into kilobase namespace for CNPG
+# CNPG requires serverCASecret and clientCASecret in the cluster's namespace.
+# The CA cert lives in cert-manager namespace (internal-ca-key-pair), so we
+# use a Crossplane Object to maintain a copy in kilobase.
+#
+# The ca.crt value is the public certificate of internal-ca-issuer (self-signed CA).
+# This is NOT a private key — it is safe to store in git as it is the public
+# trust anchor used to verify TLS certificates issued by internal-ca-issuer.
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+    name: cnpg-ca-secret
+    annotations:
+        argocd.argoproj.io/sync-wave: '14'
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+    references:
+        - patchesFrom:
+              apiVersion: v1
+              kind: Secret
+              name: internal-ca-key-pair
+              namespace: cert-manager
+              fieldPath: data.ca.crt
+          toFieldPath: data.ca.crt
+        - patchesFrom:
+              apiVersion: v1
+              kind: Secret
+              name: internal-ca-key-pair
+              namespace: cert-manager
+              fieldPath: data.tls.crt
+          toFieldPath: data.tls.crt
+    forProvider:
+        manifest:
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: internal-ca-key-pair
+                namespace: kilobase
+            type: Opaque
+            data:
+                ca.crt: ''
+                tls.crt: ''
+    providerConfigRef:
+        name: kubernetes-provider


### PR DESCRIPTION
## Summary
- Adds a Crossplane Object that replicates `internal-ca-key-pair` from `cert-manager` namespace into `kilobase`
- Uses Crossplane Object `references` to patch `ca.crt` and `tls.crt` from the source secret (public certs only, no private key)

## Problem
After PR #7736 switched CNPG to cert-manager-managed TLS, the cluster reported:
```
missing specified server CA secret internal-ca-key-pair: Secret "internal-ca-key-pair" not found
```
The CA secret exists in `cert-manager` namespace but CNPG expects it in `kilobase` (same namespace as the cluster).

## Fix
Crossplane Object with `references` that reads `ca.crt` and `tls.crt` from `cert-manager/internal-ca-key-pair` and creates a matching secret in `kilobase`. The Object is set to sync-wave 14 (before the Certificate Objects at sync-wave 15).

## Test plan
- [ ] Secret `internal-ca-key-pair` appears in `kilobase` namespace
- [ ] CNPG cluster phase returns to "Cluster in healthy state"
- [ ] No more "SecretNotFound" warnings in CNPG events
- [ ] Database pods remain running throughout (zero disruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)