### PR TITLE
feat(osrs): add 50 item overrides - god vestments, wizard robes, trimmed armour

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -801,6 +801,91 @@ Focus on items with clear processing chains and market flip potential.
 | 12379 | Rune cane       | Hard clue, cosmetic weapon |
 | 12377 | Adamant cane    | Hard clue, cosmetic weapon |
 
+### God Vestments — Saradomin/Guthix/Zamorak Completion (Implemented - Mar 2026)
+
+| ID    | Item                | Override Focus               |
+| ----- | ------------------- | ---------------------------- |
+| 10452 | Saradomin mitre     | Medium clue, +5 Prayer, head |
+| 10456 | Zamorak mitre       | Medium clue, +5 Prayer, head |
+| 10458 | Saradomin robe top  | Easy clue, +6 Prayer, body   |
+| 10462 | Guthix robe top     | Easy clue, +6 Prayer, body   |
+| 10464 | Saradomin robe legs | Easy clue, +5 Prayer, legs   |
+| 10466 | Guthix robe legs    | Easy clue, +5 Prayer, legs   |
+| 10442 | Guthix crozier      | Hard clue, +6 Prayer, weapon |
+| 10444 | Zamorak crozier     | Hard clue, +6 Prayer, weapon |
+| 10446 | Saradomin cloak     | Medium clue, +3 Prayer, cape |
+| 10448 | Guthix cloak        | Medium clue, +3 Prayer, cape |
+| 10450 | Zamorak cloak       | Medium clue, +3 Prayer, cape |
+| 10472 | Guthix stole        | Hard clue, +10 Prayer, neck  |
+
+### God Vestments — Ancient (Implemented - Mar 2026)
+
+| ID    | Item              | Override Focus               |
+| ----- | ----------------- | ---------------------------- |
+| 12193 | Ancient robe top  | Easy clue, +6 Prayer, body   |
+| 12195 | Ancient robe legs | Easy clue, +5 Prayer, legs   |
+| 12197 | Ancient cloak     | Medium clue, +3 Prayer, cape |
+| 12199 | Ancient crozier   | Hard clue, +6 Prayer, weapon |
+| 12201 | Ancient stole     | Hard clue, +10 Prayer, neck  |
+| 12203 | Ancient mitre     | Medium clue, +5 Prayer, head |
+
+### God Vestments — Armadyl (Implemented - Mar 2026)
+
+| ID    | Item              | Override Focus               |
+| ----- | ----------------- | ---------------------------- |
+| 12253 | Armadyl robe top  | Easy clue, +6 Prayer, body   |
+| 12255 | Armadyl robe legs | Easy clue, +5 Prayer, legs   |
+| 12257 | Armadyl stole     | Hard clue, +10 Prayer, neck  |
+| 12259 | Armadyl mitre     | Medium clue, +5 Prayer, head |
+| 12261 | Armadyl cloak     | Medium clue, +3 Prayer, cape |
+| 12263 | Armadyl crozier   | Hard clue, +6 Prayer, weapon |
+
+### God Vestments — Bandos (Implemented - Mar 2026)
+
+| ID    | Item             | Override Focus               |
+| ----- | ---------------- | ---------------------------- |
+| 12265 | Bandos robe top  | Easy clue, +6 Prayer, body   |
+| 12267 | Bandos robe legs | Easy clue, +5 Prayer, legs   |
+| 12269 | Bandos stole     | Hard clue, +10 Prayer, neck  |
+| 12271 | Bandos mitre     | Medium clue, +5 Prayer, head |
+| 12273 | Bandos cloak     | Medium clue, +3 Prayer, cape |
+| 12275 | Bandos crozier   | Hard clue, +6 Prayer, weapon |
+
+### Trimmed/Gold Wizard Robes (Implemented - Mar 2026)
+
+| ID    | Item                  | Override Focus           |
+| ----- | --------------------- | ------------------------ |
+| 7390  | Blue wizard robe (g)  | Easy clue, +3 Magic body |
+| 7392  | Blue wizard robe (t)  | Easy clue, +3 Magic body |
+| 7394  | Blue wizard hat (g)   | Easy clue, +2 Magic head |
+| 7396  | Blue wizard hat (t)   | Easy clue, +2 Magic head |
+| 12449 | Black wizard robe (g) | Easy clue, +3 Magic body |
+| 12451 | Black wizard robe (t) | Easy clue, +3 Magic body |
+| 12453 | Black wizard hat (g)  | Easy clue, +2 Magic head |
+| 12455 | Black wizard hat (t)  | Easy clue, +2 Magic head |
+
+### Black Trimmed Armour (Implemented - Mar 2026)
+
+| ID   | Item                 | Override Focus           |
+| ---- | -------------------- | ------------------------ |
+| 2583 | Black platebody (t)  | Easy clue, 10 Def body   |
+| 2585 | Black platelegs (t)  | Easy clue, 10 Def legs   |
+| 2587 | Black full helm (t)  | Easy clue, 10 Def head   |
+| 2589 | Black kiteshield (t) | Easy clue, 10 Def shield |
+| 2591 | Black platebody (g)  | Easy clue, 10 Def body   |
+| 2593 | Black platelegs (g)  | Easy clue, 10 Def legs   |
+
+### Adamant Trimmed Armour (Implemented - Mar 2026)
+
+| ID   | Item                   | Override Focus             |
+| ---- | ---------------------- | -------------------------- |
+| 2599 | Adamant platebody (t)  | Medium clue, 30 Def body   |
+| 2601 | Adamant platelegs (t)  | Medium clue, 30 Def legs   |
+| 2603 | Adamant kiteshield (t) | Medium clue, 30 Def shield |
+| 2605 | Adamant full helm (t)  | Medium clue, 30 Def head   |
+| 2607 | Adamant platebody (g)  | Medium clue, 30 Def body   |
+| 2609 | Adamant platelegs (g)  | Medium clue, 30 Def legs   |
+
 ---
 
 ## Future Override Priorities
@@ -1389,17 +1474,18 @@ const description = generateMetaDescription(item);
 
 Record batch completions here:
 
-| Date         | Items Added                                              | Total Overrides |
-| ------------ | -------------------------------------------------------- | --------------- |
-| Jan 2026     | Initial ~100 items                                       | ~100            |
-| Jan 7, 2026  | +35 items (potions, weapons, raid gear)                  | ~135            |
-| Jan 21, 2026 | +42 items (barrows, hilts, potions, utility)             | ~881            |
-| Mar 11, 2026 | +20 items (jewelry chains, misc weapons)                 | ~901            |
-| Mar 12, 2026 | +20 items (dragon bolts e, mystic, trimmed)              | ~921            |
-| Mar 12, 2026 | +20 items (god d'hide sets, rune weapons)                | ~941            |
-| Mar 12, 2026 | +20 items (god chaps/coifs/bracers, misc)                | ~961            |
-| Mar 13, 2026 | +20 items (gilded/trimmed d'hide, misc)                  | ~981            |
-| Mar 13, 2026 | +50 items (elegant sets, HAM, robes, vestments, amulets) | ~1031           |
+| Date         | Items Added                                                    | Total Overrides |
+| ------------ | -------------------------------------------------------------- | --------------- |
+| Jan 2026     | Initial ~100 items                                             | ~100            |
+| Jan 7, 2026  | +35 items (potions, weapons, raid gear)                        | ~135            |
+| Jan 21, 2026 | +42 items (barrows, hilts, potions, utility)                   | ~881            |
+| Mar 11, 2026 | +20 items (jewelry chains, misc weapons)                       | ~901            |
+| Mar 12, 2026 | +20 items (dragon bolts e, mystic, trimmed)                    | ~921            |
+| Mar 12, 2026 | +20 items (god d'hide sets, rune weapons)                      | ~941            |
+| Mar 12, 2026 | +20 items (god chaps/coifs/bracers, misc)                      | ~961            |
+| Mar 13, 2026 | +20 items (gilded/trimmed d'hide, misc)                        | ~981            |
+| Mar 13, 2026 | +50 items (elegant sets, HAM, robes, vestments, amulets)       | ~1031           |
+| Mar 13, 2026 | +50 items (god vestments, wizard robes, black/adamant trimmed) | ~1081           |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10442.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10442.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "weapon"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 10472
+    item_name: "Guthix stole"
+    slug: "guthix-stole"
+    relationship: "set-piece"
+    description: "Guthix vestment neck piece"
+---
+
+## Examine
+> *"A Guthix crozier."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Guthix crozier is a weapon slot staff from the Guthix vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as a Guthixian item in the God Wars Dungeon. Primarily used for prayer bonus and fashionscape.
+
+## Related Items
+- [Guthix stole](/osrs/guthix-stole/) - Vestment neck (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10444.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10444.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "weapon"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 10474
+    item_name: "Zamorak stole"
+    slug: "zamorak-stole"
+    relationship: "set-piece"
+    description: "Zamorak vestment neck piece"
+---
+
+## Examine
+> *"A Zamorak crozier."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Zamorak crozier is a weapon slot staff from the Zamorak vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as a Zamorakian item in the God Wars Dungeon. Primarily used for prayer bonus and fashionscape.
+
+## Related Items
+- [Zamorak stole](/osrs/zamorak-stole/) - Vestment neck (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10446.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10446.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "cape"
+  requirements:
+    prayer: 40
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 10458
+    item_name: "Saradomin robe top"
+    slug: "saradomin-robe-top"
+    relationship: "set-piece"
+    description: "Saradomin vestment body"
+---
+
+## Examine
+> *"A Saradomin cloak."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Saradomin cloak is the cape piece of the Saradomin vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Saradominist item in the God Wars Dungeon.
+
+## Related Items
+- [Saradomin robe top](/osrs/saradomin-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10448.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10448.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "cape"
+  requirements:
+    prayer: 40
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 10462
+    item_name: "Guthix robe top"
+    slug: "guthix-robe-top"
+    relationship: "set-piece"
+    description: "Guthix vestment body"
+---
+
+## Examine
+> *"A Guthix cloak."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Guthix cloak is the cape piece of the Guthix vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Guthixian item in the God Wars Dungeon.
+
+## Related Items
+- [Guthix robe top](/osrs/guthix-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10450.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10450.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "cape"
+  requirements:
+    prayer: 40
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 10460
+    item_name: "Zamorak robe top"
+    slug: "zamorak-robe-top"
+    relationship: "set-piece"
+    description: "Zamorak vestment body"
+---
+
+## Examine
+> *"A Zamorak cloak."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Zamorak cloak is the cape piece of the Zamorak vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Zamorakian item in the God Wars Dungeon.
+
+## Related Items
+- [Zamorak robe top](/osrs/zamorak-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10452.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10452.mdx
@@ -1,0 +1,33 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    prayer: 40
+    magic: 40
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 10458
+    item_name: "Saradomin robe top"
+    slug: "saradomin-robe-top"
+    relationship: "set-piece"
+    description: "Saradomin vestment body"
+  - item_id: 10464
+    item_name: "Saradomin robe legs"
+    slug: "saradomin-robe-legs"
+    relationship: "set-piece"
+    description: "Saradomin vestment legs"
+---
+
+## Examine
+> *"A Saradomin mitre."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Saradomin mitre is a head slot item from the Saradomin vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Offers the second-highest prayer bonus for head slot items while matching mystic hat magic bonuses. Counts as a Saradominist item in the God Wars Dungeon.
+
+## Related Items
+- [Saradomin robe top](/osrs/saradomin-robe-top/) - Vestment body (+6 Prayer)
+- [Saradomin robe legs](/osrs/saradomin-robe-legs/) - Vestment legs (+5 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10456.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10456.mdx
@@ -1,0 +1,33 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    prayer: 40
+    magic: 40
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 10460
+    item_name: "Zamorak robe top"
+    slug: "zamorak-robe-top"
+    relationship: "set-piece"
+    description: "Zamorak vestment body"
+  - item_id: 10468
+    item_name: "Zamorak robe legs"
+    slug: "zamorak-robe-legs"
+    relationship: "set-piece"
+    description: "Zamorak vestment legs"
+---
+
+## Examine
+> *"A Zamorak mitre."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Zamorak mitre is a head slot item from the Zamorak vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Offers the second-highest prayer bonus for head slot items while matching mystic hat magic bonuses. Counts as a Zamorakian item in the God Wars Dungeon.
+
+## Related Items
+- [Zamorak robe top](/osrs/zamorak-robe-top/) - Vestment body (+6 Prayer)
+- [Zamorak robe legs](/osrs/zamorak-robe-legs/) - Vestment legs (+5 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10458.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10458.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 10464
+    item_name: "Saradomin robe legs"
+    slug: "saradomin-robe-legs"
+    relationship: "set-piece"
+    description: "Saradomin vestment legs"
+  - item_id: 10452
+    item_name: "Saradomin mitre"
+    slug: "saradomin-mitre"
+    relationship: "set-piece"
+    description: "Saradomin vestment head"
+---
+
+## Examine
+> *"Saradomin Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Saradomin robe top is the body piece of the Saradomin vestment set. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Counts as a Saradominist item in the God Wars Dungeon, providing protection from Saradomin followers.
+
+## Related Items
+- [Saradomin robe legs](/osrs/saradomin-robe-legs/) - Vestment legs (+5 Prayer)
+- [Saradomin mitre](/osrs/saradomin-mitre/) - Vestment head (+5 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10462.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10462.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 10466
+    item_name: "Guthix robe legs"
+    slug: "guthix-robe-legs"
+    relationship: "set-piece"
+    description: "Guthix vestment legs"
+  - item_id: 10454
+    item_name: "Guthix mitre"
+    slug: "guthix-mitre"
+    relationship: "set-piece"
+    description: "Guthix vestment head"
+---
+
+## Examine
+> *"Guthix Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Guthix robe top is the body piece of the Guthix vestment set. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Counts as a Guthixian item in the God Wars Dungeon, providing protection from Guthix followers.
+
+## Related Items
+- [Guthix robe legs](/osrs/guthix-robe-legs/) - Vestment legs (+5 Prayer)
+- [Guthix mitre](/osrs/guthix-mitre/) - Vestment head (+5 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10464.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10464.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 10458
+    item_name: "Saradomin robe top"
+    slug: "saradomin-robe-top"
+    relationship: "set-piece"
+    description: "Saradomin vestment body"
+---
+
+## Examine
+> *"Leggings from the Saradomin Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Saradomin robe legs are the legs piece of the Saradomin vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as a Saradominist item in the God Wars Dungeon.
+
+## Related Items
+- [Saradomin robe top](/osrs/saradomin-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10466.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10466.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 10462
+    item_name: "Guthix robe top"
+    slug: "guthix-robe-top"
+    relationship: "set-piece"
+    description: "Guthix vestment body"
+---
+
+## Examine
+> *"Leggings from the Guthix Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Guthix robe legs are the legs piece of the Guthix vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as a Guthixian item in the God Wars Dungeon.
+
+## Related Items
+- [Guthix robe top](/osrs/guthix-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10472.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10472.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "neck"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 10
+related_items:
+  - item_id: 10470
+    item_name: "Saradomin stole"
+    slug: "saradomin-stole"
+    relationship: "variant"
+    description: "Saradomin equivalent stole"
+  - item_id: 10474
+    item_name: "Zamorak stole"
+    slug: "zamorak-stole"
+    relationship: "variant"
+    description: "Zamorak equivalent stole"
+---
+
+## Examine
+> *"A Guthix stole."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Guthix stole is a neck slot item from the Guthix vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. One of the highest prayer bonus items available in the neck slot. Counts as a Guthixian item in the God Wars Dungeon.
+
+## Related Items
+- [Saradomin stole](/osrs/saradomin-stole/) - Saradomin equivalent (+10 Prayer)
+- [Zamorak stole](/osrs/zamorak-stole/) - Zamorak equivalent (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12193.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12193.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 12195
+    item_name: "Ancient robe legs"
+    slug: "ancient-robe-legs"
+    relationship: "set-piece"
+    description: "Ancient vestment legs"
+  - item_id: 12203
+    item_name: "Ancient mitre"
+    slug: "ancient-mitre"
+    relationship: "set-piece"
+    description: "Ancient vestment head"
+---
+
+## Examine
+> *"Ancient Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Ancient robe top is the body piece of the Ancient vestment set. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Counts as a Zarosian item in the God Wars Dungeon.
+
+## Related Items
+- [Ancient robe legs](/osrs/ancient-robe-legs/) - Vestment legs (+5 Prayer)
+- [Ancient mitre](/osrs/ancient-mitre/) - Vestment head (+5 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12195.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12195.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 12193
+    item_name: "Ancient robe top"
+    slug: "ancient-robe-top"
+    relationship: "set-piece"
+    description: "Ancient vestment body"
+---
+
+## Examine
+> *"Leggings from the Ancient Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Ancient robe legs are the legs piece of the Ancient vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as a Zarosian item in the God Wars Dungeon.
+
+## Related Items
+- [Ancient robe top](/osrs/ancient-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12197.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12197.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "cape"
+  requirements:
+    prayer: 40
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 12193
+    item_name: "Ancient robe top"
+    slug: "ancient-robe-top"
+    relationship: "set-piece"
+    description: "Ancient vestment body"
+---
+
+## Examine
+> *"An Ancient cloak."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Ancient cloak is the cape piece of the Ancient vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Zarosian item in the God Wars Dungeon.
+
+## Related Items
+- [Ancient robe top](/osrs/ancient-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12199.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12199.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "weapon"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 12201
+    item_name: "Ancient stole"
+    slug: "ancient-stole"
+    relationship: "set-piece"
+    description: "Ancient vestment neck piece"
+---
+
+## Examine
+> *"An Ancient crozier."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Ancient crozier is a weapon slot staff from the Ancient vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as a Zarosian item in the God Wars Dungeon. Cannot autocast Ancient Magicks despite the name.
+
+## Related Items
+- [Ancient stole](/osrs/ancient-stole/) - Vestment neck (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12201.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12201.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "neck"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 10
+related_items:
+  - item_id: 12199
+    item_name: "Ancient crozier"
+    slug: "ancient-crozier"
+    relationship: "set-piece"
+    description: "Ancient vestment weapon"
+---
+
+## Examine
+> *"An Ancient stole."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Ancient stole is a neck slot item from the Ancient vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. One of the highest prayer bonus items available in the neck slot. Counts as a Zarosian item in the God Wars Dungeon.
+
+## Related Items
+- [Ancient crozier](/osrs/ancient-crozier/) - Vestment weapon (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12203.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12203.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    prayer: 40
+    magic: 40
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 12193
+    item_name: "Ancient robe top"
+    slug: "ancient-robe-top"
+    relationship: "set-piece"
+    description: "Ancient vestment body"
+---
+
+## Examine
+> *"An Ancient mitre."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Ancient mitre is a head slot item from the Ancient vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Offers the second-highest prayer bonus for head slot items. Counts as a Zarosian item in the God Wars Dungeon.
+
+## Related Items
+- [Ancient robe top](/osrs/ancient-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12253.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12253.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 12255
+    item_name: "Armadyl robe legs"
+    slug: "armadyl-robe-legs"
+    relationship: "set-piece"
+    description: "Armadyl vestment legs"
+  - item_id: 12259
+    item_name: "Armadyl mitre"
+    slug: "armadyl-mitre"
+    relationship: "set-piece"
+    description: "Armadyl vestment head"
+---
+
+## Examine
+> *"Armadyl Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Armadyl robe top is the body piece of the Armadyl vestment set. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Counts as an Armadylean item in the God Wars Dungeon, providing protection from Armadyl followers.
+
+## Related Items
+- [Armadyl robe legs](/osrs/armadyl-robe-legs/) - Vestment legs (+5 Prayer)
+- [Armadyl mitre](/osrs/armadyl-mitre/) - Vestment head (+5 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12255.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12255.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 12253
+    item_name: "Armadyl robe top"
+    slug: "armadyl-robe-top"
+    relationship: "set-piece"
+    description: "Armadyl vestment body"
+---
+
+## Examine
+> *"Leggings from the Armadyl Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Armadyl robe legs are the legs piece of the Armadyl vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as an Armadylean item in the God Wars Dungeon.
+
+## Related Items
+- [Armadyl robe top](/osrs/armadyl-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12257.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12257.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "neck"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 10
+related_items:
+  - item_id: 12263
+    item_name: "Armadyl crozier"
+    slug: "armadyl-crozier"
+    relationship: "set-piece"
+    description: "Armadyl vestment weapon"
+---
+
+## Examine
+> *"An Armadyl stole."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Armadyl stole is a neck slot item from the Armadyl vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. One of the highest prayer bonus items available in the neck slot. Counts as an Armadylean item in the God Wars Dungeon.
+
+## Related Items
+- [Armadyl crozier](/osrs/armadyl-crozier/) - Vestment weapon (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12259.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12259.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    prayer: 40
+    magic: 40
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 12253
+    item_name: "Armadyl robe top"
+    slug: "armadyl-robe-top"
+    relationship: "set-piece"
+    description: "Armadyl vestment body"
+---
+
+## Examine
+> *"An Armadyl mitre."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Armadyl mitre is a head slot item from the Armadyl vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Counts as an Armadylean item in the God Wars Dungeon.
+
+## Related Items
+- [Armadyl robe top](/osrs/armadyl-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12261.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12261.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "cape"
+  requirements:
+    prayer: 40
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 12253
+    item_name: "Armadyl robe top"
+    slug: "armadyl-robe-top"
+    relationship: "set-piece"
+    description: "Armadyl vestment body"
+---
+
+## Examine
+> *"An Armadyl cloak."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Armadyl cloak is the cape piece of the Armadyl vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as an Armadylean item in the God Wars Dungeon.
+
+## Related Items
+- [Armadyl robe top](/osrs/armadyl-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12263.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12263.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "weapon"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 12257
+    item_name: "Armadyl stole"
+    slug: "armadyl-stole"
+    relationship: "set-piece"
+    description: "Armadyl vestment neck piece"
+---
+
+## Examine
+> *"An Armadyl crozier."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Armadyl crozier is a weapon slot staff from the Armadyl vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as an Armadylean item in the God Wars Dungeon.
+
+## Related Items
+- [Armadyl stole](/osrs/armadyl-stole/) - Vestment neck (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12265.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12265.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 12267
+    item_name: "Bandos robe legs"
+    slug: "bandos-robe-legs"
+    relationship: "set-piece"
+    description: "Bandos vestment legs"
+  - item_id: 12271
+    item_name: "Bandos mitre"
+    slug: "bandos-mitre"
+    relationship: "set-piece"
+    description: "Bandos vestment head"
+---
+
+## Examine
+> *"Bandos Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Bandos robe top is the body piece of the Bandos vestment set. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Counts as a Bandosian item in the God Wars Dungeon.
+
+## Related Items
+- [Bandos robe legs](/osrs/bandos-robe-legs/) - Vestment legs (+5 Prayer)
+- [Bandos mitre](/osrs/bandos-mitre/) - Vestment head (+5 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12267.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12267.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    prayer: 20
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 12265
+    item_name: "Bandos robe top"
+    slug: "bandos-robe-top"
+    relationship: "set-piece"
+    description: "Bandos vestment body"
+---
+
+## Examine
+> *"Leggings from the Bandos Vestments."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The Bandos robe legs are the legs piece of the Bandos vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as a Bandosian item in the God Wars Dungeon.
+
+## Related Items
+- [Bandos robe top](/osrs/bandos-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12269.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12269.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "neck"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 10
+related_items:
+  - item_id: 12275
+    item_name: "Bandos crozier"
+    slug: "bandos-crozier"
+    relationship: "set-piece"
+    description: "Bandos vestment weapon"
+---
+
+## Examine
+> *"A Bandos stole."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Bandos stole is a neck slot item from the Bandos vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. One of the highest prayer bonus items available in the neck slot. Counts as a Bandosian item in the God Wars Dungeon.
+
+## Related Items
+- [Bandos crozier](/osrs/bandos-crozier/) - Vestment weapon (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12271.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12271.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    prayer: 40
+    magic: 40
+  other_bonus:
+    prayer: 5
+related_items:
+  - item_id: 12265
+    item_name: "Bandos robe top"
+    slug: "bandos-robe-top"
+    relationship: "set-piece"
+    description: "Bandos vestment body"
+---
+
+## Examine
+> *"A Bandos mitre."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Bandos mitre is a head slot item from the Bandos vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Counts as a Bandosian item in the God Wars Dungeon.
+
+## Related Items
+- [Bandos robe top](/osrs/bandos-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12273.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12273.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "cape"
+  requirements:
+    prayer: 40
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 12265
+    item_name: "Bandos robe top"
+    slug: "bandos-robe-top"
+    relationship: "set-piece"
+    description: "Bandos vestment body"
+---
+
+## Examine
+> *"A Bandos cloak."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The Bandos cloak is the cape piece of the Bandos vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Bandosian item in the God Wars Dungeon. Required for certain master clue steps.
+
+## Related Items
+- [Bandos robe top](/osrs/bandos-robe-top/) - Vestment body (+6 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12275.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12275.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "weapon"
+  requirements:
+    prayer: 60
+  other_bonus:
+    prayer: 6
+related_items:
+  - item_id: 12269
+    item_name: "Bandos stole"
+    slug: "bandos-stole"
+    relationship: "set-piece"
+    description: "Bandos vestment neck piece"
+---
+
+## Examine
+> *"A Bandos crozier."*
+
+## Obtaining
+Obtained from **Hard Clue Scrolls**.
+
+## About
+The Bandos crozier is a weapon slot staff from the Bandos vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as a Bandosian item in the God Wars Dungeon.
+
+## Related Items
+- [Bandos stole](/osrs/bandos-stole/) - Vestment neck (+10 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12449.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12449.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+  attack_bonus:
+    magic: 3
+  defence_bonus:
+    magic: 3
+related_items:
+  - item_id: 12453
+    item_name: "Black wizard hat (g)"
+    slug: "black-wizard-hat-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed wizard hat"
+---
+
+## Examine
+> *"I can do magic better in this."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black wizard robe (g) is a gold-trimmed cosmetic variant of the black wizard robe. It provides +3 magic attack and defence with no requirements. Significantly rarer and more expensive than the blue variant. F2P item.
+
+## Related Items
+- [Black wizard hat (g)](/osrs/black-wizard-hat-g/) - Matching gold-trimmed hat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12451.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12451.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+  attack_bonus:
+    magic: 3
+  defence_bonus:
+    magic: 3
+related_items:
+  - item_id: 12455
+    item_name: "Black wizard hat (t)"
+    slug: "black-wizard-hat-t"
+    relationship: "set-piece"
+    description: "Matching trimmed wizard hat"
+---
+
+## Examine
+> *"I can do magic better in this."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black wizard robe (t) is a trimmed cosmetic variant of the black wizard robe. It provides +3 magic attack and defence with no requirements. F2P item.
+
+## Related Items
+- [Black wizard hat (t)](/osrs/black-wizard-hat-t/) - Matching trimmed hat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12453.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12453.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "head"
+  requirements: {}
+  attack_bonus:
+    magic: 2
+  defence_bonus:
+    magic: 2
+related_items:
+  - item_id: 12449
+    item_name: "Black wizard robe (g)"
+    slug: "black-wizard-robe-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed wizard robe"
+---
+
+## Examine
+> *"A silly pointed hat, with colourful trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black wizard hat (g) is a gold-trimmed cosmetic variant of the wizard hat. It provides +2 magic attack and defence with no requirements. F2P item.
+
+## Related Items
+- [Black wizard robe (g)](/osrs/black-wizard-robe-g/) - Matching gold-trimmed robe

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12455.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12455.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "head"
+  requirements: {}
+  attack_bonus:
+    magic: 2
+  defence_bonus:
+    magic: 2
+related_items:
+  - item_id: 12451
+    item_name: "Black wizard robe (t)"
+    slug: "black-wizard-robe-t"
+    relationship: "set-piece"
+    description: "Matching trimmed wizard robe"
+---
+
+## Examine
+> *"A silly pointed hat, with colourful trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black wizard hat (t) is a trimmed cosmetic variant of the wizard hat. It provides +2 magic attack and defence with no requirements. F2P item.
+
+## Related Items
+- [Black wizard robe (t)](/osrs/black-wizard-robe-t/) - Matching trimmed robe

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2583.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2583.mdx
@@ -1,0 +1,36 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    defence: 10
+  defence_bonus:
+    stab: 41
+    slash: 40
+    crush: 30
+    magic: -6
+    ranged: 40
+related_items:
+  - item_id: 2585
+    item_name: "Black platelegs (t)"
+    slug: "black-platelegs-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platelegs"
+  - item_id: 2591
+    item_name: "Black platebody (g)"
+    slug: "black-platebody-g"
+    relationship: "variant"
+    description: "Gold-trimmed variant"
+---
+
+## Examine
+> *"Black platebody with trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black platebody (t) is a trimmed cosmetic variant of the standard black platebody. Identical stats, requiring 10 Defence. Cannot be made through Smithing — clue scroll exclusive. Popular with low-level fashionscape builds.
+
+## Related Items
+- [Black platelegs (t)](/osrs/black-platelegs-t/) - Matching trimmed platelegs
+- [Black platebody (g)](/osrs/black-platebody-g/) - Gold-trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2585.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2585.mdx
@@ -1,0 +1,30 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    defence: 10
+related_items:
+  - item_id: 2583
+    item_name: "Black platebody (t)"
+    slug: "black-platebody-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platebody"
+  - item_id: 2593
+    item_name: "Black platelegs (g)"
+    slug: "black-platelegs-g"
+    relationship: "variant"
+    description: "Gold-trimmed variant"
+---
+
+## Examine
+> *"Black platelegs with trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black platelegs (t) are a trimmed cosmetic variant of standard black platelegs. Identical stats, requiring 10 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Black platebody (t)](/osrs/black-platebody-t/) - Matching trimmed platebody
+- [Black platelegs (g)](/osrs/black-platelegs-g/) - Gold-trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2587.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2587.mdx
@@ -1,0 +1,24 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    defence: 10
+related_items:
+  - item_id: 2583
+    item_name: "Black platebody (t)"
+    slug: "black-platebody-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platebody"
+---
+
+## Examine
+> *"Black full helm with trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black full helm (t) is a trimmed cosmetic variant of the standard black full helm. Identical stats, requiring 10 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Black platebody (t)](/osrs/black-platebody-t/) - Matching trimmed platebody

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2589.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2589.mdx
@@ -1,0 +1,24 @@
+---
+equipment:
+  slot: "shield"
+  requirements:
+    defence: 10
+related_items:
+  - item_id: 2583
+    item_name: "Black platebody (t)"
+    slug: "black-platebody-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platebody"
+---
+
+## Examine
+> *"Black kiteshield with trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black kiteshield (t) is a trimmed cosmetic variant of the standard black kiteshield. Identical stats, requiring 10 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Black platebody (t)](/osrs/black-platebody-t/) - Matching trimmed platebody

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2591.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2591.mdx
@@ -1,0 +1,36 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    defence: 10
+  defence_bonus:
+    stab: 41
+    slash: 40
+    crush: 30
+    magic: -6
+    ranged: 40
+related_items:
+  - item_id: 2593
+    item_name: "Black platelegs (g)"
+    slug: "black-platelegs-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed platelegs"
+  - item_id: 2583
+    item_name: "Black platebody (t)"
+    slug: "black-platebody-t"
+    relationship: "variant"
+    description: "Trimmed variant"
+---
+
+## Examine
+> *"Black platebody with gold trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black platebody (g) is a gold-trimmed cosmetic variant of the standard black platebody. Identical stats, requiring 10 Defence. Clue scroll exclusive. More prestigious appearance than the trimmed variant.
+
+## Related Items
+- [Black platelegs (g)](/osrs/black-platelegs-g/) - Matching gold-trimmed platelegs
+- [Black platebody (t)](/osrs/black-platebody-t/) - Trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2593.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2593.mdx
@@ -1,0 +1,30 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    defence: 10
+related_items:
+  - item_id: 2591
+    item_name: "Black platebody (g)"
+    slug: "black-platebody-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed platebody"
+  - item_id: 2585
+    item_name: "Black platelegs (t)"
+    slug: "black-platelegs-t"
+    relationship: "variant"
+    description: "Trimmed variant"
+---
+
+## Examine
+> *"Black platelegs with gold trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The black platelegs (g) are a gold-trimmed cosmetic variant of standard black platelegs. Identical stats, requiring 10 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Black platebody (g)](/osrs/black-platebody-g/) - Matching gold-trimmed platebody
+- [Black platelegs (t)](/osrs/black-platelegs-t/) - Trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2599.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2599.mdx
@@ -1,0 +1,36 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    defence: 30
+  defence_bonus:
+    stab: 65
+    slash: 63
+    crush: 55
+    magic: -6
+    ranged: 63
+related_items:
+  - item_id: 2601
+    item_name: "Adamant platelegs (t)"
+    slug: "adamant-platelegs-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platelegs"
+  - item_id: 2607
+    item_name: "Adamant platebody (g)"
+    slug: "adamant-platebody-g"
+    relationship: "variant"
+    description: "Gold-trimmed variant"
+---
+
+## Examine
+> *"Adamant platebody with trim."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The adamant platebody (t) is a trimmed cosmetic variant of the standard adamant platebody. Identical stats, requiring 30 Defence. Cannot be made through Smithing — clue scroll exclusive.
+
+## Related Items
+- [Adamant platelegs (t)](/osrs/adamant-platelegs-t/) - Matching trimmed platelegs
+- [Adamant platebody (g)](/osrs/adamant-platebody-g/) - Gold-trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2601.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2601.mdx
@@ -1,0 +1,30 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    defence: 30
+related_items:
+  - item_id: 2599
+    item_name: "Adamant platebody (t)"
+    slug: "adamant-platebody-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platebody"
+  - item_id: 2609
+    item_name: "Adamant platelegs (g)"
+    slug: "adamant-platelegs-g"
+    relationship: "variant"
+    description: "Gold-trimmed variant"
+---
+
+## Examine
+> *"Adamant platelegs with trim."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The adamant platelegs (t) are a trimmed cosmetic variant of standard adamant platelegs. Identical stats, requiring 30 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Adamant platebody (t)](/osrs/adamant-platebody-t/) - Matching trimmed platebody
+- [Adamant platelegs (g)](/osrs/adamant-platelegs-g/) - Gold-trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2603.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2603.mdx
@@ -1,0 +1,24 @@
+---
+equipment:
+  slot: "shield"
+  requirements:
+    defence: 30
+related_items:
+  - item_id: 2599
+    item_name: "Adamant platebody (t)"
+    slug: "adamant-platebody-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platebody"
+---
+
+## Examine
+> *"Adamant kiteshield with trim."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The adamant kiteshield (t) is a trimmed cosmetic variant of the standard adamant kiteshield. Identical stats, requiring 30 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Adamant platebody (t)](/osrs/adamant-platebody-t/) - Matching trimmed platebody

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2605.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2605.mdx
@@ -1,0 +1,24 @@
+---
+equipment:
+  slot: "head"
+  requirements:
+    defence: 30
+related_items:
+  - item_id: 2599
+    item_name: "Adamant platebody (t)"
+    slug: "adamant-platebody-t"
+    relationship: "set-piece"
+    description: "Matching trimmed platebody"
+---
+
+## Examine
+> *"Adamant full helm with trim."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The adamant full helm (t) is a trimmed cosmetic variant of the standard adamant full helm. Identical stats, requiring 30 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Adamant platebody (t)](/osrs/adamant-platebody-t/) - Matching trimmed platebody

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2607.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2607.mdx
@@ -1,0 +1,36 @@
+---
+equipment:
+  slot: "body"
+  requirements:
+    defence: 30
+  defence_bonus:
+    stab: 65
+    slash: 63
+    crush: 55
+    magic: -6
+    ranged: 63
+related_items:
+  - item_id: 2609
+    item_name: "Adamant platelegs (g)"
+    slug: "adamant-platelegs-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed platelegs"
+  - item_id: 2599
+    item_name: "Adamant platebody (t)"
+    slug: "adamant-platebody-t"
+    relationship: "variant"
+    description: "Trimmed variant"
+---
+
+## Examine
+> *"Adamant platebody with gold trim."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The adamant platebody (g) is a gold-trimmed cosmetic variant of the standard adamant platebody. Identical stats, requiring 30 Defence. Clue scroll exclusive. More prestigious appearance than the trimmed variant.
+
+## Related Items
+- [Adamant platelegs (g)](/osrs/adamant-platelegs-g/) - Matching gold-trimmed platelegs
+- [Adamant platebody (t)](/osrs/adamant-platebody-t/) - Trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_2609.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_2609.mdx
@@ -1,0 +1,30 @@
+---
+equipment:
+  slot: "legs"
+  requirements:
+    defence: 30
+related_items:
+  - item_id: 2607
+    item_name: "Adamant platebody (g)"
+    slug: "adamant-platebody-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed platebody"
+  - item_id: 2601
+    item_name: "Adamant platelegs (t)"
+    slug: "adamant-platelegs-t"
+    relationship: "variant"
+    description: "Trimmed variant"
+---
+
+## Examine
+> *"Adamant platelegs with gold trim."*
+
+## Obtaining
+Obtained from **Medium Clue Scrolls**.
+
+## About
+The adamant platelegs (g) are a gold-trimmed cosmetic variant of standard adamant platelegs. Identical stats, requiring 30 Defence. Clue scroll exclusive.
+
+## Related Items
+- [Adamant platebody (g)](/osrs/adamant-platebody-g/) - Matching gold-trimmed platebody
+- [Adamant platelegs (t)](/osrs/adamant-platelegs-t/) - Trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7390.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7390.mdx
@@ -1,0 +1,33 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+  attack_bonus:
+    magic: 3
+  defence_bonus:
+    magic: 3
+related_items:
+  - item_id: 7394
+    item_name: "Blue wizard hat (g)"
+    slug: "blue-wizard-hat-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed wizard hat"
+  - item_id: 7392
+    item_name: "Blue wizard robe (t)"
+    slug: "blue-wizard-robe-t"
+    relationship: "variant"
+    description: "Trimmed variant"
+---
+
+## Examine
+> *"I can do magic better in this."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The blue wizard robe (g) is a gold-trimmed cosmetic variant of the standard blue wizard robe. It provides identical stats (+3 magic attack and defence) but with decorative gold trim. No requirements to equip, making it popular with pure accounts. F2P item.
+
+## Related Items
+- [Blue wizard hat (g)](/osrs/blue-wizard-hat-g/) - Matching gold-trimmed hat
+- [Blue wizard robe (t)](/osrs/blue-wizard-robe-t/) - Trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7392.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7392.mdx
@@ -1,0 +1,33 @@
+---
+equipment:
+  slot: "body"
+  requirements: {}
+  attack_bonus:
+    magic: 3
+  defence_bonus:
+    magic: 3
+related_items:
+  - item_id: 7396
+    item_name: "Blue wizard hat (t)"
+    slug: "blue-wizard-hat-t"
+    relationship: "set-piece"
+    description: "Matching trimmed wizard hat"
+  - item_id: 7390
+    item_name: "Blue wizard robe (g)"
+    slug: "blue-wizard-robe-g"
+    relationship: "variant"
+    description: "Gold-trimmed variant"
+---
+
+## Examine
+> *"I can do magic better in this."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The blue wizard robe (t) is a trimmed cosmetic variant of the standard blue wizard robe. It provides identical stats (+3 magic attack and defence) but with decorative trim. No requirements to equip. F2P item.
+
+## Related Items
+- [Blue wizard hat (t)](/osrs/blue-wizard-hat-t/) - Matching trimmed hat
+- [Blue wizard robe (g)](/osrs/blue-wizard-robe-g/) - Gold-trimmed variant

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7394.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7394.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "head"
+  requirements: {}
+  attack_bonus:
+    magic: 2
+  defence_bonus:
+    magic: 2
+related_items:
+  - item_id: 7390
+    item_name: "Blue wizard robe (g)"
+    slug: "blue-wizard-robe-g"
+    relationship: "set-piece"
+    description: "Matching gold-trimmed wizard robe"
+---
+
+## Examine
+> *"A silly pointed hat, with colourful trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The blue wizard hat (g) is a gold-trimmed cosmetic variant of the standard wizard hat. It provides +2 magic attack and defence with no requirements. Popular with pure accounts as a wealth indicator. F2P item.
+
+## Related Items
+- [Blue wizard robe (g)](/osrs/blue-wizard-robe-g/) - Matching gold-trimmed robe

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_7396.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_7396.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "head"
+  requirements: {}
+  attack_bonus:
+    magic: 2
+  defence_bonus:
+    magic: 2
+related_items:
+  - item_id: 7392
+    item_name: "Blue wizard robe (t)"
+    slug: "blue-wizard-robe-t"
+    relationship: "set-piece"
+    description: "Matching trimmed wizard robe"
+---
+
+## Examine
+> *"A silly pointed hat, with colourful trim."*
+
+## Obtaining
+Obtained from **Easy Clue Scrolls**.
+
+## About
+The blue wizard hat (t) is a trimmed cosmetic variant of the standard wizard hat. It provides +2 magic attack and defence with no requirements. F2P item.
+
+## Related Items
+- [Blue wizard robe (t)](/osrs/blue-wizard-robe-t/) - Matching trimmed robe


### PR DESCRIPTION
## Summary
- **50 new OSRS item override files** bringing total to ~1,081
- 30 god vestment pieces completing all 6 god sets:
  - Saradomin/Guthix/Zamorak: mitres, cloaks, croziers, stoles, robe tops/legs (12 pieces)
  - Ancient: full 6-piece set (robe top, legs, cloak, crozier, stole, mitre)
  - Armadyl: full 6-piece set
  - Bandos: full 6-piece set
- 8 trimmed/gold wizard robes (blue g/t, black g/t — robes and hats)
- 6 black trimmed armour pieces (platebody/platelegs/helm/shield in t and g)
- 6 adamant trimmed armour pieces (platebody/platelegs/helm/shield in t and g)
- Updated OSRS.md tracking with all new sections and session log

## Test plan
- [ ] Verify override files parse correctly with `pnpm generate:osrs`
- [ ] Spot-check 2-3 items render properly in browser
- [ ] Confirm OSRS.md tracking sections are accurate