### PR TITLE
feat(isometric): guest auth and auto-reconnect on tab resume

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -498,13 +498,35 @@ fn process_auth_messages(
 ) {
     for (entity, mut receiver, mut sender) in &mut query {
         for msg in receiver.receive() {
+            // --- Guest path: empty JWT → anonymous session ---
+            // Works regardless of whether SUPABASE_JWT_SECRET is set.
+            // Guests get a unique counter-based identity (guest_0, guest_1, …).
+            if msg.jwt.is_empty() || msg.jwt.trim().is_empty() {
+                let guest_idx = PLAYER_COUNTER.load(std::sync::atomic::Ordering::Relaxed);
+                let guest_user_id = format!("guest_{guest_idx}");
+                tracing::info!("client {entity:?} connecting as guest: {guest_user_id}");
+                let player_id = user_id_to_player_id(&guest_user_id);
+                let player_entity = spawn_player(&mut commands, player_id);
+                sender.send::<GameChannel>(AuthResponse {
+                    success: true,
+                    user_id: guest_user_id.clone(),
+                    player_id,
+                });
+                commands.entity(entity).remove::<PendingAuth>();
+                authenticated.0.insert(entity, guest_user_id);
+                client_player_map.0.insert(entity, player_entity);
+                continue;
+            }
+
+            // --- JWT path: validate with Supabase secret ---
             if jwt_secret.0.is_empty() {
-                tracing::warn!(
-                    "SUPABASE_JWT_SECRET not set — skipping JWT validation for {entity:?}"
-                );
-                // Anonymous: use counter-based ID (unique per session)
+                // No secret configured — treat any JWT as anonymous
+                // (dev/staging environments without Supabase)
                 let anon_idx = PLAYER_COUNTER.load(std::sync::atomic::Ordering::Relaxed);
                 let anon_user_id = format!("anon_{anon_idx}");
+                tracing::warn!(
+                    "SUPABASE_JWT_SECRET not set — accepting {entity:?} as {anon_user_id}"
+                );
                 let player_id = user_id_to_player_id(&anon_user_id);
                 let player_entity = spawn_player(&mut commands, player_id);
                 sender.send::<GameChannel>(AuthResponse {
@@ -516,7 +538,6 @@ fn process_auth_messages(
                 authenticated.0.insert(entity, anon_user_id.clone());
                 client_player_map.0.insert(entity, player_entity);
 
-                // Kick off async username lookup
                 let _ = profile_tx.0.send(ProfileRequest::LookupUsername {
                     player_entity,
                     user_id: anon_user_id,
@@ -539,7 +560,6 @@ fn process_auth_messages(
                     authenticated.0.insert(entity, user_id.clone());
                     client_player_map.0.insert(entity, player_entity);
 
-                    // Kick off async username lookup
                     let _ = profile_tx.0.send(ProfileRequest::LookupUsername {
                         player_entity,
                         user_id,

--- a/apps/kbve/isometric/src/components/GoOnlineButton.tsx
+++ b/apps/kbve/isometric/src/components/GoOnlineButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { go_online, get_online_status } from '../../wasm-pkg/isometric_game.js';
 import { GlassPanel } from '../ui/shared/GlassPanel';
 
@@ -70,16 +70,47 @@ async function getSupabaseJwt(): Promise<string> {
 	});
 }
 
+/** Build the WebSocket URL for the current environment. */
+function resolveWsUrl(): string {
+	const hostname = window.location.hostname;
+	const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+	return isLocal ? 'ws://127.0.0.1:5000' : `wss://${hostname}/ws`;
+}
+
 export function GoOnlineButton() {
 	const [online, setOnline] = useState(false);
 	const [connecting, setConnecting] = useState(false);
 	const [hasAuth, setHasAuth] = useState<boolean | null>(null);
+
+	// Track whether the user has opted into going online this session.
+	// Used by the visibilitychange handler to auto-reconnect.
+	const wantOnline = useRef(false);
+	// Guard against concurrent reconnect attempts.
+	const reconnecting = useRef(false);
 
 	// Check if user is logged in (has a Supabase session)
 	useEffect(() => {
 		getSupabaseJwt().then((jwt) => setHasAuth(jwt.length > 0));
 	}, []);
 
+	// Shared connect logic — used by both the button and auto-reconnect.
+	const doConnect = useCallback(async () => {
+		if (reconnecting.current) return;
+		reconnecting.current = true;
+		try {
+			const jwt = await getSupabaseJwt();
+			const wsUrl = resolveWsUrl();
+			go_online(wsUrl, jwt);
+		} finally {
+			// Clear the guard after a short delay so the status poll
+			// has time to detect the new connection attempt.
+			setTimeout(() => {
+				reconnecting.current = false;
+			}, 2000);
+		}
+	}, []);
+
+	// Poll connection status every 500ms.
 	useEffect(() => {
 		const interval = setInterval(() => {
 			try {
@@ -93,21 +124,45 @@ export function GoOnlineButton() {
 		return () => clearInterval(interval);
 	}, []);
 
+	// Auto-reconnect when the tab becomes visible again.
+	// Browsers throttle / tear down WebSocket connections in backgrounded
+	// tabs. When the user returns and we detect the connection dropped,
+	// silently reconnect using the same params.
+	useEffect(() => {
+		const onVisibilityChange = () => {
+			if (document.visibilityState !== 'visible') return;
+			if (!wantOnline.current) return;
+
+			// Give the status poll a moment to settle — the connection may
+			// still be alive but the poll hasn't fired yet.
+			setTimeout(() => {
+				try {
+					if (!get_online_status()) {
+						console.log(
+							'[GoOnlineButton] tab resumed, connection lost — auto-reconnecting',
+						);
+						setConnecting(true);
+						doConnect();
+					}
+				} catch {
+					// WASM not ready
+				}
+			}, 600);
+		};
+
+		document.addEventListener('visibilitychange', onVisibilityChange);
+		return () =>
+			document.removeEventListener(
+				'visibilitychange',
+				onVisibilityChange,
+			);
+	}, [doConnect]);
+
 	const handleClick = async () => {
 		if (online || connecting) return;
 		setConnecting(true);
-		try {
-			const jwt = await getSupabaseJwt();
-			const hostname = window.location.hostname;
-			const isLocal =
-				hostname === 'localhost' || hostname === '127.0.0.1';
-			const wsUrl = isLocal
-				? 'ws://127.0.0.1:5000'
-				: `wss://${hostname}/ws`;
-			go_online(wsUrl, jwt);
-		} catch {
-			setConnecting(false);
-		}
+		wantOnline.current = true;
+		await doConnect();
 	};
 
 	// Don't show button if auth check hasn't completed


### PR DESCRIPTION
## Summary
- Server accepts empty JWT as guest session (`guest_0`, `guest_1`, …) even when `SUPABASE_JWT_SECRET` is set — unauthenticated players can now join without Supabase auth
- JS `GoOnlineButton` listens for `visibilitychange` and auto-reconnects when the tab resumes and the WebSocket connection was lost (tab switching / minimize)
- Shared `doConnect()` with concurrency guard prevents duplicate reconnect attempts

## Test plan
- [ ] Open the game as a guest (no Supabase login) — verify connection succeeds and player spawns
- [ ] Minimize the tab for 30+ seconds, return — verify auto-reconnect fires and the player rejoins
- [ ] Login with Supabase, go online, minimize/return — verify authenticated reconnect works
- [ ] Verify the server logs show `guest_N` for unauthenticated and proper `user_id` for authenticated
