### PR TITLE
fix(net): multiplayer connection, movement, and interpolation

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -56,6 +56,7 @@ lightyear = { version = "0.26", default-features = false, features = [
     "input_native",
     "websocket",
     "avian3d",
+    "raw_connection",
 ] }
 lightyear_avian3d = { version = "0.26", default-features = false, features = ["3d"] }
 bevy_kbve_net = { path = "../../../packages/rust/bevy/bevy_kbve_net" }

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -128,6 +128,7 @@ fn start_server(commands: &mut Commands, ws_addr: SocketAddr) {
 
     let server_entity = commands
         .spawn((
+            lightyear::prelude::server::RawServer,
             Server::default(),
             LocalAddr(ws_addr),
             WebSocketServerIo { config },

--- a/apps/kbve/isometric/index.html
+++ b/apps/kbve/isometric/index.html
@@ -42,6 +42,19 @@
     <body>
         <canvas id="bevy-canvas" tabindex="0"></canvas>
         <div id="root"></div>
+        <script>
+            // Auto-focus the Bevy canvas so keyboard events reach winit.
+            // Re-focus after any click on the page (React buttons steal focus).
+            document.addEventListener('pointerup', function() {
+                var c = document.getElementById('bevy-canvas');
+                if (c && document.activeElement !== c) c.focus();
+            });
+            // Focus on first keydown if canvas isn't focused
+            document.addEventListener('keydown', function() {
+                var c = document.getElementById('bevy-canvas');
+                if (c && document.activeElement !== c) c.focus();
+            });
+        </script>
         <script type="module" src="/src/main.tsx"></script>
     </body>
 </html>

--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -19,6 +19,15 @@
 				"cwd": "apps/kbve/isometric"
 			}
 		},
+		"quick": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"lsof -ti:1420 | xargs kill 2>/dev/null; lsof -ti:5000 | xargs kill 2>/dev/null; set -a && [ -f ../../../.env ] && . ../../../.env && set +a && export PATH=\"$HOME/.cargo/bin:$PATH\" && cd src-tauri && wasm-pack build --dev --target web --out-dir ../wasm-pkg --out-name isometric_game && cd .. && cargo run -p axum-kbve & pnpm dev"
+				],
+				"cwd": "apps/kbve/isometric"
+			}
+		},
 		"build": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -138,9 +138,16 @@ impl Plugin for NetPlugin {
         app.add_systems(PostUpdate, update_remote_transforms);
 
         // --- Debug observers for connection lifecycle ---
+        // Lightyear-level states
         app.add_observer(on_connecting);
         app.add_observer(on_connected);
         app.add_observer(on_disconnected);
+        // Link-level states (aeronet ↔ lightyear bridge)
+        app.add_observer(on_linking);
+        app.add_observer(on_linked);
+        app.add_observer(on_unlinked);
+        // Aeronet session endpoint (fires when aeronet spawns the session entity)
+        app.add_observer(on_session_endpoint);
 
         // Periodic connection-state heartbeat (logs every ~2 seconds)
         app.add_systems(Update, debug_connection_heartbeat);
@@ -149,19 +156,62 @@ impl Plugin for NetPlugin {
     }
 }
 
-/// Debug observer: fires when lightyear adds `Connecting` to our client entity.
+/// Debug: link layer — Linking added (WebSocket connection attempt started).
+fn on_linking(trigger: On<Add, lightyear::prelude::Linking>) {
+    let entity = trigger.entity;
+    info!("[net][link] LINKING — entity {entity:?} transport connection starting");
+}
+
+/// When the link layer connects, promote to lightyear Connected state.
+/// This replaces RawConnectionPlugin::on_linked which requires LocalAddr
+/// (not available on WASM WebSocket).
+fn on_linked(
+    trigger: On<Add, lightyear::prelude::Linked>,
+    query: Query<Entity, With<Client>>,
+    mut commands: Commands,
+) {
+    let entity = trigger.entity;
+    info!("[net][link] LINKED — entity {entity:?} transport connected!");
+
+    // Only promote our Client entity, not other linked entities
+    if query.get(entity).is_ok() {
+        use lightyear::prelude::*;
+        info!("[net][link] promoting entity {entity:?} to Connected (raw connection bridge)");
+        commands.entity(entity).insert((
+            Connected,
+            lightyear::prelude::LocalId(lightyear::prelude::PeerId::Raw(
+                std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+            )),
+            lightyear::prelude::RemoteId(lightyear::prelude::PeerId::Server),
+        ));
+    }
+}
+
+/// Debug: link layer — Unlinked added (transport failed or closed).
+fn on_unlinked(trigger: On<Add, lightyear::prelude::Unlinked>) {
+    let entity = trigger.entity;
+    warn!("[net][link] UNLINKED — entity {entity:?} transport failed or closed");
+}
+
+/// Debug: fires when LinkStart is triggered (our trigger → lightyear processes it).
+fn on_session_endpoint(trigger: On<lightyear::prelude::LinkStart>) {
+    let entity = trigger.entity;
+    info!("[net][link] LINKSTART triggered — entity {entity:?}");
+}
+
+/// Debug: lightyear Connecting added.
 fn on_connecting(trigger: On<Add, Connecting>) {
     let entity = trigger.entity;
-    info!("[net][lifecycle] CONNECTING — entity {entity:?} is attempting WebSocket handshake");
+    info!("[net][lifecycle] CONNECTING — entity {entity:?} lightyear handshake in progress");
 }
 
-/// Debug observer: fires when lightyear adds `Connected` to our client entity.
+/// Debug: lightyear Connected added.
 fn on_connected(trigger: On<Add, Connected>) {
     let entity = trigger.entity;
-    info!("[net][lifecycle] CONNECTED — entity {entity:?} WebSocket handshake succeeded!");
+    info!("[net][lifecycle] CONNECTED — entity {entity:?} fully connected!");
 }
 
-/// Debug observer: fires when lightyear adds `Disconnected` to our client entity.
+/// Debug: lightyear Disconnected added.
 fn on_disconnected(trigger: On<Add, Disconnected>) {
     let entity = trigger.entity;
     warn!("[net][lifecycle] DISCONNECTED — entity {entity:?} lost connection or failed to connect");
@@ -233,10 +283,11 @@ fn poll_go_online_request(
 }
 
 /// Send AuthMessage to server once the connection is established.
-/// Sends empty JWT for guest connections.
+/// Polls every frame until MessageSender is available (may take a few frames
+/// after Connected is inserted for lightyear to register message components).
 fn send_auth_on_connect(
     mut pending_auth: ResMut<PendingAuth>,
-    mut query: Query<(Entity, &mut MessageSender<AuthMessage>), Added<Connected>>,
+    mut query: Query<(Entity, &mut MessageSender<AuthMessage>), With<Connected>>,
 ) {
     if pending_auth.sent {
         return;
@@ -246,7 +297,7 @@ fn send_auth_on_connect(
         let jwt = pending_auth.jwt.take().unwrap_or_default();
         let jwt_len = jwt.len();
         info!(
-            "[net] Connected component detected on entity {entity:?} — sending AuthMessage (jwt_len={jwt_len})"
+            "[net] Connected + MessageSender ready on entity {entity:?} — sending AuthMessage (jwt_len={jwt_len})"
         );
         sender.send::<GameChannel>(AuthMessage { jwt });
         pending_auth.sent = true;
@@ -257,9 +308,14 @@ fn send_auth_on_connect(
 }
 
 /// Receive AuthResponse from the server and store our player ID.
+/// If a replicated entity for our own player was already spawned as a
+/// RemotePlayer (race: replication arrived before AuthResponse), despawn
+/// its visual so we don't see a "ghost" duplicate.
 fn receive_auth_response(
+    mut commands: Commands,
     mut my_player_id: ResMut<MyPlayerId>,
     mut query: Query<(Entity, &mut MessageReceiver<AuthResponse>)>,
+    remote_query: Query<(Entity, &PlayerId), With<RemotePlayer>>,
 ) {
     for (entity, mut receiver) in &mut query {
         for msg in receiver.receive() {
@@ -269,6 +325,21 @@ fn receive_auth_response(
                     "[net] AUTH SUCCESS from entity {entity:?} — user='{}' player_id={}",
                     msg.user_id, msg.player_id
                 );
+
+                // Remove ghost visual if our own replicated entity was
+                // already spawned as a remote player before we knew our ID.
+                for (remote_entity, pid) in &remote_query {
+                    if pid.0 == msg.player_id {
+                        info!(
+                            "[net] removing ghost visual for own player entity {remote_entity:?}"
+                        );
+                        commands.entity(remote_entity).remove::<(
+                            RemotePlayer,
+                            Mesh3d,
+                            MeshMaterial3d<StandardMaterial>,
+                        )>();
+                    }
+                }
             } else {
                 warn!("[net] AUTH FAILED from entity {entity:?}");
             }
@@ -336,10 +407,17 @@ fn spawn_remote_player_visuals(
     }
 }
 
-/// Sync remote player transforms from their replicated Position component.
-fn update_remote_transforms(mut query: Query<(&Position, &mut Transform), With<RemotePlayer>>) {
+/// Smoothly interpolate remote player transforms toward their replicated Position.
+/// Uses exponential smoothing so movement looks fluid despite 100ms update intervals.
+const REMOTE_LERP_SPEED: f32 = 12.0;
+
+fn update_remote_transforms(
+    time: Res<Time>,
+    mut query: Query<(&Position, &mut Transform), With<RemotePlayer>>,
+) {
+    let t = (REMOTE_LERP_SPEED * time.delta_secs()).min(1.0);
     for (position, mut transform) in &mut query {
-        transform.translation = position.0;
+        transform.translation = transform.translation.lerp(position.0, t);
     }
 }
 
@@ -363,13 +441,14 @@ fn connect_to_server(commands: &mut Commands, addr: &GameServerAddr) {
         ))
         .id();
 
-    info!("[net] client entity spawned: {client_entity:?} — triggering Connect");
+    info!("[net] client entity spawned: {client_entity:?} — triggering Connect (entity-targeted)");
 
+    // Trigger Connect + LinkStart to initiate the connection
     commands.trigger(Connect {
         entity: client_entity,
     });
-    // NOTE: IS_CONNECTED is set in send_auth_on_connect once we detect the
-    // `Connected` component, not here — avoids false-positive if the
-    // WebSocket handshake fails.
+    commands.trigger(lightyear::prelude::LinkStart {
+        entity: client_entity,
+    });
     info!("[net] Connect trigger dispatched — waiting for Connecting → Connected lifecycle");
 }

--- a/apps/kbve/isometric/src-tauri/src/game/player.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/player.rs
@@ -178,8 +178,21 @@ fn move_player(
             PLAYER_HEIGHT * 0.9,
             PLAYER_HALF_Z * 2.0 * 0.85,
         );
-        let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+        let base_filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
         let pos = transform.translation;
+
+        // Exclude entities that already overlap the sweep collider at the
+        // start position. Without this, overlapping colliders cause cast_shape
+        // to return distance 0 in every direction, freezing the player.
+        let overlapping =
+            spatial_query.shape_intersections(&sweep_collider, pos, Quat::IDENTITY, &base_filter);
+        let filter = if overlapping.is_empty() {
+            base_filter
+        } else {
+            let mut excluded: Vec<Entity> = vec![entity];
+            excluded.extend_from_slice(&overlapping);
+            SpatialQueryFilter::default().with_excluded_entities(excluded)
+        };
 
         // Sweep horizontal movement (XZ) — slide along walls by trying each
         // axis independently when the combined sweep is blocked.

--- a/apps/kbve/isometric/src-tauri/src/lib.rs
+++ b/apps/kbve/isometric/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(start)]
 pub fn wasm_main() {
     console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Debug).expect("logger");
+    console_log::init_with_level(log::Level::Info).expect("logger");
 
     use avian3d::prelude::*;
     use bevy::prelude::*;

--- a/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
@@ -72,12 +72,19 @@ impl Plugin for ProtocolPlugin {
         app.add_channel::<GameChannel>(ChannelSettings {
             mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
             ..default()
-        });
+        })
+        .add_direction(NetworkDirection::Bidirectional);
 
         // --- Messages ---
-        app.register_message::<AuthMessage>();
-        app.register_message::<AuthResponse>();
-        app.register_message::<PositionUpdate>();
+        // AuthMessage: client → server
+        app.register_message::<AuthMessage>()
+            .add_direction(NetworkDirection::ClientToServer);
+        // AuthResponse: server → client
+        app.register_message::<AuthResponse>()
+            .add_direction(NetworkDirection::ServerToClient);
+        // PositionUpdate: client → server
+        app.register_message::<PositionUpdate>()
+            .add_direction(NetworkDirection::ClientToServer);
 
         // --- Replicated components (custom game components) ---
 


### PR DESCRIPTION
## Summary
- Fix multiplayer WebSocket connection flow: add `raw_connection` feature, `RawServer` component, WASM `Linked→Connected` bridge, and `LinkStart` trigger
- Fix `ChannelNotFound` error: add `.add_direction()` to `GameChannel` and all message registrations so `Transport` senders/receivers are wired up
- Fix player movement freeze: exclude already-overlapping entities from sweep shape casts (collider overlap at start position blocked all directions)
- Fix ghost duplicate player: remove own replicated visual when `AuthResponse` arrives (race between replication and auth)
- Add smooth lerp interpolation for remote player transforms (12x/s exponential smoothing)
- Add canvas auto-focus JS so keyboard input works after clicking React UI buttons
- Add `isometric:quick` nx target for fast WASM dev builds with game server

## Test plan
- [ ] Run `nx run isometric:quick`, verify game loads and player moves with WASD/arrows/joystick
- [ ] Click "Go Online", verify connection succeeds (console shows `AUTH SUCCESS`)
- [ ] Open second tab, verify both players see each other with smooth movement
- [ ] Verify no ghost duplicate of own player appears
- [ ] Verify keyboard works after clicking UI buttons (canvas auto-focus)