### PR TITLE
fix(ci): grant write permissions for tauri WASM deploy job

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -160,7 +160,8 @@ jobs:
         needs: ['generate_tauri_matrix']
         if: ${{ needs.generate_tauri_matrix.outputs.matrix != 'null' }}
         permissions:
-            contents: read
+            contents: write
+            pull-requests: write
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.generate_tauri_matrix.outputs.matrix) }}


### PR DESCRIPTION
## Summary
- The `build_tauri` caller in `ci-main.yml` only had `contents: read`, but the nested `deploy-wasm` job in `utils-tauri-build.yml` needs `contents: write` and `pull-requests: write` to push WASM asset branches and create PRs
- Added the required permissions to the caller job

## Test plan
- [ ] Verify `ci-main.yml` passes GitHub workflow validation
- [ ] Confirm tauri WASM deploy job can create branches and PRs on next isometric change