### PR TITLE
chore(deps): bump solana crates to latest stable 2.3.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,12 +227,23 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a2c365c0245cbb8959de725fc2b44c754b673fdf34c9a7f9d4a25c35a7bf1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "solana-epoch-schedule",
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
  "solana-svm-feature-set",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -3011,7 +3022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -4816,7 +4827,7 @@ version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "457481173e6db5ca9fa2be93a58df8f4c7be639587aeb4853b526c6cf87db4e6"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "document-features",
  "egui",
@@ -4855,7 +4866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
 dependencies = [
  "accesskit",
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.11.0",
  "emath",
  "epaint",
@@ -4874,7 +4885,7 @@ version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "document-features",
  "egui",
@@ -5150,7 +5161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
 dependencies = [
  "ab_glyph",
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "ecolor",
  "emath",
@@ -6645,6 +6656,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -6652,7 +6666,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -8915,7 +8929,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "portable-atomic",
 ]
 
@@ -13611,7 +13625,7 @@ version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93b93971e289d6425f88e6e3cb6668c4b05df78b3c518c249be55ced8efd6b6d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "lazy_static",
  "solana-epoch-schedule",
  "solana-hash",
@@ -13990,7 +14004,7 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37192c0be5c222ca49dbc5667288c5a8bb14837051dd98e541ee4dad160a5da9"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bincode 1.3.3",
  "bv",
  "bytes",
@@ -18729,7 +18743,7 @@ version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.0",

--- a/packages/rust/soul/Cargo.toml
+++ b/packages/rust/soul/Cargo.toml
@@ -18,9 +18,9 @@ exclude = [
 #crate-type = ["cdylib"]
 
 [dependencies]
-solana-client = "2.2.2"
-solana-sdk = "2.2.1"
-solana-program = "2.2.1"
+solana-client = "2.3"
+solana-sdk = "2.3"
+solana-program = "2.3"
 papaya = "0.1.8"
 borsh = "1.5.5"
 borsh-derive = "1.5.5"


### PR DESCRIPTION
## Summary
- Bumps all three Solana crates in `packages/rust/soul/` to latest stable 2.3.x:
  - `solana-client` 2.2.2 → **2.3.13**
  - `solana-sdk` 2.2.1 → **2.3.1**
  - `solana-program` 2.2.1 → **2.3.0**
- Supersedes Dependabot PRs #7819 (`solana-client`) and #7165 (`solana-program`) — both can be closed after merge

## Why not 4.x?
Attempted the 4.x upgrade but the Solana ecosystem has an unresolved upstream compile issue:
- `solana-sdk` 4.0.1 → depends on `solana-keypair` 3.1.2
- `solana-keypair` 3.1.2 uses `five8::DecodeError` which doesn't implement `std::error::Error`
- This causes `E0277` compile errors in `solana-keypair` itself (not our code)
- `solana-client` 4.x is still beta-only (`4.0.0-beta.2`)
- Once Solana stabilizes 4.x and fixes the transitive dep issue, we can upgrade

## Test plan
- [x] `cargo check -p soul` compiles cleanly
- [x] All Solana import paths unchanged (`solana_client::client_error::ClientError`)
- [ ] CI lint + test pass