### PR TITLE
feat(isometric): procedural grass system with wind and walk-flatten

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/grass.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/grass.rs
@@ -1,0 +1,87 @@
+use bevy::prelude::*;
+
+use super::player::Player;
+
+const FLATTEN_RADIUS: f32 = 1.5;
+const FLATTEN_SPEED: f32 = 8.0;
+const WIND_SPEED: f32 = 1.2;
+const WIND_STRENGTH: f32 = 0.15; // ~8° max tilt
+
+#[derive(Component)]
+pub struct GrassTuft {
+    pub wind_phase: f32,
+    pub flatten: f32,
+}
+
+pub struct GrassPlugin;
+
+impl Plugin for GrassPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, (animate_grass_wind, flatten_grass_near_player));
+    }
+}
+
+/// Gentle sinusoidal sway — each tuft has a unique phase so they don't move in unison.
+fn animate_grass_wind(time: Res<Time>, mut query: Query<(&mut Transform, &GrassTuft)>) {
+    let t = time.elapsed_secs();
+
+    for (mut tf, tuft) in &mut query {
+        // Skip tufts that are being flattened (flatten system handles their rotation)
+        if tuft.flatten > 0.05 {
+            continue;
+        }
+
+        let sway = (t * WIND_SPEED + tuft.wind_phase).sin() * WIND_STRENGTH;
+        let base_rot = Quat::from_rotation_y(tuft.wind_phase);
+        let wind_rot = Quat::from_rotation_x(sway);
+        tf.rotation = base_rot * wind_rot;
+    }
+}
+
+/// Scale down and tilt tufts away from the player when within range.
+fn flatten_grass_near_player(
+    time: Res<Time>,
+    player_q: Query<&Transform, With<Player>>,
+    mut grass_q: Query<(&mut Transform, &mut GrassTuft), Without<Player>>,
+) {
+    let Ok(player_tf) = player_q.single() else {
+        return;
+    };
+    let player_xz = Vec2::new(player_tf.translation.x, player_tf.translation.z);
+    let dt = time.delta_secs();
+    let t = time.elapsed_secs();
+
+    for (mut tf, mut tuft) in &mut grass_q {
+        let tuft_xz = Vec2::new(tf.translation.x, tf.translation.z);
+        let dist = player_xz.distance(tuft_xz);
+
+        let target = if dist < FLATTEN_RADIUS {
+            ((FLATTEN_RADIUS - dist) / FLATTEN_RADIUS).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+
+        tuft.flatten += (target - tuft.flatten) * (dt * FLATTEN_SPEED).min(1.0);
+
+        // Scale Y down when flattened (min 30% height), preserve original XZ scale
+        let base_scale = tf.scale.x; // uniform base from spawn
+        let scale_y = base_scale * (1.0 - tuft.flatten * 0.7);
+        tf.scale = Vec3::new(base_scale, scale_y, base_scale);
+
+        if tuft.flatten > 0.05 {
+            // Tilt away from player
+            let away = (tuft_xz - player_xz).normalize_or_zero();
+            let tilt_angle = tuft.flatten * 0.8; // ~45° max lean
+            let tilt_rot =
+                Quat::from_rotation_y(away.y.atan2(away.x)) * Quat::from_rotation_z(tilt_angle);
+
+            // Blend wind with flatten
+            let wind_amount = 1.0 - tuft.flatten;
+            let wind_sway = (t * WIND_SPEED + tuft.wind_phase).sin() * WIND_STRENGTH * wind_amount;
+            let wind_rot =
+                Quat::from_rotation_y(tuft.wind_phase) * Quat::from_rotation_x(wind_sway);
+
+            tf.rotation = wind_rot.slerp(tilt_rot, tuft.flatten);
+        }
+    }
+}

--- a/apps/kbve/isometric/src-tauri/src/game/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/mod.rs
@@ -1,4 +1,5 @@
 pub mod camera;
+pub mod grass;
 pub mod object_registry;
 pub mod pixelate;
 pub mod player;
@@ -10,6 +11,7 @@ pub mod tilemap;
 use bevy::app::{PluginGroup, PluginGroupBuilder};
 
 use camera::IsometricCameraPlugin;
+use grass::GrassPlugin;
 use object_registry::ObjectRegistryPlugin;
 // PixelatePlugin disabled — two-stage render-to-texture pipeline handles pixelation.
 // use pixelate::PixelatePlugin;
@@ -30,6 +32,7 @@ impl PluginGroup for GamePluginGroup {
             .add(TerrainPlugin)
             .add(IsometricCameraPlugin)
             .add(TilemapPlugin)
+            .add(GrassPlugin)
             .add(PlayerPlugin)
             .add(ObjectRegistryPlugin)
             .add(SceneObjectsPlugin)

--- a/apps/kbve/isometric/src-tauri/src/game/terrain.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/terrain.rs
@@ -18,7 +18,7 @@ pub const TERRAIN_SEED: u32 = 42;
 // ---------------------------------------------------------------------------
 
 /// Deterministic hash of two integers to a float in [0.0, 1.0).
-fn hash2d(x: i32, z: i32) -> f32 {
+pub fn hash2d(x: i32, z: i32) -> f32 {
     let mut h = (x.wrapping_mul(374761393)) ^ (z.wrapping_mul(668265263));
     h = (h ^ (h >> 13)).wrapping_mul(1274126177);
     h = h ^ (h >> 16);

--- a/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
@@ -1,9 +1,12 @@
+use bevy::asset::RenderAssetUsages;
 use bevy::light::{CascadeShadowConfigBuilder, DirectionalLightShadowMap};
+use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 
 use bevy_rapier3d::prelude::*;
 
-use super::terrain::{CHUNK_SIZE, TerrainMap};
+use super::grass::GrassTuft;
+use super::terrain::{CHUNK_SIZE, TerrainMap, hash2d};
 
 pub const TILE_SIZE: f32 = 1.0;
 /// Thin cap on top of each column — bright surface that contrasts with darker body.
@@ -18,13 +21,16 @@ pub struct Tile {
     pub height: f32,
 }
 
-/// Pre-created materials for all tiles.
-/// - `cap`: checkerboard pair for the bright top surface
-/// - `body`: darker material for cliff/side faces
+/// Pre-created materials and meshes for all tiles.
 #[derive(Resource)]
 struct TileMaterials {
     cap: [[Handle<StandardMaterial>; 2]; 4],
     body: [Handle<StandardMaterial>; 4],
+    grass_caps: [Handle<StandardMaterial>; 8],
+    grass_tuft_mat: Handle<StandardMaterial>,
+    grass_tall_mat: Handle<StandardMaterial>,
+    grass_tuft_mesh: Handle<Mesh>,
+    grass_tall_mesh: Handle<Mesh>,
 }
 
 pub struct TilemapPlugin;
@@ -70,7 +76,54 @@ fn make_body(
     })
 }
 
-fn setup_tile_materials(mut commands: Commands, mut materials: ResMut<Assets<StandardMaterial>>) {
+/// Build a crossed-plane mesh (two quads at 90° forming an X shape).
+fn make_grass_mesh(hw: f32, h: f32) -> Mesh {
+    // Plane 1: along X axis (vertices at ±hw X, 0..h Y, Z=0)
+    // Plane 2: along Z axis (vertices at X=0, 0..h Y, ±hw Z)
+    #[rustfmt::skip]
+    let positions: Vec<[f32; 3]> = vec![
+        // Plane 1
+        [-hw, 0.0, 0.0], [ hw, 0.0, 0.0], [ hw,  h, 0.0], [-hw,  h, 0.0],
+        // Plane 2
+        [0.0, 0.0, -hw], [0.0, 0.0,  hw], [0.0,  h,  hw], [0.0,  h, -hw],
+    ];
+
+    #[rustfmt::skip]
+    let normals: Vec<[f32; 3]> = vec![
+        // Plane 1 normals (face +Z)
+        [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0],
+        // Plane 2 normals (face +X)
+        [1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0],
+    ];
+
+    #[rustfmt::skip]
+    let uvs: Vec<[f32; 2]> = vec![
+        [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0],
+        [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0],
+    ];
+
+    // Double-sided via material cull_mode: None, so we only need front-facing tris
+    #[rustfmt::skip]
+    let indices: Vec<u32> = vec![
+        0, 1, 2,  0, 2, 3, // Plane 1
+        4, 5, 6,  4, 6, 7, // Plane 2
+    ];
+
+    Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    )
+    .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+    .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
+    .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
+    .with_inserted_indices(Indices::U32(indices))
+}
+
+fn setup_tile_materials(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
     // Base colors per height band: grass, dirt, stone, snow
     let bands: [(f32, f32, f32); 4] = [
         (0.3, 0.6, 0.2),
@@ -78,6 +131,42 @@ fn setup_tile_materials(mut commands: Commands, mut materials: ResMut<Assets<Sta
         (0.5, 0.5, 0.5),
         (0.9, 0.9, 0.95),
     ];
+
+    // 8 noise-varied grass shades (dark forest → dry/yellow)
+    let grass_shades: [(f32, f32, f32); 8] = [
+        (0.22, 0.50, 0.15),
+        (0.28, 0.55, 0.18),
+        (0.30, 0.60, 0.20),
+        (0.34, 0.62, 0.22),
+        (0.38, 0.65, 0.22),
+        (0.42, 0.58, 0.20),
+        (0.35, 0.52, 0.18),
+        (0.45, 0.55, 0.25),
+    ];
+
+    let grass_caps: [Handle<StandardMaterial>; 8] = grass_shades.map(|(r, g, b)| {
+        materials.add(StandardMaterial {
+            base_color: Color::srgb(r, g, b),
+            ..default()
+        })
+    });
+
+    let grass_tuft_mat = materials.add(StandardMaterial {
+        base_color: Color::srgb(0.25, 0.55, 0.15),
+        cull_mode: None,
+        double_sided: true,
+        ..default()
+    });
+
+    let grass_tall_mat = materials.add(StandardMaterial {
+        base_color: Color::srgb(0.20, 0.50, 0.12),
+        cull_mode: None,
+        double_sided: true,
+        ..default()
+    });
+
+    let grass_tuft_mesh = meshes.add(make_grass_mesh(0.15, 0.25));
+    let grass_tall_mesh = meshes.add(make_grass_mesh(0.10, 0.45));
 
     commands.insert_resource(TileMaterials {
         cap: [
@@ -92,6 +181,11 @@ fn setup_tile_materials(mut commands: Commands, mut materials: ResMut<Assets<Sta
             make_body(&mut materials, bands[2].0, bands[2].1, bands[2].2),
             make_body(&mut materials, bands[3].0, bands[3].1, bands[3].2),
         ],
+        grass_caps,
+        grass_tuft_mat,
+        grass_tall_mat,
+        grass_tuft_mesh,
+        grass_tall_mesh,
     });
 }
 
@@ -125,12 +219,6 @@ fn spawn_lighting(mut commands: Commands) {
 }
 
 /// Spawn/despawn tile entities based on terrain chunk updates.
-///
-/// Each tile is two meshes:
-/// - **body**: the tall column (darker material) showing cliff/side faces
-/// - **cap**: a thin slab on top (bright checkerboard material) for the walkable surface
-///
-/// The color difference between cap and body creates a visible edge at elevation changes.
 fn process_chunk_spawns_and_despawns(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -165,14 +253,13 @@ fn process_chunk_spawns_and_despawns(
                 // Minimum column height so ground-level tiles are still visible
                 let column_h = h.max(0.5);
 
-                // Height band index + checkerboard
+                // Height band index
                 let band = match h as i32 {
                     0..=1 => 0,
                     2..=3 => 1,
                     4..=5 => 2,
                     _ => 3,
                 };
-                let checker = ((tx + tz) & 1) as usize;
 
                 // --- Body (tall column, darker cliff faces) ---
                 let body_h = column_h - CAP_HEIGHT;
@@ -193,23 +280,31 @@ fn process_chunk_spawns_and_despawns(
                 entities.push(body_entity);
 
                 // --- Cap (thin bright top surface) ---
-                // Inset only on the specific edges that face a lower neighbor (cliff edges).
                 let inset = |nh: f32| if h - nh >= 1.0 { EDGE_INSET } else { 0.0 };
-                let inset_nx = inset(terrain.height_at(tx - 1, tz)); // -X side
-                let inset_px = inset(terrain.height_at(tx + 1, tz)); // +X side
-                let inset_nz = inset(terrain.height_at(tx, tz - 1)); // -Z side
-                let inset_pz = inset(terrain.height_at(tx, tz + 1)); // +Z side
+                let inset_nx = inset(terrain.height_at(tx - 1, tz));
+                let inset_px = inset(terrain.height_at(tx + 1, tz));
+                let inset_nz = inset(terrain.height_at(tx, tz - 1));
+                let inset_pz = inset(terrain.height_at(tx, tz + 1));
 
                 let cap_w = TILE_SIZE - inset_nx - inset_px;
                 let cap_d = TILE_SIZE - inset_nz - inset_pz;
                 let cap_offset_x = (inset_nx - inset_px) / 2.0;
                 let cap_offset_z = (inset_nz - inset_pz) / 2.0;
 
+                // Grass band: use noise-varied shade; others: checkerboard
+                let cap_material = if band == 0 {
+                    let shade_idx = (hash2d(tx + 1337, tz) * 8.0) as usize % 8;
+                    tile_materials.grass_caps[shade_idx].clone()
+                } else {
+                    let checker = ((tx + tz) & 1) as usize;
+                    tile_materials.cap[band][checker].clone()
+                };
+
                 let cap_mesh = meshes.add(Cuboid::new(cap_w, CAP_HEIGHT, cap_d));
                 let cap_entity = commands
                     .spawn((
                         Mesh3d(cap_mesh),
-                        MeshMaterial3d(tile_materials.cap[band][checker].clone()),
+                        MeshMaterial3d(cap_material),
                         Transform::from_xyz(
                             tx as f32 * TILE_SIZE + cap_offset_x,
                             body_h + CAP_HEIGHT / 2.0,
@@ -223,6 +318,66 @@ fn process_chunk_spawns_and_despawns(
                     ))
                     .id();
                 entities.push(cap_entity);
+
+                // --- Grass pieces (multiple per tile with variety) ---
+                if band == 0 {
+                    // Each slot uses different noise seeds for independent placement
+                    let grass_slots: [(i32, i32, f32, bool); 3] = [
+                        (7919, 3571, 0.45, false), // short tuft, ~45%
+                        (2131, 8461, 0.20, true),  // tall blade, ~20%
+                        (4253, 6173, 0.30, false), // short tuft, ~30%
+                    ];
+
+                    for (seed_x, seed_z, density, tall) in grass_slots {
+                        let noise = hash2d(tx + seed_x, tz + seed_z);
+                        if noise >= density {
+                            continue;
+                        }
+
+                        // Full-tile jitter with unique seeds per slot
+                        let jx = (hash2d(tx + seed_x + 100, tz + seed_z) - 0.5) * 0.85;
+                        let jz = (hash2d(tx + seed_x, tz + seed_z + 100) - 0.5) * 0.85;
+
+                        // Per-instance scale variation (0.7 to 1.4)
+                        let scale_noise = hash2d(tx + seed_x + 200, tz + seed_z + 200);
+                        let scale = 0.7 + scale_noise * 0.7;
+
+                        let wind_phase = noise * std::f32::consts::TAU;
+                        let rot_y =
+                            hash2d(tx + seed_x + 300, tz + seed_z + 300) * std::f32::consts::TAU;
+
+                        let (mesh, mat) = if tall {
+                            (
+                                tile_materials.grass_tall_mesh.clone(),
+                                tile_materials.grass_tall_mat.clone(),
+                            )
+                        } else {
+                            (
+                                tile_materials.grass_tuft_mesh.clone(),
+                                tile_materials.grass_tuft_mat.clone(),
+                            )
+                        };
+
+                        let tuft = commands
+                            .spawn((
+                                Mesh3d(mesh),
+                                MeshMaterial3d(mat),
+                                Transform::from_xyz(
+                                    tx as f32 * TILE_SIZE + jx,
+                                    body_h + CAP_HEIGHT,
+                                    tz as f32 * TILE_SIZE + jz,
+                                )
+                                .with_rotation(Quat::from_rotation_y(rot_y))
+                                .with_scale(Vec3::splat(scale)),
+                                GrassTuft {
+                                    wind_phase,
+                                    flatten: 0.0,
+                                },
+                            ))
+                            .id();
+                        entities.push(tuft);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Add procedural grass rendering with 8 noise-varied shade materials on grass-band tiles
- Spawn crossed-plane grass meshes (short tufts + tall blades) with full-tile jitter and scale variation
- Wind sway animation with per-tuft phase offset for natural wave patterns
- Walk-flatten system: tufts near the player scale down and tilt away, spring back when player leaves

## Test plan
- [x] Desktop compiles clean (`cargo check`)
- [x] WASM compiles clean (`cargo check --target wasm32-unknown-unknown --lib`)
- [x] Visual: grass tiles show varied greens instead of uniform checkerboard
- [x] Visual: short tufts and tall blades visible with random placement
- [x] Visual: tufts sway with wind animation
- [x] Visual: tufts flatten when player walks over them

🤖 Generated with [Claude Code](https://claude.com/claude-code)