### PR TITLE
fix(isometric): remove client-side decompression for WASM loading

### DIFF
--- a/apps/kbve/astro-kbve/public/isometric/assets/index.js
+++ b/apps/kbve/astro-kbve/public/isometric/assets/index.js
@@ -49,9 +49,9 @@ const scriptRel = 'modulepreload',
 	__vitePreload = function (c, i, f) {
 		let _ = Promise.resolve();
 		if (i && i.length > 0) {
-			let y = function (O) {
+			let y = function (p) {
 				return Promise.all(
-					O.map((z) =>
+					p.map((z) =>
 						Promise.resolve(z).then(
 							(H) => ({ status: 'fulfilled', value: H }),
 							(H) => ({ status: 'rejected', reason: H }),
@@ -65,18 +65,18 @@ const scriptRel = 'modulepreload',
 					(S == null ? void 0 : S.nonce) ||
 					(S == null ? void 0 : S.getAttribute('nonce'));
 			_ = y(
-				i.map((O) => {
-					if (((O = assetsURL(O)), O in seen)) return;
-					seen[O] = true;
-					const z = O.endsWith('.css'),
+				i.map((p) => {
+					if (((p = assetsURL(p)), p in seen)) return;
+					seen[p] = true;
+					const z = p.endsWith('.css'),
 						H = z ? '[rel="stylesheet"]' : '';
-					if (document.querySelector(`link[href="${O}"]${H}`)) return;
+					if (document.querySelector(`link[href="${p}"]${H}`)) return;
 					const J = document.createElement('link');
 					if (
 						((J.rel = z ? 'stylesheet' : scriptRel),
 						z || (J.as = 'script'),
 						(J.crossOrigin = ''),
-						(J.href = O),
+						(J.href = p),
 						x && J.setAttribute('nonce', x),
 						document.head.appendChild(J),
 						z)
@@ -86,7 +86,7 @@ const scriptRel = 'modulepreload',
 								J.addEventListener('error', () =>
 									De(
 										new Error(
-											`Unable to preload CSS for ${O}`,
+											`Unable to preload CSS for ${p}`,
 										),
 									),
 								);
@@ -191,7 +191,7 @@ function requireReact_production() {
 		y = Symbol.for('react.context'),
 		S = Symbol.for('react.forward_ref'),
 		x = Symbol.for('react.suspense'),
-		O = Symbol.for('react.memo'),
+		p = Symbol.for('react.memo'),
 		z = Symbol.for('react.lazy'),
 		H = Symbol.for('react.activity'),
 		J = Symbol.iterator;
@@ -240,7 +240,7 @@ function requireReact_production() {
 	(at.constructor = Re),
 		ze(at, Ke.prototype),
 		(at.isPureReactComponent = true);
-	var Ot = Array.isArray;
+	var pt = Array.isArray;
 	function Ue() {}
 	var k = { H: null, A: null, T: null, S: null },
 		Be = Object.prototype.hasOwnProperty;
@@ -269,7 +269,7 @@ function requireReact_production() {
 			})
 		);
 	}
-	var On = /\/+/g;
+	var pn = /\/+/g;
 	function Et(m, D) {
 		return typeof m == 'object' && m !== null && m.key != null
 			? Ge('' + m.key)
@@ -336,9 +336,9 @@ function requireReact_production() {
 			return (
 				(V = V(m)),
 				(te = U === '' ? '.' + Et(m, 0) : U),
-				Ot(V)
+				pt(V)
 					? ((C = ''),
-						te != null && (C = te.replace(On, '$&/') + '/'),
+						te != null && (C = te.replace(pn, '$&/') + '/'),
 						A(V, D, C, '', function (va) {
 							return va;
 						}))
@@ -349,7 +349,7 @@ function requireReact_production() {
 								C +
 									(V.key == null || (m && m.key === V.key)
 										? ''
-										: ('' + V.key).replace(On, '$&/') +
+										: ('' + V.key).replace(pn, '$&/') +
 											'/') +
 									te,
 							)),
@@ -358,7 +358,7 @@ function requireReact_production() {
 			);
 		te = 0;
 		var He = U === '' ? '.' : U + ':';
-		if (Ot(m))
+		if (pt(m))
 			for (var ge = 0; ge < m.length; ge++)
 				(U = m[ge]), (Q = He + Et(U, ge)), (te += A(U, D, C, Q, V));
 		else if (((ge = Ce(m)), typeof ge == 'function'))
@@ -579,7 +579,7 @@ function requireReact_production() {
 			};
 		}),
 		(react_production.memo = function (m, D) {
-			return { $$typeof: O, type: m, compare: D === void 0 ? null : D };
+			return { $$typeof: p, type: m, compare: D === void 0 ? null : D };
 		}),
 		(react_production.startTransition = function (m) {
 			var D = k.T,
@@ -752,7 +752,7 @@ function requireScheduler_production() {
 					};
 				}
 				var x = [],
-					O = [],
+					p = [],
 					z = 1,
 					H = null,
 					J = 3,
@@ -765,21 +765,21 @@ function requireScheduler_production() {
 						typeof clearTimeout == 'function' ? clearTimeout : null,
 					Re = typeof setImmediate < 'u' ? setImmediate : null;
 				function at(A) {
-					for (var R = i(O); R !== null; ) {
-						if (R.callback === null) f(O);
+					for (var R = i(p); R !== null; ) {
+						if (R.callback === null) f(p);
 						else if (R.startTime <= A)
-							f(O), (R.sortIndex = R.expirationTime), c(x, R);
+							f(p), (R.sortIndex = R.expirationTime), c(x, R);
 						else break;
-						R = i(O);
+						R = i(p);
 					}
 				}
-				function Ot(A) {
+				function pt(A) {
 					if (((ze = false), at(A), !De))
 						if (i(x) !== null)
 							(De = true), Ue || ((Ue = true), Ge());
 						else {
-							var R = i(O);
-							R !== null && dt(Ot, R.startTime - A);
+							var R = i(p);
+							R !== null && dt(pt, R.startTime - A);
 						}
 				}
 				var Ue = false,
@@ -830,9 +830,9 @@ function requireScheduler_production() {
 										}
 										if (H !== null) R = true;
 										else {
-											var m = i(O);
+											var m = i(p);
 											m !== null &&
-												dt(Ot, m.startTime - A),
+												dt(pt, m.startTime - A),
 												(R = false);
 										}
 									}
@@ -853,9 +853,9 @@ function requireScheduler_production() {
 						Re(jt);
 					};
 				else if (typeof MessageChannel < 'u') {
-					var On = new MessageChannel(),
-						Et = On.port2;
-					(On.port1.onmessage = jt),
+					var pn = new MessageChannel(),
+						Et = pn.port2;
+					(pn.port1.onmessage = jt),
 						(Ge = function () {
 							Et.postMessage(null);
 						});
@@ -966,11 +966,11 @@ function requireScheduler_production() {
 							}),
 							q > ce
 								? ((A.sortIndex = q),
-									c(O, A),
+									c(p, A),
 									i(x) === null &&
-										A === i(O) &&
+										A === i(p) &&
 										(ze ? (Zt(k), (k = -1)) : (ze = true),
-										dt(Ot, q - ce)))
+										dt(pt, q - ce)))
 								: ((A.sortIndex = re),
 									c(x, A),
 									De ||
@@ -1023,17 +1023,17 @@ function requireReactDom_production() {
 	hasRequiredReactDom_production = 1;
 	var a = requireReact();
 	function c(x) {
-		var O = 'https://react.dev/errors/' + x;
+		var p = 'https://react.dev/errors/' + x;
 		if (1 < arguments.length) {
-			O += '?args[]=' + encodeURIComponent(arguments[1]);
+			p += '?args[]=' + encodeURIComponent(arguments[1]);
 			for (var z = 2; z < arguments.length; z++)
-				O += '&args[]=' + encodeURIComponent(arguments[z]);
+				p += '&args[]=' + encodeURIComponent(arguments[z]);
 		}
 		return (
 			'Minified React error #' +
 			x +
 			'; visit ' +
-			O +
+			p +
 			' for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
 		);
 	}
@@ -1056,7 +1056,7 @@ function requireReactDom_production() {
 			findDOMNode: null,
 		},
 		_ = Symbol.for('react.portal');
-	function d(x, O, z) {
+	function d(x, p, z) {
 		var H =
 			3 < arguments.length && arguments[3] !== void 0
 				? arguments[3]
@@ -1065,69 +1065,69 @@ function requireReactDom_production() {
 			$$typeof: _,
 			key: H == null ? null : '' + H,
 			children: x,
-			containerInfo: O,
+			containerInfo: p,
 			implementation: z,
 		};
 	}
 	var y = a.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
-	function S(x, O) {
+	function S(x, p) {
 		if (x === 'font') return '';
-		if (typeof O == 'string') return O === 'use-credentials' ? O : '';
+		if (typeof p == 'string') return p === 'use-credentials' ? p : '';
 	}
 	return (
 		(reactDom_production.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE =
 			f),
-		(reactDom_production.createPortal = function (x, O) {
+		(reactDom_production.createPortal = function (x, p) {
 			var z =
 				2 < arguments.length && arguments[2] !== void 0
 					? arguments[2]
 					: null;
 			if (
-				!O ||
-				(O.nodeType !== 1 && O.nodeType !== 9 && O.nodeType !== 11)
+				!p ||
+				(p.nodeType !== 1 && p.nodeType !== 9 && p.nodeType !== 11)
 			)
 				throw Error(c(299));
-			return d(x, O, null, z);
+			return d(x, p, null, z);
 		}),
 		(reactDom_production.flushSync = function (x) {
-			var O = y.T,
+			var p = y.T,
 				z = f.p;
 			try {
 				if (((y.T = null), (f.p = 2), x)) return x();
 			} finally {
-				(y.T = O), (f.p = z), f.d.f();
+				(y.T = p), (f.p = z), f.d.f();
 			}
 		}),
-		(reactDom_production.preconnect = function (x, O) {
+		(reactDom_production.preconnect = function (x, p) {
 			typeof x == 'string' &&
-				(O
-					? ((O = O.crossOrigin),
-						(O =
-							typeof O == 'string'
-								? O === 'use-credentials'
-									? O
+				(p
+					? ((p = p.crossOrigin),
+						(p =
+							typeof p == 'string'
+								? p === 'use-credentials'
+									? p
 									: ''
 								: void 0))
-					: (O = null),
-				f.d.C(x, O));
+					: (p = null),
+				f.d.C(x, p));
 		}),
 		(reactDom_production.prefetchDNS = function (x) {
 			typeof x == 'string' && f.d.D(x);
 		}),
-		(reactDom_production.preinit = function (x, O) {
-			if (typeof x == 'string' && O && typeof O.as == 'string') {
-				var z = O.as,
-					H = S(z, O.crossOrigin),
-					J = typeof O.integrity == 'string' ? O.integrity : void 0,
+		(reactDom_production.preinit = function (x, p) {
+			if (typeof x == 'string' && p && typeof p.as == 'string') {
+				var z = p.as,
+					H = S(z, p.crossOrigin),
+					J = typeof p.integrity == 'string' ? p.integrity : void 0,
 					Ce =
-						typeof O.fetchPriority == 'string'
-							? O.fetchPriority
+						typeof p.fetchPriority == 'string'
+							? p.fetchPriority
 							: void 0;
 				z === 'style'
 					? f.d.S(
 							x,
-							typeof O.precedence == 'string'
-								? O.precedence
+							typeof p.precedence == 'string'
+								? p.precedence
 								: void 0,
 							{ crossOrigin: H, integrity: J, fetchPriority: Ce },
 						)
@@ -1137,73 +1137,73 @@ function requireReactDom_production() {
 							integrity: J,
 							fetchPriority: Ce,
 							nonce:
-								typeof O.nonce == 'string' ? O.nonce : void 0,
+								typeof p.nonce == 'string' ? p.nonce : void 0,
 						});
 			}
 		}),
-		(reactDom_production.preinitModule = function (x, O) {
+		(reactDom_production.preinitModule = function (x, p) {
 			if (typeof x == 'string')
-				if (typeof O == 'object' && O !== null) {
-					if (O.as == null || O.as === 'script') {
-						var z = S(O.as, O.crossOrigin);
+				if (typeof p == 'object' && p !== null) {
+					if (p.as == null || p.as === 'script') {
+						var z = S(p.as, p.crossOrigin);
 						f.d.M(x, {
 							crossOrigin: z,
 							integrity:
-								typeof O.integrity == 'string'
-									? O.integrity
+								typeof p.integrity == 'string'
+									? p.integrity
 									: void 0,
 							nonce:
-								typeof O.nonce == 'string' ? O.nonce : void 0,
+								typeof p.nonce == 'string' ? p.nonce : void 0,
 						});
 					}
-				} else O == null && f.d.M(x);
+				} else p == null && f.d.M(x);
 		}),
-		(reactDom_production.preload = function (x, O) {
+		(reactDom_production.preload = function (x, p) {
 			if (
 				typeof x == 'string' &&
-				typeof O == 'object' &&
-				O !== null &&
-				typeof O.as == 'string'
+				typeof p == 'object' &&
+				p !== null &&
+				typeof p.as == 'string'
 			) {
-				var z = O.as,
-					H = S(z, O.crossOrigin);
+				var z = p.as,
+					H = S(z, p.crossOrigin);
 				f.d.L(x, z, {
 					crossOrigin: H,
 					integrity:
-						typeof O.integrity == 'string' ? O.integrity : void 0,
-					nonce: typeof O.nonce == 'string' ? O.nonce : void 0,
-					type: typeof O.type == 'string' ? O.type : void 0,
+						typeof p.integrity == 'string' ? p.integrity : void 0,
+					nonce: typeof p.nonce == 'string' ? p.nonce : void 0,
+					type: typeof p.type == 'string' ? p.type : void 0,
 					fetchPriority:
-						typeof O.fetchPriority == 'string'
-							? O.fetchPriority
+						typeof p.fetchPriority == 'string'
+							? p.fetchPriority
 							: void 0,
 					referrerPolicy:
-						typeof O.referrerPolicy == 'string'
-							? O.referrerPolicy
+						typeof p.referrerPolicy == 'string'
+							? p.referrerPolicy
 							: void 0,
 					imageSrcSet:
-						typeof O.imageSrcSet == 'string'
-							? O.imageSrcSet
+						typeof p.imageSrcSet == 'string'
+							? p.imageSrcSet
 							: void 0,
 					imageSizes:
-						typeof O.imageSizes == 'string' ? O.imageSizes : void 0,
-					media: typeof O.media == 'string' ? O.media : void 0,
+						typeof p.imageSizes == 'string' ? p.imageSizes : void 0,
+					media: typeof p.media == 'string' ? p.media : void 0,
 				});
 			}
 		}),
-		(reactDom_production.preloadModule = function (x, O) {
+		(reactDom_production.preloadModule = function (x, p) {
 			if (typeof x == 'string')
-				if (O) {
-					var z = S(O.as, O.crossOrigin);
+				if (p) {
+					var z = S(p.as, p.crossOrigin);
 					f.d.m(x, {
 						as:
-							typeof O.as == 'string' && O.as !== 'script'
-								? O.as
+							typeof p.as == 'string' && p.as !== 'script'
+								? p.as
 								: void 0,
 						crossOrigin: z,
 						integrity:
-							typeof O.integrity == 'string'
-								? O.integrity
+							typeof p.integrity == 'string'
+								? p.integrity
 								: void 0,
 					});
 				} else f.d.m(x);
@@ -1211,11 +1211,11 @@ function requireReactDom_production() {
 		(reactDom_production.requestFormReset = function (x) {
 			f.d.r(x);
 		}),
-		(reactDom_production.unstable_batchedUpdates = function (x, O) {
-			return x(O);
+		(reactDom_production.unstable_batchedUpdates = function (x, p) {
+			return x(p);
 		}),
-		(reactDom_production.useFormState = function (x, O, z) {
-			return y.H.useFormState(x, O, z);
+		(reactDom_production.useFormState = function (x, p, z) {
+			return y.H.useFormState(x, p, z);
 		}),
 		(reactDom_production.useFormStatus = function () {
 			return y.H.useHostTransitionStatus();
@@ -1323,7 +1323,7 @@ function requireReactDomClient_production() {
 	function x(e) {
 		if (d(e) !== e) throw Error(f(188));
 	}
-	function O(e) {
+	function p(e) {
 		var t = e.alternate;
 		if (!t) {
 			if (((t = d(e)), t === null)) throw Error(f(188));
@@ -1400,7 +1400,7 @@ function requireReactDomClient_production() {
 		Zt = Symbol.for('react.consumer'),
 		Re = Symbol.for('react.context'),
 		at = Symbol.for('react.forward_ref'),
-		Ot = Symbol.for('react.suspense'),
+		pt = Symbol.for('react.suspense'),
 		Ue = Symbol.for('react.suspense_list'),
 		k = Symbol.for('react.memo'),
 		Be = Symbol.for('react.lazy'),
@@ -1413,11 +1413,11 @@ function requireReactDomClient_production() {
 			: ((e = (jt && e[jt]) || e['@@iterator']),
 				typeof e == 'function' ? e : null);
 	}
-	var On = Symbol.for('react.client.reference');
+	var pn = Symbol.for('react.client.reference');
 	function Et(e) {
 		if (e == null) return null;
 		if (typeof e == 'function')
-			return e.$$typeof === On ? null : e.displayName || e.name || null;
+			return e.$$typeof === pn ? null : e.displayName || e.name || null;
 		if (typeof e == 'string') return e;
 		switch (e) {
 			case ze:
@@ -1426,7 +1426,7 @@ function requireReactDomClient_production() {
 				return 'Profiler';
 			case St:
 				return 'StrictMode';
-			case Ot:
+			case pt:
 				return 'Suspense';
 			case Ue:
 				return 'SuspenseList';
@@ -1720,7 +1720,7 @@ Error generating stack: ` +
 		cs = a.unstable_getCurrentPriorityLevel,
 		er = a.unstable_ImmediatePriority,
 		tr = a.unstable_UserBlockingPriority,
-		pc = a.unstable_NormalPriority,
+		Oc = a.unstable_NormalPriority,
 		us = a.unstable_LowPriority,
 		nr = a.unstable_IdlePriority,
 		ls = a.log,
@@ -1742,7 +1742,7 @@ Error generating stack: ` +
 	function os(e) {
 		return (e >>>= 0), e === 0 ? 32 : (31 - ((rs(e) / fs) | 0)) | 0;
 	}
-	var Oc = 256,
+	var pc = 256,
 		yc = 262144,
 		jc = 4194304;
 	function jn(e) {
@@ -2167,7 +2167,7 @@ Error generating stack: ` +
 			(t === 'checkbox' || t === 'radio')
 		);
 	}
-	function ps(e, t, n) {
+	function Os(e, t, n) {
 		var u = Object.getOwnPropertyDescriptor(e.constructor.prototype, t);
 		if (
 			!e.hasOwnProperty(t) &&
@@ -2205,7 +2205,7 @@ Error generating stack: ` +
 	function Zu(e) {
 		if (!e._valueTracker) {
 			var t = dr(e) ? 'checked' : 'value';
-			e._valueTracker = ps(e, t, '' + e[t]);
+			e._valueTracker = Os(e, t, '' + e[t]);
 		}
 	}
 	function gr(e) {
@@ -2232,9 +2232,9 @@ Error generating stack: ` +
 			return e.body;
 		}
 	}
-	var Os = /[\n"\\]/g;
+	var ps = /[\n"\\]/g;
 	function ut(e) {
-		return e.replace(Os, function (t) {
+		return e.replace(ps, function (t) {
 			return '\\' + t.charCodeAt(0).toString(16) + ' ';
 		});
 	}
@@ -2322,7 +2322,7 @@ Error generating stack: ` +
 			t !== null && (t.selected = true);
 		}
 	}
-	function pr(e, t, n) {
+	function Or(e, t, n) {
 		if (
 			t != null &&
 			((t = '' + ct(t)), t !== e.value && (e.value = t), n == null)
@@ -2332,7 +2332,7 @@ Error generating stack: ` +
 		}
 		e.defaultValue = n != null ? '' + ct(n) : '';
 	}
-	function Or(e, t, n, u) {
+	function pr(e, t, n, u) {
 		if (t == null) {
 			if (u != null) {
 				if (n != null) throw Error(f(92));
@@ -2562,7 +2562,7 @@ Error generating stack: ` +
 					}
 					break e;
 				case 'textarea':
-					pr(e, n.value, n.defaultValue);
+					Or(e, n.value, n.defaultValue);
 					break e;
 				case 'select':
 					(t = n.value), t != null && Qn(e, !!n.multiple, t, false);
@@ -3041,7 +3041,7 @@ Error generating stack: ` +
 	var Ha = null,
 		Na = null;
 	function Is(e) {
-		O_(e, 0);
+		p_(e, 0);
 	}
 	function Rc(e) {
 		var t = Ta(e);
@@ -3497,10 +3497,10 @@ Error generating stack: ` +
 						(e.lanes = r),
 						e
 					);
-				case Ot:
+				case pt:
 					return (
 						(e = Ie(13, n, t, l)),
-						(e.elementType = Ot),
+						(e.elementType = pt),
 						(e.lanes = r),
 						e
 					);
@@ -3604,10 +3604,10 @@ Error generating stack: ` +
 				(wt = r + e);
 		} else (ht = (1 << r) | (n << l) | u), (wt = e);
 	}
-	function pl(e) {
+	function Ol(e) {
 		e.return !== null && (Rt(e, 1), tf(e, 1, 0));
 	}
-	function Ol(e) {
+	function pl(e) {
 		for (; e === Bc; )
 			(Bc = Pn[--ea]), (Pn[ea] = null), (Ga = Pn[--ea]), (Pn[ea] = null);
 		for (; e === Jt; )
@@ -3689,7 +3689,7 @@ Error generating stack: ` +
 				K('invalid', t);
 				break;
 			case 'textarea':
-				K('invalid', t), Or(t, u.value, u.defaultValue, u.children);
+				K('invalid', t), pr(t, u.value, u.defaultValue, u.children);
 		}
 		(n = u.children),
 			(typeof n != 'string' &&
@@ -3918,7 +3918,7 @@ Error generating stack: ` +
 					},
 		fb = a.unstable_scheduleCallback,
 		ob = a.unstable_NormalPriority,
-		Oe = {
+		pe = {
 			$$typeof: Re,
 			Consumer: null,
 			Provider: null,
@@ -4014,7 +4014,7 @@ Error generating stack: ` +
 	}
 	function ff() {
 		var e = El();
-		return e === null ? null : { parent: Oe._currentValue, pool: e };
+		return e === null ? null : { parent: pe._currentValue, pool: e };
 	}
 	var ua = Error(f(460)),
 		Al = Error(f(474)),
@@ -4110,189 +4110,189 @@ Error generating stack: ` +
 				));
 	}
 	function df(e) {
-		function t(p, g) {
+		function t(O, g) {
 			if (e) {
-				var j = p.deletions;
-				j === null ? ((p.deletions = [g]), (p.flags |= 16)) : j.push(g);
+				var j = O.deletions;
+				j === null ? ((O.deletions = [g]), (O.flags |= 16)) : j.push(g);
 			}
 		}
-		function n(p, g) {
+		function n(O, g) {
 			if (!e) return null;
-			for (; g !== null; ) t(p, g), (g = g.sibling);
+			for (; g !== null; ) t(O, g), (g = g.sibling);
 			return null;
 		}
-		function u(p) {
-			for (var g = /* @__PURE__ */ new Map(); p !== null; )
-				p.key !== null ? g.set(p.key, p) : g.set(p.index, p),
-					(p = p.sibling);
+		function u(O) {
+			for (var g = /* @__PURE__ */ new Map(); O !== null; )
+				O.key !== null ? g.set(O.key, O) : g.set(O.index, O),
+					(O = O.sibling);
 			return g;
 		}
-		function l(p, g) {
-			return (p = Dt(p, g)), (p.index = 0), (p.sibling = null), p;
+		function l(O, g) {
+			return (O = Dt(O, g)), (O.index = 0), (O.sibling = null), O;
 		}
-		function r(p, g, j) {
+		function r(O, g, j) {
 			return (
-				(p.index = j),
+				(O.index = j),
 				e
-					? ((j = p.alternate),
+					? ((j = O.alternate),
 						j !== null
 							? ((j = j.index),
-								j < g ? ((p.flags |= 67108866), g) : j)
-							: ((p.flags |= 67108866), g))
-					: ((p.flags |= 1048576), g)
+								j < g ? ((O.flags |= 67108866), g) : j)
+							: ((O.flags |= 67108866), g))
+					: ((O.flags |= 1048576), g)
 			);
 		}
-		function o(p) {
-			return e && p.alternate === null && (p.flags |= 67108866), p;
+		function o(O) {
+			return e && O.alternate === null && (O.flags |= 67108866), O;
 		}
-		function s(p, g, j, T) {
+		function s(O, g, j, T) {
 			return g === null || g.tag !== 6
-				? ((g = gl(j, p.mode, T)), (g.return = p), g)
-				: ((g = l(g, j)), (g.return = p), g);
+				? ((g = gl(j, O.mode, T)), (g.return = O), g)
+				: ((g = l(g, j)), (g.return = O), g);
 		}
-		function b(p, g, j, T) {
+		function b(O, g, j, T) {
 			var G = j.type;
 			return G === ze
-				? E(p, g, j.props.children, T, j.key)
+				? E(O, g, j.props.children, T, j.key)
 				: g !== null &&
 					  (g.elementType === G ||
 							(typeof G == 'object' &&
 								G !== null &&
 								G.$$typeof === Be &&
 								Rn(G) === g.type))
-					? ((g = l(g, j.props)), Xa(g, j), (g.return = p), g)
-					: ((g = Uc(j.type, j.key, j.props, null, p.mode, T)),
+					? ((g = l(g, j.props)), Xa(g, j), (g.return = O), g)
+					: ((g = Uc(j.type, j.key, j.props, null, O.mode, T)),
 						Xa(g, j),
-						(g.return = p),
+						(g.return = O),
 						g);
 		}
-		function h(p, g, j, T) {
+		function h(O, g, j, T) {
 			return g === null ||
 				g.tag !== 4 ||
 				g.stateNode.containerInfo !== j.containerInfo ||
 				g.stateNode.implementation !== j.implementation
-				? ((g = ml(j, p.mode, T)), (g.return = p), g)
-				: ((g = l(g, j.children || [])), (g.return = p), g);
+				? ((g = ml(j, O.mode, T)), (g.return = O), g)
+				: ((g = l(g, j.children || [])), (g.return = O), g);
 		}
-		function E(p, g, j, T, G) {
+		function E(O, g, j, T, G) {
 			return g === null || g.tag !== 7
-				? ((g = En(j, p.mode, T, G)), (g.return = p), g)
-				: ((g = l(g, j)), (g.return = p), g);
+				? ((g = En(j, O.mode, T, G)), (g.return = O), g)
+				: ((g = l(g, j)), (g.return = O), g);
 		}
-		function M(p, g, j) {
+		function M(O, g, j) {
 			if (
 				(typeof g == 'string' && g !== '') ||
 				typeof g == 'number' ||
 				typeof g == 'bigint'
 			)
-				return (g = gl('' + g, p.mode, j)), (g.return = p), g;
+				return (g = gl('' + g, O.mode, j)), (g.return = O), g;
 			if (typeof g == 'object' && g !== null) {
 				switch (g.$$typeof) {
 					case Ce:
 						return (
-							(j = Uc(g.type, g.key, g.props, null, p.mode, j)),
+							(j = Uc(g.type, g.key, g.props, null, O.mode, j)),
 							Xa(j, g),
-							(j.return = p),
+							(j.return = O),
 							j
 						);
 					case De:
-						return (g = ml(g, p.mode, j)), (g.return = p), g;
+						return (g = ml(g, O.mode, j)), (g.return = O), g;
 					case Be:
-						return (g = Rn(g)), M(p, g, j);
+						return (g = Rn(g)), M(O, g, j);
 				}
 				if (dt(g) || Ge(g))
-					return (g = En(g, p.mode, j, null)), (g.return = p), g;
-				if (typeof g.then == 'function') return M(p, Xc(g), j);
-				if (g.$$typeof === Re) return M(p, Lc(p, g), j);
-				Qc(p, g);
+					return (g = En(g, O.mode, j, null)), (g.return = O), g;
+				if (typeof g.then == 'function') return M(O, Xc(g), j);
+				if (g.$$typeof === Re) return M(O, Lc(O, g), j);
+				Qc(O, g);
 			}
 			return null;
 		}
-		function w(p, g, j, T) {
+		function w(O, g, j, T) {
 			var G = g !== null ? g.key : null;
 			if (
 				(typeof j == 'string' && j !== '') ||
 				typeof j == 'number' ||
 				typeof j == 'bigint'
 			)
-				return G !== null ? null : s(p, g, '' + j, T);
+				return G !== null ? null : s(O, g, '' + j, T);
 			if (typeof j == 'object' && j !== null) {
 				switch (j.$$typeof) {
 					case Ce:
-						return j.key === G ? b(p, g, j, T) : null;
+						return j.key === G ? b(O, g, j, T) : null;
 					case De:
-						return j.key === G ? h(p, g, j, T) : null;
+						return j.key === G ? h(O, g, j, T) : null;
 					case Be:
-						return (j = Rn(j)), w(p, g, j, T);
+						return (j = Rn(j)), w(O, g, j, T);
 				}
 				if (dt(j) || Ge(j))
-					return G !== null ? null : E(p, g, j, T, null);
-				if (typeof j.then == 'function') return w(p, g, Xc(j), T);
-				if (j.$$typeof === Re) return w(p, g, Lc(p, j), T);
-				Qc(p, j);
+					return G !== null ? null : E(O, g, j, T, null);
+				if (typeof j.then == 'function') return w(O, g, Xc(j), T);
+				if (j.$$typeof === Re) return w(O, g, Lc(O, j), T);
+				Qc(O, j);
 			}
 			return null;
 		}
-		function v(p, g, j, T, G) {
+		function v(O, g, j, T, G) {
 			if (
 				(typeof T == 'string' && T !== '') ||
 				typeof T == 'number' ||
 				typeof T == 'bigint'
 			)
-				return (p = p.get(j) || null), s(g, p, '' + T, G);
+				return (O = O.get(j) || null), s(g, O, '' + T, G);
 			if (typeof T == 'object' && T !== null) {
 				switch (T.$$typeof) {
 					case Ce:
 						return (
-							(p = p.get(T.key === null ? j : T.key) || null),
-							b(g, p, T, G)
+							(O = O.get(T.key === null ? j : T.key) || null),
+							b(g, O, T, G)
 						);
 					case De:
 						return (
-							(p = p.get(T.key === null ? j : T.key) || null),
-							h(g, p, T, G)
+							(O = O.get(T.key === null ? j : T.key) || null),
+							h(g, O, T, G)
 						);
 					case Be:
-						return (T = Rn(T)), v(p, g, j, T, G);
+						return (T = Rn(T)), v(O, g, j, T, G);
 				}
 				if (dt(T) || Ge(T))
-					return (p = p.get(j) || null), E(g, p, T, G, null);
-				if (typeof T.then == 'function') return v(p, g, j, Xc(T), G);
-				if (T.$$typeof === Re) return v(p, g, j, Lc(g, T), G);
+					return (O = O.get(j) || null), E(g, O, T, G, null);
+				if (typeof T.then == 'function') return v(O, g, j, Xc(T), G);
+				if (T.$$typeof === Re) return v(O, g, j, Lc(g, T), G);
 				Qc(g, T);
 			}
 			return null;
 		}
-		function N(p, g, j, T) {
+		function N(O, g, j, T) {
 			for (
 				var G = null, $ = null, B = g, X = (g = 0), W = null;
 				B !== null && X < j.length;
 				X++
 			) {
 				B.index > X ? ((W = B), (B = null)) : (W = B.sibling);
-				var P = w(p, B, j[X], T);
+				var P = w(O, B, j[X], T);
 				if (P === null) {
 					B === null && (B = W);
 					break;
 				}
-				e && B && P.alternate === null && t(p, B),
+				e && B && P.alternate === null && t(O, B),
 					(g = r(P, g, X)),
 					$ === null ? (G = P) : ($.sibling = P),
 					($ = P),
 					(B = W);
 			}
-			if (X === j.length) return n(p, B), I && Rt(p, X), G;
+			if (X === j.length) return n(O, B), I && Rt(O, X), G;
 			if (B === null) {
 				for (; X < j.length; X++)
-					(B = M(p, j[X], T)),
+					(B = M(O, j[X], T)),
 						B !== null &&
 							((g = r(B, g, X)),
 							$ === null ? (G = B) : ($.sibling = B),
 							($ = B));
-				return I && Rt(p, X), G;
+				return I && Rt(O, X), G;
 			}
 			for (B = u(B); X < j.length; X++)
-				(W = v(B, p, X, j[X], T)),
+				(W = v(B, O, X, j[X], T)),
 					W !== null &&
 						(e &&
 							W.alternate !== null &&
@@ -4302,14 +4302,14 @@ Error generating stack: ` +
 						($ = W));
 			return (
 				e &&
-					B.forEach(function (pn) {
-						return t(p, pn);
+					B.forEach(function (On) {
+						return t(O, On);
 					}),
-				I && Rt(p, X),
+				I && Rt(O, X),
 				G
 			);
 		}
-		function L(p, g, j, T) {
+		function L(O, g, j, T) {
 			if (j == null) throw Error(f(151));
 			for (
 				var G = null,
@@ -4322,29 +4322,29 @@ Error generating stack: ` +
 				X++, P = j.next()
 			) {
 				B.index > X ? ((W = B), (B = null)) : (W = B.sibling);
-				var pn = w(p, B, P.value, T);
-				if (pn === null) {
+				var On = w(O, B, P.value, T);
+				if (On === null) {
 					B === null && (B = W);
 					break;
 				}
-				e && B && pn.alternate === null && t(p, B),
-					(g = r(pn, g, X)),
-					$ === null ? (G = pn) : ($.sibling = pn),
-					($ = pn),
+				e && B && On.alternate === null && t(O, B),
+					(g = r(On, g, X)),
+					$ === null ? (G = On) : ($.sibling = On),
+					($ = On),
 					(B = W);
 			}
-			if (P.done) return n(p, B), I && Rt(p, X), G;
+			if (P.done) return n(O, B), I && Rt(O, X), G;
 			if (B === null) {
 				for (; !P.done; X++, P = j.next())
-					(P = M(p, P.value, T)),
+					(P = M(O, P.value, T)),
 						P !== null &&
 							((g = r(P, g, X)),
 							$ === null ? (G = P) : ($.sibling = P),
 							($ = P));
-				return I && Rt(p, X), G;
+				return I && Rt(O, X), G;
 			}
 			for (B = u(B); !P.done; X++, P = j.next())
-				(P = v(B, p, X, P.value, T)),
+				(P = v(B, O, X, P.value, T)),
 					P !== null &&
 						(e &&
 							P.alternate !== null &&
@@ -4355,13 +4355,13 @@ Error generating stack: ` +
 			return (
 				e &&
 					B.forEach(function (vd) {
-						return t(p, vd);
+						return t(O, vd);
 					}),
-				I && Rt(p, X),
+				I && Rt(O, X),
 				G
 			);
 		}
-		function ie(p, g, j, T) {
+		function ie(O, g, j, T) {
 			if (
 				(typeof j == 'object' &&
 					j !== null &&
@@ -4377,10 +4377,10 @@ Error generating stack: ` +
 								if (g.key === G) {
 									if (((G = j.type), G === ze)) {
 										if (g.tag === 7) {
-											n(p, g.sibling),
+											n(O, g.sibling),
 												(T = l(g, j.props.children)),
-												(T.return = p),
-												(p = T);
+												(T.return = O),
+												(O = T);
 											break e;
 										}
 									} else if (
@@ -4390,35 +4390,35 @@ Error generating stack: ` +
 											G.$$typeof === Be &&
 											Rn(G) === g.type)
 									) {
-										n(p, g.sibling),
+										n(O, g.sibling),
 											(T = l(g, j.props)),
 											Xa(T, j),
-											(T.return = p),
-											(p = T);
+											(T.return = O),
+											(O = T);
 										break e;
 									}
-									n(p, g);
+									n(O, g);
 									break;
-								} else t(p, g);
+								} else t(O, g);
 								g = g.sibling;
 							}
 							j.type === ze
-								? ((T = En(j.props.children, p.mode, T, j.key)),
-									(T.return = p),
-									(p = T))
+								? ((T = En(j.props.children, O.mode, T, j.key)),
+									(T.return = O),
+									(O = T))
 								: ((T = Uc(
 										j.type,
 										j.key,
 										j.props,
 										null,
-										p.mode,
+										O.mode,
 										T,
 									)),
 									Xa(T, j),
-									(T.return = p),
-									(p = T));
+									(T.return = O),
+									(O = T));
 						}
-						return o(p);
+						return o(O);
 					case De:
 						e: {
 							for (G = j.key; g !== null; ) {
@@ -4430,59 +4430,59 @@ Error generating stack: ` +
 										g.stateNode.implementation ===
 											j.implementation
 									) {
-										n(p, g.sibling),
+										n(O, g.sibling),
 											(T = l(g, j.children || [])),
-											(T.return = p),
-											(p = T);
+											(T.return = O),
+											(O = T);
 										break e;
 									} else {
-										n(p, g);
+										n(O, g);
 										break;
 									}
-								else t(p, g);
+								else t(O, g);
 								g = g.sibling;
 							}
-							(T = ml(j, p.mode, T)), (T.return = p), (p = T);
+							(T = ml(j, O.mode, T)), (T.return = O), (O = T);
 						}
-						return o(p);
+						return o(O);
 					case Be:
-						return (j = Rn(j)), ie(p, g, j, T);
+						return (j = Rn(j)), ie(O, g, j, T);
 				}
-				if (dt(j)) return N(p, g, j, T);
+				if (dt(j)) return N(O, g, j, T);
 				if (Ge(j)) {
 					if (((G = Ge(j)), typeof G != 'function'))
 						throw Error(f(150));
-					return (j = G.call(j)), L(p, g, j, T);
+					return (j = G.call(j)), L(O, g, j, T);
 				}
-				if (typeof j.then == 'function') return ie(p, g, Xc(j), T);
-				if (j.$$typeof === Re) return ie(p, g, Lc(p, j), T);
-				Qc(p, j);
+				if (typeof j.then == 'function') return ie(O, g, Xc(j), T);
+				if (j.$$typeof === Re) return ie(O, g, Lc(O, j), T);
+				Qc(O, j);
 			}
 			return (typeof j == 'string' && j !== '') ||
 				typeof j == 'number' ||
 				typeof j == 'bigint'
 				? ((j = '' + j),
 					g !== null && g.tag === 6
-						? (n(p, g.sibling),
+						? (n(O, g.sibling),
 							(T = l(g, j)),
-							(T.return = p),
-							(p = T))
-						: (n(p, g),
-							(T = gl(j, p.mode, T)),
-							(T.return = p),
-							(p = T)),
-					o(p))
-				: n(p, g);
+							(T.return = O),
+							(O = T))
+						: (n(O, g),
+							(T = gl(j, O.mode, T)),
+							(T.return = O),
+							(O = T)),
+					o(O))
+				: n(O, g);
 		}
-		return function (p, g, j, T) {
+		return function (O, g, j, T) {
 			try {
 				Ya = 0;
-				var G = ie(p, g, j, T);
+				var G = ie(O, g, j, T);
 				return (la = null), G;
 			} catch (B) {
 				if (B === ua || B === Vc) throw B;
-				var $ = Ie(29, B, null, p.mode);
-				return ($.lanes = T), ($.return = p), $;
+				var $ = Ie(29, B, null, O.mode);
+				return ($.lanes = T), ($.return = O), $;
 			} finally {
 			}
 		};
@@ -4684,14 +4684,14 @@ Error generating stack: ` +
 		if (typeof e != 'function') throw Error(f(191, e));
 		e.call(t);
 	}
-	function pf(e, t) {
+	function Of(e, t) {
 		var n = e.callbacks;
 		if (n !== null)
 			for (e.callbacks = null, e = 0; e < n.length; e++) mf(n[e], t);
 	}
 	var ia = m(null),
 		Zc = m(0);
-	function Of(e, t) {
+	function pf(e, t) {
 		(e = Yt), C(Zc, e), C(ia, t), (Yt = e | t.baseLanes);
 	}
 	function Cl() {
@@ -4870,7 +4870,7 @@ Error generating stack: ` +
 			ye === null ? (Y.memoizedState = ye = e) : (ye = ye.next = e), ye
 		);
 	}
-	function pe() {
+	function Oe() {
 		if (ue === null) {
 			var e = Y.alternate;
 			e = e !== null ? e.memoizedState : null;
@@ -4951,7 +4951,7 @@ Error generating stack: ` +
 		return typeof t == 'function' ? t(e) : t;
 	}
 	function Ic(e) {
-		var t = pe();
+		var t = Oe();
 		return Vl(t, ue, e);
 	}
 	function Vl(e, t, n) {
@@ -5041,7 +5041,7 @@ Error generating stack: ` +
 		return l === null && (u.lanes = 0), [e.memoizedState, u.dispatch];
 	}
 	function Yl(e) {
-		var t = pe(),
+		var t = Oe(),
 			n = t.queue;
 		if (n === null) throw Error(f(311));
 		n.lastRenderedReducer = e;
@@ -5062,7 +5062,7 @@ Error generating stack: ` +
 	}
 	function wf(e, t, n) {
 		var u = Y,
-			l = pe(),
+			l = Oe(),
 			r = I;
 		if (r) {
 			if (n === void 0) throw Error(f(407));
@@ -5293,7 +5293,7 @@ Error generating stack: ` +
 		);
 	}
 	function Nf(e) {
-		var t = pe();
+		var t = Oe();
 		return Uf(t, ue, e);
 	}
 	function Uf(e, t, n) {
@@ -5308,7 +5308,7 @@ Error generating stack: ` +
 				throw o === ua ? Vc : o;
 			}
 		else u = t;
-		t = pe();
+		t = Oe();
 		var l = t.queue,
 			r = l.dispatch;
 		return (
@@ -5322,10 +5322,10 @@ Error generating stack: ` +
 		e.action = t;
 	}
 	function Bf(e) {
-		var t = pe(),
+		var t = Oe(),
 			n = ue;
 		if (n !== null) return Uf(t, n, e);
-		pe(), (t = t.memoizedState), (n = pe());
+		Oe(), (t = t.memoizedState), (n = Oe());
 		var u = n.queue.dispatch;
 		return (n.memoizedState = e), [t, u, false];
 	}
@@ -5345,7 +5345,7 @@ Error generating stack: ` +
 		);
 	}
 	function Gf() {
-		return pe().memoizedState;
+		return Oe().memoizedState;
 	}
 	function $c(e, t, n, u) {
 		var l = Ne();
@@ -5358,7 +5358,7 @@ Error generating stack: ` +
 			));
 	}
 	function Pc(e, t, n, u) {
-		var l = pe();
+		var l = Oe();
 		u = u === void 0 ? null : u;
 		var r = l.memoizedState.inst;
 		ue !== null && u !== null && Nl(u, ue.memoizedState.deps)
@@ -5371,7 +5371,7 @@ Error generating stack: ` +
 	function Zl(e, t) {
 		Pc(2048, 8, e, t);
 	}
-	function pb(e) {
+	function Ob(e) {
 		Y.flags |= 4;
 		var t = Y.updateQueue;
 		if (t === null) (t = Jc()), (Y.updateQueue = t), (t.events = [e]);
@@ -5381,9 +5381,9 @@ Error generating stack: ` +
 		}
 	}
 	function qf(e) {
-		var t = pe().memoizedState;
+		var t = Oe().memoizedState;
 		return (
-			pb({ ref: t, nextImpl: e }),
+			Ob({ ref: t, nextImpl: e }),
 			function () {
 				if ((ee & 2) !== 0) throw Error(f(440));
 				return t.impl.apply(void 0, arguments);
@@ -5419,7 +5419,7 @@ Error generating stack: ` +
 	}
 	function Kl() {}
 	function Zf(e, t) {
-		var n = pe();
+		var n = Oe();
 		t = t === void 0 ? null : t;
 		var u = n.memoizedState;
 		return t !== null && Nl(t, u[1])
@@ -5427,7 +5427,7 @@ Error generating stack: ` +
 			: ((n.memoizedState = [e, t]), e);
 	}
 	function Kf(e, t) {
-		var n = pe();
+		var n = Oe();
 		t = t === void 0 ? null : t;
 		var u = n.memoizedState;
 		if (t !== null && Nl(t, u[1])) return u[0];
@@ -5487,7 +5487,7 @@ Error generating stack: ` +
 				(A.T = o);
 		}
 	}
-	function Ob() {}
+	function pb() {}
 	function Wl(e, t, n, u) {
 		if (e.tag !== 5) throw Error(f(476));
 		var l = Jf(e).queue;
@@ -5497,7 +5497,7 @@ Error generating stack: ` +
 			t,
 			q,
 			n === null
-				? Ob
+				? pb
 				: function () {
 						return kf(e), n(u);
 					},
@@ -5549,10 +5549,10 @@ Error generating stack: ` +
 		return Ae(sc);
 	}
 	function If() {
-		return pe().memoizedState;
+		return Oe().memoizedState;
 	}
 	function $f() {
-		return pe().memoizedState;
+		return Oe().memoizedState;
 	}
 	function yb(e) {
 		for (var t = e.return; t !== null; ) {
@@ -5850,12 +5850,12 @@ Error generating stack: ` +
 			},
 			useDebugValue: Kl,
 			useDeferredValue: function (e, t) {
-				var n = pe();
+				var n = Oe();
 				return Ff(n, ue.memoizedState, e, t);
 			},
 			useTransition: function () {
 				var e = Ic(Nt)[0],
-					t = pe().memoizedState;
+					t = Oe().memoizedState;
 				return [typeof e == 'boolean' ? e : Wa(e), t];
 			},
 			useSyncExternalStore: wf,
@@ -5864,7 +5864,7 @@ Error generating stack: ` +
 			useFormState: Nf,
 			useActionState: Nf,
 			useOptimistic: function (e, t) {
-				var n = pe();
+				var n = Oe();
 				return Tf(n, ue, e, t);
 			},
 			useMemoCache: ql,
@@ -5888,12 +5888,12 @@ Error generating stack: ` +
 		},
 		useDebugValue: Kl,
 		useDeferredValue: function (e, t) {
-			var n = pe();
+			var n = Oe();
 			return ue === null ? Fl(n, e, t) : Ff(n, ue.memoizedState, e, t);
 		},
 		useTransition: function () {
 			var e = Yl(Nt)[0],
-				t = pe().memoizedState;
+				t = Oe().memoizedState;
 			return [typeof e == 'boolean' ? e : Wa(e), t];
 		},
 		useSyncExternalStore: wf,
@@ -5902,7 +5902,7 @@ Error generating stack: ` +
 		useFormState: Bf,
 		useActionState: Bf,
 		useOptimistic: function (e, t) {
-			var n = pe();
+			var n = Oe();
 			return ue !== null
 				? Tf(n, ue, e, t)
 				: ((n.baseState = e), [e, n.queue.dispatch]);
@@ -6195,7 +6195,7 @@ Error generating stack: ` +
 			(s = Bl()),
 			e !== null && !je
 				? (Gl(e, t, l), Ut(e, t, l))
-				: (I && s && pl(t), (t.flags |= 1), Te(e, t, u, l), t.child)
+				: (I && s && Ol(t), (t.flags |= 1), Te(e, t, u, l), t.child)
 		);
 	}
 	function bo(e, t, n, u, l) {
@@ -6258,21 +6258,21 @@ Error generating stack: ` +
 						(l = l | u.lanes | u.childLanes), (u = u.sibling);
 					u = l & ~r;
 				} else (u = 0), (t.child = null);
-				return po(e, t, r, n, u);
+				return Oo(e, t, r, n, u);
 			}
 			if ((n & 536870912) !== 0)
 				(t.memoizedState = { baseLanes: 0, cachePool: null }),
 					e !== null && qc(t, r !== null ? r.cachePool : null),
-					r !== null ? Of(t, r) : Cl(),
+					r !== null ? pf(t, r) : Cl(),
 					yf(t);
 			else
 				return (
 					(u = t.lanes = 536870912),
-					po(e, t, r !== null ? r.baseLanes | n : n, n, u)
+					Oo(e, t, r !== null ? r.baseLanes | n : n, n, u)
 				);
 		} else
 			r !== null
-				? (qc(t, r.cachePool), Of(t, r), an(), (t.memoizedState = null))
+				? (qc(t, r.cachePool), pf(t, r), an(), (t.memoizedState = null))
 				: (e !== null && qc(t, null), Cl(), an());
 		return Te(e, t, l, n), t.child;
 	}
@@ -6289,10 +6289,10 @@ Error generating stack: ` +
 			t.sibling
 		);
 	}
-	function po(e, t, n, u, l) {
+	function Oo(e, t, n, u, l) {
 		var r = El();
 		return (
-			(r = r === null ? null : { parent: Oe._currentValue, pool: r }),
+			(r = r === null ? null : { parent: pe._currentValue, pool: r }),
 			(t.memoizedState = { baseLanes: n, cachePool: r }),
 			e !== null && qc(t, null),
 			Cl(),
@@ -6311,7 +6311,7 @@ Error generating stack: ` +
 			t
 		);
 	}
-	function Oo(e, t, n) {
+	function po(e, t, n) {
 		return (
 			zn(t, e.child, null, n),
 			(e = nu(t, t.pendingProps)),
@@ -6360,7 +6360,7 @@ Error generating stack: ` +
 		if (r !== null) {
 			var o = r.dehydrated;
 			if ((Hl(t), l))
-				if (t.flags & 256) (t.flags &= -257), (t = Oo(e, t, n));
+				if (t.flags & 256) (t.flags &= -257), (t = po(e, t, n));
 				else if (t.memoizedState !== null)
 					(t.child = e.child), (t.flags |= 128), (t = null);
 				else throw Error(f(558));
@@ -6375,7 +6375,7 @@ Error generating stack: ` +
 						((o = lr(u, n)), o !== 0 && o !== r.retryLane))
 				)
 					throw ((r.retryLane = o), Sn(e, o), Ze(u, e, o), ti);
-				bu(), (t = Oo(e, t, n));
+				bu(), (t = po(e, t, n));
 			} else
 				(e = r.treeContext),
 					(oe = st(o.nextSibling)),
@@ -6412,7 +6412,7 @@ Error generating stack: ` +
 			(u = Bl()),
 			e !== null && !je
 				? (Gl(e, t, l), Ut(e, t, l))
-				: (I && u && pl(t), (t.flags |= 1), Te(e, t, n, l), t.child)
+				: (I && u && Ol(t), (t.flags |= 1), Te(e, t, n, l), t.child)
 		);
 	}
 	function yo(e, t, n, u, l, r) {
@@ -6424,7 +6424,7 @@ Error generating stack: ` +
 			(u = Bl()),
 			e !== null && !je
 				? (Gl(e, t, r), Ut(e, t, r))
-				: (I && u && pl(t), (t.flags |= 1), Te(e, t, n, r), t.child)
+				: (I && u && Ol(t), (t.flags |= 1), Te(e, t, n, r), t.child)
 		);
 	}
 	function jo(e, t, n, u, l) {
@@ -6772,7 +6772,7 @@ Error generating stack: ` +
 					? (s = ci(n))
 					: ((l = s.cachePool),
 						l !== null
-							? ((b = Oe._currentValue),
+							? ((b = pe._currentValue),
 								(l =
 									l.parent !== b
 										? { parent: b, pool: b }
@@ -6936,7 +6936,7 @@ Error generating stack: ` +
 		switch (t.tag) {
 			case 3:
 				He(t, t.stateNode.containerInfo),
-					$t(t, Oe, e.memoizedState.cache),
+					$t(t, pe, e.memoizedState.cache),
 					An();
 				break;
 			case 27:
@@ -6989,7 +6989,7 @@ Error generating stack: ` +
 			case 22:
 				return (t.lanes = 0), mo(e, t, n, t.pendingProps);
 			case 24:
-				$t(t, Oe, e.memoizedState.cache);
+				$t(t, pe, e.memoizedState.cache);
 		}
 		return Ut(e, t, n);
 	}
@@ -7047,8 +7047,8 @@ Error generating stack: ` +
 					var o = t.memoizedState;
 					if (
 						((u = o.cache),
-						$t(t, Oe, u),
-						u !== r.cache && vl(t, [Oe], n, true),
+						$t(t, pe, u),
+						u !== r.cache && vl(t, [pe], n, true),
 						Za(),
 						(u = o.element),
 						r.isDehydrated)
@@ -7240,7 +7240,7 @@ Error generating stack: ` +
 			case 24:
 				return (
 					Mn(t),
-					(u = Ae(Oe)),
+					(u = Ae(pe)),
 					e === null
 						? ((l = El()),
 							l === null &&
@@ -7252,7 +7252,7 @@ Error generating stack: ` +
 								(l = r)),
 							(t.memoizedState = { parent: u, cache: l }),
 							Tl(t),
-							$t(t, Oe, l))
+							$t(t, pe, l))
 						: ((e.lanes & n) !== 0 &&
 								(Ml(e, t), Ka(t, null, null, n), Za()),
 							(l = e.memoizedState),
@@ -7264,10 +7264,10 @@ Error generating stack: ` +
 										(t.memoizedState =
 											t.updateQueue.baseState =
 												l),
-									$t(t, Oe, u))
+									$t(t, pe, u))
 								: ((u = r.cache),
-									$t(t, Oe, u),
-									u !== l.cache && vl(t, [Oe], n, true))),
+									$t(t, pe, u),
+									u !== l.cache && vl(t, [pe], n, true))),
 					Te(e, t, t.pendingProps.children, n),
 					t.child
 				);
@@ -7343,7 +7343,7 @@ Error generating stack: ` +
 	}
 	function xb(e, t, n) {
 		var u = t.pendingProps;
-		switch ((Ol(t), t.tag)) {
+		switch ((pl(t), t.tag)) {
 			case 16:
 			case 15:
 			case 0:
@@ -7362,7 +7362,7 @@ Error generating stack: ` +
 					(u = null),
 					e !== null && (u = e.memoizedState.cache),
 					t.memoizedState.cache !== u && (t.flags |= 2048),
-					zt(Oe),
+					zt(pe),
 					ge(),
 					n.pendingContext &&
 						((n.context = n.pendingContext),
@@ -7769,7 +7769,7 @@ Error generating stack: ` +
 					(n = null),
 					e !== null && (n = e.memoizedState.cache),
 					t.memoizedState.cache !== n && (t.flags |= 2048),
-					zt(Oe),
+					zt(pe),
 					_e(t),
 					null
 				);
@@ -7781,7 +7781,7 @@ Error generating stack: ` +
 		throw Error(f(156, t.tag));
 	}
 	function Sb(e, t) {
-		switch ((Ol(t), t.tag)) {
+		switch ((pl(t), t.tag)) {
 			case 1:
 				return (
 					(e = t.flags),
@@ -7789,7 +7789,7 @@ Error generating stack: ` +
 				);
 			case 3:
 				return (
-					zt(Oe),
+					zt(pe),
 					ge(),
 					(e = t.flags),
 					(e & 65536) !== 0 && (e & 128) === 0
@@ -7838,7 +7838,7 @@ Error generating stack: ` +
 					e & 65536 ? ((t.flags = (e & -65537) | 128), t) : null
 				);
 			case 24:
-				return zt(Oe), null;
+				return zt(pe), null;
 			case 25:
 				return null;
 			default:
@@ -7846,9 +7846,9 @@ Error generating stack: ` +
 		}
 	}
 	function Ao(e, t) {
-		switch ((Ol(t), t.tag)) {
+		switch ((pl(t), t.tag)) {
 			case 3:
-				zt(Oe), ge();
+				zt(pe), ge();
 				break;
 			case 26:
 			case 27:
@@ -7875,7 +7875,7 @@ Error generating stack: ` +
 				Pe(t), zl(), e !== null && D(Dn);
 				break;
 			case 24:
-				zt(Oe);
+				zt(pe);
 		}
 	}
 	function Pa(e, t) {
@@ -7933,7 +7933,7 @@ Error generating stack: ` +
 		if (t !== null) {
 			var n = e.stateNode;
 			try {
-				pf(t, n);
+				Of(t, n);
 			} catch (u) {
 				ae(e, e.return, u);
 			}
@@ -8294,7 +8294,7 @@ Error generating stack: ` +
 								t = n.child.stateNode;
 						}
 					try {
-						pf(e, t);
+						Of(e, t);
 					} catch (o) {
 						ae(n, n.return, o);
 					}
@@ -9131,7 +9131,7 @@ Error generating stack: ` +
 			(t = t.memoizedState.cache),
 			t !== e && (t.refCount++, e != null && qa(e));
 	}
-	function pt(e, t, n, u) {
+	function Ot(e, t, n, u) {
 		if (t.subtreeFlags & 10256)
 			for (t = t.child; t !== null; ) Vo(e, t, n, u), (t = t.sibling);
 	}
@@ -9141,13 +9141,13 @@ Error generating stack: ` +
 			case 0:
 			case 11:
 			case 15:
-				pt(e, t, n, u), l & 2048 && Pa(9, t);
+				Ot(e, t, n, u), l & 2048 && Pa(9, t);
 				break;
 			case 1:
-				pt(e, t, n, u);
+				Ot(e, t, n, u);
 				break;
 			case 3:
-				pt(e, t, n, u),
+				Ot(e, t, n, u),
 					l & 2048 &&
 						((e = null),
 						t.alternate !== null &&
@@ -9157,7 +9157,7 @@ Error generating stack: ` +
 				break;
 			case 12:
 				if (l & 2048) {
-					pt(e, t, n, u), (e = t.stateNode);
+					Ot(e, t, n, u), (e = t.stateNode);
 					try {
 						var r = t.memoizedProps,
 							o = r.id,
@@ -9172,13 +9172,13 @@ Error generating stack: ` +
 					} catch (b) {
 						ae(t, t.return, b);
 					}
-				} else pt(e, t, n, u);
+				} else Ot(e, t, n, u);
 				break;
 			case 31:
-				pt(e, t, n, u);
+				Ot(e, t, n, u);
 				break;
 			case 13:
-				pt(e, t, n, u);
+				Ot(e, t, n, u);
 				break;
 			case 23:
 				break;
@@ -9187,10 +9187,10 @@ Error generating stack: ` +
 					(o = t.alternate),
 					t.memoizedState !== null
 						? r._visibility & 2
-							? pt(e, t, n, u)
+							? Ot(e, t, n, u)
 							: tc(e, t)
 						: r._visibility & 2
-							? pt(e, t, n, u)
+							? Ot(e, t, n, u)
 							: ((r._visibility |= 2),
 								_a(
 									e,
@@ -9202,10 +9202,10 @@ Error generating stack: ` +
 					l & 2048 && gi(o, t);
 				break;
 			case 24:
-				pt(e, t, n, u), l & 2048 && mi(t.alternate, t);
+				Ot(e, t, n, u), l & 2048 && mi(t.alternate, t);
 				break;
 			default:
-				pt(e, t, n, u);
+				Ot(e, t, n, u);
 		}
 	}
 	function _a(e, t, n, u, l) {
@@ -9411,12 +9411,12 @@ Error generating stack: ` +
 	}
 	var Tb = {
 			getCacheForType: function (e) {
-				var t = Ae(Oe),
+				var t = Ae(pe),
 					n = t.data.get(e);
 				return n === void 0 && ((n = e()), t.data.set(e, n)), n;
 			},
 			cacheSignal: function () {
-				return Ae(Oe).controller.signal;
+				return Ae(pe).controller.signal;
 			},
 		},
 		Mb = typeof WeakMap == 'function' ? WeakMap : Map,
@@ -9428,12 +9428,12 @@ Error generating stack: ` +
 		et = null,
 		un = false,
 		ba = false,
-		pi = false,
+		Oi = false,
 		Yt = 0,
 		de = 0,
 		ln = 0,
 		Bn = 0,
-		Oi = 0,
+		pi = 0,
 		tt = 0,
 		da = 0,
 		cc = null,
@@ -9507,7 +9507,7 @@ Error generating stack: ` +
 								(o = xi(s, o, false)),
 								o !== 2)
 							) {
-								if (pi && !b) {
+								if (Oi && !b) {
 									(s.errorRecoveryDisabledLanes |= r),
 										(Bn |= r),
 										(l = 4);
@@ -9666,7 +9666,7 @@ Error generating stack: ` +
 		return true;
 	}
 	function on(e, t, n, u) {
-		(t &= ~Oi),
+		(t &= ~pi),
 			(t &= ~Bn),
 			(e.suspendedLanes |= t),
 			(e.pingedLanes &= ~t),
@@ -9710,8 +9710,8 @@ Error generating stack: ` +
 			(et = null),
 			(un = false),
 			(ba = Sa(e, t)),
-			(pi = false),
-			(da = tt = Oi = Bn = ln = de = 0),
+			(Oi = false),
+			(da = tt = pi = Bn = ln = de = 0),
 			(Qe = cc = null),
 			(yi = false),
 			(t & 8) !== 0 && (t |= t & 32);
@@ -9790,14 +9790,14 @@ Error generating stack: ` +
 							$e.current === null && (t = true);
 							var h = ne;
 							if (
-								((ne = 0), (et = null), pa(e, s, b, h), n && ba)
+								((ne = 0), (et = null), Oa(e, s, b, h), n && ba)
 							) {
 								o = 0;
 								break e;
 							}
 							break;
 						default:
-							(h = ne), (ne = 0), (et = null), pa(e, s, b, h);
+							(h = ne), (ne = 0), (et = null), Oa(e, s, b, h);
 					}
 				}
 				Rb(), (o = de);
@@ -9834,7 +9834,7 @@ Error generating stack: ` +
 					var r = et;
 					t: switch (ne) {
 						case 1:
-							(ne = 0), (et = null), pa(e, t, r, 1);
+							(ne = 0), (et = null), Oa(e, t, r, 1);
 							break;
 						case 2:
 						case 9:
@@ -9857,7 +9857,7 @@ Error generating stack: ` +
 						case 7:
 							of(r)
 								? ((ne = 0), (et = null), n_(t))
-								: ((ne = 0), (et = null), pa(e, t, r, 7));
+								: ((ne = 0), (et = null), Oa(e, t, r, 7));
 							break;
 						case 5:
 							var o = null;
@@ -9880,10 +9880,10 @@ Error generating stack: ` +
 										break t;
 									}
 							}
-							(ne = 0), (et = null), pa(e, t, r, 5);
+							(ne = 0), (et = null), Oa(e, t, r, 5);
 							break;
 						case 6:
-							(ne = 0), (et = null), pa(e, t, r, 6);
+							(ne = 0), (et = null), Oa(e, t, r, 6);
 							break;
 						case 8:
 							vi(), (de = 6);
@@ -9931,7 +9931,7 @@ Error generating stack: ` +
 		}
 		(e.memoizedProps = e.pendingProps), t === null ? du(e) : (Z = t);
 	}
-	function pa(e, t, n, u) {
+	function Oa(e, t, n, u) {
 		(Ct = Tn = null), Ll(t), (la = null), (Ya = 0);
 		var l = t.return;
 		try {
@@ -10022,7 +10022,7 @@ Error generating stack: ` +
 				(t.subtreeFlags & 10256) !== 0 || (t.flags & 10256) !== 0
 					? ((e.callbackNode = null),
 						(e.callbackPriority = 0),
-						Bb(pc, function () {
+						Bb(Oc, function () {
 							return f_(), null;
 						}))
 					: ((e.callbackNode = null), (e.callbackPriority = 0)),
@@ -10093,19 +10093,19 @@ Error generating stack: ` +
 									!v.extend &&
 										L > ie &&
 										((o = ie), (ie = L), (L = o));
-									var p = Vr(s, L),
+									var O = Vr(s, L),
 										g = Vr(s, ie);
 									if (
-										p &&
+										O &&
 										g &&
 										(v.rangeCount !== 1 ||
-											v.anchorNode !== p.node ||
-											v.anchorOffset !== p.offset ||
+											v.anchorNode !== O.node ||
+											v.anchorOffset !== O.offset ||
 											v.focusNode !== g.node ||
 											v.focusOffset !== g.offset)
 									) {
 										var j = M.createRange();
-										j.setStart(p.node, p.offset),
+										j.setStart(O.node, O.offset),
 											v.removeAllRanges(),
 											L > ie
 												? (v.addRange(j),
@@ -10291,7 +10291,7 @@ Error generating stack: ` +
 			(l = u.get(t)),
 				l === void 0 && ((l = /* @__PURE__ */ new Set()), u.set(t, l));
 		l.has(n) ||
-			((pi = true), l.add(n), (e = Hb.bind(null, e, t, n)), t.then(e, e));
+			((Oi = true), l.add(n), (e = Hb.bind(null, e, t, n)), t.then(e, e));
 	}
 	function Hb(e, t, n) {
 		var u = e.pingCache;
@@ -10303,7 +10303,7 @@ Error generating stack: ` +
 				(de === 4 ||
 				(de === 3 && (F & 62914560) === F && 300 > Fe() - fu)
 					? (ee & 2) === 0 && ma(e, 0)
-					: (Oi |= n),
+					: (pi |= n),
 				da === F && (da = 0)),
 			xt(e);
 	}
@@ -10339,20 +10339,20 @@ Error generating stack: ` +
 		return Gu(e, t);
 	}
 	var mu = null,
-		Oa = null,
+		pa = null,
 		Ei = false,
-		pu = false,
+		Ou = false,
 		Ai = false,
 		_n = 0;
 	function xt(e) {
-		e !== Oa &&
+		e !== pa &&
 			e.next === null &&
-			(Oa === null ? (mu = Oa = e) : (Oa = Oa.next = e)),
-			(pu = true),
+			(pa === null ? (mu = pa = e) : (pa = pa.next = e)),
+			(Ou = true),
 			Ei || ((Ei = true), Lb());
 	}
 	function lc(e, t) {
-		if (!Ai && pu) {
+		if (!Ai && Ou) {
 			Ai = true;
 			do
 				for (var n = false, u = mu; u !== null; ) {
@@ -10391,7 +10391,7 @@ Error generating stack: ` +
 		s_();
 	}
 	function s_() {
-		pu = Ei = false;
+		Ou = Ei = false;
 		var e = 0;
 		_n !== 0 && Jb() && (e = _n);
 		for (var t = Fe(), n = null, u = mu; u !== null; ) {
@@ -10400,8 +10400,8 @@ Error generating stack: ` +
 			r === 0
 				? ((u.next = null),
 					n === null ? (mu = l) : (n.next = l),
-					l === null && (Oa = n))
-				: ((n = u), (e !== 0 || (r & 3) !== 0) && (pu = true)),
+					l === null && (pa = n))
+				: ((n = u), (e !== 0 || (r & 3) !== 0) && (Ou = true)),
 				(u = l);
 		}
 		(we !== 0 && we !== 5) || lc(e), _n !== 0 && (_n = 0);
@@ -10449,13 +10449,13 @@ Error generating stack: ` +
 					n = tr;
 					break;
 				case 32:
-					n = pc;
+					n = Oc;
 					break;
 				case 268435456:
 					n = nr;
 					break;
 				default:
-					n = pc;
+					n = Oc;
 			}
 			return (
 				(u = d_.bind(null, e)),
@@ -10506,7 +10506,7 @@ Error generating stack: ` +
 		if (_n === 0) {
 			var e = aa;
 			e === 0 &&
-				((e = Oc), (Oc <<= 1), (Oc & 261888) === 0 && (Oc = 256)),
+				((e = pc), (pc <<= 1), (pc & 261888) === 0 && (pc = 256)),
 				(_n = e);
 		}
 		return _n;
@@ -10518,7 +10518,7 @@ Error generating stack: ` +
 				? e
 				: Sc('' + e);
 	}
-	function p_(e, t) {
+	function O_(e, t) {
 		var n = t.ownerDocument.createElement('input');
 		return (
 			(n.name = t.name),
@@ -10548,7 +10548,7 @@ Error generating stack: ` +
 						listener: function () {
 							if (u.defaultPrevented) {
 								if (_n !== 0) {
-									var b = o ? p_(l, o) : new FormData(l);
+									var b = o ? O_(l, o) : new FormData(l);
 									Wl(
 										n,
 										{
@@ -10564,7 +10564,7 @@ Error generating stack: ` +
 							} else
 								typeof r == 'function' &&
 									(s.preventDefault(),
-									(b = o ? p_(l, o) : new FormData(l)),
+									(b = o ? O_(l, o) : new FormData(l)),
 									Wl(
 										n,
 										{
@@ -10648,7 +10648,7 @@ Error generating stack: ` +
 				.split(' ')
 				.concat(ic),
 		);
-	function O_(e, t) {
+	function p_(e, t) {
 		t = (t & 4) !== 0;
 		for (var n = 0; n < e.length; n++) {
 			var u = e[n],
@@ -10705,27 +10705,27 @@ Error generating stack: ` +
 		var u = 0;
 		t && (u |= 4), y_(n, e, u, t);
 	}
-	var Ou = '_reactListening' + Math.random().toString(36).slice(2);
+	var pu = '_reactListening' + Math.random().toString(36).slice(2);
 	function Ci(e) {
-		if (!e[Ou]) {
-			(e[Ou] = true),
+		if (!e[pu]) {
+			(e[pu] = true),
 				or.forEach(function (n) {
 					n !== 'selectionchange' &&
 						(Xb.has(n) || Ri(n, false, e), Ri(n, true, e));
 				});
 			var t = e.nodeType === 9 ? e : e.ownerDocument;
 			t === null ||
-				t[Ou] ||
-				((t[Ou] = true), Ri('selectionchange', false, t));
+				t[pu] ||
+				((t[pu] = true), Ri('selectionchange', false, t));
 		}
 	}
 	function y_(e, t, n, u) {
 		switch (W_(t)) {
 			case 2:
-				var l = pd;
+				var l = Od;
 				break;
 			case 8:
-				l = Od;
+				l = pd;
 				break;
 			default:
 				l = Fi;
@@ -10866,7 +10866,7 @@ Error generating stack: ` +
 					}
 					var L = (t & 4) !== 0,
 						ie = !L && (e === 'scroll' || e === 'scrollend'),
-						p = L ? (w !== null ? w + 'Capture' : null) : w;
+						O = L ? (w !== null ? w + 'Capture' : null) : w;
 					L = [];
 					for (var g = h, j; g !== null; ) {
 						var T = g;
@@ -10875,8 +10875,8 @@ Error generating stack: ` +
 							(T = T.tag),
 							(T !== 5 && T !== 26 && T !== 27) ||
 								j === null ||
-								p === null ||
-								((T = Ma(g, p)),
+								O === null ||
+								((T = Ma(g, O)),
 								T != null && L.push(rc(g, T, j))),
 							ie)
 						)
@@ -10923,12 +10923,12 @@ Error generating stack: ` +
 						if (
 							((L = Sr),
 							(T = 'onMouseLeave'),
-							(p = 'onMouseEnter'),
+							(O = 'onMouseEnter'),
 							(g = 'mouse'),
 							(e === 'pointerout' || e === 'pointerover') &&
 								((L = Ar),
 								(T = 'onPointerLeave'),
-								(p = 'onPointerEnter'),
+								(O = 'onPointerEnter'),
 								(g = 'pointer')),
 							(ie = v == null ? w : Ta(v)),
 							(j = N == null ? w : Ta(N)),
@@ -10937,7 +10937,7 @@ Error generating stack: ` +
 							(w.relatedTarget = j),
 							(T = null),
 							qn(E) === h &&
-								((L = new L(p, g + 'enter', N, n, E)),
+								((L = new L(O, g + 'enter', N, n, E)),
 								(L.target = j),
 								(L.relatedTarget = ie),
 								(T = L)),
@@ -10946,24 +10946,24 @@ Error generating stack: ` +
 						)
 							t: {
 								for (
-									L = Qb, p = v, g = N, j = 0, T = p;
+									L = Qb, O = v, g = N, j = 0, T = O;
 									T;
 									T = L(T)
 								)
 									j++;
 								T = 0;
 								for (var G = g; G; G = L(G)) T++;
-								for (; 0 < j - T; ) (p = L(p)), j--;
+								for (; 0 < j - T; ) (O = L(O)), j--;
 								for (; 0 < T - j; ) (g = L(g)), T--;
 								for (; j--; ) {
 									if (
-										p === g ||
-										(g !== null && p === g.alternate)
+										O === g ||
+										(g !== null && O === g.alternate)
 									) {
-										L = p;
+										L = O;
 										break t;
 									}
-									(p = L(p)), (g = L(g));
+									(O = L(O)), (g = L(g));
 								}
 								L = null;
 							}
@@ -11077,7 +11077,7 @@ Error generating stack: ` +
 							(B.data = X))),
 					qb(M, e, h, n, E);
 			}
-			O_(M, t);
+			p_(M, t);
 		});
 	}
 	function rc(e, t, n) {
@@ -11567,7 +11567,7 @@ Error generating stack: ` +
 							default:
 								le(e, t, o, s, n, null);
 						}
-				Or(e, u, l, r);
+				pr(e, u, l, r);
 				return;
 			case 'option':
 				for (b in n)
@@ -11787,7 +11787,7 @@ Error generating stack: ` +
 							default:
 								l !== r && le(e, t, o, l, u, r);
 						}
-				pr(e, w, v);
+				Or(e, w, v);
 				return;
 			case 'option':
 				for (var N in n)
@@ -11879,12 +11879,12 @@ Error generating stack: ` +
 					return;
 				}
 		}
-		for (var p in n)
-			(w = n[p]),
-				n.hasOwnProperty(p) &&
+		for (var O in n)
+			(w = n[O]),
+				n.hasOwnProperty(O) &&
 					w != null &&
-					!u.hasOwnProperty(p) &&
-					le(e, t, p, null, u, w);
+					!u.hasOwnProperty(O) &&
+					le(e, t, O, null, u, w);
 		for (M in u)
 			(w = u[M]),
 				(v = n[M]),
@@ -13048,7 +13048,7 @@ Error generating stack: ` +
 		}
 	}
 	var Au = true;
-	function pd(e, t, n, u) {
+	function Od(e, t, n, u) {
 		var l = A.T;
 		A.T = null;
 		var r = R.p;
@@ -13058,7 +13058,7 @@ Error generating stack: ` +
 			(R.p = r), (A.T = l);
 		}
 	}
-	function Od(e, t, n, u) {
+	function pd(e, t, n, u) {
 		var l = A.T;
 		A.T = null;
 		var r = R.p;
@@ -13225,7 +13225,7 @@ Error generating stack: ` +
 						return 2;
 					case tr:
 						return 8;
-					case pc:
+					case Oc:
 					case us:
 						return 32;
 					case nr:
@@ -13531,7 +13531,7 @@ Error generating stack: ` +
 				? Error(f(188))
 				: ((e = Object.keys(e).join(',')), Error(f(268, e)));
 		return (
-			(e = O(t)),
+			(e = p(t)),
 			(e = e !== null ? z(e) : null),
 			(e = e === null ? null : e.stateNode),
 			e
@@ -13784,14 +13784,14 @@ function ModalProvider({ children: a }) {
 		reactExports.useEffect(() => {
 			const f = gameEvents.on(
 					'modal:open',
-					({ id: d, title: y, content: S, size: x, onClose: O }) => {
+					({ id: d, title: y, content: S, size: x, onClose: p }) => {
 						i({
 							type: 'OPEN',
 							modal: {
 								id: d ?? crypto.randomUUID(),
 								title: y,
 								content: S,
-								onClose: O,
+								onClose: p,
 								closeOnOverlayClick: true,
 								closeOnEscape: true,
 								size: x ?? 'md',
@@ -14519,7 +14519,7 @@ function __wbg_get_imports() {
 			y,
 			S,
 			x,
-			O,
+			p,
 			z,
 		) {
 			getObject(a).blitFramebuffer(
@@ -14531,7 +14531,7 @@ function __wbg_get_imports() {
 				y,
 				S,
 				x,
-				O >>> 0,
+				p >>> 0,
 				z >>> 0,
 			);
 		},
@@ -14729,7 +14729,7 @@ function __wbg_get_imports() {
 			y,
 			S,
 			x,
-			O,
+			p,
 		) {
 			getObject(a).compressedTexSubImage2D(
 				c >>> 0,
@@ -14740,7 +14740,7 @@ function __wbg_get_imports() {
 				y,
 				S >>> 0,
 				x,
-				O,
+				p,
 			);
 		},
 		__wbg_compressedTexSubImage3D_77a6ab77487aa211: function (
@@ -14753,7 +14753,7 @@ function __wbg_get_imports() {
 			y,
 			S,
 			x,
-			O,
+			p,
 			z,
 			H,
 		) {
@@ -14766,7 +14766,7 @@ function __wbg_get_imports() {
 				y,
 				S,
 				x,
-				O >>> 0,
+				p >>> 0,
 				z,
 				H,
 			);
@@ -14781,7 +14781,7 @@ function __wbg_get_imports() {
 			y,
 			S,
 			x,
-			O,
+			p,
 			z,
 		) {
 			getObject(a).compressedTexSubImage3D(
@@ -14793,7 +14793,7 @@ function __wbg_get_imports() {
 				y,
 				S,
 				x,
-				O >>> 0,
+				p >>> 0,
 				getObject(z),
 			);
 		},
@@ -14878,9 +14878,9 @@ function __wbg_get_imports() {
 			y,
 			S,
 			x,
-			O,
+			p,
 		) {
-			getObject(a).copyTexSubImage3D(c >>> 0, i, f, _, d, y, S, x, O);
+			getObject(a).copyTexSubImage3D(c >>> 0, i, f, _, d, y, S, x, p);
 		},
 		__wbg_copyTextureToBuffer_f5501895b13306e1: function () {
 			return handleError(function (a, c, i, f) {
@@ -15904,10 +15904,10 @@ function __wbg_get_imports() {
 			return getObject(a).location;
 		},
 		__wbg_log_0c201ade58bb55e1: function (a, c, i, f, _, d, y, S) {
-			let x, O;
+			let x, p;
 			try {
 				(x = a),
-					(O = c),
+					(p = c),
 					console.log(
 						getStringFromWasm0(a, c),
 						getStringFromWasm0(i, f),
@@ -15915,7 +15915,7 @@ function __wbg_get_imports() {
 						getStringFromWasm0(y, S),
 					);
 			} finally {
-				wasm.__wbindgen_export4(x, O, 1);
+				wasm.__wbindgen_export4(x, p, 1);
 			}
 		},
 		__wbg_log_70972330cfc941dd: function (a, c, i, f) {
@@ -17309,7 +17309,7 @@ function __wbg_get_imports() {
 			getObject(a).submit(getObject(c));
 		},
 		__wbg_texImage2D_32ed4220040ca614: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texImage2D(
 					c >>> 0,
 					i,
@@ -17319,12 +17319,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texImage2D_d8c284c813952313: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texImage2D(
 					c >>> 0,
 					i,
@@ -17334,12 +17334,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					O,
+					p,
 				);
 			}, arguments);
 		},
 		__wbg_texImage2D_f4ae6c314a9a4bbe: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texImage2D(
 					c >>> 0,
 					i,
@@ -17349,12 +17349,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texImage3D_88ff1fa41be127b9: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z) {
 				getObject(a).texImage3D(
 					c >>> 0,
 					i,
@@ -17364,13 +17364,13 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x >>> 0,
-					O >>> 0,
+					p >>> 0,
 					getObject(z),
 				);
 			}, arguments);
 		},
 		__wbg_texImage3D_9a207e0459a4f276: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z) {
 				getObject(a).texImage3D(
 					c >>> 0,
 					i,
@@ -17380,7 +17380,7 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x >>> 0,
-					O >>> 0,
+					p >>> 0,
 					z,
 				);
 			}, arguments);
@@ -17398,7 +17398,7 @@ function __wbg_get_imports() {
 			getObject(a).texStorage3D(c >>> 0, i, f >>> 0, _, d, y);
 		},
 		__wbg_texSubImage2D_1e7d6febf82b9bed: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17408,12 +17408,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage2D_271ffedb47424d0d: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17423,12 +17423,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage2D_3bb41b987f2bfe39: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17438,12 +17438,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage2D_68e0413824eddc12: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17453,12 +17453,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage2D_b6cdbbe62097211a: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17468,12 +17468,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage2D_c8919d8f32f723da: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17483,12 +17483,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage2D_d784df0b813dc1ab: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17498,12 +17498,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					O,
+					p,
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage2D_dd1d50234b61de4b: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p) {
 				getObject(a).texSubImage2D(
 					c >>> 0,
 					i,
@@ -17513,12 +17513,12 @@ function __wbg_get_imports() {
 					y,
 					S >>> 0,
 					x >>> 0,
-					getObject(O),
+					getObject(p),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage3D_09cc863aedf44a21: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z, H) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z, H) {
 				getObject(a).texSubImage3D(
 					c >>> 0,
 					i,
@@ -17528,14 +17528,14 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x,
-					O >>> 0,
+					p >>> 0,
 					z >>> 0,
 					getObject(H),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage3D_4665e67a8f0f7806: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z, H) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z, H) {
 				getObject(a).texSubImage3D(
 					c >>> 0,
 					i,
@@ -17545,14 +17545,14 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x,
-					O >>> 0,
+					p >>> 0,
 					z >>> 0,
 					getObject(H),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage3D_61ed187f3ec11ecc: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z, H) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z, H) {
 				getObject(a).texSubImage3D(
 					c >>> 0,
 					i,
@@ -17562,14 +17562,14 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x,
-					O >>> 0,
+					p >>> 0,
 					z >>> 0,
 					getObject(H),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage3D_6a46981af8bc8e49: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z, H) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z, H) {
 				getObject(a).texSubImage3D(
 					c >>> 0,
 					i,
@@ -17579,14 +17579,14 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x,
-					O >>> 0,
+					p >>> 0,
 					z >>> 0,
 					getObject(H),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage3D_9eca35d234d51b8a: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z, H) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z, H) {
 				getObject(a).texSubImage3D(
 					c >>> 0,
 					i,
@@ -17596,14 +17596,14 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x,
-					O >>> 0,
+					p >>> 0,
 					z >>> 0,
 					getObject(H),
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage3D_b3cbbb79fe54da6d: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z, H) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z, H) {
 				getObject(a).texSubImage3D(
 					c >>> 0,
 					i,
@@ -17613,14 +17613,14 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x,
-					O >>> 0,
+					p >>> 0,
 					z >>> 0,
 					H,
 				);
 			}, arguments);
 		},
 		__wbg_texSubImage3D_f9c3af789162846a: function () {
-			return handleError(function (a, c, i, f, _, d, y, S, x, O, z, H) {
+			return handleError(function (a, c, i, f, _, d, y, S, x, p, z, H) {
 				getObject(a).texSubImage3D(
 					c >>> 0,
 					i,
@@ -17630,7 +17630,7 @@ function __wbg_get_imports() {
 					y,
 					S,
 					x,
-					O >>> 0,
+					p >>> 0,
 					z >>> 0,
 					getObject(H),
 				);
@@ -18890,10 +18890,10 @@ function useInventory() {
 					const y = /* @__PURE__ */ new Map();
 					for (const x of d.items) y.set(x.kind, x.quantity);
 					const S = i.current;
-					for (const [x, O] of y) {
+					for (const [x, p] of y) {
 						const z = S.get(x) ?? 0;
-						if (O > z) {
-							const H = O - z,
+						if (p > z) {
+							const H = p - z,
 								J = ITEM_NAMES[x] ?? x;
 							gameEvents.emit('toast:show', {
 								message: `+${H} ${J}`,
@@ -19092,10 +19092,10 @@ function worldToScreen(a, c, i, f) {
 		y = i / f,
 		S = d * y,
 		x = dot(_, AXES.right) / S,
-		O = dot(_, AXES.up) / d;
-	return Math.abs(x) > 1.2 || Math.abs(O) > 1.2
+		p = dot(_, AXES.up) / d;
+	return Math.abs(x) > 1.2 || Math.abs(p) > 1.2
 		? null
-		: { x: ((x + 1) / 2) * i, y: ((1 - O) / 2) * f };
+		: { x: ((x + 1) / 2) * i, y: ((1 - p) / 2) * f };
 }
 const OBJECT_NAMES = {
 		tree: 'Tree',
@@ -19155,13 +19155,13 @@ function ObjectLabel() {
 							y.position[2] + CAMERA_OFFSET[2],
 						],
 						x = [_.position[0], _.position[1] + 1.5, _.position[2]],
-						O = worldToScreen(
+						p = worldToScreen(
 							x,
 							S,
 							window.innerWidth,
 							window.innerHeight,
 						);
-					if (!O) {
+					if (!p) {
 						c(null);
 						return;
 					}
@@ -19175,7 +19175,7 @@ function ObjectLabel() {
 						_.kind === 'mushroom' &&
 							_.sub_kind &&
 							(z = MUSHROOM_NAMES[_.sub_kind] ?? z),
-						c({ name: z, screenX: O.x, screenY: O.y });
+						c({ name: z, screenX: p.x, screenY: p.y });
 				} catch {
 					c(null);
 				}
@@ -19486,51 +19486,25 @@ function App() {
 		})
 	);
 }
-function supportsDecompression(a) {
-	try {
-		return new DecompressionStream(a), true;
-	} catch {
-		return false;
-	}
-}
-async function fetchCompressedWasm(a) {
-	const c = [];
-	supportsDecompression('brotli') &&
-		c.push({ ext: '.wasm.br', encoding: 'brotli' }),
-		c.push({ ext: '.wasm.gz', encoding: 'gzip' });
-	for (const { ext: i, encoding: f } of c)
-		try {
-			const _ = await fetch(new URL('isometric_game_bg' + i, a));
-			if (!_.ok) continue;
-			const d = _.body.pipeThrough(new DecompressionStream(f)),
-				y = await new Response(d).arrayBuffer();
-			return WebAssembly.compile(y);
-		} catch {
-			continue;
-		}
-	throw new Error('Failed to load compressed WASM');
-}
 async function bootstrap() {
 	if (!navigator.gpu) {
-		const f = document.getElementById('root');
-		f &&
-			((f.innerHTML =
+		const c = document.getElementById('root');
+		c &&
+			((c.innerHTML =
 				'<div style="color:#fff;padding:2rem;text-align:center"><h2>WebGPU Not Available</h2><p>This browser does not support WebGPU (Chrome 113+, Edge 113+, Safari 18+).</p></div>'),
-			(f.style.pointerEvents = 'auto'));
+			(c.style.pointerEvents = 'auto'));
 		return;
 	}
 	const { default: a } = await __vitePreload(
-			async () => {
-				const { default: f } = await Promise.resolve().then(
-					() => isometric_game,
-				);
-				return { default: f };
-			},
-			void 0,
-		),
-		c = new URL('/isometric/assets/', window.location.origin),
-		i = await fetchCompressedWasm(c);
-	await a(i),
+		async () => {
+			const { default: c } = await Promise.resolve().then(
+				() => isometric_game,
+			);
+			return { default: c };
+		},
+		void 0,
+	);
+	await a(),
 		ReactDOM.createRoot(document.getElementById('root')).render(
 			jsxRuntimeExports.jsx(React.StrictMode, {
 				children: jsxRuntimeExports.jsx(GameUIProvider, {

--- a/apps/kbve/isometric/src/main.tsx
+++ b/apps/kbve/isometric/src/main.tsx
@@ -4,40 +4,6 @@ import './app.css';
 import { GameUIProvider } from './ui/provider/GameUIProvider';
 import App from './App';
 
-function supportsDecompression(encoding: CompressionFormat | string): boolean {
-	try {
-		new DecompressionStream(encoding as CompressionFormat);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-async function fetchCompressedWasm(base: URL): Promise<WebAssembly.Module> {
-	const variants: Array<{
-		ext: string;
-		encoding: CompressionFormat | string;
-	}> = [];
-	if (supportsDecompression('brotli'))
-		variants.push({ ext: '.wasm.br', encoding: 'brotli' });
-	variants.push({ ext: '.wasm.gz', encoding: 'gzip' });
-
-	for (const { ext, encoding } of variants) {
-		try {
-			const res = await fetch(new URL('isometric_game_bg' + ext, base));
-			if (!res.ok) continue;
-			const decompressed = res.body!.pipeThrough(
-				new DecompressionStream(encoding as CompressionFormat),
-			);
-			const bytes = await new Response(decompressed).arrayBuffer();
-			return WebAssembly.compile(bytes);
-		} catch {
-			continue;
-		}
-	}
-	throw new Error('Failed to load compressed WASM');
-}
-
 async function bootstrap() {
 	// Verify WebGPU is available before loading the WASM game
 	if (!(navigator as unknown as { gpu?: unknown }).gpu) {
@@ -54,12 +20,9 @@ async function bootstrap() {
 	}
 
 	// Load and initialize Bevy WASM — starts the game loop (non-blocking)
+	// Tower-http serves pre-compressed .wasm.br/.wasm.gz transparently via Content-Encoding
 	const { default: init } = await import('../wasm-pkg/isometric_game.js');
-
-	// Fetch pre-compressed WASM and decompress client-side (brotli → gzip fallback)
-	const wasmBase = new URL('/isometric/assets/', window.location.origin);
-	const wasmBytes = await fetchCompressedWasm(wasmBase);
-	await init(wasmBytes);
+	await init();
 
 	// Render React UI overlay
 	ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
## Summary
- Remove `fetchCompressedWasm()`, `supportsDecompression()`, and `DecompressionStream` client-side code from `main.tsx`
- Revert to simple `init()` call — tower-http's `precompressed_br()`/`precompressed_gzip()` already serves `.wasm.br`/`.wasm.gz` with `Content-Encoding` header, so the browser auto-decompresses
- **Root cause**: double-decompression (tower-http decompresses via header + client-side `DecompressionStream`) corrupted WASM bytes → `__wasm_bindgen_func_elem_120991 is not a function` runtime crash
- Rebuild `index.js` asset without decompression code

## Test plan
- [ ] Deploy and verify kbve.com/arcade/isometric/ loads without WASM errors
- [ ] Confirm `.wasm.br` is served with `Content-Encoding: br` header
- [ ] Verify game initializes correctly in Chrome/Safari