### PR TITLE
fix(vector): switch to memory buffer for ClickHouse sink

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -252,7 +252,7 @@ data:
               max_bytes: 10485760
               timeout_secs: 5
             buffer:
-              type: disk
-              max_size: 536870912
+              type: memory
+              max_events: 10000
             encoding:
               timestamp_format: rfc3339


### PR DESCRIPTION
## Summary
- Switch Vector ClickHouse sink buffer from `disk` to `memory` (10k events)
- Disk buffer was failing with "Read-only file system (os error 30)" on the hostPath volume, causing CrashLoopBackOff
- This is the follow-up fix to #8054 which resolved the VRL coalescing and buffer size issues but didn't address the read-only filesystem

## Test plan
- [ ] ArgoCD syncs the updated ConfigMap
- [ ] Vector pods exit CrashLoopBackOff and reach Running state
- [ ] Verify rows landing in `observability.logs_raw` via ClickHouse query

Ref: #8015