### PR TITLE
feat(osrs): add 20 overrides — gilded/trimmed d'hide sets

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -671,6 +671,46 @@ Focus on items with clear processing chains and market flip potential.
 | 6908 | Beginner wand | MTA entry wand    |
 | 6912 | Teacher wand  | MTA mid-tier wand |
 
+### Gilded D'hide (Implemented - Mar 2026)
+
+| ID    | Item                    | Override Focus             |
+| ----- | ----------------------- | -------------------------- |
+| 23264 | Gilded d'hide body      | Elite clue, cosmetic body  |
+| 23267 | Gilded d'hide chaps     | Elite clue, cosmetic chaps |
+| 23261 | Gilded d'hide vambraces | Elite clue, cosmetic vambs |
+| 23258 | Gilded coif             | Elite clue, cosmetic coif  |
+
+### Trimmed D'hide Bodies (Implemented - Mar 2026)
+
+| ID    | Item                  | Override Focus         |
+| ----- | --------------------- | ---------------------- |
+| 12385 | Black d'hide body (t) | Elite clue, 70 Ranged  |
+| 7374  | Blue d'hide body (g)  | Hard clue, 50 Ranged   |
+| 7376  | Blue d'hide body (t)  | Hard clue, 50 Ranged   |
+| 7370  | Green d'hide body (g) | Medium clue, 40 Ranged |
+| 7372  | Green d'hide body (t) | Medium clue, 40 Ranged |
+| 12327 | Red d'hide body (g)   | Hard clue, 60 Ranged   |
+| 12331 | Red d'hide body (t)   | Hard clue, 60 Ranged   |
+
+### Trimmed D'hide Chaps (Implemented - Mar 2026)
+
+| ID    | Item                   | Override Focus         |
+| ----- | ---------------------- | ---------------------- |
+| 12387 | Black d'hide chaps (t) | Hard clue, 70 Ranged   |
+| 7382  | Blue d'hide chaps (g)  | Medium clue, 50 Ranged |
+| 7384  | Blue d'hide chaps (t)  | Medium clue, 50 Ranged |
+| 7378  | Green d'hide chaps (g) | Medium clue, 40 Ranged |
+| 7380  | Green d'hide chaps (t) | Medium clue, 40 Ranged |
+| 12329 | Red d'hide chaps (g)   | Hard clue, 60 Ranged   |
+| 12333 | Red d'hide chaps (t)   | Hard clue, 60 Ranged   |
+
+### Misc Weapons (Implemented - Mar 2026)
+
+| ID    | Item              | Override Focus         |
+| ----- | ----------------- | ---------------------- |
+| 6910  | Apprentice wand   | MTA mid wand, 50 Magic |
+| 10156 | Hunter's crossbow | Kebbit bolt crossbow   |
+
 ---
 
 ## Future Override Priorities
@@ -1268,6 +1308,7 @@ Record batch completions here:
 | Mar 12, 2026 | +20 items (dragon bolts e, mystic, trimmed)  | ~921            |
 | Mar 12, 2026 | +20 items (god d'hide sets, rune weapons)    | ~941            |
 | Mar 12, 2026 | +20 items (god chaps/coifs/bracers, misc)    | ~961            |
+| Mar 13, 2026 | +20 items (gilded/trimmed d'hide, misc)      | ~981            |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10156.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10156.mdx
@@ -1,0 +1,124 @@
+---
+equipment:
+  slot: "weapon"
+  type: "crossbow"
+  attack_style: "ranged"
+  attack_speed: 4
+  requirements:
+    ranged: 50
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: 0
+    attack_ranged: 55
+    defence_stab: 0
+    defence_slash: 0
+    defence_crush: 0
+    defence_magic: 0
+    defence_ranged: 0
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 5
+obtaining:
+  methods:
+    - source: "Leon's Prototype Crossbow shop"
+      location: "Yanille"
+      cost: 1300
+    - source: "Grand Exchange"
+      notes: "Tradeable"
+related_items:
+  - item_id: 10158
+    item_name: "Kebbit bolts"
+    slug: "kebbit-bolts"
+    relationship: "ammo"
+    description: "Standard ammo for this crossbow"
+  - item_id: 10159
+    item_name: "Long kebbit bolts"
+    slug: "long-kebbit-bolts"
+    relationship: "ammo"
+    description: "Long-range ammo variant"
+  - item_id: 9174
+    item_name: "Adamant crossbow"
+    slug: "adamant-crossbow"
+    relationship: "alternative"
+    description: "Similar ranged requirement crossbow"
+---
+
+## Examine
+
+"A weapon made of bone and wood."
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Weapon (Main-hand) |
+| Type | Crossbow |
+| Tradeable | Yes |
+| Weight | 5 kg |
+| Attack Speed | 4 tick (2.4s) |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | +0 |
+| Ranged Attack | +55 |
+| Stab Defence | +0 |
+| Slash Defence | +0 |
+| Crush Defence | +0 |
+| Magic Defence | +0 |
+| Ranged Defence | +0 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 50 Ranged
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Leon's Prototype Crossbow shop | 1,300 coins (Yanille) |
+| Grand Exchange | Tradeable |
+
+Purchased from Leon in Yanille or via the Grand Exchange. Cannot be crafted by players.
+
+## Comparison
+
+| Crossbow | Ranged Atk | Requirements | Ammo |
+|----------|-----------|-------------|------|
+| Hunter's crossbow | +55 | 50 Ranged | Kebbit bolts |
+| Adamant crossbow | +46 | 46 Ranged | Bolts up to adamant |
+| Rune crossbow | +90 | 61 Ranged | Bolts up to rune |
+
+The hunter's crossbow has a high ranged attack bonus for its level but is limited to kebbit bolts, which have low ranged strength. This makes it a niche weapon primarily used for the Hunter skill rather than general combat.
+
+## Market Strategy
+
+**Buy Limit:** 70 per 4 hours
+
+**Demand Drivers:**
+- Hunter skill training
+- Niche PvM use with kebbit bolts
+- Low overall demand
+
+**Tips:**
+- Very cheap, available from NPC shop for 1,300 gp
+- Only fires kebbit bolts and long kebbit bolts
+- Not practical for general combat due to limited ammo
+- Primarily a Hunter utility item
+
+## Related Items
+
+- [Kebbit bolts](/osrs/kebbit-bolts/) - Standard ammo for this crossbow
+- [Long kebbit bolts](/osrs/long-kebbit-bolts/) - Long-range ammo variant
+- [Adamant crossbow](/osrs/adamant-crossbow/) - Similar ranged requirement crossbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12327.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12327.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 60
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 25
+    defence_stab: 26
+    defence_slash: 34
+    defence_crush: 36
+    defence_magic: 36
+    defence_ranged: 45
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6.803
+obtaining:
+  methods:
+    - source: "Reward casket (hard)"
+      drop_rate: "1/1,625"
+related_items:
+  - item_id: 2501
+    item_name: "Red d'hide body"
+    slug: "red-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-trimmed"
+  - item_id: 12331
+    item_name: "Red d'hide body (t)"
+    slug: "red-dhide-body-t"
+    relationship: "alternative"
+    description: "Trimmed variant, same stats"
+  - item_id: 12385
+    item_name: "Black d'hide body (t)"
+    slug: "black-dhide-body-t"
+    relationship: "alternative"
+    description: "Higher tier trimmed body"
+---
+
+## Examine
+
+"Made from 100% real dragonhide. With colourful trim!"
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6.803 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +25 |
+| Stab Defence | +26 |
+| Slash Defence | +34 |
+| Crush Defence | +36 |
+| Magic Defence | +36 |
+| Ranged Defence | +45 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 60 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (hard) | 1/1,625 |
+
+Obtained as a rare reward from hard Treasure Trails. This is a purely cosmetic gold-trimmed variant of the standard red d'hide body with identical stats.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Red d'hide body (g) | +25 | +45 | +36 | Hard clues |
+| Red d'hide body | +25 | +45 | +36 | Crafting (77) |
+
+Stats are identical to the standard red d'hide body. The gold-trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Hard clue reward rarity
+- Collection log completionists
+- Trimmed d'hide set completion
+
+**Tips:**
+- Identical stats to red d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Red d'hide body](/osrs/red-dhide-body/) - Same stats, non-trimmed
+- [Red d'hide body (t)](/osrs/red-dhide-body-t/) - Trimmed variant, same stats
+- [Black d'hide body (t)](/osrs/black-dhide-body-t/) - Higher tier trimmed body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12329.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12329.mdx
@@ -1,0 +1,95 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged armour"
+  attack_style: "ranged"
+  requirements:
+    ranged: 60
+  stats:
+    attack_ranged: 14
+    attack_magic: -10
+    defence_stab: 15
+    defence_slash: 18
+    defence_crush: 22
+    defence_magic: 18
+    defence_ranged: 20
+    ranged_strength: 0
+    prayer_bonus: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      requirements:
+        clue_type: "Hard"
+      rarity: "Rare"
+      description: "Rare reward from hard clue scrolls"
+related_items:
+  - item_id: 2495
+    item_name: "Red d'hide chaps"
+    slug: "red-dhide-chaps"
+    relationship: "base-variant"
+    description: "Standard version with identical stats"
+  - item_id: 12333
+    item_name: "Red d'hide chaps (t)"
+    slug: "red-dhide-chaps-t"
+    relationship: "cosmetic-variant"
+    description: "Trimmed variant with team-coloured trim"
+---
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Members Only | Yes |
+| Weight | 5.443 kg |
+
+## Examine
+
+Made from 100% real dragonhide. With colourful trim!
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Source | Hard Clue Scrolls |
+| Rarity | Rare (1/1,625) |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +14 |
+| Magic Attack | -10 |
+| Stab Defence | +15 |
+| Slash Defence | +18 |
+| Crush Defence | +22 |
+| Magic Defence | +18 |
+| Ranged Defence | +20 |
+
+**Requirements:** 60 Ranged
+
+## About
+
+Red d'hide chaps (g) are a cosmetic variant of red d'hide chaps featuring gold trim. They are obtained exclusively from hard Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard red d'hide chaps, making this item purely aesthetic.
+
+These chaps require 60 Ranged to equip and provide strong ranged defence bonuses for higher-level rangers. The gold trimming is the only visual difference from the base version.
+
+## Market Strategy
+
+**Investment Notes:**
+- Purely cosmetic upgrade over standard red d'hide chaps
+- Price is driven by fashion demand rather than combat utility
+- Hard clue scroll rewards have lower supply than medium clue items
+
+**Trading Tips:**
+- Compare price to standard red d'hide chaps to gauge the cosmetic premium
+- Hard clue trimmed items tend to hold more value than medium clue equivalents
+- Gold-trimmed variants are generally more popular than team-trimmed versions
+
+## Related Items
+
+- [Red d'hide chaps](/osrs/red-dhide-chaps/) - Standard version with identical stats
+- [Red d'hide chaps (t)](/osrs/red-dhide-chaps-t/) - Trimmed variant with team-coloured trim
+- [Black d'hide chaps (t)](/osrs/black-dhide-chaps-t/) - Team-trimmed black d'hide chaps from hard clues

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12331.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12331.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 60
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 25
+    defence_stab: 26
+    defence_slash: 34
+    defence_crush: 36
+    defence_magic: 36
+    defence_ranged: 45
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6.803
+obtaining:
+  methods:
+    - source: "Reward casket (hard)"
+      drop_rate: "1/1,625"
+related_items:
+  - item_id: 2501
+    item_name: "Red d'hide body"
+    slug: "red-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-trimmed"
+  - item_id: 12327
+    item_name: "Red d'hide body (g)"
+    slug: "red-dhide-body-g"
+    relationship: "alternative"
+    description: "Gold-trimmed variant, same stats"
+  - item_id: 12385
+    item_name: "Black d'hide body (t)"
+    slug: "black-dhide-body-t"
+    relationship: "alternative"
+    description: "Higher tier trimmed body"
+---
+
+## Examine
+
+"Made from 100% real dragonhide. With colourful trim!"
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6.803 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +25 |
+| Stab Defence | +26 |
+| Slash Defence | +34 |
+| Crush Defence | +36 |
+| Magic Defence | +36 |
+| Ranged Defence | +45 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 60 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (hard) | 1/1,625 |
+
+Obtained as a rare reward from hard Treasure Trails. This is a purely cosmetic trimmed variant of the standard red d'hide body with identical stats.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Red d'hide body (t) | +25 | +45 | +36 | Hard clues |
+| Red d'hide body | +25 | +45 | +36 | Crafting (77) |
+
+Stats are identical to the standard red d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Hard clue reward rarity
+- Collection log completionists
+- Trimmed d'hide set completion
+
+**Tips:**
+- Identical stats to red d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Red d'hide body](/osrs/red-dhide-body/) - Same stats, non-trimmed
+- [Red d'hide body (g)](/osrs/red-dhide-body-g/) - Gold-trimmed variant, same stats
+- [Black d'hide body (t)](/osrs/black-dhide-body-t/) - Higher tier trimmed body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12333.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12333.mdx
@@ -1,0 +1,95 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged armour"
+  attack_style: "ranged"
+  requirements:
+    ranged: 60
+  stats:
+    attack_ranged: 14
+    attack_magic: -10
+    defence_stab: 15
+    defence_slash: 18
+    defence_crush: 22
+    defence_magic: 18
+    defence_ranged: 20
+    ranged_strength: 0
+    prayer_bonus: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      requirements:
+        clue_type: "Hard"
+      rarity: "Rare"
+      description: "Rare reward from hard clue scrolls"
+related_items:
+  - item_id: 2495
+    item_name: "Red d'hide chaps"
+    slug: "red-dhide-chaps"
+    relationship: "base-variant"
+    description: "Standard version with identical stats"
+  - item_id: 12329
+    item_name: "Red d'hide chaps (g)"
+    slug: "red-dhide-chaps-g"
+    relationship: "cosmetic-variant"
+    description: "Gold-trimmed variant with identical stats"
+---
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Members Only | Yes |
+| Weight | 5.443 kg |
+
+## Examine
+
+Made from 100% real dragonhide. With colourful trim!
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Source | Hard Clue Scrolls |
+| Rarity | Rare (1/1,625) |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +14 |
+| Magic Attack | -10 |
+| Stab Defence | +15 |
+| Slash Defence | +18 |
+| Crush Defence | +22 |
+| Magic Defence | +18 |
+| Ranged Defence | +20 |
+
+**Requirements:** 60 Ranged
+
+## About
+
+Red d'hide chaps (t) are a cosmetic variant of red d'hide chaps featuring team-coloured trim. They are obtained exclusively from hard Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard red d'hide chaps, making this item purely aesthetic.
+
+These chaps require 60 Ranged to equip and provide strong ranged defence bonuses for higher-level rangers. The coloured trimming is the only visual difference from the base version.
+
+## Market Strategy
+
+**Investment Notes:**
+- Purely cosmetic upgrade over standard red d'hide chaps
+- Price is driven by fashion demand rather than combat utility
+- Hard clue scroll rewards have lower supply than medium clue items
+
+**Trading Tips:**
+- Compare price to standard red d'hide chaps to gauge the cosmetic premium
+- Hard clue trimmed items tend to hold more value than medium clue equivalents
+- Team-trimmed variants may have different demand patterns than gold-trimmed
+
+## Related Items
+
+- [Red d'hide chaps](/osrs/red-dhide-chaps/) - Standard version with identical stats
+- [Red d'hide chaps (g)](/osrs/red-dhide-chaps-g/) - Gold-trimmed variant with identical stats
+- [Black d'hide chaps (t)](/osrs/black-dhide-chaps-t/) - Team-trimmed black d'hide chaps from hard clues

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12385.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12385.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 70
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 30
+    defence_stab: 30
+    defence_slash: 38
+    defence_crush: 45
+    defence_magic: 45
+    defence_ranged: 50
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6.803
+obtaining:
+  methods:
+    - source: "Reward casket (elite)"
+      drop_rate: "Rare"
+related_items:
+  - item_id: 2503
+    item_name: "Black d'hide body"
+    slug: "black-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-trimmed"
+  - item_id: 12383
+    item_name: "Black d'hide body (g)"
+    slug: "black-dhide-body-g"
+    relationship: "alternative"
+    description: "Gold-trimmed variant, same stats"
+  - item_id: 12331
+    item_name: "Red d'hide body (t)"
+    slug: "red-dhide-body-t"
+    relationship: "alternative"
+    description: "Lower tier trimmed body"
+---
+
+## Examine
+
+"Made from 100% real dragonhide. With colourful trim!"
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6.803 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +30 |
+| Stab Defence | +30 |
+| Slash Defence | +38 |
+| Crush Defence | +45 |
+| Magic Defence | +45 |
+| Ranged Defence | +50 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 70 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (elite) | Rare |
+
+Obtained as a rare reward from elite Treasure Trails. This is a purely cosmetic trimmed variant of the standard black d'hide body with identical stats.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Black d'hide body (t) | +30 | +50 | +45 | Elite clues |
+| Black d'hide body | +30 | +50 | +45 | Crafting (84) |
+
+Stats are identical to the standard black d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Elite clue reward rarity
+- Collection log completionists
+- Trimmed d'hide set completion
+
+**Tips:**
+- Identical stats to black d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Black d'hide body](/osrs/black-dhide-body/) - Same stats, non-trimmed
+- [Black d'hide body (g)](/osrs/black-dhide-body-g/) - Gold-trimmed variant, same stats
+- [Red d'hide body (t)](/osrs/red-dhide-body-t/) - Lower tier trimmed body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12387.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12387.mdx
@@ -1,0 +1,97 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged armour"
+  attack_style: "ranged"
+  requirements:
+    ranged: 70
+  stats:
+    attack_ranged: 17
+    attack_magic: -10
+    defence_stab: 18
+    defence_slash: 20
+    defence_crush: 26
+    defence_magic: 23
+    defence_ranged: 26
+    ranged_strength: 0
+    prayer_bonus: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      requirements:
+        clue_type: "Hard"
+      rarity: "Rare"
+      description: "Rare reward from hard clue scrolls"
+related_items:
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-dhide-chaps"
+    relationship: "base-variant"
+    description: "Standard version with identical stats"
+  - item_id: 12385
+    item_name: "Black d'hide chaps (g)"
+    slug: "black-dhide-chaps-g"
+    relationship: "cosmetic-variant"
+    description: "Gold-trimmed variant with identical stats"
+---
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Members Only | Yes |
+| Weight | 5.443 kg |
+
+## Examine
+
+Made from 100% real dragonhide. With colourful trim!
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Source | Hard Clue Scrolls |
+| Rarity | Rare |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +17 |
+| Magic Attack | -10 |
+| Stab Defence | +18 |
+| Slash Defence | +20 |
+| Crush Defence | +26 |
+| Magic Defence | +23 |
+| Ranged Defence | +26 |
+
+**Requirements:** 70 Ranged
+
+## About
+
+Black d'hide chaps (t) are a cosmetic variant of black d'hide chaps featuring team-coloured trim. They are obtained exclusively from hard Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard black d'hide chaps, making this item purely aesthetic.
+
+These chaps require 70 Ranged to equip and provide the best ranged defence bonuses among all d'hide chaps. The coloured trimming is the only visual difference from the base version. Unlike some other black dragonhide equipment, these chaps have no Defence level requirement.
+
+## Market Strategy
+
+**Investment Notes:**
+- Purely cosmetic upgrade over standard black d'hide chaps
+- Price is driven by fashion demand rather than combat utility
+- Hard clue scroll rewards have lower supply than medium clue items
+- Black d'hide trimmed items are among the higher-value hard clue rewards
+
+**Trading Tips:**
+- Compare price to standard black d'hide chaps to gauge the cosmetic premium
+- Hard clue trimmed items tend to hold more value than medium clue equivalents
+- Black d'hide trimmed pieces are popular for fashionscape builds
+
+## Related Items
+
+- [Black d'hide chaps](/osrs/black-dhide-chaps/) - Standard version with identical stats
+- [Black d'hide chaps (g)](/osrs/black-dhide-chaps-g/) - Gold-trimmed variant with identical stats
+- [Red d'hide chaps (g)](/osrs/red-dhide-chaps-g/) - Gold-trimmed red d'hide chaps from hard clues
+- [Red d'hide chaps (t)](/osrs/red-dhide-chaps-t/) - Team-trimmed red d'hide chaps from hard clues

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23258.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23258.mdx
@@ -1,0 +1,126 @@
+---
+equipment:
+  slot: "head"
+  type: "ranged_armour"
+  requirements:
+    ranged: 40
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -1
+    attack_ranged: 4
+    defence_stab: 4
+    defence_slash: 7
+    defence_crush: 8
+    defence_magic: 4
+    defence_ranged: 6
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 0.9
+obtaining:
+  methods:
+    - source: "Reward casket (elite)"
+      drop_rate: "1/14,662.5"
+    - source: "Reward casket (master)"
+      drop_rate: "1/13,616"
+related_items:
+  - item_id: 1169
+    item_name: "Coif"
+    slug: "coif"
+    relationship: "alternative"
+    description: "Standard coif, same stats"
+  - item_id: 23264
+    item_name: "Gilded d'hide body"
+    slug: "gilded-dhide-body"
+    relationship: "alternative"
+    description: "Matching gilded body"
+  - item_id: 23267
+    item_name: "Gilded d'hide chaps"
+    slug: "gilded-dhide-chaps"
+    relationship: "alternative"
+    description: "Matching gilded legs"
+  - item_id: 23261
+    item_name: "Gilded d'hide vambraces"
+    slug: "gilded-dhide-vambraces"
+    relationship: "alternative"
+    description: "Matching gilded gloves"
+---
+
+## Examine
+
+"Made with 100% golden dragonhide."
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Head |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 0.9 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -1 |
+| Ranged Attack | +4 |
+| Stab Defence | +4 |
+| Slash Defence | +7 |
+| Crush Defence | +8 |
+| Magic Defence | +4 |
+| Ranged Defence | +6 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 40 Ranged
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (elite) | 1/14,662.5 |
+| Reward casket (master) | 1/13,616 |
+
+Obtained as a rare reward from elite and master Treasure Trails. This is a gilded cosmetic variant of the standard coif.
+
+## Comparison
+
+| Item | Ranged Atk | Crush Def | Ranged Def | Source |
+|------|-----------|----------|-----------|--------|
+| Gilded coif | +4 | +8 | +6 | Elite/Master clues |
+| Coif | +4 | +8 | +6 | Crafting (38) |
+
+Stats are identical to the standard coif. The gilded version is purely cosmetic and significantly more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Elite clue reward rarity
+- Collection log completionists
+- Full gilded d'hide set completion
+
+**Tips:**
+- Identical stats to standard coif
+- Value is purely cosmetic rarity
+- Completes the gilded d'hide set with body, chaps, and vambraces
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Coif](/osrs/coif/) - Standard coif, same stats
+- [Gilded d'hide body](/osrs/gilded-dhide-body/) - Matching gilded body
+- [Gilded d'hide chaps](/osrs/gilded-dhide-chaps/) - Matching gilded legs
+- [Gilded d'hide vambraces](/osrs/gilded-dhide-vambraces/) - Matching gilded gloves

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23261.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23261.mdx
@@ -1,0 +1,125 @@
+---
+equipment:
+  slot: "hands"
+  type: "ranged_armour"
+  requirements:
+    ranged: 40
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -10
+    attack_ranged: 8
+    defence_stab: 3
+    defence_slash: 2
+    defence_crush: 4
+    defence_magic: 2
+    defence_ranged: 0
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 1
+obtaining:
+  methods:
+    - source: "Reward casket (elite)"
+      drop_rate: "1/14,662.5"
+    - source: "Reward casket (master)"
+      drop_rate: "1/13,616"
+related_items:
+  - item_id: 2491
+    item_name: "Black d'hide vambraces"
+    slug: "black-dhide-vambraces"
+    relationship: "alternative"
+    description: "Same stats, non-gilded"
+  - item_id: 23264
+    item_name: "Gilded d'hide body"
+    slug: "gilded-dhide-body"
+    relationship: "alternative"
+    description: "Matching gilded body"
+  - item_id: 23267
+    item_name: "Gilded d'hide chaps"
+    slug: "gilded-dhide-chaps"
+    relationship: "alternative"
+    description: "Matching gilded legs"
+  - item_id: 23258
+    item_name: "Gilded coif"
+    slug: "gilded-coif"
+    relationship: "alternative"
+    description: "Matching gilded helm"
+---
+
+## Examine
+
+"Made with 100% golden dragonhide."
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Hands |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 1 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -10 |
+| Ranged Attack | +8 |
+| Stab Defence | +3 |
+| Slash Defence | +2 |
+| Crush Defence | +4 |
+| Magic Defence | +2 |
+| Ranged Defence | +0 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 40 Ranged
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (elite) | 1/14,662.5 |
+| Reward casket (master) | 1/13,616 |
+
+Obtained as a rare reward from elite and master Treasure Trails. This is a cosmetic variant with identical stats to the black d'hide vambraces.
+
+## Comparison
+
+| Item | Ranged Atk | Stab Def | Crush Def | Source |
+|------|-----------|---------|----------|--------|
+| Gilded d'hide vambraces | +8 | +3 | +4 | Elite/Master clues |
+| Black d'hide vambraces | +8 | +3 | +4 | Crafting (79) |
+
+Stats are identical to the black d'hide vambraces. The gilded version is purely cosmetic and significantly more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Elite clue reward rarity
+- Collection log completionists
+
+**Tips:**
+- Identical stats to black d'hide vambraces
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Black d'hide vambraces](/osrs/black-dhide-vambraces/) - Same stats, non-gilded
+- [Gilded d'hide body](/osrs/gilded-dhide-body/) - Matching gilded body
+- [Gilded d'hide chaps](/osrs/gilded-dhide-chaps/) - Matching gilded legs
+- [Gilded coif](/osrs/gilded-coif/) - Matching gilded helm

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23264.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23264.mdx
@@ -1,0 +1,127 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 40
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 15
+    defence_stab: 40
+    defence_slash: 32
+    defence_crush: 45
+    defence_magic: 20
+    defence_ranged: 40
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6
+obtaining:
+  methods:
+    - source: "Reward casket (elite)"
+      drop_rate: "1/14,662.5"
+    - source: "Reward casket (master)"
+      drop_rate: "1/13,616"
+related_items:
+  - item_id: 2503
+    item_name: "Black d'hide body"
+    slug: "black-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-gilded"
+  - item_id: 23267
+    item_name: "Gilded d'hide chaps"
+    slug: "gilded-dhide-chaps"
+    relationship: "alternative"
+    description: "Matching gilded legs"
+  - item_id: 23261
+    item_name: "Gilded d'hide vambraces"
+    slug: "gilded-dhide-vambraces"
+    relationship: "alternative"
+    description: "Matching gilded gloves"
+  - item_id: 23258
+    item_name: "Gilded coif"
+    slug: "gilded-coif"
+    relationship: "alternative"
+    description: "Matching gilded helm"
+---
+
+## Examine
+
+"Made with 100% golden dragonhide."
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +15 |
+| Stab Defence | +40 |
+| Slash Defence | +32 |
+| Crush Defence | +45 |
+| Magic Defence | +20 |
+| Ranged Defence | +40 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 40 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (elite) | 1/14,662.5 |
+| Reward casket (master) | 1/13,616 |
+
+Obtained as a rare reward from elite and master Treasure Trails. This is a cosmetic variant with identical stats to the black d'hide body.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Gilded d'hide body | +15 | +40 | +20 | Elite/Master clues |
+| Black d'hide body | +15 | +40 | +20 | Crafting (84) |
+
+Stats are identical to the black d'hide body. The gilded version is purely cosmetic and significantly more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Elite clue reward rarity
+- Collection log completionists
+
+**Tips:**
+- Identical stats to black d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Black d'hide body](/osrs/black-dhide-body/) - Same stats, non-gilded
+- [Gilded d'hide chaps](/osrs/gilded-dhide-chaps/) - Matching gilded legs
+- [Gilded d'hide vambraces](/osrs/gilded-dhide-vambraces/) - Matching gilded gloves
+- [Gilded coif](/osrs/gilded-coif/) - Matching gilded helm

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23267.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23267.mdx
@@ -1,0 +1,125 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged_armour"
+  requirements:
+    ranged: 40
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -10
+    attack_ranged: 8
+    defence_stab: 22
+    defence_slash: 16
+    defence_crush: 24
+    defence_magic: 8
+    defence_ranged: 22
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 5
+obtaining:
+  methods:
+    - source: "Reward casket (elite)"
+      drop_rate: "1/14,662.5"
+    - source: "Reward casket (master)"
+      drop_rate: "1/13,616"
+related_items:
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-dhide-chaps"
+    relationship: "alternative"
+    description: "Same stats, non-gilded"
+  - item_id: 23264
+    item_name: "Gilded d'hide body"
+    slug: "gilded-dhide-body"
+    relationship: "alternative"
+    description: "Matching gilded body"
+  - item_id: 23261
+    item_name: "Gilded d'hide vambraces"
+    slug: "gilded-dhide-vambraces"
+    relationship: "alternative"
+    description: "Matching gilded gloves"
+  - item_id: 23258
+    item_name: "Gilded coif"
+    slug: "gilded-coif"
+    relationship: "alternative"
+    description: "Matching gilded helm"
+---
+
+## Examine
+
+"Made with 100% golden dragonhide."
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 5 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -10 |
+| Ranged Attack | +8 |
+| Stab Defence | +22 |
+| Slash Defence | +16 |
+| Crush Defence | +24 |
+| Magic Defence | +8 |
+| Ranged Defence | +22 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 40 Ranged
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (elite) | 1/14,662.5 |
+| Reward casket (master) | 1/13,616 |
+
+Obtained as a rare reward from elite and master Treasure Trails. This is a cosmetic variant with identical stats to the black d'hide chaps.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Gilded d'hide chaps | +8 | +22 | +8 | Elite/Master clues |
+| Black d'hide chaps | +8 | +22 | +8 | Crafting (82) |
+
+Stats are identical to the black d'hide chaps. The gilded version is purely cosmetic and significantly more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Elite clue reward rarity
+- Collection log completionists
+
+**Tips:**
+- Identical stats to black d'hide chaps
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Black d'hide chaps](/osrs/black-dhide-chaps/) - Same stats, non-gilded
+- [Gilded d'hide body](/osrs/gilded-dhide-body/) - Matching gilded body
+- [Gilded d'hide vambraces](/osrs/gilded-dhide-vambraces/) - Matching gilded gloves
+- [Gilded coif](/osrs/gilded-coif/) - Matching gilded helm

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6910.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6910.mdx
@@ -1,0 +1,129 @@
+---
+equipment:
+  slot: "weapon"
+  type: "magic_weapon"
+  attack_style: "magic"
+  attack_speed: 4
+  requirements:
+    magic: 50
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: 10
+    attack_ranged: 0
+    defence_stab: 0
+    defence_slash: 0
+    defence_crush: 0
+    defence_magic: 10
+    defence_ranged: 0
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 0.255
+obtaining:
+  methods:
+    - source: "Mage Training Arena"
+      requirements:
+        magic: 50
+      pizazz_points:
+        telekinetic: 60
+        alchemist: 60
+        enchantment: 600
+        graveyard: 60
+      notes: "Requires beginner wand plus pizazz points"
+related_items:
+  - item_id: 6908
+    item_name: "Beginner wand"
+    slug: "beginner-wand"
+    relationship: "downgrade"
+    description: "Previous tier wand"
+  - item_id: 6912
+    item_name: "Teacher wand"
+    slug: "teacher-wand"
+    relationship: "upgrade"
+    description: "Next tier wand"
+  - item_id: 6914
+    item_name: "Master wand"
+    slug: "master-wand"
+    relationship: "upgrade"
+    description: "Best MTA wand"
+---
+
+## Examine
+
+"An apprentice level wand."
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Weapon (Main-hand) |
+| Type | Magic Weapon |
+| Tradeable | Yes |
+| Weight | 0.255 kg |
+| Attack Speed | 4 tick (2.4s) |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | +10 |
+| Ranged Attack | +0 |
+| Stab Defence | +0 |
+| Slash Defence | +0 |
+| Crush Defence | +0 |
+| Magic Defence | +10 |
+| Ranged Defence | +0 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 50 Magic
+
+## Obtaining
+
+| Method | Requirements |
+|--------|--------------|
+| Mage Training Arena | 50 Magic, beginner wand |
+| Pizazz Points | 60 Telekinetic, 60 Alchemist, 600 Enchantment, 60 Graveyard |
+
+Purchased from the Mage Training Arena reward shop by trading in a beginner wand along with the required pizazz points. Can also be bought from other players via the Grand Exchange.
+
+## Comparison
+
+| Wand | Magic Atk | Magic Def | Requirements |
+|------|----------|----------|-------------|
+| Beginner wand | +5 | +5 | 45 Magic |
+| Apprentice wand | +10 | +10 | 50 Magic |
+| Teacher wand | +15 | +15 | 55 Magic |
+| Master wand | +20 | +20 | 60 Magic |
+
+The apprentice wand is the second tier in the Mage Training Arena wand progression. Each upgrade requires the previous wand plus additional pizazz points.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Mid-level magic training
+- Stepping stone to master wand
+- Ironman progression
+
+**Tips:**
+- Most players skip directly to master wand if possible
+- Required as a component for the teacher wand upgrade
+- Low demand compared to master wand
+- Time-intensive to obtain from MTA
+
+## Related Items
+
+- [Beginner wand](/osrs/beginner-wand/) - Previous tier wand
+- [Teacher wand](/osrs/teacher-wand/) - Next tier wand
+- [Master wand](/osrs/master-wand/) - Best MTA wand

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7370.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7370.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 40
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 15
+    defence_stab: 18
+    defence_slash: 27
+    defence_crush: 24
+    defence_magic: 20
+    defence_ranged: 35
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6.803
+obtaining:
+  methods:
+    - source: "Reward casket (medium)"
+      drop_rate: "1/1,133"
+related_items:
+  - item_id: 1135
+    item_name: "Green d'hide body"
+    slug: "green-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-trimmed"
+  - item_id: 7372
+    item_name: "Green d'hide body (t)"
+    slug: "green-dhide-body-t"
+    relationship: "alternative"
+    description: "Trimmed variant, same stats"
+  - item_id: 7374
+    item_name: "Blue d'hide body (g)"
+    slug: "blue-dhide-body-g"
+    relationship: "alternative"
+    description: "Higher tier gold-trimmed body"
+---
+
+## Examine
+
+"Made from 100% real dragonhide. With colourful trim!"
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6.803 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +15 |
+| Stab Defence | +18 |
+| Slash Defence | +27 |
+| Crush Defence | +24 |
+| Magic Defence | +20 |
+| Ranged Defence | +35 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 40 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (medium) | 1/1,133 |
+
+Obtained as a rare reward from medium Treasure Trails. This is a purely cosmetic gold-trimmed variant of the standard green d'hide body with identical stats.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Green d'hide body (g) | +15 | +35 | +20 | Medium clues |
+| Green d'hide body | +15 | +35 | +20 | Crafting (63) |
+
+Stats are identical to the standard green d'hide body. The gold-trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Medium clue reward rarity
+- Collection log completionists
+- Trimmed d'hide set completion
+
+**Tips:**
+- Identical stats to green d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Green d'hide body](/osrs/green-dhide-body/) - Same stats, non-trimmed
+- [Green d'hide body (t)](/osrs/green-dhide-body-t/) - Trimmed variant, same stats
+- [Blue d'hide body (g)](/osrs/blue-dhide-body-g/) - Higher tier gold-trimmed body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7372.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7372.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 40
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 15
+    defence_stab: 18
+    defence_slash: 27
+    defence_crush: 24
+    defence_magic: 20
+    defence_ranged: 35
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6.803
+obtaining:
+  methods:
+    - source: "Reward casket (medium)"
+      drop_rate: "1/1,133"
+related_items:
+  - item_id: 1135
+    item_name: "Green d'hide body"
+    slug: "green-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-trimmed"
+  - item_id: 7370
+    item_name: "Green d'hide body (g)"
+    slug: "green-dhide-body-g"
+    relationship: "alternative"
+    description: "Gold-trimmed variant, same stats"
+  - item_id: 7376
+    item_name: "Blue d'hide body (t)"
+    slug: "blue-dhide-body-t"
+    relationship: "alternative"
+    description: "Higher tier trimmed body"
+---
+
+## Examine
+
+"Made from 100% real dragonhide. With colourful trim!"
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6.803 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +15 |
+| Stab Defence | +18 |
+| Slash Defence | +27 |
+| Crush Defence | +24 |
+| Magic Defence | +20 |
+| Ranged Defence | +35 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 40 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (medium) | 1/1,133 |
+
+Obtained as a rare reward from medium Treasure Trails. This is a purely cosmetic trimmed variant of the standard green d'hide body with identical stats.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Green d'hide body (t) | +15 | +35 | +20 | Medium clues |
+| Green d'hide body | +15 | +35 | +20 | Crafting (63) |
+
+Stats are identical to the standard green d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Medium clue reward rarity
+- Collection log completionists
+- Trimmed d'hide set completion
+
+**Tips:**
+- Identical stats to green d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Green d'hide body](/osrs/green-dhide-body/) - Same stats, non-trimmed
+- [Green d'hide body (g)](/osrs/green-dhide-body-g/) - Gold-trimmed variant, same stats
+- [Blue d'hide body (t)](/osrs/blue-dhide-body-t/) - Higher tier trimmed body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7374.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7374.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 50
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 20
+    defence_stab: 23
+    defence_slash: 30
+    defence_crush: 30
+    defence_magic: 28
+    defence_ranged: 40
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6.803
+obtaining:
+  methods:
+    - source: "Reward casket (hard)"
+      drop_rate: "1/1,625"
+related_items:
+  - item_id: 2499
+    item_name: "Blue d'hide body"
+    slug: "blue-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-trimmed"
+  - item_id: 7376
+    item_name: "Blue d'hide body (t)"
+    slug: "blue-dhide-body-t"
+    relationship: "alternative"
+    description: "Trimmed variant, same stats"
+  - item_id: 7370
+    item_name: "Green d'hide body (g)"
+    slug: "green-dhide-body-g"
+    relationship: "alternative"
+    description: "Lower tier gold-trimmed body"
+---
+
+## Examine
+
+"Made from 100% real dragonhide. With colourful trim!"
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6.803 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +20 |
+| Stab Defence | +23 |
+| Slash Defence | +30 |
+| Crush Defence | +30 |
+| Magic Defence | +28 |
+| Ranged Defence | +40 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 50 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (hard) | 1/1,625 |
+
+Obtained as a rare reward from hard Treasure Trails. This is a purely cosmetic gold-trimmed variant of the standard blue d'hide body with identical stats.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Blue d'hide body (g) | +20 | +40 | +28 | Hard clues |
+| Blue d'hide body | +20 | +40 | +28 | Crafting (71) |
+
+Stats are identical to the standard blue d'hide body. The gold-trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Hard clue reward rarity
+- Collection log completionists
+- Trimmed d'hide set completion
+
+**Tips:**
+- Identical stats to blue d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Blue d'hide body](/osrs/blue-dhide-body/) - Same stats, non-trimmed
+- [Blue d'hide body (t)](/osrs/blue-dhide-body-t/) - Trimmed variant, same stats
+- [Green d'hide body (g)](/osrs/green-dhide-body-g/) - Lower tier gold-trimmed body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7376.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7376.mdx
@@ -1,0 +1,119 @@
+---
+equipment:
+  slot: "body"
+  type: "ranged_armour"
+  requirements:
+    ranged: 50
+    defence: 40
+    quest: "Dragon Slayer I"
+  stats:
+    attack_stab: 0
+    attack_slash: 0
+    attack_crush: 0
+    attack_magic: -15
+    attack_ranged: 20
+    defence_stab: 23
+    defence_slash: 30
+    defence_crush: 30
+    defence_magic: 28
+    defence_ranged: 40
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+  weight: 6.803
+obtaining:
+  methods:
+    - source: "Reward casket (hard)"
+      drop_rate: "1/1,625"
+related_items:
+  - item_id: 2499
+    item_name: "Blue d'hide body"
+    slug: "blue-dhide-body"
+    relationship: "alternative"
+    description: "Same stats, non-trimmed"
+  - item_id: 7374
+    item_name: "Blue d'hide body (g)"
+    slug: "blue-dhide-body-g"
+    relationship: "alternative"
+    description: "Gold-trimmed variant, same stats"
+  - item_id: 7372
+    item_name: "Green d'hide body (t)"
+    slug: "green-dhide-body-t"
+    relationship: "alternative"
+    description: "Lower tier trimmed body"
+---
+
+## Examine
+
+"Made from 100% real dragonhide. With colourful trim!"
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Body |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Weight | 6.803 kg |
+| Members | Yes |
+
+## Stats
+
+| Stat | Value |
+|------|-------|
+| Stab Attack | +0 |
+| Slash Attack | +0 |
+| Crush Attack | +0 |
+| Magic Attack | -15 |
+| Ranged Attack | +20 |
+| Stab Defence | +23 |
+| Slash Defence | +30 |
+| Crush Defence | +30 |
+| Magic Defence | +28 |
+| Ranged Defence | +40 |
+| Melee Strength | +0 |
+| Ranged Strength | +0 |
+| Magic Damage | +0% |
+| Prayer | +0 |
+
+**Requirements:** 50 Ranged, 40 Defence, Dragon Slayer I
+
+## Obtaining
+
+| Source | Drop Rate |
+|--------|-----------|
+| Reward casket (hard) | 1/1,625 |
+
+Obtained as a rare reward from hard Treasure Trails. This is a purely cosmetic trimmed variant of the standard blue d'hide body with identical stats.
+
+## Comparison
+
+| Item | Ranged Atk | Ranged Def | Magic Def | Source |
+|------|-----------|-----------|----------|--------|
+| Blue d'hide body (t) | +20 | +40 | +28 | Hard clues |
+| Blue d'hide body | +20 | +40 | +28 | Crafting (71) |
+
+Stats are identical to the standard blue d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+
+## Market Strategy
+
+**Buy Limit:** 8 per 4 hours
+
+**Demand Drivers:**
+- Fashionscape / cosmetic flex
+- Hard clue reward rarity
+- Collection log completionists
+- Trimmed d'hide set completion
+
+**Tips:**
+- Identical stats to blue d'hide body
+- Value is purely cosmetic rarity
+- Price fluctuates with clue scroll activity
+- Low trade volume, watch for manipulation
+
+## Related Items
+
+- [Blue d'hide body](/osrs/blue-dhide-body/) - Same stats, non-trimmed
+- [Blue d'hide body (g)](/osrs/blue-dhide-body-g/) - Gold-trimmed variant, same stats
+- [Green d'hide body (t)](/osrs/green-dhide-body-t/) - Lower tier trimmed body

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7378.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7378.mdx
@@ -1,0 +1,96 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged armour"
+  attack_style: "ranged"
+  requirements:
+    ranged: 40
+  stats:
+    attack_ranged: 8
+    attack_magic: -10
+    defence_stab: 12
+    defence_slash: 15
+    defence_crush: 18
+    defence_magic: 8
+    defence_ranged: 17
+    ranged_strength: 0
+    prayer_bonus: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      requirements:
+        clue_type: "Medium"
+      rarity: "Rare"
+      description: "Rare reward from medium clue scrolls"
+related_items:
+  - item_id: 2487
+    item_name: "Green d'hide chaps"
+    slug: "green-dhide-chaps"
+    relationship: "base-variant"
+    description: "Standard version with identical stats"
+  - item_id: 7380
+    item_name: "Green d'hide chaps (t)"
+    slug: "green-dhide-chaps-t"
+    relationship: "cosmetic-variant"
+    description: "Trimmed variant with team-coloured trim"
+---
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Members Only | No |
+| Weight | 5.443 kg |
+
+## Examine
+
+Made from 100% real dragonhide. With colourful trim!
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Source | Medium Clue Scrolls |
+| Rarity | Rare |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +8 |
+| Magic Attack | -10 |
+| Stab Defence | +12 |
+| Slash Defence | +15 |
+| Crush Defence | +18 |
+| Magic Defence | +8 |
+| Ranged Defence | +17 |
+
+**Requirements:** 40 Ranged
+
+## About
+
+Green d'hide chaps (g) are a cosmetic variant of green d'hide chaps featuring gold trim. They are obtained exclusively from medium Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard green d'hide chaps, making this item purely aesthetic.
+
+These chaps require 40 Ranged to equip, making them accessible to lower-level rangers. The gold trimming is the only visual difference from the base version.
+
+## Market Strategy
+
+**Investment Notes:**
+- Purely cosmetic upgrade over standard green d'hide chaps
+- Price is driven by fashion demand rather than combat utility
+- Medium clue scroll rewards tend to have moderate supply
+
+**Trading Tips:**
+- Compare price to standard green d'hide chaps to gauge the cosmetic premium
+- Green d'hide trimmed items are among the most affordable treasure trail rewards
+- Gold-trimmed variants are generally more popular than team-trimmed versions
+
+## Related Items
+
+- [Green d'hide chaps](/osrs/green-dhide-chaps/) - Standard version with identical stats
+- [Green d'hide chaps (t)](/osrs/green-dhide-chaps-t/) - Trimmed variant with team-coloured trim
+- [Blue d'hide chaps (g)](/osrs/blue-dhide-chaps-g/) - Gold-trimmed blue d'hide chaps from medium clues
+- [Blue d'hide chaps (t)](/osrs/blue-dhide-chaps-t/) - Team-trimmed blue d'hide chaps from medium clues

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7380.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7380.mdx
@@ -1,0 +1,96 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged armour"
+  attack_style: "ranged"
+  requirements:
+    ranged: 40
+  stats:
+    attack_ranged: 8
+    attack_magic: -10
+    defence_stab: 12
+    defence_slash: 15
+    defence_crush: 18
+    defence_magic: 8
+    defence_ranged: 17
+    ranged_strength: 0
+    prayer_bonus: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      requirements:
+        clue_type: "Medium"
+      rarity: "Rare"
+      description: "Rare reward from medium clue scrolls"
+related_items:
+  - item_id: 2487
+    item_name: "Green d'hide chaps"
+    slug: "green-dhide-chaps"
+    relationship: "base-variant"
+    description: "Standard version with identical stats"
+  - item_id: 7378
+    item_name: "Green d'hide chaps (g)"
+    slug: "green-dhide-chaps-g"
+    relationship: "cosmetic-variant"
+    description: "Gold-trimmed variant with identical stats"
+---
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Members Only | No |
+| Weight | 5.443 kg |
+
+## Examine
+
+Made from 100% real dragonhide. With colourful trim!
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Source | Medium Clue Scrolls |
+| Rarity | Rare |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +8 |
+| Magic Attack | -10 |
+| Stab Defence | +12 |
+| Slash Defence | +15 |
+| Crush Defence | +18 |
+| Magic Defence | +8 |
+| Ranged Defence | +17 |
+
+**Requirements:** 40 Ranged
+
+## About
+
+Green d'hide chaps (t) are a cosmetic variant of green d'hide chaps featuring team-coloured trim. They are obtained exclusively from medium Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard green d'hide chaps, making this item purely aesthetic.
+
+These chaps require 40 Ranged to equip, making them accessible to lower-level rangers. The coloured trimming is the only visual difference from the base version.
+
+## Market Strategy
+
+**Investment Notes:**
+- Purely cosmetic upgrade over standard green d'hide chaps
+- Price is driven by fashion demand rather than combat utility
+- Medium clue scroll rewards tend to have moderate supply
+
+**Trading Tips:**
+- Compare price to standard green d'hide chaps to gauge the cosmetic premium
+- Green d'hide trimmed items are among the most affordable treasure trail rewards
+- Team-trimmed variants may have different demand patterns than gold-trimmed
+
+## Related Items
+
+- [Green d'hide chaps](/osrs/green-dhide-chaps/) - Standard version with identical stats
+- [Green d'hide chaps (g)](/osrs/green-dhide-chaps-g/) - Gold-trimmed variant with identical stats
+- [Blue d'hide chaps (g)](/osrs/blue-dhide-chaps-g/) - Gold-trimmed blue d'hide chaps from medium clues
+- [Blue d'hide chaps (t)](/osrs/blue-dhide-chaps-t/) - Team-trimmed blue d'hide chaps from medium clues

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7382.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7382.mdx
@@ -1,0 +1,96 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged armour"
+  attack_style: "ranged"
+  requirements:
+    ranged: 50
+  stats:
+    attack_ranged: 11
+    attack_magic: -10
+    defence_stab: 13
+    defence_slash: 16
+    defence_crush: 20
+    defence_magic: 14
+    defence_ranged: 20
+    ranged_strength: 0
+    prayer_bonus: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      requirements:
+        clue_type: "Medium"
+      rarity: "Rare"
+      description: "Rare reward from medium clue scrolls"
+related_items:
+  - item_id: 2493
+    item_name: "Blue d'hide chaps"
+    slug: "blue-dhide-chaps"
+    relationship: "base-variant"
+    description: "Standard version with identical stats"
+  - item_id: 7384
+    item_name: "Blue d'hide chaps (t)"
+    slug: "blue-dhide-chaps-t"
+    relationship: "cosmetic-variant"
+    description: "Trimmed variant with team-coloured trim"
+---
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Members Only | No |
+| Weight | 5.443 kg |
+
+## Examine
+
+Made from 100% real dragonhide. With colourful trim!
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Source | Medium Clue Scrolls |
+| Rarity | Rare |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +11 |
+| Magic Attack | -10 |
+| Stab Defence | +13 |
+| Slash Defence | +16 |
+| Crush Defence | +20 |
+| Magic Defence | +14 |
+| Ranged Defence | +20 |
+
+**Requirements:** 50 Ranged
+
+## About
+
+Blue d'hide chaps (g) are a cosmetic variant of blue d'hide chaps featuring gold trim. They are obtained exclusively from medium Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard blue d'hide chaps, making this item purely aesthetic.
+
+These chaps require 50 Ranged to equip and provide solid ranged defence bonuses for mid-level rangers. The gold trimming is the only visual difference from the base version.
+
+## Market Strategy
+
+**Investment Notes:**
+- Purely cosmetic upgrade over standard blue d'hide chaps
+- Price is driven by fashion demand rather than combat utility
+- Medium clue scroll rewards tend to have moderate supply
+
+**Trading Tips:**
+- Compare price to standard blue d'hide chaps to gauge the cosmetic premium
+- Consider demand cycles around Treasure Trail update announcements
+- Gold-trimmed variants are generally more popular than team-trimmed versions
+
+## Related Items
+
+- [Blue d'hide chaps](/osrs/blue-dhide-chaps/) - Standard version with identical stats
+- [Blue d'hide chaps (t)](/osrs/blue-dhide-chaps-t/) - Trimmed variant with team-coloured trim
+- [Green d'hide chaps (g)](/osrs/green-dhide-chaps-g/) - Gold-trimmed green d'hide chaps from medium clues
+- [Green d'hide chaps (t)](/osrs/green-dhide-chaps-t/) - Team-trimmed green d'hide chaps from medium clues

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7384.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7384.mdx
@@ -1,0 +1,96 @@
+---
+equipment:
+  slot: "legs"
+  type: "ranged armour"
+  attack_style: "ranged"
+  requirements:
+    ranged: 50
+  stats:
+    attack_ranged: 11
+    attack_magic: -10
+    defence_stab: 13
+    defence_slash: 16
+    defence_crush: 20
+    defence_magic: 14
+    defence_ranged: 20
+    ranged_strength: 0
+    prayer_bonus: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      requirements:
+        clue_type: "Medium"
+      rarity: "Rare"
+      description: "Rare reward from medium clue scrolls"
+related_items:
+  - item_id: 2493
+    item_name: "Blue d'hide chaps"
+    slug: "blue-dhide-chaps"
+    relationship: "base-variant"
+    description: "Standard version with identical stats"
+  - item_id: 7382
+    item_name: "Blue d'hide chaps (g)"
+    slug: "blue-dhide-chaps-g"
+    relationship: "cosmetic-variant"
+    description: "Gold-trimmed variant with identical stats"
+---
+
+## Equipment Info
+
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Type | Ranged Armour |
+| Tradeable | Yes |
+| Members Only | No |
+| Weight | 5.443 kg |
+
+## Examine
+
+Made from 100% real dragonhide. With colourful trim!
+
+## Obtaining
+
+| Method | Details |
+|--------|---------|
+| Source | Medium Clue Scrolls |
+| Rarity | Rare |
+
+## Combat Stats
+
+| Stat | Value |
+|------|-------|
+| Ranged Attack | +11 |
+| Magic Attack | -10 |
+| Stab Defence | +13 |
+| Slash Defence | +16 |
+| Crush Defence | +20 |
+| Magic Defence | +14 |
+| Ranged Defence | +20 |
+
+**Requirements:** 50 Ranged
+
+## About
+
+Blue d'hide chaps (t) are a cosmetic variant of blue d'hide chaps featuring team-coloured trim. They are obtained exclusively from medium Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard blue d'hide chaps, making this item purely aesthetic.
+
+These chaps require 50 Ranged to equip and provide solid ranged defence bonuses for mid-level rangers. The coloured trimming is the only visual difference from the base version.
+
+## Market Strategy
+
+**Investment Notes:**
+- Purely cosmetic upgrade over standard blue d'hide chaps
+- Price is driven by fashion demand rather than combat utility
+- Medium clue scroll rewards tend to have moderate supply
+
+**Trading Tips:**
+- Compare price to standard blue d'hide chaps to gauge the cosmetic premium
+- Consider demand cycles around Treasure Trail update announcements
+- Team-trimmed variants may have different demand patterns than gold-trimmed
+
+## Related Items
+
+- [Blue d'hide chaps](/osrs/blue-dhide-chaps/) - Standard version with identical stats
+- [Blue d'hide chaps (g)](/osrs/blue-dhide-chaps-g/) - Gold-trimmed variant with identical stats
+- [Green d'hide chaps (g)](/osrs/green-dhide-chaps-g/) - Gold-trimmed green d'hide chaps from medium clues
+- [Green d'hide chaps (t)](/osrs/green-dhide-chaps-t/) - Team-trimmed green d'hide chaps from medium clues


### PR DESCRIPTION
## Summary
- 4 gilded d'hide: body, chaps, vambraces, coif (elite clue cosmetics)
- 7 trimmed d'hide bodies: black (t), blue (g/t), green (g/t), red (g/t)
- 7 trimmed d'hide chaps: black (t), blue (g/t), green (g/t), red (g/t)
- 2 misc: apprentice wand (MTA), hunter's crossbow (kebbit bolts)

All stats Wiki-sourced. Trimmed variants confirmed identical to base versions.

## Test plan
- [ ] Verify override files parse correctly with `pnpm generate:osrs`
- [ ] Spot-check 2-3 items for correct internal links and formatting
- [ ] Confirm OSRS.md tracking sections are accurate