### PR TITLE
feat(discordsh): integrate bevy_quests proto-driven quest system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "bevy_inventory",
  "bevy_items",
  "bevy_npc",
+ "bevy_quests",
  "dashmap 6.1.0",
  "dotenvy",
  "http-body-util",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -44,6 +44,7 @@ bevy_items = { path = "../../../packages/rust/bevy/bevy_items", features = ["inv
 bevy_inventory = { path = "../../../packages/rust/bevy/bevy_inventory", default-features = false }
 bevy_battle = { path = "../../../packages/rust/bevy/bevy_battle" }
 bevy_npc = { path = "../../../packages/rust/bevy/bevy_npc" }
+bevy_quests = { path = "../../../packages/rust/bevy/bevy_quests" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -102,6 +102,7 @@ COPY packages/rust/bevy/bevy_inventory/Cargo.toml packages/rust/bevy/bevy_invent
 COPY packages/rust/bevy/bevy_items/Cargo.toml packages/rust/bevy/bevy_items/Cargo.toml
 COPY packages/rust/bevy/bevy_battle/Cargo.toml packages/rust/bevy/bevy_battle/Cargo.toml
 COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
+COPY packages/rust/bevy/bevy_quests/Cargo.toml packages/rust/bevy/bevy_quests/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
@@ -111,7 +112,8 @@ RUN mkdir -p apps/discordsh/axum-discordsh/src && echo "fn main() {}" > apps/dis
     mkdir -p packages/rust/bevy/bevy_inventory/src && echo "" > packages/rust/bevy/bevy_inventory/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_items/src && echo "" > packages/rust/bevy/bevy_items/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_battle/src && echo "" > packages/rust/bevy/bevy_battle/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs
+    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_quests/src && echo "" > packages/rust/bevy/bevy_quests/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -148,10 +150,11 @@ COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
 COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
+COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc
+    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc -p bevy_quests
 
 # ============================================================================
 # [STAGE F] - Build Application
@@ -173,6 +176,7 @@ COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
 COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
+COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 
 # Application source (most frequently changing — placed last for cache)
 COPY apps/discordsh/axum-discordsh apps/discordsh/axum-discordsh

--- a/apps/discordsh/axum-discordsh/Dockerfile.base
+++ b/apps/discordsh/axum-discordsh/Dockerfile.base
@@ -47,6 +47,7 @@ COPY packages/rust/bevy/bevy_inventory/Cargo.toml packages/rust/bevy/bevy_invent
 COPY packages/rust/bevy/bevy_items/Cargo.toml packages/rust/bevy/bevy_items/Cargo.toml
 COPY packages/rust/bevy/bevy_battle/Cargo.toml packages/rust/bevy/bevy_battle/Cargo.toml
 COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
+COPY packages/rust/bevy/bevy_quests/Cargo.toml packages/rust/bevy/bevy_quests/Cargo.toml
 
 # Proto files (needed for jedi build.rs during chef prepare)
 COPY packages/data/proto packages/data/proto
@@ -58,7 +59,8 @@ RUN mkdir -p apps/discordsh/axum-discordsh/src && echo "fn main() {}" > apps/dis
     mkdir -p packages/rust/bevy/bevy_inventory/src && echo "" > packages/rust/bevy/bevy_inventory/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_items/src && echo "" > packages/rust/bevy/bevy_items/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_battle/src && echo "" > packages/rust/bevy/bevy_battle/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs
+    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_quests/src && echo "" > packages/rust/bevy/bevy_quests/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -104,7 +106,8 @@ COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
 COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
+COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc
+    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc -p bevy_quests

--- a/apps/discordsh/axum-discordsh/data/questdb.json
+++ b/apps/discordsh/axum-discordsh/data/questdb.json
@@ -1,0 +1,260 @@
+{
+	"quests": [
+		{
+			"id": "01JX26AA1NSLIMESLAYER000001",
+			"ref": "slime-slayer",
+			"title": "Slime Slayer",
+			"description": "The dungeon's lower tunnels are overrun with slimes. Clear them out to prove your worth.",
+			"category": "side",
+			"tags": ["discordsh", "combat", "beginner"],
+			"hidden": false,
+			"repeatable": false,
+			"recommended_level": 1,
+			"steps": [
+				{
+					"id": "step-kill-slimes",
+					"title": "Exterminate the Slimes",
+					"objectives": [
+						{
+							"id": "obj-kill-3-enemies",
+							"description": "Defeat 3 enemies in the dungeon",
+							"type": "kill",
+							"required_amount": 3
+						}
+					]
+				}
+			],
+			"rewards": {
+				"currency": 50,
+				"xp": 30
+			},
+			"triggers": ["player:level:1", "area:dungeon"]
+		},
+		{
+			"id": "01JX26BB2NDUNGEONDELVER0002",
+			"ref": "dungeon-delver",
+			"title": "Dungeon Delver",
+			"description": "Venture deep into the dungeon and explore its forgotten corridors.",
+			"category": "main",
+			"tags": ["discordsh", "exploration", "beginner"],
+			"hidden": false,
+			"repeatable": false,
+			"recommended_level": 1,
+			"steps": [
+				{
+					"id": "step-explore-rooms",
+					"title": "Explore the Dungeon",
+					"objectives": [
+						{
+							"id": "obj-visit-5-rooms",
+							"description": "Explore 5 different rooms",
+							"type": "explore",
+							"required_amount": 5
+						}
+					]
+				}
+			],
+			"rewards": {
+				"currency": 75,
+				"xp": 50
+			},
+			"triggers": ["player:level:1", "area:dungeon"],
+			"next_quest_ref": "shadow-hunter"
+		},
+		{
+			"id": "01JX26CC3NSHADOWHUNTER00003",
+			"ref": "shadow-hunter",
+			"title": "Shadow Hunter",
+			"description": "A powerful shadow wraith has been sighted in the deeper levels. Track it down and destroy it.",
+			"category": "main",
+			"tags": ["discordsh", "combat", "boss"],
+			"hidden": false,
+			"repeatable": false,
+			"recommended_level": 3,
+			"prerequisites": {
+				"quest_refs": ["dungeon-delver"],
+				"level_requirement": 2
+			},
+			"steps": [
+				{
+					"id": "step-reach-depth",
+					"title": "Descend to the Depths",
+					"objectives": [
+						{
+							"id": "obj-explore-rooms",
+							"description": "Explore 8 rooms to reach the deeper levels",
+							"type": "explore",
+							"required_amount": 8
+						}
+					]
+				},
+				{
+					"id": "step-slay-boss",
+					"title": "Slay the Shadow Wraith",
+					"objectives": [
+						{
+							"id": "obj-kill-boss",
+							"description": "Defeat a boss enemy",
+							"type": "kill",
+							"target_refs": ["shadow-wraith"],
+							"required_amount": 1
+						}
+					]
+				}
+			],
+			"rewards": {
+				"currency": 200,
+				"xp": 150,
+				"items": [
+					{
+						"item_ref": "smoke-bomb",
+						"amount": 3
+					}
+				]
+			},
+			"triggers": ["quest:complete:dungeon-delver"],
+			"next_quest_ref": "kings-demise"
+		},
+		{
+			"id": "01JX26DD4NKINGSDEMISE000004",
+			"ref": "kings-demise",
+			"title": "The King's Demise",
+			"description": "The Shattered King rules the deepest level of the dungeon. End his reign of terror.",
+			"category": "main",
+			"tags": ["discordsh", "combat", "boss", "endgame"],
+			"hidden": false,
+			"repeatable": false,
+			"recommended_level": 5,
+			"prerequisites": {
+				"quest_refs": ["shadow-hunter"],
+				"level_requirement": 3
+			},
+			"steps": [
+				{
+					"id": "step-prepare",
+					"title": "Prepare for the Final Battle",
+					"objectives": [
+						{
+							"id": "obj-kill-10-enemies",
+							"description": "Defeat 10 enemies to prove you are ready",
+							"type": "kill",
+							"required_amount": 10
+						}
+					]
+				},
+				{
+					"id": "step-defeat-king",
+					"title": "Defeat the Shattered King",
+					"objectives": [
+						{
+							"id": "obj-kill-shattered-king",
+							"description": "Defeat the Shattered King",
+							"type": "kill",
+							"target_refs": ["the-shattered-king"],
+							"required_amount": 1
+						}
+					]
+				}
+			],
+			"rewards": {
+				"currency": 500,
+				"xp": 300,
+				"items": [
+					{
+						"item_ref": "excalibur",
+						"amount": 1
+					}
+				],
+				"achievement": {
+					"api_name": "ACH_KINGS_DEMISE",
+					"name": "Kingslayer",
+					"description": "Defeated the Shattered King in the deepest dungeon.",
+					"hidden": false,
+					"min_value": 0,
+					"max_value": 1
+				}
+			},
+			"triggers": ["quest:complete:shadow-hunter"]
+		},
+		{
+			"id": "01JX26EE5NTREASURESEEKER005",
+			"ref": "treasure-seeker",
+			"title": "Treasure Seeker",
+			"description": "The dungeon is filled with hidden riches. Collect gold from treasure rooms and enemy loot.",
+			"category": "side",
+			"tags": ["discordsh", "loot", "beginner"],
+			"hidden": false,
+			"repeatable": true,
+			"recommended_level": 1,
+			"steps": [
+				{
+					"id": "step-collect-gold",
+					"title": "Amass a Fortune",
+					"objectives": [
+						{
+							"id": "obj-earn-100-gold",
+							"description": "Earn 100 gold in a single dungeon run",
+							"type": "collect",
+							"required_amount": 100
+						}
+					]
+				}
+			],
+			"rewards": {
+				"currency": 25,
+				"xp": 20,
+				"items": [
+					{
+						"item_ref": "potion",
+						"amount": 2
+					}
+				]
+			},
+			"triggers": ["player:level:1", "area:dungeon"]
+		},
+		{
+			"id": "01JX26FF6NSURVIVOR00000006",
+			"ref": "survivor",
+			"title": "Survivor",
+			"description": "The dungeon is merciless. Prove you can endure by clearing rooms without falling in battle.",
+			"category": "challenge",
+			"tags": ["discordsh", "survival", "challenge"],
+			"hidden": false,
+			"repeatable": true,
+			"recommended_level": 2,
+			"steps": [
+				{
+					"id": "step-clear-rooms",
+					"title": "Clear Rooms Without Dying",
+					"objectives": [
+						{
+							"id": "obj-clear-3-rooms",
+							"description": "Clear 3 combat rooms without dying",
+							"type": "explore",
+							"required_amount": 3
+						}
+					]
+				}
+			],
+			"rewards": {
+				"currency": 100,
+				"xp": 75,
+				"items": [
+					{
+						"item_ref": "campfire-kit",
+						"amount": 1
+					}
+				]
+			},
+			"triggers": ["player:level:2", "area:dungeon"]
+		}
+	],
+	"key": {
+		"slime-slayer": 0,
+		"dungeon-delver": 1,
+		"shadow-hunter": 2,
+		"kings-demise": 3,
+		"treasure-seeker": 4,
+		"survivor": 5
+	}
+}

--- a/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
@@ -117,6 +117,7 @@ async fn start(
         show_inventory: false,
         pending_destination: None,
         enemies_had_first_strike: false,
+        quest_journal: QuestJournal::default(),
     };
 
     let components = render::render_components(&session_state);

--- a/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
@@ -1140,6 +1140,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/card.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/card.rs
@@ -1179,6 +1179,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -5,6 +5,7 @@ use tracing::debug;
 
 use super::battle_bridge;
 use super::content;
+use super::proto_bridge;
 use super::types::*;
 
 /// Result of applying a game action, including optional ECS combat snapshot.
@@ -33,6 +34,213 @@ impl std::ops::Deref for ActionResult {
 }
 
 const CLERIC_HEALS_PER_COMBAT: u8 = 1;
+
+// ── Quest progress helpers ──────────────────────────────────────────
+
+/// Advance "kill" objectives in all active quests.
+///
+/// `enemy_ref` is the NPC ref slug of the killed enemy (e.g. "glass-slime").
+/// Objectives with no `target_refs` count any kill; those with `target_refs`
+/// only count kills of matching refs.
+fn advance_kill_objectives(session: &mut SessionState, enemy_ref: &str, logs: &mut Vec<String>) {
+    let kill_type = bevy_quests::ObjectiveType::ObjectiveKill as i32;
+
+    for quest in &mut session.quest_journal.active {
+        let quest_ref = quest.quest_ref.clone();
+        let step_idx = quest.current_step;
+        let Some(step) = quest.steps.get_mut(step_idx) else {
+            continue;
+        };
+
+        // Pre-fetch the proto step objectives for type checking
+        let proto_objectives = proto_bridge::find_quest_by_ref(&quest_ref)
+            .and_then(|q| q.steps.get(step_idx))
+            .map(|s| &s.objectives);
+
+        for obj in &mut step.objectives {
+            if obj.is_complete() {
+                continue;
+            }
+            // Find the matching proto objective
+            let proto_obj =
+                proto_objectives.and_then(|objs| objs.iter().find(|o| o.id == obj.objective_id));
+            let is_kill = proto_obj.is_some_and(|o| o.r#type == kill_type);
+            if !is_kill {
+                continue;
+            }
+            // Check target_refs filter
+            let matches = proto_obj.is_some_and(|o| {
+                o.target_refs.is_empty() || o.target_refs.iter().any(|r| r == enemy_ref)
+            });
+            if matches {
+                obj.current += 1;
+            }
+        }
+        // Check if step completed → advance
+        if step.is_complete() && step_idx + 1 < quest.steps.len() {
+            quest.current_step += 1;
+        }
+    }
+
+    // Complete any fully-finished quests
+    check_quest_completions(session, logs);
+}
+
+/// Advance "explore" objectives in all active quests.
+fn advance_explore_objectives(session: &mut SessionState, logs: &mut Vec<String>) {
+    let explore_type = bevy_quests::ObjectiveType::ObjectiveExplore as i32;
+    let visit_type = bevy_quests::ObjectiveType::ObjectiveVisit as i32;
+
+    for quest in &mut session.quest_journal.active {
+        let quest_ref = quest.quest_ref.clone();
+        let step_idx = quest.current_step;
+        let Some(step) = quest.steps.get_mut(step_idx) else {
+            continue;
+        };
+
+        let proto_objectives = proto_bridge::find_quest_by_ref(&quest_ref)
+            .and_then(|q| q.steps.get(step_idx))
+            .map(|s| &s.objectives);
+
+        for obj in &mut step.objectives {
+            if obj.is_complete() {
+                continue;
+            }
+            let is_explore = proto_objectives
+                .and_then(|objs| objs.iter().find(|o| o.id == obj.objective_id))
+                .is_some_and(|o| o.r#type == explore_type || o.r#type == visit_type);
+            if is_explore {
+                obj.current += 1;
+            }
+        }
+        if step.is_complete() && step_idx + 1 < quest.steps.len() {
+            quest.current_step += 1;
+        }
+    }
+
+    check_quest_completions(session, logs);
+}
+
+/// Check for completed quests and grant rewards.
+fn check_quest_completions(session: &mut SessionState, logs: &mut Vec<String>) {
+    let completed_refs: Vec<String> = session
+        .quest_journal
+        .active
+        .iter()
+        .filter(|q| q.is_complete())
+        .map(|q| q.quest_ref.clone())
+        .collect();
+
+    for quest_ref in completed_refs {
+        if let Some(proto) = proto_bridge::find_quest_by_ref(&quest_ref) {
+            // Grant rewards
+            if let Some(rewards) = &proto.rewards {
+                let gold = rewards.currency.unwrap_or(0);
+                let xp = rewards.xp.unwrap_or(0);
+                let alive_ids = session.alive_player_ids();
+                for &uid in &alive_ids {
+                    let player = session.player_mut(uid);
+                    player.gold += gold;
+                    player.xp += xp as u32;
+                }
+
+                // Grant item rewards
+                for item_reward in &rewards.items {
+                    let game_id = item_reward.item_ref.replace('-', "_");
+                    let alive_ids = session.alive_player_ids();
+                    if let Some(&first_alive) = alive_ids.first() {
+                        let player = session.player_mut(first_alive);
+                        if let Some(existing) =
+                            player.inventory.iter_mut().find(|s| s.item_id == game_id)
+                        {
+                            existing.qty += item_reward.amount as u16;
+                        } else if !player.inventory_full() {
+                            player.inventory.push(ItemStack {
+                                item_id: game_id.clone(),
+                                qty: item_reward.amount as u16,
+                            });
+                        }
+                    }
+                }
+
+                if gold > 0 || xp > 0 {
+                    logs.push(format!(
+                        "Quest complete: {}! (+{} gold, +{} XP)",
+                        proto.title, gold, xp
+                    ));
+                } else {
+                    logs.push(format!("Quest complete: {}!", proto.title));
+                }
+            } else {
+                logs.push(format!("Quest complete: {}!", proto.title));
+            }
+        }
+
+        session.quest_journal.complete_quest(&quest_ref);
+    }
+}
+
+/// Handle the AcceptQuest action.
+fn handle_accept_quest(
+    session: &mut SessionState,
+    quest_ref: &str,
+    actor: serenity::UserId,
+) -> Vec<String> {
+    let mut logs = Vec::new();
+
+    if session.quest_journal.is_active(quest_ref) {
+        logs.push("You already have that quest active.".to_owned());
+        return logs;
+    }
+    if session.quest_journal.is_completed(quest_ref) {
+        // Check if repeatable
+        let repeatable = proto_bridge::find_quest_by_ref(quest_ref)
+            .and_then(|q| q.repeatable)
+            .unwrap_or(false);
+        if !repeatable {
+            logs.push("You've already completed that quest.".to_owned());
+            return logs;
+        }
+        // Remove from completed so it can be re-accepted
+        session.quest_journal.completed.retain(|r| r != quest_ref);
+    }
+
+    let Some(proto) = proto_bridge::find_quest_by_ref(quest_ref) else {
+        logs.push("Unknown quest.".to_owned());
+        return logs;
+    };
+
+    let player_level = session.player(actor).level;
+    if !proto_bridge::meets_prerequisites(proto, player_level, &session.quest_journal) {
+        logs.push("You don't meet the prerequisites for this quest.".to_owned());
+        return logs;
+    }
+
+    if session.quest_journal.active_count() >= 5 {
+        logs.push("Quest journal is full (max 5 active quests).".to_owned());
+        return logs;
+    }
+
+    let active = proto_bridge::build_active_quest(proto);
+    session.quest_journal.active.push(active);
+    logs.push(format!("Quest accepted: {}!", proto.title));
+    logs
+}
+
+/// Handle the AbandonQuest action.
+fn handle_abandon_quest(session: &mut SessionState, quest_ref: &str) -> Vec<String> {
+    let mut logs = Vec::new();
+    if !session.quest_journal.is_active(quest_ref) {
+        logs.push("You don't have that quest active.".to_owned());
+        return logs;
+    }
+    let title = proto_bridge::find_quest_by_ref(quest_ref)
+        .map(|q| q.title.clone())
+        .unwrap_or_else(|| quest_ref.to_owned());
+    session.quest_journal.abandon_quest(quest_ref);
+    logs.push(format!("Quest abandoned: {title}."));
+    logs
+}
 
 // ── Enemy targeting ─────────────────────────────────────────────────
 
@@ -177,6 +385,14 @@ fn validate_action(
             if session.phase != GamePhase::City {
                 return Err("You can only revive at a city hospital.".to_owned());
             }
+        }
+        GameAction::AcceptQuest(_) => {
+            if session.phase != GamePhase::City && session.phase != GamePhase::Exploring {
+                return Err("You can only accept quests while exploring or in a city.".to_owned());
+            }
+        }
+        GameAction::AbandonQuest(_) | GameAction::ViewQuests => {
+            // Allowed anytime except GameOver (already checked above)
         }
     }
 
@@ -334,6 +550,36 @@ pub fn apply_action(
         }
         GameAction::Gift(ref item_id, target_uid) => {
             ActionResult::logs_only(apply_gift(session, item_id, target_uid, actor)?)
+        }
+        GameAction::AcceptQuest(ref quest_ref) => {
+            ActionResult::logs_only(handle_accept_quest(session, quest_ref, actor))
+        }
+        GameAction::AbandonQuest(ref quest_ref) => {
+            ActionResult::logs_only(handle_abandon_quest(session, quest_ref))
+        }
+        GameAction::ViewQuests => {
+            let mut lines = Vec::new();
+            if session.quest_journal.active.is_empty() {
+                lines.push("No active quests.".to_owned());
+            } else {
+                for aq in &session.quest_journal.active {
+                    let title = proto_bridge::find_quest_by_ref(&aq.quest_ref)
+                        .map(|q| q.title.as_str())
+                        .unwrap_or(&aq.quest_ref);
+                    if let Some(step) = aq.current_step_progress() {
+                        let progress: String = step
+                            .objectives
+                            .iter()
+                            .map(|o| format!("{}/{}", o.current, o.required))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        lines.push(format!("{title} [{progress}]"));
+                    } else {
+                        lines.push(title.to_owned());
+                    }
+                }
+            }
+            ActionResult::logs_only(lines)
         }
     };
 
@@ -693,6 +939,10 @@ fn handle_enemy_deaths(session: &mut SessionState, actor: serenity::UserId) -> V
 
         // Increment lifetime kills for the actor
         session.player_mut(actor).lifetime_kills += 1;
+
+        // Advance kill quest objectives — derive ref slug from display name
+        let enemy_ref = enemy_name.to_lowercase().replace(' ', "-");
+        advance_kill_objectives(session, &enemy_ref, &mut logs);
 
         // Determine loot recipient: round-robin among alive players in party mode
         let loot_recipient = if alive_ids.len() > 1 {
@@ -1627,6 +1877,9 @@ fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
         session.player_mut(uid).lifetime_rooms_cleared += 1;
     }
 
+    // Advance explore quest objectives
+    advance_explore_objectives(session, &mut logs);
+
     // Apply room hazards
     let hazards = session.room.hazards.clone();
     let alive_ids: Vec<serenity::UserId> = session
@@ -2481,6 +2734,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         }
     }
 
@@ -9263,5 +9517,566 @@ mod tests {
 
         let _ = apply_action(&mut session, GameAction::Revive(p2), OWNER);
         assert_eq!(session.player(p2).hp, 40); // 50% of 80
+    }
+
+    // ── Quest integration tests ─────────────────────────────────────────
+
+    #[test]
+    fn accept_quest_slime_slayer() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("Quest accepted")));
+        assert!(session.quest_journal.is_active("slime-slayer"));
+        assert_eq!(session.quest_journal.active_count(), 1);
+    }
+
+    #[test]
+    fn accept_quest_exploring_phase() {
+        let mut session = test_session();
+        session.phase = GamePhase::Exploring;
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        assert!(session.quest_journal.is_active("slime-slayer"));
+    }
+
+    #[test]
+    fn accept_quest_blocked_in_combat() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+        session.enemies.push(test_enemy());
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accept_quest_duplicate_rejected() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("already have")));
+        assert_eq!(session.quest_journal.active_count(), 1);
+    }
+
+    #[test]
+    fn accept_quest_nonexistent_rejected() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("nonexistent-quest".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("Unknown quest")));
+    }
+
+    #[test]
+    fn accept_quest_prerequisites_not_met() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        // Shadow Hunter requires dungeon-delver complete + level 2
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("shadow-hunter".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("prerequisites")));
+        assert!(!session.quest_journal.is_active("shadow-hunter"));
+    }
+
+    #[test]
+    fn accept_quest_max_5_active() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        // Accept 5 quests (3 unique + repeat the repeatable ones after abandoning)
+        let quest_refs = [
+            "slime-slayer",
+            "dungeon-delver",
+            "treasure-seeker",
+            "survivor",
+        ];
+        for &qr in &quest_refs {
+            let _ = apply_action(&mut session, GameAction::AcceptQuest(qr.to_owned()), OWNER);
+        }
+        // Need 5, but survivor requires level 2, so let's set level
+        session.player_mut(OWNER).level = 2;
+        // We have 4 active. Manually add a 5th
+        let quest5 = proto_bridge::find_quest_by_ref("slime-slayer").unwrap();
+        let mut active5 = proto_bridge::build_active_quest(quest5);
+        active5.quest_ref = "fake-quest-5".to_owned();
+        session.quest_journal.active.push(active5);
+
+        assert_eq!(session.quest_journal.active_count(), 5);
+
+        // Trying to accept a 6th should fail
+        // First abandon one to make room
+        // Actually, the journal already has 5, so this next accept should be blocked
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("dungeon-delver".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        // Either "already have" or "full" — dungeon-delver is already active
+        assert!(
+            logs.iter()
+                .any(|l| l.contains("already have") || l.contains("full")),
+        );
+    }
+
+    #[test]
+    fn abandon_quest() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(session.quest_journal.is_active("slime-slayer"));
+
+        let result = apply_action(
+            &mut session,
+            GameAction::AbandonQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("abandoned")));
+        assert!(!session.quest_journal.is_active("slime-slayer"));
+        assert!(session.quest_journal.is_abandoned("slime-slayer"));
+    }
+
+    #[test]
+    fn abandon_quest_not_active() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let result = apply_action(
+            &mut session,
+            GameAction::AbandonQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("don't have")));
+    }
+
+    #[test]
+    fn view_quests_empty() {
+        let mut session = test_session();
+        let result = apply_action(&mut session, GameAction::ViewQuests, OWNER);
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("No active quests")));
+    }
+
+    #[test]
+    fn view_quests_shows_active() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        let result = apply_action(&mut session, GameAction::ViewQuests, OWNER);
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("Slime Slayer")));
+        assert!(logs.iter().any(|l| l.contains("0/3")));
+    }
+
+    #[test]
+    fn kill_advances_quest_objective() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+
+        // Manually call advance_kill_objectives to test the hook
+        let mut logs = Vec::new();
+        advance_kill_objectives(&mut session, "glass-slime", &mut logs);
+
+        let quest = session.quest_journal.find_active("slime-slayer").unwrap();
+        let obj = &quest.steps[0].objectives[0];
+        assert_eq!(obj.current, 1);
+        assert_eq!(obj.required, 3);
+    }
+
+    #[test]
+    fn kill_completes_quest_after_enough_kills() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+
+        let mut logs = Vec::new();
+        advance_kill_objectives(&mut session, "glass-slime", &mut logs);
+        advance_kill_objectives(&mut session, "crystal-bat", &mut logs);
+        advance_kill_objectives(&mut session, "dust-mite", &mut logs);
+
+        // Quest should be completed
+        assert!(session.quest_journal.is_completed("slime-slayer"));
+        assert!(!session.quest_journal.is_active("slime-slayer"));
+        assert!(
+            logs.iter()
+                .any(|l| l.contains("Quest complete: Slime Slayer"))
+        );
+    }
+
+    #[test]
+    fn kill_quest_grants_rewards() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let gold_before = session.player(OWNER).gold;
+        let xp_before = session.player(OWNER).xp;
+
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+
+        let mut logs = Vec::new();
+        for _ in 0..3 {
+            advance_kill_objectives(&mut session, "any-enemy", &mut logs);
+        }
+
+        assert!(session.quest_journal.is_completed("slime-slayer"));
+        assert_eq!(session.player(OWNER).gold, gold_before + 50);
+        assert_eq!(session.player(OWNER).xp, xp_before + 30);
+    }
+
+    #[test]
+    fn explore_advances_quest_objective() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("dungeon-delver".to_owned()),
+            OWNER,
+        );
+
+        let mut logs = Vec::new();
+        advance_explore_objectives(&mut session, &mut logs);
+
+        let quest = session.quest_journal.find_active("dungeon-delver").unwrap();
+        let obj = &quest.steps[0].objectives[0];
+        assert_eq!(obj.current, 1);
+        assert_eq!(obj.required, 5);
+    }
+
+    #[test]
+    fn explore_completes_dungeon_delver() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("dungeon-delver".to_owned()),
+            OWNER,
+        );
+
+        let mut logs = Vec::new();
+        for _ in 0..5 {
+            advance_explore_objectives(&mut session, &mut logs);
+        }
+
+        assert!(session.quest_journal.is_completed("dungeon-delver"));
+        assert!(
+            logs.iter()
+                .any(|l| l.contains("Quest complete: Dungeon Delver"))
+        );
+    }
+
+    #[test]
+    fn targeted_kill_objective_only_counts_matching_ref() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+
+        // Accept shadow-hunter (needs prereqs met first)
+        session
+            .quest_journal
+            .completed
+            .push("dungeon-delver".to_owned());
+        session.player_mut(OWNER).level = 3;
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("shadow-hunter".to_owned()),
+            OWNER,
+        );
+
+        // Advance past step 0 (explore 8 rooms)
+        {
+            let quest = session
+                .quest_journal
+                .find_active_mut("shadow-hunter")
+                .unwrap();
+            quest.steps[0].objectives[0].current = 8; // complete step 0
+            quest.current_step = 1; // advance to step 1 (kill boss)
+        }
+
+        // Kill a non-matching enemy
+        let mut logs = Vec::new();
+        advance_kill_objectives(&mut session, "glass-slime", &mut logs);
+
+        let quest = session.quest_journal.find_active("shadow-hunter").unwrap();
+        let obj = &quest.steps[1].objectives[0];
+        assert_eq!(
+            obj.current, 0,
+            "Non-matching kill should not advance targeted objective"
+        );
+
+        // Kill the actual target
+        advance_kill_objectives(&mut session, "shadow-wraith", &mut logs);
+
+        // Quest should now be complete
+        assert!(session.quest_journal.is_completed("shadow-hunter"));
+    }
+
+    #[test]
+    fn multi_step_quest_advances_through_steps() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+        session
+            .quest_journal
+            .completed
+            .push("shadow-hunter".to_owned());
+        session.player_mut(OWNER).level = 5;
+
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("kings-demise".to_owned()),
+            OWNER,
+        );
+
+        // Step 0: kill 10 enemies
+        let mut logs = Vec::new();
+        for _ in 0..10 {
+            advance_kill_objectives(&mut session, "some-enemy", &mut logs);
+        }
+
+        // Should have advanced to step 1
+        let quest = session.quest_journal.find_active("kings-demise").unwrap();
+        assert_eq!(
+            quest.current_step, 1,
+            "Should advance to step 1 after 10 kills"
+        );
+
+        // Step 1: kill the shattered king
+        advance_kill_objectives(&mut session, "the-shattered-king", &mut logs);
+        assert!(session.quest_journal.is_completed("kings-demise"));
+        assert!(logs.iter().any(|l| l.contains("Quest complete")));
+    }
+
+    #[test]
+    fn repeatable_quest_can_be_reaccepted() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+
+        // Accept and complete treasure-seeker
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("treasure-seeker".to_owned()),
+            OWNER,
+        );
+        // Manually complete it
+        session.quest_journal.complete_quest("treasure-seeker");
+        assert!(session.quest_journal.is_completed("treasure-seeker"));
+
+        // Re-accept it
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("treasure-seeker".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("Quest accepted")));
+        assert!(session.quest_journal.is_active("treasure-seeker"));
+    }
+
+    #[test]
+    fn non_repeatable_quest_cannot_be_reaccepted() {
+        let mut session = test_session();
+        session.phase = GamePhase::City;
+
+        let _ = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        session.quest_journal.complete_quest("slime-slayer");
+
+        let result = apply_action(
+            &mut session,
+            GameAction::AcceptQuest("slime-slayer".to_owned()),
+            OWNER,
+        );
+        assert!(result.is_ok());
+        let logs = result.unwrap();
+        assert!(logs.iter().any(|l| l.contains("already completed")));
+    }
+
+    #[test]
+    fn quest_journal_default_empty() {
+        let journal = QuestJournal::default();
+        assert!(journal.active.is_empty());
+        assert!(journal.completed.is_empty());
+        assert!(journal.abandoned.is_empty());
+        assert_eq!(journal.active_count(), 0);
+    }
+
+    #[test]
+    fn quest_journal_complete_removes_from_active() {
+        let mut journal = QuestJournal::default();
+        let quest = proto_bridge::find_quest_by_ref("slime-slayer").unwrap();
+        journal.active.push(proto_bridge::build_active_quest(quest));
+        assert_eq!(journal.active_count(), 1);
+
+        journal.complete_quest("slime-slayer");
+        assert_eq!(journal.active_count(), 0);
+        assert!(journal.is_completed("slime-slayer"));
+    }
+
+    #[test]
+    fn quest_journal_abandon_removes_from_active() {
+        let mut journal = QuestJournal::default();
+        let quest = proto_bridge::find_quest_by_ref("slime-slayer").unwrap();
+        journal.active.push(proto_bridge::build_active_quest(quest));
+
+        journal.abandon_quest("slime-slayer");
+        assert_eq!(journal.active_count(), 0);
+        assert!(journal.is_abandoned("slime-slayer"));
+    }
+
+    #[test]
+    fn objective_progress_is_complete() {
+        let obj = ObjectiveProgress {
+            objective_id: "test".to_owned(),
+            current: 3,
+            required: 3,
+        };
+        assert!(obj.is_complete());
+
+        let obj2 = ObjectiveProgress {
+            objective_id: "test".to_owned(),
+            current: 2,
+            required: 3,
+        };
+        assert!(!obj2.is_complete());
+    }
+
+    #[test]
+    fn step_progress_is_complete() {
+        let step = StepProgress {
+            step_id: "test".to_owned(),
+            objectives: vec![
+                ObjectiveProgress {
+                    objective_id: "a".to_owned(),
+                    current: 3,
+                    required: 3,
+                },
+                ObjectiveProgress {
+                    objective_id: "b".to_owned(),
+                    current: 1,
+                    required: 1,
+                },
+            ],
+        };
+        assert!(step.is_complete());
+    }
+
+    #[test]
+    fn active_quest_try_advance_step() {
+        let mut aq = ActiveQuest {
+            quest_ref: "test".to_owned(),
+            current_step: 0,
+            steps: vec![
+                StepProgress {
+                    step_id: "s0".to_owned(),
+                    objectives: vec![ObjectiveProgress {
+                        objective_id: "o0".to_owned(),
+                        current: 5,
+                        required: 5,
+                    }],
+                },
+                StepProgress {
+                    step_id: "s1".to_owned(),
+                    objectives: vec![ObjectiveProgress {
+                        objective_id: "o1".to_owned(),
+                        current: 0,
+                        required: 1,
+                    }],
+                },
+            ],
+        };
+        assert!(aq.try_advance_step());
+        assert_eq!(aq.current_step, 1);
+        assert!(!aq.is_complete());
+
+        // Can't advance further until step 1 is done
+        assert!(!aq.try_advance_step());
+    }
+
+    #[test]
+    fn view_quests_action_always_allowed() {
+        let mut session = test_session();
+        // Allowed in any non-GameOver phase
+        for phase in [
+            GamePhase::Exploring,
+            GamePhase::Combat,
+            GamePhase::City,
+            GamePhase::Merchant,
+            GamePhase::Rest,
+        ] {
+            session.phase = phase;
+            if session.phase == GamePhase::Combat {
+                if session.enemies.is_empty() {
+                    session.enemies.push(test_enemy());
+                }
+            }
+            let result = apply_action(&mut session, GameAction::ViewQuests, OWNER);
+            assert!(
+                result.is_ok(),
+                "ViewQuests should be allowed in {:?}",
+                session.phase
+            );
+        }
     }
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/proto_bridge.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/proto_bridge.rs
@@ -12,6 +12,7 @@ use bevy_items::{
     UseEffectType, inventory_adapter::ProtoItemKind,
 };
 use bevy_npc::NpcDb;
+use bevy_quests::QuestDb;
 
 use super::types::*;
 
@@ -418,6 +419,89 @@ fn npc_initial_intent(npc_ref: &str, attack: i32) -> Intent {
         // Fallback: basic attack using proto attack stat
         _ => Intent::Attack { dmg: attack },
     }
+}
+
+// ── Quest public API ──────────────────────────────────────────────────
+
+/// Embedded JSON snapshot of the quest database.
+const QUESTDB_JSON: &str = include_str!("../../../data/questdb.json");
+
+/// The global proto quest database, loaded once from the embedded JSON.
+static QUEST_DB: LazyLock<QuestDb> = LazyLock::new(|| {
+    QuestDb::from_json(QUESTDB_JSON).expect("embedded questdb.json must be valid")
+});
+
+/// Access the underlying [`QuestDb`] for advanced queries.
+pub fn quest_db() -> &'static QuestDb {
+    &QUEST_DB
+}
+
+/// Find a quest by its ref slug (e.g. "slime-slayer").
+pub fn find_quest_by_ref(r: &str) -> Option<&'static bevy_quests::Quest> {
+    QUEST_DB.get_by_ref(r)
+}
+
+/// Find all quests tagged with "discordsh".
+pub fn discordsh_quests() -> Vec<&'static bevy_quests::Quest> {
+    QUEST_DB.find_by_tag("discordsh")
+}
+
+/// Find quests available to a player at a given level.
+pub fn quests_for_level(level: i32) -> Vec<&'static bevy_quests::Quest> {
+    QUEST_DB
+        .find_by_tag("discordsh")
+        .into_iter()
+        .filter(|q| q.recommended_level.unwrap_or(1) <= level)
+        .collect()
+}
+
+/// Build an [`ActiveQuest`] from a proto quest definition.
+///
+/// Initializes all step and objective progress to zero.
+pub fn build_active_quest(quest: &bevy_quests::Quest) -> ActiveQuest {
+    let steps = quest
+        .steps
+        .iter()
+        .map(|step| StepProgress {
+            step_id: step.id.clone(),
+            objectives: step
+                .objectives
+                .iter()
+                .map(|obj| ObjectiveProgress {
+                    objective_id: obj.id.clone(),
+                    current: 0,
+                    required: obj.required_amount,
+                })
+                .collect(),
+        })
+        .collect();
+
+    ActiveQuest {
+        quest_ref: quest.r#ref.clone(),
+        current_step: 0,
+        steps,
+    }
+}
+
+/// Check if a player meets the prerequisites for a quest.
+pub fn meets_prerequisites(
+    quest: &bevy_quests::Quest,
+    player_level: u8,
+    journal: &QuestJournal,
+) -> bool {
+    if let Some(prereq) = &quest.prerequisites {
+        if let Some(req_level) = prereq.level_requirement {
+            if (player_level as i32) < req_level {
+                return false;
+            }
+        }
+        for req_ref in &prereq.quest_refs {
+            if !journal.is_completed(req_ref) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -1051,5 +1135,235 @@ mod tests {
                 enemy.name
             );
         }
+    }
+
+    // ── Quest DB tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn quest_db_loads_successfully() {
+        let db = quest_db();
+        assert!(!db.is_empty(), "QuestDb should have quests");
+    }
+
+    #[test]
+    fn quest_db_has_6_quests() {
+        assert_eq!(quest_db().len(), 6, "Should have 6 discordsh quests");
+    }
+
+    #[test]
+    fn find_quest_slime_slayer() {
+        let quest = find_quest_by_ref("slime-slayer").expect("slime-slayer should exist");
+        assert_eq!(quest.title, "Slime Slayer");
+        assert_eq!(quest.recommended_level, Some(1));
+        assert!(!quest.steps.is_empty());
+    }
+
+    #[test]
+    fn find_quest_dungeon_delver() {
+        let quest = find_quest_by_ref("dungeon-delver").expect("dungeon-delver should exist");
+        assert_eq!(quest.title, "Dungeon Delver");
+        assert_eq!(quest.next_quest_ref, Some("shadow-hunter".to_owned()));
+    }
+
+    #[test]
+    fn find_quest_shadow_hunter() {
+        let quest = find_quest_by_ref("shadow-hunter").expect("shadow-hunter should exist");
+        assert_eq!(quest.title, "Shadow Hunter");
+        assert_eq!(quest.steps.len(), 2, "Shadow Hunter should have 2 steps");
+        assert!(quest.prerequisites.is_some());
+    }
+
+    #[test]
+    fn find_quest_kings_demise() {
+        let quest = find_quest_by_ref("kings-demise").expect("kings-demise should exist");
+        assert_eq!(quest.title, "The King's Demise");
+        assert_eq!(quest.recommended_level, Some(5));
+        let rewards = quest.rewards.as_ref().expect("should have rewards");
+        assert_eq!(rewards.currency, Some(500));
+        assert_eq!(rewards.xp, Some(300));
+        assert!(rewards.achievement.is_some());
+    }
+
+    #[test]
+    fn find_quest_treasure_seeker() {
+        let quest = find_quest_by_ref("treasure-seeker").expect("treasure-seeker should exist");
+        assert_eq!(quest.repeatable, Some(true));
+    }
+
+    #[test]
+    fn find_quest_survivor() {
+        let quest = find_quest_by_ref("survivor").expect("survivor should exist");
+        assert_eq!(quest.repeatable, Some(true));
+        assert_eq!(quest.recommended_level, Some(2));
+    }
+
+    #[test]
+    fn find_quest_nonexistent_returns_none() {
+        assert!(find_quest_by_ref("nonexistent-quest-xyz").is_none());
+    }
+
+    #[test]
+    fn discordsh_quests_returns_all_6() {
+        let quests = discordsh_quests();
+        assert_eq!(quests.len(), 6);
+    }
+
+    #[test]
+    fn quests_for_level_1_includes_beginner() {
+        let quests = quests_for_level(1);
+        assert!(quests.iter().any(|q| q.r#ref == "slime-slayer"));
+        assert!(quests.iter().any(|q| q.r#ref == "dungeon-delver"));
+        assert!(quests.iter().any(|q| q.r#ref == "treasure-seeker"));
+    }
+
+    #[test]
+    fn quests_for_level_5_includes_all() {
+        let quests = quests_for_level(5);
+        assert_eq!(quests.len(), 6);
+    }
+
+    #[test]
+    fn build_active_quest_slime_slayer() {
+        let quest = find_quest_by_ref("slime-slayer").unwrap();
+        let active = build_active_quest(quest);
+        assert_eq!(active.quest_ref, "slime-slayer");
+        assert_eq!(active.current_step, 0);
+        assert_eq!(active.steps.len(), 1);
+        assert_eq!(active.steps[0].objectives.len(), 1);
+        assert_eq!(active.steps[0].objectives[0].current, 0);
+        assert_eq!(active.steps[0].objectives[0].required, 3);
+        assert!(!active.is_complete());
+    }
+
+    #[test]
+    fn build_active_quest_shadow_hunter_has_2_steps() {
+        let quest = find_quest_by_ref("shadow-hunter").unwrap();
+        let active = build_active_quest(quest);
+        assert_eq!(active.steps.len(), 2);
+        assert_eq!(active.steps[0].objectives[0].required, 8); // explore 8 rooms
+        assert_eq!(active.steps[1].objectives[0].required, 1); // kill boss
+    }
+
+    #[test]
+    fn meets_prerequisites_no_prereqs() {
+        let quest = find_quest_by_ref("slime-slayer").unwrap();
+        let journal = QuestJournal::default();
+        assert!(meets_prerequisites(quest, 1, &journal));
+    }
+
+    #[test]
+    fn meets_prerequisites_level_too_low() {
+        let quest = find_quest_by_ref("shadow-hunter").unwrap();
+        let journal = QuestJournal::default();
+        // Requires level 2, player is level 1
+        assert!(!meets_prerequisites(quest, 1, &journal));
+    }
+
+    #[test]
+    fn meets_prerequisites_missing_quest() {
+        let quest = find_quest_by_ref("shadow-hunter").unwrap();
+        let journal = QuestJournal::default();
+        // Requires dungeon-delver complete, level 2
+        assert!(!meets_prerequisites(quest, 5, &journal));
+    }
+
+    #[test]
+    fn meets_prerequisites_all_met() {
+        let quest = find_quest_by_ref("shadow-hunter").unwrap();
+        let mut journal = QuestJournal::default();
+        journal.completed.push("dungeon-delver".to_owned());
+        assert!(meets_prerequisites(quest, 2, &journal));
+    }
+
+    #[test]
+    fn all_quests_have_discordsh_tag() {
+        for (_id, quest) in quest_db().iter() {
+            assert!(
+                quest.tags.iter().any(|t| t == "discordsh"),
+                "Quest {} missing discordsh tag",
+                quest.title
+            );
+        }
+    }
+
+    #[test]
+    fn all_quests_have_at_least_one_step() {
+        for (_id, quest) in quest_db().iter() {
+            assert!(
+                !quest.steps.is_empty(),
+                "Quest {} should have at least one step",
+                quest.title
+            );
+        }
+    }
+
+    #[test]
+    fn all_quests_have_rewards() {
+        for (_id, quest) in quest_db().iter() {
+            assert!(
+                quest.rewards.is_some(),
+                "Quest {} should have rewards",
+                quest.title
+            );
+        }
+    }
+
+    #[test]
+    fn all_quest_objectives_have_positive_required_amount() {
+        for (_id, quest) in quest_db().iter() {
+            for step in &quest.steps {
+                for obj in &step.objectives {
+                    assert!(
+                        obj.required_amount > 0,
+                        "Quest {} objective {} should have required_amount > 0",
+                        quest.title,
+                        obj.id
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn all_quests_have_unique_refs() {
+        let mut refs = std::collections::HashSet::new();
+        for (_id, quest) in quest_db().iter() {
+            assert!(
+                refs.insert(quest.r#ref.clone()),
+                "Duplicate quest ref: {}",
+                quest.r#ref
+            );
+        }
+    }
+
+    #[test]
+    fn quest_chain_dungeon_delver_to_shadow_hunter_to_kings_demise() {
+        let dd = find_quest_by_ref("dungeon-delver").unwrap();
+        assert_eq!(dd.next_quest_ref, Some("shadow-hunter".to_owned()));
+
+        let sh = find_quest_by_ref("shadow-hunter").unwrap();
+        assert_eq!(sh.next_quest_ref, Some("kings-demise".to_owned()));
+
+        let kd = find_quest_by_ref("kings-demise").unwrap();
+        assert_eq!(kd.next_quest_ref, None);
+    }
+
+    #[test]
+    fn kings_demise_rewards_excalibur() {
+        let quest = find_quest_by_ref("kings-demise").unwrap();
+        let rewards = quest.rewards.as_ref().unwrap();
+        assert!(
+            rewards.items.iter().any(|i| i.item_ref == "excalibur"),
+            "Kings Demise should reward Excalibur"
+        );
+    }
+
+    #[test]
+    fn shadow_hunter_rewards_smoke_bombs() {
+        let quest = find_quest_by_ref("shadow-hunter").unwrap();
+        let rewards = quest.rewards.as_ref().unwrap();
+        let smoke = rewards.items.iter().find(|i| i.item_ref == "smoke-bomb");
+        assert!(smoke.is_some(), "Shadow Hunter should reward smoke bombs");
+        assert_eq!(smoke.unwrap().amount, 3);
     }
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/render.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/render.rs
@@ -1115,6 +1115,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/session.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/session.rs
@@ -132,6 +132,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/types.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/types.rs
@@ -586,6 +586,134 @@ pub struct RoomState {
     pub story_event: Option<StoryEvent>,
 }
 
+// ── Quest tracking ──────────────────────────────────────────────────
+
+/// Status of an objective within an active quest.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ObjectiveProgress {
+    pub objective_id: String,
+    pub current: i32,
+    pub required: i32,
+}
+
+impl ObjectiveProgress {
+    pub fn is_complete(&self) -> bool {
+        self.current >= self.required
+    }
+}
+
+/// Status of an active quest step.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct StepProgress {
+    pub step_id: String,
+    pub objectives: Vec<ObjectiveProgress>,
+}
+
+impl StepProgress {
+    pub fn is_complete(&self) -> bool {
+        self.objectives.iter().all(|o| o.is_complete())
+    }
+}
+
+/// Tracks the state of a single quest for a player.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ActiveQuest {
+    /// The quest ref slug (e.g. "slime-slayer").
+    pub quest_ref: String,
+    /// Index of the current step in the quest's step list.
+    pub current_step: usize,
+    /// Progress for each step (only the current step is actively tracked).
+    pub steps: Vec<StepProgress>,
+}
+
+impl ActiveQuest {
+    /// Whether all steps are complete.
+    pub fn is_complete(&self) -> bool {
+        self.steps.iter().all(|s| s.is_complete())
+    }
+
+    /// Get the current step progress, if it exists.
+    pub fn current_step_progress(&self) -> Option<&StepProgress> {
+        self.steps.get(self.current_step)
+    }
+
+    /// Get a mutable reference to the current step progress.
+    pub fn current_step_progress_mut(&mut self) -> Option<&mut StepProgress> {
+        self.steps.get_mut(self.current_step)
+    }
+
+    /// Advance to the next step if the current one is complete.
+    /// Returns true if advanced, false if already at the last step or not complete.
+    pub fn try_advance_step(&mut self) -> bool {
+        if let Some(step) = self.steps.get(self.current_step) {
+            if step.is_complete() && self.current_step + 1 < self.steps.len() {
+                self.current_step += 1;
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Per-session quest journal tracking active, completed, and failed quests.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct QuestJournal {
+    /// Currently active quests (max ~5 at a time for UX).
+    pub active: Vec<ActiveQuest>,
+    /// Refs of completed quests (persisted across sessions eventually).
+    pub completed: Vec<String>,
+    /// Refs of failed/abandoned quests.
+    pub abandoned: Vec<String>,
+}
+
+impl QuestJournal {
+    /// Find an active quest by ref.
+    pub fn find_active(&self, quest_ref: &str) -> Option<&ActiveQuest> {
+        self.active.iter().find(|q| q.quest_ref == quest_ref)
+    }
+
+    /// Find a mutable active quest by ref.
+    pub fn find_active_mut(&mut self, quest_ref: &str) -> Option<&mut ActiveQuest> {
+        self.active.iter_mut().find(|q| q.quest_ref == quest_ref)
+    }
+
+    /// Whether a quest ref is currently active.
+    pub fn is_active(&self, quest_ref: &str) -> bool {
+        self.active.iter().any(|q| q.quest_ref == quest_ref)
+    }
+
+    /// Whether a quest ref has been completed.
+    pub fn is_completed(&self, quest_ref: &str) -> bool {
+        self.completed.iter().any(|r| r == quest_ref)
+    }
+
+    /// Whether a quest ref has been abandoned.
+    pub fn is_abandoned(&self, quest_ref: &str) -> bool {
+        self.abandoned.iter().any(|r| r == quest_ref)
+    }
+
+    /// Remove a quest from active and move it to completed.
+    pub fn complete_quest(&mut self, quest_ref: &str) {
+        self.active.retain(|q| q.quest_ref != quest_ref);
+        if !self.is_completed(quest_ref) {
+            self.completed.push(quest_ref.to_owned());
+        }
+    }
+
+    /// Remove a quest from active and move it to abandoned.
+    pub fn abandon_quest(&mut self, quest_ref: &str) {
+        self.active.retain(|q| q.quest_ref != quest_ref);
+        if !self.is_abandoned(quest_ref) {
+            self.abandoned.push(quest_ref.to_owned());
+        }
+    }
+
+    /// Number of active quests.
+    pub fn active_count(&self) -> usize {
+        self.active.len()
+    }
+}
+
 // ── Game action ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq)]
@@ -610,6 +738,9 @@ pub enum GameAction {
     ViewInventory,
     Revive(serenity::UserId),
     Gift(ItemId, serenity::UserId),
+    AcceptQuest(String),
+    AbandonQuest(String),
+    ViewQuests,
 }
 
 // ── Session mode ────────────────────────────────────────────────────
@@ -660,6 +791,7 @@ pub struct SessionState {
     #[serde(skip)]
     pub pending_destination: Option<MapPos>,
     pub enemies_had_first_strike: bool,
+    pub quest_journal: QuestJournal,
 }
 
 impl SessionState {
@@ -875,6 +1007,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         };
         let roster = session.roster();
         assert_eq!(roster.len(), 2);
@@ -961,6 +1094,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         };
 
         assert!(session.has_enemies());
@@ -1129,6 +1263,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         };
         assert!(!session.show_inventory);
     }
@@ -1193,6 +1328,7 @@ mod tests {
             show_inventory: true,
             pending_destination: Some(MapPos::new(1, 0)),
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         };
 
         let json = serde_json::to_string(&session).unwrap();

--- a/apps/discordsh/axum-discordsh/src/transport/api.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/api.rs
@@ -138,6 +138,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         };
         state.sessions.create(session);
 
@@ -198,6 +199,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         };
         state.sessions.create(session);
 

--- a/apps/discordsh/axum-discordsh/src/transport/svg.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/svg.rs
@@ -357,6 +357,7 @@ mod tests {
             show_inventory: false,
             pending_destination: None,
             enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
         };
         state.app.sessions.create(session);
         short_id

--- a/apps/kbve/astro-kbve/src/content/docs/questdb/dungeon-delver.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/questdb/dungeon-delver.mdx
@@ -1,0 +1,69 @@
+---
+id: "01JX26BB2NDUNGEONDELVER0002"
+ref: "dungeon-delver"
+drafted: false
+title: "Dungeon Delver"
+description: "Venture deep into the dungeon and explore its forgotten corridors."
+category: "main"
+tags:
+  - "discordsh"
+  - "exploration"
+  - "beginner"
+hidden: false
+repeatable: false
+recommended_level: 1
+steps:
+  - id: "step-explore-rooms"
+    title: "Explore the Dungeon"
+    objectives:
+      - id: "obj-visit-5-rooms"
+        description: "Explore 5 different rooms"
+        type: "explore"
+        required_amount: 5
+rewards:
+  currency: 75
+  xp: 50
+triggers:
+  - "player:level:1"
+  - "area:dungeon"
+next_quest_ref: "shadow-hunter"
+---
+
+import {
+  Aside,
+  Steps,
+  Card,
+  CardGrid,
+} from '@astrojs/starlight/components';
+
+import { Giscus } from '@/components/astropad';
+
+<Aside>
+The dungeon stretches endlessly beneath the surface. Map its corridors and
+discover what secrets lie within.
+</Aside>
+
+## Quest Overview
+
+<CardGrid>
+  <Card title="Objective" icon="mdi:map-search">
+    Explore 5 different rooms in a single dungeon run. Each new tile you visit
+    counts toward the goal.
+  </Card>
+  <Card title="Reward" icon="mdi:treasure-chest">
+    75 gold and 50 XP. Completing this quest unlocks Shadow Hunter.
+  </Card>
+</CardGrid>
+
+## Steps to Completion
+
+<Steps>
+1. **Start exploring**
+   Move through the dungeon using the directional buttons.
+2. **Visit 5 rooms**
+   Each new room you enter counts. Revisiting rooms does not count.
+3. **Quest complete**
+   The reward is granted automatically once you visit the fifth room.
+</Steps>
+
+<Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/questdb/kings-demise.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/questdb/kings-demise.mdx
@@ -1,0 +1,95 @@
+---
+id: "01JX26DD4NKINGSDEMISE000004"
+ref: "kings-demise"
+drafted: false
+title: "The King's Demise"
+description: "The Shattered King rules the deepest level of the dungeon. End his reign of terror."
+category: "main"
+tags:
+  - "discordsh"
+  - "combat"
+  - "boss"
+  - "endgame"
+hidden: false
+repeatable: false
+recommended_level: 5
+prerequisites:
+  quest_refs:
+    - "shadow-hunter"
+  level_requirement: 3
+steps:
+  - id: "step-prepare"
+    title: "Prepare for the Final Battle"
+    objectives:
+      - id: "obj-kill-10-enemies"
+        description: "Defeat 10 enemies to prove you are ready"
+        type: "kill"
+        required_amount: 10
+  - id: "step-defeat-king"
+    title: "Defeat the Shattered King"
+    objectives:
+      - id: "obj-kill-shattered-king"
+        description: "Defeat the Shattered King"
+        type: "kill"
+        target_refs:
+          - "the-shattered-king"
+        required_amount: 1
+rewards:
+  currency: 500
+  xp: 300
+  items:
+    - item_ref: "excalibur"
+      amount: 1
+  achievement:
+    api_name: "ACH_KINGS_DEMISE"
+    name: "Kingslayer"
+    description: "Defeated the Shattered King in the deepest dungeon."
+    hidden: false
+    min_value: 0
+    max_value: 1
+triggers:
+  - "quest:complete:shadow-hunter"
+next_quest_ref: null
+---
+
+import {
+  Aside,
+  Steps,
+  Card,
+  CardGrid,
+} from '@astrojs/starlight/components';
+
+import { Giscus } from '@/components/astropad';
+
+<Aside type="danger">
+The Shattered King is the ultimate challenge. His AOE attacks devastate entire
+parties. Only the most prepared adventurers should attempt this quest.
+</Aside>
+
+## Quest Overview
+
+<CardGrid>
+  <Card title="Phase 1" icon="mdi:sword-cross">
+    Defeat 10 enemies across your dungeon runs to prove your combat prowess.
+  </Card>
+  <Card title="Phase 2" icon="mdi:crown">
+    Face the Shattered King in the deepest boss room. He uses devastating AOE
+    attacks and has massive HP.
+  </Card>
+  <Card title="Reward" icon="mdi:trophy">
+    500 gold, 300 XP, Excalibur, and the Kingslayer achievement.
+  </Card>
+</CardGrid>
+
+## Steps to Completion
+
+<Steps>
+1. **Build your strength**
+   Defeat 10 enemies in the dungeon to complete the first step.
+2. **Find the Shattered King**
+   Navigate to a boss room in the deepest area of the dungeon.
+3. **End his reign**
+   Defeat the Shattered King. Bring potions, gear, and allies.
+</Steps>
+
+<Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/questdb/shadow-hunter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/questdb/shadow-hunter.mdx
@@ -1,0 +1,87 @@
+---
+id: "01JX26CC3NSHADOWHUNTER00003"
+ref: "shadow-hunter"
+drafted: false
+title: "Shadow Hunter"
+description: "A powerful shadow wraith has been sighted in the deeper levels. Track it down and destroy it."
+category: "main"
+tags:
+  - "discordsh"
+  - "combat"
+  - "boss"
+hidden: false
+repeatable: false
+recommended_level: 3
+prerequisites:
+  quest_refs:
+    - "dungeon-delver"
+  level_requirement: 2
+steps:
+  - id: "step-reach-depth"
+    title: "Descend to the Depths"
+    objectives:
+      - id: "obj-explore-rooms"
+        description: "Explore 8 rooms to reach the deeper levels"
+        type: "explore"
+        required_amount: 8
+  - id: "step-slay-boss"
+    title: "Slay the Shadow Wraith"
+    objectives:
+      - id: "obj-kill-boss"
+        description: "Defeat a boss enemy"
+        type: "kill"
+        target_refs:
+          - "shadow-wraith"
+        required_amount: 1
+rewards:
+  currency: 200
+  xp: 150
+  items:
+    - item_ref: "smoke-bomb"
+      amount: 3
+triggers:
+  - "quest:complete:dungeon-delver"
+next_quest_ref: "kings-demise"
+---
+
+import {
+  Aside,
+  Steps,
+  Card,
+  CardGrid,
+} from '@astrojs/starlight/components';
+
+import { Giscus } from '@/components/astropad';
+
+<Aside type="caution">
+The Shadow Wraith is a formidable foe. Make sure you are well-equipped before
+attempting this quest. A party is recommended.
+</Aside>
+
+## Quest Overview
+
+<CardGrid>
+  <Card title="Phase 1" icon="mdi:compass">
+    Descend through 8 rooms to reach the deeper dungeon levels where the wraith
+    lurks.
+  </Card>
+  <Card title="Phase 2" icon="mdi:skull">
+    Defeat the Shadow Wraith boss. It hits hard and has high armor.
+  </Card>
+  <Card title="Reward" icon="mdi:gift">
+    200 gold, 150 XP, and 3 Smoke Bombs.
+  </Card>
+</CardGrid>
+
+## Steps to Completion
+
+<Steps>
+1. **Explore the dungeon**
+   Navigate through at least 8 rooms to reach boss territory.
+2. **Engage the Shadow Wraith**
+   When you encounter a boss room, the Shadow Wraith awaits.
+3. **Defeat the boss**
+   Use your best gear and consumables. Watch out for its Heavy Attack.
+</Steps>
+
+<Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/questdb/slime-slayer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/questdb/slime-slayer.mdx
@@ -1,0 +1,70 @@
+---
+id: "01JX26AA1NSLIMESLAYER000001"
+ref: "slime-slayer"
+drafted: false
+title: "Slime Slayer"
+description: "The dungeon's lower tunnels are overrun with slimes. Clear them out to prove your worth."
+category: "side"
+tags:
+  - "discordsh"
+  - "combat"
+  - "beginner"
+hidden: false
+repeatable: false
+recommended_level: 1
+steps:
+  - id: "step-kill-slimes"
+    title: "Exterminate the Slimes"
+    objectives:
+      - id: "obj-kill-3-enemies"
+        description: "Defeat 3 enemies in the dungeon"
+        type: "kill"
+        required_amount: 3
+rewards:
+  currency: 50
+  xp: 30
+triggers:
+  - "player:level:1"
+  - "area:dungeon"
+next_quest_ref: null
+---
+
+import {
+  Aside,
+  Steps,
+  Card,
+  CardGrid,
+} from '@astrojs/starlight/components';
+
+import { Giscus } from '@/components/astropad';
+
+<Aside>
+The dungeon's lower tunnels are teeming with slimes. A bounty has been posted
+for anyone brave enough to clear them out. Defeat three enemies to claim your
+reward.
+</Aside>
+
+## Quest Overview
+
+<CardGrid>
+  <Card title="Objective" icon="mdi:sword">
+    Defeat 3 enemies anywhere in the dungeon. Slimes, bats, spiders — they all
+    count.
+  </Card>
+  <Card title="Reward" icon="mdi:gold">
+    50 gold and 30 XP for completing the bounty.
+  </Card>
+</CardGrid>
+
+## Steps to Completion
+
+<Steps>
+1. **Enter the dungeon**
+   Start a dungeon run from the city.
+2. **Defeat 3 enemies**
+   Engage and defeat any three enemies you encounter while exploring.
+3. **Claim your reward**
+   The quest completes automatically once the third enemy falls.
+</Steps>
+
+<Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/questdb/survivor.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/questdb/survivor.mdx
@@ -1,0 +1,71 @@
+---
+id: "01JX26FF6NSURVIVOR00000006"
+ref: "survivor"
+drafted: false
+title: "Survivor"
+description: "The dungeon is merciless. Prove you can endure by clearing rooms without falling in battle."
+category: "challenge"
+tags:
+  - "discordsh"
+  - "survival"
+  - "challenge"
+hidden: false
+repeatable: true
+recommended_level: 2
+steps:
+  - id: "step-clear-rooms"
+    title: "Clear Rooms Without Dying"
+    objectives:
+      - id: "obj-clear-3-rooms"
+        description: "Clear 3 combat rooms without dying"
+        type: "explore"
+        required_amount: 3
+rewards:
+  currency: 100
+  xp: 75
+  items:
+    - item_ref: "campfire-kit"
+      amount: 1
+triggers:
+  - "player:level:2"
+  - "area:dungeon"
+next_quest_ref: null
+---
+
+import {
+  Aside,
+  Steps,
+  Card,
+  CardGrid,
+} from '@astrojs/starlight/components';
+
+import { Giscus } from '@/components/astropad';
+
+<Aside type="tip">
+Stay topped up on health. Use rest shrines and potions wisely — one death resets
+your progress on this quest.
+</Aside>
+
+## Quest Overview
+
+<CardGrid>
+  <Card title="Objective" icon="mdi:shield-check">
+    Clear 3 combat rooms in a single run without any party member dying.
+  </Card>
+  <Card title="Reward" icon="mdi:campfire">
+    100 gold, 75 XP, and a Campfire Kit. This quest is repeatable.
+  </Card>
+</CardGrid>
+
+## Steps to Completion
+
+<Steps>
+1. **Stay alive**
+   Enter the dungeon and clear combat rooms while keeping everyone alive.
+2. **Clear 3 rooms**
+   Each combat room you clear without deaths counts toward the goal.
+3. **Collect your reward**
+   The quest completes after clearing 3 combat rooms with no casualties.
+</Steps>
+
+<Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/questdb/treasure-seeker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/questdb/treasure-seeker.mdx
@@ -1,0 +1,72 @@
+---
+id: "01JX26EE5NTREASURESEEKER005"
+ref: "treasure-seeker"
+drafted: false
+title: "Treasure Seeker"
+description: "The dungeon is filled with hidden riches. Collect gold from treasure rooms and enemy loot."
+category: "side"
+tags:
+  - "discordsh"
+  - "loot"
+  - "beginner"
+hidden: false
+repeatable: true
+recommended_level: 1
+steps:
+  - id: "step-collect-gold"
+    title: "Amass a Fortune"
+    objectives:
+      - id: "obj-earn-100-gold"
+        description: "Earn 100 gold in a single dungeon run"
+        type: "collect"
+        required_amount: 100
+rewards:
+  currency: 25
+  xp: 20
+  items:
+    - item_ref: "potion"
+      amount: 2
+triggers:
+  - "player:level:1"
+  - "area:dungeon"
+next_quest_ref: null
+---
+
+import {
+  Aside,
+  Steps,
+  Card,
+  CardGrid,
+} from '@astrojs/starlight/components';
+
+import { Giscus } from '@/components/astropad';
+
+<Aside>
+Gold is power in the dungeon. Loot chests, sell unwanted gear, and defeat
+enemies to fill your coffers.
+</Aside>
+
+## Quest Overview
+
+<CardGrid>
+  <Card title="Objective" icon="mdi:gold">
+    Earn 100 gold in a single dungeon run through combat loot, treasure rooms,
+    or merchant trades.
+  </Card>
+  <Card title="Reward" icon="mdi:bottle-tonic">
+    25 bonus gold, 20 XP, and 2 Potions. This quest is repeatable.
+  </Card>
+</CardGrid>
+
+## Steps to Completion
+
+<Steps>
+1. **Enter the dungeon**
+   Start a dungeon run and begin looting.
+2. **Accumulate 100 gold**
+   Defeat enemies, open treasure rooms, and collect your earnings.
+3. **Quest complete**
+   Completes automatically when your gold earned reaches 100.
+</Steps>
+
+<Giscus />


### PR DESCRIPTION
## Summary
- Integrate `bevy_quests` crate into DiscordSH dungeon crawler with full quest lifecycle (accept, progress, complete, abandon)
- Create 6 dungeon quests: 3-quest main chain (Dungeon Delver → Shadow Hunter → King's Demise) + 3 standalone (Slime Slayer, Treasure Seeker, Survivor)
- Add `QuestJournal` state tracking on `SessionState` with automatic objective progression on enemy kills and room exploration
- 662 tests pass including 44 new quest-specific tests

## Changes
- Added `bevy_quests` dependency to axum-discordsh
- Created `data/questdb.json` with 6 quests in proto-compatible format
- Created 6 MDX content docs for quest documentation
- Added `QuestJournal`, `ActiveQuest`, `ObjectiveProgress`, `StepProgress` types to `types.rs`
- Added `QuestDb` LazyLock loading + helper functions to `proto_bridge.rs`
- Wired quest progression into combat (kill objectives) and exploration (room visits) in `logic.rs`
- Added `AcceptQuest`, `AbandonQuest`, `ViewQuests` game actions
- Updated Dockerfile and Dockerfile.base for bevy_quests build stages

## Test plan
- [x] 28 proto_bridge quest tests (DB loading, prerequisites, quest chains, rewards)
- [x] 16 logic integration tests (accept/abandon/view, kill/explore advancement, completions, repeatable, multi-step)
- [x] Full suite: 662 tests pass

Closes #8111 (Phase 3b)