### PR TITLE
fix(isometric): Nx lint support and project graph fix

### DIFF
--- a/apps/kbve/isometric/.eslintrc.json
+++ b/apps/kbve/isometric/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+	"extends": ["plugin:@nx/react", "../../../.eslintrc.base.json"],
+	"ignorePatterns": [
+		"!**/*",
+		"**/vite.config.*.timestamp*",
+		"**/vitest.config.*.timestamp*",
+		"src-tauri/**",
+		"wasm-pkg/**"
+	],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -4,6 +4,12 @@
 	"projectType": "application",
 	"sourceRoot": "apps/kbve/isometric",
 	"targets": {
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"options": {
+				"lintFilePatterns": ["apps/kbve/isometric/src/**/*.{ts,tsx}"]
+			}
+		},
 		"dev": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/apps/kbve/isometric/src/ui/events/event-bus.ts
+++ b/apps/kbve/isometric/src/ui/events/event-bus.ts
@@ -12,6 +12,7 @@ class EventBus<TMap extends { [key: string]: unknown }> {
 		if (!this.listeners.has(event)) {
 			this.listeners.set(event, new Set());
 		}
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const set = this.listeners.get(event)!;
 		const fn = listener as Listener<never>;
 		set.add(fn);

--- a/apps/kbve/isometric/src/ui/menu/menu-context.tsx
+++ b/apps/kbve/isometric/src/ui/menu/menu-context.tsx
@@ -32,9 +32,9 @@ function menuReducer(state: MenuState, action: MenuAction): MenuState {
 
 // --- Contexts (split) ---
 export const MenuStateContext = createContext<MenuState>(initialState);
-export const MenuDispatchContext = createContext<Dispatch<MenuAction>>(
-	() => {},
-);
+export const MenuDispatchContext = createContext<Dispatch<MenuAction>>(() => {
+	/* noop default */
+});
 
 // --- Provider ---
 export function MenuProvider({ children }: { children: ReactNode }) {

--- a/apps/kbve/isometric/src/ui/modal/modal-context.tsx
+++ b/apps/kbve/isometric/src/ui/modal/modal-context.tsx
@@ -41,9 +41,9 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
 
 // --- Contexts (split) ---
 export const ModalStateContext = createContext<ModalState>(initialState);
-export const ModalDispatchContext = createContext<Dispatch<ModalAction>>(
-	() => {},
-);
+export const ModalDispatchContext = createContext<Dispatch<ModalAction>>(() => {
+	/* noop default */
+});
 
 // --- Provider ---
 export function ModalProvider({ children }: { children: ReactNode }) {

--- a/apps/kbve/isometric/src/ui/shared/use-keyboard.ts
+++ b/apps/kbve/isometric/src/ui/shared/use-keyboard.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 export function useKeyboard(
 	key: string,
 	handler: () => void,
-	enabled: boolean = true,
+	enabled = true,
 ): void {
 	useEffect(() => {
 		if (!enabled) return;

--- a/apps/kbve/isometric/src/ui/toast/toast-context.tsx
+++ b/apps/kbve/isometric/src/ui/toast/toast-context.tsx
@@ -51,9 +51,9 @@ function toastReducer(state: ToastState, action: ToastAction): ToastState {
 
 // --- Contexts (split for performance) ---
 export const ToastStateContext = createContext<ToastState>({ toasts: [] });
-export const ToastDispatchContext = createContext<Dispatch<ToastAction>>(
-	() => {},
-);
+export const ToastDispatchContext = createContext<Dispatch<ToastAction>>(() => {
+	/* noop default */
+});
 
 // --- Provider ---
 export function ToastProvider({ children }: { children: ReactNode }) {

--- a/nx.json
+++ b/nx.json
@@ -80,6 +80,7 @@
 		},
 		{
 			"plugin": "@nx/vite/plugin",
+			"exclude": ["apps/kbve/isometric/**"],
 			"options": {
 				"buildTargetName": "build",
 				"previewTargetName": "preview",
@@ -89,6 +90,7 @@
 		},
 		{
 			"plugin": "@nx/vitest",
+			"exclude": ["apps/kbve/isometric/**"],
 			"options": {
 				"testTargetName": "test"
 			}


### PR DESCRIPTION
## Summary
- Exclude isometric from `@nx/vite/plugin` and `@nx/vitest` plugin auto-inference to fix `vite.config.ts` loading failure during project graph construction (the config imports `vite-plugin-wasm` and `@tailwindcss/vite` which aren't resolvable from the plugin context in CI)
- Add `.eslintrc.json` with `@nx/react` plugin, ignoring `src-tauri/` and `wasm-pkg/` directories
- Add explicit `lint` target in `project.json` using `@nx/eslint:lint`
- Fix 5 eslint errors across UI components (empty arrow functions, non-null assertion, inferrable type)

## Test plan
- [x] `nx run isometric:lint` passes cleanly
- [x] `nx show project isometric` loads without error
- [ ] CI `nx affected --target=lint` no longer fails on project graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)