### PR TITLE
fix(isometric): move build-std to cargo config and auto-install wasm-pack

### DIFF
--- a/apps/kbve/isometric/package.json
+++ b/apps/kbve/isometric/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"build:wasm": "cd src-tauri && wasm-pack build --target web --out-dir ../wasm-pkg --out-name isometric_game -- -Z build-std=panic_abort,std",
+		"build:wasm": "cd src-tauri && wasm-pack build --target web --out-dir ../wasm-pkg --out-name isometric_game",
 		"dev": "vite",
 		"build": "npm run build:wasm && npx tsc && vite build && mkdir -p dist/assets/shaders dist/assets/textures && cp -r public/assets/shaders/*.wgsl dist/assets/shaders/ && cp -r public/assets/textures/* dist/assets/textures/",
 		"preview": "vite preview"

--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -23,7 +23,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"lsof -ti:1420 | xargs kill 2>/dev/null; lsof -ti:5000 | xargs kill 2>/dev/null; set -a && [ -f ../../../.env ] && . ../../../.env && set +a && export PATH=\"$HOME/.cargo/bin:$PATH\" && cd src-tauri && wasm-pack build --dev --target web --out-dir ../wasm-pkg --out-name isometric_game -- -Z build-std=panic_abort,std && cd .. && cargo run -p axum-kbve & pnpm dev"
+					"lsof -ti:1420 | xargs kill 2>/dev/null; lsof -ti:5000 | xargs kill 2>/dev/null; set -a && [ -f ../../../.env ] && . ../../../.env && set +a && export PATH=\"$HOME/.cargo/bin:$PATH\" && command -v wasm-pack >/dev/null || cargo install wasm-pack --locked && cd src-tauri && wasm-pack build --dev --target web --out-dir ../wasm-pkg --out-name isometric_game && cd .. && cargo run -p axum-kbve & pnpm dev"
 				],
 				"cwd": "apps/kbve/isometric"
 			}

--- a/apps/kbve/isometric/src-tauri/.cargo/config.toml
+++ b/apps/kbve/isometric/src-tauri/.cargo/config.toml
@@ -5,3 +5,6 @@ rustflags = [
     "-C", "link-arg=--import-memory",
     "-C", "link-arg=--max-memory=4294967296",
 ]
+
+[unstable]
+build-std = ["panic_abort", "std"]


### PR DESCRIPTION
## Summary
- **Fix**: `wasm-pack build` doesn't forward `-- -Z` flags to cargo — was erroring with "is `-Z` the wrong directory?"
- **Solution**: Move `build-std = ["panic_abort", "std"]` into `.cargo/config.toml` `[unstable]` section so it applies automatically
- **Belt and suspenders**: `quick` target now auto-installs wasm-pack if missing (`command -v wasm-pack || cargo install`)
- Remove `-- -Z build-std=panic_abort,std` from `package.json` and `project.json` commands

## Test plan
- [ ] `./kbve.sh -nx isometric:quick` builds WASM successfully
- [ ] `pnpm build:wasm` in isometric dir works
- [ ] CI WASM build picks up `.cargo/config.toml` automatically