### PR TITLE
fix(mc): copy full pumpkin workspace in Dockerfile.dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,7 +28,21 @@ target
 
 # Large / irrelevant app directories not needed by any Dockerfile
 apps/mc/pumpkin
+!apps/mc/pumpkin/Cargo.toml
+!apps/mc/pumpkin/Cargo.lock
+!apps/mc/pumpkin/rust-toolchain.toml
+!apps/mc/pumpkin/assets
 !apps/mc/pumpkin/pumpkin
+!apps/mc/pumpkin/pumpkin-nbt
+!apps/mc/pumpkin/pumpkin-api-macros
+!apps/mc/pumpkin/pumpkin-util
+!apps/mc/pumpkin/pumpkin-data
+!apps/mc/pumpkin/pumpkin-macros
+!apps/mc/pumpkin/pumpkin-config
+!apps/mc/pumpkin/pumpkin-codegen
+!apps/mc/pumpkin/pumpkin-world
+!apps/mc/pumpkin/pumpkin-protocol
+!apps/mc/pumpkin/pumpkin-inventory
 apps/postgres
 apps/irc/ergo
 apps/godot

--- a/apps/mc/Dockerfile.dev
+++ b/apps/mc/Dockerfile.dev
@@ -67,15 +67,41 @@ RUN find . -type f \( \
 FROM ${BASE_IMAGE} AS core
 
 # --- Pumpkin: build server (parallel with plugin) ---
+#     Copy full workspace so source is always fresh even if the base image is stale.
+#     The base image still provides cached .rlib artifacts for incremental builds.
 FROM core AS builder
+COPY ./apps/mc/pumpkin/Cargo.toml ./apps/mc/pumpkin/Cargo.lock /pumpkin/
+COPY ./apps/mc/pumpkin/assets /pumpkin/assets
 COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
+COPY ./apps/mc/pumpkin/pumpkin-nbt /pumpkin/pumpkin-nbt
+COPY ./apps/mc/pumpkin/pumpkin-api-macros /pumpkin/pumpkin-api-macros
+COPY ./apps/mc/pumpkin/pumpkin-util /pumpkin/pumpkin-util
+COPY ./apps/mc/pumpkin/pumpkin-data /pumpkin/pumpkin-data
+COPY ./apps/mc/pumpkin/pumpkin-macros /pumpkin/pumpkin-macros
+COPY ./apps/mc/pumpkin/pumpkin-config /pumpkin/pumpkin-config
+COPY ./apps/mc/pumpkin/pumpkin-codegen /pumpkin/pumpkin-codegen
+COPY ./apps/mc/pumpkin/pumpkin-world /pumpkin/pumpkin-world
+COPY ./apps/mc/pumpkin/pumpkin-protocol /pumpkin/pumpkin-protocol
+COPY ./apps/mc/pumpkin/pumpkin-inventory /pumpkin/pumpkin-inventory
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release && cp target/release/pumpkin /pumpkin.bin
 
 # --- Plugin: build (parallel with pumpkin, reuses all pre-compiled crates) ---
 FROM core AS plugin-builder
+COPY ./apps/mc/pumpkin/Cargo.toml ./apps/mc/pumpkin/Cargo.lock /pumpkin/
+COPY ./apps/mc/pumpkin/assets /pumpkin/assets
 COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
+COPY ./apps/mc/pumpkin/pumpkin-nbt /pumpkin/pumpkin-nbt
+COPY ./apps/mc/pumpkin/pumpkin-api-macros /pumpkin/pumpkin-api-macros
+COPY ./apps/mc/pumpkin/pumpkin-util /pumpkin/pumpkin-util
+COPY ./apps/mc/pumpkin/pumpkin-data /pumpkin/pumpkin-data
+COPY ./apps/mc/pumpkin/pumpkin-macros /pumpkin/pumpkin-macros
+COPY ./apps/mc/pumpkin/pumpkin-config /pumpkin/pumpkin-config
+COPY ./apps/mc/pumpkin/pumpkin-codegen /pumpkin/pumpkin-codegen
+COPY ./apps/mc/pumpkin/pumpkin-world /pumpkin/pumpkin-world
+COPY ./apps/mc/pumpkin/pumpkin-protocol /pumpkin/pumpkin-protocol
+COPY ./apps/mc/pumpkin/pumpkin-inventory /pumpkin/pumpkin-inventory
 COPY ./apps/mc/plugins /plugins
 # Inject Astro-built players page as Askama template (compiled into the .so)
 COPY --from=astro-builder /app/dist/apps/astro-mc/players/index.html /plugins/kbve-mc-plugin/templates/askama/players.html


### PR DESCRIPTION
## Summary
- `Dockerfile.dev` now copies the full pumpkin workspace (all crates, not just the binary crate) so it builds correctly even when the base image is stale
- Expanded `.dockerignore` whitelist to allow all pumpkin workspace crates through

**Root cause**: The previous commit (#7780) fixed the `.dockerignore` path issue but the base image (`ghcr.io/kbve/mc-rust-base:latest`) still had stale source from the old submodule. API changes in `pumpkin-world`, `pumpkin-nbt` etc. caused 13 compile errors.

## Test plan
- [ ] CI Docker build (`Dev Docker Build — MC`) passes
- [ ] MC server starts and players can connect