### PR TITLE
fix(isometric): prevent terrain clipping and spawn-before-terrain race

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/player.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/player.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 
 use super::state::PlayerState;
 use super::terrain::TerrainMap;
+use super::tilemap::TerrainReady;
 use super::virtual_joystick::VirtualJoystickState;
 
 /// Fired when the player takes fall damage. The networking layer picks this up
@@ -131,10 +132,17 @@ fn move_player(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut joystick: ResMut<VirtualJoystickState>,
     time: Res<Time>,
+    terrain_ready: Option<Res<TerrainReady>>,
+    terrain: Res<TerrainMap>,
     spatial_query: SpatialQuery,
     sensor_query: Query<Entity, With<Sensor>>,
     mut query: Query<(Entity, &mut Transform, &mut PlayerPhysics), With<Player>>,
 ) {
+    // Freeze player until terrain colliders exist around spawn area.
+    if terrain_ready.is_none() {
+        return;
+    }
+
     for (entity, mut transform, mut physics) in &mut query {
         // WASD + Arrow keys → isometric directions
         let mut direction = Vec3::ZERO;
@@ -223,6 +231,20 @@ fn move_player(
         }
 
         transform.translation += resolved_h + resolved_v;
+
+        // --- Fallback floor: prevent falling through unloaded chunks ---
+        // If the player is below the terrain surface (e.g. chunk collider not
+        // yet spawned), snap them back up. This is the last line of defense.
+        let floor_y = terrain.height_at_loaded(
+            transform.translation.x.round() as i32,
+            transform.translation.z.round() as i32,
+        );
+        let min_y = floor_y + PLAYER_HEIGHT / 2.0;
+        if transform.translation.y < min_y - 0.5 {
+            transform.translation.y = min_y + 0.1;
+            physics.velocity_y = 0.0;
+            physics.on_ground = true;
+        }
     }
 }
 

--- a/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
@@ -1263,14 +1263,23 @@ pub(super) struct TileMaterials {
     water_mat: Handle<WaterMaterial>,
 }
 
-/// Global wind state. Speed in MPH drives all sway amplitudes.
+/// Inserted once the player's spawn-area chunks (and their colliders) have
+/// been spawned. Player movement is frozen until this resource exists.
+#[derive(Resource)]
+pub struct TerrainReady;
+
 pub struct TilemapPlugin;
 
 impl Plugin for TilemapPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CollectedTiles>();
         app.add_systems(Startup, setup_tile_materials);
-        app.add_systems(Update, process_chunk_spawns_and_despawns);
+        // Run chunk spawning before player movement so colliders exist
+        // before the first shape cast of each frame.
+        app.add_systems(
+            Update,
+            process_chunk_spawns_and_despawns.before(super::player::PlayerMovement),
+        );
     }
 }
 
@@ -1392,6 +1401,7 @@ fn process_chunk_spawns_and_despawns(
     blob_shadow: Option<Res<BlobShadowAssets>>,
     player_query: Query<&Transform, With<Player>>,
     collected_tiles: Res<CollectedTiles>,
+    terrain_ready: Option<Res<TerrainReady>>,
 ) {
     let Some(tile_materials) = tile_materials else {
         return;
@@ -1434,6 +1444,7 @@ fn process_chunk_spawns_and_despawns(
             far.push((cx, cz));
         }
     }
+    let had_near = !near.is_empty();
     far.truncate(MAX_DISTANT_SPAWNS);
     let mut spawns = near;
     spawns.extend(far);
@@ -1880,5 +1891,12 @@ fn process_chunk_spawns_and_despawns(
         }
 
         terrain.link_chunk_entities(*cx, *cz, entities);
+    }
+
+    // Once the player's immediate chunks have been spawned (with colliders),
+    // insert TerrainReady so the player controller can start moving.
+    if had_near && terrain_ready.is_none() {
+        commands.insert_resource(TerrainReady);
+        info!("[tilemap] TerrainReady — spawn-area colliders are live");
     }
 }


### PR DESCRIPTION
## Summary
- **TerrainReady gate**: Player movement is frozen until spawn-area chunk colliders are live — prevents the player from falling through empty space on first frame
- **System ordering**: `process_chunk_spawns_and_despawns` now runs `.before(PlayerMovement)` so colliders exist before shape casts fire each frame
- **Fallback floor**: If the player somehow falls below terrain height (unloaded chunk edge case), they're snapped back to the surface — last line of defense against clipping

## Test plan
- [ ] Start the game — verify player doesn't fall through terrain on first load
- [ ] Walk/jump across chunk boundaries — verify no clipping through ground
- [ ] Jump on steep terrain edges — verify player lands correctly
- [ ] Verify movement feels the same (no unintended changes to physics)