### PR TITLE
feat(astro): upgrade Astro v5 → v6, Zod v3 → v4

### DIFF
--- a/apps/discordsh/astro-discordsh/project.json
+++ b/apps/discordsh/astro-discordsh/project.json
@@ -1,67 +1,60 @@
 {
-  "name": "astro-discordsh",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/discordsh/astro-discordsh/src",
-  "tags": [],
-  "targets": {
-    "dev": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/discordsh/astro-discordsh",
-        "commands": [
-          "rm -rf .astro",
-          "nx exec -- astro sync",
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
-        ],
-        "parallel": false
-      }
-    },
-    "build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/discordsh/astro-discordsh",
-        "commands": [
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
-        ],
-        "parallel": false
-      }
-    },
-    "preview": {
-      "dependsOn": [
-        {
-          "target": "build",
-          "projects": "self"
-        }
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/discordsh/astro-discordsh",
-        "commands": [
-          "nx exec -- astro preview"
-        ],
-        "parallel": false
-      }
-    },
-    "check": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/discordsh/astro-discordsh",
-        "commands": [
-          "nx exec -- astro check"
-        ],
-        "parallel": false
-      }
-    },
-    "sync": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/discordsh/astro-discordsh",
-        "commands": [
-          "nx exec -- astro sync"
-        ],
-        "parallel": false
-      }
-    }
-  }
+	"name": "astro-discordsh",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/discordsh/astro-discordsh/src",
+	"tags": [],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/discordsh/astro-discordsh",
+				"commands": [
+					"rm -rf .astro",
+					"nx exec -- astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build --root apps/discordsh/astro-discordsh"
+				],
+				"parallel": false
+			}
+		},
+		"preview": {
+			"dependsOn": [
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/discordsh/astro-discordsh",
+				"commands": ["nx exec -- astro preview"],
+				"parallel": false
+			}
+		},
+		"check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/discordsh/astro-discordsh",
+				"commands": ["nx exec -- astro check"],
+				"parallel": false
+			}
+		},
+		"sync": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/discordsh/astro-discordsh",
+				"commands": ["nx exec -- astro sync"],
+				"parallel": false
+			}
+		}
+	}
 }

--- a/apps/gamejam/cryptothrone.com/project.json
+++ b/apps/gamejam/cryptothrone.com/project.json
@@ -1,47 +1,47 @@
 {
-  "name": "cryptothrone.com",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/gamejam/cryptothrone.com/src",
-  "tags": [],
-  "targets": {
-    "dev": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/gamejam/cryptothrone.com",
-        "commands": [
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
-        ],
-        "parallel": false
-      }
-    },
-    "build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/gamejam/cryptothrone.com",
-        "commands": [
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
-        ],
-        "parallel": false
-      }
-    },
-    "buildx": {
-      "executor": "@nxtensions/astro:build",
-      "options": {}
-    },
-    "devx": {
-      "executor": "@nxtensions/astro:dev",
-      "options": {}
-    },
-    "preview": {
-      "executor": "@nxtensions/astro:preview",
-      "options": {}
-    },
-    "check": {
-      "executor": "@nxtensions/astro:check"
-    },
-    "sync": {
-      "executor": "@nxtensions/astro:sync"
-    }
-  }
+	"name": "cryptothrone.com",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/gamejam/cryptothrone.com/src",
+	"tags": ["deprecated"],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/gamejam/cryptothrone.com",
+				"commands": [
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/gamejam/cryptothrone.com",
+				"commands": [
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
+				],
+				"parallel": false
+			}
+		},
+		"buildx": {
+			"executor": "@nxtensions/astro:build",
+			"options": {}
+		},
+		"devx": {
+			"executor": "@nxtensions/astro:dev",
+			"options": {}
+		},
+		"preview": {
+			"executor": "@nxtensions/astro:preview",
+			"options": {}
+		},
+		"check": {
+			"executor": "@nxtensions/astro:check"
+		},
+		"sync": {
+			"executor": "@nxtensions/astro:sync"
+		}
+	}
 }

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
-import starlightSiteGraph from 'starlight-site-graph';
+// TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
+// import starlightSiteGraph from 'starlight-site-graph';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
@@ -72,28 +73,8 @@ export default defineConfig({
 				PageSidebar: './src/components/pagesidebar/PageSidebar.astro',
 				Footer: './src/components/footer/AstroFooter.astro',
 			},
-			plugins: [
-				starlightSiteGraph({
-					graphConfig: {
-						actions: [
-							'fullscreen',
-							'depth',
-							'reset-zoom',
-							'render-arrows',
-							'settings',
-						],
-						renderLabels: true,
-						renderArrows: true,
-						depth: 3,
-						depthDirection: 'both',
-						minZoom: 0.05,
-						maxZoom: 4,
-						enableZoom: true,
-						enablePan: true,
-					},
-					overridePageSidebar: false,
-				}),
-			],
+			// TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
+			// plugins: [starlightSiteGraph({ ... })],
 			sidebar: [
 				{
 					label: 'Dashboard',

--- a/apps/kbve/astro-kbve/src/components/pagesidebar/PageSidebar.astro
+++ b/apps/kbve/astro-kbve/src/components/pagesidebar/PageSidebar.astro
@@ -1,6 +1,7 @@
 ---
 import Default from '@astrojs/starlight/components/PageSidebar.astro';
-import { PageGraph, PageBacklinks } from 'starlight-site-graph/components';
+// TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
+// import { PageGraph, PageBacklinks } from 'starlight-site-graph/components';
 ---
 
 <div class="mx-auto p-3">
@@ -23,16 +24,20 @@ import { PageGraph, PageBacklinks } from 'starlight-site-graph/components';
 	</a>
 </div>
 
+<!-- TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
 <PageGraph class="right-sidebar-panel slsg-graph-panel graph-panel">
 	<h2 slot="title">Das {Astro.locals.t('starlight-site-graph.graph')}</h2>
 </PageGraph>
+-->
 
 <Default>
 	<slot />
 </Default>
 
+<!-- TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
 <PageBacklinks class="right-sidebar-panel backlinks-panel">
 	<h2 slot="title">{Astro.locals.t('starlight-site-graph.backlinks')}</h2>
 </PageBacklinks>
+-->
 
 <br />

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -1,7 +1,8 @@
 import { z, defineCollection } from 'astro:content';
 import { docsSchema } from '@astrojs/starlight/schema';
 import { docsLoader } from '@astrojs/starlight/loaders';
-import { pageSiteGraphSchema } from 'starlight-site-graph/schema';
+// TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
+// import { pageSiteGraphSchema } from 'starlight-site-graph/schema';
 import { glob } from 'astro/loaders';
 
 import {
@@ -78,14 +79,12 @@ export const collections = {
 	docs: defineCollection({
 		loader: docsLoader(),
 		schema: docsSchema({
-			extend: pageSiteGraphSchema.merge(
-				z.object({
-					itemdb: z.array(IObjectSchema).optional(),
-					questdb: z.array(IQuestSchema).optional(),
-					mapdb: z.array(IMapObjectSchema).optional(),
-					osrs: OSRSFrontmatterSchema.optional(),
-				}),
-			),
+			extend: z.object({
+				itemdb: z.array(IObjectSchema).optional(),
+				questdb: z.array(IQuestSchema).optional(),
+				mapdb: z.array(IMapObjectSchema).optional(),
+				osrs: OSRSFrontmatterSchema.optional(),
+			}),
 		}),
 	}),
 	itemdb,

--- a/apps/kbve/astro-kbve/src/data/schema/IScriptBindingSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/IScriptBindingSchema.ts
@@ -2,7 +2,9 @@ import { z } from 'astro:content';
 
 export const IScriptBindingSchema = z.object({
 	guid: z.string().regex(/^[a-f0-9]{32}$/),
-	vars: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+	vars: z
+		.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+		.optional(),
 });
 
 export type ScriptBindingType = z.infer<typeof IScriptBindingSchema>;

--- a/apps/kbve/astro-kbve/src/data/schema/osrs/IOSRSSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/osrs/IOSRSSchema.ts
@@ -37,7 +37,7 @@ export const OSRSHeadTagSchema = z.object({
 		'noscript',
 		'template',
 	]),
-	attrs: z.record(z.union([z.string(), z.boolean()])).optional(),
+	attrs: z.record(z.string(), z.union([z.string(), z.boolean()])).optional(),
 	content: z.string().optional(),
 });
 

--- a/apps/kbve/astro-kbve/src/data/schema/osrs/generated.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/osrs/generated.ts
@@ -63,7 +63,7 @@ export const OSRSHeadTagSchema = z.object({
 		'noscript',
 		'template',
 	]),
-	attrs: z.record(z.union([z.string(), z.boolean()])).optional(),
+	attrs: z.record(z.string(), z.union([z.string(), z.boolean()])).optional(),
 	content: z.string().optional(),
 });
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
 	"license": "MIT",
 	"private": true,
 	"devDependencies": {
-		"@astrojs/check": "^0.9.6",
-		"@astrojs/mdx": "^4.3.13",
-		"@astrojs/partytown": "^2.1.4",
-		"@astrojs/react": "^4.4.2",
-		"@astrojs/sitemap": "^3.7.0",
-		"@astrojs/starlight": "^0.37.7",
-		"@astrojs/starlight-tailwind": "^4.0.2",
-		"@astrojs/ts-plugin": "^1.10.6",
+		"@astrojs/check": "^0.9.7",
+		"@astrojs/mdx": "^5.0.0",
+		"@astrojs/partytown": "^2.1.5",
+		"@astrojs/react": "^5.0.0",
+		"@astrojs/sitemap": "^3.7.1",
+		"@astrojs/starlight": "^0.38.1",
+		"@astrojs/starlight-tailwind": "^5.0.0",
+		"@astrojs/ts-plugin": "^1.10.7",
 		"@babel/core": "^7.25.9",
 		"@babel/preset-react": "^7.28.5",
 		"@babel/runtime": "7.27.6",
@@ -64,7 +64,7 @@
 		"@vitest/ui": "4.0.9",
 		"@vitest/web-worker": "4.0.9",
 		"@webcomponents/template-shadowroot": "^0.2.1",
-		"astro": "5.18.0",
+		"astro": "6.0.4",
 		"astro-compressor": "^1.2.0",
 		"astro-vtbot": "^2.1.11",
 		"autoprefixer": "^10.4.24",
@@ -176,7 +176,7 @@
 		"three-stdlib": "^2.36.0",
 		"tslib": "^2.8.0",
 		"vaul": "^1.1.1",
-		"zod": "^3.23.8"
+		"zod": "^4.0.0"
 	},
 	"lint-staged": {
 		"*.{ts,tsx,js,jsx}": [

--- a/packages/npm/droid/package.json
+++ b/packages/npm/droid/package.json
@@ -52,7 +52,7 @@
 		"nanostores": "^1.1.0",
 		"@nanostores/persistent": "^1.3.3",
 		"dexie": "^4.0.9",
-		"zod": "^3.23.8",
+		"zod": "^4.0.0",
 		"flatbuffers": "^25.2.10"
 	},
 	"peerDependencies": {

--- a/packages/npm/droid/src/lib/types/bento.ts
+++ b/packages/npm/droid/src/lib/types/bento.ts
@@ -5,7 +5,12 @@ export const BENTO_VARIANTS = ['default', 'minimal', 'image-heavy'] as const;
 export const BENTO_ANIMATIONS = ['fade-in', 'slide-up', 'none'] as const;
 export const BENTO_TARGETS = ['_self', '_blank', '_parent', '_top'] as const;
 export const BENTO_ROLES = ['button', 'link', 'region', 'article'] as const;
-export const BENTO_BADGE_TYPES = ['default', 'success', 'warning', 'error'] as const;
+export const BENTO_BADGE_TYPES = [
+	'default',
+	'success',
+	'warning',
+	'error',
+] as const;
 
 // Regex validators
 const tailwindColorRegex = /^[a-z]+-(100|200|300|400|500|600|700|800|900)$/;
@@ -13,68 +18,102 @@ const spanRegex = /^(?:(?:[a-z]+:)?(col|row)-span-\d+\s*)+$/;
 const ulidRegex = /^01[0-9A-HJKMNP-TV-Z]{24}$/;
 
 // Schema
-export const BentoTileSchema = z.object({
-  id: z.string().regex(ulidRegex, 'Invalid ULID format').optional(),
+export const BentoTileSchema = z
+	.object({
+		id: z.string().regex(ulidRegex, 'Invalid ULID format').optional(),
 
-  title: z.string().min(1, 'Title is required'),
-  subtitle: z.string().optional(),
-  description: z.string().optional(),
-  span: z.string().regex(spanRegex, 'Invalid span format (e.g., col-span-2, row-span-1)').optional(),
+		title: z.string().min(1, 'Title is required'),
+		subtitle: z.string().optional(),
+		description: z.string().optional(),
+		span: z
+			.string()
+			.regex(
+				spanRegex,
+				'Invalid span format (e.g., col-span-2, row-span-1)',
+			)
+			.optional(),
 
-  primaryColor: z.string().regex(tailwindColorRegex, 'Invalid Tailwind color format (e.g., blue-500)'),
-  secondaryColor: z.string().regex(tailwindColorRegex, 'Invalid Tailwind color format (e.g., blue-500)'),
+		primaryColor: z
+			.string()
+			.regex(
+				tailwindColorRegex,
+				'Invalid Tailwind color format (e.g., blue-500)',
+			),
+		secondaryColor: z
+			.string()
+			.regex(
+				tailwindColorRegex,
+				'Invalid Tailwind color format (e.g., blue-500)',
+			),
 
-  icon: z.string().optional(),
-  backgroundImage: z.string().url().optional(),
+		icon: z.string().optional(),
+		backgroundImage: z.string().url().optional(),
 
-  onclick: z.string().optional(),
-  href: z.string().url().optional(),
-  target: z.enum(BENTO_TARGETS).optional(),
+		onclick: z.string().optional(),
+		href: z.string().url().optional(),
+		target: z.enum(BENTO_TARGETS).optional(),
 
-  ariaLabel: z.string().optional(),
-  role: z.enum(BENTO_ROLES).optional(),
+		ariaLabel: z.string().optional(),
+		role: z.enum(BENTO_ROLES).optional(),
 
-  variant: z.enum(BENTO_VARIANTS).optional(),
-  animation: z.enum(BENTO_ANIMATIONS).optional(),
+		variant: z.enum(BENTO_VARIANTS).optional(),
+		animation: z.enum(BENTO_ANIMATIONS).optional(),
 
-  badge: z.string().optional(),
-  badgeType: z.enum(BENTO_BADGE_TYPES).optional(),
+		badge: z.string().optional(),
+		badgeType: z.enum(BENTO_BADGE_TYPES).optional(),
 
-  priority: z.number().int().min(0).optional(),
-  tooltip: z.string().optional(),
-  disabled: z.boolean().optional(),
+		priority: z.number().int().min(0).optional(),
+		tooltip: z.string().optional(),
+		disabled: z.boolean().optional(),
 
-  meta: z.record(z.any()).optional(),
-  dataset: z.record(z.string()).optional(),
-  className: z.string().optional(),
-}).refine(
-  (data) => !data.href || (data.href && data.target),
-  { message: 'target is required when href is provided', path: ['target'] }
-).refine(
-  (data) => !data.badgeType || (data.badge && data.badge.length > 0),
-  { message: 'badge must be provided if badgeType is set', path: ['badge'] }
-);
+		meta: z.record(z.string(), z.any()).optional(),
+		dataset: z.record(z.string(), z.string()).optional(),
+		className: z.string().optional(),
+	})
+	.refine((data) => !data.href || (data.href && data.target), {
+		message: 'target is required when href is provided',
+		path: ['target'],
+	})
+	.refine(
+		(data) => !data.badgeType || (data.badge && data.badge.length > 0),
+		{
+			message: 'badge must be provided if badgeType is set',
+			path: ['badge'],
+		},
+	);
 
 // Types
 export type BentoTile = z.infer<typeof BentoTileSchema>;
 export type BentoVariantClass = { base: string; hover?: string };
 
 // Mappings
-export const BENTO_VARIANT_CLASS_MAP: Record<(typeof BENTO_VARIANTS)[number], BentoVariantClass> = {
-  default: { base: 'p-4 flex flex-col justify-between' },
-  minimal: { base: 'p-2 bg-opacity-30 backdrop-blur-sm', hover: 'bg-opacity-50' },
-  'image-heavy': { base: 'p-0 overflow-hidden', hover: 'scale-105' },
+export const BENTO_VARIANT_CLASS_MAP: Record<
+	(typeof BENTO_VARIANTS)[number],
+	BentoVariantClass
+> = {
+	default: { base: 'p-4 flex flex-col justify-between' },
+	minimal: {
+		base: 'p-2 bg-opacity-30 backdrop-blur-sm',
+		hover: 'bg-opacity-50',
+	},
+	'image-heavy': { base: 'p-0 overflow-hidden', hover: 'scale-105' },
 };
 
-export const BENTO_ANIMATION_CLASS_MAP: Record<(typeof BENTO_ANIMATIONS)[number], string> = {
-  'fade-in': 'animate-fade-in',
-  'slide-up': 'animate-slide-up',
-  none: '',
+export const BENTO_ANIMATION_CLASS_MAP: Record<
+	(typeof BENTO_ANIMATIONS)[number],
+	string
+> = {
+	'fade-in': 'animate-fade-in',
+	'slide-up': 'animate-slide-up',
+	none: '',
 };
 
-export const BENTO_BADGE_CLASS_MAP: Record<(typeof BENTO_BADGE_TYPES)[number], string> = {
-  default: 'bg-white/30 text-white',
-  success: 'bg-green-500/80 text-white',
-  warning: 'bg-yellow-500/80 text-black',
-  error: 'bg-red-500/80 text-white',
+export const BENTO_BADGE_CLASS_MAP: Record<
+	(typeof BENTO_BADGE_TYPES)[number],
+	string
+> = {
+	default: 'bg-white/30 text-white',
+	success: 'bg-green-500/80 text-white',
+	warning: 'bg-yellow-500/80 text-black',
+	error: 'bg-red-500/80 text-white',
 };

--- a/packages/npm/droid/src/lib/types/ui-event-types.ts
+++ b/packages/npm/droid/src/lib/types/ui-event-types.ts
@@ -3,14 +3,14 @@ import type { VirtualNode } from './modules';
 
 // Recursive VirtualNode schema matching the type in modules.ts.
 // Validates worker-produced descriptors at runtime.
-const VirtualNodeSchema: z.ZodType<VirtualNode> = z.lazy(() =>
+const VirtualNodeSchema: z.ZodType<VirtualNode, VirtualNode> = z.lazy(() =>
 	z.object({
 		tag: z.string(),
 		id: z.string().optional(),
 		key: z.string().optional(),
 		class: z.string().optional(),
-		attrs: z.record(z.any()).optional(),
-		style: z.record(z.string()).optional(),
+		attrs: z.record(z.string(), z.any()).optional(),
+		style: z.record(z.string(), z.string()).optional(),
 		children: z.array(z.union([z.string(), VirtualNodeSchema])).optional(),
 	}),
 );
@@ -59,7 +59,7 @@ export const ModalPayloadSchema = z.object({
 	id: z.string(),
 	content: VirtualNodeSchema.optional(),
 	title: z.string().optional(),
-	metadata: z.record(z.any()).optional(),
+	metadata: z.record(z.string(), z.any()).optional(),
 });
 export type ModalPayload = z.infer<typeof ModalPayloadSchema>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
                 version: 5.90.20
             astro-mermaid:
                 specifier: ^1.3.1
-                version: 1.3.1(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(mermaid@11.12.0)
+                version: 1.3.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(mermaid@11.12.0)
             axios:
                 specifier: 1.6.7
                 version: 1.6.7
@@ -209,33 +209,33 @@ importers:
                 specifier: ^1.1.1
                 version: 1.1.2(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
             zod:
-                specifier: ^3.23.8
-                version: 3.24.2
+                specifier: ^4.0.0
+                version: 4.3.6
         devDependencies:
             '@astrojs/check':
-                specifier: ^0.9.6
-                version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
+                specifier: ^0.9.7
+                version: 0.9.7(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
             '@astrojs/mdx':
-                specifier: ^4.3.13
-                version: 4.3.13(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+                specifier: ^5.0.0
+                version: 5.0.0(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
             '@astrojs/partytown':
-                specifier: ^2.1.4
-                version: 2.1.4
+                specifier: ^2.1.5
+                version: 2.1.5
             '@astrojs/react':
-                specifier: ^4.4.2
-                version: 4.4.2(@types/node@18.19.17)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
+                specifier: ^5.0.0
+                version: 5.0.0(@types/node@18.19.17)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
             '@astrojs/sitemap':
-                specifier: ^3.7.0
-                version: 3.7.0
+                specifier: ^3.7.1
+                version: 3.7.1
             '@astrojs/starlight':
-                specifier: ^0.37.7
-                version: 0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+                specifier: ^0.38.1
+                version: 0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
             '@astrojs/starlight-tailwind':
-                specifier: ^4.0.2
-                version: 4.0.2(@astrojs/starlight@0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.3)
+                specifier: ^5.0.0
+                version: 5.0.0(@astrojs/starlight@0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.3)
             '@astrojs/ts-plugin':
-                specifier: ^1.10.6
-                version: 1.10.6
+                specifier: ^1.10.7
+                version: 1.10.7
             '@babel/core':
                 specifier: ^7.25.9
                 version: 7.26.10
@@ -376,7 +376,7 @@ importers:
                 version: 7.18.0(eslint@8.57.0)(typescript@5.9.3)
             '@vite-pwa/astro':
                 specifier: ^1.2.0
-                version: 1.2.0(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(vite-plugin-pwa@1.0.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))
+                version: 1.2.0(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(vite-plugin-pwa@1.0.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))
             '@vitejs/plugin-react':
                 specifier: 4.2.1
                 version: 4.2.1(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))
@@ -393,8 +393,8 @@ importers:
                 specifier: ^0.2.1
                 version: 0.2.1
             astro:
-                specifier: 5.18.0
-                version: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+                specifier: 6.0.4
+                version: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
             astro-compressor:
                 specifier: ^1.2.0
                 version: 1.2.0
@@ -493,7 +493,7 @@ importers:
                 version: 3.0.0
             starlight-site-graph:
                 specifier: ^0.5.0
-                version: 0.5.0(@astrojs/starlight@0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+                version: 0.5.0(@astrojs/starlight@0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
             tailwindcss:
                 specifier: ^4.1.3
                 version: 4.1.3
@@ -616,20 +616,14 @@ packages:
         peerDependencies:
             ajv: '>=8'
 
-    '@astrojs/check@0.9.6':
+    '@astrojs/check@0.9.7':
         resolution:
             {
-                integrity: sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA==,
+                integrity: sha512-dA7U5/OFg8/xaMUb2vUOOJuuJXnMpHy6F0BM8ZhL7WT5OkTBwJ0GoW38n4fC4CXt+lT9mLWL0y8Pa74tFByBpQ==,
             }
         hasBin: true
         peerDependencies:
             typescript: ^5.0.0
-
-    '@astrojs/compiler@2.12.2':
-        resolution:
-            {
-                integrity: sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==,
-            }
 
     '@astrojs/compiler@2.13.1':
         resolution:
@@ -637,10 +631,22 @@ packages:
                 integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==,
             }
 
+    '@astrojs/compiler@3.0.0':
+        resolution:
+            {
+                integrity: sha512-MwAbDE5mawZ1SS+D8qWiHdprdME5Tlj2e0YjxnEICvcOpbSukNS7Sa7hA5PK+6RrmUr/t6Gi5YgrdZKjbO/WPQ==,
+            }
+
     '@astrojs/internal-helpers@0.7.5':
         resolution:
             {
                 integrity: sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==,
+            }
+
+    '@astrojs/internal-helpers@0.8.0':
+        resolution:
+            {
+                integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==,
             }
 
     '@astrojs/language-server@2.16.3':
@@ -664,19 +670,25 @@ packages:
                 integrity: sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==,
             }
 
-    '@astrojs/mdx@4.3.13':
+    '@astrojs/markdown-remark@7.0.0':
         resolution:
             {
-                integrity: sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q==,
+                integrity: sha512-jTAXHPy45L7o1ljH4jYV+ShtOHtyQUa1mGp3a5fJp1soX8lInuTJQ6ihmldHzVM4Q7QptU4SzIDIcKbBJO7sXQ==,
             }
-        engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
-        peerDependencies:
-            astro: ^5.0.0
 
-    '@astrojs/partytown@2.1.4':
+    '@astrojs/mdx@5.0.0':
         resolution:
             {
-                integrity: sha512-loUrAu0cGYFDC6dHVRiomdsBJ41VjDYXPA+B3Br51V5hENFgDSOLju86OIj1TvBACcsB22UQV7BlppODDG5gig==,
+                integrity: sha512-J4rW6eT+qgVw7+RXdBYO4vYyWGeXXQp8wop9dXsOlLzIsVSxyttMCgkGCWvIR2ogBqKqeYgI6YDW93PaDHkCaA==,
+            }
+        engines: { node: ^20.19.1 || >=22.12.0 }
+        peerDependencies:
+            astro: ^6.0.0-alpha.0
+
+    '@astrojs/partytown@2.1.5':
+        resolution:
+            {
+                integrity: sha512-Uo2Uqmvjh/5w08wGoVAspdj14hUoE28uQH8SkzaBMw9bTBNIviEkPi3VkJi+tj1ZYAY9oX7OSkRDJ48QRtMhlw==,
             }
 
     '@astrojs/prism@3.3.0':
@@ -686,40 +698,47 @@ packages:
             }
         engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
-    '@astrojs/react@4.4.2':
+    '@astrojs/prism@4.0.0':
         resolution:
             {
-                integrity: sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==,
+                integrity: sha512-NndtNPpxaGinRpRytljGBvYHpTOwHycSZ/c+lQi5cHvkqqrHKWdkPEhImlODBNmbuB+vyQUNUDXyjzt66CihJg==,
             }
-        engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+        engines: { node: ^20.19.1 || >=22.12.0 }
+
+    '@astrojs/react@5.0.0':
+        resolution:
+            {
+                integrity: sha512-OuM+0QFsoPkvv8ZB57kVLxKOqvR+84GR/Em9lh/tAL4fV4CnpBPDxc++0vd1CipH4o99Is7GribuTHFy3doF6g==,
+            }
+        engines: { node: ^20.19.1 || >=22.12.0 }
         peerDependencies:
             '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
             '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
             react: ^17.0.2 || ^18.0.0 || ^19.0.0
             react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
 
-    '@astrojs/sitemap@3.7.0':
+    '@astrojs/sitemap@3.7.1':
         resolution:
             {
-                integrity: sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==,
+                integrity: sha512-IzQqdTeskaMX+QDZCzMuJIp8A8C1vgzMBp/NmHNnadepHYNHcxQdGLQZYfkbd2EbRXUfOS+UDIKx8sKg0oWVdw==,
             }
 
-    '@astrojs/starlight-tailwind@4.0.2':
+    '@astrojs/starlight-tailwind@5.0.0':
         resolution:
             {
-                integrity: sha512-SYN/6zq6hJO5tWqbQ2tWT9/jd8ubUkzkBCcF94vByC/ZJ20Mi5GPjFvAh89Yky/aIM+jXxT6W5q4p6l58GKHiQ==,
+                integrity: sha512-VivF+bWg++4ma/ffr5sgHsd/ONtGdVJIKAaRZ6jmL4yqxy7bviu59MGNi5aW3nd8psP9i/aivBTrpwGxRM1XyA==,
             }
         peerDependencies:
-            '@astrojs/starlight': '>=0.34.0'
+            '@astrojs/starlight': '>=0.38.0'
             tailwindcss: ^4.0.0
 
-    '@astrojs/starlight@0.37.7':
+    '@astrojs/starlight@0.38.1':
         resolution:
             {
-                integrity: sha512-KyBnou8aKIlPJUSNx6a1SN7XyH22oj/VAvTGC+Edld4Bnei1A//pmCRTBvSrSeoGrdUjK0ErFUfaEhhO1bPfDg==,
+                integrity: sha512-CATPH4Dy44OYAJhoyUHh6NqpColWEVufanGVwnM0l/bcaNMo5V/rypwL0Vu0Edp+ZIXE7/1DA9CrNj5jmCVSLQ==,
             }
         peerDependencies:
-            astro: ^5.5.0
+            astro: ^6.0.0
 
     '@astrojs/telemetry@3.3.0':
         resolution:
@@ -728,16 +747,22 @@ packages:
             }
         engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
-    '@astrojs/ts-plugin@1.10.6':
+    '@astrojs/ts-plugin@1.10.7':
         resolution:
             {
-                integrity: sha512-Ke5CNwxn/ozsh6THJKuayUlBToa3uiPDi2oSwcXmTdeiJ0PGr+UkdQJf9hdMgBjbIka9fhnSn3UhYamfNfJ73A==,
+                integrity: sha512-CFJQgMLxi7F21VMcLBuAQmD9KrnT/ACfhZgdhsmVzOcb5Lscu7MIUl/ZxYDviXqDnhDBF1JzYOj+kusJlGmG8w==,
             }
 
     '@astrojs/yaml2ts@0.2.2':
         resolution:
             {
                 integrity: sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==,
+            }
+
+    '@astrojs/yaml2ts@0.2.3':
+        resolution:
+            {
+                integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==,
             }
 
     '@astropub/worker@0.2.0':
@@ -756,13 +781,6 @@ packages:
         resolution:
             {
                 integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/code-frame@7.27.1':
-        resolution:
-            {
-                integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==,
             }
         engines: { node: '>=6.9.0' }
 
@@ -794,13 +812,6 @@ packages:
             }
         engines: { node: '>=6.9.0' }
 
-    '@babel/core@7.28.4':
-        resolution:
-            {
-                integrity: sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==,
-            }
-        engines: { node: '>=6.9.0' }
-
     '@babel/core@7.29.0':
         resolution:
             {
@@ -812,13 +823,6 @@ packages:
         resolution:
             {
                 integrity: sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/generator@7.28.3':
-        resolution:
-            {
-                integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==,
             }
         engines: { node: '>=6.9.0' }
 
@@ -847,13 +851,6 @@ packages:
         resolution:
             {
                 integrity: sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-compilation-targets@7.27.2':
-        resolution:
-            {
-                integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==,
             }
         engines: { node: '>=6.9.0' }
 
@@ -934,15 +931,6 @@ packages:
         peerDependencies:
             '@babel/core': ^7.0.0
 
-    '@babel/helper-module-transforms@7.28.3':
-        resolution:
-            {
-                integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0
-
     '@babel/helper-module-transforms@7.28.6':
         resolution:
             {
@@ -1012,13 +1000,6 @@ packages:
             }
         engines: { node: '>=6.9.0' }
 
-    '@babel/helper-validator-identifier@7.27.1':
-        resolution:
-            {
-                integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==,
-            }
-        engines: { node: '>=6.9.0' }
-
     '@babel/helper-validator-identifier@7.28.5':
         resolution:
             {
@@ -1051,13 +1032,6 @@ packages:
         resolution:
             {
                 integrity: sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helpers@7.28.4':
-        resolution:
-            {
-                integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==,
             }
         engines: { node: '>=6.9.0' }
 
@@ -1990,13 +1964,6 @@ packages:
             }
         engines: { node: '>=6.9.0' }
 
-    '@babel/template@7.27.2':
-        resolution:
-            {
-                integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==,
-            }
-        engines: { node: '>=6.9.0' }
-
     '@babel/template@7.28.6':
         resolution:
             {
@@ -2011,13 +1978,6 @@ packages:
             }
         engines: { node: '>=6.9.0' }
 
-    '@babel/traverse@7.28.4':
-        resolution:
-            {
-                integrity: sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==,
-            }
-        engines: { node: '>=6.9.0' }
-
     '@babel/traverse@7.29.0':
         resolution:
             {
@@ -2029,13 +1989,6 @@ packages:
         resolution:
             {
                 integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/types@7.28.4':
-        resolution:
-            {
-                integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==,
             }
         engines: { node: '>=6.9.0' }
 
@@ -2177,6 +2130,18 @@ packages:
         resolution:
             {
                 integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==,
+            }
+
+    '@clack/core@1.1.0':
+        resolution:
+            {
+                integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==,
+            }
+
+    '@clack/prompts@1.1.0':
+        resolution:
+            {
+                integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==,
             }
 
     '@cspotcode/source-map-support@0.8.1':
@@ -3081,28 +3046,28 @@ packages:
             }
         hasBin: true
 
-    '@expressive-code/core@0.41.1':
+    '@expressive-code/core@0.41.7':
         resolution:
             {
-                integrity: sha512-mG2IrN4t/NGPmEeeswmttsW7W7c96sz3ASjo1psQnOqU5QWAF61HpnBu3lPxHI8iQJyZI8wfAroo9FFpwlkvAQ==,
+                integrity: sha512-ck92uZYZ9Wba2zxkiZLsZGi9N54pMSAVdrI9uW3Oo9AtLglD5RmrdTwbYPCT2S/jC36JGB2i+pnQtBm/Ib2+dg==,
             }
 
-    '@expressive-code/plugin-frames@0.41.1':
+    '@expressive-code/plugin-frames@0.41.7':
         resolution:
             {
-                integrity: sha512-cwUUWMr2jNpKpgiepEzM9BGnU60WepE5/Ar3H2aOn8IzcDa4Eeuk0JqQB1Vvpo0bu+VRIxaTA2njoAIeQuMN5w==,
+                integrity: sha512-diKtxjQw/979cTglRFaMCY/sR6hWF0kSMg8jsKLXaZBSfGS0I/Hoe7Qds3vVEgeoW+GHHQzMcwvgx/MOIXhrTA==,
             }
 
-    '@expressive-code/plugin-shiki@0.41.1':
+    '@expressive-code/plugin-shiki@0.41.7':
         resolution:
             {
-                integrity: sha512-xJHk89ECxQpvf7ftTmtEfAKoApYYr5Um7d6fiE6GuY7+WuXN02+ZHH8r5pSJpxlQMfAmavqbNPd3dEJ9v/zHnQ==,
+                integrity: sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ==,
             }
 
-    '@expressive-code/plugin-text-markers@0.41.1':
+    '@expressive-code/plugin-text-markers@0.41.7':
         resolution:
             {
-                integrity: sha512-PFvk91yY+H8KVEcyZSrktLoWzBgLVpowvMxOJooFn74roGxnU4TEBJpWcRnJFtMEwTLzWNnk10MSOApOccvSKg==,
+                integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==,
             }
 
     '@fastify/busboy@2.1.1':
@@ -5817,10 +5782,10 @@ packages:
                 integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==,
             }
 
-    '@qwik.dev/partytown@0.11.0':
+    '@qwik.dev/partytown@0.11.2':
         resolution:
             {
-                integrity: sha512-MHime7cxj7KGrapGZ1VqLkXXq5BLNqvjNZndRJVvMkUWn92F2bsezlWW1lKDoFaKCKu2xv9LRUZL99RYOs+ccA==,
+                integrity: sha512-795y49CqBiKiwKAD+QBZlzlqEK275hVcazZ7wBPSfgC23L+vWuA7PJmMpgxojOucZHzYi5rAAQ+IP1I3BKVZxw==,
             }
         engines: { node: '>=18.0.0' }
         hasBin: true
@@ -6686,10 +6651,10 @@ packages:
             }
         engines: { node: ^20.9.0 || ^22.11.0 || ^24, pnpm: ^10.0.0 }
 
-    '@rolldown/pluginutils@1.0.0-beta.27':
+    '@rolldown/pluginutils@1.0.0-rc.3':
         resolution:
             {
-                integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
+                integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==,
             }
 
     '@rollup/plugin-babel@5.3.1':
@@ -7219,6 +7184,13 @@ packages:
                 integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==,
             }
 
+    '@shikijs/core@4.0.2':
+        resolution:
+            {
+                integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==,
+            }
+        engines: { node: '>=20' }
+
     '@shikijs/engine-javascript@1.29.2':
         resolution:
             {
@@ -7230,6 +7202,13 @@ packages:
             {
                 integrity: sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==,
             }
+
+    '@shikijs/engine-javascript@4.0.2':
+        resolution:
+            {
+                integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==,
+            }
+        engines: { node: '>=20' }
 
     '@shikijs/engine-oniguruma@1.29.2':
         resolution:
@@ -7243,6 +7222,13 @@ packages:
                 integrity: sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==,
             }
 
+    '@shikijs/engine-oniguruma@4.0.2':
+        resolution:
+            {
+                integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==,
+            }
+        engines: { node: '>=20' }
+
     '@shikijs/langs@1.29.2':
         resolution:
             {
@@ -7254,6 +7240,20 @@ packages:
             {
                 integrity: sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==,
             }
+
+    '@shikijs/langs@4.0.2':
+        resolution:
+            {
+                integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==,
+            }
+        engines: { node: '>=20' }
+
+    '@shikijs/primitive@4.0.2':
+        resolution:
+            {
+                integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==,
+            }
+        engines: { node: '>=20' }
 
     '@shikijs/themes@1.29.2':
         resolution:
@@ -7267,6 +7267,13 @@ packages:
                 integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==,
             }
 
+    '@shikijs/themes@4.0.2':
+        resolution:
+            {
+                integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==,
+            }
+        engines: { node: '>=20' }
+
     '@shikijs/types@1.29.2':
         resolution:
             {
@@ -7278,6 +7285,13 @@ packages:
             {
                 integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==,
             }
+
+    '@shikijs/types@4.0.2':
+        resolution:
+            {
+                integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==,
+            }
+        engines: { node: '>=20' }
 
     '@shikijs/vscode-textmate@10.0.2':
         resolution:
@@ -8482,16 +8496,16 @@ packages:
                 integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==,
             }
 
-    '@types/node@17.0.45':
-        resolution:
-            {
-                integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
-            }
-
     '@types/node@18.19.17':
         resolution:
             {
                 integrity: sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==,
+            }
+
+    '@types/node@24.12.0':
+        resolution:
+            {
+                integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==,
             }
 
     '@types/node@25.0.3':
@@ -9228,14 +9242,14 @@ packages:
         peerDependencies:
             vite: ^4.2.0 || ^5.0.0
 
-    '@vitejs/plugin-react@4.7.0':
+    '@vitejs/plugin-react@5.2.0':
         resolution:
             {
-                integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
+                integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==,
             }
-        engines: { node: ^14.18.0 || >=16.0.0 }
+        engines: { node: ^20.19.0 || >=22.12.0 }
         peerDependencies:
-            vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+            vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
     '@vitest/coverage-v8@4.0.9':
         resolution:
@@ -9795,14 +9809,6 @@ packages:
         engines: { node: '>=0.4.0' }
         hasBin: true
 
-    acorn@8.15.0:
-        resolution:
-            {
-                integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
-            }
-        engines: { node: '>=0.4.0' }
-        hasBin: true
-
     acorn@8.16.0:
         resolution:
             {
@@ -10327,13 +10333,13 @@ packages:
             }
         engines: { node: '>=22' }
 
-    astro-expressive-code@0.41.1:
+    astro-expressive-code@0.41.7:
         resolution:
             {
-                integrity: sha512-za6HlekMOczwlkuYuQQTd6LkKFwsnfAjwjIprCzOqsjp9vkYrAcriXM5cIG7V1Zxx88sVXF6iGnyNl4J0DL2Mg==,
+                integrity: sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ==,
             }
         peerDependencies:
-            astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0
+            astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
     astro-integration-kit@0.18.0:
         resolution:
@@ -10375,17 +10381,13 @@ packages:
             }
         hasBin: true
 
-    astro@5.18.0:
+    astro@6.0.4:
         resolution:
             {
-                integrity: sha512-CHiohwJIS4L0G6/IzE1Fx3dgWqXBCXus/od0eGUfxrZJD2um2pE7ehclMmgL/fXqbU7NfE1Ze2pq34h2QaA6iQ==,
+                integrity: sha512-1piLJCPTL/x7AMO2cjVFSTFyRqKuC3W8sSEySCt1aJio+p/wGs5H3K+Xr/rE9ftKtknLUtjxCqCE7/0NsXfGpQ==,
             }
         engines:
-            {
-                node: 18.20.8 || ^20.3.0 || >=22.0.0,
-                npm: '>=9.6.5',
-                pnpm: '>=7.1.0',
-            }
+            { node: ^20.19.1 || >=22.12.0, npm: '>=9.6.5', pnpm: '>=7.1.0' }
         hasBin: true
 
     async-function@1.0.0:
@@ -11692,6 +11694,13 @@ packages:
             {
                 integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
             }
+
+    common-ancestor-path@2.0.0:
+        resolution:
+            {
+                integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==,
+            }
+        engines: { node: '>= 18' }
 
     common-path-prefix@3.0.0:
         resolution:
@@ -13006,6 +13015,12 @@ packages:
                 integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==,
             }
 
+    devalue@5.6.4:
+        resolution:
+            {
+                integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==,
+            }
+
     devlop@1.1.0:
         resolution:
             {
@@ -14104,10 +14119,10 @@ packages:
             }
         engines: { node: '>= 0.10.0' }
 
-    expressive-code@0.41.1:
+    expressive-code@0.41.7:
         resolution:
             {
-                integrity: sha512-O3+bDWGw+y7b0L3Y3xc7LbPgRTvFy2tqXzYY24TBbDwnHbIwb0OFdS4v+1PpX6NEsF7XsVv9sqY5xo22yWe7Hw==,
+                integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==,
             }
 
     exsolve@1.0.7:
@@ -18884,13 +18899,6 @@ packages:
             }
         engines: { node: 20 || >=22 }
 
-    minimatch@10.2.2:
-        resolution:
-            {
-                integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==,
-            }
-        engines: { node: 18 || 20 || >=22 }
-
     minimatch@10.2.4:
         resolution:
             {
@@ -19753,6 +19761,13 @@ packages:
             }
         engines: { node: '>=18' }
 
+    p-limit@7.3.0:
+        resolution:
+            {
+                integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
+            }
+        engines: { node: '>=20' }
+
     p-locate@4.1.0:
         resolution:
             {
@@ -19781,6 +19796,13 @@ packages:
             }
         engines: { node: '>=18' }
 
+    p-queue@9.1.0:
+        resolution:
+            {
+                integrity: sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==,
+            }
+        engines: { node: '>=20' }
+
     p-retry@6.2.0:
         resolution:
             {
@@ -19794,6 +19816,13 @@ packages:
                 integrity: sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==,
             }
         engines: { node: '>=14.16' }
+
+    p-timeout@7.0.1:
+        resolution:
+            {
+                integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
+            }
+        engines: { node: '>=20' }
 
     p-try@2.2.0:
         resolution:
@@ -21472,10 +21501,10 @@ packages:
             }
         engines: { node: '>=0.10.0' }
 
-    react-refresh@0.17.0:
+    react-refresh@0.18.0:
         resolution:
             {
-                integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
+                integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==,
             }
         engines: { node: '>=0.10.0' }
 
@@ -21846,10 +21875,10 @@ packages:
             }
         hasBin: true
 
-    rehype-expressive-code@0.41.1:
+    rehype-expressive-code@0.41.7:
         resolution:
             {
-                integrity: sha512-QApC3js5/AwrF6VqWfGsNY9Y1qLC0LQDWcqOHEAhbl3CB4e5GMor2SpWaGOWBW+mmrkVCEymayLPCPIbx0tcQQ==,
+                integrity: sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ==,
             }
 
     rehype-external-links@3.0.0:
@@ -22542,12 +22571,6 @@ packages:
         engines: { node: '>=14.0.0' }
         hasBin: true
 
-    sax@1.4.1:
-        resolution:
-            {
-                integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==,
-            }
-
     sax@1.4.4:
         resolution:
             {
@@ -22847,6 +22870,13 @@ packages:
                 integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==,
             }
 
+    shiki@4.0.2:
+        resolution:
+            {
+                integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==,
+            }
+        engines: { node: '>=20' }
+
     side-channel-list@1.0.0:
         resolution:
             {
@@ -22919,12 +22949,12 @@ packages:
                 integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
             }
 
-    sitemap@8.0.2:
+    sitemap@9.0.1:
         resolution:
             {
-                integrity: sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==,
+                integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==,
             }
-        engines: { node: '>=14.0.0', npm: '>=6.0.0' }
+        engines: { node: '>=20.19.5', npm: '>=10.8.2' }
         hasBin: true
 
     slash@3.0.0:
@@ -23977,6 +24007,13 @@ packages:
                 integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
             }
 
+    tinyclip@0.1.12:
+        resolution:
+            {
+                integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==,
+            }
+        engines: { node: ^16.14.0 || >= 17.3.0 }
+
     tinycolor2@1.6.0:
         resolution:
             {
@@ -24566,6 +24603,12 @@ packages:
                 integrity: sha512-b0GtQzKCyuSHGsfj5vyN8st7muZ6VCI4XD4vFlr7Uy1rlWVYxC3npnfk8MyreHxJYrz1ooLDqDzFe9XqQTlAhA==,
             }
 
+    unifont@0.7.4:
+        resolution:
+            {
+                integrity: sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==,
+            }
+
     union@0.5.0:
         resolution:
             {
@@ -24644,6 +24687,12 @@ packages:
         resolution:
             {
                 integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==,
+            }
+
+    unist-util-visit@5.1.0:
+        resolution:
+            {
+                integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
             }
 
     universal-user-agent@6.0.1:
@@ -25155,6 +25204,17 @@ packages:
             }
         peerDependencies:
             vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+        peerDependenciesMeta:
+            vite:
+                optional: true
+
+    vitefu@1.1.2:
+        resolution:
+            {
+                integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==,
+            }
+        peerDependencies:
+            vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
         peerDependenciesMeta:
             vite:
                 optional: true
@@ -26076,6 +26136,13 @@ packages:
             }
         engines: { node: '>=12' }
 
+    yargs-parser@22.0.0:
+        resolution:
+            {
+                integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
+            }
+        engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
+
     yargs@15.4.1:
         resolution:
             {
@@ -26115,6 +26182,13 @@ packages:
         resolution:
             {
                 integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==,
+            }
+        engines: { node: '>=12.20' }
+
+    yocto-queue@1.2.2:
+        resolution:
+            {
+                integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==,
             }
         engines: { node: '>=12.20' }
 
@@ -26171,16 +26245,16 @@ packages:
         peerDependencies:
             zod: ^3.25.0 || ^4.0.0
 
-    zod@3.24.2:
-        resolution:
-            {
-                integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==,
-            }
-
     zod@3.25.76:
         resolution:
             {
                 integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
+            }
+
+    zod@4.3.6:
+        resolution:
+            {
+                integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
             }
 
     zustand@4.5.6:
@@ -26302,7 +26376,7 @@ snapshots:
             jsonpointer: 5.0.1
             leven: 3.1.0
 
-    '@astrojs/check@0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
+    '@astrojs/check@0.9.7(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
         dependencies:
             '@astrojs/language-server': 2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
             chokidar: 4.0.3
@@ -26313,11 +26387,15 @@ snapshots:
             - prettier
             - prettier-plugin-astro
 
-    '@astrojs/compiler@2.12.2': {}
-
     '@astrojs/compiler@2.13.1': {}
 
+    '@astrojs/compiler@3.0.0': {}
+
     '@astrojs/internal-helpers@0.7.5': {}
+
+    '@astrojs/internal-helpers@0.8.0':
+        dependencies:
+            picomatch: 4.0.3
 
     '@astrojs/language-server@2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
         dependencies:
@@ -26371,13 +26449,38 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@astrojs/mdx@4.3.13(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))':
+    '@astrojs/markdown-remark@7.0.0':
         dependencies:
-            '@astrojs/markdown-remark': 6.3.10
+            '@astrojs/internal-helpers': 0.8.0
+            '@astrojs/prism': 4.0.0
+            github-slugger: 2.0.0
+            hast-util-from-html: 2.0.3
+            hast-util-to-text: 4.0.2
+            js-yaml: 4.1.1
+            mdast-util-definitions: 6.0.0
+            rehype-raw: 7.0.0
+            rehype-stringify: 10.0.1
+            remark-gfm: 4.0.1
+            remark-parse: 11.0.0
+            remark-rehype: 11.1.2
+            remark-smartypants: 3.0.2
+            shiki: 4.0.2
+            smol-toml: 1.6.0
+            unified: 11.0.5
+            unist-util-remove-position: 5.0.0
+            unist-util-visit: 5.1.0
+            unist-util-visit-parents: 6.0.2
+            vfile: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@astrojs/mdx@5.0.0(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))':
+        dependencies:
+            '@astrojs/markdown-remark': 7.0.0
             '@mdx-js/mdx': 3.1.1
-            acorn: 8.15.0
-            astro: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
-            es-module-lexer: 1.7.0
+            acorn: 8.16.0
+            astro: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+            es-module-lexer: 2.0.0
             estree-util-visit: 2.0.0
             hast-util-to-html: 9.0.5
             piccolore: 0.1.3
@@ -26385,29 +26488,35 @@ snapshots:
             remark-gfm: 4.0.1
             remark-smartypants: 3.0.2
             source-map: 0.7.6
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
             vfile: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
-    '@astrojs/partytown@2.1.4':
+    '@astrojs/partytown@2.1.5':
         dependencies:
-            '@qwik.dev/partytown': 0.11.0
+            '@qwik.dev/partytown': 0.11.2
             mrmime: 2.0.1
 
     '@astrojs/prism@3.3.0':
         dependencies:
             prismjs: 1.30.0
 
-    '@astrojs/react@4.4.2(@types/node@18.19.17)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)':
+    '@astrojs/prism@4.0.0':
         dependencies:
+            prismjs: 1.30.0
+
+    '@astrojs/react@5.0.0(@types/node@18.19.17)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)':
+        dependencies:
+            '@astrojs/internal-helpers': 0.8.0
             '@types/react': 19.2.9
             '@types/react-dom': 19.1.5(@types/react@19.2.9)
-            '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))
+            '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))
+            devalue: 5.6.4
             react: 19.2.4
             react-dom: 19.2.4(react@19.2.4)
             ultrahtml: 1.6.0
-            vite: 6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
+            vite: 7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
         transitivePeerDependencies:
             - '@types/node'
             - jiti
@@ -26422,28 +26531,28 @@ snapshots:
             - tsx
             - yaml
 
-    '@astrojs/sitemap@3.7.0':
+    '@astrojs/sitemap@3.7.1':
         dependencies:
-            sitemap: 8.0.2
+            sitemap: 9.0.1
             stream-replace-string: 2.0.0
-            zod: 3.25.76
+            zod: 4.3.6
 
-    '@astrojs/starlight-tailwind@4.0.2(@astrojs/starlight@0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.3)':
+    '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.3)':
         dependencies:
-            '@astrojs/starlight': 0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+            '@astrojs/starlight': 0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
             tailwindcss: 4.1.3
 
-    '@astrojs/starlight@0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))':
+    '@astrojs/starlight@0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))':
         dependencies:
-            '@astrojs/markdown-remark': 6.3.10
-            '@astrojs/mdx': 4.3.13(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
-            '@astrojs/sitemap': 3.7.0
+            '@astrojs/markdown-remark': 7.0.0
+            '@astrojs/mdx': 5.0.0(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+            '@astrojs/sitemap': 3.7.1
             '@pagefind/default-ui': 1.3.0
             '@types/hast': 3.0.4
             '@types/js-yaml': 4.0.9
             '@types/mdast': 4.0.4
-            astro: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
-            astro-expressive-code: 0.41.1(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+            astro: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+            astro-expressive-code: 0.41.7(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
             bcp-47: 2.1.0
             hast-util-from-html: 2.0.3
             hast-util-select: 6.0.3
@@ -26479,10 +26588,10 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@astrojs/ts-plugin@1.10.6':
+    '@astrojs/ts-plugin@1.10.7':
         dependencies:
-            '@astrojs/compiler': 2.12.2
-            '@astrojs/yaml2ts': 0.2.2
+            '@astrojs/compiler': 2.13.1
+            '@astrojs/yaml2ts': 0.2.3
             '@jridgewell/sourcemap-codec': 1.5.5
             '@volar/language-core': 2.4.28
             '@volar/typescript': 2.4.28
@@ -26491,7 +26600,11 @@ snapshots:
 
     '@astrojs/yaml2ts@0.2.2':
         dependencies:
-            yaml: 2.7.1
+            yaml: 2.8.2
+
+    '@astrojs/yaml2ts@0.2.3':
+        dependencies:
+            yaml: 2.8.2
 
     '@astropub/worker@0.2.0': {}
 
@@ -26503,12 +26616,6 @@ snapshots:
     '@babel/code-frame@7.26.2':
         dependencies:
             '@babel/helper-validator-identifier': 7.25.9
-            js-tokens: 4.0.0
-            picocolors: 1.1.1
-
-    '@babel/code-frame@7.27.1':
-        dependencies:
-            '@babel/helper-validator-identifier': 7.27.1
             js-tokens: 4.0.0
             picocolors: 1.1.1
 
@@ -26536,26 +26643,6 @@ snapshots:
             '@babel/types': 7.27.0
             convert-source-map: 2.0.0
             debug: 4.3.7(supports-color@5.5.0)
-            gensync: 1.0.0-beta.2
-            json5: 2.2.3
-            semver: 6.3.1
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/core@7.28.4':
-        dependencies:
-            '@babel/code-frame': 7.27.1
-            '@babel/generator': 7.28.3
-            '@babel/helper-compilation-targets': 7.27.2
-            '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
-            '@babel/helpers': 7.28.4
-            '@babel/parser': 7.29.0
-            '@babel/template': 7.27.2
-            '@babel/traverse': 7.28.4
-            '@babel/types': 7.28.4
-            '@jridgewell/remapping': 2.3.5
-            convert-source-map: 2.0.0
-            debug: 4.4.3(supports-color@5.5.0)
             gensync: 1.0.0-beta.2
             json5: 2.2.3
             semver: 6.3.1
@@ -26590,14 +26677,6 @@ snapshots:
             '@jridgewell/trace-mapping': 0.3.25
             jsesc: 3.1.0
 
-    '@babel/generator@7.28.3':
-        dependencies:
-            '@babel/parser': 7.29.0
-            '@babel/types': 7.29.0
-            '@jridgewell/gen-mapping': 0.3.13
-            '@jridgewell/trace-mapping': 0.3.31
-            jsesc: 3.1.0
-
     '@babel/generator@7.29.1':
         dependencies:
             '@babel/parser': 7.29.0
@@ -26619,14 +26698,6 @@ snapshots:
             '@babel/compat-data': 7.26.8
             '@babel/helper-validator-option': 7.25.9
             browserslist: 4.24.4
-            lru-cache: 5.1.1
-            semver: 6.3.1
-
-    '@babel/helper-compilation-targets@7.27.2':
-        dependencies:
-            '@babel/compat-data': 7.29.0
-            '@babel/helper-validator-option': 7.27.1
-            browserslist: 4.28.1
             lru-cache: 5.1.1
             semver: 6.3.1
 
@@ -26742,15 +26813,6 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
-        dependencies:
-            '@babel/core': 7.28.4
-            '@babel/helper-module-imports': 7.28.6
-            '@babel/helper-validator-identifier': 7.27.1
-            '@babel/traverse': 7.29.0(supports-color@5.5.0)
-        transitivePeerDependencies:
-            - supports-color
-
     '@babel/helper-module-transforms@7.28.6(@babel/core@7.26.10)':
         dependencies:
             '@babel/core': 7.26.10
@@ -26827,8 +26889,6 @@ snapshots:
 
     '@babel/helper-validator-identifier@7.25.9': {}
 
-    '@babel/helper-validator-identifier@7.27.1': {}
-
     '@babel/helper-validator-identifier@7.28.5': {}
 
     '@babel/helper-validator-option@7.25.9': {}
@@ -26847,11 +26907,6 @@ snapshots:
         dependencies:
             '@babel/template': 7.27.0
             '@babel/types': 7.27.0
-
-    '@babel/helpers@7.28.4':
-        dependencies:
-            '@babel/template': 7.28.6
-            '@babel/types': 7.29.0
 
     '@babel/helpers@7.28.6':
         dependencies:
@@ -27663,9 +27718,9 @@ snapshots:
             '@babel/helper-plugin-utils': 7.28.6
         optional: true
 
-    '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.4)':
+    '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
         dependencies:
-            '@babel/core': 7.28.4
+            '@babel/core': 7.29.0
             '@babel/helper-plugin-utils': 7.28.6
 
     '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.10)':
@@ -27679,9 +27734,9 @@ snapshots:
             '@babel/helper-plugin-utils': 7.28.6
         optional: true
 
-    '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.4)':
+    '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
         dependencies:
-            '@babel/core': 7.28.4
+            '@babel/core': 7.29.0
             '@babel/helper-plugin-utils': 7.28.6
 
     '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.26.10)':
@@ -28017,12 +28072,6 @@ snapshots:
             '@babel/parser': 7.27.0
             '@babel/types': 7.27.0
 
-    '@babel/template@7.27.2':
-        dependencies:
-            '@babel/code-frame': 7.29.0
-            '@babel/parser': 7.29.0
-            '@babel/types': 7.29.0
-
     '@babel/template@7.28.6':
         dependencies:
             '@babel/code-frame': 7.29.0
@@ -28038,18 +28087,6 @@ snapshots:
             '@babel/types': 7.27.0
             debug: 4.3.7(supports-color@5.5.0)
             globals: 11.12.0
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/traverse@7.28.4':
-        dependencies:
-            '@babel/code-frame': 7.29.0
-            '@babel/generator': 7.29.1
-            '@babel/helper-globals': 7.28.0
-            '@babel/parser': 7.29.0
-            '@babel/template': 7.28.6
-            '@babel/types': 7.29.0
-            debug: 4.4.3(supports-color@5.5.0)
         transitivePeerDependencies:
             - supports-color
 
@@ -28069,11 +28106,6 @@ snapshots:
         dependencies:
             '@babel/helper-string-parser': 7.25.9
             '@babel/helper-validator-identifier': 7.25.9
-
-    '@babel/types@7.28.4':
-        dependencies:
-            '@babel/helper-string-parser': 7.27.1
-            '@babel/helper-validator-identifier': 7.27.1
 
     '@babel/types@7.29.0':
         dependencies:
@@ -28140,6 +28172,15 @@ snapshots:
 
     '@chevrotain/utils@11.0.3': {}
 
+    '@clack/core@1.1.0':
+        dependencies:
+            sisteransi: 1.0.5
+
+    '@clack/prompts@1.1.0':
+        dependencies:
+            '@clack/core': 1.1.0
+            sisteransi: 1.0.5
+
     '@cspotcode/source-map-support@0.8.1':
         dependencies:
             '@jridgewell/trace-mapping': 0.3.9
@@ -28180,7 +28221,7 @@ snapshots:
             eventemitter3: 5.0.1
             lodash.transform: 4.6.0
             uuid: 10.0.0
-            zod: 3.24.2
+            zod: 3.25.76
 
     '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
         dependencies:
@@ -28853,7 +28894,7 @@ snapshots:
             js-yaml: 4.1.1
         optional: true
 
-    '@expressive-code/core@0.41.1':
+    '@expressive-code/core@0.41.7':
         dependencies:
             '@ctrl/tinycolor': 4.1.0
             hast-util-select: 6.0.3
@@ -28865,18 +28906,18 @@ snapshots:
             unist-util-visit: 5.0.0
             unist-util-visit-parents: 6.0.2
 
-    '@expressive-code/plugin-frames@0.41.1':
+    '@expressive-code/plugin-frames@0.41.7':
         dependencies:
-            '@expressive-code/core': 0.41.1
+            '@expressive-code/core': 0.41.7
 
-    '@expressive-code/plugin-shiki@0.41.1':
+    '@expressive-code/plugin-shiki@0.41.7':
         dependencies:
-            '@expressive-code/core': 0.41.1
+            '@expressive-code/core': 0.41.7
             shiki: 3.22.0
 
-    '@expressive-code/plugin-text-markers@0.41.1':
+    '@expressive-code/plugin-text-markers@0.41.7':
         dependencies:
-            '@expressive-code/core': 0.41.1
+            '@expressive-code/core': 0.41.7
 
     '@fastify/busboy@2.1.1': {}
 
@@ -29468,7 +29509,7 @@ snapshots:
             '@types/estree-jsx': 1.0.5
             '@types/hast': 3.0.4
             '@types/mdx': 2.0.13
-            acorn: 8.15.0
+            acorn: 8.16.0
             collapse-white-space: 2.1.0
             devlop: 1.1.0
             estree-util-is-identifier-name: 3.0.0
@@ -29477,7 +29518,7 @@ snapshots:
             hast-util-to-jsx-runtime: 2.3.2
             markdown-extensions: 2.0.0
             recma-build-jsx: 1.0.0
-            recma-jsx: 1.0.0(acorn@8.15.0)
+            recma-jsx: 1.0.0(acorn@8.16.0)
             recma-stringify: 1.0.0
             rehype-recma: 1.0.0
             remark-mdx: 3.1.0
@@ -29487,7 +29528,7 @@ snapshots:
             unified: 11.0.5
             unist-util-position-from-estree: 2.0.0
             unist-util-stringify-position: 4.0.0
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
             vfile: 6.0.3
         transitivePeerDependencies:
             - supports-color
@@ -31157,7 +31198,7 @@ snapshots:
 
     '@polka/url@1.0.0-next.29': {}
 
-    '@qwik.dev/partytown@0.11.0':
+    '@qwik.dev/partytown@0.11.2':
         dependencies:
             dotenv: 16.4.7
 
@@ -31989,7 +32030,7 @@ snapshots:
 
     '@renovatebot/pep440@4.2.1': {}
 
-    '@rolldown/pluginutils@1.0.0-beta.27': {}
+    '@rolldown/pluginutils@1.0.0-rc.3': {}
 
     '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)':
         dependencies:
@@ -32304,6 +32345,14 @@ snapshots:
             '@types/hast': 3.0.4
             hast-util-to-html: 9.0.5
 
+    '@shikijs/core@4.0.2':
+        dependencies:
+            '@shikijs/primitive': 4.0.2
+            '@shikijs/types': 4.0.2
+            '@shikijs/vscode-textmate': 10.0.2
+            '@types/hast': 3.0.4
+            hast-util-to-html: 9.0.5
+
     '@shikijs/engine-javascript@1.29.2':
         dependencies:
             '@shikijs/types': 1.29.2
@@ -32313,6 +32362,12 @@ snapshots:
     '@shikijs/engine-javascript@3.22.0':
         dependencies:
             '@shikijs/types': 3.22.0
+            '@shikijs/vscode-textmate': 10.0.2
+            oniguruma-to-es: 4.3.4
+
+    '@shikijs/engine-javascript@4.0.2':
+        dependencies:
+            '@shikijs/types': 4.0.2
             '@shikijs/vscode-textmate': 10.0.2
             oniguruma-to-es: 4.3.4
 
@@ -32326,6 +32381,11 @@ snapshots:
             '@shikijs/types': 3.22.0
             '@shikijs/vscode-textmate': 10.0.2
 
+    '@shikijs/engine-oniguruma@4.0.2':
+        dependencies:
+            '@shikijs/types': 4.0.2
+            '@shikijs/vscode-textmate': 10.0.2
+
     '@shikijs/langs@1.29.2':
         dependencies:
             '@shikijs/types': 1.29.2
@@ -32333,6 +32393,16 @@ snapshots:
     '@shikijs/langs@3.22.0':
         dependencies:
             '@shikijs/types': 3.22.0
+
+    '@shikijs/langs@4.0.2':
+        dependencies:
+            '@shikijs/types': 4.0.2
+
+    '@shikijs/primitive@4.0.2':
+        dependencies:
+            '@shikijs/types': 4.0.2
+            '@shikijs/vscode-textmate': 10.0.2
+            '@types/hast': 3.0.4
 
     '@shikijs/themes@1.29.2':
         dependencies:
@@ -32342,12 +32412,21 @@ snapshots:
         dependencies:
             '@shikijs/types': 3.22.0
 
+    '@shikijs/themes@4.0.2':
+        dependencies:
+            '@shikijs/types': 4.0.2
+
     '@shikijs/types@1.29.2':
         dependencies:
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
 
     '@shikijs/types@3.22.0':
+        dependencies:
+            '@shikijs/vscode-textmate': 10.0.2
+            '@types/hast': 3.0.4
+
+    '@shikijs/types@4.0.2':
         dependencies:
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
@@ -33095,11 +33174,13 @@ snapshots:
         dependencies:
             '@types/node': 18.19.17
 
-    '@types/node@17.0.45': {}
-
     '@types/node@18.19.17':
         dependencies:
             undici-types: 5.26.5
+
+    '@types/node@24.12.0':
+        dependencies:
+            undici-types: 7.16.0
 
     '@types/node@25.0.3':
         dependencies:
@@ -33610,9 +33691,9 @@ snapshots:
             minimatch: 7.4.6
             semver: 7.6.3
 
-    '@vite-pwa/astro@1.2.0(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(vite-plugin-pwa@1.0.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))':
+    '@vite-pwa/astro@1.2.0(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(vite-plugin-pwa@1.0.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))':
         dependencies:
-            astro: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+            astro: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
             vite-plugin-pwa: 1.0.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
 
     '@vitejs/plugin-react@4.2.1(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))':
@@ -33626,15 +33707,15 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))':
+    '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))':
         dependencies:
-            '@babel/core': 7.28.4
-            '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
-            '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
-            '@rolldown/pluginutils': 1.0.0-beta.27
+            '@babel/core': 7.29.0
+            '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+            '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+            '@rolldown/pluginutils': 1.0.0-rc.3
             '@types/babel__core': 7.20.5
-            react-refresh: 0.17.0
-            vite: 6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
+            react-refresh: 0.18.0
+            vite: 7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
         transitivePeerDependencies:
             - supports-color
 
@@ -33778,7 +33859,7 @@ snapshots:
         dependencies:
             '@volar/language-core': 2.4.28
             path-browserify: 1.0.1
-            vscode-uri: 3.0.8
+            vscode-uri: 3.1.0
 
     '@vscode/emmet-helper@2.9.3':
         dependencies:
@@ -33850,7 +33931,7 @@ snapshots:
 
     '@vue/language-core@2.2.0(typescript@5.9.3)':
         dependencies:
-            '@volar/language-core': 2.4.11
+            '@volar/language-core': 2.4.28
             '@vue/compiler-dom': 3.5.12
             '@vue/compiler-vue2': 2.7.16
             '@vue/shared': 3.5.12
@@ -34064,10 +34145,6 @@ snapshots:
         dependencies:
             acorn: 8.16.0
 
-    acorn-jsx@5.3.2(acorn@8.15.0):
-        dependencies:
-            acorn: 8.15.0
-
     acorn-jsx@5.3.2(acorn@8.16.0):
         dependencies:
             acorn: 8.16.0
@@ -34077,8 +34154,6 @@ snapshots:
             acorn: 8.16.0
 
     acorn@8.14.1: {}
-
-    acorn@8.15.0: {}
 
     acorn@8.16.0: {}
 
@@ -34418,20 +34493,20 @@ snapshots:
 
     astro-compressor@1.2.0: {}
 
-    astro-expressive-code@0.41.1(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)):
+    astro-expressive-code@0.41.7(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)):
         dependencies:
-            astro: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
-            rehype-expressive-code: 0.41.1
+            astro: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+            rehype-expressive-code: 0.41.7
 
-    astro-integration-kit@0.18.0(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)):
+    astro-integration-kit@0.18.0(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)):
         dependencies:
-            astro: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+            astro: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
             pathe: 1.1.2
             recast: 0.23.9
 
-    astro-mermaid@1.3.1(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(mermaid@11.12.0):
+    astro-mermaid@1.3.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(mermaid@11.12.0):
         dependencies:
-            astro: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+            astro: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
             import-meta-resolve: 4.2.0
             mdast-util-to-string: 4.0.0
             mermaid: 11.12.0
@@ -34547,71 +34622,63 @@ snapshots:
             - uploadthing
             - yaml
 
-    astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2):
+    astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2):
         dependencies:
-            '@astrojs/compiler': 2.13.1
-            '@astrojs/internal-helpers': 0.7.5
-            '@astrojs/markdown-remark': 6.3.10
+            '@astrojs/compiler': 3.0.0
+            '@astrojs/internal-helpers': 0.8.0
+            '@astrojs/markdown-remark': 7.0.0
             '@astrojs/telemetry': 3.3.0
             '@capsizecss/unpack': 4.0.0
+            '@clack/prompts': 1.1.0
             '@oslojs/encoding': 1.1.0
             '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-            acorn: 8.16.0
             aria-query: 5.3.2
             axobject-query: 4.1.0
-            boxen: 8.0.1
             ci-info: 4.4.0
             clsx: 2.1.1
-            common-ancestor-path: 1.0.1
+            common-ancestor-path: 2.0.0
             cookie: 1.1.1
-            cssesc: 3.0.0
-            debug: 4.4.3(supports-color@5.5.0)
-            deterministic-object-hash: 2.0.2
-            devalue: 5.6.2
+            devalue: 5.6.4
             diff: 8.0.3
             dlv: 1.1.3
             dset: 3.1.4
-            es-module-lexer: 1.7.0
+            es-module-lexer: 2.0.0
             esbuild: 0.27.3
-            estree-walker: 3.0.3
             flattie: 1.1.1
             fontace: 0.4.1
             github-slugger: 2.0.0
             html-escaper: 3.0.3
             http-cache-semantics: 4.2.0
-            import-meta-resolve: 4.2.0
             js-yaml: 4.1.1
             magic-string: 0.30.21
             magicast: 0.5.2
             mrmime: 2.0.1
             neotraverse: 0.6.18
-            p-limit: 6.2.0
-            p-queue: 8.1.1
+            obug: 2.1.1
+            p-limit: 7.3.0
+            p-queue: 9.1.0
             package-manager-detector: 1.6.0
             piccolore: 0.1.3
             picomatch: 4.0.3
-            prompts: 2.4.2
             rehype: 13.0.2
             semver: 7.7.4
-            shiki: 3.22.0
+            shiki: 4.0.2
             smol-toml: 1.6.0
             svgo: 4.0.0
+            tinyclip: 0.1.12
             tinyexec: 1.0.2
             tinyglobby: 0.2.15
             tsconfck: 3.1.6(typescript@5.9.3)
             ultrahtml: 1.6.0
-            unifont: 0.7.3
-            unist-util-visit: 5.0.0
+            unifont: 0.7.4
+            unist-util-visit: 5.1.0
             unstorage: 1.17.4(@planetscale/database@1.19.0)
             vfile: 6.0.3
-            vite: 6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
-            vitefu: 1.1.1(vite@6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))
+            vite: 7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
+            vitefu: 1.1.2(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))
             xxhash-wasm: 1.1.0
-            yargs-parser: 21.1.1
-            yocto-spinner: 0.2.3
-            zod: 3.25.76
-            zod-to-json-schema: 3.25.1(zod@3.25.76)
-            zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+            yargs-parser: 22.0.0
+            zod: 4.3.6
         optionalDependencies:
             sharp: 0.34.5
         transitivePeerDependencies:
@@ -35550,6 +35617,8 @@ snapshots:
 
     common-ancestor-path@1.0.1: {}
 
+    common-ancestor-path@2.0.0: {}
+
     common-path-prefix@3.0.0: {}
 
     common-tags@1.8.2: {}
@@ -36347,6 +36416,8 @@ snapshots:
 
     devalue@5.6.2: {}
 
+    devalue@5.6.4: {}
+
     devlop@1.1.0:
         dependencies:
             dequal: 2.0.3
@@ -36927,8 +36998,8 @@ snapshots:
             '@babel/parser': 7.29.0
             eslint: 8.57.0
             hermes-parser: 0.25.1
-            zod: 3.25.76
-            zod-validation-error: 4.0.2(zod@3.25.76)
+            zod: 4.3.6
+            zod-validation-error: 4.0.2(zod@4.3.6)
         transitivePeerDependencies:
             - supports-color
 
@@ -37297,12 +37368,12 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    expressive-code@0.41.1:
+    expressive-code@0.41.7:
         dependencies:
-            '@expressive-code/core': 0.41.1
-            '@expressive-code/plugin-frames': 0.41.1
-            '@expressive-code/plugin-shiki': 0.41.1
-            '@expressive-code/plugin-text-markers': 0.41.1
+            '@expressive-code/core': 0.41.7
+            '@expressive-code/plugin-frames': 0.41.7
+            '@expressive-code/plugin-shiki': 0.41.7
+            '@expressive-code/plugin-text-markers': 0.41.7
 
     exsolve@1.0.7: {}
 
@@ -37787,7 +37858,7 @@ snapshots:
 
     glob@13.0.6:
         dependencies:
-            minimatch: 10.2.2
+            minimatch: 10.2.4
             minipass: 7.1.3
             path-scurry: 2.0.2
         optional: true
@@ -38128,7 +38199,7 @@ snapshots:
             mdast-util-to-hast: 13.2.0
             parse5: 7.2.1
             unist-util-position: 5.0.0
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
             vfile: 6.0.3
             web-namespaces: 2.0.1
             zwitch: 2.0.4
@@ -40017,7 +40088,7 @@ snapshots:
         dependencies:
             '@types/mdast': 4.0.4
             '@types/unist': 3.0.3
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
 
     mdast-util-directive@3.0.0:
         dependencies:
@@ -40176,7 +40247,7 @@ snapshots:
             micromark-util-sanitize-uri: 2.0.0
             trim-lines: 3.0.1
             unist-util-position: 5.0.0
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
             vfile: 6.0.3
 
     mdast-util-to-markdown@2.1.0:
@@ -40957,11 +41028,6 @@ snapshots:
         dependencies:
             '@isaacs/brace-expansion': 5.0.1
 
-    minimatch@10.2.2:
-        dependencies:
-            brace-expansion: 5.0.3
-        optional: true
-
     minimatch@10.2.4:
         dependencies:
             brace-expansion: 5.0.3
@@ -41508,6 +41574,10 @@ snapshots:
         dependencies:
             yocto-queue: 1.1.1
 
+    p-limit@7.3.0:
+        dependencies:
+            yocto-queue: 1.2.2
+
     p-locate@4.1.0:
         dependencies:
             p-limit: 2.3.0
@@ -41525,6 +41595,11 @@ snapshots:
             eventemitter3: 5.0.1
             p-timeout: 6.1.3
 
+    p-queue@9.1.0:
+        dependencies:
+            eventemitter3: 5.0.1
+            p-timeout: 7.0.1
+
     p-retry@6.2.0:
         dependencies:
             '@types/retry': 0.12.2
@@ -41532,6 +41607,8 @@ snapshots:
             retry: 0.13.1
 
     p-timeout@6.1.3: {}
+
+    p-timeout@7.0.1: {}
 
     p-try@2.2.0: {}
 
@@ -42600,7 +42677,7 @@ snapshots:
 
     react-refresh@0.14.2: {}
 
-    react-refresh@0.17.0: {}
+    react-refresh@0.18.0: {}
 
     react-remove-scroll-bar@2.3.8(@types/react@19.2.9)(react@19.2.4):
         dependencies:
@@ -42801,9 +42878,9 @@ snapshots:
             estree-util-build-jsx: 3.0.1
             vfile: 6.0.3
 
-    recma-jsx@1.0.0(acorn@8.15.0):
+    recma-jsx@1.0.0(acorn@8.16.0):
         dependencies:
-            acorn-jsx: 5.3.2(acorn@8.15.0)
+            acorn-jsx: 5.3.2(acorn@8.16.0)
             estree-util-to-js: 2.0.0
             recma-parse: 1.0.0
             recma-stringify: 1.0.0
@@ -42896,9 +42973,9 @@ snapshots:
         dependencies:
             jsesc: 3.1.0
 
-    rehype-expressive-code@0.41.1:
+    rehype-expressive-code@0.41.7:
         dependencies:
-            expressive-code: 0.41.1
+            expressive-code: 0.41.7
 
     rehype-external-links@3.0.0:
         dependencies:
@@ -43014,7 +43091,7 @@ snapshots:
             retext: 9.0.0
             retext-smartypants: 6.2.0
             unified: 11.0.5
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
 
     remark-stringify@11.0.0:
         dependencies:
@@ -43131,7 +43208,7 @@ snapshots:
         dependencies:
             '@types/nlcst': 2.0.3
             nlcst-to-string: 4.0.0
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
 
     retext-stringify@4.0.0:
         dependencies:
@@ -43381,8 +43458,6 @@ snapshots:
         optionalDependencies:
             '@parcel/watcher': 2.4.1
 
-    sax@1.4.1: {}
-
     sax@1.4.4: {}
 
     saxes@6.0.0:
@@ -43623,6 +43698,17 @@ snapshots:
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
 
+    shiki@4.0.2:
+        dependencies:
+            '@shikijs/core': 4.0.2
+            '@shikijs/engine-javascript': 4.0.2
+            '@shikijs/engine-oniguruma': 4.0.2
+            '@shikijs/langs': 4.0.2
+            '@shikijs/themes': 4.0.2
+            '@shikijs/types': 4.0.2
+            '@shikijs/vscode-textmate': 10.0.2
+            '@types/hast': 3.0.4
+
     side-channel-list@1.0.0:
         dependencies:
             es-errors: 1.3.0
@@ -43677,12 +43763,12 @@ snapshots:
 
     sisteransi@1.0.5: {}
 
-    sitemap@8.0.2:
+    sitemap@9.0.1:
         dependencies:
-            '@types/node': 17.0.45
+            '@types/node': 24.12.0
             '@types/sax': 1.2.7
             arg: 5.0.2
-            sax: 1.4.1
+            sax: 1.4.4
 
     slash@3.0.0: {}
 
@@ -43825,19 +43911,19 @@ snapshots:
         dependencies:
             type-fest: 0.7.1
 
-    starlight-site-graph@0.5.0(@astrojs/starlight@0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)):
+    starlight-site-graph@0.5.0(@astrojs/starlight@0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)))(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)):
         dependencies:
             '@types/chroma-js': 3.1.1
             '@types/d3': 7.4.3
-            astro: 5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
-            astro-integration-kit: 0.18.0(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+            astro: 6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
+            astro-integration-kit: 0.18.0(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
             chroma-js: 3.1.2
             d3: 7.9.0
             gray-matter: 4.0.3
             htmlparser2: 10.0.0
             micromatch: 4.0.8
         optionalDependencies:
-            '@astrojs/starlight': 0.37.7(astro@5.18.0(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
+            '@astrojs/starlight': 0.38.1(astro@6.0.4(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))
 
     stats-gl@2.2.8:
         dependencies:
@@ -44386,6 +44472,8 @@ snapshots:
 
     tinybench@2.9.0: {}
 
+    tinyclip@0.1.12: {}
+
     tinycolor2@1.6.0: {}
 
     tinyexec@0.3.2: {}
@@ -44738,6 +44826,12 @@ snapshots:
             ofetch: 1.5.1
             ohash: 2.0.11
 
+    unifont@0.7.4:
+        dependencies:
+            css-tree: 3.1.0
+            ofetch: 1.5.1
+            ohash: 2.0.11
+
     union@0.5.0:
         dependencies:
             qs: 6.14.0
@@ -44771,7 +44865,7 @@ snapshots:
     unist-util-remove-position@5.0.0:
         dependencies:
             '@types/unist': 3.0.3
-            unist-util-visit: 5.0.0
+            unist-util-visit: 5.1.0
 
     unist-util-stringify-position@4.0.0:
         dependencies:
@@ -44792,6 +44886,12 @@ snapshots:
             unist-util-is: 6.0.0
 
     unist-util-visit@5.0.0:
+        dependencies:
+            '@types/unist': 3.0.3
+            unist-util-is: 6.0.0
+            unist-util-visit-parents: 6.0.2
+
+    unist-util-visit@5.1.0:
         dependencies:
             '@types/unist': 3.0.3
             unist-util-is: 6.0.0
@@ -45140,6 +45240,10 @@ snapshots:
     vitefu@1.1.1(vite@6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)):
         optionalDependencies:
             vite: 6.4.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
+
+    vitefu@1.1.2(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)):
+        optionalDependencies:
+            vite: 7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
 
     vitest@4.0.9(@types/debug@4.1.12)(@types/node@18.19.17)(@vitest/ui@4.0.9)(happy-dom@20.6.1)(jiti@2.4.2)(jsdom@22.1.0)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2):
         dependencies:
@@ -45819,6 +45923,8 @@ snapshots:
 
     yargs-parser@21.1.1: {}
 
+    yargs-parser@22.0.0: {}
+
     yargs@15.4.1:
         dependencies:
             cliui: 6.0.0
@@ -45855,6 +45961,8 @@ snapshots:
 
     yocto-queue@1.1.1: {}
 
+    yocto-queue@1.2.2: {}
+
     yocto-spinner@0.2.3:
         dependencies:
             yoctocolors: 2.1.1
@@ -45878,13 +45986,13 @@ snapshots:
             typescript: 5.9.3
             zod: 3.25.76
 
-    zod-validation-error@4.0.2(zod@3.25.76):
+    zod-validation-error@4.0.2(zod@4.3.6):
         dependencies:
-            zod: 3.25.76
-
-    zod@3.24.2: {}
+            zod: 4.3.6
 
     zod@3.25.76: {}
+
+    zod@4.3.6: {}
 
     zustand@4.5.6(@types/react@19.2.9)(react@19.2.4):
         dependencies:


### PR DESCRIPTION
## Summary

- Upgrade Astro 5.18.0 → 6.0.4, @astrojs/mdx → 5.0.0, @astrojs/react → 5.0.0, @astrojs/starlight-tailwind → 5.0.0
- Upgrade Zod 3.24.2 → 4.3.6 across root and @kbve/droid
- Fix all `z.record()` calls for Zod 4 (now requires key + value schema arguments)
- Fix `z.ZodType` generic signature for Zod 4 compatibility
- Temporarily disable `starlight-site-graph` v0.5.0 (incompatible with Zod 4, tracked in #7956)
- Fix astro-discordsh image build: use `--root` flag to resolve Astro 6 bug with `outDir` outside CWD
- Tag `gamejam/cryptothrone.com` as deprecated

## Test plan

- [x] All 7 production Astro projects build successfully (`nx run-many --target=build`)
- [ ] Verify deployed sites render correctly
- [ ] Confirm no regressions in content collections or Starlight sidebar