### PR TITLE
fix(edge-e2e): correct version.toml path in health tests

### DIFF
--- a/apps/kbve/edge-e2e/e2e/health.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/health.spec.ts
@@ -6,7 +6,7 @@ import { createJwt } from './helpers/jwt';
 
 /** Parse version.toml — single source of truth for version + function registry. */
 function parseManifest() {
-	const tomlPath = resolve(__dirname, '../../../edge/version.toml');
+	const tomlPath = resolve(__dirname, '../../edge/version.toml');
 	const content = readFileSync(tomlPath, 'utf-8');
 
 	const versionMatch = content.match(/^version\s*=\s*"([^"]+)"/m);


### PR DESCRIPTION
## Summary
- 2 tests in `health.spec.ts` fail with `ENOENT` because the relative path to `version.toml` has an extra `../` — resolves to `apps/edge/version.toml` instead of `apps/kbve/edge/version.toml`
- Fixes `../../../edge/version.toml` → `../../edge/version.toml`
- Ref: https://github.com/KBVE/kbve/actions/runs/23184119778/job/67365678678

## Test plan
- Edge e2e tests should pass on next CI run (79 passed, 2 failed → 81 passed)