### PR TITLE
feat(isometric): Bevy WASM rendering in Tauri webview

### DIFF
--- a/apps/kbve/isometric/.gitignore
+++ b/apps/kbve/isometric/.gitignore
@@ -1,0 +1,1 @@
+wasm-pkg/

--- a/apps/kbve/isometric/index.html
+++ b/apps/kbve/isometric/index.html
@@ -12,20 +12,33 @@
             }
             html,
             body {
-                background: transparent;
+                background: #1a1a26;
                 overflow: hidden;
                 width: 100%;
                 height: 100%;
             }
-            #root {
+            #bevy-canvas {
+                position: fixed;
+                top: 0;
+                left: 0;
                 width: 100%;
                 height: 100%;
+                z-index: 0;
+            }
+            #root {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                z-index: 1;
                 pointer-events: none;
             }
             /* pointer-events managed per-component via Tailwind pointer-events-auto */
         </style>
     </head>
     <body>
+        <canvas id="bevy-canvas"></canvas>
         <div id="root"></div>
         <script type="module" src="/src/main.tsx"></script>
     </body>

--- a/apps/kbve/isometric/package.json
+++ b/apps/kbve/isometric/package.json
@@ -4,8 +4,9 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
+		"build:wasm": "cd src-tauri && wasm-pack build --target web --out-dir ../wasm-pkg --out-name isometric_game",
 		"dev": "vite",
-		"build": "tsc && vite build",
+		"build": "npm run build:wasm && tsc && vite build",
 		"preview": "vite preview"
 	},
 	"dependencies": {
@@ -21,6 +22,8 @@
 		"@vitejs/plugin-react": "^4.0.0",
 		"tailwindcss": "^4.1.3",
 		"typescript": "^5.0.0",
-		"vite": "^6.0.0"
+		"vite": "^6.0.0",
+		"vite-plugin-wasm": "^3.3.0",
+		"vite-plugin-top-level-await": "^1.4.4"
 	}
 }

--- a/apps/kbve/isometric/pnpm-lock.yaml
+++ b/apps/kbve/isometric/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
             vite:
                 specifier: ^6.0.0
                 version: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
+            vite-plugin-top-level-await:
+                specifier: ^1.4.4
+                version: 1.6.0(rollup@4.59.0)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
+            vite-plugin-wasm:
+                specifier: ^3.3.0
+                version: 3.5.0(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1))
 
 packages:
     '@babel/code-frame@7.29.0':
@@ -454,6 +460,18 @@ packages:
                 integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
             }
 
+    '@rollup/plugin-virtual@3.0.2':
+        resolution:
+            {
+                integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==,
+            }
+        engines: { node: '>=14.0.0' }
+        peerDependencies:
+            rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+        peerDependenciesMeta:
+            rollup:
+                optional: true
+
     '@rollup/rollup-android-arm-eabi@4.59.0':
         resolution:
             {
@@ -653,6 +671,126 @@ packages:
             }
         cpu: [x64]
         os: [win32]
+
+    '@swc/core-darwin-arm64@1.15.18':
+        resolution:
+            {
+                integrity: sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==,
+            }
+        engines: { node: '>=10' }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@swc/core-darwin-x64@1.15.18':
+        resolution:
+            {
+                integrity: sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==,
+            }
+        engines: { node: '>=10' }
+        cpu: [x64]
+        os: [darwin]
+
+    '@swc/core-linux-arm-gnueabihf@1.15.18':
+        resolution:
+            {
+                integrity: sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==,
+            }
+        engines: { node: '>=10' }
+        cpu: [arm]
+        os: [linux]
+
+    '@swc/core-linux-arm64-gnu@1.15.18':
+        resolution:
+            {
+                integrity: sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==,
+            }
+        engines: { node: '>=10' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@swc/core-linux-arm64-musl@1.15.18':
+        resolution:
+            {
+                integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==,
+            }
+        engines: { node: '>=10' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@swc/core-linux-x64-gnu@1.15.18':
+        resolution:
+            {
+                integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==,
+            }
+        engines: { node: '>=10' }
+        cpu: [x64]
+        os: [linux]
+
+    '@swc/core-linux-x64-musl@1.15.18':
+        resolution:
+            {
+                integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==,
+            }
+        engines: { node: '>=10' }
+        cpu: [x64]
+        os: [linux]
+
+    '@swc/core-win32-arm64-msvc@1.15.18':
+        resolution:
+            {
+                integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==,
+            }
+        engines: { node: '>=10' }
+        cpu: [arm64]
+        os: [win32]
+
+    '@swc/core-win32-ia32-msvc@1.15.18':
+        resolution:
+            {
+                integrity: sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==,
+            }
+        engines: { node: '>=10' }
+        cpu: [ia32]
+        os: [win32]
+
+    '@swc/core-win32-x64-msvc@1.15.18':
+        resolution:
+            {
+                integrity: sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==,
+            }
+        engines: { node: '>=10' }
+        cpu: [x64]
+        os: [win32]
+
+    '@swc/core@1.15.18':
+        resolution:
+            {
+                integrity: sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==,
+            }
+        engines: { node: '>=10' }
+        peerDependencies:
+            '@swc/helpers': '>=0.5.17'
+        peerDependenciesMeta:
+            '@swc/helpers':
+                optional: true
+
+    '@swc/counter@0.1.3':
+        resolution:
+            {
+                integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==,
+            }
+
+    '@swc/types@0.1.25':
+        resolution:
+            {
+                integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==,
+            }
+
+    '@swc/wasm@1.15.18':
+        resolution:
+            {
+                integrity: sha512-zeSORFArxqUwfVMTRHu8AN9k9LlfSn0CKDSzLhJDITpgLoS0xpnocxsgMjQjUcVYDgO47r9zLP49HEjH/iGsFg==,
+            }
 
     '@tailwindcss/node@4.2.1':
         resolution:
@@ -1242,6 +1380,29 @@ packages:
         peerDependencies:
             browserslist: '>= 4.21.0'
 
+    uuid@10.0.0:
+        resolution:
+            {
+                integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
+            }
+        hasBin: true
+
+    vite-plugin-top-level-await@1.6.0:
+        resolution:
+            {
+                integrity: sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==,
+            }
+        peerDependencies:
+            vite: '>=2.8'
+
+    vite-plugin-wasm@3.5.0:
+        resolution:
+            {
+                integrity: sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==,
+            }
+        peerDependencies:
+            vite: ^2 || ^3 || ^4 || ^5 || ^6 || ^7
+
     vite@6.4.1:
         resolution:
             {
@@ -1503,6 +1664,10 @@ snapshots:
 
     '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+    '@rollup/plugin-virtual@3.0.2(rollup@4.59.0)':
+        optionalDependencies:
+            rollup: 4.59.0
+
     '@rollup/rollup-android-arm-eabi@4.59.0':
         optional: true
 
@@ -1577,6 +1742,60 @@ snapshots:
 
     '@rollup/rollup-win32-x64-msvc@4.59.0':
         optional: true
+
+    '@swc/core-darwin-arm64@1.15.18':
+        optional: true
+
+    '@swc/core-darwin-x64@1.15.18':
+        optional: true
+
+    '@swc/core-linux-arm-gnueabihf@1.15.18':
+        optional: true
+
+    '@swc/core-linux-arm64-gnu@1.15.18':
+        optional: true
+
+    '@swc/core-linux-arm64-musl@1.15.18':
+        optional: true
+
+    '@swc/core-linux-x64-gnu@1.15.18':
+        optional: true
+
+    '@swc/core-linux-x64-musl@1.15.18':
+        optional: true
+
+    '@swc/core-win32-arm64-msvc@1.15.18':
+        optional: true
+
+    '@swc/core-win32-ia32-msvc@1.15.18':
+        optional: true
+
+    '@swc/core-win32-x64-msvc@1.15.18':
+        optional: true
+
+    '@swc/core@1.15.18':
+        dependencies:
+            '@swc/counter': 0.1.3
+            '@swc/types': 0.1.25
+        optionalDependencies:
+            '@swc/core-darwin-arm64': 1.15.18
+            '@swc/core-darwin-x64': 1.15.18
+            '@swc/core-linux-arm-gnueabihf': 1.15.18
+            '@swc/core-linux-arm64-gnu': 1.15.18
+            '@swc/core-linux-arm64-musl': 1.15.18
+            '@swc/core-linux-x64-gnu': 1.15.18
+            '@swc/core-linux-x64-musl': 1.15.18
+            '@swc/core-win32-arm64-msvc': 1.15.18
+            '@swc/core-win32-ia32-msvc': 1.15.18
+            '@swc/core-win32-x64-msvc': 1.15.18
+
+    '@swc/counter@0.1.3': {}
+
+    '@swc/types@0.1.25':
+        dependencies:
+            '@swc/counter': 0.1.3
+
+    '@swc/wasm@1.15.18': {}
 
     '@tailwindcss/node@4.2.1':
         dependencies:
@@ -1909,6 +2128,23 @@ snapshots:
             browserslist: 4.28.1
             escalade: 3.2.0
             picocolors: 1.1.1
+
+    uuid@10.0.0: {}
+
+    vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1)):
+        dependencies:
+            '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
+            '@swc/core': 1.15.18
+            '@swc/wasm': 1.15.18
+            uuid: 10.0.0
+            vite: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
+        transitivePeerDependencies:
+            - '@swc/helpers'
+            - rollup
+
+    vite-plugin-wasm@3.5.0(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1)):
+        dependencies:
+            vite: 6.4.1(jiti@2.6.1)(lightningcss@1.31.1)
 
     vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1):
         dependencies:

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -3,6 +3,12 @@ name = "isometric-game"
 version = "0.1.0"
 edition = "2021"
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
+
 [lib]
 name = "isometric_game"
 crate-type = ["cdylib", "rlib"]
@@ -42,7 +48,7 @@ log = "0.4"
 
 # --- Desktop-only dependencies ---
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tauri = { version = "2", features = ["macos-private-api"] }
+tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 wgpu = "27"
 pollster = "0.4"
@@ -52,6 +58,11 @@ dashmap = "6"
 [target.'cfg(target_os = "linux")'.dependencies.bevy]
 version = "0.18"
 features = ["x11", "wayland"]
+
+# --- WASM-only Bevy features (WebGL2 backend) ---
+[target.'cfg(target_arch = "wasm32")'.dependencies.bevy]
+version = "0.18"
+features = ["webgl2"]
 
 # --- WASM-only dependencies ---
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/apps/kbve/isometric/src-tauri/Trunk.toml
+++ b/apps/kbve/isometric/src-tauri/Trunk.toml
@@ -1,6 +1,0 @@
-[build]
-target = "index.html"
-dist = "../dist-wasm"
-
-[watch]
-watch = ["src"]

--- a/apps/kbve/isometric/src-tauri/src/lib.rs
+++ b/apps/kbve/isometric/src-tauri/src/lib.rs
@@ -40,9 +40,20 @@ pub fn wasm_main() {
             }),
             ..default()
         }))
+        .add_plugins(bevy::diagnostic::FrameTimeDiagnosticsPlugin::default())
         .add_plugins(bevy::picking::mesh_picking::MeshPickingPlugin)
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
-        .add_plugins(RapierDebugRenderPlugin::default())
         .add_plugins(GamePluginGroup)
+        .add_systems(Update, update_fps_counter)
         .run();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn update_fps_counter(diagnostics: bevy::prelude::Res<bevy::diagnostic::DiagnosticsStore>) {
+    use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
+    if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
+        if let Some(avg) = fps.smoothed() {
+            AVERAGE_FRAME_RATE.store(avg as usize, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
 }

--- a/apps/kbve/isometric/src-tauri/src/main.rs
+++ b/apps/kbve/isometric/src-tauri/src/main.rs
@@ -1,65 +1,9 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use bevy::prelude::*;
-use bevy_rapier3d::prelude::*;
-
-use isometric_game::game::GamePluginGroup;
-use isometric_game::game::input_bridge::InputBridgePlugin;
-use isometric_game::tauri_plugin::TauriPlugin;
-
 fn main() {
-    let mut app = App::new();
-
-    app.insert_resource(ClearColor(Color::srgb(0.1, 0.1, 0.15)));
-
-    // --- Non-rendering core plugins (registered upfront) ---
-    // WinitPlugin is skipped — Tauri manages the OS window.
-    app.add_plugins((
-        bevy::app::PanicHandlerPlugin::default(),
-        bevy::app::TaskPoolPlugin::default(),
-        bevy::diagnostic::FrameCountPlugin,
-        bevy::time::TimePlugin,
-        bevy::transform::TransformPlugin,
-        bevy::diagnostic::DiagnosticsPlugin,
-        bevy::input::InputPlugin,
-        bevy::asset::AssetPlugin::default(),
-        bevy::state::app::StatesPlugin,
-    ));
-
-    // Window entity (Bevy tracks it; actual OS window is Tauri's)
-    app.add_plugins(bevy::window::WindowPlugin {
-        primary_window: Some(bevy::window::Window {
-            title: "KBVE Isometric".to_string(),
-            resolution: bevy::window::WindowResolution::new(1024, 768),
-            ..default()
-        }),
-        ..default()
-    });
-
-    // Tauri (builds app, sets custom runner, defers render plugins to Ready event)
-    app.add_plugins(TauriPlugin::new(|builder| {
-        builder
-            .plugin(tauri_plugin_opener::init())
-            .invoke_handler(tauri::generate_handler![
-                isometric_game::commands::get_fps,
-                isometric_game::commands::get_player_state,
-                isometric_game::commands::get_object_registry,
-                isometric_game::commands::on_input_frame,
-                isometric_game::commands::greet,
-            ])
-    }));
-
-    // Physics (no render dependency)
-    app.add_plugins(RapierPhysicsPlugin::<NoUserData>::default());
-
-    // Game plugins (Startup systems run on first update after Ready handler
-    // adds render plugins, so Assets<Mesh>/Assets<StandardMaterial> exist by then)
-    app.add_plugins(GamePluginGroup);
-
-    // Input bridge: forwards keyboard/mouse from webview JS to Bevy messages
-    // (desktop-only, not needed for WASM which has WinitPlugin)
-    app.add_plugins(InputBridgePlugin);
-
-    app.run();
+    tauri::Builder::default()
+        .plugin(tauri_plugin_opener::init())
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/apps/kbve/isometric/src-tauri/tauri.conf.json
+++ b/apps/kbve/isometric/src-tauri/tauri.conf.json
@@ -15,14 +15,12 @@
 				"label": "main",
 				"title": "KBVE Isometric",
 				"width": 1024,
-				"height": 768,
-				"transparent": true
+				"height": 768
 			}
 		],
 		"security": {
 			"csp": null
-		},
-		"macOSPrivateApi": true
+		}
 	},
 	"bundle": {
 		"active": true,

--- a/apps/kbve/isometric/src/App.tsx
+++ b/apps/kbve/isometric/src/App.tsx
@@ -1,10 +1,8 @@
 import { HUD } from './components/HUD';
 import { Inventory } from './components/Inventory';
 import { FPSCounter } from './components/FPSCounter';
-import { useInputBridge } from './hooks/useInputBridge';
 
 function App() {
-	useInputBridge();
 	return (
 		<div className="fixed inset-0 pointer-events-none font-game text-white">
 			<FPSCounter />

--- a/apps/kbve/isometric/src/components/FPSCounter.tsx
+++ b/apps/kbve/isometric/src/components/FPSCounter.tsx
@@ -1,16 +1,15 @@
 import { useEffect, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
+import { get_fps } from '../../wasm-pkg/isometric_game.js';
 
 export function FPSCounter() {
 	const [fps, setFps] = useState(0);
 
 	useEffect(() => {
-		const interval = setInterval(async () => {
+		const interval = setInterval(() => {
 			try {
-				const value = await invoke<number>('get_fps');
-				setFps(value);
+				setFps(get_fps());
 			} catch {
-				// IPC not ready yet
+				// WASM not ready yet
 			}
 		}, 1000);
 		return () => clearInterval(interval);

--- a/apps/kbve/isometric/src/components/HUD.tsx
+++ b/apps/kbve/isometric/src/components/HUD.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
+import { get_player_state_json } from '../../wasm-pkg/isometric_game.js';
 import { GlassPanel } from '../ui/shared/GlassPanel';
 import { ProgressBar } from '../ui/shared/ProgressBar';
 
@@ -16,12 +16,12 @@ export function HUD() {
 	const [state, setState] = useState<PlayerState | null>(null);
 
 	useEffect(() => {
-		const interval = setInterval(async () => {
+		const interval = setInterval(() => {
 			try {
-				const s = await invoke<PlayerState>('get_player_state');
-				setState(s);
+				const json = get_player_state_json();
+				if (json) setState(JSON.parse(json));
 			} catch {
-				// IPC not ready
+				// WASM not ready
 			}
 		}, 250);
 		return () => clearInterval(interval);

--- a/apps/kbve/isometric/src/main.tsx
+++ b/apps/kbve/isometric/src/main.tsx
@@ -4,10 +4,19 @@ import './app.css';
 import { GameUIProvider } from './ui/provider/GameUIProvider';
 import App from './App';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-	<React.StrictMode>
-		<GameUIProvider>
-			<App />
-		</GameUIProvider>
-	</React.StrictMode>,
-);
+async function bootstrap() {
+	// Load and initialize Bevy WASM — starts the game loop (non-blocking)
+	const { default: init } = await import('../wasm-pkg/isometric_game.js');
+	await init();
+
+	// Render React UI overlay
+	ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+		<React.StrictMode>
+			<GameUIProvider>
+				<App />
+			</GameUIProvider>
+		</React.StrictMode>,
+	);
+}
+
+bootstrap().catch(console.error);

--- a/apps/kbve/isometric/vite.config.ts
+++ b/apps/kbve/isometric/vite.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import wasm from 'vite-plugin-wasm';
+import topLevelAwait from 'vite-plugin-top-level-await';
 
 const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig(async () => ({
-	plugins: [react(), tailwindcss()],
+	plugins: [react(), tailwindcss(), wasm(), topLevelAwait()],
 	clearScreen: false,
 	server: {
 		port: 1420,
@@ -14,5 +16,8 @@ export default defineConfig(async () => ({
 		watch: {
 			ignored: ['**/src-tauri/**'],
 		},
+	},
+	optimizeDeps: {
+		exclude: ['isometric_game'],
 	},
 }));


### PR DESCRIPTION
## Summary
- Replaces native shared-window Metal rendering with WASM-in-webview approach
- Bevy compiles to WASM via `wasm-pack`, renders on `<canvas>` element, React UI overlays via CSS z-index
- Eliminates macOS CAMetalLayer/WKWebView layer ordering conflicts that made React UI invisible
- Uses WebGL2 backend (`webgl2` Bevy feature) for broad WKWebView compatibility

## Changes
- `main.rs` → plain Tauri shell (no Bevy, no game plugins)
- `lib.rs` → WASM entry with FPS tracking via `FrameTimeDiagnosticsPlugin`
- React components use `wasm-bindgen` exports instead of Tauri IPC `invoke()`
- Added `vite-plugin-wasm` + `vite-plugin-top-level-await` for WASM module loading
- Removed `transparent` window and `macOSPrivateApi` (no longer needed)
- Deleted unused `Trunk.toml`

## Test plan
- [x] `wasm-pack build --target web` compiles clean
- [x] `cargo tauri dev` launches Tauri window with Bevy game rendering on canvas
- [x] React UI (FPS counter, HUD, Inventory) visible on top of game
- [x] FPS counter shows non-zero values (~20 FPS on WebGL2)
- [ ] WASD movement works via WinitPlugin
- [ ] Window resize works (`fit_canvas_to_parent: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)