### PR TITLE
fix(axum-kbve): force HTTP/1.1 on ArgoCD proxy to prevent ALPN h2 hang

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -324,6 +324,7 @@ pub fn init_argo_proxy() -> bool {
 
     let mut builder = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
+        .http1_only()
         .connect_timeout(Duration::from_secs(5))
         .timeout(Duration::from_secs(15));
 


### PR DESCRIPTION
## Summary
- Add `.http1_only()` to the ArgoCD proxy reqwest client builder
- rustls was negotiating HTTP/2 via ALPN with ArgoCD, routing the connection to gRPC instead of the REST API, causing the proxy to hang silently and return 502
- Grafana proxy was unaffected because it uses plain HTTP (no TLS/ALPN)
- TLS, CA cert verification, and encryption remain fully intact

## Test plan
- [ ] Deploy and verify `kbve.com/dashboard/argo/proxy/api/v1/applications` returns ArgoCD data instead of 502
- [ ] Verify Grafana proxy still works at `kbve.com/dashboard/grafana/proxy/`