### PR TITLE
feat(isometric): two-stage pixel art render pipeline

### DIFF
--- a/apps/kbve/isometric/src-tauri/assets/shaders/pixelate.wgsl
+++ b/apps/kbve/isometric/src-tauri/assets/shaders/pixelate.wgsl
@@ -59,14 +59,11 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
     let edge_factor = min(max(normal_edge, depth_edge), 1.0);
 
-    // Edge application depends on mode:
+    // Darken at block boundaries where edges are detected
     var final_edge: f32;
     if settings.pixel_size < 1.5 {
-        // Low-res render-to-texture mode: each pixel IS one block.
-        // Apply edge darkening directly to edge pixels (no block outline).
         final_edge = edge_factor;
     } else {
-        // Normal post-process mode: darken only at block boundaries.
         let block_pos = fract(in.uv * block_count);
         let edge_width = 1.0 / settings.pixel_size;
         let at_edge = select(0.0, 1.0,

--- a/apps/kbve/isometric/src-tauri/src/game/camera.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/camera.rs
@@ -1,25 +1,68 @@
+use bevy::camera::visibility::RenderLayers;
+use bevy::core_pipeline::tonemapping::Tonemapping;
+use bevy::image::ImageSampler;
 use bevy::prelude::*;
+use bevy::render::render_resource::TextureFormat;
+use bevy::window::PrimaryWindow;
+use bevy_rapier3d::prelude::PhysicsSet;
 
 use super::player::{Player, PlayerMovement};
 
 const CAMERA_OFFSET: Vec3 = Vec3::new(15.0, 20.0, 15.0);
 const VIEWPORT_HEIGHT: f32 = 20.0;
+/// Downscale factor: render at 1/PIXEL_SCALE resolution, nearest-neighbor upscale.
+const PIXEL_SCALE: u32 = 2;
+/// RenderLayer for the display quad (separate from the 3D scene on layer 0).
+const DISPLAY_LAYER: usize = 1;
 
 #[derive(Component)]
 pub struct IsometricCamera;
+
+#[derive(Component)]
+struct DisplayQuad;
 
 pub struct IsometricCameraPlugin;
 
 impl Plugin for IsometricCameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup_camera);
-        app.add_systems(Update, camera_follow_player.after(PlayerMovement));
+        app.add_systems(
+            PostUpdate,
+            camera_follow_player
+                .after(PhysicsSet::Writeback)
+                .in_set(PlayerMovement),
+        );
     }
 }
 
-fn setup_camera(mut commands: Commands) {
+fn setup_camera(
+    mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Ok(window) = windows.single() else { return };
+    let render_w = ((window.width() / PIXEL_SCALE as f32) as u32).max(1);
+    let render_h = ((window.height() / PIXEL_SCALE as f32) as u32).max(1);
+
+    // Low-res render target with nearest-neighbor sampling for crisp pixel art
+    let mut render_img =
+        Image::new_target_texture(render_w, render_h, TextureFormat::Bgra8UnormSrgb, None);
+    render_img.sampler = ImageSampler::nearest();
+    let render_handle = images.add(render_img);
+
+    // --- Stage 1: Scene camera renders 3D world to the low-res texture ---
+    // Default RenderLayers (layer 0) — sees all scene entities.
     commands.spawn((
         Camera3d::default(),
+        Camera {
+            order: -1,
+            ..default()
+        },
+        Msaa::Off,
+        Tonemapping::None,
+        bevy::camera::RenderTarget::Image(render_handle.clone().into()),
         Projection::from(OrthographicProjection {
             scaling_mode: bevy::camera::ScalingMode::FixedVertical {
                 viewport_height: VIEWPORT_HEIGHT,
@@ -29,11 +72,56 @@ fn setup_camera(mut commands: Commands) {
         Transform::from_translation(CAMERA_OFFSET).looking_at(Vec3::ZERO, Vec3::Y),
         IsometricCamera,
     ));
+
+    // --- Stage 2: Display camera renders a textured quad to the window ---
+    // Uses RenderLayers(DISPLAY_LAYER) so it only sees the display quad.
+    let aspect = window.width() / window.height();
+    commands.spawn((
+        Camera3d::default(),
+        Camera {
+            order: 0,
+            ..default()
+        },
+        Msaa::Off,
+        Tonemapping::None,
+        Projection::from(OrthographicProjection {
+            scaling_mode: bevy::camera::ScalingMode::FixedVertical {
+                viewport_height: 1.0,
+            },
+            ..OrthographicProjection::default_3d()
+        }),
+        Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        RenderLayers::layer(DISPLAY_LAYER),
+    ));
+
+    // Fullscreen quad with the render texture (unlit = display pixels as-is).
+    // Slightly oversized (+2 texels) so sub-pixel offset doesn't expose clear color at edges.
+    let texel_pad = 2.0 / render_h as f32;
+    let quad_material = materials.add(StandardMaterial {
+        base_color_texture: Some(render_handle),
+        unlit: true,
+        ..default()
+    });
+    commands.spawn((
+        Mesh3d(meshes.add(Rectangle::new(aspect + texel_pad * aspect, 1.0 + texel_pad))),
+        MeshMaterial3d(quad_material),
+        Transform::default(),
+        RenderLayers::layer(DISPLAY_LAYER),
+        DisplayQuad,
+    ));
 }
 
 fn camera_follow_player(
-    player_query: Query<&Transform, (With<Player>, Without<IsometricCamera>)>,
-    mut camera_query: Query<&mut Transform, (With<IsometricCamera>, Without<Player>)>,
+    player_query: Query<&Transform, (With<Player>, Without<IsometricCamera>, Without<DisplayQuad>)>,
+    mut camera_query: Query<
+        &mut Transform,
+        (With<IsometricCamera>, Without<Player>, Without<DisplayQuad>),
+    >,
+    mut quad_query: Query<
+        &mut Transform,
+        (With<DisplayQuad>, Without<IsometricCamera>, Without<Player>),
+    >,
+    windows: Query<&Window, With<PrimaryWindow>>,
 ) {
     let Ok(player_tf) = player_query.single() else {
         return;
@@ -41,5 +129,44 @@ fn camera_follow_player(
     let Ok(mut camera_tf) = camera_query.single_mut() else {
         return;
     };
-    camera_tf.translation = player_tf.translation + CAMERA_OFFSET;
+
+    let desired = player_tf.translation + CAMERA_OFFSET;
+
+    let Ok(window) = windows.single() else {
+        camera_tf.translation = desired;
+        return;
+    };
+
+    let render_h = (window.height() / PIXEL_SCALE as f32).floor();
+    if render_h < 1.0 {
+        camera_tf.translation = desired;
+        return;
+    }
+
+    let pixel_world_size = VIEWPORT_HEIGHT / render_h;
+
+    // Decompose desired position along camera axes
+    let right = camera_tf.right().as_vec3();
+    let up = camera_tf.up().as_vec3();
+    let forward = camera_tf.forward().as_vec3();
+
+    let right_proj = desired.dot(right);
+    let up_proj = desired.dot(up);
+    let forward_proj = desired.dot(forward);
+
+    // Snap camera to texel grid — pixels stay locked to fixed world positions (no swimming).
+    let snapped_right = (right_proj / pixel_world_size).round() * pixel_world_size;
+    let snapped_up = (up_proj / pixel_world_size).round() * pixel_world_size;
+
+    camera_tf.translation = snapped_right * right + snapped_up * up + forward_proj * forward;
+
+    // Sub-pixel offset: shift display quad by the fractional remainder.
+    // This makes movement appear smooth despite the camera snapping to a grid.
+    // The display camera has viewport_height=1.0, so divide by VIEWPORT_HEIGHT.
+    if let Ok(mut quad_tf) = quad_query.single_mut() {
+        let remainder_right = right_proj - snapped_right;
+        let remainder_up = up_proj - snapped_up;
+        quad_tf.translation.x = -remainder_right / VIEWPORT_HEIGHT;
+        quad_tf.translation.y = -remainder_up / VIEWPORT_HEIGHT;
+    }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/mod.rs
@@ -11,7 +11,8 @@ use bevy::app::{PluginGroup, PluginGroupBuilder};
 
 use camera::IsometricCameraPlugin;
 use object_registry::ObjectRegistryPlugin;
-use pixelate::PixelatePlugin;
+// PixelatePlugin disabled — two-stage render-to-texture pipeline handles pixelation.
+// use pixelate::PixelatePlugin;
 use player::PlayerPlugin;
 use scene_objects::SceneObjectsPlugin;
 use state::GameStatePlugin;
@@ -32,6 +33,5 @@ impl PluginGroup for GamePluginGroup {
             .add(PlayerPlugin)
             .add(ObjectRegistryPlugin)
             .add(SceneObjectsPlugin)
-            .add(PixelatePlugin)
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/pixelate.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/pixelate.rs
@@ -21,9 +21,9 @@ pub struct PixelateSettings {
 impl Default for PixelateSettings {
     fn default() -> Self {
         Self {
-            pixel_size: 4.0,
-            edge_strength: 0.6,
-            depth_edge_strength: 0.4,
+            pixel_size: 2.0,
+            edge_strength: 0.3,
+            depth_edge_strength: 0.2,
             scale_factor: 1.0,
         }
     }
@@ -62,7 +62,6 @@ pub struct PixelatePlugin;
 impl Plugin for PixelatePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(FullscreenMaterialPlugin::<PixelateSettings>::default());
-        // scale_factor sync disabled — when rendering to a low-res texture,
-        // there's no DPI scaling and scale_factor must stay 1.0.
+        app.add_systems(Update, sync_scale_factor);
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/main.rs
+++ b/apps/kbve/isometric/src-tauri/src/main.rs
@@ -43,7 +43,6 @@ fn main() {
 
     // Rapier physics engine
     app.add_plugins(RapierPhysicsPlugin::<NoUserData>::default());
-    app.add_plugins(RapierDebugRenderPlugin::default());
 
     // Game plugins
     app.add_plugins(GamePluginGroup);


### PR DESCRIPTION
## Summary
- Replace single-camera rendering with a dual Camera3d render-to-texture pipeline for crisp pixel art
- Scene renders to a half-resolution texture with nearest-neighbor sampling, then upscales via a fullscreen quad
- Camera snaps to texel grid (no pixel swimming), display quad shifts by sub-texel remainder (smooth motion)
- Disable MSAA and tonemapping on both cameras for hard aliased edges
- Remove RapierDebugRenderPlugin and disable PixelatePlugin (superseded by pipeline)

## Test plan
- [ ] `cargo tauri dev` launches with pixelated rendering
- [ ] WASD movement is smooth with no pixel swimming or jitter
- [ ] Pixel blocks stay locked to fixed world positions when camera moves
- [ ] No edge gaps visible during movement (quad is slightly oversized)
- [ ] Scene objects and terrain render correctly through the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)