### PR TITLE
chore(kbve): bump lru from 0.12 to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
  "jedi",
  "jsonwebtoken",
  "kbve",
- "lru 0.16.3",
+ "lru",
  "num_cpus",
  "prost",
  "prost-build",
@@ -7280,7 +7280,7 @@ dependencies = [
  "dotenvy",
  "jedi",
  "jsonwebtoken",
- "lru 0.12.5",
+ "lru",
  "num-bigint 0.4.6",
  "once_cell",
  "r2d2",
@@ -7575,15 +7575,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "lru"

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -52,7 +52,7 @@ regex = "1.10.2"
 once_cell = "1"
 ulid = "1.1.0"
 num-bigint = "0.4"
-lru = { version = "0.12", optional = true }
+lru = { version = "0.16", optional = true }
 resvg = { version = "0.47.0", optional = true }
 jedi = { path = "../jedi" }
 


### PR DESCRIPTION
## Summary
- Bumps `lru` dependency in `packages/rust/kbve` from 0.12 to 0.16 (resolves #7816)
- All 57 unit tests pass, clippy clean with `--all-features`

## Test plan
- [x] `cargo clippy -p kbve --all-features -- -D warnings` passes
- [x] `cargo test -p kbve --all-features` — 57 tests pass