### PR TITLE
feat(osrs): add 10 new item overrides and enrich 10 existing

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -386,6 +386,36 @@ Focus on items with clear processing chains and market flip potential.
 | 6724  | Seercull          | DK Supreme bow, spec   |
 | 1729  | Amulet of defence | Defensive amulet       |
 
+### Dragon Weapons (Implemented - Mar 2026)
+
+| ID   | Item            | Override Focus          |
+| ---- | --------------- | ----------------------- |
+| 1215 | Dragon dagger   | PvP spec weapon, iconic |
+| 1249 | Dragon spear    | Shove spec, Corp Beast  |
+| 7158 | Dragon 2h sword | AoE Powerstab spec      |
+
+### Spined Armour (Implemented - Mar 2026)
+
+| ID   | Item         | Override Focus        |
+| ---- | ------------ | --------------------- |
+| 6131 | Spined helm  | Fremennik ranged helm |
+| 6133 | Spined body  | Fremennik ranged body |
+| 6135 | Spined chaps | Fremennik ranged legs |
+
+### Boots/Shields (Implemented - Mar 2026)
+
+| ID   | Item           | Override Focus            |
+| ---- | -------------- | ------------------------- |
+| 3105 | Climbing boots | +2 Str, no Def req, pures |
+| 6524 | Toktz-ket-xil  | +5 Str shield, 60 Def     |
+
+### Enchanted Rings (Implemented - Mar 2026)
+
+| ID   | Item            | Override Focus             |
+| ---- | --------------- | -------------------------- |
+| 2568 | Ring of forging | 100% iron smelt, 140 uses  |
+| 2570 | Ring of life    | Emergency teleport at ≤10% |
+
 ---
 
 ## Future Override Priorities

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1215.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1215.mdx
@@ -1,0 +1,122 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 4
+  attack_bonus:
+    stab: 40
+    slash: 25
+    crush: -4
+    magic: 1
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 1
+    ranged: 0
+  other_bonus:
+    melee_strength: 40
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    attack: 60
+  weight: 0.453
+special_attack:
+  name: "Puncture"
+  energy: 25
+  description: "Two rapid hits with +15% accuracy and +15% damage each. Rolls against opponent's slash defence."
+related_items:
+  - item_id: 5698
+    item_name: "Dragon dagger(p++)"
+    slug: "dragon-dagger-p-5698"
+    relationship: "upgrade"
+    description: "Poisoned variant with super poison"
+  - item_id: 13265
+    item_name: "Abyssal dagger"
+    slug: "abyssal-dagger"
+    relationship: "upgrade"
+    description: "Superior dagger with better stats"
+  - item_id: 1333
+    item_name: "Rune scimitar"
+    slug: "rune-scimitar"
+    relationship: "alternative"
+    description: "F2P training weapon"
+---
+
+## Obtaining
+
+- **Zanaris weapon shop** (Lost City quest required)
+- **Drops:** Various high-level monsters
+- **Grand Exchange**
+
+Requires completion of **Lost City** quest to wield.
+
+> *"A powerful dagger."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Stab | **+40** |
+| Slash | +25 |
+
+| Other | Value |
+|-------|-------|
+| Strength | +40 |
+
+**Requirements:** 60 Attack | **Speed:** 4 tick (2.4s) | **Weight:** 0.45 kg
+
+## Special Attack — Puncture
+
+**Cost:** 25% special attack energy
+
+Deals **two rapid hits** simultaneously, each with +15% accuracy and +15% damage. Both hits roll against the opponent's **slash defence** (not stab). This makes it one of the highest burst-damage weapons at its price point.
+
+**Maximum damage:** ~23 per hit (46 total) at base stats, scaling higher with Strength bonuses and prayers. With max melee gear, hits can reach 48-48 (96 total).
+
+## PvP Meta
+
+The dragon dagger is the most iconic **knockout weapon** in PvP:
+- 25% spec cost means **four specs** per bar
+- Two rapid hits can stack for surprise KOs
+- Budget alternative to Dragon claws (50% spec, more expensive)
+- Almost always used in its **poisoned (p++)** variant for extra damage-over-time
+
+The "DDS spec" is a defining part of OSRS PvP culture.
+
+## Comparison
+
+| Weapon | Speed | Stab | Str | Spec Cost | Spec Effect |
+|--------|-------|------|-----|-----------|-------------|
+| Dragon dagger | 4 tick | +40 | +40 | 25% | 2 hits, +15% acc/dmg |
+| Abyssal dagger | 4 tick | +75 | +75 | 50% | 2 hits, +25% acc |
+| Dragon claws | 4 tick | +41 | +56 | 50% | 4 hits, guaranteed min |
+
+The dragon dagger's 25% spec cost is its biggest advantage — allowing four specs versus two for claws or abyssal dagger.
+
+## Poison Variants
+
+| Variant | Poison Damage | Item ID |
+|---------|--------------|---------|
+| Dragon dagger | None | 1215 |
+| Dragon dagger(p) | 6 starting | 1231 |
+| Dragon dagger(p+) | 8 starting | 5680 |
+| Dragon dagger(p++) | **10 starting** | 5698 |
+
+The **(p++)** variant is standard for PvP — apply weapon poison(++) to the base dagger.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours | **High Alch:** 18,000 GP
+
+**Tips:**
+- Base dagger is cheap; p++ variant costs more
+- Extremely high demand PvP weapon
+- Lost City quest gate limits early access
+
+## Related Items
+
+- [Dragon dagger(p++)](/osrs/dragon-dagger-p-5698/) - Standard PvP variant
+- [Abyssal dagger](/osrs/abyssal-dagger/) - Superior stats, higher spec cost
+- [Dragon claws](/osrs/dragon-claws/) - Premium KO spec weapon

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1249.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1249.mdx
@@ -1,0 +1,117 @@
+---
+equipment:
+  slot: "weapon"
+  two_handed: true
+  attack_speed: 4
+  attack_bonus:
+    stab: 55
+    slash: 55
+    crush: 55
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 5
+    slash: 5
+    crush: 5
+    magic: 5
+    ranged: 5
+  other_bonus:
+    melee_strength: 60
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    attack: 60
+  weight: 2.267
+special_attack:
+  name: "Shove"
+  energy: 25
+  description: "Pushes target back one tile and stuns them for 3 seconds. Cannot be used on already-stunned targets."
+drop_table:
+  sources:
+    - source: "Brutal black dragon"
+      combat_level: 318
+      quantity: "1"
+      rarity: "rare"
+      drop_rate: "1/512"
+      members_only: true
+    - source: "Rare drop table"
+      combat_level: 0
+      quantity: "1"
+      rarity: "very rare"
+      members_only: true
+related_items:
+  - item_id: 11824
+    item_name: "Zamorakian spear"
+    slug: "zamorakian-spear"
+    relationship: "upgrade"
+    description: "Superior spear from K'ril"
+  - item_id: 1347
+    item_name: "Rune warhammer"
+    slug: "rune-warhammer"
+    relationship: "alternative"
+    description: "One-handed crush weapon"
+---
+
+## Obtaining
+
+- **Brutal black dragons** — 1/512 drop rate
+- **Goraks** (with Ring of wealth) — 1/325
+- **Rare drop table** — accessible from many monsters
+- **Elite Treasure Trails** — reward
+
+> *"A dragon tipped spear."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Stab | +55 |
+| Slash | +55 |
+| Crush | +55 |
+
+| Defence | Value |
+|---------|-------|
+| All styles | +5 |
+
+| Other | Value |
+|-------|-------|
+| Strength | +60 |
+
+**Requirements:** 60 Attack | **Speed:** 4 tick (2.4s) | **Two-handed**
+
+## Unique Properties
+
+The dragon spear has **equal bonuses across all three attack styles** (+55 each) — the only dragon weapon with this property. It also provides +5 to all defence stats, unusual for a weapon.
+
+## Special Attack — Shove
+
+**Cost:** 25% special attack energy
+
+Pushes the target back one tile and **stuns them for 3 seconds** (5 game ticks). Cannot be used on targets already stunned or on large NPCs (multi-tile).
+
+## PvP Applications
+
+The Shove spec is notorious in **multi-combat PvP**:
+- Teams use coordinated dragon spear specs to chain-stun a single target
+- The victim cannot eat, drink potions, or teleport while stunned
+- Combined with smite, this can drain all Prayer points for **item protection removal**
+- Known as "spear-speccing" or "spearing out" — a core multi-PK strategy
+
+## Corporeal Beast
+
+Two dragon spears are needed for certain **Corporeal Beast** team strategies — players use Shove specs to keep Corp pinned against a wall, preventing it from moving to heal at its spawn point.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours | **High Alch:** 37,500 GP
+
+**Tips:**
+- Rare drop table item — obtainable from many bosses/monsters
+- PvP demand drives price above alch value
+- Ironmen need two for elite clue emote requirements
+
+## Related Items
+
+- [Zamorakian spear](/osrs/zamorakian-spear/) - Superior spear from K'ril Tsutsaroth
+- [Dragon halberd](/osrs/dragon-halberd/) - Two-handed with reach

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1289.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1289.mdx
@@ -41,27 +41,62 @@ related_items:
 
 ## Obtaining
 
-- Smithing: 2 Runite bars at 89 Smithing
-- Monster drops (various)
-- Grand Exchange
+- **Smithing:** Level 89 using 2 Runite bars (150 XP)
+- **Shop:** Champions' Guild sword shop
+- **Drops:** Various dragons and high-level monsters
 
-## Usage
+> *"A razor-sharp longsword."*
 
-Rune-tier stab weapon:
-- Best F2P stab weapon
-- Useful against stab-weak monsters
-- Generally outclassed by rune scimitar for training
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Stab | **+38** |
+| Slash | +26 |
+
+| Other | Value |
+|-------|-------|
+| Strength | +39 |
+
+**Requirements:** 40 Attack | **Speed:** 4 tick (2.4s)
+
+## Best F2P Stab Weapon
+
+The rune sword is the **best stab weapon available in F2P**. While the rune scimitar has higher slash (+45) and is preferred for general training, the rune sword's +38 stab is valuable against stab-weak monsters.
+
+## Comparison
+
+| Stat | Rune Sword | Rune Scimitar | Rune Longsword |
+|------|-----------|---------------|----------------|
+| Stab | **+38** | +7 | +38 |
+| Slash | +26 | **+45** | +40 |
+| Strength | +39 | **+44** | +49 |
+| Speed | 4 tick | 4 tick | 5 tick |
+| DPS Role | Stab | Slash (best) | Slow slash |
+
+Same speed as the scimitar but lower overall DPS. Use it specifically when **stab accuracy** matters.
+
+## Smithing Economics
+
+| Component | Value |
+|-----------|-------|
+| 2 Runite bars | ~24,600 GP |
+| High Alch | 19,200 GP |
+| GE Price | ~19,000 GP |
+
+Currently a **loss** to smith and sell. Better as a high alch target.
 
 ## Market Strategy
 
-**Buy Limit:** 70 per 4 hours
+**Buy Limit:** 70 per 4 hours | **High Alch:** 19,200 GP
 
 **Tips:**
-- Commonly smithed for XP
-- Low demand vs rune scimitar
-- High alch value matters
+- Commonly smithed for XP (2 runite bars)
+- GE price tracks near alch value
+- Niche F2P stab weapon demand
 
 ## Related Items
 
-- [Rune scimitar](/osrs/rune-scimitar/) - Preferred for training
+- [Rune scimitar](/osrs/rune-scimitar/) - Preferred for training (slash)
 - [Rune battleaxe](/osrs/rune-battleaxe/) - Strength training option
+- [Rune warhammer](/osrs/rune-warhammer/) - Crush alternative

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1373.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1373.mdx
@@ -41,28 +41,56 @@ related_items:
 
 ## Obtaining
 
-- Smithing: 3 Runite bars at 95 Smithing
-- Monster drops (various)
-- Grand Exchange
+- **Smithing:** Level 95 using 3 Runite bars (225 XP)
+- **Shop:** Champions' Guild weapon shop
+- **Drops:** Various dragons, TzHaar creatures, Revenant dragons
 
-## Usage
+> *"A very large axe."*
 
-Rune-tier Strength weapon:
-- Highest Strength bonus of rune weapons (+64)
-- Very slow attack speed (6 tick / 3.6s)
-- F2P Strength training option
-- Outclassed by faster weapons for DPS
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Slash | **+48** |
+| Crush | +42 |
+
+| Other | Value |
+|-------|-------|
+| Strength | **+64** |
+
+**Requirements:** 40 Attack | **Speed:** 6 tick (3.6s)
+
+## Highest Rune Strength Bonus
+
+At **+64 Strength**, the rune battleaxe has the highest Strength bonus of any rune weapon. However, its slow 6-tick speed (3.6s) means it has lower DPS than the rune scimitar.
+
+## Comparison
+
+| Stat | Rune Battleaxe | Rune Scimitar | Rune Warhammer | Rune 2h Sword |
+|------|---------------|---------------|----------------|---------------|
+| Best Atk | +48 slash | +45 slash | +53 crush | +69 slash |
+| Strength | **+64** | +44 | +62 | +69 |
+| Speed | 6 tick | **4 tick** | 6 tick | 7 tick |
+| Hands | 1H | 1H | 1H | 2H |
+
+For raw strength training in F2P, the battleaxe offers the best Strength bonus in a one-handed weapon. The warhammer is close (+62) and was buffed to compete.
+
+## Special Attack
+
+**Rampage** (100% energy): Drains Attack, Defence, Ranged, and Magic by 10%, then boosts Strength by 10% + 10 levels. Useful for maximizing hits in PvM — use before switching to a faster weapon.
 
 ## Market Strategy
 
-**Buy Limit:** 70 per 4 hours
+**Buy Limit:** 70 per 4 hours | **High Alch:** 24,960 GP
 
 **Tips:**
-- Smithing training product
-- High alch target
-- Niche F2P Strength training
+- Smithing training product (3 runite bars)
+- GE price near alch value
+- F2P Strength training niche
+- Rampage spec used as a budget Strength boost
 
 ## Related Items
 
-- [Rune scimitar](/osrs/rune-scimitar/) - Better DPS for training
-- [Rune warhammer](/osrs/rune-warhammer/) - Crush alternative
+- [Rune scimitar](/osrs/rune-scimitar/) - Better DPS for general training
+- [Rune warhammer](/osrs/rune-warhammer/) - Crush alternative (+62 Str)
+- [Dragon battleaxe](/osrs/dragon-battleaxe/) - 60 Attack upgrade

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1637.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1637.mdx
@@ -30,24 +30,42 @@ related_items:
 
 ## Creation
 
-| Input | Skill | Level | XP |
-|-------|-------|-------|----|
-| [Sapphire](/osrs/sapphire/) + [Gold bar](/osrs/gold-bar/) | Crafting | 20 | 40 |
+**Crafting** (Level 20): [Sapphire](/osrs/sapphire/) + [Gold bar](/osrs/gold-bar/) at a furnace (40 XP)
 
-## Enchanting
+> *"A sapphire ring."*
 
-Enchant with Lvl-1 Enchant (Magic 7) to create [Ring of recoil](/osrs/ring-of-recoil/).
+## Enchanting → Ring of Recoil
+
+**Lvl-1 Enchant** (7 Magic): 1 cosmic rune + 1 water rune (17.5 XP)
+
+The [Ring of recoil](/osrs/ring-of-recoil/) reflects **10% of damage taken** back to the attacker (up to 40 total damage before breaking). One of the most consumed items in the game — used in:
+- **PvP** — extra chip damage on opponents
+- **Zulrah** — passive damage during boss fight
+- **Vorkath** — consistent damage reflection
+- **AFK training** — damage without attacking
+
+## Ring Crafting Chain
+
+| Ring | Crafting | Gem | Enchant | Enchanted Ring |
+|------|----------|-----|---------|---------------|
+| **Sapphire ring** | **20** | Sapphire | Lvl-1 (7) | Ring of recoil |
+| Emerald ring | 27 | Emerald | Lvl-2 (27) | Ring of dueling |
+| Ruby ring | 34 | Ruby | Lvl-3 (49) | Ring of forging |
+| Diamond ring | 43 | Diamond | Lvl-4 (57) | Ring of life |
+| Dragonstone ring | 55 | Dragonstone | Lvl-5 (68) | Ring of wealth |
+| Onyx ring | 67 | Onyx | Lvl-6 (87) | Ring of stone |
+| Zenyte ring | 89 | Zenyte | Lvl-7 (93) | Ring of suffering |
 
 ## Market Strategy
 
-**Buy Limit:** 10,000 per 4 hours
+**Buy Limit:** 10,000 per 4 hours | **High Alch:** 525 GP
 
 **Tips:**
-- Crafting training material
-- Ring of recoil is highly consumed
-- Check enchant profit margins
+- Very high volume — ring of recoil is constantly consumed
+- Enchanting is often profitable
+- Popular Crafting training product
 
 ## Related Items
 
-- [Ring of recoil](/osrs/ring-of-recoil/) - Enchanted version
-- [Emerald ring](/osrs/emerald-ring/) - Next tier
+- [Ring of recoil](/osrs/ring-of-recoil/) - Enchanted version (reflects damage)
+- [Emerald ring](/osrs/emerald-ring/) - Next tier ring

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1639.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1639.mdx
@@ -35,22 +35,29 @@ related_items:
 
 ## Creation
 
-| Input | Skill | Level | XP |
-|-------|-------|-------|----|
-| [Emerald](/osrs/emerald/) + [Gold bar](/osrs/gold-bar/) | Crafting | 27 | 55 |
+**Crafting** (Level 27): [Emerald](/osrs/emerald/) + [Gold bar](/osrs/gold-bar/) at a furnace (55 XP)
 
-## Enchanting
+> *"An emerald ring."*
 
-Enchant with Lvl-2 Enchant (Magic 27) to create Ring of dueling.
+## Enchanting → Ring of Dueling
+
+**Lvl-2 Enchant** (27 Magic): 1 cosmic rune + 3 air runes (37 XP)
+
+The Ring of dueling provides **8 charges** of teleportation to:
+- **Duel Arena** (Al Kharid)
+- **Castle Wars** lobby
+- **Ferox Enclave** (free restoration pool)
+
+The Ferox Enclave teleport makes this one of the most useful budget teleports — providing free HP/Prayer restoration and a bank.
 
 ## Market Strategy
 
-**Buy Limit:** 10,000 per 4 hours
+**Buy Limit:** 10,000 per 4 hours | **High Alch:** 675 GP
 
 **Tips:**
-- Ring of dueling is consumed on use
-- Steady demand for teleports
-- Check enchant profit margins
+- Ring of dueling consumed after 8 charges — steady demand
+- Ferox Enclave access drives most of the demand
+- Enchanting is frequently profitable
 
 ## Related Items
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1641.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1641.mdx
@@ -35,22 +35,24 @@ related_items:
 
 ## Creation
 
-| Input | Skill | Level | XP |
-|-------|-------|-------|----|
-| [Ruby](/osrs/ruby/) + [Gold bar](/osrs/gold-bar/) | Crafting | 34 | 70 |
+**Crafting** (Level 34): [Ruby](/osrs/ruby/) + [Gold bar](/osrs/gold-bar/) at a furnace (70 XP)
 
-## Enchanting
+> *"A ruby ring."*
 
-Enchant with Lvl-3 Enchant (Magic 49) to create Ring of forging (140 charges, 100% iron ore smelting).
+## Enchanting → Ring of Forging
+
+**Lvl-3 Enchant** (49 Magic): 1 cosmic rune + 5 fire runes (59 XP)
+
+The [Ring of forging](/osrs/ring-of-forging/) guarantees **100% success** when smelting iron ore (normally 50% chance). Provides 140 charges before crumbling. Essential for iron bar production at regular furnaces — though unnecessary at the Blast Furnace which already guarantees 100%.
 
 ## Market Strategy
 
-**Buy Limit:** 10,000 per 4 hours
+**Buy Limit:** 10,000 per 4 hours | **High Alch:** 825 GP
 
 **Tips:**
-- Ring of forging consumed in Blast Furnace
-- Check enchant profit margins
-- Iron smelting meta drives demand
+- Ring of forging consumed after 140 charges
+- Demand tied to iron smelting activity
+- Enchanting margins vary — check before bulk enchanting
 
 ## Related Items
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1643.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1643.mdx
@@ -35,22 +35,27 @@ related_items:
 
 ## Creation
 
-| Input | Skill | Level | XP |
-|-------|-------|-------|----|
-| [Diamond](/osrs/diamond/) + [Gold bar](/osrs/gold-bar/) | Crafting | 43 | 85 |
+**Crafting** (Level 43): [Diamond](/osrs/diamond/) + [Gold bar](/osrs/gold-bar/) at a furnace (85 XP)
 
-## Enchanting
+> *"A diamond ring."*
 
-Enchant with Lvl-4 Enchant (Magic 57) to create Ring of life (teleports to spawn when below 10% HP).
+## Enchanting → Ring of Life
+
+**Lvl-4 Enchant** (57 Magic): 1 cosmic rune + 10 earth runes (67 XP)
+
+The [Ring of life](/osrs/ring-of-life/) automatically **teleports you to your respawn point** when HP drops to 10% or below. Destroyed after one use. Works up to level 30 Wilderness (higher than most jewelry). Popular safety item for:
+- **Hardcore Ironman** accounts
+- **Wilderness skilling**
+- **AFK training**
 
 ## Market Strategy
 
-**Buy Limit:** 10,000 per 4 hours
+**Buy Limit:** 10,000 per 4 hours | **High Alch:** 1,575 GP
 
 **Tips:**
-- Ring of life consumed on activation
-- Popular safety item for PvM
-- Steady enchant demand
+- Ring of life consumed on activation — recurring demand
+- Popular with HCIM and Wilderness players
+- Diamond cost is the main expense
 
 ## Related Items
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1645.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1645.mdx
@@ -35,22 +35,31 @@ related_items:
 
 ## Creation
 
-| Input | Skill | Level | XP |
-|-------|-------|-------|----|
-| [Dragonstone](/osrs/dragonstone/) + [Gold bar](/osrs/gold-bar/) | Crafting | 55 | 100 |
+**Crafting** (Level 55): [Dragonstone](/osrs/dragonstone/) + [Gold bar](/osrs/gold-bar/) at a furnace (100 XP)
 
-## Enchanting
+> *"A dragonstone ring."*
 
-Enchant with Lvl-5 Enchant (Magic 68) to create [Ring of wealth](/osrs/ring-of-wealth/) (improved Rare Drop Table access).
+## Enchanting → Ring of Wealth
+
+**Lvl-5 Enchant** (68 Magic): 1 cosmic rune + 15 earth runes + 15 water runes (78 XP)
+
+The [Ring of wealth](/osrs/ring-of-wealth/) improves the **Rare Drop Table (RDT)**:
+- Removes empty slots from the RDT, effectively increasing the chance of receiving a valuable drop
+- Provides **5 charges** of teleportation (Miscellania, Grand Exchange, Falador Park)
+- Shows a notification when a RDT drop is received
+- Can be imbued at the Nightmare Zone for double effect in the Wilderness
+
+The ring of wealth is one of the most widely used rings for general PvM, particularly for players without better ring options.
 
 ## Market Strategy
 
-**Buy Limit:** 10,000 per 4 hours
+**Buy Limit:** 10,000 per 4 hours | **High Alch:** 5,175 GP
 
 **Tips:**
-- Ring of wealth is widely used
-- Dragonstone cost drives price
-- Enchant margin varies
+- Ring of wealth is rechargeable (not destroyed on use)
+- Dragonstone cost drives the ring price
+- Enchanting is usually profitable
+- High demand — used by many players for general PvM
 
 ## Related Items
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_19538.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_19538.mdx
@@ -35,25 +35,49 @@ related_items:
 
 ## Creation
 
-| Input | Skill | Level | XP |
-|-------|-------|-------|----|
-| [Zenyte](/osrs/zenyte/) + [Gold bar](/osrs/gold-bar/) | Crafting | 89 | 150 |
+**Crafting** (Level 89): [Zenyte](/osrs/zenyte/) + [Gold bar](/osrs/gold-bar/) at a furnace (150 XP)
 
-## Enchanting
+> *"A zenyte ring."*
 
-Enchant with Lvl-7 Enchant (Magic 93) to create [Ring of suffering](/osrs/ring-of-suffering/) (BiS defensive ring, stores recoils).
+## Enchanting → Ring of Suffering
+
+**Lvl-7 Enchant** (93 Magic): 1 cosmic rune + 20 blood runes + 20 soul runes (110 XP)
+
+The [Ring of suffering](/osrs/ring-of-suffering/) is the **best-in-slot defensive ring**:
+- **+20 to all defence styles** (highest of any ring)
+- **+4 Prayer** bonus
+- Can store up to **100,000 ring of recoil charges** — automatically reflects damage without consuming individual recoil rings
+- Can be **imbued** at the Nightmare Zone for doubled stats (+20 → +20 stays, but adds offensive bonuses)
+
+## Zenyte Acquisition
+
+Zenyte is crafted from:
+1. **Zenyte shard** — dropped by Demonic gorillas (1/300, after Monkey Madness II)
+2. Combine with an **Onyx** at a furnace using the Crafting skill (89 Crafting)
+
+This makes zenyte jewelry the most valuable craftable jewelry in the game.
+
+## All Zenyte Jewelry
+
+| Jewelry | Slot | Key Stat | Enchanted |
+|---------|------|----------|-----------|
+| Zenyte ring | Ring | → Ring of suffering | BiS defensive ring |
+| Zenyte necklace | Neck | → Necklace of anguish | BiS ranged necklace |
+| Zenyte bracelet | Hands | → Tormented bracelet | BiS magic bracelet |
+| Zenyte amulet | Neck | → Amulet of torture | BiS melee amulet |
 
 ## Market Strategy
 
-**Buy Limit:** 8 per 4 hours
+**Buy Limit:** 8 per 4 hours | **High Alch:** 45,000 GP
 
 **Tips:**
-- Zenyte shard from demonic gorillas + onyx
-- Ring of suffering is BiS defensive
-- High-value enchant
+- Zenyte shard from Demonic gorillas (requires MM2)
+- Very high value enchant — check margins
+- Ring of suffering has permanent demand as BiS defensive ring
+- Blood and soul runes for Lvl-7 Enchant add to enchant cost
 
 ## Related Items
 
 - [Onyx ring](/osrs/onyx-ring/) - Previous tier
-- [Ring of suffering](/osrs/ring-of-suffering/) - Enchanted version
-- [Zenyte](/osrs/zenyte/) - Key component
+- [Ring of suffering](/osrs/ring-of-suffering/) - Enchanted version (BiS defensive)
+- [Zenyte](/osrs/zenyte/) - Key component from demonic gorillas

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2568.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2568.mdx
@@ -1,0 +1,99 @@
+---
+equipment:
+  slot: "ring"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements: {}
+  weight: 0.006
+recipes:
+  - skill: "magic"
+    level: 49
+    xp: 59
+    inputs:
+      - item_name: "Ruby ring"
+        quantity: 1
+      - item_name: "Cosmic rune"
+        quantity: 1
+      - item_name: "Fire rune"
+        quantity: 5
+    output_quantity: 1
+related_items:
+  - item_id: 2570
+    item_name: "Ring of life"
+    slug: "ring-of-life"
+    relationship: "alternative"
+    description: "Emergency teleport ring"
+  - item_id: 2550
+    item_name: "Ring of recoil"
+    slug: "ring-of-recoil"
+    relationship: "alternative"
+    description: "Damage reflection ring"
+---
+
+## Obtaining
+
+- **Lvl-3 Enchant** (49 Magic): Ruby ring + 1 cosmic rune + 5 fire runes (59 XP)
+- **Murky Matt** (Grand Exchange): Enchants ruby rings for 250 coins (F2P accessible)
+
+> *"An enchanted ring."*
+
+## Stats
+
+No combat bonuses. The ring's value is entirely in its skilling effect.
+
+**Requirements:** None to wear | **Weight:** 0.006 kg
+
+## Effect
+
+Guarantees **100% success rate** when smelting iron ore into iron bars. Without the ring, iron ore normally has only a **50% success rate** (each ore has a 50% chance of failing).
+
+**Charges:** 140 uses before the ring crumbles to dust. Each iron ore smelted consumes one charge.
+
+**Important:** Charges are tracked per player, not per ring — swapping to a new ring does not reset the counter.
+
+## Economics
+
+| Method | Iron Bars per Ring | Cost per Ring |
+|--------|-------------------|---------------|
+| Without ring | ~70 bars (50% rate) | Free |
+| With ring | **140 bars** (100%) | ~800 GP |
+
+The ring effectively doubles your iron bar output, saving ~70 iron ores worth of value per ring.
+
+## Blast Furnace
+
+At the **Blast Furnace**, iron ore already smelts at 100% — making the ring of forging unnecessary there. The ring is primarily useful at regular furnaces.
+
+## Ironman Significance
+
+Essential for **Ironman accounts** producing iron bars at regular furnaces, where the 50% failure rate would waste hard-earned ores. Most ironmen transition to Blast Furnace eventually, but the ring is valuable during early-mid game.
+
+## Market Strategy
+
+**Buy Limit:** 125 per 4 hours | **High Alch:** 555 GP
+
+**Tips:**
+- Cheap to enchant (ruby ring + cosmic + fire runes)
+- Consumed on use — steady recurring demand
+- F2P accessible via Murky Matt (250 coins)
+- Less useful once Blast Furnace is unlocked
+
+## Related Items
+
+- [Ring of life](/osrs/ring-of-life/) - Emergency teleport ring
+- [Ring of recoil](/osrs/ring-of-recoil/) - Damage reflection ring

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2570.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2570.mdx
@@ -1,0 +1,102 @@
+---
+equipment:
+  slot: "ring"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements: {}
+  weight: 0.006
+recipes:
+  - skill: "magic"
+    level: 57
+    xp: 67
+    inputs:
+      - item_name: "Diamond ring"
+        quantity: 1
+      - item_name: "Cosmic rune"
+        quantity: 1
+      - item_name: "Earth rune"
+        quantity: 10
+    output_quantity: 1
+related_items:
+  - item_id: 2572
+    item_name: "Ring of wealth"
+    slug: "ring-of-wealth"
+    relationship: "upgrade"
+    description: "RDT improvement ring"
+  - item_id: 2550
+    item_name: "Ring of recoil"
+    slug: "ring-of-recoil"
+    relationship: "alternative"
+    description: "Damage reflection ring"
+---
+
+## Obtaining
+
+**Lvl-4 Enchant** (57 Magic): Diamond ring + 1 cosmic rune + 10 earth runes (67 XP)
+
+> *"An enchanted ring."*
+
+## Stats
+
+No combat bonuses. The ring's value is entirely in its passive effect.
+
+**Requirements:** None to wear | **Weight:** 0.006 kg
+
+## Passive Effect
+
+When HP drops to **10% or below** of your maximum Hitpoints after taking damage, the ring automatically **teleports you to your respawn point** and crumbles to dust.
+
+**Example:** At 99 HP, the ring triggers at 9 HP or below.
+
+## Limitations
+
+- **Single use** — destroyed after activating
+- Does not trigger if a single hit takes you from above 10% straight to 0
+- Does **not** cure poison (you may still die after teleporting)
+- Blocked by **Tele Block** in PvP
+- Works up to **level 30 Wilderness** (higher than most jewelry at level 20)
+- Does not activate in some boss arenas (e.g., Fight Caves, Inferno)
+
+## Usage
+
+- **Wilderness skilling** — safety net while training Agility, hunting black chinchompas, or collecting resources
+- **Slayer tasks** — insurance against unexpected high damage
+- **AFK training** — reduces risk of dying while semi-AFK
+- **HCIM accounts** — cheap life insurance for Hardcore Ironmen
+
+## Alternatives
+
+| Item | Effect | Reusable? |
+|------|--------|-----------|
+| Ring of life | Teleport at ≤10% HP | No (destroyed) |
+| Defence cape | Same as ring of life | **Yes** (99 Def perk) |
+| Phoenix necklace | Heal 30% HP at ≤20% | No (destroyed) |
+
+## Market Strategy
+
+**Buy Limit:** 125 per 4 hours | **High Alch:** 630 GP
+
+**Tips:**
+- Cheap to enchant (diamond ring + cosmic + earth runes)
+- Steady demand from Wilderness skillers and HCIM
+- Consumed on use — recurring demand
+
+## Related Items
+
+- [Ring of wealth](/osrs/ring-of-wealth/) - RDT improvement ring
+- [Ring of recoil](/osrs/ring-of-recoil/) - Damage reflection ring

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_3105.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_3105.mdx
@@ -1,0 +1,94 @@
+---
+equipment:
+  slot: "feet"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 2
+    crush: 2
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 2
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements: {}
+  weight: 0.34
+related_items:
+  - item_id: 4131
+    item_name: "Rune boots"
+    slug: "rune-boots"
+    relationship: "alternative"
+    description: "Same strength bonus, higher defence"
+  - item_id: 11840
+    item_name: "Dragon boots"
+    slug: "dragon-boots"
+    relationship: "upgrade"
+    description: "+4 Strength boots"
+---
+
+## Obtaining
+
+**Tenzing** at Death Plateau — 12 coins after completing **Death Plateau** quest.
+
+> *"Boots made for climbing."*
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Slash | +2 |
+| Crush | +2 |
+
+| Other | Value |
+|-------|-------|
+| Strength | **+2** |
+
+**Requirements:** Death Plateau quest | **Weight:** 0.34 kg
+
+## Why They Matter
+
+The **+2 Strength bonus** with zero combat requirements makes climbing boots one of the most efficient items in the game:
+- Available immediately after Death Plateau (no combat stats needed)
+- Same Strength bonus as **rune boots** (which require 40 Defence)
+- Only 12 coins from the shop
+- No negative bonuses of any kind
+
+## Boots Progression (Melee Strength)
+
+| Boots | Str Bonus | Def Req | Approx Cost |
+|-------|-----------|---------|-------------|
+| Climbing boots | **+2** | None | 12 GP |
+| Rune boots | +2 | 40 Def | ~7K GP |
+| Dragon boots | **+4** | 60 Def | ~200K GP |
+| Primordial boots | **+5** | 75 Def | ~25M GP |
+
+Climbing boots match rune boots for Strength — making them best-in-slot for any account without 60 Defence.
+
+## Pure Builds
+
+Essential for **1 Defence pures** and **low-Defence builds**:
+- +2 Strength with no Defence requirement
+- Negligible cost (12 coins)
+- Lightweight (0.34 kg)
+- No quest combat requirements to complete Death Plateau
+
+## Market Strategy
+
+**Buy Limit:** 200 per 4 hours | **High Alch:** 45 GP
+
+**Tips:**
+- Buy from Tenzing for 12 coins (functionally free)
+- GE price inflated above shop price
+- Essential pure/zerker item
+
+## Related Items
+
+- [Rune boots](/osrs/rune-boots/) - Same Strength, 40 Def requirement
+- [Dragon boots](/osrs/dragon-boots/) - +4 Strength, 60 Def

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4091.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4091.mdx
@@ -36,26 +36,64 @@ related_items:
 
 ## Obtaining
 
-- Slayer Tower creatures (Infernal Mages)
-- Various boss drops
-- Purchasable from Wizard Beniami in Wizards' Guild (99 Magic)
+- **Infernal Mages** (Slayer Tower) — common drop
+- **Aberrant spectres** — 1/128 (light blue variant)
+- **Wizard Beniami** (Wizards' Guild, 99 Magic) — 15,000 coins
+- **Various boss drops** — Dagannoth Kings, Crazy Archaeologist
+
+> *"A very powerful mage robe top."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Magic | **+20** |
+
+| Defence | Value |
+|---------|-------|
+| Magic | +20 |
+
+**Requirements:** 40 Magic, 20 Defence
+
+## Colour Variants
+
+| Variant | Source | Stats |
+|---------|--------|-------|
+| Mystic robe top (blue) | Slayer monsters, shops | Identical |
+| Mystic robe top (dark) | Slayer monsters | Identical |
+| Mystic robe top (light) | Aberrant spectres | Identical |
+| Mystic robe top (dusk) | Hallowed Sepulchre | Identical |
+
+All variants share **identical stats** — the difference is purely cosmetic. Dark and dusk variants trade at a premium for fashionscape.
+
+## Comparison
+
+| Stat | Mystic Top | Splitbark Body | Ahrim's Robetop | Infinity Top |
+|------|-----------|----------------|-----------------|-------------|
+| Magic Atk | **+20** | +10 | **+30** | **+22** |
+| Stab Def | 0 | **+36** | 0 | 0 |
+| Magic Def | +20 | +15 | **+30** | **+22** |
+| Req | 40 Mage/20 Def | 40 Mage/40 Def | 70 Mage/70 Def | 50 Mage/25 Def |
+
+The mystic robe top offers the best magic bonus at 40 Magic without requiring significant Defence. Splitbark trades magic power for melee defence.
 
 ## Usage
 
-Budget magic top:
-- Entry-level magic armour
-- Affordable for new players
-- Commonly used for Barrows
+- Standard magic top for **Barrows** runs
+- Budget magic gear for **Slayer** tasks
+- Common PKing item (cheap to risk)
+- Stepping stone before Ahrim's or Ancestral
 
 ## Market Strategy
 
-**Buy Limit:** 70 per 4 hours
+**Buy Limit:** 70 per 4 hours | **High Alch:** 9,000 GP
 
 **Tips:**
-- High supply from Slayer
-- Budget magic option
-- Multiple color variants available
+- High supply from Slayer drops
+- Very affordable for its magic bonus
+- Dark/dusk variants trade at premium
 
 ## Related Items
 
 - [Mystic robe bottom](/osrs/mystic-robe-bottom/) - Matching leg piece
+- [Splitbark body](/osrs/splitbark-body/) - Defence-focused alternative

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4093.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4093.mdx
@@ -36,26 +36,59 @@ related_items:
 
 ## Obtaining
 
-- Slayer Tower creatures (Infernal Mages)
-- Various boss drops
-- Purchasable from Wizard Beniami in Wizards' Guild
+- **Infernal Mages** (Slayer Tower) — common drop
+- **Aberrant spectres** — 1/128 (light blue variant)
+- **Wizard Beniami** (Wizards' Guild, 99 Magic) — 10,000 coins
+- **Various boss drops** — Dagannoth Kings, Crazy Archaeologist
 
-## Usage
+> *"A very powerful mage robe bottom."*
 
-Budget magic legs:
-- Entry-level magic armour
-- Affordable for new players
-- Commonly paired with Mystic robe top
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Magic | **+15** |
+
+| Defence | Value |
+|---------|-------|
+| Magic | +15 |
+
+**Requirements:** 40 Magic, 20 Defence
+
+## Colour Variants
+
+All four variants (blue, dark, light, dusk) share **identical stats** — purely cosmetic differences. See [Mystic robe top](/osrs/mystic-robe-top/) for variant details.
+
+## Comparison
+
+| Stat | Mystic Bottom | Splitbark Legs | Ahrim's Robeskirt | Infinity Bottoms |
+|------|--------------|----------------|-------------------|-----------------|
+| Magic Atk | **+15** | +7 | **+22** | **+17** |
+| Stab Def | 0 | **+22** | 0 | 0 |
+| Magic Def | +15 | +10 | **+22** | **+17** |
+| Req | 40 Mage/20 Def | 40 Mage/40 Def | 70 Mage/70 Def | 50 Mage/25 Def |
+
+Best magic bonus at 40 Magic without requiring high Defence. Splitbark trades magic power for melee survivability.
+
+## Full Mystic Set
+
+| Piece | Magic Atk | Magic Def |
+|-------|-----------|-----------|
+| Mystic hat | +4 | +4 |
+| Mystic robe top | +20 | +20 |
+| Mystic robe bottom | +15 | +15 |
+| **Total** | **+39** | **+39** |
 
 ## Market Strategy
 
-**Buy Limit:** 70 per 4 hours
+**Buy Limit:** 70 per 4 hours | **High Alch:** 6,000 GP
 
 **Tips:**
-- High supply from Slayer
-- Budget magic option
-- Multiple color variants
+- High supply from Slayer drops
+- Commonly paired with mystic top for mid-game magic
+- Dark/dusk variants trade at premium
 
 ## Related Items
 
 - [Mystic robe top](/osrs/mystic-robe-top/) - Matching body piece
+- [Splitbark legs](/osrs/splitbark-legs/) - Defence-focused alternative

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6131.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6131.mdx
@@ -1,0 +1,98 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: -6
+    slash: -6
+    crush: -6
+    magic: -6
+    ranged: 6
+  defence_bonus:
+    stab: 6
+    slash: 6
+    crush: 6
+    magic: 6
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 40
+    ranged: 40
+  weight: 2.721
+related_items:
+  - item_id: 6133
+    item_name: "Spined body"
+    slug: "spined-body"
+    relationship: "set"
+    description: "Matching body piece"
+  - item_id: 6135
+    item_name: "Spined chaps"
+    slug: "spined-chaps"
+    relationship: "set"
+    description: "Matching leg piece"
+---
+
+## Obtaining
+
+**Sigli the Huntsman** in Rellekka — bring materials:
+- 1 Dagannoth hide
+- 1 Circular hide (from Dagannoths on Waterbirth Island)
+- 5,000 coins
+
+Requires completion of **The Fremennik Trials**.
+
+> *"A helm made from dagannoth hide."*
+
+## Stats
+
+| Ranged | Value |
+|--------|-------|
+| Ranged Attack | +6 |
+
+| Defence | Value |
+|---------|-------|
+| All melee | +6 |
+| Magic | +6 |
+
+**Requirements:** 40 Defence, 40 Ranged
+
+## Fremennik Armour System
+
+The spined set is the **ranged variant** of the three Fremennik armour sets:
+- **Rock-shell** — melee (Skulgrimen)
+- **Skeletal** — magic (Peer the Seer)
+- **Spined** — ranged (Sigli the Huntsman)
+
+All require The Fremennik Trials and dagannoth hides.
+
+## Comparison vs Green D'hide Coif
+
+| Stat | Spined Helm | Coif |
+|------|------------|------|
+| Ranged Atk | +6 | +4 |
+| Melee Def | +6 each | +4/+6/+8 |
+| Magic Def | +6 | +4 |
+| Req | 40 Def/Rng | 40 Rng |
+
+Slightly better than the coif in ranged attack and more consistent defence, but requires 40 Defence.
+
+## Storage
+
+Storable in a **Costume Room armour case** as part of the complete spined set.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 6,000 GP
+
+**Tips:**
+- Circular hides from Dagannoths on Waterbirth Island
+- Low demand — green d'hide is easier to obtain
+- Collector's/fashionscape piece
+
+## Related Items
+
+- [Spined body](/osrs/spined-body/) - Matching body
+- [Spined chaps](/osrs/spined-chaps/) - Matching legs

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6133.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6133.mdx
@@ -1,0 +1,111 @@
+---
+equipment:
+  slot: "body"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -15
+    ranged: 15
+  defence_bonus:
+    stab: 40
+    slash: 32
+    crush: 45
+    magic: 20
+    ranged: 40
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 40
+    ranged: 40
+  weight: 6.803
+drop_table:
+  sources:
+    - source: "Dagannoth Supreme"
+      combat_level: 303
+      quantity: "1"
+      rarity: "uncommon"
+      drop_rate: "1/128"
+      members_only: true
+related_items:
+  - item_id: 6131
+    item_name: "Spined helm"
+    slug: "spined-helm"
+    relationship: "set"
+    description: "Matching helm piece"
+  - item_id: 6135
+    item_name: "Spined chaps"
+    slug: "spined-chaps"
+    relationship: "set"
+    description: "Matching leg piece"
+  - item_id: 1135
+    item_name: "Green d'hide body"
+    slug: "green-dhide-body"
+    relationship: "alternative"
+    description: "Easier to obtain, no Def req"
+---
+
+## Obtaining
+
+- **Sigli the Huntsman** in Rellekka: 3 dagannoth hides + 1 flattened hide + 10,000 coins
+- **Dagannoth Supreme** (Level 303) — 1/128 drop rate
+
+Requires completion of **The Fremennik Trials**.
+
+> *"A body armour made from dagannoth hide."*
+
+## Stats
+
+| Ranged | Value |
+|--------|-------|
+| Ranged Attack | +15 |
+
+| Defence | Value |
+|---------|-------|
+| Stab | +40 |
+| Slash | +32 |
+| Crush | **+45** |
+| Magic | +20 |
+| Ranged | +40 |
+
+**Requirements:** 40 Defence, 40 Ranged
+
+## Comparison vs Green D'hide Body
+
+| Stat | Spined Body | Green D'hide Body |
+|------|------------|-------------------|
+| Ranged Atk | +15 | **+15** |
+| Stab Def | **+40** | +40 |
+| Slash Def | +32 | +34 |
+| Crush Def | **+45** | +38 |
+| Magic Def | **+20** | +20 |
+| Ranged Def | +40 | +40 |
+| Req | 40 Def + 40 Rng | 40 Rng |
+
+Very similar stats to green d'hide body — slightly better crush defence (+45 vs +38) but slightly worse slash defence. The spined body requires 40 Defence in addition to 40 Ranged, making green d'hide more accessible.
+
+## Dagannoth Supreme
+
+Supreme (ranged DK) drops the spined body at 1/128. Players farming all three DKs will accumulate these passively.
+
+## Storage
+
+Storable in a **Costume Room armour case** as part of the complete spined set.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 27,000 GP
+
+**Tips:**
+- Dagannoth Supreme drop (passive from DK farming)
+- Green d'hide body is generally preferred (no Def req)
+- Low trade volume
+
+## Related Items
+
+- [Spined helm](/osrs/spined-helm/) - Matching helm
+- [Spined chaps](/osrs/spined-chaps/) - Matching legs
+- [Green d'hide body](/osrs/green-dhide-body/) - Easier to obtain alternative

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6135.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6135.mdx
@@ -1,0 +1,108 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -10
+    ranged: 8
+  defence_bonus:
+    stab: 22
+    slash: 16
+    crush: 24
+    magic: 8
+    ranged: 22
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 40
+    ranged: 40
+  weight: 5.443
+drop_table:
+  sources:
+    - source: "Dagannoth Supreme"
+      combat_level: 303
+      quantity: "1"
+      rarity: "uncommon"
+      drop_rate: "1/128"
+      members_only: true
+related_items:
+  - item_id: 6131
+    item_name: "Spined helm"
+    slug: "spined-helm"
+    relationship: "set"
+    description: "Matching helm piece"
+  - item_id: 6133
+    item_name: "Spined body"
+    slug: "spined-body"
+    relationship: "set"
+    description: "Matching body piece"
+---
+
+## Obtaining
+
+- **Sigli the Huntsman** in Rellekka: 2 dagannoth hides + 1 stretched hide + 7,500 coins
+- **Dagannoth Supreme** (Level 303) — 1/128 drop rate
+
+Requires completion of **The Fremennik Trials**.
+
+> *"A pair of chaps made from dagannoth hide."*
+
+## Stats
+
+| Ranged | Value |
+|--------|-------|
+| Ranged Attack | +8 |
+
+| Defence | Value |
+|---------|-------|
+| Stab | +22 |
+| Slash | +16 |
+| Crush | +24 |
+| Magic | +8 |
+| Ranged | +22 |
+
+**Requirements:** 40 Defence, 40 Ranged
+
+## Comparison vs Green D'hide Chaps
+
+| Stat | Spined Chaps | Green D'hide Chaps |
+|------|-------------|-------------------|
+| Ranged Atk | **+8** | +8 |
+| Stab Def | **+22** | +22 |
+| Slash Def | +16 | +16 |
+| Crush Def | **+24** | +20 |
+| Magic Def | **+8** | +8 |
+| Ranged Def | +22 | +22 |
+| Req | 40 Def + 40 Rng | 40 Rng |
+
+Virtually identical to green d'hide chaps with slightly better crush defence (+24 vs +20). The additional 40 Defence requirement makes green d'hide chaps more accessible.
+
+## Full Set Totals (Spined)
+
+| Stat | Total |
+|------|-------|
+| Ranged Atk | **+29** |
+| Stab Def | +68 |
+| Slash Def | +54 |
+| Crush Def | +75 |
+| Magic Def | +34 |
+| Total cost | 22,500 coins + hides |
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 24,000 GP
+
+**Tips:**
+- Dagannoth Supreme drop (passive from DK farming)
+- Green d'hide chaps preferred for accessibility
+- Low trade volume — collector's piece
+
+## Related Items
+
+- [Spined helm](/osrs/spined-helm/) - Matching helm
+- [Spined body](/osrs/spined-body/) - Matching body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6524.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6524.mdx
@@ -1,0 +1,101 @@
+---
+equipment:
+  slot: "shield"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -12
+    ranged: -8
+  defence_bonus:
+    stab: 40
+    slash: 42
+    crush: 38
+    magic: 0
+    ranged: 65
+  other_bonus:
+    melee_strength: 5
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 60
+  weight: 3.628
+related_items:
+  - item_id: 3122
+    item_name: "Granite shield"
+    slug: "granite-shield"
+    relationship: "alternative"
+    description: "Same defence stats, no Strength bonus"
+  - item_id: 12954
+    item_name: "Dragon defender"
+    slug: "dragon-defender"
+    relationship: "alternative"
+    description: "Offensive alternative with accuracy bonuses"
+  - item_id: 6522
+    item_name: "Toktz-xil-ul"
+    slug: "toktz-xil-ul"
+    relationship: "set"
+    description: "Obsidian throwing rings"
+---
+
+## Obtaining
+
+- **Shop:** TzHaar-Hur-Lek's Ore and Gem Store (67,500 Tokkul, 58,500 with Karamja gloves)
+- **Drop:** TzHaar-Ket (Level 149/221) — 1/512 rarity
+
+> *"A spiked shield of obsidian."*
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Stab | +40 |
+| Slash | +42 |
+| Crush | +38 |
+| Ranged | **+65** |
+
+| Other | Value |
+|-------|-------|
+| Strength | **+5** |
+
+**Requirements:** 60 Defence | **Weight:** 3.6 kg
+
+## Strength Bonus Shield
+
+The Toktz-ket-xil is unique among shields — it provides **+5 melee Strength** while maintaining strong defensive stats. No other shield in the game offers this combination of Strength and defence.
+
+## Comparison
+
+| Stat | Toktz-ket-xil | Granite Shield | Dragon Defender | Rune Kiteshield |
+|------|--------------|----------------|-----------------|-----------------|
+| Stab Def | +40 | +40 | +25 | +44 |
+| Slash Def | +42 | +42 | +24 | +48 |
+| Crush Def | +38 | +38 | +23 | +42 |
+| Ranged Def | **+65** | **+65** | +23 | +46 |
+| Str Bonus | **+5** | 0 | **+5** | 0 |
+| Atk Bonus | 0 | 0 | **+20 stab/slash** | 0 |
+| Req | 60 Def | 50 Def/Str | 60 Def + quest | 40 Def |
+
+The dragon defender trades defensive stats for offensive accuracy bonuses. The Toktz-ket-xil is the tanky alternative with the same +5 Strength.
+
+## Shield vs Defender
+
+- **Defender** — better for DPS (accuracy bonuses speed up kills)
+- **Toktz-ket-xil** — better for tanking (superior defence with same Strength)
+- Use the obsidian shield when survivability matters more than kill speed
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours | **High Alch:** 27,000 GP
+
+**Tips:**
+- Shop price is 67,500 Tokkul (farm Fight Caves/Inferno for Tokkul)
+- Karamja gloves reduce shop cost to 58,500
+- GE price significantly above alch value due to +5 Strength utility
+
+## Related Items
+
+- [Granite shield](/osrs/granite-shield/) - Same defence, no Strength bonus
+- [Dragon defender](/osrs/dragon-defender/) - Offensive alternative
+- [Toktz-xil-ul](/osrs/toktz-xil-ul/) - Obsidian throwing rings

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7158.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7158.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "weapon"
+  two_handed: true
+  attack_speed: 7
+  attack_bonus:
+    stab: -4
+    slash: 92
+    crush: 80
+    magic: -4
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: -1
+  other_bonus:
+    melee_strength: 93
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    attack: 60
+  weight: 3.628
+special_attack:
+  name: "Powerstab"
+  energy: 60
+  description: "Hits all targets within 1 tile in multi-combat areas. Maximum 14 NPCs or 3 players per use."
+drop_table:
+  sources:
+    - source: "Kalphite Queen"
+      combat_level: 333
+      quantity: "1"
+      rarity: "uncommon"
+      drop_rate: "1/128"
+      members_only: true
+    - source: "Chaos Elemental"
+      combat_level: 305
+      quantity: "1"
+      rarity: "uncommon"
+      drop_rate: "1/128"
+      members_only: true
+related_items:
+  - item_id: 1377
+    item_name: "Dragon battleaxe"
+    slug: "dragon-battleaxe"
+    relationship: "alternative"
+    description: "One-handed dragon strength weapon"
+  - item_id: 1249
+    item_name: "Dragon spear"
+    slug: "dragon-spear"
+    relationship: "alternative"
+    description: "Two-handed with stun spec"
+---
+
+## Obtaining
+
+- **Kalphite Queen** — 1/128 drop rate
+- **Wilderness bosses** — Chaos Elemental, Callisto, Vet'ion, Venenatis, Scorpia (and revenant variants)
+- **Cannot be smithed**
+
+> *"A two-handed Dragon Sword."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Slash | **+92** |
+| Crush | +80 |
+
+| Other | Value |
+|-------|-------|
+| Strength | **+93** |
+
+**Requirements:** 60 Attack | **Speed:** 7 tick (4.2s) | **Two-handed**
+
+The highest Strength bonus (+93) and Slash attack (+92) of any dragon weapon, but extremely slow at 7-tick speed.
+
+## Special Attack — Powerstab
+
+**Cost:** 60% special attack energy
+
+In **multi-combat areas**, hits all targets within a 1-tile radius:
+- Maximum **14 NPCs** or **3 players** per use
+- No benefit in single-combat areas
+- Area-of-effect damage makes it unique among dragon weapons
+
+## Multi-Combat Training
+
+The Powerstab spec excels in:
+- **Nightmare Zone** — hit multiple bosses simultaneously
+- **Catacombs of Kourend** — multi-target training
+- **Multi-combat Slayer** — clear clusters of monsters
+- **PvP multi-combat** — hit up to 3 players at once
+
+## Comparison
+
+| Weapon | Speed | Slash | Str | Spec |
+|--------|-------|-------|-----|------|
+| Dragon 2h sword | 7 tick | **+92** | **+93** | AoE (60%) |
+| Dragon scimitar | 4 tick | +67 | +66 | Def drain (55%) |
+| Dragon battleaxe | 6 tick | +70 | +85 | Str boost (100%) |
+
+Highest raw stats but the slowest speed makes it impractical for standard training. Best used for spec switching in multi-combat.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours | **High Alch:** 120,000 GP
+
+**Tips:**
+- Kalphite Queen and Wilderness bosses are primary sources
+- PvP demand for multi-spec
+- Price sits near alch value
+
+## Related Items
+
+- [Dragon battleaxe](/osrs/dragon-battleaxe/) - One-handed strength weapon
+- [Dragon spear](/osrs/dragon-spear/) - Two-handed with stun spec


### PR DESCRIPTION
## Summary
- **10 new overrides**: Dragon dagger (1215), Climbing boots (3105), Toktz-ket-xil (6524), Dragon spear (1249), Dragon 2h sword (7158), Spined helm/body/chaps (6131-6135), Ring of life (2570), Ring of forging (2568)
- **10 enriched overrides**: Mystic robe top/bottom, Rune sword, Rune battleaxe, Sapphire/Emerald/Ruby/Diamond/Dragonstone/Zenyte rings — added examine texts, comparison tables, enchant details, special attack info, and market data
- Updated OSRS.md tracking doc with new sections

## Test plan
- [ ] Verify new override files have valid YAML frontmatter
- [ ] Run `pnpm generate:osrs` to confirm overrides inject correctly
- [ ] Spot-check 2-3 items in browser for proper rendering