### PR TITLE
feat(isometric): UI HUD infrastructure with Tailwind v4, event bus, toasts, modals, and menus

### DIFF
--- a/apps/kbve/isometric/index.html
+++ b/apps/kbve/isometric/index.html
@@ -22,9 +22,7 @@
                 height: 100%;
                 pointer-events: none;
             }
-            #root > * {
-                pointer-events: auto;
-            }
+            /* pointer-events managed per-component via Tailwind pointer-events-auto */
         </style>
     </head>
     <body>

--- a/apps/kbve/isometric/package.json
+++ b/apps/kbve/isometric/package.json
@@ -15,9 +15,11 @@
 		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
+		"@tailwindcss/vite": "^4.1.3",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"@vitejs/plugin-react": "^4.0.0",
+		"tailwindcss": "^4.1.3",
 		"typescript": "^5.0.0",
 		"vite": "^6.0.0"
 	}

--- a/apps/kbve/isometric/pnpm-lock.yaml
+++ b/apps/kbve/isometric/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
                 specifier: ^19.0.0
                 version: 19.2.4(react@19.2.4)
         devDependencies:
+            '@tailwindcss/vite':
+                specifier: ^4.1.3
+                version: 4.2.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
             '@types/react':
                 specifier: ^19.0.0
                 version: 19.2.14
@@ -28,13 +31,16 @@ importers:
                 version: 19.2.3(@types/react@19.2.14)
             '@vitejs/plugin-react':
                 specifier: ^4.0.0
-                version: 4.7.0(vite@6.4.1)
+                version: 4.7.0(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
+            tailwindcss:
+                specifier: ^4.1.3
+                version: 4.2.1
             typescript:
                 specifier: ^5.0.0
                 version: 5.9.3
             vite:
                 specifier: ^6.0.0
-                version: 6.4.1
+                version: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
 
 packages:
     '@babel/code-frame@7.29.0':
@@ -648,6 +654,141 @@ packages:
         cpu: [x64]
         os: [win32]
 
+    '@tailwindcss/node@4.2.1':
+        resolution:
+            {
+                integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==,
+            }
+
+    '@tailwindcss/oxide-android-arm64@4.2.1':
+        resolution:
+            {
+                integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [arm64]
+        os: [android]
+
+    '@tailwindcss/oxide-darwin-arm64@4.2.1':
+        resolution:
+            {
+                integrity: sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@tailwindcss/oxide-darwin-x64@4.2.1':
+        resolution:
+            {
+                integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [x64]
+        os: [darwin]
+
+    '@tailwindcss/oxide-freebsd-x64@4.2.1':
+        resolution:
+            {
+                integrity: sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [x64]
+        os: [freebsd]
+
+    '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+        resolution:
+            {
+                integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [arm]
+        os: [linux]
+
+    '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+        resolution:
+            {
+                integrity: sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+        resolution:
+            {
+                integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+        resolution:
+            {
+                integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [x64]
+        os: [linux]
+
+    '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+        resolution:
+            {
+                integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [x64]
+        os: [linux]
+
+    '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+        resolution:
+            {
+                integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==,
+            }
+        engines: { node: '>=14.0.0' }
+        cpu: [wasm32]
+        bundledDependencies:
+            - '@napi-rs/wasm-runtime'
+            - '@emnapi/core'
+            - '@emnapi/runtime'
+            - '@tybys/wasm-util'
+            - '@emnapi/wasi-threads'
+            - tslib
+
+    '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+        resolution:
+            {
+                integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [arm64]
+        os: [win32]
+
+    '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+        resolution:
+            {
+                integrity: sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==,
+            }
+        engines: { node: '>= 20' }
+        cpu: [x64]
+        os: [win32]
+
+    '@tailwindcss/oxide@4.2.1':
+        resolution:
+            {
+                integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==,
+            }
+        engines: { node: '>= 20' }
+
+    '@tailwindcss/vite@4.2.1':
+        resolution:
+            {
+                integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==,
+            }
+        peerDependencies:
+            vite: ^5.2.0 || ^6 || ^7
+
     '@tauri-apps/api@2.10.1':
         resolution:
             {
@@ -759,11 +900,25 @@ packages:
             supports-color:
                 optional: true
 
+    detect-libc@2.1.2:
+        resolution:
+            {
+                integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+            }
+        engines: { node: '>=8' }
+
     electron-to-chromium@1.5.307:
         resolution:
             {
                 integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==,
             }
+
+    enhanced-resolve@5.20.0:
+        resolution:
+            {
+                integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==,
+            }
+        engines: { node: '>=10.13.0' }
 
     esbuild@0.25.12:
         resolution:
@@ -807,6 +962,19 @@ packages:
             }
         engines: { node: '>=6.9.0' }
 
+    graceful-fs@4.2.11:
+        resolution:
+            {
+                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+            }
+
+    jiti@2.6.1:
+        resolution:
+            {
+                integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
+            }
+        hasBin: true
+
     js-tokens@4.0.0:
         resolution:
             {
@@ -829,10 +997,122 @@ packages:
         engines: { node: '>=6' }
         hasBin: true
 
+    lightningcss-android-arm64@1.31.1:
+        resolution:
+            {
+                integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [arm64]
+        os: [android]
+
+    lightningcss-darwin-arm64@1.31.1:
+        resolution:
+            {
+                integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [arm64]
+        os: [darwin]
+
+    lightningcss-darwin-x64@1.31.1:
+        resolution:
+            {
+                integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [x64]
+        os: [darwin]
+
+    lightningcss-freebsd-x64@1.31.1:
+        resolution:
+            {
+                integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [x64]
+        os: [freebsd]
+
+    lightningcss-linux-arm-gnueabihf@1.31.1:
+        resolution:
+            {
+                integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [arm]
+        os: [linux]
+
+    lightningcss-linux-arm64-gnu@1.31.1:
+        resolution:
+            {
+                integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [arm64]
+        os: [linux]
+
+    lightningcss-linux-arm64-musl@1.31.1:
+        resolution:
+            {
+                integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [arm64]
+        os: [linux]
+
+    lightningcss-linux-x64-gnu@1.31.1:
+        resolution:
+            {
+                integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [x64]
+        os: [linux]
+
+    lightningcss-linux-x64-musl@1.31.1:
+        resolution:
+            {
+                integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [x64]
+        os: [linux]
+
+    lightningcss-win32-arm64-msvc@1.31.1:
+        resolution:
+            {
+                integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [arm64]
+        os: [win32]
+
+    lightningcss-win32-x64-msvc@1.31.1:
+        resolution:
+            {
+                integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==,
+            }
+        engines: { node: '>= 12.0.0' }
+        cpu: [x64]
+        os: [win32]
+
+    lightningcss@1.31.1:
+        resolution:
+            {
+                integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==,
+            }
+        engines: { node: '>= 12.0.0' }
+
     lru-cache@5.1.1:
         resolution:
             {
                 integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
+            }
+
+    magic-string@0.30.21:
+        resolution:
+            {
+                integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
             }
 
     ms@2.1.3:
@@ -924,6 +1204,19 @@ packages:
                 integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
             }
         engines: { node: '>=0.10.0' }
+
+    tailwindcss@4.2.1:
+        resolution:
+            {
+                integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==,
+            }
+
+    tapable@2.3.0:
+        resolution:
+            {
+                integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==,
+            }
+        engines: { node: '>=6' }
 
     tinyglobby@0.2.15:
         resolution:
@@ -1285,6 +1578,74 @@ snapshots:
     '@rollup/rollup-win32-x64-msvc@4.59.0':
         optional: true
 
+    '@tailwindcss/node@4.2.1':
+        dependencies:
+            '@jridgewell/remapping': 2.3.5
+            enhanced-resolve: 5.20.0
+            jiti: 2.6.1
+            lightningcss: 1.31.1
+            magic-string: 0.30.21
+            source-map-js: 1.2.1
+            tailwindcss: 4.2.1
+
+    '@tailwindcss/oxide-android-arm64@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-darwin-arm64@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-darwin-x64@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-freebsd-x64@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+        optional: true
+
+    '@tailwindcss/oxide@4.2.1':
+        optionalDependencies:
+            '@tailwindcss/oxide-android-arm64': 4.2.1
+            '@tailwindcss/oxide-darwin-arm64': 4.2.1
+            '@tailwindcss/oxide-darwin-x64': 4.2.1
+            '@tailwindcss/oxide-freebsd-x64': 4.2.1
+            '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.1
+            '@tailwindcss/oxide-linux-arm64-gnu': 4.2.1
+            '@tailwindcss/oxide-linux-arm64-musl': 4.2.1
+            '@tailwindcss/oxide-linux-x64-gnu': 4.2.1
+            '@tailwindcss/oxide-linux-x64-musl': 4.2.1
+            '@tailwindcss/oxide-wasm32-wasi': 4.2.1
+            '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
+            '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
+
+    '@tailwindcss/vite@4.2.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))':
+        dependencies:
+            '@tailwindcss/node': 4.2.1
+            '@tailwindcss/oxide': 4.2.1
+            tailwindcss: 4.2.1
+            vite: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
+
     '@tauri-apps/api@2.10.1': {}
 
     '@tauri-apps/plugin-opener@2.5.3':
@@ -1322,7 +1683,7 @@ snapshots:
         dependencies:
             csstype: 3.2.3
 
-    '@vitejs/plugin-react@4.7.0(vite@6.4.1)':
+    '@vitejs/plugin-react@4.7.0(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))':
         dependencies:
             '@babel/core': 7.29.0
             '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -1330,7 +1691,7 @@ snapshots:
             '@rolldown/pluginutils': 1.0.0-beta.27
             '@types/babel__core': 7.20.5
             react-refresh: 0.17.0
-            vite: 6.4.1
+            vite: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
         transitivePeerDependencies:
             - supports-color
 
@@ -1354,7 +1715,14 @@ snapshots:
         dependencies:
             ms: 2.1.3
 
+    detect-libc@2.1.2: {}
+
     electron-to-chromium@1.5.307: {}
+
+    enhanced-resolve@5.20.0:
+        dependencies:
+            graceful-fs: 4.2.11
+            tapable: 2.3.0
 
     esbuild@0.25.12:
         optionalDependencies:
@@ -1396,15 +1764,72 @@ snapshots:
 
     gensync@1.0.0-beta.2: {}
 
+    graceful-fs@4.2.11: {}
+
+    jiti@2.6.1: {}
+
     js-tokens@4.0.0: {}
 
     jsesc@3.1.0: {}
 
     json5@2.2.3: {}
 
+    lightningcss-android-arm64@1.31.1:
+        optional: true
+
+    lightningcss-darwin-arm64@1.31.1:
+        optional: true
+
+    lightningcss-darwin-x64@1.31.1:
+        optional: true
+
+    lightningcss-freebsd-x64@1.31.1:
+        optional: true
+
+    lightningcss-linux-arm-gnueabihf@1.31.1:
+        optional: true
+
+    lightningcss-linux-arm64-gnu@1.31.1:
+        optional: true
+
+    lightningcss-linux-arm64-musl@1.31.1:
+        optional: true
+
+    lightningcss-linux-x64-gnu@1.31.1:
+        optional: true
+
+    lightningcss-linux-x64-musl@1.31.1:
+        optional: true
+
+    lightningcss-win32-arm64-msvc@1.31.1:
+        optional: true
+
+    lightningcss-win32-x64-msvc@1.31.1:
+        optional: true
+
+    lightningcss@1.31.1:
+        dependencies:
+            detect-libc: 2.1.2
+        optionalDependencies:
+            lightningcss-android-arm64: 1.31.1
+            lightningcss-darwin-arm64: 1.31.1
+            lightningcss-darwin-x64: 1.31.1
+            lightningcss-freebsd-x64: 1.31.1
+            lightningcss-linux-arm-gnueabihf: 1.31.1
+            lightningcss-linux-arm64-gnu: 1.31.1
+            lightningcss-linux-arm64-musl: 1.31.1
+            lightningcss-linux-x64-gnu: 1.31.1
+            lightningcss-linux-x64-musl: 1.31.1
+            lightningcss-win32-arm64-msvc: 1.31.1
+            lightningcss-win32-x64-msvc: 1.31.1
+
     lru-cache@5.1.1:
         dependencies:
             yallist: 3.1.1
+
+    magic-string@0.30.21:
+        dependencies:
+            '@jridgewell/sourcemap-codec': 1.5.5
 
     ms@2.1.3: {}
 
@@ -1468,6 +1893,10 @@ snapshots:
 
     source-map-js@1.2.1: {}
 
+    tailwindcss@4.2.1: {}
+
+    tapable@2.3.0: {}
+
     tinyglobby@0.2.15:
         dependencies:
             fdir: 6.5.0(picomatch@4.0.3)
@@ -1481,7 +1910,7 @@ snapshots:
             escalade: 3.2.0
             picocolors: 1.1.1
 
-    vite@6.4.1:
+    vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1):
         dependencies:
             esbuild: 0.25.12
             fdir: 6.5.0(picomatch@4.0.3)
@@ -1491,5 +1920,7 @@ snapshots:
             tinyglobby: 0.2.15
         optionalDependencies:
             fsevents: 2.3.3
+            jiti: 2.6.1
+            lightningcss: 1.31.1
 
     yallist@3.1.1: {}

--- a/apps/kbve/isometric/src/App.tsx
+++ b/apps/kbve/isometric/src/App.tsx
@@ -4,14 +4,7 @@ import { FPSCounter } from './components/FPSCounter';
 
 function App() {
 	return (
-		<div
-			style={{
-				position: 'fixed',
-				inset: 0,
-				pointerEvents: 'none',
-				fontFamily: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif",
-				color: '#fff',
-			}}>
+		<div className="fixed inset-0 pointer-events-none font-game text-white">
 			<FPSCounter />
 			<HUD />
 			<Inventory />

--- a/apps/kbve/isometric/src/app.css
+++ b/apps/kbve/isometric/src/app.css
@@ -1,0 +1,71 @@
+@import 'tailwindcss';
+
+@theme {
+	/* --- Game Color Palette --- */
+	--color-glass: oklch(0% 0 0 / 0.55);
+	--color-glass-light: oklch(100% 0 0 / 0.08);
+	--color-glass-border: oklch(100% 0 0 / 0.15);
+	--color-glass-hover: oklch(100% 0 0 / 0.12);
+
+	--color-hp: oklch(55% 0.2 25);
+	--color-mp: oklch(55% 0.18 250);
+	--color-xp: oklch(70% 0.18 145);
+
+	--color-toast-info: oklch(65% 0.15 250);
+	--color-toast-success: oklch(65% 0.18 145);
+	--color-toast-warning: oklch(75% 0.18 80);
+	--color-toast-error: oklch(55% 0.2 25);
+	--color-toast-loot: oklch(75% 0.18 85);
+
+	--color-overlay: oklch(0% 0 0 / 0.6);
+
+	/* --- Shadows --- */
+	--shadow-glass: 0 4px 16px oklch(0% 0 0 / 0.3);
+	--shadow-toast: 0 2px 8px oklch(0% 0 0 / 0.4);
+
+	/* --- Border Radius --- */
+	--radius-panel: 8px;
+	--radius-slot: 4px;
+	--radius-toast: 6px;
+
+	/* --- Font --- */
+	--font-game: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+
+	/* --- Animation Durations --- */
+	--animate-toast-in: toast-slide-in 300ms ease-out forwards;
+	--animate-toast-out: toast-slide-out 200ms ease-in forwards;
+	--animate-modal-in: modal-fade-in 200ms ease-out forwards;
+}
+
+@keyframes toast-slide-in {
+	from {
+		opacity: 0;
+		transform: translateX(100%);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
+@keyframes toast-slide-out {
+	from {
+		opacity: 1;
+		transform: translateX(0);
+	}
+	to {
+		opacity: 0;
+		transform: translateX(100%);
+	}
+}
+
+@keyframes modal-fade-in {
+	from {
+		opacity: 0;
+		transform: scale(0.95);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}

--- a/apps/kbve/isometric/src/components/FPSCounter.tsx
+++ b/apps/kbve/isometric/src/components/FPSCounter.tsx
@@ -17,17 +17,7 @@ export function FPSCounter() {
 	}, []);
 
 	return (
-		<div
-			style={{
-				position: 'absolute',
-				top: 8,
-				right: 8,
-				padding: '4px 10px',
-				background: 'rgba(0,0,0,0.5)',
-				borderRadius: 4,
-				fontSize: 13,
-				pointerEvents: 'auto',
-			}}>
+		<div className="absolute top-2 right-2 px-2.5 py-1 bg-glass rounded-slot text-[13px] pointer-events-auto">
 			{fps} FPS
 		</div>
 	);

--- a/apps/kbve/isometric/src/components/HUD.tsx
+++ b/apps/kbve/isometric/src/components/HUD.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { GlassPanel } from '../ui/shared/GlassPanel';
+import { ProgressBar } from '../ui/shared/ProgressBar';
 
 interface PlayerState {
 	health: number;
@@ -8,50 +10,6 @@ interface PlayerState {
 	max_mana: number;
 	position: [number, number, number];
 	inventory_slots: number;
-}
-
-function Bar({
-	value,
-	max,
-	color,
-	label,
-}: {
-	value: number;
-	max: number;
-	color: string;
-	label: string;
-}) {
-	const pct = max > 0 ? (value / max) * 100 : 0;
-	return (
-		<div style={{ marginBottom: 6 }}>
-			<div
-				style={{
-					fontSize: 11,
-					marginBottom: 2,
-					textShadow: '0 1px 2px rgba(0,0,0,0.8)',
-				}}>
-				{label}: {value}/{max}
-			</div>
-			<div
-				style={{
-					width: 180,
-					height: 14,
-					background: 'rgba(0,0,0,0.6)',
-					borderRadius: 3,
-					overflow: 'hidden',
-					border: '1px solid rgba(255,255,255,0.15)',
-				}}>
-				<div
-					style={{
-						width: `${pct}%`,
-						height: '100%',
-						background: color,
-						transition: 'width 0.3s ease',
-					}}
-				/>
-			</div>
-		</div>
-	);
 }
 
 export function HUD() {
@@ -72,32 +30,22 @@ export function HUD() {
 	if (!state) return null;
 
 	return (
-		<div
-			style={{
-				position: 'absolute',
-				bottom: 16,
-				left: 16,
-				padding: '12px 16px',
-				background: 'rgba(0,0,0,0.55)',
-				borderRadius: 8,
-				backdropFilter: 'blur(4px)',
-				pointerEvents: 'auto',
-			}}>
-			<Bar
+		<GlassPanel className="absolute bottom-4 left-4 px-4 py-3">
+			<ProgressBar
 				label="HP"
 				value={state.health}
 				max={state.max_health}
-				color="#c0392b"
+				color="bg-hp"
 			/>
-			<Bar
+			<ProgressBar
 				label="MP"
 				value={state.mana}
 				max={state.max_mana}
-				color="#2980b9"
+				color="bg-mp"
 			/>
-			<div style={{ fontSize: 10, opacity: 0.6, marginTop: 4 }}>
+			<div className="text-[10px] opacity-60 mt-1">
 				Pos: {state.position.map((v) => v.toFixed(1)).join(', ')}
 			</div>
-		</div>
+		</GlassPanel>
 	);
 }

--- a/apps/kbve/isometric/src/components/Inventory.tsx
+++ b/apps/kbve/isometric/src/components/Inventory.tsx
@@ -1,45 +1,22 @@
+import { GlassPanel } from '../ui/shared/GlassPanel';
+
 const GRID_COLS = 4;
 const GRID_ROWS = 4;
-const SLOT_SIZE = 44;
-const GAP = 4;
 
 export function Inventory() {
 	const slots = Array.from({ length: GRID_COLS * GRID_ROWS });
 
 	return (
-		<div
-			style={{
-				position: 'absolute',
-				bottom: 16,
-				right: 16,
-				padding: 10,
-				background: 'rgba(0,0,0,0.55)',
-				borderRadius: 8,
-				backdropFilter: 'blur(4px)',
-				pointerEvents: 'auto',
-			}}>
-			<div style={{ fontSize: 11, marginBottom: 6, textAlign: 'center' }}>
-				Inventory
-			</div>
-			<div
-				style={{
-					display: 'grid',
-					gridTemplateColumns: `repeat(${GRID_COLS}, ${SLOT_SIZE}px)`,
-					gap: GAP,
-				}}>
+		<GlassPanel className="absolute bottom-4 right-4 p-2.5">
+			<div className="text-[11px] mb-1.5 text-center">Inventory</div>
+			<div className="grid grid-cols-4 gap-1">
 				{slots.map((_, i) => (
 					<div
 						key={i}
-						style={{
-							width: SLOT_SIZE,
-							height: SLOT_SIZE,
-							background: 'rgba(255,255,255,0.08)',
-							border: '1px solid rgba(255,255,255,0.15)',
-							borderRadius: 4,
-						}}
+						className="w-11 h-11 bg-glass-light border border-glass-border rounded-slot"
 					/>
 				))}
 			</div>
-		</div>
+		</GlassPanel>
 	);
 }

--- a/apps/kbve/isometric/src/main.tsx
+++ b/apps/kbve/isometric/src/main.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './app.css';
+import { GameUIProvider } from './ui/provider/GameUIProvider';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 	<React.StrictMode>
-		<App />
+		<GameUIProvider>
+			<App />
+		</GameUIProvider>
 	</React.StrictMode>,
 );

--- a/apps/kbve/isometric/src/ui/events/event-bus.ts
+++ b/apps/kbve/isometric/src/ui/events/event-bus.ts
@@ -1,0 +1,50 @@
+import type { GameEventMap } from './event-map';
+
+type Listener<T> = (payload: T) => void;
+
+class EventBus<TMap extends { [key: string]: unknown }> {
+	private listeners = new Map<keyof TMap, Set<Listener<never>>>();
+
+	on<K extends keyof TMap>(
+		event: K,
+		listener: Listener<TMap[K]>,
+	): () => void {
+		if (!this.listeners.has(event)) {
+			this.listeners.set(event, new Set());
+		}
+		const set = this.listeners.get(event)!;
+		const fn = listener as Listener<never>;
+		set.add(fn);
+		return () => {
+			set.delete(fn);
+		};
+	}
+
+	once<K extends keyof TMap>(
+		event: K,
+		listener: Listener<TMap[K]>,
+	): () => void {
+		const unsub = this.on(event, ((payload: TMap[K]) => {
+			unsub();
+			listener(payload);
+		}) as Listener<TMap[K]>);
+		return unsub;
+	}
+
+	emit<K extends keyof TMap>(
+		event: K,
+		...args: TMap[K] extends void ? [] : [payload: TMap[K]]
+	): void {
+		const set = this.listeners.get(event);
+		if (set) {
+			const payload = args[0] as TMap[K];
+			set.forEach((fn) => (fn as Listener<TMap[K]>)(payload));
+		}
+	}
+
+	off<K extends keyof TMap>(event: K): void {
+		this.listeners.delete(event);
+	}
+}
+
+export const gameEvents = new EventBus<GameEventMap>();

--- a/apps/kbve/isometric/src/ui/events/event-map.ts
+++ b/apps/kbve/isometric/src/ui/events/event-map.ts
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+
+export type ToastSeverity = 'info' | 'success' | 'warning' | 'error' | 'loot';
+
+export type GameEventMap = {
+	// Toast events
+	'toast:show': {
+		message: string;
+		severity: ToastSeverity;
+		duration?: number;
+	};
+	'toast:dismiss': { id: string };
+	'toast:clear': void;
+
+	// Modal events
+	'modal:open': {
+		id?: string;
+		title: string;
+		content: ReactNode;
+		onClose?: () => void;
+	};
+	'modal:close': void;
+
+	// Menu events
+	'menu:toggle': void;
+	'menu:open': void;
+	'menu:close': void;
+
+	// Game state events (from Tauri IPC bridge)
+	'game:damage': { amount: number; source: string };
+	'game:heal': { amount: number };
+	'game:item-pickup': { name: string; quantity: number };
+	'game:achievement': { title: string; description: string };
+	'game:death': void;
+
+	// Settings
+	'settings:changed': { key: string; value: unknown };
+};

--- a/apps/kbve/isometric/src/ui/events/use-event.ts
+++ b/apps/kbve/isometric/src/ui/events/use-event.ts
@@ -1,0 +1,27 @@
+import { useEffect, useCallback } from 'react';
+import { gameEvents } from './event-bus';
+import type { GameEventMap } from './event-map';
+
+export function useEvent<K extends keyof GameEventMap>(
+	event: K,
+	handler: (payload: GameEventMap[K]) => void,
+): void {
+	useEffect(() => {
+		return gameEvents.on(event, handler);
+	}, [event, handler]);
+}
+
+export function useEmit() {
+	return useCallback(
+		<K extends keyof GameEventMap>(
+			event: K,
+			...args: GameEventMap[K] extends void
+				? []
+				: [payload: GameEventMap[K]]
+		) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(gameEvents.emit as any)(event, ...args);
+		},
+		[],
+	);
+}

--- a/apps/kbve/isometric/src/ui/menu/PauseMenu.tsx
+++ b/apps/kbve/isometric/src/ui/menu/PauseMenu.tsx
@@ -1,0 +1,122 @@
+import { useContext } from 'react';
+import { createPortal } from 'react-dom';
+import { getPortalRoot } from '../shared/portal';
+import { MenuStateContext, MenuDispatchContext } from './menu-context';
+import type { SettingsCategory } from './menu-types';
+
+const CATEGORIES: { key: SettingsCategory; label: string }[] = [
+	{ key: 'general', label: 'General' },
+	{ key: 'audio', label: 'Audio' },
+	{ key: 'video', label: 'Video' },
+	{ key: 'controls', label: 'Controls' },
+];
+
+function SettingsContent({ category }: { category: SettingsCategory }) {
+	switch (category) {
+		case 'general':
+			return (
+				<div className="space-y-3">
+					<h3 className="text-sm font-semibold mb-2">
+						General Settings
+					</h3>
+					<div className="text-[13px] text-white/60">
+						Game settings will be added here.
+					</div>
+				</div>
+			);
+		case 'audio':
+			return (
+				<div className="space-y-3">
+					<h3 className="text-sm font-semibold mb-2">
+						Audio Settings
+					</h3>
+					<div className="text-[13px] text-white/60">
+						Volume controls will be added here.
+					</div>
+				</div>
+			);
+		case 'video':
+			return (
+				<div className="space-y-3">
+					<h3 className="text-sm font-semibold mb-2">
+						Video Settings
+					</h3>
+					<div className="text-[13px] text-white/60">
+						Resolution and display options will be added here.
+					</div>
+				</div>
+			);
+		case 'controls':
+			return (
+				<div className="space-y-3">
+					<h3 className="text-sm font-semibold mb-2">Controls</h3>
+					<div className="text-[13px] text-white/60 space-y-1">
+						<div>W / A / S / D — Move</div>
+						<div>Space — Jump</div>
+						<div>Escape — Toggle Menu</div>
+					</div>
+				</div>
+			);
+	}
+}
+
+export function PauseMenu() {
+	const { isOpen, activeCategory } = useContext(MenuStateContext);
+	const dispatch = useContext(MenuDispatchContext);
+
+	if (!isOpen) return null;
+
+	return createPortal(
+		<div className="fixed inset-0 bg-overlay backdrop-blur-[8px] flex items-center justify-center pointer-events-auto">
+			<div className="bg-glass backdrop-blur-[4px] rounded-panel border border-glass-border shadow-glass w-full max-w-lg mx-4 animate-modal-in">
+				{/* Header */}
+				<div className="flex items-center justify-between px-4 py-3 border-b border-glass-border">
+					<h2 className="text-sm font-semibold">Settings</h2>
+					<button
+						onClick={() => dispatch({ type: 'CLOSE' })}
+						className="text-white/50 hover:text-white text-lg leading-none cursor-pointer">
+						&times;
+					</button>
+				</div>
+
+				{/* Body: sidebar + content */}
+				<div className="flex min-h-[240px]">
+					{/* Sidebar */}
+					<div className="w-32 border-r border-glass-border p-2 flex flex-col gap-1">
+						{CATEGORIES.map(({ key, label }) => (
+							<button
+								key={key}
+								onClick={() =>
+									dispatch({
+										type: 'SET_CATEGORY',
+										category: key,
+									})
+								}
+								className={`
+									text-left text-[13px] px-3 py-1.5 rounded-slot cursor-pointer transition-colors
+									${activeCategory === key ? 'bg-glass-light text-white' : 'text-white/60 hover:text-white hover:bg-glass-hover'}
+								`}>
+								{label}
+							</button>
+						))}
+					</div>
+
+					{/* Content */}
+					<div className="flex-1 p-4">
+						<SettingsContent category={activeCategory} />
+					</div>
+				</div>
+
+				{/* Footer */}
+				<div className="flex justify-end px-4 py-3 border-t border-glass-border">
+					<button
+						onClick={() => dispatch({ type: 'CLOSE' })}
+						className="px-4 py-1.5 text-[13px] bg-glass-light border border-glass-border rounded-slot hover:bg-glass-hover cursor-pointer transition-colors">
+						Resume
+					</button>
+				</div>
+			</div>
+		</div>,
+		getPortalRoot('menu-root'),
+	);
+}

--- a/apps/kbve/isometric/src/ui/menu/menu-context.tsx
+++ b/apps/kbve/isometric/src/ui/menu/menu-context.tsx
@@ -1,0 +1,68 @@
+import {
+	createContext,
+	useReducer,
+	useEffect,
+	type ReactNode,
+	type Dispatch,
+} from 'react';
+import { gameEvents } from '../events/event-bus';
+import type { MenuState, SettingsCategory } from './menu-types';
+
+// --- Actions ---
+export type MenuAction =
+	| { type: 'TOGGLE' }
+	| { type: 'OPEN' }
+	| { type: 'CLOSE' }
+	| { type: 'SET_CATEGORY'; category: SettingsCategory };
+
+const initialState: MenuState = { isOpen: false, activeCategory: 'general' };
+
+function menuReducer(state: MenuState, action: MenuAction): MenuState {
+	switch (action.type) {
+		case 'TOGGLE':
+			return { ...state, isOpen: !state.isOpen };
+		case 'OPEN':
+			return { ...state, isOpen: true };
+		case 'CLOSE':
+			return { ...state, isOpen: false, activeCategory: 'general' };
+		case 'SET_CATEGORY':
+			return { ...state, activeCategory: action.category };
+	}
+}
+
+// --- Contexts (split) ---
+export const MenuStateContext = createContext<MenuState>(initialState);
+export const MenuDispatchContext = createContext<Dispatch<MenuAction>>(
+	() => {},
+);
+
+// --- Provider ---
+export function MenuProvider({ children }: { children: ReactNode }) {
+	const [state, dispatch] = useReducer(menuReducer, initialState);
+
+	// Bridge: event bus → menu state
+	useEffect(() => {
+		const unsubToggle = gameEvents.on('menu:toggle', () => {
+			dispatch({ type: 'TOGGLE' });
+		});
+		const unsubOpen = gameEvents.on('menu:open', () => {
+			dispatch({ type: 'OPEN' });
+		});
+		const unsubClose = gameEvents.on('menu:close', () => {
+			dispatch({ type: 'CLOSE' });
+		});
+		return () => {
+			unsubToggle();
+			unsubOpen();
+			unsubClose();
+		};
+	}, []);
+
+	return (
+		<MenuStateContext value={state}>
+			<MenuDispatchContext value={dispatch}>
+				{children}
+			</MenuDispatchContext>
+		</MenuStateContext>
+	);
+}

--- a/apps/kbve/isometric/src/ui/menu/menu-types.ts
+++ b/apps/kbve/isometric/src/ui/menu/menu-types.ts
@@ -1,0 +1,6 @@
+export type SettingsCategory = 'general' | 'audio' | 'video' | 'controls';
+
+export interface MenuState {
+	isOpen: boolean;
+	activeCategory: SettingsCategory;
+}

--- a/apps/kbve/isometric/src/ui/menu/use-menu.ts
+++ b/apps/kbve/isometric/src/ui/menu/use-menu.ts
@@ -1,0 +1,28 @@
+import { useContext, useCallback } from 'react';
+import { MenuDispatchContext } from './menu-context';
+import type { SettingsCategory } from './menu-types';
+
+export function useMenu() {
+	const dispatch = useContext(MenuDispatchContext);
+
+	const toggle = useCallback(() => {
+		dispatch({ type: 'TOGGLE' });
+	}, [dispatch]);
+
+	const open = useCallback(() => {
+		dispatch({ type: 'OPEN' });
+	}, [dispatch]);
+
+	const close = useCallback(() => {
+		dispatch({ type: 'CLOSE' });
+	}, [dispatch]);
+
+	const setCategory = useCallback(
+		(category: SettingsCategory) => {
+			dispatch({ type: 'SET_CATEGORY', category });
+		},
+		[dispatch],
+	);
+
+	return { toggle, open, close, setCategory };
+}

--- a/apps/kbve/isometric/src/ui/modal/ModalOverlay.tsx
+++ b/apps/kbve/isometric/src/ui/modal/ModalOverlay.tsx
@@ -1,0 +1,46 @@
+import { useContext } from 'react';
+import { createPortal } from 'react-dom';
+import { getPortalRoot } from '../shared/portal';
+import { ModalStateContext, ModalDispatchContext } from './modal-context';
+import { MODAL_SIZE_CLASSES } from './modal-types';
+
+export function ModalOverlay() {
+	const { stack, isOpen } = useContext(ModalStateContext);
+	const dispatch = useContext(ModalDispatchContext);
+
+	if (!isOpen || stack.length === 0) return null;
+
+	const topModal = stack[stack.length - 1];
+	const sizeClass = MODAL_SIZE_CLASSES[topModal.size ?? 'md'];
+
+	return createPortal(
+		<div
+			className="fixed inset-0 bg-overlay backdrop-blur-[8px] flex items-center justify-center pointer-events-auto"
+			onClick={() => {
+				if (topModal.closeOnOverlayClick !== false) {
+					dispatch({ type: 'CLOSE' });
+				}
+			}}>
+			<div
+				className={`
+					${sizeClass} w-full mx-4
+					bg-glass backdrop-blur-[4px] rounded-panel border border-glass-border shadow-glass
+					animate-modal-in
+				`}
+				onClick={(e) => e.stopPropagation()}>
+				{/* Title bar */}
+				<div className="flex items-center justify-between px-4 py-3 border-b border-glass-border">
+					<h2 className="text-sm font-semibold">{topModal.title}</h2>
+					<button
+						onClick={() => dispatch({ type: 'CLOSE' })}
+						className="text-white/50 hover:text-white text-lg leading-none cursor-pointer">
+						&times;
+					</button>
+				</div>
+				{/* Content */}
+				<div className="p-4">{topModal.content}</div>
+			</div>
+		</div>,
+		getPortalRoot('modal-root'),
+	);
+}

--- a/apps/kbve/isometric/src/ui/modal/modal-context.tsx
+++ b/apps/kbve/isometric/src/ui/modal/modal-context.tsx
@@ -1,0 +1,87 @@
+import {
+	createContext,
+	useReducer,
+	useEffect,
+	type ReactNode,
+	type Dispatch,
+} from 'react';
+import { gameEvents } from '../events/event-bus';
+import type { ModalConfig, ModalState } from './modal-types';
+
+// --- Actions ---
+export type ModalAction =
+	| { type: 'OPEN'; modal: ModalConfig }
+	| { type: 'CLOSE' }
+	| { type: 'CLOSE_ALL' };
+
+const initialState: ModalState = { stack: [], isOpen: false };
+
+function modalReducer(state: ModalState, action: ModalAction): ModalState {
+	switch (action.type) {
+		case 'OPEN':
+			return {
+				stack: [...state.stack, action.modal],
+				isOpen: true,
+			};
+		case 'CLOSE': {
+			const popped = state.stack[state.stack.length - 1];
+			const newStack = state.stack.slice(0, -1);
+			popped?.onClose?.();
+			return {
+				stack: newStack,
+				isOpen: newStack.length > 0,
+			};
+		}
+		case 'CLOSE_ALL': {
+			state.stack.forEach((m) => m.onClose?.());
+			return initialState;
+		}
+	}
+}
+
+// --- Contexts (split) ---
+export const ModalStateContext = createContext<ModalState>(initialState);
+export const ModalDispatchContext = createContext<Dispatch<ModalAction>>(
+	() => {},
+);
+
+// --- Provider ---
+export function ModalProvider({ children }: { children: ReactNode }) {
+	const [state, dispatch] = useReducer(modalReducer, initialState);
+
+	// Bridge: event bus → modal state
+	useEffect(() => {
+		const unsubOpen = gameEvents.on(
+			'modal:open',
+			({ id, title, content, onClose }) => {
+				dispatch({
+					type: 'OPEN',
+					modal: {
+						id: id ?? crypto.randomUUID(),
+						title,
+						content,
+						onClose,
+						closeOnOverlayClick: true,
+						closeOnEscape: true,
+						size: 'md',
+					},
+				});
+			},
+		);
+		const unsubClose = gameEvents.on('modal:close', () => {
+			dispatch({ type: 'CLOSE' });
+		});
+		return () => {
+			unsubOpen();
+			unsubClose();
+		};
+	}, []);
+
+	return (
+		<ModalStateContext value={state}>
+			<ModalDispatchContext value={dispatch}>
+				{children}
+			</ModalDispatchContext>
+		</ModalStateContext>
+	);
+}

--- a/apps/kbve/isometric/src/ui/modal/modal-types.ts
+++ b/apps/kbve/isometric/src/ui/modal/modal-types.ts
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+
+export interface ModalConfig {
+	id: string;
+	title: string;
+	content: ReactNode;
+	onClose?: () => void;
+	closeOnOverlayClick?: boolean;
+	closeOnEscape?: boolean;
+	size?: 'sm' | 'md' | 'lg';
+}
+
+export interface ModalState {
+	stack: ModalConfig[];
+	isOpen: boolean;
+}
+
+export const MODAL_SIZE_CLASSES: Record<string, string> = {
+	sm: 'max-w-sm',
+	md: 'max-w-md',
+	lg: 'max-w-lg',
+};

--- a/apps/kbve/isometric/src/ui/modal/use-modal.ts
+++ b/apps/kbve/isometric/src/ui/modal/use-modal.ts
@@ -1,0 +1,33 @@
+import { useContext, useCallback } from 'react';
+import { ModalDispatchContext } from './modal-context';
+import type { ModalConfig } from './modal-types';
+
+export function useModal() {
+	const dispatch = useContext(ModalDispatchContext);
+
+	const open = useCallback(
+		(config: Omit<ModalConfig, 'id'> & { id?: string }) => {
+			dispatch({
+				type: 'OPEN',
+				modal: {
+					id: config.id ?? crypto.randomUUID(),
+					closeOnOverlayClick: true,
+					closeOnEscape: true,
+					size: 'md',
+					...config,
+				},
+			});
+		},
+		[dispatch],
+	);
+
+	const close = useCallback(() => {
+		dispatch({ type: 'CLOSE' });
+	}, [dispatch]);
+
+	const closeAll = useCallback(() => {
+		dispatch({ type: 'CLOSE_ALL' });
+	}, [dispatch]);
+
+	return { open, close, closeAll };
+}

--- a/apps/kbve/isometric/src/ui/provider/GameUIProvider.tsx
+++ b/apps/kbve/isometric/src/ui/provider/GameUIProvider.tsx
@@ -1,0 +1,50 @@
+import { useContext, useCallback, type ReactNode } from 'react';
+import { ToastProvider } from '../toast/toast-context';
+import { ModalProvider } from '../modal/modal-context';
+import { MenuProvider } from '../menu/menu-context';
+import { ToastContainer } from '../toast/ToastContainer';
+import { ModalOverlay } from '../modal/ModalOverlay';
+import { PauseMenu } from '../menu/PauseMenu';
+import {
+	ModalStateContext,
+	ModalDispatchContext,
+} from '../modal/modal-context';
+import { MenuStateContext, MenuDispatchContext } from '../menu/menu-context';
+import { useKeyboard } from '../shared/use-keyboard';
+
+function KeyboardRouter() {
+	const modalState = useContext(ModalStateContext);
+	const modalDispatch = useContext(ModalDispatchContext);
+	const menuState = useContext(MenuStateContext);
+	const menuDispatch = useContext(MenuDispatchContext);
+
+	const handleEscape = useCallback(() => {
+		if (modalState.isOpen) {
+			modalDispatch({ type: 'CLOSE' });
+		} else if (menuState.isOpen) {
+			menuDispatch({ type: 'CLOSE' });
+		} else {
+			menuDispatch({ type: 'OPEN' });
+		}
+	}, [modalState.isOpen, menuState.isOpen, modalDispatch, menuDispatch]);
+
+	useKeyboard('Escape', handleEscape);
+
+	return null;
+}
+
+export function GameUIProvider({ children }: { children: ReactNode }) {
+	return (
+		<ToastProvider>
+			<ModalProvider>
+				<MenuProvider>
+					<KeyboardRouter />
+					{children}
+					<ToastContainer />
+					<ModalOverlay />
+					<PauseMenu />
+				</MenuProvider>
+			</ModalProvider>
+		</ToastProvider>
+	);
+}

--- a/apps/kbve/isometric/src/ui/shared/GlassPanel.tsx
+++ b/apps/kbve/isometric/src/ui/shared/GlassPanel.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface GlassPanelProps {
+	children: ReactNode;
+	className?: string;
+}
+
+export function GlassPanel({ children, className = '' }: GlassPanelProps) {
+	return (
+		<div
+			className={`bg-glass backdrop-blur-[4px] rounded-panel border border-glass-border shadow-glass pointer-events-auto ${className}`}>
+			{children}
+		</div>
+	);
+}

--- a/apps/kbve/isometric/src/ui/shared/ProgressBar.tsx
+++ b/apps/kbve/isometric/src/ui/shared/ProgressBar.tsx
@@ -1,0 +1,23 @@
+interface ProgressBarProps {
+	value: number;
+	max: number;
+	color: string;
+	label: string;
+}
+
+export function ProgressBar({ value, max, color, label }: ProgressBarProps) {
+	const pct = max > 0 ? (value / max) * 100 : 0;
+	return (
+		<div className="mb-1.5">
+			<div className="text-[11px] mb-0.5 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]">
+				{label}: {value}/{max}
+			</div>
+			<div className="w-[180px] h-3.5 bg-black/60 rounded-slot overflow-hidden border border-glass-border">
+				<div
+					className={`h-full ${color} transition-[width] duration-300 ease-out`}
+					style={{ width: `${pct}%` }}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/isometric/src/ui/shared/portal.ts
+++ b/apps/kbve/isometric/src/ui/shared/portal.ts
@@ -1,0 +1,22 @@
+const portalCache = new Map<string, HTMLElement>();
+
+const Z_INDEX: Record<string, string> = {
+	'toast-root': '100',
+	'modal-root': '90',
+	'menu-root': '80',
+};
+
+export function getPortalRoot(id: string): HTMLElement {
+	let el = portalCache.get(id);
+	if (!el || !document.body.contains(el)) {
+		el = document.createElement('div');
+		el.id = id;
+		el.style.position = 'fixed';
+		el.style.inset = '0';
+		el.style.pointerEvents = 'none';
+		el.style.zIndex = Z_INDEX[id] ?? '50';
+		document.body.appendChild(el);
+		portalCache.set(id, el);
+	}
+	return el;
+}

--- a/apps/kbve/isometric/src/ui/shared/use-keyboard.ts
+++ b/apps/kbve/isometric/src/ui/shared/use-keyboard.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export function useKeyboard(
+	key: string,
+	handler: () => void,
+	enabled: boolean = true,
+): void {
+	useEffect(() => {
+		if (!enabled) return;
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === key) {
+				e.preventDefault();
+				handler();
+			}
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	}, [key, handler, enabled]);
+}

--- a/apps/kbve/isometric/src/ui/toast/ToastContainer.tsx
+++ b/apps/kbve/isometric/src/ui/toast/ToastContainer.tsx
@@ -1,0 +1,37 @@
+import { useContext, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { getPortalRoot } from '../shared/portal';
+import { ToastStateContext, ToastDispatchContext } from './toast-context';
+import { ToastItem } from './ToastItem';
+
+export function ToastContainer() {
+	const { toasts } = useContext(ToastStateContext);
+	const dispatch = useContext(ToastDispatchContext);
+
+	const handleDismiss = useCallback(
+		(id: string) => {
+			const toast = toasts.find((t) => t.id === id);
+			if (toast?.exiting) {
+				dispatch({ type: 'REMOVE', id });
+			} else {
+				dispatch({ type: 'MARK_EXITING', id });
+			}
+		},
+		[toasts, dispatch],
+	);
+
+	if (toasts.length === 0) return null;
+
+	return createPortal(
+		<div className="fixed top-14 right-4 flex flex-col items-end pointer-events-none">
+			{toasts.map((toast) => (
+				<ToastItem
+					key={toast.id}
+					toast={toast}
+					onDismiss={handleDismiss}
+				/>
+			))}
+		</div>,
+		getPortalRoot('toast-root'),
+	);
+}

--- a/apps/kbve/isometric/src/ui/toast/ToastItem.tsx
+++ b/apps/kbve/isometric/src/ui/toast/ToastItem.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import type { Toast } from './toast-types';
+import { SEVERITY_BORDER_COLORS } from './toast-types';
+
+interface ToastItemProps {
+	toast: Toast;
+	onDismiss: (id: string) => void;
+}
+
+export function ToastItem({ toast, onDismiss }: ToastItemProps) {
+	useEffect(() => {
+		if (toast.duration <= 0 || toast.exiting) return;
+		const timer = setTimeout(() => onDismiss(toast.id), toast.duration);
+		return () => clearTimeout(timer);
+	}, [toast.id, toast.duration, toast.exiting, onDismiss]);
+
+	const borderClass = SEVERITY_BORDER_COLORS[toast.severity];
+
+	return (
+		<div
+			className={`
+				pointer-events-auto mb-2 px-3 py-2.5 min-w-[220px] max-w-[320px]
+				bg-glass backdrop-blur-[4px] rounded-toast shadow-toast
+				border border-glass-border border-l-4 ${borderClass}
+				${toast.exiting ? 'animate-toast-out' : 'animate-toast-in'}
+				flex items-start gap-2
+			`}
+			onAnimationEnd={() => {
+				if (toast.exiting) onDismiss(toast.id);
+			}}>
+			<span className="text-[13px] leading-snug flex-1">
+				{toast.message}
+			</span>
+			<button
+				onClick={() => onDismiss(toast.id)}
+				className="text-white/50 hover:text-white text-sm leading-none mt-0.5 cursor-pointer">
+				&times;
+			</button>
+		</div>
+	);
+}

--- a/apps/kbve/isometric/src/ui/toast/toast-context.tsx
+++ b/apps/kbve/isometric/src/ui/toast/toast-context.tsx
@@ -1,0 +1,100 @@
+import {
+	createContext,
+	useReducer,
+	useEffect,
+	type ReactNode,
+	type Dispatch,
+} from 'react';
+import { gameEvents } from '../events/event-bus';
+import type { Toast } from './toast-types';
+import { DEFAULT_TOAST_CONFIG, SEVERITY_DURATIONS } from './toast-types';
+
+// --- Actions ---
+export type ToastAction =
+	| { type: 'ADD'; toast: Toast }
+	| { type: 'MARK_EXITING'; id: string }
+	| { type: 'REMOVE'; id: string }
+	| { type: 'CLEAR' };
+
+// --- State ---
+export interface ToastState {
+	toasts: Toast[];
+}
+
+function toastReducer(state: ToastState, action: ToastAction): ToastState {
+	switch (action.type) {
+		case 'ADD': {
+			let toasts = [...state.toasts, action.toast];
+			if (toasts.length > DEFAULT_TOAST_CONFIG.maxVisible) {
+				toasts = toasts.map((t, i) =>
+					i === 0 && !t.exiting ? { ...t, exiting: true } : t,
+				);
+			}
+			return { toasts };
+		}
+		case 'MARK_EXITING':
+			return {
+				toasts: state.toasts.map((t) =>
+					t.id === action.id ? { ...t, exiting: true } : t,
+				),
+			};
+		case 'REMOVE':
+			return {
+				toasts: state.toasts.filter((t) => t.id !== action.id),
+			};
+		case 'CLEAR':
+			return {
+				toasts: state.toasts.map((t) => ({ ...t, exiting: true })),
+			};
+	}
+}
+
+// --- Contexts (split for performance) ---
+export const ToastStateContext = createContext<ToastState>({ toasts: [] });
+export const ToastDispatchContext = createContext<Dispatch<ToastAction>>(
+	() => {},
+);
+
+// --- Provider ---
+export function ToastProvider({ children }: { children: ReactNode }) {
+	const [state, dispatch] = useReducer(toastReducer, { toasts: [] });
+
+	// Bridge: event bus → toast state
+	useEffect(() => {
+		const unsubShow = gameEvents.on(
+			'toast:show',
+			({ message, severity, duration }) => {
+				dispatch({
+					type: 'ADD',
+					toast: {
+						id: crypto.randomUUID(),
+						message,
+						severity,
+						duration: duration ?? SEVERITY_DURATIONS[severity],
+						createdAt: Date.now(),
+						exiting: false,
+					},
+				});
+			},
+		);
+		const unsubDismiss = gameEvents.on('toast:dismiss', ({ id }) => {
+			dispatch({ type: 'MARK_EXITING', id });
+		});
+		const unsubClear = gameEvents.on('toast:clear', () => {
+			dispatch({ type: 'CLEAR' });
+		});
+		return () => {
+			unsubShow();
+			unsubDismiss();
+			unsubClear();
+		};
+	}, []);
+
+	return (
+		<ToastStateContext value={state}>
+			<ToastDispatchContext value={dispatch}>
+				{children}
+			</ToastDispatchContext>
+		</ToastStateContext>
+	);
+}

--- a/apps/kbve/isometric/src/ui/toast/toast-types.ts
+++ b/apps/kbve/isometric/src/ui/toast/toast-types.ts
@@ -1,0 +1,36 @@
+export type ToastSeverity = 'info' | 'success' | 'warning' | 'error' | 'loot';
+
+export interface Toast {
+	id: string;
+	message: string;
+	severity: ToastSeverity;
+	duration: number;
+	createdAt: number;
+	exiting: boolean;
+}
+
+export interface ToastConfig {
+	maxVisible: number;
+	defaultDuration: number;
+}
+
+export const DEFAULT_TOAST_CONFIG: ToastConfig = {
+	maxVisible: 5,
+	defaultDuration: 4000,
+};
+
+export const SEVERITY_DURATIONS: Record<ToastSeverity, number> = {
+	info: 3000,
+	success: 3000,
+	warning: 5000,
+	error: 6000,
+	loot: 4000,
+};
+
+export const SEVERITY_BORDER_COLORS: Record<ToastSeverity, string> = {
+	info: 'border-l-toast-info',
+	success: 'border-l-toast-success',
+	warning: 'border-l-toast-warning',
+	error: 'border-l-toast-error',
+	loot: 'border-l-toast-loot',
+};

--- a/apps/kbve/isometric/src/ui/toast/use-toast.ts
+++ b/apps/kbve/isometric/src/ui/toast/use-toast.ts
@@ -1,0 +1,42 @@
+import { useContext, useCallback } from 'react';
+import { ToastDispatchContext } from './toast-context';
+import type { ToastSeverity } from './toast-types';
+import { SEVERITY_DURATIONS } from './toast-types';
+
+export function useToast() {
+	const dispatch = useContext(ToastDispatchContext);
+
+	const show = useCallback(
+		(
+			message: string,
+			severity: ToastSeverity = 'info',
+			duration?: number,
+		) => {
+			dispatch({
+				type: 'ADD',
+				toast: {
+					id: crypto.randomUUID(),
+					message,
+					severity,
+					duration: duration ?? SEVERITY_DURATIONS[severity],
+					createdAt: Date.now(),
+					exiting: false,
+				},
+			});
+		},
+		[dispatch],
+	);
+
+	const dismiss = useCallback(
+		(id: string) => {
+			dispatch({ type: 'MARK_EXITING', id });
+		},
+		[dispatch],
+	);
+
+	const clear = useCallback(() => {
+		dispatch({ type: 'CLEAR' });
+	}, [dispatch]);
+
+	return { show, dismiss, clear };
+}

--- a/apps/kbve/isometric/vite.config.ts
+++ b/apps/kbve/isometric/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 
 const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig(async () => ({
-	plugins: [react()],
+	plugins: [react(), tailwindcss()],
 	clearScreen: false,
 	server: {
 		port: 1420,


### PR DESCRIPTION
## Summary
- Adds TailwindCSS v4 with game-themed design tokens (glass-morphism, HP/MP/XP colors, toast severities, custom animations)
- Implements typed event bus (`GameEventMap`) with 15 event types for decoupled game-to-UI communication
- Adds toast system (5 severity levels, auto-dismiss, slide animations, portal rendering)
- Adds modal system (stacking support, backdrop blur, size variants, click-outside dismiss)
- Adds pause menu with sidebar settings navigation (General/Audio/Video/Controls placeholders)
- Creates `GameUIProvider` compositing all providers with centralized `KeyboardRouter` (Escape priority: modal > menu close > menu open)
- Extracts shared components: `GlassPanel`, `ProgressBar`, `useKeyboard` hook, portal utility
- Refactors existing FPSCounter, HUD, and Inventory from inline styles to Tailwind classes

## Test plan
- [ ] `tsc --noEmit` passes (verified locally)
- [ ] `vite build` succeeds (verified locally — 17.88 KB CSS, 206 KB JS)
- [ ] Existing HUD, Inventory, FPSCounter render correctly with Tailwind classes
- [ ] Escape key toggles pause menu
- [ ] Toast system renders notifications via `useToast().show()`
- [ ] Modal system renders dialogs via `useModal().open()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)