### PR TITLE
fix(crossplane): use bracket notation for dotted secret key paths

### DIFF
--- a/apps/kube/crossplane/providers/cnpg-ca-secret.yaml
+++ b/apps/kube/crossplane/providers/cnpg-ca-secret.yaml
@@ -20,15 +20,15 @@ spec:
               kind: Secret
               name: internal-ca-key-pair
               namespace: cert-manager
-              fieldPath: data.ca.crt
-          toFieldPath: data.ca.crt
+              fieldPath: data[ca.crt]
+          toFieldPath: data[ca.crt]
         - patchesFrom:
               apiVersion: v1
               kind: Secret
               name: internal-ca-key-pair
               namespace: cert-manager
-              fieldPath: data.tls.crt
-          toFieldPath: data.tls.crt
+              fieldPath: data[tls.crt]
+          toFieldPath: data[tls.crt]
     forProvider:
         manifest:
             apiVersion: v1


### PR DESCRIPTION
## Summary
- Fixes Crossplane Object reference `fieldPath` for secret keys containing dots (`ca.crt`, `tls.crt`)
- Changes `data.ca.crt` → `data[ca.crt]` and `data.tls.crt` → `data[tls.crt]`

## Problem
PR #7748 introduced the CA secret mirror but Crossplane's field path parser interprets dots as path separators:
```
data.ca.crt → data -> ca -> crt  (wrong — "no such field")
data[ca.crt] → data -> "ca.crt"  (correct — bracket notation)
```

The Object was stuck `SYNCED: False` with: `cannot patch from referenced resource: data.ca: no such field`

## Test plan
- [ ] `cnpg-ca-secret` Object becomes SYNCED+READY
- [ ] Secret `internal-ca-key-pair` appears in `kilobase` namespace with `ca.crt` and `tls.crt` keys
- [ ] CNPG cluster returns to "Cluster in healthy state"

🤖 Generated with [Claude Code](https://claude.com/claude-code)