### PR TITLE
fix(proto): resolve duplicate field tags in mapdb.proto WorldObjectDef

### DIFF
--- a/packages/data/proto/map/mapdb.proto
+++ b/packages/data/proto/map/mapdb.proto
@@ -515,8 +515,8 @@ message WorldObjectDef {
   repeated MapExtension extensions = 24;
 
   // Metadata
-  optional string credits = 37;
-  optional bool drafted = 38;
+  optional string credits = 40;
+  optional bool drafted = 41;
 }
 
 // Resource cost for constructing a structure


### PR DESCRIPTION
## Summary
- Fix duplicate protobuf field tags in `WorldObjectDef` message
- `credits` (tag 37) and `drafted` (tag 38) collided with `resource_type` and `container_type`
- Reassigned to tags 40 and 41
- This was blocking `astro-kbve:proto` → `astro-kbve:build` → `axum-kbve-e2e`

## Test plan
- [ ] `buf generate` succeeds without tag collision errors
- [ ] `axum-kbve-e2e` e2e passes