### PR TITLE
fix(isometric): move bag button above ACT/JMP buttons

### DIFF
--- a/apps/kbve/isometric/src/components/Inventory.tsx
+++ b/apps/kbve/isometric/src/components/Inventory.tsx
@@ -55,7 +55,7 @@ export function Inventory() {
 	const items = inventory?.items ?? [];
 
 	return (
-		<div className="absolute bottom-4 right-4 md:bottom-6 md:right-6 pointer-events-auto">
+		<div className="absolute bottom-40 right-4 md:bottom-44 md:right-6 pointer-events-auto">
 			{/* Toggle button */}
 			<button
 				onClick={() => setOpen(!open)}


### PR DESCRIPTION
## Summary
- Inventory bag button was positioned at `bottom-4 right-4`, directly overlapping the Bevy-rendered ACT and JMP action buttons
- Moved to `bottom-40 right-4` (160px from bottom) so it sits above the action button stack with proper spacing

## Test plan
- [ ] Bag button visible above ACT/JMP on mobile
- [ ] Bag button clickable without triggering action buttons
- [ ] Inventory grid opens upward from the bag button without clipping