### PR TITLE
fix(ci): pin Rust 1.94 in lint workflow + fix clippy warnings

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -82,6 +82,12 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v7
 
+            - name: Setup Rust 1.94
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: '1.94'
+                  components: clippy
+
             - name: Install system libraries for wry/webkit2gtk
               run: |
                   sudo apt-get update -qq

--- a/apps/discordsh/axum-discordsh/src/discord/bot.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/bot.rs
@@ -36,11 +36,11 @@ pub type Context<'a> = poise::Context<'a, Data, Error>;
 /// 2. Supabase Vault via `vault-reader` Edge Function (production)
 async fn resolve_token() -> Option<String> {
     // 1. Try direct env var (dev mode / backward compatible)
-    if let Ok(t) = std::env::var("DISCORD_TOKEN") {
-        if !t.is_empty() {
-            info!("Using Discord token from DISCORD_TOKEN env var");
-            return Some(t);
-        }
+    if let Ok(t) = std::env::var("DISCORD_TOKEN")
+        && !t.is_empty()
+    {
+        info!("Using Discord token from DISCORD_TOKEN env var");
+        return Some(t);
     }
 
     // 2. Try Supabase Vault

--- a/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
@@ -158,19 +158,19 @@ async fn start(
     ctx.data().app.sessions.create(final_state);
 
     // One-time guest notice
-    if let MemberStatus::Guest { notified } = &member_status_raw {
-        if !notified {
-            ctx.send(
-                poise::CreateReply::default()
-                    .content(
-                        "You're playing as a **Guest**. Link your Discord account at \
+    if let MemberStatus::Guest { notified } = &member_status_raw
+        && !notified
+    {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(
+                    "You're playing as a **Guest**. Link your Discord account at \
                          <https://kbve.com> to unlock Member perks!",
-                    )
-                    .ephemeral(true),
-            )
-            .await?;
-            ctx.data().app.members.mark_notified(user.get());
-        }
+                )
+                .ephemeral(true),
+        )
+        .await?;
+        ctx.data().app.members.mark_notified(user.get());
     }
 
     Ok(())
@@ -328,19 +328,19 @@ async fn join(
     .await?;
 
     // One-time guest notice for joining player
-    if let MemberStatus::Guest { notified } = &member_status_raw {
-        if !notified {
-            ctx.send(
-                poise::CreateReply::default()
-                    .content(
-                        "You're playing as a **Guest**. Link your Discord account at \
+    if let MemberStatus::Guest { notified } = &member_status_raw
+        && !notified
+    {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(
+                    "You're playing as a **Guest**. Link your Discord account at \
                          <https://kbve.com> to unlock Member perks!",
-                    )
-                    .ephemeral(true),
-            )
-            .await?;
-            ctx.data().app.members.mark_notified(user.get());
-        }
+                )
+                .ephemeral(true),
+        )
+        .await?;
+        ctx.data().app.members.mark_notified(user.get());
     }
 
     Ok(())

--- a/apps/discordsh/axum-discordsh/src/discord/components/status_buttons.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/components/status_buttons.rs
@@ -155,10 +155,10 @@ pub async fn handle_status_component(
                     if let Err(e) = thread_id.delete_messages(&http, &to_delete).await {
                         tracing::warn!(error = %e, count, "Failed to bulk-delete thread messages");
                     }
-                } else if count == 1 {
-                    if let Err(e) = thread_id.delete_message(&http, to_delete[0]).await {
-                        tracing::warn!(error = %e, "Failed to delete thread message");
-                    }
+                } else if count == 1
+                    && let Err(e) = thread_id.delete_message(&http, to_delete[0]).await
+                {
+                    tracing::warn!(error = %e, "Failed to delete thread message");
                 }
                 info!(deleted = count, "Thread cleanup complete");
             });

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -53,10 +53,10 @@ fn validate_actor(session: &SessionState, actor: serenity::UserId) -> Result<(),
     }
 
     // Check if the player is still alive
-    if let Some(player) = session.players.get(&actor) {
-        if !player.alive {
-            return Err("You have been defeated and cannot act.".to_owned());
-        }
+    if let Some(player) = session.players.get(&actor)
+        && !player.alive
+    {
+        return Err("You have been defeated and cannot act.".to_owned());
     }
 
     Ok(())
@@ -82,10 +82,10 @@ fn validate_action(
             if session.phase != GamePhase::Combat && session.phase != GamePhase::WaitingForActions {
                 return Err("You can only heal during combat.".to_owned());
             }
-            if let Some(player) = session.players.get(&actor) {
-                if player.class != ClassType::Cleric {
-                    return Err("Only Clerics can heal allies.".to_owned());
-                }
+            if let Some(player) = session.players.get(&actor)
+                && player.class != ClassType::Cleric
+            {
+                return Err("Only Clerics can heal allies.".to_owned());
             }
         }
         GameAction::Equip(_) | GameAction::Unequip(_) => {
@@ -462,8 +462,8 @@ fn resolve_combat_turn_party(
     let alive_ids = session.alive_player_ids();
     let mut auto_defended = Vec::new();
     for uid in alive_ids {
-        if !session.pending_actions.contains_key(&uid) {
-            session.pending_actions.insert(uid, GameAction::Defend);
+        if let std::collections::hash_map::Entry::Vacant(e) = session.pending_actions.entry(uid) {
+            e.insert(GameAction::Defend);
             auto_defended.push(uid);
         }
     }
@@ -526,18 +526,16 @@ fn resolve_combat_turn_party(
                 }
 
                 // Cleric defend proc: Prayer of Healing (25% chance)
-                if pclass == ClassType::Cleric {
-                    if rng.random::<f32>() < 0.25 {
-                        let heal = rng.random_range(5..=10);
-                        let player = session.player_mut(*uid);
-                        let healed = heal.min(player.max_hp - player.hp);
-                        player.hp = (player.hp + heal).min(player.max_hp);
-                        if healed > 0 {
-                            logs.push(format!(
-                                "{} whispers a prayer, restoring {} HP!",
-                                pname, healed
-                            ));
-                        }
+                if pclass == ClassType::Cleric && rng.random::<f32>() < 0.25 {
+                    let heal = rng.random_range(5..=10);
+                    let player = session.player_mut(*uid);
+                    let healed = heal.min(player.max_hp - player.hp);
+                    player.hp = (player.hp + heal).min(player.max_hp);
+                    if healed > 0 {
+                        logs.push(format!(
+                            "{} whispers a prayer, restoring {} HP!",
+                            pname, healed
+                        ));
                     }
                 }
             }
@@ -981,33 +979,34 @@ fn handle_enemy_deaths(session: &mut SessionState, actor: serenity::UserId) -> V
 
             // Roll gear loot — suppressed if this kill already dropped a Rare+ item,
             // or if the encounter has already hit the rare drop cap.
-            if !item_was_rare && rare_drops_this_encounter < max_rare_drops {
-                if let Some(gear_id) = content::roll_gear_loot(loot_id) {
-                    let gear_is_rare = content::is_rare_or_above(gear_id);
+            if !item_was_rare
+                && rare_drops_this_encounter < max_rare_drops
+                && let Some(gear_id) = content::roll_gear_loot(loot_id)
+            {
+                let gear_is_rare = content::is_rare_or_above(gear_id);
 
-                    if gear_is_rare && rare_drops_this_encounter >= max_rare_drops {
-                        // Rare gear suppressed
-                    } else {
-                        if add_item_to_inventory(
-                            &mut session.player_mut(loot_recipient).inventory,
-                            gear_id,
-                        ) {
-                            if let Some(gear) = content::find_gear(gear_id) {
-                                if alive_ids.len() > 1 {
-                                    logs.push(format!(
-                                        "{} received gear: {}!",
-                                        recipient_name, gear.name
-                                    ));
-                                } else {
-                                    logs.push(format!("Dropped gear: {}!", gear.name));
-                                }
+                if gear_is_rare && rare_drops_this_encounter >= max_rare_drops {
+                    // Rare gear suppressed
+                } else {
+                    if add_item_to_inventory(
+                        &mut session.player_mut(loot_recipient).inventory,
+                        gear_id,
+                    ) {
+                        if let Some(gear) = content::find_gear(gear_id) {
+                            if alive_ids.len() > 1 {
+                                logs.push(format!(
+                                    "{} received gear: {}!",
+                                    recipient_name, gear.name
+                                ));
+                            } else {
+                                logs.push(format!("Dropped gear: {}!", gear.name));
                             }
-                        } else if let Some(gear) = content::find_gear(gear_id) {
-                            logs.push(format!("Inventory full! Lost gear: {}", gear.name));
                         }
-                        if gear_is_rare {
-                            rare_drops_this_encounter += 1;
-                        }
+                    } else if let Some(gear) = content::find_gear(gear_id) {
+                        logs.push(format!("Inventory full! Lost gear: {}", gear.name));
+                    }
+                    if gear_is_rare {
+                        rare_drops_this_encounter += 1;
                     }
                 }
             }
@@ -1353,7 +1352,7 @@ fn single_enemy_turn(
 
             // Thorns from effect
             let thorns_stacks = player.effect_stacks(&EffectKind::Thorns);
-            let thorns_dmg_effect = thorns_stacks as i32 * 1;
+            let thorns_dmg_effect = thorns_stacks as i32;
 
             // Thorns from gear
             let thorns_dmg_gear = player
@@ -1853,11 +1852,11 @@ fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
     session.map.position = pos;
 
     // Mark visited
-    if let Some(tile) = session.map.tiles.get_mut(&pos) {
-        if !tile.visited {
-            tile.visited = true;
-            session.map.tiles_visited += 1;
-        }
+    if let Some(tile) = session.map.tiles.get_mut(&pos)
+        && !tile.visited
+    {
+        tile.visited = true;
+        session.map.tiles_visited += 1;
     }
 
     // Reveal neighbors
@@ -2133,7 +2132,7 @@ fn tick_effects(effects: &mut Vec<EffectInstance>) -> (Vec<String>, i32) {
         let dmg = match effect.kind {
             EffectKind::Poison => 2 * effect.stacks as i32,
             EffectKind::Burning => 3 * effect.stacks as i32,
-            EffectKind::Bleed => 1 * effect.stacks as i32,
+            EffectKind::Bleed => effect.stacks as i32,
             // Sharpened, Thorns, Shielded, Weakened, Stunned deal no tick damage
             _ => 0,
         };

--- a/apps/discordsh/axum-discordsh/src/discord/game/proto_bridge.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/proto_bridge.rs
@@ -98,6 +98,7 @@ pub fn is_rare_or_above(id: &str) -> bool {
 }
 
 /// Access the underlying [`ItemDb`] for advanced queries.
+#[allow(dead_code)]
 pub fn item_db() -> &'static ItemDb {
     &ITEM_DB
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/render.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/render.rs
@@ -182,15 +182,15 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
             format!("Bosses Defeated: {}", owner.lifetime_bosses_defeated),
             format!("Final Level: {}", owner.level),
         ];
-        if let Some(ref wep) = owner.weapon {
-            if let Some(gear) = super::content::find_gear(wep) {
-                stats.push(format!("Weapon: {} {}", gear.emoji, gear.name));
-            }
+        if let Some(ref wep) = owner.weapon
+            && let Some(gear) = super::content::find_gear(wep)
+        {
+            stats.push(format!("Weapon: {} {}", gear.emoji, gear.name));
         }
-        if let Some(ref arm) = owner.armor_gear {
-            if let Some(gear) = super::content::find_gear(arm) {
-                stats.push(format!("Armor: {} {}", gear.emoji, gear.name));
-            }
+        if let Some(ref arm) = owner.armor_gear
+            && let Some(gear) = super::content::find_gear(arm)
+        {
+            stats.push(format!("Armor: {} {}", gear.emoji, gear.name));
         }
         embed = embed.field("-- Final Stats --", stats.join("\n"), false);
     }
@@ -205,15 +205,15 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
                 format!("DEF `{}`  Gold `{}`", player.armor, player.gold),
                 progress_bar("\u{2726}", player.xp as i32, player.xp_to_next as i32, 8),
             ];
-            if let Some(ref wep) = player.weapon {
-                if let Some(gear) = super::content::find_gear(wep) {
-                    lines.push(format!("Weapon: {} {}", gear.emoji, gear.name));
-                }
+            if let Some(ref wep) = player.weapon
+                && let Some(gear) = super::content::find_gear(wep)
+            {
+                lines.push(format!("Weapon: {} {}", gear.emoji, gear.name));
             }
-            if let Some(ref arm) = player.armor_gear {
-                if let Some(gear) = super::content::find_gear(arm) {
-                    lines.push(format!("Armor: {} {}", gear.emoji, gear.name));
-                }
+            if let Some(ref arm) = player.armor_gear
+                && let Some(gear) = super::content::find_gear(arm)
+            {
+                lines.push(format!("Armor: {} {}", gear.emoji, gear.name));
             }
             if let Some(fx) = format_effects(&player.effects) {
                 lines.push(format!("Status: {fx}"));
@@ -240,15 +240,15 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
             format!("DEF `{}`  Gold `{}`", owner.armor, owner.gold),
             progress_bar("\u{2726}", owner.xp as i32, owner.xp_to_next as i32, 8),
         ];
-        if let Some(ref wep) = owner.weapon {
-            if let Some(gear) = super::content::find_gear(wep) {
-                player_lines.push(format!("Weapon: {} {}", gear.emoji, gear.name));
-            }
+        if let Some(ref wep) = owner.weapon
+            && let Some(gear) = super::content::find_gear(wep)
+        {
+            player_lines.push(format!("Weapon: {} {}", gear.emoji, gear.name));
         }
-        if let Some(ref arm) = owner.armor_gear {
-            if let Some(gear) = super::content::find_gear(arm) {
-                player_lines.push(format!("Armor: {} {}", gear.emoji, gear.name));
-            }
+        if let Some(ref arm) = owner.armor_gear
+            && let Some(gear) = super::content::find_gear(arm)
+        {
+            player_lines.push(format!("Armor: {} {}", gear.emoji, gear.name));
         }
         if let Some(fx) = format_effects(&owner.effects) {
             player_lines.push(format!("Status: {fx}"));
@@ -380,16 +380,16 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
     }
 
     // Story event choices (always shown — matches interactive story buttons)
-    if session.phase == GamePhase::Event {
-        if let Some(ref event) = session.room.story_event {
-            let choice_lines: Vec<String> = event
-                .choices
-                .iter()
-                .enumerate()
-                .map(|(i, c)| format!("{}. **{}** -- {}", i + 1, c.label, c.description))
-                .collect();
-            embed = embed.field("-- Choices --", choice_lines.join("\n"), false);
-        }
+    if session.phase == GamePhase::Event
+        && let Some(ref event) = session.room.story_event
+    {
+        let choice_lines: Vec<String> = event
+            .choices
+            .iter()
+            .enumerate()
+            .map(|(i, c)| format!("{}. **{}** -- {}", i + 1, c.label, c.description))
+            .collect();
+        embed = embed.field("-- Choices --", choice_lines.join("\n"), false);
     }
 
     // Adventure log (last 5 entries)
@@ -451,22 +451,22 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
 fn build_unequip_menu(owner: &PlayerState, sid: &str, rows: &mut Vec<serenity::CreateActionRow>) {
     let mut options = Vec::new();
 
-    if let Some(ref weapon_id) = owner.weapon {
-        if let Some(gear) = super::content::find_gear(weapon_id) {
-            options.push(serenity::CreateSelectMenuOption::new(
-                format!("{} {} [Weapon]", gear.emoji, gear.name),
-                "weapon",
-            ));
-        }
+    if let Some(ref weapon_id) = owner.weapon
+        && let Some(gear) = super::content::find_gear(weapon_id)
+    {
+        options.push(serenity::CreateSelectMenuOption::new(
+            format!("{} {} [Weapon]", gear.emoji, gear.name),
+            "weapon",
+        ));
     }
 
-    if let Some(ref armor_id) = owner.armor_gear {
-        if let Some(gear) = super::content::find_gear(armor_id) {
-            options.push(serenity::CreateSelectMenuOption::new(
-                format!("{} {} [Armor]", gear.emoji, gear.name),
-                "armor",
-            ));
-        }
+    if let Some(ref armor_id) = owner.armor_gear
+        && let Some(gear) = super::content::find_gear(armor_id)
+    {
+        options.push(serenity::CreateSelectMenuOption::new(
+            format!("{} {} [Armor]", gear.emoji, gear.name),
+            "armor",
+        ));
     }
 
     if !options.is_empty() {
@@ -1012,22 +1012,23 @@ pub fn render_components(session: &SessionState) -> Vec<serenity::CreateActionRo
     }
 
     // Story choice buttons
-    if session.phase == GamePhase::Event && !game_over {
-        if let Some(ref event) = session.room.story_event {
-            let story_buttons: Vec<serenity::CreateButton> = event
-                .choices
-                .iter()
-                .enumerate()
-                .map(|(i, choice)| {
-                    serenity::CreateButton::new(format!("dng|{sid}|story|{i}"))
-                        .label(&choice.label)
-                        .style(serenity::ButtonStyle::Primary)
-                })
-                .collect();
+    if session.phase == GamePhase::Event
+        && !game_over
+        && let Some(ref event) = session.room.story_event
+    {
+        let story_buttons: Vec<serenity::CreateButton> = event
+            .choices
+            .iter()
+            .enumerate()
+            .map(|(i, choice)| {
+                serenity::CreateButton::new(format!("dng|{sid}|story|{i}"))
+                    .label(&choice.label)
+                    .style(serenity::ButtonStyle::Primary)
+            })
+            .collect();
 
-            if !story_buttons.is_empty() {
-                rows.push(serenity::CreateActionRow::Buttons(story_buttons));
-            }
+        if !story_buttons.is_empty() {
+            rows.push(serenity::CreateActionRow::Buttons(story_buttons));
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/github.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/github.rs
@@ -16,11 +16,11 @@ const ENV_KEYS: &[&str] = &["GITHUB_TOKEN", "GITHUB_TOKEN_API", "GITHUB_TOKEN_PA
 pub async fn resolve_github_token(guild_id: Option<u64>) -> Option<String> {
     // 1. Check env vars
     for key in ENV_KEYS {
-        if let Ok(val) = std::env::var(key) {
-            if !val.is_empty() {
-                info!(source = key, "Using GitHub token from env var");
-                return Some(val);
-            }
+        if let Ok(val) = std::env::var(key)
+            && !val.is_empty()
+        {
+            info!(source = key, "Using GitHub token from env var");
+            return Some(val);
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/mod.rs
@@ -3,4 +3,5 @@ pub mod commands;
 pub mod components;
 pub mod embeds;
 pub mod game;
+#[allow(dead_code)]
 pub mod github;


### PR DESCRIPTION
## Summary
- Pin Rust 1.94 in `utils-ci-lint-test.yml` — `bevy_items` requires edition 2024 / MSRV 1.94, but `ubuntu-latest` ships Rust 1.93.1
- Fix all 23 `collapsible_if` clippy warnings in `axum-discordsh` via `cargo clippy --fix`
- Suppress `dead_code` on scaffolded `github` module and `item_db()` function (intended for future use)

## Test plan
- [ ] CI lint passes for `axum-discordsh` with Rust 1.94
- [ ] No clippy warnings remain