### PR TITLE
fix(fudster): resolve all CodeQL alerts and improve package

### DIFF
--- a/packages/python/fudster/fudster/__init__.py
+++ b/packages/python/fudster/fudster/__init__.py
@@ -1,35 +1,41 @@
 """Fudster - A composable ML library for haystack-ai and pgvector integrations."""
 
+import logging as _logging
+
+_logger = _logging.getLogger(__name__)
+
 # Broadcast models
-from .models import CommandModel, LoggerModel, BroadcastModel, KBVELoginModel, HandshakeModel, model_map  # noqa: F401
+from .models import (  # noqa: F401, E402
+    CommandModel, LoggerModel, BroadcastModel, KBVELoginModel, HandshakeModel, model_map,
+)
 
 # API models
-from .models.rss import RssItem, RssFeed  # noqa: F401
-from .models.poem import PoemDB  # noqa: F401
-from .models.coindesk import CoinDeskAPIResponse  # noqa: F401
-from .models.groq import AiGroqPayload, GroqResponse  # noqa: F401
-from .models.rsps import GameEvent, GameStat, GameInventory  # noqa: F401
+from .models.rss import RssItem, RssFeed  # noqa: F401, E402
+from .models.poem import PoemDB  # noqa: F401, E402
+from .models.coindesk import CoinDeskAPIResponse  # noqa: F401, E402
+from .models.groq import AiGroqPayload, GroqResponse  # noqa: F401, E402
+from .models.rsps import GameEvent, GameStat, GameInventory  # noqa: F401, E402
 
 # Core API
-from .api import Routes, CORS, WS, APIConnector  # noqa: F401
+from .api import Routes, CORS, WS, APIConnector  # noqa: F401, E402
 
 # API clients
-from .api.clients import CoinDeskClient, PoetryDBClient, GroqClient, WebsocketEchoClient  # noqa: F401
+from .api.clients import CoinDeskClient, PoetryDBClient, GroqClient, WebsocketEchoClient  # noqa: F401, E402
 
 # API utils
-from .api.utils import RSSUtility, KRDecorator, DynamicEndpoint  # noqa: F401
+from .api.utils import RSSUtility, KRDecorator, DynamicEndpoint  # noqa: F401, E402
 
 try:
-    from .api.utils import ImageUtility  # noqa: F401
+    from .api.utils import ImageUtility  # noqa: F401, E402
 except ImportError:
-    pass
+    _logger.debug("ImageUtility unavailable — install fudster[image] for image processing support")
 
 # Apps
-from .apps import RuneLiteClient  # noqa: F401
+from .apps import RuneLiteClient  # noqa: F401, E402
 
 try:
-    from .apps import ScreenClient, ChromeClient, DiscordClient, NoVNCClient  # noqa: F401
+    from .apps import ScreenClient, ChromeClient, DiscordClient, NoVNCClient  # noqa: F401, E402
 except ImportError:
-    pass
+    _logger.debug("Optional app clients unavailable — install fudster[browser,automation,vnc] as needed")
 
 __version__ = "0.1.0"

--- a/packages/python/fudster/fudster/api/api_connector.py
+++ b/packages/python/fudster/fudster/api/api_connector.py
@@ -12,6 +12,13 @@ class APIConnector:
         self.session = aiohttp.ClientSession(timeout=ClientTimeout(total=timeout))
         self.websocket = websocket
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+        return False
+
     async def _request(self, method: str, endpoint: str, **kwargs) -> Any:
         url = f"{self.base_url}/{endpoint}"
         headers = self._prepare_headers(kwargs.pop('auth', None))
@@ -69,6 +76,7 @@ class APIConnector:
             return msg.data
         elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
             raise Exception("WebSocket connection closed or encountered an error.")
+        raise Exception(f"Unexpected WebSocket message type: {msg.type}")
 
     def _prepare_headers(self, auth: Optional[str] = None) -> dict:
         """Prepare headers for HTTP or WebSocket connection."""

--- a/packages/python/fudster/fudster/api/utils/__init__.py
+++ b/packages/python/fudster/fudster/api/utils/__init__.py
@@ -1,9 +1,13 @@
 """API Utilities"""
-from .rss_utils import RSSUtility  # noqa: F401
-from .kr_decorator import KRDecorator  # noqa: F401
-from .dynamic_endpoint_utils import DynamicEndpoint  # noqa: F401
+import logging as _logging
+
+_logger = _logging.getLogger(__name__)
+
+from .rss_utils import RSSUtility  # noqa: F401, E402
+from .kr_decorator import KRDecorator  # noqa: F401, E402
+from .dynamic_endpoint_utils import DynamicEndpoint  # noqa: F401, E402
 
 try:
-    from .image_utils import ImageUtility  # noqa: F401
+    from .image_utils import ImageUtility  # noqa: F401, E402
 except ImportError:
-    pass
+    _logger.debug("ImageUtility unavailable — install Pillow for image processing support")

--- a/packages/python/fudster/fudster/apps/__init__.py
+++ b/packages/python/fudster/fudster/apps/__init__.py
@@ -1,21 +1,25 @@
-from .runelite import RuneLiteClient  # noqa: F401
+import logging as _logging
+
+_logger = _logging.getLogger(__name__)
+
+from .runelite import RuneLiteClient  # noqa: F401, E402
 
 try:
-    from .screen_client import ScreenClient  # noqa: F401
+    from .screen_client import ScreenClient  # noqa: F401, E402
 except ImportError:
-    pass
+    _logger.debug("ScreenClient unavailable — install fudster[automation]")
 
 try:
-    from .chrome_client import ChromeClient  # noqa: F401
+    from .chrome_client import ChromeClient  # noqa: F401, E402
 except ImportError:
-    pass
+    _logger.debug("ChromeClient unavailable — install fudster[browser]")
 
 try:
-    from .discord_client import DiscordClient  # noqa: F401
+    from .discord_client import DiscordClient  # noqa: F401, E402
 except ImportError:
-    pass
+    _logger.debug("DiscordClient unavailable — install fudster[browser]")
 
 try:
-    from .novnc_client import NoVNCClient  # noqa: F401
+    from .novnc_client import NoVNCClient  # noqa: F401, E402
 except ImportError:
-    pass
+    _logger.debug("NoVNCClient unavailable — install fudster[vnc]")

--- a/packages/python/fudster/fudster/apps/chrome_client.py
+++ b/packages/python/fudster/fudster/apps/chrome_client.py
@@ -136,6 +136,7 @@ class ChromeClient:
             return f"Failed to navigate to GitLab sign-in page: {e}"
         finally:
             await self.stop_chrome_async()
+        return "GitLab sign-in page navigation completed."
 
     async def close(self):
         pass

--- a/packages/python/fudster/fudster/apps/discord_client.py
+++ b/packages/python/fudster/fudster/apps/discord_client.py
@@ -59,9 +59,10 @@ class DiscordClient:
                 if attempt < retries - 1:
                     await sleep(2)
                 else:
-                    raise e
+                    raise
             finally:
                 await self.chrome_client.stop_chrome_async()
+        return "Discord login failed after all retries."
 
     async def verify_login(self):
         """

--- a/packages/python/fudster/tests/test_hello.py
+++ b/packages/python/fudster/tests/test_hello.py
@@ -123,3 +123,9 @@ def test_utils_importable():
     assert RSSUtility is not None
     assert KRDecorator is not None
     assert DynamicEndpoint is not None
+
+
+def test_api_connector_context_manager():
+    """Test APIConnector supports async context manager protocol."""
+    assert hasattr(APIConnector, '__aenter__')
+    assert hasattr(APIConnector, '__aexit__')


### PR DESCRIPTION
## Summary
- Replace 7 bare `except: pass` blocks with `_logger.debug()` messages for optional dependency imports (CodeQL `py/empty-except` #51-57)
- Fix 3 mixed-return paths by adding explicit return statements or raising exceptions (CodeQL `py/mixed-returns` #44-46)
- Add async context manager (`__aenter__`/`__aexit__`) to `APIConnector` to prevent session leaks
- Fix `raise e` → `raise` anti-pattern in `DiscordClient` to preserve tracebacks

## Test plan
- [x] All 15 fudster unit tests pass (including new `test_api_connector_context_manager`)
- [x] flake8 lint passes with `--max-line-length 120`
- [ ] Verify CodeQL alerts resolve after merge