### PR TITLE
chore(axum-kbve): bump to 1.0.33

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.32"
+version = "1.0.33"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Bump axum-kbve to 1.0.33 to trigger CI rebuild pipeline

## Test plan
- [ ] CI `axum-kbve:container:ci` builds successfully
- [ ] E2E tests pass