### PR TITLE
feat(isometric): integrate bevy_inventory plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7015,6 +7015,7 @@ name = "isometric-game"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_inventory",
  "bevy_rapier3d",
  "console_error_panic_hook",
  "console_log 1.0.0",

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ bevy = { version = "0.18", default-features = false, features = [
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bevy_rapier3d = { version = "0.33", features = ["debug-render-3d"] }
+bevy_inventory = { path = "../../../../packages/rust/bevy/bevy_inventory" }
 log = "0.4"
 
 # --- Desktop-only dependencies ---

--- a/apps/kbve/isometric/src-tauri/src/commands.rs
+++ b/apps/kbve/isometric/src-tauri/src/commands.rs
@@ -1,12 +1,10 @@
 use crate::AVERAGE_FRAME_RATE;
-use crate::game::inventory::get_inventory_snapshot;
+use crate::game::inventory::get_inventory_snapshot_json;
 use crate::game::object_registry::get_registry_snapshot;
 use crate::game::scene_objects::{get_hovered_snapshot, get_selected_snapshot};
 use crate::game::state::get_player_snapshot;
 use std::sync::atomic::Ordering;
 
-#[cfg(not(target_arch = "wasm32"))]
-use crate::game::inventory::Inventory;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::game::object_registry::ObjectRegistrySnapshot;
 #[cfg(not(target_arch = "wasm32"))]
@@ -50,8 +48,8 @@ pub fn get_hovered_object() -> Option<HoveredObject> {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tauri::command]
-pub fn get_inventory() -> Option<Inventory> {
-    get_inventory_snapshot()
+pub fn get_inventory() -> Option<String> {
+    get_inventory_snapshot_json()
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -134,7 +132,7 @@ pub fn get_hovered_object_json() -> Option<String> {
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn get_inventory_json() -> Option<String> {
-    get_inventory_snapshot().map(|s| serde_json::to_string(&s).unwrap_or_default())
+    get_inventory_snapshot_json()
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/apps/kbve/isometric/src-tauri/src/game/inventory.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/inventory.rs
@@ -1,7 +1,12 @@
-use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::scene_objects::{FlowerArchetype, MushroomKind, RockKind};
+
+// Re-export bevy_inventory types that the rest of the game uses.
+pub use bevy_inventory::{
+    Inventory, InventoryFullEvent, InventoryPlugin, ItemStack, LootEvent,
+    get_inventory_snapshot_json,
+};
 
 // ── Item definitions ────────────────────────────────────────────────────
 
@@ -31,8 +36,8 @@ pub enum ItemKind {
     FlyAgaric,
 }
 
-impl ItemKind {
-    pub fn display_name(&self) -> &'static str {
+impl bevy_inventory::ItemKind for ItemKind {
+    fn display_name(&self) -> &'static str {
         match self {
             ItemKind::Log => "Log",
             ItemKind::Stone => "Stone",
@@ -56,6 +61,19 @@ impl ItemKind {
         }
     }
 
+    fn max_stack(&self) -> u32 {
+        match self {
+            // Resources stack higher
+            ItemKind::Log | ItemKind::Stone | ItemKind::MossyStone => 64,
+            ItemKind::CopperOre | ItemKind::IronOre => 32,
+            ItemKind::CrystalOre => 16,
+            // Flowers and mushrooms stack moderately
+            _ => 32,
+        }
+    }
+}
+
+impl ItemKind {
     pub fn from_rock_kind(kind: &RockKind) -> Self {
         match kind {
             RockKind::Boulder => ItemKind::Stone,
@@ -86,111 +104,6 @@ impl ItemKind {
             MushroomKind::Porcini => ItemKind::Porcini,
             MushroomKind::Chanterelle => ItemKind::Chanterelle,
             MushroomKind::FlyAgaric => ItemKind::FlyAgaric,
-        }
-    }
-}
-
-// ── Inventory resource ──────────────────────────────────────────────────
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ItemStack {
-    pub kind: ItemKind,
-    pub quantity: u32,
-}
-
-#[derive(Resource, Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Inventory {
-    pub items: Vec<ItemStack>,
-    pub max_slots: usize,
-}
-
-impl Inventory {
-    pub fn new(max_slots: usize) -> Self {
-        Self {
-            items: Vec::new(),
-            max_slots,
-        }
-    }
-
-    /// Add items to the inventory. Stacks with existing items of the same kind.
-    pub fn add(&mut self, kind: ItemKind, quantity: u32) {
-        for stack in &mut self.items {
-            if stack.kind == kind {
-                stack.quantity += quantity;
-                return;
-            }
-        }
-        // New item — only add if we have room
-        if self.items.len() < self.max_slots {
-            self.items.push(ItemStack { kind, quantity });
-        }
-    }
-}
-
-// ── Loot event ──────────────────────────────────────────────────────────
-
-#[derive(Event, Debug, Clone)]
-pub struct LootEvent {
-    pub kind: ItemKind,
-    pub quantity: u32,
-}
-
-// ── Snapshot (same pattern as PlayerState) ───────────────────────────────
-
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::{LazyLock, Mutex};
-
-#[cfg(not(target_arch = "wasm32"))]
-static INVENTORY_SNAPSHOT: LazyLock<Mutex<Option<Inventory>>> = LazyLock::new(|| Mutex::new(None));
-
-#[cfg(target_arch = "wasm32")]
-use std::cell::RefCell;
-
-#[cfg(target_arch = "wasm32")]
-thread_local! {
-    static INVENTORY_SNAPSHOT_WASM: RefCell<Option<Inventory>> = const { RefCell::new(None) };
-}
-
-pub fn get_inventory_snapshot() -> Option<Inventory> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        INVENTORY_SNAPSHOT.lock().unwrap().clone()
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        INVENTORY_SNAPSHOT_WASM.with(|cell| cell.borrow().clone())
-    }
-}
-
-// ── Plugin ──────────────────────────────────────────────────────────────
-
-pub struct InventoryPlugin;
-
-impl Plugin for InventoryPlugin {
-    fn build(&self, app: &mut App) {
-        app.insert_resource(Inventory::new(16));
-        app.add_observer(process_loot_events);
-        app.add_systems(Update, snapshot_inventory);
-    }
-}
-
-// ── Systems ─────────────────────────────────────────────────────────────
-
-fn process_loot_events(event: On<LootEvent>, mut inventory: ResMut<Inventory>) {
-    inventory.add(event.kind, event.quantity);
-}
-
-fn snapshot_inventory(inventory: Res<Inventory>) {
-    if inventory.is_changed() {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            *INVENTORY_SNAPSHOT.lock().unwrap() = Some(inventory.clone());
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            INVENTORY_SNAPSHOT_WASM.with(|cell| {
-                *cell.borrow_mut() = Some(inventory.clone());
-            });
         }
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/mod.rs
@@ -24,7 +24,7 @@ use bevy::app::{PluginGroup, PluginGroupBuilder};
 use actions::ActionsPlugin;
 use camera::IsometricCameraPlugin;
 use insects::InsectsPlugin;
-use inventory::InventoryPlugin;
+use inventory::{InventoryPlugin, ItemKind};
 use object_registry::ObjectRegistryPlugin;
 use orb_hud::OrbHudPlugin;
 use pixelate::PixelatePlugin;
@@ -54,7 +54,7 @@ impl PluginGroup for GamePluginGroup {
             .add(SceneObjectsPlugin)
             .add(TreesPlugin)
             .add(WaterPlugin)
-            .add(InventoryPlugin)
+            .add(InventoryPlugin::<ItemKind>::new(16))
             .add(WeatherPlugin)
             .add(InsectsPlugin)
             .add(VirtualJoystickPlugin)


### PR DESCRIPTION
## Summary
- Replace custom inventory implementation with `bevy_inventory` crate integration
- Implement `bevy_inventory::ItemKind` trait on game's `ItemKind` enum with proper `max_stack()` values
- Re-export plugin types (`Inventory`, `LootEvent`, `InventoryPlugin`, `ItemStack`) for seamless usage across the game
- Update Tauri IPC and WASM commands to use `get_inventory_snapshot_json()` API

## Test plan
- [x] Compiles clean on native target
- [ ] Verify inventory snapshot returns valid JSON via Tauri `get_inventory` command
- [ ] Confirm loot events (chop tree, mine rock, collect flower/mushroom) add items to inventory
- [ ] Verify WASM build compiles and `get_inventory_json()` works