### PR TITLE
feat(vector): noise filter for infra namespaces

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -17,11 +17,7 @@ data:
             type: kubernetes_logs
             self_node_name: "${VECTOR_SELF_NODE_NAME}"
             exclude_paths_glob_patterns:
-              - "**/supabase-vector-*/**"
-              - "**/vector/**"
-              - "**/kube-system/**"
-              - "**/kube-node-lease/**"
-              - "**/kube-public/**"
+              - "**/vector_*/**"
             auto_partial_merge: true
             data_dir: "/vector-data-dir"
 
@@ -41,10 +37,29 @@ data:
               del(.stream)
               del(.file)
               del(.host)
+          # Drop info/debug from noisy infra namespaces, keep all for app namespaces
+          noise_filter:
+            type: filter
+            inputs:
+              - project_logs
+            condition:
+              type: vrl
+              source: |-
+                noisy = ["clickhouse", "arc-systems", "arc-runners", "monitoring",
+                         "kube-system", "kube-node-lease", "kube-public",
+                         "longhorn-system", "metallb-system", "cnpg-system",
+                         "cert-manager", "external-secrets-system"]
+                ns = string(.pod_namespace) ?? ""
+                if !includes(noisy, ns) {
+                    true
+                } else {
+                    msg = string(.event_message) ?? ""
+                    match(msg, r'(?i)(warn|error|fatal|panic|crit|exception|fail)')
+                }
           router:
             type: route
             inputs:
-              - project_logs
+              - noise_filter
             route:
               kong: '.appname == "supabase-kong" || .appname == "kong-kong" || .appname == "proxy"'
               auth: '.appname == "supabase-auth" || .appname == "gotrue"'


### PR DESCRIPTION
## Summary
- Add `noise_filter` transform between `project_logs` and `router`
- Noisy infra namespaces (clickhouse, arc-systems, arc-runners, monitoring, kube-system, longhorn-system, metallb-system, cnpg-system, cert-manager, external-secrets-system) only keep logs matching warn/error/fatal/panic/crit/exception/fail
- App namespaces (kilobase, discordsh, mc, kbve, bugwars, etc.) keep all log levels
- Fix glob exclusion pattern to properly match Vector's own pod log paths
- Collect from all namespaces including kube-system — errors from storage (longhorn), networking (metallb), etc. are valuable

## Test plan
- [ ] Vector restarts cleanly with the new filter transform
- [ ] `SELECT pod_namespace, count() FROM observability.logs_raw WHERE timestamp > now() - INTERVAL 10 MINUTE GROUP BY pod_namespace` shows infra namespaces with much lower counts
- [ ] Infra namespace logs that do appear contain warn/error/fatal level messages

Ref: #8015