### PR TITLE
feat(kube): add websocket ingress route for Lightyear game server

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -31,6 +31,9 @@ spec:
                       - name: http
                         containerPort: 4321
                         protocol: TCP
+                      - name: ws
+                        containerPort: 5000
+                        protocol: TCP
                   livenessProbe:
                       httpGet:
                           path: /health
@@ -120,6 +123,11 @@ spec:
     selector:
         app: kbve
     ports:
-        - port: 4321
+        - name: http
+          port: 4321
           targetPort: 4321
+          protocol: TCP
+        - name: ws
+          port: 5000
+          targetPort: 5000
           protocol: TCP

--- a/apps/kube/kbve/manifest/kbve-ws-ingress.yaml
+++ b/apps/kube/kbve/manifest/kbve-ws-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: kbve-ws-ingress
+    namespace: kbve
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: '300'
+        nginx.ingress.kubernetes.io/upstream-hash-by: '$remote_addr'
+spec:
+    rules:
+        - host: kbve.com
+          http:
+              paths:
+                  - path: /ws
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 5000

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
     - kbve-internal-ca-cert.yaml
     - kbve-deployment.yaml
     - nginx-ingress.yaml
+    - kbve-ws-ingress.yaml


### PR DESCRIPTION
## Summary
- Expose port 5000 (Lightyear WebSocket) in the kbve container spec and Service
- Add dedicated NGINX Ingress at `kbve.com/ws` → port 5000 with 1-hour read/send timeouts and sticky sessions via `upstream-hash-by`
- Verified via local `aeronet_websocket` source that Lightyear accepts WS upgrades on any path (no rewrite needed)

## Test plan
- [ ] ArgoCD syncs the updated manifests without errors
- [ ] WebSocket connection to `wss://kbve.com/ws` successfully upgrades and authenticates
- [ ] Existing HTTP traffic on `kbve.com/` remains unaffected