### PR TITLE
feat(data): add unified quest proto definition (questdb.proto)

### DIFF
--- a/packages/data/proto/npc/npcdb.proto
+++ b/packages/data/proto/npc/npcdb.proto
@@ -237,11 +237,47 @@ message FlavorPool {
   repeated string messages = 2;     // {name}, {target}, {damage} placeholders
 }
 
-// Dialogue line for non-combat interactions
+// Dialogue line for non-combat interactions (simple / legacy)
 message DialogueLine {
   string trigger = 1;               // e.g. "greet", "shop_open", "quest_offer"
   repeated string lines = 2;        // Randomly selected
   optional string condition = 3;    // Optional expression / flag gate
+}
+
+// Dialogue option — a player response within a dialogue node
+message DialogueOption {
+  string id = 1;                          // Unique within node
+  string label = 2;                       // Displayed text
+  optional string next_node_id = 3;       // Navigate to this dialogue node
+  optional string consequence_type = 4;   // e.g. "advance_quest", "give_item", "reputation"
+  optional string consequence_ref = 5;    // Target ref (quest, item, faction slug)
+  optional int32 consequence_value = 6;   // Magnitude
+  repeated string required_item_refs = 7; // Items player must have
+  optional string required_class = 8;     // Class restriction
+  optional string required_quest_status = 9; // e.g. "active:quest-slug", "complete:quest-slug"
+  repeated string required_flags = 10;    // World-state flags that must be set
+  optional string set_flag = 11;          // Flag to set when chosen
+}
+
+// Dialogue node — one beat in a conversation tree
+message DialogueNode {
+  string id = 1;                          // Unique within NPC (e.g. "greet_01", "quest_accept")
+  string text = 2;                        // NPC speech text
+  optional string speaker_override = 3;   // Override speaker name (for multi-NPC scenes)
+  optional string portrait_override = 4;  // Override portrait/emote
+  repeated DialogueOption options = 5;    // Player responses
+  optional string next_node_id = 6;       // Auto-advance (no player choice, just "Continue")
+  optional string quest_ref = 7;          // Quest this node interacts with
+  optional string condition = 8;          // Expression gate (e.g. "flag:rescued_prisoner")
+  optional int32 priority = 9;            // Higher priority nodes override lower ones
+  optional string trigger_on_enter = 10;  // Event fired when node is reached
+  optional string trigger_on_exit = 11;   // Event fired when node is left
+}
+
+// Dialogue tree — a full conversation graph for an NPC
+message DialogueTree {
+  string entry_node_id = 1;              // Starting node ID
+  repeated DialogueNode nodes = 2;       // All nodes in this tree
 }
 
 // Spawn rule — where and how this NPC appears
@@ -379,7 +415,8 @@ message Npc {
   repeated FlavorPool flavor_text = 23;
 
   // Dialogue (merchants, quest givers, companions)
-  repeated DialogueLine dialogue = 24;
+  repeated DialogueLine dialogue = 24;          // Simple trigger-based lines (legacy)
+  optional DialogueTree dialogue_tree = 50;     // Full conversation graph (quest-aware)
 
   // Linkage — quest and shop references
   repeated string quest_refs = 41;         // Quest IDs this NPC offers/advances

--- a/packages/data/proto/quest/README.md
+++ b/packages/data/proto/quest/README.md
@@ -1,16 +1,27 @@
-# Quest Proto — Universal Quest Database
+# Quest Proto — Universal Branching Quest Graph
 
-Single source of truth for quest definitions across all KBVE games (astro-kbve questdb, discordsh dungeon events, isometric).
+A data-driven, branching quest system proto for multi-game use, supporting staged progression, prerequisites, timed availability, NPC/dialogue integration, player choice, outcome-driven narrative flow, and world-state flags.
 
 ## File
 
 - **`questdb.proto`** — complete quest schema with registry
 
-## Existing Integration Points
+## Architecture
+
+The quest system operates as a **narrative quest graph** with these layers:
+
+1. **Core definition** — identity, category, tags, visual
+2. **Progression model** — ordered steps with objectives, triggers, chain membership
+3. **World integration** — NPC linkage (giver/turn-in), zone refs, party size
+4. **Rules and gating** — prerequisites, class/faction/item/flag restrictions, time windows
+5. **Narrative and branching** — choices with consequences, multiple outcomes, world-state flags
+6. **Dialogue hooks** — references into NPC dialogue trees at quest transition points
+
+## Integration Points
 
 | System | How Quests Are Referenced |
 |--------|-------------------------|
-| NPC proto | `quest_refs`, `prerequisite_quest_refs`, `NPC_TYPE_QUEST_GIVER` |
+| NPC proto | `quest_refs`, `prerequisite_quest_refs`, `NPC_TYPE_QUEST_GIVER`, `DialogueTree` |
 | Item proto | `quest_requirement`, `ITEM_TYPE_QUEST`, `source_type: "quest"` |
 | astro-kbve | MDX frontmatter via `IQuestSchema`, served at `/api/questdb.json` |
 | discordsh | Story events and room choices (implicit objectives, no formal quest system yet) |
@@ -22,16 +33,24 @@ Single source of truth for quest definitions across all KBVE games (astro-kbve q
 |------|--------|---------|
 | `QuestCategory` | 8 types | main, side, daily, event, challenge, tutorial, bounty, guild |
 | `ObjectiveType` | 9 types | collect, kill, visit, interact, escort, defend, craft, explore, custom |
-| `QuestStatus` | 7 states | Runtime tracking: locked → available → active → complete → turned_in |
-| `ChoiceConsequenceType` | 10 types | What happens when player picks a dialogue choice |
+| `QuestStatus` | 7 states | Runtime tracking: locked → available → active → complete → turned_in → failed → abandoned |
+| `ChoiceConsequenceType` | 13 types | advance, fail, branch, give/take item, reputation, spawn, teleport, unlock, set/clear flag, NPC disposition |
+| `FailurePolicy` | 4 modes | permanent, retry step, retry quest, soft-fail |
+| `RewardPolicy` | 3 modes | individual, shared (split), leader-only |
 
 ## Sub-messages
 
 ### Objectives & Steps
 
 - **`QuestObjective`** — type, target refs, required amount, optional/hidden flags, zone restriction, sequential ordering
-- **`QuestStep`** — one stage in quest progression with title, dialogue, speaker NPC, objectives, branching choices, intermediate rewards, and start/complete triggers
-- **`QuestChoice`** — dialogue option with consequence type, class/item restrictions, and step override for branching
+- **`QuestStep`** — one stage in quest progression with objectives, choices, step rewards, dialogue hooks, failure policy, per-step timeout, and behavior flags (parallel, auto_complete, hidden, skippable)
+- **`QuestChoice`** — dialogue option with consequence type, class/item restrictions, outcome selection, flag setting, and dialogue node jump
+
+### Branching & Outcomes
+
+- **`QuestOutcome`** — a possible ending with its own rewards, chain continuation, consequence flags, ending type (good/neutral/evil/secret), and canonical flag
+- **`QuestDialogueHooks`** — references into NPC dialogue trees at accept/in-progress/complete/turn-in/fail/abandon transition points
+- **`RepeatRewards`** — first-time vs subsequent completion reward variants
 
 ### Prerequisites & Time
 
@@ -59,12 +78,19 @@ Prerequisites:   prerequisites { level, quests, faction, items, class, trigger }
 Behavior:        hidden, repeatable, auto_accept, auto_complete, shareable,
                  abandonable, tracked
 Time:            time_limits { time_limit, available_after/until, cooldown, daily_reset }
-Steps:           steps[] { id, title, dialogue, speaker, objectives[], choices[],
-                           next_step, step_rewards, triggers }
+Steps:           steps[] { id, title, description, speaker, objectives[], choices[],
+                           next_step, step_rewards, triggers, parallel, auto_complete,
+                           hidden, skippable, failure_policy, step_timeout, dialogue_hooks }
+Outcomes:        outcomes[] { id, description, rewards, next_quest_ref, flags, ending_type }
 Chain:           next_quest_ref, chain_ref
 NPC linkage:     giver_npc_refs[], turn_in_npc_refs[]
 Location:        zone_refs[], recommended_level, recommended_party_size
 Rewards:         rewards { items, currency, xp, bonuses, achievement, unlocks, reputation }
+Repeat rewards:  repeat_rewards { first_time, repeat }
+Reward policy:   reward_policy (individual / shared / leader)
+Failure:         failure_policy (permanent / retry_step / retry_quest / soft_fail)
+Dialogue:        dialogue_hooks { accept, in_progress, complete, turn_in, fail, abandon }
+World state:     required_flags[], blocked_by_flags[]
 Triggers:        triggers[]
 Extensions:      extensions[]
 Metadata:        credits, drafted
@@ -78,14 +104,18 @@ Metadata:        credits, drafted
 
 ## Design Decisions
 
-- **Steps vs flat objectives**: Quests use ordered `QuestStep` messages so multi-stage quests (talk → collect → return) are first-class, not hacked via triggers.
-- **Choices with consequences**: `QuestChoice` supports branching, class-gated options, and consequence types (advance, fail, branch, give/take items, reputation, spawn enemies).
-- **QuestStatus is runtime-only**: The enum exists for game clients to track progress but is NOT stored in the definition proto — quest definitions are static data.
-- **Triggers are string expressions**: Format is game-specific (e.g. `"player:level:5"`, `"area:kitchen-zone"`, `"npc:killed:glass-slime"`). Keeps the proto agnostic to game engine.
+- **Quest graph, not quest record**: Quests support non-linear flow via `QuestOutcome`, branching `QuestChoice`, and world-state flags that gate availability.
+- **Steps with independent failure**: Each `QuestStep` can have its own `FailurePolicy` and timeout, so a timed escort step can soft-fail without killing the entire quest.
+- **Dialogue is owned by NPCs**: Quest proto only stores `QuestDialogueHooks` — references to entry points in the NPC's `DialogueTree`. Content lives in `npcdb.proto`.
+- **Outcomes drive divergence**: Multiple `QuestOutcome` entries allow different rewards, chain continuations, and world-state consequences per ending. A quest with no outcomes uses the single `rewards` field.
+- **World-state flags**: `required_flags` and `blocked_by_flags` on quests, plus `set_flags` on choices, enable quests to react to prior player decisions across the entire game.
+- **Reward policies**: Party quests specify whether rewards are individual, shared, or leader-only. Repeatable quests can give different rewards on first vs subsequent completions.
+- **QuestStatus is runtime-only**: The enum exists for game clients to track progress but is NOT stored in the definition proto.
+- **Triggers are string expressions**: Format is game-specific (e.g. `"player:level:5"`, `"area:kitchen-zone"`). Keeps the proto agnostic to game engine.
 
 ## Related
 
-- NPC proto: [`../npc/`](../npc/) (quest_refs, giver NPCs)
+- NPC proto: [`../npc/`](../npc/) (quest_refs, giver NPCs, DialogueTree)
 - Item proto: [`../item/`](../item/) (quest requirements, quest items)
 - Common types: [`../kbve/common.proto`](../kbve/common.proto)
 - Astro-kbve quest schema: `apps/kbve/astro-kbve/src/data/schema/IQuestSchema.ts`

--- a/packages/data/proto/quest/questdb.proto
+++ b/packages/data/proto/quest/questdb.proto
@@ -56,6 +56,24 @@ enum ChoiceConsequenceType {
   CONSEQUENCE_SPAWN_ENEMY    = 7;   // Trigger combat encounter
   CONSEQUENCE_TELEPORT       = 8;   // Move player to location
   CONSEQUENCE_UNLOCK         = 9;   // Unlock area / feature / recipe
+  CONSEQUENCE_SET_FLAG       = 10;  // Set a world-state flag
+  CONSEQUENCE_CLEAR_FLAG     = 11;  // Clear a world-state flag
+  CONSEQUENCE_NPC_DISPOSITION = 12; // Change NPC attitude toward player
+}
+
+// Failure behavior — what happens when a quest or step fails
+enum FailurePolicy {
+  FAILURE_PERMANENT  = 0;   // Cannot retry, quest locked forever
+  FAILURE_RETRY_STEP = 1;   // Restart current step, keep prior progress
+  FAILURE_RETRY_QUEST = 2;  // Restart entire quest from beginning
+  FAILURE_SOFT_FAIL  = 3;   // Mark failed but allow re-acceptance later
+}
+
+// Reward distribution policy for party quests
+enum RewardPolicy {
+  REWARD_INDIVIDUAL = 0;    // Each player gets full rewards independently
+  REWARD_SHARED     = 1;    // Rewards split across party members
+  REWARD_LEADER     = 2;    // Only quest owner / party leader gets rewards
 }
 
 // =============================================================================
@@ -120,6 +138,37 @@ message QuestChoice {
   optional string next_step_id = 7;     // Override: jump to specific step instead of sequential
   repeated string required_item_refs = 8; // Items player must have to pick this choice
   optional string required_class = 9;   // Class restriction (e.g. "rogue", "cleric")
+  optional string outcome_id = 10;      // Which QuestOutcome this choice leads to
+  repeated string set_flags = 11;       // World-state flags set when chosen
+  optional string dialogue_node_ref = 12; // Jump to a dialogue node (in NPC dialogue tree)
+}
+
+// Branching quest outcome — different endings with different rewards/chains
+message QuestOutcome {
+  string id = 1;                        // Unique within quest (e.g. "saved_village", "betrayed")
+  string description = 2;              // Narrative text for this ending
+  optional QuestRewards rewards = 3;   // Rewards specific to this outcome
+  optional string next_quest_ref = 4;  // Chain continues differently per outcome
+  repeated string consequence_flags = 5; // World-state flags set permanently
+  optional string ending_type = 6;     // e.g. "good", "neutral", "evil", "secret"
+  optional bool canonical = 7;         // Is this the "canon" ending for lore purposes
+}
+
+// Dialogue hooks — references into NPC dialogue trees at quest transition points.
+// Dialogue content lives in NPC proto; quests only store entry-point references.
+message QuestDialogueHooks {
+  optional string accept_ref = 1;       // Dialogue node when quest is offered/accepted
+  optional string in_progress_ref = 2;  // Dialogue node while quest is active
+  optional string complete_ref = 3;     // Dialogue node when objectives done, awaiting turn-in
+  optional string turn_in_ref = 4;      // Dialogue node on turn-in / reward claim
+  optional string fail_ref = 5;         // Dialogue node if quest fails
+  optional string abandon_ref = 6;      // Dialogue node if player drops quest
+}
+
+// Repeat reward policy — different rewards on subsequent completions
+message RepeatRewards {
+  optional QuestRewards first_time = 1;  // Full rewards on first completion
+  optional QuestRewards repeat = 2;      // Reduced rewards on subsequent completions
 }
 
 // A quest step — one stage in the quest progression
@@ -127,7 +176,6 @@ message QuestStep {
   string id = 1;                        // Unique within quest
   optional string title = 2;            // Step title (e.g. "Find the missing parts")
   optional string description = 3;      // Narrative text shown to player
-  optional string dialogue = 4;         // NPC dialogue text
   optional string speaker_ref = 5;      // NPC ref who speaks this step
   repeated QuestObjective objectives = 6; // What to do in this step
   repeated QuestChoice choices = 7;     // Branching options (if any)
@@ -135,6 +183,19 @@ message QuestStep {
   optional QuestRewards step_rewards = 9; // Intermediate rewards on step completion
   optional string trigger_on_start = 10; // Event fired when step begins
   optional string trigger_on_complete = 11; // Event fired when step ends
+
+  // Step behavior
+  optional bool parallel = 12;          // Objectives can be done in any order (vs sequential)
+  optional bool auto_complete = 13;     // Step advances automatically when objectives met
+  optional bool hidden = 14;            // Step not shown until previous step completes
+  optional bool skippable = 15;         // Player can skip this step
+
+  // Failure handling
+  optional FailurePolicy failure_policy = 16;
+  optional int32 step_time_limit_secs = 17; // Per-step timeout (independent of quest timeout)
+
+  // Dialogue hooks for this step
+  optional QuestDialogueHooks dialogue_hooks = 18;
 }
 
 // Quest prerequisite — what must be true before quest is available
@@ -221,11 +282,30 @@ message Quest {
   optional int32 recommended_level = 26; // Suggested player level
   optional int32 recommended_party_size = 27; // Suggested party size
 
-  // Rewards (on final completion)
+  // Rewards (on final completion — used when no outcomes defined)
   optional QuestRewards rewards = 28;
+
+  // Branching outcomes — multiple possible endings
+  repeated QuestOutcome outcomes = 33;
+
+  // Repeat reward policy (first-time vs subsequent)
+  optional RepeatRewards repeat_rewards = 34;
+
+  // Reward distribution in party
+  optional RewardPolicy reward_policy = 35;
+
+  // Failure handling (quest-level default, steps can override)
+  optional FailurePolicy failure_policy = 36;
+
+  // Dialogue hooks — references into NPC dialogue trees
+  optional QuestDialogueHooks dialogue_hooks = 37;
 
   // Triggers — event expressions that activate/progress the quest
   repeated string triggers = 29;        // e.g. "player:level:5", "area:kitchen-zone"
+
+  // World-state conditions — flags that must be set/unset for quest availability
+  repeated string required_flags = 38;  // Flags that must be set
+  repeated string blocked_by_flags = 39; // Flags that prevent quest (e.g. "betrayed_village")
 
   // Extensions — game-specific key-value pairs
   repeated QuestExtension extensions = 30;


### PR DESCRIPTION
## Summary
- Add `questdb.proto` under `packages/data/proto/quest/` as the universal quest source of truth
- 8 quest categories (main, side, daily, event, challenge, tutorial, bounty, guild)
- 9 objective types (collect, kill, visit, interact, escort, defend, craft, explore, custom)
- Stepped progression with branching dialogue choices and consequence types
- Prerequisites (level, completed quests, faction, items, class), time limits, and availability windows
- Rewards with items, currency, XP, arbitrary stat bonuses, Steam achievement integration, and faction reputation
- Quest chains for grouping storylines with chain-completion bonus rewards
- NPC linkage (giver + turn-in refs) aligns with existing `npcdb.proto` quest_refs
- Game-specific `QuestExtension` key-value pairs for future needs
- README with full field reference, design decisions, and integration points

## Integration Points
- NPC proto: `quest_refs`, `prerequisite_quest_refs`, `NPC_TYPE_QUEST_GIVER`
- Item proto: `quest_requirement`, `ITEM_TYPE_QUEST`, `source_type: "quest"`
- Astro-kbve: `IQuestSchema` + MDX content at `src/content/docs/questdb/`

## Test plan
- [x] Proto syntax is valid
- [x] All existing NPC/item quest references (`quest_refs`, `quest_requirement`) align with Quest.id format
- [x] README documents all fields, enums, and design decisions
- [ ] Future: codegen Zod schema from proto to replace hand-written `IQuestSchema.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)