### PR TITLE
fix(ci): bump timeout to 120m for Tauri builds and Docker tests

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -26,7 +26,7 @@ jobs:
     test:
         name: Test ${{ inputs.project }} Docker App
         runs-on: ${{ inputs.runner }}
-        timeout-minutes: 60
+        timeout-minutes: 120
         env:
             NX_NO_CLOUD: true
         permissions:

--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -68,7 +68,7 @@ jobs:
         needs: guard
         if: needs.guard.outputs.allowed == 'true'
         runs-on: ${{ inputs.linux_runner }}
-        timeout-minutes: 60
+        timeout-minutes: 120
         permissions:
             contents: read
 
@@ -184,7 +184,7 @@ jobs:
     build-macos:
         name: Build macOS
         runs-on: macos-latest
-        timeout-minutes: 60
+        timeout-minutes: 120
         permissions:
             contents: read
 
@@ -277,7 +277,7 @@ jobs:
     build-windows:
         name: Build Windows
         runs-on: windows-latest
-        timeout-minutes: 60
+        timeout-minutes: 120
         permissions:
             contents: read
 


### PR DESCRIPTION
## Summary
- Bump `timeout-minutes` from 60 to 120 in `utils-tauri-build.yml` for Linux, macOS, and Windows builds
- Bump `timeout-minutes` from 60 to 120 in `docker-test-app.yml` for Docker e2e tests
- Both were cancelling at 60m as project scope grows (Tauri Linux build, axum-kbve-e2e Docker test)

## Test plan
- [ ] Tauri Linux build completes within 120m
- [ ] Docker test app (axum-kbve-e2e) completes within 120m