### PR TITLE
fix(isometric): pin wasm-bindgen and improve CI WASM build

### DIFF
--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -399,6 +399,10 @@ jobs:
             - name: Install pnpm Dependencies
               run: pnpm install
 
+            - name: Install project-local npm dependencies
+              working-directory: ${{ inputs.project_path }}
+              run: npm install
+
             - name: Build WASM + Frontend
               working-directory: ${{ inputs.project_path }}
               run: pnpm build

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -66,7 +66,7 @@ features = ["webgpu"]
 
 # --- WASM-only dependencies ---
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.114"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement"] }
 console_error_panic_hook = "0.1"


### PR DESCRIPTION
## Summary
- Pin `wasm-bindgen = "=0.2.114"` in `Cargo.toml` to prevent version mismatch between wasm-pack CLI and crate (fixes `TypeError: wasm.__wasm_bindgen_func_elem_120991 is not a function`)
- Add `npm install` step to CI `build-wasm` job to ensure project-local dependencies (e.g. `vite-plugin-wasm`) are available

## Test plan
- [ ] Verify isometric WASM build passes in CI
- [ ] Confirm no runtime `__wasm_bindgen_func_elem` errors in deployed app