### PR TITLE
fix(isometric): align CI/NX with pthreads build and add COOP headers

### DIFF
--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -288,8 +288,12 @@ jobs:
                           - 'apps/kbve/edge/version.toml'
                       isometric:
                           - 'apps/kbve/isometric/src/**'
+                          - 'apps/kbve/isometric/public/**'
                           - 'apps/kbve/isometric/src-tauri/src/**'
                           - 'apps/kbve/isometric/src-tauri/Cargo.toml'
+                          - 'apps/kbve/isometric/src-tauri/.cargo/**'
+                          - 'apps/kbve/isometric/src-tauri/rust-toolchain.toml'
                           - 'apps/kbve/isometric/src-tauri/tauri.conf.json'
                           - 'apps/kbve/isometric/package.json'
                           - 'apps/kbve/isometric/vite.config.ts'
+                          - 'packages/rust/bevy/bevy_tasker/**'

--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -381,10 +381,11 @@ jobs:
                   fetch-depth: 0
                   submodules: recursive
 
-            - name: Setup Rust
-              uses: dtolnay/rust-toolchain@stable
+            - name: Setup Rust (nightly for -Z build-std + atomics)
+              uses: dtolnay/rust-toolchain@nightly
               with:
                   targets: wasm32-unknown-unknown
+                  components: rust-src
 
             - name: Rust Cache
               uses: Swatinem/rust-cache@v2

--- a/apps/kbve/axum-kbve/src/astro/mod.rs
+++ b/apps/kbve/axum-kbve/src/astro/mod.rs
@@ -2,13 +2,14 @@ pub mod askama;
 
 use axum::{
     Router,
-    http::{StatusCode, header},
+    http::{HeaderValue, StatusCode, header},
     response::IntoResponse,
 };
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tower_http::services::ServeDir;
+use tower_http::set_header::SetResponseHeaderLayer;
 
 pub struct StaticConfig {
     pub base_dir: PathBuf,
@@ -89,12 +90,26 @@ pub fn build_static_router(config: &StaticConfig) -> Router {
         }
     };
 
+    // Isometric game requires cross-origin isolation for SharedArrayBuffer (WASM pthreads)
+    let isometric_service = serve_dir(base.join("isometric"));
+    let isometric_router = Router::new()
+        .nest_service("/", isometric_service)
+        .layer(SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("cross-origin-opener-policy"),
+            HeaderValue::from_static("same-origin"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("cross-origin-embedder-policy"),
+            HeaderValue::from_static("require-corp"),
+        ));
+
     Router::new()
         .nest_service("/_astro", astro_service)
         .nest_service("/assets", assets_service)
         .nest_service("/chunks", chunks_service)
         .nest_service("/images", images_service)
         .nest_service("/pagefind", pagefind_service)
+        .nest("/isometric", isometric_router)
         .fallback_service(fallback_svc)
 }
 

--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -23,7 +23,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"lsof -ti:1420 | xargs kill 2>/dev/null; lsof -ti:5000 | xargs kill 2>/dev/null; set -a && [ -f ../../../.env ] && . ../../../.env && set +a && export PATH=\"$HOME/.cargo/bin:$PATH\" && cd src-tauri && wasm-pack build --dev --target web --out-dir ../wasm-pkg --out-name isometric_game && cd .. && cargo run -p axum-kbve & pnpm dev"
+					"lsof -ti:1420 | xargs kill 2>/dev/null; lsof -ti:5000 | xargs kill 2>/dev/null; set -a && [ -f ../../../.env ] && . ../../../.env && set +a && export PATH=\"$HOME/.cargo/bin:$PATH\" && cd src-tauri && wasm-pack build --dev --target web --out-dir ../wasm-pkg --out-name isometric_game -- -Z build-std=panic_abort,std && cd .. && cargo run -p axum-kbve & pnpm dev"
 				],
 				"cwd": "apps/kbve/isometric"
 			}

--- a/apps/kbve/isometric/src/main.tsx
+++ b/apps/kbve/isometric/src/main.tsx
@@ -63,7 +63,8 @@ async function bootstrap() {
 
 		if (wasmModule && wasmMemory) {
 			for (let i = 0; i < numWorkers; i++) {
-				const worker = new Worker('/wasm-worker.js');
+				const base = import.meta.env.BASE_URL;
+				const worker = new Worker(`${base}wasm-worker.js`);
 				worker.postMessage({ module: wasmModule, memory: wasmMemory });
 			}
 			console.log(`[pthreads] Spawned ${numWorkers} WASM worker threads`);


### PR DESCRIPTION
## Summary
- **CI**: WASM build job switched from `@stable` to `@nightly` toolchain with `rust-src` component for `-Z build-std=panic_abort,std` (atomics rebuild)
- **CI**: File alteration triggers expanded to include `public/**`, `.cargo/**`, `rust-toolchain.toml`, and `bevy_tasker/**`
- **NX**: `quick` target wasm-pack command updated with `-Z build-std` flag
- **Runtime**: Worker URL uses `import.meta.env.BASE_URL` instead of hardcoded `/` so `wasm-worker.js` resolves under `/isometric/`
- **axum-kbve**: Scoped `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers on `/isometric/` routes — required for `SharedArrayBuffer` which WASM pthreads depend on

## Test plan
- [ ] CI WASM build job runs with nightly toolchain and `-Z build-std`
- [ ] `wasm-worker.js` loads at `/isometric/wasm-worker.js` in production
- [ ] `SharedArrayBuffer` is available in browser (verify `crossOriginIsolated === true` in console)
- [ ] Other routes (non-isometric) are unaffected by COOP/COEP headers
- [ ] NX `quick` target builds WASM with atomics locally

