### PR TITLE
feat(isometric): downscale droid workers before WASM load

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
+++ b/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
@@ -38,10 +38,43 @@
 	<link rel="stylesheet" crossorigin href="/isometric/assets/index.css" />
 	<script is:inline>
 		(function () {
+			// Downscale droid workers to free threads for WASM pthreads
+			function downscaleDroid() {
+				if (
+					window.kbve &&
+					typeof window.kbve.downscale === 'function'
+				) {
+					window.kbve.downscale().catch(function (e) {
+						console.warn('[Isometric] Droid downscale failed:', e);
+					});
+					return;
+				}
+				// Poll until droid is ready (max ~5s)
+				var attempts = 0;
+				var poll = setInterval(function () {
+					attempts++;
+					if (
+						window.kbve &&
+						typeof window.kbve.downscale === 'function'
+					) {
+						clearInterval(poll);
+						window.kbve.downscale().catch(function (e) {
+							console.warn(
+								'[Isometric] Droid downscale failed:',
+								e,
+							);
+						});
+					} else if (attempts > 50) {
+						clearInterval(poll);
+					}
+				}, 100);
+			}
+
 			if (navigator.gpu) {
 				document.getElementById('game-loading').style.display = 'flex';
 				document.getElementById('bevy-canvas').style.display = '';
 				document.getElementById('root').style.display = '';
+				downscaleDroid();
 				var s = document.createElement('script');
 				s.type = 'module';
 				s.src = '/isometric/assets/index.js';


### PR DESCRIPTION
## Summary
- Adds inline script to the isometric game Astro page that calls `window.kbve.downscale()` before WASM pthreads load
- Polls for `window.kbve` availability (max ~5s, 100ms interval) since droid may initialize after the page script runs
- Gracefully handles cases where droid isn't present (timeout, no error)
- No changes to the isometric game code itself — only the Astro wrapper

## Test plan
- [ ] Verify isometric game still loads and runs correctly
- [ ] Check browser console for `[Isometric] Droid downscale failed` — should not appear
- [ ] Confirm droid canvas worker is terminated before WASM init (check `window.kbve.scaleLevel()` returns `'minimal'`)