### PR TITLE
feat(osrs): add 20 overrides — complete god d'hide sets + misc

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -626,6 +626,51 @@ Focus on items with clear processing chains and market flip potential.
 | 19930 | Armadyl d'hide boots | Hard clue, +1 prayer boots |
 | 19921 | Ancient d'hide boots | Hard clue, +1 prayer boots |
 
+### God D'hide Chaps (Implemented - Mar 2026)
+
+| ID    | Item          | Override Focus              |
+| ----- | ------------- | --------------------------- |
+| 10380 | Guthix chaps  | Hard clue, no Def req chaps |
+| 10372 | Zamorak chaps | Hard clue, no Def req chaps |
+| 12502 | Bandos chaps  | Hard clue, no Def req chaps |
+| 12510 | Armadyl chaps | Hard clue, no Def req chaps |
+| 12494 | Ancient chaps | Hard clue, no Def req chaps |
+
+### God D'hide Coifs (Implemented - Mar 2026)
+
+| ID    | Item         | Override Focus            |
+| ----- | ------------ | ------------------------- |
+| 10382 | Guthix coif  | Hard clue, +1 prayer head |
+| 10374 | Zamorak coif | Hard clue, +1 prayer head |
+| 12504 | Bandos coif  | Hard clue, +1 prayer head |
+| 12512 | Armadyl coif | Hard clue, +1 prayer head |
+| 12496 | Ancient coif | Hard clue, +1 prayer head |
+
+### God D'hide Bracers (Implemented - Mar 2026)
+
+| ID    | Item            | Override Focus              |
+| ----- | --------------- | --------------------------- |
+| 10376 | Guthix bracers  | Hard clue, no Def req hands |
+| 10368 | Zamorak bracers | Hard clue, no Def req hands |
+| 12498 | Bandos bracers  | Hard clue, no Def req hands |
+| 12506 | Armadyl bracers | Hard clue, no Def req hands |
+| 12490 | Ancient bracers | Hard clue, no Def req hands |
+
+### Studded/Leather Armour (Implemented - Mar 2026)
+
+| ID   | Item             | Override Focus     |
+| ---- | ---------------- | ------------------ |
+| 1133 | Studded body     | F2P 20 Ranged body |
+| 1097 | Studded chaps    | F2P 20 Ranged legs |
+| 1131 | Hardleather body | F2P 10 Def body    |
+
+### Mage Training Arena Wands (Implemented - Mar 2026)
+
+| ID   | Item          | Override Focus    |
+| ---- | ------------- | ----------------- |
+| 6908 | Beginner wand | MTA entry wand    |
+| 6912 | Teacher wand  | MTA mid-tier wand |
+
 ---
 
 ## Future Override Priorities
@@ -1222,6 +1267,7 @@ Record batch completions here:
 | Mar 11, 2026 | +20 items (jewelry chains, misc weapons)     | ~901            |
 | Mar 12, 2026 | +20 items (dragon bolts e, mystic, trimmed)  | ~921            |
 | Mar 12, 2026 | +20 items (god d'hide sets, rune weapons)    | ~941            |
+| Mar 12, 2026 | +20 items (god chaps/coifs/bracers, misc)    | ~961            |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10368.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10368.mdx
@@ -1,0 +1,93 @@
+---
+equipment:
+  slot: "hands"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 11
+  defence_bonus:
+    stab: 6
+    slash: 5
+    crush: 7
+    magic: 6
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10376
+    item_name: "Guthix bracers"
+    slug: "guthix-bracers"
+    relationship: "variant"
+  - item_id: 12498
+    item_name: "Bandos bracers"
+    slug: "bandos-bracers"
+    relationship: "variant"
+  - item_id: 12506
+    item_name: "Armadyl bracers"
+    slug: "armadyl-bracers"
+    relationship: "variant"
+  - item_id: 12490
+    item_name: "Ancient bracers"
+    slug: "ancient-bracers"
+    relationship: "variant"
+  - item_id: 2491
+    item_name: "Black d'hide vambraces"
+    slug: "black-d-hide-vambraces"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Zamorak blessed dragonhide vambraces."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Hands |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +11 |
+| Stab Defence | +6 |
+| Slash Defence | +5 |
+| Crush Defence | +7 |
+| Magic Defence | +6 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Vambraces
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +11 | +11 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+
+## Market Strategy
+- Hard clue exclusive
+- Best-in-slot ranged gloves for pures
+- All god variants are functionally identical
+
+## Related Items
+- [Guthix bracers](/item/10376)
+- [Bandos bracers](/item/12498)
+- [Armadyl bracers](/item/12506)
+- [Ancient bracers](/item/12490)
+- [Black d'hide vambraces](/item/2491)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10372.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10372.mdx
@@ -1,0 +1,100 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 8
+  defence_bonus:
+    stab: 17
+    slash: 20
+    crush: 16
+    magic: 18
+    ranged: 17
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10380
+    item_name: "Guthix chaps"
+    slug: "guthix-chaps"
+    relationship: "variant"
+  - item_id: 12502
+    item_name: "Bandos chaps"
+    slug: "bandos-chaps"
+    relationship: "variant"
+  - item_id: 12510
+    item_name: "Armadyl chaps"
+    slug: "armadyl-chaps"
+    relationship: "variant"
+  - item_id: 12494
+    item_name: "Ancient chaps"
+    slug: "ancient-chaps"
+    relationship: "variant"
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-d-hide-chaps"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Zamorak blessed dragonhide chaps."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +8 |
+| Magic Attack | -4 |
+| Stab Defence | +17 |
+| Slash Defence | +20 |
+| Crush Defence | +16 |
+| Magic Defence | +18 |
+| Ranged Defence | +17 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Chaps
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +8 | +8 |
+| Stab Defence | +17 | +17 |
+| Slash Defence | +20 | +20 |
+| Crush Defence | +16 | +16 |
+| Magic Defence | +18 | +18 |
+| Ranged Defence | +17 | +17 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+The key advantage: blessed chaps have **no Defence requirement**, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+
+## Market Strategy
+- Hard clue exclusive — supply tied to clue completion rates
+- Popular with 1-Defence pures who need best-in-slot ranged legs
+- All god variants are functionally identical
+- Armadyl and Ancient variants tend to have slight premiums
+
+## Related Items
+- [Guthix chaps](/item/10380)
+- [Bandos chaps](/item/12502)
+- [Armadyl chaps](/item/12510)
+- [Ancient chaps](/item/12494)
+- [Black d'hide chaps](/item/2497)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10374.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10374.mdx
@@ -1,0 +1,92 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -1
+    ranged: 7
+  defence_bonus:
+    stab: 4
+    slash: 7
+    crush: 10
+    magic: 4
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+    defence: 40
+related_items:
+  - item_id: 10382
+    item_name: "Guthix coif"
+    slug: "guthix-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12504
+    item_name: "Bandos coif"
+    slug: "bandos-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12512
+    item_name: "Armadyl coif"
+    slug: "armadyl-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12496
+    item_name: "Ancient coif"
+    slug: "ancient-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+---
+
+## Examine
+> *"A Zamorak blessed dragonhide coif."*
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Head |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.9 kg |
+| Requirements | 70 Ranged, 40 Defence |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +7 |
+| Magic Attack | -1 |
+| Stab Defence | +4 |
+| Slash Defence | +7 |
+| Crush Defence | +10 |
+| Magic Defence | +4 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Comparison
+
+All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
+
+## Market Strategy
+
+- Hard clue exclusive — supply tied to clue completion rates
+- Price differences between gods are cosmetic preference only
+- Armadyl and Ancient tend to command slight premiums
+
+## Related Items
+
+- [Guthix coif](/item/10382)
+- [Bandos coif](/item/12504)
+- [Armadyl coif](/item/12512)
+- [Ancient coif](/item/12496)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10376.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10376.mdx
@@ -1,0 +1,93 @@
+---
+equipment:
+  slot: "hands"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 11
+  defence_bonus:
+    stab: 6
+    slash: 5
+    crush: 7
+    magic: 6
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10368
+    item_name: "Zamorak bracers"
+    slug: "zamorak-bracers"
+    relationship: "variant"
+  - item_id: 12498
+    item_name: "Bandos bracers"
+    slug: "bandos-bracers"
+    relationship: "variant"
+  - item_id: 12506
+    item_name: "Armadyl bracers"
+    slug: "armadyl-bracers"
+    relationship: "variant"
+  - item_id: 12490
+    item_name: "Ancient bracers"
+    slug: "ancient-bracers"
+    relationship: "variant"
+  - item_id: 2491
+    item_name: "Black d'hide vambraces"
+    slug: "black-d-hide-vambraces"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Guthix blessed dragonhide vambraces."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Hands |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +11 |
+| Stab Defence | +6 |
+| Slash Defence | +5 |
+| Crush Defence | +7 |
+| Magic Defence | +6 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Vambraces
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +11 | +11 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+
+## Market Strategy
+- Hard clue exclusive
+- Best-in-slot ranged gloves for pures
+- All god variants are functionally identical
+
+## Related Items
+- [Zamorak bracers](/item/10368)
+- [Bandos bracers](/item/12498)
+- [Armadyl bracers](/item/12506)
+- [Ancient bracers](/item/12490)
+- [Black d'hide vambraces](/item/2491)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10380.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10380.mdx
@@ -1,0 +1,100 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 8
+  defence_bonus:
+    stab: 17
+    slash: 20
+    crush: 16
+    magic: 18
+    ranged: 17
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10372
+    item_name: "Zamorak chaps"
+    slug: "zamorak-chaps"
+    relationship: "variant"
+  - item_id: 12502
+    item_name: "Bandos chaps"
+    slug: "bandos-chaps"
+    relationship: "variant"
+  - item_id: 12510
+    item_name: "Armadyl chaps"
+    slug: "armadyl-chaps"
+    relationship: "variant"
+  - item_id: 12494
+    item_name: "Ancient chaps"
+    slug: "ancient-chaps"
+    relationship: "variant"
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-d-hide-chaps"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Guthix blessed dragonhide chaps."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +8 |
+| Magic Attack | -4 |
+| Stab Defence | +17 |
+| Slash Defence | +20 |
+| Crush Defence | +16 |
+| Magic Defence | +18 |
+| Ranged Defence | +17 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Chaps
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +8 | +8 |
+| Stab Defence | +17 | +17 |
+| Slash Defence | +20 | +20 |
+| Crush Defence | +16 | +16 |
+| Magic Defence | +18 | +18 |
+| Ranged Defence | +17 | +17 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+The key advantage: blessed chaps have **no Defence requirement**, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+
+## Market Strategy
+- Hard clue exclusive — supply tied to clue completion rates
+- Popular with 1-Defence pures who need best-in-slot ranged legs
+- All god variants are functionally identical
+- Armadyl and Ancient variants tend to have slight premiums
+
+## Related Items
+- [Zamorak chaps](/item/10372)
+- [Bandos chaps](/item/12502)
+- [Armadyl chaps](/item/12510)
+- [Ancient chaps](/item/12494)
+- [Black d'hide chaps](/item/2497)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10382.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10382.mdx
@@ -1,0 +1,92 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -1
+    ranged: 7
+  defence_bonus:
+    stab: 4
+    slash: 7
+    crush: 10
+    magic: 4
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+    defence: 40
+related_items:
+  - item_id: 10374
+    item_name: "Zamorak coif"
+    slug: "zamorak-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12504
+    item_name: "Bandos coif"
+    slug: "bandos-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12512
+    item_name: "Armadyl coif"
+    slug: "armadyl-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12496
+    item_name: "Ancient coif"
+    slug: "ancient-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+---
+
+## Examine
+> *"A Guthix blessed dragonhide coif."*
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Head |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.9 kg |
+| Requirements | 70 Ranged, 40 Defence |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +7 |
+| Magic Attack | -1 |
+| Stab Defence | +4 |
+| Slash Defence | +7 |
+| Crush Defence | +10 |
+| Magic Defence | +4 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Comparison
+
+All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
+
+## Market Strategy
+
+- Hard clue exclusive — supply tied to clue completion rates
+- Price differences between gods are cosmetic preference only
+- Armadyl and Ancient tend to command slight premiums
+
+## Related Items
+
+- [Zamorak coif](/item/10374)
+- [Bandos coif](/item/12504)
+- [Armadyl coif](/item/12512)
+- [Ancient coif](/item/12496)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1097.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1097.mdx
@@ -1,0 +1,125 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged_armour"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -5
+    ranged: 6
+  defence_bonus:
+    stab: 15
+    slash: 16
+    crush: 17
+    magic: 6
+    ranged: 16
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    ranged: 20
+  weight: 4.535
+recipes:
+  - skill: crafting
+    level: 44
+    xp: 42
+    materials:
+      - item_name: "Leather chaps"
+        item_id: 1095
+        quantity: 1
+      - item_name: "Steel studs"
+        item_id: 2370
+        quantity: 1
+    product: "Studded chaps"
+    product_id: 1097
+    product_quantity: 1
+    ticks: 3
+related_items:
+  - item_id: 1095
+    item_name: "Leather chaps"
+    slug: "leather-chaps"
+    relationship: "component"
+    description: "Base chaps before studding"
+  - item_id: 2370
+    item_name: "Steel studs"
+    slug: "steel-studs"
+    relationship: "component"
+    description: "Studs added to leather chaps"
+  - item_id: 1133
+    item_name: "Studded body"
+    slug: "studded-body"
+    relationship: "alternative"
+    description: "Matching body slot armour"
+  - item_id: 1099
+    item_name: "Green d'hide chaps"
+    slug: "green-dhide-chaps"
+    relationship: "upgrade"
+    description: "Next tier ranged legs (40 Ranged)"
+---
+
+> *"Those studs should provide a bit more protection."*
+
+## Stats
+
+| Stat | Attack | Defence |
+|------|--------|---------|
+| Stab | 0 | **+15** |
+| Slash | 0 | **+16** |
+| Crush | 0 | **+17** |
+| Magic | -5 | +6 |
+| Ranged | **+6** | **+16** |
+
+**Requirements:** 20 Ranged | **Weight:** 4.54 kg
+
+## Obtaining
+
+- **Crafting:** Level 44 using 1 Leather chaps + 1 Steel studs (42 XP, 3 ticks)
+- **Shops:** Available from Ranging shops for 750 gp
+- **Grand Exchange**
+- **Monster drops**
+
+## Crafting
+
+| Method | Level | Materials | XP |
+|--------|-------|-----------|----|
+| Crafting | 44 | 1 Leather chaps + 1 Steel studs | 42 |
+
+Created by using steel studs on leather chaps. Takes 3 ticks (1.8 seconds) per craft. Requires a higher Crafting level than the studded body (44 vs 41).
+
+## Comparison
+
+The studded chaps are the **best F2P ranged leg armour**:
+
+| Armour | Ranged Atk | Ranged Def | Req |
+|--------|-----------|-----------|-----|
+| Leather chaps | +4 | +8 | 1 Ranged |
+| **Studded chaps** | **+6** | **+16** | **20 Ranged** |
+| Green d'hide chaps | +8 | +22 | 40 Ranged (P2P) |
+
+## F2P Significance
+
+Studded chaps fill an important role in F2P:
+- **Best ranged legs** for free players
+- **No Defence requirement** unlike the studded body
+- **PKing** staple for F2P ranged and hybrid setups
+- Pairs with studded body for full studded leather set
+
+## Market Strategy
+
+**Buy Limit:** 125 per 4 hours | **High Alch:** 450 GP
+
+**Tips:**
+- Low GE price (~290 gp), high alch at 450 gp offers alch profit
+- Steady F2P demand for ranged training and PKing
+- Crafting at level 44 is slightly higher than studded body
+- No Defence requirement makes them popular with pures
+
+## Related Items
+
+- [Leather chaps](/osrs/leather-chaps/) - Base component
+- [Steel studs](/osrs/steel-studs/) - Required crafting material
+- [Studded body](/osrs/studded-body/) - Matching body armour
+- [Green d'hide chaps](/osrs/green-dhide-chaps/) - P2P upgrade

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1131.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1131.mdx
@@ -1,0 +1,135 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 8
+  defence_bonus:
+    stab: 12
+    slash: 15
+    crush: 18
+    magic: 6
+    ranged: 15
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    ranged: 1
+    defence: 10
+  weight: 3.628
+recipes:
+  - skill: crafting
+    level: 28
+    xp: 35
+    materials:
+      - item_name: "Hard leather"
+        item_id: 1743
+        quantity: 1
+      - item_name: "Thread"
+        item_id: 1734
+        quantity: 1
+    product: "Hardleather body"
+    product_id: 1131
+    product_quantity: 1
+    facility: "Needle and thread"
+    ticks: 2
+related_items:
+  - item_id: 1743
+    item_name: "Hard leather"
+    slug: "hard-leather"
+    relationship: "component"
+    description: "Tanned cowhide material"
+  - item_id: 1734
+    item_name: "Thread"
+    slug: "thread"
+    relationship: "component"
+    description: "Sewing thread"
+  - item_id: 1133
+    item_name: "Studded body"
+    slug: "studded-body"
+    relationship: "upgrade"
+    description: "Next tier F2P ranged body (20 Ranged, 20 Def)"
+  - item_id: 1129
+    item_name: "Leather body"
+    slug: "leather-body"
+    relationship: "downgrade"
+    description: "Lower tier leather armour"
+  - item_id: 1135
+    item_name: "Green d'hide body"
+    slug: "green-dhide-body"
+    relationship: "upgrade"
+    description: "P2P dragonhide upgrade (40 Ranged)"
+---
+
+> *"Harder than normal leather."*
+
+## Stats
+
+| Stat | Attack | Defence |
+|------|--------|---------|
+| Stab | 0 | **+12** |
+| Slash | 0 | **+15** |
+| Crush | 0 | **+18** |
+| Magic | -4 | +6 |
+| Ranged | **+8** | **+15** |
+
+**Requirements:** 1 Ranged, 10 Defence | **Weight:** 3.63 kg
+
+## Obtaining
+
+- **Crafting:** Level 28 using 1 Hard leather + needle and thread (35 XP, 2 ticks)
+- **Treasure Trails:** Easy and Medium clue rewards
+- **Monster drops:** Various low-level monsters
+- **Shops:** Available for 170 gp
+- **Grand Exchange**
+
+## Crafting
+
+| Method | Level | Materials | XP |
+|--------|-------|-----------|----|
+| Crafting | 28 | 1 Hard leather + thread | 35 |
+
+The hardleather body is crafted with a needle and thread on hard leather. At 2 ticks (1.2 seconds) per craft, it is quick to produce but yields low XP.
+
+## Comparison
+
+The hardleather body sits between the leather body and the studded body:
+
+| Armour | Ranged Atk | Ranged Def | Crush Def | Req |
+|--------|-----------|-----------|-----------|-----|
+| Leather body | +2 | +8 | +10 | 1 Ranged |
+| **Hardleather body** | **+8** | **+15** | **+18** | **1 Ranged, 10 Def** |
+| Studded body | +8 | +25 | +22 | 20 Ranged, 20 Def |
+
+Notably, the hardleather body matches the studded body's ranged attack bonus (+8) but falls behind significantly in defence.
+
+## F2P Significance
+
+- **Early-game ranged armour** for players under 20 Ranged/Defence
+- **Low requirements** make it accessible to new accounts quickly
+- **Crafting training** at level 28 is an early milestone
+- Quickly outclassed by studded body once requirements are met
+
+## Market Strategy
+
+**Buy Limit:** 125 per 4 hours | **High Alch:** 102 GP
+
+**Tips:**
+- Extremely low GE value (~10 gp) well below alch value
+- Crafting this item results in a loss (-168 gp per craft)
+- Very little market activity due to low value
+- Mainly used as Crafting training stepping stone
+- Hard leather costs more than the finished product
+
+## Related Items
+
+- [Hard leather](/osrs/hard-leather/) - Crafting material
+- [Leather body](/osrs/leather-body/) - Lower tier body
+- [Studded body](/osrs/studded-body/) - F2P upgrade (20 Ranged, 20 Def)
+- [Green d'hide body](/osrs/green-dhide-body/) - P2P upgrade (40 Ranged)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_1133.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_1133.mdx
@@ -1,0 +1,132 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 8
+  defence_bonus:
+    stab: 18
+    slash: 25
+    crush: 22
+    magic: 8
+    ranged: 25
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    ranged: 20
+    defence: 20
+  weight: 5.443
+recipes:
+  - skill: crafting
+    level: 41
+    xp: 40
+    materials:
+      - item_name: "Leather body"
+        item_id: 1129
+        quantity: 1
+      - item_name: "Steel studs"
+        item_id: 2370
+        quantity: 1
+    product: "Studded body"
+    product_id: 1133
+    product_quantity: 1
+    ticks: 3
+related_items:
+  - item_id: 1129
+    item_name: "Leather body"
+    slug: "leather-body"
+    relationship: "component"
+    description: "Base armour before studding"
+  - item_id: 2370
+    item_name: "Steel studs"
+    slug: "steel-studs"
+    relationship: "component"
+    description: "Studs added to leather body"
+  - item_id: 1097
+    item_name: "Studded chaps"
+    slug: "studded-chaps"
+    relationship: "alternative"
+    description: "Matching leg slot armour"
+  - item_id: 1131
+    item_name: "Hardleather body"
+    slug: "hardleather-body"
+    relationship: "downgrade"
+    description: "Lower tier ranged body"
+  - item_id: 1135
+    item_name: "Green d'hide body"
+    slug: "green-dhide-body"
+    relationship: "upgrade"
+    description: "Next tier ranged body (40 Ranged)"
+---
+
+> *"Those studs should provide a bit more protection."*
+
+## Stats
+
+| Stat | Attack | Defence |
+|------|--------|---------|
+| Stab | 0 | **+18** |
+| Slash | 0 | **+25** |
+| Crush | 0 | **+22** |
+| Magic | -4 | +8 |
+| Ranged | **+8** | **+25** |
+
+**Requirements:** 20 Ranged, 20 Defence | **Weight:** 5.44 kg
+
+## Obtaining
+
+- **Crafting:** Level 41 using 1 Leather body + 1 Steel studs (40 XP, 3 ticks)
+- **Shops:** Available from various Ranging shops for 850 gp
+- **Grand Exchange**
+- **Monster drops**
+
+## Crafting
+
+| Method | Level | Materials | XP |
+|--------|-------|-----------|----|
+| Crafting | 41 | 1 Leather body + 1 Steel studs | 40 |
+
+The studded body is created by using steel studs on a leather body. This is a quick craft at 3 ticks (1.8 seconds) per item.
+
+## Comparison
+
+The studded body is the **best F2P ranged body armour**, sitting between the hardleather body and the members-only green d'hide body:
+
+| Armour | Ranged Atk | Ranged Def | Req |
+|--------|-----------|-----------|-----|
+| Hardleather body | +8 | +15 | 1 Ranged, 10 Def |
+| **Studded body** | **+8** | **+25** | **20 Ranged, 20 Def** |
+| Green d'hide body | +15 | +40 | 40 Ranged (P2P) |
+
+## F2P Significance
+
+The studded body is essential F2P ranged gear:
+- **Best ranged body** available to free players
+- **PKing** standard for F2P ranged builds
+- **PvM** solid early-game ranged defence
+- Affordable and easy to replace
+
+## Market Strategy
+
+**Buy Limit:** 125 per 4 hours | **High Alch:** 510 GP
+
+**Tips:**
+- Very low GE price (~353 gp), high alch at 510 gp provides small margin
+- F2P demand keeps volume steady (~1,800 units daily)
+- Crafting profit is minimal but positive after GE tax
+- Steel studs are the bottleneck material
+
+## Related Items
+
+- [Leather body](/osrs/leather-body/) - Base component
+- [Steel studs](/osrs/steel-studs/) - Required crafting material
+- [Studded chaps](/osrs/studded-chaps/) - Matching leg armour
+- [Hardleather body](/osrs/hardleather-body/) - Lower tier option
+- [Green d'hide body](/osrs/green-dhide-body/) - P2P upgrade

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12490.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12490.mdx
@@ -1,0 +1,93 @@
+---
+equipment:
+  slot: "hands"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 11
+  defence_bonus:
+    stab: 6
+    slash: 5
+    crush: 7
+    magic: 6
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10376
+    item_name: "Guthix bracers"
+    slug: "guthix-bracers"
+    relationship: "variant"
+  - item_id: 10368
+    item_name: "Zamorak bracers"
+    slug: "zamorak-bracers"
+    relationship: "variant"
+  - item_id: 12498
+    item_name: "Bandos bracers"
+    slug: "bandos-bracers"
+    relationship: "variant"
+  - item_id: 12506
+    item_name: "Armadyl bracers"
+    slug: "armadyl-bracers"
+    relationship: "variant"
+  - item_id: 2491
+    item_name: "Black d'hide vambraces"
+    slug: "black-d-hide-vambraces"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Ancient blessed dragonhide vambraces."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Hands |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +11 |
+| Stab Defence | +6 |
+| Slash Defence | +5 |
+| Crush Defence | +7 |
+| Magic Defence | +6 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Vambraces
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +11 | +11 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+
+## Market Strategy
+- Hard clue exclusive
+- Best-in-slot ranged gloves for pures
+- All god variants are functionally identical
+
+## Related Items
+- [Guthix bracers](/item/10376)
+- [Zamorak bracers](/item/10368)
+- [Bandos bracers](/item/12498)
+- [Armadyl bracers](/item/12506)
+- [Black d'hide vambraces](/item/2491)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12494.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12494.mdx
@@ -1,0 +1,100 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 8
+  defence_bonus:
+    stab: 17
+    slash: 20
+    crush: 16
+    magic: 18
+    ranged: 17
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10380
+    item_name: "Guthix chaps"
+    slug: "guthix-chaps"
+    relationship: "variant"
+  - item_id: 10372
+    item_name: "Zamorak chaps"
+    slug: "zamorak-chaps"
+    relationship: "variant"
+  - item_id: 12502
+    item_name: "Bandos chaps"
+    slug: "bandos-chaps"
+    relationship: "variant"
+  - item_id: 12510
+    item_name: "Armadyl chaps"
+    slug: "armadyl-chaps"
+    relationship: "variant"
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-d-hide-chaps"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Ancient blessed dragonhide chaps."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +8 |
+| Magic Attack | -4 |
+| Stab Defence | +17 |
+| Slash Defence | +20 |
+| Crush Defence | +16 |
+| Magic Defence | +18 |
+| Ranged Defence | +17 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Chaps
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +8 | +8 |
+| Stab Defence | +17 | +17 |
+| Slash Defence | +20 | +20 |
+| Crush Defence | +16 | +16 |
+| Magic Defence | +18 | +18 |
+| Ranged Defence | +17 | +17 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+The key advantage: blessed chaps have **no Defence requirement**, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+
+## Market Strategy
+- Hard clue exclusive — supply tied to clue completion rates
+- Popular with 1-Defence pures who need best-in-slot ranged legs
+- All god variants are functionally identical
+- Armadyl and Ancient variants tend to have slight premiums
+
+## Related Items
+- [Guthix chaps](/item/10380)
+- [Zamorak chaps](/item/10372)
+- [Bandos chaps](/item/12502)
+- [Armadyl chaps](/item/12510)
+- [Black d'hide chaps](/item/2497)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12496.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12496.mdx
@@ -1,0 +1,92 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -1
+    ranged: 7
+  defence_bonus:
+    stab: 4
+    slash: 7
+    crush: 10
+    magic: 4
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+    defence: 40
+related_items:
+  - item_id: 10382
+    item_name: "Guthix coif"
+    slug: "guthix-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 10374
+    item_name: "Zamorak coif"
+    slug: "zamorak-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12504
+    item_name: "Bandos coif"
+    slug: "bandos-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12512
+    item_name: "Armadyl coif"
+    slug: "armadyl-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+---
+
+## Examine
+> *"An Ancient blessed dragonhide coif."*
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Head |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.9 kg |
+| Requirements | 70 Ranged, 40 Defence |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +7 |
+| Magic Attack | -1 |
+| Stab Defence | +4 |
+| Slash Defence | +7 |
+| Crush Defence | +10 |
+| Magic Defence | +4 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Comparison
+
+All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
+
+## Market Strategy
+
+- Hard clue exclusive — supply tied to clue completion rates
+- Price differences between gods are cosmetic preference only
+- Armadyl and Ancient tend to command slight premiums
+
+## Related Items
+
+- [Guthix coif](/item/10382)
+- [Zamorak coif](/item/10374)
+- [Bandos coif](/item/12504)
+- [Armadyl coif](/item/12512)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12498.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12498.mdx
@@ -1,0 +1,93 @@
+---
+equipment:
+  slot: "hands"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 11
+  defence_bonus:
+    stab: 6
+    slash: 5
+    crush: 7
+    magic: 6
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10376
+    item_name: "Guthix bracers"
+    slug: "guthix-bracers"
+    relationship: "variant"
+  - item_id: 10368
+    item_name: "Zamorak bracers"
+    slug: "zamorak-bracers"
+    relationship: "variant"
+  - item_id: 12506
+    item_name: "Armadyl bracers"
+    slug: "armadyl-bracers"
+    relationship: "variant"
+  - item_id: 12490
+    item_name: "Ancient bracers"
+    slug: "ancient-bracers"
+    relationship: "variant"
+  - item_id: 2491
+    item_name: "Black d'hide vambraces"
+    slug: "black-d-hide-vambraces"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Bandos blessed dragonhide vambraces."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Hands |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +11 |
+| Stab Defence | +6 |
+| Slash Defence | +5 |
+| Crush Defence | +7 |
+| Magic Defence | +6 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Vambraces
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +11 | +11 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+
+## Market Strategy
+- Hard clue exclusive
+- Best-in-slot ranged gloves for pures
+- All god variants are functionally identical
+
+## Related Items
+- [Guthix bracers](/item/10376)
+- [Zamorak bracers](/item/10368)
+- [Armadyl bracers](/item/12506)
+- [Ancient bracers](/item/12490)
+- [Black d'hide vambraces](/item/2491)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12502.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12502.mdx
@@ -1,0 +1,100 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 8
+  defence_bonus:
+    stab: 17
+    slash: 20
+    crush: 16
+    magic: 18
+    ranged: 17
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10380
+    item_name: "Guthix chaps"
+    slug: "guthix-chaps"
+    relationship: "variant"
+  - item_id: 10372
+    item_name: "Zamorak chaps"
+    slug: "zamorak-chaps"
+    relationship: "variant"
+  - item_id: 12510
+    item_name: "Armadyl chaps"
+    slug: "armadyl-chaps"
+    relationship: "variant"
+  - item_id: 12494
+    item_name: "Ancient chaps"
+    slug: "ancient-chaps"
+    relationship: "variant"
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-d-hide-chaps"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Bandos blessed dragonhide chaps."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +8 |
+| Magic Attack | -4 |
+| Stab Defence | +17 |
+| Slash Defence | +20 |
+| Crush Defence | +16 |
+| Magic Defence | +18 |
+| Ranged Defence | +17 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Chaps
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +8 | +8 |
+| Stab Defence | +17 | +17 |
+| Slash Defence | +20 | +20 |
+| Crush Defence | +16 | +16 |
+| Magic Defence | +18 | +18 |
+| Ranged Defence | +17 | +17 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+The key advantage: blessed chaps have **no Defence requirement**, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+
+## Market Strategy
+- Hard clue exclusive — supply tied to clue completion rates
+- Popular with 1-Defence pures who need best-in-slot ranged legs
+- All god variants are functionally identical
+- Armadyl and Ancient variants tend to have slight premiums
+
+## Related Items
+- [Guthix chaps](/item/10380)
+- [Zamorak chaps](/item/10372)
+- [Armadyl chaps](/item/12510)
+- [Ancient chaps](/item/12494)
+- [Black d'hide chaps](/item/2497)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12504.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12504.mdx
@@ -1,0 +1,92 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -1
+    ranged: 7
+  defence_bonus:
+    stab: 4
+    slash: 7
+    crush: 10
+    magic: 4
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+    defence: 40
+related_items:
+  - item_id: 10382
+    item_name: "Guthix coif"
+    slug: "guthix-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 10374
+    item_name: "Zamorak coif"
+    slug: "zamorak-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12512
+    item_name: "Armadyl coif"
+    slug: "armadyl-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12496
+    item_name: "Ancient coif"
+    slug: "ancient-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+---
+
+## Examine
+> *"A Bandos blessed dragonhide coif."*
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Head |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.9 kg |
+| Requirements | 70 Ranged, 40 Defence |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +7 |
+| Magic Attack | -1 |
+| Stab Defence | +4 |
+| Slash Defence | +7 |
+| Crush Defence | +10 |
+| Magic Defence | +4 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Comparison
+
+All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
+
+## Market Strategy
+
+- Hard clue exclusive — supply tied to clue completion rates
+- Price differences between gods are cosmetic preference only
+- Armadyl and Ancient tend to command slight premiums
+
+## Related Items
+
+- [Guthix coif](/item/10382)
+- [Zamorak coif](/item/10374)
+- [Armadyl coif](/item/12512)
+- [Ancient coif](/item/12496)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12506.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12506.mdx
@@ -1,0 +1,93 @@
+---
+equipment:
+  slot: "hands"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 11
+  defence_bonus:
+    stab: 6
+    slash: 5
+    crush: 7
+    magic: 6
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10376
+    item_name: "Guthix bracers"
+    slug: "guthix-bracers"
+    relationship: "variant"
+  - item_id: 10368
+    item_name: "Zamorak bracers"
+    slug: "zamorak-bracers"
+    relationship: "variant"
+  - item_id: 12498
+    item_name: "Bandos bracers"
+    slug: "bandos-bracers"
+    relationship: "variant"
+  - item_id: 12490
+    item_name: "Ancient bracers"
+    slug: "ancient-bracers"
+    relationship: "variant"
+  - item_id: 2491
+    item_name: "Black d'hide vambraces"
+    slug: "black-d-hide-vambraces"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Armadyl blessed dragonhide vambraces."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Hands |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +11 |
+| Stab Defence | +6 |
+| Slash Defence | +5 |
+| Crush Defence | +7 |
+| Magic Defence | +6 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Vambraces
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +11 | +11 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+
+## Market Strategy
+- Hard clue exclusive
+- Best-in-slot ranged gloves for pures
+- All god variants are functionally identical
+
+## Related Items
+- [Guthix bracers](/item/10376)
+- [Zamorak bracers](/item/10368)
+- [Bandos bracers](/item/12498)
+- [Ancient bracers](/item/12490)
+- [Black d'hide vambraces](/item/2491)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12510.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12510.mdx
@@ -1,0 +1,100 @@
+---
+equipment:
+  slot: "legs"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 8
+  defence_bonus:
+    stab: 17
+    slash: 20
+    crush: 16
+    magic: 18
+    ranged: 17
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+related_items:
+  - item_id: 10380
+    item_name: "Guthix chaps"
+    slug: "guthix-chaps"
+    relationship: "variant"
+  - item_id: 10372
+    item_name: "Zamorak chaps"
+    slug: "zamorak-chaps"
+    relationship: "variant"
+  - item_id: 12502
+    item_name: "Bandos chaps"
+    slug: "bandos-chaps"
+    relationship: "variant"
+  - item_id: 12494
+    item_name: "Ancient chaps"
+    slug: "ancient-chaps"
+    relationship: "variant"
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-d-hide-chaps"
+    relationship: "upgrade-from"
+    description: "Standard version requiring 40 Defence"
+---
+
+## Examine
+> *"Armadyl blessed dragonhide chaps."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 5 kg |
+| Requirements | 70 Ranged |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +8 |
+| Magic Attack | -4 |
+| Stab Defence | +17 |
+| Slash Defence | +20 |
+| Crush Defence | +16 |
+| Magic Defence | +18 |
+| Ranged Defence | +17 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Blessed vs Black D'hide Chaps
+| Stat | Blessed | Black D'hide |
+|------|--------:|-----------:|
+| Ranged Attack | +8 | +8 |
+| Stab Defence | +17 | +17 |
+| Slash Defence | +20 | +20 |
+| Crush Defence | +16 | +16 |
+| Magic Defence | +18 | +18 |
+| Ranged Defence | +17 | +17 |
+| Prayer | +1 | 0 |
+| Ranged Req | 70 | 70 |
+| Defence Req | **None** | **40** |
+
+The key advantage: blessed chaps have **no Defence requirement**, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+
+## Market Strategy
+- Hard clue exclusive — supply tied to clue completion rates
+- Popular with 1-Defence pures who need best-in-slot ranged legs
+- All god variants are functionally identical
+- Armadyl and Ancient variants tend to have slight premiums
+
+## Related Items
+- [Guthix chaps](/item/10380)
+- [Zamorak chaps](/item/10372)
+- [Bandos chaps](/item/12502)
+- [Ancient chaps](/item/12494)
+- [Black d'hide chaps](/item/2497)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12512.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12512.mdx
@@ -1,0 +1,92 @@
+---
+equipment:
+  slot: "head"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -1
+    ranged: 7
+  defence_bonus:
+    stab: 4
+    slash: 7
+    crush: 10
+    magic: 4
+    ranged: 8
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+  requirements:
+    ranged: 70
+    defence: 40
+related_items:
+  - item_id: 10382
+    item_name: "Guthix coif"
+    slug: "guthix-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 10374
+    item_name: "Zamorak coif"
+    slug: "zamorak-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12504
+    item_name: "Bandos coif"
+    slug: "bandos-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+  - item_id: 12496
+    item_name: "Ancient coif"
+    slug: "ancient-coif"
+    relationship: "variant"
+    description: "God blessed coif variant"
+---
+
+## Examine
+> *"An Armadyl blessed dragonhide coif."*
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Head |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.9 kg |
+| Requirements | 70 Ranged, 40 Defence |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +7 |
+| Magic Attack | -1 |
+| Stab Defence | +4 |
+| Slash Defence | +7 |
+| Crush Defence | +10 |
+| Magic Defence | +4 |
+| Ranged Defence | +8 |
+| Prayer | +1 |
+
+## Obtaining
+
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+## Comparison
+
+All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
+
+## Market Strategy
+
+- Hard clue exclusive — supply tied to clue completion rates
+- Price differences between gods are cosmetic preference only
+- Armadyl and Ancient tend to command slight premiums
+
+## Related Items
+
+- [Guthix coif](/item/10382)
+- [Zamorak coif](/item/10374)
+- [Bandos coif](/item/12504)
+- [Ancient coif](/item/12496)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6908.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6908.mdx
@@ -1,0 +1,123 @@
+---
+equipment:
+  slot: "weapon"
+  type: "wand"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 5
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 5
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    magic: 45
+  weight: 0.283
+  attack_speed: 4
+  combat_style: "staff"
+  autocast: "standard"
+shop:
+  currency: "pizazz_points"
+  cost:
+    telekinetic: 30
+    alchemist: 30
+    enchantment: 300
+    graveyard: 30
+related_items:
+  - item_id: 6910
+    item_name: "Apprentice wand"
+    slug: "apprentice-wand"
+    relationship: "upgrade"
+    description: "Next tier MTA wand (50 Magic)"
+  - item_id: 6912
+    item_name: "Teacher wand"
+    slug: "teacher-wand"
+    relationship: "upgrade"
+    description: "Third tier MTA wand (55 Magic)"
+  - item_id: 6914
+    item_name: "Master wand"
+    slug: "master-wand"
+    relationship: "upgrade"
+    description: "Highest tier MTA wand (60 Magic)"
+  - item_id: 11998
+    item_name: "Kodai wand"
+    slug: "kodai-wand"
+    relationship: "upgrade"
+    description: "Best-in-slot wand from Chambers of Xeric"
+---
+
+> *"A beginner level wand."*
+
+## Stats
+
+| Stat | Attack | Defence |
+|------|--------|---------|
+| Stab | 0 | 0 |
+| Slash | 0 | 0 |
+| Crush | 0 | 0 |
+| Magic | **+5** | **+5** |
+| Ranged | 0 | 0 |
+
+**Requirements:** 45 Magic | **Weight:** 0.28 kg | **Speed:** 4 ticks (2.4s)
+
+## Obtaining
+
+The beginner wand is the entry-level reward from the Mage Training Arena, purchased with pizazz points:
+
+| Point Type | Cost |
+|-----------|------|
+| Telekinetic | 30 |
+| Alchemist | 30 |
+| Enchantment | 300 |
+| Graveyard | 30 |
+
+Also tradeable on the Grand Exchange (~175,905 gp).
+
+## Autocast
+
+The beginner wand supports **Standard Spellbook** autocast with both offensive and defensive casting styles. It cannot autocast Ancient Magicks or Arceuus spells. As a one-handed weapon, it allows a shield or book in the off-hand slot.
+
+## Comparison
+
+The beginner wand is the first tier in the Mage Training Arena wand line:
+
+| Wand | Magic Atk | Magic Def | Req | Notes |
+|------|----------|----------|-----|-------|
+| **Beginner wand** | **+5** | **+5** | **45** | **This item** |
+| Apprentice wand | +10 | +10 | 50 | Requires beginner wand trade-in |
+| Teacher wand | +15 | +15 | 55 | Requires apprentice wand |
+| Master wand | +20 | +20 | 60 | Best MTA wand |
+| Kodai wand | +28 | +20 | 75 | Best-in-slot, Chambers of Xeric |
+
+The beginner wand offers modest stats. Its primary value is as the starting point for the wand upgrade chain.
+
+## Mage Training Arena
+
+The beginner wand is the cheapest MTA reward, requiring only 30 points in three categories and 300 enchantment points. Players typically acquire it early in the MTA grind and trade it in for the apprentice wand shortly after. Each subsequent upgrade requires trading in the previous tier plus additional points.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** Low value
+
+**Tips:**
+- GE price (~176K gp) reflects the time spent at MTA rather than raw stats
+- Most buyers purchase it to skip early MTA grinding
+- Demand is steady from players progressing through the wand chain
+- Significantly cheaper than higher-tier wands
+- One-handed slot is the main mechanical advantage over staves
+
+## Related Items
+
+- [Apprentice wand](/osrs/apprentice-wand/) - Next tier (50 Magic)
+- [Teacher wand](/osrs/teacher-wand/) - Third tier (55 Magic)
+- [Master wand](/osrs/master-wand/) - Final MTA wand (60 Magic)
+- [Kodai wand](/osrs/kodai-wand/) - Best-in-slot upgrade

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6912.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6912.mdx
@@ -1,0 +1,126 @@
+---
+equipment:
+  slot: "weapon"
+  type: "wand"
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 15
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 15
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  requirements:
+    magic: 55
+  weight: 0.226
+  attack_speed: 4
+  combat_style: "staff"
+  autocast: "standard"
+shop:
+  currency: "pizazz_points"
+  cost:
+    telekinetic: 150
+    alchemist: 200
+    enchantment: 1500
+    graveyard: 150
+  requires_item:
+    item_id: 6910
+    item_name: "Apprentice wand"
+related_items:
+  - item_id: 6908
+    item_name: "Beginner wand"
+    slug: "beginner-wand"
+    relationship: "downgrade"
+    description: "Entry-level MTA wand (45 Magic)"
+  - item_id: 6910
+    item_name: "Apprentice wand"
+    slug: "apprentice-wand"
+    relationship: "downgrade"
+    description: "Previous tier MTA wand (50 Magic)"
+  - item_id: 6914
+    item_name: "Master wand"
+    slug: "master-wand"
+    relationship: "upgrade"
+    description: "Highest tier MTA wand (60 Magic)"
+  - item_id: 11998
+    item_name: "Kodai wand"
+    slug: "kodai-wand"
+    relationship: "upgrade"
+    description: "Best-in-slot wand from Chambers of Xeric"
+---
+
+> *"A teacher level wand."*
+
+## Stats
+
+| Stat | Attack | Defence |
+|------|--------|---------|
+| Stab | 0 | 0 |
+| Slash | 0 | 0 |
+| Crush | 0 | 0 |
+| Magic | **+15** | **+15** |
+| Ranged | 0 | 0 |
+
+**Requirements:** 55 Magic | **Weight:** 0.23 kg | **Speed:** 4 ticks (2.4s)
+
+## Obtaining
+
+The teacher wand is purchased from the Mage Training Arena reward shop using pizazz points. You must trade in an **apprentice wand** along with the points.
+
+| Point Type | Cost |
+|-----------|------|
+| Telekinetic | 150 |
+| Alchemist | 200 |
+| Enchantment | 1,500 |
+| Graveyard | 150 |
+
+Also tradeable on the Grand Exchange (~1,869,033 gp).
+
+## Autocast
+
+The teacher wand supports **Standard Spellbook** autocast only. It cannot autocast Ancient Magicks or Arceuus spells. As a one-handed wand, it allows use of a shield or book in the off-hand slot.
+
+## Comparison
+
+The teacher wand is the third tier in the Mage Training Arena wand progression:
+
+| Wand | Magic Atk | Magic Def | Req | Notes |
+|------|----------|----------|-----|-------|
+| Beginner wand | +5 | +5 | 45 | Entry tier |
+| Apprentice wand | +10 | +10 | 50 | Required to buy teacher |
+| **Teacher wand** | **+15** | **+15** | **55** | **This item** |
+| Master wand | +20 | +20 | 60 | Best MTA wand |
+| Kodai wand | +28 | +20 | 75 | Best-in-slot, Chambers of Xeric |
+
+Each wand upgrade adds +5 magic attack and +5 magic defence. The teacher wand sits in the middle of the progression and is often skipped in favour of saving for the master wand.
+
+## Mage Training Arena
+
+The wand progression requires trading in the previous tier plus additional pizazz points at each step. Cumulative point costs increase significantly for higher tiers. Players aiming for the master wand will pass through the teacher wand as an intermediate step.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours | **High Alch:** 1,200 GP
+
+**Tips:**
+- High GE value (~1.87M gp) due to time-gated MTA grind
+- Often purchased as a stepping stone toward master wand
+- Some players buy from GE to skip part of the MTA grind
+- Demand is relatively stable from mid-level mages
+- The one-handed slot makes it useful with mage books and shields
+
+## Related Items
+
+- [Beginner wand](/osrs/beginner-wand/) - Entry MTA wand (45 Magic)
+- [Apprentice wand](/osrs/apprentice-wand/) - Previous tier (50 Magic)
+- [Master wand](/osrs/master-wand/) - Final MTA wand (60 Magic)
+- [Kodai wand](/osrs/kodai-wand/) - Best-in-slot upgrade


### PR DESCRIPTION
## Summary
- 5 god d'hide chaps: Guthix, Zamorak, Bandos, Armadyl, Ancient (no Defence req, +1 prayer)
- 5 god d'hide coifs: Guthix, Zamorak, Bandos, Armadyl, Ancient (+1 prayer head)
- 5 god d'hide bracers: Guthix, Zamorak, Bandos, Armadyl, Ancient (no Defence req, +1 prayer)
- 3 F2P armour: studded body, studded chaps, hardleather body
- 2 MTA wands: beginner wand, teacher wand

Completes all 30 blessed d'hide pieces across v6+v7 (body/shield/boots/chaps/coif/bracers for all 5 gods).

## Test plan
- [ ] Verify override files parse correctly with `pnpm generate:osrs`
- [ ] Spot-check 2-3 items for correct internal links and formatting
- [ ] Confirm OSRS.md tracking sections are accurate