### PR TITLE
feat(kube): restrict CronJob egress to kube-apiserver only

### DIFF
--- a/apps/kube/crossplane/providers/cronjob-networkpolicy.yaml
+++ b/apps/kube/crossplane/providers/cronjob-networkpolicy.yaml
@@ -1,0 +1,41 @@
+# Restrict CronJob pod egress to kube-apiserver + DNS only.
+# CronJobs in crossplane-system (s3-healthcheck) only need kubectl access.
+# Blocks all other outbound traffic (database, internet, other services).
+#
+# Resolves: https://github.com/KBVE/kbve/issues/7656
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: cronjob-egress-apiserver-only
+    namespace: crossplane-system
+    labels:
+        app.kubernetes.io/name: crossplane
+        app.kubernetes.io/component: network-policy
+        app.kubernetes.io/managed-by: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '10'
+spec:
+    podSelector:
+        matchLabels:
+            app.kubernetes.io/component: s3-healthcheck
+    policyTypes:
+        - Egress
+    egress:
+        # kube-apiserver (kubectl commands)
+        - to:
+              - ipBlock:
+                    cidr: 10.96.0.1/32
+          ports:
+              - protocol: TCP
+                port: 443
+        # DNS resolution (required for kubectl to resolve kubernetes.default.svc)
+        - to:
+              - namespaceSelector: {}
+                podSelector:
+                    matchLabels:
+                        k8s-app: kube-dns
+          ports:
+              - protocol: UDP
+                port: 53
+              - protocol: TCP
+                port: 53

--- a/apps/kube/kilobase/manifests/cronjob-networkpolicy.yaml
+++ b/apps/kube/kilobase/manifests/cronjob-networkpolicy.yaml
@@ -1,0 +1,43 @@
+# Restrict CronJob pod egress to kube-apiserver + DNS only.
+# CronJobs in kilobase (backup-restore-test, backup-watchdog) only need kubectl access.
+# Blocks all other outbound traffic (database, internet, other services).
+#
+# Resolves: https://github.com/KBVE/kbve/issues/7656
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: cronjob-egress-apiserver-only
+    namespace: kilobase
+    labels:
+        app.kubernetes.io/name: kilobase
+        app.kubernetes.io/component: network-policy
+        app.kubernetes.io/managed-by: argocd
+spec:
+    podSelector:
+        matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+                  - backup-testing
+                  - backup-watchdog
+    policyTypes:
+        - Egress
+    egress:
+        # kube-apiserver (kubectl commands)
+        - to:
+              - ipBlock:
+                    cidr: 10.96.0.1/32
+          ports:
+              - protocol: TCP
+                port: 443
+        # DNS resolution (required for kubectl to resolve kubernetes.default.svc)
+        - to:
+              - namespaceSelector: {}
+                podSelector:
+                    matchLabels:
+                        k8s-app: kube-dns
+          ports:
+              - protocol: UDP
+                port: 53
+              - protocol: TCP
+                port: 53


### PR DESCRIPTION
## Summary
- Adds NetworkPolicies to restrict CronJob pods to only kube-apiserver + DNS egress
- **crossplane-system**: locks down `s3-healthcheck` CronJob
- **kilobase**: locks down `backup-restore-test` and `backup-watchdog` CronJobs
- All three CronJobs only use `kubectl` — no internet, database, or cross-service access needed

## Details
- Egress allowed: kube-apiserver (`10.96.0.1:443`) and kube-dns (UDP/TCP 53)
- All other outbound traffic is blocked (database, internet, other cluster services)
- Uses `matchExpressions` in kilobase to cover both CronJob components in a single policy
- Follows the same pattern as the existing `arc-runner-egress` NetworkPolicy

Closes #7656

## Test plan
- [ ] Verify NetworkPolicies exist: `kubectl get networkpolicy -n crossplane-system` and `kubectl get networkpolicy -n kilobase`
- [ ] Trigger s3-healthcheck manually: `kubectl create job --from=cronjob/s3-healthcheck s3-healthcheck-test -n crossplane-system`
- [ ] Trigger backup-watchdog manually: `kubectl create job --from=cronjob/backup-watchdog backup-watchdog-test -n kilobase`
- [ ] Confirm both jobs complete successfully (kubectl access still works)