### PR TITLE
feat(osrs): add 50 item overrides - cannon, fletching, potions

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -976,6 +976,91 @@ Focus on items with clear processing chains and market flip potential.
 | 12447 | Black skirt (t)     | Easy clue, wizard skirt  |
 | 10364 | Strength amulet (t) | Medium clue, +10 Str     |
 
+### Dwarf Multicannon Parts (Implemented - Mar 2026)
+
+| ID  | Item           | Notes                         |
+| --- | -------------- | ----------------------------- |
+| 6   | Cannon base    | First cannon component        |
+| 8   | Cannon stand   | Second cannon component       |
+| 10  | Cannon barrels | Third cannon component        |
+| 12  | Cannon furnace | Fourth/final cannon component |
+
+### Quest/Utility Items (Implemented - Mar 2026)
+
+| ID  | Item             | Notes                           |
+| --- | ---------------- | ------------------------------- |
+| 28  | Insect repellent | Merlin's Crystal, Troll Romance |
+| 30  | Bucket of wax    | Made from beehives              |
+| 36  | Candle           | Light source, quest item        |
+
+### Arrowtips (Implemented - Mar 2026)
+
+| ID  | Item              | Notes                   |
+| --- | ----------------- | ----------------------- |
+| 39  | Bronze arrowtips  | 5 Smithing, 1 Fletching |
+| 40  | Iron arrowtips    | 20 Smithing, 15 Fletch  |
+| 41  | Steel arrowtips   | 35 Smithing, 30 Fletch  |
+| 42  | Mithril arrowtips | 55 Smithing, 45 Fletch  |
+| 43  | Adamant arrowtips | 75 Smithing, 60 Fletch  |
+| 44  | Rune arrowtips    | 90 Smithing, 75 Fletch  |
+
+### Bolt Tips (Implemented - Mar 2026)
+
+| ID  | Item            | Notes                    |
+| --- | --------------- | ------------------------ |
+| 45  | Opal bolt tips  | 11 Fletching             |
+| 46  | Pearl bolt tips | 41 Fletching             |
+| 47  | Barb bolttips   | Ranging Guild, 51 Fletch |
+
+### Unstrung Bows (Implemented - Mar 2026)
+
+| ID  | Item                | Notes        |
+| --- | ------------------- | ------------ |
+| 48  | Longbow (u)         | 10 Fletching |
+| 50  | Shortbow (u)        | 5 Fletching  |
+| 54  | Oak shortbow (u)    | 20 Fletching |
+| 56  | Oak longbow (u)     | 25 Fletching |
+| 58  | Willow longbow (u)  | 40 Fletching |
+| 60  | Willow shortbow (u) | 35 Fletching |
+| 62  | Maple longbow (u)   | 55 Fletching |
+| 64  | Maple shortbow (u)  | 50 Fletching |
+| 68  | Yew shortbow (u)    | 65 Fletching |
+| 70  | Magic longbow (u)   | 85 Fletching |
+| 72  | Magic shortbow (u)  | 80 Fletching |
+
+### Potions — Standard Combat (Implemented - Mar 2026)
+
+| ID  | Item               | Notes                |
+| --- | ------------------ | -------------------- |
+| 115 | Strength potion(3) | 12 Herblore, F2P     |
+| 117 | Strength potion(2) | Dose variant         |
+| 119 | Strength potion(1) | Dose variant         |
+| 121 | Attack potion(3)   | 3 Herblore, members  |
+| 123 | Attack potion(2)   | Dose variant         |
+| 125 | Attack potion(1)   | Dose variant         |
+| 127 | Restore potion(3)  | 22 Herblore, members |
+| 129 | Restore potion(2)  | Dose variant         |
+| 131 | Restore potion(1)  | Dose variant         |
+| 133 | Defence potion(3)  | 30 Herblore, members |
+| 135 | Defence potion(2)  | Dose variant         |
+| 137 | Defence potion(1)  | Dose variant         |
+
+### Potions — Super Combat (Implemented - Mar 2026)
+
+| ID  | Item              | Notes        |
+| --- | ----------------- | ------------ |
+| 145 | Super attack(3)   | 45 Herblore  |
+| 147 | Super attack(2)   | Dose variant |
+| 149 | Super attack(1)   | Dose variant |
+| 151 | Fishing potion(3) | 50 Herblore  |
+| 153 | Fishing potion(2) | Dose variant |
+| 155 | Fishing potion(1) | Dose variant |
+| 157 | Super strength(3) | 55 Herblore  |
+| 159 | Super strength(2) | Dose variant |
+| 161 | Super strength(1) | Dose variant |
+| 163 | Super defence(3)  | 66 Herblore  |
+| 165 | Super defence(2)  | Dose variant |
+
 ---
 
 ## Future Override Priorities
@@ -1577,6 +1662,7 @@ Record batch completions here:
 | Mar 13, 2026 | +50 items (elegant sets, HAM, robes, vestments, amulets)         | ~1031           |
 | Mar 13, 2026 | +50 items (god vestments, wizard robes, black/adamant trimmed)   | ~1081           |
 | Mar 13, 2026 | +50 items (rune/steel/black trimmed, monk robes, heraldic, misc) | ~1131           |
+| Mar 13, 2026 | +50 items (cannon parts, fletching supplies, potions)            | ~1181           |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_10.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_10.mdx
@@ -1,0 +1,36 @@
+---
+related_items:
+  - item_id: 6
+    item_name: "Cannon base"
+    slug: "cannon-base"
+    relationship: "set-piece"
+    description: "Multicannon base component"
+  - item_id: 8
+    item_name: "Cannon stand"
+    slug: "cannon-stand"
+    relationship: "set-piece"
+    description: "Multicannon stand component"
+  - item_id: 12
+    item_name: "Cannon furnace"
+    slug: "cannon-furnace"
+    relationship: "set-piece"
+    description: "Multicannon furnace component"
+---
+
+## Examine
+
+> _"The barrels of the multicannon."_
+
+## Obtaining
+
+Purchased from **Nulodion** at the Ice Mountain workshop for 200,625 coins. Free replacement if lost.
+
+## About
+
+The cannon barrels are the third component placed when assembling a dwarf multicannon. Requires completion of the Dwarf Cannon quest to use. Placed on top of the cannon stand. Tradeable on the Grand Exchange.
+
+## Related Items
+
+- [Cannon base](/osrs/cannon-base/) - Multicannon base component
+- [Cannon stand](/osrs/cannon-stand/) - Multicannon stand component
+- [Cannon furnace](/osrs/cannon-furnace/) - Multicannon furnace component

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_115.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_115.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 117
+    item_name: "Strength potion(2)"
+    slug: "strength-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 119
+    item_name: "Strength potion(1)"
+    slug: "strength-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of Strength potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 12) using a tarromin potion (unf) and limpwurt root. Also available from the Apothecary in Varrock (F2P method).
+
+## About
+
+The strength potion boosts Strength by 3 + 10% of current level (rounded down). Available to both F2P and members, though Herblore brewing is members-only. The Apothecary can make a 4-dose version using limpwurt root, red spiders' eggs, and 5 coins.
+
+## Related Items
+
+- [Strength potion(2)](/osrs/strength-potion-2/) - 2-dose version
+- [Strength potion(1)](/osrs/strength-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_117.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_117.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 115
+    item_name: "Strength potion(3)"
+    slug: "strength-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 119
+    item_name: "Strength potion(1)"
+    slug: "strength-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of Strength potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **strength potion(3)**.
+
+## About
+
+A 2-dose strength potion. Boosts Strength by 3 + 10% of current level. Available to F2P and members.
+
+## Related Items
+
+- [Strength potion(3)](/osrs/strength-potion-3/) - 3-dose version
+- [Strength potion(1)](/osrs/strength-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_119.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_119.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 115
+    item_name: "Strength potion(3)"
+    slug: "strength-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 117
+    item_name: "Strength potion(2)"
+    slug: "strength-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of Strength potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **strength potion(2)**.
+
+## About
+
+A 1-dose strength potion. Boosts Strength by 3 + 10% of current level. Available to F2P and members.
+
+## Related Items
+
+- [Strength potion(3)](/osrs/strength-potion-3/) - 3-dose version
+- [Strength potion(2)](/osrs/strength-potion-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_12.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_12.mdx
@@ -1,0 +1,36 @@
+---
+related_items:
+  - item_id: 6
+    item_name: "Cannon base"
+    slug: "cannon-base"
+    relationship: "set-piece"
+    description: "Multicannon base component"
+  - item_id: 8
+    item_name: "Cannon stand"
+    slug: "cannon-stand"
+    relationship: "set-piece"
+    description: "Multicannon stand component"
+  - item_id: 10
+    item_name: "Cannon barrels"
+    slug: "cannon-barrels"
+    relationship: "set-piece"
+    description: "Multicannon barrels component"
+---
+
+## Examine
+
+> _"This powers the multicannon."_
+
+## Obtaining
+
+Purchased from **Nulodion** at the Ice Mountain workshop for 200,625 coins. Free replacement if lost.
+
+## About
+
+The cannon furnace is the fourth and final component placed when assembling a dwarf multicannon. Requires completion of the Dwarf Cannon quest to use. Once placed, the cannon can be loaded with cannonballs and fired. Tradeable on the Grand Exchange.
+
+## Related Items
+
+- [Cannon base](/osrs/cannon-base/) - Multicannon base component
+- [Cannon stand](/osrs/cannon-stand/) - Multicannon stand component
+- [Cannon barrels](/osrs/cannon-barrels/) - Multicannon barrels component

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_121.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_121.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 123
+    item_name: "Attack potion(2)"
+    slug: "attack-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 125
+    item_name: "Attack potion(1)"
+    slug: "attack-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of Attack potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 3) using a guam potion (unf) and eye of newt. Members only.
+
+## About
+
+The attack potion boosts Attack by 3 + 10% of current level (rounded down). The lowest-level potion brewable with Herblore.
+
+## Related Items
+
+- [Attack potion(2)](/osrs/attack-potion-2/) - 2-dose version
+- [Attack potion(1)](/osrs/attack-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_123.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_123.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 121
+    item_name: "Attack potion(3)"
+    slug: "attack-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 125
+    item_name: "Attack potion(1)"
+    slug: "attack-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of Attack potion."_
+
+## Obtaining
+
+Created by drinking one dose from an **attack potion(3)**. Members only.
+
+## About
+
+A 2-dose attack potion. Boosts Attack by 3 + 10% of current level.
+
+## Related Items
+
+- [Attack potion(3)](/osrs/attack-potion-3/) - 3-dose version
+- [Attack potion(1)](/osrs/attack-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_125.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_125.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 121
+    item_name: "Attack potion(3)"
+    slug: "attack-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 123
+    item_name: "Attack potion(2)"
+    slug: "attack-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of Attack potion."_
+
+## Obtaining
+
+Created by drinking one dose from an **attack potion(2)**. Members only.
+
+## About
+
+A 1-dose attack potion. Boosts Attack by 3 + 10% of current level.
+
+## Related Items
+
+- [Attack potion(3)](/osrs/attack-potion-3/) - 3-dose version
+- [Attack potion(2)](/osrs/attack-potion-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_127.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_127.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 129
+    item_name: "Restore potion(2)"
+    slug: "restore-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 131
+    item_name: "Restore potion(1)"
+    slug: "restore-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of restore potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 22) using a harralander potion (unf) and red spiders' eggs. Members only.
+
+## About
+
+The restore potion restores temporarily reduced Attack, Strength, Defence, Ranged, and Magic by 10 + 30% of the stat's max level. Does not restore Prayer or boost above base level.
+
+## Related Items
+
+- [Restore potion(2)](/osrs/restore-potion-2/) - 2-dose version
+- [Restore potion(1)](/osrs/restore-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_129.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_129.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 127
+    item_name: "Restore potion(3)"
+    slug: "restore-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 131
+    item_name: "Restore potion(1)"
+    slug: "restore-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of restore potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **restore potion(3)**. Members only.
+
+## About
+
+A 2-dose restore potion. Restores reduced combat stats by 10 + 30% of max level.
+
+## Related Items
+
+- [Restore potion(3)](/osrs/restore-potion-3/) - 3-dose version
+- [Restore potion(1)](/osrs/restore-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_131.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_131.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 127
+    item_name: "Restore potion(3)"
+    slug: "restore-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 129
+    item_name: "Restore potion(2)"
+    slug: "restore-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of restore potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **restore potion(2)**. Members only.
+
+## About
+
+A 1-dose restore potion. Restores reduced combat stats by 10 + 30% of max level.
+
+## Related Items
+
+- [Restore potion(3)](/osrs/restore-potion-3/) - 3-dose version
+- [Restore potion(2)](/osrs/restore-potion-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_133.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_133.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 135
+    item_name: "Defence potion(2)"
+    slug: "defence-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 137
+    item_name: "Defence potion(1)"
+    slug: "defence-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of Defence potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 30) using a ranarr potion (unf) and white berries. Members only.
+
+## About
+
+The defence potion boosts Defence by 3 + 10% of current level (rounded down). A mid-level Herblore potion useful for early combat training.
+
+## Related Items
+
+- [Defence potion(2)](/osrs/defence-potion-2/) - 2-dose version
+- [Defence potion(1)](/osrs/defence-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_135.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_135.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 133
+    item_name: "Defence potion(3)"
+    slug: "defence-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 137
+    item_name: "Defence potion(1)"
+    slug: "defence-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of Defence potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **defence potion(3)**. Members only.
+
+## About
+
+A 2-dose defence potion. Boosts Defence by 3 + 10% of current level.
+
+## Related Items
+
+- [Defence potion(3)](/osrs/defence-potion-3/) - 3-dose version
+- [Defence potion(1)](/osrs/defence-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_137.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_137.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 133
+    item_name: "Defence potion(3)"
+    slug: "defence-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 135
+    item_name: "Defence potion(2)"
+    slug: "defence-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of Defence potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **defence potion(2)**. Members only.
+
+## About
+
+A 1-dose defence potion. Boosts Defence by 3 + 10% of current level.
+
+## Related Items
+
+- [Defence potion(3)](/osrs/defence-potion-3/) - 3-dose version
+- [Defence potion(2)](/osrs/defence-potion-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_145.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_145.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 147
+    item_name: "Super attack(2)"
+    slug: "super-attack-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 149
+    item_name: "Super attack(1)"
+    slug: "super-attack-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of super Attack potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 45) using an irit potion (unf) and eye of newt. Members only.
+
+## About
+
+The super attack potion boosts Attack by 5 + 15% of current level (rounded down). A significant upgrade over the regular attack potion, commonly used in combat.
+
+## Related Items
+
+- [Super attack(2)](/osrs/super-attack-2/) - 2-dose version
+- [Super attack(1)](/osrs/super-attack-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_147.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_147.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 145
+    item_name: "Super attack(3)"
+    slug: "super-attack-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 149
+    item_name: "Super attack(1)"
+    slug: "super-attack-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of super Attack potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **super attack(3)**. Members only.
+
+## About
+
+A 2-dose super attack potion. Boosts Attack by 5 + 15% of current level.
+
+## Related Items
+
+- [Super attack(3)](/osrs/super-attack-3/) - 3-dose version
+- [Super attack(1)](/osrs/super-attack-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_149.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_149.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 145
+    item_name: "Super attack(3)"
+    slug: "super-attack-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 147
+    item_name: "Super attack(2)"
+    slug: "super-attack-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of super Attack potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **super attack(2)**. Members only.
+
+## About
+
+A 1-dose super attack potion. Boosts Attack by 5 + 15% of current level.
+
+## Related Items
+
+- [Super attack(3)](/osrs/super-attack-3/) - 3-dose version
+- [Super attack(2)](/osrs/super-attack-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_151.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_151.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 153
+    item_name: "Fishing potion(2)"
+    slug: "fishing-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 155
+    item_name: "Fishing potion(1)"
+    slug: "fishing-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of Fishing potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 50) using an avantoe potion (unf) and snape grass. Members only.
+
+## About
+
+The fishing potion provides a temporary +3 Fishing boost. Useful for catching fish slightly above your current level.
+
+## Related Items
+
+- [Fishing potion(2)](/osrs/fishing-potion-2/) - 2-dose version
+- [Fishing potion(1)](/osrs/fishing-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_153.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_153.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 151
+    item_name: "Fishing potion(3)"
+    slug: "fishing-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 155
+    item_name: "Fishing potion(1)"
+    slug: "fishing-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of Fishing potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **fishing potion(3)**. Members only.
+
+## About
+
+A 2-dose fishing potion. Provides a temporary +3 Fishing boost.
+
+## Related Items
+
+- [Fishing potion(3)](/osrs/fishing-potion-3/) - 3-dose version
+- [Fishing potion(1)](/osrs/fishing-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_155.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_155.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 151
+    item_name: "Fishing potion(3)"
+    slug: "fishing-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 153
+    item_name: "Fishing potion(2)"
+    slug: "fishing-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of Fishing potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **fishing potion(2)**. Members only.
+
+## About
+
+A 1-dose fishing potion. Provides a temporary +3 Fishing boost.
+
+## Related Items
+
+- [Fishing potion(3)](/osrs/fishing-potion-3/) - 3-dose version
+- [Fishing potion(2)](/osrs/fishing-potion-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_157.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_157.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 159
+    item_name: "Super strength(2)"
+    slug: "super-strength-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 161
+    item_name: "Super strength(1)"
+    slug: "super-strength-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of super Strength potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 55) using a kwuarm potion (unf) and limpwurt root. Members only.
+
+## About
+
+The super strength potion boosts Strength by 5 + 15% of current level (rounded down). A key combat potion, commonly paired with super attack for PvM.
+
+## Related Items
+
+- [Super strength(2)](/osrs/super-strength-2/) - 2-dose version
+- [Super strength(1)](/osrs/super-strength-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_159.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_159.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 157
+    item_name: "Super strength(3)"
+    slug: "super-strength-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 161
+    item_name: "Super strength(1)"
+    slug: "super-strength-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of super Strength potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **super strength(3)**. Members only.
+
+## About
+
+A 2-dose super strength potion. Boosts Strength by 5 + 15% of current level.
+
+## Related Items
+
+- [Super strength(3)](/osrs/super-strength-3/) - 3-dose version
+- [Super strength(1)](/osrs/super-strength-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_161.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_161.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 157
+    item_name: "Super strength(3)"
+    slug: "super-strength-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 159
+    item_name: "Super strength(2)"
+    slug: "super-strength-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of super Strength potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **super strength(2)**. Members only.
+
+## About
+
+A 1-dose super strength potion. Boosts Strength by 5 + 15% of current level.
+
+## Related Items
+
+- [Super strength(3)](/osrs/super-strength-3/) - 3-dose version
+- [Super strength(2)](/osrs/super-strength-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_163.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_163.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 165
+    item_name: "Super defence(2)"
+    slug: "super-defence-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 167
+    item_name: "Super defence(1)"
+    slug: "super-defence-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of super Defence potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 66) using a cadantine potion (unf) and white berries. Members only.
+
+## About
+
+The super defence potion boosts Defence by 5 + 15% of current level (rounded down). Part of the "super" combat potion trio alongside super attack and super strength. Can be combined into a super combat potion at 90 Herblore.
+
+## Related Items
+
+- [Super defence(2)](/osrs/super-defence-2/) - 2-dose version
+- [Super defence(1)](/osrs/super-defence-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_165.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_165.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 163
+    item_name: "Super defence(3)"
+    slug: "super-defence-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 167
+    item_name: "Super defence(1)"
+    slug: "super-defence-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of super Defence potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **super defence(3)**. Members only.
+
+## About
+
+A 2-dose super defence potion. Boosts Defence by 5 + 15% of current level.
+
+## Related Items
+
+- [Super defence(3)](/osrs/super-defence-3/) - 3-dose version
+- [Super defence(1)](/osrs/super-defence-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_28.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_28.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 30
+    item_name: "Bucket of wax"
+    slug: "bucket-of-wax"
+    relationship: "used-with"
+    description: "Made by using repellent on beehive"
+---
+
+## Examine
+
+> _"Drives away all known 6 legged creatures."_
+
+## Obtaining
+
+Found in a house north of **Catherby** bank. Also purchasable on the Grand Exchange.
+
+## About
+
+Insect repellent is a members-only quest item used in Merlin's Crystal and Troll Romance. Applied to beehives near Catherby to safely collect a bucket of wax. Also reduces combat stats of mosquitoes during Tai Bwo Wannai Cleanup.
+
+## Related Items
+
+- [Bucket of wax](/osrs/bucket-of-wax/) - Made by using repellent on beehive

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_30.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_30.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 28
+    item_name: "Insect repellent"
+    slug: "insect-repellent"
+    relationship: "used-with"
+    description: "Used on beehive to safely collect wax"
+---
+
+## Examine
+
+> _"It's a bucket of wax."_
+
+## Obtaining
+
+Collected from **beehives** south of Seers' Village using insect repellent or full beekeeper's outfit.
+
+## About
+
+A bucket of wax is a members-only quest item. Used in Merlin's Crystal (given to the candle maker in Catherby to create a black candle) and Troll Romance (combined with swamp tar and cake tin to wax a sled).
+
+## Related Items
+
+- [Insect repellent](/osrs/insect-repellent/) - Used on beehive to collect wax safely

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_36.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_36.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A candle."_
+
+## Obtaining
+
+Purchased from **candle sellers** for 3 coins. Also spawns in houses at Hosidius and other locations, or stolen from candle stands (20 Thieving).
+
+## About
+
+A candle is a members-only light source. Can be lit with a tinderbox (1 Firemaking). Used in quests including Enlightened Journey and Enakhra's Lament. Can be placed in a candle lantern for a safer light source, as an open candle can ignite swamp gas in certain caves.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_39.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_39.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 40
+    item_name: "Iron arrowtips"
+    slug: "iron-arrowtips"
+    relationship: "variant"
+    description: "Higher tier arrowtips"
+---
+
+## Examine
+
+> _"I can make some arrows with these."_
+
+## Obtaining
+
+Smithed from a **bronze bar** (5 Smithing, yields 15 tips). Also purchased from archery shops.
+
+## About
+
+Bronze arrowtips are members-only Fletching supplies. Attach to headless arrows at 1 Fletching to create bronze arrows. The lowest tier arrowtips, commonly used for early Fletching training.
+
+## Related Items
+
+- [Iron arrowtips](/osrs/iron-arrowtips/) - Higher tier arrowtips (20 Smithing)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_40.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_40.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 39
+    item_name: "Bronze arrowtips"
+    slug: "bronze-arrowtips"
+    relationship: "variant"
+    description: "Lower tier arrowtips"
+  - item_id: 41
+    item_name: "Steel arrowtips"
+    slug: "steel-arrowtips"
+    relationship: "variant"
+    description: "Higher tier arrowtips"
+---
+
+## Examine
+
+> _"I can make some arrows with these."_
+
+## Obtaining
+
+Smithed from an **iron bar** (20 Smithing, yields 15 tips).
+
+## About
+
+Iron arrowtips are members-only Fletching supplies. Attach to headless arrows at 15 Fletching to create iron arrows.
+
+## Related Items
+
+- [Bronze arrowtips](/osrs/bronze-arrowtips/) - Lower tier (5 Smithing)
+- [Steel arrowtips](/osrs/steel-arrowtips/) - Higher tier (35 Smithing)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_41.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_41.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 40
+    item_name: "Iron arrowtips"
+    slug: "iron-arrowtips"
+    relationship: "variant"
+    description: "Lower tier arrowtips"
+  - item_id: 42
+    item_name: "Mithril arrowtips"
+    slug: "mithril-arrowtips"
+    relationship: "variant"
+    description: "Higher tier arrowtips"
+---
+
+## Examine
+
+> _"I can make some arrows with these."_
+
+## Obtaining
+
+Smithed from a **steel bar** (35 Smithing, yields 15 tips).
+
+## About
+
+Steel arrowtips are members-only Fletching supplies. Attach to headless arrows at 30 Fletching to create steel arrows.
+
+## Related Items
+
+- [Iron arrowtips](/osrs/iron-arrowtips/) - Lower tier (20 Smithing)
+- [Mithril arrowtips](/osrs/mithril-arrowtips/) - Higher tier (55 Smithing)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_42.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_42.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 41
+    item_name: "Steel arrowtips"
+    slug: "steel-arrowtips"
+    relationship: "variant"
+    description: "Lower tier arrowtips"
+  - item_id: 43
+    item_name: "Adamant arrowtips"
+    slug: "adamant-arrowtips"
+    relationship: "variant"
+    description: "Higher tier arrowtips"
+---
+
+## Examine
+
+> _"I can make some arrows with these."_
+
+## Obtaining
+
+Smithed from a **mithril bar** (55 Smithing, yields 15 tips).
+
+## About
+
+Mithril arrowtips are members-only Fletching supplies. Attach to headless arrows at 45 Fletching to create mithril arrows.
+
+## Related Items
+
+- [Steel arrowtips](/osrs/steel-arrowtips/) - Lower tier (35 Smithing)
+- [Adamant arrowtips](/osrs/adamant-arrowtips/) - Higher tier (75 Smithing)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_43.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_43.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 42
+    item_name: "Mithril arrowtips"
+    slug: "mithril-arrowtips"
+    relationship: "variant"
+    description: "Lower tier arrowtips"
+  - item_id: 44
+    item_name: "Rune arrowtips"
+    slug: "rune-arrowtips"
+    relationship: "variant"
+    description: "Higher tier arrowtips"
+---
+
+## Examine
+
+> _"I can make some arrows with these."_
+
+## Obtaining
+
+Smithed from an **adamantite bar** (75 Smithing, yields 15 tips).
+
+## About
+
+Adamant arrowtips are members-only Fletching supplies. Attach to headless arrows at 60 Fletching to create adamant arrows.
+
+## Related Items
+
+- [Mithril arrowtips](/osrs/mithril-arrowtips/) - Lower tier (55 Smithing)
+- [Rune arrowtips](/osrs/rune-arrowtips/) - Higher tier (90 Smithing)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_44.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_44.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 43
+    item_name: "Adamant arrowtips"
+    slug: "adamant-arrowtips"
+    relationship: "variant"
+    description: "Lower tier arrowtips"
+---
+
+## Examine
+
+> _"I can make some arrows with these."_
+
+## Obtaining
+
+Smithed from a **runite bar** (90 Smithing, yields 15 tips).
+
+## About
+
+Rune arrowtips are members-only Fletching supplies. Attach to headless arrows at 75 Fletching to create rune arrows. The highest tier of standard arrowtips.
+
+## Related Items
+
+- [Adamant arrowtips](/osrs/adamant-arrowtips/) - Lower tier (75 Smithing)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_45.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_45.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 46
+    item_name: "Pearl bolt tips"
+    slug: "pearl-bolt-tips"
+    relationship: "variant"
+    description: "Higher tier bolt tips"
+---
+
+## Examine
+
+> _"Opal bolt tips."_
+
+## Obtaining
+
+Cut from an **opal** using a chisel (11 Fletching, yields 12 tips).
+
+## About
+
+Opal bolt tips are members-only Fletching supplies. Attach to bronze bolts at 11 Fletching to create opal bolts. The lowest tier of gem-tipped bolt tips.
+
+## Related Items
+
+- [Pearl bolt tips](/osrs/pearl-bolt-tips/) - Higher tier bolt tips (41 Fletching)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_46.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_46.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 45
+    item_name: "Opal bolt tips"
+    slug: "opal-bolt-tips"
+    relationship: "variant"
+    description: "Lower tier bolt tips"
+  - item_id: 47
+    item_name: "Barb bolttips"
+    slug: "barb-bolttips"
+    relationship: "variant"
+    description: "Barbed bolt tips"
+---
+
+## Examine
+
+> _"Pearl bolt tips."_
+
+## Obtaining
+
+Cut from an **oyster pearl** using a chisel (41 Fletching).
+
+## About
+
+Pearl bolt tips are members-only Fletching supplies. Attach to iron bolts at 41 Fletching to create pearl bolts. Pearl bolts can be enchanted to create pearl bolts (e) which have a special effect against fiery creatures.
+
+## Related Items
+
+- [Opal bolt tips](/osrs/opal-bolt-tips/) - Lower tier bolt tips (11 Fletching)
+- [Barb bolttips](/osrs/barb-bolttips/) - Barbed bolt tips

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_47.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_47.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 46
+    item_name: "Pearl bolt tips"
+    slug: "pearl-bolt-tips"
+    relationship: "variant"
+    description: "Pearl bolt tips"
+---
+
+## Examine
+
+> _"I can make bolts with these."_
+
+## Obtaining
+
+Purchased from the **Ranging Guild** Ticket Exchange for 140 archery tickets (30 tips).
+
+## About
+
+Barb bolttips are members-only Fletching supplies. Attach to bronze bolts at 51 Fletching to create barbed bolts. Unlike gem bolt tips, these are only available from the Ranging Guild or the Grand Exchange — they cannot be crafted from raw materials.
+
+## Related Items
+
+- [Pearl bolt tips](/osrs/pearl-bolt-tips/) - Pearl bolt tips

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_48.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_48.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 50
+    item_name: "Shortbow (u)"
+    slug: "shortbow-u"
+    relationship: "variant"
+    description: "Unstrung shortbow from regular logs"
+  - item_id: 56
+    item_name: "Oak longbow (u)"
+    slug: "oak-longbow-u"
+    relationship: "variant"
+    description: "Higher tier unstrung longbow"
+---
+
+## Examine
+
+> _"I need to find a string for this."_
+
+## Obtaining
+
+Fletched from **regular logs** using a knife (10 Fletching).
+
+## About
+
+The longbow (u) is an unstrung longbow made from regular logs. String with a bowstring at 10 Fletching to create a longbow. Members only. One of the first items available for Fletching training.
+
+## Related Items
+
+- [Shortbow (u)](/osrs/shortbow-u/) - Unstrung shortbow from regular logs
+- [Oak longbow (u)](/osrs/oak-longbow-u/) - Higher tier unstrung longbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_50.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_50.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 48
+    item_name: "Longbow (u)"
+    slug: "longbow-u"
+    relationship: "variant"
+    description: "Unstrung longbow from regular logs"
+  - item_id: 54
+    item_name: "Oak shortbow (u)"
+    slug: "oak-shortbow-u"
+    relationship: "variant"
+    description: "Higher tier unstrung shortbow"
+---
+
+## Examine
+
+> _"I need to find a string for this."_
+
+## Obtaining
+
+Fletched from **regular logs** using a knife (5 Fletching).
+
+## About
+
+The shortbow (u) is an unstrung shortbow made from regular logs. String with a bowstring at 5 Fletching to create a shortbow. Members only. The very first item available for Fletching training.
+
+## Related Items
+
+- [Longbow (u)](/osrs/longbow-u/) - Unstrung longbow from regular logs
+- [Oak shortbow (u)](/osrs/oak-shortbow-u/) - Higher tier unstrung shortbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_54.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_54.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 50
+    item_name: "Shortbow (u)"
+    slug: "shortbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung shortbow"
+  - item_id: 56
+    item_name: "Oak longbow (u)"
+    slug: "oak-longbow-u"
+    relationship: "variant"
+    description: "Matching unstrung oak longbow"
+---
+
+## Examine
+
+> _"An unstrung oak shortbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **oak logs** using a knife (20 Fletching).
+
+## About
+
+The oak shortbow (u) is an unstrung shortbow made from oak logs. String with a bowstring at 20 Fletching to create an oak shortbow. Members only.
+
+## Related Items
+
+- [Shortbow (u)](/osrs/shortbow-u/) - Lower tier unstrung shortbow
+- [Oak longbow (u)](/osrs/oak-longbow-u/) - Matching unstrung oak longbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_56.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_56.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 48
+    item_name: "Longbow (u)"
+    slug: "longbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung longbow"
+  - item_id: 54
+    item_name: "Oak shortbow (u)"
+    slug: "oak-shortbow-u"
+    relationship: "variant"
+    description: "Matching unstrung oak shortbow"
+---
+
+## Examine
+
+> _"An unstrung oak longbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **oak logs** using a knife (25 Fletching).
+
+## About
+
+The oak longbow (u) is an unstrung longbow made from oak logs. String with a bowstring at 25 Fletching to create an oak longbow. Members only.
+
+## Related Items
+
+- [Longbow (u)](/osrs/longbow-u/) - Lower tier unstrung longbow
+- [Oak shortbow (u)](/osrs/oak-shortbow-u/) - Matching unstrung oak shortbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_58.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_58.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 56
+    item_name: "Oak longbow (u)"
+    slug: "oak-longbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung longbow"
+  - item_id: 60
+    item_name: "Willow shortbow (u)"
+    slug: "willow-shortbow-u"
+    relationship: "variant"
+    description: "Matching unstrung willow shortbow"
+---
+
+## Examine
+
+> _"An unstrung willow longbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **willow logs** using a knife (40 Fletching).
+
+## About
+
+The willow longbow (u) is an unstrung longbow made from willow logs. String with a bowstring at 40 Fletching to create a willow longbow. Members only.
+
+## Related Items
+
+- [Oak longbow (u)](/osrs/oak-longbow-u/) - Lower tier unstrung longbow
+- [Willow shortbow (u)](/osrs/willow-shortbow-u/) - Matching unstrung willow shortbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_6.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_6.mdx
@@ -1,0 +1,36 @@
+---
+related_items:
+  - item_id: 8
+    item_name: "Cannon stand"
+    slug: "cannon-stand"
+    relationship: "set-piece"
+    description: "Multicannon stand component"
+  - item_id: 10
+    item_name: "Cannon barrels"
+    slug: "cannon-barrels"
+    relationship: "set-piece"
+    description: "Multicannon barrels component"
+  - item_id: 12
+    item_name: "Cannon furnace"
+    slug: "cannon-furnace"
+    relationship: "set-piece"
+    description: "Multicannon furnace component"
+---
+
+## Examine
+
+> _"The cannon is built on this."_
+
+## Obtaining
+
+Purchased from **Nulodion** at the Ice Mountain workshop for 200,625 coins. Free replacement if lost.
+
+## About
+
+The cannon base is the first component placed when setting up a dwarf multicannon. Requires completion of the Dwarf Cannon quest to use. All four cannon parts must be placed in order: base, stand, barrels, furnace. Tradeable on the Grand Exchange.
+
+## Related Items
+
+- [Cannon stand](/osrs/cannon-stand/) - Multicannon stand component
+- [Cannon barrels](/osrs/cannon-barrels/) - Multicannon barrels component
+- [Cannon furnace](/osrs/cannon-furnace/) - Multicannon furnace component

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_60.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_60.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 54
+    item_name: "Oak shortbow (u)"
+    slug: "oak-shortbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung shortbow"
+  - item_id: 58
+    item_name: "Willow longbow (u)"
+    slug: "willow-longbow-u"
+    relationship: "variant"
+    description: "Matching unstrung willow longbow"
+---
+
+## Examine
+
+> _"An unstrung willow shortbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **willow logs** using a knife (35 Fletching).
+
+## About
+
+The willow shortbow (u) is an unstrung shortbow made from willow logs. String with a bowstring at 35 Fletching to create a willow shortbow. Members only.
+
+## Related Items
+
+- [Oak shortbow (u)](/osrs/oak-shortbow-u/) - Lower tier unstrung shortbow
+- [Willow longbow (u)](/osrs/willow-longbow-u/) - Matching unstrung willow longbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_62.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_62.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 58
+    item_name: "Willow longbow (u)"
+    slug: "willow-longbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung longbow"
+  - item_id: 64
+    item_name: "Maple shortbow (u)"
+    slug: "maple-shortbow-u"
+    relationship: "variant"
+    description: "Matching unstrung maple shortbow"
+---
+
+## Examine
+
+> _"An unstrung maple longbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **maple logs** using a knife (55 Fletching).
+
+## About
+
+The maple longbow (u) is an unstrung longbow made from maple logs. String with a bowstring at 55 Fletching to create a maple longbow. Members only.
+
+## Related Items
+
+- [Willow longbow (u)](/osrs/willow-longbow-u/) - Lower tier unstrung longbow
+- [Maple shortbow (u)](/osrs/maple-shortbow-u/) - Matching unstrung maple shortbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_64.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_64.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 60
+    item_name: "Willow shortbow (u)"
+    slug: "willow-shortbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung shortbow"
+  - item_id: 62
+    item_name: "Maple longbow (u)"
+    slug: "maple-longbow-u"
+    relationship: "variant"
+    description: "Matching unstrung maple longbow"
+---
+
+## Examine
+
+> _"An unstrung maple shortbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **maple logs** using a knife (50 Fletching).
+
+## About
+
+The maple shortbow (u) is an unstrung shortbow made from maple logs. String with a bowstring at 50 Fletching to create a maple shortbow. Members only.
+
+## Related Items
+
+- [Willow shortbow (u)](/osrs/willow-shortbow-u/) - Lower tier unstrung shortbow
+- [Maple longbow (u)](/osrs/maple-longbow-u/) - Matching unstrung maple longbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_68.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_68.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 64
+    item_name: "Maple shortbow (u)"
+    slug: "maple-shortbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung shortbow"
+  - item_id: 66
+    item_name: "Yew longbow (u)"
+    slug: "yew-longbow-u"
+    relationship: "variant"
+    description: "Matching unstrung yew longbow"
+---
+
+## Examine
+
+> _"An unstrung yew shortbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **yew logs** using a knife (65 Fletching).
+
+## About
+
+The yew shortbow (u) is an unstrung shortbow made from yew logs. String with a bowstring at 65 Fletching to create a yew shortbow. Members only.
+
+## Related Items
+
+- [Maple shortbow (u)](/osrs/maple-shortbow-u/) - Lower tier unstrung shortbow
+- [Yew longbow (u)](/osrs/yew-longbow-u/) - Matching unstrung yew longbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_70.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_70.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 66
+    item_name: "Yew longbow (u)"
+    slug: "yew-longbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung longbow"
+  - item_id: 72
+    item_name: "Magic shortbow (u)"
+    slug: "magic-shortbow-u"
+    relationship: "variant"
+    description: "Matching unstrung magic shortbow"
+---
+
+## Examine
+
+> _"An unstrung magic longbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **magic logs** using a knife (85 Fletching).
+
+## About
+
+The magic longbow (u) is an unstrung longbow made from magic logs. String with a bowstring at 85 Fletching to create a magic longbow. Members only. The highest tier of standard unstrung longbows.
+
+## Related Items
+
+- [Yew longbow (u)](/osrs/yew-longbow-u/) - Lower tier unstrung longbow
+- [Magic shortbow (u)](/osrs/magic-shortbow-u/) - Matching unstrung magic shortbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_72.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_72.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 68
+    item_name: "Yew shortbow (u)"
+    slug: "yew-shortbow-u"
+    relationship: "variant"
+    description: "Lower tier unstrung shortbow"
+  - item_id: 70
+    item_name: "Magic longbow (u)"
+    slug: "magic-longbow-u"
+    relationship: "variant"
+    description: "Matching unstrung magic longbow"
+---
+
+## Examine
+
+> _"An unstrung magic shortbow; I need a bowstring for this."_
+
+## Obtaining
+
+Fletched from **magic logs** using a knife (80 Fletching).
+
+## About
+
+The magic shortbow (u) is an unstrung shortbow made from magic logs. String with a bowstring at 80 Fletching to create a magic shortbow. Members only. The highest tier of standard unstrung shortbows.
+
+## Related Items
+
+- [Yew shortbow (u)](/osrs/yew-shortbow-u/) - Lower tier unstrung shortbow
+- [Magic longbow (u)](/osrs/magic-longbow-u/) - Matching unstrung magic longbow

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_8.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_8.mdx
@@ -1,0 +1,36 @@
+---
+related_items:
+  - item_id: 6
+    item_name: "Cannon base"
+    slug: "cannon-base"
+    relationship: "set-piece"
+    description: "Multicannon base component"
+  - item_id: 10
+    item_name: "Cannon barrels"
+    slug: "cannon-barrels"
+    relationship: "set-piece"
+    description: "Multicannon barrels component"
+  - item_id: 12
+    item_name: "Cannon furnace"
+    slug: "cannon-furnace"
+    relationship: "set-piece"
+    description: "Multicannon furnace component"
+---
+
+## Examine
+
+> _"The mounting for the multicannon."_
+
+## Obtaining
+
+Purchased from **Nulodion** at the Ice Mountain workshop for 200,625 coins. Free replacement if lost.
+
+## About
+
+The cannon stand is the second component placed when assembling a dwarf multicannon. Requires completion of the Dwarf Cannon quest to use. Placed on top of the cannon base. Tradeable on the Grand Exchange.
+
+## Related Items
+
+- [Cannon base](/osrs/cannon-base/) - Multicannon base component
+- [Cannon barrels](/osrs/cannon-barrels/) - Multicannon barrels component
+- [Cannon furnace](/osrs/cannon-furnace/) - Multicannon furnace component


### PR DESCRIPTION
## Summary
- Added 50 new OSRS item override files with accurate stats, examine text, and related items
- Categories: dwarf multicannon (4), quest/utility items (3), arrowtips (6), bolt tips (3), unstrung bows (11), standard combat potions (12), super combat potions (11)
- Updated OSRS.md tracking document with new sections and session log

## Items Added
| Category | Count | Items |
|----------|-------|-------|
| Dwarf multicannon | 4 | Cannon base/stand/barrels/furnace |
| Quest/utility | 3 | Insect repellent, bucket of wax, candle |
| Arrowtips | 6 | Bronze through rune arrowtips |
| Bolt tips | 3 | Opal, pearl, barb bolttips |
| Unstrung bows | 11 | Shortbow/longbow (u) from regular through magic |
| Standard potions | 12 | Strength/attack/restore/defence (3/2/1 dose) |
| Super potions | 11 | Super attack/strength/defence, fishing potion (3/2/1 dose) |

## Test plan
- [ ] Verify override files merge correctly with auto-generated OSRS item pages
- [ ] Check frontmatter validates against OSRSExtendedSchema
- [ ] Confirm related item links resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)