### PR TITLE
fix(vector): extract log level from raw message patterns

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -37,6 +37,20 @@ data:
               del(.stream)
               del(.file)
               del(.host)
+
+              # Drop empty messages
+              if is_empty(string(.event_message) ?? "") { abort }
+
+              # Strip ANSI escape codes
+              .event_message = replace(.event_message, r'\x1b\[[0-9;]*m', "")
+
+              # Try parsing JSON messages (argocd, etc.) to extract level/msg
+              parsed, err = parse_json(.event_message)
+              if err == null {
+                  if exists(parsed.level) { .severity = del(parsed.level) }
+                  if exists(parsed.msg) { .event_message = string(parsed.msg) ?? .event_message }
+                  .metadata = parsed
+              }
           # Drop info/debug from noisy infra namespaces, keep all for app namespaces
           noise_filter:
             type: filter


### PR DESCRIPTION
## Summary
- Fix level extraction in `ch_normalize` — was defaulting all 4.15M rows to `"info"`
- Metadata-based level only works for Supabase service transforms; all other namespaces had no level set
- Now parses level from raw message text covering all observed formats:
  - **ClickHouse**: `<Error>`, `<Warning>`, `<Debug>`, `<Information>`
  - **kube-system**: `E0302` (error), `W0302` (warn), `I0302` (info), `F0302` (fatal)
  - **Structured logs**: `level=error`, `level=warn`, `level=INFO`
  - **ANSI/generic**: `ERROR`, `WARN`, `DEBUG`, `FATAL`, `PANIC` keywords

## Test plan
- [ ] Vector restarts cleanly
- [ ] `SELECT level, count() FROM observability.logs_raw WHERE timestamp > now() - INTERVAL 10 MINUTE GROUP BY level` shows multiple levels (not just "info")
- [ ] Error/warn queries return actual errors and warnings

Ref: #8015