### PR TITLE
feat(discordsh): wire party Defend through bevy_battle bridge + structured turn results

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
@@ -121,6 +121,51 @@ fn to_bb_personality(p: &Personality) -> bevy_battle::Personality {
     }
 }
 
+/// Convert a session UseEffect → bevy_battle UseEffect for combat-relevant variants.
+///
+/// Returns `None` for session-level effects (GuaranteedFlee, CampfireRest,
+/// TeleportCity, ReviveAlly) that must be handled in logic.rs.
+pub fn to_bb_use_effect(effect: &UseEffect) -> Option<bevy_battle::UseEffect> {
+    match effect {
+        UseEffect::Heal { amount } => Some(bevy_battle::UseEffect::Heal { amount: *amount }),
+        UseEffect::DamageEnemy { amount } => {
+            Some(bevy_battle::UseEffect::DamageEnemy { amount: *amount })
+        }
+        UseEffect::ApplyEffect {
+            kind,
+            stacks,
+            turns,
+        } => Some(bevy_battle::UseEffect::ApplyEffect {
+            kind: to_bb_effect(kind),
+            stacks: *stacks,
+            turns: *turns,
+        }),
+        UseEffect::RemoveEffect { kind } => Some(bevy_battle::UseEffect::RemoveEffect {
+            kind: to_bb_effect(kind),
+        }),
+        UseEffect::FullHeal => Some(bevy_battle::UseEffect::FullHeal),
+        UseEffect::RemoveAllNegativeEffects => {
+            Some(bevy_battle::UseEffect::RemoveAllNegativeEffects)
+        }
+        UseEffect::DamageAndApply {
+            damage,
+            kind,
+            stacks,
+            turns,
+        } => Some(bevy_battle::UseEffect::DamageAndApply {
+            damage: *damage,
+            kind: to_bb_effect(kind),
+            stacks: *stacks,
+            turns: *turns,
+        }),
+        // Session-level effects — not handled by bevy_battle
+        UseEffect::GuaranteedFlee
+        | UseEffect::CampfireRest { .. }
+        | UseEffect::TeleportCity
+        | UseEffect::ReviveAlly { .. } => None,
+    }
+}
+
 // ── Gear → EquippedGear resolution ─────────────────────────────────
 
 /// Build EquippedGear component from a player's equipped weapon + armor IDs.
@@ -664,14 +709,25 @@ pub fn outcome_to_log(outcome: &CombatOutcome, world: &CombatWorld) -> Option<St
 
 // ── High-level bridge entry point ──────────────────────────────────
 
-/// Run a full combat turn through bevy_battle and return log entries.
+/// Result of a combat turn through the bridge.
+///
+/// Contains both human-readable logs and structured outcomes for callers
+/// that need to post-process specific outcome types (e.g. filtering Defend
+/// logs for auto-defended players in party mode).
+pub struct CombatTurnResult {
+    pub logs: Vec<String>,
+    pub outcomes: Vec<CombatOutcome>,
+}
+
+/// Run a full combat turn through bevy_battle and return results.
 ///
 /// This is the main entry point for the bridge. It:
 /// 1. Creates a CombatWorld from the session
-/// 2. Converts player actions to bridge PlayerActions
+/// 2. Sends player action intents
 /// 3. Runs one ECS update
-/// 4. Collects outcomes as log strings
+/// 4. Collects outcomes as log strings + structured data
 /// 5. Syncs state back to the session
+/// 6. Removes fled enemies and transitions phase if needed
 ///
 /// If `skip_enemy_turns` is true, enemy turns are skipped (used when
 /// first-strike already ran enemy turns via the old code path).
@@ -679,7 +735,7 @@ pub fn run_combat_turn(
     session: &mut SessionState,
     actions: &[(serenity::UserId, PlayerAction)],
     skip_enemy_turns: bool,
-) -> Vec<String> {
+) -> CombatTurnResult {
     let mut combat = CombatWorld::from_session(session);
     combat.run_turn(actions, skip_enemy_turns, true);
 
@@ -710,7 +766,7 @@ pub fn run_combat_turn(
         session.phase = GamePhase::Exploring;
     }
 
-    logs
+    CombatTurnResult { logs, outcomes }
 }
 
 /// Run a flee attempt through bevy_battle. Returns (logs, fled_successfully).
@@ -912,9 +968,9 @@ mod tests {
         let owner = session.owner;
 
         let actions = vec![(owner, PlayerAction::Attack { target_idx: 0 })];
-        let logs = run_combat_turn(&mut session, &actions, false);
+        let result = run_combat_turn(&mut session, &actions, false);
 
-        assert!(!logs.is_empty(), "Should produce log entries");
+        assert!(!result.logs.is_empty(), "Should produce log entries");
         // Enemy should have taken damage (or player missed, either is valid)
         // The key test: sync_out wrote back to session
         let enemy = &session.enemies[0];
@@ -928,7 +984,7 @@ mod tests {
         let owner = session.owner;
 
         let actions = vec![(owner, PlayerAction::Defend)];
-        let _logs = run_combat_turn(&mut session, &actions, false);
+        let _result = run_combat_turn(&mut session, &actions, false);
 
         // After sync_out, defending should reflect the ECS state
         // Note: bevy_battle defend system sets defending=true, but enemy turn

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -423,11 +423,9 @@ fn resolve_combat_turn_solo(
 
     // Run combat through bevy_battle ECS.
     // Skip enemy turns if first-strike already ran them this round.
-    logs.extend(battle_bridge::run_combat_turn(
-        session,
-        &[(actor, bridge_action)],
-        first_strike_fired,
-    ));
+    let result =
+        battle_bridge::run_combat_turn(session, &[(actor, bridge_action)], first_strike_fired);
+    logs.extend(result.logs);
 
     // Handle loot/xp/gold for dead enemies (bridge synced HP back)
     logs.extend(handle_enemy_deaths(session, actor));
@@ -446,8 +444,8 @@ fn resolve_combat_turn_solo(
 /// Party mode combat: resolve immediately via bevy_battle ECS bridge.
 ///
 /// First-strike, stun, UseItem, HealAlly, and ToggleItems are handled
-/// here (session-level concerns). Attack/Defend are delegated to
-/// `battle_bridge::run_combat_turn`.
+/// here (session-level concerns). Attack and Defend (including auto-defend
+/// with custom log text) are delegated to `battle_bridge::run_combat_turn`.
 fn resolve_combat_turn_party(
     session: &mut SessionState,
     player_action: GameAction,
@@ -481,11 +479,10 @@ fn resolve_combat_turn_party(
     let actions: Vec<(serenity::UserId, GameAction)> = session.pending_actions.drain().collect();
 
     // Phase 1: Process session-level actions first.
-    // Defend is handled here (custom auto-defend text + Cleric prayer proc).
+    // Defend goes through bridge (defending flag + Cleric prayer proc).
     // UseItem/HealAlly/ToggleItems are session-level operations.
-    // Attack actions are collected for bridge delegation.
+    // Attack/Defend actions are collected for bridge delegation.
     let mut bridge_actions: Vec<(serenity::UserId, battle_bridge::PlayerAction)> = Vec::new();
-    let mut rng = rand::rng();
 
     for (uid, action) in &actions {
         // Stunned check (legacy field, not in bevy_battle)
@@ -521,35 +518,16 @@ fn resolve_combat_turn_party(
                 bridge_actions.push((*uid, battle_bridge::PlayerAction::Attack { target_idx }));
             }
             GameAction::Defend => {
-                // Defend handled in logic.rs: set flag, emit log, run Cleric proc.
-                // The defending flag is synced into ECS via from_session so the
-                // bridge still applies damage reduction correctly.
-                let player = session.player_mut(*uid);
-                player.defending = true;
-                let pname = player.name.clone();
-                let pclass = player.class.clone();
+                // Auto-defended players get custom log text here; the bridge
+                // handles the actual defending flag + Cleric prayer proc.
                 if auto_defended.contains(uid) {
+                    let pname = session.player(*uid).name.clone();
                     logs.push(format!(
                         "{} takes a defensive stance, covering the party's flank!",
                         pname
                     ));
-                } else {
-                    logs.push(format!("{} braces for impact!", pname));
                 }
-
-                // Cleric defend proc: Prayer of Healing (25% chance)
-                if pclass == ClassType::Cleric && rng.random::<f32>() < 0.25 {
-                    let heal = rng.random_range(5..=10);
-                    let player = session.player_mut(*uid);
-                    let healed = heal.min(player.max_hp - player.hp);
-                    player.hp = (player.hp + heal).min(player.max_hp);
-                    if healed > 0 {
-                        logs.push(format!(
-                            "{} whispers a prayer, restoring {} HP!",
-                            pname, healed
-                        ));
-                    }
-                }
+                bridge_actions.push((*uid, battle_bridge::PlayerAction::Defend));
             }
             GameAction::UseItem(item_id, target_opt) => {
                 match apply_item(session, item_id, *uid, *target_opt) {
@@ -568,15 +546,28 @@ fn resolve_combat_turn_party(
         }
     }
 
-    // Phase 2: Run Attack actions + enemy turns + effect ticks through
+    // Collect auto-defended player names to filter their Defend logs from bridge
+    let auto_defend_names: Vec<String> = auto_defended
+        .iter()
+        .map(|uid| session.player(*uid).name.clone())
+        .collect();
+
+    // Phase 2: Run Attack + Defend actions + enemy turns + effect ticks through
     // bevy_battle ECS bridge. Always run the bridge so effects tick even
     // when no attacks are submitted.
     // Skip enemy turns if first-strike already ran them this round.
-    logs.extend(battle_bridge::run_combat_turn(
-        session,
-        &bridge_actions,
-        first_strike_fired,
-    ));
+    let result = battle_bridge::run_combat_turn(session, &bridge_actions, first_strike_fired);
+
+    // Filter out "braces for impact!" logs for auto-defended players (they
+    // already got custom text above). Keep all other logs.
+    for log in &result.logs {
+        let is_auto_defend_log = auto_defend_names
+            .iter()
+            .any(|name| *log == format!("{} braces for impact!", name));
+        if !is_auto_defend_log {
+            logs.push(log.clone());
+        }
+    }
 
     // Handle loot/xp/gold for dead enemies (bridge synced HP back)
     let first_actor = actions


### PR DESCRIPTION
## Summary
- Party Defend now goes through `bevy_battle` ECS via `DefendIntent`, removing duplicated Cleric prayer proc logic from `logic.rs`
- Auto-defended players get custom log text ("covering the party's flank!") in `logic.rs` while the bridge handles the defending flag + Cleric prayer proc via `defend_system`
- Added `CombatTurnResult` struct: `run_combat_turn` now returns both `logs: Vec<String>` and `outcomes: Vec<CombatOutcome>`, enabling callers to filter/post-process specific outcome types
- Added `to_bb_use_effect` converter for translating game `UseEffect` → `bevy_battle::UseEffect`, preparing for future combat item integration via `bevy_items`

## What's bridged now (complete list)
- Attack (solo + party)
- Defend (solo + party, including Cleric prayer proc)
- Flee
- First-strike enemy turns
- UseItem/HealAlly enemy turns
- Effect ticks
- Death detection
- Enemy flee removal

## Test plan
- [x] All 545 tests pass (`cargo test -p axum-discordsh`)
- [x] `cargo build -p axum-discordsh` compiles clean

Ref: #8010