### PR TITLE
fix(vector): fix VRL del() coalescing and disk buffer size

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -32,8 +32,8 @@ data:
               .project = "default"
               .event_message = del(.message)
               .appname = del(.container_name)
-              .pod_name = del(.pod_name) ?? ""
-              .pod_namespace = del(.pod_namespace) ?? ""
+              .pod_name = del(.pod_name)
+              .pod_namespace = del(.pod_namespace)
               del(.container_created_at)
               del(.container_id)
               del(.source_type)
@@ -253,6 +253,6 @@ data:
               timeout_secs: 5
             buffer:
               type: disk
-              max_size: 268435456
+              max_size: 536870912
             encoding:
               timestamp_format: rfc3339


### PR DESCRIPTION
## Summary
- Remove unnecessary `?? ""` after `del()` calls — VRL treats `del()` as infallible, rejects error coalescing
- Bump disk buffer `max_size` from 256MB to 512MB — Vector requires minimum 268435488 bytes

Vector was CrashLoopBackOff due to these config errors after #8053.

## Test plan
- [ ] Vector pod starts without CrashLoopBackOff
- [ ] Logs appear in `observability.logs_raw`

Ref #8015