### PR TITLE
fix(auth): resolve IndexedDB race condition on sign-out

### DIFF
--- a/apps/discordsh/astro-discordsh/src/pages/auth/logout.astro
+++ b/apps/discordsh/astro-discordsh/src/pages/auth/logout.astro
@@ -4,106 +4,112 @@
 
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Signing out...</title>
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        font-family: system-ui, -apple-system, sans-serif;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
-      }
-      .container {
-        text-align: center;
-        color: white;
-      }
-      .spinner {
-        width: 50px;
-        height: 50px;
-        margin: 0 auto 20px;
-        border: 4px solid rgba(255, 255, 255, 0.3);
-        border-top-color: white;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-      }
-      @keyframes spin {
-        to { transform: rotate(360deg); }
-      }
-      .message {
-        font-size: 18px;
-        margin-bottom: 10px;
-      }
-      .sub-message {
-        font-size: 14px;
-        opacity: 0.8;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="spinner"></div>
-      <div class="message">Signing out...</div>
-      <div class="sub-message">Please wait</div>
-    </div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Signing out...</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 100vh;
+				background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
+			}
+			.container {
+				text-align: center;
+				color: white;
+			}
+			.spinner {
+				width: 50px;
+				height: 50px;
+				margin: 0 auto 20px;
+				border: 4px solid rgba(255, 255, 255, 0.3);
+				border-top-color: white;
+				border-radius: 50%;
+				animation: spin 1s linear infinite;
+			}
+			@keyframes spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			.message {
+				font-size: 18px;
+				margin-bottom: 10px;
+			}
+			.sub-message {
+				font-size: 14px;
+				opacity: 0.8;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<div class="spinner"></div>
+			<div class="message">Signing out...</div>
+			<div class="sub-message">Please wait</div>
+		</div>
 
-    <script>
-      import { authBridge } from '../../lib/supa';
+		<script>
+			import { authBridge } from '../../lib/supa';
 
-      (async () => {
-        try {
-          try {
-            await authBridge.signOut();
-          } catch (err) {
-            console.log('[Logout] AuthBridge sign-out skipped:', err);
-          }
+			(async () => {
+				try {
+					try {
+						await authBridge.signOut();
+					} catch (err) {
+						console.log(
+							'[Logout] AuthBridge sign-out skipped:',
+							err,
+						);
+					}
 
-          await new Promise(resolve => setTimeout(resolve, 100));
+					// Clear all auth data from IndexedDB and close the local connection.
+					// This avoids the deleteDatabase race condition with open worker connections.
+					try {
+						await authBridge.destroy();
+					} catch (err) {
+						console.warn('[Logout] AuthBridge destroy error:', err);
+					}
 
-          // Clear IndexedDB auth database
-          try {
-            await new Promise((resolve, reject) => {
-              const deleteRequest = indexedDB.deleteDatabase('sb-auth-v2');
-              deleteRequest.onsuccess = () => resolve(true);
-              deleteRequest.onerror = () => reject(deleteRequest.error);
-              deleteRequest.onblocked = () => setTimeout(() => resolve(true), 200);
-            });
-          } catch (err) {
-            console.warn('[Logout] Failed to clear IndexedDB:', err);
-          }
+					// Clear localStorage supabase keys
+					Object.keys(localStorage).forEach((key) => {
+						if (key.includes('supabase') || key.includes('sb-')) {
+							localStorage.removeItem(key);
+						}
+					});
 
-          // Clear localStorage supabase keys
-          Object.keys(localStorage).forEach(key => {
-            if (key.includes('supabase') || key.includes('sb-')) {
-              localStorage.removeItem(key);
-            }
-          });
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Signed out successfully';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Signed out successfully';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 500);
+				} catch (error) {
+					console.error('[Logout] Sign-out error:', error);
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Sign-out error occurred';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 500);
-        } catch (error) {
-          console.error('[Logout] Sign-out error:', error);
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Sign-out error occurred';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
-
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 1000);
-        }
-      })();
-    </script>
-  </body>
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 1000);
+				}
+			})();
+		</script>
+	</body>
 </html>

--- a/apps/herbmail/astro-herbmail/src/pages/auth/logout.astro
+++ b/apps/herbmail/astro-herbmail/src/pages/auth/logout.astro
@@ -4,106 +4,112 @@
 
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Signing out...</title>
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        font-family: system-ui, -apple-system, sans-serif;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        background: linear-gradient(135deg, #22c55e 0%, #15803d 100%);
-      }
-      .container {
-        text-align: center;
-        color: white;
-      }
-      .spinner {
-        width: 50px;
-        height: 50px;
-        margin: 0 auto 20px;
-        border: 4px solid rgba(255, 255, 255, 0.3);
-        border-top-color: white;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-      }
-      @keyframes spin {
-        to { transform: rotate(360deg); }
-      }
-      .message {
-        font-size: 18px;
-        margin-bottom: 10px;
-      }
-      .sub-message {
-        font-size: 14px;
-        opacity: 0.8;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="spinner"></div>
-      <div class="message">Signing out...</div>
-      <div class="sub-message">Please wait</div>
-    </div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Signing out...</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 100vh;
+				background: linear-gradient(135deg, #22c55e 0%, #15803d 100%);
+			}
+			.container {
+				text-align: center;
+				color: white;
+			}
+			.spinner {
+				width: 50px;
+				height: 50px;
+				margin: 0 auto 20px;
+				border: 4px solid rgba(255, 255, 255, 0.3);
+				border-top-color: white;
+				border-radius: 50%;
+				animation: spin 1s linear infinite;
+			}
+			@keyframes spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			.message {
+				font-size: 18px;
+				margin-bottom: 10px;
+			}
+			.sub-message {
+				font-size: 14px;
+				opacity: 0.8;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<div class="spinner"></div>
+			<div class="message">Signing out...</div>
+			<div class="sub-message">Please wait</div>
+		</div>
 
-    <script>
-      import { authBridge } from '../../lib/supa';
+		<script>
+			import { authBridge } from '../../lib/supa';
 
-      (async () => {
-        try {
-          try {
-            await authBridge.signOut();
-          } catch (err) {
-            console.log('[Logout] AuthBridge sign-out skipped:', err);
-          }
+			(async () => {
+				try {
+					try {
+						await authBridge.signOut();
+					} catch (err) {
+						console.log(
+							'[Logout] AuthBridge sign-out skipped:',
+							err,
+						);
+					}
 
-          await new Promise(resolve => setTimeout(resolve, 100));
+					// Clear all auth data from IndexedDB and close the local connection.
+					// This avoids the deleteDatabase race condition with open worker connections.
+					try {
+						await authBridge.destroy();
+					} catch (err) {
+						console.warn('[Logout] AuthBridge destroy error:', err);
+					}
 
-          // Clear IndexedDB auth database
-          try {
-            await new Promise((resolve, reject) => {
-              const deleteRequest = indexedDB.deleteDatabase('sb-auth-v2');
-              deleteRequest.onsuccess = () => resolve(true);
-              deleteRequest.onerror = () => reject(deleteRequest.error);
-              deleteRequest.onblocked = () => setTimeout(() => resolve(true), 200);
-            });
-          } catch (err) {
-            console.warn('[Logout] Failed to clear IndexedDB:', err);
-          }
+					// Clear localStorage supabase keys
+					Object.keys(localStorage).forEach((key) => {
+						if (key.includes('supabase') || key.includes('sb-')) {
+							localStorage.removeItem(key);
+						}
+					});
 
-          // Clear localStorage supabase keys
-          Object.keys(localStorage).forEach(key => {
-            if (key.includes('supabase') || key.includes('sb-')) {
-              localStorage.removeItem(key);
-            }
-          });
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Signed out successfully';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Signed out successfully';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 500);
+				} catch (error) {
+					console.error('[Logout] Sign-out error:', error);
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Sign-out error occurred';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 500);
-        } catch (error) {
-          console.error('[Logout] Sign-out error:', error);
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Sign-out error occurred';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
-
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 1000);
-        }
-      })();
-    </script>
-  </body>
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 1000);
+				}
+			})();
+		</script>
+	</body>
 </html>

--- a/apps/irc/astro-irc/src/pages/auth/logout.astro
+++ b/apps/irc/astro-irc/src/pages/auth/logout.astro
@@ -4,106 +4,112 @@
 
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Signing out...</title>
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        font-family: system-ui, -apple-system, sans-serif;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
-      }
-      .container {
-        text-align: center;
-        color: white;
-      }
-      .spinner {
-        width: 50px;
-        height: 50px;
-        margin: 0 auto 20px;
-        border: 4px solid rgba(255, 255, 255, 0.3);
-        border-top-color: white;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-      }
-      @keyframes spin {
-        to { transform: rotate(360deg); }
-      }
-      .message {
-        font-size: 18px;
-        margin-bottom: 10px;
-      }
-      .sub-message {
-        font-size: 14px;
-        opacity: 0.8;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="spinner"></div>
-      <div class="message">Signing out...</div>
-      <div class="sub-message">Please wait</div>
-    </div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Signing out...</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 100vh;
+				background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
+			}
+			.container {
+				text-align: center;
+				color: white;
+			}
+			.spinner {
+				width: 50px;
+				height: 50px;
+				margin: 0 auto 20px;
+				border: 4px solid rgba(255, 255, 255, 0.3);
+				border-top-color: white;
+				border-radius: 50%;
+				animation: spin 1s linear infinite;
+			}
+			@keyframes spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			.message {
+				font-size: 18px;
+				margin-bottom: 10px;
+			}
+			.sub-message {
+				font-size: 14px;
+				opacity: 0.8;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<div class="spinner"></div>
+			<div class="message">Signing out...</div>
+			<div class="sub-message">Please wait</div>
+		</div>
 
-    <script>
-      import { authBridge } from '../../lib/supa';
+		<script>
+			import { authBridge } from '../../lib/supa';
 
-      (async () => {
-        try {
-          try {
-            await authBridge.signOut();
-          } catch (err) {
-            console.log('[Logout] AuthBridge sign-out skipped:', err);
-          }
+			(async () => {
+				try {
+					try {
+						await authBridge.signOut();
+					} catch (err) {
+						console.log(
+							'[Logout] AuthBridge sign-out skipped:',
+							err,
+						);
+					}
 
-          await new Promise(resolve => setTimeout(resolve, 100));
+					// Clear all auth data from IndexedDB and close the local connection.
+					// This avoids the deleteDatabase race condition with open worker connections.
+					try {
+						await authBridge.destroy();
+					} catch (err) {
+						console.warn('[Logout] AuthBridge destroy error:', err);
+					}
 
-          // Clear IndexedDB auth database
-          try {
-            await new Promise((resolve, reject) => {
-              const deleteRequest = indexedDB.deleteDatabase('sb-auth-v2');
-              deleteRequest.onsuccess = () => resolve(true);
-              deleteRequest.onerror = () => reject(deleteRequest.error);
-              deleteRequest.onblocked = () => setTimeout(() => resolve(true), 200);
-            });
-          } catch (err) {
-            console.warn('[Logout] Failed to clear IndexedDB:', err);
-          }
+					// Clear localStorage supabase keys
+					Object.keys(localStorage).forEach((key) => {
+						if (key.includes('supabase') || key.includes('sb-')) {
+							localStorage.removeItem(key);
+						}
+					});
 
-          // Clear localStorage supabase keys
-          Object.keys(localStorage).forEach(key => {
-            if (key.includes('supabase') || key.includes('sb-')) {
-              localStorage.removeItem(key);
-            }
-          });
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Signed out successfully';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Signed out successfully';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 500);
+				} catch (error) {
+					console.error('[Logout] Sign-out error:', error);
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Sign-out error occurred';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 500);
-        } catch (error) {
-          console.error('[Logout] Sign-out error:', error);
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Sign-out error occurred';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
-
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 1000);
-        }
-      })();
-    </script>
-  </body>
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 1000);
+				}
+			})();
+		</script>
+	</body>
 </html>

--- a/apps/kbve/astro-kbve/src/components/auth/ReactAuthLogout.tsx
+++ b/apps/kbve/astro-kbve/src/components/auth/ReactAuthLogout.tsx
@@ -12,7 +12,7 @@ export default function ReactAuthLogout() {
 			try {
 				console.log('[Logout] Starting sign-out process...');
 
-				// Try to sign out from AuthBridge first (window client)
+				// Sign out via AuthBridge (tells Supabase to revoke the session)
 				try {
 					await authBridge.signOut();
 					console.log('[Logout] AuthBridge sign-out complete');
@@ -23,83 +23,30 @@ export default function ReactAuthLogout() {
 					);
 				}
 
-				// DON'T initialize SharedWorker - we need to keep it closed so IndexedDB can be deleted
-				console.log(
-					'[Logout] Skipping SharedWorker initialization to allow IndexedDB deletion',
-				);
-
-				// Wait a moment for any active connections to close
-				await new Promise((resolve) => setTimeout(resolve, 100));
-
-				// Clear IndexedDB manually to ensure session is gone
-				console.log('[Logout] Clearing IndexedDB...');
-
-				// First, list all databases
-				if ('databases' in indexedDB) {
-					const dbs = await indexedDB.databases();
-					console.log(
-						'[Logout] Existing databases:',
-						dbs.map((db) => db.name),
-					);
-				}
-
-				// Delete the auth database completely
+				// Clear all auth data from IndexedDB and close the local
+				// Dexie connection. This avoids the race condition where
+				// deleteDatabase() gets blocked by open connections held by
+				// SharedWorker, DB workers, and WorkerCommunication.
 				try {
-					await new Promise((resolve, reject) => {
-						const deleteRequest =
-							indexedDB.deleteDatabase('sb-auth-v2');
-						deleteRequest.onsuccess = () => {
-							console.log(
-								'[Logout] Successfully deleted IndexedDB: sb-auth-v2',
-							);
-							resolve(true);
-						};
-						deleteRequest.onerror = () => {
-							console.error(
-								'[Logout] Error deleting sb-auth-v2:',
-								deleteRequest.error,
-							);
-							reject(deleteRequest.error);
-						};
-						deleteRequest.onblocked = () => {
-							console.warn(
-								'[Logout] IndexedDB sb-auth-v2 deletion blocked - trying to continue anyway',
-							);
-							// Wait a bit and resolve anyway
-							setTimeout(() => resolve(true), 200);
-						};
-					});
-				} catch (err) {
-					console.warn('[Logout] Failed to clear sb-auth-v2:', err);
-				}
-
-				// Verify deletion
-				if ('databases' in indexedDB) {
-					const dbsAfter = await indexedDB.databases();
+					await authBridge.destroy();
 					console.log(
-						'[Logout] Remaining databases after deletion:',
-						dbsAfter.map((db) => db.name),
+						'[Logout] AuthBridge destroyed (IDB data cleared, connection closed)',
 					);
+				} catch (err) {
+					console.warn('[Logout] AuthBridge destroy error:', err);
 				}
 
-				// Also clear localStorage as a precaution
+				// Clear localStorage as a precaution
 				Object.keys(localStorage).forEach((key) => {
 					if (key.includes('supabase') || key.includes('sb-')) {
 						localStorage.removeItem(key);
-						console.log(`[Logout] Cleared localStorage: ${key}`);
 					}
 				});
 
-				// Success! Show message
 				setIsLoading(false);
 				setMessage('Signed out successfully');
 				setSubMessage('Redirecting to home...');
 
-				console.log(
-					'[Logout] Sign-out complete! Redirecting to home page...',
-				);
-
-				// Wait a moment to show the success message, then redirect
 				setTimeout(() => {
 					window.location.href = '/?_=' + Date.now();
 				}, 500);
@@ -109,7 +56,6 @@ export default function ReactAuthLogout() {
 				setMessage('Sign-out error occurred');
 				setSubMessage('Redirecting to home...');
 
-				// Even on error, redirect to home after a moment
 				setTimeout(() => {
 					window.location.href = '/?_=' + Date.now();
 				}, 1000);

--- a/apps/memes/astro-memes/src/pages/auth/logout.astro
+++ b/apps/memes/astro-memes/src/pages/auth/logout.astro
@@ -4,106 +4,112 @@
 
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Signing out...</title>
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        font-family: system-ui, -apple-system, sans-serif;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        background: linear-gradient(135deg, #06b6d4 0%, #0e7490 100%);
-      }
-      .container {
-        text-align: center;
-        color: white;
-      }
-      .spinner {
-        width: 50px;
-        height: 50px;
-        margin: 0 auto 20px;
-        border: 4px solid rgba(255, 255, 255, 0.3);
-        border-top-color: white;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-      }
-      @keyframes spin {
-        to { transform: rotate(360deg); }
-      }
-      .message {
-        font-size: 18px;
-        margin-bottom: 10px;
-      }
-      .sub-message {
-        font-size: 14px;
-        opacity: 0.8;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="spinner"></div>
-      <div class="message">Signing out...</div>
-      <div class="sub-message">Please wait</div>
-    </div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Signing out...</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 100vh;
+				background: linear-gradient(135deg, #06b6d4 0%, #0e7490 100%);
+			}
+			.container {
+				text-align: center;
+				color: white;
+			}
+			.spinner {
+				width: 50px;
+				height: 50px;
+				margin: 0 auto 20px;
+				border: 4px solid rgba(255, 255, 255, 0.3);
+				border-top-color: white;
+				border-radius: 50%;
+				animation: spin 1s linear infinite;
+			}
+			@keyframes spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			.message {
+				font-size: 18px;
+				margin-bottom: 10px;
+			}
+			.sub-message {
+				font-size: 14px;
+				opacity: 0.8;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<div class="spinner"></div>
+			<div class="message">Signing out...</div>
+			<div class="sub-message">Please wait</div>
+		</div>
 
-    <script>
-      import { authBridge } from '../../lib/supa';
+		<script>
+			import { authBridge } from '../../lib/supa';
 
-      (async () => {
-        try {
-          try {
-            await authBridge.signOut();
-          } catch (err) {
-            console.log('[Logout] AuthBridge sign-out skipped:', err);
-          }
+			(async () => {
+				try {
+					try {
+						await authBridge.signOut();
+					} catch (err) {
+						console.log(
+							'[Logout] AuthBridge sign-out skipped:',
+							err,
+						);
+					}
 
-          await new Promise(resolve => setTimeout(resolve, 100));
+					// Clear all auth data from IndexedDB and close the local connection.
+					// This avoids the deleteDatabase race condition with open worker connections.
+					try {
+						await authBridge.destroy();
+					} catch (err) {
+						console.warn('[Logout] AuthBridge destroy error:', err);
+					}
 
-          // Clear IndexedDB auth database
-          try {
-            await new Promise((resolve, reject) => {
-              const deleteRequest = indexedDB.deleteDatabase('sb-auth-v2');
-              deleteRequest.onsuccess = () => resolve(true);
-              deleteRequest.onerror = () => reject(deleteRequest.error);
-              deleteRequest.onblocked = () => setTimeout(() => resolve(true), 200);
-            });
-          } catch (err) {
-            console.warn('[Logout] Failed to clear IndexedDB:', err);
-          }
+					// Clear localStorage supabase keys
+					Object.keys(localStorage).forEach((key) => {
+						if (key.includes('supabase') || key.includes('sb-')) {
+							localStorage.removeItem(key);
+						}
+					});
 
-          // Clear localStorage supabase keys
-          Object.keys(localStorage).forEach(key => {
-            if (key.includes('supabase') || key.includes('sb-')) {
-              localStorage.removeItem(key);
-            }
-          });
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Signed out successfully';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Signed out successfully';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 500);
+				} catch (error) {
+					console.error('[Logout] Sign-out error:', error);
+					const messageEl = document.querySelector('.message');
+					const subMessageEl = document.querySelector('.sub-message');
+					if (messageEl)
+						messageEl.textContent = 'Sign-out error occurred';
+					if (subMessageEl)
+						subMessageEl.textContent = 'Redirecting to home...';
 
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 500);
-        } catch (error) {
-          console.error('[Logout] Sign-out error:', error);
-          const messageEl = document.querySelector('.message');
-          const subMessageEl = document.querySelector('.sub-message');
-          if (messageEl) messageEl.textContent = 'Sign-out error occurred';
-          if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
-
-          setTimeout(() => {
-            window.location.href = '/?_=' + Date.now();
-          }, 1000);
-        }
-      })();
-    </script>
-  </body>
+					setTimeout(() => {
+						window.location.href = '/?_=' + Date.now();
+					}, 1000);
+				}
+			})();
+		</script>
+	</body>
 </html>

--- a/packages/npm/astro/src/auth/AuthBridge.ts
+++ b/packages/npm/astro/src/auth/AuthBridge.ts
@@ -55,6 +55,20 @@ export class AuthBridge {
 		if (error) throw error;
 	}
 
+	/**
+	 * Full cleanup: clear all auth data from IndexedDB and close the connection.
+	 * Call this during logout to avoid blocking `deleteDatabase` from other tabs.
+	 */
+	async destroy() {
+		try {
+			await this.storage.clearAll();
+		} catch {
+			// best-effort
+		}
+		this.storage.close();
+		this.client = null;
+	}
+
 	async getSession() {
 		const client = this.ensureClient();
 		const { data, error } = await client.auth.getSession();

--- a/packages/npm/astro/src/auth/IDBStorage.ts
+++ b/packages/npm/astro/src/auth/IDBStorage.ts
@@ -37,4 +37,12 @@ export class IDBStorage {
 	async removeItem(key: string): Promise<void> {
 		await this.db.kv.delete(key);
 	}
+
+	async clearAll(): Promise<void> {
+		await this.db.kv.clear();
+	}
+
+	close(): void {
+		this.db.close();
+	}
 }

--- a/packages/npm/droid/src/lib/gateway/WorkerCommunication.ts
+++ b/packages/npm/droid/src/lib/gateway/WorkerCommunication.ts
@@ -1,42 +1,26 @@
 // Unified communication layer for all workers (SharedWorker, WebWorker, main thread)
-// Uses BroadcastChannel for real-time events + Dexie for persistent state
+// Uses BroadcastChannel for real-time events
 
-import Dexie, { type Table } from 'dexie';
 import type { BroadcastEvent } from './types';
-
-interface KVPair {
-	key: string;
-	value: string;
-}
-
-class StateDB extends Dexie {
-	kv!: Table<KVPair>;
-
-	constructor() {
-		super('sb-auth-v2');
-		this.version(1).stores({
-			kv: 'key',
-		});
-	}
-}
 
 /**
  * WorkerCommunication: Unified communication layer for workers
  *
  * Features:
  * - BroadcastChannel for real-time events
- * - Dexie for persistent state storage
  * - Works in SharedWorker, WebWorker, and main thread
+ *
+ * Note: This layer does NOT open IndexedDB. The SharedWorker is the single
+ * writer to the auth database (sb-auth-v2). All other contexts receive
+ * auth state via BroadcastChannel or postMessage.
  */
 export class WorkerCommunication {
 	private bc: BroadcastChannel | null = null;
-	private db: StateDB;
 	private listeners = new Map<string, Set<(payload: unknown) => void>>();
 	private channelName: string;
 
 	constructor(channelName = 'supabase_events') {
 		this.channelName = channelName;
-		this.db = new StateDB();
 		this.initBroadcastChannel();
 	}
 
@@ -112,36 +96,6 @@ export class WorkerCommunication {
 				}
 			});
 		}
-	}
-
-	/**
-	 * Persist state to IndexedDB (accessible across all workers and tabs)
-	 */
-	async setState(key: string, value: unknown): Promise<void> {
-		const serialized =
-			typeof value === 'string' ? value : JSON.stringify(value);
-		await this.db.kv.put({ key, value: serialized });
-	}
-
-	/**
-	 * Get state from IndexedDB
-	 */
-	async getState<T = unknown>(key: string): Promise<T | null> {
-		const item = await this.db.kv.get(key);
-		if (!item) return null;
-
-		try {
-			return JSON.parse(item.value) as T;
-		} catch {
-			return item.value as T;
-		}
-	}
-
-	/**
-	 * Remove state from IndexedDB
-	 */
-	async removeState(key: string): Promise<void> {
-		await this.db.kv.delete(key);
 	}
 
 	/**

--- a/packages/npm/droid/src/lib/workers/supabase-db-worker.ts
+++ b/packages/npm/droid/src/lib/workers/supabase-db-worker.ts
@@ -1,8 +1,8 @@
 /// <reference lib="webworker" />
 // Database worker for Supabase operations (used in worker pool)
+// Uses in-memory storage — the SharedWorker is the single auth writer to IndexedDB.
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import Dexie, { type Table } from 'dexie';
 
 type WorkerMessage =
 	| { id: string; type: 'ping'; payload?: unknown }
@@ -64,59 +64,24 @@ type WorkerMessage =
 declare const self: DedicatedWorkerGlobalScope;
 
 let client: SupabaseClient | null = null;
-let workerId: number | null = null;
-
-// IDB-backed namespaced storage using Dexie 4
-interface KVPair {
-	key: string;
-	value: string;
-}
-
-class StateDB extends Dexie {
-	kv!: Table<KVPair>;
-
-	constructor() {
-		super('sb-auth-v2');
-		this.version(1).stores({
-			kv: 'key',
-		});
-	}
-}
-
-const db = new StateDB();
 
 /**
- * Namespaced storage adapter for worker isolation
- *
- * - Reads: shared auth state from SharedWorker
- * - Writes: worker-namespaced keys to prevent conflicts
+ * In-memory storage for DB workers.
+ * DB workers only need the access token to make authenticated API calls.
+ * The SharedWorker is the single writer to IndexedDB (sb-auth-v2).
  */
-function createWorkerStorage(id: number) {
-	return {
-		async getItem(key: string): Promise<string | null> {
-			try {
-				const workerKey = `worker:${id}:${key}`;
-				let item = await db.kv.get(workerKey);
-				if (!item) {
-					const authKey = `auth:${key}`;
-					item = await db.kv.get(authKey);
-				}
-				return item?.value ?? null;
-			} catch (err) {
-				console.error(`[DB Worker ${id}] getItem error:`, err);
-				return null;
-			}
-		},
-		async setItem(key: string, value: string): Promise<void> {
-			const workerKey = `worker:${id}:${key}`;
-			await db.kv.put({ key: workerKey, value });
-		},
-		async removeItem(key: string): Promise<void> {
-			const workerKey = `worker:${id}:${key}`;
-			await db.kv.delete(workerKey);
-		},
-	};
-}
+const memoryStore = new Map<string, string>();
+const memoryStorage = {
+	async getItem(key: string): Promise<string | null> {
+		return memoryStore.get(key) ?? null;
+	},
+	async setItem(key: string, value: string): Promise<void> {
+		memoryStore.set(key, value);
+	},
+	async removeItem(key: string): Promise<void> {
+		memoryStore.delete(key);
+	},
+};
 
 console.log('[DB Worker] Initializing...');
 
@@ -133,15 +98,6 @@ self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
 			case 'init': {
 				const { url, anonKey, options } = payload;
 
-				if (self.name && self.name.includes('db-worker-')) {
-					workerId = parseInt(self.name.split('db-worker-')[1], 10);
-				} else {
-					workerId = Math.floor(Math.random() * 1000);
-				}
-
-				console.log(`[DB Worker] Assigned ID: ${workerId}`);
-				const workerStorage = createWorkerStorage(workerId);
-
 				const authOverrides =
 					options?.['auth'] && typeof options['auth'] === 'object'
 						? (options['auth'] as Record<string, unknown>)
@@ -151,7 +107,7 @@ self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
 					...options,
 					auth: {
 						...authOverrides,
-						storage: workerStorage,
+						storage: memoryStorage,
 						storageKey: 'sb-auth-token',
 						autoRefreshToken: true,
 						persistSession: true,


### PR DESCRIPTION
## Summary
- Replace `indexedDB.deleteDatabase('sb-auth-v2')` with `authBridge.destroy()` (clears data + closes connection) to eliminate the race condition where SharedWorker/DB worker connections block database deletion during logout
- Remove Dexie from DB workers — use in-memory storage instead (SharedWorker is the single IDB writer)
- Remove unused Dexie dependency from WorkerCommunication (setState/getState were never called)

## Test plan
- [ ] Sign out on kbve.com — verify no `"Another connection wants to delete database"` warnings in console
- [ ] Sign out on discordsh, irc, memes, herbmail apps — same verification
- [ ] Sign in after sign out — verify auth session is established correctly
- [ ] Open multiple tabs, sign out from one — verify other tabs detect sign-out via BroadcastChannel

🤖 Generated with [Claude Code](https://claude.com/claude-code)