### PR TITLE
feat(kube): add NetworkPolicy to restrict runner egress

### DIFF
--- a/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
+++ b/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
@@ -1,0 +1,32 @@
+# Egress restriction for self-hosted GitHub Actions runners
+# Allows only the ports needed for CI/CD (DNS, HTTPS, HTTP, SSH)
+# Blocks direct access to internal cluster services on non-standard ports
+# (e.g., PostgreSQL 5432, Redis 6379, RCON 25575)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: arc-runner-egress
+    namespace: arc-runners
+spec:
+    podSelector: {}
+    policyTypes:
+        - Egress
+    egress:
+        # DNS resolution (kube-dns)
+        - ports:
+              - port: 53
+                protocol: UDP
+              - port: 53
+                protocol: TCP
+        # HTTPS (GitHub API, container registries, npm/cargo registries)
+        - ports:
+              - port: 443
+                protocol: TCP
+        # HTTP (some registries, apt/apk repos)
+        - ports:
+              - port: 80
+                protocol: TCP
+        # SSH (git clone via SSH)
+        - ports:
+              - port: 22
+                protocol: TCP


### PR DESCRIPTION
## Summary
- Adds egress NetworkPolicy to `arc-runners` namespace
- Allows only DNS (53), HTTPS (443), HTTP (80), SSH (22) outbound
- Blocks runners from reaching internal cluster services on non-standard ports (PostgreSQL 5432, Redis 6379, RCON 25575, etc.)

## Why
Self-hosted runners currently have unrestricted network access within the cluster. A compromised workflow could reach internal databases, game servers, or other sensitive services. This policy limits egress to only the ports needed for CI/CD operations.

## Risk
**Low** — purely additive. Only restricts ports that runners shouldn't need. All CI operations (GitHub API, container pulls, package installs, git clone) use standard ports that remain open.

## Test plan
- [ ] NetworkPolicy created in `arc-runners` namespace
- [ ] Trigger a CI workflow that uses `arc-runner-set` — should complete normally
- [ ] Verify runners can still pull images, install packages, push to registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)