### PR TITLE
fix(droid-e2e): use getScaleLevel import directly in ScaleTest

### DIFF
--- a/packages/npm/droid-e2e/src/app/ScaleTest.tsx
+++ b/packages/npm/droid-e2e/src/app/ScaleTest.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { droid, workerURLs } from '@kbve/droid';
+import { droid, workerURLs, getScaleLevel } from '@kbve/droid';
 import type { DroidScaleLevel } from '@kbve/droid';
 
 export function ScaleTest() {
@@ -19,11 +19,7 @@ export function ScaleTest() {
 	const refreshState = useCallback(() => {
 		const kbve = (window as any).kbve;
 		if (!kbve) return;
-		setScaleLevel(
-			typeof kbve.scaleLevel === 'function'
-				? kbve.scaleLevel()
-				: 'unknown',
-		);
+		setScaleLevel(getScaleLevel());
 		setHasOverlay(!!kbve.overlay);
 		setHasCanvasWorker(!!kbve.uiux?.worker);
 		setHasGateway(!!kbve.gateway);


### PR DESCRIPTION
## Summary
- Uses the imported `getScaleLevel()` function directly instead of going through `window.kbve.scaleLevel()`
- Resolves CodeQL unused import notice while keeping the test meaningful

## Test plan
- [ ] droid-e2e 50 tests pass