### PR TITLE
feat(astro-kbve): add npcdb content collection and API endpoint

### DIFF
--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -9,6 +9,7 @@ import {
 	IObjectSchema,
 	IQuestSchema,
 	IMapObjectSchema,
+	INpcSchema,
 	OSRSExtendedSchema,
 } from '@/data/schema';
 
@@ -75,6 +76,14 @@ const mapdb = defineCollection({
 	schema: IMapObjectSchema,
 });
 
+const npcdb = defineCollection({
+	loader: glob({
+		pattern: '**/*.mdx',
+		base: './src/content/docs/npcdb',
+	}),
+	schema: INpcSchema,
+});
+
 export const collections = {
 	docs: defineCollection({
 		loader: docsLoader(),
@@ -83,12 +92,14 @@ export const collections = {
 				itemdb: z.array(IObjectSchema).optional(),
 				questdb: z.array(IQuestSchema).optional(),
 				mapdb: z.array(IMapObjectSchema).optional(),
+				npcdb: z.array(INpcSchema).optional(),
 				osrs: OSRSFrontmatterSchema.optional(),
 			}),
 		}),
 	}),
 	itemdb,
 	questdb,
+	npcdb,
 	application,
 	project,
 	mapdb,

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/index.mdx
@@ -1,0 +1,18 @@
+---
+title: 'NPC Database Index'
+description: |
+    Placeholder entry for the NPC database content collection.
+    This file is filtered out during API generation.
+slug: 'npcdb-index'
+id: '00000000000000000000000000'
+name: 'Index'
+type_flags: 0
+rarity: 'uncommon'
+personality: 'stoic'
+rank: 'elite'
+family: 'humanoid'
+level: 0
+drafted: true
+---
+
+NPC Database index — this entry is excluded from the API output.

--- a/apps/kbve/astro-kbve/src/data/schema/INpcSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/INpcSchema.ts
@@ -1,0 +1,97 @@
+/**
+ * Astro content collection schema for npcdb entries.
+ *
+ * Game-logic fields come from the proto-generated NpcSchema
+ * (packages/data/codegen/generated/npcdb-schema.ts).
+ */
+import { z } from 'astro:content';
+import {
+	NpcSchema,
+	NpcTypeFlagSchema,
+	NpcRaritySchema,
+	NpcRankSchema,
+	PersonalitySchema,
+	ElementSchema,
+	CreatureFamilySchema,
+	NpcStatsSchema,
+	NpcAbilitySchema,
+	ElementalAffinitySchema,
+	IntentWeightSchema,
+	BehaviorTraitsSchema,
+	FactionInfoSchema,
+	LootTableSchema,
+	EquipmentLoadoutSchema,
+	FlavorPoolSchema,
+	DialogueLineSchema,
+	DialogueTreeSchema,
+	SpawnRuleSchema,
+	PhaseRuleSchema,
+	DifficultyOverrideSchema,
+	PartyScalingSchema,
+	SpatialPropertiesSchema,
+	InteractionFlagsSchema,
+	NpcExtensionSchema,
+} from '../../../../../../packages/data/codegen/generated/npcdb-schema';
+
+// Re-export generated types for downstream consumers
+export {
+	NpcTypeFlagSchema,
+	NpcRaritySchema,
+	NpcRankSchema,
+	PersonalitySchema,
+	ElementSchema,
+	CreatureFamilySchema,
+	NpcStatsSchema,
+	NpcAbilitySchema,
+	ElementalAffinitySchema,
+	IntentWeightSchema,
+	BehaviorTraitsSchema,
+	FactionInfoSchema,
+	LootTableSchema,
+	EquipmentLoadoutSchema,
+	FlavorPoolSchema,
+	DialogueLineSchema,
+	DialogueTreeSchema,
+	SpawnRuleSchema,
+	PhaseRuleSchema,
+	DifficultyOverrideSchema,
+	PartyScalingSchema,
+	SpatialPropertiesSchema,
+	InteractionFlagsSchema,
+	NpcExtensionSchema,
+};
+export type {
+	Npc,
+	NpcTypeFlag,
+	NpcRarityValue,
+	NpcRankValue,
+	PersonalityValue,
+	ElementValue,
+	CreatureFamilyValue,
+	NpcStats,
+	NpcAbility,
+	ElementalAffinity,
+	IntentWeight,
+	BehaviorTraits,
+	FactionInfo,
+	LootTable,
+	EquipmentLoadout,
+	FlavorPool,
+	DialogueLine,
+	DialogueTree,
+	SpawnRule,
+	PhaseRule,
+	DifficultyOverride,
+	PartyScaling,
+	SpatialProperties,
+	InteractionFlags,
+	NpcExtension,
+} from '../../../../../../packages/data/codegen/generated/npcdb-schema';
+
+// ---------------------------------------------------------------------------
+// Combined schema — proto source of truth, merged with Astro extras
+// ---------------------------------------------------------------------------
+
+export const INpcSchema = NpcSchema.passthrough();
+
+export type INpc = z.infer<typeof INpcSchema>;

--- a/apps/kbve/astro-kbve/src/data/schema/index.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './IObjectSchema';
 export * from './IQuestSchema';
 export * from './IMapSchema';
+export * from './INpcSchema';
 export * from './osrs';

--- a/apps/kbve/astro-kbve/src/pages/api/npcdb.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/npcdb.json.ts
@@ -1,0 +1,57 @@
+import { getCollection } from 'astro:content';
+import type { INpc } from '@/data/schema';
+
+export const GET = async () => {
+	const npcEntries = (await getCollection('npcdb')).filter(
+		(entry) =>
+			!entry.id.endsWith('index.mdx') && entry.data.drafted !== true,
+	);
+
+	const npcs: INpc[] = [];
+	const index: Record<string, number> = {};
+
+	for (const entry of npcEntries) {
+		const { id, slug, name } = entry.data;
+		if (!id || !slug || !name) continue;
+
+		const npc = {
+			...entry.data,
+		};
+
+		const idx = npcs.length;
+		npcs.push(npc as INpc);
+
+		index[id] = idx;
+		index[slug] = idx;
+		index[name] = idx;
+	}
+
+	validateNpcUniqueness(npcs);
+
+	return new Response(JSON.stringify({ npcs, index }, null, 2), {
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	});
+};
+
+function validateNpcUniqueness(npcs: INpc[]) {
+	const seenIds = new Set<string>();
+	const seenSlugs = new Set<string>();
+	const seenNames = new Set<string>();
+
+	for (const npc of npcs) {
+		if (seenIds.has(npc.id)) {
+			throw new Error(`Duplicate NPC id detected: ${npc.id}`);
+		}
+		if (seenSlugs.has(npc.slug)) {
+			throw new Error(`Duplicate NPC slug detected: ${npc.slug}`);
+		}
+		if (seenNames.has(npc.name)) {
+			throw new Error(`Duplicate NPC name detected: ${npc.name}`);
+		}
+		seenIds.add(npc.id);
+		seenSlugs.add(npc.slug);
+		seenNames.add(npc.name);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `INpcSchema.ts` — Astro content schema wrapping the proto-generated `NpcSchema` from `npcdb-schema.ts`
- Registers `npcdb` content collection in `content.config.ts` (glob loader for `src/content/docs/npcdb/**/*.mdx`)
- Adds `/api/npcdb.json.ts` API endpoint with uniqueness validation (id, slug, name)
- Creates placeholder `index.mdx` (drafted, filtered from API output)

## Test plan
- [ ] Verify Astro build passes with the new collection
- [ ] Add an NPC MDX entry and confirm it validates against the schema
- [ ] Hit `/api/npcdb.json` and verify JSON structure matches `{ npcs, index }`
- [ ] Populate with discordsh NPCs after merge