### PR TITLE
fix(ci): install build-essential on arc-runner for cargo-audit

### DIFF
--- a/.github/workflows/ci-nx-security.yml
+++ b/.github/workflows/ci-nx-security.yml
@@ -104,6 +104,16 @@ jobs:
                     echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
                   fi
 
+            - name: Install build tools
+              run: |
+                  set -euo pipefail
+                  if ! command -v cc &>/dev/null; then
+                    apt-get update -qq && apt-get install -y -qq build-essential pkg-config libssl-dev
+                    echo "build-essential installed"
+                  else
+                    echo "cc already available: $(cc --version | head -1)"
+                  fi
+
             - name: Install audit tools
               run: |
                   set -euo pipefail


### PR DESCRIPTION
## Summary
- `arc-runner-set` self-hosted runner lacks a C linker (`cc`), causing `cargo install cargo-audit` to fail with `error: linker cc not found` (exit code 101)
- Adds an "Install build tools" step before audit tool installation that installs `build-essential`, `pkg-config`, and `libssl-dev` when `cc` is missing
- Ref: https://github.com/KBVE/kbve/actions/runs/23182678451

## Test plan
- Re-run the `CI - Weekly NX Security Audit` workflow dispatch after merge and verify the `Install audit tools` step succeeds