### PR TITLE
fix(discordsh-e2e): open sign-in modal before asserting OAuth button class

### DIFF
--- a/apps/discordsh/discordsh-e2e/e2e/audit.spec.ts
+++ b/apps/discordsh/discordsh-e2e/e2e/audit.spec.ts
@@ -265,11 +265,18 @@ test.describe('Audit: NavBar CSS Classes', () => {
 		await page.goto('/');
 		await page.waitForLoadState('domcontentloaded');
 
-		// OAuth buttons only render inside the sign-in modal, so just verify
-		// the page loaded without inline style errors. The nb-oauth-* classes
-		// are defined in global.css and available site-wide.
-		const body = await page.content();
-		expect(body).toContain('nb-oauth-discord');
+		// OAuth buttons only render inside the sign-in modal which is
+		// conditionally mounted by React. Wait for the island to hydrate,
+		// then open the modal before asserting.
+		const signInBtn = page.locator('button[aria-label="Sign in"]');
+		// The React island may take a moment to hydrate — wait up to 10s.
+		await signInBtn.first().waitFor({ state: 'visible', timeout: 10_000 });
+		await signInBtn.first().click();
+
+		// Modal is portal-mounted; wait for the Discord OAuth button.
+		const discordBtn = page.locator('.nb-oauth-discord');
+		await discordBtn.waitFor({ state: 'visible', timeout: 5_000 });
+		await expect(discordBtn).toHaveClass(/nb-oauth-btn/);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Fix failing `OAuth buttons use nb-oauth-btn class` e2e test
- The `nb-oauth-discord` button lives inside a conditionally-rendered React modal (`client:only="react"`) — it doesn't exist in the DOM until the user opens it
- Previous test checked `page.content()` after `domcontentloaded`, which only has the SSR shell (no React output)
- Now waits for React hydration, clicks the "Sign in" button to open the modal, then asserts the Discord OAuth button has the correct CSS classes

## Test plan
- [ ] Verify `e2e:docker discordsh-e2e` passes all 44 tests (43 previously passing + this fix)