### PR TITLE
feat(discordsh): wire item consumption through bevy_inventory bridge (#8010)

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
@@ -296,6 +296,65 @@ fn ecs_inventory_to_session(inv: &Inventory<ProtoItemKind>) -> Vec<ItemStack> {
     items
 }
 
+// ── Session-level inventory operations ────────────────────────────
+//
+// These operate directly on a player's `Vec<ItemStack>` via bevy_inventory,
+// without needing a full CombatWorld. Used by `apply_item` and other
+// session-level logic that runs outside of the ECS combat loop.
+
+/// Consume one unit of an item from a player's session inventory.
+///
+/// Converts to `Inventory<ProtoItemKind>`, removes the item using
+/// `bevy_inventory::Inventory::remove()` (which handles stacking and
+/// auto-removes empty slots), then writes back.
+///
+/// Returns `true` if the item was found and consumed.
+pub fn consume_from_session(inventory: &mut Vec<ItemStack>, game_id: &str) -> bool {
+    let Some(kind) = pb::game_id_to_proto_item_kind(game_id) else {
+        return false;
+    };
+    let mut inv = session_inventory_to_ecs(inventory, MAX_INVENTORY_SLOTS as usize);
+    if inv.remove(kind, 1) == 0 {
+        return false;
+    }
+    *inventory = ecs_inventory_to_session(&inv);
+    true
+}
+
+/// Add items to a player's session inventory via bevy_inventory stacking.
+///
+/// Returns the number of items that could NOT fit (overflow).
+#[allow(dead_code)]
+pub fn add_to_session(inventory: &mut Vec<ItemStack>, game_id: &str, qty: u32) -> u32 {
+    let Some(kind) = pb::game_id_to_proto_item_kind(game_id) else {
+        return qty;
+    };
+    let mut inv = session_inventory_to_ecs(inventory, MAX_INVENTORY_SLOTS as usize);
+    let overflow = inv.add(kind, qty);
+    *inventory = ecs_inventory_to_session(&inv);
+    overflow
+}
+
+/// Check how many of an item a player has in their session inventory.
+#[allow(dead_code)]
+pub fn count_in_session(inventory: &[ItemStack], game_id: &str) -> u32 {
+    let Some(kind) = pb::game_id_to_proto_item_kind(game_id) else {
+        return 0;
+    };
+    let inv = session_inventory_to_ecs(inventory, MAX_INVENTORY_SLOTS as usize);
+    inv.count(kind)
+}
+
+/// Check whether a player's session inventory has room for an item.
+#[allow(dead_code)]
+pub fn has_room_in_session(inventory: &[ItemStack], game_id: &str, qty: u32) -> bool {
+    let Some(kind) = pb::game_id_to_proto_item_kind(game_id) else {
+        return false;
+    };
+    let inv = session_inventory_to_ecs(inventory, MAX_INVENTORY_SLOTS as usize);
+    inv.has_room_for(kind, qty)
+}
+
 // ── CombatWorld ────────────────────────────────────────────────────
 
 /// Wraps a headless Bevy App for running one combat turn.

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -1479,11 +1479,8 @@ fn apply_item(
             .retain(|e| e.kind != EffectKind::Bleed);
     }
 
-    // Decrement stack quantity
-    let player = session.player_mut(actor);
-    if let Some(stack) = player.inventory.iter_mut().find(|s| s.item_id == item_id) {
-        stack.qty -= 1;
-    }
+    // Consume one unit via bevy_inventory (handles stacking + empty slot cleanup)
+    battle_bridge::consume_from_session(&mut session.player_mut(actor).inventory, item_id);
     session.show_items = false;
 
     Ok(msg)
@@ -8764,13 +8761,16 @@ mod tests {
             GameAction::UseItem("phoenix_feather".to_owned(), None),
             OWNER,
         );
-        let stack = session
+        // bevy_inventory auto-removes empty stacks, so the item should be gone entirely
+        let has_feather = session
             .player(OWNER)
             .inventory
             .iter()
-            .find(|s| s.item_id == "phoenix_feather");
-        assert!(stack.is_some());
-        assert_eq!(stack.unwrap().qty, 0);
+            .any(|s| s.item_id == "phoenix_feather");
+        assert!(
+            !has_feather,
+            "phoenix_feather should be consumed and removed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace manual `stack.qty -= 1` in `apply_item` with `battle_bridge::consume_from_session()` which routes through `bevy_inventory::Inventory::remove()` — auto-cleans empty stacks instead of leaving qty=0 ghosts
- Add session-level inventory helpers: `consume_from_session`, `add_to_session`, `count_in_session`, `has_room_in_session` that convert to/from `Inventory<ProtoItemKind>` at the boundary
- Update `phoenix_feather_consumes_item` test to expect stack removal (bevy_inventory behavior) instead of qty=0

## Test plan
- [x] `cargo test -p axum-discordsh` — all 556 tests pass
- [x] All item-use tests pass including fire_flask, potion, smoke_bomb, campfire_kit, teleport_rune, phoenix_feather variants