### PR TITLE
fix(kbve): fix ArgoCD proxy 502 showing unknown reason

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoDashboard.tsx
@@ -883,7 +883,11 @@ export default function ReactArgoDashboard() {
 								? 'The upstream server did not respond in time. It may be starting up or under heavy load.'
 								: errorReason === 'connection failed'
 									? 'Unable to connect to the ArgoCD server. The service may be down or restarting.'
-									: `Reason: ${errorReason}`}
+									: errorReason?.startsWith(
+												'upstream returned',
+										  )
+										? `The ArgoCD server responded with an error (${errorReason}). It may be misconfigured or experiencing issues.`
+										: `Reason: ${errorReason}`}
 						</div>
 					)}
 				</div>

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -119,9 +119,11 @@ impl ServiceProxy {
             }
         };
 
-        let status = StatusCode::from_u16(upstream_resp.status().as_u16())
-            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let upstream_status = upstream_resp.status().as_u16();
+        let status =
+            StatusCode::from_u16(upstream_status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
+        // Collect headers before consuming the body
         let mut resp_headers = HeaderMap::new();
         for (k, v) in upstream_resp.headers() {
             if let Ok(name) = axum::http::HeaderName::from_bytes(k.as_str().as_bytes()) {
@@ -142,6 +144,29 @@ impl ServiceProxy {
                     .into_response();
             }
         };
+
+        // When upstream returns a server error (5xx), wrap in our standard
+        // format so the frontend always gets a parseable {"reason", "detail"}
+        // response instead of raw upstream HTML/text.
+        if upstream_status >= 500 {
+            let body_preview =
+                String::from_utf8_lossy(&resp_body[..resp_body.len().min(512)]).to_string();
+
+            warn!(
+                %upstream_url, upstream_status,
+                "{} upstream returned {}: {}", self.name, upstream_status, body_preview
+            );
+
+            return (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(json!({
+                    "error": format!("{} upstream error", self.name),
+                    "reason": format!("upstream returned {upstream_status}"),
+                    "detail": body_preview,
+                })),
+            )
+                .into_response();
+        }
 
         let mut response = Response::builder().status(status);
         if let Some(h) = response.headers_mut() {


### PR DESCRIPTION
## Summary
- When ArgoCD upstream returns a 5xx error, the proxy now wraps it in the standard `{"error","reason","detail"}` JSON format instead of blindly relaying the raw upstream body
- This fixes the dashboard showing "Reason: unknown" because the frontend couldn't parse ArgoCD's raw HTML/text error response
- Improved frontend error message for upstream error codes (e.g. "upstream returned 502")
- Applies to both ArgoCD and Grafana proxies (shared `ServiceProxy::forward`)

## Root cause
The `ServiceProxy::forward` method only returned structured JSON when `reqwest::send()` itself failed (connection/timeout). When the upstream **responded** with a 5xx, the raw body was relayed — which the frontend couldn't parse as `{reason}`.

## Test plan
- [ ] Verify ArgoCD dashboard shows descriptive error when upstream is down
- [ ] Verify normal 2xx responses still pass through correctly
- [ ] Verify 4xx responses from upstream still pass through (only 5xx is wrapped)