### PR TITLE
fix(vector): correct kubernetes field paths + bump to v0.54.0

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -31,17 +31,14 @@ data:
             source: |-
               .project = "default"
               .event_message = del(.message)
-              .appname = del(.container_name)
-              .pod_name = del(.pod_name)
-              .pod_namespace = del(.pod_namespace)
-              del(.container_created_at)
-              del(.container_id)
+              .appname = del(.kubernetes.container_name)
+              .pod_name = del(.kubernetes.pod_name)
+              .pod_namespace = del(.kubernetes.pod_namespace)
+              del(.kubernetes)
               del(.source_type)
               del(.stream)
-              del(.label)
-              del(.image)
+              del(.file)
               del(.host)
-              del(.stream)
           router:
             type: route
             inputs:
@@ -52,7 +49,7 @@ data:
               rest: '.appname == "supabase-rest" || .appname == "postgrest"'
               realtime: '.appname == "supabase-realtime" || .appname == "realtime"'
               storage: '.appname == "supabase-storage" || .appname == "storage"'
-              functions: '.appname == "supabase-functions" || .appname == "functions"'
+              functions: '.appname == "supabase-functions" || .appname == "functions" || .appname == "edge-functions"'
               db: '.appname == "supabase-db" || .appname == "postgres"'
               analytics: '.appname == "logflare" || .appname == "supabase-analytics"'
               meta: '.appname == "postgres-meta" || .appname == "supabase-meta"'
@@ -213,6 +210,7 @@ data:
               - meta_logs
               - studio_logs
               - router.functions
+              - router._unmatched
             source: |-
               # Extract level from metadata or severity field
               .level = string(.severity) ??
@@ -230,9 +228,6 @@ data:
               del(.appname)
               del(.severity)
               del(.project)
-              del(.file)
-              del(.pod_labels)
-              del(.kubernetes)
 
         sinks:
           clickhouse:

--- a/apps/kube/vector/manifests/vector-daemonset.yaml
+++ b/apps/kube/vector/manifests/vector-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
             serviceAccountName: vector
             containers:
                 - name: vector
-                  image: timberio/vector:0.49.0-alpine
+                  image: timberio/vector:0.54.0-alpine
                   ports:
                       - containerPort: 9001
                         name: api


### PR DESCRIPTION
## Summary
- Fix `.container_name` → `.kubernetes.container_name` (same for pod_name, pod_namespace) — all events were falling to `router._unmatched` because the top-level fields don't exist in Vector's kubernetes_logs source
- Bump Vector 0.49.0 → 0.54.0
- Route `router._unmatched` into `ch_normalize` so unmatched containers (pgbouncer, bootstrap-controller, etc.) still land in ClickHouse
- Add `edge-functions` container name to functions route

## Test plan
- [ ] Vector pods restart with new image and config
- [ ] GraphQL API shows non-zero `receivedEventsTotal` on downstream transforms (kong_logs, auth_logs, etc.) and clickhouse sink
- [ ] `SELECT count() FROM observability.logs_raw` returns rows

Ref: #8015