### PR TITLE
feat(discordsh): add notice board and task board embed generators

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -37,6 +37,7 @@ lru = "0.16"
 uuid = { version = "1", features = ["v4", "serde"] }
 rand = "0.10"
 rand_chacha = "0.10"
+chrono = "0.4"
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi" }

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/mod.rs
@@ -1,5 +1,7 @@
+pub mod notice_board_embed;
 mod status_embed;
 mod status_state;
+pub mod task_board_embed;
 
 pub use status_embed::{StatusSnapshot, build_status_embed};
 pub use status_state::StatusState;

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/notice_board_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/notice_board_embed.rs
@@ -1,0 +1,261 @@
+//! Notice Board embed — surfaces blockers, stagnation, and coordination issues
+//! from GitHub issues/PRs as rich Discord embeds.
+
+use jedi::entity::github::{GitHubClient, GitHubIssue, GitHubPull};
+use poise::serenity_prelude as serenity;
+
+// ── Priority ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoticePriority {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+impl NoticePriority {
+    pub fn color(self) -> u32 {
+        match self {
+            Self::Critical => 0xE74C3C, // red
+            Self::High => 0xE67E22,     // orange
+            Self::Medium => 0xF1C40F,   // yellow
+            Self::Low => 0x2ECC71,      // green
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Critical => "CRITICAL",
+            Self::High => "HIGH",
+            Self::Medium => "MEDIUM",
+            Self::Low => "LOW",
+        }
+    }
+
+    /// Derive priority from GitHub labels (case-insensitive).
+    pub fn from_labels(labels: &[jedi::entity::github::GitHubLabel]) -> Self {
+        for label in labels {
+            let name = label.name.to_lowercase();
+            if name.contains("critical") || name.contains("blocker") {
+                return Self::Critical;
+            }
+            if name.contains("high") || name.contains("urgent") {
+                return Self::High;
+            }
+            if name.contains("medium") {
+                return Self::Medium;
+            }
+            if name.contains("low") {
+                return Self::Low;
+            }
+        }
+        Self::Medium
+    }
+}
+
+// ── Notice Item ─────────────────────────────────────────────────────
+
+/// A single notice board entry derived from a GitHub issue or PR.
+pub struct NoticeItem {
+    pub number: u64,
+    pub title: String,
+    pub description: String,
+    pub priority: NoticePriority,
+    pub reporter: String,
+    pub html_url: String,
+    pub labels: Vec<String>,
+    pub stale_days: Option<u64>,
+    pub updated_at: String,
+}
+
+impl NoticeItem {
+    /// Create a notice from a GitHub issue.
+    pub fn from_issue(issue: &GitHubIssue, stale_days: Option<u64>) -> Self {
+        Self {
+            number: issue.number,
+            title: issue.title.clone(),
+            description: truncate(&issue.title, 200),
+            priority: NoticePriority::from_labels(&issue.labels),
+            reporter: issue.user.login.clone(),
+            html_url: issue.html_url.clone(),
+            labels: issue.labels.iter().map(|l| l.name.clone()).collect(),
+            stale_days,
+            updated_at: issue.updated_at.clone(),
+        }
+    }
+
+    /// Create a notice from a GitHub pull request.
+    pub fn from_pull(pull: &GitHubPull, stale_days: Option<u64>) -> Self {
+        Self {
+            number: pull.number,
+            title: format!("PR: {}", pull.title),
+            description: truncate(&pull.title, 200),
+            priority: NoticePriority::High,
+            reporter: pull.user.login.clone(),
+            html_url: pull.html_url.clone(),
+            labels: Vec::new(),
+            stale_days,
+            updated_at: pull.updated_at.clone(),
+        }
+    }
+}
+
+// ── Embed Builders ──────────────────────────────────────────────────
+
+/// Build a single notice board embed for one item.
+pub fn build_notice_embed(item: &NoticeItem, repo_name: &str) -> serenity::CreateEmbed {
+    let mut embed = serenity::CreateEmbed::new()
+        .title(truncate(&item.title, 256))
+        .url(&item.html_url)
+        .color(item.priority.color())
+        .field("Ticket", format!("`#{}`", item.number), true)
+        .field("Priority", format!("`{}`", item.priority.label()), true)
+        .field("Reporter", format!("`{}`", item.reporter), true);
+
+    if !item.labels.is_empty() {
+        let labels_str = item
+            .labels
+            .iter()
+            .map(|l| format!("`{l}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        embed = embed.field("Labels", labels_str, false);
+    }
+
+    if let Some(days) = item.stale_days {
+        embed = embed.field(
+            "Stagnation",
+            format!("`{days} days`\nLast activity: `{}`", item.updated_at),
+            false,
+        );
+    }
+
+    embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
+        "Notice Board • {}",
+        repo_name
+    )));
+
+    embed
+}
+
+/// Build a summary embed listing multiple notices (compact view).
+pub fn build_notice_board_summary(items: &[NoticeItem], repo_name: &str) -> serenity::CreateEmbed {
+    let critical_count = items
+        .iter()
+        .filter(|i| i.priority == NoticePriority::Critical)
+        .count();
+    let high_count = items
+        .iter()
+        .filter(|i| i.priority == NoticePriority::High)
+        .count();
+
+    let color = if critical_count > 0 {
+        0xE74C3C
+    } else if high_count > 0 {
+        0xE67E22
+    } else {
+        0x2ECC71
+    };
+
+    let mut embed = serenity::CreateEmbed::new()
+        .title(format!("Notice Board — {}", repo_name))
+        .color(color);
+
+    if items.is_empty() {
+        embed = embed.description("No active notices. All clear!");
+        return embed;
+    }
+
+    embed = embed.description(format!(
+        "**{}** notice(s) — {} critical, {} high",
+        items.len(),
+        critical_count,
+        high_count
+    ));
+
+    // Group up to 25 items (Discord embed field limit)
+    for item in items.iter().take(25) {
+        let stale_tag = item
+            .stale_days
+            .map(|d| format!(" — stale {d}d"))
+            .unwrap_or_default();
+
+        embed = embed.field(
+            format!(
+                "[{}] #{} {}",
+                item.priority.label(),
+                item.number,
+                truncate(&item.title, 100)
+            ),
+            format!(
+                "by `{}` | [view]({}){stale_tag}",
+                item.reporter, item.html_url
+            ),
+            false,
+        );
+    }
+
+    if items.len() > 25 {
+        embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
+            "Showing 25 of {} • {}",
+            items.len(),
+            repo_name
+        )));
+    } else {
+        embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
+            "Notice Board • {}",
+            repo_name
+        )));
+    }
+
+    embed
+}
+
+/// Build notice items from stale issues and PRs using the GitHubClient helpers.
+pub fn notices_from_stale(
+    issues: &[GitHubIssue],
+    pulls: &[GitHubPull],
+    threshold_days: u64,
+) -> Vec<NoticeItem> {
+    let mut notices = Vec::new();
+
+    let stale_issues = GitHubClient::stale_issues(issues, threshold_days);
+    for issue in stale_issues {
+        let days = days_since_update(&issue.updated_at).unwrap_or(0);
+        notices.push(NoticeItem::from_issue(issue, Some(days)));
+    }
+
+    let stale_pulls = GitHubClient::stale_pulls(pulls, threshold_days);
+    for pull in stale_pulls {
+        let days = days_since_update(&pull.updated_at).unwrap_or(0);
+        notices.push(NoticeItem::from_pull(pull, Some(days)));
+    }
+
+    // Sort by priority (critical first), then by stale days (most stale first)
+    notices.sort_by(|a, b| {
+        (a.priority as u8)
+            .cmp(&(b.priority as u8))
+            .then_with(|| b.stale_days.unwrap_or(0).cmp(&a.stale_days.unwrap_or(0)))
+    });
+
+    notices
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max - 1])
+    }
+}
+
+fn days_since_update(updated_at: &str) -> Option<u64> {
+    let dt = chrono::DateTime::parse_from_rfc3339(updated_at)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    let diff: chrono::TimeDelta = chrono::Utc::now() - dt;
+    Some(diff.num_days().max(0) as u64)
+}

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/task_board_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/task_board_embed.rs
@@ -1,0 +1,190 @@
+//! Task Board embed — renders phase-based project tracking with per-department
+//! task breakdowns from GitHub issues as rich Discord embeds.
+
+use jedi::entity::github::GitHubIssue;
+use poise::serenity_prelude as serenity;
+use std::collections::BTreeMap;
+
+// ── Task Status ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy)]
+pub enum TaskStatus {
+    Open,
+    Closed,
+    Merged,
+}
+
+impl TaskStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Open => "OPEN",
+            Self::Closed => "CLOSED",
+            Self::Merged => "MERGED",
+        }
+    }
+
+    pub fn from_issue(issue: &GitHubIssue) -> Self {
+        match issue.state.as_str() {
+            "closed" => Self::Closed,
+            _ => Self::Open,
+        }
+    }
+}
+
+// ── Task Item ───────────────────────────────────────────────────────
+
+/// A single task derived from a GitHub issue.
+pub struct TaskItem {
+    pub number: u64,
+    pub title: String,
+    pub status: TaskStatus,
+    pub assignee: String,
+    pub html_url: String,
+    pub department: String,
+}
+
+impl TaskItem {
+    /// Create a task from a GitHub issue.
+    ///
+    /// Department is derived from labels matching known department names,
+    /// or falls back to "General".
+    pub fn from_issue(issue: &GitHubIssue) -> Self {
+        let department = extract_department(&issue.labels);
+        let assignee = issue.user.login.clone();
+
+        Self {
+            number: issue.number,
+            title: issue.title.clone(),
+            status: TaskStatus::from_issue(issue),
+            assignee,
+            html_url: issue.html_url.clone(),
+            department,
+        }
+    }
+}
+
+// ── Embed Builder ───────────────────────────────────────────────────
+
+/// Build a task board embed grouping issues by department label.
+pub fn build_task_board_embed(
+    items: &[TaskItem],
+    phase_title: &str,
+    phase_description: &str,
+    repo_url: &str,
+) -> serenity::CreateEmbed {
+    let mut embed = serenity::CreateEmbed::new()
+        .title(format!("Task Board — {}", phase_title))
+        .description(phase_description)
+        .color(0x3498DB);
+
+    if items.is_empty() {
+        embed = embed.field("No Tasks", "No tasks found for this phase.", false);
+        return add_footer(embed, repo_url);
+    }
+
+    // Group by department (BTreeMap for consistent ordering)
+    let mut departments: BTreeMap<&str, Vec<&TaskItem>> = BTreeMap::new();
+    for item in items {
+        departments.entry(&item.department).or_default().push(item);
+    }
+
+    for (dept, tasks) in &departments {
+        let mut lines = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            let title = truncate(&task.title, 80);
+            lines.push(format!(
+                "• [***{}***]({}) — **{}** — ***Status: {}***",
+                title,
+                task.html_url,
+                task.assignee,
+                task.status.label()
+            ));
+        }
+
+        // Discord field value limit is 1024 chars
+        let value = truncate_value(&lines.join("\n"), 1024);
+        embed = embed.field(dept.to_string(), value, false);
+    }
+
+    // Summary counts
+    let open = items
+        .iter()
+        .filter(|i| matches!(i.status, TaskStatus::Open))
+        .count();
+    let closed = items
+        .iter()
+        .filter(|i| matches!(i.status, TaskStatus::Closed | TaskStatus::Merged))
+        .count();
+    embed = embed.field(
+        "Progress",
+        format!("{closed}/{} completed", items.len()),
+        true,
+    );
+    embed = embed.field("Open", format!("{open}"), true);
+
+    add_footer(embed, repo_url)
+}
+
+/// Build task items from a list of GitHub issues.
+pub fn tasks_from_issues(issues: &[GitHubIssue]) -> Vec<TaskItem> {
+    issues.iter().map(TaskItem::from_issue).collect()
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const DEPARTMENTS: &[&str] = &[
+    "programming",
+    "3d art",
+    "narrative",
+    "design",
+    "audio",
+    "qa",
+    "devops",
+    "infrastructure",
+];
+
+fn extract_department(labels: &[jedi::entity::github::GitHubLabel]) -> String {
+    for label in labels {
+        let lower = label.name.to_lowercase();
+        for dept in DEPARTMENTS {
+            if lower.contains(dept) {
+                // Capitalize first letter
+                let mut chars = dept.chars();
+                match chars.next() {
+                    Some(c) => {
+                        return format!("{}{}", c.to_uppercase(), chars.as_str());
+                    }
+                    None => continue,
+                }
+            }
+        }
+    }
+    "General".to_string()
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max - 1])
+    }
+}
+
+fn truncate_value(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let truncated = &s[..max.saturating_sub(20)];
+        // Try to cut at a newline boundary
+        match truncated.rfind('\n') {
+            Some(pos) => format!("{}\n*…and more*", &truncated[..pos]),
+            None => format!("{}…", &truncated[..max.saturating_sub(2)]),
+        }
+    }
+}
+
+fn add_footer(embed: serenity::CreateEmbed, repo_url: &str) -> serenity::CreateEmbed {
+    embed
+        .field("Repository", repo_url, false)
+        .footer(serenity::CreateEmbedFooter::new("Task Board"))
+}


### PR DESCRIPTION
## Summary
- **Notice Board embed** (`notice_board_embed.rs`): Surfaces blockers and stagnation from GitHub issues/PRs as priority-colored Discord embeds. Supports single-item detail view and multi-item summary view. Derives priority from GitHub labels (critical/high/medium/low).
- **Task Board embed** (`task_board_embed.rs`): Renders phase-based project tracking grouped by department labels. Shows status (OPEN/CLOSED/MERGED), assignee, and progress counters per department.
- Both are pure builder functions consuming `jedi::GitHubClient` types — no async, no side effects
- Added `chrono` dependency to axum-discordsh for stagnation day calculation

## Test plan
- [x] `cargo check -p axum-discordsh` passes
- [ ] Integration with slash commands (#7855) to verify embed rendering in Discord

## Usage
```rust
// Notice board
let issues = gh.list_issues("KBVE", "kbve", Some("open"), Some(50)).await?;
let pulls = gh.list_pulls("KBVE", "kbve", Some("open"), Some(50)).await?;
let notices = notices_from_stale(&issues, &pulls, 3);
let embed = build_notice_board_summary(&notices, "KBVE/kbve");

// Task board
let tasks = tasks_from_issues(&issues);
let embed = build_task_board_embed(&tasks, "Phase 0", "Infrastructure setup", "https://github.com/KBVE/kbve");
```

Ref: #7853, #7854