### PR TITLE
fix(ci): strip ANSI codes from nx report output

### DIFF
--- a/.github/workflows/ci-weekly-nx-report.yml
+++ b/.github/workflows/ci-weekly-nx-report.yml
@@ -114,7 +114,8 @@ jobs:
               id: nx-report
               run: |
                   set -euo pipefail
-                  pnpm nx report > /tmp/nx-report-raw.txt 2>&1 || true
+                  # Capture report and strip ANSI color/bold codes that nx emits
+                  pnpm nx report 2>&1 | sed 's/\x1b\[[0-9;]*m//g' > /tmp/nx-report-raw.txt || true
                   echo "report_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
                   echo "report_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- `nx report` emits ANSI color/bold escape codes (e.g. `\e[32mnx\e[39m`)
- `grep "^nx "` failed to match, causing the Build NX Report MDX step to exit 1 under `set -euo pipefail`
- Fix: pipe through `sed 's/\x1b\[[0-9;]*m//g'` when capturing the report

## Related
- Failed run: https://github.com/KBVE/kbve/actions/runs/23102698405

## Test plan
- [ ] Re-run `ci-weekly-nx-report` via workflow_dispatch after merge