### PR TITLE
feat(ch): add Logflare-compatible ClickHouse OTEL schemas

### DIFF
--- a/packages/data/ch/dev-docker-compose.yml
+++ b/packages/data/ch/dev-docker-compose.yml
@@ -1,0 +1,59 @@
+# Local ClickHouse for validating Logflare-compatible schemas.
+# No Logflare or Postgres — just ClickHouse to test DDL.
+#
+# Usage:
+#   cp dev-docker-compose.yml docker-compose.yml
+#   docker compose up -d
+#   # Apply schemas:
+#   docker compose exec -T clickhouse clickhouse-client \
+#     --user logflare --password logflare \
+#     --multiquery < schemas/database.sql
+#   docker compose exec -T clickhouse clickhouse-client \
+#     --user logflare --password logflare -d logflare \
+#     --multiquery < schemas/logs.sql
+#   docker compose exec -T clickhouse clickhouse-client \
+#     --user logflare --password logflare -d logflare \
+#     --multiquery < schemas/metrics.sql
+#   docker compose exec -T clickhouse clickhouse-client \
+#     --user logflare --password logflare -d logflare \
+#     --multiquery < schemas/traces.sql
+#   # Inspect:
+#   docker compose exec clickhouse clickhouse-client \
+#     --user logflare --password logflare -d logflare \
+#     -q "SHOW TABLES"
+#   # Tear down:
+#   docker compose down -v
+
+services:
+    clickhouse:
+        image: clickhouse/clickhouse-server:25.12
+        ports:
+            - '8123:8123'
+            - '9000:9000'
+        tmpfs:
+            - /var/lib/clickhouse:size=1G
+            - /var/log/clickhouse-server:size=100M
+        environment:
+            CLICKHOUSE_DB: logflare
+            CLICKHOUSE_USER: logflare
+            CLICKHOUSE_PASSWORD: logflare
+            CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+        deploy:
+            resources:
+                limits:
+                    memory: 1500M
+                    cpus: '1.0'
+        shm_size: 256M
+        ulimits:
+            nofile:
+                soft: 262144
+                hard: 262144
+        healthcheck:
+            test:
+                [
+                    'CMD-SHELL',
+                    "clickhouse-client --user logflare --password logflare -q 'SELECT 1'",
+                ]
+            interval: 5s
+            timeout: 3s
+            retries: 10

--- a/packages/data/ch/schemas/database.sql
+++ b/packages/data/ch/schemas/database.sql
@@ -1,0 +1,11 @@
+-- =============================================================================
+-- Logflare ClickHouse Backend — Database Setup
+-- =============================================================================
+-- Creates the logflare database.
+-- Run this before the table schemas.
+--
+-- Production (clustered):
+--   CREATE DATABASE IF NOT EXISTS logflare ON CLUSTER 'cluster';
+-- =============================================================================
+
+CREATE DATABASE IF NOT EXISTS logflare;

--- a/packages/data/ch/schemas/logs.sql
+++ b/packages/data/ch/schemas/logs.sql
@@ -1,0 +1,86 @@
+-- =============================================================================
+-- Logflare ClickHouse Backend — Logs Schema
+-- =============================================================================
+-- Extracted from Logflare source (QueryTemplates.ex).
+-- Logflare creates tables per source token (otel_logs_<token>).
+-- These are reference templates using MergeTree (Logflare default).
+--
+-- Engine: MergeTree (default). Logflare config overrides for production:
+--   config :logflare, :clickhouse_backend_adaptor, engine: "ReplicatedMergeTree"
+-- TTL: 90 days
+-- Partition: daily by timestamp
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Standard OTEL Logs (JSON attribute columns)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS logflare.otel_logs_template (
+    `id`                    UUID,
+    `source_uuid`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `source_name`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `project`               String                  CODEC(ZSTD(1)),
+    `trace_id`              String                  CODEC(ZSTD(1)),
+    `span_id`               String                  CODEC(ZSTD(1)),
+    `trace_flags`           UInt8,
+    `severity_text`         LowCardinality(String)  CODEC(ZSTD(1)),
+    `severity_number`       UInt8,
+    `service_name`          LowCardinality(String)  CODEC(ZSTD(1)),
+    `event_message`         String                  CODEC(ZSTD(1)),
+    `scope_name`            String                  CODEC(ZSTD(1)),
+    `scope_version`         LowCardinality(String)  CODEC(ZSTD(1)),
+    `scope_schema_url`      LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_schema_url`   LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_attributes`   JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `scope_attributes`      JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `log_attributes`        JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `mapping_config_id`     UUID,
+    `timestamp`             DateTime64(9)           CODEC(Delta(8), ZSTD(1)),
+    `timestamp_time`        DateTime                DEFAULT toDateTime(timestamp),
+    `timestamp_hour`        DateTime                DEFAULT toStartOfHour(timestamp),
+    INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1
+)
+ENGINE = MergeTree
+PARTITION BY toDate(timestamp)
+PRIMARY KEY (project, source_name, toDateTime(timestamp))
+ORDER BY (project, source_name, toDateTime(timestamp), timestamp)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+
+-- ---------------------------------------------------------------------------
+-- Simple OTEL Logs (Map attribute columns)
+-- ---------------------------------------------------------------------------
+-- For ClickHouse versions without JSON type support.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS logflare.simple_otel_logs_template (
+    `id`                    UUID,
+    `source_uuid`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `source_name`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `project`               String                  CODEC(ZSTD(1)),
+    `trace_id`              String                  CODEC(ZSTD(1)),
+    `span_id`               String                  CODEC(ZSTD(1)),
+    `trace_flags`           UInt8,
+    `severity_text`         LowCardinality(String)  CODEC(ZSTD(1)),
+    `severity_number`       UInt8,
+    `service_name`          LowCardinality(String)  CODEC(ZSTD(1)),
+    `event_message`         String                  CODEC(ZSTD(1)),
+    `scope_name`            String                  CODEC(ZSTD(1)),
+    `scope_version`         LowCardinality(String)  CODEC(ZSTD(1)),
+    `scope_schema_url`      LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_schema_url`   LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_attributes`   Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `scope_attributes`      Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `log_attributes`        Map(String, String)     CODEC(ZSTD(1)),
+    `mapping_config_id`     UUID,
+    `timestamp`             DateTime64(9)           CODEC(Delta(8), ZSTD(1)),
+    `timestamp_time`        DateTime                DEFAULT toDateTime(timestamp),
+    `timestamp_hour`        DateTime                DEFAULT toStartOfHour(timestamp),
+    INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1
+)
+ENGINE = MergeTree
+PARTITION BY toDate(timestamp)
+ORDER BY (source_name, project, timestamp_hour)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/packages/data/ch/schemas/metrics.sql
+++ b/packages/data/ch/schemas/metrics.sql
@@ -1,0 +1,125 @@
+-- =============================================================================
+-- Logflare ClickHouse Backend — Metrics Schema
+-- =============================================================================
+-- Extracted from Logflare source (QueryTemplates.ex).
+-- OTEL-aligned metrics tables.
+--
+-- Engine: MergeTree (default)
+-- TTL: 90 days
+-- Partition: daily by timestamp
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Standard OTEL Metrics (JSON attribute columns)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS logflare.otel_metrics_template (
+    `id`                          UUID,
+    `source_uuid`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `source_name`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `project`                     String                  CODEC(ZSTD(1)),
+    `time_unix`                   Nullable(DateTime64(9)) CODEC(Delta(8), ZSTD(1)),
+    `start_time_unix`             Nullable(DateTime64(9)) CODEC(Delta(8), ZSTD(1)),
+    `metric_name`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `metric_description`          String                  CODEC(ZSTD(1)),
+    `metric_unit`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `metric_type`                 Enum8('gauge' = 1, 'sum' = 2, 'histogram' = 3, 'exponential_histogram' = 4, 'summary' = 5),
+    `service_name`                LowCardinality(String)  CODEC(ZSTD(1)),
+    `event_message`               String                  CODEC(ZSTD(1)),
+    `scope_name`                  String                  CODEC(ZSTD(1)),
+    `scope_version`               LowCardinality(String)  CODEC(ZSTD(1)),
+    `scope_schema_url`            LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_schema_url`         LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_attributes`         JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `scope_attributes`            JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `attributes`                  JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `aggregation_temporality`     LowCardinality(String)  CODEC(ZSTD(1)),
+    `is_monotonic`                Bool,
+    `flags`                       UInt32                  CODEC(ZSTD(1)),
+    `value`                       Float64                 CODEC(ZSTD(1)),
+    `count`                       UInt64                  CODEC(ZSTD(1)),
+    `sum`                         Float64                 CODEC(ZSTD(1)),
+    `bucket_counts`               Array(UInt64)           CODEC(ZSTD(1)),
+    `explicit_bounds`             Array(Float64)          CODEC(ZSTD(1)),
+    `min`                         Float64                 CODEC(ZSTD(1)),
+    `max`                         Float64                 CODEC(ZSTD(1)),
+    `scale`                       Int32                   CODEC(ZSTD(1)),
+    `zero_count`                  UInt64                  CODEC(ZSTD(1)),
+    `positive_offset`             Int32                   CODEC(ZSTD(1)),
+    `positive_bucket_counts`      Array(UInt64)           CODEC(ZSTD(1)),
+    `negative_offset`             Int32                   CODEC(ZSTD(1)),
+    `negative_bucket_counts`      Array(UInt64)           CODEC(ZSTD(1)),
+    `quantile_values`             Array(Float64)          CODEC(ZSTD(1)),
+    `quantiles`                   Array(Float64)          CODEC(ZSTD(1)),
+    `exemplars.filtered_attributes` Array(JSON(max_dynamic_paths=0, max_dynamic_types=1)) CODEC(ZSTD(1)),
+    `exemplars.time_unix`         Array(DateTime64(9))    CODEC(ZSTD(1)),
+    `exemplars.value`             Array(Float64)          CODEC(ZSTD(1)),
+    `exemplars.span_id`           Array(String)           CODEC(ZSTD(1)),
+    `exemplars.trace_id`          Array(String)           CODEC(ZSTD(1)),
+    `mapping_config_id`           UUID,
+    `timestamp`                   DateTime64(9)           CODEC(Delta(8), ZSTD(1)),
+    `timestamp_hour`              DateTime                DEFAULT toStartOfHour(timestamp)
+)
+ENGINE = MergeTree
+PARTITION BY toDate(timestamp)
+ORDER BY (source_name, metric_name, project, timestamp_hour)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+
+-- ---------------------------------------------------------------------------
+-- Simple OTEL Metrics (Map attribute columns)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS logflare.simple_otel_metrics_template (
+    `id`                          UUID,
+    `source_uuid`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `source_name`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `project`                     String                  CODEC(ZSTD(1)),
+    `time_unix`                   Nullable(DateTime64(9)) CODEC(Delta(8), ZSTD(1)),
+    `start_time_unix`             Nullable(DateTime64(9)) CODEC(Delta(8), ZSTD(1)),
+    `metric_name`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `metric_description`          String                  CODEC(ZSTD(1)),
+    `metric_unit`                 LowCardinality(String)  CODEC(ZSTD(1)),
+    `metric_type`                 Enum8('gauge' = 1, 'sum' = 2, 'histogram' = 3, 'exponential_histogram' = 4, 'summary' = 5),
+    `service_name`                LowCardinality(String)  CODEC(ZSTD(1)),
+    `event_message`               String                  CODEC(ZSTD(1)),
+    `scope_name`                  String                  CODEC(ZSTD(1)),
+    `scope_version`               LowCardinality(String)  CODEC(ZSTD(1)),
+    `scope_schema_url`            LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_schema_url`         LowCardinality(String)  CODEC(ZSTD(1)),
+    `resource_attributes`         Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `scope_attributes`            Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `attributes`                  Map(String, String)     CODEC(ZSTD(1)),
+    `aggregation_temporality`     LowCardinality(String)  CODEC(ZSTD(1)),
+    `is_monotonic`                Bool,
+    `flags`                       UInt32                  CODEC(ZSTD(1)),
+    `value`                       Float64                 CODEC(ZSTD(1)),
+    `count`                       UInt64                  CODEC(ZSTD(1)),
+    `sum`                         Float64                 CODEC(ZSTD(1)),
+    `bucket_counts`               Array(UInt64)           CODEC(ZSTD(1)),
+    `explicit_bounds`             Array(Float64)          CODEC(ZSTD(1)),
+    `min`                         Float64                 CODEC(ZSTD(1)),
+    `max`                         Float64                 CODEC(ZSTD(1)),
+    `scale`                       Int32                   CODEC(ZSTD(1)),
+    `zero_count`                  UInt64                  CODEC(ZSTD(1)),
+    `positive_offset`             Int32                   CODEC(ZSTD(1)),
+    `positive_bucket_counts`      Array(UInt64)           CODEC(ZSTD(1)),
+    `negative_offset`             Int32                   CODEC(ZSTD(1)),
+    `negative_bucket_counts`      Array(UInt64)           CODEC(ZSTD(1)),
+    `quantile_values`             Array(Float64)          CODEC(ZSTD(1)),
+    `quantiles`                   Array(Float64)          CODEC(ZSTD(1)),
+    `exemplars.filtered_attributes` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    `exemplars.time_unix`         Array(DateTime64(9))    CODEC(ZSTD(1)),
+    `exemplars.value`             Array(Float64)          CODEC(ZSTD(1)),
+    `exemplars.span_id`           Array(String)           CODEC(ZSTD(1)),
+    `exemplars.trace_id`          Array(String)           CODEC(ZSTD(1)),
+    `mapping_config_id`           UUID,
+    `timestamp`                   DateTime64(9)           CODEC(Delta(8), ZSTD(1)),
+    `timestamp_hour`              DateTime                DEFAULT toStartOfHour(timestamp)
+)
+ENGINE = MergeTree
+PARTITION BY toDate(timestamp)
+ORDER BY (source_name, metric_name, project, timestamp_hour)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/packages/data/ch/schemas/traces.sql
+++ b/packages/data/ch/schemas/traces.sql
@@ -1,0 +1,97 @@
+-- =============================================================================
+-- Logflare ClickHouse Backend — Traces Schema
+-- =============================================================================
+-- Extracted from Logflare source (QueryTemplates.ex).
+-- OTEL-aligned traces tables.
+--
+-- Engine: MergeTree (default)
+-- TTL: 90 days
+-- Partition: daily by timestamp
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Standard OTEL Traces (JSON attribute columns)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS logflare.otel_traces_template (
+    `id`                    UUID,
+    `source_uuid`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `source_name`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `project`               String                  CODEC(ZSTD(1)),
+    `trace_id`              String                  CODEC(ZSTD(1)),
+    `span_id`               String                  CODEC(ZSTD(1)),
+    `parent_span_id`        String                  CODEC(ZSTD(1)),
+    `trace_state`           String                  CODEC(ZSTD(1)),
+    `span_name`             LowCardinality(String)  CODEC(ZSTD(1)),
+    `span_kind`             LowCardinality(String)  CODEC(ZSTD(1)),
+    `service_name`          LowCardinality(String)  CODEC(ZSTD(1)),
+    `event_message`         String                  CODEC(ZSTD(1)),
+    `duration`              UInt64                  CODEC(ZSTD(1)),
+    `status_code`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `status_message`        String                  CODEC(ZSTD(1)),
+    `scope_name`            String                  CODEC(ZSTD(1)),
+    `scope_version`         String                  CODEC(ZSTD(1)),
+    `resource_attributes`   JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `span_attributes`       JSON(max_dynamic_paths=0, max_dynamic_types=1) CODEC(ZSTD(1)),
+    `events.timestamp`      Array(DateTime64(9))    CODEC(ZSTD(1)),
+    `events.name`           Array(LowCardinality(String)) CODEC(ZSTD(1)),
+    `events.attributes`     Array(JSON(max_dynamic_paths=0, max_dynamic_types=1)) CODEC(ZSTD(1)),
+    `links.trace_id`        Array(String)           CODEC(ZSTD(1)),
+    `links.span_id`         Array(String)           CODEC(ZSTD(1)),
+    `links.trace_state`     Array(String)           CODEC(ZSTD(1)),
+    `links.attributes`      Array(JSON(max_dynamic_paths=0, max_dynamic_types=1)) CODEC(ZSTD(1)),
+    `mapping_config_id`     UUID,
+    `timestamp`             DateTime64(9)           CODEC(Delta(8), ZSTD(1)),
+    `timestamp_hour`        DateTime                DEFAULT toStartOfHour(timestamp),
+    INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_duration duration TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+PARTITION BY toDate(timestamp)
+ORDER BY (source_name, span_name, project, timestamp_hour)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+
+-- ---------------------------------------------------------------------------
+-- Simple OTEL Traces (Map attribute columns)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS logflare.simple_otel_traces_template (
+    `id`                    UUID,
+    `source_uuid`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `source_name`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `project`               String                  CODEC(ZSTD(1)),
+    `trace_id`              String                  CODEC(ZSTD(1)),
+    `span_id`               String                  CODEC(ZSTD(1)),
+    `parent_span_id`        String                  CODEC(ZSTD(1)),
+    `trace_state`           String                  CODEC(ZSTD(1)),
+    `span_name`             LowCardinality(String)  CODEC(ZSTD(1)),
+    `span_kind`             LowCardinality(String)  CODEC(ZSTD(1)),
+    `service_name`          LowCardinality(String)  CODEC(ZSTD(1)),
+    `event_message`         String                  CODEC(ZSTD(1)),
+    `duration`              UInt64                  CODEC(ZSTD(1)),
+    `status_code`           LowCardinality(String)  CODEC(ZSTD(1)),
+    `status_message`        String                  CODEC(ZSTD(1)),
+    `scope_name`            String                  CODEC(ZSTD(1)),
+    `scope_version`         String                  CODEC(ZSTD(1)),
+    `resource_attributes`   Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `span_attributes`       Map(String, String)     CODEC(ZSTD(1)),
+    `events.timestamp`      Array(DateTime64(9))    CODEC(ZSTD(1)),
+    `events.name`           Array(LowCardinality(String)) CODEC(ZSTD(1)),
+    `events.attributes`     Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    `links.trace_id`        Array(String)           CODEC(ZSTD(1)),
+    `links.span_id`         Array(String)           CODEC(ZSTD(1)),
+    `links.trace_state`     Array(String)           CODEC(ZSTD(1)),
+    `links.attributes`      Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    `mapping_config_id`     UUID,
+    `timestamp`             DateTime64(9)           CODEC(Delta(8), ZSTD(1)),
+    `timestamp_hour`        DateTime                DEFAULT toStartOfHour(timestamp),
+    INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_duration duration TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+PARTITION BY toDate(timestamp)
+ORDER BY (source_name, span_name, project, timestamp_hour)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;


### PR DESCRIPTION
## Summary
- Add `packages/data/ch/schemas/` with Logflare-compatible ClickHouse DDL for logs, metrics, and traces (standard JSON + simple Map variants)
- DDL extracted from Logflare `QueryTemplates.ex` source and validated against local ClickHouse 25.12
- Add `dev-docker-compose.yml` for local schema testing (ClickHouse only, no Postgres/Logflare needed)

## Context
First step toward migrating Supabase Analytics from PostgreSQL to ClickHouse (Vector → Logflare → ClickHouse pipeline). These reference schemas document the exact tables Logflare auto-creates per source token when configured with `LOGFLARE_BACKEND=clickhouse`.

## Test plan
- [x] Applied all schemas against local ClickHouse 25.12 via docker-compose
- [x] Verified all 6 tables created successfully (`SHOW TABLES`)
- [x] Confirmed `SHOW CREATE TABLE` output matches Logflare source