### PR TITLE
fix(ci): add build-essential and tauri-cli to Tauri build workflow

### DIFF
--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -87,6 +87,7 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends \
+                    build-essential \
                     pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev \
                     libayatana-appindicator3-dev libxdo-dev \
                     libasound2-dev libudev-dev libvulkan-dev
@@ -112,6 +113,9 @@ jobs:
 
             - name: Install wasm-pack
               run: cargo install wasm-pack --locked
+
+            - name: Install tauri-cli
+              run: cargo install tauri-cli --locked
 
             - name: Setup Node v24
               uses: actions/setup-node@v6
@@ -201,6 +205,9 @@ jobs:
             - name: Install wasm-pack
               run: cargo install wasm-pack --locked
 
+            - name: Install tauri-cli
+              run: cargo install tauri-cli --locked
+
             - name: Setup Node v24
               uses: actions/setup-node@v6
               with:
@@ -286,6 +293,9 @@ jobs:
 
             - name: Install wasm-pack
               run: cargo install wasm-pack --locked
+
+            - name: Install tauri-cli
+              run: cargo install tauri-cli --locked
 
             - name: Setup Node v24
               uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- **Linux**: added `build-essential` to apt-get install — self-hosted runner lacked `gcc`, causing `linker 'cc' not found` when compiling wasm-pack
- **macOS & Windows**: added `cargo install tauri-cli --locked` — `cargo tauri build` failed with `no such command: 'tauri'`
- WASM build job left unchanged (it doesn't use `cargo tauri`)

Fixes [Build Linux failure](https://github.com/KBVE/kbve/actions/runs/22929254467/job/66547075793)

## Test plan
- [ ] Verify Linux Tauri build passes (wasm-pack compiles, then `cargo tauri build` runs)
- [ ] Verify macOS Tauri build passes
- [ ] Verify Windows Tauri build passes
- [ ] Verify WASM build still passes (unchanged)