### PR TITLE
fix(ci): bump Node 20 actions and guard MC Rust toolchain

### DIFF
--- a/.github/workflows/ci-monday-e2e.yml
+++ b/.github/workflows/ci-monday-e2e.yml
@@ -35,17 +35,17 @@ jobs:
             has_projects: ${{ steps.matrix.outputs.has_projects }}
         steps:
             - name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@v6
               with:
                   ref: ${{ inputs.branch || 'dev' }}
 
             - name: Setup Node v24
-              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+              uses: pnpm/action-setup@v4
               with:
                   version: 10
                   run_install: false
@@ -137,7 +137,7 @@ jobs:
             contents: read
         steps:
             - name: Download test markers
-              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+              uses: actions/download-artifact@v8
               with:
                   pattern: test-passed-docker-*
                   path: ./test-results

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -158,7 +158,7 @@ jobs:
 
             - name: Set up QEMU
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@v4
 
             - name: Set up Docker Buildx
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}

--- a/.github/workflows/utils-self-hosted-job.yml
+++ b/.github/workflows/utils-self-hosted-job.yml
@@ -244,7 +244,7 @@ jobs:
             # ── Toolchain: Docker ─────────────────────────────────
             - name: Set up QEMU
               if: inputs.setup_docker
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@v4
 
             - name: Set up Docker Buildx
               if: inputs.setup_docker

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -69,6 +69,8 @@ FROM ${BASE_IMAGE} AS core
 # --- Pumpkin: build server (parallel with plugin) ---
 #     Copy full workspace so source is always fresh even if the base image is stale.
 FROM core AS builder
+COPY ./apps/mc/pumpkin/rust-toolchain.toml /pumpkin/rust-toolchain.toml
+RUN rustup show active-toolchain || rustup toolchain install
 COPY ./apps/mc/pumpkin/Cargo.toml ./apps/mc/pumpkin/Cargo.lock /pumpkin/
 COPY ./apps/mc/pumpkin/assets /pumpkin/assets
 COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
@@ -88,6 +90,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
 
 # --- Plugin: build (parallel with pumpkin, reuses all pre-compiled crates) ---
 FROM core AS plugin-builder
+COPY ./apps/mc/pumpkin/rust-toolchain.toml /pumpkin/rust-toolchain.toml
+RUN rustup show active-toolchain || rustup toolchain install
 COPY ./apps/mc/pumpkin/Cargo.toml ./apps/mc/pumpkin/Cargo.lock /pumpkin/
 COPY ./apps/mc/pumpkin/assets /pumpkin/assets
 COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin

--- a/apps/mc/Dockerfile.dev
+++ b/apps/mc/Dockerfile.dev
@@ -70,6 +70,8 @@ FROM ${BASE_IMAGE} AS core
 #     Copy full workspace so source is always fresh even if the base image is stale.
 #     The base image still provides cached .rlib artifacts for incremental builds.
 FROM core AS builder
+COPY ./apps/mc/pumpkin/rust-toolchain.toml /pumpkin/rust-toolchain.toml
+RUN rustup show active-toolchain || rustup toolchain install
 COPY ./apps/mc/pumpkin/Cargo.toml ./apps/mc/pumpkin/Cargo.lock /pumpkin/
 COPY ./apps/mc/pumpkin/assets /pumpkin/assets
 COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin
@@ -89,6 +91,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
 
 # --- Plugin: build (parallel with pumpkin, reuses all pre-compiled crates) ---
 FROM core AS plugin-builder
+COPY ./apps/mc/pumpkin/rust-toolchain.toml /pumpkin/rust-toolchain.toml
+RUN rustup show active-toolchain || rustup toolchain install
 COPY ./apps/mc/pumpkin/Cargo.toml ./apps/mc/pumpkin/Cargo.lock /pumpkin/
 COPY ./apps/mc/pumpkin/assets /pumpkin/assets
 COPY ./apps/mc/pumpkin/pumpkin /pumpkin/pumpkin


### PR DESCRIPTION
## Summary
- Bump `docker/setup-qemu-action` from `v3` to `v4` in `utils-publish-docker-image.yml` and `utils-self-hosted-job.yml` (Node.js 20 → 24)
- Remove SHA-pinned actions in `ci-monday-e2e.yml` — use version tags (`@v6`, `@v4`, `@v8`) instead of commit SHAs
- Add `rustup show active-toolchain || rustup toolchain install` guard in MC `Dockerfile` and `Dockerfile.dev` builder/plugin-builder stages to handle stale base images with older Rust versions

## Context
- GitHub will force Node.js 24 on June 2nd, 2026 — `setup-qemu-action@v3` uses Node 20 and will break
- MC dev Docker build fails with `rustc 1.93.1 is not supported` because the cached `:latest` base image is stale (Trivy blocked the last push). The toolchain guard ensures the correct Rust version is installed even when the base image lags behind.

## Test Plan
- CI workflows should no longer emit Node.js 20 deprecation warnings
- MC Docker dev build should succeed with correct Rust toolchain