### PR TITLE
fix(kube): move hardcoded MC RCON password to SealedSecret

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -80,7 +80,10 @@ spec:
                       - name: MC_RCON_PORT
                         value: '25575'
                       - name: MC_RCON_PASSWORD
-                        value: 'kbve-rcon'
+                        valueFrom:
+                            secretKeyRef:
+                                name: mc-rcon
+                                key: rcon-password
                       - name: GRAFANA_UPSTREAM_URL
                         value: 'http://monitoring-grafana.monitoring.svc.cluster.local:80'
                       - name: ARGOCD_UPSTREAM_URL

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: kbve
 resources:
     - kbve-serviceaccount.yaml
     - kbve-externalsecret.yaml
+    - mc-rcon-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml
     - kbve-deployment.yaml

--- a/apps/kube/kbve/manifest/mc-rcon-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/mc-rcon-externalsecret.yaml
@@ -1,0 +1,45 @@
+# SecretStore: pull secrets from mc namespace via kbve-external-secrets SA
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: mc-remote-secret-store
+    namespace: kbve
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: mc
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: sync mc-rcon-secret from mc namespace into kbve namespace
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: kbve-mc-rcon-secret
+    namespace: kbve
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: mc-remote-secret-store
+        kind: SecretStore
+    target:
+        name: mc-rcon
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                rcon-password: '{{ .rconpassword }}'
+    data:
+        - secretKey: rconpassword
+          remoteRef:
+              key: mc-rcon-secret
+              property: rcon-password

--- a/apps/kube/mc/manifest/mc-rcon-sealedsecret.yaml
+++ b/apps/kube/mc/manifest/mc-rcon-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: mc-rcon-secret
+    namespace: mc
+spec:
+    encryptedData:
+        rcon-password: AgA8j3RValSbdxUxY4x61tw7KVyYRN71F6/J4O88W2oz5RDz9oQmrxzjyxNT/71iZn/x2gjP9m3no4jtK1HiE5g/TJjAnqeuMscUPMaJLAJdZpgBa54GGRU3WdILIKeGls8yTyBI1xIgXDXbiPNXHg14yC0XkyXMle2gvZT9owrs2mj2NN8Swuit92Qa9XVzfM2/7SFS3DLA5FuVECJ+P0eZL4eu3PWcYQtfGpXXxceLN+3/00fYEBMlVLWbgOGPSa4qzOO98B/SVQ9GhXJA9owSpJBpDujdIumPrOGE+3TE4HgqTvgPD3IRulCrumfFbU+Qo7vcSepmxKNugXkumqxQwWzSmyDl8priC/8azSp34K8J3q094Mvg41rIxnKk+FR44lUvf2JnqGkmT8tP5AclSH+sux7PcDVavVTlBCLE/gpF1HZV9hiLHE/dCiMRTHfXHkKAdzLJ7eZi4g9IvlbV90ebK7/NC1w744+4XusaqxROoBuvxU9xGtExS1EXgqm2gIpfJvLDRpZIP56yyv4Kx55LthryHi9ay1SFB7StLCghQFL2nINNU1eU29XkOin1Xo6Bm0K0h8PNiCISa+1ToMZKVxOlEyEH6gBfybaENhOtiESZq+Ch4Bme/EqseRtKvkcsqo6eJTi2WSSrxJCcw2NtJyIkJCYkarwS9GVslLhQkYraYzJYxcy6SqIygR0mgeMnzPtLcxw=
+    template:
+        metadata:
+            name: mc-rcon-secret
+            namespace: mc

--- a/apps/kube/mc/manifest/rcon-rbac.yaml
+++ b/apps/kube/mc/manifest/rcon-rbac.yaml
@@ -1,0 +1,29 @@
+# RBAC to allow kbve namespace to read the mc-rcon-secret from mc namespace
+# This enables the kbve SecretStore to pull the RCON password via ExternalSecret
+---
+# Role in mc namespace that grants access to mc-rcon-secret only
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: rcon-secret-reader
+    namespace: mc
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['mc-rcon-secret']
+      verbs: ['get', 'list', 'watch']
+---
+# RoleBinding to allow kbve-external-secrets SA to read secrets in mc namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-read-rcon-secret
+    namespace: mc
+subjects:
+    - kind: ServiceAccount
+      name: kbve-external-secrets
+      namespace: kbve
+roleRef:
+    kind: Role
+    name: rcon-secret-reader
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/kube/mc/seal-rcon-password.sh
+++ b/apps/kube/mc/seal-rcon-password.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# seal-rcon-password.sh — Seal the MC RCON password
+#
+# Pipeline that:
+#   1. Prompts for (or reads from env) the RCON password
+#   2. Wraps it in a Kubernetes Secret (kubectl --dry-run)
+#   3. Encrypts it via kubeseal (cluster public key)
+#   4. Writes ONLY the SealedSecret YAML to the repo
+#
+# The plaintext password exists only in memory between pipe stages.
+# It never touches disk, shell history, or git.
+#
+# Prerequisites:
+#   - kubectl configured with cluster access
+#   - kubeseal installed (brew install kubeseal)
+#   - sealed-secrets-controller running in kube-system
+#
+# Usage:
+#   ./seal-rcon-password.sh
+#   # or: MC_RCON_PASSWORD=<value> ./seal-rcon-password.sh
+#   # Output: apps/kube/mc/manifest/mc-rcon-sealedsecret.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_FILE="${SCRIPT_DIR}/manifest/mc-rcon-sealedsecret.yaml"
+TARGET_NS="mc"
+
+# --- Preflight checks ---
+
+for cmd in kubectl kubeseal; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is not installed or not in PATH" >&2
+        exit 1
+    fi
+done
+
+if ! kubectl cluster-info &>/dev/null; then
+    echo "Error: Cannot connect to Kubernetes cluster" >&2
+    exit 1
+fi
+
+if ! kubectl get deployment sealed-secrets-controller -n kube-system &>/dev/null; then
+    echo "Error: sealed-secrets-controller not found in kube-system namespace" >&2
+    exit 1
+fi
+
+# --- Get password ---
+
+if [[ -z "${MC_RCON_PASSWORD:-}" ]]; then
+    echo -n "Enter RCON password: "
+    read -rs MC_RCON_PASSWORD
+    echo
+fi
+
+if [[ -z "${MC_RCON_PASSWORD}" ]]; then
+    echo "Error: RCON password cannot be empty" >&2
+    exit 1
+fi
+
+# --- Seal the password ---
+
+echo "Sealing RCON password..."
+
+echo -n "${MC_RCON_PASSWORD}" \
+| kubectl create secret generic mc-rcon-secret \
+    --namespace="${TARGET_NS}" \
+    --from-file=rcon-password=/dev/stdin \
+    --dry-run=client \
+    -o yaml \
+| kubeseal \
+    --controller-name=sealed-secrets-controller \
+    --controller-namespace=kube-system \
+    --format=yaml \
+> "${OUTPUT_FILE}"
+
+echo ""
+echo "Sealed secret written to: ${OUTPUT_FILE}"
+echo "Plaintext password was never written to disk."
+echo ""
+echo "Next steps:"
+echo "  1. git add ${OUTPUT_FILE}"
+echo "  2. Add mc-rcon-sealedsecret.yaml to kustomization.yaml"
+echo "  3. Commit and push — ArgoCD will sync the SealedSecret"
+echo "  4. Update kbve-deployment.yaml to use secretKeyRef"


### PR DESCRIPTION
## Summary
- Remove hardcoded `MC_RCON_PASSWORD: 'kbve-rcon'` from kbve-deployment.yaml
- Create SealedSecret (`mc-rcon-secret`) in mc namespace via `seal-rcon-password.sh`
- Add scoped RBAC (Role + RoleBinding) so kbve-external-secrets SA can read only `mc-rcon-secret` from mc namespace
- Add SecretStore + ExternalSecret to sync the RCON password into kbve namespace as `mc-rcon` secret
- Update deployment to use `secretKeyRef` instead of plain-text value
- All dry-runs pass against the live cluster

## Test plan
- [ ] ArgoCD syncs mc namespace (SealedSecret + RBAC)
- [ ] ArgoCD syncs kbve namespace (ExternalSecret + updated deployment)
- [ ] ExternalSecret status shows `SecretSynced`
- [ ] kbve pod starts successfully with RCON password from secret
- [ ] MC RCON connectivity still works