### PR TITLE
feat(functions): route edge functions through PgBouncer poolers

### DIFF
--- a/apps/kube/functions/manifests/functions-deployment.yaml
+++ b/apps/kube/functions/manifests/functions-deployment.yaml
@@ -47,6 +47,11 @@ spec:
                             secretKeyRef:
                                 name: supabase-shared
                                 key: db-url
+                      - name: SUPABASE_DB_URL_RO
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url-ro
                       - name: HCAPTCHA_SECRET
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/functions/manifests/functions-externalsecret.yaml
+++ b/apps/kube/functions/manifests/functions-externalsecret.yaml
@@ -1,37 +1,38 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: functions-supabase-secrets
-  namespace: kilobase
+    name: functions-supabase-secrets
+    namespace: kilobase
 spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: k8s-secret-store
-    kind: SecretStore
-  target:
-    name: supabase-shared
-    creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        jwt-secret: "{{ .jwtsecret }}"
-        anon-key: "{{ .anonkey }}"
-        service-role-key: "{{ .servicekey }}"
-        db-url: "postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase"
-  data:
-  - secretKey: jwtsecret
-    remoteRef:
-      key: supabase-jwt
-      property: secret
-  - secretKey: anonkey
-    remoteRef:
-      key: supabase-jwt
-      property: anon-key
-  - secretKey: servicekey
-    remoteRef:
-      key: supabase-jwt
-      property: service-key
-  - secretKey: dbpassword
-    remoteRef:
-      key: supabase-postgres
-      property: password
+    refreshInterval: 1h
+    secretStoreRef:
+        name: k8s-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                jwt-secret: '{{ .jwtsecret }}'
+                anon-key: '{{ .anonkey }}'
+                service-role-key: '{{ .servicekey }}'
+                db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-pooler-rw.kilobase.svc.cluster.local:5432/supabase'
+                db-url-ro: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-pooler-ro.kilobase.svc.cluster.local:5432/supabase'
+    data:
+        - secretKey: jwtsecret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-jwt
+              property: service-key
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password


### PR DESCRIPTION
## Summary
- Switches Edge Functions `SUPABASE_DB_URL` from direct `supabase-cluster-rw` to `supabase-cluster-pooler-rw` (PgBouncer transaction mode, 3 instances)
- Adds `SUPABASE_DB_URL_RO` pointing to `supabase-cluster-pooler-ro` (PgBouncer session mode, 2 instances) for read-only queries
- First service migrated under #7593 Phase 2

## Details
Edge Functions primarily use the Supabase SDK via Kong/PostgREST (RPC calls), but the `SUPABASE_DB_URL` env var is available for direct DB access by the edge runtime. Routing through the pooler:
- Reduces direct connections to PostgreSQL
- Enables connection multiplexing for short-lived function invocations
- The RO URL allows read-heavy routes (feeds, lookups) to use replica poolers

## Test plan
- [ ] Verify `supabase-shared` secret is refreshed with new `db-url` and `db-url-ro` keys
- [ ] Confirm Edge Functions pod restarts with the new env vars
- [ ] Test edge function endpoints (meme feed, MC player, health check)
- [ ] Verify no errors in edge function logs related to DB connectivity
- [ ] Check PgBouncer stats: `kubectl exec <pooler-pod> -n kilobase -- pgbouncer -d /tmp/pgbouncer.ini -R`