### PR TITLE
feat(osrs): add 50 item overrides - javelins, knives, arrows, bolts, utility

### DIFF
--- a/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/OSRS.md
@@ -1136,6 +1136,79 @@ Focus on items with clear processing chains and market flip potential.
 | 395 | Raw sea turtle | Trawler minigame, members  |
 | 397 | Sea turtle     | 21 HP, 82 Cooking, members |
 
+### Dart Tips (Implemented - Mar 2026)
+
+| ID  | Item             | Notes                     |
+| --- | ---------------- | ------------------------- |
+| 819 | Bronze dart tip  | 4 Smithing, 1 Fletching   |
+| 820 | Iron dart tip    | 19 Smithing, 22 Fletching |
+| 821 | Steel dart tip   | 34 Smithing, 37 Fletching |
+| 822 | Mithril dart tip | 54 Smithing, 52 Fletching |
+| 823 | Adamant dart tip | 74 Smithing, 67 Fletching |
+| 824 | Rune dart tip    | 89 Smithing, 81 Fletching |
+
+### Javelins & Poisoned Javelins (Implemented - Mar 2026)
+
+| ID  | Item                | Notes                     |
+| --- | ------------------- | ------------------------- |
+| 825 | Bronze javelin      | No req, +25 ranged str    |
+| 826 | Iron javelin        | 1 Ranged, +32 ranged str  |
+| 827 | Steel javelin       | 5 Ranged, +40 ranged str  |
+| 828 | Mithril javelin     | 20 Ranged, +49 ranged str |
+| 829 | Adamant javelin     | 30 Ranged, +59 ranged str |
+| 831 | Bronze javelin (p)  | Poisoned, no req          |
+| 832 | Iron javelin (p)    | Poisoned, 1 Ranged        |
+| 833 | Steel javelin (p)   | Poisoned, 5 Ranged        |
+| 834 | Mithril javelin (p) | Poisoned, 20 Ranged       |
+| 835 | Adamant javelin (p) | Poisoned, 30 Ranged       |
+| 836 | Rune javelin (p)    | Poisoned, 40 Ranged       |
+
+### Poisoned Knives (Implemented - Mar 2026)
+
+| ID  | Item              | Notes                    |
+| --- | ----------------- | ------------------------ |
+| 869 | Black knife       | 10 Ranged, +8 ranged str |
+| 870 | Bronze knife (p)  | No req, basic poison     |
+| 871 | Iron knife (p)    | 1 Ranged, basic poison   |
+| 872 | Steel knife (p)   | 5 Ranged, basic poison   |
+| 873 | Mithril knife (p) | 20 Ranged, basic poison  |
+| 874 | Black knife (p)   | 10 Ranged, basic poison  |
+| 875 | Adamant knife (p) | 30 Ranged, basic poison  |
+| 876 | Rune knife (p)    | 40 Ranged, basic poison  |
+
+### Bolts & Poisoned Arrows (Implemented - Mar 2026)
+
+| ID  | Item              | Notes                       |
+| --- | ----------------- | --------------------------- |
+| 837 | Crossbow          | 1 Ranged, +6 ranged, F2P    |
+| 878 | Bronze bolts (p)  | Poisoned, +10 ranged str    |
+| 879 | Opal bolts        | +14 ranged str, enchantable |
+| 880 | Pearl bolts       | +48 ranged str, enchantable |
+| 881 | Barbed bolts      | +12, Ranging Guild only     |
+| 883 | Bronze arrow (p)  | Poisoned, +7 ranged str     |
+| 885 | Iron arrow (p)    | Poisoned, +10 ranged str    |
+| 887 | Steel arrow (p)   | Poisoned, +16 ranged str    |
+| 889 | Mithril arrow (p) | Poisoned, +22 ranged str    |
+| 891 | Adamant arrow (p) | Poisoned, +31 ranged str    |
+| 893 | Rune arrow (p)    | Poisoned, +49 ranged str    |
+
+### General Utility & Misc Items (Implemented - Mar 2026)
+
+| ID  | Item              | Notes                          |
+| --- | ----------------- | ------------------------------ |
+| 946 | Knife             | Fletching/Crafting tool, F2P   |
+| 948 | Bear fur          | Crafting material, F2P         |
+| 950 | Silk              | 20 Thieving to steal, F2P      |
+| 952 | Spade             | Farming/clue tool, F2P         |
+| 954 | Rope              | Quest essential, F2P           |
+| 958 | Grey wolf fur     | Crafting material, members     |
+| 962 | Christmas cracker | Holiday item, tradeable        |
+| 970 | Papyrus           | Used with charcoal, members    |
+| 973 | Charcoal          | Used with papyrus, members     |
+| 975 | Machete           | Jungle cutting tool, members   |
+| 981 | Disk of returning | Dwarven Mine teleport, members |
+| 983 | Brass key         | Edgeville Dungeon access, F2P  |
+
 ### Fishing Misc & Oysters (Implemented - Mar 2026)
 
 | ID  | Item           | Notes                          |
@@ -1820,6 +1893,7 @@ Record batch completions here:
 | Mar 13, 2026 | +50 items (cannon parts, fletching supplies, potions)            | ~1181           |
 | Mar 13, 2026 | +50 items (potions, herbs, fishing equipment, fish)              | ~1231           |
 | Mar 13, 2026 | +50 items (gnome clothes, thrownaxes, darts, bones, misc)        | ~1281           |
+| Mar 13, 2026 | +50 items (javelins, knives, arrows, bolts, dart tips, utility)  | ~1331           |
 
 ### Quick Stats
 

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_816.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_816.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 30
+  attack_bonus:
+    ranged: 11
+  ranged_strength: 14
+related_items:
+  - item_id: 815
+    item_name: "Mithril dart (p)"
+    slug: "mithril-dart-p"
+    relationship: "variant"
+    description: "Lower tier poisoned dart"
+  - item_id: 817
+    item_name: "Rune dart (p)"
+    slug: "rune-dart-p"
+    relationship: "variant"
+    description: "Higher tier poisoned dart"
+---
+
+## Examine
+
+> _"An adamant tipped dart with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to adamant darts. Members only.
+
+## About
+
+An adamant dart tipped with basic weapon poison. Requires 30 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Mithril dart (p)](/osrs/mithril-dart-p/) - Lower tier poisoned dart
+- [Rune dart (p)](/osrs/rune-dart-p/) - Higher tier poisoned dart

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_817.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_817.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 40
+  attack_bonus:
+    ranged: 13
+  ranged_strength: 19
+related_items:
+  - item_id: 816
+    item_name: "Adamant dart (p)"
+    slug: "adamant-dart-p"
+    relationship: "variant"
+    description: "Lower tier poisoned dart"
+---
+
+## Examine
+
+> _"A rune tipped dart with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to rune darts. Members only.
+
+## About
+
+A rune dart tipped with basic weapon poison. Requires 40 Ranged. The highest standard tier of poisoned dart.
+
+## Related Items
+
+- [Adamant dart (p)](/osrs/adamant-dart-p/) - Lower tier poisoned dart

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_819.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_819.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 820
+    item_name: "Iron dart tip"
+    slug: "iron-dart-tip"
+    relationship: "variant"
+    description: "Higher tier dart tip"
+---
+
+## Examine
+
+> _"Can be used to make bronze darts."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 4) from a bronze bar. Members only.
+
+## About
+
+Bronze dart tips are used with feathers at 1 Fletching to create bronze darts (1.8 XP each). One bar makes 10 tips.
+
+## Related Items
+
+- [Iron dart tip](/osrs/iron-dart-tip/) - Higher tier dart tip

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_820.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_820.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 819
+    item_name: "Bronze dart tip"
+    slug: "bronze-dart-tip"
+    relationship: "variant"
+    description: "Lower tier dart tip"
+  - item_id: 821
+    item_name: "Steel dart tip"
+    slug: "steel-dart-tip"
+    relationship: "variant"
+    description: "Higher tier dart tip"
+---
+
+## Examine
+
+> _"Can be used to make iron darts."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 19) from an iron bar. Members only.
+
+## About
+
+Iron dart tips are used with feathers at 22 Fletching to create iron darts (3.8 XP each). One bar makes 10 tips.
+
+## Related Items
+
+- [Bronze dart tip](/osrs/bronze-dart-tip/) - Lower tier dart tip
+- [Steel dart tip](/osrs/steel-dart-tip/) - Higher tier dart tip

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_821.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_821.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 820
+    item_name: "Iron dart tip"
+    slug: "iron-dart-tip"
+    relationship: "variant"
+    description: "Lower tier dart tip"
+  - item_id: 822
+    item_name: "Mithril dart tip"
+    slug: "mithril-dart-tip"
+    relationship: "variant"
+    description: "Higher tier dart tip"
+---
+
+## Examine
+
+> _"Can be used to make steel darts."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 34) from a steel bar. Members only.
+
+## About
+
+Steel dart tips are used with feathers at 37 Fletching to create steel darts (7.5 XP each). One bar makes 10 tips.
+
+## Related Items
+
+- [Iron dart tip](/osrs/iron-dart-tip/) - Lower tier dart tip
+- [Mithril dart tip](/osrs/mithril-dart-tip/) - Higher tier dart tip

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_822.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_822.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 821
+    item_name: "Steel dart tip"
+    slug: "steel-dart-tip"
+    relationship: "variant"
+    description: "Lower tier dart tip"
+  - item_id: 823
+    item_name: "Adamant dart tip"
+    slug: "adamant-dart-tip"
+    relationship: "variant"
+    description: "Higher tier dart tip"
+---
+
+## Examine
+
+> _"Can be used to make mithril darts."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 54) from a mithril bar. Members only.
+
+## About
+
+Mithril dart tips are used with feathers at 52 Fletching to create mithril darts (11.2 XP each). One bar makes 10 tips.
+
+## Related Items
+
+- [Steel dart tip](/osrs/steel-dart-tip/) - Lower tier dart tip
+- [Adamant dart tip](/osrs/adamant-dart-tip/) - Higher tier dart tip

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_823.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_823.mdx
@@ -1,0 +1,30 @@
+---
+related_items:
+  - item_id: 822
+    item_name: "Mithril dart tip"
+    slug: "mithril-dart-tip"
+    relationship: "variant"
+    description: "Lower tier dart tip"
+  - item_id: 824
+    item_name: "Rune dart tip"
+    slug: "rune-dart-tip"
+    relationship: "variant"
+    description: "Higher tier dart tip"
+---
+
+## Examine
+
+> _"Can be used to make adamant darts."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 74) from an adamantite bar. Members only.
+
+## About
+
+Adamant dart tips are used with feathers at 67 Fletching to create adamant darts (15 XP each). One bar makes 10 tips.
+
+## Related Items
+
+- [Mithril dart tip](/osrs/mithril-dart-tip/) - Lower tier dart tip
+- [Rune dart tip](/osrs/rune-dart-tip/) - Higher tier dart tip

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_824.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_824.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 823
+    item_name: "Adamant dart tip"
+    slug: "adamant-dart-tip"
+    relationship: "variant"
+    description: "Lower tier dart tip"
+---
+
+## Examine
+
+> _"Can be used to make rune darts."_
+
+## Obtaining
+
+Smithed with **Smithing** (level 89) from a runite bar. Members only.
+
+## About
+
+Rune dart tips are used with feathers at 81 Fletching to create rune darts (18.8 XP each). One bar makes 10 tips. The highest standard dart tip.
+
+## Related Items
+
+- [Adamant dart tip](/osrs/adamant-dart-tip/) - Lower tier dart tip

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_825.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_825.mdx
@@ -1,0 +1,36 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  attack_bonus:
+    ranged: 6
+  ranged_strength: 25
+related_items:
+  - item_id: 826
+    item_name: "Iron javelin"
+    slug: "iron-javelin"
+    relationship: "variant"
+    description: "Higher tier javelin"
+  - item_id: 831
+    item_name: "Bronze javelin (p)"
+    slug: "bronze-javelin-p"
+    relationship: "variant"
+    description: "Poisoned version"
+---
+
+## Examine
+
+> _"A bronze tipped javelin."_
+
+## Obtaining
+
+Smithed or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The bronze javelin is the lowest-tier javelin. No Ranged requirement. Javelins are slower than darts but have higher ranged strength per hit. Used primarily with the heavy ballista.
+
+## Related Items
+
+- [Iron javelin](/osrs/iron-javelin/) - Higher tier javelin
+- [Bronze javelin (p)](/osrs/bronze-javelin-p/) - Poisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_826.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_826.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 1
+  attack_bonus:
+    ranged: 8
+  ranged_strength: 32
+related_items:
+  - item_id: 825
+    item_name: "Bronze javelin"
+    slug: "bronze-javelin"
+    relationship: "variant"
+    description: "Lower tier javelin"
+  - item_id: 827
+    item_name: "Steel javelin"
+    slug: "steel-javelin"
+    relationship: "variant"
+    description: "Higher tier javelin"
+---
+
+## Examine
+
+> _"An iron tipped javelin."_
+
+## Obtaining
+
+Smithed or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The iron javelin requires 1 Ranged. Higher ranged strength than iron darts but slower attack speed.
+
+## Related Items
+
+- [Bronze javelin](/osrs/bronze-javelin/) - Lower tier javelin
+- [Steel javelin](/osrs/steel-javelin/) - Higher tier javelin

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_827.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_827.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 5
+  attack_bonus:
+    ranged: 12
+  ranged_strength: 40
+related_items:
+  - item_id: 826
+    item_name: "Iron javelin"
+    slug: "iron-javelin"
+    relationship: "variant"
+    description: "Lower tier javelin"
+  - item_id: 828
+    item_name: "Mithril javelin"
+    slug: "mithril-javelin"
+    relationship: "variant"
+    description: "Higher tier javelin"
+---
+
+## Examine
+
+> _"A steel tipped javelin."_
+
+## Obtaining
+
+Smithed or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The steel javelin requires 5 Ranged. Mid-low tier javelin.
+
+## Related Items
+
+- [Iron javelin](/osrs/iron-javelin/) - Lower tier javelin
+- [Mithril javelin](/osrs/mithril-javelin/) - Higher tier javelin

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_828.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_828.mdx
@@ -1,0 +1,38 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 20
+  attack_bonus:
+    ranged: 17
+  ranged_strength: 49
+related_items:
+  - item_id: 827
+    item_name: "Steel javelin"
+    slug: "steel-javelin"
+    relationship: "variant"
+    description: "Lower tier javelin"
+  - item_id: 829
+    item_name: "Adamant javelin"
+    slug: "adamant-javelin"
+    relationship: "variant"
+    description: "Higher tier javelin"
+---
+
+## Examine
+
+> _"A mithril tipped javelin."_
+
+## Obtaining
+
+Smithed or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The mithril javelin requires 20 Ranged. Mid-tier javelin ammunition.
+
+## Related Items
+
+- [Steel javelin](/osrs/steel-javelin/) - Lower tier javelin
+- [Adamant javelin](/osrs/adamant-javelin/) - Higher tier javelin

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_829.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_829.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 30
+  attack_bonus:
+    ranged: 20
+  ranged_strength: 59
+related_items:
+  - item_id: 828
+    item_name: "Mithril javelin"
+    slug: "mithril-javelin"
+    relationship: "variant"
+    description: "Lower tier javelin"
+---
+
+## Examine
+
+> _"An adamant tipped javelin."_
+
+## Obtaining
+
+Smithed or purchased from the **Ranging Guild**. Members only.
+
+## About
+
+The adamant javelin requires 30 Ranged. Commonly used as affordable heavy ballista ammunition.
+
+## Related Items
+
+- [Mithril javelin](/osrs/mithril-javelin/) - Lower tier javelin

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_831.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_831.mdx
@@ -1,0 +1,30 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  attack_bonus:
+    ranged: 6
+  ranged_strength: 25
+related_items:
+  - item_id: 825
+    item_name: "Bronze javelin"
+    slug: "bronze-javelin"
+    relationship: "variant"
+    description: "Unpoisoned version"
+---
+
+## Examine
+
+> _"A bronze tipped javelin with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to bronze javelins. Members only.
+
+## About
+
+A bronze javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Bronze javelin](/osrs/bronze-javelin/) - Unpoisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_832.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_832.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 1
+  attack_bonus:
+    ranged: 8
+  ranged_strength: 32
+related_items:
+  - item_id: 826
+    item_name: "Iron javelin"
+    slug: "iron-javelin"
+    relationship: "variant"
+    description: "Unpoisoned version"
+---
+
+## Examine
+
+> _"An iron tipped javelin with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to iron javelins. Members only.
+
+## About
+
+An iron javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Iron javelin](/osrs/iron-javelin/) - Unpoisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_833.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_833.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 5
+  attack_bonus:
+    ranged: 12
+  ranged_strength: 40
+related_items:
+  - item_id: 827
+    item_name: "Steel javelin"
+    slug: "steel-javelin"
+    relationship: "variant"
+    description: "Unpoisoned version"
+---
+
+## Examine
+
+> _"A steel tipped javelin with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to steel javelins. Members only.
+
+## About
+
+A steel javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Steel javelin](/osrs/steel-javelin/) - Unpoisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_834.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_834.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 20
+  attack_bonus:
+    ranged: 17
+  ranged_strength: 49
+related_items:
+  - item_id: 828
+    item_name: "Mithril javelin"
+    slug: "mithril-javelin"
+    relationship: "variant"
+    description: "Unpoisoned version"
+---
+
+## Examine
+
+> _"A mithril tipped javelin with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to mithril javelins. Members only.
+
+## About
+
+A mithril javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Mithril javelin](/osrs/mithril-javelin/) - Unpoisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_835.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_835.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 30
+  attack_bonus:
+    ranged: 20
+  ranged_strength: 59
+related_items:
+  - item_id: 829
+    item_name: "Adamant javelin"
+    slug: "adamant-javelin"
+    relationship: "variant"
+    description: "Unpoisoned version"
+---
+
+## Examine
+
+> _"An adamant tipped javelin with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to adamant javelins. Members only.
+
+## About
+
+An adamant javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Adamant javelin](/osrs/adamant-javelin/) - Unpoisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_836.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_836.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 40
+  attack_bonus:
+    ranged: 25
+  ranged_strength: 72
+related_items: []
+---
+
+## Examine
+
+> _"A rune tipped javelin with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to rune javelins. Members only.
+
+## About
+
+A rune javelin tipped with basic weapon poison. Requires 40 Ranged. The highest standard tier of poisoned javelin. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_837.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_837.mdx
@@ -1,0 +1,26 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 6
+  requirements:
+    ranged: 1
+  attack_bonus:
+    ranged: 6
+related_items: []
+---
+
+## Examine
+
+> _"This fires crossbow bolts."_
+
+## Obtaining
+
+Bought from shops or made with **Fletching** (level 9). F2P item.
+
+## About
+
+The crossbow is the most basic crossbow, requiring 1 Ranged. Fires bronze bolts and above. Slower than shortbows but usable with a shield for defensive setups.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_869.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_869.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 10
+  attack_bonus:
+    ranged: 8
+  ranged_strength: 8
+related_items:
+  - item_id: 874
+    item_name: "Black knife (p)"
+    slug: "black-knife-p"
+    relationship: "variant"
+    description: "Poisoned version"
+---
+
+## Examine
+
+> _"A finely balanced throwing knife."_
+
+## Obtaining
+
+Dropped by various **monsters** including shadow warriors. Members only.
+
+## About
+
+The black knife requires 10 Ranged. Cannot be smithed — only obtained as drops. Slightly better stats than steel knives.
+
+## Related Items
+
+- [Black knife (p)](/osrs/black-knife-p/) - Poisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_870.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_870.mdx
@@ -1,0 +1,25 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  attack_bonus:
+    ranged: 3
+  ranged_strength: 2
+related_items: []
+---
+
+## Examine
+
+> _"A very sharp\"bronze\" knife with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to bronze knives. Members only.
+
+## About
+
+A bronze knife tipped with basic weapon poison. No Ranged requirement. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_871.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_871.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 1
+  attack_bonus:
+    ranged: 4
+  ranged_strength: 3
+related_items: []
+---
+
+## Examine
+
+> _"A very sharp iron knife with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to iron knives. Members only.
+
+## About
+
+An iron knife tipped with basic weapon poison. Requires 1 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_872.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_872.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 5
+  attack_bonus:
+    ranged: 7
+  ranged_strength: 6
+related_items: []
+---
+
+## Examine
+
+> _"A very sharp steel knife with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to steel knives. Members only.
+
+## About
+
+A steel knife tipped with basic weapon poison. Requires 5 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_873.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_873.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 20
+  attack_bonus:
+    ranged: 9
+  ranged_strength: 9
+related_items: []
+---
+
+## Examine
+
+> _"A very sharp mithril knife with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to mithril knives. Members only.
+
+## About
+
+A mithril knife tipped with basic weapon poison. Requires 20 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_874.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_874.mdx
@@ -1,0 +1,32 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 10
+  attack_bonus:
+    ranged: 8
+  ranged_strength: 8
+related_items:
+  - item_id: 869
+    item_name: "Black knife"
+    slug: "black-knife"
+    relationship: "variant"
+    description: "Unpoisoned version"
+---
+
+## Examine
+
+> _"A very sharp black knife with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to black knives. Members only.
+
+## About
+
+A black knife tipped with basic weapon poison. Requires 10 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+- [Black knife](/osrs/black-knife/) - Unpoisoned version

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_875.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_875.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 30
+  attack_bonus:
+    ranged: 12
+  ranged_strength: 14
+related_items: []
+---
+
+## Examine
+
+> _"A very sharp adamant knife with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to adamant knives. Members only.
+
+## About
+
+An adamant knife tipped with basic weapon poison. Requires 30 Ranged. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_876.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_876.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "weapon"
+  attack_speed: 3
+  requirements:
+    ranged: 40
+  attack_bonus:
+    ranged: 15
+  ranged_strength: 24
+related_items: []
+---
+
+## Examine
+
+> _"A very sharp rune knife with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to rune knives. Members only.
+
+## About
+
+A rune knife tipped with basic weapon poison. Requires 40 Ranged. The highest standard tier of poisoned knife. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_878.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_878.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 10
+related_items: []
+---
+
+## Examine
+
+> _"Bronze crossbow bolts with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to bronze bolts. Members only.
+
+## About
+
+Bronze bolts tipped with basic weapon poison. Usable with any crossbow. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_879.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_879.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 14
+related_items:
+  - item_id: 880
+    item_name: "Pearl bolts"
+    slug: "pearl-bolts"
+    relationship: "variant"
+    description: "Another gem bolt type"
+---
+
+## Examine
+
+> _"Opal tipped Bronze crossbow bolts."_
+
+## Obtaining
+
+Use **opal bolt tips** on bronze bolts (24 Fletching). Members only.
+
+## About
+
+Opal bolts provide +14 ranged strength. When enchanted, they become opal bolts (e) with the Lucky Lightning special effect that deals extra damage.
+
+## Related Items
+
+- [Pearl bolts](/osrs/pearl-bolts/) - Another low-tier gem bolt

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_880.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_880.mdx
@@ -1,0 +1,27 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 48
+related_items:
+  - item_id: 879
+    item_name: "Opal bolts"
+    slug: "opal-bolts"
+    relationship: "variant"
+    description: "Another gem bolt type"
+---
+
+## Examine
+
+> _"Pearl tipped Iron crossbow bolts."_
+
+## Obtaining
+
+Use **pearl bolt tips** on iron bolts (41 Fletching). Members only.
+
+## About
+
+Pearl bolts provide +48 ranged strength. When enchanted, they become pearl bolts (e) with the Sea Curse effect — deals extra damage to fiery creatures.
+
+## Related Items
+
+- [Opal bolts](/osrs/opal-bolts/) - Another low-tier gem bolt

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_881.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_881.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 12
+related_items: []
+---
+
+## Examine
+
+> _"Barbed crossbow bolts."_
+
+## Obtaining
+
+Purchased from the **Ranging Guild** for 80 Archery tickets each. Members only.
+
+## About
+
+Barbed bolts provide +12 ranged strength. Only obtainable from the Ranging Guild ticket exchange. A niche bolt type rarely used in practice.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_883.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_883.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 7
+related_items: []
+---
+
+## Examine
+
+> _"Bronze arrows with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to bronze arrows. Members only.
+
+## About
+
+Bronze arrows tipped with basic weapon poison. Poison deals 2-4 damage over time. Usable with any bow.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_885.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_885.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 10
+related_items: []
+---
+
+## Examine
+
+> _"Iron arrows with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to iron arrows. Members only.
+
+## About
+
+Iron arrows tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_887.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_887.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 16
+related_items: []
+---
+
+## Examine
+
+> _"Steel arrows with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to steel arrows. Members only.
+
+## About
+
+Steel arrows tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_889.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_889.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 22
+related_items: []
+---
+
+## Examine
+
+> _"Mithril arrows with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to mithril arrows. Members only.
+
+## About
+
+Mithril arrows tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_891.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_891.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 31
+related_items: []
+---
+
+## Examine
+
+> _"Adamant arrows with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to adamant arrows. Members only.
+
+## About
+
+Adamant arrows tipped with basic weapon poison. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_893.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_893.mdx
@@ -1,0 +1,22 @@
+---
+equipment:
+  slot: "ammo"
+  ranged_strength: 49
+related_items: []
+---
+
+## Examine
+
+> _"Rune arrows with a poisoned tip."_
+
+## Obtaining
+
+Apply **weapon poison** to rune arrows. Members only.
+
+## About
+
+Rune arrows tipped with basic weapon poison. The highest standard tier of poisoned arrow. Poison deals 2-4 damage over time.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_946.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_946.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A relatively small knife."_
+
+## Obtaining
+
+Spawns in numerous locations. Purchased from **general stores**. F2P item.
+
+## About
+
+The knife is a utility tool used in Crafting (cutting leather, stringing bows) and Fletching (making arrow shafts from logs). One of the most essential tools alongside the tinderbox and chisel.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_948.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_948.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 958
+    item_name: "Grey wolf fur"
+    slug: "grey-wolf-fur"
+    relationship: "variant"
+    description: "Another fur type"
+---
+
+## Examine
+
+> _"Ew it's a\"smelly\" fur."_
+
+## Obtaining
+
+Dropped by **bears** and grizzly bears. Also purchasable from fur traders. F2P item.
+
+## About
+
+Bear fur is used in Crafting and quests. Required for crafting fancy clothes at the Fancy Dress Shop in Varrock. Also used in the Nature Spirit quest.
+
+## Related Items
+
+- [Grey wolf fur](/osrs/grey-wolf-fur/) - Another fur type used in Crafting

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_950.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_950.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"It's a\"piece\" of silk."_
+
+## Obtaining
+
+Stolen from **silk stalls** (20 Thieving) or purchased from silk traders for 3 coins. F2P item.
+
+## About
+
+Silk is used in Crafting and can be sold to the silk trader in Ardougne for 60 coins (if you wait). Also used in quests and for making various items at the Fancy Dress Shop.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_952.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_952.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A fairly small spade."_
+
+## Obtaining
+
+Spawns in numerous locations. Purchased from **farming shops**. F2P item.
+
+## About
+
+The spade is a versatile tool used for digging in Farming, completing treasure trails, and various quests. Essential for planting seeds and digging up crops. Also used to dig at specific locations in clue scrolls.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_954.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_954.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A coil of rope."_
+
+## Obtaining
+
+Purchased from **general stores** for 23 coins. Also made by spinning 4 balls of wool on a spinning wheel. F2P item.
+
+## About
+
+Rope is used in numerous quests and activities. Required for tying things, crossing obstacles, and many quest objectives. One of the most commonly needed quest items in the game.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_958.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_958.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 948
+    item_name: "Bear fur"
+    slug: "bear-fur"
+    relationship: "variant"
+    description: "Another fur type"
+---
+
+## Examine
+
+> _"This\"would\" " make a\"nice\" hat."_
+
+## Obtaining
+
+Dropped by **big wolves** and other wolves. Members only.
+
+## About
+
+Grey wolf fur is used in Crafting to make items at the Fancy Dress Shop in Varrock. Also used in Fremennik Trials to craft a lyre and in other quests.
+
+## Related Items
+
+- [Bear fur](/osrs/bear-fur/) - Another fur type

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_962.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_962.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"I need to pull this."_
+
+## Obtaining
+
+Reward from **Christmas holiday events**. Tradeable on the Grand Exchange.
+
+## About
+
+The Christmas cracker is a holiday item. When used on another player, both receive rewards — a partyhat (in various colours) and a secondary item. Players can choose which specific partyhat they receive. One of the original holiday-themed items.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_970.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_970.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 973
+    item_name: "Charcoal"
+    slug: "charcoal"
+    relationship: "used-with"
+    description: "Used together for notes"
+---
+
+## Examine
+
+> _"A\"piece\" of\"papyrus\"."_
+
+## Obtaining
+
+Purchased from **general stores** and the Grand Tree grocer for 10 coins. Members only.
+
+## About
+
+Papyrus is used with charcoal to make notes and maps. Required in several quests including Nature Spirit and Shilo Village. Also used in Treasure Trails.
+
+## Related Items
+
+- [Charcoal](/osrs/charcoal/) - Used together for writing

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_973.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_973.mdx
@@ -1,0 +1,24 @@
+---
+related_items:
+  - item_id: 970
+    item_name: "Papyrus"
+    slug: "papyrus"
+    relationship: "used-with"
+    description: "Used together for notes"
+---
+
+## Examine
+
+> _"A\"piece\" of charcoal."_
+
+## Obtaining
+
+Purchased from **general stores** for 45 coins. Also found in Tai Bwo Wannai. Members only.
+
+## About
+
+Charcoal is used with papyrus to write notes and maps. Required in several quests. Also used in some Crafting recipes.
+
+## Related Items
+
+- [Papyrus](/osrs/papyrus/) - Used together for writing

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_975.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_975.mdx
@@ -1,0 +1,21 @@
+---
+equipment:
+  slot: "weapon"
+related_items: []
+---
+
+## Examine
+
+> _"Good for\"cutting\" through\"vegetation\"."_
+
+## Obtaining
+
+Purchased from general stores on **Karamja** for 40 coins. Members only.
+
+## About
+
+The machete is used to cut through jungle undergrowth on Karamja and in Tai Bwo Wannai Cleanup. Required for accessing various areas on Karamja. Can be upgraded to jade, red topaz, or opal machetes for faster cutting.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_981.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_981.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"Used to get out of Thordur's blackhole."_
+
+## Obtaining
+
+Purchased from **Diango's Toy Store** in Draynor Village for 21,000 coins. Members only.
+
+## About
+
+The disk of returning teleports between the Dwarven Mine and Thordur's Blackhole. When used in the mines, it enters the blackhole; using it again returns you to the mine. A niche fast travel tool.
+
+## Related Items
+
+None.

--- a/apps/kbve/astro-kbve/data/osrs-overrides/_983.mdx
+++ b/apps/kbve/astro-kbve/data/osrs-overrides/_983.mdx
@@ -1,0 +1,19 @@
+---
+related_items: []
+---
+
+## Examine
+
+> _"A\"heavy\" brass key."_
+
+## Obtaining
+
+Found on the ground near the **Edgeville Dungeon** entrance by the River Lum. F2P item.
+
+## About
+
+The brass key opens the shed door west of the Cooks' Guild, providing a shortcut into the Edgeville Dungeon. Useful for accessing hill giants and other dungeon creatures.
+
+## Related Items
+
+None.


### PR DESCRIPTION
## Summary
- Added 50 new OSRS item override files with accurate stats, examine text, and related items
- Categories: dart tips (6), javelins + poisoned (11), poisoned knives (8), crossbow + bolts (4), poisoned darts (2), poisoned arrows (6), black knife (1), general utility items (12)
- Updated OSRS.md tracking document with new sections and session log

## Items Added
| Category | Count | Items |
|----------|-------|-------|
| Dart tips | 6 | Bronze through rune dart tips |
| Javelins | 5 | Bronze through adamant javelins |
| Poisoned javelins | 6 | Bronze through rune javelin (p) |
| Poisoned darts | 2 | Adamant/rune dart (p) |
| Black knife + poisoned knives | 8 | Black knife, bronze-rune knife (p) |
| Crossbow + bolts | 4 | Crossbow, bronze bolts (p), opal/pearl/barbed bolts |
| Poisoned arrows | 6 | Bronze through rune arrow (p) |
| Utility items | 12 | Knife, bear fur, silk, spade, rope, wolf fur, cracker, papyrus, charcoal, machete, disk of returning, brass key |

## Test plan
- [ ] Verify override files merge correctly with auto-generated OSRS item pages
- [ ] Check frontmatter validates against OSRSExtendedSchema
- [ ] Confirm related item links resolve properly