### PR TITLE
refactor(isometric): replace HUD bars with orb shaders, fix mobile layout

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/orb_hud.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/orb_hud.rs
@@ -139,11 +139,12 @@ fn spawn_orbs(mut commands: Commands, mut orb_materials: ResMut<Assets<OrbMateri
         },
     });
 
+    // Mana orb — bottom-right, above action buttons (24px margin + 56+12+56 = 148px)
     commands.spawn((
         Node {
             position_type: PositionType::Absolute,
             right: Val::Px(ORB_MARGIN),
-            bottom: Val::Px(ORB_MARGIN),
+            bottom: Val::Px(160.0),
             width: Val::Px(ORB_SIZE),
             height: Val::Px(ORB_SIZE),
             ..default()
@@ -152,7 +153,7 @@ fn spawn_orbs(mut commands: Commands, mut orb_materials: ResMut<Assets<OrbMateri
         ManaOrb,
     ));
 
-    // Energy orb — bottom-right, above mana
+    // Energy orb — bottom-right, above mana orb
     let ep_mat = orb_materials.add(OrbMaterial {
         uniforms: OrbUniforms {
             fill: 1.0,
@@ -170,7 +171,7 @@ fn spawn_orbs(mut commands: Commands, mut orb_materials: ResMut<Assets<OrbMateri
         Node {
             position_type: PositionType::Absolute,
             right: Val::Px(ORB_MARGIN),
-            bottom: Val::Px(ORB_MARGIN + ORB_SIZE + 8.0), // above mana orb
+            bottom: Val::Px(160.0 + ORB_SIZE + 8.0), // above mana orb
             width: Val::Px(ORB_SIZE),
             height: Val::Px(ORB_SIZE),
             ..default()

--- a/apps/kbve/isometric/src/app.css
+++ b/apps/kbve/isometric/src/app.css
@@ -26,6 +26,7 @@
 	/* --- Stat Bars --- */
 	--color-hp: #b83030;
 	--color-mp: #3060b8;
+	--color-ep: #b89030;
 	--color-xp: #4a7a3a;
 
 	/* --- Toast Severity --- */

--- a/apps/kbve/isometric/src/components/FPSCounter.tsx
+++ b/apps/kbve/isometric/src/components/FPSCounter.tsx
@@ -16,7 +16,7 @@ export function FPSCounter() {
 	}, []);
 
 	return (
-		<div className="absolute top-2 right-2 md:top-3 md:right-3 px-2 py-1 md:px-3 md:py-1.5 bg-panel border border-panel-border text-[7px] md:text-[10px] text-text-muted pointer-events-auto">
+		<div className="absolute top-12 left-4 md:top-14 md:left-6 px-2 py-1 md:px-3 md:py-1.5 bg-panel border border-panel-border text-[7px] md:text-[10px] text-text-muted pointer-events-auto">
 			{fps} FPS
 		</div>
 	);

--- a/apps/kbve/isometric/src/components/HUD.tsx
+++ b/apps/kbve/isometric/src/components/HUD.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { get_player_state_json } from '../../wasm-pkg/isometric_game.js';
 import { GlassPanel } from '../ui/shared/GlassPanel';
-import { ProgressBar } from '../ui/shared/ProgressBar';
 
 interface PlayerState {
 	health: number;
@@ -32,26 +31,8 @@ export function HUD() {
 	if (!state) return null;
 
 	return (
-		<GlassPanel className="absolute top-4 right-4 md:top-6 md:right-6 px-3 py-2 md:px-4 md:py-3 pointer-events-none">
-			<ProgressBar
-				label="HP"
-				value={state.health}
-				max={state.max_health}
-				color="bg-hp"
-			/>
-			<ProgressBar
-				label="MP"
-				value={state.mana}
-				max={state.max_mana}
-				color="bg-mp"
-			/>
-			<ProgressBar
-				label="EP"
-				value={state.energy}
-				max={state.max_energy}
-				color="bg-ep"
-			/>
-			<div className="text-[7px] md:text-[9px] text-text-muted mt-1">
+		<GlassPanel className="absolute top-12 right-4 md:top-14 md:right-6 px-3 py-1.5 md:px-4 md:py-2 pointer-events-none">
+			<div className="text-[7px] md:text-[9px] text-text-muted">
 				Pos: {state.position.map((v) => v.toFixed(1)).join(', ')}
 			</div>
 		</GlassPanel>


### PR DESCRIPTION
## Summary
- Remove React HP/MP/EP progress bars from HUD overlay — Bevy orb shaders are now the sole stat display
- Fix mana and energy orb positions overlapping action buttons (repositioned above the button stack)
- Move FPS counter and position HUD panel down from top edge to avoid phone notch/status bar cutoff (`top-2` → `top-12`)
- Add missing `--color-ep` CSS variable (energy bar was invisible due to undefined color)

## Test plan
- [ ] Verify orb shaders display HP (red, bottom-left), MP (blue, bottom-right), EP (yellow, above MP)
- [ ] Confirm orbs don't overlap joystick (left) or action buttons (right)
- [ ] Check FPS counter and position panel are visible on mobile (not clipped by notch)
- [ ] Verify energy orb starts full (not empty)