### PR TITLE
fix(edge): version.toml as single source of truth for health + dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeDashboard.tsx
@@ -19,35 +19,15 @@ const EDGE_CACHE_KEY = 'cache:edge:health';
 const CACHE_TTL_MS = 30 * 1000; // 30 seconds
 const FETCH_TIMEOUT_MS = 10_000;
 
-const EDGE_FUNCTIONS = [
-	{ name: 'health', label: 'Health', description: 'Core health check' },
-	{ name: 'meme', label: 'Meme', description: 'Meme feed and reactions' },
-	{ name: 'mc', label: 'Minecraft', description: 'MC data operations' },
-	{
-		name: 'discordsh',
-		label: 'Discord',
-		description: 'Discord server integration',
-	},
-	{
-		name: 'user-vault',
-		label: 'User Vault',
-		description: 'User API token management',
-	},
-	{
-		name: 'guild-vault',
-		label: 'Guild Vault',
-		description: 'Guild token management',
-	},
-	{
-		name: 'vault-reader',
-		label: 'Vault Reader',
-		description: 'System secret access',
-	},
-] as const;
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+interface EdgeFunctionDef {
+	name: string;
+	label: string;
+	description: string;
+}
 
 interface FunctionHealth {
 	name: string;
@@ -94,7 +74,7 @@ function setCachedHealth(data: CachedHealth): void {
 // ---------------------------------------------------------------------------
 
 async function checkFunctionHealth(
-	fn: (typeof EDGE_FUNCTIONS)[number],
+	fn: EdgeFunctionDef,
 ): Promise<FunctionHealth> {
 	const url = `${SUPABASE_URL}/functions/v1/${fn.name}`;
 	const start = performance.now();
@@ -103,10 +83,9 @@ async function checkFunctionHealth(
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-		// Health endpoint is a simple GET, other functions expect POST
-		// We use OPTIONS (preflight) for non-health functions to avoid
-		// triggering auth errors — a 200 on OPTIONS means the function
-		// is deployed and responding.
+		// Health is already confirmed reachable (we got the manifest from it).
+		// For other functions, OPTIONS (preflight) avoids auth errors —
+		// a 200 means the function is deployed and responding.
 		const method = fn.name === 'health' ? 'GET' : 'OPTIONS';
 
 		const resp = await fetch(url, {
@@ -128,13 +107,8 @@ async function checkFunctionHealth(
 			};
 		}
 
-		// For non-health functions, OPTIONS returning 200 means alive
 		if (method === 'OPTIONS' && resp.ok) {
-			return {
-				...fn,
-				status: 'ok',
-				latencyMs,
-			};
+			return { ...fn, status: 'ok', latencyMs };
 		}
 
 		return {
@@ -157,6 +131,29 @@ async function checkFunctionHealth(
 					: 'Unknown error',
 		};
 	}
+}
+
+/** Fetch the function registry from the health endpoint. */
+async function fetchManifest(): Promise<EdgeFunctionDef[]> {
+	const url = `${SUPABASE_URL}/functions/v1/health`;
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+	try {
+		const resp = await fetch(url, { signal: controller.signal });
+		clearTimeout(timeout);
+
+		if (!resp.ok) return [];
+
+		const data = await resp.json();
+		if (Array.isArray(data.functions) && data.functions.length > 0) {
+			return data.functions;
+		}
+	} catch {
+		// Health unreachable — dashboard will show empty state
+	}
+
+	return [];
 }
 
 // ---------------------------------------------------------------------------
@@ -216,9 +213,7 @@ function StatusCard({ fn }: { fn: FunctionHealth }) {
 // ---------------------------------------------------------------------------
 
 export default function ReactEdgeDashboard() {
-	const [functions, setFunctions] = useState<FunctionHealth[]>(
-		EDGE_FUNCTIONS.map((fn) => ({ ...fn, status: 'pending' as const })),
-	);
+	const [functions, setFunctions] = useState<FunctionHealth[]>([]);
 	const [fromCache, setFromCache] = useState(false);
 	const [refreshing, setRefreshing] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -240,8 +235,20 @@ export default function ReactEdgeDashboard() {
 		setFromCache(false);
 
 		try {
+			// Step 1: Get the function registry from the health endpoint
+			const manifest = await fetchManifest();
+
+			if (manifest.length === 0) {
+				setError(
+					'Could not reach the health endpoint to load function registry',
+				);
+				setFunctions([]);
+				return;
+			}
+
+			// Step 2: Check each function's health
 			const results = await Promise.all(
-				EDGE_FUNCTIONS.map(checkFunctionHealth),
+				manifest.map(checkFunctionHealth),
 			);
 			setFunctions(results);
 			setLastChecked(new Date());

--- a/apps/kbve/edge-e2e/e2e/health.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/health.spec.ts
@@ -1,6 +1,27 @@
 import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { BASE_URL, waitForReady } from './helpers/http';
 import { createJwt } from './helpers/jwt';
+
+/** Parse version.toml — single source of truth for version + function registry. */
+function parseManifest() {
+	const tomlPath = resolve(__dirname, '../../../edge/version.toml');
+	const content = readFileSync(tomlPath, 'utf-8');
+
+	const versionMatch = content.match(/^version\s*=\s*"([^"]+)"/m);
+	if (!versionMatch)
+		throw new Error('Could not parse version from version.toml');
+
+	const functionNames: string[] = [];
+	const blocks = content.split(/\[\[functions\]\]/g).slice(1);
+	for (const block of blocks) {
+		const name = block.match(/^name\s*=\s*"([^"]+)"/m)?.[1];
+		if (name) functionNames.push(name);
+	}
+
+	return { version: versionMatch[1], functionNames };
+}
 
 describe('Edge Runtime Health', () => {
 	beforeAll(async () => {
@@ -29,6 +50,24 @@ describe('Edge Runtime Health', () => {
 		expect(body.status).toBe('ok');
 		expect(body.version).toBeDefined();
 		expect(body.timestamp).toBeDefined();
+	});
+
+	it('should return version matching version.toml', async () => {
+		const { version } = parseManifest();
+		const res = await fetch(`${BASE_URL}/health`);
+		const body = await res.json();
+		expect(body.version).toBe(version);
+	});
+
+	it('should return functions array matching version.toml registry', async () => {
+		const { functionNames } = parseManifest();
+		const res = await fetch(`${BASE_URL}/health`);
+		const body = await res.json();
+		expect(Array.isArray(body.functions)).toBe(true);
+		const returnedNames = body.functions.map(
+			(f: { name: string }) => f.name,
+		);
+		expect(returnedNames).toEqual(functionNames);
 	});
 
 	it('should return a valid ISO timestamp in health response', async () => {

--- a/apps/kbve/edge/Dockerfile
+++ b/apps/kbve/edge/Dockerfile
@@ -1,3 +1,4 @@
 FROM supabase/edge-runtime:v1.70.5
 
+COPY --chown=deno:deno ./version.toml /home/deno/version.toml
 COPY ./functions /home/deno/functions

--- a/apps/kbve/edge/functions/health/index.ts
+++ b/apps/kbve/edge/functions/health/index.ts
@@ -1,7 +1,49 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
 
-const EDGE_VERSION = Deno.env.get("EDGE_VERSION") ?? "0.1.8";
+interface EdgeFunction {
+  name: string;
+  label: string;
+  description: string;
+}
+
+interface EdgeManifest {
+  version: string;
+  functions: EdgeFunction[];
+}
+
+async function loadManifest(): Promise<EdgeManifest> {
+  const fallback: EdgeManifest = { version: "0.1.11", functions: [] };
+
+  const envVersion = Deno.env.get("EDGE_VERSION");
+
+  try {
+    const toml = await Deno.readTextFile("/home/deno/version.toml");
+
+    // Parse version
+    const versionMatch = toml.match(/^version\s*=\s*"([^"]+)"/m);
+    const version = envVersion ?? versionMatch?.[1] ?? fallback.version;
+
+    // Parse [[functions]] blocks
+    const functions: EdgeFunction[] = [];
+    const blocks = toml.split(/\[\[functions\]\]/g).slice(1);
+
+    for (const block of blocks) {
+      const name = block.match(/^name\s*=\s*"([^"]+)"/m)?.[1];
+      const label = block.match(/^label\s*=\s*"([^"]+)"/m)?.[1];
+      const description = block.match(/^description\s*=\s*"([^"]+)"/m)?.[1];
+      if (name && label && description) {
+        functions.push({ name, label, description });
+      }
+    }
+
+    return { version, functions };
+  } catch {
+    return { ...fallback, version: envVersion ?? fallback.version };
+  }
+}
+
+const manifest = await loadManifest();
 
 serve((req) => {
   if (req.method === "OPTIONS") {
@@ -11,7 +53,8 @@ serve((req) => {
   return new Response(
     JSON.stringify({
       status: "ok",
-      version: EDGE_VERSION,
+      version: manifest.version,
+      functions: manifest.functions,
       timestamp: new Date().toISOString(),
     }),
     {

--- a/apps/kbve/edge/functions/types.d.ts
+++ b/apps/kbve/edge/functions/types.d.ts
@@ -5,6 +5,8 @@ declare namespace Deno {
     toObject(): Record<string, string>;
   }
   const env: Env;
+
+  function readTextFile(path: string): Promise<string>;
 }
 
 // Edge Runtime types

--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -1,1 +1,41 @@
 version = "0.1.11"
+
+[[functions]]
+name = "health"
+label = "Health"
+description = "Core health check"
+
+[[functions]]
+name = "meme"
+label = "Meme"
+description = "Meme feed and reactions"
+
+[[functions]]
+name = "mc"
+label = "Minecraft"
+description = "MC data operations"
+
+[[functions]]
+name = "discordsh"
+label = "Discord"
+description = "Discord server integration"
+
+[[functions]]
+name = "user-vault"
+label = "User Vault"
+description = "User API token management"
+
+[[functions]]
+name = "guild-vault"
+label = "Guild Vault"
+description = "Guild token management"
+
+[[functions]]
+name = "vault-reader"
+label = "Vault Reader"
+description = "System secret access"
+
+[[functions]]
+name = "logs"
+label = "Logs"
+description = "ClickHouse observability logs"


### PR DESCRIPTION
## Summary
- **version.toml** is now the single source of truth for edge version AND function registry (name, label, description)
- **Dockerfile** bakes `version.toml` into the container at `/home/deno/version.toml` with `--chown=deno:deno` for proper read permissions
- **health/index.ts** parses `version.toml` at startup and serves version + full function list in its JSON response
- **ReactEdgeDashboard** fetches the function registry dynamically from `/health` instead of maintaining a hardcoded list — adding a new edge function only requires a `[[functions]]` entry in `version.toml`
- **Removed** `EDGE_VERSION` env var from k8s deployment manifest (no longer needed)
- **Added** `Deno.readTextFile` type declaration to `types.d.ts`
- **e2e tests** validate that health endpoint returns version and function names matching `version.toml`

## Test plan
- [ ] Build edge Docker image locally and verify `/health` returns version `0.1.11` + 8 functions
- [ ] Verify dashboard loads function list dynamically from health endpoint
- [ ] Run `nx run edge-e2e:e2e` to validate version and function registry assertions
- [ ] Confirm `deno` user can read `/home/deno/version.toml` inside the container