### PR TITLE
fix(astro-kbve): resolve CodeQL tainted format string #219

### DIFF
--- a/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
@@ -481,7 +481,7 @@ self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
 				});
 		}
 	} catch (err: any) {
-		console.error(`[WebSocket Worker] Error handling ${type}:`, err);
+		console.error('[WebSocket Worker] Error handling message:', type, err);
 		respond(id, { ok: false, error: err.message || String(err) });
 	}
 };


### PR DESCRIPTION
## Summary
- Fixes CodeQL code-scanning alert #219 (js/tainted-format-string, CWE-134)
- In `supabase.websocket.ts` worker, the user-controlled `type` variable was interpolated into a `console.error` template literal format string
- Changed to pass `type` as a separate argument: `console.error('[WebSocket Worker] Error handling message:', type, err)`

## Test plan
- [ ] Verify CodeQL alert #219 is resolved after merge
- [ ] Confirm websocket worker error logging still functions correctly