### PR TITLE
feat(isometric): generic object selection + modal system

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/commands.rs
+++ b/apps/kbve/isometric/src-tauri/src/commands.rs
@@ -1,10 +1,13 @@
 use crate::AVERAGE_FRAME_RATE;
 use crate::game::object_registry::get_registry_snapshot;
+use crate::game::scene_objects::get_selected_snapshot;
 use crate::game::state::get_player_snapshot;
 use std::sync::atomic::Ordering;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::game::object_registry::ObjectRegistrySnapshot;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::game::scene_objects::SelectedObject;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::game::state::PlayerState;
 
@@ -28,6 +31,12 @@ pub fn get_player_state() -> PlayerState {
 #[tauri::command]
 pub fn get_object_registry() -> Option<ObjectRegistrySnapshot> {
     get_registry_snapshot()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tauri::command]
+pub fn get_selected_object() -> Option<SelectedObject> {
+    get_selected_snapshot()
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -84,6 +93,12 @@ pub fn get_player_state_json() -> String {
 #[wasm_bindgen]
 pub fn get_object_registry_json() -> Option<String> {
     get_registry_snapshot().map(|s| serde_json::to_string(&s).unwrap_or_default())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn get_selected_object_json() -> Option<String> {
+    get_selected_snapshot().map(|s| serde_json::to_string(&s).unwrap_or_default())
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/apps/kbve/isometric/src-tauri/src/game/object_registry.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/object_registry.rs
@@ -11,8 +11,8 @@ use std::sync::LazyLock;
 use bevy_rapier3d::prelude::*;
 
 use super::scene_objects::{
-    AnimatedCrystal, HoverOutline, Occludable, OriginalEmissive, RotatingBox, on_pointer_out,
-    on_pointer_over,
+    AnimatedCrystal, HoverOutline, Interactable, InteractableKind, Occludable, OriginalEmissive,
+    RotatingBox, on_pointer_out, on_pointer_over,
 };
 use super::terrain::TerrainMap;
 
@@ -338,6 +338,9 @@ fn spawn_object_entity(
                     HoverOutline {
                         half_extents: Vec3::splat(half),
                     },
+                    Interactable {
+                        kind: InteractableKind::Crate,
+                    },
                 ))
                 .observe(on_pointer_over)
                 .observe(on_pointer_out)
@@ -366,6 +369,9 @@ fn spawn_object_entity(
                     HoverOutline {
                         half_extents: Vec3::splat(half),
                     },
+                    Interactable {
+                        kind: InteractableKind::Crate,
+                    },
                 ))
                 .observe(on_pointer_over)
                 .observe(on_pointer_out)
@@ -393,6 +399,9 @@ fn spawn_object_entity(
                     HoverOutline {
                         half_extents: Vec3::splat(1.0),
                     },
+                    Interactable {
+                        kind: InteractableKind::Crystal,
+                    },
                 ))
                 .observe(on_pointer_over)
                 .observe(on_pointer_out)
@@ -416,6 +425,9 @@ fn spawn_object_entity(
                 OriginalEmissive(LinearRgba::BLACK),
                 HoverOutline {
                     half_extents: Vec3::new(0.4, 2.0, 0.4),
+                },
+                Interactable {
+                    kind: InteractableKind::Pillar,
                 },
             ))
             .observe(on_pointer_over)
@@ -441,6 +453,9 @@ fn spawn_object_entity(
                     OriginalEmissive(LinearRgba::BLACK),
                     HoverOutline {
                         half_extents: Vec3::splat(radius),
+                    },
+                    Interactable {
+                        kind: InteractableKind::Sphere,
                     },
                 ))
                 .observe(on_pointer_over)

--- a/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
@@ -2,6 +2,7 @@ use bevy::picking::events::{Out, Over, Pointer};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use bevy_rapier3d::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::camera::IsometricCamera;
 use super::player::Player;
@@ -12,6 +13,14 @@ use super::input_bridge::BridgedCursorPosition;
 
 // Re-export EntityEvent so event_target() is available
 use bevy::ecs::event::EntityEvent;
+
+// Desktop: thread-safe snapshot for selected object
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{LazyLock, Mutex};
+
+// WASM: single-threaded RefCell
+#[cfg(target_arch = "wasm32")]
+use std::cell::RefCell;
 
 /// Marker for objects that become semi-transparent when occluding the player.
 #[derive(Component)]
@@ -39,6 +48,59 @@ pub struct AnimatedCrystal {
 #[derive(Component)]
 pub struct RotatingBox;
 
+// ---------------------------------------------------------------------------
+// Generic interactable system
+// ---------------------------------------------------------------------------
+
+/// Discriminated union of all clickable object types.
+/// React maps each variant to typed modal content + actions.
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractableKind {
+    Tree,
+    Crate,
+    Crystal,
+    Pillar,
+    Sphere,
+}
+
+/// Marker: this entity can be clicked to open an interaction modal.
+/// Attach to any entity that also has `HoverOutline`.
+#[derive(Component)]
+pub struct Interactable {
+    pub kind: InteractableKind,
+}
+
+/// Snapshot written on click, read (and cleared) by React polling.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SelectedObject {
+    pub kind: InteractableKind,
+    pub position: [f32; 3],
+    pub entity_id: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub static SELECTED_OBJECT_SNAPSHOT: LazyLock<Mutex<Option<SelectedObject>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    pub static SELECTED_OBJECT_SNAPSHOT_WASM: RefCell<Option<SelectedObject>> =
+        const { RefCell::new(None) };
+}
+
+/// Read and clear the selected object snapshot (take semantics).
+pub fn get_selected_snapshot() -> Option<SelectedObject> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        SELECTED_OBJECT_SNAPSHOT.lock().unwrap().take()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        SELECTED_OBJECT_SNAPSHOT_WASM.with(|cell| cell.borrow_mut().take())
+    }
+}
+
 pub struct SceneObjectsPlugin;
 
 impl Plugin for SceneObjectsPlugin {
@@ -51,6 +113,7 @@ impl Plugin for SceneObjectsPlugin {
                 update_occlusion,
                 update_hover_highlight,
                 draw_hover_outline,
+                detect_click_selection,
             ),
         );
 
@@ -303,6 +366,39 @@ fn update_hover_highlight(
                 }
             }
         }
+    }
+}
+
+/// On left-click, if a hovered entity has Interactable, write its data to the snapshot.
+/// React polls this snapshot to open a modal with object-specific content.
+fn detect_click_selection(
+    mouse: Res<ButtonInput<MouseButton>>,
+    hovered_query: Query<(Entity, &GlobalTransform, &Interactable), With<Hovered>>,
+) {
+    if !mouse.just_pressed(MouseButton::Left) {
+        return;
+    }
+
+    let Some((entity, gt, interactable)) = hovered_query.iter().next() else {
+        return;
+    };
+
+    let pos = gt.translation();
+    let snapshot = SelectedObject {
+        kind: interactable.kind,
+        position: [pos.x, pos.y, pos.z],
+        entity_id: entity.to_bits(),
+    };
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        *SELECTED_OBJECT_SNAPSHOT.lock().unwrap() = Some(snapshot);
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        SELECTED_OBJECT_SNAPSHOT_WASM.with(|cell| {
+            *cell.borrow_mut() = Some(snapshot);
+        });
     }
 }
 

--- a/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
@@ -6,7 +6,9 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
 use super::player::Player;
-use super::scene_objects::{HoverOutline, on_pointer_out, on_pointer_over};
+use super::scene_objects::{
+    HoverOutline, Interactable, InteractableKind, on_pointer_out, on_pointer_over,
+};
 use super::terrain::{CHUNK_SIZE, TerrainMap, hash2d};
 
 pub const TILE_SIZE: f32 = 1.0;
@@ -781,6 +783,9 @@ fn process_chunk_spawns_and_despawns(
                                         (trunk_h + canopy_h) / 2.0,
                                         0.275,
                                     ),
+                                },
+                                Interactable {
+                                    kind: InteractableKind::Tree,
                                 },
                             ))
                             .observe(on_pointer_over)

--- a/apps/kbve/isometric/src/App.tsx
+++ b/apps/kbve/isometric/src/App.tsx
@@ -1,8 +1,11 @@
 import { HUD } from './components/HUD';
 import { Inventory } from './components/Inventory';
 import { FPSCounter } from './components/FPSCounter';
+import { useObjectSelection } from './hooks/useObjectSelection';
 
 function App() {
+	useObjectSelection();
+
 	return (
 		<div className="fixed inset-0 pointer-events-none font-game text-white">
 			<FPSCounter />

--- a/apps/kbve/isometric/src/hooks/useObjectSelection.tsx
+++ b/apps/kbve/isometric/src/hooks/useObjectSelection.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import { get_selected_object_json } from '../../wasm-pkg/isometric_game.js';
+import { gameEvents } from '../ui/events/event-bus';
+import type { InteractableKind } from '../ui/events/event-map';
+
+interface ObjectInfo {
+	title: string;
+	description: string;
+	action: string;
+}
+
+const OBJECT_INFO: Record<InteractableKind, ObjectInfo> = {
+	tree: {
+		title: 'Tree',
+		description: 'A sturdy tree with rough bark.',
+		action: 'Chop Tree',
+	},
+	crate: {
+		title: 'Wooden Crate',
+		description: 'A wooden crate. Might contain something.',
+		action: 'Open Crate',
+	},
+	crystal: {
+		title: 'Crystal',
+		description: 'A glowing crystal pulsing with energy.',
+		action: 'Mine Crystal',
+	},
+	pillar: {
+		title: 'Stone Pillar',
+		description: 'An ancient stone pillar.',
+		action: 'Examine',
+	},
+	sphere: {
+		title: 'Metallic Sphere',
+		description: 'A mysterious metallic sphere.',
+		action: 'Examine',
+	},
+};
+
+function ActionContent({
+	info,
+	kind,
+}: {
+	info: ObjectInfo;
+	kind: InteractableKind;
+}) {
+	return (
+		<div className="space-y-3">
+			<p className="text-sm opacity-80">{info.description}</p>
+			<button
+				className="w-full px-3 py-2 text-sm font-semibold rounded
+					bg-white/10 hover:bg-white/20 border border-white/20
+					transition-colors cursor-pointer"
+				onClick={() => {
+					gameEvents.emit('toast:show', {
+						message: `${info.action}: ${info.title}`,
+						severity: 'info',
+					});
+					gameEvents.emit('modal:close');
+				}}>
+				{info.action}
+			</button>
+		</div>
+	);
+}
+
+export function useObjectSelection() {
+	const modalOpenRef = useRef(false);
+
+	useEffect(() => {
+		const interval = setInterval(() => {
+			// Don't poll while modal is already showing an action
+			if (modalOpenRef.current) return;
+
+			try {
+				const json = get_selected_object_json();
+				if (!json) return;
+
+				const selected = JSON.parse(json) as {
+					kind: InteractableKind;
+					position: [number, number, number];
+					entity_id: number;
+				};
+
+				const info = OBJECT_INFO[selected.kind];
+				if (!info) return;
+
+				modalOpenRef.current = true;
+
+				gameEvents.emit('modal:open', {
+					title: info.title,
+					content: <ActionContent info={info} kind={selected.kind} />,
+					onClose: () => {
+						modalOpenRef.current = false;
+					},
+				});
+			} catch {
+				// WASM not ready
+			}
+		}, 100);
+
+		return () => clearInterval(interval);
+	}, []);
+}

--- a/apps/kbve/isometric/src/ui/events/event-map.ts
+++ b/apps/kbve/isometric/src/ui/events/event-map.ts
@@ -2,6 +2,13 @@ import type { ReactNode } from 'react';
 
 export type ToastSeverity = 'info' | 'success' | 'warning' | 'error' | 'loot';
 
+export type InteractableKind =
+	| 'tree'
+	| 'crate'
+	| 'crystal'
+	| 'pillar'
+	| 'sphere';
+
 export type GameEventMap = {
 	// Toast events
 	'toast:show': {
@@ -32,6 +39,13 @@ export type GameEventMap = {
 	'game:item-pickup': { name: string; quantity: number };
 	'game:achievement': { title: string; description: string };
 	'game:death': void;
+
+	// Object selection (from Bevy game via snapshot polling)
+	'game:object-selected': {
+		kind: InteractableKind;
+		position: [number, number, number];
+		entity_id: number;
+	};
 
 	// Settings
 	'settings:changed': { key: string; value: unknown };


### PR DESCRIPTION
## Summary
- Add `InteractableKind` discriminated union (`Tree`, `Crate`, `Crystal`, `Pillar`, `Sphere`) as a generic `<T>` pattern for clickable objects
- Bevy `detect_click_selection` system writes `SelectedObject` snapshot on left-click of hovered `Interactable` entities (take semantics — read clears)
- React `useObjectSelection` hook polls snapshot every 100ms and opens the existing modal with kind-specific title, description, and action button
- All hoverable entities (trees, crates, crystals, pillars, spheres) now carry `Interactable` component

## Test plan
- [ ] Click a highlighted tree — modal opens with "Tree" title and "Chop Tree" button
- [ ] Click a highlighted crate — modal opens with "Wooden Crate" and "Open Crate"
- [ ] Click crystal/pillar/sphere — corresponding modal content appears
- [ ] Close modal, click another object — new modal opens
- [ ] Click with nothing hovered — nothing happens
- [ ] Action button shows toast confirmation (placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)