### PR TITLE
fix(mc): resolve CVE-2026-22184 zlib buffer overflow

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -148,7 +148,7 @@ COPY --from=astro-precompressor /static /pumpkin/web
 COPY ./apps/mc/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-RUN apk add --no-cache libgcc && chown -R 2613:2613 .
+RUN apk upgrade --no-cache && apk add --no-cache libgcc && chown -R 2613:2613 .
 
 ENV RUST_BACKTRACE=1
 EXPOSE 25565 8080 25575

--- a/apps/mc/Dockerfile.dev
+++ b/apps/mc/Dockerfile.dev
@@ -149,7 +149,7 @@ RUN chmod +x /entrypoint.sh
 # Create mountable directories (logs + world persistence)
 RUN mkdir -p /pumpkin/logs /pumpkin/world
 
-RUN apk add --no-cache libgcc && chown -R 2613:2613 .
+RUN apk upgrade --no-cache && apk add --no-cache libgcc && chown -R 2613:2613 .
 
 ENV RUST_BACKTRACE=full
 EXPOSE 25565 8080 25575


### PR DESCRIPTION
## Summary
- Add `apk upgrade --no-cache` to final image stages in `Dockerfile` and `Dockerfile.dev`
- Bumps zlib from 1.3.1-r2 to 1.3.2-r0, resolving CVE-2026-22184 (critical buffer overflow in untgz)
- `Dockerfile.base` already had `apk upgrade` in the chef stage

## Test plan
- [ ] Verify `mc` Docker publish workflow passes Trivy scan
- [ ] Confirm final image runs correctly (`docker run` + healthcheck)