### PR TITLE
fix(kbve): restructure profile page parallax and layout

### DIFF
--- a/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
@@ -563,31 +563,34 @@ const discordRolesBlock = `{% if let Some(is_member) = discord_is_guild_member %
 		<!-- Skip link for a11y -->
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 
-		<!-- STICKY PARALLAX HERO with Unsplash image and Profile Capsule -->
+		<!-- FIXED PARALLAX BACKGROUND -->
 		<div
-			class="parallax-hero"
+			class="parallax-bg"
 			role="img"
 			aria-label="Profile banner image"
 			id="parallax-hero">
 			<!-- LQIP Placeholder -->
 			<div
-				class="parallax-hero__placeholder"
+				class="parallax-bg__placeholder"
 				id="banner-placeholder"
 				style={`background-image: url('https://images.unsplash.com/photo-${askamaBannerId}?q=10&w=20&auto=format&fit=crop');`}
 				aria-hidden="true">
 			</div>
-			<!-- Full resolution parallax background -->
+			<!-- Full resolution background -->
 			<div
-				class="parallax-hero__bg"
+				class="parallax-bg__image"
 				id="banner-image"
 				style={`background-image: url('https://images.unsplash.com/photo-${askamaBannerId}?q=80&w=1920&auto=format&fit=crop&fm=webp'); opacity: 0;`}
 				aria-hidden="true">
 			</div>
 			<!-- Gradient overlay -->
-			<div class="parallax-hero__overlay" aria-hidden="true"></div>
+			<div class="parallax-bg__overlay" aria-hidden="true"></div>
+		</div>
 
-			<!-- Profile capsule - floats at bottom of sticky hero -->
-			<div class="profile-capsule">
+		<!-- MAIN CONTENT - sits on top of fixed background -->
+		<main id="main-content" class="profile-content" role="main">
+			<!-- Profile header card - in normal content flow -->
+			<div class="profile-header-section">
 				<header
 					class="profile-hero"
 					role="banner"
@@ -617,10 +620,6 @@ const discordRolesBlock = `{% if let Some(is_member) = discord_is_guild_member %
 					</div>
 				</header>
 			</div>
-		</div>
-
-		<!-- MAIN CONTENT - sits on top of sticky parallax hero -->
-		<main id="main-content" class="profile-content" role="main">
 			<div class="profile-grid">
 				<!-- Primary column: Connected Accounts + Detail Cards -->
 				<div class="main-column flex flex-col gap-4">
@@ -919,77 +918,76 @@ const discordRolesBlock = `{% if let Some(is_member) = discord_is_guild_member %
 	}
 
 	/* ============================================
-       STICKY PARALLAX HERO SECTION
+       FIXED PARALLAX BACKGROUND
        ============================================ */
-	.parallax-hero {
-		position: sticky;
+	.parallax-bg {
+		position: fixed;
 		top: 0;
+		left: 0;
 		height: 100vh;
 		width: 100vw;
 		z-index: 0;
 		overflow: hidden;
+		pointer-events: none;
 	}
 
-	.parallax-hero__placeholder {
+	.parallax-bg__placeholder {
 		position: absolute;
-		inset: -10%;
-		width: 120%;
-		height: 120%;
+		inset: 0;
+		width: 100%;
+		height: 100%;
 		background-size: cover;
 		background-position: center;
 		filter: blur(20px);
 		transition: opacity 500ms ease-out;
 	}
 
-	.parallax-hero__bg {
+	.parallax-bg__image {
 		position: absolute;
-		inset: -10%;
-		width: 120%;
-		height: 120%;
+		inset: 0;
+		width: 100%;
+		height: 100%;
 		background-size: cover;
 		background-position: center;
-		will-change: transform;
 		transition: opacity 500ms ease-out;
 	}
 
-	.parallax-hero__overlay {
+	.parallax-bg__overlay {
 		position: absolute;
 		inset: 0;
 		background: linear-gradient(
 			to bottom,
-			rgba(10, 10, 10, 0.3) 0%,
-			rgba(10, 10, 10, 0.4) 30%,
-			rgba(10, 10, 10, 0.4) 70%,
-			rgba(10, 10, 10, 0.8) 100%
+			rgba(10, 10, 10, 0.4) 0%,
+			rgba(10, 10, 10, 0.55) 40%,
+			rgba(10, 10, 10, 0.75) 70%,
+			rgba(10, 10, 10, 0.9) 100%
 		);
-	}
-
-	/* Profile capsule - centered vertically in sticky hero */
-	.profile-capsule {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-		width: 100%;
-		max-width: 1200px;
-		padding: 0 1rem;
-		z-index: 10;
-	}
-
-	@media (min-width: 768px) {
-		.profile-capsule {
-			padding: 0 1.5rem;
-		}
 	}
 
 	/* Reduced motion */
 	@media (prefers-reduced-motion: reduce) {
-		.parallax-hero__placeholder,
-		.parallax-hero__bg {
+		.parallax-bg__placeholder,
+		.parallax-bg__image {
 			transition: none;
-			inset: 0;
-			width: 100%;
-			height: 100%;
+		}
+	}
+
+	/* Profile header section - in normal content flow */
+	.profile-header-section {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1.25rem 0;
+	}
+
+	@media (min-width: 640px) {
+		.profile-header-section {
+			padding: 2.5rem 1.5rem 0;
+		}
+	}
+
+	@media (min-width: 768px) {
+		.profile-header-section {
+			padding: 3rem 2rem 0;
 		}
 	}
 
@@ -1340,21 +1338,11 @@ const discordRolesBlock = `{% if let Some(is_member) = discord_is_guild_member %
 	}
 
 	/* ============================================
-       MAIN CONTENT AREA - Sits on top of sticky parallax hero
+       MAIN CONTENT AREA - Sits on top of fixed parallax background
        ============================================ */
 	.profile-content {
 		position: relative;
 		z-index: 1;
-		/* Semi-transparent background so parallax bleeds through */
-		background: linear-gradient(
-			to bottom,
-			rgba(10, 10, 10, 0.85) 0%,
-			rgba(10, 10, 10, 0.92) 10%,
-			rgba(10, 10, 10, 0.95) 30%,
-			var(--profile-bg) 100%
-		);
-		backdrop-filter: blur(8px);
-		-webkit-backdrop-filter: blur(8px);
 		min-height: 100vh;
 		width: 100%;
 	}
@@ -2787,41 +2775,29 @@ const discordRolesBlock = `{% if let Some(is_member) = discord_is_guild_member %
 		}
 	})();
 
-	// Smooth parallax scroll effect with lerp interpolation
+	// Subtle parallax effect on fixed background
 	(function () {
-		const hero = document.getElementById('parallax-hero');
 		const bgImage = document.getElementById('banner-image');
-		if (!hero || !bgImage) return;
+		if (!bgImage) return;
 
-		// Check for reduced motion preference
 		const prefersReducedMotion = window.matchMedia(
 			'(prefers-reduced-motion: reduce)',
 		).matches;
-		if (prefersReducedMotion) {
-			bgImage.style.transform = 'none';
-			return;
-		}
+		if (prefersReducedMotion) return;
 
-		// Smooth interpolation values
 		let currentY = 0;
 		let targetY = 0;
-		const ease = 0.08; // Lower = smoother but slower (0.05-0.15 range)
-		const parallaxSpeed = 0.3;
+		const ease = 0.06;
+		const parallaxSpeed = 0.15;
 
-		// Linear interpolation for buttery smooth motion
 		function lerp(start, end, factor) {
 			return start + (end - start) * factor;
 		}
 
-		// Animation loop for smooth updates
 		function animate() {
-			// Calculate target based on scroll position
 			targetY = window.pageYOffset * parallaxSpeed;
-
-			// Smoothly interpolate current toward target
 			currentY = lerp(currentY, targetY, ease);
 
-			// Only update DOM if there's meaningful change (reduces micro-jitter)
 			if (Math.abs(currentY - targetY) > 0.01) {
 				bgImage.style.transform = `translate3d(0, ${currentY}px, 0)`;
 			}
@@ -2829,10 +2805,7 @@ const discordRolesBlock = `{% if let Some(is_member) = discord_is_guild_member %
 			requestAnimationFrame(animate);
 		}
 
-		// Start animation loop
 		requestAnimationFrame(animate);
-
-		// Ensure GPU acceleration
 		bgImage.style.willChange = 'transform';
 	})();
 

--- a/apps/kbve/axum-kbve/templates/askama/profile/index.html
+++ b/apps/kbve/axum-kbve/templates/askama/profile/index.html
@@ -68,58 +68,55 @@
         }
 
         /* ============================================
-           FULL-PAGE STICKY PARALLAX HERO
+           FIXED PARALLAX BACKGROUND
            ============================================ */
 
-        /* Sticky parallax container - stays in viewport */
-        .parallax-hero {
-            position: sticky;
+        /* Fixed background - stays behind all content */
+        .parallax-bg {
+            position: fixed;
             top: 0;
+            left: 0;
             height: 100vh;
             width: 100%;
             z-index: 0;
             overflow: hidden;
+            pointer-events: none;
         }
 
         /* Background image layer */
-        .parallax-hero__bg {
+        .parallax-bg__image {
             position: absolute;
-            inset: -10%;
-            width: 120%;
-            height: 120%;
+            inset: 0;
+            width: 100%;
+            height: 100%;
             background-size: cover;
             background-position: center;
             will-change: transform;
         }
 
-        /* Gradient overlay for readability - balanced for centered content */
-        .parallax-hero__overlay {
+        /* Gradient overlay for readability */
+        .parallax-bg__overlay {
             position: absolute;
             inset: 0;
             background: linear-gradient(
                 to bottom,
-                rgba(10, 10, 10, 0.3) 0%,
-                rgba(10, 10, 10, 0.35) 30%,
-                rgba(10, 10, 10, 0.35) 70%,
-                rgba(10, 10, 10, 0.7) 100%
+                rgba(10, 10, 10, 0.4) 0%,
+                rgba(10, 10, 10, 0.55) 40%,
+                rgba(10, 10, 10, 0.75) 70%,
+                rgba(10, 10, 10, 0.9) 100%
             );
         }
 
-        /* Profile capsule card - centered in parallax hero */
-        .profile-capsule {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            width: 100%;
+        /* Profile header section - in normal content flow */
+        .profile-header-section {
             max-width: 1200px;
-            padding: 0 1rem;
-            z-index: 10;
+            margin: 0 auto;
+            padding: 2rem 1rem 0;
         }
 
         @media (min-width: 768px) {
-            .profile-capsule {
-                padding: 0 1.5rem;
+            .profile-header-section {
+                padding: 3rem 1.5rem 0;
             }
         }
 
@@ -293,29 +290,17 @@
             border-color: rgba(88, 101, 242, 0.3);
         }
 
-        /* Main content sits below the sticky hero - semi-transparent */
+        /* Main content area */
         .profile-main {
             position: relative;
             z-index: 1;
-            /* Semi-transparent background so parallax bleeds through */
-            background: linear-gradient(
-                to bottom,
-                rgba(10, 10, 10, 0.85) 0%,
-                rgba(10, 10, 10, 0.92) 10%,
-                rgba(10, 10, 10, 0.95) 30%,
-                var(--sl-color-bg) 100%
-            );
-            backdrop-filter: blur(8px);
-            -webkit-backdrop-filter: blur(8px);
             min-height: 100vh;
         }
 
-        /* Reduced motion for a11y - parallax */
+        /* Reduced motion for a11y */
         @media (prefers-reduced-motion: reduce) {
-            .parallax-hero__bg {
-                inset: 0;
-                width: 100%;
-                height: 100%;
+            .parallax-bg__image {
+                will-change: auto;
             }
         }
 
@@ -709,8 +694,9 @@
                 animation-iteration-count: 1 !important;
                 transition-duration: 0.01ms !important;
             }
-            .parallax-hero__bg {
+            .parallax-bg__image {
                 transform: none !important;
+                will-change: auto;
             }
         }
 
@@ -743,20 +729,22 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <!-- STICKY PARALLAX HERO - stays visible as you scroll -->
-    <div class="parallax-hero" role="img" aria-label="Profile banner image">
-        <!-- Background image with parallax effect -->
+    <div class="not-content">
+    <!-- FIXED PARALLAX BACKGROUND -->
+    <div class="parallax-bg" role="img" aria-label="Profile banner image">
         <div
-            class="parallax-hero__bg"
+            class="parallax-bg__image"
             id="parallax-bg"
             style="background-image: url('https://images.unsplash.com/photo-{{ unsplash_banner_id }}?q=80&w=1920&auto=format&fit=crop&fm=webp');"
             aria-hidden="true"
         ></div>
-        <!-- Gradient overlay -->
-        <div class="parallax-hero__overlay" aria-hidden="true"></div>
+        <div class="parallax-bg__overlay" aria-hidden="true"></div>
+    </div>
 
-        <!-- Profile Capsule Card - floating on parallax -->
-        <div class="profile-capsule">
+    <!-- MAIN CONTENT - sits on top of fixed background -->
+    <main id="main-content" class="profile-main" role="main">
+        <!-- Profile header card - in normal content flow -->
+        <div class="profile-header-section">
             <div class="profile-capsule__card">
                 <!-- Avatar -->
                 <figure class="profile-capsule__avatar" role="img" aria-label="Profile avatar for {{ username }}">
@@ -794,10 +782,6 @@
                 </div>
             </div>
         </div>
-    </div>
-
-    <!-- MAIN CONTENT - sits on top of sticky hero -->
-    <main id="main-content" class="profile-main" role="main">
         <div class="profile-content">
         <div class="profile-grid">
             <!-- Primary column: Connected Accounts -->
@@ -945,40 +929,30 @@
         </div>
         </div>
     </main>
+    </div>
 
     <script>
-    // Smooth parallax scroll effect with lerp interpolation
+    // Subtle parallax effect on fixed background
     (function() {
         const parallaxBg = document.getElementById('parallax-bg');
         if (!parallaxBg) return;
 
-        // Check for reduced motion preference
         const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        if (prefersReducedMotion) {
-            parallaxBg.style.transform = 'none';
-            return;
-        }
+        if (prefersReducedMotion) return;
 
-        // Smooth interpolation values
         let currentY = 0;
         let targetY = 0;
-        const ease = 0.08; // Lower = smoother but slower (0.05-0.15 range)
-        const parallaxSpeed = 0.3;
+        const ease = 0.06;
+        const parallaxSpeed = 0.15;
 
-        // Linear interpolation
         function lerp(start, end, factor) {
             return start + (end - start) * factor;
         }
 
-        // Animation loop for smooth updates
         function animate() {
-            // Calculate target based on scroll
             targetY = window.pageYOffset * parallaxSpeed;
-
-            // Smoothly interpolate current toward target
             currentY = lerp(currentY, targetY, ease);
 
-            // Only update DOM if there's meaningful change (reduces jitter)
             if (Math.abs(currentY - targetY) > 0.01) {
                 parallaxBg.style.transform = `translate3d(0, ${currentY}px, 0)`;
             }
@@ -986,10 +960,7 @@
             requestAnimationFrame(animate);
         }
 
-        // Start animation loop
         requestAnimationFrame(animate);
-
-        // Ensure GPU acceleration
         parallaxBg.style.willChange = 'transform';
     })();
     </script>


### PR DESCRIPTION
## Summary
- Move profile page parallax from sticky full-viewport hero to a fixed background element
- Profile card now renders in normal content flow instead of floating centered inside the parallax
- Wrap standalone Askama template in `not-content` class to prevent Starlight style interference
- Reduce parallax scroll speed (0.3 → 0.15) for subtler background movement
- Updated both `AskamaProfileProvider.astro` and `templates/askama/profile/index.html`

## Test plan
- [ ] Visit `/@h0lybyte` and verify parallax is a subtle fixed background
- [ ] Verify profile card (avatar, username, badges) renders in normal content flow
- [ ] Verify connected accounts and sidebar render correctly below the profile header
- [ ] Check mobile responsiveness
- [ ] Verify `prefers-reduced-motion` disables parallax

🤖 Generated with [Claude Code](https://claude.com/claude-code)