### PR TITLE
chore(deps-dev): bump babel-plugin-styled-components 1.10.7 → 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"astro-vtbot": "^2.1.11",
 		"autoprefixer": "^10.4.24",
 		"babel-plugin-macros": "^3.1.0",
-		"babel-plugin-styled-components": "1.10.7",
+		"babel-plugin-styled-components": "2.1.4",
 		"cssnano": "^7.0.6",
 		"esbuild": "0.25.0",
 		"eslint": "8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,8 +408,8 @@ importers:
                 specifier: ^3.1.0
                 version: 3.1.0
             babel-plugin-styled-components:
-                specifier: 1.10.7
-                version: 1.10.7(styled-components@5.3.6(@babel/core@7.26.10)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4))
+                specifier: 2.1.4
+                version: 2.1.4(@babel/core@7.26.10)(styled-components@5.3.6(@babel/core@7.26.10)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4))(supports-color@5.5.0)
             cssnano:
                 specifier: ^7.0.6
                 version: 7.0.6(postcss@8.5.3)
@@ -833,13 +833,6 @@ packages:
             }
         engines: { node: '>=6.9.0' }
 
-    '@babel/helper-annotate-as-pure@7.25.9':
-        resolution:
-            {
-                integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==,
-            }
-        engines: { node: '>=6.9.0' }
-
     '@babel/helper-annotate-as-pure@7.27.3':
         resolution:
             {
@@ -905,13 +898,6 @@ packages:
         resolution:
             {
                 integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-module-imports@7.27.1':
-        resolution:
-            {
-                integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==,
             }
         engines: { node: '>=6.9.0' }
 
@@ -1236,15 +1222,6 @@ packages:
             {
                 integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==,
             }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-syntax-jsx@7.25.9':
-        resolution:
-            {
-                integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==,
-            }
-        engines: { node: '>=6.9.0' }
         peerDependencies:
             '@babel/core': ^7.0.0-0
 
@@ -10617,14 +10594,6 @@ packages:
                 integrity: sha512-SPD0J6qjJn8231i0HZhlAGH6NORe+QvRSQM2mwQEzJ2Fb3E4ruWTiiicPlHjmeWShDXLcvoorOCXjeR7k/lyWA==,
             }
 
-    babel-plugin-styled-components@1.10.7:
-        resolution:
-            {
-                integrity: sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==,
-            }
-        peerDependencies:
-            styled-components: '>= 2'
-
     babel-plugin-styled-components@2.1.4:
         resolution:
             {
@@ -10637,12 +10606,6 @@ packages:
         resolution:
             {
                 integrity: sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==,
-            }
-
-    babel-plugin-syntax-jsx@6.18.0:
-        resolution:
-            {
-                integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==,
             }
 
     babel-plugin-transform-flow-enums@0.0.2:
@@ -26701,10 +26664,6 @@ snapshots:
             '@jridgewell/trace-mapping': 0.3.31
             jsesc: 3.1.0
 
-    '@babel/helper-annotate-as-pure@7.25.9':
-        dependencies:
-            '@babel/types': 7.27.0
-
     '@babel/helper-annotate-as-pure@7.27.3':
         dependencies:
             '@babel/types': 7.29.0
@@ -26806,14 +26765,7 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
-        dependencies:
-            '@babel/traverse': 7.29.0(supports-color@5.5.0)
-            '@babel/types': 7.29.0
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-module-imports@7.28.6':
+    '@babel/helper-module-imports@7.28.6(supports-color@5.5.0)':
         dependencies:
             '@babel/traverse': 7.29.0(supports-color@5.5.0)
             '@babel/types': 7.29.0
@@ -26832,7 +26784,7 @@ snapshots:
     '@babel/helper-module-transforms@7.28.6(@babel/core@7.26.10)':
         dependencies:
             '@babel/core': 7.26.10
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-validator-identifier': 7.28.5
             '@babel/traverse': 7.29.0(supports-color@5.5.0)
         transitivePeerDependencies:
@@ -26842,7 +26794,7 @@ snapshots:
     '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
         dependencies:
             '@babel/core': 7.29.0
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-validator-identifier': 7.28.5
             '@babel/traverse': 7.29.0(supports-color@5.5.0)
         transitivePeerDependencies:
@@ -27113,11 +27065,6 @@ snapshots:
             '@babel/core': 7.29.0
             '@babel/helper-plugin-utils': 7.28.6
 
-    '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10)':
-        dependencies:
-            '@babel/core': 7.26.10
-            '@babel/helper-plugin-utils': 7.28.6
-
     '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.26.10)':
         dependencies:
             '@babel/core': 7.26.10
@@ -27258,7 +27205,7 @@ snapshots:
     '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.26.10)':
         dependencies:
             '@babel/core': 7.26.10
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-plugin-utils': 7.28.6
             '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.10)
         transitivePeerDependencies:
@@ -27268,7 +27215,7 @@ snapshots:
     '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
         dependencies:
             '@babel/core': 7.29.0
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-plugin-utils': 7.28.6
             '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
         transitivePeerDependencies:
@@ -27759,7 +27706,7 @@ snapshots:
         dependencies:
             '@babel/core': 7.26.10
             '@babel/helper-annotate-as-pure': 7.27.3
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-plugin-utils': 7.28.6
             '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.26.10)
             '@babel/types': 7.29.0
@@ -27770,7 +27717,7 @@ snapshots:
         dependencies:
             '@babel/core': 7.29.0
             '@babel/helper-annotate-as-pure': 7.27.3
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-plugin-utils': 7.28.6
             '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
             '@babel/types': 7.29.0
@@ -27814,7 +27761,7 @@ snapshots:
     '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.26.10)':
         dependencies:
             '@babel/core': 7.26.10
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-plugin-utils': 7.28.6
             babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.26.10)
             babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.26.10)
@@ -27827,7 +27774,7 @@ snapshots:
     '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0)':
         dependencies:
             '@babel/core': 7.29.0
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/helper-plugin-utils': 7.28.6
             babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
             babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
@@ -29572,7 +29519,7 @@ snapshots:
             '@rushstack/rig-package': 0.5.3
             '@rushstack/terminal': 0.15.1(@types/node@18.19.17)
             '@rushstack/ts-command-line': 4.23.6(@types/node@18.19.17)
-            lodash: 4.17.21
+            lodash: 4.17.23
             minimatch: 3.0.8
             resolve: 1.22.10
             semver: 7.5.4
@@ -32051,7 +31998,7 @@ snapshots:
     '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)':
         dependencies:
             '@babel/core': 7.29.0
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
             rollup: 2.80.0
         optionalDependencies:
@@ -32062,7 +32009,7 @@ snapshots:
     '@rollup/plugin-babel@6.1.0(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@4.57.1)':
         dependencies:
             '@babel/core': 7.26.10
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
         optionalDependencies:
             '@types/babel__core': 7.20.5
@@ -34341,7 +34288,7 @@ snapshots:
             graceful-fs: 4.2.11
             is-stream: 2.0.1
             lazystream: 1.0.1
-            lodash: 4.17.21
+            lodash: 4.17.23
             normalize-path: 3.0.0
             readable-stream: 4.7.0
 
@@ -34944,22 +34891,12 @@ snapshots:
     babel-plugin-react-native-web@0.21.2:
         optional: true
 
-    babel-plugin-styled-components@1.10.7(styled-components@5.3.6(@babel/core@7.26.10)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)):
-        dependencies:
-            '@babel/helper-annotate-as-pure': 7.25.9
-            '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
-            babel-plugin-syntax-jsx: 6.18.0
-            lodash: 4.17.21
-            styled-components: 5.3.6(@babel/core@7.26.10)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)
-        transitivePeerDependencies:
-            - supports-color
-
     babel-plugin-styled-components@2.1.4(@babel/core@7.26.10)(styled-components@5.3.6(@babel/core@7.26.10)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4))(supports-color@5.5.0):
         dependencies:
-            '@babel/helper-annotate-as-pure': 7.25.9
-            '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-            '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10)
-            lodash: 4.17.21
+            '@babel/helper-annotate-as-pure': 7.27.3
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
+            '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.26.10)
+            lodash: 4.17.23
             picomatch: 2.3.1
             styled-components: 5.3.6(@babel/core@7.26.10)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)
         transitivePeerDependencies:
@@ -34969,8 +34906,6 @@ snapshots:
     babel-plugin-syntax-hermes-parser@0.29.1:
         dependencies:
             hermes-parser: 0.29.1
-
-    babel-plugin-syntax-jsx@6.18.0: {}
 
     babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.26.10):
         dependencies:
@@ -35026,7 +34961,7 @@ snapshots:
 
     babel-preset-expo@54.0.10(@babel/core@7.26.10)(@babel/runtime@7.27.6)(expo@54.0.9)(react-refresh@0.14.2):
         dependencies:
-            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
             '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.26.10)
             '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.26.10)
             '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.26.10)
@@ -40007,7 +39942,7 @@ snapshots:
         dependencies:
             graceful-fs: 4.2.11
             is-promise: 2.2.2
-            lodash: 4.17.21
+            lodash: 4.17.23
             pify: 3.0.0
             steno: 0.4.4
 
@@ -44488,7 +44423,7 @@ snapshots:
     tiled-property-flattener@1.1.1:
         dependencies:
             '@types/minimist': 1.2.5
-            lodash: 4.17.21
+            lodash: 4.17.23
             minimist: 1.2.8
 
     tiny-inflate@1.0.3: {}


### PR DESCRIPTION
## Summary
- Bumps `babel-plugin-styled-components` from `1.10.7` (v1) to `2.1.4` (v2)
- Supersedes Dependabot PR #7820 (can be closed after this merges)
- v2 aligns with `styled-components` v5+ (already in use in this repo)
- Migrates off EOL babel packages, includes bug fixes and dependency bumps
- The lockfile already had v2.1.4 as a transitive dependency — this promotes the direct dep to match

## Test plan
- [x] `pnpm install` succeeds with clean lockfile
- [x] Lint-staged passes
- [ ] CI lint + test pass