### PR TITLE
fix(isometric): shared memory, worker bindings and COOP headers for pthreads

### DIFF
--- a/apps/kbve/axum-kbve/src/astro/mod.rs
+++ b/apps/kbve/axum-kbve/src/astro/mod.rs
@@ -3,13 +3,13 @@ pub mod askama;
 use axum::{
     Router,
     http::{HeaderValue, StatusCode, header},
+    middleware::Next,
     response::IntoResponse,
 };
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tower_http::services::ServeDir;
-use tower_http::set_header::SetResponseHeaderLayer;
 
 pub struct StaticConfig {
     pub base_dir: PathBuf,
@@ -90,27 +90,35 @@ pub fn build_static_router(config: &StaticConfig) -> Router {
         }
     };
 
-    // Isometric game requires cross-origin isolation for SharedArrayBuffer (WASM pthreads)
-    let isometric_service = serve_dir(base.join("isometric"));
-    let isometric_router = Router::new()
-        .nest_service("/", isometric_service)
-        .layer(SetResponseHeaderLayer::overriding(
-            header::HeaderName::from_static("cross-origin-opener-policy"),
-            HeaderValue::from_static("same-origin"),
-        ))
-        .layer(SetResponseHeaderLayer::overriding(
-            header::HeaderName::from_static("cross-origin-embedder-policy"),
-            HeaderValue::from_static("require-corp"),
-        ));
-
     Router::new()
         .nest_service("/_astro", astro_service)
         .nest_service("/assets", assets_service)
         .nest_service("/chunks", chunks_service)
         .nest_service("/images", images_service)
         .nest_service("/pagefind", pagefind_service)
-        .nest("/isometric", isometric_router)
         .fallback_service(fallback_svc)
+        // Isometric game requires cross-origin isolation for SharedArrayBuffer (WASM pthreads).
+        // Scoped to /isometric/ paths only to avoid breaking other pages.
+        .layer(axum::middleware::from_fn(coop_coep_isometric))
+}
+
+/// Middleware that adds COOP/COEP headers to /isometric/ responses,
+/// enabling SharedArrayBuffer for WASM pthreads.
+async fn coop_coep_isometric(req: axum::extract::Request, next: Next) -> impl IntoResponse {
+    let is_isometric = req.uri().path().starts_with("/isometric");
+    let mut resp = next.run(req).await;
+    if is_isometric {
+        let headers = resp.headers_mut();
+        headers.insert(
+            header::HeaderName::from_static("cross-origin-opener-policy"),
+            HeaderValue::from_static("same-origin"),
+        );
+        headers.insert(
+            header::HeaderName::from_static("cross-origin-embedder-policy"),
+            HeaderValue::from_static("require-corp"),
+        );
+    }
+    resp
 }
 
 #[cfg(test)]

--- a/apps/kbve/isometric/package.json
+++ b/apps/kbve/isometric/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"build:wasm": "cd src-tauri && wasm-pack build --target web --out-dir ../wasm-pkg --out-name isometric_game",
+		"build:wasm": "cd src-tauri && RUSTUP_TOOLCHAIN=nightly cargo build --lib --target wasm32-unknown-unknown -Z build-std=panic_abort,std --release && command -v wasm-bindgen >/dev/null || cargo install wasm-bindgen-cli@0.2.114 --locked && wasm-bindgen ../../../dist/target/wasm32-unknown-unknown/release/isometric_game.wasm --out-dir ../wasm-pkg --target web --out-name isometric_game",
 		"dev": "vite",
 		"build": "npm run build:wasm && npx tsc && vite build && mkdir -p dist/assets/shaders dist/assets/textures && cp -r public/assets/shaders/*.wgsl dist/assets/shaders/ && cp -r public/assets/textures/* dist/assets/textures/",
 		"preview": "vite preview"

--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -23,7 +23,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"lsof -ti:1420 | xargs kill 2>/dev/null; lsof -ti:5000 | xargs kill 2>/dev/null; set -a && [ -f ../../../.env ] && . ../../../.env && set +a && export PATH=\"$HOME/.cargo/bin:$PATH\" && command -v wasm-pack >/dev/null || cargo install wasm-pack --locked && cd src-tauri && wasm-pack build --dev --target web --out-dir ../wasm-pkg --out-name isometric_game && cd .. && cargo run -p axum-kbve & pnpm dev"
+					"lsof -ti:1420 | xargs kill 2>/dev/null; lsof -ti:5000 | xargs kill 2>/dev/null; set -a && [ -f ../../../.env ] && . ../../../.env && set +a && export PATH=\"$HOME/.cargo/bin:$PATH\" && command -v wasm-bindgen >/dev/null || cargo install wasm-bindgen-cli@0.2.114 --locked && cd src-tauri && RUSTUP_TOOLCHAIN=nightly cargo build --lib --target wasm32-unknown-unknown -Z build-std=panic_abort,std && wasm-bindgen ../../../dist/target/wasm32-unknown-unknown/debug/isometric_game.wasm --out-dir ../wasm-pkg --target web --out-name isometric_game --debug && cd .. && cargo run -p axum-kbve & pnpm dev"
 				],
 				"cwd": "apps/kbve/isometric"
 			}

--- a/apps/kbve/isometric/src-tauri/.cargo/config.toml
+++ b/apps/kbve/isometric/src-tauri/.cargo/config.toml
@@ -3,8 +3,6 @@ rustflags = [
     "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals,+reference-types,+simd128",
     "-C", "llvm-args=--wasm-enable-sjlj",
     "-C", "link-arg=--import-memory",
+    "-C", "link-arg=--shared-memory",
     "-C", "link-arg=--max-memory=4294967296",
 ]
-
-[unstable]
-build-std = ["panic_abort", "std"]

--- a/packages/rust/bevy/bevy_tasker/src/job.rs
+++ b/packages/rust/bevy/bevy_tasker/src/job.rs
@@ -18,6 +18,7 @@ pub(crate) use local_runnable::LocalRunnable;
 extern crate alloc;
 
 /// A unit of async work enqueued on the microtask queue.
+#[allow(dead_code)] // Send is used in the non-atomics WASM path
 pub(crate) enum Job {
     /// A Send runnable — can execute on any thread.
     Send(Runnable),

--- a/packages/rust/bevy/bevy_tasker/src/worker.rs
+++ b/packages/rust/bevy/bevy_tasker/src/worker.rs
@@ -7,7 +7,6 @@
 
 #[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
 mod wasm_threads {
-    use alloc::sync::Arc;
     use alloc::vec::Vec;
     use core::sync::atomic::{AtomicI32, AtomicUsize, Ordering};
 
@@ -118,12 +117,12 @@ mod wasm_threads {
 
         let result = atomics_wait_async(&array, index, current);
 
-        if result.async_() {
+        if wait_result_async(&result) {
             // Not yet notified — set up continuation.
             let continuation = Closure::new(move |_: JsValue| {
                 poll_shared_queue();
             });
-            let _ = result.value().then(&continuation);
+            let _ = wait_result_value(&result).then(&continuation);
             continuation.forget();
         } else {
             // Already notified (work arrived between pop and wait) — poll again immediately.
@@ -145,19 +144,23 @@ mod wasm_threads {
     extern "C" {
         #[wasm_bindgen(js_name = queueMicrotask)]
         fn queue_microtask(closure: &Closure<dyn FnMut(JsValue)>);
+    }
 
-        type WaitAsyncResult;
-
-        #[wasm_bindgen(static_method_of = Atomics, js_name = waitAsync)]
-        fn atomics_wait_async(buf: &js_sys::Int32Array, index: u32, value: i32) -> WaitAsyncResult;
-
-        type Atomics;
-
-        #[wasm_bindgen(method, getter, structural, js_name = async)]
-        fn async_(this: &WaitAsyncResult) -> bool;
-
-        #[wasm_bindgen(method, getter, structural)]
-        fn value(this: &WaitAsyncResult) -> js_sys::Promise;
+    #[wasm_bindgen(inline_js = r#"
+        export function atomics_wait_async(buf, index, value) {
+            return Atomics.waitAsync(buf, index, value);
+        }
+        export function wait_result_async(result) {
+            return result.async;
+        }
+        export function wait_result_value(result) {
+            return result.value;
+        }
+    "#)]
+    extern "C" {
+        fn atomics_wait_async(buf: &js_sys::Int32Array, index: u32, value: i32) -> JsValue;
+        fn wait_result_async(result: &JsValue) -> bool;
+        fn wait_result_value(result: &JsValue) -> js_sys::Promise;
     }
 }
 


### PR DESCRIPTION
## Summary
- **Build chain**: Replace wasm-pack with `cargo build -Z build-std` + `wasm-bindgen` CLI (wasm-pack can't forward `-Z` flags)
- **Shared memory**: Add `--shared-memory` linker flag so WASM memory uses `SharedArrayBuffer` (fixes `Atomics.waitAsync` TypeError)
- **Worker bindings**: Fix `atomics_wait_async` — replace broken `static_method_of` extern with `inline_js` bindings
- **COOP/COEP**: Replace panicking `nest()` with path-checking middleware scoped to `/isometric/` routes
- **Belt and suspenders**: `RUSTUP_TOOLCHAIN=nightly` + auto-install `wasm-bindgen-cli` if missing
- Suppress `dead_code` warning on `Job::Send` (used in non-atomics path only)

## Test plan
- [ ] `./kbve.sh -nx isometric:quick` builds and runs
- [ ] Browser console shows `SharedArrayBuffer` available (`crossOriginIsolated === true`)
- [ ] No `Atomics.waitAsync` TypeError
- [ ] axum-kbve starts without nest() panic
- [ ] Non-isometric routes unaffected by COOP/COEP headers