### PR TITLE
fix(axum-kbve): enforce HTTPS for external API requests

### DIFF
--- a/apps/kbve/axum-kbve/src/db/discord.rs
+++ b/apps/kbve/axum-kbve/src/db/discord.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 use tokio::sync::OnceCell;
 
+use super::ensure_https;
 use super::supabase::{SupabaseClient, SupabaseConfig};
 
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
@@ -211,10 +212,11 @@ impl DiscordClient {
             "{}/guilds/{}/members/{}",
             DISCORD_API_BASE, self.config.guild_id, user_id
         );
+        let url = ensure_https(&url)?;
 
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .header("Authorization", format!("Bot {}", self.config.bot_token))
             .header("User-Agent", "KBVE-Bot/1.0")
             .send()
@@ -251,10 +253,11 @@ impl DiscordClient {
     #[allow(dead_code)]
     pub async fn get_user(&self, user_id: &str) -> Result<Option<DiscordUser>, String> {
         let url = format!("{}/users/{}", DISCORD_API_BASE, user_id);
+        let url = ensure_https(&url)?;
 
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .header("Authorization", format!("Bot {}", self.config.bot_token))
             .header("User-Agent", "KBVE-Bot/1.0")
             .send()
@@ -317,10 +320,11 @@ impl DiscordClient {
     /// GET /guilds/{guild.id}/roles
     pub async fn get_guild_roles(&self) -> Result<Vec<DiscordRole>, String> {
         let url = format!("{}/guilds/{}/roles", DISCORD_API_BASE, self.config.guild_id);
+        let url = ensure_https(&url)?;
 
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .header("Authorization", format!("Bot {}", self.config.bot_token))
             .header("User-Agent", "KBVE-Bot/1.0")
             .send()

--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -11,6 +11,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tracing::{debug, warn};
 
+use super::ensure_https;
+
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -241,7 +243,8 @@ impl McService {
 
         // Fetch UUID from Mojang
         let url = format!("{MOJANG_API}/{name}");
-        let resp = self.http.get(&url).send().await.ok()?;
+        let url = ensure_https(&url).ok()?;
+        let resp = self.http.get(url).send().await.ok()?;
         if !resp.status().is_success() {
             return None;
         }
@@ -275,7 +278,8 @@ impl McService {
     /// Fetch skin texture URL from Mojang session server.
     async fn fetch_skin_url(&self, uuid: &str) -> Option<String> {
         let url = format!("{MOJANG_SESSION}/{uuid}");
-        let resp = self.http.get(&url).send().await.ok()?;
+        let url = ensure_https(&url).ok()?;
+        let resp = self.http.get(url).send().await.ok()?;
         if !resp.status().is_success() {
             return None;
         }

--- a/apps/kbve/axum-kbve/src/db/mod.rs
+++ b/apps/kbve/axum-kbve/src/db/mod.rs
@@ -9,6 +9,18 @@ mod rentearth;
 mod supabase;
 mod twitch;
 
+/// Validate that a URL uses HTTPS before transmitting sensitive data.
+/// Returns `Err` if the URL does not start with `https://`.
+pub(crate) fn ensure_https(url: &str) -> Result<&str, String> {
+    if url.starts_with("https://") {
+        Ok(url)
+    } else {
+        Err(format!(
+            "refusing to transmit sensitive data over non-HTTPS URL: {url}"
+        ))
+    }
+}
+
 pub use cache::{ProfileCache, get_profile_cache, init_profile_cache};
 pub use discord::{DiscordClient, get_discord_client, get_role_names, init_discord_client};
 pub use mc::{get_mc_service, init_mc_service};

--- a/apps/kbve/axum-kbve/src/db/twitch.rs
+++ b/apps/kbve/axum-kbve/src/db/twitch.rs
@@ -9,6 +9,8 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
+use super::ensure_https;
+
 const TWITCH_API_BASE: &str = "https://api.twitch.tv/helix";
 const TWITCH_OAUTH_URL: &str = "https://id.twitch.tv/oauth2/token";
 // Refresh token 1 hour before expiry to be safe
@@ -216,10 +218,11 @@ impl TwitchClient {
     pub async fn get_user_by_id(&self, user_id: &str) -> Result<Option<TwitchUser>, String> {
         let token = self.get_token().await?;
         let url = format!("{}/users?id={}", TWITCH_API_BASE, user_id);
+        let url = ensure_https(&url)?;
 
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .header("Authorization", format!("Bearer {}", token))
             .header("Client-Id", &self.config.client_id)
             .send()
@@ -260,10 +263,11 @@ impl TwitchClient {
     ) -> Result<Option<TwitchStream>, String> {
         let token = self.get_token().await?;
         let url = format!("{}/streams?user_id={}", TWITCH_API_BASE, user_id);
+        let url = ensure_https(&url)?;
 
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .header("Authorization", format!("Bearer {}", token))
             .header("Client-Id", &self.config.client_id)
             .send()


### PR DESCRIPTION
## Summary
- Adds `ensure_https()` guard to validate URL scheme before transmitting sensitive data (user IDs, UUIDs, auth tokens)
- Applied to all outbound API calls in `discord.rs`, `twitch.rs`, and `mc.rs`
- Prevents accidental cleartext transmission if a base URL constant is ever changed from HTTPS
- Resolves CodeQL alerts #257, #258, #259, #260, #279 (`rust/cleartext-transmission`)

## Test plan
- [x] `cargo check -p axum-kbve` compiles cleanly
- [x] All base URLs are already hardcoded HTTPS — `ensure_https()` acts as defense-in-depth
- [ ] Verify no behavioral changes in Discord/Twitch/MC API calls after deploy