### PR TITLE
feat(npcdb): populate npcdb with 23 discordsh dungeon NPCs

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/bone-archer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/bone-archer.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Bone Archer'
+description: |
+    A skeletal figure that draws a creaking bow with trembling, bony fingers.
+slug: 'bone-archer'
+id: '01KKR5QWTA6KARZ9EQB9Y476S4'
+name: 'Bone Archer'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'fearful'
+rank: 'elite'
+family: 'undead'
+level: 2
+stats:
+    hp: 22
+    max_hp: 22
+    attack: 7
+    defense: 1
+    speed: 4
+    armor: 1
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    In life they were conscript archers, and in death their muscle memory persists — though their aim wavers with fear.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A skeletal figure that draws a creaking bow with trembling, bony fingers.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/cave-spider.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/cave-spider.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Cave Spider'
+description: |
+    A pale spider that lurks in dungeon shadows, striking first with venomous fangs.
+slug: 'cave-spider'
+id: '01KKR5QWTARVPDS4ENXBK4MBD2'
+name: 'Cave Spider'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'feral'
+rank: 'elite'
+family: 'beast'
+element: 'poison'
+level: 1
+stats:
+    hp: 14
+    max_hp: 14
+    attack: 3
+    defense: 0
+    speed: 7
+    armor: 0
+behavior:
+    movement_type: 'random_wander'
+    first_strike: true
+lore: |
+    Cave Spiders weave nearly invisible webs across dungeon passages, paralyzing prey with a single bite.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A pale spider that lurks in dungeon shadows, striking first with venomous fangs.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/corrupted-warden.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/corrupted-warden.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Corrupted Warden'
+description: |
+    Once a noble guardian, now twisted by dark energy into a relentless engine of destruction.
+slug: 'corrupted-warden'
+id: '01KKR5QWTB3TXCY87HZXFHYFYG'
+name: 'Corrupted Warden'
+type_flags: 33
+rarity: 'epic'
+personality: 'aggressive'
+rank: 'rare_elite'
+family: 'humanoid'
+element: 'shadow'
+level: 5
+stats:
+    hp: 50
+    max_hp: 50
+    attack: 8
+    defense: 10
+    speed: 4
+    armor: 10
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    The Corrupted Warden was the dungeon's most loyal protector until dark magic seeped into its very soul, turning devotion into obsession.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+Once a noble guardian, now twisted by dark energy into a relentless engine of destruction.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/crumbling-statue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/crumbling-statue.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Crumbling Statue'
+description: |
+    An ancient stone figure that stirs to life when intruders approach, defending its post with weathered resolve.
+slug: 'crumbling-statue'
+id: '01KKR5QWTADGEX9BC9H29E0YB9'
+name: 'Crumbling Statue'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'stoic'
+rank: 'elite'
+family: 'construct'
+element: 'earth'
+level: 1
+stats:
+    hp: 22
+    max_hp: 22
+    attack: 4
+    defense: 3
+    speed: 1
+    armor: 2
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Once proud guardians of a forgotten temple, these statues continue their vigil long after their creators turned to dust.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+An ancient stone figure that stirs to life when intruders approach, defending its post with weathered resolve.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/crystal-bat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/crystal-bat.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Crystal Bat'
+description: |
+    A small bat with crystalline wings that catch the light, darting through dark caverns.
+slug: 'crystal-bat'
+id: '01KKR5QWTAMADFK3GY8Q47GQ6N'
+name: 'Crystal Bat'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'feral'
+rank: 'elite'
+family: 'beast'
+level: 1
+stats:
+    hp: 15
+    max_hp: 15
+    attack: 4
+    defense: 0
+    speed: 6
+    armor: 0
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Crystal Bats roost in mineral-rich caves, their wings slowly encrusted with gemstone formations.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A small bat with crystalline wings that catch the light, darting through dark caverns.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/crystal-golem.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/crystal-golem.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Crystal Golem'
+description: |
+    A towering construct of living crystal that charges through obstacles, its body refracting light into blinding rainbows.
+slug: 'crystal-golem'
+id: '01KKR5QWTBC89E1XJHM3CZ5SRK'
+name: 'Crystal Golem'
+type_flags: 1
+rarity: 'epic'
+personality: 'stoic'
+rank: 'elite'
+family: 'construct'
+element: 'arcane'
+level: 3
+stats:
+    hp: 45
+    max_hp: 45
+    attack: 8
+    defense: 8
+    speed: 2
+    armor: 8
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Crystal Golems were forged in the heart of a dying star, their bodies nearly indestructible and infused with raw magical energy.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A towering construct of living crystal that charges through obstacles, its body refracting light into blinding rainbows.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/cursed-knight.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/cursed-knight.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Cursed Knight'
+description: |
+    A heavily armored undead warrior consumed by rage, cursed to fight for eternity.
+slug: 'cursed-knight'
+id: '01KKR5QWTBV72R8B4V4JBNG308'
+name: 'Cursed Knight'
+type_flags: 1
+rarity: 'rare'
+personality: 'aggressive'
+rank: 'elite'
+family: 'undead'
+element: 'shadow'
+level: 2
+stats:
+    hp: 35
+    max_hp: 35
+    attack: 6
+    defense: 5
+    speed: 3
+    armor: 5
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Once noble champions, these knights fell to a dark curse that twisted their valor into unending fury.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A heavily armored undead warrior consumed by rage, cursed to fight for eternity.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/dust-mite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/dust-mite.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Dust Mite'
+description: |
+    A near-invisible arthropod that strikes with surprising ferocity for its minuscule size.
+slug: 'dust-mite'
+id: '01KKR5QWTA8JDZGRMHM21CR2J1'
+name: 'Dust Mite'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'feral'
+rank: 'elite'
+family: 'beast'
+level: 1
+stats:
+    hp: 12
+    max_hp: 12
+    attack: 6
+    defense: 0
+    speed: 8
+    armor: 0
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Dust Mites thrive in forgotten ruins, feeding on magical residue left behind by ancient civilizations.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A near-invisible arthropod that strikes with surprising ferocity for its minuscule size.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/ember-wisp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/ember-wisp.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Ember Wisp'
+description: |
+    A floating orb of pale fire that drifts through corridors, leaving trails of burning air.
+slug: 'ember-wisp'
+id: '01KKR5QWTBPWP2WD71838AMPZB'
+name: 'Ember Wisp'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'fearful'
+rank: 'elite'
+family: 'elemental'
+element: 'fire'
+level: 2
+stats:
+    hp: 16
+    max_hp: 16
+    attack: 4
+    defense: 0
+    speed: 5
+    armor: 0
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Ember Wisps are fragments of dying fire elementals, flickering between existence and oblivion.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A floating orb of pale fire that drifts through corridors, leaving trails of burning air.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/fire-imp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/fire-imp.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Fire Imp'
+description: |
+    A small demonic creature wreathed in flame, cackling as it hurls fireballs at anything that moves.
+slug: 'fire-imp'
+id: '01KKR5QWTBNKBVAN8J4168AFRW'
+name: 'Fire Imp'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'fearful'
+rank: 'elite'
+family: 'demon'
+element: 'fire'
+level: 2
+stats:
+    hp: 18
+    max_hp: 18
+    attack: 8
+    defense: 0
+    speed: 6
+    armor: 0
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Fire Imps are summoned servants that outlived their masters, now running wild in the dungeon depths.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A small demonic creature wreathed in flame, cackling as it hurls fireballs at anything that moves.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/fungal-brute.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/fungal-brute.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Fungal Brute'
+description: |
+    A massive fungal creature that lumbers forward with devastating force, its body thick with toxic spores.
+slug: 'fungal-brute'
+id: '01KKR5QWTB7S5FY2HNXJN5Y4NY'
+name: 'Fungal Brute'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'feral'
+rank: 'elite'
+family: 'plant'
+element: 'poison'
+level: 2
+stats:
+    hp: 38
+    max_hp: 38
+    attack: 10
+    defense: 2
+    speed: 2
+    armor: 2
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Fungal Brutes grow in the deepest caverns, their bodies an amalgamation of countless smaller fungi merged into one hulking mass.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A massive fungal creature that lumbers forward with devastating force, its body thick with toxic spores.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/glass-assassin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/glass-assassin.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Glass Assassin'
+description: |
+    A humanoid figure made of living glass that strikes with lethal precision, its transparent body nearly invisible.
+slug: 'glass-assassin'
+id: '01KKR5QWTBH0QF9K030QMZFQWC'
+name: 'Glass Assassin'
+type_flags: 1
+rarity: 'rare'
+personality: 'cunning'
+rank: 'elite'
+family: 'construct'
+level: 3
+stats:
+    hp: 22
+    max_hp: 22
+    attack: 10
+    defense: 1
+    speed: 9
+    armor: 1
+behavior:
+    movement_type: 'random_wander'
+    first_strike: true
+lore: |
+    Glass Assassins were created as perfect killers — transparent, silent, and razor-sharp.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A humanoid figure made of living glass that strikes with lethal precision, its transparent body nearly invisible.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/glass-golem.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/glass-golem.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Glass Golem'
+description: |
+    An enormous golem of fused glass that towers over all challengers, its body a maze of razor-sharp edges.
+slug: 'glass-golem'
+id: '01KKR5QWTBJ3ZFEHR24YGT6VYX'
+name: 'Glass Golem'
+type_flags: 33
+rarity: 'epic'
+personality: 'stoic'
+rank: 'rare_elite'
+family: 'construct'
+element: 'arcane'
+level: 5
+stats:
+    hp: 60
+    max_hp: 60
+    attack: 10
+    defense: 8
+    speed: 3
+    armor: 8
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    The Glass Golem was created as a final guardian, its body forged from the crystallized tears of a dying god.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+An enormous golem of fused glass that towers over all challengers, its body a maze of razor-sharp edges.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/glass-slime.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/glass-slime.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Glass Slime'
+description: |
+    A translucent blob of living glass that oozes through dungeon corridors, absorbing anything it touches.
+slug: 'glass-slime'
+id: '01KKR5QWT9998CCD18XN2B3726'
+name: 'Glass Slime'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'feral'
+rank: 'elite'
+family: 'aberration'
+level: 1
+stats:
+    hp: 20
+    max_hp: 20
+    attack: 5
+    defense: 0
+    speed: 3
+    armor: 0
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Born from shattered crystal and ambient mana, Glass Slimes are among the first threats dungeon delvers encounter.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A translucent blob of living glass that oozes through dungeon corridors, absorbing anything it touches.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/mushroom-sprite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/mushroom-sprite.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Mushroom Sprite'
+description: |
+    A tiny fungal creature that bounces erratically, releasing clouds of irritating spores.
+slug: 'mushroom-sprite'
+id: '01KKR5QWTAJEKFBFF31JNDW8Q9'
+name: 'Mushroom Sprite'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'feral'
+rank: 'elite'
+family: 'plant'
+element: 'poison'
+level: 1
+stats:
+    hp: 18
+    max_hp: 18
+    attack: 4
+    defense: 0
+    speed: 4
+    armor: 0
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Mushroom Sprites are animated by deep earth magic, tending underground fungal gardens when not disturbed.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A tiny fungal creature that bounces erratically, releasing clouds of irritating spores.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/phantom-knight.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/phantom-knight.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Phantom Knight'
+description: |
+    The ghost of a fallen knight that charges through the battlefield, armor clanking with otherworldly echoes.
+slug: 'phantom-knight'
+id: '01KKR5QWTB1TRDD9W2D6MFNME5'
+name: 'Phantom Knight'
+type_flags: 1
+rarity: 'rare'
+personality: 'aggressive'
+rank: 'elite'
+family: 'spirit'
+element: 'shadow'
+level: 3
+stats:
+    hp: 28
+    max_hp: 28
+    attack: 8
+    defense: 4
+    speed: 5
+    armor: 4
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Phantom Knights died in battles they believed unjust, and now fight an eternal war against all who cross their path.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+The ghost of a fallen knight that charges through the battlefield, armor clanking with otherworldly echoes.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/shade-stalker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/shade-stalker.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Shade Stalker'
+description: |
+    A dark figure that moves between shadows, striking before its prey even knows it is there.
+slug: 'shade-stalker'
+id: '01KKR5QWTBAF71Q1NJTD7RZKEW'
+name: 'Shade Stalker'
+type_flags: 1
+rarity: 'rare'
+personality: 'cunning'
+rank: 'elite'
+family: 'spirit'
+element: 'shadow'
+level: 2
+stats:
+    hp: 20
+    max_hp: 20
+    attack: 8
+    defense: 1
+    speed: 8
+    armor: 1
+behavior:
+    movement_type: 'random_wander'
+    first_strike: true
+lore: |
+    Shade Stalkers are remnants of assassins who died mid-hunt, their killing intent crystallized into spectral form.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A dark figure that moves between shadows, striking before its prey even knows it is there.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/shadow-wraith.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/shadow-wraith.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Shadow Wraith'
+description: |
+    A ghostly figure that phases through walls, delivering devastating blows from the darkness.
+slug: 'shadow-wraith'
+id: '01KKR5QWTBF2XX7BG384X7V5V1'
+name: 'Shadow Wraith'
+type_flags: 1
+rarity: 'rare'
+personality: 'cunning'
+rank: 'elite'
+family: 'spirit'
+element: 'shadow'
+level: 3
+stats:
+    hp: 25
+    max_hp: 25
+    attack: 12
+    defense: 2
+    speed: 7
+    armor: 2
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Shadow Wraiths are formed from concentrated malice, hunting the living to feed their insatiable hunger.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A ghostly figure that phases through walls, delivering devastating blows from the darkness.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/skeleton-guard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/skeleton-guard.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Skeleton Guard'
+description: |
+    A reanimated skeleton clad in rusted armor, standing eternal watch over dusty corridors.
+slug: 'skeleton-guard'
+id: '01KKR5QWTAEV48Y4WK51JWBXTX'
+name: 'Skeleton Guard'
+type_flags: 1
+rarity: 'uncommon'
+personality: 'stoic'
+rank: 'elite'
+family: 'undead'
+level: 2
+stats:
+    hp: 30
+    max_hp: 30
+    attack: 5
+    defense: 5
+    speed: 3
+    armor: 3
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Skeleton Guards are bound by ancient oaths that persist beyond death, endlessly patrolling their designated posts.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A reanimated skeleton clad in rusted armor, standing eternal watch over dusty corridors.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/stone-sentinel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/stone-sentinel.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Stone Sentinel'
+description: |
+    A massive stone construct that defends its territory with unwavering determination and crushing force.
+slug: 'stone-sentinel'
+id: '01KKR5QWTB0Y8E1VSW19X56NVW'
+name: 'Stone Sentinel'
+type_flags: 1
+rarity: 'rare'
+personality: 'stoic'
+rank: 'elite'
+family: 'construct'
+element: 'earth'
+level: 3
+stats:
+    hp: 40
+    max_hp: 40
+    attack: 6
+    defense: 6
+    speed: 2
+    armor: 6
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Stone Sentinels were crafted by master artisans to guard vaults of immense importance, and they have never abandoned their duty.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A massive stone construct that defends its territory with unwavering determination and crushing force.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/the-shattered-king.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/the-shattered-king.mdx
@@ -1,0 +1,31 @@
+---
+title: 'The Shattered King'
+description: |
+    An ancient ruler whose fractured body radiates immense power, speaking in riddles of ages past.
+slug: 'the-shattered-king'
+id: '01KKR5QWTCHDFP2XHQEZMR3J4F'
+name: 'The Shattered King'
+type_flags: 33
+rarity: 'legendary'
+personality: 'ancient'
+rank: 'world_boss'
+family: 'undead'
+element: 'shadow'
+level: 5
+stats:
+    hp: 55
+    max_hp: 55
+    attack: 8
+    defense: 6
+    speed: 5
+    armor: 6
+behavior:
+    movement_type: 'random_wander'
+    first_strike: true
+lore: |
+    The Shattered King once ruled an empire that spanned continents. When his kingdom fell, his rage shattered his own crown and bound his soul to the ruins forever.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+An ancient ruler whose fractured body radiates immense power, speaking in riddles of ages past.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/venomfang-lurker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/venomfang-lurker.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Venomfang Lurker'
+description: |
+    A serpentine creature that coils in darkness, delivering multiple doses of deadly venom before its prey can react.
+slug: 'venomfang-lurker'
+id: '01KKR5QWTBD4Y94FSMS25SR13H'
+name: 'Venomfang Lurker'
+type_flags: 1
+rarity: 'rare'
+personality: 'feral'
+rank: 'elite'
+family: 'beast'
+element: 'poison'
+level: 3
+stats:
+    hp: 26
+    max_hp: 26
+    attack: 6
+    defense: 3
+    speed: 7
+    armor: 3
+behavior:
+    movement_type: 'random_wander'
+    first_strike: true
+lore: |
+    Venomfang Lurkers have evolved venom so potent that a single bite can fell creatures many times their size.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A serpentine creature that coils in darkness, delivering multiple doses of deadly venom before its prey can react.

--- a/apps/kbve/astro-kbve/src/content/docs/npcdb/void-walker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/npcdb/void-walker.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Void Walker'
+description: |
+    A being that exists between planes, striking from impossible angles with reality-bending attacks.
+slug: 'void-walker'
+id: '01KKR5QWTBFFJ36ZASQAVP8WN0'
+name: 'Void Walker'
+type_flags: 1
+rarity: 'rare'
+personality: 'cunning'
+rank: 'elite'
+family: 'aberration'
+element: 'arcane'
+level: 3
+stats:
+    hp: 30
+    max_hp: 30
+    attack: 10
+    defense: 3
+    speed: 6
+    armor: 3
+behavior:
+    movement_type: 'random_wander'
+    first_strike: false
+lore: |
+    Void Walkers slip through cracks in reality, drawn to places where the boundaries between worlds grow thin.
+credits: |
+    Ported from KBVE DiscordSH dungeon crawler.
+---
+
+A being that exists between planes, striking from impossible angles with reality-bending attacks.


### PR DESCRIPTION
## Summary
- Adds 23 NPC MDX entries ported from the DiscordSH dungeon crawler (`content.rs`)
- Covers all 4 difficulty brackets: Level 1 (6 NPCs), Level 2 (7 NPCs), Level 3 (7 NPCs), Boss (3 NPCs)
- Each entry includes full stats (hp, attack, defense, speed, armor), personality, creature family, element, behavior traits, lore, and unique ULID
- Bosses: Glass Golem, Corrupted Warden, The Shattered King (world_boss, legendary)

## NPC Breakdown
| Bracket | Level | NPCs |
|---------|-------|------|
| Starter | 1 | Glass Slime, Crystal Bat, Mushroom Sprite, Dust Mite, Cave Spider, Crumbling Statue |
| Mid | 2 | Skeleton Guard, Bone Archer, Cursed Knight, Fire Imp, Shade Stalker, Fungal Brute, Ember Wisp |
| Advanced | 3 | Shadow Wraith, Phantom Knight, Void Walker, Stone Sentinel, Glass Assassin, Venomfang Lurker, Crystal Golem |
| Boss | 5 | Glass Golem, Corrupted Warden, The Shattered King |

## Test plan
- [ ] Verify Astro build validates all 23 entries against `INpcSchema`
- [ ] Hit `/api/npcdb.json` and confirm all NPCs appear with correct stats
- [ ] Verify uniqueness validation passes (no duplicate id/slug/name)