### PR TITLE
fix(axum-kbve): revert template paths to fix lint, override in Dockerfile

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -167,8 +167,9 @@ COPY packages/rust/kbve packages/rust/kbve
 # Application source (most frequently changing — placed last for cache)
 COPY apps/kbve/axum-kbve apps/kbve/axum-kbve
 
-# Copy Askama templates
+# Copy Askama templates, then overwrite with Astro-generated Starlight versions
 COPY apps/kbve/axum-kbve/templates/askama /app/apps/kbve/axum-kbve/templates/askama
+RUN cp -a /app/apps/kbve/axum-kbve/templates/dist/askama/. /app/apps/kbve/axum-kbve/templates/askama/
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -9,7 +9,6 @@
 			"options": {
 				"commands": [
 					"./kbve.sh -nx astro-kbve:build",
-					"rm -rf ./apps/kbve/axum-kbve/templates/dist && mkdir -p ./apps/kbve/axum-kbve/templates/dist && cp -a ./dist/apps/astro-kbve/. ./apps/kbve/axum-kbve/templates/dist/",
 					"STATIC_DIR=./dist/apps/astro-kbve STATIC_PRECOMPRESSED=false cargo run -p axum-kbve"
 				],
 				"parallel": false

--- a/apps/kbve/axum-kbve/src/astro/askama.rs
+++ b/apps/kbve/axum-kbve/src/astro/askama.rs
@@ -73,7 +73,7 @@ pub struct RentEarthCharacterDisplay {
 
 /// User profile page template (Astro-built)
 #[derive(Template)]
-#[template(path = "dist/askama/profile/index.html")]
+#[template(path = "askama/profile/index.html")]
 pub struct ProfileTemplate {
     pub username: String,
     pub username_first_char: String,
@@ -112,7 +112,7 @@ pub struct ProfileTemplate {
 
 /// Profile not found template (Astro-built)
 #[derive(Template)]
-#[template(path = "dist/askama/profile_not_found/index.html")]
+#[template(path = "askama/profile_not_found/index.html")]
 pub struct ProfileNotFoundTemplate {
     pub username: String,
 }


### PR DESCRIPTION
## Summary
- Revert Askama template paths from `dist/askama/` back to `askama/` so `cargo clippy` (lint) works without a full Astro build
- Dockerfile now overwrites hand-written templates with Astro-generated Starlight versions via `cp -a` before `cargo build --release`
- Remove unnecessary copy step from the dev target in project.json

## Test plan
- [x] `nx run axum-kbve:lint` passes locally
- [ ] Docker build produces Starlight-wrapped profile pages