### PR TITLE
fix(isometric): collision-aware player movement via shape casting

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/player.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/player.rs
@@ -20,6 +20,9 @@ const MAX_STEP_HEIGHT: f32 = 0.35;
 const FALL_DAMAGE_THRESHOLD: f32 = 3.0;
 const FALL_DAMAGE_PER_UNIT: f32 = 15.0;
 
+/// Small skin distance to prevent the player from touching colliders exactly.
+const COLLISION_SKIN: f32 = 0.01;
+
 // ---------------------------------------------------------------------------
 // Components
 // ---------------------------------------------------------------------------
@@ -121,9 +124,10 @@ fn move_player(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut joystick: ResMut<VirtualJoystickState>,
     time: Res<Time>,
-    mut query: Query<(&mut Transform, &mut PlayerPhysics), With<Player>>,
+    spatial_query: SpatialQuery,
+    mut query: Query<(Entity, &mut Transform, &mut PlayerPhysics), With<Player>>,
 ) {
-    for (mut transform, mut physics) in &mut query {
+    for (entity, mut transform, mut physics) in &mut query {
         // WASD + Arrow keys → isometric directions
         let mut direction = Vec3::ZERO;
         if keyboard.pressed(KeyCode::KeyW) || keyboard.pressed(KeyCode::ArrowUp) {
@@ -167,9 +171,121 @@ fn move_player(
 
         let vertical = Vec3::new(0.0, physics.velocity_y * time.delta_secs(), 0.0);
 
-        // Directly move the kinematic body's transform
-        transform.translation += horizontal + vertical;
+        // -- Collision-aware movement via shape casting -------------------------
+        // Use a slightly shrunk collider for sweeping to avoid edge-catching.
+        let sweep_collider = Collider::cuboid(
+            PLAYER_HALF_X * 2.0 * 0.85,
+            PLAYER_HEIGHT * 0.9,
+            PLAYER_HALF_Z * 2.0 * 0.85,
+        );
+        let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+        let pos = transform.translation;
+
+        // Sweep horizontal movement (XZ) — slide along walls by trying each
+        // axis independently when the combined sweep is blocked.
+        let resolved_h = sweep_move(&spatial_query, &sweep_collider, pos, horizontal, &filter);
+
+        // Sweep vertical movement from the post-horizontal position.
+        let pos_after_h = pos + resolved_h;
+        let resolved_v = sweep_move(
+            &spatial_query,
+            &sweep_collider,
+            pos_after_h,
+            vertical,
+            &filter,
+        );
+
+        // If vertical movement was blocked while falling, land.
+        if physics.velocity_y < 0.0 && resolved_v.y.abs() < vertical.y.abs() * 0.5 {
+            physics.velocity_y = 0.0;
+        }
+
+        transform.translation += resolved_h + resolved_v;
     }
+}
+
+/// Sweep a shape along `delta` and return the safe displacement.
+/// If the full sweep is blocked, tries sliding along each axis independently.
+fn sweep_move(
+    spatial_query: &SpatialQuery,
+    collider: &Collider,
+    origin: Vec3,
+    delta: Vec3,
+    filter: &SpatialQueryFilter,
+) -> Vec3 {
+    let dist = delta.length();
+    if dist < 1e-6 {
+        return Vec3::ZERO;
+    }
+
+    // Try the full movement first.
+    if let Some(safe) = try_cast(spatial_query, collider, origin, delta, dist, filter) {
+        if safe >= dist - COLLISION_SKIN {
+            return delta; // No obstruction.
+        }
+    } else {
+        return delta; // No hit — clear path.
+    }
+
+    // Blocked: try sliding along each axis independently (XZ then Y).
+    let mut result = Vec3::ZERO;
+
+    // X axis
+    let dx = Vec3::new(delta.x, 0.0, 0.0);
+    let dx_len = dx.length();
+    if dx_len > 1e-6 {
+        if let Some(safe) = try_cast(spatial_query, collider, origin, dx, dx_len, filter) {
+            let clamped = (safe - COLLISION_SKIN).max(0.0);
+            result.x = dx.x.signum() * clamped.min(dx_len);
+        } else {
+            result.x = dx.x;
+        }
+    }
+
+    // Z axis
+    let dz = Vec3::new(0.0, 0.0, delta.z);
+    let dz_len = dz.length();
+    if dz_len > 1e-6 {
+        let slide_origin = origin + result; // account for X slide
+        if let Some(safe) = try_cast(spatial_query, collider, slide_origin, dz, dz_len, filter) {
+            let clamped = (safe - COLLISION_SKIN).max(0.0);
+            result.z = dz.z.signum() * clamped.min(dz_len);
+        } else {
+            result.z = dz.z;
+        }
+    }
+
+    // Y axis
+    let dy = Vec3::new(0.0, delta.y, 0.0);
+    let dy_len = dy.length();
+    if dy_len > 1e-6 {
+        let slide_origin = origin + result;
+        if let Some(safe) = try_cast(spatial_query, collider, slide_origin, dy, dy_len, filter) {
+            let clamped = (safe - COLLISION_SKIN).max(0.0);
+            result.y = dy.y.signum() * clamped.min(dy_len);
+        } else {
+            result.y = dy.y;
+        }
+    }
+
+    result
+}
+
+/// Cast the shape along a direction and return `Some(safe_distance)` if hit,
+/// or `None` if the path is clear.
+fn try_cast(
+    spatial_query: &SpatialQuery,
+    collider: &Collider,
+    origin: Vec3,
+    delta: Vec3,
+    max_dist: f32,
+    filter: &SpatialQueryFilter,
+) -> Option<f32> {
+    let dir = Dir3::new(delta).ok()?;
+    let config = ShapeCastConfig::from_max_distance(max_dist);
+    spatial_query
+        .cast_shape(collider, origin, Quat::IDENTITY, dir, &config, filter)
+        .map(|hit| hit.distance)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Player could walk through all static objects (trees, rocks, terrain) because movement used direct `transform.translation +=` on a kinematic body with no collision response
- Now sweeps the player's collider along the movement vector using Avian3d's `SpatialQuery::cast_shape()` before applying translation
- When blocked, falls back to axis-by-axis sliding (X → Z → Y) so the player slides along walls instead of getting stuck
- Vertical collision detection also zeroes downward velocity on impact

## Test plan
- [ ] Walk into trees, rocks, and terrain edges — player should stop and slide along surfaces
- [ ] Jump and land on elevated terrain — no clipping through
- [ ] Virtual joystick movement respects collisions equally
- [ ] No regression in ground detection or fall damage