### PR TITLE
feat(discordsh): wire resolve_combat_turn_solo through bevy_battle bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,6 +2555,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_skills"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bevy_sprite"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
@@ -10,8 +10,8 @@ use poise::serenity_prelude as serenity;
 use bevy_battle::{
     ActiveEffects, App, Armor, AttackIntent, BevyBattlePlugin, CombatIndex, CombatModifiers,
     CombatName, CombatOutcome, CombatStats, Combatant, CurrentIntent, DefendIntent, EnemyAI,
-    EnemyTag, EnemyTurnRequest, Entity, EquippedGear, FleeIntent, Health, Messages, MinimalPlugins,
-    PlayerClass, PlayerTag, TickEffectsRequest, UseItemIntent,
+    EnemyTag, EnemyTurnRequest, Entity, EquippedGear, FirstStrikeFired, FleeIntent, Health,
+    Messages, MinimalPlugins, PlayerClass, PlayerTag, TickEffectsRequest, UseItemIntent,
 };
 
 use super::content;
@@ -322,7 +322,14 @@ impl CombatWorld {
 
     /// Send player action intents, enemy turn request, and effect tick request,
     /// then run one update cycle.
-    pub fn run_turn(&mut self, actions: &[(serenity::UserId, PlayerAction)]) {
+    ///
+    /// If `skip_enemy_turns` is true, `EnemyTurnRequest` is not sent (used when
+    /// first-strike already ran enemy turns via the old code path).
+    pub fn run_turn(
+        &mut self,
+        actions: &[(serenity::UserId, PlayerAction)],
+        skip_enemy_turns: bool,
+    ) {
         // Send player intents
         for (uid, action) in actions {
             let Some(player_entity) = self.entity_map.player_entity(*uid) else {
@@ -360,8 +367,11 @@ impl CombatWorld {
             }
         }
 
-        // Request enemy turns and effect ticking
-        self.app.world_mut().write_message(EnemyTurnRequest);
+        // Request enemy turns (unless first-strike already ran them)
+        if !skip_enemy_turns {
+            self.app.world_mut().write_message(EnemyTurnRequest);
+        }
+        // Always tick effects
         self.app.world_mut().write_message(TickEffectsRequest);
 
         // Run one update cycle — all systems execute in order
@@ -377,8 +387,16 @@ impl CombatWorld {
 
     /// Sync ECS state back into session.
     ///
-    /// Updates HP, armor, effects, defending, intents, and marks dead enemies.
+    /// Updates HP, armor, effects, defending, intents, marks dead enemies,
+    /// and syncs the first-strike flag.
     pub fn sync_out(&self, session: &mut SessionState) {
+        // Sync first-strike flag
+        if let Some(flag) = self.app.world().get_resource::<FirstStrikeFired>() {
+            if flag.0 {
+                session.enemies_had_first_strike = true;
+            }
+        }
+
         // Sync players
         for (uid, entity) in &self.entity_map.players {
             let world = self.app.world();
@@ -498,16 +516,13 @@ pub fn outcome_to_log(outcome: &CombatOutcome, world: &CombatWorld) -> Option<St
         } => {
             let aname = name_of(*attacker);
             let tname = name_of(*target);
-            let mut msg = if *crit {
-                format!(
-                    "**CRITICAL HIT!** {} strikes {} for **{}** damage!",
-                    aname, tname, damage
-                )
-            } else {
-                format!("{} attacks {} for **{}** damage!", aname, tname, damage)
-            };
+            let crit_msg = if *crit { " Critical hit!" } else { "" };
+            let mut msg = format!(
+                "{} strikes {} for {} damage!{}",
+                aname, tname, damage, crit_msg
+            );
             if *overkill {
-                msg.push_str(" 💀 *Overkill!*");
+                msg.push_str(" Overkill!");
             }
             Some(msg)
         }
@@ -652,12 +667,16 @@ pub fn outcome_to_log(outcome: &CombatOutcome, world: &CombatWorld) -> Option<St
 /// 3. Runs one ECS update
 /// 4. Collects outcomes as log strings
 /// 5. Syncs state back to the session
+///
+/// If `skip_enemy_turns` is true, enemy turns are skipped (used when
+/// first-strike already ran enemy turns via the old code path).
 pub fn run_combat_turn(
     session: &mut SessionState,
     actions: &[(serenity::UserId, PlayerAction)],
+    skip_enemy_turns: bool,
 ) -> Vec<String> {
     let mut combat = CombatWorld::from_session(session);
-    combat.run_turn(actions);
+    combat.run_turn(actions, skip_enemy_turns);
 
     let outcomes = combat.collect_outcomes();
     let logs: Vec<String> = outcomes
@@ -666,6 +685,25 @@ pub fn run_combat_turn(
         .collect();
 
     combat.sync_out(session);
+
+    // Remove enemies that fled (EnemyFled outcome → remove from session)
+    let fled_entities: Vec<Entity> = outcomes
+        .iter()
+        .filter_map(|o| match o {
+            CombatOutcome::EnemyFled { entity } => Some(*entity),
+            _ => None,
+        })
+        .collect();
+    for fled_entity in &fled_entities {
+        if let Some(idx) = combat.entity_map.enemy_index(*fled_entity) {
+            session.enemies.retain(|e| e.index != idx);
+        }
+    }
+
+    // If all enemies fled or died, transition to exploring
+    if !session.has_enemies() && session.phase == GamePhase::Combat {
+        session.phase = GamePhase::Exploring;
+    }
 
     logs
 }
@@ -780,7 +818,7 @@ mod tests {
         let owner = session.owner;
 
         let actions = vec![(owner, PlayerAction::Attack { target_idx: 0 })];
-        let logs = run_combat_turn(&mut session, &actions);
+        let logs = run_combat_turn(&mut session, &actions, false);
 
         assert!(!logs.is_empty(), "Should produce log entries");
         // Enemy should have taken damage (or player missed, either is valid)
@@ -796,7 +834,7 @@ mod tests {
         let owner = session.owner;
 
         let actions = vec![(owner, PlayerAction::Defend)];
-        let _logs = run_combat_turn(&mut session, &actions);
+        let _logs = run_combat_turn(&mut session, &actions, false);
 
         // After sync_out, defending should reflect the ECS state
         // Note: bevy_battle defend system sets defending=true, but enemy turn
@@ -810,7 +848,7 @@ mod tests {
         let owner = session.owner;
 
         let actions = vec![(owner, PlayerAction::Attack { target_idx: 0 })];
-        run_combat_turn(&mut session, &actions);
+        run_combat_turn(&mut session, &actions, false);
 
         // After a turn, enemy should have rolled a new intent
         // (original was Attack{dmg:5}, new should be different with high probability)

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -2,6 +2,7 @@ use poise::serenity_prelude as serenity;
 use rand::prelude::*;
 use tracing::debug;
 
+use super::battle_bridge;
 use super::content;
 use super::types::*;
 
@@ -341,7 +342,11 @@ fn resolve_combat_turn(
     resolve_combat_turn_solo(session, player_action, actor)
 }
 
-/// Solo mode combat: resolve immediately.
+/// Solo mode combat: resolve immediately via bevy_battle ECS bridge.
+///
+/// First-strike, stun, and target fallback are handled here (session-level
+/// concerns). The core combat (player attack/defend, enemy turns, effect
+/// ticks) is delegated to `battle_bridge::run_combat_turn`.
 fn resolve_combat_turn_solo(
     session: &mut SessionState,
     player_action: GameAction,
@@ -358,7 +363,7 @@ fn resolve_combat_turn_solo(
         return logs;
     }
 
-    // Stunned check
+    // Stunned check (legacy field, not in bevy_battle)
     {
         let player = session.player_mut(actor);
         if player.stunned_turns > 0 {
@@ -374,74 +379,53 @@ fn resolve_combat_turn_solo(
         }
     }
 
-    // Determine target enemy index — auto-select first alive enemy when no
-    // explicit target was chosen (e.g., player pressed the Attack button
-    // instead of using the target dropdown with multiple enemies).
+    // Determine target enemy index with fallback to first alive enemy
     let target_idx = match &player_action {
-        GameAction::AttackTarget(idx) => *idx,
+        GameAction::AttackTarget(idx) => {
+            if session.enemy_at(*idx).is_some() {
+                *idx
+            } else {
+                debug!(
+                    target_idx = idx,
+                    enemies_alive = session.enemies.len(),
+                    "Target index not found, falling back to first alive enemy"
+                );
+                session.enemies.first().map(|e| e.index).unwrap_or(0)
+            }
+        }
         _ => session.enemies.first().map(|e| e.index).unwrap_or(0),
     };
     debug!(
         target_idx,
         enemy_count = session.enemies.len(),
         enemy_indices = ?session.enemies.iter().map(|e| e.index).collect::<Vec<_>>(),
-        "Solo combat target resolution"
+        "Solo combat target resolution (bridge)"
     );
 
-    // Player phase
-    match player_action {
+    // Convert GameAction → bridge PlayerAction
+    let bridge_action = match player_action {
         GameAction::Attack | GameAction::AttackTarget(_) => {
-            logs.extend(resolve_player_attack(session, actor, target_idx));
+            battle_bridge::PlayerAction::Attack { target_idx }
         }
-        GameAction::Defend => {
-            let player = session.player_mut(actor);
-            player.defending = true;
-            let pname = player.name.clone();
-            let pclass = player.class.clone();
-            logs.push(format!("{} braces for impact!", pname));
+        GameAction::Defend => battle_bridge::PlayerAction::Defend,
+        _ => return logs,
+    };
 
-            // Cleric defend proc: Prayer of Healing (25% chance, heal 5-10 HP)
-            if pclass == ClassType::Cleric {
-                let mut rng = rand::rng();
-                if rng.random::<f32>() < 0.25 {
-                    let heal = rng.random_range(5..=10);
-                    let player = session.player_mut(actor);
-                    let healed = heal.min(player.max_hp - player.hp);
-                    player.hp = (player.hp + heal).min(player.max_hp);
-                    if healed > 0 {
-                        logs.push(format!(
-                            "{} whispers a prayer, restoring {} HP!",
-                            pname, healed
-                        ));
-                    }
-                }
-            }
-        }
-        _ => {}
-    }
+    // Run combat through bevy_battle ECS.
+    // Skip enemy turns if first-strike already ran them this round.
+    logs.extend(battle_bridge::run_combat_turn(
+        session,
+        &[(actor, bridge_action)],
+        first_strike_fired,
+    ));
 
-    // Check enemy deaths and handle loot/xp
+    // Handle loot/xp/gold for dead enemies (bridge synced HP back)
     logs.extend(handle_enemy_deaths(session, actor));
 
-    // If all enemies dead, we're done
-    if !session.has_enemies() {
-        return logs;
+    // Check for game over (bridge synced player alive status)
+    if session.all_players_dead() {
+        session.phase = GamePhase::GameOver(GameOverReason::Defeated);
     }
-
-    // Enemy phase — skip if first strike already ran enemy turns this round
-    if !first_strike_fired {
-        let target = pick_enemy_target(session, actor);
-        logs.extend(enemy_turns(session, target));
-    }
-
-    // Tick effects for all alive players
-    logs.extend(tick_all_effects(session, actor));
-
-    // Tick enemy effects
-    logs.extend(tick_all_enemy_effects(session));
-
-    // Check enemy deaths from DoT
-    logs.extend(handle_enemy_deaths(session, actor));
 
     // Reset defending for the actor
     session.player_mut(actor).defending = false;

--- a/packages/rust/bevy/bevy_battle/src/system/attack.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/attack.rs
@@ -110,6 +110,28 @@ pub fn attack_system(
         let overkill = dmg > enemy_hp.current;
         enemy_hp.take_damage(dmg);
 
+        // Emit charge/ambush class proc BEFORE the attack outcome
+        if is_charge {
+            outcomes.write(CombatOutcome::ClassProc {
+                entity: intent.attacker,
+                proc_name: "Charge",
+                detail: format!(
+                    "{} spots an opening and charges into {}! {} damage!",
+                    player_name.0, enemy_name.0, dmg
+                ),
+            });
+        }
+        if is_ambush && crit {
+            outcomes.write(CombatOutcome::ClassProc {
+                entity: intent.attacker,
+                proc_name: "Ambush",
+                detail: format!(
+                    "{} strikes from the shadows, ambushing {}! {} damage! Critical hit!",
+                    player_name.0, enemy_name.0, dmg
+                ),
+            });
+        }
+
         outcomes.write(CombatOutcome::Attack {
             attacker: intent.attacker,
             target: intent.target,


### PR DESCRIPTION
## Summary
- Wires `resolve_combat_turn_solo` in `logic.rs` to delegate core combat (player attack/defend, enemy turns, effect ticks) through `battle_bridge::run_combat_turn` / bevy_battle ECS
- First-strike, stun check, and target fallback remain as pre-checks in `logic.rs` (session-level concerns)
- Bridge now supports `skip_enemy_turns` flag for when first-strike already ran enemy turns
- `sync_out` syncs `enemies_had_first_strike` from `FirstStrikeFired` resource
- Enemy flee properly removes enemies from session and triggers phase transition
- bevy_battle attack system emits ClassProc outcomes for Warrior Charge and Rogue Ambush (compatible log text)

## Context
Part of #8010 Phase 2. Follows #8036 (bridge module) and #8027 (bevy_battle crate). This is the first wiring PR — solo mode Attack/Defend now runs through the ECS. Party mode, Flee, UseItem, and HealAlly remain on the old code path for safety.

## Test plan
- [x] `cargo test -p bevy_battle` — 52 tests pass
- [x] `cargo test -p axum-discordsh` — 545 tests pass (all existing + bridge tests)
- [x] 3x full suite runs with 0 failures
- [ ] Docker build (CI validates)