### PR TITLE
feat(itemdb): add 32 DiscordSH game items to Astro itemdb

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/antidote.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/antidote.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Antidote'
+description: 'A cleansing tonic that removes all negative status effects.'
+slug: 'antidote'
+key: 75
+id: '01KKR7QNRC81EVK4PF70V5E3FR'
+name: 'Antidote'
+type_flags: 544
+consumable: true
+stackable: true
+max_stack: 2
+rarity: 'uncommon'
+buy_price: 45
+emoji: '🧴'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'remove_all_negative' }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/bandage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/bandage.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Bandage'
+description: 'A simple cloth bandage that heals 5 HP and stops bleeding.'
+slug: 'bandage'
+key: 68
+id: '01KKR7QNRCPH4QEYXHHXV2301B'
+name: 'Bandage'
+type_flags: 544
+consumable: true
+stackable: true
+max_stack: 5
+rarity: 'common'
+buy_price: 10
+emoji: '🧷'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'heal', amount: 5 }
+  - { type: 'remove_effect', status_effect: 'bleed' }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/bomb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/bomb.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Bomb'
+description: 'An explosive device that deals 10 damage to a single enemy.'
+slug: 'bomb'
+key: 69
+id: '01KKR7QNRCXEWSCSYHRKEVJ20N'
+name: 'Bomb'
+type_flags: 8704
+consumable: true
+stackable: true
+max_stack: 3
+rarity: 'uncommon'
+buy_price: 50
+emoji: '💣'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'damage_enemy', amount: 10 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/campfire-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/campfire-kit.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Campfire Kit'
+description: 'Set up camp and rest. Heals 50% HP and clears debuffs for the whole party.'
+slug: 'campfire-kit'
+key: 77
+id: '01KKR7QNRCDVADFBQ4TTESGDQA'
+name: 'Campfire Kit'
+type_flags: 8704
+consumable: true
+stackable: true
+max_stack: 1
+rarity: 'rare'
+buy_price: 150
+emoji: '🔥'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'campfire_rest', percent: 50 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/chain-mail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/chain-mail.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Chain Mail'
+description: 'Interlocking metal rings providing solid defense. +4 armor, +5 HP.'
+slug: 'chain-mail'
+key: 93
+id: '01KKR7QNRCHKCKBSFQW8Z8DC7G'
+name: 'Chain Mail'
+type_flags: 514
+consumable: false
+stackable: false
+rarity: 'uncommon'
+buy_price: 80
+emoji: '⛓️'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'chest'
+  bonuses:
+    armor: 4
+    health: 5
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/crystal-armor.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/crystal-armor.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Crystal Armor'
+description: 'Armor forged from enchanted crystal. +6 armor, +10 HP.'
+slug: 'crystal-armor'
+key: 95
+id: '01KKR7QNRC18GWKPEPKM2VDYWM'
+name: 'Crystal Armor'
+type_flags: 514
+consumable: false
+stackable: false
+rarity: 'epic'
+buy_price: 400
+emoji: '💎'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'chest'
+  bonuses:
+    armor: 6
+    health: 10
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/dragon-scale.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/dragon-scale.mdx
@@ -1,0 +1,37 @@
+---
+title: 'Dragon Scale'
+description: 'Scales shed by an ancient dragon, forged into legendary armor. +8 armor, +15 HP, 10% damage reduction.'
+slug: 'dragon-scale'
+key: 98
+id: '01KKR7QNRCD9Z8VG601R379C71'
+name: 'Dragon Scale'
+type_flags: 514
+consumable: false
+stackable: false
+rarity: 'legendary'
+buy_price: 1500
+emoji: '🐉'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'chest'
+  bonuses:
+    armor: 8
+    health: 15
+  special: 'damage_reduction'
+  special_value: 0.1
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/elixir.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/elixir.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Elixir'
+description: 'A legendary potion that fully restores HP to maximum.'
+slug: 'elixir'
+key: 73
+id: '01KKR7QNRCNNPNQD46DYT110R9'
+name: 'Elixir'
+type_flags: 33312
+consumable: true
+stackable: true
+max_stack: 1
+rarity: 'legendary'
+buy_price: 500
+emoji: '✨'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'full_heal' }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/excalibur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/excalibur.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Excalibur'
+description: 'The legendary blade of kings. +6 attack, +5 HP, +10% crit chance.'
+slug: 'excalibur'
+key: 90
+id: '01KKR7QNRCNZ64AGRD8M3H09YP'
+name: 'Excalibur'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'legendary'
+buy_price: 1000
+emoji: '⚔️'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 6
+    health: 5
+    crit_chance: 0.1
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/fire-flask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/fire-flask.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Fire Flask'
+description: 'A flask of volatile liquid that deals 8 damage and inflicts Burning for 3 turns.'
+slug: 'fire-flask'
+key: 80
+id: '01KKR7QNRC7V62X0C8J3ZX22DA'
+name: 'Fire Flask'
+type_flags: 8704
+consumable: true
+stackable: true
+max_stack: 3
+rarity: 'uncommon'
+buy_price: 65
+emoji: '🔥'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'damage_and_apply', amount: 8, status_effect: 'burning', stacks: 2, turns: 3 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/flame-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/flame-axe.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Flame Axe'
+description: 'An axe wreathed in smoldering embers. +4 attack damage.'
+slug: 'flame-axe'
+key: 86
+id: '01KKR7QNRC0XKBPFD6BNWV57SR'
+name: 'Flame Axe'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'rare'
+buy_price: 150
+emoji: '🪓'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 4
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/glass-stiletto.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/glass-stiletto.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Glass Stiletto'
+description: 'A razor-thin blade of enchanted glass. +3 attack, +15% crit chance.'
+slug: 'glass-stiletto'
+key: 89
+id: '01KKR7QNRC6837QFCM9K0BD1N9'
+name: 'Glass Stiletto'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'rare'
+buy_price: 180
+emoji: '🔪'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 3
+    crit_chance: 0.15
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/iron-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/iron-mace.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Iron Mace'
+description: 'A heavy blunt weapon forged from solid iron. +3 attack damage.'
+slug: 'iron-mace'
+key: 88
+id: '01KKR7QNRCCDST7FEYK9CFPX26'
+name: 'Iron Mace'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'uncommon'
+buy_price: 70
+emoji: '🔨'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 3
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/iron-skin-potion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/iron-skin-potion.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Iron Skin Potion'
+description: 'A metallic brew that grants the Shielded effect for 3 turns.'
+slug: 'iron-skin-potion'
+key: 81
+id: '01KKR7QNRCWS11606Z2MJC11QA'
+name: 'Iron Skin Potion'
+type_flags: 544
+consumable: true
+stackable: true
+max_stack: 2
+rarity: 'uncommon'
+buy_price: 55
+emoji: '🛡️'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'apply_effect', status_effect: 'shielded', stacks: 1, turns: 3 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/leather-vest.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/leather-vest.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Leather Vest'
+description: 'A basic leather vest offering modest protection. +2 armor.'
+slug: 'leather-vest'
+key: 92
+id: '01KKR7QNRC3B4Y2629KQY1YDB6'
+name: 'Leather Vest'
+type_flags: 514
+consumable: false
+stackable: false
+rarity: 'common'
+buy_price: 25
+emoji: '🥋'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'chest'
+  bonuses:
+    armor: 2
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/phoenix-feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/phoenix-feather.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Phoenix Feather'
+description: 'A radiant feather that revives a fallen party member at 30% HP.'
+slug: 'phoenix-feather'
+key: 83
+id: '01KKR7QNRCKPV43AZDEN3GMME7'
+name: 'Phoenix Feather'
+type_flags: 10784
+consumable: true
+stackable: true
+max_stack: 1
+rarity: 'epic'
+buy_price: 300
+emoji: '🔥'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'revive_ally', percent: 30 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/potion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/potion.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Potion'
+description: 'A basic healing potion that restores 15 HP.'
+slug: 'potion'
+key: 67
+id: '01KKR7QNRATCW9JB66FKPMYB65'
+name: 'Potion'
+type_flags: 544
+consumable: true
+stackable: true
+max_stack: 5
+rarity: 'common'
+buy_price: 25
+emoji: '🧪'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'heal', amount: 15 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/rage-draught.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/rage-draught.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Rage Draught'
+description: 'A fiery tonic that sharpens your weapon for 4 turns with doubled potency (+6 dmg).'
+slug: 'rage-draught'
+key: 82
+id: '01KKR7QNRC4PXBN13CNS1YR9HY'
+name: 'Rage Draught'
+type_flags: 544
+consumable: true
+stackable: true
+max_stack: 2
+rarity: 'rare'
+buy_price: 100
+emoji: '🧪'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'apply_effect', status_effect: 'sharpened', stacks: 2, turns: 4 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/rations.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/rations.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Rations'
+description: 'Dried travel food that heals 8 HP. Best used out of combat.'
+slug: 'rations'
+key: 71
+id: '01KKR7QNRCTKXB470J4ENW4KCK'
+name: 'Rations'
+type_flags: 520
+consumable: true
+stackable: true
+max_stack: 3
+rarity: 'common'
+buy_price: 15
+emoji: '🍞'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'heal', amount: 8 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/runeguard-plate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/runeguard-plate.mdx
@@ -1,0 +1,37 @@
+---
+title: 'Runeguard Plate'
+description: 'Ancient plate armor inscribed with protective runes. +5 armor, +5 HP, reflects 2 damage.'
+slug: 'runeguard-plate'
+key: 97
+id: '01KKR7QNRC5MQGKPW28R7FR2X6'
+name: 'Runeguard Plate'
+type_flags: 514
+consumable: false
+stackable: false
+rarity: 'rare'
+buy_price: 220
+emoji: '🛡️'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'chest'
+  bonuses:
+    armor: 5
+    health: 5
+  special: 'thorns'
+  special_value: 2
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/rusty-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/rusty-sword.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Rusty Sword'
+description: 'A worn but serviceable blade. Adds +2 attack damage.'
+slug: 'rusty-sword'
+key: 84
+id: '01KKR7QNRCH0N5SPC9X86XRC96'
+name: 'Rusty Sword'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'common'
+buy_price: 30
+emoji: '⚔️'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 2
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/shadow-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/shadow-cloak.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Shadow Cloak'
+description: 'A cloak woven from shadow threads. +3 armor, +1 attack.'
+slug: 'shadow-cloak'
+key: 96
+id: '01KKR7QNRC1W3SZRYP385BX2ST'
+name: 'Shadow Cloak'
+type_flags: 514
+consumable: false
+stackable: false
+rarity: 'uncommon'
+buy_price: 85
+emoji: '🧥'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'chest'
+  bonuses:
+    armor: 3
+    attack: 1
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/shadow-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/shadow-dagger.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Shadow Dagger'
+description: 'A dark-forged dagger that strikes with precision. +3 attack, +5% crit chance.'
+slug: 'shadow-dagger'
+key: 85
+id: '01KKR7QNRCCGPJS1BY1R6NEN8B'
+name: 'Shadow Dagger'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'uncommon'
+buy_price: 75
+emoji: '🗡️'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 3
+    crit_chance: 0.05
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/smoke-bomb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/smoke-bomb.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Smoke Bomb'
+description: 'Releases a thick cloud of smoke, guaranteeing escape from combat.'
+slug: 'smoke-bomb'
+key: 72
+id: '01KKR7QNRCN8GS74B9NMC7DDDW'
+name: 'Smoke Bomb'
+type_flags: 8704
+consumable: true
+stackable: true
+max_stack: 1
+rarity: 'rare'
+buy_price: 120
+emoji: '💨'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'guaranteed_flee' }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/spiked-plate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/spiked-plate.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Spiked Plate'
+description: 'Armor covered in sharp spikes that damage attackers. +5 armor, reflects 3 damage.'
+slug: 'spiked-plate'
+key: 94
+id: '01KKR7QNRCF2PAF55RNCVZ5H5S'
+name: 'Spiked Plate'
+type_flags: 514
+consumable: false
+stackable: false
+rarity: 'rare'
+buy_price: 200
+emoji: '🛡️'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'chest'
+  bonuses:
+    armor: 5
+  special: 'thorns'
+  special_value: 3
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/teleport-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/teleport-rune.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Teleport Rune'
+description: 'An inscribed stone that teleports the party back to the nearest city.'
+slug: 'teleport-rune'
+key: 78
+id: '01KKR7QNRC3336DJ0D3SJA8SA7'
+name: 'Teleport Rune'
+type_flags: 10752
+consumable: true
+stackable: true
+max_stack: 1
+rarity: 'rare'
+buy_price: 200
+emoji: '🌀'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'teleport_city' }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/trap-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/trap-kit.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Trap Kit'
+description: 'Deploys a trap that reflects 5 damage back to attackers for 2 turns.'
+slug: 'trap-kit'
+key: 76
+id: '01KKR7QNRCECPB1TANAW22C8B2'
+name: 'Trap Kit'
+type_flags: 8704
+consumable: true
+stackable: true
+max_stack: 2
+rarity: 'uncommon'
+buy_price: 55
+emoji: '🪤'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'apply_effect', status_effect: 'thorns', stacks: 5, turns: 2 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/vampiric-blade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/vampiric-blade.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Vampiric Blade'
+description: 'A cursed sword that siphons life force. +3 attack, 20% lifesteal.'
+slug: 'vampiric-blade'
+key: 87
+id: '01KKR7QNRCAJDADA45HXS0KGWF'
+name: 'Vampiric Blade'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'epic'
+buy_price: 350
+emoji: '🩸'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 3
+  special: 'life_steal'
+  special_value: 0.2
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/vitality-potion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/vitality-potion.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Vitality Potion'
+description: 'A potent healing potion that restores 25 HP.'
+slug: 'vitality-potion'
+key: 79
+id: '01KKR7QNRCYBZP4ZZ0WCCBBKA4'
+name: 'Vitality Potion'
+type_flags: 544
+consumable: true
+stackable: true
+max_stack: 3
+rarity: 'uncommon'
+buy_price: 60
+emoji: '💊'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'heal', amount: 25 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/void-scythe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/void-scythe.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Void Scythe'
+description: 'A weapon from beyond the veil. +7 attack, 15% lifesteal.'
+slug: 'void-scythe'
+key: 91
+id: '01KKR7QNRCF2G0B210XXC8HSVA'
+name: 'Void Scythe'
+type_flags: 513
+consumable: false
+stackable: false
+rarity: 'legendary'
+buy_price: 1200
+emoji: '🌀'
+action: 'equip'
+tags:
+  - discordsh
+equipment:
+  slot: 'main_hand'
+  bonuses:
+    attack: 7
+  special: 'life_steal'
+  special_value: 0.15
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/ward.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/ward.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Ward'
+description: 'A protective charm that grants the Shielded effect for 2 turns.'
+slug: 'ward'
+key: 70
+id: '01KKR7QNRCT4AA6ZG8P0Z37NM0'
+name: 'Ward'
+type_flags: 2592
+consumable: true
+stackable: true
+max_stack: 2
+rarity: 'rare'
+buy_price: 80
+emoji: '🧿'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'apply_effect', status_effect: 'shielded', stacks: 1, turns: 2 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/whetstone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/whetstone.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Whetstone'
+description: 'Sharpens your weapon, granting +3 bonus damage for 3 turns.'
+slug: 'whetstone'
+key: 74
+id: '01KKR7QNRCB0P53ECK35DY6AZQ'
+name: 'Whetstone'
+type_flags: 8704
+consumable: true
+stackable: true
+max_stack: 2
+rarity: 'uncommon'
+buy_price: 40
+emoji: '🪨'
+action: 'consume'
+tags:
+  - discordsh
+use_effects:
+  - { type: 'apply_effect', status_effect: 'sharpened', stacks: 1, turns: 3 }
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />


### PR DESCRIPTION
## Summary
- Add 32 MDX item files to the Astro itemdb, migrating all hardcoded items from DiscordSH `content.rs`
- **17 consumables**: potion, bandage, bomb, ward, rations, smoke-bomb, elixir, whetstone, antidote, trap-kit, campfire-kit, teleport-rune, vitality-potion, fire-flask, iron-skin-potion, rage-draught, phoenix-feather
- **8 weapons**: rusty-sword, shadow-dagger, flame-axe, vampiric-blade, iron-mace, glass-stiletto, excalibur, void-scythe
- **7 armor**: leather-vest, chain-mail, spiked-plate, crystal-armor, shadow-cloak, runeguard-plate, dragon-scale
- All items tagged with `discordsh` for easy filtering
- Proto-compatible frontmatter: `use_effects`, `equipment.slot`, `equipment.bonuses`, `equipment.special`

Closes #8010 (Phase 0)

## Test plan
- [ ] Astro build passes with all 32 new MDX files
- [ ] `/api/itemdb.json` includes all 32 items with correct slugs
- [ ] Each item page renders at `kbve.com/itemdb/<slug>/`