### PR TITLE
feat(osrs): add 50 item overrides - potions, herbs, fishing, fish

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -1061,6 +1061,81 @@ Focus on items with clear processing chains and market flip potential.
 | 163 | Super defence(3)  | 66 Herblore  |
 | 165 | Super defence(2)  | Dose variant |
 
+### Potions — Ranging/Antipoison/Zamorak (Implemented - Mar 2026)
+
+| ID  | Item               | Notes                       |
+| --- | ------------------ | --------------------------- |
+| 167 | Super defence(1)   | Dose variant                |
+| 169 | Ranging potion(3)  | 72 Herblore                 |
+| 171 | Ranging potion(2)  | Dose variant                |
+| 173 | Ranging potion(1)  | Dose variant                |
+| 175 | Antipoison(3)      | 5 Herblore, F2P purchasable |
+| 177 | Antipoison(2)      | Dose variant                |
+| 179 | Antipoison(1)      | Dose variant                |
+| 181 | Superantipoison(3) | 48 Herblore                 |
+| 183 | Superantipoison(2) | Dose variant                |
+| 185 | Superantipoison(1) | Dose variant                |
+| 189 | Zamorak brew(3)    | 78 Herblore                 |
+| 191 | Zamorak brew(2)    | Dose variant                |
+| 193 | Zamorak brew(1)    | Dose variant                |
+
+### Quest/Utility Items (Implemented - Mar 2026)
+
+| ID  | Item              | Notes                      |
+| --- | ----------------- | -------------------------- |
+| 197 | Poison chalice    | Random effect drink        |
+| 233 | Pestle and mortar | Essential Herblore tool    |
+| 272 | Fish food         | Ernest the Chicken quest   |
+| 273 | Poison            | Ernest the Chicken quest   |
+| 288 | Goblin mail       | Goblin Diplomacy quest     |
+| 299 | Mithril seeds     | PvP utility, Legends Guild |
+
+### Grimy/Clean Herbs (Implemented - Mar 2026)
+
+| ID  | Item             | Notes                  |
+| --- | ---------------- | ---------------------- |
+| 199 | Grimy guam leaf  | 3 Herblore to clean    |
+| 201 | Grimy marrentill | 5 Herblore to clean    |
+| 203 | Grimy tarromin   | 11 Herblore to clean   |
+| 249 | Guam leaf        | Lowest-tier clean herb |
+| 251 | Marrentill       | Antipoison herb        |
+| 253 | Tarromin         | Strength potion herb   |
+| 255 | Harralander      | Restore/energy herb    |
+
+### Fishing Equipment (Implemented - Mar 2026)
+
+| ID  | Item              | Notes                      |
+| --- | ----------------- | -------------------------- |
+| 301 | Lobster pot       | 40 Fishing for lobsters    |
+| 303 | Small fishing net | Shrimps/anchovies, F2P     |
+| 305 | Big fishing net   | Sea fish, members          |
+| 307 | Fishing rod       | Sardine/herring, F2P       |
+| 309 | Fly fishing rod   | Trout/salmon, F2P          |
+| 311 | Harpoon           | Tuna/swordfish/shark, F2P  |
+| 313 | Fishing bait      | Used with fishing rod, F2P |
+
+### Fish — Raw & Cooked (Implemented - Mar 2026)
+
+| ID  | Item           | Notes                      |
+| --- | -------------- | -------------------------- |
+| 315 | Shrimps        | 3 HP, 1 Cooking, F2P       |
+| 319 | Anchovies      | 1 HP, 1 Cooking, F2P       |
+| 321 | Raw anchovies  | 15 Fishing, F2P            |
+| 325 | Sardine        | 4 HP, 1 Cooking, F2P       |
+| 327 | Raw sardine    | 5 Fishing, F2P             |
+| 339 | Cod            | 7 HP, 18 Cooking, members  |
+| 341 | Raw cod        | Big net catch, members     |
+| 345 | Raw herring    | 10 Fishing, F2P            |
+| 347 | Herring        | 5 HP, 5 Cooking, F2P       |
+| 349 | Raw pike       | 25 Fishing, F2P            |
+| 351 | Pike           | 8 HP, 20 Cooking, F2P      |
+| 353 | Raw mackerel   | 16 Fishing, members        |
+| 355 | Mackerel       | 6 HP, 10 Cooking, members  |
+| 363 | Raw bass       | 46 Fishing, members        |
+| 365 | Bass           | 13 HP, 43 Cooking, members |
+| 395 | Raw sea turtle | Trawler minigame, members  |
+| 397 | Sea turtle     | 21 HP, 82 Cooking, members |
+
 ---
 
 ## Future Override Priorities
@@ -1663,6 +1738,7 @@ Record batch completions here:
 | Mar 13, 2026 | +50 items (god vestments, wizard robes, black/adamant trimmed)   | ~1081           |
 | Mar 13, 2026 | +50 items (rune/steel/black trimmed, monk robes, heraldic, misc) | ~1131           |
 | Mar 13, 2026 | +50 items (cannon parts, fletching supplies, potions)            | ~1181           |
+| Mar 13, 2026 | +50 items (potions, herbs, fishing equipment, fish)              | ~1231           |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_167.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_167.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 163
+    item_name: "Super defence(3)"
+    slug: "super-defence-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 165
+    item_name: "Super defence(2)"
+    slug: "super-defence-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of super Defence potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **super defence(2)**. Members only.
+
+## About
+
+A 1-dose super defence potion. Boosts Defence by 5 + 15% of current level.
+
+## Related Items
+
+- [Super defence(3)](/osrs/super-defence-3/) - 3-dose version
+- [Super defence(2)](/osrs/super-defence-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_169.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_169.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 171
+    item_name: "Ranging potion(2)"
+    slug: "ranging-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 173
+    item_name: "Ranging potion(1)"
+    slug: "ranging-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of ranging potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 72) using a dwarf weed potion (unf) and wine of zamorak. Members only.
+
+## About
+
+The ranging potion boosts Ranged by 4 + 10% of current level (rounded down). Essential for ranged combat, commonly used at bosses and in PvP.
+
+## Related Items
+
+- [Ranging potion(2)](/osrs/ranging-potion-2/) - 2-dose version
+- [Ranging potion(1)](/osrs/ranging-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_171.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_171.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 169
+    item_name: "Ranging potion(3)"
+    slug: "ranging-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 173
+    item_name: "Ranging potion(1)"
+    slug: "ranging-potion-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of ranging potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **ranging potion(3)**. Members only.
+
+## About
+
+A 2-dose ranging potion. Boosts Ranged by 4 + 10% of current level.
+
+## Related Items
+
+- [Ranging potion(3)](/osrs/ranging-potion-3/) - 3-dose version
+- [Ranging potion(1)](/osrs/ranging-potion-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_173.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_173.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 169
+    item_name: "Ranging potion(3)"
+    slug: "ranging-potion-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 171
+    item_name: "Ranging potion(2)"
+    slug: "ranging-potion-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of ranging potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **ranging potion(2)**. Members only.
+
+## About
+
+A 1-dose ranging potion. Boosts Ranged by 4 + 10% of current level.
+
+## Related Items
+
+- [Ranging potion(3)](/osrs/ranging-potion-3/) - 3-dose version
+- [Ranging potion(2)](/osrs/ranging-potion-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_175.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_175.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 177
+    item_name: "Antipoison(2)"
+    slug: "antipoison-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 179
+    item_name: "Antipoison(1)"
+    slug: "antipoison-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of antipoison potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 5) using a marrentill potion (unf) and unicorn horn dust. Available to F2P through purchase.
+
+## About
+
+The antipoison cures poison and grants 90 seconds of poison immunity per dose. Two doses cure venom. One of the earliest potions brewable with Herblore.
+
+## Related Items
+
+- [Antipoison(2)](/osrs/antipoison-2/) - 2-dose version
+- [Antipoison(1)](/osrs/antipoison-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_177.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_177.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 175
+    item_name: "Antipoison(3)"
+    slug: "antipoison-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 179
+    item_name: "Antipoison(1)"
+    slug: "antipoison-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of antipoison potion."_
+
+## Obtaining
+
+Created by drinking one dose from an **antipoison(3)**.
+
+## About
+
+A 2-dose antipoison. Cures poison and grants 90 seconds immunity per dose.
+
+## Related Items
+
+- [Antipoison(3)](/osrs/antipoison-3/) - 3-dose version
+- [Antipoison(1)](/osrs/antipoison-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_179.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_179.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 175
+    item_name: "Antipoison(3)"
+    slug: "antipoison-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 177
+    item_name: "Antipoison(2)"
+    slug: "antipoison-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of antipoison potion."_
+
+## Obtaining
+
+Created by drinking one dose from an **antipoison(2)**.
+
+## About
+
+A 1-dose antipoison. Cures poison and grants 90 seconds immunity.
+
+## Related Items
+
+- [Antipoison(3)](/osrs/antipoison-3/) - 3-dose version
+- [Antipoison(2)](/osrs/antipoison-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_181.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_181.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 183
+    item_name: "Superantipoison(2)"
+    slug: "superantipoison-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 185
+    item_name: "Superantipoison(1)"
+    slug: "superantipoison-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of super antipoison potion."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 48) using an irit potion (unf) and unicorn horn dust. Members only.
+
+## About
+
+The superantipoison cures poison and grants 6 minutes of poison immunity per dose. Two doses cure venom. A significant upgrade over regular antipoison.
+
+## Related Items
+
+- [Superantipoison(2)](/osrs/superantipoison-2/) - 2-dose version
+- [Superantipoison(1)](/osrs/superantipoison-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_183.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_183.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 181
+    item_name: "Superantipoison(3)"
+    slug: "superantipoison-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 185
+    item_name: "Superantipoison(1)"
+    slug: "superantipoison-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of super antipoison potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **superantipoison(3)**. Members only.
+
+## About
+
+A 2-dose superantipoison. Cures poison and grants 6 minutes immunity.
+
+## Related Items
+
+- [Superantipoison(3)](/osrs/superantipoison-3/) - 3-dose version
+- [Superantipoison(1)](/osrs/superantipoison-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_185.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_185.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 181
+    item_name: "Superantipoison(3)"
+    slug: "superantipoison-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 183
+    item_name: "Superantipoison(2)"
+    slug: "superantipoison-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of super antipoison potion."_
+
+## Obtaining
+
+Created by drinking one dose from a **superantipoison(2)**. Members only.
+
+## About
+
+A 1-dose superantipoison. Cures poison and grants 6 minutes immunity.
+
+## Related Items
+
+- [Superantipoison(3)](/osrs/superantipoison-3/) - 3-dose version
+- [Superantipoison(2)](/osrs/superantipoison-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_189.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_189.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 191
+    item_name: "Zamorak brew(2)"
+    slug: "zamorak-brew-2"
+    relationship: "variant"
+    description: "2-dose version"
+  - item_id: 193
+    item_name: "Zamorak brew(1)"
+    slug: "zamorak-brew-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"3 doses of Zamorak brew."_
+
+## Obtaining
+
+Brewed with **Herblore** (level 78) using a torstol potion (unf) and jangerberries. Members only.
+
+## About
+
+The Zamorak brew boosts Attack and Strength while draining Defence and Hitpoints. Also restores approximately 10% of Prayer. A high-risk, high-reward potion used in advanced PvM and PvP.
+
+## Related Items
+
+- [Zamorak brew(2)](/osrs/zamorak-brew-2/) - 2-dose version
+- [Zamorak brew(1)](/osrs/zamorak-brew-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_191.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_191.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 189
+    item_name: "Zamorak brew(3)"
+    slug: "zamorak-brew-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 193
+    item_name: "Zamorak brew(1)"
+    slug: "zamorak-brew-1"
+    relationship: "variant"
+    description: "1-dose version"
+---
+
+## Examine
+
+> _"2 doses of Zamorak brew."_
+
+## Obtaining
+
+Created by drinking one dose from a **Zamorak brew(3)**. Members only.
+
+## About
+
+A 2-dose Zamorak brew. Boosts Attack and Strength, drains Defence and Hitpoints, restores Prayer.
+
+## Related Items
+
+- [Zamorak brew(3)](/osrs/zamorak-brew-3/) - 3-dose version
+- [Zamorak brew(1)](/osrs/zamorak-brew-1/) - 1-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_193.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_193.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 189
+    item_name: "Zamorak brew(3)"
+    slug: "zamorak-brew-3"
+    relationship: "variant"
+    description: "3-dose version"
+  - item_id: 191
+    item_name: "Zamorak brew(2)"
+    slug: "zamorak-brew-2"
+    relationship: "variant"
+    description: "2-dose version"
+---
+
+## Examine
+
+> _"1 dose of Zamorak brew."_
+
+## Obtaining
+
+Created by drinking one dose from a **Zamorak brew(2)**. Members only.
+
+## About
+
+A 1-dose Zamorak brew. Boosts Attack and Strength, drains Defence and Hitpoints, restores Prayer.
+
+## Related Items
+
+- [Zamorak brew(3)](/osrs/zamorak-brew-3/) - 3-dose version
+- [Zamorak brew(2)](/osrs/zamorak-brew-2/) - 2-dose version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_197.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_197.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A cup of a strange brew..."_
+
+## Obtaining
+
+Given for free by **Stankers** near the Coal Trucks west of Seers' Village. Members only.
+
+## About
+
+The poison chalice produces a random effect when drunk — anything from healing 15-30% HP and boosting Thieving or Crafting, to dealing 5-50% of your HP as damage. Cannot reduce HP below 4. Leaves behind an empty cocktail glass.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_199.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_199.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 249
+    item_name: "Guam leaf"
+    slug: "guam-leaf"
+    relationship: "product"
+    description: "Cleaned version"
+---
+
+## Examine
+
+> _"It needs cleaning."_
+
+## Obtaining
+
+Dropped by various **monsters** or grown via Farming (9 Farming). Members only.
+
+## About
+
+Grimy guam leaf requires 3 Herblore to clean into a guam leaf (2.5 XP). Guam is the lowest-tier herb, used in attack potions and guam potions (unf).
+
+## Related Items
+
+- [Guam leaf](/osrs/guam-leaf/) - Cleaned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_201.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_201.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 251
+    item_name: "Marrentill"
+    slug: "marrentill"
+    relationship: "product"
+    description: "Cleaned version"
+---
+
+## Examine
+
+> _"It needs cleaning."_
+
+## Obtaining
+
+Dropped by various **monsters** or grown via Farming (14 Farming). Members only.
+
+## About
+
+Grimy marrentill requires 5 Herblore to clean (3.8 XP). Used in antipoison potions and as incense on the Incense Burner in a Player-Owned House.
+
+## Related Items
+
+- [Marrentill](/osrs/marrentill/) - Cleaned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_203.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_203.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 253
+    item_name: "Tarromin"
+    slug: "tarromin"
+    relationship: "product"
+    description: "Cleaned version"
+---
+
+## Examine
+
+> _"It needs cleaning."_
+
+## Obtaining
+
+Dropped by various **monsters** or grown via Farming (19 Farming). Members only.
+
+## About
+
+Grimy tarromin requires 11 Herblore to clean (5 XP). Used in strength potions and serum 207.
+
+## Related Items
+
+- [Tarromin](/osrs/tarromin/) - Cleaned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_233.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_233.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"I can grind things for potions in this."_
+
+## Obtaining
+
+Purchased from **herbalist shops** for 4-6 coins. Spawns at Isle of Souls and Outer Fortis. Members only.
+
+## About
+
+The pestle and mortar is an essential Herblore tool used to crush ingredients into powders and pastes. Required for 20+ quests. Auto-grinds all matching items in inventory when used. Cannot be stored in a tool belt.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_249.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_249.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 199
+    item_name: "Grimy guam leaf"
+    slug: "grimy-guam-leaf"
+    relationship: "component"
+    description: "Uncleaned version"
+---
+
+## Examine
+
+> _"A bitter green herb."_
+
+## Obtaining
+
+Cleaned from a **grimy guam leaf** (3 Herblore). Members only.
+
+## About
+
+Guam leaf is the lowest-tier clean herb. Used to make guam potions (unf) which are the base for attack potions (3 Herblore) and guam tar.
+
+## Related Items
+
+- [Grimy guam leaf](/osrs/grimy-guam-leaf/) - Uncleaned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_251.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_251.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 201
+    item_name: "Grimy marrentill"
+    slug: "grimy-marrentill"
+    relationship: "component"
+    description: "Uncleaned version"
+---
+
+## Examine
+
+> _"A herb used in poison cures."_
+
+## Obtaining
+
+Cleaned from a **grimy marrentill** (5 Herblore). Members only.
+
+## About
+
+Marrentill is used to make antipoison potions (5 Herblore) and as incense on POH burners. Also used in Druidic Ritual and other quests.
+
+## Related Items
+
+- [Grimy marrentill](/osrs/grimy-marrentill/) - Uncleaned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_253.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_253.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 203
+    item_name: "Grimy tarromin"
+    slug: "grimy-tarromin"
+    relationship: "component"
+    description: "Uncleaned version"
+---
+
+## Examine
+
+> _"A useful herb."_
+
+## Obtaining
+
+Cleaned from a **grimy tarromin** (11 Herblore). Members only.
+
+## About
+
+Tarromin is used to make strength potions (12 Herblore) and serum 207 for the Shades of Mort'ton quest/minigame.
+
+## Related Items
+
+- [Grimy tarromin](/osrs/grimy-tarromin/) - Uncleaned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_255.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_255.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A useful herb."_
+
+## Obtaining
+
+Cleaned from a **grimy harralander** (20 Herblore). Members only.
+
+## About
+
+Harralander is used to make restore potions (22 Herblore), energy potions (26 Herblore), and combat potions (36 Herblore). A mid-tier herb commonly obtained from monster drops.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_272.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_272.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 273
+    item_name: "Poison"
+    slug: "poison-item"
+    relationship: "used-with"
+    description: "Combined to make poisoned fish food"
+---
+
+## Examine
+
+> _"Keeps your pet fish strong and healthy."_
+
+## Obtaining
+
+Found on the **second floor of Draynor Manor**. F2P item.
+
+## About
+
+Fish food is a quest item used in Ernest the Chicken. Combined with poison to create poisoned fish food, which kills piranhas in a fountain to retrieve a pressure gauge.
+
+## Related Items
+
+- [Poison](/osrs/poison-item/) - Combined to make poisoned fish food

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_273.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_273.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 272
+    item_name: "Fish food"
+    slug: "fish-food"
+    relationship: "used-with"
+    description: "Combined to make poisoned fish food"
+---
+
+## Examine
+
+> _"This stuff looks nasty."_
+
+## Obtaining
+
+Found inside **Draynor Manor**. Also sold by Rasolo and Jossik. F2P item.
+
+## About
+
+Poison is a quest item used in Ernest the Chicken (combined with fish food) and Hazeel Cult. A simple utility item with no combat application.
+
+## Related Items
+
+- [Fish food](/osrs/fish-food/) - Combined to make poisoned fish food

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_288.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_288.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"Some brown armour designed to fit goblins."_
+
+## Obtaining
+
+Dropped by **goblins** and hobgoblins. Also found in crates at Goblin Village. F2P item.
+
+## About
+
+Goblin mail is a quest item required for Goblin Diplomacy (3 pieces) and Land of the Goblins (5 pieces). Can be dyed various colours using dyes for quest objectives.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_299.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_299.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"Magical seeds in a mithril case."_
+
+## Obtaining
+
+Purchased from the **Legends Guild** shop (300 coins). Also received as a reward from Waterfall Quest (40 seeds). Members only.
+
+## About
+
+Mithril seeds force the player one tile when planted, growing into random flowers. Used in PvP to move while frozen. Can also be used to grief Hunter and Firemaking spots by blocking tile placement.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_301.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_301.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 311
+    item_name: "Harpoon"
+    slug: "harpoon"
+    relationship: "variant"
+    description: "Alternative fishing tool"
+---
+
+## Examine
+
+> _"Useful for catching lobsters."_
+
+## Obtaining
+
+Purchased from **fishing shops** for 20 coins. F2P item.
+
+## About
+
+The lobster pot is used at cage/harpoon fishing spots to catch raw lobsters (40 Fishing). A basic fishing tool with no requirements to use beyond the Fishing level for the catch.
+
+## Related Items
+
+- [Harpoon](/osrs/harpoon/) - Alternative tool at the same fishing spots

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_303.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_303.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 305
+    item_name: "Big fishing net"
+    slug: "big-fishing-net"
+    relationship: "variant"
+    description: "Catches multiple fish at once"
+---
+
+## Examine
+
+> _"Useful for catching small fish."_
+
+## Obtaining
+
+Purchased from **fishing shops** for 5 coins. Free from the Fishing tutor near Lumbridge. F2P item.
+
+## About
+
+The small fishing net is used to catch shrimps (1 Fishing) and anchovies (15 Fishing) at net/bait fishing spots. The first fishing tool most players use.
+
+## Related Items
+
+- [Big fishing net](/osrs/big-fishing-net/) - Catches multiple fish at once

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_305.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_305.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 303
+    item_name: "Small fishing net"
+    slug: "small-fishing-net"
+    relationship: "variant"
+    description: "Basic fishing net"
+---
+
+## Examine
+
+> _"Useful for catching lots of fish."_
+
+## Obtaining
+
+Purchased from **fishing shops** for 20 coins. Members only.
+
+## About
+
+The big fishing net is used at net/harpoon fishing spots to catch mackerel, cod, bass, and other sea fish. Can also catch random items like seaweed and caskets.
+
+## Related Items
+
+- [Small fishing net](/osrs/small-fishing-net/) - Basic fishing net for shrimps/anchovies

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_307.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_307.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 309
+    item_name: "Fly fishing rod"
+    slug: "fly-fishing-rod"
+    relationship: "variant"
+    description: "For trout and salmon"
+  - item_id: 313
+    item_name: "Fishing bait"
+    slug: "fishing-bait"
+    relationship: "used-with"
+    description: "Required bait"
+---
+
+## Examine
+
+> _"Useful for catching sardine or herring."_
+
+## Obtaining
+
+Purchased from **fishing shops** for 5 coins. F2P item.
+
+## About
+
+The fishing rod is used with fishing bait at net/bait fishing spots to catch sardines (5 Fishing) and herring (10 Fishing). One of the earliest fishing tools.
+
+## Related Items
+
+- [Fly fishing rod](/osrs/fly-fishing-rod/) - For trout and salmon
+- [Fishing bait](/osrs/fishing-bait/) - Required bait

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_309.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_309.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 307
+    item_name: "Fishing rod"
+    slug: "fishing-rod"
+    relationship: "variant"
+    description: "For sardines and herring"
+---
+
+## Examine
+
+> _"Useful for catching salmon or trout."_
+
+## Obtaining
+
+Purchased from **fishing shops** for 5 coins. F2P item.
+
+## About
+
+The fly fishing rod is used with feathers at lure/bait fishing spots to catch trout (20 Fishing) and salmon (30 Fishing). The most popular early-game Fishing training method.
+
+## Related Items
+
+- [Fishing rod](/osrs/fishing-rod/) - For sardines and herring

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_311.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_311.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 301
+    item_name: "Lobster pot"
+    slug: "lobster-pot"
+    relationship: "variant"
+    description: "For catching lobsters"
+---
+
+## Examine
+
+> _"Useful for catching really big fish."_
+
+## Obtaining
+
+Purchased from **fishing shops** for 5 coins. F2P item.
+
+## About
+
+The harpoon is used at cage/harpoon fishing spots to catch tuna (35 Fishing), swordfish (50 Fishing), and sharks (76 Fishing). Can be replaced by a barb-tail harpoon or dragon harpoon for faster catches.
+
+## Related Items
+
+- [Lobster pot](/osrs/lobster-pot/) - For catching lobsters at the same spots

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_313.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_313.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 307
+    item_name: "Fishing rod"
+    slug: "fishing-rod"
+    relationship: "used-with"
+    description: "Used with fishing rod"
+---
+
+## Examine
+
+> _"For use with a fishing rod."_
+
+## Obtaining
+
+Purchased from **fishing shops** for 3 coins. Dropped by many monsters. F2P item.
+
+## About
+
+Fishing bait is consumed one per catch when using a fishing rod. Used to catch sardines (5 Fishing), herring (10 Fishing), pike (25 Fishing), and other bait fish. Stackable.
+
+## Related Items
+
+- [Fishing rod](/osrs/fishing-rod/) - Used with fishing bait

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_315.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_315.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 319
+    item_name: "Anchovies"
+    slug: "anchovies"
+    relationship: "variant"
+    description: "Another net-caught fish"
+---
+
+## Examine
+
+> _"Some nicely cooked shrimp."_
+
+## Obtaining
+
+Cooked from **raw shrimps** (1 Cooking). F2P item.
+
+## About
+
+Shrimps heal 3 Hitpoints. The very first food most players cook, caught with a small fishing net at 1 Fishing. Cheap and abundant.
+
+## Related Items
+
+- [Anchovies](/osrs/anchovies/) - Another net-caught fish

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_319.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_319.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 315
+    item_name: "Shrimps"
+    slug: "shrimps"
+    relationship: "variant"
+    description: "Another net-caught fish"
+  - item_id: 321
+    item_name: "Raw anchovies"
+    slug: "raw-anchovies"
+    relationship: "component"
+    description: "Uncooked version"
+---
+
+## Examine
+
+> _"Some nicely cooked anchovies."_
+
+## Obtaining
+
+Cooked from **raw anchovies** (1 Cooking). F2P item.
+
+## About
+
+Anchovies heal 1 Hitpoint. Caught with a small fishing net at 15 Fishing. Despite low healing, they're useful as an ingredient for anchovy pizza.
+
+## Related Items
+
+- [Shrimps](/osrs/shrimps/) - Another net-caught fish
+- [Raw anchovies](/osrs/raw-anchovies/) - Uncooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_321.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_321.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 319
+    item_name: "Anchovies"
+    slug: "anchovies"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught with a **small fishing net** at 15 Fishing. F2P item.
+
+## About
+
+Raw anchovies can be cooked at 1 Cooking to make anchovies. Also used as an ingredient in anchovy pizza. Caught at the same spots as raw shrimps.
+
+## Related Items
+
+- [Anchovies](/osrs/anchovies/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_325.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_325.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 327
+    item_name: "Raw sardine"
+    slug: "raw-sardine"
+    relationship: "component"
+    description: "Uncooked version"
+  - item_id: 347
+    item_name: "Herring"
+    slug: "herring"
+    relationship: "variant"
+    description: "Next tier bait fish"
+---
+
+## Examine
+
+> _"Some nicely cooked sardines."_
+
+## Obtaining
+
+Cooked from **raw sardines** (1 Cooking). F2P item.
+
+## About
+
+Sardines heal 4 Hitpoints. Caught with a fishing rod and bait at 5 Fishing. A slight upgrade over shrimps for early-game food.
+
+## Related Items
+
+- [Raw sardine](/osrs/raw-sardine/) - Uncooked version
+- [Herring](/osrs/herring/) - Next tier bait fish

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_327.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_327.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 325
+    item_name: "Sardine"
+    slug: "sardine"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught with a **fishing rod** and bait at 5 Fishing. F2P item.
+
+## About
+
+Raw sardines can be cooked at 1 Cooking to make sardines. One of the first fish caught with a fishing rod.
+
+## Related Items
+
+- [Sardine](/osrs/sardine/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_339.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_339.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 341
+    item_name: "Raw cod"
+    slug: "raw-cod"
+    relationship: "component"
+    description: "Uncooked version"
+---
+
+## Examine
+
+> _"Some nicely cooked cod."_
+
+## Obtaining
+
+Cooked from **raw cod** (18 Cooking). Members only.
+
+## About
+
+Cod heals 7 Hitpoints. Caught with a big fishing net at net/harpoon spots. A mid-tier members food.
+
+## Related Items
+
+- [Raw cod](/osrs/raw-cod/) - Uncooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_341.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_341.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 339
+    item_name: "Cod"
+    slug: "cod"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught with a **big fishing net** at net/harpoon spots. Members only.
+
+## About
+
+Raw cod can be cooked at 18 Cooking. Caught alongside mackerel, bass, and other sea fish.
+
+## Related Items
+
+- [Cod](/osrs/cod/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_345.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_345.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 347
+    item_name: "Herring"
+    slug: "herring"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught with a **fishing rod** and bait at 10 Fishing. F2P item.
+
+## About
+
+Raw herring can be cooked at 5 Cooking to make herring. Caught at the same bait spots as sardines.
+
+## Related Items
+
+- [Herring](/osrs/herring/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_347.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_347.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 345
+    item_name: "Raw herring"
+    slug: "raw-herring"
+    relationship: "component"
+    description: "Uncooked version"
+  - item_id: 325
+    item_name: "Sardine"
+    slug: "sardine"
+    relationship: "variant"
+    description: "Lower tier bait fish"
+---
+
+## Examine
+
+> _"Some nicely cooked herring."_
+
+## Obtaining
+
+Cooked from **raw herring** (5 Cooking). F2P item.
+
+## About
+
+Herring heals 5 Hitpoints. Caught with a fishing rod and bait at 10 Fishing.
+
+## Related Items
+
+- [Raw herring](/osrs/raw-herring/) - Uncooked version
+- [Sardine](/osrs/sardine/) - Lower tier bait fish

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_349.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_349.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 351
+    item_name: "Pike"
+    slug: "pike"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught with a **fishing rod** and bait at 25 Fishing. F2P item.
+
+## About
+
+Raw pike can be cooked at 20 Cooking. The highest-tier fish catchable with bait in F2P.
+
+## Related Items
+
+- [Pike](/osrs/pike/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_351.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_351.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 349
+    item_name: "Raw pike"
+    slug: "raw-pike"
+    relationship: "component"
+    description: "Uncooked version"
+---
+
+## Examine
+
+> _"Some nicely cooked pike."_
+
+## Obtaining
+
+Cooked from **raw pike** (20 Cooking). F2P item.
+
+## About
+
+Pike heals 8 Hitpoints. Caught with a fishing rod and bait at 25 Fishing. A decent mid-level F2P food.
+
+## Related Items
+
+- [Raw pike](/osrs/raw-pike/) - Uncooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_353.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_353.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 355
+    item_name: "Mackerel"
+    slug: "mackerel"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught with a **big fishing net** at 16 Fishing. Members only.
+
+## About
+
+Raw mackerel can be cooked at 10 Cooking. One of the first fish caught with a big fishing net at sea fishing spots.
+
+## Related Items
+
+- [Mackerel](/osrs/mackerel/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_355.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_355.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 353
+    item_name: "Raw mackerel"
+    slug: "raw-mackerel"
+    relationship: "component"
+    description: "Uncooked version"
+---
+
+## Examine
+
+> _"Some nicely cooked mackerel."_
+
+## Obtaining
+
+Cooked from **raw mackerel** (10 Cooking). Members only.
+
+## About
+
+Mackerel heals 6 Hitpoints. A low-tier members fish caught with a big fishing net.
+
+## Related Items
+
+- [Raw mackerel](/osrs/raw-mackerel/) - Uncooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_363.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_363.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 365
+    item_name: "Bass"
+    slug: "bass"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught with a **big fishing net** at 46 Fishing. Members only.
+
+## About
+
+Raw bass can be cooked at 43 Cooking. The highest-tier fish commonly caught with a big fishing net.
+
+## Related Items
+
+- [Bass](/osrs/bass/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_365.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_365.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 363
+    item_name: "Raw bass"
+    slug: "raw-bass"
+    relationship: "component"
+    description: "Uncooked version"
+---
+
+## Examine
+
+> _"Wow, this is a big fish."_
+
+## Obtaining
+
+Cooked from **raw bass** (43 Cooking). Members only.
+
+## About
+
+Bass heals 13 Hitpoints. A decent mid-level members food. Commonly caught with a big fishing net at Catherby or the Fishing Guild.
+
+## Related Items
+
+- [Raw bass](/osrs/raw-bass/) - Uncooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_395.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_395.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 397
+    item_name: "Sea turtle"
+    slug: "sea-turtle"
+    relationship: "product"
+    description: "Cooked version"
+---
+
+## Examine
+
+> _"I should try cooking this."_
+
+## Obtaining
+
+Caught while **Trawler** minigame or from Drift Net fishing. Members only.
+
+## About
+
+Raw sea turtle can be cooked at 82 Cooking. A high-level fish primarily obtained from the Fishing Trawler minigame.
+
+## Related Items
+
+- [Sea turtle](/osrs/sea-turtle/) - Cooked version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_397.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_397.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 395
+    item_name: "Raw sea turtle"
+    slug: "raw-sea-turtle"
+    relationship: "component"
+    description: "Uncooked version"
+---
+
+## Examine
+
+> _"Tasty!"_
+
+## Obtaining
+
+Cooked from **raw sea turtle** (82 Cooking). Members only.
+
+## About
+
+Sea turtle heals 21 Hitpoints. A high-level food primarily obtained from the Fishing Trawler minigame. Slightly less healing than manta ray (22) but cheaper.
+
+## Related Items
+
+- [Raw sea turtle](/osrs/raw-sea-turtle/) - Uncooked version


### PR DESCRIPTION
## Summary
- Added 50 new OSRS item override files with accurate stats, examine text, and related items
- Categories: potions (13), quest/utility items (6), grimy/clean herbs (7), fishing equipment (7), raw & cooked fish (17)
- Updated OSRS.md tracking document with new sections and session log

## Items Added
| Category | Count | Items |
|----------|-------|-------|
| Potions | 13 | Super defence(1), ranging potion(3/2/1), antipoison(3/2/1), superantipoison(3/2/1), zamorak brew(3/2/1) |
| Quest/utility | 6 | Poison chalice, pestle & mortar, fish food, poison, goblin mail, mithril seeds |
| Herbs | 7 | Grimy guam/marrentill/tarromin, guam leaf, marrentill, tarromin, harralander |
| Fishing equipment | 7 | Lobster pot, small/big fishing net, fishing/fly rod, harpoon, bait |
| Fish (raw & cooked) | 17 | Shrimps, anchovies, sardine, herring, cod, pike, mackerel, bass, sea turtle |

## Test plan
- [ ] Verify override files merge correctly with auto-generated OSRS item pages
- [ ] Check frontmatter validates against OSRSExtendedSchema
- [ ] Confirm related item links resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)