### PR TITLE
fix(axum-kbve): remove disabled TLS certificate check from ArgoCD proxy

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -322,10 +322,31 @@ pub fn init_argo_proxy() -> bool {
         Err(_) => return false,
     };
 
-    let client = Client::builder()
+    let mut builder = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(Duration::from_secs(5))
-        .timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(15));
+
+    if let Ok(ca_path) = std::env::var("ARGOCD_CA_CERT_PATH") {
+        match std::fs::read(&ca_path) {
+            Ok(pem) => match reqwest::Certificate::from_pem(&pem) {
+                Ok(cert) => {
+                    builder = builder.add_root_certificate(cert);
+                    debug!("loaded ArgoCD CA certificate from {ca_path}");
+                }
+                Err(e) => {
+                    warn!("failed to parse ArgoCD CA cert at {ca_path}: {e}");
+                    return false;
+                }
+            },
+            Err(e) => {
+                warn!("failed to read ArgoCD CA cert at {ca_path}: {e}");
+                return false;
+            }
+        }
+    }
+
+    let client = builder
         .build()
         .expect("failed to build reqwest client for argo proxy");
 

--- a/apps/kube/argocd/manifests/argocd-server-cert.yaml
+++ b/apps/kube/argocd/manifests/argocd-server-cert.yaml
@@ -1,0 +1,21 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: argocd-server-tls
+    namespace: argocd
+spec:
+    secretName: argocd-server-tls
+    issuerRef:
+        name: internal-ca-issuer
+        kind: ClusterIssuer
+        group: cert-manager.io
+    dnsNames:
+        - argocd-server
+        - argocd-server.argocd
+        - argocd-server.argocd.svc
+        - argocd-server.argocd.svc.cluster.local
+    duration: 8760h # 1 year
+    renewBefore: 720h # 30 days
+    privateKey:
+        algorithm: ECDSA
+        size: 256

--- a/apps/kube/argocd/manifests/kustomization.yaml
+++ b/apps/kube/argocd/manifests/kustomization.yaml
@@ -1,10 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
-  - ingress.yaml
+    - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+    - ingress.yaml
+    - argocd-server-cert.yaml
 patches:
-  - path: patch-argocd-cm-cert-health.yaml
-    target:
-      kind: ConfigMap
-      name: argocd-cm
+    - path: patch-argocd-cm-cert-health.yaml
+      target:
+          kind: ConfigMap
+          name: argocd-cm

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -87,6 +87,12 @@ spec:
                             secretKeyRef:
                                 name: argocd-auth
                                 key: argocd-auth-token
+                      - name: ARGOCD_CA_CERT_PATH
+                        value: '/etc/ssl/argocd/ca.crt'
+                  volumeMounts:
+                      - name: argocd-ca
+                        mountPath: /etc/ssl/argocd
+                        readOnly: true
                   resources:
                       requests:
                           memory: '512Mi'
@@ -94,6 +100,13 @@ spec:
                       limits:
                           memory: '1024Mi'
                           cpu: '4000m'
+            volumes:
+                - name: argocd-ca
+                  secret:
+                      secretName: kbve-internal-ca-tls
+                      items:
+                          - key: ca.crt
+                            path: ca.crt
 ---
 apiVersion: v1
 kind: Service

--- a/apps/kube/kbve/manifest/kbve-internal-ca-cert.yaml
+++ b/apps/kube/kbve/manifest/kbve-internal-ca-cert.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: kbve-internal-ca-tls
+    namespace: kbve
+spec:
+    secretName: kbve-internal-ca-tls
+    issuerRef:
+        name: internal-ca-issuer
+        kind: ClusterIssuer
+        group: cert-manager.io
+    commonName: kbve-internal-client
+    dnsNames:
+        - kbve-internal-client.kbve.svc.cluster.local
+    duration: 8760h
+    renewBefore: 720h
+    privateKey:
+        algorithm: ECDSA
+        size: 256

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
     - kbve-serviceaccount.yaml
     - kbve-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
+    - kbve-internal-ca-cert.yaml
     - kbve-deployment.yaml
     - nginx-ingress.yaml


### PR DESCRIPTION
## Summary
- Removes `danger_accept_invalid_certs(true)` from the ArgoCD proxy's reqwest client
- Resolves [CodeQL alert #280](https://github.com/KBVE/kbve/security/code-scanning/280) (`rust/disabled-certificate-check`)
- The ArgoCD upstream should present a valid TLS certificate; disabling verification exposed the proxy to MITM attacks

## Test plan
- [x] `cargo check -p axum-kbve` compiles cleanly
- [ ] Verify ArgoCD upstream serves a valid cert (if self-signed, configure a proper CA or use `ARGOCD_UPSTREAM_URL` with a trusted endpoint)