### PR TITLE
feat(isometric): dual-tone edge detection shader

### DIFF
--- a/apps/kbve/isometric/src-tauri/assets/shaders/pixelate.wgsl
+++ b/apps/kbve/isometric/src-tauri/assets/shaders/pixelate.wgsl
@@ -2,9 +2,17 @@
 
 struct PixelateSettings {
     pixel_size: f32,
-    edge_strength: f32,
-    depth_edge_strength: f32,
+    highlight_strength: f32,
+    shadow_strength: f32,
     scale_factor: f32,
+    shadow_darkness: f32,
+    highlight_brightness: f32,
+    normal_threshold_low: f32,
+    normal_threshold_high: f32,
+    depth_threshold_low: f32,
+    depth_threshold_high: f32,
+    artifact_suppression: f32,
+    _padding: f32,
 }
 
 @group(0) @binding(0) var screen_texture: texture_2d<f32>;
@@ -15,6 +23,11 @@ struct PixelateSettings {
 fn sample_block(uv: vec2<f32>, resolution: vec2<f32>) -> vec4<f32> {
     let coord = vec2<i32>(clamp(uv * resolution, vec2(0.0), resolution - 1.0));
     return textureLoad(screen_texture, coord, 0);
+}
+
+// Perceived luminance (Rec. 709). Works on linear RGB (Tonemapping::None).
+fn luminance(c: vec3<f32>) -> f32 {
+    return dot(c, vec3(0.2126, 0.7152, 0.0722));
 }
 
 @fragment
@@ -32,45 +45,97 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let color = sample_block(block_uv, resolution);
 
     // Sample 4 neighbor blocks
-    let color_left = sample_block(((block - vec2(1.0, 0.0)) + 0.5) / block_count, resolution);
-    let color_top = sample_block(((block - vec2(0.0, 1.0)) + 0.5) / block_count, resolution);
-    let color_right = sample_block(((block + vec2(1.0, 0.0)) + 0.5) / block_count, resolution);
-    let color_bottom = sample_block(((block + vec2(0.0, 1.0)) + 0.5) / block_count, resolution);
+    let color_left   = sample_block(((block + vec2(-1.0,  0.0)) + 0.5) / block_count, resolution);
+    let color_right  = sample_block(((block + vec2( 1.0,  0.0)) + 0.5) / block_count, resolution);
+    let color_top    = sample_block(((block + vec2( 0.0, -1.0)) + 0.5) / block_count, resolution);
+    let color_bottom = sample_block(((block + vec2( 0.0,  1.0)) + 0.5) / block_count, resolution);
 
-    // --- Normal-like edge detection (color direction shift) ---
-    let norm_c = normalize(color.rgb + vec3(0.001));
-    let norm_l = normalize(color_left.rgb + vec3(0.001));
-    let norm_t = normalize(color_top.rgb + vec3(0.001));
-    let norm_r = normalize(color_right.rgb + vec3(0.001));
-    let norm_b = normalize(color_bottom.rgb + vec3(0.001));
+    // ── HIGHLIGHT EDGES (color direction shift) ──────────────────────────
+    // Normalized color vectors detect hue changes independent of brightness.
+    let eps = vec3(0.001);
+    let norm_c = normalize(color.rgb + eps);
+    let norm_l = normalize(color_left.rgb + eps);
+    let norm_r = normalize(color_right.rgb + eps);
+    let norm_t = normalize(color_top.rgb + eps);
+    let norm_b = normalize(color_bottom.rgb + eps);
 
-    let hue_diff = max(
+    let normal_diff = max(
         max(length(norm_c - norm_l), length(norm_c - norm_r)),
         max(length(norm_c - norm_t), length(norm_c - norm_b))
     );
-    let normal_edge = smoothstep(0.15, 0.45, hue_diff) * settings.edge_strength;
+    let normal_edge = smoothstep(
+        settings.normal_threshold_low,
+        settings.normal_threshold_high,
+        normal_diff
+    ) * settings.highlight_strength;
 
-    // --- Depth-like edge detection (large absolute color jumps) ---
-    let diff_max = max(
-        max(length(color.rgb - color_left.rgb), length(color.rgb - color_right.rgb)),
-        max(length(color.rgb - color_top.rgb), length(color.rgb - color_bottom.rgb))
+    // ── SHADOW EDGES (luminance-based depth proxy, two-sided) ────────────
+    // Luminance better approximates depth discontinuities than raw RGB
+    // distance because brightness correlates with light-facing vs occluded.
+    let lum_c = luminance(color.rgb);
+    let lum_l = luminance(color_left.rgb);
+    let lum_r = luminance(color_right.rgb);
+    let lum_t = luminance(color_top.rgb);
+    let lum_b = luminance(color_bottom.rgb);
+
+    // Positive: neighbor brighter (outer silhouette, center in shadow)
+    let pos_depth = max(
+        max(lum_l - lum_c, lum_r - lum_c),
+        max(lum_t - lum_c, lum_b - lum_c)
     );
-    let depth_edge = smoothstep(0.30, 0.70, diff_max) * settings.depth_edge_strength;
 
-    let edge_factor = min(max(normal_edge, depth_edge), 1.0);
+    // Negative: center brighter (inner edge, center lit)
+    let neg_depth = max(
+        max(lum_c - lum_l, lum_c - lum_r),
+        max(lum_c - lum_t, lum_c - lum_b)
+    );
 
-    // Darken at block boundaries where edges are detected
-    var final_edge: f32;
+    // Either direction means a depth-like boundary
+    let depth_raw = max(pos_depth, neg_depth);
+    let depth_edge = smoothstep(
+        settings.depth_threshold_low,
+        settings.depth_threshold_high,
+        depth_raw
+    ) * settings.shadow_strength;
+
+    // ── ARTIFACT SUPPRESSION ─────────────────────────────────────────────
+    // Where depth and normal edges coincide, suppress highlights to avoid
+    // double-lining (dark shadow + bright highlight side by side).
+    let neg_depth_edge = smoothstep(
+        settings.depth_threshold_low,
+        settings.depth_threshold_high,
+        neg_depth
+    );
+    let suppressed_highlight = clamp(
+        normal_edge - neg_depth_edge * settings.artifact_suppression,
+        0.0,
+        1.0
+    );
+
+    // ── BLOCK-BOUNDARY GATING ────────────────────────────────────────────
+    // For pixel_size >= 1.5, edges only render at block borders for a
+    // classic pixel-art grid-aligned outline look.
+    var at_edge: f32;
     if settings.pixel_size < 1.5 {
-        final_edge = edge_factor;
+        at_edge = 1.0;
     } else {
         let block_pos = fract(in.uv * block_count);
         let edge_width = 1.0 / settings.pixel_size;
-        let at_edge = select(0.0, 1.0,
+        at_edge = select(0.0, 1.0,
             block_pos.x < edge_width || block_pos.y < edge_width);
-        final_edge = edge_factor * at_edge;
     }
 
-    let result = mix(color.rgb, color.rgb * 0.35, final_edge);
+    let final_shadow = depth_edge * at_edge;
+    let final_highlight = suppressed_highlight * at_edge;
+
+    // ── DUAL-TONE COMPOSITING ────────────────────────────────────────────
+    // Shadow first: depth edges darken toward (color * shadow_darkness).
+    let shadow_color = color.rgb * settings.shadow_darkness;
+    var result = mix(color.rgb, shadow_color, final_shadow);
+
+    // Highlight on top: normal edges brighten toward white.
+    let highlight_color = mix(result, vec3(1.0), settings.highlight_brightness);
+    result = mix(result, highlight_color, final_highlight);
+
     return vec4(result, color.a);
 }

--- a/apps/kbve/isometric/src-tauri/src/game/camera.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/camera.rs
@@ -6,6 +6,7 @@ use bevy::render::render_resource::TextureFormat;
 use bevy::window::PrimaryWindow;
 use bevy_rapier3d::prelude::PhysicsSet;
 
+use super::pixelate::PixelateSettings;
 use super::player::{Player, PlayerMovement};
 
 const CAMERA_OFFSET: Vec3 = Vec3::new(15.0, 20.0, 15.0);
@@ -122,6 +123,7 @@ fn setup_camera(
         }),
         Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
         RenderLayers::layer(DISPLAY_LAYER),
+        PixelateSettings::default(),
     ));
 
     // Fullscreen quad with the render texture (unlit = display pixels as-is).

--- a/apps/kbve/isometric/src-tauri/src/game/pixelate.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/pixelate.rs
@@ -10,21 +10,44 @@ use bevy::shader::ShaderRef;
 pub struct PixelateSettings {
     /// Size of each pixel block (in logical pixels).
     pub pixel_size: f32,
-    /// Strength of normal-like edge outlines (0.0 = off, 1.0 = full).
-    pub edge_strength: f32,
-    /// Strength of depth-like edge outlines (0.0 = off, 1.0 = full).
-    pub depth_edge_strength: f32,
+    /// Strength of highlight edges from color-direction shifts (0.0 = off, 1.0 = full).
+    pub highlight_strength: f32,
+    /// Strength of shadow edges from luminance jumps (0.0 = off, 1.0 = full).
+    pub shadow_strength: f32,
     /// Window DPI scale factor (auto-updated from the window).
     pub scale_factor: f32,
+    /// How dark shadow edges get (0.0 = black, 1.0 = original color).
+    pub shadow_darkness: f32,
+    /// How bright highlight edges get (0.0 = no brightening, 1.0 = full white).
+    pub highlight_brightness: f32,
+    /// Smoothstep low threshold for normal (hue) edge detection.
+    pub normal_threshold_low: f32,
+    /// Smoothstep high threshold for normal (hue) edge detection.
+    pub normal_threshold_high: f32,
+    /// Smoothstep low threshold for depth (luminance) edge detection.
+    pub depth_threshold_low: f32,
+    /// Smoothstep high threshold for depth (luminance) edge detection.
+    pub depth_threshold_high: f32,
+    /// Suppresses highlights at hard depth edges to avoid double-lining.
+    pub artifact_suppression: f32,
+    pub _padding: f32,
 }
 
 impl Default for PixelateSettings {
     fn default() -> Self {
         Self {
             pixel_size: 2.0,
-            edge_strength: 0.3,
-            depth_edge_strength: 0.2,
+            highlight_strength: 0.6,
+            shadow_strength: 0.5,
             scale_factor: 1.0,
+            shadow_darkness: 0.3,
+            highlight_brightness: 0.35,
+            normal_threshold_low: 0.12,
+            normal_threshold_high: 0.40,
+            depth_threshold_low: 0.25,
+            depth_threshold_high: 0.65,
+            artifact_suppression: 1.0,
+            _padding: 0.0,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rewrite pixelate shader with dual-tone edge detection inspired by Godot 3D pixel-art demo
- Shadow edges use Rec.709 luminance as a depth proxy with two-sided detection (outer silhouettes + inner edges)
- Highlight edges use color-direction divergence for bright rim outlines on surface boundaries
- Artifact suppression prevents double-lining where both edge types coincide
- Expand PixelateSettings from 4 to 12 configurable uniforms (thresholds, colors, strengths)
- Attach PixelateSettings to the display camera to activate the previously dormant post-process effect

## Test plan
- [ ] Verify dual-tone edges render: dark outlines on depth boundaries, bright rims on color-direction shifts
- [ ] Confirm no double-lining artifacts at hard depth edges
- [ ] Check that pixel block boundary gating still works at pixel_size >= 1.5
- [ ] Verify shadow/highlight strengths are visually balanced at default values
- [ ] Confirm no regression in game performance (shader runs per-fragment on display camera)