### PR TITLE
fix(axum-kbve-e2e): correct mapdb.json itemsKey to mapObjects

### DIFF
--- a/apps/kbve/axum-kbve-e2e/e2e/content-routes.spec.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/content-routes.spec.ts
@@ -34,7 +34,7 @@ const API_ENDPOINTS: ApiEndpoint[] = [
 	{
 		path: '/api/mapdb.json',
 		label: 'MapDB',
-		itemsKey: 'objects',
+		itemsKey: 'mapObjects',
 		indexKey: 'index',
 		refPrefix: '/mapdb/',
 	},


### PR DESCRIPTION
## Summary
- The `mapdb.json` API endpoint returns `{ mapObjects, index }` but the e2e test expected the key `objects` instead of `mapObjects`
- One-line fix in `content-routes.spec.ts`

## Test plan
- [ ] CI re-runs `axum-kbve-e2e` and all 23 content-route tests pass