### PR TITLE
feat(osrs): add 50 item overrides - gnome clothes, thrownaxes, bones, misc

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -1136,6 +1136,86 @@ Focus on items with clear processing chains and market flip potential.
 | 395 | Raw sea turtle | Trawler minigame, members  |
 | 397 | Sea turtle     | 21 HP, 82 Cooking, members |
 
+### Fishing Misc & Oysters (Implemented - Mar 2026)
+
+| ID  | Item           | Notes                          |
+| --- | -------------- | ------------------------------ |
+| 403 | Edible seaweed | 4 HP heal, soda ash ingredient |
+| 405 | Casket         | Big net fishing loot           |
+| 407 | Oyster         | Big net fishing, pearls inside |
+| 411 | Oyster pearl   | Crafting ingredient            |
+| 413 | Oyster pearls  | Crafting ingredient            |
+
+### Prayer/Religious Gear (Implemented - Mar 2026)
+
+| ID  | Item                 | Notes                   |
+| --- | -------------------- | ----------------------- |
+| 426 | Priest gown (top)    | +3 Prayer, F2P          |
+| 428 | Priest gown (bottom) | +3 Prayer, F2P          |
+| 528 | Burnt bones          | 4.5 Prayer XP           |
+| 530 | Bat bones            | 5.3 Prayer XP, F2P      |
+| 534 | Babydragon bones     | 30 Prayer XP, members   |
+| 538 | Druid's robe         | +4 Prayer legs, members |
+| 540 | Druid's robe top     | +4 Prayer body, members |
+
+### Misc Utility & Quest Items (Implemented - Mar 2026)
+
+| ID  | Item           | Notes                 |
+| --- | -------------- | --------------------- |
+| 464 | Strange fruit  | Cures poison, 30% run |
+| 581 | Black robe     | Cosmetic body, F2P    |
+| 590 | Tinderbox      | Firemaking tool, F2P  |
+| 592 | Ashes          | Fire byproduct, F2P   |
+| 596 | Unlit torch    | Light source, F2P     |
+| 621 | Ship ticket    | Port Sarim to Karamja |
+| 751 | Gnomeball      | Gnomeball minigame    |
+| 753 | Cadava berries | Quest item, F2P       |
+
+### Gnome Clothing Sets (Implemented - Mar 2026)
+
+| ID  | Item                   | Notes              |
+| --- | ---------------------- | ------------------ |
+| 626 | Pink boots             | Gnome set, members |
+| 628 | Green boots            | Gnome set, members |
+| 630 | Blue boots             | Gnome set, members |
+| 632 | Cream boots            | Gnome set, members |
+| 634 | Turquoise boots        | Gnome set, members |
+| 636 | Pink robe top          | Gnome set, members |
+| 638 | Green robe top         | Gnome set, members |
+| 640 | Blue robe top          | Gnome set, members |
+| 642 | Cream robe top         | Gnome set, members |
+| 644 | Turquoise robe top     | Gnome set, members |
+| 646 | Pink robe bottoms      | Gnome set, members |
+| 648 | Green robe bottoms     | Gnome set, members |
+| 650 | Blue robe bottoms      | Gnome set, members |
+| 652 | Cream robe bottoms     | Gnome set, members |
+| 654 | Turquoise robe bottoms | Gnome set, members |
+| 656 | Pink hat               | Gnome set, members |
+| 658 | Green hat              | Gnome set, members |
+| 660 | Blue hat               | Gnome set, members |
+| 662 | Cream hat              | Gnome set, members |
+| 664 | Turquoise hat          | Gnome set, members |
+
+### Thrownaxes (Implemented - Mar 2026)
+
+| ID  | Item              | Notes                     |
+| --- | ----------------- | ------------------------- |
+| 800 | Bronze thrownaxe  | No req, +5 ranged str     |
+| 801 | Iron thrownaxe    | 1 Ranged, +7 ranged str   |
+| 802 | Steel thrownaxe   | 5 Ranged, +11 ranged str  |
+| 803 | Mithril thrownaxe | 20 Ranged, +16 ranged str |
+| 804 | Adamant thrownaxe | 30 Ranged, +23 ranged str |
+| 805 | Rune thrownaxe    | 40 Ranged, +36 ranged str |
+
+### Poisoned Darts (Implemented - Mar 2026)
+
+| ID  | Item             | Notes                   |
+| --- | ---------------- | ----------------------- |
+| 812 | Bronze dart (p)  | No req, basic poison    |
+| 813 | Iron dart (p)    | 1 Ranged, basic poison  |
+| 814 | Steel dart (p)   | 5 Ranged, basic poison  |
+| 815 | Mithril dart (p) | 20 Ranged, basic poison |
+
 ---
 
 ## Future Override Priorities
@@ -1739,6 +1819,7 @@ Record batch completions here:
 | Mar 13, 2026 | +50 items (rune/steel/black trimmed, monk robes, heraldic, misc) | ~1131           |
 | Mar 13, 2026 | +50 items (cannon parts, fletching supplies, potions)            | ~1181           |
 | Mar 13, 2026 | +50 items (potions, herbs, fishing equipment, fish)              | ~1231           |
+| Mar 13, 2026 | +50 items (gnome clothes, thrownaxes, darts, bones, misc)        | ~1281           |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_403.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_403.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"Slightly damp seaweed."_
+
+## Obtaining
+
+Found on beaches at **Fossil Island** and Mos Le'Harmless. Dropped by Rock Crabs, Dagannoths, and Kraken. Members only.
+
+## About
+
+Edible seaweed heals 4 Hitpoints when eaten. Can also be cooked on a fire or range to produce soda ash, used in making molten glass for Crafting.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_405.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_405.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"I hope there's treasure in it."_
+
+## Obtaining
+
+Obtained from **big net fishing** (~1/128 chance), monster drops from water creatures, and the Quiz Master random event. Members only.
+
+## About
+
+Opening a casket yields random loot averaging ~537 coins, including coins, uncut gems, cosmic talismans, and rarely key halves worth ~10,000 coins each. A wearing a charged skills necklace slightly increases the fishing drop rate.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_407.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_407.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 411
+    item_name: "Oyster pearl"
+    slug: "oyster-pearl"
+    relationship: "product"
+    description: "Possible contents"
+  - item_id: 413
+    item_name: "Oyster pearls"
+    slug: "oyster-pearls"
+    relationship: "product"
+    description: "Possible contents"
+---
+
+## Examine
+
+> _"It's a big oyster."_
+
+## Obtaining
+
+Caught via **big net fishing**. Members only.
+
+## About
+
+Opening an oyster may yield an oyster pearl or oyster pearls, used in Crafting to make pearl items. Can also be empty.
+
+## Related Items
+
+- [Oyster pearl](/osrs/oyster-pearl/) - Single pearl result
+- [Oyster pearls](/osrs/oyster-pearls/) - Multiple pearls result

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_411.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_411.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 407
+    item_name: "Oyster"
+    slug: "oyster"
+    relationship: "component"
+    description: "Source item"
+---
+
+## Examine
+
+> _"A little pearl."_
+
+## Obtaining
+
+Found inside **oysters** from big net fishing. Members only.
+
+## About
+
+An oyster pearl can be used with a chisel to craft a pearl bolt tip (41 Crafting) or a pearl ring. Worth slightly less than oyster pearls.
+
+## Related Items
+
+- [Oyster](/osrs/oyster/) - Source item

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_413.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_413.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 407
+    item_name: "Oyster"
+    slug: "oyster"
+    relationship: "component"
+    description: "Source item"
+---
+
+## Examine
+
+> _"Some little pearls."_
+
+## Obtaining
+
+Found inside **oysters** from big net fishing. Members only.
+
+## About
+
+Oyster pearls can be used with a chisel to craft pearl bolt tips (41 Crafting). The rarer drop from oysters compared to a single oyster pearl.
+
+## Related Items
+
+- [Oyster](/osrs/oyster/) - Source item

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_426.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_426.mdx
@@ -1,0 +1,28 @@
+---
+equipment:
+  slot: "body"
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 428
+    item_name: "Priest gown (bottom)"
+    slug: "priest-gown-bottom"
+    relationship: "set-piece"
+    description: "Matching bottom"
+---
+
+## Examine
+
+> _"Top half of a priest suit."_
+
+## Obtaining
+
+Purchased from **clothing shops** in Varrock for 5 coins. F2P item.
+
+## About
+
+The priest gown top provides +3 Prayer bonus with no requirements. One of the cheapest Prayer-boosting items available, popular with F2P prayer builds and low-level accounts.
+
+## Related Items
+
+- [Priest gown (bottom)](/osrs/priest-gown-bottom/) - Matching bottom (+3 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_428.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_428.mdx
@@ -1,0 +1,28 @@
+---
+equipment:
+  slot: "legs"
+  other_bonus:
+    prayer: 3
+related_items:
+  - item_id: 426
+    item_name: "Priest gown (top)"
+    slug: "priest-gown-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"Bottom half of a priest suit."_
+
+## Obtaining
+
+Purchased from **clothing shops** in Varrock for 5 coins. F2P item.
+
+## About
+
+The priest gown bottom provides +3 Prayer bonus with no requirements. Combined with the top, gives +6 Prayer bonus for just 10 coins total.
+
+## Related Items
+
+- [Priest gown (top)](/osrs/priest-gown-top/) - Matching top (+3 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_464.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_464.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"I wonder what this tastes like?"_
+
+## Obtaining
+
+From **Strange Plant** random event, Forestry flowering trees, fruit stall theft (25 Thieving), and boss drops. Members only.
+
+## About
+
+Strange fruit cures poison and venom instantly, grants ~18 seconds poison immunity, and restores 30% run energy. Does not heal Hitpoints. Useful as a lightweight anti-poison alternative.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_528.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_528.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 530
+    item_name: "Bat bones"
+    slug: "bat-bones"
+    relationship: "variant"
+    description: "Another bone type"
+---
+
+## Examine
+
+> _"A\"charred\" set of bones."_
+
+## Obtaining
+
+Dropped by **fire-based monsters** and found in various locations. F2P item.
+
+## About
+
+Burnt bones give 4.5 Prayer XP when buried, slightly more than regular bones (4.5). Primarily dropped by fiery creatures and found in Lava Dragon Isle.
+
+## Related Items
+
+- [Bat bones](/osrs/bat-bones/) - Another bone type (5.3 XP)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_530.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_530.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 534
+    item_name: "Babydragon bones"
+    slug: "babydragon-bones"
+    relationship: "variant"
+    description: "Higher tier bones"
+---
+
+## Examine
+
+> _"Ew it's a pile of bones."_
+
+## Obtaining
+
+Dropped by **bats** and giant bats. F2P item.
+
+## About
+
+Bat bones give 5.3 Prayer XP when buried. A minor upgrade over regular bones (4.5 XP). Commonly obtained from bats in various caves and dungeons.
+
+## Related Items
+
+- [Babydragon bones](/osrs/babydragon-bones/) - Higher tier bones (30 XP)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_534.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_534.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 530
+    item_name: "Bat bones"
+    slug: "bat-bones"
+    relationship: "variant"
+    description: "Lower tier bones"
+---
+
+## Examine
+
+> _"Ew it's a pile of bones."_
+
+## Obtaining
+
+Dropped by **baby dragons** (blue, red, black, green, lava). Members only.
+
+## About
+
+Babydragon bones give 30 Prayer XP when buried. A cost-effective way to train Prayer, especially from blue baby dragons in Taverley Dungeon. Also usable on gilded altars (105 XP) or the Chaos Temple (210 XP).
+
+## Related Items
+
+- [Bat bones](/osrs/bat-bones/) - Lower tier bones (5.3 XP)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_538.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_538.mdx
@@ -1,0 +1,28 @@
+---
+equipment:
+  slot: "legs"
+  other_bonus:
+    prayer: 4
+related_items:
+  - item_id: 540
+    item_name: "Druid's robe top"
+    slug: "druid-s-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"Keeps a druid's knees nice and warm."_
+
+## Obtaining
+
+Dropped by **Chaos druids** and found in the Taverley dungeon area. Members only.
+
+## About
+
+The druid's robe (bottom) provides +4 Prayer bonus with no requirements. One of the best free Prayer-bonus leg items for low-level accounts.
+
+## Related Items
+
+- [Druid's robe top](/osrs/druid-s-robe-top/) - Matching top (+4 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_540.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_540.mdx
@@ -1,0 +1,28 @@
+---
+equipment:
+  slot: "body"
+  other_bonus:
+    prayer: 4
+related_items:
+  - item_id: 538
+    item_name: "Druid's robe"
+    slug: "druid-s-robe"
+    relationship: "set-piece"
+    description: "Matching bottom"
+---
+
+## Examine
+
+> _"I feel closer to the gods when I wear this."_
+
+## Obtaining
+
+Dropped by **Chaos druids** and found in the Taverley dungeon area. Members only.
+
+## About
+
+The druid's robe top provides +4 Prayer bonus with no requirements. Combined with the bottom, gives +8 Prayer bonus — excellent for low-level prayer setups.
+
+## Related Items
+
+- [Druid's robe](/osrs/druid-s-robe/) - Matching bottom (+4 Prayer)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_581.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_581.mdx
@@ -1,0 +1,21 @@
+---
+equipment:
+  slot: "body"
+related_items: []
+---
+
+## Examine
+
+> _"A\"dark\" black robe."_
+
+## Obtaining
+
+Purchased from the **Varrock clothing shop** for 13 coins. Also dropped by Dark wizards. F2P item.
+
+## About
+
+The black robe is a basic cosmetic body item with no combat bonuses. Sometimes used for roleplaying or budget dark wizard fashionscape.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_590.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_590.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"Useful for lighting fires."_
+
+## Obtaining
+
+Purchased from **general stores** for 1 coin. Spawns in numerous locations. F2P item.
+
+## About
+
+The tinderbox is used to light fires with logs (1 Firemaking) and light various light sources. One of the most essential tools in the game. Can be stored in a tool belt equivalent.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_592.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_592.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A pile of ashes."_
+
+## Obtaining
+
+Left behind when a **fire** burns out. Also dropped by various demons and fire creatures. F2P item.
+
+## About
+
+Ashes are a common byproduct of Firemaking. Used in several quests and as a Herblore secondary ingredient. Give 0 Prayer XP if scattered but can be used to make serum 207 and other niche items.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_596.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_596.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"An unlit torch."_
+
+## Obtaining
+
+Purchased from **general stores** and various shops. Also found as item spawns. F2P item.
+
+## About
+
+An unlit torch can be lit with a tinderbox to create a lit torch, providing a light source in dark areas like the Lumbridge Swamp Caves. Burns out over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_621.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_621.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"Take this to the ship captain."_
+
+## Obtaining
+
+Purchased for 30 coins from the **Port Sarim** docks. F2P item.
+
+## About
+
+A ship ticket is used to travel by ship between Port Sarim and Karamja. Consumed on use. The one-time 30 coin fee is one of the earliest travel costs new players encounter.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_626.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_626.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "feet"
+related_items:
+  - item_id: 636
+    item_name: "Pink robe top"
+    slug: "pink-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A\"nice\" pair of pink boots."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 650 coins. Members only.
+
+## About
+
+Pink boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Pink robe top](/osrs/pink-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_628.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_628.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "feet"
+related_items:
+  - item_id: 638
+    item_name: "Green robe top"
+    slug: "green-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A pair of green boots."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 650 coins. Members only.
+
+## About
+
+Green boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Green robe top](/osrs/green-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_630.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_630.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "feet"
+related_items:
+  - item_id: 640
+    item_name: "Blue robe top"
+    slug: "blue-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A pair of blue boots."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 650 coins. Members only.
+
+## About
+
+Blue boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Blue robe top](/osrs/blue-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_632.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_632.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "feet"
+related_items:
+  - item_id: 642
+    item_name: "Cream robe top"
+    slug: "cream-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A pair of cream coloured boots."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 650 coins. Members only.
+
+## About
+
+Cream boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Cream robe top](/osrs/cream-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_634.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_634.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "feet"
+related_items:
+  - item_id: 644
+    item_name: "Turquoise robe top"
+    slug: "turquoise-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A pair of turquoise boots."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 650 coins. Members only.
+
+## About
+
+Turquoise boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Turquoise robe top](/osrs/turquoise-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_636.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_636.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+related_items:
+  - item_id: 626
+    item_name: "Pink boots"
+    slug: "pink-boots"
+    relationship: "set-piece"
+    description: "Matching boots"
+  - item_id: 646
+    item_name: "Pink robe bottoms"
+    slug: "pink-robe-bottoms"
+    relationship: "set-piece"
+    description: "Matching bottoms"
+---
+
+## Examine
+
+> _"A pink robe top."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+The pink robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Pink boots](/osrs/pink-boots/) - Matching boots
+- [Pink robe bottoms](/osrs/pink-robe-bottoms/) - Matching bottoms

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_638.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_638.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+related_items:
+  - item_id: 628
+    item_name: "Green boots"
+    slug: "green-boots"
+    relationship: "set-piece"
+    description: "Matching boots"
+  - item_id: 648
+    item_name: "Green robe bottoms"
+    slug: "green-robe-bottoms"
+    relationship: "set-piece"
+    description: "Matching bottoms"
+---
+
+## Examine
+
+> _"A green robe top."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+The green robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Green boots](/osrs/green-boots/) - Matching boots
+- [Green robe bottoms](/osrs/green-robe-bottoms/) - Matching bottoms

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_640.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_640.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+related_items:
+  - item_id: 630
+    item_name: "Blue boots"
+    slug: "blue-boots"
+    relationship: "set-piece"
+    description: "Matching boots"
+  - item_id: 650
+    item_name: "Blue robe bottoms"
+    slug: "blue-robe-bottoms"
+    relationship: "set-piece"
+    description: "Matching bottoms"
+---
+
+## Examine
+
+> _"A blue robe top."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+The blue robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Blue boots](/osrs/blue-boots/) - Matching boots
+- [Blue robe bottoms](/osrs/blue-robe-bottoms/) - Matching bottoms

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_642.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_642.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+related_items:
+  - item_id: 632
+    item_name: "Cream boots"
+    slug: "cream-boots"
+    relationship: "set-piece"
+    description: "Matching boots"
+  - item_id: 652
+    item_name: "Cream robe bottoms"
+    slug: "cream-robe-bottoms"
+    relationship: "set-piece"
+    description: "Matching bottoms"
+---
+
+## Examine
+
+> _"A cream robe top."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+The cream robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Cream boots](/osrs/cream-boots/) - Matching boots
+- [Cream robe bottoms](/osrs/cream-robe-bottoms/) - Matching bottoms

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_644.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_644.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "body"
+related_items:
+  - item_id: 634
+    item_name: "Turquoise boots"
+    slug: "turquoise-boots"
+    relationship: "set-piece"
+    description: "Matching boots"
+  - item_id: 654
+    item_name: "Turquoise robe bottoms"
+    slug: "turquoise-robe-bottoms"
+    relationship: "set-piece"
+    description: "Matching bottoms"
+---
+
+## Examine
+
+> _"A turquoise robe top."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+The turquoise robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Turquoise boots](/osrs/turquoise-boots/) - Matching boots
+- [Turquoise robe bottoms](/osrs/turquoise-robe-bottoms/) - Matching bottoms

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_646.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_646.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "legs"
+related_items:
+  - item_id: 636
+    item_name: "Pink robe top"
+    slug: "pink-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+  - item_id: 656
+    item_name: "Pink hat"
+    slug: "pink-hat"
+    relationship: "set-piece"
+    description: "Matching hat"
+---
+
+## Examine
+
+> _"A\"nice\" pair of pink robe bottoms."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+Pink robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Pink robe top](/osrs/pink-robe-top/) - Matching top
+- [Pink hat](/osrs/pink-hat/) - Matching hat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_648.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_648.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "legs"
+related_items:
+  - item_id: 638
+    item_name: "Green robe top"
+    slug: "green-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+  - item_id: 658
+    item_name: "Green hat"
+    slug: "green-hat"
+    relationship: "set-piece"
+    description: "Matching hat"
+---
+
+## Examine
+
+> _"A pair of green robe bottoms."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+Green robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Green robe top](/osrs/green-robe-top/) - Matching top
+- [Green hat](/osrs/green-hat/) - Matching hat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_650.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_650.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "legs"
+related_items:
+  - item_id: 640
+    item_name: "Blue robe top"
+    slug: "blue-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+  - item_id: 660
+    item_name: "Blue hat"
+    slug: "blue-hat"
+    relationship: "set-piece"
+    description: "Matching hat"
+---
+
+## Examine
+
+> _"A pair of blue robe bottoms."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+Blue robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Blue robe top](/osrs/blue-robe-top/) - Matching top
+- [Blue hat](/osrs/blue-hat/) - Matching hat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_652.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_652.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "legs"
+related_items:
+  - item_id: 642
+    item_name: "Cream robe top"
+    slug: "cream-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+  - item_id: 662
+    item_name: "Cream hat"
+    slug: "cream-hat"
+    relationship: "set-piece"
+    description: "Matching hat"
+---
+
+## Examine
+
+> _"A pair of cream robe bottoms."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+Cream robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Cream robe top](/osrs/cream-robe-top/) - Matching top
+- [Cream hat](/osrs/cream-hat/) - Matching hat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_654.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_654.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "legs"
+related_items:
+  - item_id: 644
+    item_name: "Turquoise robe top"
+    slug: "turquoise-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+  - item_id: 664
+    item_name: "Turquoise hat"
+    slug: "turquoise-hat"
+    relationship: "set-piece"
+    description: "Matching hat"
+---
+
+## Examine
+
+> _"A pair of turquoise robe bottoms."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 1,300 coins. Members only.
+
+## About
+
+Turquoise robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Turquoise robe top](/osrs/turquoise-robe-top/) - Matching top
+- [Turquoise hat](/osrs/turquoise-hat/) - Matching hat

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_656.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_656.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "head"
+related_items:
+  - item_id: 636
+    item_name: "Pink robe top"
+    slug: "pink-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A\"nice\" pink hat."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 160 coins. Members only.
+
+## About
+
+The pink hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Pink robe top](/osrs/pink-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_658.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_658.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "head"
+related_items:
+  - item_id: 638
+    item_name: "Green robe top"
+    slug: "green-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A green hat."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 160 coins. Members only.
+
+## About
+
+The green hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Green robe top](/osrs/green-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_660.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_660.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "head"
+related_items:
+  - item_id: 640
+    item_name: "Blue robe top"
+    slug: "blue-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A blue hat."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 160 coins. Members only.
+
+## About
+
+The blue hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Blue robe top](/osrs/blue-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_662.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_662.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "head"
+related_items:
+  - item_id: 642
+    item_name: "Cream robe top"
+    slug: "cream-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A cream hat."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 160 coins. Members only.
+
+## About
+
+The cream hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Cream robe top](/osrs/cream-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_664.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_664.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "head"
+related_items:
+  - item_id: 644
+    item_name: "Turquoise robe top"
+    slug: "turquoise-robe-top"
+    relationship: "set-piece"
+    description: "Matching top"
+---
+
+## Examine
+
+> _"A turquoise hat."_
+
+## Obtaining
+
+Purchased from **Rometti** at the Grand Tree for 160 coins. Members only.
+
+## About
+
+The turquoise hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+
+## Related Items
+
+- [Turquoise robe top](/osrs/turquoise-robe-top/) - Matching gnome top

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_751.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_751.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"It's a gnomeball."_
+
+## Obtaining
+
+Obtained during the **Gnomeball** minigame at the Gnome Stronghold. Members only.
+
+## About
+
+The gnomeball is used in the Gnomeball minigame north of the Gnome Stronghold. Players pass the ball between gnomes to score goals. Can be thrown at other players for fun.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_753.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_753.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"Some cadava berries."_
+
+## Obtaining
+
+Picked from **cadava bushes** south-east of Varrock. F2P item.
+
+## About
+
+Cadava berries are a quest item used in Romeo & Juliet to create a cadava potion. They're poisonous if eaten (deal 1 damage). Also used in the Plague City quest.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_800.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_800.mdx
@@ -1,0 +1,30 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 5
+  attack_bonus:
+    ranged: 4
+  ranged_strength: 5
+related_items:
+  - item_id: 801
+    item_name: "Iron thrownaxe"
+    slug: "iron-thrownaxe"
+    relationship: "variant"
+    description: "Higher tier thrownaxe"
+---
+
+## Examine
+
+> _"A finely balanced throwing axe."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 1) or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The bronze thrownaxe is the lowest-tier thrownaxe. No Ranged requirement to wield. Thrownaxes have a special attack that bounces between targets. Rarely used due to low stats.
+
+## Related Items
+
+- [Iron thrownaxe](/osrs/iron-thrownaxe/) - Higher tier (+7 ranged str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_801.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_801.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 5
+  requirements:
+    ranged: 1
+  attack_bonus:
+    ranged: 5
+  ranged_strength: 7
+related_items:
+  - item_id: 800
+    item_name: "Bronze thrownaxe"
+    slug: "bronze-thrownaxe"
+    relationship: "variant"
+    description: "Lower tier thrownaxe"
+  - item_id: 802
+    item_name: "Steel thrownaxe"
+    slug: "steel-thrownaxe"
+    relationship: "variant"
+    description: "Higher tier thrownaxe"
+---
+
+## Examine
+
+> _"A finely balanced throwing axe."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 15) or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The iron thrownaxe requires 1 Ranged. Features the thrownaxe special attack that bounces between multiple targets.
+
+## Related Items
+
+- [Bronze thrownaxe](/osrs/bronze-thrownaxe/) - Lower tier (+5 ranged str)
+- [Steel thrownaxe](/osrs/steel-thrownaxe/) - Higher tier (+11 ranged str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_802.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_802.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 5
+  requirements:
+    ranged: 5
+  attack_bonus:
+    ranged: 8
+  ranged_strength: 11
+related_items:
+  - item_id: 801
+    item_name: "Iron thrownaxe"
+    slug: "iron-thrownaxe"
+    relationship: "variant"
+    description: "Lower tier thrownaxe"
+  - item_id: 803
+    item_name: "Mithril thrownaxe"
+    slug: "mithril-thrownaxe"
+    relationship: "variant"
+    description: "Higher tier thrownaxe"
+---
+
+## Examine
+
+> _"A finely balanced throwing axe."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 30) or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The steel thrownaxe requires 5 Ranged. Features the bouncing special attack shared by all thrownaxes.
+
+## Related Items
+
+- [Iron thrownaxe](/osrs/iron-thrownaxe/) - Lower tier (+7 ranged str)
+- [Mithril thrownaxe](/osrs/mithril-thrownaxe/) - Higher tier (+16 ranged str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_803.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_803.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 5
+  requirements:
+    ranged: 20
+  attack_bonus:
+    ranged: 12
+  ranged_strength: 16
+related_items:
+  - item_id: 802
+    item_name: "Steel thrownaxe"
+    slug: "steel-thrownaxe"
+    relationship: "variant"
+    description: "Lower tier thrownaxe"
+  - item_id: 804
+    item_name: "Adamant thrownaxe"
+    slug: "adamant-thrownaxe"
+    relationship: "variant"
+    description: "Higher tier thrownaxe"
+---
+
+## Examine
+
+> _"A finely balanced throwing axe."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 45) or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The mithril thrownaxe requires 20 Ranged. Mid-tier thrownaxe with the bouncing special attack.
+
+## Related Items
+
+- [Steel thrownaxe](/osrs/steel-thrownaxe/) - Lower tier (+11 ranged str)
+- [Adamant thrownaxe](/osrs/adamant-thrownaxe/) - Higher tier (+23 ranged str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_804.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_804.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 5
+  requirements:
+    ranged: 30
+  attack_bonus:
+    ranged: 15
+  ranged_strength: 23
+related_items:
+  - item_id: 803
+    item_name: "Mithril thrownaxe"
+    slug: "mithril-thrownaxe"
+    relationship: "variant"
+    description: "Lower tier thrownaxe"
+  - item_id: 805
+    item_name: "Rune thrownaxe"
+    slug: "rune-thrownaxe"
+    relationship: "variant"
+    description: "Higher tier thrownaxe"
+---
+
+## Examine
+
+> _"A finely balanced throwing axe."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 60) or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The adamant thrownaxe requires 30 Ranged. Features the bouncing special attack.
+
+## Related Items
+
+- [Mithril thrownaxe](/osrs/mithril-thrownaxe/) - Lower tier (+16 ranged str)
+- [Rune thrownaxe](/osrs/rune-thrownaxe/) - Higher tier (+36 ranged str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_805.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_805.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 5
+  requirements:
+    ranged: 40
+  attack_bonus:
+    ranged: 17
+  ranged_strength: 36
+related_items:
+  - item_id: 804
+    item_name: "Adamant thrownaxe"
+    slug: "adamant-thrownaxe"
+    relationship: "variant"
+    description: "Lower tier thrownaxe"
+---
+
+## Examine
+
+> _"A finely balanced throwing axe."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 75) or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The rune thrownaxe is the highest standard thrownaxe, requiring 40 Ranged. Has +36 ranged strength and the bouncing special attack that hits multiple adjacent targets — useful in multicombat areas.
+
+## Related Items
+
+- [Adamant thrownaxe](/osrs/adamant-thrownaxe/) - Lower tier (+23 ranged str)

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_812.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_812.mdx
@@ -1,0 +1,30 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  attack_bonus:
+    ranged: 3
+  ranged_strength: 1
+related_items:
+  - item_id: 813
+    item_name: "Iron dart (p)"
+    slug: "iron-dart-p"
+    relationship: "variant"
+    description: "Higher tier poisoned dart"
+---
+
+## Examine
+
+> _"A bronze tipped dart with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to bronze darts. Members only.
+
+## About
+
+A bronze dart tipped with basic weapon poison. No Ranged requirement. Poison deals 2-4 damage over time. Cheap and effective for poisoning enemies in early-game.
+
+## Related Items
+
+- [Iron dart (p)](/osrs/iron-dart-p/) - Higher tier poisoned dart

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_813.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_813.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 1
+  attack_bonus:
+    ranged: 4
+  ranged_strength: 3
+related_items:
+  - item_id: 812
+    item_name: "Bronze dart (p)"
+    slug: "bronze-dart-p"
+    relationship: "variant"
+    description: "Lower tier poisoned dart"
+  - item_id: 814
+    item_name: "Steel dart (p)"
+    slug: "steel-dart-p"
+    relationship: "variant"
+    description: "Higher tier poisoned dart"
+---
+
+## Examine
+
+> _"An iron tipped dart with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to iron darts. Members only.
+
+## About
+
+An iron dart tipped with basic weapon poison. Requires 1 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Bronze dart (p)](/osrs/bronze-dart-p/) - Lower tier poisoned dart
+- [Steel dart (p)](/osrs/steel-dart-p/) - Higher tier poisoned dart

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_814.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_814.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 5
+  attack_bonus:
+    ranged: 6
+  ranged_strength: 6
+related_items:
+  - item_id: 813
+    item_name: "Iron dart (p)"
+    slug: "iron-dart-p"
+    relationship: "variant"
+    description: "Lower tier poisoned dart"
+  - item_id: 815
+    item_name: "Mithril dart (p)"
+    slug: "mithril-dart-p"
+    relationship: "variant"
+    description: "Higher tier poisoned dart"
+---
+
+## Examine
+
+> _"A steel tipped dart with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to steel darts. Members only.
+
+## About
+
+A steel dart tipped with basic weapon poison. Requires 5 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Iron dart (p)](/osrs/iron-dart-p/) - Lower tier poisoned dart
+- [Mithril dart (p)](/osrs/mithril-dart-p/) - Higher tier poisoned dart

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_815.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_815.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 20
+  attack_bonus:
+    ranged: 8
+  ranged_strength: 9
+related_items:
+  - item_id: 814
+    item_name: "Steel dart (p)"
+    slug: "steel-dart-p"
+    relationship: "variant"
+    description: "Lower tier poisoned dart"
+---
+
+## Examine
+
+> _"A mithril tipped dart with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to mithril darts. Members only.
+
+## About
+
+A mithril dart tipped with basic weapon poison. Requires 20 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Steel dart (p)](/osrs/steel-dart-p/) - Lower tier poisoned dart


### PR DESCRIPTION
## Summary
- Added 50 new OSRS item override files with accurate stats, examine text, and related items
- Categories: gnome clothing (20), thrownaxes (6), poisoned darts (4), prayer items/bones (7), fishing misc (5), utility/quest items (8)
- Updated OSRS.md tracking document with new sections and session log

## Items Added
| Category | Count | Items |
|----------|-------|-------|
| Gnome clothing | 20 | Pink/green/blue/cream/turquoise boots, tops, bottoms, hats |
| Thrownaxes | 6 | Bronze through rune thrownaxes |
| Poisoned darts | 4 | Bronze/iron/steel/mithril dart (p) |
| Prayer gear/bones | 7 | Priest gown set, druid's robes, burnt/bat/babydragon bones |
| Fishing misc | 5 | Edible seaweed, casket, oyster, oyster pearl(s) |
| Utility/quest | 8 | Strange fruit, black robe, tinderbox, ashes, torch, ship ticket, gnomeball, cadava berries |

## Test plan
- [ ] Verify override files merge correctly with auto-generated OSRS item pages
- [ ] Check frontmatter validates against OSRSExtendedSchema
- [ ] Confirm related item links resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)