### PR TITLE
feat(ci): add Monday e2e full-sweep scheduled workflow

### DIFF
--- a/.github/workflows/ci-monday-e2e.yml
+++ b/.github/workflows/ci-monday-e2e.yml
@@ -33,17 +33,17 @@ jobs:
             has_projects: ${{ steps.matrix.outputs.has_projects }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: ${{ inputs.branch || 'dev' }}
 
             - name: Setup Node v24
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
               with:
                   version: 10
                   run_install: false
@@ -135,7 +135,7 @@ jobs:
             contents: read
         steps:
             - name: Download test markers
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   pattern: test-passed-docker-*
                   path: ./test-results


### PR DESCRIPTION
## Summary
- Adds a weekly Monday e2e workflow (`ci-monday-e2e.yml`) that runs **all** e2e tests across the monorepo
- Scheduled every Monday at 06:00 UTC, also triggerable via `workflow_dispatch`
- **3-job architecture**:
  1. **Discover** — dynamically finds all Nx projects with an `e2e` target, builds a JSON matrix with per-project runner assignments
  2. **E2E** — fans out via `docker-test-app.yml` reusable workflow, one isolated runner per project
  3. **Summary** — collects pass/fail markers and writes a results table to GitHub Actions step summary

### Runner assignments
| Runner | Projects |
|--------|----------|
| `arc-runner-set` | axum-kbve-e2e, mc-e2e, edge-e2e (Docker-heavy, need more resources) |
| `ubuntu-latest` | All Playwright and vitest-only projects |

### Complements existing CI
| Workflow | Schedule | Scope |
|----------|----------|-------|
| **Monday E2E** (new) | Mon 6am UTC | Full sweep — all e2e projects |
| Docker Smoke Test | Sun 4am UTC | Docker image builds only |
| CodeQL Security | Mon 6:30am UTC | Static analysis |
| ci-main / ci-dev | On push/PR | Affected projects only |

## Test plan
- [x] YAML validates (`js-yaml`)
- [x] Lint-staged passes
- [ ] Trigger via `workflow_dispatch` after merge to verify discovery + fan-out