### PR TITLE
fix(axum-kbve): add AppState::new() constructor for tests

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -39,6 +39,16 @@ pub struct AppStateInner {
 }
 
 impl AppState {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(AppStateInner {
+                start_time: std::time::Instant::now(),
+                version: env!("CARGO_PKG_VERSION"),
+                game: None,
+            }),
+        }
+    }
+
     pub fn new_with_gameserver(game: crate::gameserver::GameServerState) -> Self {
         Self {
             inner: Arc::new(AppStateInner {


### PR DESCRIPTION
## Summary
- `AppState` only had `new_with_gameserver(game)` but two tests (`test_health_html_endpoint`, `test_api_status_endpoint`) called `AppState::new()` which didn't exist
- Added a parameterless `AppState::new()` that creates state with `game: None`
- Fixes `nx run axum-kbve:test` CI failure ([run](https://github.com/KBVE/kbve/actions/runs/22901725355/job/66449663476))

## Test plan
- [x] `cargo test -p axum-kbve` — all 19 tests pass locally