### PR TITLE
refactor(bevy_inventory): rename plugin and feature-gate snapshot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 	'apps/kbve/axum-kbve',
 	'apps/cryptothrone/axum-cryptothrone',
 	'apps/kbve/isometric/src-tauri',
-	'packages/rust/bevy/bevy_kbve_inventory',
+	'packages/rust/bevy/bevy_inventory',
 	'packages/rust/bevy/bevy_kbve_state',
 	'packages/rust/bevy/bevy_kbve_player',
 	'packages/rust/bevy/bevy_kbve_camera',

--- a/packages/rust/bevy/bevy_inventory/Cargo.toml
+++ b/packages/rust/bevy/bevy_inventory/Cargo.toml
@@ -7,16 +7,20 @@ rust-version = "1.94"
 license = "MIT"
 description = "Generic Bevy inventory plugin with item stacking, slot limits, and loot events."
 homepage = "https://kbve.com/"
-repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_kbve_inventory"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_inventory"
 keywords = ["bevy", "inventory", "gamedev", "ecs", "plugin"]
 categories = ["game-development", "game-engines"]
+
+[features]
+default = ["snapshot"]
+snapshot = ["dep:serde_json"]
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [
     "bevy_state",
 ] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/rust/bevy/bevy_inventory/src/lib.rs
+++ b/packages/rust/bevy/bevy_inventory/src/lib.rs
@@ -831,10 +831,14 @@ pub struct InventoryActionResult {
 // be read from outside the Bevy ECS — for example from a Tauri command
 // handler or a WASM JS binding.
 //
+// Gated behind the `snapshot` feature (enabled by default). Disable it
+// to drop the `serde_json` dependency if you don't need cross-boundary reads.
+//
 // On native targets we use `LazyLock<Mutex<_>>` for thread safety.
 // On WASM (single-threaded) we use `thread_local!` + `RefCell` to avoid
 // pulling in synchronisation primitives that don't exist on `wasm32`.
 
+#[cfg(feature = "snapshot")]
 #[cfg(not(target_arch = "wasm32"))]
 mod snapshot_store {
     use std::sync::{LazyLock, Mutex};
@@ -853,6 +857,7 @@ mod snapshot_store {
     }
 }
 
+#[cfg(feature = "snapshot")]
 #[cfg(target_arch = "wasm32")]
 mod snapshot_store {
     use std::cell::RefCell;
@@ -878,6 +883,7 @@ mod snapshot_store {
 /// system has not run) or if deserialisation fails.
 ///
 /// This function is safe to call from any thread (native) or from JS (WASM).
+#[cfg(feature = "snapshot")]
 pub fn get_inventory_snapshot<K: ItemKind>() -> Option<Inventory<K>> {
     let json = snapshot_store::read()?;
     serde_json::from_str(&json).ok()
@@ -887,6 +893,7 @@ pub fn get_inventory_snapshot<K: ItemKind>() -> Option<Inventory<K>> {
 ///
 /// Useful when you need to forward the data without deserialising it
 /// (e.g. returning it directly from a Tauri command or FFI boundary).
+#[cfg(feature = "snapshot")]
 pub fn get_inventory_snapshot_json() -> Option<String> {
     snapshot_store::read()
 }
@@ -937,6 +944,7 @@ impl<K: ItemKind> Plugin for InventoryPlugin<K> {
         app.add_observer(process_split_action::<K>);
         app.add_observer(process_merge_action::<K>);
         app.add_observer(process_move_action::<K>);
+        #[cfg(feature = "snapshot")]
         app.add_systems(Update, snapshot_inventory::<K>);
     }
 }
@@ -1077,6 +1085,7 @@ fn process_move_action<K: ItemKind>(
     });
 }
 
+#[cfg(feature = "snapshot")]
 fn snapshot_inventory<K: ItemKind>(inventory: Res<Inventory<K>>) {
     if inventory.is_changed() {
         if let Ok(json) = serde_json::to_string(inventory.as_ref()) {


### PR DESCRIPTION
## Summary
- Rename directory `bevy_kbve_inventory` → `bevy_inventory` for standalone crates.io readiness
- Feature-gate the JSON snapshot system behind optional `snapshot` feature (enabled by default)
- Consumers can use `default-features = false` to drop `serde_json` if they don't need cross-boundary reads
- All 83 tests pass, compiles with and without snapshot feature

## Test plan
- [x] `cargo check -p bevy_inventory` (with default features)
- [x] `cargo check -p bevy_inventory --no-default-features` (without snapshot)
- [x] `cargo test -p bevy_inventory` (69 unit + 14 doc tests)
- [x] `cargo check -p isometric-game` (workspace still compiles)