### PR TITLE
feat(isometric): RPG pixel-art UI restyle

### DIFF
--- a/apps/kbve/isometric/index.html
+++ b/apps/kbve/isometric/index.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>KBVE Isometric</title>
+        <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
         <style>
             * {
                 margin: 0;

--- a/apps/kbve/isometric/src/App.tsx
+++ b/apps/kbve/isometric/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
 	useObjectSelection();
 
 	return (
-		<div className="fixed inset-0 pointer-events-none font-game text-white">
+		<div className="fixed inset-0 pointer-events-none font-game text-text rpg-text-shadow">
 			<FPSCounter />
 			<HUD />
 			<Inventory />

--- a/apps/kbve/isometric/src/app.css
+++ b/apps/kbve/isometric/src/app.css
@@ -1,40 +1,75 @@
 @import 'tailwindcss';
 
 @theme {
-	/* --- Game Color Palette --- */
+	/* --- RPG Panel Colors --- */
+	--color-panel: #2b1d0e;
+	--color-panel-inner: #3d2b14;
+	--color-panel-border: #8b6914;
+	--color-panel-border-dark: #5a4a2a;
+
+	/* --- Glass (kept for HUD, FPS, Toasts) --- */
 	--color-glass: oklch(0% 0 0 / 0.55);
 	--color-glass-light: oklch(100% 0 0 / 0.08);
 	--color-glass-border: oklch(100% 0 0 / 0.15);
 	--color-glass-hover: oklch(100% 0 0 / 0.12);
 
-	--color-hp: oklch(55% 0.2 25);
-	--color-mp: oklch(55% 0.18 250);
-	--color-xp: oklch(70% 0.18 145);
+	/* --- RPG Button Colors --- */
+	--color-btn: #4a7a3a;
+	--color-btn-hover: #5a9a4a;
+	--color-btn-active: #3a6a2a;
+	--color-btn-border: #2d5a1f;
 
-	--color-toast-info: oklch(65% 0.15 250);
-	--color-toast-success: oklch(65% 0.18 145);
-	--color-toast-warning: oklch(75% 0.18 80);
-	--color-toast-error: oklch(55% 0.2 25);
-	--color-toast-loot: oklch(75% 0.18 85);
+	/* --- RPG Text Colors --- */
+	--color-text: #e8d8b8;
+	--color-text-muted: #a89878;
 
-	--color-overlay: oklch(0% 0 0 / 0.6);
+	/* --- Stat Bars --- */
+	--color-hp: #b83030;
+	--color-mp: #3060b8;
+	--color-xp: #4a7a3a;
+
+	/* --- Toast Severity --- */
+	--color-toast-info: #3060b8;
+	--color-toast-success: #4a7a3a;
+	--color-toast-warning: #b89030;
+	--color-toast-error: #b83030;
+	--color-toast-loot: #c8a832;
+
+	/* --- Overlay --- */
+	--color-overlay: rgba(0, 0, 0, 0.7);
+
+	/* --- Slot --- */
+	--color-slot: #1e1408;
+	--color-slot-border: #5a4a2a;
 
 	/* --- Shadows --- */
+	--shadow-panel:
+		inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 4px 12px rgba(0, 0, 0, 0.6);
 	--shadow-glass: 0 4px 16px oklch(0% 0 0 / 0.3);
-	--shadow-toast: 0 2px 8px oklch(0% 0 0 / 0.4);
+	--shadow-toast: 0 2px 8px rgba(0, 0, 0, 0.5);
 
 	/* --- Border Radius --- */
-	--radius-panel: 8px;
-	--radius-slot: 4px;
-	--radius-toast: 6px;
+	--radius-panel: 0px;
+	--radius-slot: 0px;
+	--radius-toast: 0px;
+	--radius-glass: 6px;
 
 	/* --- Font --- */
-	--font-game: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+	--font-game: 'Press Start 2P', monospace;
 
-	/* --- Animation Durations --- */
+	/* --- Animations --- */
 	--animate-toast-in: toast-slide-in 300ms ease-out forwards;
 	--animate-toast-out: toast-slide-out 200ms ease-in forwards;
 	--animate-modal-in: modal-fade-in 200ms ease-out forwards;
+}
+
+/* RPG pixel-art text outline */
+.rpg-text-shadow {
+	text-shadow:
+		-1px 0 #000,
+		0 1px #000,
+		1px 0 #000,
+		0 -1px #000;
 }
 
 @keyframes toast-slide-in {

--- a/apps/kbve/isometric/src/components/FPSCounter.tsx
+++ b/apps/kbve/isometric/src/components/FPSCounter.tsx
@@ -16,7 +16,7 @@ export function FPSCounter() {
 	}, []);
 
 	return (
-		<div className="absolute top-2 right-2 px-2.5 py-1 bg-glass rounded-slot text-[13px] pointer-events-auto">
+		<div className="absolute top-2 right-2 px-2 py-1 bg-panel border border-panel-border text-[7px] text-text-muted pointer-events-auto">
 			{fps} FPS
 		</div>
 	);

--- a/apps/kbve/isometric/src/components/HUD.tsx
+++ b/apps/kbve/isometric/src/components/HUD.tsx
@@ -30,7 +30,7 @@ export function HUD() {
 	if (!state) return null;
 
 	return (
-		<GlassPanel className="absolute bottom-4 left-4 px-4 py-3">
+		<GlassPanel className="absolute bottom-4 left-4 px-3 py-2">
 			<ProgressBar
 				label="HP"
 				value={state.health}
@@ -43,7 +43,7 @@ export function HUD() {
 				max={state.max_mana}
 				color="bg-mp"
 			/>
-			<div className="text-[10px] opacity-60 mt-1">
+			<div className="text-[7px] text-text-muted mt-1">
 				Pos: {state.position.map((v) => v.toFixed(1)).join(', ')}
 			</div>
 		</GlassPanel>

--- a/apps/kbve/isometric/src/components/Inventory.tsx
+++ b/apps/kbve/isometric/src/components/Inventory.tsx
@@ -1,5 +1,3 @@
-import { GlassPanel } from '../ui/shared/GlassPanel';
-
 const GRID_COLS = 4;
 const GRID_ROWS = 4;
 
@@ -7,16 +5,18 @@ export function Inventory() {
 	const slots = Array.from({ length: GRID_COLS * GRID_ROWS });
 
 	return (
-		<GlassPanel className="absolute bottom-4 right-4 p-2.5">
-			<div className="text-[11px] mb-1.5 text-center">Inventory</div>
+		<div className="absolute bottom-4 right-4 p-2 bg-panel border-2 border-panel-border shadow-panel pointer-events-auto">
+			<div className="text-[8px] mb-1.5 text-center text-text-muted">
+				Inventory
+			</div>
 			<div className="grid grid-cols-4 gap-1">
 				{slots.map((_, i) => (
 					<div
 						key={i}
-						className="w-11 h-11 bg-glass-light border border-glass-border rounded-slot"
+						className="w-10 h-10 bg-slot border border-slot-border"
 					/>
 				))}
 			</div>
-		</GlassPanel>
+		</div>
 	);
 }

--- a/apps/kbve/isometric/src/hooks/useObjectSelection.tsx
+++ b/apps/kbve/isometric/src/hooks/useObjectSelection.tsx
@@ -71,11 +71,11 @@ const FLOWER_INFO: Record<
 function ActionContent({ info }: { info: ObjectInfo }) {
 	return (
 		<div className="space-y-3">
-			<p className="text-sm opacity-80">{info.description}</p>
+			<p className="text-[8px] text-text-muted">{info.description}</p>
 			<button
-				className="w-full px-3 py-2 text-sm font-semibold rounded
-					bg-white/10 hover:bg-white/20 border border-white/20
-					transition-colors cursor-pointer"
+				className="w-full px-3 py-2 text-[8px] bg-btn border border-btn-border
+					hover:bg-btn-hover active:bg-btn-active
+					transition-colors cursor-pointer text-text"
 				onClick={() => {
 					gameEvents.emit('toast:show', {
 						message: `${info.action}: ${info.title}`,

--- a/apps/kbve/isometric/src/ui/menu/PauseMenu.tsx
+++ b/apps/kbve/isometric/src/ui/menu/PauseMenu.tsx
@@ -16,10 +16,8 @@ function SettingsContent({ category }: { category: SettingsCategory }) {
 		case 'general':
 			return (
 				<div className="space-y-3">
-					<h3 className="text-sm font-semibold mb-2">
-						General Settings
-					</h3>
-					<div className="text-[13px] text-white/60">
+					<h3 className="text-[9px] mb-2">General Settings</h3>
+					<div className="text-[8px] text-text-muted">
 						Game settings will be added here.
 					</div>
 				</div>
@@ -27,10 +25,8 @@ function SettingsContent({ category }: { category: SettingsCategory }) {
 		case 'audio':
 			return (
 				<div className="space-y-3">
-					<h3 className="text-sm font-semibold mb-2">
-						Audio Settings
-					</h3>
-					<div className="text-[13px] text-white/60">
+					<h3 className="text-[9px] mb-2">Audio Settings</h3>
+					<div className="text-[8px] text-text-muted">
 						Volume controls will be added here.
 					</div>
 				</div>
@@ -38,10 +34,8 @@ function SettingsContent({ category }: { category: SettingsCategory }) {
 		case 'video':
 			return (
 				<div className="space-y-3">
-					<h3 className="text-sm font-semibold mb-2">
-						Video Settings
-					</h3>
-					<div className="text-[13px] text-white/60">
+					<h3 className="text-[9px] mb-2">Video Settings</h3>
+					<div className="text-[8px] text-text-muted">
 						Resolution and display options will be added here.
 					</div>
 				</div>
@@ -49,8 +43,8 @@ function SettingsContent({ category }: { category: SettingsCategory }) {
 		case 'controls':
 			return (
 				<div className="space-y-3">
-					<h3 className="text-sm font-semibold mb-2">Controls</h3>
-					<div className="text-[13px] text-white/60 space-y-1">
+					<h3 className="text-[9px] mb-2">Controls</h3>
+					<div className="text-[8px] text-text-muted space-y-1">
 						<div>W / A / S / D — Move</div>
 						<div>Space — Jump</div>
 						<div>Escape — Toggle Menu</div>
@@ -67,22 +61,22 @@ export function PauseMenu() {
 	if (!isOpen) return null;
 
 	return createPortal(
-		<div className="fixed inset-0 bg-overlay backdrop-blur-[8px] flex items-center justify-center pointer-events-auto">
-			<div className="bg-glass backdrop-blur-[4px] rounded-panel border border-glass-border shadow-glass w-full max-w-lg mx-4 animate-modal-in">
+		<div className="fixed inset-0 bg-overlay flex items-center justify-center pointer-events-auto">
+			<div className="bg-panel border-2 border-panel-border shadow-panel w-full max-w-lg mx-4 animate-modal-in">
 				{/* Header */}
-				<div className="flex items-center justify-between px-4 py-3 border-b border-glass-border">
-					<h2 className="text-sm font-semibold">Settings</h2>
+				<div className="flex items-center justify-between px-3 py-2 border-b-2 border-panel-border bg-panel-inner">
+					<h2 className="text-[10px]">Settings</h2>
 					<button
 						onClick={() => dispatch({ type: 'CLOSE' })}
-						className="text-white/50 hover:text-white text-lg leading-none cursor-pointer">
-						&times;
+						className="text-text-muted hover:text-text text-[10px] leading-none cursor-pointer">
+						&#x2715;
 					</button>
 				</div>
 
 				{/* Body: sidebar + content */}
 				<div className="flex min-h-[240px]">
 					{/* Sidebar */}
-					<div className="w-32 border-r border-glass-border p-2 flex flex-col gap-1">
+					<div className="w-32 border-r-2 border-panel-border p-2 flex flex-col gap-1 bg-panel-inner">
 						{CATEGORIES.map(({ key, label }) => (
 							<button
 								key={key}
@@ -93,8 +87,8 @@ export function PauseMenu() {
 									})
 								}
 								className={`
-									text-left text-[13px] px-3 py-1.5 rounded-slot cursor-pointer transition-colors
-									${activeCategory === key ? 'bg-glass-light text-white' : 'text-white/60 hover:text-white hover:bg-glass-hover'}
+									text-left text-[8px] px-3 py-1.5 cursor-pointer transition-colors
+									${activeCategory === key ? 'bg-btn text-text' : 'text-text-muted hover:text-text hover:bg-btn/30'}
 								`}>
 								{label}
 							</button>
@@ -102,16 +96,16 @@ export function PauseMenu() {
 					</div>
 
 					{/* Content */}
-					<div className="flex-1 p-4">
+					<div className="flex-1 p-4 bg-panel-inner">
 						<SettingsContent category={activeCategory} />
 					</div>
 				</div>
 
 				{/* Footer */}
-				<div className="flex justify-end px-4 py-3 border-t border-glass-border">
+				<div className="flex justify-end px-3 py-2 border-t-2 border-panel-border bg-panel-inner">
 					<button
 						onClick={() => dispatch({ type: 'CLOSE' })}
-						className="px-4 py-1.5 text-[13px] bg-glass-light border border-glass-border rounded-slot hover:bg-glass-hover cursor-pointer transition-colors">
+						className="px-4 py-1.5 text-[8px] bg-btn border border-btn-border hover:bg-btn-hover cursor-pointer transition-colors text-text">
 						Resume
 					</button>
 				</div>

--- a/apps/kbve/isometric/src/ui/modal/ModalOverlay.tsx
+++ b/apps/kbve/isometric/src/ui/modal/ModalOverlay.tsx
@@ -15,7 +15,7 @@ export function ModalOverlay() {
 
 	return createPortal(
 		<div
-			className="fixed inset-0 bg-overlay backdrop-blur-[8px] flex items-center justify-center pointer-events-auto"
+			className="fixed inset-0 bg-overlay flex items-center justify-center pointer-events-auto"
 			onClick={() => {
 				if (topModal.closeOnOverlayClick !== false) {
 					dispatch({ type: 'CLOSE' });
@@ -24,21 +24,23 @@ export function ModalOverlay() {
 			<div
 				className={`
 					${sizeClass} w-full mx-4
-					bg-glass backdrop-blur-[4px] rounded-panel border border-glass-border shadow-glass
+					bg-panel border-2 border-panel-border shadow-panel
 					animate-modal-in
 				`}
 				onClick={(e) => e.stopPropagation()}>
 				{/* Title bar */}
-				<div className="flex items-center justify-between px-4 py-3 border-b border-glass-border">
-					<h2 className="text-sm font-semibold">{topModal.title}</h2>
+				<div className="flex items-center justify-between px-3 py-2 border-b-2 border-panel-border bg-panel-inner">
+					<h2 className="text-[10px]">{topModal.title}</h2>
 					<button
 						onClick={() => dispatch({ type: 'CLOSE' })}
-						className="text-white/50 hover:text-white text-lg leading-none cursor-pointer">
-						&times;
+						className="text-text-muted hover:text-text text-[10px] leading-none cursor-pointer">
+						&#x2715;
 					</button>
 				</div>
 				{/* Content */}
-				<div className="p-4">{topModal.content}</div>
+				<div className="p-3 bg-panel-inner text-[8px]">
+					{topModal.content}
+				</div>
 			</div>
 		</div>,
 		getPortalRoot('modal-root'),

--- a/apps/kbve/isometric/src/ui/shared/GlassPanel.tsx
+++ b/apps/kbve/isometric/src/ui/shared/GlassPanel.tsx
@@ -8,7 +8,7 @@ interface GlassPanelProps {
 export function GlassPanel({ children, className = '' }: GlassPanelProps) {
 	return (
 		<div
-			className={`bg-glass backdrop-blur-[4px] rounded-panel border border-glass-border shadow-glass pointer-events-auto ${className}`}>
+			className={`bg-glass backdrop-blur-[4px] rounded-glass border border-glass-border shadow-glass pointer-events-auto ${className}`}>
 			{children}
 		</div>
 	);

--- a/apps/kbve/isometric/src/ui/shared/ProgressBar.tsx
+++ b/apps/kbve/isometric/src/ui/shared/ProgressBar.tsx
@@ -9,10 +9,10 @@ export function ProgressBar({ value, max, color, label }: ProgressBarProps) {
 	const pct = max > 0 ? (value / max) * 100 : 0;
 	return (
 		<div className="mb-1.5">
-			<div className="text-[11px] mb-0.5 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]">
+			<div className="text-[8px] mb-0.5">
 				{label}: {value}/{max}
 			</div>
-			<div className="w-[180px] h-3.5 bg-black/60 rounded-slot overflow-hidden border border-glass-border">
+			<div className="w-[180px] h-4 bg-slot border-2 border-panel-border-dark overflow-hidden">
 				<div
 					className={`h-full ${color} transition-[width] duration-300 ease-out`}
 					style={{ width: `${pct}%` }}

--- a/apps/kbve/isometric/src/ui/toast/ToastItem.tsx
+++ b/apps/kbve/isometric/src/ui/toast/ToastItem.tsx
@@ -19,22 +19,22 @@ export function ToastItem({ toast, onDismiss }: ToastItemProps) {
 	return (
 		<div
 			className={`
-				pointer-events-auto mb-2 px-3 py-2.5 min-w-[220px] max-w-[320px]
-				bg-glass backdrop-blur-[4px] rounded-toast shadow-toast
-				border border-glass-border border-l-4 ${borderClass}
+				pointer-events-auto mb-2 px-3 py-2 min-w-[220px] max-w-[320px]
+				bg-panel shadow-toast
+				border-2 border-panel-border border-l-4 ${borderClass}
 				${toast.exiting ? 'animate-toast-out' : 'animate-toast-in'}
 				flex items-start gap-2
 			`}
 			onAnimationEnd={() => {
 				if (toast.exiting) onDismiss(toast.id);
 			}}>
-			<span className="text-[13px] leading-snug flex-1">
+			<span className="text-[8px] leading-relaxed flex-1">
 				{toast.message}
 			</span>
 			<button
 				onClick={() => onDismiss(toast.id)}
-				className="text-white/50 hover:text-white text-sm leading-none mt-0.5 cursor-pointer">
-				&times;
+				className="text-text-muted hover:text-text text-[8px] leading-none mt-0.5 cursor-pointer">
+				&#x2715;
 			</button>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Restyle all 12 React UI components from glass-morphism to RPG pixel-art aesthetic inspired by RPGUI and CraftPix
- Add Press Start 2P pixel font, earthy color palette (dark wood panels, golden-brown borders, cream text), 4-direction black text shadow
- Solid RPG panels for modals, inventory, and pause menu; glass effect kept for HUD and FPS counter
- Green RPG action buttons, dark inset inventory slots, severity-colored toast borders

## Test plan
- [ ] Verify Press Start 2P font loads and renders across all components
- [ ] Check HUD stat bars (HP/MP) display with RPG styling
- [ ] Open modal via object interaction — confirm solid RPG dialog appearance
- [ ] Trigger toast notifications — verify severity border colors
- [ ] Open pause menu — confirm solid panel, green active tabs, resume button
- [ ] Check inventory grid — dark inset slots with brown borders
- [ ] Verify FPS counter badge in top-right corner
- [ ] Confirm text readability with black outline shadow against game background

🤖 Generated with [Claude Code](https://claude.com/claude-code)