### PR TITLE
feat(bevy_statemachine): add first-class Bevy FSM bridge integration

### DIFF
--- a/packages/rust/bevy/bevy_statemachine/src/bridge.rs
+++ b/packages/rust/bevy/bevy_statemachine/src/bridge.rs
@@ -1,0 +1,287 @@
+//! FSM bridge — first-class integration with Bevy's `bevy_state` system.
+//!
+//! Automatically snapshots FSM state values and transition events to the
+//! global snapshot stores, making them readable by external consumers
+//! (Tauri IPC, WASM JS) without touching the ECS.
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+
+use crate::store;
+
+// ---------------------------------------------------------------------------
+// Snapshot wrapper types
+// ---------------------------------------------------------------------------
+
+/// Wrapper that stores the current FSM state value in the snapshot store.
+///
+/// External consumers read the current state via
+/// `get_snapshot::<FsmSnapshot<MyState>>()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use bevy_statemachine::{StateBridgePlugin, FsmSnapshot, get_snapshot};
+///
+/// #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash,
+///          serde::Serialize, serde::Deserialize)]
+/// enum GameState { #[default] Menu, Playing, Paused }
+///
+/// // After registering StateBridgePlugin::<GameState>::new():
+/// let state: Option<FsmSnapshot<GameState>> = get_snapshot();
+/// ```
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FsmSnapshot<S> {
+    /// The current FSM state value.
+    pub current: S,
+}
+
+/// Serializable record of a state transition, written to the take-once store.
+///
+/// External consumers call
+/// `take_snapshot::<StateTransitionRecord<MyState>>()` to detect transitions.
+/// The value is consumed on read (take-once semantics).
+///
+/// # Examples
+///
+/// ```ignore
+/// use bevy_statemachine::{take_snapshot, StateTransitionRecord};
+///
+/// // After a state transition occurs:
+/// if let Some(record) = take_snapshot::<StateTransitionRecord<GameState>>() {
+///     println!("Transitioned from {:?} to {:?}", record.exited, record.entered);
+/// }
+/// ```
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct StateTransitionRecord<S> {
+    /// The state that was exited (`None` if state was just created).
+    pub exited: Option<S>,
+    /// The state that was entered (`None` if state was removed).
+    pub entered: Option<S>,
+}
+
+// ---------------------------------------------------------------------------
+// StateBridgePlugin<S> — FSM → snapshot bridge
+// ---------------------------------------------------------------------------
+
+/// Bevy plugin that bridges a `States` type to the snapshot system.
+///
+/// Adds two systems:
+/// 1. **Persistent snapshot** — writes `FsmSnapshot<S>` to the persistent store
+///    whenever the state changes, readable via `get_snapshot::<FsmSnapshot<S>>()`.
+/// 2. **Transition record** — writes `StateTransitionRecord<S>` to the take-once
+///    store on each transition, readable via `take_snapshot::<StateTransitionRecord<S>>()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use bevy::prelude::*;
+/// use bevy_statemachine::StateBridgePlugin;
+///
+/// #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash,
+///          serde::Serialize, serde::Deserialize)]
+/// enum GameState { #[default] Menu, Playing, Paused }
+///
+/// app.init_state::<GameState>();
+/// app.add_plugins(StateBridgePlugin::<GameState>::new());
+/// ```
+pub struct StateBridgePlugin<S: States + 'static> {
+    _marker: PhantomData<S>,
+}
+
+impl<S: States + 'static> StateBridgePlugin<S> {
+    /// Create a new FSM bridge plugin for state type `S`.
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S: States + 'static> Default for StateBridgePlugin<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<S> Plugin for StateBridgePlugin<S>
+where
+    S: States + serde::Serialize + for<'de> serde::Deserialize<'de> + 'static,
+{
+    fn build(&self, app: &mut App) {
+        app.add_systems(PostUpdate, fsm_snapshot_system::<S>);
+        app.add_systems(PostUpdate, fsm_transition_system::<S>);
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+impl<S: States + 'static> Plugin for StateBridgePlugin<S> {
+    fn build(&self, _app: &mut App) {}
+}
+
+#[cfg(feature = "serde")]
+fn fsm_snapshot_system<S>(state: Res<State<S>>)
+where
+    S: States + serde::Serialize + 'static,
+{
+    if state.is_changed() {
+        let snapshot = FsmSnapshot {
+            current: state.get().clone(),
+        };
+
+        #[cfg(feature = "serde")]
+        let json = serde_json::to_string(&snapshot).ok();
+
+        #[cfg(feature = "bincode")]
+        let binary = bincode::serialize(&snapshot).ok();
+
+        store::write_snapshot::<FsmSnapshot<S>>(
+            #[cfg(feature = "serde")]
+            json,
+            #[cfg(feature = "bincode")]
+            binary,
+        );
+    }
+}
+
+#[cfg(feature = "serde")]
+fn fsm_transition_system<S>(mut transitions: MessageReader<StateTransitionEvent<S>>)
+where
+    S: States + serde::Serialize + 'static,
+{
+    if let Some(event) = transitions.read().last() {
+        let record = StateTransitionRecord {
+            exited: event.exited.clone(),
+            entered: event.entered.clone(),
+        };
+        crate::take::write_take_snapshot(&record);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ScopedSnapshotPlugin<S, R> — state-scoped resource snapshots
+// ---------------------------------------------------------------------------
+
+/// Bevy plugin that snapshots a resource `R` only while in a specific state.
+///
+/// When the FSM exits the target state, the snapshot is automatically cleared.
+/// Useful for state-specific UI: "only show inventory while Playing."
+///
+/// # Examples
+///
+/// ```ignore
+/// use bevy::prelude::*;
+/// use bevy_statemachine::ScopedSnapshotPlugin;
+///
+/// #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash)]
+/// enum GameState { #[default] Menu, Playing }
+///
+/// #[derive(Resource, Clone, Default, serde::Serialize)]
+/// struct Inventory { items: Vec<String> }
+///
+/// // Only snapshot Inventory while in Playing state:
+/// app.add_plugins(ScopedSnapshotPlugin::<GameState, Inventory>::new(GameState::Playing));
+/// ```
+pub struct ScopedSnapshotPlugin<S: States + 'static, R: Resource + Clone + 'static> {
+    state: S,
+    _marker: PhantomData<R>,
+}
+
+impl<S: States + 'static, R: Resource + Clone + 'static> ScopedSnapshotPlugin<S, R> {
+    /// Create a scoped snapshot plugin that only snapshots `R` while in `state`.
+    pub fn new(state: S) -> Self {
+        Self {
+            state,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<S, R> Plugin for ScopedSnapshotPlugin<S, R>
+where
+    S: States + 'static,
+    R: Resource + Clone + serde::Serialize + 'static,
+{
+    fn build(&self, app: &mut App) {
+        let state = self.state.clone();
+        app.add_systems(
+            PostUpdate,
+            scoped_snapshot_system::<R>.run_if(in_state(state)),
+        );
+        app.add_systems(OnExit(self.state.clone()), scoped_clear_system::<R>);
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+impl<S: States + 'static, R: Resource + Clone + 'static> Plugin for ScopedSnapshotPlugin<S, R> {
+    fn build(&self, _app: &mut App) {}
+}
+
+#[cfg(feature = "serde")]
+fn scoped_snapshot_system<R>(resource: Res<R>)
+where
+    R: Resource + Clone + serde::Serialize + 'static,
+{
+    if resource.is_changed() {
+        #[cfg(feature = "serde")]
+        let json = serde_json::to_string(resource.as_ref()).ok();
+
+        #[cfg(feature = "bincode")]
+        let binary = bincode::serialize(resource.as_ref()).ok();
+
+        store::write_snapshot::<R>(
+            #[cfg(feature = "serde")]
+            json,
+            #[cfg(feature = "bincode")]
+            binary,
+        );
+    }
+}
+
+fn scoped_clear_system<R: 'static>() {
+    store::clear_snapshot::<R>();
+}
+
+// ---------------------------------------------------------------------------
+// Batch version query macro
+// ---------------------------------------------------------------------------
+
+/// Query snapshot versions for multiple types at once.
+///
+/// Returns a `Vec<(&str, u64)>` of `(type_name, version)` pairs.
+/// Useful for reducing IPC round-trips when polling from a UI frontend.
+///
+/// # Examples
+///
+/// ```
+/// use bevy_statemachine::{snapshot_versions_batch, snapshot_version, clear_snapshot};
+///
+/// #[derive(Clone, serde::Serialize, serde::Deserialize)]
+/// struct A { x: i32 }
+/// #[derive(Clone, serde::Serialize, serde::Deserialize)]
+/// struct B { y: i32 }
+///
+/// bevy_statemachine::store::write_snapshot::<A>(Some(r#"{"x":1}"#.into()), );
+/// bevy_statemachine::store::write_snapshot::<B>(Some(r#"{"y":2}"#.into()), );
+///
+/// let versions = snapshot_versions_batch!(A, B);
+/// assert_eq!(versions.len(), 2);
+/// assert!(versions[0].1 > 0); // A has been written
+/// assert!(versions[1].1 > 0); // B has been written
+///
+/// clear_snapshot::<A>();
+/// clear_snapshot::<B>();
+/// ```
+#[macro_export]
+macro_rules! snapshot_versions_batch {
+    ($($t:ty),+ $(,)?) => {{
+        vec![
+            $((stringify!($t), $crate::snapshot_version::<$t>())),+
+        ]
+    }};
+}

--- a/packages/rust/bevy/bevy_statemachine/src/lib.rs
+++ b/packages/rust/bevy/bevy_statemachine/src/lib.rs
@@ -47,6 +47,7 @@
 //! let event: Option<ClickEvent> = take_snapshot();
 //! ```
 
+pub mod bridge;
 pub mod config;
 pub mod plugin;
 pub mod store;
@@ -69,6 +70,9 @@ pub use take::{peek_take_snapshot, take_snapshot, write_take_snapshot};
 // Re-exports — plugins and config
 pub use config::{SnapshotConfig, SnapshotSchedule};
 pub use plugin::{StateSnapshotPlugin, TakeSnapshotPlugin};
+
+// Re-exports — FSM bridge
+pub use bridge::{FsmSnapshot, ScopedSnapshotPlugin, StateBridgePlugin, StateTransitionRecord};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -830,5 +834,357 @@ mod tests {
         assert_eq!(parsed["name"], "test");
 
         clear_snapshot::<JsonValidState>();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FSM bridge integration tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod bridge_tests {
+    use super::*;
+    use bevy::prelude::*;
+    use bevy::state::app::StatesPlugin;
+    use serde::{Deserialize, Serialize};
+
+    // Unique state enums per test to avoid global store interference.
+
+    // === Helper: build a minimal Bevy app with state support ===============
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(StatesPlugin);
+        app
+    }
+
+    // === StateBridgePlugin tests ==========================================
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum InitState {
+        #[default]
+        Loading,
+        Playing,
+    }
+
+    #[test]
+    fn fsm_snapshot_written_on_init() {
+        let mut app = test_app();
+        app.init_state::<InitState>();
+        app.add_plugins(StateBridgePlugin::<InitState>::new());
+
+        app.update();
+
+        let snap: FsmSnapshot<InitState> = get_snapshot().unwrap();
+        assert_eq!(snap.current, InitState::Loading);
+
+        clear_snapshot::<FsmSnapshot<InitState>>();
+    }
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum TransState {
+        #[default]
+        Menu,
+        InGame,
+        Paused,
+    }
+
+    #[test]
+    fn fsm_snapshot_updates_on_transition() {
+        let mut app = test_app();
+        app.init_state::<TransState>();
+        app.add_plugins(StateBridgePlugin::<TransState>::new());
+
+        app.update();
+        let snap: FsmSnapshot<TransState> = get_snapshot().unwrap();
+        assert_eq!(snap.current, TransState::Menu);
+
+        // Transition to InGame.
+        app.world_mut()
+            .resource_mut::<NextState<TransState>>()
+            .set(TransState::InGame);
+        app.update();
+
+        let snap: FsmSnapshot<TransState> = get_snapshot().unwrap();
+        assert_eq!(snap.current, TransState::InGame);
+
+        clear_snapshot::<FsmSnapshot<TransState>>();
+    }
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum RecordState {
+        #[default]
+        A,
+        B,
+    }
+
+    #[test]
+    fn fsm_transition_record_written() {
+        let mut app = test_app();
+        app.init_state::<RecordState>();
+        app.add_plugins(StateBridgePlugin::<RecordState>::new());
+
+        app.update();
+
+        // Consume the initial transition record (None -> A).
+        let init_record: Option<StateTransitionRecord<RecordState>> = take_snapshot();
+        assert!(init_record.is_some());
+        let init_record = init_record.unwrap();
+        assert_eq!(init_record.exited, None);
+        assert_eq!(init_record.entered, Some(RecordState::A));
+
+        // Transition A -> B.
+        app.world_mut()
+            .resource_mut::<NextState<RecordState>>()
+            .set(RecordState::B);
+        app.update();
+
+        let record: StateTransitionRecord<RecordState> = take_snapshot().unwrap();
+        assert_eq!(record.exited, Some(RecordState::A));
+        assert_eq!(record.entered, Some(RecordState::B));
+
+        clear_snapshot::<FsmSnapshot<RecordState>>();
+    }
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum TakeOnceState {
+        #[default]
+        X,
+        Y,
+    }
+
+    #[test]
+    fn fsm_transition_record_is_take_once() {
+        let mut app = test_app();
+        app.init_state::<TakeOnceState>();
+        app.add_plugins(StateBridgePlugin::<TakeOnceState>::new());
+
+        app.update();
+
+        // First take consumes the record.
+        let _: Option<StateTransitionRecord<TakeOnceState>> = take_snapshot();
+
+        // Second take returns None.
+        let second: Option<StateTransitionRecord<TakeOnceState>> = take_snapshot();
+        assert!(second.is_none());
+
+        clear_snapshot::<FsmSnapshot<TakeOnceState>>();
+    }
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum VersionState {
+        #[default]
+        V1,
+        V2,
+        V3,
+    }
+
+    #[test]
+    fn fsm_snapshot_version_increments() {
+        let mut app = test_app();
+        app.init_state::<VersionState>();
+        app.add_plugins(StateBridgePlugin::<VersionState>::new());
+
+        app.update();
+        let v1 = snapshot_version::<FsmSnapshot<VersionState>>();
+        assert!(v1 > 0);
+
+        app.world_mut()
+            .resource_mut::<NextState<VersionState>>()
+            .set(VersionState::V2);
+        app.update();
+        let v2 = snapshot_version::<FsmSnapshot<VersionState>>();
+        assert!(v2 > v1);
+
+        clear_snapshot::<FsmSnapshot<VersionState>>();
+    }
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum JsonState {
+        #[default]
+        Alpha,
+        Beta,
+    }
+
+    #[test]
+    fn fsm_snapshot_json_is_valid() {
+        let mut app = test_app();
+        app.init_state::<JsonState>();
+        app.add_plugins(StateBridgePlugin::<JsonState>::new());
+
+        app.update();
+
+        let json = get_snapshot_json::<FsmSnapshot<JsonState>>().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["current"], "Alpha");
+
+        clear_snapshot::<FsmSnapshot<JsonState>>();
+    }
+
+    // === ScopedSnapshotPlugin tests =======================================
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum ScopedState {
+        #[default]
+        Lobby,
+        Match,
+    }
+
+    #[derive(Resource, Clone, Default, Serialize, Deserialize, PartialEq, Debug)]
+    struct MatchData {
+        score: u32,
+    }
+
+    #[test]
+    fn scoped_snapshot_active_in_state() {
+        let mut app = test_app();
+        app.init_state::<ScopedState>();
+        app.insert_resource(MatchData { score: 0 });
+        app.add_plugins(ScopedSnapshotPlugin::<ScopedState, MatchData>::new(
+            ScopedState::Match,
+        ));
+
+        // In Lobby — scoped snapshot should NOT be written.
+        app.update();
+        assert!(get_snapshot::<MatchData>().is_none());
+
+        // Transition to Match.
+        app.world_mut()
+            .resource_mut::<NextState<ScopedState>>()
+            .set(ScopedState::Match);
+        app.update();
+
+        // Now in Match — resource changed (first time in state), snapshot should exist.
+        // Force a change detection by mutating the resource.
+        app.world_mut().resource_mut::<MatchData>().score = 42;
+        app.update();
+
+        let data: MatchData = get_snapshot().unwrap();
+        assert_eq!(data.score, 42);
+
+        clear_snapshot::<MatchData>();
+    }
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum ScopedExitState {
+        #[default]
+        Active,
+        Inactive,
+    }
+
+    #[derive(Resource, Clone, Default, Serialize, Deserialize, PartialEq, Debug)]
+    struct ScopedResource {
+        val: i32,
+    }
+
+    #[test]
+    fn scoped_snapshot_cleared_on_exit() {
+        let mut app = test_app();
+        app.init_state::<ScopedExitState>();
+        app.insert_resource(ScopedResource { val: 10 });
+        app.add_plugins(
+            ScopedSnapshotPlugin::<ScopedExitState, ScopedResource>::new(ScopedExitState::Active),
+        );
+
+        // Start in Active — force resource mutation so snapshot writes.
+        app.update();
+        app.world_mut().resource_mut::<ScopedResource>().val = 99;
+        app.update();
+
+        assert!(get_snapshot::<ScopedResource>().is_some());
+
+        // Transition to Inactive — snapshot should be cleared.
+        app.world_mut()
+            .resource_mut::<NextState<ScopedExitState>>()
+            .set(ScopedExitState::Inactive);
+        app.update();
+
+        assert!(get_snapshot::<ScopedResource>().is_none());
+        assert_eq!(snapshot_version::<ScopedResource>(), 0);
+    }
+
+    // === Batch versions macro =============================================
+
+    #[test]
+    fn batch_versions_macro_works() {
+        #[derive(Clone, Serialize, Deserialize)]
+        struct BatchA {
+            a: i32,
+        }
+        #[derive(Clone, Serialize, Deserialize)]
+        struct BatchB {
+            b: i32,
+        }
+
+        store::write_snapshot::<BatchA>(
+            #[cfg(feature = "serde")]
+            Some(r#"{"a":1}"#.to_string()),
+            #[cfg(feature = "bincode")]
+            None,
+        );
+        store::write_snapshot::<BatchB>(
+            #[cfg(feature = "serde")]
+            Some(r#"{"b":2}"#.to_string()),
+            #[cfg(feature = "bincode")]
+            None,
+        );
+
+        let versions = snapshot_versions_batch!(BatchA, BatchB);
+        assert_eq!(versions.len(), 2);
+        assert!(versions[0].1 > 0);
+        assert!(versions[1].1 > 0);
+        assert_eq!(versions[0].0, "BatchA");
+        assert_eq!(versions[1].0, "BatchB");
+
+        clear_snapshot::<BatchA>();
+        clear_snapshot::<BatchB>();
+    }
+
+    // === Multiple FSM bridges =============================================
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum IsoA {
+        #[default]
+        One,
+        Two,
+    }
+
+    #[derive(States, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    enum IsoB {
+        #[default]
+        Red,
+        Blue,
+    }
+
+    #[test]
+    fn multiple_fsm_bridges_isolated() {
+        let mut app = test_app();
+        app.init_state::<IsoA>();
+        app.init_state::<IsoB>();
+        app.add_plugins(StateBridgePlugin::<IsoA>::new());
+        app.add_plugins(StateBridgePlugin::<IsoB>::new());
+
+        app.update();
+
+        let a: FsmSnapshot<IsoA> = get_snapshot().unwrap();
+        let b: FsmSnapshot<IsoB> = get_snapshot().unwrap();
+        assert_eq!(a.current, IsoA::One);
+        assert_eq!(b.current, IsoB::Red);
+
+        // Transition only A.
+        app.world_mut()
+            .resource_mut::<NextState<IsoA>>()
+            .set(IsoA::Two);
+        app.update();
+
+        let a: FsmSnapshot<IsoA> = get_snapshot().unwrap();
+        let b: FsmSnapshot<IsoB> = get_snapshot().unwrap();
+        assert_eq!(a.current, IsoA::Two);
+        assert_eq!(b.current, IsoB::Red); // unchanged
+
+        clear_snapshot::<FsmSnapshot<IsoA>>();
+        clear_snapshot::<FsmSnapshot<IsoB>>();
     }
 }


### PR DESCRIPTION
## Summary

Adds `bridge.rs` module with full `bevy_state` FSM integration to the `bevy_statemachine` crate.

## New Public API

- **`StateBridgePlugin<S>`** — Auto-snapshots any `States` type to the global store on transitions. Writes `FsmSnapshot<S>` to persistent store and `StateTransitionRecord<S>` to take-once store.
- **`FsmSnapshot<S>`** — Wrapper holding the current FSM state value with versioning.
- **`StateTransitionRecord<S>`** — Serializable transition record with `exited`/`entered` fields.
- **`ScopedSnapshotPlugin<S, R>`** — State-scoped resource snapshots that auto-clear on `OnExit`.
- **`snapshot_versions_batch!`** — Batch version query macro for reducing IPC round-trips.

## Tests

47 unit tests (37 existing + 10 new bridge integration tests) + 11 doctests, all passing.

New bridge tests use full Bevy `App` with `StatesPlugin` to verify real FSM transitions drive snapshot writes.