### PR TITLE
fix(clickhouse): use grants for logflare user DDL access

### DIFF
--- a/apps/kube/analytics/manifests/logflare-ch-setup-job.yaml
+++ b/apps/kube/analytics/manifests/logflare-ch-setup-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: logflare-ch-setup-v2-script
+    name: logflare-ch-setup-v3-script
     namespace: kilobase
 data:
     setup.sh: |
@@ -38,8 +38,11 @@ data:
 
         # --- Create the logflare database on ClickHouse ---
         echo "Creating logflare database on ClickHouse..."
-        curl -sf "${CH_URL}/?user=${CH_USERNAME}&password=${CH_PASSWORD}" \
-          -d "CREATE DATABASE IF NOT EXISTS ${CH_DATABASE}"
+        DB_RESULT=$(curl -sf --max-time 10 "${CH_URL}/?user=${CH_USERNAME}&password=${CH_PASSWORD}" \
+          -d "CREATE DATABASE IF NOT EXISTS ${CH_DATABASE}" 2>&1) || {
+          echo "ERROR: Failed to create database: ${DB_RESULT}"
+          exit 1
+        }
         echo "Database created."
 
         # --- Remove existing ClickHouse backend if present ---
@@ -112,10 +115,10 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: logflare-ch-setup-v2
+    name: logflare-ch-setup-v3
     namespace: kilobase
     labels:
-        app: logflare-ch-setup-v2
+        app: logflare-ch-setup-v3
         component: analytics
 spec:
     ttlSecondsAfterFinished: 86400
@@ -123,7 +126,7 @@ spec:
     template:
         metadata:
             labels:
-                app: logflare-ch-setup-v2
+                app: logflare-ch-setup-v3
         spec:
             restartPolicy: OnFailure
             containers:
@@ -183,5 +186,5 @@ spec:
             volumes:
                 - name: setup-script
                   configMap:
-                      name: logflare-ch-setup-v2-script
+                      name: logflare-ch-setup-v3-script
                       defaultMode: 0555

--- a/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
+++ b/apps/kube/clickhouse/manifests/clickhouse-installation.yaml
@@ -15,8 +15,8 @@ spec:
             logflare/networks/ip:
                 - '::/0'
             logflare/profile: 'default'
-            logflare/allow_databases:
-                - 'logflare'
+            logflare/grants:
+                - 'SHOW DATABASES,SELECT,INSERT,ALTER,CREATE TABLE,DROP TABLE,CREATE VIEW,DROP VIEW,CREATE DATABASE ON logflare.*'
         # Top-level ZooKeeper configuration - references the keeper service
         zookeeper:
             nodes:


### PR DESCRIPTION
## Summary
- Replace `allow_databases` with `grants` directive for the `logflare` ClickHouse user
- Add `--max-time 10` to `CREATE DATABASE` curl to prevent indefinite hangs
- Bump setup Job to v3 to force re-run with corrected grants

## What went wrong
The Altinity CH operator manages users via XML config, which is read-only for SQL GRANTs. The `allow_databases` setting restricts visibility but doesn't grant DDL permissions (`CREATE DATABASE`, `CREATE TABLE`, etc.). The Job hung on `CREATE DATABASE` because the curl got a 403-equivalent response that wasn't properly handled.

## What this fixes
Uses the operator's `grants` directive which properly grants DDL access:
```yaml
logflare/grants:
  - 'SHOW DATABASES,SELECT,INSERT,ALTER,CREATE TABLE,DROP TABLE,CREATE VIEW,DROP VIEW,CREATE DATABASE ON logflare.*'
```

## Test plan
- [ ] Verify CH operator reconciles the grant: `kubectl exec` into CH pod, test `CREATE TABLE` as logflare user
- [ ] Watch Job v3 logs: `kubectl logs -n kilobase job/logflare-ch-setup-v3`
- [ ] Confirm full pipeline: database created → backend configured → sources assigned → tables auto-created

Ref: #8015