### PR TITLE
feat(nx): add repo-wide stats and per-project coverage targets

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -50,6 +50,14 @@
 		"@nx/vitest:test": {
 			"cache": true,
 			"inputs": ["default", "^production"]
+		},
+		"coverage": {
+			"cache": false,
+			"inputs": ["default", "^production"]
+		},
+		"stats": {
+			"cache": true,
+			"inputs": ["default"]
 		}
 	},
 	"namedInputs": {

--- a/packages/npm/astro/project.json
+++ b/packages/npm/astro/project.json
@@ -42,6 +42,12 @@
 				"parallel": false
 			}
 		},
+		"coverage": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "vitest run --coverage --config packages/npm/astro/vite.config.ts"
+			}
+		},
 		"publish": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/packages/npm/devops/project.json
+++ b/packages/npm/devops/project.json
@@ -35,6 +35,12 @@
 				"parallel": false
 			}
 		},
+		"coverage": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "vitest run --coverage --config packages/npm/devops/vite.config.ts"
+			}
+		},
 		"publish": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/packages/npm/droid/project.json
+++ b/packages/npm/droid/project.json
@@ -41,6 +41,12 @@
 				"parallel": false
 			}
 		},
+		"coverage": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "vitest run --coverage --config packages/npm/droid/vite.config.ts"
+			}
+		},
 		"publish": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/packages/npm/khashvault/project.json
+++ b/packages/npm/khashvault/project.json
@@ -35,6 +35,12 @@
 				"parallel": false
 			}
 		},
+		"coverage": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "vitest run --coverage --config packages/npm/khashvault/vite.config.ts"
+			}
+		},
 		"publish": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/packages/npm/laser/project.json
+++ b/packages/npm/laser/project.json
@@ -35,6 +35,12 @@
 				"parallel": false
 			}
 		},
+		"coverage": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "vitest run --coverage --config packages/npm/laser/vite.config.ts"
+			}
+		},
 		"publish": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/project.json
+++ b/project.json
@@ -10,6 +10,22 @@
 				"config": ".verdaccio/config.yml",
 				"storage": "tmp/local-registry/storage"
 			}
+		},
+		"stats": {
+			"executor": "nx:run-commands",
+			"cache": true,
+			"inputs": ["default"],
+			"options": {
+				"command": "scc . --exclude-dir=node_modules,dist,.nx,.git,target,coverage,pumpkin,ergo,postgres --no-cocomo || npx --yes cloc . --exclude-dir=node_modules,dist,.nx,.git,target,coverage,pumpkin,ergo,postgres"
+			}
+		},
+		"stats-json": {
+			"executor": "nx:run-commands",
+			"cache": true,
+			"inputs": ["default"],
+			"options": {
+				"command": "scc . --exclude-dir=node_modules,dist,.nx,.git,target,coverage,pumpkin,ergo,postgres --format json --no-cocomo || npx --yes cloc . --exclude-dir=node_modules,dist,.nx,.git,target,coverage,pumpkin,ergo,postgres --json"
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `stats` and `stats-json` targets to root project using `scc` (with `npx cloc` fallback) for repo-wide LOC statistics
- Add `coverage` targets to vitest-based npm packages: droid, devops, khashvault, laser, astro
- Add `coverage` and `stats` targetDefaults to `nx.json` for workspace-wide configuration

## Usage
- `nx run @kbve/source:stats` — repo-wide LOC stats
- `nx run @kbve/source:stats-json` — JSON format
- `nx run droid:coverage` — per-project coverage
- `nx affected -t coverage` — coverage for changed projects

## Test plan
- [x] Verified `nx run @kbve/source:stats` produces scc output
- [x] Verified coverage targets are detected by Nx project graph
- [ ] CI validates lint/format passes