### PR TITLE
feat(isometric): responsive UI scaling with Tailwind md breakpoints

### DIFF
--- a/apps/kbve/isometric/src/components/FPSCounter.tsx
+++ b/apps/kbve/isometric/src/components/FPSCounter.tsx
@@ -16,7 +16,7 @@ export function FPSCounter() {
 	}, []);
 
 	return (
-		<div className="absolute top-2 right-2 px-2 py-1 bg-panel border border-panel-border text-[7px] text-text-muted pointer-events-auto">
+		<div className="absolute top-2 right-2 md:top-3 md:right-3 px-2 py-1 md:px-3 md:py-1.5 bg-panel border border-panel-border text-[7px] md:text-[10px] text-text-muted pointer-events-auto">
 			{fps} FPS
 		</div>
 	);

--- a/apps/kbve/isometric/src/components/HUD.tsx
+++ b/apps/kbve/isometric/src/components/HUD.tsx
@@ -30,7 +30,7 @@ export function HUD() {
 	if (!state) return null;
 
 	return (
-		<GlassPanel className="absolute bottom-4 left-4 px-3 py-2">
+		<GlassPanel className="absolute bottom-4 left-4 md:bottom-6 md:left-6 px-3 py-2 md:px-4 md:py-3">
 			<ProgressBar
 				label="HP"
 				value={state.health}
@@ -43,7 +43,7 @@ export function HUD() {
 				max={state.max_mana}
 				color="bg-mp"
 			/>
-			<div className="text-[7px] text-text-muted mt-1">
+			<div className="text-[7px] md:text-[9px] text-text-muted mt-1">
 				Pos: {state.position.map((v) => v.toFixed(1)).join(', ')}
 			</div>
 		</GlassPanel>

--- a/apps/kbve/isometric/src/components/Inventory.tsx
+++ b/apps/kbve/isometric/src/components/Inventory.tsx
@@ -5,21 +5,21 @@ export function Inventory() {
 	const slots = Array.from({ length: GRID_COLS * GRID_ROWS });
 
 	return (
-		<div className="absolute bottom-4 right-4 pointer-events-auto">
+		<div className="absolute bottom-4 right-4 md:bottom-6 md:right-6 pointer-events-auto">
 			{/* Outer frame — golden border */}
 			<div className="border-[3px] border-panel-border shadow-[0_0_0_1px_#1a1008,0_4px_12px_rgba(0,0,0,0.6)]">
 				{/* Inner frame — dark inset */}
-				<div className="border-2 border-[#1a1008] bg-panel-inner p-2">
-					<div className="text-[7px] mb-1.5 text-center text-[#c8a832]">
+				<div className="border-2 border-[#1a1008] bg-panel-inner p-2 md:p-3">
+					<div className="text-[7px] md:text-[10px] mb-1.5 md:mb-2 text-center text-[#c8a832]">
 						Inventory
 					</div>
 					{/* Slot grid inside inset panel */}
-					<div className="p-1 bg-[#1e1408] border border-[#5a4a2a]">
-						<div className="grid grid-cols-4 gap-px">
+					<div className="p-1 md:p-1.5 bg-[#1e1408] border border-[#5a4a2a]">
+						<div className="grid grid-cols-4 gap-px md:gap-0.5">
 							{slots.map((_, i) => (
 								<div
 									key={i}
-									className="w-7 h-7 bg-[#261a0a] border border-[#3d2b14]
+									className="w-7 h-7 md:w-11 md:h-11 bg-[#261a0a] border border-[#3d2b14]
 										shadow-[inset_0_1px_2px_rgba(0,0,0,0.4)]"
 								/>
 							))}

--- a/apps/kbve/isometric/src/hooks/useObjectSelection.tsx
+++ b/apps/kbve/isometric/src/hooks/useObjectSelection.tsx
@@ -70,17 +70,17 @@ const FLOWER_INFO: Record<
 
 function ActionContent({ info }: { info: ObjectInfo }) {
 	return (
-		<div className="space-y-2">
+		<div className="space-y-2 md:space-y-3">
 			{/* Description in inset panel */}
-			<div className="px-2 py-1.5 bg-[#1e1408] border border-[#5a4a2a]">
-				<p className="text-[8px] text-text leading-relaxed">
+			<div className="px-2 py-1.5 md:px-3 md:py-2 bg-[#1e1408] border border-[#5a4a2a]">
+				<p className="text-[8px] md:text-xs text-text leading-relaxed">
 					{info.description}
 				</p>
 			</div>
 			{/* Centered RPG button */}
 			<div className="flex justify-center pt-1">
 				<button
-					className="px-4 py-1.5 text-[8px] text-text
+					className="px-4 py-1.5 md:px-6 md:py-2 text-[8px] md:text-xs text-text
 						bg-btn border-2 border-btn-border
 						shadow-[inset_0_1px_0_rgba(255,255,255,0.15),0_2px_0_#1a3a10]
 						hover:bg-btn-hover active:bg-btn-active active:shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)]
@@ -138,7 +138,7 @@ export function useObjectSelection() {
 
 				gameEvents.emit('modal:open', {
 					title: info.title,
-					size: 'xs' as const,
+					size: 'sm' as const,
 					content: <ActionContent info={info} />,
 					onClose: () => {
 						modalOpenRef.current = false;

--- a/apps/kbve/isometric/src/ui/modal/ModalOverlay.tsx
+++ b/apps/kbve/isometric/src/ui/modal/ModalOverlay.tsx
@@ -32,22 +32,22 @@ export function ModalOverlay() {
 				onClick={(e) => e.stopPropagation()}>
 				{/* Inner frame — dark inset border for depth */}
 				<div className="border-2 border-[#1a1008]">
-					{/* Title bar — darker strip with centered title */}
-					<div className="flex items-center justify-between px-3 py-2 bg-[#1e1408] border-b border-[#5a4a2a]">
-						<h2 className="text-[10px] text-[#c8a832]">
+					{/* Title bar */}
+					<div className="flex items-center justify-between px-3 py-2 md:px-4 md:py-3 bg-[#1e1408] border-b border-[#5a4a2a]">
+						<h2 className="text-[10px] md:text-sm text-[#c8a832]">
 							{topModal.title}
 						</h2>
 						<button
 							onClick={() => dispatch({ type: 'CLOSE' })}
-							className="w-5 h-5 flex items-center justify-center
+							className="w-5 h-5 md:w-7 md:h-7 flex items-center justify-center
 								bg-[#3d2b14] border border-[#5a4a2a]
 								text-text-muted hover:text-[#c8a832] hover:border-panel-border
-								text-[8px] leading-none cursor-pointer transition-colors">
+								text-[8px] md:text-xs leading-none cursor-pointer transition-colors">
 							&#x2715;
 						</button>
 					</div>
-					{/* Content area — wood panel background */}
-					<div className="p-3 bg-panel-inner text-[8px]">
+					{/* Content area */}
+					<div className="p-3 md:p-4 bg-panel-inner text-[8px] md:text-xs">
 						{topModal.content}
 					</div>
 				</div>

--- a/apps/kbve/isometric/src/ui/shared/ProgressBar.tsx
+++ b/apps/kbve/isometric/src/ui/shared/ProgressBar.tsx
@@ -8,11 +8,11 @@ interface ProgressBarProps {
 export function ProgressBar({ value, max, color, label }: ProgressBarProps) {
 	const pct = max > 0 ? (value / max) * 100 : 0;
 	return (
-		<div className="mb-1.5">
-			<div className="text-[8px] mb-0.5">
+		<div className="mb-1.5 md:mb-2">
+			<div className="text-[8px] md:text-[10px] mb-0.5">
 				{label}: {value}/{max}
 			</div>
-			<div className="w-[180px] h-4 bg-slot border-2 border-panel-border-dark overflow-hidden">
+			<div className="w-[140px] md:w-[200px] h-3 md:h-5 bg-slot border-2 border-panel-border-dark overflow-hidden">
 				<div
 					className={`h-full ${color} transition-[width] duration-300 ease-out`}
 					style={{ width: `${pct}%` }}

--- a/apps/kbve/isometric/src/ui/toast/ToastItem.tsx
+++ b/apps/kbve/isometric/src/ui/toast/ToastItem.tsx
@@ -19,7 +19,7 @@ export function ToastItem({ toast, onDismiss }: ToastItemProps) {
 	return (
 		<div
 			className={`
-				pointer-events-auto mb-2 px-3 py-2 min-w-[220px] max-w-[320px]
+				pointer-events-auto mb-2 px-3 py-2 md:px-4 md:py-3 min-w-[180px] md:min-w-[260px] max-w-[280px] md:max-w-[380px]
 				bg-panel shadow-toast
 				border-2 border-panel-border border-l-4 ${borderClass}
 				${toast.exiting ? 'animate-toast-out' : 'animate-toast-in'}
@@ -28,12 +28,12 @@ export function ToastItem({ toast, onDismiss }: ToastItemProps) {
 			onAnimationEnd={() => {
 				if (toast.exiting) onDismiss(toast.id);
 			}}>
-			<span className="text-[8px] leading-relaxed flex-1">
+			<span className="text-[8px] md:text-xs leading-relaxed flex-1">
 				{toast.message}
 			</span>
 			<button
 				onClick={() => onDismiss(toast.id)}
-				className="text-text-muted hover:text-text text-[8px] leading-none mt-0.5 cursor-pointer">
+				className="text-text-muted hover:text-text text-[8px] md:text-xs leading-none mt-0.5 cursor-pointer">
 				&#x2715;
 			</button>
 		</div>


### PR DESCRIPTION
## Summary
- Add responsive `md:` breakpoints to all RPG UI components so they scale up on desktop (768px+) while staying compact on mobile
- Modal: title 10px→14px, content 8px→12px, close button 20px→28px, padding scales up
- Inventory: slots 28px→44px, gaps and padding scale, title text 7px→10px
- Progress bars: width 140px→200px, height 12px→20px, label text 8px→10px
- Toasts: text 8px→12px, min/max width scales, padding increases
- FPS counter: text 7px→10px, padding scales
- Object selection modal bumped from `xs` to `sm` for better desktop readability

## Test plan
- [ ] Verify mobile/small screen (<768px) renders same compact sizes as before
- [ ] Verify desktop (768px+) UI elements scale up to readable sizes
- [ ] Check modal, inventory, HUD, toasts, and FPS counter at both breakpoints