### PR TITLE
feat(isometric): add loading screen during WASM initialization

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
+++ b/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
@@ -23,12 +23,23 @@
 			<a href="/arcade/" class="back-link">Back to Arcade</a>
 		</div>
 	</div>
+	<div id="game-loading" class="not-content">
+		<div class="loading-card">
+			<div class="loading-spinner"></div>
+			<h2>Loading Game</h2>
+			<p id="loading-status">Initializing...</p>
+			<div class="loading-bar-track">
+				<div id="loading-bar" class="loading-bar-fill"></div>
+			</div>
+		</div>
+	</div>
 	<canvas id="bevy-canvas" style="display: none;"></canvas>
 	<div id="root" style="display: none;"></div>
 	<link rel="stylesheet" crossorigin href="/isometric/assets/index.css" />
 	<script is:inline>
 		(function () {
 			if (navigator.gpu) {
+				document.getElementById('game-loading').style.display = 'flex';
 				document.getElementById('bevy-canvas').style.display = '';
 				document.getElementById('root').style.display = '';
 				var s = document.createElement('script');
@@ -170,6 +181,69 @@
 
 	.back-link:hover {
 		background: #4a4a8a;
+	}
+
+	#game-loading {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		display: none;
+		align-items: center;
+		justify-content: center;
+		z-index: 50;
+		background: var(--sl-color-bg, #1a1a26);
+	}
+
+	.loading-card {
+		text-align: center;
+		color: var(--sl-color-text, #e0e0e0);
+	}
+
+	.loading-spinner {
+		width: 48px;
+		height: 48px;
+		margin: 0 auto 1.25rem;
+		border: 3px solid var(--sl-color-gray-5, #3a3a5c);
+		border-top-color: var(--sl-color-text-accent, #7a7aff);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.loading-card h2 {
+		font-size: 1.25rem;
+		margin: 0 0 0.5rem;
+		color: var(--sl-color-white, #c0c0e0);
+	}
+
+	.loading-card p {
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3, #808090);
+		margin: 0 0 1.25rem;
+	}
+
+	.loading-bar-track {
+		width: 240px;
+		height: 4px;
+		background: var(--sl-color-gray-6, #2a2a3a);
+		border-radius: 2px;
+		overflow: hidden;
+		margin: 0 auto;
+	}
+
+	.loading-bar-fill {
+		height: 100%;
+		width: 0%;
+		background: var(--sl-color-text-accent, #7a7aff);
+		border-radius: 2px;
+		transition: width 0.3s ease;
 	}
 
 	:global(body:has(.isometric-game-container)) {

--- a/apps/kbve/isometric/src/main.tsx
+++ b/apps/kbve/isometric/src/main.tsx
@@ -4,6 +4,22 @@ import './app.css';
 import { GameUIProvider } from './ui/provider/GameUIProvider';
 import App from './App';
 
+function setLoadingProgress(status: string, percent: number) {
+	const el = document.getElementById('loading-status');
+	const bar = document.getElementById('loading-bar');
+	if (el) el.textContent = status;
+	if (bar) bar.style.width = percent + '%';
+}
+
+function hideLoadingScreen() {
+	const el = document.getElementById('game-loading');
+	if (el) {
+		el.style.opacity = '0';
+		el.style.transition = 'opacity 0.4s ease';
+		setTimeout(() => el.remove(), 400);
+	}
+}
+
 async function bootstrap() {
 	// Verify WebGPU is available before loading the WASM game
 	if (!(navigator as unknown as { gpu?: unknown }).gpu) {
@@ -19,10 +35,17 @@ async function bootstrap() {
 		return;
 	}
 
+	setLoadingProgress('Loading game module...', 20);
+
 	// Load and initialize Bevy WASM — starts the game loop (non-blocking)
 	// Tower-http serves pre-compressed .wasm.br/.wasm.gz transparently via Content-Encoding
 	const { default: init } = await import('../wasm-pkg/isometric_game.js');
+
+	setLoadingProgress('Initializing WebGPU...', 60);
+
 	await init();
+
+	setLoadingProgress('Starting...', 90);
 
 	// Render React UI overlay
 	ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
@@ -32,6 +55,12 @@ async function bootstrap() {
 			</GameUIProvider>
 		</React.StrictMode>,
 	);
+
+	setLoadingProgress('Ready', 100);
+	hideLoadingScreen();
 }
 
-bootstrap().catch(console.error);
+bootstrap().catch((err) => {
+	setLoadingProgress('Failed to load game', 0);
+	console.error(err);
+});


### PR DESCRIPTION
## Summary
- Add static HTML loading screen in AstroIsometric.astro that renders instantly before any JS loads
- Shows spinner, status text, and animated progress bar
- React (`main.tsx`) updates progress through stages: Initializing → Loading module (20%) → WebGPU init (60%) → Starting (90%) → Ready (100%)
- Loading screen fades out once game is ready
- Uses `not-content` class and Starlight CSS variables (`--sl-color-text-accent`, `--sl-color-bg`, etc.) for consistent theming
- Error state shows "Failed to load game" if bootstrap crashes

## Test plan
- [ ] Verify loading screen appears immediately on page load
- [ ] Confirm progress bar animates through stages
- [ ] Verify loading screen fades out once game renders
- [ ] Check WebGPU warning still shows on unsupported browsers
- [ ] Verify no Starlight style conflicts with `not-content`