### PR TITLE
feat(osrs): add 50 item overrides - elegant, HAM, vestments, amulets

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -711,6 +711,96 @@ Focus on items with clear processing chains and market flip potential.
 | 6910  | Apprentice wand   | MTA mid wand, 50 Magic |
 | 10156 | Hunter's crossbow | Kebbit bolt crossbow   |
 
+### Elegant Shirts & Legs — Men's (Implemented - Mar 2026)
+
+| ID    | Item                 | Override Focus         |
+| ----- | -------------------- | ---------------------- |
+| 10404 | Red elegant shirt    | Easy clue, body slot   |
+| 10406 | Red elegant legs     | Easy clue, legs slot   |
+| 10408 | Blue elegant shirt   | Easy clue, body slot   |
+| 10410 | Blue elegant legs    | Easy clue, legs slot   |
+| 10412 | Green elegant shirt  | Easy clue, body slot   |
+| 10414 | Green elegant legs   | Easy clue, legs slot   |
+| 10400 | Black elegant shirt  | Medium clue, body slot |
+| 10402 | Black elegant legs   | Medium clue, legs slot |
+| 10416 | Purple elegant shirt | Medium clue, body slot |
+| 10418 | Purple elegant legs  | Medium clue, legs slot |
+| 10420 | White elegant blouse | Medium clue, body slot |
+| 10422 | White elegant skirt  | Medium clue, legs slot |
+| 12347 | Gold elegant shirt   | Medium clue, body slot |
+| 12349 | Gold elegant legs    | Medium clue, legs slot |
+| 12315 | Pink elegant shirt   | Medium clue, body slot |
+| 12317 | Pink elegant legs    | Medium clue, legs slot |
+
+### Elegant Blouses & Skirts — Women's (Implemented - Mar 2026)
+
+| ID    | Item                  | Override Focus         |
+| ----- | --------------------- | ---------------------- |
+| 10424 | Red elegant blouse    | Easy clue, body slot   |
+| 10426 | Red elegant skirt     | Easy clue, legs slot   |
+| 10428 | Blue elegant blouse   | Easy clue, body slot   |
+| 10430 | Blue elegant skirt    | Easy clue, legs slot   |
+| 10432 | Green elegant blouse  | Easy clue, body slot   |
+| 10434 | Green elegant skirt   | Easy clue, legs slot   |
+| 10436 | Purple elegant blouse | Medium clue, body slot |
+| 10438 | Purple elegant skirt  | Medium clue, legs slot |
+| 12343 | Gold elegant blouse   | Medium clue, body slot |
+| 12345 | Gold elegant skirt    | Medium clue, legs slot |
+| 12339 | Pink elegant blouse   | Medium clue, body slot |
+| 12341 | Pink elegant skirt    | Medium clue, legs slot |
+
+### H.A.M. Robes Set (Implemented - Mar 2026)
+
+| ID   | Item       | Override Focus             |
+| ---- | ---------- | -------------------------- |
+| 4302 | Ham hood   | Head slot, pickpocket set  |
+| 4298 | Ham shirt  | Body slot, pickpocket set  |
+| 4300 | Ham robe   | Legs slot, pickpocket set  |
+| 4304 | Ham cloak  | Cape slot, pickpocket set  |
+| 4308 | Ham gloves | Hands slot, pickpocket set |
+| 4310 | Ham boots  | Feet slot, pickpocket set  |
+
+### Shade Robes (Implemented - Mar 2026)
+
+| ID  | Item           | Override Focus      |
+| --- | -------------- | ------------------- |
+| 546 | Shade robe top | +5 Prayer, F2P body |
+| 548 | Shade robe     | +4 Prayer, F2P legs |
+
+### Zamorak Vestments (Implemented - Mar 2026)
+
+| ID    | Item              | Override Focus              |
+| ----- | ----------------- | --------------------------- |
+| 10460 | Zamorak robe top  | Easy clue, +6 Prayer, 20 Pr |
+| 10468 | Zamorak robe legs | Easy clue, +5 Prayer, 20 Pr |
+
+### God Vestment Accessories (Implemented - Mar 2026)
+
+| ID    | Item              | Override Focus               |
+| ----- | ----------------- | ---------------------------- |
+| 10470 | Saradomin stole   | Hard clue, +10 Prayer, neck  |
+| 10474 | Zamorak stole     | Hard clue, +10 Prayer, neck  |
+| 10440 | Saradomin crozier | Hard clue, +6 Prayer, weapon |
+| 10454 | Guthix mitre      | Medium clue, +5 Prayer, head |
+
+### Trimmed Amulets (Implemented - Mar 2026)
+
+| ID    | Item                  | Override Focus                |
+| ----- | --------------------- | ----------------------------- |
+| 10354 | Amulet of glory (t4)  | Hard clue, trimmed glory      |
+| 10366 | Amulet of magic (t)   | Hard clue, trimmed magic ammy |
+| 23309 | Amulet of defence (t) | Hard clue, trimmed defence    |
+| 23354 | Amulet of power (t)   | Hard clue, trimmed power      |
+
+### Misc Treasure Trail Gear (Implemented - Mar 2026)
+
+| ID    | Item            | Override Focus             |
+| ----- | --------------- | -------------------------- |
+| 23389 | Spiked manacles | Medium clue, +4 Str boots  |
+| 23246 | Fremennik kilt  | Medium clue, cosmetic legs |
+| 12379 | Rune cane       | Hard clue, cosmetic weapon |
+| 12377 | Adamant cane    | Hard clue, cosmetic weapon |
+
 ---
 
 ## Future Override Priorities
@@ -1299,16 +1389,17 @@ const description = generateMetaDescription(item);
 
 Record batch completions here:
 
-| Date         | Items Added                                  | Total Overrides |
-| ------------ | -------------------------------------------- | --------------- |
-| Jan 2026     | Initial ~100 items                           | ~100            |
-| Jan 7, 2026  | +35 items (potions, weapons, raid gear)      | ~135            |
-| Jan 21, 2026 | +42 items (barrows, hilts, potions, utility) | ~881            |
-| Mar 11, 2026 | +20 items (jewelry chains, misc weapons)     | ~901            |
-| Mar 12, 2026 | +20 items (dragon bolts e, mystic, trimmed)  | ~921            |
-| Mar 12, 2026 | +20 items (god d'hide sets, rune weapons)    | ~941            |
-| Mar 12, 2026 | +20 items (god chaps/coifs/bracers, misc)    | ~961            |
-| Mar 13, 2026 | +20 items (gilded/trimmed d'hide, misc)      | ~981            |
+| Date         | Items Added                                              | Total Overrides |
+| ------------ | -------------------------------------------------------- | --------------- |
+| Jan 2026     | Initial ~100 items                                       | ~100            |
+| Jan 7, 2026  | +35 items (potions, weapons, raid gear)                  | ~135            |
+| Jan 21, 2026 | +42 items (barrows, hilts, potions, utility)             | ~881            |
+| Mar 11, 2026 | +20 items (jewelry chains, misc weapons)                 | ~901            |
+| Mar 12, 2026 | +20 items (dragon bolts e, mystic, trimmed)              | ~921            |
+| Mar 12, 2026 | +20 items (god d'hide sets, rune weapons)                | ~941            |
+| Mar 12, 2026 | +20 items (god chaps/coifs/bracers, misc)                | ~961            |
+| Mar 13, 2026 | +20 items (gilded/trimmed d'hide, misc)                  | ~981            |
+| Mar 13, 2026 | +50 items (elegant sets, HAM, robes, vestments, amulets) | ~1031           |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10354.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10354.mdx
@@ -1,0 +1,128 @@
+---
+equipment:
+  slot: neck
+  weight: 0.01
+  attack_bonus:
+    stab: 10
+    slash: 10
+    crush: 10
+    magic: 10
+    ranged: 10
+  defence_bonus:
+    stab: 3
+    slash: 3
+    crush: 3
+    magic: 3
+    ranged: 3
+  other_bonus:
+    melee_strength: 6
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 3
+charges:
+  current: 4
+  max: 6
+  recharge: "Fountain of Rune"
+special_effect:
+  name: "Glory Effect"
+  description: "Teleports to Edgeville, Karamja, Draynor, Al Kharid. Increases gem mining chance."
+  triggers: "on_use"
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Hard"
+      drop_rate: "1/1,625"
+      description: "Rare reward from hard clue scrolls"
+related_items:
+  - item_id: 1704
+    item_name: "Amulet of glory(4)"
+    slug: "amulet-of-glory-4"
+    relationship: "variant"
+    description: "Standard (untrimmed) version with 4 charges"
+  - item_id: 10362
+    item_name: "Amulet of glory (t)"
+    slug: "amulet-of-glory-t"
+    relationship: "variant"
+    description: "Uncharged trimmed version"
+  - item_id: 11964
+    item_name: "Amulet of glory (t6)"
+    slug: "amulet-of-glory-t6"
+    relationship: "variant"
+    description: "Fully charged trimmed version (6 charges)"
+  - item_id: 6585
+    item_name: "Amulet of fury"
+    slug: "amulet-of-fury"
+    relationship: "upgrade"
+    description: "Superior combat amulet"
+---
+
+## Examine
+> *"A very powerful dragonstone amulet."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Neck |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 0.01 kg |
+| Charges | 4 |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Stab Attack | +10 |
+| Slash Attack | +10 |
+| Crush Attack | +10 |
+| Magic Attack | +10 |
+| Ranged Attack | +10 |
+| Stab Defence | +3 |
+| Slash Defence | +3 |
+| Crush Defence | +3 |
+| Magic Defence | +3 |
+| Ranged Defence | +3 |
+| Melee Strength | +6 |
+| Prayer | +3 |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+The trimmed amulet of glory is a cosmetic variant of the regular amulet of glory. It has identical stats and functionality, including the same teleport destinations and gem mining bonus. The only difference is the gold trim applied to its appearance.
+
+## Teleport Locations
+- Edgeville
+- Karamja (Musa Point)
+- Draynor Village
+- Al Kharid
+
+## Comparison: Trimmed vs Regular Glory
+| Property | Glory (4) | Glory (t4) |
+|----------|-----------|------------|
+| All Attack | +10 | +10 |
+| All Defence | +3 | +3 |
+| Strength | +6 | +6 |
+| Prayer | +3 | +3 |
+| Teleports | Yes (4) | Yes (4) |
+| Appearance | Standard | Gold trimmed |
+| Source | Enchanting | Hard clue |
+
+Stats are identical. The trimmed version is purely a cosmetic upgrade obtained through Treasure Trails.
+
+## Market Strategy
+
+**Investment Notes:**
+- Hard clue exclusive cosmetic
+- Functions identically to regular glory with 4 charges
+- Fashionscape demand drives pricing
+- Recharge at Fountain of Rune for 6 charges (becomes t6)
+
+**Tips:**
+- Can be recharged just like a regular glory
+- All charge variants (t1 through t6) maintain the trimmed appearance
+- Popular among players who want a premium look for everyday teleporting
+
+## Related Items
+- [Amulet of glory(4)](/item/1704) - Standard (untrimmed) version with 4 charges
+- [Amulet of glory (t)](/item/10362) - Uncharged trimmed version
+- [Amulet of glory (t6)](/item/11964) - Fully charged trimmed version (6 charges)
+- [Amulet of fury](/item/6585) - Superior combat amulet upgrade

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10366.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10366.mdx
@@ -1,0 +1,93 @@
+---
+equipment:
+  slot: neck
+  weight: 0.01
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 10
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Easy"
+      drop_rate: "1/3,960"
+      description: "Rare reward from easy clue scrolls"
+related_items:
+  - item_id: 1727
+    item_name: "Amulet of magic"
+    slug: "amulet-of-magic"
+    relationship: "variant"
+    description: "Standard (untrimmed) version"
+  - item_id: 10366
+    item_name: "Amulet of magic (t)"
+    slug: "amulet-of-magic-t"
+    relationship: "self"
+  - item_id: 6919
+    item_name: "Amulet of power"
+    slug: "amulet-of-power"
+    relationship: "upgrade"
+    description: "All-round combat amulet upgrade"
+---
+
+## Examine
+> *"An enchanted sapphire amulet of magic."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Neck |
+| Tradeable | Yes |
+| Members | No |
+| Weight | 0.01 kg |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Magic Attack | +10 |
+
+All other bonuses are +0.
+
+## Obtaining
+Obtained exclusively from **Easy Clue Scrolls** at a rate of **1/3,960** per casket.
+
+The trimmed amulet of magic is a cosmetic variant of the regular amulet of magic. It has identical stats, providing only a +10 magic attack bonus. The only difference is the decorative gold trim on the amulet's appearance. Unlike the regular version, this item cannot be crafted and is only available through Treasure Trails.
+
+## Comparison: Trimmed vs Regular
+| Property | Amulet of Magic | Amulet of Magic (t) |
+|----------|----------------|---------------------|
+| Magic Attack | +10 | +10 |
+| Appearance | Standard | Gold trimmed |
+| Source | Crafting (Lvl-1 Enchant) | Easy clue |
+| F2P | Yes | Yes |
+
+Stats are identical. The trimmed version is purely cosmetic.
+
+## Market Strategy
+
+**Investment Notes:**
+- Easy clue exclusive cosmetic
+- Free-to-play tradeable
+- Low-tier amulet with niche demand from F2P magic pures
+- Collection log hunters drive some demand
+
+**Tips:**
+- Best magic amulet available in F2P without other requirements
+- Commonly used by F2P magic pures for the cosmetic upgrade
+- Price fluctuates with clue scroll reward table changes
+
+## Related Items
+- [Amulet of magic](/item/1727) - Standard (untrimmed) version
+- [Amulet of power](/item/6919) - All-round combat amulet upgrade

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10400.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10400.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10402
+    item_name: "Black elegant legs"
+    slug: "black-elegant-legs"
+    relationship: "set-piece"
+    description: "Matching elegant legs"
+---
+
+## Examine
+> *"A well made elegant men's black shirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the black elegant clothing set used for fashionscape and emote clue requirements.
+
+## Related Items
+- [Black elegant legs](/osrs/black-elegant-legs/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10402.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10402.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10400
+    item_name: "Black elegant shirt"
+    slug: "black-elegant-shirt"
+    relationship: "set-piece"
+    description: "Matching elegant shirt"
+---
+
+## Examine
+> *"A rather elegant pair of men's black pantaloons."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the black elegant clothing set.
+
+## Related Items
+- [Black elegant shirt](/osrs/black-elegant-shirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10404.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10404.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10406
+    item_name: "Red elegant legs"
+    slug: "red-elegant-legs"
+    relationship: "set-piece"
+    description: "Matching elegant legs"
+---
+
+## Examine
+> *"A well made elegant men's red shirt."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the red elegant clothing set used for fashionscape and emote clue requirements.
+
+## Related Items
+- [Red elegant legs](/osrs/red-elegant-legs/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10406.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10406.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10404
+    item_name: "Red elegant shirt"
+    slug: "red-elegant-shirt"
+    relationship: "set-piece"
+    description: "Matching elegant shirt"
+---
+
+## Examine
+> *"A rather elegant pair of men's red pantaloons."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the red elegant clothing set.
+
+## Related Items
+- [Red elegant shirt](/osrs/red-elegant-shirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10408.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10408.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10410
+    item_name: "Blue elegant legs"
+    slug: "blue-elegant-legs"
+    relationship: "set-piece"
+    description: "Matching elegant legs"
+---
+
+## Examine
+> *"A well made elegant men's blue shirt."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the blue elegant clothing set.
+
+## Related Items
+- [Blue elegant legs](/osrs/blue-elegant-legs/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10410.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10410.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10408
+    item_name: "Blue elegant shirt"
+    slug: "blue-elegant-shirt"
+    relationship: "set-piece"
+    description: "Matching elegant shirt"
+---
+
+## Examine
+> *"A rather elegant pair of men's blue pantaloons."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the blue elegant clothing set.
+
+## Related Items
+- [Blue elegant shirt](/osrs/blue-elegant-shirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10412.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10412.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10414
+    item_name: "Green elegant legs"
+    slug: "green-elegant-legs"
+    relationship: "set-piece"
+    description: "Matching elegant legs"
+---
+
+## Examine
+> *"A well made elegant men's green shirt."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set.
+
+## Related Items
+- [Green elegant legs](/osrs/green-elegant-legs/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10414.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10414.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10412
+    item_name: "Green elegant shirt"
+    slug: "green-elegant-shirt"
+    relationship: "set-piece"
+    description: "Matching elegant shirt"
+---
+
+## Examine
+> *"A rather elegant pair of men's green pantaloons."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set.
+
+## Related Items
+- [Green elegant shirt](/osrs/green-elegant-shirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10416.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10416.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10418
+    item_name: "Purple elegant legs"
+    slug: "purple-elegant-legs"
+    relationship: "set-piece"
+    description: "Matching elegant legs"
+---
+
+## Examine
+> *"A well made elegant men's purple shirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the purple elegant clothing set.
+
+## Related Items
+- [Purple elegant legs](/osrs/purple-elegant-legs/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10418.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10418.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10416
+    item_name: "Purple elegant shirt"
+    slug: "purple-elegant-shirt"
+    relationship: "set-piece"
+    description: "Matching elegant shirt"
+---
+
+## Examine
+> *"A rather elegant pair of men's purple pantaloons."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the purple elegant clothing set.
+
+## Related Items
+- [Purple elegant shirt](/osrs/purple-elegant-shirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10420.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10420.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10422
+    item_name: "White elegant skirt"
+    slug: "white-elegant-skirt"
+    relationship: "set-piece"
+    description: "Matching elegant skirt"
+---
+
+## Examine
+> *"A well made elegant ladies' white blouse."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the white elegant clothing set.
+
+## Related Items
+- [White elegant skirt](/osrs/white-elegant-skirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10422.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10422.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10420
+    item_name: "White elegant blouse"
+    slug: "white-elegant-blouse"
+    relationship: "set-piece"
+    description: "Matching elegant blouse"
+---
+
+## Examine
+> *"A rather elegant white skirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the white elegant clothing set.
+
+## Related Items
+- [White elegant blouse](/osrs/white-elegant-blouse/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10424.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10424.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10426
+    item_name: "Red elegant skirt"
+    slug: "red-elegant-skirt"
+    relationship: "set-piece"
+    description: "Matching elegant skirt"
+---
+
+## Examine
+> *"A well made elegant ladies' red blouse."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the red elegant clothing set (women's variant). Pairs with the red elegant skirt.
+
+## Related Items
+- [Red elegant skirt](/osrs/red-elegant-skirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10426.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10426.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10424
+    item_name: "Red elegant blouse"
+    slug: "red-elegant-blouse"
+    relationship: "set-piece"
+    description: "Matching elegant blouse"
+---
+
+## Examine
+> *"A rather elegant red skirt."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the red elegant clothing set (women's variant). Pairs with the red elegant blouse.
+
+## Related Items
+- [Red elegant blouse](/osrs/red-elegant-blouse/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10428.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10428.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10430
+    item_name: "Blue elegant skirt"
+    slug: "blue-elegant-skirt"
+    relationship: "set-piece"
+    description: "Matching elegant skirt"
+---
+
+## Examine
+> *"A well made elegant ladies' blue blouse."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the blue elegant clothing set (women's variant). Pairs with the blue elegant skirt.
+
+## Related Items
+- [Blue elegant skirt](/osrs/blue-elegant-skirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10430.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10430.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10428
+    item_name: "Blue elegant blouse"
+    slug: "blue-elegant-blouse"
+    relationship: "set-piece"
+    description: "Matching elegant blouse"
+---
+
+## Examine
+> *"A rather elegant blue skirt."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the blue elegant clothing set (women's variant). Pairs with the blue elegant blouse.
+
+## Related Items
+- [Blue elegant blouse](/osrs/blue-elegant-blouse/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10432.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10432.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10434
+    item_name: "Green elegant skirt"
+    slug: "green-elegant-skirt"
+    relationship: "set-piece"
+    description: "Matching elegant skirt"
+---
+
+## Examine
+> *"A well made elegant ladies' green blouse."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set (women's variant). Pairs with the green elegant skirt.
+
+## Related Items
+- [Green elegant skirt](/osrs/green-elegant-skirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10434.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10434.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10432
+    item_name: "Green elegant blouse"
+    slug: "green-elegant-blouse"
+    relationship: "set-piece"
+    description: "Matching elegant blouse"
+---
+
+## Examine
+> *"A rather elegant green skirt."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set (women's variant). Pairs with the green elegant blouse.
+
+## Related Items
+- [Green elegant blouse](/osrs/green-elegant-blouse/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10436.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10436.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 10438
+    item_name: "Purple elegant skirt"
+    slug: "purple-elegant-skirt"
+    relationship: "set-piece"
+    description: "Matching elegant skirt"
+---
+
+## Examine
+> *"A well made elegant ladies' purple blouse."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the purple elegant clothing set (women's variant). Pairs with the purple elegant skirt.
+
+## Related Items
+- [Purple elegant skirt](/osrs/purple-elegant-skirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10438.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10438.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 10436
+    item_name: "Purple elegant blouse"
+    slug: "purple-elegant-blouse"
+    relationship: "set-piece"
+    description: "Matching elegant blouse"
+---
+
+## Examine
+> *"A rather elegant purple skirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the purple elegant clothing set (women's variant). Pairs with the purple elegant blouse.
+
+## Related Items
+- [Purple elegant blouse](/osrs/purple-elegant-blouse/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10440.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10440.mdx
@@ -1,0 +1,31 @@
+---
+equipment:
+  slot: "weapon"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 6
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Hard"
+      description: "Reward from hard clue scrolls"
+related_items:
+  - item_id: 10470
+    item_name: "Saradomin stole"
+    slug: "saradomin-stole"
+    relationship: "set-piece"
+    description: "Saradomin vestment neck piece"
+---
+
+## Examine
+> *"A Saradomin crozier."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Saradomin crozier is a weapon slot staff from the Saradomin vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. As a Saradominist item, it counts for God Wars Dungeon protection. Primarily used for its prayer bonus and fashionscape rather than combat.
+
+## Related Items
+- [Saradomin stole](/osrs/saradomin-stole/) - Saradomin vestment neck piece (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10454.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10454.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    prayer: 40
+    magic: 40
+  other_bonus:
+    prayer: 5
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Medium"
+      description: "Reward from medium clue scrolls"
+related_items:
+  - item_id: 10452
+    item_name: "Guthix robe top"
+    slug: "guthix-robe-top"
+    relationship: "set-piece"
+    description: "Guthix vestment body piece"
+---
+
+## Examine
+> *"A Guthix mitre."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Guthix mitre is a head slot item from the Guthix vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. As a Guthixian item, it provides protection in the God Wars Dungeon. Offers one of the higher prayer bonuses for the head slot while also providing modest magic bonuses.
+
+## Related Items
+- [Guthix robe top](/osrs/guthix-robe-top/) - Guthix vestment body piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10460.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10460.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 6
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Easy"
+      drop_rate: "1/1,404"
+      description: "Rare reward from easy clue scrolls"
+related_items:
+  - item_id: 10468
+    item_name: "Zamorak robe legs"
+    slug: "zamorak-robe-legs"
+    relationship: "set-piece"
+    description: "Matching Zamorak vestment legs"
+---
+
+## Examine
+> *"Zamorak Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls** at a rate of **1/1,404** per casket.
+
+## About
+The Zamorak robe top is the body piece of the Zamorak vestment set, obtained from easy treasure trails. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Part of the god vestment sets used by prayer-focused builds, particularly useful in the God Wars Dungeon for Zamorak protection.
+
+## Related Items
+- [Zamorak robe legs](/osrs/zamorak-robe-legs/) - Matching vestment legs (+5 Prayer, 20 Prayer req)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10468.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10468.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 5
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Easy"
+      drop_rate: "1/1,404"
+      description: "Rare reward from easy clue scrolls"
+related_items:
+  - item_id: 10460
+    item_name: "Zamorak robe top"
+    slug: "zamorak-robe-top"
+    relationship: "set-piece"
+    description: "Matching Zamorak vestment top"
+---
+
+## Examine
+> *"Leggings from the Zamorak Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls** at a rate of **1/1,404** per casket.
+
+## About
+The Zamorak robe legs are the legs piece of the Zamorak vestment set, obtained from easy treasure trails. They provide a +5 Prayer bonus and require 20 Prayer to equip. Part of the god vestment sets, useful in the God Wars Dungeon for Zamorak protection.
+
+## Related Items
+- [Zamorak robe top](/osrs/zamorak-robe-top/) - Matching vestment top (+6 Prayer, 20 Prayer req)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10470.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10470.mdx
@@ -1,0 +1,36 @@
+---
+equipment:
+  slot: "neck"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 10
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Hard"
+      description: "Reward from hard clue scrolls"
+related_items:
+  - item_id: 10474
+    item_name: "Zamorak stole"
+    slug: "zamorak-stole"
+    relationship: "variant"
+    description: "Zamorak equivalent stole"
+  - item_id: 10460
+    item_name: "Zamorak robe top"
+    slug: "zamorak-robe-top"
+    relationship: "related"
+    description: "Zamorak vestment body piece"
+---
+
+## Examine
+> *"A Saradomin stole."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Saradomin stole is a neck slot item from the Saradomin vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. As a Saradominist item, it provides protection in the God Wars Dungeon Saradomin encampment. One of the highest prayer bonus items available in the neck slot.
+
+## Related Items
+- [Zamorak stole](/osrs/zamorak-stole/) - Zamorak equivalent (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10474.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10474.mdx
@@ -1,0 +1,36 @@
+---
+equipment:
+  slot: "neck"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 10
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Hard"
+      description: "Reward from hard clue scrolls"
+related_items:
+  - item_id: 10470
+    item_name: "Saradomin stole"
+    slug: "saradomin-stole"
+    relationship: "variant"
+    description: "Saradomin equivalent stole"
+  - item_id: 10468
+    item_name: "Zamorak robe legs"
+    slug: "zamorak-robe-legs"
+    relationship: "set-piece"
+    description: "Zamorak vestment legs piece"
+---
+
+## Examine
+> *"A Zamorak stole."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Zamorak stole is a neck slot item from the Zamorak vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. As a Zamorakian item, it provides protection in the God Wars Dungeon Zamorak encampment. One of the highest prayer bonus items available in the neck slot.
+
+## Related Items
+- [Saradomin stole](/osrs/saradomin-stole/) - Saradomin equivalent (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12315.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12315.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 12317
+    item_name: "Pink elegant legs"
+    slug: "pink-elegant-legs"
+    relationship: "set-piece"
+    description: "Matching elegant legs"
+---
+
+## Examine
+> *"A well made elegant men's pink shirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set.
+
+## Related Items
+- [Pink elegant legs](/osrs/pink-elegant-legs/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12317.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12317.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 12315
+    item_name: "Pink elegant shirt"
+    slug: "pink-elegant-shirt"
+    relationship: "set-piece"
+    description: "Matching elegant shirt"
+---
+
+## Examine
+> *"A rather elegant pair of men's pink pantaloons."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set.
+
+## Related Items
+- [Pink elegant shirt](/osrs/pink-elegant-shirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12339.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12339.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 12341
+    item_name: "Pink elegant skirt"
+    slug: "pink-elegant-skirt"
+    relationship: "set-piece"
+    description: "Matching elegant skirt"
+---
+
+## Examine
+> *"A well made elegant ladies' pink blouse."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set (women's variant). Pairs with the pink elegant skirt.
+
+## Related Items
+- [Pink elegant skirt](/osrs/pink-elegant-skirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12341.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12341.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 12339
+    item_name: "Pink elegant blouse"
+    slug: "pink-elegant-blouse"
+    relationship: "set-piece"
+    description: "Matching elegant blouse"
+---
+
+## Examine
+> *"A rather elegant pink skirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set (women's variant). Pairs with the pink elegant blouse.
+
+## Related Items
+- [Pink elegant blouse](/osrs/pink-elegant-blouse/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12343.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12343.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 12345
+    item_name: "Gold elegant skirt"
+    slug: "gold-elegant-skirt"
+    relationship: "set-piece"
+    description: "Matching elegant skirt"
+---
+
+## Examine
+> *"A well made elegant ladies' gold blouse."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set (women's variant). Pairs with the gold elegant skirt.
+
+## Related Items
+- [Gold elegant skirt](/osrs/gold-elegant-skirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12345.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12345.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 12343
+    item_name: "Gold elegant blouse"
+    slug: "gold-elegant-blouse"
+    relationship: "set-piece"
+    description: "Matching elegant blouse"
+---
+
+## Examine
+> *"A rather elegant gold skirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set (women's variant). Pairs with the gold elegant blouse.
+
+## Related Items
+- [Gold elegant blouse](/osrs/gold-elegant-blouse/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12347.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12347.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 12349
+    item_name: "Gold elegant legs"
+    slug: "gold-elegant-legs"
+    relationship: "set-piece"
+    description: "Matching elegant legs"
+---
+
+## Examine
+> *"A well made elegant men's gold shirt."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set.
+
+## Related Items
+- [Gold elegant legs](/osrs/gold-elegant-legs/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12349.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12349.mdx
@@ -1,0 +1,23 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 12347
+    item_name: "Gold elegant shirt"
+    slug: "gold-elegant-shirt"
+    relationship: "set-piece"
+    description: "Matching elegant shirt"
+---
+
+## Examine
+> *"A rather elegant pair of men's gold pantaloons."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set.
+
+## Related Items
+- [Gold elegant shirt](/osrs/gold-elegant-shirt/) - Matching set piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12377.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12377.mdx
@@ -1,0 +1,115 @@
+---
+equipment:
+  slot: weapon
+  type: "spiked"
+  attack_speed: 5
+  attack_bonus:
+    stab: 13
+    slash: -2
+    crush: 25
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 23
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 3
+  requirements:
+    attack: 28
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Medium"
+      drop_rate: "1/1,133"
+      description: "Rare reward from medium clue scrolls"
+related_items:
+  - item_id: 12379
+    item_name: "Rune cane"
+    slug: "rune-cane"
+    relationship: "upgrade"
+    description: "Higher-tier cane from hard clues"
+  - item_id: 12375
+    item_name: "Mithril cane"
+    slug: "mithril-cane"
+    relationship: "downgrade"
+    description: "Lower-tier cane from easy clues"
+  - item_id: 12381
+    item_name: "Dragon cane"
+    slug: "dragon-cane"
+    relationship: "upgrade"
+    description: "Highest-tier cane from elite clues"
+---
+
+## Examine
+> *"A diamond topped cane."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Weapon (one-handed) |
+| Type | Spiked |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 1.814 kg |
+| Attack Speed | 5 (3.0s) |
+| Requirements | 28 Attack |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Stab Attack | +13 |
+| Slash Attack | -2 |
+| Crush Attack | +25 |
+| Melee Strength | +23 |
+| Prayer | +3 |
+
+All defence bonuses are +0.
+
+## Combat Styles
+| Style | Type | Experience |
+|-------|------|-----------|
+| Pound | Crush | Attack |
+| Pummel | Crush | Strength |
+| Spike | Stab | Shared |
+| Block | Crush | Defence |
+
+## Obtaining
+Obtained exclusively from **Medium Clue Scrolls** at a rate of **1/1,133** per casket.
+
+The adamant cane is a cosmetic one-handed spiked weapon topped with a diamond. It requires only 28 Attack to wield, making it accessible to lower-level accounts. Like all canes, it features a notable prayer bonus (+3) relative to its combat tier. It primarily serves as a fashionscape item rather than a practical combat weapon.
+
+## Comparison: Cane Tier Progression
+| Property | Mithril Cane | Adamant Cane | Rune Cane | Dragon Cane |
+|----------|-------------|--------------|-----------|-------------|
+| Crush Attack | +17 | +25 | +39 | +50 |
+| Strength | +16 | +23 | +36 | +48 |
+| Prayer | +2 | +3 | +4 | +5 |
+| Attack Req | 20 | 28 | 40 | 60 |
+| Clue Tier | Easy | Medium | Hard | Elite |
+
+Each cane tier increases in stats and prayer bonus, matching progressively harder clue scroll requirements.
+
+## Market Strategy
+
+**Investment Notes:**
+- Medium clue exclusive cosmetic weapon
+- Low Attack requirement makes it accessible
+- Prayer bonus is notable for the tier
+- Primarily a fashionscape and collection log item
+
+**Tips:**
+- Not efficient for combat compared to adamant scimitar
+- Gentleman's outfit fashionscape pairs well with top hat and monocle
+- Medium clues are fast to farm, so supply is reasonable
+- Collection log completionists provide steady demand
+
+## Related Items
+- [Rune cane](/item/12379) - Higher-tier cane from hard clues
+- [Mithril cane](/item/12375) - Lower-tier cane from easy clues
+- [Dragon cane](/item/12381) - Highest-tier cane from elite clues

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12379.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12379.mdx
@@ -1,0 +1,113 @@
+---
+equipment:
+  slot: weapon
+  type: "spiked"
+  attack_speed: 5
+  attack_bonus:
+    stab: 20
+    slash: -2
+    crush: 39
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  other_bonus:
+    melee_strength: 36
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 4
+  requirements:
+    attack: 40
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Hard"
+      drop_rate: "1/1,625"
+      description: "Rare reward from hard clue scrolls"
+related_items:
+  - item_id: 12377
+    item_name: "Adamant cane"
+    slug: "adamant-cane"
+    relationship: "downgrade"
+    description: "Lower-tier cane from medium clues"
+  - item_id: 12381
+    item_name: "Dragon cane"
+    slug: "dragon-cane"
+    relationship: "upgrade"
+    description: "Higher-tier cane from elite clues"
+  - item_id: 1333
+    item_name: "Rune scimitar"
+    slug: "rune-scimitar"
+    relationship: "alternative"
+    description: "Common rune-tier weapon"
+---
+
+## Examine
+> *"A dragonstone topped cane."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Weapon (one-handed) |
+| Type | Spiked |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 1.814 kg |
+| Attack Speed | 5 (3.0s) |
+| Requirements | 40 Attack |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Stab Attack | +20 |
+| Slash Attack | -2 |
+| Crush Attack | +39 |
+| Melee Strength | +36 |
+| Prayer | +4 |
+
+All defence bonuses are +0.
+
+## Combat Styles
+| Style | Type | Experience |
+|-------|------|-----------|
+| Pound | Crush | Attack |
+| Pummel | Crush | Strength |
+| Spike | Stab | Shared |
+| Block | Crush | Defence |
+
+## Obtaining
+Obtained exclusively from **Hard Clue Scrolls** at a rate of **1/1,625** per casket.
+
+The rune cane is a cosmetic one-handed spiked weapon topped with a dragonstone. It requires 40 Attack to wield and has stats roughly comparable to a rune mace, though with a different attack style distribution favoring crush. The +4 prayer bonus is a notable feature for a weapon of this tier.
+
+## Comparison: Rune-Tier Weapons
+| Property | Rune Cane | Rune Mace | Rune Scimitar |
+|----------|-----------|-----------|---------------|
+| Best Attack | +39 Crush | +36 Crush | +45 Slash |
+| Strength | +36 | +36 | +44 |
+| Prayer | **+4** | +1 | 0 |
+| Speed | 5 | 5 | 4 |
+| Source | Hard clue | Smithing/drops | Smithing/drops |
+
+The rune cane trades raw DPS for a superior prayer bonus. It is primarily a cosmetic weapon used for fashionscape rather than efficient combat.
+
+## Market Strategy
+
+**Investment Notes:**
+- Hard clue exclusive cosmetic weapon
+- Prayer bonus makes it a niche option for prayer-focused setups
+- Primarily valued for fashionscape and collection log
+
+**Tips:**
+- Not efficient for combat compared to rune scimitar
+- Collection log completionists drive demand
+- Pairs with other cane-tier items for a gentleman's outfit
+
+## Related Items
+- [Adamant cane](/item/12377) - Lower-tier cane from medium clues
+- [Dragon cane](/item/12381) - Higher-tier cane from elite clues
+- [Rune scimitar](/item/1333) - Common rune-tier weapon

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23246.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23246.mdx
@@ -1,0 +1,103 @@
+---
+equipment:
+  slot: legs
+  weight: 3.0
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -21
+    ranged: -7
+  defence_bonus:
+    stab: 11
+    slash: 10
+    crush: 10
+    magic: -4
+    ranged: 10
+  other_bonus:
+    melee_strength: 1
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Elite"
+      drop_rate: "1/1,275"
+      description: "Rare reward from elite clue scrolls"
+related_items:
+  - item_id: 4087
+    item_name: "Rune platelegs"
+    slug: "rune-platelegs"
+    relationship: "alternative"
+    description: "Similar defence stats but no strength bonus"
+  - item_id: 2497
+    item_name: "Black d'hide chaps"
+    slug: "black-dhide-chaps"
+    relationship: "alternative"
+    description: "Ranged leg slot option"
+  - item_id: 11834
+    item_name: "Bandos tassets"
+    slug: "bandos-tassets"
+    relationship: "upgrade"
+    description: "Best-in-slot melee legs (+2 str, requires 65 Defence)"
+---
+
+## Examine
+> *"A kilt worn by the mightiest of Fremennik warriors."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Legs |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 3.0 kg |
+| Requirements | None |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Magic Attack | -21 |
+| Ranged Attack | -7 |
+| Stab Defence | +11 |
+| Slash Defence | +10 |
+| Crush Defence | +10 |
+| Magic Defence | -4 |
+| Ranged Defence | +10 |
+| Melee Strength | +1 |
+
+## Obtaining
+Obtained exclusively from **Elite Clue Scrolls** at a rate of **1/1,275** per casket.
+
+The Fremennik kilt is a legs-slot item that provides a +1 melee strength bonus along with moderate defensive stats, all with no level requirements to equip. This makes it one of the few leg-slot items that offers a strength bonus accessible to pure accounts.
+
+## Comparison: Melee Legs with Strength Bonus
+| Property | Fremennik Kilt | Bandos Tassets | Obsidian Platelegs |
+|----------|---------------|----------------|-------------------|
+| Melee Strength | **+1** | +2 | +1 |
+| Stab Defence | +11 | +71 | +50 |
+| Slash Defence | +10 | +63 | +48 |
+| Crush Defence | +10 | +66 | +52 |
+| Defence Req | **None** | 65 | 60 |
+| Source | Elite clue | General Graardor | TzHaar shops |
+
+The Fremennik kilt is the only legs-slot item with a strength bonus and no requirements, making it valuable for pures and restricted accounts.
+
+## Market Strategy
+
+**Investment Notes:**
+- Elite clue exclusive with niche demand from pure community
+- Only no-requirement legs with a strength bonus
+- Shares +1 strength with obsidian platelegs but needs no Defence level
+
+**Tips:**
+- Essential for melee pures seeking maximum strength bonus
+- Pair with spiked manacles for a no-requirement strength gear setup
+- Elite clues are slower to complete, keeping supply limited
+- Price driven by the pure PvP community
+
+## Related Items
+- [Rune platelegs](/item/4087) - Similar defence stats but no strength bonus
+- [Black d'hide chaps](/item/2497) - Ranged leg slot option
+- [Bandos tassets](/item/11834) - Best-in-slot melee legs (+2 str, requires 65 Defence)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23309.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23309.mdx
@@ -1,0 +1,99 @@
+---
+equipment:
+  slot: neck
+  weight: 0.01
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: 0
+    ranged: 0
+  defence_bonus:
+    stab: 7
+    slash: 7
+    crush: 7
+    magic: 7
+    ranged: 7
+  other_bonus:
+    melee_strength: 0
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Beginner"
+      drop_rate: "1/360"
+      description: "Rare reward from beginner clue scrolls"
+related_items:
+  - item_id: 1729
+    item_name: "Amulet of defence"
+    slug: "amulet-of-defence"
+    relationship: "variant"
+    description: "Standard (untrimmed) version"
+  - item_id: 1725
+    item_name: "Amulet of strength"
+    slug: "amulet-of-strength"
+    relationship: "alternative"
+    description: "Offensive amulet alternative"
+  - item_id: 6919
+    item_name: "Amulet of power"
+    slug: "amulet-of-power"
+    relationship: "upgrade"
+    description: "All-round combat amulet with offensive and defensive stats"
+---
+
+## Examine
+> *"An enchanted emerald amulet of protection that looks good."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Neck |
+| Tradeable | Yes |
+| Members | No |
+| Weight | 0.01 kg |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Stab Defence | +7 |
+| Slash Defence | +7 |
+| Crush Defence | +7 |
+| Magic Defence | +7 |
+| Ranged Defence | +7 |
+
+All attack bonuses and other bonuses are +0.
+
+## Obtaining
+Obtained exclusively from **Beginner Clue Scrolls** at a rate of **1/360** per casket.
+
+The trimmed amulet of defence is a cosmetic variant of the regular amulet of defence. It provides the same +7 bonus to all defensive stats. The only difference is the decorative gold trim. This item cannot be crafted and is only available through Treasure Trails.
+
+## Comparison: Trimmed vs Regular
+| Property | Amulet of Defence | Amulet of Defence (t) |
+|----------|-------------------|----------------------|
+| All Defence | +7 | +7 |
+| Appearance | Standard | Gold trimmed |
+| Source | Crafting (Lvl-2 Enchant) | Beginner clue |
+| F2P | Yes | Yes |
+
+Stats are identical. The trimmed version is purely cosmetic.
+
+## Market Strategy
+
+**Investment Notes:**
+- Beginner clue exclusive cosmetic
+- Free-to-play tradeable
+- Higher drop rate than other trimmed amulets (1/360)
+- Defensive-only amulet with limited PvP demand
+
+**Tips:**
+- Good starter defensive amulet for new accounts
+- Beginner clues are the fastest to complete, so supply is relatively high
+- Collection log item for completionists
+
+## Related Items
+- [Amulet of defence](/item/1729) - Standard (untrimmed) version
+- [Amulet of strength](/item/1725) - Offensive amulet alternative
+- [Amulet of power](/item/6919) - All-round combat amulet upgrade

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23354.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23354.mdx
@@ -1,0 +1,108 @@
+---
+equipment:
+  slot: neck
+  weight: 0.01
+  attack_bonus:
+    stab: 6
+    slash: 6
+    crush: 6
+    magic: 6
+    ranged: 6
+  defence_bonus:
+    stab: 6
+    slash: 6
+    crush: 6
+    magic: 6
+    ranged: 6
+  other_bonus:
+    melee_strength: 6
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 1
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Easy"
+      drop_rate: "1/1,404"
+      description: "Rare reward from easy clue scrolls"
+related_items:
+  - item_id: 6919
+    item_name: "Amulet of power"
+    slug: "amulet-of-power"
+    relationship: "variant"
+    description: "Standard (untrimmed) version"
+  - item_id: 1704
+    item_name: "Amulet of glory(4)"
+    slug: "amulet-of-glory-4"
+    relationship: "upgrade"
+    description: "Superior amulet with teleports"
+  - item_id: 6585
+    item_name: "Amulet of fury"
+    slug: "amulet-of-fury"
+    relationship: "upgrade"
+    description: "Best-in-slot hybrid amulet"
+---
+
+## Examine
+> *"An enchanted diamond amulet that looks good."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Neck |
+| Tradeable | Yes |
+| Members | No |
+| Weight | 0.01 kg |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Stab Attack | +6 |
+| Slash Attack | +6 |
+| Crush Attack | +6 |
+| Magic Attack | +6 |
+| Ranged Attack | +6 |
+| Stab Defence | +6 |
+| Slash Defence | +6 |
+| Crush Defence | +6 |
+| Magic Defence | +6 |
+| Ranged Defence | +6 |
+| Melee Strength | +6 |
+| Prayer | +1 |
+
+## Obtaining
+Obtained exclusively from **Easy Clue Scrolls** at a rate of **1/1,404** per casket.
+
+The trimmed amulet of power is a cosmetic variant of the regular amulet of power. It provides the same well-rounded combat bonuses: +6 to all attack and defence styles, +6 melee strength, and +1 prayer. The only difference is the decorative gold trim. This item cannot be crafted and is only available through Treasure Trails.
+
+## Comparison: Trimmed vs Regular
+| Property | Amulet of Power | Amulet of Power (t) |
+|----------|----------------|---------------------|
+| All Attack | +6 | +6 |
+| All Defence | +6 | +6 |
+| Strength | +6 | +6 |
+| Prayer | +1 | +1 |
+| Appearance | Standard | Gold trimmed |
+| Source | Crafting (Lvl-4 Enchant) | Easy clue |
+| F2P | Yes | Yes |
+
+Stats are identical. The trimmed version is purely cosmetic.
+
+## Market Strategy
+
+**Investment Notes:**
+- Easy clue exclusive cosmetic
+- Free-to-play tradeable
+- Popular hybrid amulet for mid-level accounts
+- Best F2P amulet for balanced combat styles
+
+**Tips:**
+- Solid all-round amulet before accessing glory or fury
+- No requirements to equip, making it accessible to all account builds
+- Good choice for F2P PKing due to balanced offensive and defensive stats
+- Collection log item for completionists
+
+## Related Items
+- [Amulet of power](/item/6919) - Standard (untrimmed) version
+- [Amulet of glory(4)](/item/1704) - Superior amulet with teleports
+- [Amulet of fury](/item/6585) - Best-in-slot hybrid amulet

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_23389.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_23389.mdx
@@ -1,0 +1,100 @@
+---
+equipment:
+  slot: feet
+  weight: 3.0
+  attack_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -3
+    ranged: -1
+  defence_bonus:
+    stab: 0
+    slash: 0
+    crush: 0
+    magic: -4
+    ranged: 0
+  other_bonus:
+    melee_strength: 4
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
+obtaining:
+  methods:
+    - source: "Treasure Trails"
+      tier: "Medium"
+      drop_rate: "1/1,133"
+      description: "Rare reward from medium clue scrolls"
+related_items:
+  - item_id: 11840
+    item_name: "Dragon boots"
+    slug: "dragon-boots"
+    relationship: "alternative"
+    description: "Best melee boots for mains (+4 str, requires 60 Defence)"
+  - item_id: 13239
+    item_name: "Primordial boots"
+    slug: "primordial-boots"
+    relationship: "upgrade"
+    description: "Best-in-slot melee boots (+5 str, requires 75 Defence)"
+  - item_id: 4131
+    item_name: "Rune boots"
+    slug: "rune-boots"
+    relationship: "alternative"
+    description: "Alternative boots for pures (+2 str, no requirements)"
+---
+
+## Examine
+> *"Some very spikey metal bands, better make sure I don't cut myself while walking."*
+
+## Equipment Info
+| Property | Value |
+|----------|-------|
+| Slot | Feet |
+| Tradeable | Yes |
+| Members | Yes |
+| Weight | 3.0 kg |
+| Requirements | None |
+
+## Combat Stats
+| Stat | Value |
+|------|-------|
+| Magic Attack | -3 |
+| Ranged Attack | -1 |
+| Magic Defence | -4 |
+| Melee Strength | +4 |
+
+All other bonuses are +0.
+
+## Obtaining
+Obtained exclusively from **Medium Clue Scrolls** at a rate of **1/1,133** per casket.
+
+Spiked manacles are a pair of feet-slot equipment that provide a +4 melee strength bonus with no level requirements. This makes them the best-in-slot strength bonus boots for 1-Defence pures and other restricted account builds that cannot wear dragon boots or primordial boots.
+
+## Comparison: Pure Boots
+| Property | Spiked Manacles | Rune Boots | Dragon Boots | Primordial Boots |
+|----------|----------------|------------|--------------|-----------------|
+| Melee Strength | **+4** | +2 | +4 | +5 |
+| Defence Req | **None** | None | 60 | 75 |
+| Magic Attack | -3 | 0 | 0 | 0 |
+| Magic Defence | -4 | 0 | 0 | 0 |
+| Source | Medium clue | Nechryael | Spiritual mages | Dragon boots + Primordial crystal |
+
+Spiked manacles match dragon boots in strength bonus while having no Defence requirement, making them essential for pure builds. The trade-off is negative magic attack and defence bonuses and zero defensive stats.
+
+## Market Strategy
+
+**Investment Notes:**
+- Best-in-slot strength boots for 1-Defence pures
+- Medium clue exclusive with consistent demand from pure community
+- No alternative provides the same strength bonus without Defence requirements
+
+**Tips:**
+- Essential purchase for any melee pure build
+- Price is driven by pure PvP meta demand
+- Consider pairing with other no-requirement strength gear
+- Medium clues are relatively fast to complete, keeping supply steady
+
+## Related Items
+- [Dragon boots](/item/11840) - Best melee boots for mains (+4 str, requires 60 Defence)
+- [Primordial boots](/item/13239) - Best-in-slot melee boots (+5 str, requires 75 Defence)
+- [Rune boots](/item/4131) - Alternative boots for pures (+2 str, no requirements)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4298.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4298.mdx
@@ -1,0 +1,35 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+related_items:
+  - item_id: 4302
+    item_name: "Ham hood"
+    slug: "ham-hood"
+    relationship: "set-piece"
+    description: "H.A.M. head piece"
+  - item_id: 4300
+    item_name: "Ham robe"
+    slug: "ham-robe"
+    relationship: "set-piece"
+    description: "H.A.M. legs piece"
+  - item_id: 4304
+    item_name: "Ham cloak"
+    slug: "ham-cloak"
+    relationship: "set-piece"
+    description: "H.A.M. cape piece"
+---
+
+## Examine
+> *"The label says 'Vivid Crimson', but it looks pink to me!"*
+
+## Obtaining
+Obtained by **pickpocketing H.A.M. Members** (15 Thieving), killing **H.A.M. Guards**, or looting the chest in **Dorgesh-Kaan** (52 Thieving). Also a reward from **The Lost Tribe** quest.
+
+## About
+The ham shirt is part of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
+
+## Related Items
+- [Ham hood](/osrs/ham-hood/) - H.A.M. head piece
+- [Ham robe](/osrs/ham-robe/) - H.A.M. legs piece
+- [Ham cloak](/osrs/ham-cloak/) - H.A.M. cape piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4300.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4300.mdx
@@ -1,0 +1,35 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+related_items:
+  - item_id: 4302
+    item_name: "Ham hood"
+    slug: "ham-hood"
+    relationship: "set-piece"
+    description: "H.A.M. head piece"
+  - item_id: 4298
+    item_name: "Ham shirt"
+    slug: "ham-shirt"
+    relationship: "set-piece"
+    description: "H.A.M. body piece"
+  - item_id: 4304
+    item_name: "Ham cloak"
+    slug: "ham-cloak"
+    relationship: "set-piece"
+    description: "H.A.M. cape piece"
+---
+
+## Examine
+> *"The label says 'Vivid Crimson', but it looks pink to me!"*
+
+## Obtaining
+Obtained by **pickpocketing H.A.M. Members** (15 Thieving), killing **H.A.M. Guards**, or looting the chest in **Dorgesh-Kaan** (52 Thieving). Also a reward from **The Lost Tribe** quest.
+
+## About
+The ham robe is the legs piece of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
+
+## Related Items
+- [Ham hood](/osrs/ham-hood/) - H.A.M. head piece
+- [Ham shirt](/osrs/ham-shirt/) - H.A.M. body piece
+- [Ham cloak](/osrs/ham-cloak/) - H.A.M. cape piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4302.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4302.mdx
@@ -1,0 +1,47 @@
+---
+equipment:
+  slot: "head"
+  requirements: {}
+related_items:
+  - item_id: 4298
+    item_name: "Ham shirt"
+    slug: "ham-shirt"
+    relationship: "set-piece"
+    description: "H.A.M. body piece"
+  - item_id: 4300
+    item_name: "Ham robe"
+    slug: "ham-robe"
+    relationship: "set-piece"
+    description: "H.A.M. legs piece"
+  - item_id: 4304
+    item_name: "Ham cloak"
+    slug: "ham-cloak"
+    relationship: "set-piece"
+    description: "H.A.M. cape piece"
+  - item_id: 4308
+    item_name: "Ham gloves"
+    slug: "ham-gloves"
+    relationship: "set-piece"
+    description: "H.A.M. hands piece"
+  - item_id: 4310
+    item_name: "Ham boots"
+    slug: "ham-boots"
+    relationship: "set-piece"
+    description: "H.A.M. feet piece"
+---
+
+## Examine
+> *"Light-weight head protection and eye shield."*
+
+## Obtaining
+Obtained by **pickpocketing H.A.M. Members** (15 Thieving), killing **H.A.M. Guards**, or looting the chest in **Dorgesh-Kaan** (52 Thieving). Also a reward from **The Lost Tribe** quest.
+
+## About
+The ham hood is part of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces of the set reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing, though it does not improve pickpocket success rates. Required for the Death to the Dorgeshuun quest.
+
+## Related Items
+- [Ham shirt](/osrs/ham-shirt/) - H.A.M. body piece
+- [Ham robe](/osrs/ham-robe/) - H.A.M. legs piece
+- [Ham cloak](/osrs/ham-cloak/) - H.A.M. cape piece
+- [Ham gloves](/osrs/ham-gloves/) - H.A.M. hands piece
+- [Ham boots](/osrs/ham-boots/) - H.A.M. feet piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4304.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4304.mdx
@@ -1,0 +1,35 @@
+---
+equipment:
+  slot: "cape"
+  requirements: {}
+related_items:
+  - item_id: 4302
+    item_name: "Ham hood"
+    slug: "ham-hood"
+    relationship: "set-piece"
+    description: "H.A.M. head piece"
+  - item_id: 4298
+    item_name: "Ham shirt"
+    slug: "ham-shirt"
+    relationship: "set-piece"
+    description: "H.A.M. body piece"
+  - item_id: 4300
+    item_name: "Ham robe"
+    slug: "ham-robe"
+    relationship: "set-piece"
+    description: "H.A.M. legs piece"
+---
+
+## Examine
+> *"A HAM cape."*
+
+## Obtaining
+Obtained by **pickpocketing H.A.M. Members** (15 Thieving), killing **H.A.M. Guards**, or looting the chest in **Dorgesh-Kaan** (52 Thieving). Required for the **Death to the Dorgeshuun** quest.
+
+## About
+The ham cloak is the cape piece of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
+
+## Related Items
+- [Ham hood](/osrs/ham-hood/) - H.A.M. head piece
+- [Ham shirt](/osrs/ham-shirt/) - H.A.M. body piece
+- [Ham robe](/osrs/ham-robe/) - H.A.M. legs piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4308.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4308.mdx
@@ -1,0 +1,35 @@
+---
+equipment:
+  slot: "hands"
+  requirements: {}
+related_items:
+  - item_id: 4302
+    item_name: "Ham hood"
+    slug: "ham-hood"
+    relationship: "set-piece"
+    description: "H.A.M. head piece"
+  - item_id: 4298
+    item_name: "Ham shirt"
+    slug: "ham-shirt"
+    relationship: "set-piece"
+    description: "H.A.M. body piece"
+  - item_id: 4310
+    item_name: "Ham boots"
+    slug: "ham-boots"
+    relationship: "set-piece"
+    description: "H.A.M. feet piece"
+---
+
+## Examine
+> *"HAM gloves as worn by the Humans Against Monsters group."*
+
+## Obtaining
+Obtained by **pickpocketing H.A.M. Members** (15 Thieving), killing **H.A.M. Guards**, or looting the chest in **Dorgesh-Kaan** (52 Thieving). Required for the **Death to the Dorgeshuun** quest.
+
+## About
+The ham gloves are the hands piece of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
+
+## Related Items
+- [Ham hood](/osrs/ham-hood/) - H.A.M. head piece
+- [Ham shirt](/osrs/ham-shirt/) - H.A.M. body piece
+- [Ham boots](/osrs/ham-boots/) - H.A.M. feet piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_4310.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_4310.mdx
@@ -1,0 +1,35 @@
+---
+equipment:
+  slot: "feet"
+  requirements: {}
+related_items:
+  - item_id: 4302
+    item_name: "Ham hood"
+    slug: "ham-hood"
+    relationship: "set-piece"
+    description: "H.A.M. head piece"
+  - item_id: 4298
+    item_name: "Ham shirt"
+    slug: "ham-shirt"
+    relationship: "set-piece"
+    description: "H.A.M. body piece"
+  - item_id: 4308
+    item_name: "Ham gloves"
+    slug: "ham-gloves"
+    relationship: "set-piece"
+    description: "H.A.M. hands piece"
+---
+
+## Examine
+> *"HAM boots as worn by the Humans Against Monsters group."*
+
+## Obtaining
+Obtained by **pickpocketing H.A.M. Members** (15 Thieving), killing **H.A.M. Guards**, or looting the chest in **Dorgesh-Kaan** (52 Thieving). Required for the **Death to the Dorgeshuun** quest.
+
+## About
+The ham boots are the feet piece of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
+
+## Related Items
+- [Ham hood](/osrs/ham-hood/) - H.A.M. head piece
+- [Ham shirt](/osrs/ham-shirt/) - H.A.M. body piece
+- [Ham gloves](/osrs/ham-gloves/) - H.A.M. hands piece

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_546.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_546.mdx
@@ -1,0 +1,25 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 548
+    item_name: "Shade robe"
+    slug: "shade-robe"
+    relationship: "set-piece"
+    description: "Matching shade robe legs"
+---
+
+## Examine
+> *"I feel closer to the gods when I am wearing this."*
+
+## Obtaining
+Dropped by **Shades** (combat levels 140, 159). Also available on the Grand Exchange.
+
+## About
+The shade robe top is a free-to-play body slot item that provides a +5 Prayer bonus. It is dropped by shades and is part of the shade robes set. Despite being dropped by high-level monsters, it has no requirements to equip, making it accessible for low-level prayer builds.
+
+## Related Items
+- [Shade robe](/osrs/shade-robe/) - Matching legs piece (+4 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_548.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_548.mdx
@@ -1,0 +1,25 @@
+---
+equipment:
+  slot: "legs"
+  requirements: {}
+  other_bonus:
+    prayer: 4
+related_items:
+  - item_id: 546
+    item_name: "Shade robe top"
+    slug: "shade-robe-top"
+    relationship: "set-piece"
+    description: "Matching shade robe top"
+---
+
+## Examine
+> *"If a shade had knees, this would keep them nice and warm."*
+
+## Obtaining
+Dropped by **Shades** (combat levels 140, 159). Also available on the Grand Exchange.
+
+## About
+The shade robe is a free-to-play legs slot item that provides a +4 Prayer bonus. It is dropped by shades and is part of the shade robes set. No requirements to equip, making it useful for prayer-focused builds at any level.
+
+## Related Items
+- [Shade robe top](/osrs/shade-robe-top/) - Matching body piece (+5 Prayer)


### PR DESCRIPTION
## Summary
- **50 new OSRS item override files** bringing total to ~1,031
- 28 elegant clothing pieces (men's shirts/legs + women's blouses/skirts in all color variants)
- 6 H.A.M. robes set pieces (hood, shirt, robe, cloak, gloves, boots)
- 2 shade robes (prayer bonus F2P items)
- 2 Zamorak vestment pieces (easy clue, 20 Prayer req)
- 4 god vestment accessories (Saradomin/Zamorak stoles, Sara crozier, Guthix mitre)
- 4 trimmed amulets (glory t4, magic t, defence t, power t)
- 4 misc treasure trail gear (spiked manacles, fremennik kilt, rune/adamant canes)
- Updated OSRS.md tracking with all new sections and session log

## Test plan
- [ ] Verify override files parse correctly with `pnpm generate:osrs`
- [ ] Spot-check 2-3 items render properly in browser
- [ ] Confirm OSRS.md tracking sections are accurate