### PR TITLE
fix(mc): patch CVE-2026-22184 zlib vulnerability in mc-rust-base

### DIFF
--- a/apps/mc/Dockerfile.base
+++ b/apps/mc/Dockerfile.base
@@ -11,7 +11,7 @@
 # --- Toolchain: install cargo-chef + rust toolchain (NO source) ---
 FROM rust:1.94-alpine3.23 AS chef
 ENV RUSTFLAGS="-C target-feature=-crt-static"
-RUN apk add --no-cache musl-dev git
+RUN apk upgrade --no-cache && apk add --no-cache musl-dev git
 RUN cargo install cargo-chef --locked \
     && rm -rf /usr/local/cargo/registry/src /usr/local/cargo/registry/cache
 WORKDIR /pumpkin


### PR DESCRIPTION
## Summary
- Add `apk upgrade --no-cache` before `apk add` in `Dockerfile.base` to pull patched `zlib 1.3.2-r0`
- Fixes Trivy scan failure: `CVE-2026-22184` (CRITICAL) — arbitrary code execution via buffer overflow in zlib's untgz utility
- The `rust:1.94-alpine3.23` base ships `zlib 1.3.1-r2` which is vulnerable

## Test Plan
- CI base image build should pass Trivy CRITICAL/HIGH scan
- No functional changes — only upgrades system packages before installing build deps