### PR TITLE
fix(isometric): tsc not found on macOS CI runner

### DIFF
--- a/apps/kbve/isometric/package.json
+++ b/apps/kbve/isometric/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build:wasm": "cd src-tauri && wasm-pack build --target web --out-dir ../wasm-pkg --out-name isometric_game",
 		"dev": "vite",
-		"build": "npm run build:wasm && tsc && vite build",
+		"build": "npm run build:wasm && npx tsc && vite build",
 		"preview": "vite preview"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary
- macOS Tauri build fails after 19min with `sh: tsc: command not found`
- WASM compiles fine but `tsc` bare command isn't in PATH on the CI runner
- Fix: `tsc` → `npx tsc` in the build script so it resolves the local typescript devDependency

## Root cause
The `build` script in `package.json` runs `npm run build:wasm && tsc && vite build`. On the macOS GitHub Actions runner, `node_modules/.bin` is not added to PATH when the Tauri `beforeBuildCommand` invokes `pnpm build`, so bare `tsc` fails.

## Test plan
- [ ] Verify macOS Tauri CI build passes after merge to main