### PR TITLE
feat(cryptothrone): fix canvas scaling and add virtual joystick

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -76,7 +76,7 @@ function GameUI() {
 export default function GameWindow() {
 	return (
 		<GameStoreProvider>
-			<div className="relative flex justify-center items-center w-full">
+			<div className="relative flex justify-center items-center w-full h-full">
 				<PhaserCanvas />
 				<GameUI />
 			</div>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -99,7 +99,7 @@ export class CloudCityScene extends Scene {
 			this,
 			this.gridEngine,
 			this.quadtree,
-			{ tileSize: 48 },
+			{ tileSize: 48, joystick: true },
 		);
 
 		this.gridEngine.moveRandomly('npc', 1500, 3);

--- a/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
+++ b/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
@@ -67,9 +67,17 @@ body:has(.game-fullscreen) .ct-footer {
 	overflow: hidden;
 }
 
-/* Let the Phaser canvas fill the viewport while keeping aspect ratio */
+/* Let the Phaser canvas expand to fill the viewport while keeping aspect ratio */
 .game-fullscreen canvas {
+	width: 100%;
+	height: 100%;
 	max-width: 100vw;
 	max-height: 100vh;
 	object-fit: contain;
+}
+
+/* Ensure the PhaserGame container div fills the game-fullscreen overlay */
+.game-fullscreen > div {
+	width: 100%;
+	height: 100%;
 }

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -22,6 +22,8 @@ export type { PhaserGameProps, PhaserGameRef } from './lib/phaser/PhaserGame';
 export { PhaserContext, usePhaserGame } from './lib/phaser/use-phaser';
 export { usePhaserEvent } from './lib/phaser/use-phaser-event';
 export { PlayerController } from './lib/phaser/player-controller';
+export { VirtualJoystick } from './lib/phaser/virtual-joystick';
+export type { VirtualJoystickConfig } from './lib/phaser/virtual-joystick';
 export {
 	getBirdNum,
 	isBird,

--- a/packages/npm/laser/src/lib/phaser/player-controller.ts
+++ b/packages/npm/laser/src/lib/phaser/player-controller.ts
@@ -3,6 +3,8 @@ import Phaser from 'phaser';
 import type { Point2D } from '../core/types';
 import type { Quadtree } from '../spatial/quadtree';
 import { laserEvents } from '../core/events';
+import { VirtualJoystick } from './virtual-joystick';
+import type { VirtualJoystickConfig } from './virtual-joystick';
 
 export class PlayerController {
 	private scene: Scene;
@@ -13,12 +15,17 @@ export class PlayerController {
 	private tooltip: Phaser.GameObjects.Text;
 	private tileSize: number;
 	private playerId: string;
+	private joystick: VirtualJoystick | null = null;
 
 	constructor(
 		scene: Scene,
 		gridEngine: any,
 		quadtree: Quadtree,
-		options?: { tileSize?: number; playerId?: string },
+		options?: {
+			tileSize?: number;
+			playerId?: string;
+			joystick?: boolean | VirtualJoystickConfig;
+		},
 	) {
 		this.scene = scene;
 		this.gridEngine = gridEngine;
@@ -35,6 +42,14 @@ export class PlayerController {
 			.setDepth(4)
 			.setPadding(3, 2, 2, 3)
 			.setVisible(false);
+
+		if (options?.joystick) {
+			const joystickConfig =
+				typeof options.joystick === 'object'
+					? options.joystick
+					: undefined;
+			this.joystick = new VirtualJoystick(scene, joystickConfig);
+		}
 	}
 
 	private initializeWASDKeys(): void {
@@ -72,11 +87,6 @@ export class PlayerController {
 	}
 
 	handleMovement(): void {
-		if (!this.cursor) return;
-
-		const cursors = this.cursor;
-		const wasd = this.wasdKeys;
-
 		if (this.scene.input.keyboard?.addKey('F').isDown) {
 			const position = this.gridEngine.getPosition(
 				this.playerId,
@@ -93,6 +103,21 @@ export class PlayerController {
 				}
 			}
 		}
+
+		// Joystick takes priority when active
+		if (this.joystick?.isActive && this.joystick.direction) {
+			this.gridEngine.move(this.playerId, this.joystick.direction);
+			this.checkForNearbyObjects();
+			return;
+		}
+
+		if (!this.cursor) {
+			this.checkForNearbyObjects();
+			return;
+		}
+
+		const cursors = this.cursor;
+		const wasd = this.wasdKeys;
 
 		if (
 			(cursors.left.isDown || wasd['A'].isDown) &&

--- a/packages/npm/laser/src/lib/phaser/virtual-joystick.ts
+++ b/packages/npm/laser/src/lib/phaser/virtual-joystick.ts
@@ -1,0 +1,164 @@
+import Phaser from 'phaser';
+
+export type GridDirection =
+	| 'up'
+	| 'down'
+	| 'left'
+	| 'right'
+	| 'up-left'
+	| 'up-right'
+	| 'down-left'
+	| 'down-right'
+	| null;
+
+export interface VirtualJoystickConfig {
+	x?: number;
+	y?: number;
+	radius?: number;
+	baseColor?: number;
+	thumbColor?: number;
+	baseAlpha?: number;
+	thumbAlpha?: number;
+	deadZone?: number;
+	fixed?: boolean;
+}
+
+export class VirtualJoystick {
+	private scene: Phaser.Scene;
+	private base: Phaser.GameObjects.Arc;
+	private thumb: Phaser.GameObjects.Arc;
+	private radius: number;
+	private deadZone: number;
+	private _direction: GridDirection = null;
+	private _isActive = false;
+	private fixed: boolean;
+	private activePointer: Phaser.Input.Pointer | null = null;
+
+	constructor(scene: Phaser.Scene, config?: VirtualJoystickConfig) {
+		this.scene = scene;
+		this.radius = config?.radius ?? 60;
+		this.deadZone = config?.deadZone ?? 0.25;
+		this.fixed = config?.fixed ?? true;
+
+		const x = config?.x ?? 120;
+		const y = config?.y ?? scene.scale.height - 120;
+
+		this.base = scene.add
+			.circle(
+				x,
+				y,
+				this.radius,
+				config?.baseColor ?? 0x888888,
+				config?.baseAlpha ?? 0.35,
+			)
+			.setDepth(100)
+			.setScrollFactor(0);
+
+		this.thumb = scene.add
+			.circle(
+				x,
+				y,
+				this.radius * 0.4,
+				config?.thumbColor ?? 0xffffff,
+				config?.thumbAlpha ?? 0.5,
+			)
+			.setDepth(101)
+			.setScrollFactor(0);
+
+		this.setupInput();
+	}
+
+	private setupInput(): void {
+		this.scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+			if (this.activePointer) return;
+
+			const dx = pointer.x - this.base.x;
+			const dy = pointer.y - this.base.y;
+			const dist = Math.sqrt(dx * dx + dy * dy);
+
+			if (this.fixed && dist > this.radius * 2) return;
+
+			if (!this.fixed) {
+				this.base.setPosition(pointer.x, pointer.y);
+				this.thumb.setPosition(pointer.x, pointer.y);
+			}
+
+			this.activePointer = pointer;
+			this._isActive = true;
+		});
+
+		this.scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+			if (pointer !== this.activePointer) return;
+			this.updateThumb(pointer.x, pointer.y);
+		});
+
+		this.scene.input.on('pointerup', (pointer: Phaser.Input.Pointer) => {
+			if (pointer !== this.activePointer) return;
+			this.resetThumb();
+		});
+	}
+
+	private updateThumb(px: number, py: number): void {
+		const dx = px - this.base.x;
+		const dy = py - this.base.y;
+		const dist = Math.sqrt(dx * dx + dy * dy);
+
+		const clampedDist = Math.min(dist, this.radius);
+		const angle = Math.atan2(dy, dx);
+
+		this.thumb.setPosition(
+			this.base.x + Math.cos(angle) * clampedDist,
+			this.base.y + Math.sin(angle) * clampedDist,
+		);
+
+		const normalizedDist = clampedDist / this.radius;
+		if (normalizedDist < this.deadZone) {
+			this._direction = null;
+			return;
+		}
+
+		this._direction = this.angleToDirection(angle);
+	}
+
+	private angleToDirection(angle: number): GridDirection {
+		// Convert to degrees [0, 360)
+		let deg = (angle * 180) / Math.PI;
+		if (deg < 0) deg += 360;
+
+		// 8-way direction mapping with 45-degree sectors
+		if (deg >= 337.5 || deg < 22.5) return 'right';
+		if (deg >= 22.5 && deg < 67.5) return 'down-right';
+		if (deg >= 67.5 && deg < 112.5) return 'down';
+		if (deg >= 112.5 && deg < 157.5) return 'down-left';
+		if (deg >= 157.5 && deg < 202.5) return 'left';
+		if (deg >= 202.5 && deg < 247.5) return 'up-left';
+		if (deg >= 247.5 && deg < 292.5) return 'up';
+		return 'up-right'; // 292.5 to 337.5
+	}
+
+	private resetThumb(): void {
+		this.thumb.setPosition(this.base.x, this.base.y);
+		this._direction = null;
+		this._isActive = false;
+		this.activePointer = null;
+	}
+
+	get direction(): GridDirection {
+		return this._direction;
+	}
+
+	get isActive(): boolean {
+		return this._isActive;
+	}
+
+	setVisible(visible: boolean): this {
+		this.base.setVisible(visible);
+		this.thumb.setVisible(visible);
+		return this;
+	}
+
+	destroy(): void {
+		this.base.destroy();
+		this.thumb.destroy();
+	}
+}


### PR DESCRIPTION
## Summary
- Fix Phaser canvas not expanding to fill viewport on large screens by adding `h-full` to the React container and proper `width`/`height` CSS rules for `.game-fullscreen` children
- Add `VirtualJoystick` class to `@kbve/laser` — a Phaser-native touch joystick that maps 8-directional swipe input to GridEngine movement directions
- Integrate joystick into `PlayerController` via new `joystick` option (accepts `boolean` or `VirtualJoystickConfig`); joystick input takes priority over keyboard when active
- Enable joystick in CryptoThrone's `CloudCityScene`

## Test plan
- [ ] Verify canvas fills the viewport on large screens (1440p+) without distortion
- [ ] Verify virtual joystick appears in bottom-left corner of the game canvas
- [ ] Test joystick: drag in 8 directions and confirm player moves accordingly
- [ ] Verify keyboard (WASD/arrows) still works when joystick is not being touched
- [ ] Test on mobile/touch device — joystick should respond to touch input