### PR TITLE
chore(ci): remove unused Rust toolchain, skip Playwright in Docker builds

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -16,6 +16,11 @@ on:
                 required: false
                 type: string
                 default: ''
+            install_playwright:
+                description: 'Install Playwright browsers on host (default: true). Set false for vitest-only e2e projects.'
+                required: false
+                type: boolean
+                default: true
 
 jobs:
     test:
@@ -67,22 +72,6 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ github.token }}
 
-            - name: Rust ToolChain
-              uses: dtolnay/rust-toolchain@stable
-
-            - name: Setup Cargo Cache
-              uses: actions/cache@v5
-              with:
-                  path: |
-                      ~/.cargo/bin/
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                      target/
-                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-cargo-
-
             - name: Setup Node v24
               uses: actions/setup-node@v6
               with:
@@ -110,6 +99,7 @@ jobs:
               run: pnpm install
 
             - name: Install Playwright Browsers
+              if: ${{ inputs.install_playwright }}
               run: pnpm exec playwright install --with-deps chromium
 
             - name: Nx e2e ${{ inputs.project }}

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -13,6 +13,10 @@ FROM --platform=linux/amd64 node:24-slim AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -13,6 +13,10 @@ FROM --platform=linux/amd64 node:24-alpine AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -5,6 +5,10 @@ FROM --platform=linux/amd64 node:24-alpine AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -5,6 +5,10 @@ FROM --platform=linux/amd64 node:24-alpine AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -8,6 +8,10 @@ FROM node:24-alpine AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)

--- a/apps/mc/Dockerfile.dev
+++ b/apps/mc/Dockerfile.dev
@@ -18,6 +18,10 @@ FROM node:24-alpine AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -5,6 +5,10 @@ FROM --platform=linux/amd64 node:24-alpine AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+# Prevent Playwright from downloading browser binaries during pnpm install —
+# they are never used in the Docker build and waste ~600MB + cause timeouts.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy root dependency and config files (layer-cached separately from source)


### PR DESCRIPTION
## Summary
- Remove unused Rust toolchain + cargo cache steps from `docker-test-app.yml` — all Rust compilation happens inside Docker, not on the host runner
- Add `install_playwright` boolean input to `docker-test-app.yml` (default: true) — can be wired to `false` for vitest-only e2e projects in a follow-up once this reaches `main`
- Add `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` to all 7 remaining app Dockerfiles (memes, cryptothrone, discordsh, herbmail, irc-gateway, mc, mc.dev) — prevents ~600MB of unused browser downloads during `pnpm install`

## Test plan
- [ ] Verify Docker e2e tests still pass (Playwright not affected — it's only skipped inside Docker builds, not on host runners)
- [ ] Verify Docker build logs no longer show Playwright browser downloads
- [ ] Verify Rust toolchain removal doesn't break any test jobs (confirmed unused — all Rust is compiled by Docker)