### PR TITLE
feat(astro-kbve): add 18 OSRS item overrides + fix imbued heart typo

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -272,6 +272,56 @@ Focus on items with clear processing chains and market flip potential.
 | 3051  | Grimy snapdragon  | Herb cleaning     |
 | 12695 | Super combat(4)   | Best melee potion |
 
+### Dragon Armour (Implemented - Mar 2026)
+
+| ID    | Item             | Override Focus     |
+| ----- | ---------------- | ------------------ |
+| 1149  | Dragon med helm  | 60 Def helm        |
+| 3140  | Dragon chainbody | 60 Def body        |
+| 4087  | Dragon platelegs | 60 Def legs        |
+| 11335 | Dragon full helm | Ultra-rare helm    |
+| 21892 | Dragon platebody | DS2 craftable body |
+
+### Melee Helms (Implemented - Mar 2026)
+
+| ID    | Item              | Override Focus    |
+| ----- | ----------------- | ----------------- |
+| 10828 | Helm of neitiznot | Iconic melee helm |
+
+### Magic Armour (Implemented - Mar 2026)
+
+| ID   | Item               | Override Focus    |
+| ---- | ------------------ | ----------------- |
+| 4091 | Mystic robe top    | Budget magic body |
+| 4093 | Mystic robe bottom | Budget magic legs |
+
+### Ring Crafting Chain (Implemented - Mar 2026)
+
+| ID    | Item             | Override Focus         |
+| ----- | ---------------- | ---------------------- |
+| 1637  | Sapphire ring    | Ring of recoil base    |
+| 1639  | Emerald ring     | Ring of dueling base   |
+| 1641  | Ruby ring        | Ring of forging base   |
+| 1643  | Diamond ring     | Ring of life base      |
+| 1645  | Dragonstone ring | Ring of wealth base    |
+| 6575  | Onyx ring        | Ring of stone base     |
+| 19538 | Zenyte ring      | Ring of suffering base |
+
+### Teleport Jewelry (Implemented - Mar 2026)
+
+| ID    | Item            | Override Focus     |
+| ----- | --------------- | ------------------ |
+| 11113 | Skills necklace | Skilling teleports |
+| 11126 | Combat bracelet | Combat teleports   |
+
+### Rune/Obsidian Weapons (Implemented - Mar 2026)
+
+| ID   | Item           | Override Focus      |
+| ---- | -------------- | ------------------- |
+| 1289 | Rune sword     | F2P stab weapon     |
+| 1373 | Rune battleaxe | F2P strength weapon |
+| 6523 | Toktz-xil-ak   | Obsidian sword      |
+
 ---
 
 ## Future Override Priorities

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10828.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10828.mdx
@@ -1,0 +1,82 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 31
+    slash: 29
+    crush: 34
+    magic: 3
+    ranged: 30
+  other_bonus:
+    melee_strength: 3
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 3
+  requirements:
+    defence: 55
+related_items:
+  - item_id: 24268
+    item_name: "Neitiznot faceguard"
+    slug: "neitiznot-faceguard"
+    relationship: "upgrade"
+    description: "BiS melee helm upgrade with Basilisk jaw"
+  - item_id: 3748
+    item_name: "Berserker helm"
+    slug: "berserker-helm"
+    relationship: "alternative"
+    description: "Fremennik helm for lower Defence"
+  - item_id: 3751
+    item_name: "Warrior helm"
+    slug: "warrior-helm"
+    relationship: "alternative"
+    description: "Alternative Fremennik helm"
+---
+
+## Obtaining
+
+Reward from **The Fremennik Isles** quest.
+
+**Requirements:**
+- The Fremennik Trials quest
+- 46 Construction (boostable)
+- 56 Crafting (boostable)
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Stab | +31 |
+| Slash | +29 |
+| Crush | +34 |
+| Magic | +3 |
+| Ranged | +30 |
+
+| Other | Value |
+|-------|-------|
+| Strength | +3 |
+| Prayer | +3 |
+
+## Usage
+
+Best free melee helm until Neitiznot faceguard:
+- Slayer tasks
+- General PvM
+- Budget melee setup
+- PvP (commonly used)
+
+**Upgrade:** Attach a [Basilisk jaw](/osrs/basilisk-jaw/) to create the Neitiznot faceguard.
+
+## Market Strategy
+
+**Untradeable** - Quest reward only.
+
+## Related Items
+
+- [Neitiznot faceguard](/osrs/neitiznot-faceguard/) - BiS melee helm upgrade
+- [Berserker helm](/osrs/berserker-helm/) - Fremennik helm alternative

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_11113.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_11113.mdx
@@ -1,0 +1,64 @@
+---
+equipment:
+  slot: "neck"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 3
+    slash: 3
+    crush: 3
+    magic: 3
+    ranged: 3
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    crafting: 72
+related_items:
+  - item_id: 11126
+    item_name: "Combat bracelet"
+    slug: "combat-bracelet"
+    relationship: "alternative"
+    description: "Combat teleport jewelry"
+  - item_id: 1704
+    item_name: "Amulet of glory"
+    slug: "amulet-of-glory"
+    relationship: "alternative"
+    description: "Popular teleport amulet"
+---
+
+## Creation
+
+Made by enchanting a dragon necklace (Lvl-5 Enchant, Magic 68).
+
+**Base:** Dragon necklace (Crafting 72, Dragonstone + Gold bar)
+
+## Usage
+
+Teleport jewelry with 4 charges:
+- Fishing Guild
+- Mining Guild
+- Crafting Guild
+- Farming Guild
+- Cooking Guild
+- Woodcutting Guild
+
+## Market Strategy
+
+**Buy Limit:** 10,000 per 4 hours
+
+**Tips:**
+- Rechargeable at Legends' Guild
+- Popular for guild access
+- Useful for skilling teleports
+
+## Related Items
+
+- [Combat bracelet](/osrs/combat-bracelet/) - Combat teleports
+- [Amulet of glory](/osrs/amulet-of-glory/) - General teleports

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_11126.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_11126.mdx
@@ -1,0 +1,74 @@
+---
+equipment:
+  slot: "hands"
+  attack_bonus:
+    stab: 3
+    slash: 3
+    crush: 3
+    magic: 3
+    ranged: 3
+  defence_bonus:
+    stab: 3
+    slash: 3
+    crush: 3
+    magic: 3
+    ranged: 3
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    crafting: 58
+recipes:
+  - skill: "crafting"
+    level: 58
+    xp: 100
+    inputs:
+      - item_id: 1615
+        item_name: "Dragonstone"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 11113
+    item_name: "Skills necklace"
+    slug: "skills-necklace"
+    relationship: "alternative"
+    description: "Skilling teleport jewelry"
+  - item_id: 1704
+    item_name: "Amulet of glory"
+    slug: "amulet-of-glory"
+    relationship: "alternative"
+    description: "Popular teleport amulet"
+---
+
+## Creation
+
+Made by enchanting a dragonstone bracelet (Lvl-5 Enchant, Magic 68).
+
+**Base:** Dragon bracelet (Crafting 58, Dragonstone + Gold bar)
+
+## Usage
+
+Teleport jewelry with 4 charges:
+- Warriors' Guild
+- Champions' Guild
+- Edgeville Monastery
+- Ranging Guild
+
+## Market Strategy
+
+**Buy Limit:** 10,000 per 4 hours
+
+**Tips:**
+- Rechargeable at Legends' Guild
+- Popular for Warriors' Guild access
+- Dragonstone price drives cost
+
+## Related Items
+
+- [Skills necklace](/osrs/skills-necklace/) - Skilling teleports
+- [Amulet of glory](/osrs/amulet-of-glory/) - General teleports

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_11335.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_11335.mdx
@@ -1,0 +1,83 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -3
+    ranged: -1
+  defence_bonus:
+    stab: 45
+    slash: 48
+    crush: 51
+    magic: -1
+    ranged: 46
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 60
+drop_table:
+  primary_source: "Mithril dragon"
+  best_drop_rate: "1/32768"
+  sources:
+    - source: "Mithril dragon"
+      combat_level: 304
+      quantity: "1"
+      rarity: "very rare"
+      drop_rate: "1/32768"
+      members_only: true
+related_items:
+  - item_id: 1149
+    item_name: "Dragon med helm"
+    slug: "dragon-med-helm"
+    relationship: "downgrade"
+    description: "Common dragon helm"
+  - item_id: 10828
+    item_name: "Helm of neitiznot"
+    slug: "helm-of-neitiznot"
+    relationship: "alternative"
+    description: "Better stats with Strength/Prayer bonus"
+---
+
+## Obtaining
+
+Extremely rare drop from Mithril dragons (1/32,768).
+
+One of the rarest tradeable drops in the game.
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Stab | +45 |
+| Slash | +48 |
+| Crush | +51 |
+| Magic | -1 |
+| Ranged | +46 |
+
+**Requirements:** 60 Defence
+
+## Usage
+
+Primarily a fashionscape and collection item:
+- High Defence stats but no offensive bonuses
+- Helm of neitiznot is preferred for melee
+- Status symbol due to extreme rarity
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Tips:**
+- Extremely rare (1/32,768)
+- Price driven by rarity, not utility
+- Collector's item
+
+## Related Items
+
+- [Dragon med helm](/osrs/dragon-med-helm/) - Common dragon helm
+- [Helm of neitiznot](/osrs/helm-of-neitiznot/) - Better for combat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1149.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1149.mdx
@@ -1,0 +1,94 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -3
+    ranged: -1
+  defence_bonus:
+    stab: 33
+    slash: 35
+    crush: 36
+    magic: -1
+    ranged: 34
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 60
+drop_table:
+  primary_source: "King Black Dragon"
+  best_drop_rate: "1/128"
+  sources:
+    - source: "King Black Dragon"
+      combat_level: 276
+      quantity: "1"
+      rarity: "uncommon"
+      drop_rate: "1/128"
+      members_only: true
+    - source: "Brutal black dragon"
+      combat_level: 318
+      quantity: "1"
+      rarity: "rare"
+      drop_rate: "1/512"
+      members_only: true
+related_items:
+  - item_id: 11335
+    item_name: "Dragon full helm"
+    slug: "dragon-full-helm"
+    relationship: "upgrade"
+    description: "Rare full helm upgrade"
+  - item_id: 10828
+    item_name: "Helm of neitiznot"
+    slug: "helm-of-neitiznot"
+    relationship: "alternative"
+    description: "Better combat stats"
+  - item_id: 1163
+    item_name: "Rune full helm"
+    slug: "rune-full-helm"
+    relationship: "downgrade"
+    description: "F2P alternative"
+---
+
+## Obtaining
+
+Dropped by dragons:
+- King Black Dragon (1/128)
+- Brutal black dragons (1/512)
+- Other high-level dragons
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Stab | +33 |
+| Slash | +35 |
+| Crush | +36 |
+| Ranged | +34 |
+
+**Requirements:** 60 Defence
+
+## Usage
+
+Mid-tier melee helm:
+- Decent Defence stats
+- No Strength or Prayer bonus
+- Helm of neitiznot is generally preferred
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Tips:**
+- Common dragon drop
+- Low value due to better alternatives
+- Entry-level dragon gear
+
+## Related Items
+
+- [Dragon full helm](/osrs/dragon-full-helm/) - Rare upgrade
+- [Helm of neitiznot](/osrs/helm-of-neitiznot/) - Better for combat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1289.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1289.mdx
@@ -1,0 +1,67 @@
+---
+equipment:
+  slot: "weapon"
+  attack_bonus:
+    stab: 38
+    slash: 26
+    crush: -2
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 1
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 39
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    attack: 40
+  attack_speed: 4
+related_items:
+  - item_id: 1333
+    item_name: "Rune scimitar"
+    slug: "rune-scimitar"
+    relationship: "alternative"
+    description: "Higher slash, preferred for training"
+  - item_id: 1373
+    item_name: "Rune battleaxe"
+    slug: "rune-battleaxe"
+    relationship: "alternative"
+    description: "Higher strength, slower speed"
+  - item_id: 1347
+    item_name: "Rune warhammer"
+    slug: "rune-warhammer"
+    relationship: "alternative"
+    description: "Crush alternative"
+---
+
+## Obtaining
+
+- Smithing: 2 Runite bars at 89 Smithing
+- Monster drops (various)
+- Grand Exchange
+
+## Usage
+
+Rune-tier stab weapon:
+- Best F2P stab weapon
+- Useful against stab-weak monsters
+- Generally outclassed by rune scimitar for training
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Tips:**
+- Commonly smithed for XP
+- Low demand vs rune scimitar
+- High alch value matters
+
+## Related Items
+
+- [Rune scimitar](/osrs/rune-scimitar/) - Preferred for training
+- [Rune battleaxe](/osrs/rune-battleaxe/) - Strength training option

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1373.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1373.mdx
@@ -1,0 +1,68 @@
+---
+equipment:
+  slot: "weapon"
+  attack_bonus:
+    stab: -2
+    slash: 48
+    crush: 42
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 64
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    attack: 40
+  attack_speed: 6
+related_items:
+  - item_id: 1333
+    item_name: "Rune scimitar"
+    slug: "rune-scimitar"
+    relationship: "alternative"
+    description: "Faster, preferred for general training"
+  - item_id: 1289
+    item_name: "Rune sword"
+    slug: "rune-sword"
+    relationship: "alternative"
+    description: "Stab alternative"
+  - item_id: 1347
+    item_name: "Rune warhammer"
+    slug: "rune-warhammer"
+    relationship: "alternative"
+    description: "Crush alternative"
+---
+
+## Obtaining
+
+- Smithing: 3 Runite bars at 95 Smithing
+- Monster drops (various)
+- Grand Exchange
+
+## Usage
+
+Rune-tier Strength weapon:
+- Highest Strength bonus of rune weapons (+64)
+- Very slow attack speed (6 tick / 3.6s)
+- F2P Strength training option
+- Outclassed by faster weapons for DPS
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Tips:**
+- Smithing training product
+- High alch target
+- Niche F2P Strength training
+
+## Related Items
+
+- [Rune scimitar](/osrs/rune-scimitar/) - Better DPS for training
+- [Rune warhammer](/osrs/rune-warhammer/) - Crush alternative

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1637.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1637.mdx
@@ -1,0 +1,53 @@
+---
+equipment:
+  slot: "ring"
+  requirements:
+    crafting: 20
+recipes:
+  - skill: "crafting"
+    level: 20
+    xp: 40
+    inputs:
+      - item_id: 1656
+        item_name: "Sapphire"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 1639
+    item_name: "Emerald ring"
+    slug: "emerald-ring"
+    relationship: "upgrade"
+    description: "Next tier ring"
+  - item_id: 2550
+    item_name: "Ring of recoil"
+    slug: "ring-of-recoil"
+    relationship: "enchanted"
+    description: "Enchanted version (reflects damage)"
+---
+
+## Creation
+
+| Input | Skill | Level | XP |
+|-------|-------|-------|----|
+| [Sapphire](/osrs/sapphire/) + [Gold bar](/osrs/gold-bar/) | Crafting | 20 | 40 |
+
+## Enchanting
+
+Enchant with Lvl-1 Enchant (Magic 7) to create [Ring of recoil](/osrs/ring-of-recoil/).
+
+## Market Strategy
+
+**Buy Limit:** 10,000 per 4 hours
+
+**Tips:**
+- Crafting training material
+- Ring of recoil is highly consumed
+- Check enchant profit margins
+
+## Related Items
+
+- [Ring of recoil](/osrs/ring-of-recoil/) - Enchanted version
+- [Emerald ring](/osrs/emerald-ring/) - Next tier

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1639.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1639.mdx
@@ -1,0 +1,58 @@
+---
+equipment:
+  slot: "ring"
+  requirements:
+    crafting: 27
+recipes:
+  - skill: "crafting"
+    level: 27
+    xp: 55
+    inputs:
+      - item_id: 1658
+        item_name: "Emerald"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 1637
+    item_name: "Sapphire ring"
+    slug: "sapphire-ring"
+    relationship: "downgrade"
+    description: "Previous tier ring"
+  - item_id: 1641
+    item_name: "Ruby ring"
+    slug: "ruby-ring"
+    relationship: "upgrade"
+    description: "Next tier ring"
+  - item_id: 2552
+    item_name: "Ring of dueling(8)"
+    slug: "ring-of-dueling-8"
+    relationship: "enchanted"
+    description: "Enchanted version (teleports)"
+---
+
+## Creation
+
+| Input | Skill | Level | XP |
+|-------|-------|-------|----|
+| [Emerald](/osrs/emerald/) + [Gold bar](/osrs/gold-bar/) | Crafting | 27 | 55 |
+
+## Enchanting
+
+Enchant with Lvl-2 Enchant (Magic 27) to create Ring of dueling.
+
+## Market Strategy
+
+**Buy Limit:** 10,000 per 4 hours
+
+**Tips:**
+- Ring of dueling is consumed on use
+- Steady demand for teleports
+- Check enchant profit margins
+
+## Related Items
+
+- [Sapphire ring](/osrs/sapphire-ring/) - Previous tier
+- [Ruby ring](/osrs/ruby-ring/) - Next tier

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1641.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1641.mdx
@@ -1,0 +1,59 @@
+---
+equipment:
+  slot: "ring"
+  requirements:
+    crafting: 34
+recipes:
+  - skill: "crafting"
+    level: 34
+    xp: 70
+    inputs:
+      - item_id: 1660
+        item_name: "Ruby"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 1639
+    item_name: "Emerald ring"
+    slug: "emerald-ring"
+    relationship: "downgrade"
+    description: "Previous tier ring"
+  - item_id: 1643
+    item_name: "Diamond ring"
+    slug: "diamond-ring"
+    relationship: "upgrade"
+    description: "Next tier ring"
+  - item_id: 2568
+    item_name: "Ring of forging"
+    slug: "ring-of-forging"
+    relationship: "enchanted"
+    description: "Enchanted version (100% smelt success)"
+---
+
+## Creation
+
+| Input | Skill | Level | XP |
+|-------|-------|-------|----|
+| [Ruby](/osrs/ruby/) + [Gold bar](/osrs/gold-bar/) | Crafting | 34 | 70 |
+
+## Enchanting
+
+Enchant with Lvl-3 Enchant (Magic 49) to create Ring of forging (140 charges, 100% iron ore smelting).
+
+## Market Strategy
+
+**Buy Limit:** 10,000 per 4 hours
+
+**Tips:**
+- Ring of forging consumed in Blast Furnace
+- Check enchant profit margins
+- Iron smelting meta drives demand
+
+## Related Items
+
+- [Emerald ring](/osrs/emerald-ring/) - Previous tier
+- [Diamond ring](/osrs/diamond-ring/) - Next tier
+- [Ring of forging](/osrs/ring-of-forging/) - Enchanted version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1643.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1643.mdx
@@ -1,0 +1,59 @@
+---
+equipment:
+  slot: "ring"
+  requirements:
+    crafting: 43
+recipes:
+  - skill: "crafting"
+    level: 43
+    xp: 85
+    inputs:
+      - item_id: 1662
+        item_name: "Diamond"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 1641
+    item_name: "Ruby ring"
+    slug: "ruby-ring"
+    relationship: "downgrade"
+    description: "Previous tier ring"
+  - item_id: 1645
+    item_name: "Dragonstone ring"
+    slug: "dragonstone-ring"
+    relationship: "upgrade"
+    description: "Next tier ring"
+  - item_id: 2570
+    item_name: "Ring of life"
+    slug: "ring-of-life"
+    relationship: "enchanted"
+    description: "Enchanted version (auto-teleport at low HP)"
+---
+
+## Creation
+
+| Input | Skill | Level | XP |
+|-------|-------|-------|----|
+| [Diamond](/osrs/diamond/) + [Gold bar](/osrs/gold-bar/) | Crafting | 43 | 85 |
+
+## Enchanting
+
+Enchant with Lvl-4 Enchant (Magic 57) to create Ring of life (teleports to spawn when below 10% HP).
+
+## Market Strategy
+
+**Buy Limit:** 10,000 per 4 hours
+
+**Tips:**
+- Ring of life consumed on activation
+- Popular safety item for PvM
+- Steady enchant demand
+
+## Related Items
+
+- [Ruby ring](/osrs/ruby-ring/) - Previous tier
+- [Dragonstone ring](/osrs/dragonstone-ring/) - Next tier
+- [Ring of life](/osrs/ring-of-life/) - Enchanted version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1645.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1645.mdx
@@ -1,0 +1,59 @@
+---
+equipment:
+  slot: "ring"
+  requirements:
+    crafting: 55
+recipes:
+  - skill: "crafting"
+    level: 55
+    xp: 100
+    inputs:
+      - item_id: 1615
+        item_name: "Dragonstone"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 1643
+    item_name: "Diamond ring"
+    slug: "diamond-ring"
+    relationship: "downgrade"
+    description: "Previous tier ring"
+  - item_id: 6575
+    item_name: "Onyx ring"
+    slug: "onyx-ring"
+    relationship: "upgrade"
+    description: "Next tier ring"
+  - item_id: 2572
+    item_name: "Ring of wealth"
+    slug: "ring-of-wealth"
+    relationship: "enchanted"
+    description: "Enchanted version (improves RDT)"
+---
+
+## Creation
+
+| Input | Skill | Level | XP |
+|-------|-------|-------|----|
+| [Dragonstone](/osrs/dragonstone/) + [Gold bar](/osrs/gold-bar/) | Crafting | 55 | 100 |
+
+## Enchanting
+
+Enchant with Lvl-5 Enchant (Magic 68) to create [Ring of wealth](/osrs/ring-of-wealth/) (improved Rare Drop Table access).
+
+## Market Strategy
+
+**Buy Limit:** 10,000 per 4 hours
+
+**Tips:**
+- Ring of wealth is widely used
+- Dragonstone cost drives price
+- Enchant margin varies
+
+## Related Items
+
+- [Diamond ring](/osrs/diamond-ring/) - Previous tier
+- [Onyx ring](/osrs/onyx-ring/) - Next tier
+- [Ring of wealth](/osrs/ring-of-wealth/) - Enchanted version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_19538.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_19538.mdx
@@ -1,0 +1,59 @@
+---
+equipment:
+  slot: "ring"
+  requirements:
+    crafting: 89
+recipes:
+  - skill: "crafting"
+    level: 89
+    xp: 150
+    inputs:
+      - item_id: 19493
+        item_name: "Zenyte"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 6575
+    item_name: "Onyx ring"
+    slug: "onyx-ring"
+    relationship: "downgrade"
+    description: "Previous tier ring"
+  - item_id: 19550
+    item_name: "Ring of suffering"
+    slug: "ring-of-suffering"
+    relationship: "enchanted"
+    description: "Enchanted version (BiS defensive ring)"
+  - item_id: 19493
+    item_name: "Zenyte"
+    slug: "zenyte"
+    relationship: "component"
+    description: "Key component from demonic gorillas"
+---
+
+## Creation
+
+| Input | Skill | Level | XP |
+|-------|-------|-------|----|
+| [Zenyte](/osrs/zenyte/) + [Gold bar](/osrs/gold-bar/) | Crafting | 89 | 150 |
+
+## Enchanting
+
+Enchant with Lvl-7 Enchant (Magic 93) to create [Ring of suffering](/osrs/ring-of-suffering/) (BiS defensive ring, stores recoils).
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Tips:**
+- Zenyte shard from demonic gorillas + onyx
+- Ring of suffering is BiS defensive
+- High-value enchant
+
+## Related Items
+
+- [Onyx ring](/osrs/onyx-ring/) - Previous tier
+- [Ring of suffering](/osrs/ring-of-suffering/) - Enchanted version
+- [Zenyte](/osrs/zenyte/) - Key component

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_20724.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_20724.mdx
@@ -16,7 +16,7 @@ drop_table:
       rate: "1/200"
     - source: "Other superiors"
       rate: "1/200 - 1/1,376"
-truemarket:
+market:
   buy_limit: 8
   price_estimate: 29000000
 related_items:

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_21892.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_21892.mdx
@@ -1,0 +1,83 @@
+---
+equipment:
+  slot: "body"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -15
+    ranged: 0
+  defence_bonus:
+    stab: 117
+    slash: 120
+    crush: 113
+    magic: -6
+    ranged: 113
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 60
+related_items:
+  - item_id: 3140
+    item_name: "Dragon chainbody"
+    slug: "dragon-chainbody"
+    relationship: "downgrade"
+    description: "Easier to obtain dragon body"
+  - item_id: 11832
+    item_name: "Bandos chestplate"
+    slug: "bandos-chestplate"
+    relationship: "upgrade"
+    description: "BiS melee body with strength bonus"
+  - item_id: 1127
+    item_name: "Rune platebody"
+    slug: "rune-platebody"
+    relationship: "downgrade"
+    description: "F2P alternative"
+---
+
+## Obtaining
+
+Created during **Dragon Slayer II** quest.
+
+Combine at the Lithkren Vault:
+- Dragon metal shard (Vorkath drop, 1/5000 from other dragons)
+- Dragon metal slice (Adamant/Rune dragons)
+- Dragon metal lump (Adamant/Rune dragons)
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Stab | +117 |
+| Slash | +120 |
+| Crush | +113 |
+| Magic | -6 |
+| Ranged | +113 |
+
+**Requirements:** 60 Defence, Dragon Slayer II
+
+## Usage
+
+Best dragon body armour:
+- Highest defensive stats for 60 Defence
+- Does not degrade
+- Cosmetically popular
+
+**Note:** Bandos chestplate is preferred for the +4 Strength bonus despite lower Defence.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Tips:**
+- Components are rare drops
+- Popular for fashionscape
+- Niche use where pure Defence matters
+
+## Related Items
+
+- [Dragon chainbody](/osrs/dragon-chainbody/) - Easier to obtain
+- [Bandos chestplate](/osrs/bandos-chestplate/) - BiS with strength bonus

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_3140.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_3140.mdx
@@ -1,0 +1,94 @@
+---
+equipment:
+  slot: "body"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -15
+    ranged: 0
+  defence_bonus:
+    stab: 81
+    slash: 93
+    crush: 83
+    magic: -3
+    ranged: 80
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 60
+drop_table:
+  primary_source: "Kalphite Queen"
+  best_drop_rate: "1/128"
+  sources:
+    - source: "Kalphite Queen"
+      combat_level: 333
+      quantity: "1"
+      rarity: "rare"
+      drop_rate: "1/128"
+      members_only: true
+    - source: "Thermonuclear smoke devil"
+      combat_level: 301
+      quantity: "1"
+      rarity: "very rare"
+      drop_rate: "1/2000"
+      members_only: true
+related_items:
+  - item_id: 21892
+    item_name: "Dragon platebody"
+    slug: "dragon-platebody"
+    relationship: "upgrade"
+    description: "Superior dragon body armour"
+  - item_id: 1127
+    item_name: "Rune platebody"
+    slug: "rune-platebody"
+    relationship: "downgrade"
+    description: "Budget alternative"
+  - item_id: 11832
+    item_name: "Bandos chestplate"
+    slug: "bandos-chestplate"
+    relationship: "upgrade"
+    description: "BiS melee body (non-degradable)"
+---
+
+## Obtaining
+
+Dropped by Kalphite Queen (1/128).
+
+**Other sources:**
+- Thermonuclear smoke devil (1/2000)
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Stab | +81 |
+| Slash | +93 |
+| Crush | +83 |
+| Magic | -3 |
+| Ranged | +80 |
+
+## Usage
+
+Mid-tier melee body armour:
+- Budget alternative to Bandos chestplate
+- 60 Defence requirement
+- Does not degrade
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Tips:**
+- Dropped by Kalphite Queen
+- Budget melee option before BCP
+- Cosmetic appeal for fashionscape
+
+## Related Items
+
+- [Dragon platebody](/osrs/dragon-platebody/) - Superior dragon armour
+- [Rune platebody](/osrs/rune-platebody/) - Budget alternative
+- [Bandos chestplate](/osrs/bandos-chestplate/) - BiS melee body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4087.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4087.mdx
@@ -1,0 +1,92 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -21
+    ranged: -7
+  defence_bonus:
+    stab: 68
+    slash: 66
+    crush: 63
+    magic: -4
+    ranged: 65
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 60
+drop_table:
+  primary_source: "Bronze dragon"
+  best_drop_rate: "1/256"
+  sources:
+    - source: "Bronze dragon"
+      combat_level: 131
+      quantity: "1"
+      rarity: "rare"
+      drop_rate: "1/256"
+      members_only: true
+    - source: "Iron dragon"
+      combat_level: 189
+      quantity: "1"
+      rarity: "rare"
+      drop_rate: "1/256"
+      members_only: true
+    - source: "Steel dragon"
+      combat_level: 246
+      quantity: "1"
+      rarity: "rare"
+      drop_rate: "1/256"
+      members_only: true
+related_items:
+  - item_id: 4585
+    item_name: "Dragon plateskirt"
+    slug: "dragon-plateskirt"
+    relationship: "variant"
+    description: "Cosmetic alternative (same stats)"
+  - item_id: 11834
+    item_name: "Bandos tassets"
+    slug: "bandos-tassets"
+    relationship: "upgrade"
+    description: "BiS melee legs (non-degradable)"
+  - item_id: 1079
+    item_name: "Rune platelegs"
+    slug: "rune-platelegs"
+    relationship: "downgrade"
+    description: "Budget alternative"
+---
+
+## Obtaining
+
+Dropped by metal dragons (1/256 each):
+- Bronze dragons
+- Iron dragons
+- Steel dragons
+
+Also available from Rare Drop Table.
+
+## Usage
+
+Mid-tier melee leg armour:
+- 60 Defence requirement
+- Does not degrade
+- Budget option before Bandos tassets
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Tips:**
+- High supply from Slayer tasks
+- Dragon plateskirt has identical stats
+- Budget melee legs before tassets
+
+## Related Items
+
+- [Bandos tassets](/osrs/bandos-tassets/) - BiS melee legs upgrade
+- [Dragon plateskirt](/osrs/dragon-plateskirt/) - Same stats, cosmetic alternative
+- [Rune platelegs](/osrs/rune-platelegs/) - Budget alternative

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4091.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4091.mdx
@@ -1,0 +1,61 @@
+---
+equipment:
+  slot: "body"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 20
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 20
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    magic: 40
+    defence: 20
+related_items:
+  - item_id: 4101
+    item_name: "Mystic robe top (dark)"
+    slug: "mystic-robe-top-dark"
+    relationship: "variant"
+    description: "Dark recolor (same stats)"
+  - item_id: 4093
+    item_name: "Mystic robe bottom"
+    slug: "mystic-robe-bottom"
+    relationship: "set"
+    description: "Matching leg piece"
+---
+
+## Obtaining
+
+- Slayer Tower creatures (Infernal Mages)
+- Various boss drops
+- Purchasable from Wizard Beniami in Wizards' Guild (99 Magic)
+
+## Usage
+
+Budget magic top:
+- Entry-level magic armour
+- Affordable for new players
+- Commonly used for Barrows
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Tips:**
+- High supply from Slayer
+- Budget magic option
+- Multiple color variants available
+
+## Related Items
+
+- [Mystic robe bottom](/osrs/mystic-robe-bottom/) - Matching leg piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4093.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4093.mdx
@@ -1,0 +1,61 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 15
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 15
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    magic: 40
+    defence: 20
+related_items:
+  - item_id: 4091
+    item_name: "Mystic robe top"
+    slug: "mystic-robe-top"
+    relationship: "set"
+    description: "Matching body piece"
+  - item_id: 4103
+    item_name: "Mystic robe bottom (dark)"
+    slug: "mystic-robe-bottom-dark"
+    relationship: "variant"
+    description: "Dark recolor (same stats)"
+---
+
+## Obtaining
+
+- Slayer Tower creatures (Infernal Mages)
+- Various boss drops
+- Purchasable from Wizard Beniami in Wizards' Guild
+
+## Usage
+
+Budget magic legs:
+- Entry-level magic armour
+- Affordable for new players
+- Commonly paired with Mystic robe top
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Tips:**
+- High supply from Slayer
+- Budget magic option
+- Multiple color variants
+
+## Related Items
+
+- [Mystic robe top](/osrs/mystic-robe-top/) - Matching body piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6523.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6523.mdx
@@ -1,0 +1,68 @@
+---
+equipment:
+  slot: "weapon"
+  attack_bonus:
+    stab: 36
+    slash: 55
+    crush: -2
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 49
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    attack: 60
+related_items:
+  - item_id: 6525
+    item_name: "Toktz-xil-ek"
+    slug: "toktz-xil-ek"
+    relationship: "alternative"
+    description: "Obsidian knife (ranged)"
+  - item_id: 6527
+    item_name: "Toktz-xil-ul"
+    slug: "toktz-xil-ul"
+    relationship: "alternative"
+    description: "Obsidian throwing ring"
+  - item_id: 6528
+    item_name: "Tzhaar-ket-om"
+    slug: "tzhaar-ket-om"
+    relationship: "alternative"
+    description: "Obsidian maul (crush)"
+---
+
+## Obtaining
+
+Purchased from TzHaar-Hur-Tel in Mor Ul Rek for 60,000 Tokkul.
+
+Also dropped by TzTok-Jad and TzHaar creatures.
+
+## Usage
+
+Strong 60 Attack weapon:
+- Benefits from Obsidian armour set effect (+10% accuracy/damage)
+- Good Strength training weapon
+- Popular for low-level PvP
+
+**With full Obsidian set + Berserker necklace:** Competitive DPS for training.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Tips:**
+- Tokkul farmable from TzHaar Fight Cave
+- Popular for Strength training meta
+- Obsidian set synergy drives demand
+
+## Related Items
+
+- [Tzhaar-ket-om](/osrs/tzhaar-ket-om/) - Obsidian maul
+- [Berserker necklace](/osrs/berserker-necklace/) - Obsidian damage boost

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6575.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6575.mdx
@@ -1,0 +1,54 @@
+---
+equipment:
+  slot: "ring"
+  requirements:
+    crafting: 67
+recipes:
+  - skill: "crafting"
+    level: 67
+    xp: 115
+    inputs:
+      - item_id: 6573
+        item_name: "Onyx"
+        quantity: 1
+      - item_id: 2357
+        item_name: "Gold bar"
+        quantity: 1
+    output_quantity: 1
+related_items:
+  - item_id: 1645
+    item_name: "Dragonstone ring"
+    slug: "dragonstone-ring"
+    relationship: "downgrade"
+    description: "Previous tier ring"
+  - item_id: 19538
+    item_name: "Zenyte ring"
+    slug: "zenyte-ring"
+    relationship: "upgrade"
+    description: "Next tier ring (zenyte)"
+---
+
+## Creation
+
+| Input | Skill | Level | XP |
+|-------|-------|-------|----|
+| [Onyx](/osrs/onyx/) + [Gold bar](/osrs/gold-bar/) | Crafting | 67 | 115 |
+
+## Enchanting
+
+Enchant with Lvl-6 Enchant (Magic 87) to create Ring of stone (cosmetic transformation).
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Tips:**
+- Onyx is expensive (~2.5M)
+- Ring of stone is cosmetic only
+- Niche crafting XP method
+
+## Related Items
+
+- [Dragonstone ring](/osrs/dragonstone-ring/) - Previous tier
+- [Zenyte ring](/osrs/zenyte-ring/) - Next tier
+- [Onyx](/osrs/onyx/) - Key component


### PR DESCRIPTION
## Summary

- Add 18 new OSRS item override files covering dragon armour (5), melee helms (1), magic armour (2), ring crafting chain (7), teleport jewelry (2), and rune/obsidian weapons (3)
- Fix typo in imbued heart override (`truemarket` -> `market`)
- Update OSRS.md documentation with new implemented sections

## New Overrides

**Dragon Armour:** Dragon med helm, chainbody, platelegs, full helm, platebody
**Magic Gear:** Mystic robe top, Mystic robe bottom
**Ring Chain:** Sapphire → Emerald → Ruby → Diamond → Dragonstone → Onyx → Zenyte
**Teleport Jewelry:** Combat bracelet, Skills necklace
**Weapons:** Rune sword, Rune battleaxe, Toktz-xil-ak (Obsidian sword)
**Melee Helms:** Helm of neitiznot

## Test plan

- [ ] Verify YAML frontmatter parses correctly in all 18 new files
- [ ] Run `pnpm generate:osrs` to confirm overrides merge into generated pages
- [ ] Check that internal `/osrs/slug/` links resolve to existing generated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)