### PR TITLE
feat(bevy_kbve_net): add npcdb feature flag for shared CreatureRegistry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,7 @@ version = "0.1.0"
 dependencies = [
  "avian3d",
  "bevy",
+ "bevy_npc",
  "lightyear",
  "serde",
 ]
@@ -7554,7 +7555,6 @@ dependencies = [
  "bevy_cam",
  "bevy_inventory",
  "bevy_kbve_net",
- "bevy_npc",
  "bevy_tasker",
  "console_error_panic_hook",
  "console_log 1.0.0",

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -59,7 +59,7 @@ lightyear = { version = "0.26", default-features = false, features = [
     "raw_connection",
 ] }
 lightyear_avian3d = { version = "0.26", default-features = false, features = ["3d"] }
-bevy_kbve_net = { path = "../../../packages/rust/bevy/bevy_kbve_net" }
+bevy_kbve_net = { path = "../../../packages/rust/bevy/bevy_kbve_net", features = ["npcdb"] }
 futures-util = "0.3"
 
 # Workspace path dependencies

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -13,6 +13,7 @@ use bevy::prelude::*;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
 
+use bevy_kbve_net::npcdb::{self, CreatureRegistry};
 use bevy_kbve_net::{
     AuthMessage, AuthResponse, CollectRequest, CreatureCaptureRequest, CreatureCaptured,
     CreatureKind, DamageEvent, GameChannel, ObjectRemoved, ObjectRespawned, PlayerName,
@@ -102,7 +103,8 @@ impl Default for WindState {
     }
 }
 
-/// Tracks which creatures have been captured (kind + index).
+/// Tracks which creatures have been captured (kind + creature_index).
+/// The server validates capture requests against the CreatureRegistry.
 #[derive(Resource, Default)]
 struct CapturedCreatures(std::collections::HashSet<(CreatureKind, u32)>);
 
@@ -307,6 +309,7 @@ fn run_bevy_app(
     app.init_resource::<CreatureSeed>();
     app.init_resource::<WindState>();
     app.init_resource::<CapturedCreatures>();
+    app.insert_resource(npcdb::build_creature_registry());
     app.init_resource::<TimeSyncTimer>();
 
     // Profile bridge resources
@@ -359,6 +362,9 @@ fn run_bevy_app(
 
     // Send time sync immediately to newly authenticated clients
     app.add_systems(Update, send_time_sync_to_new_clients);
+
+    // Process creature capture requests from clients
+    app.add_systems(Update, process_creature_captures);
 
     // Periodic debug heartbeat
     app.add_systems(Update, server_debug_heartbeat);
@@ -785,6 +791,85 @@ fn tick_respawns(
             let msg = ObjectRespawned { tile, kind };
             for mut sender in &mut senders {
                 sender.send::<bevy_kbve_net::GameChannel>(msg.clone());
+            }
+        }
+    }
+}
+
+/// Process creature capture requests: validate against CreatureRegistry, track, broadcast.
+fn process_creature_captures(
+    registry: Res<CreatureRegistry>,
+    client_player_map: Res<ClientPlayerMap>,
+    mut captured: ResMut<CapturedCreatures>,
+    mut receivers: Query<
+        (Entity, &mut MessageReceiver<CreatureCaptureRequest>),
+        Without<PendingAuth>,
+    >,
+    player_ids: Query<&bevy_kbve_net::PlayerId>,
+    mut senders: Query<&mut MessageSender<CreatureCaptured>, With<Connected>>,
+) {
+    for (client_entity, mut receiver) in &mut receivers {
+        for msg in receiver.receive() {
+            let key = (msg.kind, msg.creature_index);
+
+            // Already captured?
+            if captured.0.contains(&key) {
+                tracing::warn!(
+                    "[gameserver] creature {:?} #{} already captured — ignoring",
+                    msg.kind,
+                    msg.creature_index
+                );
+                continue;
+            }
+
+            // Validate creature_index against registry pool_size
+            let npc_ref = match msg.kind {
+                CreatureKind::Firefly => "meadow-firefly",
+                CreatureKind::Butterfly => "woodland-butterfly",
+                CreatureKind::Frog => "green-toad",
+            };
+            if let Some(config) = registry.config_by_ref(npc_ref) {
+                if msg.creature_index as usize >= config.pool_size {
+                    tracing::warn!(
+                        "[gameserver] invalid creature_index {} for {:?} (pool_size={})",
+                        msg.creature_index,
+                        msg.kind,
+                        config.pool_size
+                    );
+                    continue;
+                }
+            } else {
+                tracing::warn!(
+                    "[gameserver] unknown creature ref '{npc_ref}' for {:?}",
+                    msg.kind
+                );
+                continue;
+            }
+
+            // Track the capture
+            captured.0.insert(key);
+
+            let captor_id = client_player_map
+                .0
+                .get(&client_entity)
+                .and_then(|&pe| player_ids.get(pe).ok())
+                .map(|pid| pid.0)
+                .unwrap_or(0);
+
+            tracing::info!(
+                "[gameserver] creature captured: {:?} #{} by player {captor_id}",
+                msg.kind,
+                msg.creature_index
+            );
+
+            // Broadcast to all connected clients
+            let broadcast = CreatureCaptured {
+                kind: msg.kind,
+                creature_index: msg.creature_index,
+                captor_player_id: captor_id,
+            };
+            for mut sender in &mut senders {
+                sender.send::<GameChannel>(broadcast.clone());
             }
         }
     }

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -50,8 +50,7 @@ serde_json = "1"
 avian3d = { version = "0.5", default-features = false, features = ["3d", "f32", "parry-f32", "debug-plugin"] }
 bevy_inventory = { path = "../../../../packages/rust/bevy/bevy_inventory" }
 bevy_cam = { path = "../../../../packages/rust/bevy/bevy_cam" }
-bevy_kbve_net = { path = "../../../../packages/rust/bevy/bevy_kbve_net" }
-bevy_npc = { path = "../../../../packages/rust/bevy/bevy_npc" }
+bevy_kbve_net = { path = "../../../../packages/rust/bevy/bevy_kbve_net", features = ["npcdb"] }
 lightyear = { version = "0.26", default-features = false, features = [
     "client",
     "replication",

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/butterfly/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/butterfly/mod.rs
@@ -158,7 +158,7 @@ pub(super) fn spawn_butterflies(
     let npc_id = registry
         .npc_db
         .id_for_ref(NPC_REF)
-        .unwrap_or(bevy_npc::ProtoNpcId(0));
+        .unwrap_or(bevy_kbve_net::npcdb::ProtoNpcId(0));
     let count = config.pool_size;
 
     let wing_mesh = creature_meshes.butterfly_wings.clone();

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/creature.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/creature.rs
@@ -1,35 +1,20 @@
 //! Unified creature types for the NpcDb-driven creature system.
 //!
-//! All ambient creatures (fireflies, butterflies, frogs, and future types)
-//! share a common [`Creature`] component for pool management and chunk-based
-//! deterministic placement. Render-specific data lives in companion components
-//! ([`EmissiveData`], [`BillboardData`], [`SpriteData`]) selected by [`RenderKind`].
-//!
-//! The [`CreatureRegistry`] bridges the game-agnostic `NpcDb` proto definitions
-//! to isometric-game-specific spawn and render configuration.
-
-use std::collections::HashMap;
+//! Shared types (registry, config, slot helpers) live in `bevy_kbve_net::npcdb`
+//! so both client and server use the same definitions. This module re-exports
+//! those and adds client-only ECS components for rendering.
 
 use bevy::prelude::*;
-use bevy_npc::{self as npc_types, NpcDb, ProtoNpcId};
 
-use super::common::hash_f32;
+// Re-export shared types from bevy_kbve_net::npcdb so existing imports work.
+pub use bevy_kbve_net::npcdb::{
+    self, CreatureConfig, CreatureRegistry, ProtoNpcId, RenderKind, TimeSchedule,
+    build_creature_registry, hash_f32, slot_active, slot_anchor, slot_seed,
+};
 
 // ---------------------------------------------------------------------------
-// Enums
+// Client-only enums
 // ---------------------------------------------------------------------------
-
-/// How this creature is rendered in the isometric game.
-/// Each variant maps to a specific animate system.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum RenderKind {
-    /// Emissive sphere + glow pulse + point light + orbital motion (firefly).
-    Emissive,
-    /// Mesh billboard + wing flap + flutter offset (butterfly).
-    Billboard,
-    /// Sprite sheet + UV frame animation + hop arcs (frog).
-    Sprite,
-}
 
 /// Current lifecycle state of a creature entity in the pool.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
@@ -43,19 +28,8 @@ pub enum CreatureState {
     Captured,
 }
 
-/// When this creature type is visible.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum TimeSchedule {
-    /// Visible when `night_factor(hour) > 0` (roughly 19:00–05:30).
-    Night,
-    /// Visible when `day_factor(hour) > 0` (roughly 07:00–18:00).
-    Day,
-    /// Always visible regardless of time.
-    Always,
-}
-
 // ---------------------------------------------------------------------------
-// Core component — shared by ALL creature types
+// Core component — shared by ALL creature types (client-side ECS)
 // ---------------------------------------------------------------------------
 
 /// Unified creature component for NpcDb-driven ambient creatures.
@@ -166,277 +140,8 @@ impl Default for SpriteHopState {
 }
 
 // ---------------------------------------------------------------------------
-// Per-NPC game config (isometric-specific, not in proto)
+// Client-only slot helpers (depend on ECS components)
 // ---------------------------------------------------------------------------
-
-/// Isometric-game-specific spawn and render configuration for an NPC.
-/// This bridges the game-agnostic NpcDb to the game's rendering pipeline.
-#[derive(Clone, Debug)]
-pub struct CreatureConfig {
-    /// Which render pipeline to use.
-    pub render_kind: RenderKind,
-    /// Maximum number of pooled entities for this creature type.
-    pub pool_size: usize,
-    /// World-space chunk size for deterministic placement.
-    pub chunk_size: f32,
-    /// Potential spawn slots per chunk.
-    pub per_chunk: usize,
-    /// Fraction of slots that contain a creature (stochastic thinning).
-    pub spawn_chance: f32,
-    /// When this creature is active (day/night/always).
-    pub schedule: TimeSchedule,
-}
-
-// ---------------------------------------------------------------------------
-// Creature Registry — NpcDb + game-specific configs
-// ---------------------------------------------------------------------------
-
-/// Bevy resource bridging the game-agnostic `NpcDb` to isometric-game rendering.
-///
-/// Populated at startup with creature definitions + game-specific configs.
-/// Systems read this to know how to spawn, assign, and animate each creature type.
-#[derive(Resource)]
-pub struct CreatureRegistry {
-    /// The NPC database with proto-defined creature data.
-    pub npc_db: NpcDb,
-    /// Game-specific config per NPC, keyed by ProtoNpcId.
-    pub configs: HashMap<ProtoNpcId, CreatureConfig>,
-    /// Ordered list of creature NPC IDs for deterministic iteration.
-    pub creature_ids: Vec<ProtoNpcId>,
-}
-
-impl Default for CreatureRegistry {
-    fn default() -> Self {
-        Self {
-            npc_db: NpcDb::default(),
-            configs: HashMap::new(),
-            creature_ids: Vec::new(),
-        }
-    }
-}
-
-impl CreatureRegistry {
-    /// Register a creature NPC with its game-specific config.
-    pub fn register(&mut self, npc: npc_types::Npc, config: CreatureConfig) {
-        let id = ProtoNpcId::from_ref(&npc.r#ref);
-        self.configs.insert(id, config);
-        self.creature_ids.push(id);
-        self.npc_db.insert(npc);
-    }
-
-    /// Get the game config for a creature by NPC ref.
-    pub fn config_by_ref(&self, npc_ref: &str) -> Option<&CreatureConfig> {
-        let id = self.npc_db.id_for_ref(npc_ref)?;
-        self.configs.get(&id)
-    }
-
-    /// Get the game config for a creature by ID.
-    pub fn config(&self, id: ProtoNpcId) -> Option<&CreatureConfig> {
-        self.configs.get(&id)
-    }
-
-    /// Iterate all registered creatures with their NPC data and config.
-    pub fn iter_creatures(
-        &self,
-    ) -> impl Iterator<Item = (ProtoNpcId, &npc_types::Npc, &CreatureConfig)> {
-        self.creature_ids.iter().filter_map(move |&id| {
-            let npc = self.npc_db.get(id)?;
-            let config = self.configs.get(&id)?;
-            Some((id, npc, config))
-        })
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Builder — populates the registry with creature definitions
-// ---------------------------------------------------------------------------
-
-/// Build the creature registry with all known ambient creature types.
-///
-/// Each creature gets a proto NPC entry (game-agnostic data: name, family,
-/// rarity, stats, spawn rules) plus an isometric-game config (render kind,
-/// pool size, chunk parameters).
-pub fn build_creature_registry() -> CreatureRegistry {
-    let mut registry = CreatureRegistry::default();
-
-    // --- Meadow Firefly ---
-    registry.register(
-        npc_types::Npc {
-            r#ref: "meadow-firefly".into(),
-            name: "Meadow Firefly".into(),
-            family: npc_types::CreatureFamily::Spirit as i32,
-            rarity: npc_types::NpcRarity::Common as i32,
-            level: 1,
-            stats: Some(npc_types::NpcStats {
-                hp: 1,
-                max_hp: 1,
-                speed: 3,
-                ..Default::default()
-            }),
-            spawn_rules: vec![npc_types::SpawnRule {
-                zone: Some("grassland".into()),
-                spawn_weight: 0.55,
-                ..Default::default()
-            }],
-            spatial: Some(npc_types::SpatialProperties {
-                walk_speed: Some(0.7),
-                can_fly: Some(true),
-                ..Default::default()
-            }),
-            behavior: Some(npc_types::BehaviorTraits {
-                wander_radius: Some(12.0),
-                ..Default::default()
-            }),
-            interaction: Some(npc_types::InteractionFlags {
-                is_interactable: Some(true),
-                is_targetable: Some(true),
-                ..Default::default()
-            }),
-            phase_rules: vec![npc_types::PhaseRule {
-                time_start: Some(1900),
-                time_end: Some(530),
-                ..Default::default()
-            }],
-            ..Default::default()
-        },
-        CreatureConfig {
-            render_kind: RenderKind::Emissive,
-            pool_size: 80,
-            chunk_size: 12.0,
-            per_chunk: 3,
-            spawn_chance: 0.55,
-            schedule: TimeSchedule::Night,
-        },
-    );
-
-    // --- Woodland Butterfly ---
-    registry.register(
-        npc_types::Npc {
-            r#ref: "woodland-butterfly".into(),
-            name: "Woodland Butterfly".into(),
-            family: npc_types::CreatureFamily::Beast as i32,
-            rarity: npc_types::NpcRarity::Common as i32,
-            level: 1,
-            stats: Some(npc_types::NpcStats {
-                hp: 1,
-                max_hp: 1,
-                speed: 2,
-                ..Default::default()
-            }),
-            spawn_rules: vec![npc_types::SpawnRule {
-                zone: Some("grassland".into()),
-                spawn_weight: 1.0,
-                ..Default::default()
-            }],
-            spatial: Some(npc_types::SpatialProperties {
-                walk_speed: Some(0.35),
-                can_fly: Some(true),
-                ..Default::default()
-            }),
-            behavior: Some(npc_types::BehaviorTraits {
-                wander_radius: Some(1.4),
-                ..Default::default()
-            }),
-            interaction: Some(npc_types::InteractionFlags {
-                is_interactable: Some(true),
-                is_targetable: Some(true),
-                ..Default::default()
-            }),
-            phase_rules: vec![npc_types::PhaseRule {
-                time_start: Some(700),
-                time_end: Some(1800),
-                ..Default::default()
-            }],
-            ..Default::default()
-        },
-        CreatureConfig {
-            render_kind: RenderKind::Billboard,
-            pool_size: 14,
-            chunk_size: 16.0,
-            per_chunk: 2,
-            spawn_chance: 0.45,
-            schedule: TimeSchedule::Day,
-        },
-    );
-
-    // --- Green Toad ---
-    registry.register(
-        npc_types::Npc {
-            r#ref: "green-toad".into(),
-            name: "Green Toad".into(),
-            family: npc_types::CreatureFamily::Beast as i32,
-            rarity: npc_types::NpcRarity::Common as i32,
-            level: 1,
-            stats: Some(npc_types::NpcStats {
-                hp: 3,
-                max_hp: 3,
-                speed: 1,
-                ..Default::default()
-            }),
-            spawn_rules: vec![npc_types::SpawnRule {
-                zone: Some("grassland".into()),
-                spawn_weight: 1.0,
-                ..Default::default()
-            }],
-            spatial: Some(npc_types::SpatialProperties {
-                walk_speed: Some(2.0),
-                ..Default::default()
-            }),
-            behavior: Some(npc_types::BehaviorTraits {
-                wander_radius: Some(2.0),
-                ..Default::default()
-            }),
-            interaction: Some(npc_types::InteractionFlags {
-                is_interactable: Some(true),
-                is_targetable: Some(true),
-                ..Default::default()
-            }),
-            phase_rules: vec![npc_types::PhaseRule {
-                time_start: Some(700),
-                time_end: Some(1800),
-                ..Default::default()
-            }],
-            ..Default::default()
-        },
-        CreatureConfig {
-            render_kind: RenderKind::Sprite,
-            pool_size: 8,
-            chunk_size: 16.0,
-            per_chunk: 1,
-            spawn_chance: 0.35,
-            schedule: TimeSchedule::Day,
-        },
-    );
-
-    registry
-}
-
-// ---------------------------------------------------------------------------
-// Slot helpers — shared deterministic placement logic
-// ---------------------------------------------------------------------------
-
-/// Combine creature_seed with chunk coordinates and local index into a u32 seed.
-pub fn slot_seed(creature_seed: u64, cx: i32, cz: i32, idx: u16) -> u32 {
-    let mut h = (creature_seed as u32).wrapping_add(creature_seed.wrapping_shr(32) as u32);
-    h = h.wrapping_mul(2654435761).wrapping_add(cx as u32);
-    h = h.wrapping_mul(2246822519).wrapping_add(cz as u32);
-    h = h.wrapping_mul(3266489917).wrapping_add(idx as u32);
-    h ^= h >> 16;
-    h
-}
-
-/// Compute deterministic world-space anchor for a chunk slot.
-pub fn slot_anchor(seed: u32, cx: i32, cz: i32, chunk_size: f32) -> Vec3 {
-    let x = cx as f32 * chunk_size + hash_f32(seed) * chunk_size;
-    let z = cz as f32 * chunk_size + hash_f32(seed.wrapping_add(1)) * chunk_size;
-    let y = 1.5 + hash_f32(seed.wrapping_add(2)) * 2.5;
-    Vec3::new(x, y, z)
-}
-
-/// Stochastic thinning — not every slot produces a creature.
-pub fn slot_active(seed: u32, spawn_chance: f32) -> bool {
-    hash_f32(seed.wrapping_add(3)) < spawn_chance
-}
 
 /// Apply slot-derived animation parameters to shared creature fields.
 pub fn apply_slot_base(creature: &mut Creature, seed: u32, anchor: Vec3, slot: (i32, i32, u16)) {

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
@@ -7,8 +7,8 @@
 //! Config (pool size, chunk size, spawn chance) is read from [`CreatureRegistry`]
 //! rather than hardcoded, so tuning can happen at the NpcDb level.
 
+use super::creature::ProtoNpcId;
 use bevy::prelude::*;
-use bevy_npc::ProtoNpcId;
 use std::collections::HashSet;
 
 use super::common::{CreatureMeshes, CreaturePool, GameTime, night_factor, scene_center};

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/frog/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/frog/mod.rs
@@ -151,7 +151,7 @@ pub(super) fn spawn_frogs(
     let npc_id = registry
         .npc_db
         .id_for_ref(NPC_REF)
-        .unwrap_or(bevy_npc::ProtoNpcId(0));
+        .unwrap_or(bevy_kbve_net::npcdb::ProtoNpcId(0));
     let count = config.pool_size;
 
     let texture: Handle<Image> = asset_server.load("textures/frog_green_mob.png");

--- a/packages/rust/bevy/bevy_kbve_net/Cargo.toml
+++ b/packages/rust/bevy/bevy_kbve_net/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "Shared lightyear protocol for KBVE multiplayer — replicated components, inputs, channels"
 
+[features]
+default = []
+npcdb = ["bevy_npc"]
+
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = ["bevy_state", "bevy_render"] }
 lightyear = { version = "0.26", default-features = false, features = [
@@ -14,3 +18,4 @@ lightyear = { version = "0.26", default-features = false, features = [
 ] }
 avian3d = { version = "0.5", default-features = false, features = ["3d", "f32", "parry-f32", "serialize"] }
 serde = { version = "1", features = ["derive"] }
+bevy_npc = { path = "../bevy_npc", optional = true }

--- a/packages/rust/bevy/bevy_kbve_net/src/lib.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/lib.rs
@@ -4,6 +4,8 @@
 //! plugin used by both client and server.
 
 pub mod inputs;
+#[cfg(feature = "npcdb")]
+pub mod npcdb;
 pub mod protocol;
 pub mod worldgen;
 

--- a/packages/rust/bevy/bevy_kbve_net/src/npcdb.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/npcdb.rs
@@ -1,0 +1,323 @@
+//! NpcDb-driven creature registry and deterministic placement helpers.
+//!
+//! Available when the `npcdb` feature is enabled. Provides the shared
+//! [`CreatureRegistry`] used by both the isometric game client and the
+//! axum-kbve game server for creature spawning, validation, and capture.
+
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+// Re-export bevy_npc types so downstream crates don't need a direct dep.
+pub use bevy_npc;
+pub use bevy_npc::ProtoNpcId;
+
+use bevy_npc::{self as npc_types, NpcDb};
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// How this creature is rendered in the isometric game.
+/// Each variant maps to a specific animate system.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum RenderKind {
+    /// Emissive sphere + glow pulse + point light + orbital motion (firefly).
+    Emissive,
+    /// Mesh billboard + wing flap + flutter offset (butterfly).
+    Billboard,
+    /// Sprite sheet + UV frame animation + hop arcs (frog).
+    Sprite,
+}
+
+/// When this creature type is visible.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TimeSchedule {
+    /// Visible when `night_factor(hour) > 0` (roughly 19:00–05:30).
+    Night,
+    /// Visible when `day_factor(hour) > 0` (roughly 07:00–18:00).
+    Day,
+    /// Always visible regardless of time.
+    Always,
+}
+
+// ---------------------------------------------------------------------------
+// Per-NPC game config
+// ---------------------------------------------------------------------------
+
+/// Game-specific spawn and render configuration for an NPC.
+/// Bridges the game-agnostic NpcDb to the game's rendering pipeline.
+#[derive(Clone, Debug)]
+pub struct CreatureConfig {
+    /// Which render pipeline to use.
+    pub render_kind: RenderKind,
+    /// Maximum number of pooled entities for this creature type.
+    pub pool_size: usize,
+    /// World-space chunk size for deterministic placement.
+    pub chunk_size: f32,
+    /// Potential spawn slots per chunk.
+    pub per_chunk: usize,
+    /// Fraction of slots that contain a creature (stochastic thinning).
+    pub spawn_chance: f32,
+    /// When this creature is active (day/night/always).
+    pub schedule: TimeSchedule,
+}
+
+// ---------------------------------------------------------------------------
+// Creature Registry — NpcDb + game-specific configs
+// ---------------------------------------------------------------------------
+
+/// Bevy resource bridging the game-agnostic `NpcDb` to game rendering.
+///
+/// Populated at startup with creature definitions + game-specific configs.
+/// Systems read this to know how to spawn, assign, and animate each creature type.
+#[derive(Resource)]
+pub struct CreatureRegistry {
+    /// The NPC database with proto-defined creature data.
+    pub npc_db: NpcDb,
+    /// Game-specific config per NPC, keyed by ProtoNpcId.
+    pub configs: HashMap<ProtoNpcId, CreatureConfig>,
+    /// Ordered list of creature NPC IDs for deterministic iteration.
+    pub creature_ids: Vec<ProtoNpcId>,
+}
+
+impl Default for CreatureRegistry {
+    fn default() -> Self {
+        Self {
+            npc_db: NpcDb::default(),
+            configs: HashMap::new(),
+            creature_ids: Vec::new(),
+        }
+    }
+}
+
+impl CreatureRegistry {
+    /// Register a creature NPC with its game-specific config.
+    pub fn register(&mut self, npc: npc_types::Npc, config: CreatureConfig) {
+        let id = ProtoNpcId::from_ref(&npc.r#ref);
+        self.configs.insert(id, config);
+        self.creature_ids.push(id);
+        self.npc_db.insert(npc);
+    }
+
+    /// Get the game config for a creature by NPC ref.
+    pub fn config_by_ref(&self, npc_ref: &str) -> Option<&CreatureConfig> {
+        let id = self.npc_db.id_for_ref(npc_ref)?;
+        self.configs.get(&id)
+    }
+
+    /// Get the game config for a creature by ID.
+    pub fn config(&self, id: ProtoNpcId) -> Option<&CreatureConfig> {
+        self.configs.get(&id)
+    }
+
+    /// Iterate all registered creatures with their NPC data and config.
+    pub fn iter_creatures(
+        &self,
+    ) -> impl Iterator<Item = (ProtoNpcId, &npc_types::Npc, &CreatureConfig)> {
+        self.creature_ids.iter().filter_map(move |&id| {
+            let npc = self.npc_db.get(id)?;
+            let config = self.configs.get(&id)?;
+            Some((id, npc, config))
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Builder — populates the registry with creature definitions
+// ---------------------------------------------------------------------------
+
+/// Build the creature registry with all known ambient creature types.
+///
+/// Each creature gets a proto NPC entry (game-agnostic data: name, family,
+/// rarity, stats, spawn rules) plus a game-specific config (render kind,
+/// pool size, chunk parameters).
+pub fn build_creature_registry() -> CreatureRegistry {
+    let mut registry = CreatureRegistry::default();
+
+    // --- Meadow Firefly ---
+    registry.register(
+        npc_types::Npc {
+            r#ref: "meadow-firefly".into(),
+            name: "Meadow Firefly".into(),
+            family: npc_types::CreatureFamily::Spirit as i32,
+            rarity: npc_types::NpcRarity::Common as i32,
+            level: 1,
+            stats: Some(npc_types::NpcStats {
+                hp: 1,
+                max_hp: 1,
+                speed: 3,
+                ..Default::default()
+            }),
+            spawn_rules: vec![npc_types::SpawnRule {
+                zone: Some("grassland".into()),
+                spawn_weight: 0.55,
+                ..Default::default()
+            }],
+            spatial: Some(npc_types::SpatialProperties {
+                walk_speed: Some(0.7),
+                can_fly: Some(true),
+                ..Default::default()
+            }),
+            behavior: Some(npc_types::BehaviorTraits {
+                wander_radius: Some(12.0),
+                ..Default::default()
+            }),
+            interaction: Some(npc_types::InteractionFlags {
+                is_interactable: Some(true),
+                is_targetable: Some(true),
+                ..Default::default()
+            }),
+            phase_rules: vec![npc_types::PhaseRule {
+                time_start: Some(1900),
+                time_end: Some(530),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        CreatureConfig {
+            render_kind: RenderKind::Emissive,
+            pool_size: 80,
+            chunk_size: 12.0,
+            per_chunk: 3,
+            spawn_chance: 0.55,
+            schedule: TimeSchedule::Night,
+        },
+    );
+
+    // --- Woodland Butterfly ---
+    registry.register(
+        npc_types::Npc {
+            r#ref: "woodland-butterfly".into(),
+            name: "Woodland Butterfly".into(),
+            family: npc_types::CreatureFamily::Beast as i32,
+            rarity: npc_types::NpcRarity::Common as i32,
+            level: 1,
+            stats: Some(npc_types::NpcStats {
+                hp: 1,
+                max_hp: 1,
+                speed: 2,
+                ..Default::default()
+            }),
+            spawn_rules: vec![npc_types::SpawnRule {
+                zone: Some("grassland".into()),
+                spawn_weight: 1.0,
+                ..Default::default()
+            }],
+            spatial: Some(npc_types::SpatialProperties {
+                walk_speed: Some(0.35),
+                can_fly: Some(true),
+                ..Default::default()
+            }),
+            behavior: Some(npc_types::BehaviorTraits {
+                wander_radius: Some(1.4),
+                ..Default::default()
+            }),
+            interaction: Some(npc_types::InteractionFlags {
+                is_interactable: Some(true),
+                is_targetable: Some(true),
+                ..Default::default()
+            }),
+            phase_rules: vec![npc_types::PhaseRule {
+                time_start: Some(700),
+                time_end: Some(1800),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        CreatureConfig {
+            render_kind: RenderKind::Billboard,
+            pool_size: 14,
+            chunk_size: 16.0,
+            per_chunk: 2,
+            spawn_chance: 0.45,
+            schedule: TimeSchedule::Day,
+        },
+    );
+
+    // --- Green Toad ---
+    registry.register(
+        npc_types::Npc {
+            r#ref: "green-toad".into(),
+            name: "Green Toad".into(),
+            family: npc_types::CreatureFamily::Beast as i32,
+            rarity: npc_types::NpcRarity::Common as i32,
+            level: 1,
+            stats: Some(npc_types::NpcStats {
+                hp: 3,
+                max_hp: 3,
+                speed: 1,
+                ..Default::default()
+            }),
+            spawn_rules: vec![npc_types::SpawnRule {
+                zone: Some("grassland".into()),
+                spawn_weight: 1.0,
+                ..Default::default()
+            }],
+            spatial: Some(npc_types::SpatialProperties {
+                walk_speed: Some(2.0),
+                ..Default::default()
+            }),
+            behavior: Some(npc_types::BehaviorTraits {
+                wander_radius: Some(2.0),
+                ..Default::default()
+            }),
+            interaction: Some(npc_types::InteractionFlags {
+                is_interactable: Some(true),
+                is_targetable: Some(true),
+                ..Default::default()
+            }),
+            phase_rules: vec![npc_types::PhaseRule {
+                time_start: Some(700),
+                time_end: Some(1800),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        CreatureConfig {
+            render_kind: RenderKind::Sprite,
+            pool_size: 8,
+            chunk_size: 16.0,
+            per_chunk: 1,
+            spawn_chance: 0.35,
+            schedule: TimeSchedule::Day,
+        },
+    );
+
+    registry
+}
+
+// ---------------------------------------------------------------------------
+// Slot helpers — shared deterministic placement logic
+// ---------------------------------------------------------------------------
+
+/// Simple hash → f32 in [0, 1) for deterministic variety.
+pub fn hash_f32(seed: u32) -> f32 {
+    let mut x = seed;
+    x ^= x >> 16;
+    x = x.wrapping_mul(0x45d9f3b);
+    x ^= x >> 16;
+    (x & 0xFFFF) as f32 / 65535.0
+}
+
+/// Combine creature_seed with chunk coordinates and local index into a u32 seed.
+pub fn slot_seed(creature_seed: u64, cx: i32, cz: i32, idx: u16) -> u32 {
+    let mut h = (creature_seed as u32).wrapping_add(creature_seed.wrapping_shr(32) as u32);
+    h = h.wrapping_mul(2654435761).wrapping_add(cx as u32);
+    h = h.wrapping_mul(2246822519).wrapping_add(cz as u32);
+    h = h.wrapping_mul(3266489917).wrapping_add(idx as u32);
+    h ^= h >> 16;
+    h
+}
+
+/// Compute deterministic world-space anchor for a chunk slot.
+pub fn slot_anchor(seed: u32, cx: i32, cz: i32, chunk_size: f32) -> Vec3 {
+    let x = cx as f32 * chunk_size + hash_f32(seed) * chunk_size;
+    let z = cz as f32 * chunk_size + hash_f32(seed.wrapping_add(1)) * chunk_size;
+    let y = 1.5 + hash_f32(seed.wrapping_add(2)) * 2.5;
+    Vec3::new(x, y, z)
+}
+
+/// Stochastic thinning — not every slot produces a creature.
+pub fn slot_active(seed: u32, spawn_chance: f32) -> bool {
+    hash_f32(seed.wrapping_add(3)) < spawn_chance
+}


### PR DESCRIPTION
## Summary
- Add optional `npcdb` feature to `bevy_kbve_net` that pulls in `bevy_npc` and exposes `CreatureRegistry`, `CreatureConfig`, slot helpers, and `build_creature_registry()`
- Both `isometric-game` and `axum-kbve` enable the feature so they share identical creature definitions from a single source of truth
- Wire `process_creature_captures` system on the server to validate capture requests against the registry pool_size before broadcasting

## Test plan
- [x] `cargo check -p bevy_kbve_net` (without feature) compiles
- [x] `cargo check -p bevy_kbve_net --features npcdb` compiles
- [x] `cargo check -p isometric-game` compiles
- [x] `cargo check -p axum-kbve` compiles
- [ ] Verify creature capture flow end-to-end in staging