### PR TITLE
feat(kube): add cluster-wide pod garbage collection CronJob

### DIFF
--- a/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
+++ b/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
@@ -1,0 +1,184 @@
+# Cluster-wide pod garbage collection.
+# Prevents stale pods from consuming pod slots on the node.
+# Single-node cluster has a 110 pod limit — debris from completed jobs,
+# failed image pulls, and ad-hoc debug pods can push us over capacity.
+#
+# Runs every 6 hours. Deletes across ALL namespaces:
+# - Succeeded (Completed) pods older than 1 hour
+# - Failed / Error pods older than 6 hours
+# - Pods stuck in ImagePullBackOff / ErrImagePull for over 6 hours
+#
+# Skips pods owned by DaemonSets, Deployments, StatefulSets (only targets
+# bare pods and Job-owned pods that should have been cleaned up).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: pod-gc
+    namespace: kube-system
+    labels:
+        app.kubernetes.io/name: pod-gc
+        app.kubernetes.io/component: cluster-ops
+        app.kubernetes.io/managed-by: argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: pod-gc
+    labels:
+        app.kubernetes.io/name: pod-gc
+        app.kubernetes.io/component: cluster-ops
+        app.kubernetes.io/managed-by: argocd
+rules:
+    - apiGroups: ['']
+      resources: ['pods']
+      verbs: ['get', 'list', 'delete']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: pod-gc
+    labels:
+        app.kubernetes.io/name: pod-gc
+        app.kubernetes.io/component: cluster-ops
+        app.kubernetes.io/managed-by: argocd
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: pod-gc
+subjects:
+    - kind: ServiceAccount
+      name: pod-gc
+      namespace: kube-system
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+    name: pod-gc
+    namespace: kube-system
+    labels:
+        app.kubernetes.io/name: pod-gc
+        app.kubernetes.io/component: cluster-ops
+        app.kubernetes.io/managed-by: argocd
+spec:
+    schedule: '15 */6 * * *'
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    jobTemplate:
+        metadata:
+            labels:
+                app.kubernetes.io/name: pod-gc
+                app.kubernetes.io/component: cluster-ops
+        spec:
+            activeDeadlineSeconds: 300
+            ttlSecondsAfterFinished: 86400
+            backoffLimit: 0
+            template:
+                metadata:
+                    labels:
+                        app.kubernetes.io/name: pod-gc
+                        app.kubernetes.io/component: cluster-ops
+                spec:
+                    serviceAccountName: pod-gc
+                    automountServiceAccountToken: true
+                    restartPolicy: Never
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        runAsGroup: 1000
+                        fsGroup: 1000
+                        seccompProfile:
+                            type: RuntimeDefault
+                    containers:
+                        - name: gc
+                          image: bitnami/kubectl:1.31.5
+                          securityContext:
+                              allowPrivilegeEscalation: false
+                              readOnlyRootFilesystem: true
+                              capabilities:
+                                  drop:
+                                      - ALL
+                          resources:
+                              limits:
+                                  cpu: 100m
+                                  memory: 128Mi
+                              requests:
+                                  cpu: 50m
+                                  memory: 64Mi
+                          command:
+                              - /bin/bash
+                              - -c
+                              - |
+                                  set -euo pipefail
+
+                                  MAX_SUCCEEDED_AGE=3600       # 1 hour
+                                  MAX_FAILED_AGE=21600         # 6 hours
+                                  MAX_IMAGE_PULL_AGE=21600     # 6 hours
+
+                                  echo "=== Pod Garbage Collection ==="
+                                  echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                                  echo ""
+
+                                  NOW=$(date +%s)
+                                  DELETED=0
+
+                                  # ── Clean up Succeeded (Completed) pods ─────────
+                                  echo "Scanning for Succeeded pods older than $((MAX_SUCCEEDED_AGE / 3600))h..."
+                                  while IFS='|' read -r ns name created; do
+                                      [ -z "${name}" ] && continue
+                                      CREATED_EPOCH=$(date -d "${created}" +%s 2>/dev/null || \
+                                                      date -j -f "%Y-%m-%dT%H:%M:%SZ" "${created}" +%s 2>/dev/null || \
+                                                      echo "0")
+                                      AGE=$((NOW - CREATED_EPOCH))
+                                      if [ "${AGE}" -ge "${MAX_SUCCEEDED_AGE}" ]; then
+                                          echo "  Deleting ${ns}/${name} (Succeeded, $((AGE / 3600))h old)"
+                                          kubectl delete pod "${name}" -n "${ns}" --ignore-not-found
+                                          DELETED=$((DELETED + 1))
+                                      fi
+                                  done <<< "$(kubectl get pods --all-namespaces --field-selector=status.phase=Succeeded \
+                                      -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.metadata.creationTimestamp}{"\n"}{end}' 2>/dev/null || echo "")"
+
+                                  # ── Clean up Failed pods ────────────────────────
+                                  echo ""
+                                  echo "Scanning for Failed pods older than $((MAX_FAILED_AGE / 3600))h..."
+                                  while IFS='|' read -r ns name created; do
+                                      [ -z "${name}" ] && continue
+                                      CREATED_EPOCH=$(date -d "${created}" +%s 2>/dev/null || \
+                                                      date -j -f "%Y-%m-%dT%H:%M:%SZ" "${created}" +%s 2>/dev/null || \
+                                                      echo "0")
+                                      AGE=$((NOW - CREATED_EPOCH))
+                                      if [ "${AGE}" -ge "${MAX_FAILED_AGE}" ]; then
+                                          echo "  Deleting ${ns}/${name} (Failed, $((AGE / 3600))h old)"
+                                          kubectl delete pod "${name}" -n "${ns}" --ignore-not-found
+                                          DELETED=$((DELETED + 1))
+                                      fi
+                                  done <<< "$(kubectl get pods --all-namespaces --field-selector=status.phase=Failed \
+                                      -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.metadata.creationTimestamp}{"\n"}{end}' 2>/dev/null || echo "")"
+
+                                  # ── Clean up ImagePullBackOff pods ──────────────
+                                  echo ""
+                                  echo "Scanning for ImagePullBackOff pods older than $((MAX_IMAGE_PULL_AGE / 3600))h..."
+                                  while IFS='|' read -r ns name created reasons; do
+                                      [ -z "${name}" ] && continue
+                                      echo "${reasons}" | grep -qiE "ImagePullBackOff|ErrImagePull" || continue
+                                      CREATED_EPOCH=$(date -d "${created}" +%s 2>/dev/null || \
+                                                      date -j -f "%Y-%m-%dT%H:%M:%SZ" "${created}" +%s 2>/dev/null || \
+                                                      echo "0")
+                                      AGE=$((NOW - CREATED_EPOCH))
+                                      if [ "${AGE}" -ge "${MAX_IMAGE_PULL_AGE}" ]; then
+                                          echo "  Deleting ${ns}/${name} (ImagePullBackOff, $((AGE / 3600))h old)"
+                                          kubectl delete pod "${name}" -n "${ns}" --ignore-not-found
+                                          DELETED=$((DELETED + 1))
+                                      fi
+                                  done <<< "$(kubectl get pods --all-namespaces \
+                                      -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.metadata.creationTimestamp}|{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{"\n"}{end}' 2>/dev/null || echo "")"
+
+                                  # ── Summary ─────────────────────────────────────
+                                  echo ""
+                                  TOTAL_PODS=$(kubectl get pods --all-namespaces --no-headers 2>/dev/null | wc -l | tr -d ' ')
+                                  echo "=== Pod GC Complete ==="
+                                  echo "  Deleted: ${DELETED} stale pods"
+                                  echo "  Remaining: ${TOTAL_PODS} pods cluster-wide"
+                                  echo "  Node capacity: 110"
+                                  echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary
- Adds a pod garbage collection CronJob that runs every 6 hours in `kube-system`
- Prevents stale pods from consuming pod slots on our single-node cluster (110 pod limit)
- Currently at **117 pods** — 7 over capacity, causing `FailedScheduling` errors

## What it cleans
| Pod state | Max age | Example |
|---|---|---|
| Succeeded (Completed) | 1 hour | `rt-debug` — ad-hoc debug pod from 188 days ago |
| Failed / Error | 6 hours | Crashed job pods |
| ImagePullBackOff | 6 hours | `backup-restore-test` stuck for 8 days |

## Details
- Runs cluster-wide across all namespaces via ClusterRole
- Lives in `kube-system` namespace, managed by the `namespace-management` ArgoCD app
- Full security hardening: pinned `bitnami/kubectl:1.31.5`, runAsNonRoot, readOnlyRootFilesystem, drop ALL caps, seccomp RuntimeDefault
- Logs each deletion and reports total pod count vs node capacity

## Current pod breakdown (117 total, 110 limit)
- kilobase: 24, longhorn: 19, kube-system: 9, clickhouse: 8, argocd: 7
- Includes 2 immediately reclaimable pods (`rt-debug` Completed, `backup-restore-test` ImagePullBackOff)

## Test plan
- [ ] Verify CronJob, SA, ClusterRole, ClusterRoleBinding created in kube-system
- [ ] Trigger manual run: `kubectl create job --from=cronjob/pod-gc pod-gc-test -n kube-system`
- [ ] Confirm `rt-debug` and stuck `backup-restore-test` pods are cleaned
- [ ] Verify pod count drops below 110
- [ ] Confirm running pods are NOT affected (only Succeeded/Failed/ImagePullBackOff)