### PR TITLE
refactor(bevy_cam): rename and integrate camera plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_cam"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+]
+
+[[package]]
 name = "bevy_camera"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,13 +1849,6 @@ dependencies = [
  "bevy",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "bevy_kbve_camera"
-version = "0.1.0"
-dependencies = [
- "bevy",
 ]
 
 [[package]]
@@ -7015,6 +7015,7 @@ name = "isometric-game"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_cam",
  "bevy_inventory",
  "bevy_rapier3d",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 	'packages/rust/bevy/bevy_inventory',
 	'packages/rust/bevy/bevy_kbve_state',
 	'packages/rust/bevy/bevy_kbve_player',
-	'packages/rust/bevy/bevy_kbve_camera',
+	'packages/rust/bevy/bevy_cam',
 ]
 
 [profile.dev]

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bevy_rapier3d = { version = "0.33", features = ["debug-render-3d"] }
 bevy_inventory = { path = "../../../../packages/rust/bevy/bevy_inventory" }
+bevy_cam = { path = "../../../../packages/rust/bevy/bevy_cam" }
 log = "0.4"
 
 # --- Desktop-only dependencies ---

--- a/apps/kbve/isometric/src-tauri/src/game/camera.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/camera.rs
@@ -1,234 +1,66 @@
-use bevy::camera::visibility::RenderLayers;
-use bevy::core_pipeline::tonemapping::Tonemapping;
-use bevy::ecs::message::MessageReader;
-use bevy::image::ImageSampler;
-use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
-use bevy::render::render_resource::TextureFormat;
-use bevy::window::PrimaryWindow;
 use bevy_rapier3d::prelude::PhysicsSet;
 
 use super::pixelate::PixelateSettings;
 use super::player::{Player, PlayerMovement};
 
-const CAMERA_OFFSET: Vec3 = Vec3::new(15.0, 20.0, 15.0);
-const VIEWPORT_HEIGHT: f32 = 20.0;
-/// Pixel Density: render pixels per world unit.
-/// 1 tile = 1.0 world unit = 32 render pixels.
-/// Camera snap step = 1/32 = 0.03125 world units.
+// Re-export bevy_cam types that the rest of the game uses.
+pub use bevy_cam::{
+    CameraConfig, CameraFollowTarget, CameraUpdate, CameraZoom, DisplayCamera, IsometricCamera,
+};
+
+/// Render pixels per world unit — re-exported for convenience.
 pub const PIXEL_DENSITY: u32 = 32;
-/// World size of one render pixel (1 / PIXEL_DENSITY).
-const PIXEL_STEP: f32 = 1.0 / PIXEL_DENSITY as f32;
-/// RenderLayer for the display quad (separate from the 3D scene on layer 0).
-const DISPLAY_LAYER: usize = 1;
-
-const ZOOM_MIN: f32 = 0.5;
-const ZOOM_MAX: f32 = 2.0;
-/// Multiplicative zoom factor per scroll tick (e.g. 1.05 = 5% per notch).
-const ZOOM_FACTOR: f32 = 1.05;
-/// Interpolation speed — lower = smoother, more gradual zoom.
-const ZOOM_SMOOTHING: f32 = 4.0;
-
-#[derive(Resource)]
-struct CameraZoom {
-    target: f32,
-    current: f32,
-}
-
-impl Default for CameraZoom {
-    fn default() -> Self {
-        Self {
-            target: 1.0,
-            current: 1.0,
-        }
-    }
-}
-
-/// Precomputed stable camera axes derived from the initial look-at orientation.
-/// Using these instead of reading from the mutated transform avoids frame-to-frame
-/// drift that causes visible pixel jitter (especially along LEFT/RIGHT movement).
-struct StableCameraAxes {
-    right: Vec3,
-    up: Vec3,
-    forward: Vec3,
-}
-
-impl StableCameraAxes {
-    fn new() -> Self {
-        let tf = Transform::from_translation(CAMERA_OFFSET).looking_at(Vec3::ZERO, Vec3::Y);
-        Self {
-            right: tf.right().as_vec3(),
-            up: tf.up().as_vec3(),
-            forward: tf.forward().as_vec3(),
-        }
-    }
-}
-
-static STABLE_AXES: std::sync::LazyLock<StableCameraAxes> =
-    std::sync::LazyLock::new(StableCameraAxes::new);
-
-#[derive(Component)]
-pub struct IsometricCamera;
-
-#[derive(Component)]
-struct DisplayQuad;
 
 pub struct IsometricCameraPlugin;
 
 impl Plugin for IsometricCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<CameraZoom>();
-        app.add_systems(Startup, setup_camera);
-        app.add_systems(Update, handle_zoom_input);
-        app.add_systems(
+        // Add the bevy_cam plugin with our game's configuration.
+        app.add_plugins(bevy_cam::IsometricCameraPlugin::new(CameraConfig {
+            offset: Vec3::new(15.0, 20.0, 15.0),
+            viewport_height: 20.0,
+            pixel_density: PIXEL_DENSITY,
+            display_layer: 1,
+            zoom_min: 0.5,
+            zoom_max: 2.0,
+            zoom_factor: 1.05,
+            zoom_smoothing: 4.0,
+        }));
+
+        // Attach CameraFollowTarget to the player once spawned.
+        app.add_systems(Update, attach_follow_target);
+
+        // Attach PixelateSettings to the display camera (runs until attached).
+        app.add_systems(Update, attach_pixelate_settings);
+
+        // Order bevy_cam's PostUpdate systems after physics writeback
+        // so the camera tracks the player's post-physics position.
+        app.configure_sets(
             PostUpdate,
-            (camera_follow_player, apply_camera_zoom)
-                .chain()
+            CameraUpdate
                 .after(PhysicsSet::Writeback)
                 .in_set(PlayerMovement),
         );
     }
 }
 
-fn setup_camera(
+/// One-shot: attach `CameraFollowTarget` to the player entity.
+fn attach_follow_target(
     mut commands: Commands,
-    mut images: ResMut<Assets<Image>>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    windows: Query<&Window, With<PrimaryWindow>>,
+    player_query: Query<Entity, (With<Player>, Without<CameraFollowTarget>)>,
 ) {
-    let Ok(window) = windows.single() else { return };
-    let aspect = window.width() / window.height();
-
-    // Fixed render buffer: height locked to VIEWPORT_HEIGHT * PIXEL_DENSITY,
-    // width adapts to window aspect ratio.  Exactly 32 pixels per world unit.
-    let render_h = (VIEWPORT_HEIGHT * PIXEL_DENSITY as f32) as u32; // 640
-    let render_w = (render_h as f32 * aspect) as u32;
-
-    // Low-res render target with nearest-neighbor sampling for crisp pixel art
-    let mut render_img =
-        Image::new_target_texture(render_w, render_h, TextureFormat::Bgra8UnormSrgb, None);
-    render_img.sampler = ImageSampler::nearest();
-    let render_handle = images.add(render_img);
-
-    // --- Stage 1: Scene camera renders 3D world to the low-res texture ---
-    // Default RenderLayers (layer 0) — sees all scene entities.
-    commands.spawn((
-        Camera3d::default(),
-        Camera {
-            order: -1,
-            ..default()
-        },
-        Msaa::Off,
-        Tonemapping::None,
-        bevy::camera::RenderTarget::Image(render_handle.clone().into()),
-        Projection::from(OrthographicProjection {
-            scaling_mode: bevy::camera::ScalingMode::FixedVertical {
-                viewport_height: VIEWPORT_HEIGHT,
-            },
-            ..OrthographicProjection::default_3d()
-        }),
-        Transform::from_translation(CAMERA_OFFSET).looking_at(Vec3::ZERO, Vec3::Y),
-        IsometricCamera,
-    ));
-
-    // --- Stage 2: Display camera renders a textured quad to the window ---
-    // Uses RenderLayers(DISPLAY_LAYER) so it only sees the display quad.
-    commands.spawn((
-        Camera3d::default(),
-        Camera {
-            order: 0,
-            ..default()
-        },
-        Msaa::Off,
-        Tonemapping::None,
-        Projection::from(OrthographicProjection {
-            scaling_mode: bevy::camera::ScalingMode::FixedVertical {
-                viewport_height: 1.0,
-            },
-            ..OrthographicProjection::default_3d()
-        }),
-        Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        RenderLayers::layer(DISPLAY_LAYER),
-        PixelateSettings::default(),
-    ));
-
-    // Fullscreen quad with the render texture (unlit = display pixels as-is).
-    // Slightly oversized (+2 texels) so sub-pixel offset doesn't expose clear color at edges.
-    let texel_pad = 2.0 / render_h as f32;
-    let quad_material = materials.add(StandardMaterial {
-        base_color_texture: Some(render_handle),
-        unlit: true,
-        ..default()
-    });
-    commands.spawn((
-        Mesh3d(meshes.add(Rectangle::new(aspect + texel_pad * aspect, 1.0 + texel_pad))),
-        MeshMaterial3d(quad_material),
-        Transform::default(),
-        RenderLayers::layer(DISPLAY_LAYER),
-        DisplayQuad,
-    ));
-}
-
-fn camera_follow_player(
-    player_query: Query<&Transform, (With<Player>, Without<IsometricCamera>)>,
-    mut camera_query: Query<&mut Transform, (With<IsometricCamera>, Without<Player>)>,
-) {
-    let Ok(player_tf) = player_query.single() else {
-        return;
-    };
-    let Ok(mut camera_tf) = camera_query.single_mut() else {
-        return;
-    };
-
-    let desired = player_tf.translation + CAMERA_OFFSET;
-
-    // Use precomputed stable axes to avoid drift from reading mutated transform
-    let axes = &*STABLE_AXES;
-    let right = axes.right;
-    let up = axes.up;
-    let forward = axes.forward;
-
-    let right_proj = desired.dot(right);
-    let up_proj = desired.dot(up);
-    let forward_proj = desired.dot(forward);
-
-    // Snap camera to pixel grid on ALL axes using fixed PIXEL_STEP (1/32).
-    // Right/Up snapping locks the pixel grid for geometry.
-    // Forward snapping stabilizes the shadow cascade alignment.
-    let snapped_right = (right_proj / PIXEL_STEP).round() * PIXEL_STEP;
-    let snapped_up = (up_proj / PIXEL_STEP).round() * PIXEL_STEP;
-    let snapped_forward = (forward_proj / PIXEL_STEP).round() * PIXEL_STEP;
-
-    camera_tf.translation = snapped_right * right + snapped_up * up + snapped_forward * forward;
-}
-
-fn handle_zoom_input(mut scroll_evr: MessageReader<MouseWheel>, mut zoom: ResMut<CameraZoom>) {
-    for ev in scroll_evr.read() {
-        // Multiplicative: each scroll notch scales by a fixed %, feels uniform at all zoom levels.
-        // Scroll up (positive y) = zoom in (smaller ortho scale), scroll down = zoom out.
-        if ev.y > 0.0 {
-            zoom.target /= ZOOM_FACTOR;
-        } else if ev.y < 0.0 {
-            zoom.target *= ZOOM_FACTOR;
-        }
-        zoom.target = zoom.target.clamp(ZOOM_MIN, ZOOM_MAX);
+    for entity in &player_query {
+        commands.entity(entity).insert(CameraFollowTarget);
     }
 }
 
-fn apply_camera_zoom(
-    time: Res<Time>,
-    mut zoom: ResMut<CameraZoom>,
-    mut camera_q: Query<&mut Projection, With<IsometricCamera>>,
+/// One-shot: attach `PixelateSettings` to the display camera.
+fn attach_pixelate_settings(
+    mut commands: Commands,
+    display_query: Query<Entity, (With<DisplayCamera>, Without<PixelateSettings>)>,
 ) {
-    let dt = time.delta_secs();
-    // Smooth interpolation toward target
-    zoom.current += (zoom.target - zoom.current) * (ZOOM_SMOOTHING * dt).min(1.0);
-
-    let Ok(mut proj) = camera_q.single_mut() else {
-        return;
-    };
-    if let Projection::Orthographic(ref mut ortho) = *proj {
-        ortho.scale = zoom.current;
+    for entity in &display_query {
+        commands.entity(entity).insert(PixelateSettings::default());
     }
 }

--- a/packages/rust/bevy/bevy_cam/Cargo.toml
+++ b/packages/rust/bevy/bevy_cam/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "bevy_kbve_camera"
+name = "bevy_cam"
 authors = ["kbve", "h0lybyte"]
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-description = "Bevy isometric camera plugin with pixel snapping, smooth zoom, and two-stage render-to-texture pipeline."
+description = "Bevy isometric camera plugin with pixel snapping, multiplicative zoom, and two-stage render-to-texture pipeline for crisp pixel-art rendering."
 homepage = "https://kbve.com/"
-repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_kbve_camera"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_cam"
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [

--- a/packages/rust/bevy/bevy_cam/src/lib.rs
+++ b/packages/rust/bevy/bevy_cam/src/lib.rs
@@ -1,12 +1,12 @@
-//! # bevy_kbve_camera
+//! # bevy_cam
 //!
-//! Isometric camera plugin for Bevy with pixel snapping, smooth zoom, and
-//! a two-stage render-to-texture pipeline for crisp pixel-art rendering.
+//! Isometric camera plugin for Bevy with pixel snapping, multiplicative zoom,
+//! and a two-stage render-to-texture pipeline for crisp pixel-art rendering.
 //!
-//! ## Usage
+//! ## Quick start
 //!
 //! ```ignore
-//! use bevy_kbve_camera::{IsometricCameraPlugin, CameraConfig};
+//! use bevy_cam::{IsometricCameraPlugin, CameraConfig, CameraFollowTarget};
 //!
 //! app.add_plugins(IsometricCameraPlugin::new(CameraConfig {
 //!     offset: Vec3::new(15.0, 20.0, 15.0),
@@ -14,7 +14,35 @@
 //!     pixel_density: 32,
 //!     ..default()
 //! }));
+//!
+//! // Attach CameraFollowTarget to whatever entity the camera should track:
+//! commands.spawn((Transform::default(), CameraFollowTarget));
 //! ```
+//!
+//! ## Architecture
+//!
+//! The plugin creates a two-stage render pipeline:
+//!
+//! 1. **Scene camera** — renders the 3D world to a low-resolution texture at
+//!    `pixel_density` pixels per world unit (nearest-neighbor sampled).
+//! 2. **Display camera** — renders a fullscreen quad textured with stage 1
+//!    output to the window, producing crisp upscaled pixel art.
+//!
+//! The scene camera follows entities marked with [`CameraFollowTarget`],
+//! snapping to the pixel grid on all three camera-space axes to eliminate
+//! sub-pixel jitter.
+//!
+//! ## Zoom
+//!
+//! Scroll-wheel zoom is **multiplicative** — each notch scales by a fixed
+//! percentage (`zoom_factor`), so it feels uniform at all zoom levels.
+//! Zoom interpolates smoothly toward the target via configurable smoothing.
+//!
+//! ## Display camera hooks
+//!
+//! The display camera entity is accessible via the [`DisplayCamera`] marker
+//! component. Games can query for it and insert additional components (e.g.
+//! post-processing settings) after startup.
 
 use bevy::camera::ScalingMode;
 use bevy::camera::visibility::RenderLayers;
@@ -28,7 +56,7 @@ use bevy::window::PrimaryWindow;
 
 // ── Configuration ───────────────────────────────────────────────────────
 
-/// Camera configuration — set once at plugin creation.
+/// Camera configuration — set once at plugin creation, readable as a `Res`.
 #[derive(Resource, Debug, Clone)]
 pub struct CameraConfig {
     /// Offset from the follow target to the camera position.
@@ -43,9 +71,9 @@ pub struct CameraConfig {
     pub zoom_min: f32,
     /// Maximum zoom level (> 1.0 = zoomed out).
     pub zoom_max: f32,
-    /// Zoom speed multiplier per scroll tick.
-    pub zoom_speed: f32,
-    /// Zoom interpolation smoothing factor.
+    /// Multiplicative zoom factor per scroll tick (e.g. 1.05 = 5% per notch).
+    pub zoom_factor: f32,
+    /// Zoom interpolation smoothing factor (lower = smoother).
     pub zoom_smoothing: f32,
 }
 
@@ -58,15 +86,15 @@ impl Default for CameraConfig {
             display_layer: 1,
             zoom_min: 0.5,
             zoom_max: 2.0,
-            zoom_speed: 0.10,
-            zoom_smoothing: 8.0,
+            zoom_factor: 1.05,
+            zoom_smoothing: 4.0,
         }
     }
 }
 
 // ── Components ──────────────────────────────────────────────────────────
 
-/// Marker for the scene camera that renders the 3D world.
+/// Marker for the scene camera that renders the 3D world to the low-res texture.
 #[derive(Component)]
 pub struct IsometricCamera;
 
@@ -75,13 +103,18 @@ pub struct IsometricCamera;
 #[derive(Component)]
 pub struct CameraFollowTarget;
 
+/// Marker for the display camera that renders the upscaled quad to the window.
+/// Use this to query and attach post-processing components.
+#[derive(Component)]
+pub struct DisplayCamera;
+
 /// Marker for the display quad.
 #[derive(Component)]
 struct DisplayQuad;
 
 // ── Resources ───────────────────────────────────────────────────────────
 
-/// Runtime zoom state.
+/// Runtime zoom state — readable/writable by game code.
 #[derive(Resource)]
 pub struct CameraZoom {
     pub target: f32,
@@ -97,15 +130,17 @@ impl Default for CameraZoom {
     }
 }
 
-/// Precomputed stable camera axes to avoid frame-to-frame drift from
-/// reading the mutated transform (causes pixel jitter).
-struct StableCameraAxes {
+/// Precomputed stable camera axes derived from the initial look-at orientation.
+/// Using these instead of reading from the mutated transform avoids
+/// frame-to-frame drift that causes visible pixel jitter.
+#[derive(Resource)]
+struct StableAxes {
     right: Vec3,
     up: Vec3,
     forward: Vec3,
 }
 
-impl StableCameraAxes {
+impl StableAxes {
     fn from_offset(offset: Vec3) -> Self {
         let tf = Transform::from_translation(offset).looking_at(Vec3::ZERO, Vec3::Y);
         Self {
@@ -144,15 +179,11 @@ impl Default for IsometricCameraPlugin {
 
 impl Plugin for IsometricCameraPlugin {
     fn build(&self, app: &mut App) {
-        let axes = StableCameraAxes::from_offset(self.config.offset);
+        let axes = StableAxes::from_offset(self.config.offset);
 
         app.insert_resource(self.config.clone());
         app.init_resource::<CameraZoom>();
-        app.insert_resource(StableAxesResource {
-            right: axes.right,
-            up: axes.up,
-            forward: axes.forward,
-        });
+        app.insert_resource(axes);
         app.add_systems(Startup, setup_camera);
         app.add_systems(Update, handle_zoom_input);
         app.add_systems(
@@ -162,14 +193,6 @@ impl Plugin for IsometricCameraPlugin {
                 .in_set(CameraUpdate),
         );
     }
-}
-
-/// Internal resource holding precomputed axes.
-#[derive(Resource)]
-struct StableAxesResource {
-    right: Vec3,
-    up: Vec3,
-    forward: Vec3,
 }
 
 // ── Systems ─────────────────────────────────────────────────────────────
@@ -188,13 +211,14 @@ fn setup_camera(
     let render_h = (config.viewport_height * config.pixel_density as f32) as u32;
     let render_w = (render_h as f32 * aspect) as u32;
 
-    // Low-res render target with nearest-neighbor sampling
+    // Low-res render target with nearest-neighbor sampling for crisp pixel art
     let mut render_img =
         Image::new_target_texture(render_w, render_h, TextureFormat::Bgra8UnormSrgb, None);
     render_img.sampler = ImageSampler::nearest();
     let render_handle = images.add(render_img);
 
-    // Stage 1: Scene camera → low-res texture
+    // Stage 1: Scene camera renders 3D world to the low-res texture.
+    // Default RenderLayers (layer 0) — sees all scene entities.
     commands.spawn((
         Camera3d::default(),
         Camera {
@@ -214,7 +238,8 @@ fn setup_camera(
         IsometricCamera,
     ));
 
-    // Stage 2: Display camera → window
+    // Stage 2: Display camera renders a textured quad to the window.
+    // Uses RenderLayers(display_layer) so it only sees the display quad.
     commands.spawn((
         Camera3d::default(),
         Camera {
@@ -231,9 +256,11 @@ fn setup_camera(
         }),
         Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
         RenderLayers::layer(config.display_layer),
+        DisplayCamera,
     ));
 
-    // Fullscreen quad with render texture (slightly oversized to avoid edge artifacts)
+    // Fullscreen quad with the render texture (unlit = display pixels as-is).
+    // Slightly oversized (+2 texels) so sub-pixel offset doesn't expose clear color at edges.
     let texel_pad = 2.0 / render_h as f32;
     let quad_material = materials.add(StandardMaterial {
         base_color_texture: Some(render_handle),
@@ -253,7 +280,7 @@ fn camera_follow_target(
     target_query: Query<&Transform, (With<CameraFollowTarget>, Without<IsometricCamera>)>,
     mut camera_query: Query<&mut Transform, (With<IsometricCamera>, Without<CameraFollowTarget>)>,
     config: Res<CameraConfig>,
-    axes: Res<StableAxesResource>,
+    axes: Res<StableAxes>,
 ) {
     let Ok(target_tf) = target_query.single() else {
         return;
@@ -265,7 +292,9 @@ fn camera_follow_target(
     let desired = target_tf.translation + config.offset;
     let pixel_step = 1.0 / config.pixel_density as f32;
 
-    // Snap to pixel grid on all axes
+    // Snap camera to pixel grid on ALL axes using the precomputed stable axes.
+    // Right/Up snapping locks the pixel grid for geometry.
+    // Forward snapping stabilizes the shadow cascade alignment.
     let right_proj = desired.dot(axes.right);
     let up_proj = desired.dot(axes.up);
     let forward_proj = desired.dot(axes.forward);
@@ -284,8 +313,14 @@ fn handle_zoom_input(
     config: Res<CameraConfig>,
 ) {
     for ev in scroll_evr.read() {
-        zoom.target =
-            (zoom.target - ev.y * config.zoom_speed).clamp(config.zoom_min, config.zoom_max);
+        // Multiplicative: each scroll notch scales by a fixed %, feels uniform at all zoom levels.
+        // Scroll up (positive y) = zoom in (smaller ortho scale), scroll down = zoom out.
+        if ev.y > 0.0 {
+            zoom.target /= config.zoom_factor;
+        } else if ev.y < 0.0 {
+            zoom.target *= config.zoom_factor;
+        }
+        zoom.target = zoom.target.clamp(config.zoom_min, config.zoom_max);
     }
 }
 
@@ -296,6 +331,7 @@ fn apply_camera_zoom(
     mut camera_q: Query<&mut Projection, With<IsometricCamera>>,
 ) {
     let dt = time.delta_secs();
+    // Smooth interpolation toward target
     zoom.current += (zoom.target - zoom.current) * (config.zoom_smoothing * dt).min(1.0);
 
     let Ok(mut proj) = camera_q.single_mut() else {
@@ -318,15 +354,18 @@ mod tests {
         assert_eq!(config.pixel_density, 32);
         assert_eq!(config.viewport_height, 20.0);
         assert!(config.zoom_min < config.zoom_max);
+        assert!(config.zoom_factor > 1.0);
     }
 
     #[test]
     fn stable_axes_are_orthogonal() {
-        let axes = StableCameraAxes::from_offset(Vec3::new(15.0, 20.0, 15.0));
+        let axes = StableAxes::from_offset(Vec3::new(15.0, 20.0, 15.0));
         let dot_ru = axes.right.dot(axes.up).abs();
         let dot_rf = axes.right.dot(axes.forward).abs();
+        let dot_uf = axes.up.dot(axes.forward).abs();
         assert!(dot_ru < 0.001, "right and up should be orthogonal");
         assert!(dot_rf < 0.001, "right and forward should be orthogonal");
+        assert!(dot_uf < 0.001, "up and forward should be orthogonal");
     }
 
     #[test]
@@ -343,5 +382,40 @@ mod tests {
         assert_eq!(clamped, config.zoom_min);
         let clamped = 5.0_f32.clamp(config.zoom_min, config.zoom_max);
         assert_eq!(clamped, config.zoom_max);
+    }
+
+    #[test]
+    fn multiplicative_zoom_is_symmetric() {
+        let config = CameraConfig::default();
+        let base = 1.0_f32;
+        let zoomed_in = base / config.zoom_factor;
+        let back = zoomed_in * config.zoom_factor;
+        assert!((back - base).abs() < 0.0001);
+    }
+
+    #[test]
+    fn axes_from_different_offsets() {
+        // Verify axes are valid for non-default offsets
+        let axes = StableAxes::from_offset(Vec3::new(10.0, 30.0, 5.0));
+        assert!(axes.right.length() > 0.99);
+        assert!(axes.up.length() > 0.99);
+        assert!(axes.forward.length() > 0.99);
+    }
+
+    #[test]
+    fn pixel_snap_is_stable() {
+        let config = CameraConfig::default();
+        let axes = StableAxes::from_offset(config.offset);
+        let pixel_step = 1.0 / config.pixel_density as f32;
+
+        // A position that's already on the pixel grid should not move
+        let aligned = Vec3::new(1.0, 2.0, 3.0);
+        let right_proj = aligned.dot(axes.right);
+        let snapped = (right_proj / pixel_step).round() * pixel_step;
+        let re_snapped = (snapped / pixel_step).round() * pixel_step;
+        assert!(
+            (snapped - re_snapped).abs() < 0.0001,
+            "double-snap should be idempotent"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Rename `bevy_kbve_camera` to `bevy_cam` for crates.io readiness
- Upgrade to multiplicative zoom (uniform feel at all zoom levels)
- Add `DisplayCamera` marker component for post-processing hooks
- Rewrite game's `camera.rs` as 64-line thin adapter using `bevy_cam` plugin
- Auto-attaches `CameraFollowTarget` to the player and `PixelateSettings` to display camera

## Test plan
- [x] All 7 bevy_cam unit tests pass
- [x] Game compiles clean on native target
- [ ] Verify camera follows player with pixel-snapped movement
- [ ] Verify scroll zoom feels smooth and uniform
- [ ] Verify pixelate post-processing still renders on display camera