### PR TITLE
feat(vector): expand log collection to all cluster namespaces

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -16,10 +16,12 @@ data:
           kubernetes_logs:
             type: kubernetes_logs
             self_node_name: "${VECTOR_SELF_NODE_NAME}"
-            extra_namespace_label_selector: "kubernetes.io/metadata.name=kilobase"
             exclude_paths_glob_patterns:
               - "**/supabase-vector-*/**"
               - "**/vector/**"
+              - "**/kube-system/**"
+              - "**/kube-node-lease/**"
+              - "**/kube-public/**"
             auto_partial_merge: true
             data_dir: "/vector-data-dir"
 
@@ -29,11 +31,11 @@ data:
             inputs:
               - kubernetes_logs
             source: |-
-              .project = "default"
               .event_message = del(.message)
               .appname = del(.kubernetes.container_name)
               .pod_name = del(.kubernetes.pod_name)
               .pod_namespace = del(.kubernetes.pod_namespace)
+              .project = string(.pod_namespace) ?? "default"
               del(.kubernetes)
               del(.source_type)
               del(.stream)


### PR DESCRIPTION
## Summary
- Remove `extra_namespace_label_selector` that restricted collection to `kilobase` only
- Now collects from all namespaces: discordsh, mc, clickhouse, argocd, ingress-nginx, monitoring, redis, etc.
- Exclude kube-system, kube-node-lease, kube-public via glob patterns (noisy system logs)
- Set `.project` from `pod_namespace` instead of hardcoded `"default"` so logs are tagged by namespace
- Supabase-specific router still works for kilobase logs; all other namespaces flow through `_unmatched` → `ch_normalize`

## Test plan
- [ ] Vector restarts and begins collecting from multiple namespaces
- [ ] `SELECT pod_namespace, count() FROM observability.logs_raw GROUP BY pod_namespace` shows multiple namespaces
- [ ] No excessive log volume from excluded system namespaces

Ref: #8015