### PR TITLE
fix(ci): add nightly toolchain with rust-src to Tauri desktop builds

### DIFF
--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -92,10 +92,16 @@ jobs:
                     libayatana-appindicator3-dev libxdo-dev \
                     libasound2-dev libudev-dev libvulkan-dev
 
-            - name: Setup Rust
+            - name: Setup Rust (stable)
               uses: dtolnay/rust-toolchain@stable
               with:
                   targets: wasm32-unknown-unknown
+
+            - name: Setup Rust (nightly for -Z build-std WASM)
+              uses: dtolnay/rust-toolchain@nightly
+              with:
+                  targets: wasm32-unknown-unknown
+                  components: rust-src
 
             - name: Setup Cargo Cache
               uses: actions/cache@v5
@@ -195,10 +201,16 @@ jobs:
                   fetch-depth: 0
                   submodules: recursive
 
-            - name: Setup Rust
+            - name: Setup Rust (stable)
               uses: dtolnay/rust-toolchain@stable
               with:
                   targets: wasm32-unknown-unknown
+
+            - name: Setup Rust (nightly for -Z build-std WASM)
+              uses: dtolnay/rust-toolchain@nightly
+              with:
+                  targets: wasm32-unknown-unknown
+                  components: rust-src
 
             - name: Rust Cache
               uses: Swatinem/rust-cache@v2
@@ -288,10 +300,16 @@ jobs:
                   fetch-depth: 0
                   submodules: recursive
 
-            - name: Setup Rust
+            - name: Setup Rust (stable)
               uses: dtolnay/rust-toolchain@stable
               with:
                   targets: wasm32-unknown-unknown
+
+            - name: Setup Rust (nightly for -Z build-std WASM)
+              uses: dtolnay/rust-toolchain@nightly
+              with:
+                  targets: wasm32-unknown-unknown
+                  components: rust-src
 
             - name: Rust Cache
               uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- All three Tauri desktop builds (Linux, macOS, Windows) were failing because `build:wasm` uses `RUSTUP_TOOLCHAIN=nightly` with `-Z build-std=panic_abort,std`, but only the `stable` toolchain was installed
- The nightly toolchain requires `rust-src` component to rebuild `std` for `wasm32-unknown-unknown`
- Without it, cargo silently fails and `wasm-bindgen` can't find `isometric_game.wasm`

## Root cause
```
error: "/root/.rustup/toolchains/nightly-.../lib/rustlib/src/rust/library/Cargo.lock" does not exist, unable to build with the standard library
```

## Fix
Add `dtolnay/rust-toolchain@nightly` with `targets: wasm32-unknown-unknown` and `components: rust-src` to all three desktop build jobs (Linux, macOS, Windows), alongside the existing stable toolchain.

## Test plan
- [ ] CI runs Tauri builds on all three platforms without the `failed reading .wasm` error