### PR TITLE
feat(ci): build-once-promote pattern to eliminate double Docker build

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -367,14 +367,14 @@ jobs:
         with:
             items: |
                 [
-                  { "name": "herbmail", "condition": "${{ needs.alter.outputs.herbmail }}" },
-                  { "name": "memes", "condition": "${{ needs.alter.outputs.memes }}" },
-                  { "name": "irc", "condition": "${{ needs.alter.outputs.irc_gateway }}" },
-                  { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}" },
-                  { "name": "mc", "condition": "${{ needs.alter.outputs.mc }}" },
-                  { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}" },
-                  { "name": "cryptothrone", "condition": "${{ needs.alter.outputs.cryptothrone }}" },
-                  { "name": "axum-kbve-e2e", "condition": "${{ needs.alter.outputs.astro_kbve }}", "runner": "arc-runner-set" }
+                  { "name": "herbmail", "condition": "${{ needs.alter.outputs.herbmail }}", "image": "kbve/herbmail" },
+                  { "name": "memes", "condition": "${{ needs.alter.outputs.memes }}", "image": "kbve/memes" },
+                  { "name": "irc", "condition": "${{ needs.alter.outputs.irc_gateway }}", "image": "kbve/irc-gateway" },
+                  { "name": "discordsh", "condition": "${{ needs.alter.outputs.discordsh }}", "image": "kbve/discordsh" },
+                  { "name": "mc", "condition": "${{ needs.alter.outputs.mc }}", "image": "kbve/mc" },
+                  { "name": "edge", "condition": "${{ needs.alter.outputs.edge }}", "image": "kbve/edge" },
+                  { "name": "cryptothrone", "condition": "${{ needs.alter.outputs.cryptothrone }}", "image": "kbve/cryptothrone" },
+                  { "name": "axum-kbve-e2e", "condition": "${{ needs.alter.outputs.astro_kbve }}", "runner": "arc-runner-set", "image": "kbve/kbve" }
                 ]
 
     test_docker:
@@ -383,7 +383,7 @@ jobs:
         if: ${{ always() && needs.generate_e2e_docker_matrix.outputs.matrix != 'null' && !failure() && !cancelled() }}
         permissions:
             contents: read
-            packages: read
+            packages: write
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.generate_e2e_docker_matrix.outputs.matrix) }}
@@ -391,6 +391,7 @@ jobs:
         with:
             project: ${{ matrix.name }}
             runner: ${{ matrix.runner || 'ubuntu-latest' }}
+            image: ${{ matrix.image || '' }}
 
     collect_docker_results:
         needs:

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -11,6 +11,11 @@ on:
                 required: false
                 type: string
                 default: 'ubuntu-latest'
+            image:
+                description: 'Docker image name (e.g. kbve/kbve). If set, pushes CI image to GHCR after e2e passes.'
+                required: false
+                type: string
+                default: ''
 
 jobs:
     test:
@@ -19,7 +24,7 @@ jobs:
         timeout-minutes: 60
         permissions:
             contents: read
-            packages: read
+            packages: write
 
         steps:
             - name: Checkout the monorepo
@@ -123,3 +128,12 @@ jobs:
                   name: test-passed-docker-${{ inputs.project }}
                   path: /tmp/test-result.txt
                   retention-days: 1
+
+            - name: Push CI image to GHCR
+              if: success() && inputs.image != ''
+              run: |
+                  SHORT_SHA="${GITHUB_SHA::8}"
+                  CI_TAG="ci-${SHORT_SHA}"
+                  docker tag "${{ inputs.image }}:latest" "ghcr.io/${{ inputs.image }}:${CI_TAG}"
+                  docker push "ghcr.io/${{ inputs.image }}:${CI_TAG}"
+                  echo "Pushed ghcr.io/${{ inputs.image }}:${CI_TAG}"

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -87,51 +87,9 @@ jobs:
                     echo "should_publish=true" >> "$GITHUB_OUTPUT"
                   fi
 
-            - name: Setup Node v24
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Setup pnpm v10
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 10
-                  run_install: false
-
-            - name: Get pnpm Store
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              id: pnpm-store
-              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm Cache
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              uses: actions/cache@v5
-              with:
-                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install pnpm Dependencies
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              run: pnpm install
-
-            - name: Set up QEMU
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              uses: docker/setup-qemu-action@v3
-
-            - name: Set up Docker Buildx
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              uses: docker/setup-buildx-action@v3
-
-            - name: Login to Docker Hub
-              if: ${{ steps.version_check.outputs.should_publish != 'false' }}
-              uses: docker/login-action@v3
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            # --- Promote CI image (build-once pattern) ---
+            # Try to pull the CI-tagged image pushed by the test job.
+            # If found, retag it for release and skip the full rebuild.
 
             - name: Login to GHCR
               if: ${{ steps.version_check.outputs.should_publish != 'false' }}
@@ -141,8 +99,78 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.MY_GITHUB_TOKEN }}
 
-            - name: Build Docker Image with Nx
+            - name: Promote CI image (skip rebuild)
+              id: promote
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && inputs.image != '' && inputs.cargo_toml != '' }}
+              run: |
+                  SHORT_SHA="${GITHUB_SHA::8}"
+                  CI_IMAGE="ghcr.io/${{ inputs.image }}:ci-${SHORT_SHA}"
+                  echo "Attempting to pull CI image: ${CI_IMAGE}"
+                  if docker pull "${CI_IMAGE}" 2>/dev/null; then
+                    echo "found=true" >> "$GITHUB_OUTPUT"
+                    LOCAL_VERSION=$(grep -m1 '^version' "${{ inputs.cargo_toml }}" \
+                      | sed 's/version = "\(.*\)"/\1/')
+
+                    docker tag "${CI_IMAGE}" "${{ inputs.image }}:latest"
+                    docker tag "${CI_IMAGE}" "${{ inputs.image }}:${LOCAL_VERSION}"
+                    docker tag "${CI_IMAGE}" "ghcr.io/${{ inputs.image }}:latest"
+                    docker tag "${CI_IMAGE}" "ghcr.io/${{ inputs.image }}:${LOCAL_VERSION}"
+                    echo "Promoted ${CI_IMAGE} → ${{ inputs.image }}:{latest,${LOCAL_VERSION}}"
+                  else
+                    echo "CI image not found, will build from scratch"
+                    echo "found=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            # --- Full build path (fallback when no CI image available) ---
+
+            - name: Setup Node v24
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - name: Setup pnpm v10
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+                  run_install: false
+
+            - name: Get pnpm Store
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              id: pnpm-store
+              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+            - name: Setup pnpm Cache
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              uses: actions/cache@v5
+              with:
+                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+
+            - name: Install pnpm Dependencies
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              run: pnpm install
+
+            - name: Set up QEMU
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
+              uses: docker/setup-buildx-action@v3
+
+            - name: Login to Docker Hub
               if: ${{ steps.version_check.outputs.should_publish != 'false' }}
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build Docker Image with Nx
+              if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
               env:
                   INPUT_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
               run: |

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -13,6 +13,10 @@ FROM --platform=linux/amd64 node:24-slim AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)


### PR DESCRIPTION
## Summary
- **Eliminate double Docker build** — the pipeline was building the same Docker image twice (~43 min test + ~40 min publish = ~83 min wasted). Now the test job pushes to `ghcr.io/<image>:ci-<sha>` after e2e passes, and the publish job pulls + retags instead of rebuilding.
- **Skip Playwright in Docker build** — add `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` to Dockerfile astro-builder stage. Playwright was downloading ~600MB of browsers that are never used inside the build, and frequently timing out.
- **Fully backward-compatible** — if no CI image exists (e.g. for apps that don't pass `image`), the publish job falls back to full build.

## Changes
| File | What |
|------|------|
| `docker-test-app.yml` | New `image` input, `packages: write`, push CI image after e2e |
| `utils-publish-docker-image.yml` | Promote step pulls CI image, gates build steps on `promote.found` |
| `ci-main.yml` | Add `image` to e2e matrix, pass to test workflow, elevate permissions |
| `apps/kbve/axum-kbve/Dockerfile` | `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` |

## Expected impact
- **~1h 45min → ~1h 05min** (publish drops from ~44 min to ~2 min)
- Playwright skip saves additional ~3-5 min on the test build

## Test plan
- [ ] CI test job pushes `ghcr.io/kbve/kbve:ci-<sha>` after e2e passes
- [ ] Publish job logs "Promoted" instead of running full Nx build
- [ ] Final images on DockerHub + GHCR have correct version tags
- [ ] Playwright download no longer appears in Docker build logs
- [ ] Other Docker apps (discordsh, cryptothrone, etc.) still work with new matrix