### PR TITLE
fix(crossplane): use array syntax for S3 lifecycle rule fields

### DIFF
--- a/apps/kube/crossplane/providers/s3-backup-lifecycle.yaml
+++ b/apps/kube/crossplane/providers/s3-backup-lifecycle.yaml
@@ -22,23 +22,23 @@ spec:
             # WAL files — expire after 14 days (barman should clean at 7d)
             - id: expire-old-wals
               filter:
-                  prefix: barman/backup/kilobase-postgres-backup/wals/
+                  - prefix: barman/backup/kilobase-postgres-backup/wals/
               status: Enabled
               expiration:
-                  days: 14
+                  - days: 14
             # Base backups — expire after 30 days (barman should clean at 7d)
             # Longer retention than WALs since full backups are more valuable
             - id: expire-old-base-backups
               filter:
-                  prefix: barman/backup/kilobase-postgres-backup/base/
+                  - prefix: barman/backup/kilobase-postgres-backup/base/
               status: Enabled
               expiration:
-                  days: 30
+                  - days: 30
             # Abort incomplete multipart uploads after 3 days
             # Prevents orphaned partial uploads from accumulating
             - id: cleanup-incomplete-uploads
               filter:
-                  prefix: barman/
+                  - prefix: barman/
               status: Enabled
               abortIncompleteMultipartUpload:
-                  daysAfterInitiation: 3
+                  - daysAfterInitiation: 3


### PR DESCRIPTION
## Summary
- Fixes the S3 `BucketLifecycleConfiguration` that was stuck `OutOfSync` in ArgoCD
- The CRD expects `filter`, `expiration`, and `abortIncompleteMultipartUpload` as **arrays**, not objects
- ArgoCD was failing with: `expected list, got &{}` for all 6 rule fields

## Root cause
The Crossplane `s3.aws.m.upbound.io/v1beta1` CRD schema defines these fields as arrays (even though they logically hold a single item). The original YAML used object syntax which doesn't match the schema.

## Test plan
- [ ] Verify ArgoCD `crossplane-providers` app syncs successfully
- [ ] Confirm `BucketLifecycleConfiguration` shows SYNCED + READY
- [ ] Verify lifecycle rules appear in AWS S3 console for kilobase bucket