### PR TITLE
feat(osrs): add 10 new overrides — Fremennik helms, ranged ammo, Slayer gear

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -416,6 +416,31 @@ Focus on items with clear processing chains and market flip potential.
 | 2568 | Ring of forging | 100% iron smelt, 140 uses  |
 | 2570 | Ring of life    | Emergency teleport at ≤10% |
 
+### Fremennik Helms (Implemented - Mar 2026)
+
+| ID   | Item           | Override Focus        |
+| ---- | -------------- | --------------------- |
+| 3751 | Berserker helm | +3 Str melee helm     |
+| 3753 | Warrior helm   | +5 Slash attack helm  |
+| 3755 | Farseer helm   | +6 Magic attack helm  |
+| 3749 | Archer helm    | +6 Ranged attack helm |
+
+### Ranged Ammo & Crossbows (Implemented - Mar 2026)
+
+| ID    | Item                | Override Focus             |
+| ----- | ------------------- | -------------------------- |
+| 8880  | Dorgeshuun crossbow | Budget ranged + bone bolts |
+| 830   | Rune javelin        | Ballista ammo              |
+| 21318 | Amethyst javelin    | Best non-dragon javelin    |
+
+### Obsidian/Slayer Gear (Implemented - Mar 2026)
+
+| ID    | Item           | Override Focus           |
+| ----- | -------------- | ------------------------ |
+| 6526  | Toktz-mej-tal  | Hybrid crush/magic staff |
+| 4156  | Mirror shield  | Basilisk/Cockatrice req  |
+| 11133 | Regen bracelet | 2x HP regen, 1 Def BiS   |
+
 ---
 
 ## Future Override Priorities

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_11133.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_11133.mdx
@@ -1,0 +1,110 @@
+---
+equipment:
+  slot: "hands"
+  attack_bonus:
+    stab: 8
+    slash: 8
+    crush: 8
+    magic: 3
+    ranged: 7
+  defence_bonus:
+    stab: 6
+    slash: 6
+    crush: 6
+    magic: 3
+    ranged: 6
+  other_bonus:
+    melee_strength: 7
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements: {}
+  weight: 0.25
+recipes:
+  - skill: "magic"
+    level: 87
+    xp: 97
+    inputs:
+      - item_name: "Onyx bracelet"
+        quantity: 1
+      - item_name: "Cosmic rune"
+        quantity: 1
+      - item_name: "Fire rune"
+        quantity: 20
+      - item_name: "Earth rune"
+        quantity: 20
+    output_quantity: 1
+related_items:
+  - item_id: 7462
+    item_name: "Barrows gloves"
+    slug: "barrows-gloves"
+    relationship: "upgrade"
+    description: "BiS gloves from RFD"
+  - item_id: 11126
+    item_name: "Combat bracelet"
+    slug: "combat-bracelet"
+    relationship: "downgrade"
+    description: "Lower tier bracelet with teleports"
+---
+
+## Obtaining
+
+**Lvl-6 Enchant** (87 Magic): Onyx bracelet + 1 cosmic rune + 20 fire runes + 20 earth runes (97 XP)
+
+> *"Helps to restore Hitpoints."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Stab | +8 |
+| Slash | +8 |
+| Crush | +8 |
+| Magic | +3 |
+| Ranged | +7 |
+
+| Defence | Value |
+|---------|-------|
+| All melee | +6 |
+| Magic | +3 |
+| Ranged | +6 |
+
+| Other | Value |
+|-------|-------|
+| Strength | **+7** |
+
+**Requirements:** None to wear | **Weight:** 0.25 kg
+
+## Passive Effect — Double HP Regen
+
+The regen bracelet **doubles your natural Hitpoints regeneration** — healing 2 HP per minute instead of the standard 1. When combined with:
+- **Rapid Heal prayer** — 2 HP per 30 seconds
+- **Hitpoints cape** — further doubled regeneration
+
+## Best 1 Defence Gloves
+
+The regen bracelet is the **best-in-slot melee hand slot** for players with 1 Defence, as it has no Defence requirement. Its +7 Strength bonus matches mithril gloves while providing superior overall stats.
+
+## Comparison
+
+| Stat | Regen Bracelet | Barrows Gloves | Combat Bracelet |
+|------|---------------|---------------|----------------|
+| Melee Atk | +8/+8/+8 | +12/+12/+12 | +7/+7/+7 |
+| Strength | **+7** | **+12** | +6 |
+| Melee Def | +6/+6/+6 | +6/+6/+6 | +6/+6/+6 |
+| Special | **2x HP regen** | None | Teleports |
+| Req | None | RFD complete | None |
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours | **High Alch:** 27,000 GP
+
+**Tips:**
+- Onyx bracelet is the main cost component
+- Popular with 1 Defence pures and PKers
+- Passive healing stacks with other regen effects
+
+## Related Items
+
+- [Barrows gloves](/osrs/barrows-gloves/) - BiS gloves (requires RFD)
+- [Combat bracelet](/osrs/combat-bracelet/) - Budget alternative with teleports

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_21318.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_21318.mdx
@@ -1,0 +1,70 @@
+---
+equipment:
+  slot: "ammo"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 55
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    ranged: 50
+  weight: 0.02
+related_items:
+  - item_id: 830
+    item_name: "Rune javelin"
+    slug: "rune-javelin"
+    relationship: "downgrade"
+    description: "Lower tier javelin"
+---
+
+## Obtaining
+
+- **Fletching:** Level 84 (1 amethyst javelin head + 1 javelin shaft = 135.2 XP)
+- **Mining amethyst** at 92 Mining to create javelin heads
+- **Grand Exchange**
+
+> *"An amethyst-tipped javelin."*
+
+## Stats
+
+| Other | Value |
+|-------|-------|
+| Ranged Strength | **+55** |
+
+**Requirements:** 50 Ranged | **Weight:** 0.02 kg
+
+## Best Non-Dragon Javelin
+
+The amethyst javelin is the **strongest tradeable javelin below dragon tier**. With +55 ranged strength, it provides a significant boost over rune javelins (+46) in Heavy ballista setups.
+
+## Heavy Ballista PvP
+
+Amethyst javelins in a heavy ballista are a popular **PKing setup**:
+- High single-hit damage potential (70+ with max gear)
+- One of the best KO weapons in multi-combat
+- Cheaper than dragon javelins with comparable performance
+
+## Market Strategy
+
+**Buy Limit:** 7,000 per 4 hours | **High Alch:** 60 GP
+
+**Tips:**
+- Consumed as ammo — steady PvP demand
+- Amethyst mining at 92 Mining supplies the heads
+- Good Fletching XP at level 84
+
+## Related Items
+
+- [Rune javelin](/osrs/rune-javelin/) - Lower tier javelin (+46 Str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_3749.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_3749.mdx
@@ -1,0 +1,88 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: -5
+    slash: -5
+    crush: -5
+    magic: -5
+    ranged: 6
+  defence_bonus:
+    stab: 6
+    slash: 8
+    crush: 10
+    magic: 6
+    ranged: 6
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 45
+  weight: 2.721
+related_items:
+  - item_id: 3751
+    item_name: "Berserker helm"
+    slug: "berserker-helm"
+    relationship: "alternative"
+    description: "Melee variant (+3 Str)"
+  - item_id: 3755
+    item_name: "Farseer helm"
+    slug: "farseer-helm"
+    relationship: "alternative"
+    description: "Magic variant"
+---
+
+## Obtaining
+
+- **Skulgrimen's Battle Gear** (Rellekka) — 78,000 coins
+- **Barbarian Assault** — High Gamble reward (1/32)
+- **Dagannoth** (Waterbirth Island, level 88/90) — rare drop
+
+Requires completion of **The Fremennik Trials**.
+
+> *"This helmet is worn by archers."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Ranged | **+6** |
+
+| Defence | Value |
+|---------|-------|
+| Stab | +6 |
+| Slash | +8 |
+| Crush | +10 |
+| Magic | +6 |
+| Ranged | +6 |
+
+**Requirements:** 45 Defence | **Weight:** 2.72 kg
+
+## Mid-Tier Ranged Helm
+
+The **+6 ranged attack** makes this competitive with the Karil's coif (+7) while providing substantially better melee defence. At 45 Defence it's accessible earlier than Armadyl helm (70 Def/Ranged).
+
+## Comparison
+
+| Stat | Archer Helm | Karil's Coif | Armadyl Helm |
+|------|------------|-------------|-------------|
+| Ranged Atk | +6 | **+7** | **+10** |
+| Stab Def | **+6** | +4 | +6 |
+| Magic Def | **+6** | +4 | +10 |
+| Req | 45 Def | 70 Def | 70 Def/70 Rng |
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 36,000 GP
+
+**Tips:**
+- Budget ranged helm with solid defence
+- Useful for mid-game Slayer ranging
+- Outclassed by Armadyl/Masori at endgame
+
+## Related Items
+
+- [Berserker helm](/osrs/berserker-helm/) - Melee variant (+3 Str)
+- [Farseer helm](/osrs/farseer-helm/) - Magic variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_3751.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_3751.mdx
@@ -1,0 +1,100 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -5
+    ranged: -5
+  defence_bonus:
+    stab: 31
+    slash: 29
+    crush: 33
+    magic: 0
+    ranged: 30
+  other_bonus:
+    melee_strength: 3
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 45
+  weight: 2.721
+related_items:
+  - item_id: 3753
+    item_name: "Warrior helm"
+    slug: "warrior-helm"
+    relationship: "alternative"
+    description: "Slash attack variant"
+  - item_id: 3755
+    item_name: "Farseer helm"
+    slug: "farseer-helm"
+    relationship: "alternative"
+    description: "Magic variant"
+  - item_id: 3749
+    item_name: "Archer helm"
+    slug: "archer-helm"
+    relationship: "alternative"
+    description: "Ranged variant"
+  - item_id: 10828
+    item_name: "Helm of neitiznot"
+    slug: "helm-of-neitiznot"
+    relationship: "upgrade"
+    description: "Superior melee helm (+3 Str, +3 Prayer)"
+---
+
+## Obtaining
+
+- **Skulgrimen's Battle Gear** (Rellekka) — 78,000 coins
+- **Barbarian Assault** — High Gamble reward (1/32)
+- **Dagannoth** (Waterbirth Island, level 88/90) — rare drop
+
+Requires completion of **The Fremennik Trials**.
+
+> *"This helmet is worn by berserkers."*
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Stab | +31 |
+| Slash | +29 |
+| Crush | **+33** |
+| Ranged | +30 |
+
+| Other | Value |
+|-------|-------|
+| Strength | **+3** |
+
+**Requirements:** 45 Defence | **Weight:** 2.72 kg
+
+## Strength Bonus Significance
+
+The **+3 Strength** bonus makes this the key Fremennik helm for melee. It matches the Helm of neitiznot's Strength bonus but lacks the +3 Prayer. Popular with **combat pures** at 45 Defence who can't access the Neitiznot helm (requires The Fremennik Isles).
+
+## Fremennik Helm Comparison
+
+| Stat | Berserker | Warrior | Farseer | Archer | Neitiznot |
+|------|-----------|---------|---------|--------|-----------|
+| Best Atk | +0 | +5 slash | +6 magic | +6 ranged | +3 crush |
+| Str/Bonus | **+3 Str** | +0 | +0 | +0 | **+3 Str, +3 Pray** |
+| Stab Def | +31 | +31 | +8 | +6 | +31 |
+| Best Def | +33 crush | +33 slash | +12 crush | +10 crush | +34 crush |
+| Req | 45 Def | 45 Def | 45 Def | 45 Def | 55 Def |
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 46,800 GP
+
+**Tips:**
+- Popular with 45 Defence pures
+- Cheaper alternative to Helm of neitiznot
+- Supply from Barbarian Assault and Dagannoth drops
+
+## Related Items
+
+- [Helm of neitiznot](/osrs/helm-of-neitiznot/) - Superior upgrade (+3 Str, +3 Prayer)
+- [Warrior helm](/osrs/warrior-helm/) - Slash attack variant
+- [Farseer helm](/osrs/farseer-helm/) - Magic variant
+- [Archer helm](/osrs/archer-helm/) - Ranged variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_3753.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_3753.mdx
@@ -1,0 +1,84 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 5
+    crush: 0
+    magic: -5
+    ranged: -5
+  defence_bonus:
+    stab: 31
+    slash: 33
+    crush: 29
+    magic: 0
+    ranged: 30
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 45
+  weight: 2.721
+related_items:
+  - item_id: 3751
+    item_name: "Berserker helm"
+    slug: "berserker-helm"
+    relationship: "alternative"
+    description: "Strength bonus variant (+3 Str)"
+  - item_id: 3755
+    item_name: "Farseer helm"
+    slug: "farseer-helm"
+    relationship: "alternative"
+    description: "Magic variant"
+  - item_id: 3749
+    item_name: "Archer helm"
+    slug: "archer-helm"
+    relationship: "alternative"
+    description: "Ranged variant"
+---
+
+## Obtaining
+
+- **Skulgrimen's Battle Gear** (Rellekka) — 78,000 coins
+- **Barbarian Assault** — High Gamble reward (1/32)
+- **Dagannoth** (Waterbirth Island, level 88/90) — rare drop
+
+Requires completion of **The Fremennik Trials**.
+
+> *"This helmet is worn by warriors."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Slash | **+5** |
+
+| Defence | Value |
+|---------|-------|
+| Stab | +31 |
+| Slash | **+33** |
+| Crush | +29 |
+| Ranged | +30 |
+
+**Requirements:** 45 Defence | **Weight:** 2.72 kg
+
+## Slash Accuracy Helm
+
+The warrior helm provides **+5 slash attack** — unique among Fremennik helms. However, it lacks the Strength bonus of the berserker helm, making it less popular for general melee. The +5 slash is a marginal accuracy boost that rarely outweighs +3 Strength in DPS calculations.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 46,800 GP
+
+**Tips:**
+- Least popular Fremennik melee helm (berserker preferred)
+- Niche accuracy option for slash weapons
+- Supply from Barbarian Assault
+
+## Related Items
+
+- [Berserker helm](/osrs/berserker-helm/) - Preferred melee variant (+3 Str)
+- [Farseer helm](/osrs/farseer-helm/) - Magic variant
+- [Archer helm](/osrs/archer-helm/) - Ranged variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_3755.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_3755.mdx
@@ -1,0 +1,89 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: -5
+    slash: -5
+    crush: -5
+    magic: 6
+    ranged: -5
+  defence_bonus:
+    stab: 8
+    slash: 10
+    crush: 12
+    magic: 6
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 45
+  weight: 2.721
+related_items:
+  - item_id: 3751
+    item_name: "Berserker helm"
+    slug: "berserker-helm"
+    relationship: "alternative"
+    description: "Melee variant (+3 Str)"
+  - item_id: 3749
+    item_name: "Archer helm"
+    slug: "archer-helm"
+    relationship: "alternative"
+    description: "Ranged variant"
+---
+
+## Obtaining
+
+- **Skulgrimen's Battle Gear** (Rellekka) — 78,000 coins
+- **Barbarian Assault** — High Gamble reward (1/32)
+- **Dagannoth** (Waterbirth Island, level 88/90) — rare drop
+
+Requires completion of **The Fremennik Trials**.
+
+> *"This helmet is worn by farseers."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Magic | **+6** |
+
+| Defence | Value |
+|---------|-------|
+| Stab | +8 |
+| Slash | +10 |
+| Crush | +12 |
+| Magic | **+6** |
+
+**Requirements:** 45 Defence | **Weight:** 2.72 kg
+
+## Best Mid-Tier Magic Helm
+
+At **+6 magic attack**, the farseer helm matches the Infinity hat and is only surpassed by Ancestral hat (+8) and Virtus mask (+8) among tradeable helms. It requires only 45 Defence versus Infinity's 50 Magic/25 Defence.
+
+## Comparison
+
+| Stat | Farseer | Mystic Hat | Infinity Hat | Ancestral Hat |
+|------|---------|-----------|-------------|--------------|
+| Magic Atk | **+6** | +4 | **+6** | **+8** |
+| Magic Def | +6 | +4 | +6 | +8 |
+| Melee Def | +8/+10/+12 | 0/0/0 | 0/0/0 | 0/0/0 |
+| Req | 45 Def | 40 Mag/20 Def | 50 Mag/25 Def | 75 Mag/65 Def |
+
+The farseer's melee defence stats are a significant advantage — it's the only mid-tier magic helm with meaningful physical protection.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 46,800 GP
+
+**Tips:**
+- Best magic helm at 45 Defence
+- Popular for Barrows and mid-game Slayer
+- Affordable compared to Infinity/Ancestral
+
+## Related Items
+
+- [Berserker helm](/osrs/berserker-helm/) - Melee variant (+3 Str)
+- [Archer helm](/osrs/archer-helm/) - Ranged variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4156.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4156.mdx
@@ -1,0 +1,79 @@
+---
+equipment:
+  slot: "shield"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 10
+    slash: 15
+    crush: 5
+    magic: 5
+    ranged: 10
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    defence: 20
+  weight: 2.267
+shop_sources:
+  - shop_name: "Any Slayer Master"
+    location: "Various"
+    price: 5000
+    stock: 10
+    members_only: true
+related_items:
+  - item_id: 6524
+    item_name: "Toktz-ket-xil"
+    slug: "toktz-ket-xil"
+    relationship: "upgrade"
+    description: "Obsidian shield with better stats"
+---
+
+## Obtaining
+
+- **Any Slayer Master** — 5,000 coins
+- **Grand Exchange**
+
+Requires **25 Slayer** and **20 Defence** to equip.
+
+> *"I can just about see things in this shield's reflection."*
+
+## Stats
+
+| Defence | Value |
+|---------|-------|
+| Slash | **+15** |
+| Stab | +10 |
+| Ranged | +10 |
+| Crush | +5 |
+| Magic | +5 |
+
+**Requirements:** 20 Defence, 25 Slayer | **Weight:** 2.27 kg
+
+## Slayer Protection
+
+The mirror shield is **required** when fighting:
+- **Cockatrices** (37 Slayer) — without it, your stats are drastically reduced
+- **Basilisks** (40 Slayer) — same stat-drain effect
+- **Basilisk Knights** (60 Slayer) — upgraded basilisk variant
+
+The reflective surface prevents these monsters' petrifying gaze from affecting the player. **V's shield** (from The Fremennik Exiles) provides the same protection with superior stats.
+
+## Market Strategy
+
+**Buy Limit:** 40 per 4 hours | **High Alch:** 3,000 GP
+
+**Tips:**
+- Essential Slayer equipment — steady demand
+- Cheap from any Slayer Master (5,000 coins)
+- Keep one in bank for basilisk/cockatrice tasks
+
+## Related Items
+
+- [Toktz-ket-xil](/osrs/toktz-ket-xil/) - Obsidian shield (better stats, no Slayer protection)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6526.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6526.mdx
@@ -1,0 +1,91 @@
+---
+equipment:
+  slot: "weapon"
+  two_handed: true
+  attack_speed: 6
+  attack_bonus:
+    stab: 15
+    slash: -1
+    crush: 55
+    magic: 15
+    ranged: 0
+  defence_bonus:
+    stab: 10
+    slash: 15
+    crush: 5
+    magic: 15
+    ranged: 0
+  other_bonus:
+    melee_strength: 55
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 5
+  requirements:
+    attack: 60
+    magic: 60
+  weight: 1.814
+related_items:
+  - item_id: 6523
+    item_name: "Toktz-xil-ak"
+    slug: "toktz-xil-ak"
+    relationship: "alternative"
+    description: "Obsidian sword (melee focused)"
+  - item_id: 6524
+    item_name: "Toktz-ket-xil"
+    slug: "toktz-ket-xil"
+    relationship: "alternative"
+    description: "Obsidian shield"
+---
+
+## Obtaining
+
+- **TzHaar-Hur-Tel's Equipment Store** (Mor Ul Rek) — 52,500 Tokkul (45,500 with Karamja gloves)
+- **TzHaar-Mej** (level 103) — very rare drop
+- **Grand Exchange**
+
+> *"A staff of obsidian."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Crush | **+55** |
+| Stab | +15 |
+| Magic | **+15** |
+
+| Defence | Value |
+|---------|-------|
+| Slash | +15 |
+| Magic | **+15** |
+| Stab | +10 |
+
+| Other | Value |
+|-------|-------|
+| Strength | **+55** |
+| Prayer | **+5** |
+
+**Requirements:** 60 Attack, 60 Magic | **Speed:** 6 tick melee / 5 tick spellcasting | **Two-handed**
+
+## Hybrid Staff
+
+The Toktz-mej-tal is a unique **hybrid weapon** — functioning as both a melee weapon (+55 crush, +55 Str) and a magic staff (+15 magic attack). Its +5 Prayer bonus is rare for a weapon.
+
+However, being two-handed means you sacrifice a shield slot, and the 6-tick melee speed is slow.
+
+## Construction Use
+
+10 Toktz-mej-tal are needed to build an **Obsidian fence** at 83 Construction — a popular decorative feature.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours | **High Alch:** 33,000 GP
+
+**Tips:**
+- Tokkul shop is cheapest source (45,500 with Karamja gloves)
+- Prayer bonus is unique for a weapon
+- Construction sink provides additional demand
+
+## Related Items
+
+- [Toktz-xil-ak](/osrs/toktz-xil-ak/) - Obsidian sword (one-handed)
+- [Toktz-ket-xil](/osrs/toktz-ket-xil/) - Obsidian shield

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_830.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_830.mdx
@@ -1,0 +1,76 @@
+---
+equipment:
+  slot: "ammo"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 46
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    ranged: 40
+  weight: 0.02
+related_items:
+  - item_id: 21318
+    item_name: "Amethyst javelin"
+    slug: "amethyst-javelin"
+    relationship: "upgrade"
+    description: "Higher tier javelin"
+---
+
+## Obtaining
+
+- **Fletching:** Level 77 (1 rune javelin head + 1 javelin shaft = 124.4 XP)
+- **Drops:** Various monsters including TzHaar creatures
+- **Grand Exchange**
+
+> *"A rune-tipped javelin."*
+
+## Stats
+
+| Other | Value |
+|-------|-------|
+| Ranged Strength | **+46** |
+
+**Requirements:** 40 Ranged | **Weight:** 0.02 kg
+
+## Javelin Usage
+
+Javelins are primarily used with the **ballista** weapons:
+- **Light ballista** — requires 65 Ranged
+- **Heavy ballista** — requires 75 Ranged (one of the highest single-hit ranged weapons)
+
+Rune javelins in a heavy ballista can hit **extremely high** due to the ballista's slow speed and high max hit, making them popular for PvP KO attempts.
+
+## Javelin Tier Comparison
+
+| Javelin | Ranged Str | Req | Source |
+|---------|-----------|-----|--------|
+| Adamant | +36 | 30 | Fletching 71 |
+| Rune | **+46** | 40 | Fletching 77 |
+| Amethyst | +55 | 50 | Fletching 84 |
+| Dragon | +60 | 60 | Raids/Zulrah |
+
+## Market Strategy
+
+**Buy Limit:** 7,000 per 4 hours | **High Alch:** 48 GP
+
+**Tips:**
+- Consumed as ammo — steady demand
+- Used in Heavy ballista PvP specs
+- Fletching training product
+
+## Related Items
+
+- [Amethyst javelin](/osrs/amethyst-javelin/) - Higher tier javelin (+55 Str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_8880.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_8880.mdx
@@ -1,0 +1,83 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 5
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 42
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    ranged: 28
+  weight: 2.267
+special_attack:
+  name: "Snipe"
+  energy: 75
+  description: "Never misses unsuspecting targets. Reduces Defence by damage dealt."
+related_items:
+  - item_id: 9185
+    item_name: "Rune crossbow"
+    slug: "rune-crossbow"
+    relationship: "upgrade"
+    description: "Higher tier crossbow"
+---
+
+## Obtaining
+
+- **Nardok's Bone Weapons** (Dorgesh-Kaan) — 2,000 coins (requires The Lost Tribe)
+- **Grand Exchange** — can equip without quest completion
+
+> *"This fires crossbow bolts."*
+
+## Stats
+
+| Attack | Value |
+|--------|-------|
+| Ranged | **+42** |
+
+**Requirements:** 28 Ranged | **Speed:** 5 tick (3.0s), 4 tick on Rapid | **Weight:** 2.27 kg
+
+## Bone Bolt Synergy
+
+The Dorgeshuun crossbow is the **only crossbow that fires bone bolts** — extremely cheap ammunition (~5 GP each) with damage comparable to iron bolts. This makes it one of the most cost-efficient ranged training weapons in the game.
+
+## Special Attack — Snipe
+
+**Cost:** 75% special attack energy
+
+**Never misses** against "unsuspecting" targets (those you haven't damaged yet or that weren't last attacked by you). Additionally **reduces the target's Defence** by the damage dealt — sharing mechanics with the Bandos godsword and bone dagger.
+
+## Budget Ranged Training
+
+| Crossbow | Ranged Atk | Ammo Cost | Speed |
+|----------|-----------|-----------|-------|
+| Dorgeshuun | +42 | **~5 GP** (bone bolts) | 5 tick |
+| Rune crossbow | +90 | ~100 GP (broad bolts) | 5 tick |
+| Magic shortbow (i) | +69 | ~50 GP (rune arrows) | 3 tick |
+
+For players on a budget or training low-level accounts, the Dorgeshuun crossbow + bone bolts offers the cheapest ranged XP per hour.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours | **High Alch:** 1,200 GP
+
+**Tips:**
+- Extremely cheap training setup with bone bolts
+- Popular with low-level pures and ironmen
+- The Lost Tribe quest is short and easy
+
+## Related Items
+
+- [Rune crossbow](/osrs/rune-crossbow/) - Higher tier crossbow


### PR DESCRIPTION
## Summary
- **10 new overrides** with Wiki-sourced stats, comparisons, and market data:
  - **Fremennik helms**: Berserker (3751), Warrior (3753), Farseer (3755), Archer (3749)
  - **Ranged ammo**: Rune javelin (830), Amethyst javelin (21318), Dorgeshuun crossbow (8880)
  - **Slayer/Obsidian/Jewelry**: Toktz-mej-tal (6526), Mirror shield (4156), Regen bracelet (11133)
- Updated OSRS.md tracking doc

## Test plan
- [ ] Verify new override files have valid YAML frontmatter
- [ ] Run `pnpm generate:osrs` to confirm overrides inject correctly
- [ ] Spot-check 2-3 items in browser