### PR TITLE
fix(axum-kbve): resolve EBUSY on Astro cache mount, bump to 1.0.32

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.31"
+version = "1.0.32"
 edition = "2021"
 publish = false
 

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -32,10 +32,14 @@ COPY packages/npm/laser/ packages/npm/laser/
 COPY apps/kbve/astro-kbve/ apps/kbve/astro-kbve/
 
 # Build astro site (cache .astro dir for incremental content collection builds)
+# NOTE: Mount cache to a staging path, then copy in/out. Mounting directly on
+# .astro/ causes EBUSY when Astro tries to rmdir the mount point after build.
 WORKDIR /app/apps/kbve/astro-kbve
-RUN --mount=type=cache,target=/app/apps/kbve/astro-kbve/.astro,id=astro-cache \
+RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-cache \
+    cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
     npx astro sync && \
-    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build && \
+    cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets


### PR DESCRIPTION
## Summary
- Fix Docker build failure caused by BuildKit cache mount on `.astro/` directory. Astro's post-build cleanup tried to `rmdir` the mount point, resulting in `EBUSY: resource busy or locked` (exit code 1).
- Move cache mount to `/tmp/astro-cache` staging path and copy contents in/out to avoid the lock conflict.
- Bump version to 1.0.32 to trigger CI rebuild.

## Root Cause
CI run [#22797860494](https://github.com/KBVE/kbve/actions/runs/22797860494/job/66135487629) — the Astro build completed successfully (79.73s) but then crashed:
```
EBUSY: resource busy or locked, rmdir '/app/apps/kbve/astro-kbve/.astro/'
```

## Test plan
- [ ] CI `axum-kbve:container:ci` target passes without EBUSY
- [ ] E2E tests (`axum-kbve-e2e`) pass against the built container
- [ ] Incremental cache still works on subsequent builds