### PR TITLE
chore(kube): pin runner images and harden cache cleanup

### DIFF
--- a/apps/kube/github/runners/manifests/cache-cleanup-cronjob.yaml
+++ b/apps/kube/github/runners/manifests/cache-cleanup-cronjob.yaml
@@ -3,56 +3,71 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: arc-runner-cache-cleanup
-  namespace: arc-runners
+    name: arc-runner-cache-cleanup
+    namespace: arc-runners
 spec:
-  schedule: "0 3 * * *"  # Daily at 3 AM UTC
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
-  jobTemplate:
-    spec:
-      ttlSecondsAfterFinished: 86400  # Clean up job after 24 hours
-      template:
+    schedule: '0 3 * * *' # Daily at 3 AM UTC
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    jobTemplate:
         spec:
-          restartPolicy: OnFailure
-          containers:
-            - name: cache-cleanup
-              image: alpine:3.19
-              command:
-                - /bin/sh
-                - -c
-                - |
-                  echo "=== Cache Cleanup Started ==="
-                  echo "Current cache usage:"
-                  du -sh /cache/* 2>/dev/null || echo "Cache is empty"
-                  df -h /cache
-                  echo ""
+            activeDeadlineSeconds: 300
+            ttlSecondsAfterFinished: 86400 # Clean up job after 24 hours
+            backoffLimit: 0
+            template:
+                spec:
+                    restartPolicy: Never
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        runAsGroup: 1000
+                        fsGroup: 1000
+                        seccompProfile:
+                            type: RuntimeDefault
+                    containers:
+                        - name: cache-cleanup
+                          image: alpine:3.21
+                          securityContext:
+                              allowPrivilegeEscalation: false
+                              readOnlyRootFilesystem: true
+                              capabilities:
+                                  drop:
+                                      - ALL
+                          command:
+                              - /bin/sh
+                              - -c
+                              - |
+                                  echo "=== Cache Cleanup Started ==="
+                                  echo "Current cache usage:"
+                                  du -sh /cache/* 2>/dev/null || echo "Cache is empty"
+                                  df -h /cache
+                                  echo ""
 
-                  # Remove files not accessed in 14 days
-                  echo "Removing files not accessed in 14 days..."
-                  find /cache -type f -atime +14 -delete 2>/dev/null || true
+                                  # Remove files not accessed in 14 days
+                                  echo "Removing files not accessed in 14 days..."
+                                  find /cache -type f -atime +14 -delete 2>/dev/null || true
 
-                  # Remove empty directories
-                  echo "Removing empty directories..."
-                  find /cache -type d -empty -delete 2>/dev/null || true
+                                  # Remove empty directories
+                                  echo "Removing empty directories..."
+                                  find /cache -type d -empty -delete 2>/dev/null || true
 
-                  echo ""
-                  echo "Cache usage after cleanup:"
-                  du -sh /cache/* 2>/dev/null || echo "Cache is empty"
-                  df -h /cache
-                  echo "=== Cache Cleanup Completed ==="
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 128Mi
-                requests:
-                  cpu: 50m
-                  memory: 64Mi
-              volumeMounts:
-                - name: runner-cache
-                  mountPath: /cache
-          volumes:
-            - name: runner-cache
-              persistentVolumeClaim:
-                claimName: arc-runner-cache
+                                  echo ""
+                                  echo "Cache usage after cleanup:"
+                                  du -sh /cache/* 2>/dev/null || echo "Cache is empty"
+                                  df -h /cache
+                                  echo "=== Cache Cleanup Completed ==="
+                          resources:
+                              limits:
+                                  cpu: 100m
+                                  memory: 128Mi
+                              requests:
+                                  cpu: 50m
+                                  memory: 64Mi
+                          volumeMounts:
+                              - name: runner-cache
+                                mountPath: /cache
+                    volumes:
+                        - name: runner-cache
+                          persistentVolumeClaim:
+                              claimName: arc-runner-cache

--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -32,7 +32,7 @@ template:
         # Init container to copy externals for DinD
         initContainers:
             - name: init-dind-externals
-              image: ghcr.io/actions/actions-runner:latest
+              image: ghcr.io/actions/actions-runner:2.332.0
               command:
                   [
                       'cp',
@@ -46,7 +46,7 @@ template:
                     mountPath: /home/runner/tmpDir
         containers:
             - name: runner
-              image: ghcr.io/actions/actions-runner:latest
+              image: ghcr.io/actions/actions-runner:2.332.0
               # Fix sudoers for root before starting runner (Unity builder uses sudo)
               command:
                   [
@@ -83,7 +83,7 @@ template:
             # Docker-in-Docker sidecar
             # Note: Unity builds request high resources, DinD needs headroom
             - name: dind
-              image: docker:dind
+              image: docker:29.2.1-dind
               args:
                   - dockerd
                   - --host=unix:///var/run/docker.sock


### PR DESCRIPTION
## Summary
- Pin floating image tags to specific versions to prevent supply chain drift
- Harden cache cleanup CronJob with security context

## Changes

### Image Pinning
| Image | Before | After |
|---|---|---|
| actions-runner | `:latest` | `:2.332.0` |
| docker (DinD) | `:dind` | `:29.2.1-dind` |
| alpine (cleanup) | `:3.19` | `:3.21` |

### Cache Cleanup Hardening
- Added pod `securityContext`: runAsNonRoot (UID 1000), seccomp RuntimeDefault
- Added container `securityContext`: no privilege escalation, read-only FS, drop ALL capabilities
- Added `activeDeadlineSeconds: 300` (5 min timeout)
- Set `backoffLimit: 0` + `restartPolicy: Never` (fail fast)

## Risk
**Low** — image pins are the latest stable versions. CronJob hardening only restricts the cleanup container (read-only FS is fine since it only reads/deletes from the mounted PVC).

## Test plan
- [ ] Runner pods start with pinned image versions
- [ ] CI workflows complete successfully on `arc-runner-set`
- [ ] Cache cleanup CronJob runs at 3 AM UTC without errors
- [ ] Docker builds work with `docker:29.2.1-dind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)