### PR TITLE
fix(axum-kbve): use Astro-generated Starlight profile templates

### DIFF
--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -9,6 +9,7 @@
 			"options": {
 				"commands": [
 					"./kbve.sh -nx astro-kbve:build",
+					"rm -rf ./apps/kbve/axum-kbve/templates/dist && mkdir -p ./apps/kbve/axum-kbve/templates/dist && cp -a ./dist/apps/astro-kbve/. ./apps/kbve/axum-kbve/templates/dist/",
 					"STATIC_DIR=./dist/apps/astro-kbve STATIC_PRECOMPRESSED=false cargo run -p axum-kbve"
 				],
 				"parallel": false

--- a/apps/kbve/axum-kbve/src/astro/askama.rs
+++ b/apps/kbve/axum-kbve/src/astro/askama.rs
@@ -73,7 +73,7 @@ pub struct RentEarthCharacterDisplay {
 
 /// User profile page template (Astro-built)
 #[derive(Template)]
-#[template(path = "askama/profile/index.html")]
+#[template(path = "dist/askama/profile/index.html")]
 pub struct ProfileTemplate {
     pub username: String,
     pub username_first_char: String,
@@ -112,7 +112,7 @@ pub struct ProfileTemplate {
 
 /// Profile not found template (Astro-built)
 #[derive(Template)]
-#[template(path = "askama/profile_not_found/index.html")]
+#[template(path = "dist/askama/profile_not_found/index.html")]
 pub struct ProfileNotFoundTemplate {
     pub username: String,
 }


### PR DESCRIPTION
## Summary
- Point Askama `ProfileTemplate` and `ProfileNotFoundTemplate` paths from `askama/` to `dist/askama/`, picking up the Astro-built Starlight-wrapped templates instead of standalone hand-written HTML
- The Dockerfile already copies Astro build output to `templates/dist/` (line 160), so no Docker changes needed
- Add copy step to `dev` target in project.json so local dev also uses Astro-generated templates

## Context
Profile pages (`/@username`) were missing Starlight header/footer because the Askama template was a standalone HTML page. The Astro build already generates a Starlight-wrapped version at `dist/askama/profile/index.html` with all Askama `{{ }}` and `{% %}` syntax intact — this PR simply wires up the Rust code to use it.

## Test plan
- [ ] Verify `kbve.com/@h0lybyte` renders with Starlight header and footer
- [ ] Verify profile data (avatar, connected accounts, badges) still renders correctly
- [ ] Verify profile not found page also has Starlight chrome