### PR TITLE
feat(discordsh): Phase 4 session persistence for dungeon profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "http-body-util",
  "jedi",
  "kbve",
+ "lru",
  "num_cpus",
  "poise",
  "rand 0.10.0",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -33,6 +33,7 @@ poise = "0.6.1"
 sysinfo = "0.38.2"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 dashmap = "6.1"
+lru = "0.16"
 uuid = { version = "1", features = ["v4", "serde"] }
 rand = "0.10"
 rand_chacha = "0.10"

--- a/apps/discordsh/axum-discordsh/src/discord/bot.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/bot.rs
@@ -110,11 +110,12 @@ async fn event_handler(
             // Spawn session cleanup task for Embed Dungeon
             {
                 let sessions = data.app.sessions.clone();
+                let profiles = data.app.profiles.clone();
                 tokio::spawn(async move {
                     let mut interval = tokio::time::interval(Duration::from_secs(60));
                     loop {
                         interval.tick().await;
-                        sessions.cleanup_expired(Duration::from_secs(7200));
+                        sessions.cleanup_expired(Duration::from_secs(7200), Some(&profiles));
                     }
                 });
             }

--- a/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs
@@ -6,10 +6,13 @@ use poise::serenity_prelude as serenity;
 use kbve::MemberStatus;
 
 use crate::discord::bot::{Context, Error};
-use crate::discord::game::{self, card, content, render, types::*};
+use crate::discord::game::{self, card, content, persistence, render, types::*};
 
 /// Dungeon crawler game — stress-test embeds, buttons, and select menus.
-#[poise::command(slash_command, subcommands("start", "join", "leave", "status", "end"))]
+#[poise::command(
+    slash_command,
+    subcommands("start", "join", "leave", "status", "end", "leaderboard")
+)]
 pub async fn dungeon(_ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
 }
@@ -76,7 +79,7 @@ async fn start(
     let (class_hp, class_armor, class_dmg, class_crit, class_gold) =
         content::class_starting_stats(&player_class);
 
-    let player = PlayerState {
+    let mut player = PlayerState {
         name: player_name,
         inventory: content::starting_inventory(),
         member_status: member_tag,
@@ -89,6 +92,14 @@ async fn start(
         crit_chance: class_crit,
         ..PlayerState::default()
     };
+
+    // Load persisted profile and apply to player
+    let mut quest_journal = QuestJournal::default();
+    let saved_profile = ctx.data().app.profiles.load(user.get()).await;
+    if let Some(ref profile) = saved_profile {
+        persistence::apply_profile_to_player(profile, &mut player, &mut quest_journal);
+        player.saved_snapshot = Some(profile.clone());
+    }
 
     // We need to send the message first to get the MessageId
     let session_state = SessionState {
@@ -117,7 +128,7 @@ async fn start(
         show_inventory: false,
         pending_destination: None,
         enemies_had_first_strike: false,
-        quest_journal: QuestJournal::default(),
+        quest_journal,
     };
 
     let components = render::render_components(&session_state);
@@ -300,7 +311,7 @@ async fn join(
     let (class_hp, class_armor, class_dmg, class_crit, class_gold) =
         content::class_starting_stats(&joiner_class);
 
-    let joiner_player = PlayerState {
+    let mut joiner_player = PlayerState {
         name: joiner_name,
         inventory: content::starting_inventory(),
         member_status: joiner_tag,
@@ -313,6 +324,18 @@ async fn join(
         crit_chance: class_crit,
         ..PlayerState::default()
     };
+
+    // Load persisted profile for joining player
+    let saved_profile = ctx.data().app.profiles.load(user.get()).await;
+    if let Some(ref profile) = saved_profile {
+        persistence::apply_profile_to_player(
+            profile,
+            &mut joiner_player,
+            &mut session.quest_journal,
+        );
+        joiner_player.saved_snapshot = Some(profile.clone());
+    }
+
     session.players.insert(user, joiner_player);
 
     session
@@ -373,13 +396,27 @@ async fn leave(ctx: Context<'_>) -> Result<(), Error> {
     let mut session = handle.lock().await;
 
     if session.owner == user {
-        // Owner leaving ends the session
+        // Owner leaving ends the session — save all players
         session.phase = GamePhase::GameOver(GameOverReason::Escaped);
+        persistence::save_all_players(&ctx.data().app.profiles, &session, &GameOverReason::Escaped);
         drop(session);
         ctx.data().app.sessions.remove(&sid);
         ctx.send(poise::CreateReply::default().content("Session ended (owner left)."))
             .await?;
     } else {
+        // Save the leaving player's progress (escaped)
+        if let Some(player) = session.players.get(&user) {
+            let (profile, run) = persistence::extract_save_payload(
+                user.get(),
+                &player.name,
+                player,
+                &session.quest_journal,
+                &GameOverReason::Escaped,
+                player.saved_snapshot.as_ref(),
+                &session,
+            );
+            ctx.data().app.profiles.save_async(profile, run);
+        }
         session.party.retain(|&id| id != user);
         session.players.remove(&user);
         session
@@ -475,11 +512,64 @@ async fn end(ctx: Context<'_>) -> Result<(), Error> {
         return Ok(());
     }
 
+    // Save all players before ending
+    persistence::save_all_players(&ctx.data().app.profiles, &session, &GameOverReason::Escaped);
+
     drop(session);
     ctx.data().app.sessions.remove(&sid);
 
     ctx.send(poise::CreateReply::default().content(format!("Dungeon session `{}` ended.", sid)))
         .await?;
+
+    Ok(())
+}
+
+/// View the dungeon leaderboard.
+#[poise::command(slash_command)]
+async fn leaderboard(
+    ctx: Context<'_>,
+    #[description = "Category: xp, kills, bosses, rooms, gold"] category: Option<String>,
+) -> Result<(), Error> {
+    let (cat_id, cat_label) = match category.as_deref() {
+        Some("kills") => (2i16, "Kills"),
+        Some("bosses") => (3i16, "Bosses Defeated"),
+        Some("rooms") => (4i16, "Rooms Cleared"),
+        Some("gold") => (5i16, "Gold Earned"),
+        _ => (1i16, "XP"),
+    };
+
+    let entries = ctx.data().app.profiles.leaderboard(cat_id, 10).await;
+
+    if entries.is_empty() {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("No leaderboard data yet. Play some dungeons!")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let mut lines = Vec::new();
+    for entry in &entries {
+        let medal = match entry.rank {
+            1 => "\u{1F947}",
+            2 => "\u{1F948}",
+            3 => "\u{1F949}",
+            _ => "\u{25AB}",
+        };
+        lines.push(format!(
+            "{} **#{}** {} — Lv.{} | {} **{}**",
+            medal, entry.rank, entry.discord_name, entry.level, cat_label, entry.value
+        ));
+    }
+
+    let embed = serenity::CreateEmbed::new()
+        .title(format!("Dungeon Leaderboard — {}", cat_label))
+        .description(lines.join("\n"))
+        .color(0xFFD700);
+
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
 
     Ok(())
 }

--- a/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/battle_bridge.rs
@@ -1085,6 +1085,7 @@ mod tests {
                 lifetime_gold_earned: 0,
                 lifetime_rooms_cleared: 0,
                 lifetime_bosses_defeated: 0,
+                saved_snapshot: None,
             },
         );
 

--- a/apps/discordsh/axum-discordsh/src/discord/game/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/mod.rs
@@ -2,11 +2,13 @@ pub mod battle_bridge;
 pub mod card;
 pub mod content;
 pub mod logic;
+pub mod persistence;
 pub mod proto_bridge;
 pub mod render;
 pub mod router;
 pub mod session;
 pub mod types;
 
+pub use persistence::ProfileStore;
 pub use session::SessionStore;
 pub use types::*;

--- a/apps/discordsh/axum-discordsh/src/discord/game/persistence.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/persistence.rs
@@ -1,0 +1,663 @@
+//! Dungeon player persistence — Supabase-backed profile storage.
+//!
+//! Follows the `MemberCache` pattern: LRU cache + Supabase RPC + graceful
+//! degradation (if Supabase is unavailable, games still work in-memory).
+
+use std::num::NonZeroUsize;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tracing::{debug, error, warn};
+
+use kbve::SupabaseClient;
+
+use super::types::{ClassType, GameOverReason, ItemStack, PlayerState, QuestJournal, SessionState};
+
+const SCHEMA: &str = "discordsh";
+const CACHE_CAP: usize = 512;
+const CACHE_TTL: Duration = Duration::from_secs(300);
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+/// Persistent player profile (mirrors SQL `discordsh.dungeon_profiles`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DungeonProfile {
+    pub discord_id: i64,
+    pub discord_name: String,
+    pub class_id: i16,
+    pub level: i16,
+    pub xp: i32,
+    pub xp_to_next: i32,
+    pub gold: i32,
+    pub lifetime_kills: i32,
+    pub lifetime_gold_earned: i32,
+    pub lifetime_rooms_cleared: i32,
+    pub lifetime_bosses_defeated: i32,
+    pub lifetime_deaths: i32,
+    pub lifetime_victories: i32,
+    pub lifetime_escapes: i32,
+    pub weapon: Option<String>,
+    pub armor_gear: Option<String>,
+    pub inventory: serde_json::Value,
+    pub completed_quests: Vec<String>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+/// Per-session run summary (inserted into `discordsh.dungeon_runs`).
+#[derive(Debug, Clone, Serialize)]
+pub struct RunSummary {
+    pub outcome: i16,
+    pub rooms_cleared: i32,
+    pub kills: i32,
+    pub gold_earned: i32,
+    pub gold_lost: i32,
+    pub bosses_defeated: i32,
+    pub xp_earned: i32,
+    pub level_at_end: i16,
+    pub duration_secs: Option<i32>,
+}
+
+/// Leaderboard entry returned from `service_leaderboard`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LeaderboardEntry {
+    pub rank: i64,
+    pub discord_id: i64,
+    pub discord_name: String,
+    pub level: i16,
+    pub value: i64,
+}
+
+/// JSONB inventory slot shape.
+#[derive(Debug, Serialize, Deserialize)]
+struct InventorySlot {
+    item_id: String,
+    qty: u16,
+}
+
+struct CachedProfile {
+    profile: DungeonProfile,
+    fetched_at: Instant,
+}
+
+// ── ProfileStore ────────────────────────────────────────────────────────
+
+pub struct ProfileStore {
+    client: Option<SupabaseClient>,
+    cache: Mutex<lru::LruCache<u64, CachedProfile>>,
+    ttl: Duration,
+}
+
+impl ProfileStore {
+    /// Build from environment. Returns a no-op store if Supabase is unavailable.
+    pub fn from_env() -> Self {
+        Self {
+            client: SupabaseClient::from_env(),
+            cache: Mutex::new(lru::LruCache::new(NonZeroUsize::new(CACHE_CAP).unwrap())),
+            ttl: CACHE_TTL,
+        }
+    }
+
+    /// Load a profile, checking cache first then Supabase RPC.
+    pub async fn load(&self, discord_id: u64) -> Option<DungeonProfile> {
+        // Check cache
+        {
+            let mut cache = self.cache.lock().await;
+            if let Some(entry) = cache.get(&discord_id) {
+                if entry.fetched_at.elapsed() < self.ttl {
+                    return Some(entry.profile.clone());
+                }
+            }
+        }
+
+        let client = self.client.as_ref()?;
+        let params = serde_json::json!({ "p_discord_id": discord_id as i64 });
+
+        match client
+            .rpc_schema("service_load_profile", params, SCHEMA)
+            .await
+        {
+            Ok(resp) => {
+                if !resp.status().is_success() {
+                    warn!(
+                        status = %resp.status(),
+                        discord_id,
+                        "service_load_profile returned non-200"
+                    );
+                    return None;
+                }
+                match resp.json::<Vec<DungeonProfile>>().await {
+                    Ok(rows) if !rows.is_empty() => {
+                        let profile = rows.into_iter().next().unwrap();
+                        let mut cache = self.cache.lock().await;
+                        cache.put(
+                            discord_id,
+                            CachedProfile {
+                                profile: profile.clone(),
+                                fetched_at: Instant::now(),
+                            },
+                        );
+                        Some(profile)
+                    }
+                    Ok(_) => None,
+                    Err(e) => {
+                        warn!(error = %e, discord_id, "Failed to parse profile response");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, discord_id, "service_load_profile RPC failed");
+                None
+            }
+        }
+    }
+
+    /// Save a profile + run summary (fire-and-forget via tokio::spawn).
+    pub fn save_async(&self, profile: DungeonProfile, run: RunSummary) {
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let params = serde_json::json!({
+                "p_discord_id": profile.discord_id,
+                "p_discord_name": profile.discord_name,
+                "p_class_id": profile.class_id,
+                "p_level": profile.level,
+                "p_xp": profile.xp,
+                "p_xp_to_next": profile.xp_to_next,
+                "p_gold": profile.gold,
+                "p_lifetime_kills": profile.lifetime_kills,
+                "p_lifetime_gold_earned": profile.lifetime_gold_earned,
+                "p_lifetime_rooms_cleared": profile.lifetime_rooms_cleared,
+                "p_lifetime_bosses_defeated": profile.lifetime_bosses_defeated,
+                "p_lifetime_deaths": profile.lifetime_deaths,
+                "p_lifetime_victories": profile.lifetime_victories,
+                "p_lifetime_escapes": profile.lifetime_escapes,
+                "p_weapon": profile.weapon,
+                "p_armor_gear": profile.armor_gear,
+                "p_inventory": profile.inventory,
+                "p_completed_quests": profile.completed_quests,
+                "p_run_outcome": run.outcome,
+                "p_run_rooms_cleared": run.rooms_cleared,
+                "p_run_kills": run.kills,
+                "p_run_gold_earned": run.gold_earned,
+                "p_run_gold_lost": run.gold_lost,
+                "p_run_bosses_defeated": run.bosses_defeated,
+                "p_run_xp_earned": run.xp_earned,
+                "p_run_level_at_end": run.level_at_end,
+                "p_run_duration_secs": run.duration_secs,
+            });
+
+            match client
+                .rpc_schema("service_upsert_profile", params, SCHEMA)
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    debug!(discord_id = profile.discord_id, "Profile saved");
+                }
+                Ok(resp) => {
+                    warn!(
+                        status = %resp.status(),
+                        discord_id = profile.discord_id,
+                        "service_upsert_profile returned non-200"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        discord_id = profile.discord_id,
+                        "service_upsert_profile RPC failed"
+                    );
+                }
+            }
+        });
+    }
+
+    /// Fetch leaderboard (always fresh, no cache).
+    pub async fn leaderboard(&self, category: i16, limit: i32) -> Vec<LeaderboardEntry> {
+        let Some(client) = self.client.as_ref() else {
+            return Vec::new();
+        };
+        let params = serde_json::json!({
+            "p_category": category,
+            "p_limit": limit,
+        });
+
+        match client
+            .rpc_schema("service_leaderboard", params, SCHEMA)
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => resp
+                .json::<Vec<LeaderboardEntry>>()
+                .await
+                .unwrap_or_default(),
+            Ok(resp) => {
+                warn!(status = %resp.status(), "service_leaderboard returned non-200");
+                Vec::new()
+            }
+            Err(e) => {
+                warn!(error = %e, "service_leaderboard RPC failed");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Invalidate a cached profile (called after save).
+    pub async fn invalidate(&self, discord_id: u64) {
+        self.cache.lock().await.pop(&discord_id);
+    }
+}
+
+// ── Profile ↔ PlayerState conversion ────────────────────────────────────
+
+/// Apply a loaded profile onto a fresh PlayerState and QuestJournal.
+pub fn apply_profile_to_player(
+    profile: &DungeonProfile,
+    player: &mut PlayerState,
+    journal: &mut QuestJournal,
+) {
+    player.class = class_from_id(profile.class_id);
+    player.level = profile.level.max(1) as u8;
+    player.xp = profile.xp.max(0) as u32;
+    player.xp_to_next = profile.xp_to_next.max(1) as u32;
+    player.gold = profile.gold.max(0);
+    player.lifetime_kills = profile.lifetime_kills.max(0) as u32;
+    player.lifetime_gold_earned = profile.lifetime_gold_earned.max(0) as u32;
+    player.lifetime_rooms_cleared = profile.lifetime_rooms_cleared.max(0) as u32;
+    player.lifetime_bosses_defeated = profile.lifetime_bosses_defeated.max(0) as u32;
+    player.weapon = profile.weapon.clone();
+    player.armor_gear = profile.armor_gear.clone();
+
+    // Restore inventory from JSONB
+    if let Ok(slots) = serde_json::from_value::<Vec<InventorySlot>>(profile.inventory.clone()) {
+        for slot in slots {
+            player.inventory.push(ItemStack {
+                item_id: slot.item_id,
+                qty: slot.qty,
+            });
+        }
+    }
+
+    // Restore completed quests
+    for ref_slug in &profile.completed_quests {
+        if !journal.is_completed(ref_slug) {
+            journal.completed.push(ref_slug.clone());
+        }
+    }
+}
+
+/// Extract a save payload from session state at game over.
+///
+/// Applies death penalty for Defeated/Expired outcomes:
+/// - Level/XP: keep level, lose 25% XP (no de-level)
+/// - Gold: lose 50% of run-earned gold
+/// - Inventory: lose consumables gained this run (diff against snapshot)
+/// - Gear: always kept
+/// - Lifetime stats: always increment
+pub fn extract_save_payload(
+    discord_id: u64,
+    discord_name: &str,
+    player: &PlayerState,
+    journal: &QuestJournal,
+    reason: &GameOverReason,
+    snapshot: Option<&DungeonProfile>,
+    session: &SessionState,
+) -> (DungeonProfile, RunSummary) {
+    let is_penalty = matches!(reason, GameOverReason::Defeated | GameOverReason::Expired);
+
+    // Base lifetime stats from snapshot (or zero for new players)
+    let base_kills = snapshot.map_or(0, |s| s.lifetime_kills);
+    let base_gold_earned = snapshot.map_or(0, |s| s.lifetime_gold_earned);
+    let base_rooms = snapshot.map_or(0, |s| s.lifetime_rooms_cleared);
+    let base_bosses = snapshot.map_or(0, |s| s.lifetime_bosses_defeated);
+    let base_deaths = snapshot.map_or(0, |s| s.lifetime_deaths);
+    let base_victories = snapshot.map_or(0, |s| s.lifetime_victories);
+    let base_escapes = snapshot.map_or(0, |s| s.lifetime_escapes);
+
+    // Run-level deltas
+    let run_kills = (player.lifetime_kills as i32).saturating_sub(base_kills);
+    let run_gold = (player.lifetime_gold_earned as i32).saturating_sub(base_gold_earned);
+    let run_rooms = (player.lifetime_rooms_cleared as i32).saturating_sub(base_rooms);
+    let run_bosses = (player.lifetime_bosses_defeated as i32).saturating_sub(base_bosses);
+    let run_xp = player.xp as i32 - snapshot.map_or(0, |s| s.xp);
+
+    // Gold penalty: lose 50% of run-earned gold on defeat
+    let gold_lost = if is_penalty { run_gold / 2 } else { 0 };
+    let final_gold = if is_penalty {
+        (player.gold - gold_lost).max(0)
+    } else {
+        player.gold
+    };
+
+    // XP penalty: lose 25% of current XP on defeat (no de-level)
+    let final_xp = if is_penalty {
+        let penalty = player.xp / 4;
+        player.xp.saturating_sub(penalty)
+    } else {
+        player.xp
+    };
+
+    // Inventory: on defeat, revert to snapshot inventory (lose this run's gains)
+    let final_inventory = if is_penalty {
+        snapshot
+            .map(|s| s.inventory.clone())
+            .unwrap_or_else(|| serde_json::json!([]))
+    } else {
+        inventory_to_json(&player.inventory)
+    };
+
+    // Lifetime stats always increment
+    let lifetime_kills = base_kills + run_kills.max(0);
+    let lifetime_gold_earned = base_gold_earned + run_gold.max(0);
+    let lifetime_rooms = base_rooms + run_rooms.max(0);
+    let lifetime_bosses = base_bosses + run_bosses.max(0);
+
+    let (lifetime_deaths, lifetime_victories, lifetime_escapes) = match reason {
+        GameOverReason::Defeated | GameOverReason::Expired => {
+            (base_deaths + 1, base_victories, base_escapes)
+        }
+        GameOverReason::Victory => (base_deaths, base_victories + 1, base_escapes),
+        GameOverReason::Escaped => (base_deaths, base_victories, base_escapes + 1),
+    };
+
+    // Duration
+    let duration_secs = session.created_at.elapsed().as_secs() as i32;
+
+    let profile = DungeonProfile {
+        discord_id: discord_id as i64,
+        discord_name: discord_name.to_owned(),
+        class_id: class_to_id(&player.class),
+        level: player.level as i16,
+        xp: final_xp as i32,
+        xp_to_next: player.xp_to_next as i32,
+        gold: final_gold,
+        lifetime_kills,
+        lifetime_gold_earned,
+        lifetime_rooms_cleared: lifetime_rooms,
+        lifetime_bosses_defeated: lifetime_bosses,
+        lifetime_deaths,
+        lifetime_victories,
+        lifetime_escapes,
+        weapon: player.weapon.clone(),
+        armor_gear: player.armor_gear.clone(),
+        inventory: final_inventory,
+        completed_quests: journal.completed.clone(),
+        created_at: None,
+        updated_at: None,
+    };
+
+    let run = RunSummary {
+        outcome: reason_to_outcome(reason),
+        rooms_cleared: run_rooms.max(0),
+        kills: run_kills.max(0),
+        gold_earned: run_gold.max(0),
+        gold_lost,
+        bosses_defeated: run_bosses.max(0),
+        xp_earned: run_xp.max(0),
+        level_at_end: player.level as i16,
+        duration_secs: Some(duration_secs),
+    };
+
+    (profile, run)
+}
+
+/// Save all players in a session (called on game-over, end, leave, expire).
+pub fn save_all_players(
+    profiles: &std::sync::Arc<ProfileStore>,
+    session: &SessionState,
+    reason: &GameOverReason,
+) {
+    for (&uid, player) in &session.players {
+        let snapshot = player.saved_snapshot.as_ref();
+        let (profile, run) = extract_save_payload(
+            uid.get(),
+            &player.name,
+            player,
+            &session.quest_journal,
+            reason,
+            snapshot,
+            session,
+        );
+        profiles.save_async(profile, run);
+    }
+
+    // Invalidate cache for all players
+    let profiles = profiles.clone();
+    let uids: Vec<u64> = session.players.keys().map(|uid| uid.get()).collect();
+    tokio::spawn(async move {
+        for uid in uids {
+            profiles.invalidate(uid).await;
+        }
+    });
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn class_from_id(id: i16) -> ClassType {
+    match id {
+        2 => ClassType::Rogue,
+        3 => ClassType::Cleric,
+        _ => ClassType::Warrior,
+    }
+}
+
+fn class_to_id(class: &ClassType) -> i16 {
+    match class {
+        ClassType::Warrior => 1,
+        ClassType::Rogue => 2,
+        ClassType::Cleric => 3,
+    }
+}
+
+fn reason_to_outcome(reason: &GameOverReason) -> i16 {
+    match reason {
+        GameOverReason::Victory => 1,
+        GameOverReason::Defeated => 2,
+        GameOverReason::Escaped => 3,
+        GameOverReason::Expired => 4,
+    }
+}
+
+fn inventory_to_json(inv: &[ItemStack]) -> serde_json::Value {
+    let slots: Vec<InventorySlot> = inv
+        .iter()
+        .map(|s| InventorySlot {
+            item_id: s.item_id.clone(),
+            qty: s.qty,
+        })
+        .collect();
+    serde_json::to_value(slots).unwrap_or_else(|_| serde_json::json!([]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_round_trip() {
+        assert_eq!(
+            class_from_id(class_to_id(&ClassType::Warrior)),
+            ClassType::Warrior
+        );
+        assert_eq!(
+            class_from_id(class_to_id(&ClassType::Rogue)),
+            ClassType::Rogue
+        );
+        assert_eq!(
+            class_from_id(class_to_id(&ClassType::Cleric)),
+            ClassType::Cleric
+        );
+        assert_eq!(class_from_id(0), ClassType::Warrior); // default
+    }
+
+    #[test]
+    fn reason_round_trip() {
+        assert_eq!(reason_to_outcome(&GameOverReason::Victory), 1);
+        assert_eq!(reason_to_outcome(&GameOverReason::Defeated), 2);
+        assert_eq!(reason_to_outcome(&GameOverReason::Escaped), 3);
+        assert_eq!(reason_to_outcome(&GameOverReason::Expired), 4);
+    }
+
+    #[test]
+    fn inventory_json_round_trip() {
+        let inv = vec![
+            ItemStack {
+                item_id: "potion_hp".to_owned(),
+                qty: 3,
+            },
+            ItemStack {
+                item_id: "gold_coin".to_owned(),
+                qty: 10,
+            },
+        ];
+        let json = inventory_to_json(&inv);
+        let slots: Vec<InventorySlot> = serde_json::from_value(json).unwrap();
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0].item_id, "potion_hp");
+        assert_eq!(slots[0].qty, 3);
+    }
+
+    #[test]
+    fn death_penalty_gold() {
+        // Simulate: snapshot had 100 gold, player earned 200 more (now 300)
+        // On defeat: lose 50% of run-earned (100), keep 200
+        let snapshot = DungeonProfile {
+            discord_id: 1,
+            discord_name: "Test".to_owned(),
+            class_id: 1,
+            level: 1,
+            xp: 0,
+            xp_to_next: 100,
+            gold: 100,
+            lifetime_kills: 0,
+            lifetime_gold_earned: 100,
+            lifetime_rooms_cleared: 0,
+            lifetime_bosses_defeated: 0,
+            lifetime_deaths: 0,
+            lifetime_victories: 0,
+            lifetime_escapes: 0,
+            weapon: None,
+            armor_gear: None,
+            inventory: serde_json::json!([]),
+            completed_quests: Vec::new(),
+            created_at: None,
+            updated_at: None,
+        };
+
+        let player = PlayerState {
+            gold: 300,
+            lifetime_gold_earned: 300,
+            ..PlayerState::default()
+        };
+
+        let journal = QuestJournal::default();
+
+        // Build a minimal session for duration
+        let session = make_test_session();
+
+        let (profile, run) = extract_save_payload(
+            1,
+            "Test",
+            &player,
+            &journal,
+            &GameOverReason::Defeated,
+            Some(&snapshot),
+            &session,
+        );
+
+        assert_eq!(run.gold_earned, 200);
+        assert_eq!(run.gold_lost, 100);
+        assert_eq!(profile.gold, 200); // 300 - 100 penalty
+        assert_eq!(profile.lifetime_deaths, 1);
+        assert_eq!(profile.lifetime_gold_earned, 300);
+    }
+
+    #[test]
+    fn victory_no_penalty() {
+        let snapshot = DungeonProfile {
+            discord_id: 1,
+            discord_name: "Test".to_owned(),
+            class_id: 1,
+            level: 1,
+            xp: 0,
+            xp_to_next: 100,
+            gold: 0,
+            lifetime_kills: 0,
+            lifetime_gold_earned: 0,
+            lifetime_rooms_cleared: 0,
+            lifetime_bosses_defeated: 0,
+            lifetime_deaths: 0,
+            lifetime_victories: 0,
+            lifetime_escapes: 0,
+            weapon: None,
+            armor_gear: None,
+            inventory: serde_json::json!([]),
+            completed_quests: Vec::new(),
+            created_at: None,
+            updated_at: None,
+        };
+
+        let player = PlayerState {
+            gold: 500,
+            xp: 200,
+            lifetime_gold_earned: 500,
+            ..PlayerState::default()
+        };
+
+        let journal = QuestJournal::default();
+        let session = make_test_session();
+
+        let (profile, run) = extract_save_payload(
+            1,
+            "Test",
+            &player,
+            &journal,
+            &GameOverReason::Victory,
+            Some(&snapshot),
+            &session,
+        );
+
+        assert_eq!(profile.gold, 500); // no penalty
+        assert_eq!(profile.xp, 200); // no penalty
+        assert_eq!(run.gold_lost, 0);
+        assert_eq!(profile.lifetime_victories, 1);
+        assert_eq!(profile.lifetime_deaths, 0);
+    }
+
+    fn make_test_session() -> SessionState {
+        use crate::discord::game::{content, types::*};
+        use poise::serenity_prelude as serenity;
+
+        let owner = serenity::UserId::new(1);
+        let mut player = PlayerState::default();
+        player.inventory = content::starting_inventory();
+
+        SessionState {
+            id: uuid::Uuid::new_v4(),
+            short_id: "test1234".to_owned(),
+            owner,
+            party: Vec::new(),
+            mode: SessionMode::Solo,
+            phase: GamePhase::Exploring,
+            channel_id: serenity::ChannelId::new(1),
+            message_id: serenity::MessageId::new(1),
+            created_at: std::time::Instant::now(),
+            last_action_at: std::time::Instant::now(),
+            turn: 0,
+            players: std::collections::HashMap::from([(owner, player)]),
+            enemies: Vec::new(),
+            room: content::generate_room(0),
+            log: Vec::new(),
+            show_items: false,
+            pending_actions: std::collections::HashMap::new(),
+            map: test_map_default(),
+            show_map: false,
+            show_inventory: false,
+            pending_destination: None,
+            enemies_had_first_strike: false,
+            quest_journal: QuestJournal::default(),
+        }
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/game/router.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/router.rs
@@ -4,6 +4,7 @@ use tracing::{error, info};
 use crate::discord::bot::{Data, Error};
 
 use super::logic;
+use super::persistence;
 use super::render;
 use super::types::{Direction, GameAction, GamePhase};
 
@@ -308,6 +309,11 @@ pub async fn handle_game_component(
     // Apply action (now safe — we already acknowledged the interaction)
     match logic::apply_action(&mut session, action.clone(), actor) {
         Ok(result) => {
+            // Check if game just ended — save all players
+            if let GamePhase::GameOver(ref reason) = session.phase {
+                persistence::save_all_players(&data.app.profiles, &session, reason);
+            }
+
             // Render components while we still hold the lock
             let components = render::render_components(&session);
             let session_clone = session.clone();

--- a/apps/discordsh/axum-discordsh/src/discord/game/session.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/session.rs
@@ -68,7 +68,12 @@ impl SessionStore {
 
     /// Remove sessions that have been idle longer than `timeout`.
     /// Called periodically by a background task.
-    pub fn cleanup_expired(&self, timeout: Duration) {
+    /// Saves player profiles before removing expired sessions.
+    pub fn cleanup_expired(
+        &self,
+        timeout: Duration,
+        profiles: Option<&std::sync::Arc<super::persistence::ProfileStore>>,
+    ) {
         let now = Instant::now();
         let mut to_remove = Vec::new();
 
@@ -77,6 +82,14 @@ impl SessionStore {
                 && now.duration_since(session.last_action_at) > timeout
             {
                 session.phase = GamePhase::GameOver(GameOverReason::Expired);
+                // Save all players before expiring
+                if let Some(profiles) = profiles {
+                    super::persistence::save_all_players(
+                        profiles,
+                        &session,
+                        &GameOverReason::Expired,
+                    );
+                }
                 to_remove.push(entry.key().clone());
             }
         }
@@ -194,7 +207,7 @@ mod tests {
         store.create(test_state("new_one", 200, 2));
 
         assert_eq!(store.count(), 2);
-        store.cleanup_expired(Duration::from_secs(600));
+        store.cleanup_expired(Duration::from_secs(600), None);
         assert_eq!(store.count(), 1);
         assert!(store.get("new_one").is_some());
         assert!(store.get("old_one").is_none());

--- a/apps/discordsh/axum-discordsh/src/discord/game/types.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/types.rs
@@ -426,6 +426,9 @@ pub struct PlayerState {
     pub lifetime_gold_earned: u32,
     pub lifetime_rooms_cleared: u32,
     pub lifetime_bosses_defeated: u32,
+    /// Snapshot of the loaded profile at session start (for death penalty diff).
+    #[serde(skip)]
+    pub saved_snapshot: Option<super::persistence::DungeonProfile>,
 }
 
 impl Default for PlayerState {
@@ -457,6 +460,7 @@ impl Default for PlayerState {
             lifetime_gold_earned: 0,
             lifetime_rooms_cleared: 0,
             lifetime_bosses_defeated: 0,
+            saved_snapshot: None,
         }
     }
 }

--- a/apps/discordsh/axum-discordsh/src/state.rs
+++ b/apps/discordsh/axum-discordsh/src/state.rs
@@ -7,7 +7,7 @@ use tokio::sync::{Notify, RwLock};
 
 use kbve::{FontDb, MemberCache};
 
-use crate::discord::game::SessionStore;
+use crate::discord::game::{ProfileStore, SessionStore};
 use crate::health::HealthMonitor;
 use crate::tracker::ShardTracker;
 
@@ -51,6 +51,10 @@ pub struct AppState {
     // ── Membership ─────────────────────────────────────────────────
     /// LRU-cached membership lookup (Supabase-backed when available).
     pub members: Arc<MemberCache>,
+
+    // ── Player persistence ──────────────────────────────────────────
+    /// LRU-cached dungeon profile store (Supabase-backed when available).
+    pub profiles: Arc<ProfileStore>,
 
     // ── Image rendering ──────────────────────────────────────────
     /// Shared font database for SVG-to-PNG rendering (loaded once at startup).
@@ -97,6 +101,7 @@ impl AppState {
             bot_http: RwLock::new(None),
             sessions: Arc::new(SessionStore::new()),
             members: Arc::new(MemberCache::from_env()),
+            profiles: Arc::new(ProfileStore::from_env()),
             fontdb,
         }
     }

--- a/packages/data/proto/kbve/discordsh.proto
+++ b/packages/data/proto/kbve/discordsh.proto
@@ -89,7 +89,134 @@ message ServerTag {
 }
 
 // =============================================================================
-// Requests / Responses
+// Dungeon — Player Persistence
+// =============================================================================
+
+// Session outcome for run history
+enum DungeonOutcome {
+  DUNGEON_OUTCOME_UNSPECIFIED = 0;
+  DUNGEON_OUTCOME_VICTORY = 1;
+  DUNGEON_OUTCOME_DEFEATED = 2;
+  DUNGEON_OUTCOME_ESCAPED = 3;
+  DUNGEON_OUTCOME_EXPIRED = 4;
+}
+
+// Player class (maps to ClassType in Rust game types)
+enum DungeonClass {
+  DUNGEON_CLASS_UNSPECIFIED = 0;
+  DUNGEON_CLASS_WARRIOR = 1;
+  DUNGEON_CLASS_ROGUE = 2;
+  DUNGEON_CLASS_CLERIC = 3;
+}
+
+// Leaderboard sort category
+enum LeaderboardCategory {
+  LEADERBOARD_CATEGORY_UNSPECIFIED = 0;
+  LEADERBOARD_CATEGORY_XP = 1;
+  LEADERBOARD_CATEGORY_KILLS = 2;
+  LEADERBOARD_CATEGORY_BOSSES = 3;
+  LEADERBOARD_CATEGORY_ROOMS = 4;
+  LEADERBOARD_CATEGORY_GOLD = 5;
+}
+
+// A single inventory slot (persisted as JSONB in SQL)
+message DungeonInventorySlot {
+  string item_id = 1;
+  int32 qty = 2;
+}
+
+// Persistent player profile — one per Discord user (keyed on discord_id BIGINT)
+message DungeonProfile {
+  int64 discord_id = 1;                      // Discord snowflake (u64)
+  string discord_name = 2;                   // Display name at last save
+  DungeonClass class = 3;                    // Last played class
+  int32 level = 4;                           // Player level (1+)
+  int32 xp = 5;                             // Current XP
+  int32 xp_to_next = 6;                     // XP needed for next level
+
+  // Economy
+  int32 gold = 7;
+
+  // Lifetime stats (monotonically increasing)
+  int32 lifetime_kills = 8;
+  int32 lifetime_gold_earned = 9;
+  int32 lifetime_rooms_cleared = 10;
+  int32 lifetime_bosses_defeated = 11;
+  int32 lifetime_deaths = 12;
+  int32 lifetime_victories = 13;
+  int32 lifetime_escapes = 14;
+
+  // Equipment
+  optional string weapon = 15;              // Gear ID or absent
+  optional string armor_gear = 16;          // Gear ID or absent
+
+  // Inventory & quests
+  repeated DungeonInventorySlot inventory = 17;
+  repeated string completed_quests = 18;    // Quest ref slugs
+
+  // Timestamps (ISO 8601 strings from SQL)
+  optional string created_at = 19;
+  optional string updated_at = 20;
+}
+
+// A single completed dungeon run (append-only history)
+message DungeonRun {
+  int64 id = 1;                              // Auto-generated PK
+  int64 discord_id = 2;                      // FK to DungeonProfile
+  DungeonOutcome outcome = 3;
+  int32 rooms_cleared = 4;
+  int32 kills = 5;
+  int32 gold_earned = 6;
+  int32 gold_lost = 7;
+  int32 bosses_defeated = 8;
+  int32 xp_earned = 9;
+  int32 level_at_end = 10;
+  optional int32 duration_secs = 11;         // Wall time of session
+  optional string ended_at = 12;             // ISO 8601
+}
+
+// A leaderboard entry (returned from ranking queries)
+message LeaderboardEntry {
+  int64 rank = 1;
+  int64 discord_id = 2;
+  string discord_name = 3;
+  int32 level = 4;
+  int64 value = 5;                           // Category-specific score
+}
+
+// =============================================================================
+// Requests / Responses — Dungeon Persistence
+// =============================================================================
+
+message LoadProfileRequest {
+  int64 discord_id = 1;
+}
+
+message LoadProfileResponse {
+  bool found = 1;
+  optional DungeonProfile profile = 2;
+}
+
+message SaveProfileRequest {
+  DungeonProfile profile = 1;
+  DungeonRun run = 2;                        // Run summary to log
+}
+
+message SaveProfileResponse {
+  kbve.common.Result result = 1;
+}
+
+message LeaderboardRequest {
+  LeaderboardCategory category = 1;
+  int32 limit = 2;                           // Max entries (1-50, default 10)
+}
+
+message LeaderboardResponse {
+  repeated LeaderboardEntry entries = 1;
+}
+
+// =============================================================================
+// Requests / Responses — Server Directory
 // =============================================================================
 
 // --- List servers (feed) ---
@@ -176,4 +303,9 @@ service DiscordShData {
   // Engagement
   rpc VoteServer (VoteServerRequest) returns (VoteServerResponse);
   rpc BumpServer (BumpServerRequest) returns (BumpServerResponse);
+
+  // Dungeon — Player persistence
+  rpc LoadProfile (LoadProfileRequest) returns (LoadProfileResponse);
+  rpc SaveProfile (SaveProfileRequest) returns (SaveProfileResponse);
+  rpc GetLeaderboard (LeaderboardRequest) returns (LeaderboardResponse);
 }

--- a/packages/data/sql/dbmate/migrations/20260316210000_discordsh_dungeon_profiles.sql
+++ b/packages/data/sql/dbmate/migrations/20260316210000_discordsh_dungeon_profiles.sql
@@ -1,0 +1,584 @@
+-- migrate:up
+
+-- ============================================================
+-- DISCORDSH DUNGEON PROFILES — Player persistence for dungeon game
+--
+-- Tables: dungeon_profiles, dungeon_runs
+-- Functions: 3 service (load, upsert, leaderboard),
+--            4 trigger (updated_at, protect_timestamps, protect_ended_at, append_only)
+--
+-- Depends on: 20260228000000_discordsh_schema_init (discordsh schema)
+--
+-- Source of truth:
+--   packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
+-- ============================================================
+
+-- ===========================================
+-- TABLE: discordsh.dungeon_profiles
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS discordsh.dungeon_profiles (
+    discord_id              BIGINT PRIMARY KEY
+                            CHECK (discord_id > 0),
+    discord_name            TEXT NOT NULL
+                            CHECK (char_length(discord_name) BETWEEN 1 AND 100),
+
+    -- Class: maps to DungeonClass proto enum (1=warrior, 2=rogue, 3=cleric)
+    class_id                SMALLINT NOT NULL DEFAULT 1
+                            CHECK (class_id BETWEEN 1 AND 3),
+
+    -- Progression
+    level                   SMALLINT NOT NULL DEFAULT 1
+                            CHECK (level >= 1),
+    xp                      INT NOT NULL DEFAULT 0
+                            CHECK (xp >= 0),
+    xp_to_next              INT NOT NULL DEFAULT 100
+                            CHECK (xp_to_next > 0),
+
+    -- Economy
+    gold                    INT NOT NULL DEFAULT 0
+                            CHECK (gold >= 0),
+
+    -- Lifetime stats (monotonically increasing)
+    lifetime_kills          INT NOT NULL DEFAULT 0 CHECK (lifetime_kills >= 0),
+    lifetime_gold_earned    INT NOT NULL DEFAULT 0 CHECK (lifetime_gold_earned >= 0),
+    lifetime_rooms_cleared  INT NOT NULL DEFAULT 0 CHECK (lifetime_rooms_cleared >= 0),
+    lifetime_bosses_defeated INT NOT NULL DEFAULT 0 CHECK (lifetime_bosses_defeated >= 0),
+    lifetime_deaths         INT NOT NULL DEFAULT 0 CHECK (lifetime_deaths >= 0),
+    lifetime_victories      INT NOT NULL DEFAULT 0 CHECK (lifetime_victories >= 0),
+    lifetime_escapes        INT NOT NULL DEFAULT 0 CHECK (lifetime_escapes >= 0),
+
+    -- Equipment (gear IDs or NULL, length-bounded)
+    weapon                  TEXT
+                            CHECK (weapon IS NULL OR char_length(weapon) BETWEEN 1 AND 100),
+    armor_gear              TEXT
+                            CHECK (armor_gear IS NULL OR char_length(armor_gear) BETWEEN 1 AND 100),
+
+    -- Inventory: JSONB array of {item_id, qty} objects — shape-validated
+    inventory               JSONB NOT NULL DEFAULT '[]'::JSONB
+                            CHECK (
+                                jsonb_typeof(inventory) = 'array'
+                                AND NOT jsonb_path_exists(
+                                    inventory,
+                                    '$[*] ? (
+                                        type() != "object" ||
+                                        !exists(@.item_id) ||
+                                        !exists(@.qty) ||
+                                        @.item_id.type() != "string" ||
+                                        @.qty.type() != "number" ||
+                                        @.qty < 1
+                                    )'
+                                )
+                            ),
+
+    -- Completed quest slugs
+    completed_quests        TEXT[] NOT NULL DEFAULT '{}',
+
+    -- Timestamps
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ
+);
+
+COMMENT ON TABLE discordsh.dungeon_profiles IS
+    'Persistent dungeon player profiles — one per Discord user, keyed on snowflake ID';
+COMMENT ON COLUMN discordsh.dungeon_profiles.discord_id IS
+    'Discord snowflake (u64 stored as BIGINT)';
+COMMENT ON COLUMN discordsh.dungeon_profiles.class_id IS
+    'DungeonClass proto enum: 1=warrior, 2=rogue, 3=cleric';
+COMMENT ON COLUMN discordsh.dungeon_profiles.inventory IS
+    'JSONB array: [{item_id: string, qty: int}, ...] — shape-validated via CHECK';
+
+REVOKE ALL ON discordsh.dungeon_profiles FROM PUBLIC, anon, authenticated;
+
+-- ===========================================
+-- TABLE: discordsh.dungeon_runs
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS discordsh.dungeon_runs (
+    id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    discord_id              BIGINT NOT NULL
+                            REFERENCES discordsh.dungeon_profiles(discord_id) ON DELETE CASCADE,
+
+    -- Outcome: maps to DungeonOutcome proto enum (1=victory, 2=defeated, 3=escaped, 4=expired)
+    outcome                 SMALLINT NOT NULL
+                            CHECK (outcome BETWEEN 1 AND 4),
+
+    -- Session stats
+    rooms_cleared           INT NOT NULL DEFAULT 0 CHECK (rooms_cleared >= 0),
+    kills                   INT NOT NULL DEFAULT 0 CHECK (kills >= 0),
+    gold_earned             INT NOT NULL DEFAULT 0 CHECK (gold_earned >= 0),
+    gold_lost               INT NOT NULL DEFAULT 0 CHECK (gold_lost >= 0),
+    bosses_defeated         INT NOT NULL DEFAULT 0 CHECK (bosses_defeated >= 0),
+    xp_earned               INT NOT NULL DEFAULT 0 CHECK (xp_earned >= 0),
+    level_at_end            SMALLINT NOT NULL DEFAULT 1 CHECK (level_at_end >= 1),
+
+    -- Wall time of session (seconds)
+    duration_secs           INT CHECK (duration_secs IS NULL OR duration_secs >= 0),
+
+    -- When the run ended
+    ended_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE discordsh.dungeon_runs IS
+    'Append-only dungeon session history — one row per completed run. UPDATE/DELETE blocked by trigger.';
+COMMENT ON COLUMN discordsh.dungeon_runs.outcome IS
+    'DungeonOutcome proto enum: 1=victory, 2=defeated, 3=escaped, 4=expired';
+
+REVOKE ALL ON discordsh.dungeon_runs FROM PUBLIC, anon, authenticated;
+
+-- ===========================================
+-- INDEXES
+-- ===========================================
+
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_runs_history
+    ON discordsh.dungeon_runs (discord_id, ended_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_xp
+    ON discordsh.dungeon_profiles (level DESC, xp DESC, discord_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_kills
+    ON discordsh.dungeon_profiles (lifetime_kills DESC, discord_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_bosses
+    ON discordsh.dungeon_profiles (lifetime_bosses_defeated DESC, discord_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_rooms
+    ON discordsh.dungeon_profiles (lifetime_rooms_cleared DESC, discord_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_gold
+    ON discordsh.dungeon_profiles (lifetime_gold_earned DESC, discord_id ASC);
+
+-- ===========================================
+-- TRIGGER: auto-update updated_at on profiles
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_profiles_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_profiles_updated_at() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_profiles_updated_at() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_profiles_updated_at ON discordsh.dungeon_profiles;
+CREATE TRIGGER trg_discordsh_dungeon_profiles_updated_at
+    BEFORE UPDATE ON discordsh.dungeon_profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_profiles_updated_at();
+
+-- ===========================================
+-- TRIGGER: protect timestamps on profiles
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        NEW.created_at := NOW();
+        NEW.updated_at := NULL;
+    ELSIF TG_OP = 'UPDATE' THEN
+        NEW.created_at := OLD.created_at;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_profiles_protect_timestamps ON discordsh.dungeon_profiles;
+CREATE TRIGGER trg_discordsh_dungeon_profiles_protect_timestamps
+    BEFORE INSERT OR UPDATE ON discordsh.dungeon_profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps();
+
+-- ===========================================
+-- TRIGGER: protect ended_at on runs
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_runs_protect_ended_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        NEW.ended_at := NOW();
+    ELSIF TG_OP = 'UPDATE' THEN
+        NEW.ended_at := OLD.ended_at;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_runs_protect_ended_at() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_runs_protect_ended_at() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_runs_protect_ended_at ON discordsh.dungeon_runs;
+CREATE TRIGGER trg_discordsh_dungeon_runs_protect_ended_at
+    BEFORE INSERT OR UPDATE ON discordsh.dungeon_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_runs_protect_ended_at();
+
+-- ===========================================
+-- TRIGGER: append-only enforcement on runs
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_runs_append_only()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    RAISE EXCEPTION 'discordsh.dungeon_runs is append-only'
+        USING ERRCODE = '23514';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_runs_append_only() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_runs_append_only() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_runs_append_only ON discordsh.dungeon_runs;
+CREATE TRIGGER trg_discordsh_dungeon_runs_append_only
+    BEFORE UPDATE OR DELETE ON discordsh.dungeon_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_runs_append_only();
+
+-- ===========================================
+-- RLS
+-- ===========================================
+
+ALTER TABLE discordsh.dungeon_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE discordsh.dungeon_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON discordsh.dungeon_profiles;
+CREATE POLICY "service_role_full_access" ON discordsh.dungeon_profiles
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "service_role_full_access" ON discordsh.dungeon_runs;
+CREATE POLICY "service_role_full_access" ON discordsh.dungeon_runs
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ===========================================
+-- SERVICE FUNCTION: Load profile
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_load_profile(
+    p_discord_id BIGINT
+)
+RETURNS TABLE(
+    discord_id BIGINT,
+    discord_name TEXT,
+    class_id SMALLINT,
+    level SMALLINT,
+    xp INT,
+    xp_to_next INT,
+    gold INT,
+    lifetime_kills INT,
+    lifetime_gold_earned INT,
+    lifetime_rooms_cleared INT,
+    lifetime_bosses_defeated INT,
+    lifetime_deaths INT,
+    lifetime_victories INT,
+    lifetime_escapes INT,
+    weapon TEXT,
+    armor_gear TEXT,
+    inventory JSONB,
+    completed_quests TEXT[],
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        p.discord_id,
+        p.discord_name,
+        p.class_id,
+        p.level,
+        p.xp,
+        p.xp_to_next,
+        p.gold,
+        p.lifetime_kills,
+        p.lifetime_gold_earned,
+        p.lifetime_rooms_cleared,
+        p.lifetime_bosses_defeated,
+        p.lifetime_deaths,
+        p.lifetime_victories,
+        p.lifetime_escapes,
+        p.weapon,
+        p.armor_gear,
+        p.inventory,
+        p.completed_quests,
+        p.created_at,
+        p.updated_at
+    FROM discordsh.dungeon_profiles p
+    WHERE p.discord_id = p_discord_id;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_load_profile IS
+    'Load a dungeon profile by Discord snowflake ID. Returns empty if not found.';
+
+REVOKE ALL ON FUNCTION discordsh.service_load_profile(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_load_profile(BIGINT) TO service_role;
+ALTER FUNCTION discordsh.service_load_profile(BIGINT) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Upsert profile + insert run
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_upsert_profile(
+    p_discord_id            BIGINT,
+    p_discord_name          TEXT,
+    p_class_id              SMALLINT,
+    p_level                 SMALLINT,
+    p_xp                    INT,
+    p_xp_to_next            INT,
+    p_gold                  INT,
+    p_lifetime_kills        INT,
+    p_lifetime_gold_earned  INT,
+    p_lifetime_rooms_cleared INT,
+    p_lifetime_bosses_defeated INT,
+    p_lifetime_deaths       INT,
+    p_lifetime_victories    INT,
+    p_lifetime_escapes      INT,
+    p_weapon                TEXT DEFAULT NULL,
+    p_armor_gear            TEXT DEFAULT NULL,
+    p_inventory             JSONB DEFAULT '[]'::JSONB,
+    p_completed_quests      TEXT[] DEFAULT '{}',
+    p_run_outcome           SMALLINT DEFAULT NULL,
+    p_run_rooms_cleared     INT DEFAULT 0,
+    p_run_kills             INT DEFAULT 0,
+    p_run_gold_earned       INT DEFAULT 0,
+    p_run_gold_lost         INT DEFAULT 0,
+    p_run_bosses_defeated   INT DEFAULT 0,
+    p_run_xp_earned         INT DEFAULT 0,
+    p_run_level_at_end      SMALLINT DEFAULT 1,
+    p_run_duration_secs     INT DEFAULT NULL
+)
+RETURNS TABLE(success BOOLEAN, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- Advisory lock: serialize saves per player using discord_id directly
+    PERFORM pg_advisory_xact_lock(p_discord_id);
+
+    -- Upsert profile
+    INSERT INTO discordsh.dungeon_profiles (
+        discord_id, discord_name, class_id, level, xp, xp_to_next, gold,
+        lifetime_kills, lifetime_gold_earned, lifetime_rooms_cleared,
+        lifetime_bosses_defeated, lifetime_deaths, lifetime_victories,
+        lifetime_escapes, weapon, armor_gear, inventory, completed_quests
+    )
+    VALUES (
+        p_discord_id, p_discord_name, p_class_id, p_level, p_xp, p_xp_to_next, p_gold,
+        p_lifetime_kills, p_lifetime_gold_earned, p_lifetime_rooms_cleared,
+        p_lifetime_bosses_defeated, p_lifetime_deaths, p_lifetime_victories,
+        p_lifetime_escapes, p_weapon, p_armor_gear, p_inventory, p_completed_quests
+    )
+    ON CONFLICT (discord_id) DO UPDATE SET
+        discord_name            = EXCLUDED.discord_name,
+        class_id                = EXCLUDED.class_id,
+        level                   = EXCLUDED.level,
+        xp                      = EXCLUDED.xp,
+        xp_to_next              = EXCLUDED.xp_to_next,
+        gold                    = EXCLUDED.gold,
+        lifetime_kills          = EXCLUDED.lifetime_kills,
+        lifetime_gold_earned    = EXCLUDED.lifetime_gold_earned,
+        lifetime_rooms_cleared  = EXCLUDED.lifetime_rooms_cleared,
+        lifetime_bosses_defeated = EXCLUDED.lifetime_bosses_defeated,
+        lifetime_deaths         = EXCLUDED.lifetime_deaths,
+        lifetime_victories      = EXCLUDED.lifetime_victories,
+        lifetime_escapes        = EXCLUDED.lifetime_escapes,
+        weapon                  = EXCLUDED.weapon,
+        armor_gear              = EXCLUDED.armor_gear,
+        inventory               = EXCLUDED.inventory,
+        completed_quests        = EXCLUDED.completed_quests;
+
+    -- Insert run log (if outcome provided)
+    IF p_run_outcome IS NOT NULL THEN
+        INSERT INTO discordsh.dungeon_runs (
+            discord_id, outcome, rooms_cleared, kills,
+            gold_earned, gold_lost, bosses_defeated,
+            xp_earned, level_at_end, duration_secs
+        )
+        VALUES (
+            p_discord_id, p_run_outcome, p_run_rooms_cleared, p_run_kills,
+            p_run_gold_earned, p_run_gold_lost, p_run_bosses_defeated,
+            p_run_xp_earned, p_run_level_at_end, p_run_duration_secs
+        );
+    END IF;
+
+    RETURN QUERY SELECT true, 'Profile saved.'::TEXT;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN QUERY SELECT false, SQLERRM::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_upsert_profile IS
+    'Atomic upsert of dungeon profile + run log. Advisory-locked per discord_id. Bot-only.';
+
+REVOKE ALL ON FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) TO service_role;
+ALTER FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Leaderboard
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_leaderboard(
+    p_category  SMALLINT,
+    p_limit     INT DEFAULT 10
+)
+RETURNS TABLE(
+    rank        BIGINT,
+    discord_id  BIGINT,
+    discord_name TEXT,
+    level       SMALLINT,
+    value       BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- Reject invalid categories
+    IF p_category NOT BETWEEN 1 AND 5 THEN
+        RAISE EXCEPTION 'Invalid leaderboard category: %', p_category
+            USING ERRCODE = '22023';
+    END IF;
+
+    -- Clamp limit to 1-50
+    IF p_limit < 1 THEN p_limit := 1; END IF;
+    IF p_limit > 50 THEN p_limit := 50; END IF;
+
+    -- Per-category queries for index-friendly execution plans
+    IF p_category = 1 THEN
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.level DESC, p.xp DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.xp::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.level DESC, p.xp DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 2 THEN
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_kills DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_kills::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_kills DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 3 THEN
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_bosses_defeated DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_bosses_defeated::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_bosses_defeated DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 4 THEN
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_rooms_cleared DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_rooms_cleared::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_rooms_cleared DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 5 THEN
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_gold_earned DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_gold_earned::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_gold_earned DESC, p.discord_id ASC
+        LIMIT p_limit;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_leaderboard IS
+    'Top N players by category: 1=xp, 2=kills, 3=bosses, 4=rooms, 5=gold. Index-friendly per-category queries. Bot-only.';
+
+REVOKE ALL ON FUNCTION discordsh.service_leaderboard(SMALLINT, INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_leaderboard(SMALLINT, INT) TO service_role;
+ALTER FUNCTION discordsh.service_leaderboard(SMALLINT, INT) OWNER TO service_role;
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS discordsh.service_leaderboard(SMALLINT, INT);
+DROP FUNCTION IF EXISTS discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+);
+DROP FUNCTION IF EXISTS discordsh.service_load_profile(BIGINT);
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_runs_append_only ON discordsh.dungeon_runs;
+DROP FUNCTION IF EXISTS discordsh.trg_dungeon_runs_append_only();
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_runs_protect_ended_at ON discordsh.dungeon_runs;
+DROP FUNCTION IF EXISTS discordsh.trg_dungeon_runs_protect_ended_at();
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_profiles_protect_timestamps ON discordsh.dungeon_profiles;
+DROP FUNCTION IF EXISTS discordsh.trg_dungeon_profiles_protect_timestamps();
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_profiles_updated_at ON discordsh.dungeon_profiles;
+DROP FUNCTION IF EXISTS discordsh.trg_dungeon_profiles_updated_at();
+
+DROP TABLE IF EXISTS discordsh.dungeon_runs;
+DROP TABLE IF EXISTS discordsh.dungeon_profiles;

--- a/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
+++ b/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
@@ -1,0 +1,735 @@
+-- ============================================================
+-- DISCORDSH DUNGEON PROFILES — Player persistence for dungeon game
+--
+-- Two tables:
+--   dungeon_profiles  — one row per Discord user (persistent state)
+--   dungeon_runs      — append-only session history (enforced by trigger)
+--
+-- Security:
+--   - Bot-only (service_role): no proxy functions needed
+--   - anon/authenticated have NO access (dungeon data is private)
+--   - All writes go through service functions with advisory locks
+--   - service_role has full access via RLS bypass
+--   - dungeon_runs is append-only (UPDATE/DELETE blocked by trigger)
+--
+-- Depends on: discordsh_servers.sql (discordsh schema + permissions)
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- TABLE: discordsh.dungeon_profiles
+--
+-- One row per Discord user. Keyed on discord_id (BIGINT snowflake),
+-- NOT auth.users UUID, so both Members and Guests get persistence.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS discordsh.dungeon_profiles (
+    discord_id              BIGINT PRIMARY KEY
+                            CHECK (discord_id > 0),
+    discord_name            TEXT NOT NULL
+                            CHECK (char_length(discord_name) BETWEEN 1 AND 100),
+
+    -- Class: maps to DungeonClass proto enum (1=warrior, 2=rogue, 3=cleric)
+    class_id                SMALLINT NOT NULL DEFAULT 1
+                            CHECK (class_id BETWEEN 1 AND 3),
+
+    -- Progression
+    level                   SMALLINT NOT NULL DEFAULT 1
+                            CHECK (level >= 1),
+    xp                      INT NOT NULL DEFAULT 0
+                            CHECK (xp >= 0),
+    xp_to_next              INT NOT NULL DEFAULT 100
+                            CHECK (xp_to_next > 0),
+
+    -- Economy
+    gold                    INT NOT NULL DEFAULT 0
+                            CHECK (gold >= 0),
+
+    -- Lifetime stats (monotonically increasing)
+    lifetime_kills          INT NOT NULL DEFAULT 0 CHECK (lifetime_kills >= 0),
+    lifetime_gold_earned    INT NOT NULL DEFAULT 0 CHECK (lifetime_gold_earned >= 0),
+    lifetime_rooms_cleared  INT NOT NULL DEFAULT 0 CHECK (lifetime_rooms_cleared >= 0),
+    lifetime_bosses_defeated INT NOT NULL DEFAULT 0 CHECK (lifetime_bosses_defeated >= 0),
+    lifetime_deaths         INT NOT NULL DEFAULT 0 CHECK (lifetime_deaths >= 0),
+    lifetime_victories      INT NOT NULL DEFAULT 0 CHECK (lifetime_victories >= 0),
+    lifetime_escapes        INT NOT NULL DEFAULT 0 CHECK (lifetime_escapes >= 0),
+
+    -- Equipment (gear IDs or NULL, length-bounded)
+    weapon                  TEXT
+                            CHECK (weapon IS NULL OR char_length(weapon) BETWEEN 1 AND 100),
+    armor_gear              TEXT
+                            CHECK (armor_gear IS NULL OR char_length(armor_gear) BETWEEN 1 AND 100),
+
+    -- Inventory: JSONB array of {item_id, qty} objects
+    -- Shape-validated: must be array of objects with string item_id and numeric qty >= 1
+    inventory               JSONB NOT NULL DEFAULT '[]'::JSONB
+                            CHECK (
+                                jsonb_typeof(inventory) = 'array'
+                                AND NOT jsonb_path_exists(
+                                    inventory,
+                                    '$[*] ? (
+                                        type() != "object" ||
+                                        !exists(@.item_id) ||
+                                        !exists(@.qty) ||
+                                        @.item_id.type() != "string" ||
+                                        @.qty.type() != "number" ||
+                                        @.qty < 1
+                                    )'
+                                )
+                            ),
+
+    -- Completed quest slugs
+    completed_quests        TEXT[] NOT NULL DEFAULT '{}',
+
+    -- Timestamps
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ
+);
+
+COMMENT ON TABLE discordsh.dungeon_profiles IS
+    'Persistent dungeon player profiles — one per Discord user, keyed on snowflake ID';
+COMMENT ON COLUMN discordsh.dungeon_profiles.discord_id IS
+    'Discord snowflake (u64 stored as BIGINT)';
+COMMENT ON COLUMN discordsh.dungeon_profiles.class_id IS
+    'DungeonClass proto enum: 1=warrior, 2=rogue, 3=cleric';
+COMMENT ON COLUMN discordsh.dungeon_profiles.inventory IS
+    'JSONB array: [{item_id: string, qty: int}, ...] — shape-validated via CHECK';
+
+-- Explicit revoke for defense in depth
+REVOKE ALL ON discordsh.dungeon_profiles FROM PUBLIC, anon, authenticated;
+
+-- ===========================================
+-- TABLE: discordsh.dungeon_runs
+--
+-- Append-only session history. One row per completed dungeon session.
+-- UPDATE/DELETE blocked by trigger to enforce append-only semantics.
+-- ===========================================
+
+CREATE TABLE IF NOT EXISTS discordsh.dungeon_runs (
+    id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    discord_id              BIGINT NOT NULL
+                            REFERENCES discordsh.dungeon_profiles(discord_id) ON DELETE CASCADE,
+
+    -- Outcome: maps to DungeonOutcome proto enum (1=victory, 2=defeated, 3=escaped, 4=expired)
+    outcome                 SMALLINT NOT NULL
+                            CHECK (outcome BETWEEN 1 AND 4),
+
+    -- Session stats
+    rooms_cleared           INT NOT NULL DEFAULT 0 CHECK (rooms_cleared >= 0),
+    kills                   INT NOT NULL DEFAULT 0 CHECK (kills >= 0),
+    gold_earned             INT NOT NULL DEFAULT 0 CHECK (gold_earned >= 0),
+    gold_lost               INT NOT NULL DEFAULT 0 CHECK (gold_lost >= 0),
+    bosses_defeated         INT NOT NULL DEFAULT 0 CHECK (bosses_defeated >= 0),
+    xp_earned               INT NOT NULL DEFAULT 0 CHECK (xp_earned >= 0),
+    level_at_end            SMALLINT NOT NULL DEFAULT 1 CHECK (level_at_end >= 1),
+
+    -- Wall time of session (seconds)
+    duration_secs           INT CHECK (duration_secs IS NULL OR duration_secs >= 0),
+
+    -- When the run ended
+    ended_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE discordsh.dungeon_runs IS
+    'Append-only dungeon session history — one row per completed run. UPDATE/DELETE blocked by trigger.';
+COMMENT ON COLUMN discordsh.dungeon_runs.outcome IS
+    'DungeonOutcome proto enum: 1=victory, 2=defeated, 3=escaped, 4=expired';
+
+-- Explicit revoke for defense in depth
+REVOKE ALL ON discordsh.dungeon_runs FROM PUBLIC, anon, authenticated;
+
+-- ===========================================
+-- INDEXES
+-- ===========================================
+
+-- Personal history (most recent first)
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_runs_history
+    ON discordsh.dungeon_runs (discord_id, ended_at DESC);
+
+-- Leaderboard: by XP/level (with deterministic tie-breaker)
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_xp
+    ON discordsh.dungeon_profiles (level DESC, xp DESC, discord_id ASC);
+
+-- Leaderboard: by kills
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_kills
+    ON discordsh.dungeon_profiles (lifetime_kills DESC, discord_id ASC);
+
+-- Leaderboard: by bosses
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_bosses
+    ON discordsh.dungeon_profiles (lifetime_bosses_defeated DESC, discord_id ASC);
+
+-- Leaderboard: by rooms
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_rooms
+    ON discordsh.dungeon_profiles (lifetime_rooms_cleared DESC, discord_id ASC);
+
+-- Leaderboard: by gold
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_lb_gold
+    ON discordsh.dungeon_profiles (lifetime_gold_earned DESC, discord_id ASC);
+
+-- ===========================================
+-- TRIGGER: auto-update updated_at on profiles
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_profiles_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_profiles_updated_at() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_profiles_updated_at() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_profiles_updated_at ON discordsh.dungeon_profiles;
+CREATE TRIGGER trg_discordsh_dungeon_profiles_updated_at
+    BEFORE UPDATE ON discordsh.dungeon_profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_profiles_updated_at();
+
+-- ===========================================
+-- TRIGGER: protect timestamps on profiles
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        NEW.created_at := NOW();
+        NEW.updated_at := NULL;
+    ELSIF TG_OP = 'UPDATE' THEN
+        NEW.created_at := OLD.created_at;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_profiles_protect_timestamps ON discordsh.dungeon_profiles;
+CREATE TRIGGER trg_discordsh_dungeon_profiles_protect_timestamps
+    BEFORE INSERT OR UPDATE ON discordsh.dungeon_profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_profiles_protect_timestamps();
+
+-- ===========================================
+-- TRIGGER: protect ended_at on runs
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_runs_protect_ended_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        NEW.ended_at := NOW();
+    ELSIF TG_OP = 'UPDATE' THEN
+        NEW.ended_at := OLD.ended_at;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_runs_protect_ended_at() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_runs_protect_ended_at() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_runs_protect_ended_at ON discordsh.dungeon_runs;
+CREATE TRIGGER trg_discordsh_dungeon_runs_protect_ended_at
+    BEFORE INSERT OR UPDATE ON discordsh.dungeon_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_runs_protect_ended_at();
+
+-- ===========================================
+-- TRIGGER: append-only enforcement on runs
+--
+-- Blocks UPDATE and DELETE on dungeon_runs.
+-- Only INSERT is allowed, matching the stated design.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.trg_dungeon_runs_append_only()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    RAISE EXCEPTION 'discordsh.dungeon_runs is append-only'
+        USING ERRCODE = '23514';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION discordsh.trg_dungeon_runs_append_only() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION discordsh.trg_dungeon_runs_append_only() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS trg_discordsh_dungeon_runs_append_only ON discordsh.dungeon_runs;
+CREATE TRIGGER trg_discordsh_dungeon_runs_append_only
+    BEFORE UPDATE OR DELETE ON discordsh.dungeon_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION discordsh.trg_dungeon_runs_append_only();
+
+-- ===========================================
+-- RLS — Bot-only, no public access
+-- ===========================================
+
+ALTER TABLE discordsh.dungeon_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE discordsh.dungeon_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON discordsh.dungeon_profiles;
+CREATE POLICY "service_role_full_access" ON discordsh.dungeon_profiles
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "service_role_full_access" ON discordsh.dungeon_runs;
+CREATE POLICY "service_role_full_access" ON discordsh.dungeon_runs
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- No grants to anon or authenticated — dungeon data is private to the bot
+
+-- ===========================================
+-- SERVICE FUNCTION: Load profile
+--
+-- Returns a single profile row or empty result set.
+-- Called by the bot's ProfileStore via PostgREST RPC.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_load_profile(
+    p_discord_id BIGINT
+)
+RETURNS TABLE(
+    discord_id BIGINT,
+    discord_name TEXT,
+    class_id SMALLINT,
+    level SMALLINT,
+    xp INT,
+    xp_to_next INT,
+    gold INT,
+    lifetime_kills INT,
+    lifetime_gold_earned INT,
+    lifetime_rooms_cleared INT,
+    lifetime_bosses_defeated INT,
+    lifetime_deaths INT,
+    lifetime_victories INT,
+    lifetime_escapes INT,
+    weapon TEXT,
+    armor_gear TEXT,
+    inventory JSONB,
+    completed_quests TEXT[],
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        p.discord_id,
+        p.discord_name,
+        p.class_id,
+        p.level,
+        p.xp,
+        p.xp_to_next,
+        p.gold,
+        p.lifetime_kills,
+        p.lifetime_gold_earned,
+        p.lifetime_rooms_cleared,
+        p.lifetime_bosses_defeated,
+        p.lifetime_deaths,
+        p.lifetime_victories,
+        p.lifetime_escapes,
+        p.weapon,
+        p.armor_gear,
+        p.inventory,
+        p.completed_quests,
+        p.created_at,
+        p.updated_at
+    FROM discordsh.dungeon_profiles p
+    WHERE p.discord_id = p_discord_id;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_load_profile IS
+    'Load a dungeon profile by Discord snowflake ID. Returns empty if not found.';
+
+REVOKE ALL ON FUNCTION discordsh.service_load_profile(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_load_profile(BIGINT) TO service_role;
+ALTER FUNCTION discordsh.service_load_profile(BIGINT) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Upsert profile + insert run
+--
+-- Atomic: upserts the player profile and appends a run log entry.
+-- Uses advisory lock on discord_id (single BIGINT form) to prevent
+-- concurrent save races (e.g., timeout cleanup vs explicit /dungeon end).
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_upsert_profile(
+    -- Profile fields
+    p_discord_id            BIGINT,
+    p_discord_name          TEXT,
+    p_class_id              SMALLINT,
+    p_level                 SMALLINT,
+    p_xp                    INT,
+    p_xp_to_next            INT,
+    p_gold                  INT,
+    p_lifetime_kills        INT,
+    p_lifetime_gold_earned  INT,
+    p_lifetime_rooms_cleared INT,
+    p_lifetime_bosses_defeated INT,
+    p_lifetime_deaths       INT,
+    p_lifetime_victories    INT,
+    p_lifetime_escapes      INT,
+    p_weapon                TEXT DEFAULT NULL,
+    p_armor_gear            TEXT DEFAULT NULL,
+    p_inventory             JSONB DEFAULT '[]'::JSONB,
+    p_completed_quests      TEXT[] DEFAULT '{}',
+    -- Run fields
+    p_run_outcome           SMALLINT DEFAULT NULL,
+    p_run_rooms_cleared     INT DEFAULT 0,
+    p_run_kills             INT DEFAULT 0,
+    p_run_gold_earned       INT DEFAULT 0,
+    p_run_gold_lost         INT DEFAULT 0,
+    p_run_bosses_defeated   INT DEFAULT 0,
+    p_run_xp_earned         INT DEFAULT 0,
+    p_run_level_at_end      SMALLINT DEFAULT 1,
+    p_run_duration_secs     INT DEFAULT NULL
+)
+RETURNS TABLE(success BOOLEAN, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- Advisory lock: serialize saves per player using discord_id directly
+    PERFORM pg_advisory_xact_lock(p_discord_id);
+
+    -- Upsert profile
+    INSERT INTO discordsh.dungeon_profiles (
+        discord_id, discord_name, class_id, level, xp, xp_to_next, gold,
+        lifetime_kills, lifetime_gold_earned, lifetime_rooms_cleared,
+        lifetime_bosses_defeated, lifetime_deaths, lifetime_victories,
+        lifetime_escapes, weapon, armor_gear, inventory, completed_quests
+    )
+    VALUES (
+        p_discord_id, p_discord_name, p_class_id, p_level, p_xp, p_xp_to_next, p_gold,
+        p_lifetime_kills, p_lifetime_gold_earned, p_lifetime_rooms_cleared,
+        p_lifetime_bosses_defeated, p_lifetime_deaths, p_lifetime_victories,
+        p_lifetime_escapes, p_weapon, p_armor_gear, p_inventory, p_completed_quests
+    )
+    ON CONFLICT (discord_id) DO UPDATE SET
+        discord_name            = EXCLUDED.discord_name,
+        class_id                = EXCLUDED.class_id,
+        level                   = EXCLUDED.level,
+        xp                      = EXCLUDED.xp,
+        xp_to_next              = EXCLUDED.xp_to_next,
+        gold                    = EXCLUDED.gold,
+        lifetime_kills          = EXCLUDED.lifetime_kills,
+        lifetime_gold_earned    = EXCLUDED.lifetime_gold_earned,
+        lifetime_rooms_cleared  = EXCLUDED.lifetime_rooms_cleared,
+        lifetime_bosses_defeated = EXCLUDED.lifetime_bosses_defeated,
+        lifetime_deaths         = EXCLUDED.lifetime_deaths,
+        lifetime_victories      = EXCLUDED.lifetime_victories,
+        lifetime_escapes        = EXCLUDED.lifetime_escapes,
+        weapon                  = EXCLUDED.weapon,
+        armor_gear              = EXCLUDED.armor_gear,
+        inventory               = EXCLUDED.inventory,
+        completed_quests        = EXCLUDED.completed_quests;
+
+    -- Insert run log (if outcome provided)
+    IF p_run_outcome IS NOT NULL THEN
+        INSERT INTO discordsh.dungeon_runs (
+            discord_id, outcome, rooms_cleared, kills,
+            gold_earned, gold_lost, bosses_defeated,
+            xp_earned, level_at_end, duration_secs
+        )
+        VALUES (
+            p_discord_id, p_run_outcome, p_run_rooms_cleared, p_run_kills,
+            p_run_gold_earned, p_run_gold_lost, p_run_bosses_defeated,
+            p_run_xp_earned, p_run_level_at_end, p_run_duration_secs
+        );
+    END IF;
+
+    RETURN QUERY SELECT true, 'Profile saved.'::TEXT;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN QUERY SELECT false, SQLERRM::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_upsert_profile IS
+    'Atomic upsert of dungeon profile + run log. Advisory-locked per discord_id. Bot-only.';
+
+REVOKE ALL ON FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) TO service_role;
+ALTER FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Leaderboard
+--
+-- Returns top N players by category.
+-- Categories map to LeaderboardCategory proto enum:
+--   1=xp (level,xp), 2=kills, 3=bosses, 4=rooms, 5=gold
+--
+-- Per-category queries for proper index utilization.
+-- Deterministic tie-breakers via discord_id ASC.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_leaderboard(
+    p_category  SMALLINT,
+    p_limit     INT DEFAULT 10
+)
+RETURNS TABLE(
+    rank        BIGINT,
+    discord_id  BIGINT,
+    discord_name TEXT,
+    level       SMALLINT,
+    value       BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- Reject invalid categories
+    IF p_category NOT BETWEEN 1 AND 5 THEN
+        RAISE EXCEPTION 'Invalid leaderboard category: %', p_category
+            USING ERRCODE = '22023';
+    END IF;
+
+    -- Clamp limit to 1-50
+    IF p_limit < 1 THEN p_limit := 1; END IF;
+    IF p_limit > 50 THEN p_limit := 50; END IF;
+
+    -- Per-category queries for index-friendly execution plans
+    IF p_category = 1 THEN
+        -- XP: sort by level then xp, return xp as value (level already in output)
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.level DESC, p.xp DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.xp::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.level DESC, p.xp DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 2 THEN
+        -- Kills
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_kills DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_kills::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_kills DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 3 THEN
+        -- Bosses
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_bosses_defeated DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_bosses_defeated::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_bosses_defeated DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 4 THEN
+        -- Rooms
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_rooms_cleared DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_rooms_cleared::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_rooms_cleared DESC, p.discord_id ASC
+        LIMIT p_limit;
+
+    ELSIF p_category = 5 THEN
+        -- Gold
+        RETURN QUERY
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY p.lifetime_gold_earned DESC, p.discord_id ASC) AS rank,
+            p.discord_id,
+            p.discord_name,
+            p.level,
+            p.lifetime_gold_earned::BIGINT AS value
+        FROM discordsh.dungeon_profiles p
+        ORDER BY p.lifetime_gold_earned DESC, p.discord_id ASC
+        LIMIT p_limit;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_leaderboard IS
+    'Top N players by category: 1=xp, 2=kills, 3=bosses, 4=rooms, 5=gold. Index-friendly per-category queries. Bot-only.';
+
+REVOKE ALL ON FUNCTION discordsh.service_leaderboard(SMALLINT, INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_leaderboard(SMALLINT, INT) TO service_role;
+ALTER FUNCTION discordsh.service_leaderboard(SMALLINT, INT) OWNER TO service_role;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify tables exist
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.dungeon_profiles table creation failed';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_runs'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.dungeon_runs table creation failed';
+    END IF;
+
+    -- Verify service functions exist
+    PERFORM 'discordsh.service_load_profile(bigint)'::regprocedure;
+    PERFORM 'discordsh.service_upsert_profile(bigint, text, smallint, smallint, int, int, int, int, int, int, int, int, int, int, text, text, jsonb, text[], smallint, int, int, int, int, int, int, smallint, int)'::regprocedure;
+    PERFORM 'discordsh.service_leaderboard(smallint, int)'::regprocedure;
+
+    -- Verify trigger functions exist
+    PERFORM 'discordsh.trg_dungeon_profiles_updated_at()'::regprocedure;
+    PERFORM 'discordsh.trg_dungeon_profiles_protect_timestamps()'::regprocedure;
+    PERFORM 'discordsh.trg_dungeon_runs_protect_ended_at()'::regprocedure;
+    PERFORM 'discordsh.trg_dungeon_runs_append_only()'::regprocedure;
+
+    -- Verify anon CANNOT access dungeon tables
+    IF has_table_privilege('anon', 'discordsh.dungeon_profiles', 'SELECT') THEN
+        RAISE EXCEPTION 'anon must NOT have SELECT on discordsh.dungeon_profiles';
+    END IF;
+
+    IF has_table_privilege('anon', 'discordsh.dungeon_runs', 'SELECT') THEN
+        RAISE EXCEPTION 'anon must NOT have SELECT on discordsh.dungeon_runs';
+    END IF;
+
+    -- Verify authenticated CANNOT access dungeon tables
+    IF has_table_privilege('authenticated', 'discordsh.dungeon_profiles', 'SELECT') THEN
+        RAISE EXCEPTION 'authenticated must NOT have SELECT on discordsh.dungeon_profiles';
+    END IF;
+
+    IF has_table_privilege('authenticated', 'discordsh.dungeon_runs', 'SELECT') THEN
+        RAISE EXCEPTION 'authenticated must NOT have SELECT on discordsh.dungeon_runs';
+    END IF;
+
+    -- Verify anon/authenticated CANNOT execute service functions
+    IF has_function_privilege('anon', 'discordsh.service_load_profile(bigint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on discordsh.service_load_profile';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'discordsh.service_load_profile(bigint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on discordsh.service_load_profile';
+    END IF;
+
+    IF has_function_privilege('anon', 'discordsh.service_leaderboard(smallint, int)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on discordsh.service_leaderboard';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'discordsh.service_leaderboard(smallint, int)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on discordsh.service_leaderboard';
+    END IF;
+
+    -- Verify ownership of all functions
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.trg_dungeon_profiles_updated_at()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.trg_dungeon_profiles_updated_at must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.trg_dungeon_profiles_protect_timestamps()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.trg_dungeon_profiles_protect_timestamps must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.trg_dungeon_runs_protect_ended_at()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.trg_dungeon_runs_protect_ended_at must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.trg_dungeon_runs_append_only()'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.trg_dungeon_runs_append_only must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.service_load_profile(bigint)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.service_load_profile must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.service_upsert_profile(bigint, text, smallint, smallint, int, int, int, int, int, int, int, int, int, int, text, text, jsonb, text[], smallint, int, int, int, int, int, int, smallint, int)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.service_upsert_profile must be owned by service_role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE oid = 'discordsh.service_leaderboard(smallint, int)'::regprocedure
+          AND pg_get_userbyid(proowner) <> 'service_role'
+    ) THEN
+        RAISE EXCEPTION 'discordsh.service_leaderboard must be owned by service_role';
+    END IF;
+
+    RAISE NOTICE 'discordsh_dungeon_profiles.sql: tables, indexes, triggers, service functions verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- **Proto**: Added `DungeonProfile`, `DungeonRun`, `LeaderboardEntry` messages, enums (`DungeonOutcome`, `DungeonClass`, `LeaderboardCategory`), and RPC methods to `discordsh.proto`
- **SQL**: New `dungeon_profiles` + `dungeon_runs` tables with advisory locks, append-only enforcement trigger, JSONB inventory shape validation, per-category leaderboard queries with deterministic tie-breakers, service functions (`service_load_profile`, `service_upsert_profile`, `service_leaderboard`)
- **Rust**: `ProfileStore` (LRU cache + Supabase PostgREST RPC), death penalty logic (25% XP + 50% run gold on defeat), profile load on `/dungeon start` and `/dungeon join`, save on game-over/end/leave/expire, `/dungeon leaderboard` subcommand

### Death Penalty
| Outcome | Level/XP | Gold | Inventory | Lifetime Stats |
|---------|----------|------|-----------|----------------|
| Victory | Keep all | Keep | Keep | +1 victory |
| Escaped | Keep all | Keep | Keep | +1 escape |
| Defeated/Expired | Keep level, -25% XP | -50% run gold | Revert to snapshot | +1 death |

### Files Changed
| File | Change |
|------|--------|
| `packages/data/proto/kbve/discordsh.proto` | Dungeon persistence messages, enums, RPCs |
| `packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql` | **NEW** — reference schema |
| `packages/data/sql/dbmate/migrations/20260316210000_...sql` | **NEW** — migration |
| `apps/discordsh/axum-discordsh/src/discord/game/persistence.rs` | **NEW** — ProfileStore + save/load |
| `apps/discordsh/axum-discordsh/src/discord/game/mod.rs` | Add persistence module |
| `apps/discordsh/axum-discordsh/src/discord/game/types.rs` | Add `saved_snapshot` to PlayerState |
| `apps/discordsh/axum-discordsh/src/state.rs` | Wire ProfileStore into AppState |
| `apps/discordsh/axum-discordsh/src/discord/commands/dungeon.rs` | Load/save integration + leaderboard |
| `apps/discordsh/axum-discordsh/src/discord/game/router.rs` | Save on game-over detection |
| `apps/discordsh/axum-discordsh/src/discord/game/session.rs` | Save on expire cleanup |
| `apps/discordsh/axum-discordsh/src/discord/bot.rs` | Pass profiles to cleanup task |

## Test plan
- [x] `cargo test -p axum-discordsh` — 675 tests pass (no regressions)
- [ ] Apply migration to local postgres and verify tables/functions
- [ ] Start bot with Supabase env vars, play a dungeon, verify profile persists across sessions
- [ ] Verify leaderboard renders after a few completed runs
- [ ] Verify death penalty: defeated run loses XP/gold, victory keeps all

Closes #8111

🤖 Generated with [Claude Code](https://claude.com/claude-code)