### PR TITLE
fix(astro-kbve): wrap npcdb.json API response in object

### DIFF
--- a/apps/kbve/astro-kbve/src/pages/api/npcdb.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/npcdb.json.ts
@@ -49,7 +49,7 @@ export const GET = async () => {
 
 	validateNpcUniqueness(npcs);
 
-	return new Response(JSON.stringify(npcs, null, '\t'), {
+	return new Response(JSON.stringify({ npcs, index }, null, '\t'), {
 		headers: {
 			'Content-Type': 'application/json',
 		},


### PR DESCRIPTION
## Summary
- `/api/npcdb.json` was returning a bare array instead of `{ npcs, index }`, unlike all other API endpoints (itemdb, mapdb, questdb)
- E2e test `GET /api/npcdb.json returns valid JSON` failed because it expected `data.npcs` property

## Test plan
- [ ] `axum-kbve-e2e` content-routes.spec.ts passes (all 44 tests)