### PR TITLE
fix(kilobase): fix hourly backup bug and add WAL retention cleanup

### DIFF
--- a/apps/kube/kilobase/manifests/object-store.yaml
+++ b/apps/kube/kilobase/manifests/object-store.yaml
@@ -1,18 +1,22 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
-  name: kilobase-backup-store
-  namespace: kilobase
+    name: kilobase-backup-store
+    namespace: kilobase
 spec:
-  retentionPolicy: '3d'
-  configuration:
-    destinationPath: s3://kilobase/barman/backup
-    s3Credentials:
-      accessKeyId:
-        name: kilobase-s3-secret
-        key: keyId
-      secretAccessKey:
-        name: kilobase-s3-secret
-        key: accessKey
-    wal:
-      compression: gzip
+    retentionPolicy: '7d'
+    instanceSidecarConfiguration:
+        # Run retention cleanup every 30 minutes — deletes base backups AND WAL
+        # files older than the retention window (7 days)
+        retentionPolicyIntervalSeconds: 1800
+    configuration:
+        destinationPath: s3://kilobase/barman/backup
+        s3Credentials:
+            accessKeyId:
+                name: kilobase-s3-secret
+                key: keyId
+            secretAccessKey:
+                name: kilobase-s3-secret
+                key: accessKey
+        wal:
+            compression: gzip

--- a/apps/kube/kilobase/manifests/scheduled-backup.yaml
+++ b/apps/kube/kilobase/manifests/scheduled-backup.yaml
@@ -1,21 +1,23 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: supabase-cluster-backup
-  namespace: kilobase
+    name: supabase-cluster-backup
+    namespace: kilobase
 spec:
-  # Daily backup at 2 AM UTC
-  schedule: '0 2 * * *'
-  # Keep backup ownership tied to the ScheduledBackup resource
-  backupOwnerReference: self
-  # Target cluster
-  cluster:
-    name: supabase-cluster
-  # Prefer taking backup from standby to reduce load on primary
-  target: prefer-standby
-  # Use the barman-cloud plugin for S3 backup
-  method: plugin
-  pluginConfiguration:
-    name: barman-cloud.cloudnative-pg.io
-    parameters:
-      barmanObjectName: kilobase-backup-store
+    # Daily backup at 2 AM UTC
+    # CNPG uses 6-field cron (with seconds): sec min hour day month weekday
+    # 5-field '0 2 * * *' was misinterpreted as sec=0 min=2 hour=* → hourly!
+    schedule: '0 0 2 * * *'
+    # Keep backup ownership tied to the ScheduledBackup resource
+    backupOwnerReference: self
+    # Target cluster
+    cluster:
+        name: supabase-cluster
+    # Prefer taking backup from standby to reduce load on primary
+    target: prefer-standby
+    # Use the barman-cloud plugin for S3 backup
+    method: plugin
+    pluginConfiguration:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+            barmanObjectName: kilobase-backup-store


### PR DESCRIPTION
## Summary
- **Fixes backup running every hour instead of daily** — CNPG uses 6-field cron (with seconds), so `0 2 * * *` was parsed as `sec=0 min=2 hour=*` (hourly at :02). Fixed to `0 0 2 * * *` (daily at 2:00 AM UTC).
- **Adds WAL retention cleanup** — `instanceSidecarConfiguration.retentionPolicyIntervalSeconds: 1800` runs barman cleanup every 30 minutes, removing WAL files and base backups beyond the retention window.
- **Increases retention from 3d to 7d** — keeps a full week of backups for safety.

## Root Cause of S3 Cost Increase
The 5-field cron `0 2 * * *` was creating **24 base backups per day** instead of 1. Combined with no WAL cleanup, S3 storage was growing unbounded. This has been running since the ScheduledBackup was created (~101 days ago).

## Post-merge Manual Steps
After ArgoCD syncs, clean up the 29 failed backup CRDs:
```bash
kubectl get backups.postgresql.cnpg.io -n kilobase --no-headers | grep failed | awk '{print $1}' | xargs kubectl delete backups.postgresql.cnpg.io -n kilobase
```

The WAL cleanup sidecar will automatically start purging old WAL files from S3 within 30 minutes of deployment.

## Test plan
- [ ] ScheduledBackup shows `nextScheduleTime` ~24h from now (not ~1h)
- [ ] No new backup created at the next hour mark
- [ ] WAL cleanup runs within 30 minutes (check barman-cloud sidecar logs)
- [ ] S3 bucket size starts decreasing over the next few hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)