### PR TITLE
feat(isometric): mobile UI with action buttons and lighting fixes

### DIFF
--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -13,15 +13,23 @@
 		"dev": {
 			"executor": "nx:run-commands",
 			"options": {
-				"commands": ["pnpm build:wasm && pnpm dev"],
-				"cwd": "apps/kbve/isometric"
+				"commands": [
+					"lsof -ti:1420 | xargs kill 2>/dev/null; pnpm build:wasm && pnpm dev"
+				],
+				"cwd": "apps/kbve/isometric",
+				"env": {
+					"PATH": "${HOME}/.cargo/bin:${PATH}"
+				}
 			}
 		},
 		"build": {
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": ["pnpm build"],
-				"cwd": "apps/kbve/isometric"
+				"cwd": "apps/kbve/isometric",
+				"env": {
+					"PATH": "${HOME}/.cargo/bin:${PATH}"
+				}
 			}
 		},
 		"deploy": {

--- a/apps/kbve/isometric/src-tauri/assets/shaders/pixelate.wgsl
+++ b/apps/kbve/isometric/src-tauri/assets/shaders/pixelate.wgsl
@@ -289,16 +289,6 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         depth_raw
     ) * settings.shadow_strength;
 
-    // ── ALPHA SILHOUETTE EDGES (object-ID boundary detection) ──────────
-    // Vertex alpha encodes object type (terrain=1.0, canopy=0.75, trunk=0.85).
-    // Any alpha discontinuity between adjacent blocks marks a silhouette edge
-    // — works even when colors are identical (green canopy on green grass).
-    let alpha_diff = max(
-        max(abs(color.a - color_left.a), abs(color.a - color_right.a)),
-        max(abs(color.a - color_top.a), abs(color.a - color_bottom.a))
-    );
-    let alpha_edge = smoothstep(0.03, 0.08, alpha_diff);
-
     // ── ARTIFACT SUPPRESSION ─────────────────────────────────────────────
     let neg_depth_edge = smoothstep(
         settings.depth_threshold_low,
@@ -322,9 +312,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
             block_pos.x < edge_width || block_pos.y < edge_width);
     }
 
-    // Combine color-based edges with alpha silhouette edges.
-    // Alpha edges contribute as shadow lines (dark outlines around objects).
-    let final_shadow = max(depth_edge, alpha_edge * settings.shadow_strength) * at_edge;
+    let final_shadow = depth_edge * at_edge;
     let final_highlight = suppressed_highlight * at_edge;
 
     // ── DUAL-TONE COMPOSITING ────────────────────────────────────────────
@@ -360,6 +348,5 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         result += vec3(noise);
     }
 
-    // Force alpha=1.0: vertex alpha is used only for edge detection, not transparency.
-    return vec4(result, 1.0);
+    return vec4(result, color.a);
 }

--- a/apps/kbve/isometric/src-tauri/src/game/player.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/player.rs
@@ -121,7 +121,7 @@ fn spawn_player(
 
 fn move_player(
     keyboard: Res<ButtonInput<KeyCode>>,
-    joystick: Res<VirtualJoystickState>,
+    mut joystick: ResMut<VirtualJoystickState>,
     time: Res<Time>,
     mut query: Query<
         (
@@ -159,8 +159,11 @@ fn move_player(
 
         let horizontal = direction * PLAYER_SPEED * time.delta_secs();
 
-        // Jump
-        if keyboard.just_pressed(KeyCode::Space) && physics.on_ground {
+        // Jump (keyboard Space or mobile jump button)
+        let jump_btn = joystick.jump_requested;
+        joystick.jump_requested = false;
+        joystick.action_requested = false;
+        if (keyboard.just_pressed(KeyCode::Space) || jump_btn) && physics.on_ground {
             physics.velocity_y = JUMP_VELOCITY;
             physics.on_ground = false;
             physics.fall_start_y = transform.translation.y;

--- a/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::camera::IsometricCamera;
 use super::player::Player;
+use super::virtual_joystick::VirtualJoystickState;
 
 // Desktop: bridged cursor for Rapier raycast hover detection
 #[cfg(not(target_arch = "wasm32"))]
@@ -340,12 +341,21 @@ fn raycast_hover_detection_wasm(
     hoverable: Query<(), With<HoverOutline>>,
     current_hovered: Query<Entity, With<Hovered>>,
     player_query: Query<Entity, With<Player>>,
+    joystick: Res<VirtualJoystickState>,
     mut commands: Commands,
 ) {
     let Ok(window) = windows.single() else { return };
     let Ok((cam_gt, projection)) = camera_query.single() else {
         return;
     };
+
+    // Skip raycasting when the pointer is captured by the joystick UI.
+    if joystick.pointer_captured {
+        for entity in &current_hovered {
+            commands.entity(entity).remove::<Hovered>();
+        }
+        return;
+    }
 
     let Some(cursor_pos) = window.cursor_position() else {
         for entity in &current_hovered {

--- a/apps/kbve/isometric/src-tauri/src/game/trees.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/trees.rs
@@ -11,23 +11,6 @@ use super::tilemap::{TILE_SIZE, build_chunk_mesh, lerp3, srgb_color};
 use super::weather::BlobShadow;
 
 // ---------------------------------------------------------------------------
-// Object-ID alpha tags (used by pixelate shader for silhouette edge detection)
-// ---------------------------------------------------------------------------
-
-/// Alpha value for tree canopy vertices — distinct from terrain (1.0) so the
-/// post-process shader can detect silhouette edges even when colors match.
-const CANOPY_ALPHA: f32 = 0.75;
-
-/// Alpha value for tree trunk / bark vertices.
-const TRUNK_ALPHA: f32 = 0.85;
-
-/// Like `srgb_color` but with a custom alpha for object-ID edge detection.
-fn srgb_color_a(r: f32, g: f32, b: f32, a: f32) -> [f32; 4] {
-    let c = srgb_color(r, g, b);
-    [c[0], c[1], c[2], a]
-}
-
-// ---------------------------------------------------------------------------
 // Bark palettes
 // ---------------------------------------------------------------------------
 
@@ -203,7 +186,7 @@ const TREE_PRESETS: [TreePreset; 6] = [
 /// Returns `[top_cap, bottom, lit, shadow, semi_shadow, semi_lit]`.
 fn bark_face_colors_with(y_frac: f32, bp: &BarkPalette) -> [[f32; 4]; 6] {
     let root = if y_frac < 0.15 { 0.82 } else { 1.0 };
-    let apply = |c: (f32, f32, f32)| srgb_color_a(c.0 * root, c.1 * root, c.2 * root, TRUNK_ALPHA);
+    let apply = |c: (f32, f32, f32)| srgb_color(c.0 * root, c.1 * root, c.2 * root);
 
     let lit = lerp3(bp.mid_light, bp.highlight, 0.5 + y_frac * 0.5);
     let shadow = lerp3(bp.dark, bp.mid_dark, y_frac * 0.3);
@@ -709,15 +692,14 @@ pub fn build_tree_geometry(tx: i32, tz: i32, size_scale: f32) -> TreeGeometry {
         (canopy_base.2 - tree_hj * 0.5) * tree_bright,
     );
 
-    let c_highlight = srgb_color_a(
+    let c_highlight = srgb_color(
         (tb.0 * 1.15 + 0.03).min(1.0),
         (tb.1 * 1.10 + 0.02).min(1.0),
         (tb.2 * 0.88).min(1.0),
-        CANOPY_ALPHA,
     );
-    let c_mid = srgb_color_a(tb.0, tb.1, tb.2, CANOPY_ALPHA);
-    let c_shadow = srgb_color_a(tb.0 * 0.45, tb.1 * 0.58, tb.2 * 0.65, CANOPY_ALPHA);
-    let c_body = srgb_color_a(tb.0 * 0.72, tb.1 * 0.78, tb.2 * 0.82, CANOPY_ALPHA);
+    let c_mid = srgb_color(tb.0, tb.1, tb.2);
+    let c_shadow = srgb_color(tb.0 * 0.45, tb.1 * 0.58, tb.2 * 0.65);
+    let c_body = srgb_color(tb.0 * 0.72, tb.1 * 0.78, tb.2 * 0.82);
 
     let tree_rot_angle = hash2d(seed_base + 72, 6072) * std::f32::consts::TAU;
     let (rot_sin, rot_cos) = tree_rot_angle.sin_cos();

--- a/apps/kbve/isometric/src-tauri/src/game/virtual_joystick.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/virtual_joystick.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::ui::FocusPolicy;
 use bevy::window::PrimaryWindow;
 
 // ---------------------------------------------------------------------------
@@ -11,6 +12,13 @@ pub struct VirtualJoystickState {
     pub active: bool,
     /// Isometric movement direction (XZ plane, not normalized — magnitude = analog intensity).
     pub direction: Vec3,
+    /// True when the pointer is over or interacting with the joystick area.
+    /// Scene picking systems should skip raycasting when this is true.
+    pub pointer_captured: bool,
+    /// Set by the Bevy UI jump button; consumed (cleared) each frame by the player system.
+    pub jump_requested: bool,
+    /// Set by the Bevy UI action button; consumed each frame by the player/combat system.
+    pub action_requested: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -24,6 +32,14 @@ struct JoystickBase;
 /// Marker for the joystick knob (inner circle that moves).
 #[derive(Component)]
 struct JoystickKnob;
+
+/// Marker for the jump button (bottom-right).
+#[derive(Component)]
+struct JumpButton;
+
+/// Marker for the action button (bottom-right, above jump).
+#[derive(Component)]
+struct ActionButton;
 
 /// Tracks joystick drag state.
 #[derive(Resource, Default)]
@@ -45,6 +61,12 @@ const KNOB_SIZE: f32 = 48.0;
 const MAX_TRAVEL: f32 = (BASE_SIZE - KNOB_SIZE) / 2.0;
 /// Margin from bottom-left corner.
 const MARGIN: f32 = 24.0;
+/// Action button size.
+const ACTION_BTN_SIZE: f32 = 56.0;
+/// Margin from bottom-right corner for action buttons.
+const ACTION_MARGIN: f32 = 24.0;
+/// Gap between stacked action buttons.
+const ACTION_GAP: f32 = 12.0;
 
 // ---------------------------------------------------------------------------
 // Plugin
@@ -57,7 +79,7 @@ impl Plugin for VirtualJoystickPlugin {
         app.init_resource::<VirtualJoystickState>();
         app.init_resource::<JoystickDrag>();
         app.add_systems(Startup, spawn_joystick_ui);
-        app.add_systems(Update, handle_joystick_input);
+        app.add_systems(Update, (handle_joystick_input, handle_action_buttons));
     }
 }
 
@@ -80,6 +102,8 @@ fn spawn_joystick_ui(mut commands: Commands) {
             ..default()
         })
         .insert(BackgroundColor(Color::srgba(1.0, 1.0, 1.0, 0.12)))
+        .insert(Interaction::default())
+        .insert(FocusPolicy::Block)
         .insert(JoystickBase)
         .with_children(|parent| {
             // Knob: smaller circle inside
@@ -93,6 +117,90 @@ fn spawn_joystick_ui(mut commands: Commands) {
                 .insert(BackgroundColor(Color::srgba(1.0, 1.0, 1.0, 0.35)))
                 .insert(JoystickKnob);
         });
+
+    // --- Action buttons (bottom-right) ---
+    // Container for vertical button stack
+    commands
+        .spawn(Node {
+            position_type: PositionType::Absolute,
+            right: Val::Px(ACTION_MARGIN),
+            bottom: Val::Px(ACTION_MARGIN),
+            flex_direction: FlexDirection::Column,
+            row_gap: Val::Px(ACTION_GAP),
+            align_items: AlignItems::Center,
+            ..default()
+        })
+        .with_children(|parent| {
+            // Action button (top of stack)
+            parent
+                .spawn((
+                    Node {
+                        width: Val::Px(ACTION_BTN_SIZE),
+                        height: Val::Px(ACTION_BTN_SIZE),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        border_radius: BorderRadius::all(Val::Percent(50.0)),
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgba(0.9, 0.6, 0.2, 0.25)),
+                    Interaction::default(),
+                    FocusPolicy::Block,
+                    ActionButton,
+                ))
+                .with_child((
+                    Text::new("ACT".to_string()),
+                    TextFont {
+                        font_size: 11.0,
+                        ..default()
+                    },
+                    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.7)),
+                ));
+            // Jump button (bottom of stack)
+            parent
+                .spawn((
+                    Node {
+                        width: Val::Px(ACTION_BTN_SIZE),
+                        height: Val::Px(ACTION_BTN_SIZE),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        border_radius: BorderRadius::all(Val::Percent(50.0)),
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgba(0.3, 0.7, 1.0, 0.25)),
+                    Interaction::default(),
+                    FocusPolicy::Block,
+                    JumpButton,
+                ))
+                .with_child((
+                    Text::new("JMP".to_string()),
+                    TextFont {
+                        font_size: 11.0,
+                        ..default()
+                    },
+                    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.7)),
+                ));
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Action button handler
+// ---------------------------------------------------------------------------
+
+fn handle_action_buttons(
+    jump_query: Query<&Interaction, With<JumpButton>>,
+    action_query: Query<&Interaction, (With<ActionButton>, Without<JumpButton>)>,
+    mut joystick_state: ResMut<VirtualJoystickState>,
+) {
+    if let Ok(interaction) = jump_query.single() {
+        if *interaction == Interaction::Pressed {
+            joystick_state.jump_requested = true;
+        }
+    }
+    if let Ok(interaction) = action_query.single() {
+        if *interaction == Interaction::Pressed {
+            joystick_state.action_requested = true;
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -105,7 +213,7 @@ fn handle_joystick_input(
     windows: Query<&Window, With<PrimaryWindow>>,
     mut drag: ResMut<JoystickDrag>,
     mut joystick_state: ResMut<VirtualJoystickState>,
-    base_query: Query<(&Node, &GlobalTransform), With<JoystickBase>>,
+    base_query: Query<&Interaction, With<JoystickBase>>,
     mut knob_query: Query<&mut Node, (With<JoystickKnob>, Without<JoystickBase>)>,
 ) {
     let Ok(window) = windows.single() else {
@@ -121,26 +229,26 @@ fn handle_joystick_input(
 
     let pointer_pressed =
         !touches.iter().next().is_none() || mouse_button.pressed(MouseButton::Left);
-    let pointer_just_pressed = touches.iter_just_pressed().next().is_some()
-        || mouse_button.just_pressed(MouseButton::Left);
 
-    // Get joystick base center in screen space
-    let Ok((_base_node, _base_gt)) = base_query.single() else {
-        return;
-    };
+    // Use Bevy UI Interaction to detect press on the joystick base —
+    // this properly blocks input from passing through to the 3D scene.
+    let base_interaction = base_query
+        .single()
+        .ok()
+        .copied()
+        .unwrap_or(Interaction::None);
     let base_center = Vec2::new(
         MARGIN + BASE_SIZE / 2.0,
         window.height() - MARGIN - BASE_SIZE / 2.0,
     );
 
-    // Start drag if pointer pressed inside the base circle
-    if pointer_just_pressed {
-        if let Some(pos) = pointer_pos {
-            if pos.distance(base_center) <= BASE_SIZE / 2.0 {
-                drag.active = true;
-                drag.center = base_center;
-            }
-        }
+    // Tell scene picking systems to ignore raycasts when pointer is on the joystick.
+    joystick_state.pointer_captured = base_interaction != Interaction::None || drag.active;
+
+    // Start drag when Bevy UI reports a press on the base
+    if base_interaction == Interaction::Pressed && !drag.active {
+        drag.active = true;
+        drag.center = base_center;
     }
 
     // End drag when pointer released

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -79,9 +79,9 @@ fn sun_params(hour: f32) -> SunParams {
     let moon_dir = Vec3::new(-0.15, -0.97, -0.20).normalize();
     let direction = (sun_dir * sun_height + moon_dir * (1.0 - sun_height)).normalize();
 
-    // Illuminance: tied directly to sun height.
-    // Peaks at ~8200 lux at noon, settles to 15 lux moonlight at night.
-    let illuminance = 15.0 + sun_height * 8185.0;
+    // Illuminance: moderate sun — accent light, not the sole brightness source.
+    // Lower peak keeps shadow contrast gentle for a stylized look.
+    let illuminance = 15.0 + sun_height * 4000.0;
 
     // Light color: warm golden near horizon, white at zenith, cool blue at night.
     let lr = 0.4 + sun_height * 0.6;
@@ -89,12 +89,13 @@ fn sun_params(hour: f32) -> SunParams {
     let lb = 0.65 + sun_height * 0.35;
     let color = Color::srgb(lr, lg, lb);
 
-    // Ambient: follows sun height from dim blue night to bright day.
-    let ambient_brightness = 60.0 + sun_height * 200.0;
+    // Ambient: strong fill — the main brightness source in a stylized world.
+    // Shadowed areas stay readable as tinted, not dark. Green-tinted for grass bounce.
+    let ambient_brightness = 150.0 + sun_height * 450.0;
     let ambient_color = Color::srgb(
-        0.35 + sun_height * 0.55,
-        0.40 + sun_height * 0.52,
-        0.65 + sun_height * 0.35,
+        0.50 + sun_height * 0.40,
+        0.55 + sun_height * 0.37,
+        0.45 + sun_height * 0.30,
     );
 
     SunParams {

--- a/apps/kbve/isometric/src/components/HUD.tsx
+++ b/apps/kbve/isometric/src/components/HUD.tsx
@@ -30,7 +30,7 @@ export function HUD() {
 	if (!state) return null;
 
 	return (
-		<GlassPanel className="absolute bottom-4 left-4 md:bottom-6 md:left-6 px-3 py-2 md:px-4 md:py-3">
+		<GlassPanel className="absolute top-4 right-4 md:top-6 md:right-6 px-3 py-2 md:px-4 md:py-3 pointer-events-none">
 			<ProgressBar
 				label="HP"
 				value={state.health}

--- a/apps/kbve/isometric/src/components/Inventory.tsx
+++ b/apps/kbve/isometric/src/components/Inventory.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useInventory } from '../hooks/useInventory';
 
 const GRID_COLS = 4;
@@ -49,54 +50,68 @@ const ITEM_SHORT_NAMES: Record<string, string> = {
 };
 
 export function Inventory() {
+	const [open, setOpen] = useState(false);
 	const inventory = useInventory();
 	const items = inventory?.items ?? [];
 
 	return (
 		<div className="absolute bottom-4 right-4 md:bottom-6 md:right-6 pointer-events-auto">
-			{/* Outer frame — golden border */}
-			<div className="border-[3px] border-panel-border shadow-[0_0_0_1px_#1a1008,0_4px_12px_rgba(0,0,0,0.6)]">
-				{/* Inner frame — dark inset */}
-				<div className="border-2 border-[#1a1008] bg-panel-inner p-2 md:p-3">
-					<div className="text-[7px] md:text-[10px] mb-1.5 md:mb-2 text-center text-[#c8a832]">
-						Inventory
-					</div>
-					{/* Slot grid inside inset panel */}
-					<div className="p-1 md:p-1.5 bg-[#1e1408] border border-[#5a4a2a]">
-						<div className="grid grid-cols-4 gap-px md:gap-0.5">
-							{Array.from({ length: TOTAL_SLOTS }).map((_, i) => {
-								const item = items[i];
-								return (
-									<div
-										key={i}
-										className="w-7 h-7 md:w-11 md:h-11 bg-[#261a0a] border border-[#3d2b14]
-											shadow-[inset_0_1px_2px_rgba(0,0,0,0.4)]
-											flex flex-col items-center justify-center relative">
-										{item && (
-											<>
-												<span className="text-[10px] md:text-[14px] leading-none">
-													{ITEM_ICONS[item.kind] ??
-														'?'}
-												</span>
-												<span className="text-[5px] md:text-[7px] text-text-muted leading-none mt-px">
-													{ITEM_SHORT_NAMES[
-														item.kind
-													] ?? item.kind}
-												</span>
-												{item.quantity > 1 && (
-													<span className="absolute bottom-0 right-0.5 text-[5px] md:text-[7px] text-[#c8a832] leading-none">
-														{item.quantity}
-													</span>
+			{/* Toggle button */}
+			<button
+				onClick={() => setOpen(!open)}
+				className="block ml-auto mb-1 px-2 py-1 text-[8px] md:text-[10px]
+					bg-panel-inner border-2 border-panel-border text-[#c8a832]
+					shadow-[0_0_0_1px_#1a1008,0_2px_6px_rgba(0,0,0,0.5)]
+					hover:bg-[#2a1c0c] active:bg-[#1a1008] transition-colors">
+				{open ? 'Close' : 'Bag'}
+			</button>
+
+			{/* Inventory grid — only shown when open */}
+			{open && (
+				<div className="border-[3px] border-panel-border shadow-[0_0_0_1px_#1a1008,0_4px_12px_rgba(0,0,0,0.6)]">
+					<div className="border-2 border-[#1a1008] bg-panel-inner p-2 md:p-3">
+						<div className="text-[7px] md:text-[10px] mb-1.5 md:mb-2 text-center text-[#c8a832]">
+							Inventory
+						</div>
+						<div className="p-1 md:p-1.5 bg-[#1e1408] border border-[#5a4a2a]">
+							<div className="grid grid-cols-4 gap-px md:gap-0.5">
+								{Array.from({ length: TOTAL_SLOTS }).map(
+									(_, i) => {
+										const item = items[i];
+										return (
+											<div
+												key={i}
+												className="w-7 h-7 md:w-11 md:h-11 bg-[#261a0a] border border-[#3d2b14]
+												shadow-[inset_0_1px_2px_rgba(0,0,0,0.4)]
+												flex flex-col items-center justify-center relative">
+												{item && (
+													<>
+														<span className="text-[10px] md:text-[14px] leading-none">
+															{ITEM_ICONS[
+																item.kind
+															] ?? '?'}
+														</span>
+														<span className="text-[5px] md:text-[7px] text-text-muted leading-none mt-px">
+															{ITEM_SHORT_NAMES[
+																item.kind
+															] ?? item.kind}
+														</span>
+														{item.quantity > 1 && (
+															<span className="absolute bottom-0 right-0.5 text-[5px] md:text-[7px] text-[#c8a832] leading-none">
+																{item.quantity}
+															</span>
+														)}
+													</>
 												)}
-											</>
-										)}
-									</div>
-								);
-							})}
+											</div>
+										);
+									},
+								)}
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- **Mobile action buttons**: ACT and JMP buttons (bottom-right) for touch-based combat and jumping
- **Joystick input blocking**: 3D scene raycasts are suppressed when pointer interacts with joystick/UI, preventing accidental tree/rock selection
- **UI layout for mobile**: HUD moved to top-right, inventory converted to toggle button (bottom-right), joystick stays bottom-left
- **Valley lighting fix**: Rebalanced sun-to-ambient ratio (8200→4000 lux sun, 260→600 ambient) to prevent dark valleys at lower elevations
- **Cleanup**: Removed experimental alpha silhouette edge detection from shader and tree vertex colors
- **DX**: Added PATH env and port-kill to nx dev target for reliable wasm-pack builds

## Test plan
- [ ] Verify joystick works on mobile/touch and desktop mouse
- [ ] Verify ACT/JMP buttons appear bottom-right and JMP triggers player jump
- [ ] Verify clicking joystick area does not select trees/rocks behind it
- [ ] Verify HUD (HP/MP) displays top-right
- [ ] Verify inventory opens/closes with toggle button
- [ ] Verify valleys at lower elevation are not excessively dark
- [ ] Run `./kbve.sh -nx isometric:dev` and confirm it builds and serves without manual PATH setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)