### PR TITLE
feat(discordsh): add /github slash commands for notice and task boards

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/commands/github_board.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/github_board.rs
@@ -1,0 +1,295 @@
+//! `/github` slash commands — notice board and task board embeds
+//! powered by the guild's GitHub PAT from Supabase Vault.
+
+use jedi::entity::github::GitHubClient;
+use tracing::{info, warn};
+
+use crate::discord::bot::{Context, Error};
+use crate::discord::embeds::notice_board_embed::{build_notice_board_summary, notices_from_stale};
+use crate::discord::embeds::task_board_embed::{build_task_board_embed, tasks_from_issues};
+use crate::discord::github::resolve_github_token;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+async fn get_github_client(ctx: Context<'_>) -> Result<GitHubClient, String> {
+    let guild_id = ctx
+        .guild_id()
+        .ok_or_else(|| "This command must be used in a server.".to_string())?;
+
+    let token = resolve_github_token(Some(guild_id.get()))
+        .await
+        .ok_or_else(|| {
+            "No GitHub token configured for this server. A server admin can store one at <https://kbve.com>.".to_string()
+        })?;
+
+    Ok(GitHubClient::new(&token))
+}
+
+async fn send_error(ctx: Context<'_>, msg: &str) -> Result<(), Error> {
+    ctx.send(poise::CreateReply::default().content(msg).ephemeral(true))
+        .await?;
+    Ok(())
+}
+
+/// Parse "owner/repo" string, falling back to "KBVE/kbve" if not provided.
+fn parse_repo(repo: &Option<String>) -> (&str, &str) {
+    match repo.as_deref() {
+        Some(r) if r.contains('/') => {
+            let parts: Vec<&str> = r.splitn(2, '/').collect();
+            (parts[0], parts[1])
+        }
+        _ => ("KBVE", "kbve"),
+    }
+}
+
+// ── Parent command ──────────────────────────────────────────────────
+
+/// GitHub project boards — notice board and task board embeds.
+#[poise::command(
+    slash_command,
+    subcommands("noticeboard", "taskboard", "issues", "pulls")
+)]
+pub async fn github(_ctx: Context<'_>) -> Result<(), Error> {
+    Ok(())
+}
+
+// ── /github noticeboard ─────────────────────────────────────────────
+
+/// Show blockers and stale issues/PRs for a repository.
+#[poise::command(slash_command)]
+async fn noticeboard(
+    ctx: Context<'_>,
+    #[description = "Repository (owner/repo, default: KBVE/kbve)"] repo: Option<String>,
+    #[description = "Stale threshold in days (default: 3)"] stale_days: Option<u64>,
+) -> Result<(), Error> {
+    ctx.defer().await?;
+
+    let gh = match get_github_client(ctx).await {
+        Ok(c) => c,
+        Err(msg) => return send_error(ctx, &msg).await,
+    };
+
+    let (owner, repo_name) = parse_repo(&repo);
+    let threshold = stale_days.unwrap_or(3);
+    let full_name = format!("{}/{}", owner, repo_name);
+
+    let issues = gh
+        .list_issues(owner, repo_name, Some("open"), Some(100))
+        .await;
+    let pulls = gh
+        .list_pulls(owner, repo_name, Some("open"), Some(100))
+        .await;
+
+    match (issues, pulls) {
+        (Ok(issues), Ok(pulls)) => {
+            let notices = notices_from_stale(&issues, &pulls, threshold);
+
+            info!(
+                user = %ctx.author().name,
+                repo = full_name,
+                threshold,
+                notices = notices.len(),
+                "Notice board generated"
+            );
+
+            let embed = build_notice_board_summary(&notices, &full_name);
+            ctx.send(poise::CreateReply::default().embed(embed)).await?;
+            Ok(())
+        }
+        (Err(e), _) | (_, Err(e)) => {
+            warn!(error = %e, repo = full_name, "Failed to fetch GitHub data");
+            send_error(
+                ctx,
+                &format!(
+                    "Failed to fetch data from GitHub for `{}`. Check that the token has access.",
+                    full_name
+                ),
+            )
+            .await
+        }
+    }
+}
+
+// ── /github taskboard ───────────────────────────────────────────────
+
+/// Show task progress grouped by department for a repository.
+#[poise::command(slash_command)]
+async fn taskboard(
+    ctx: Context<'_>,
+    #[description = "Repository (owner/repo, default: KBVE/kbve)"] repo: Option<String>,
+    #[description = "Phase/milestone name (shown in title)"] phase: Option<String>,
+) -> Result<(), Error> {
+    ctx.defer().await?;
+
+    let gh = match get_github_client(ctx).await {
+        Ok(c) => c,
+        Err(msg) => return send_error(ctx, &msg).await,
+    };
+
+    let (owner, repo_name) = parse_repo(&repo);
+    let full_name = format!("{}/{}", owner, repo_name);
+    let phase_title = phase.as_deref().unwrap_or("Current Phase");
+
+    let issues = gh
+        .list_issues(owner, repo_name, Some("open"), Some(100))
+        .await;
+
+    match issues {
+        Ok(issues) => {
+            let tasks = tasks_from_issues(&issues);
+
+            info!(
+                user = %ctx.author().name,
+                repo = full_name,
+                tasks = tasks.len(),
+                "Task board generated"
+            );
+
+            let repo_url = format!("https://github.com/{}", full_name);
+            let embed = build_task_board_embed(&tasks, phase_title, "", &repo_url);
+            ctx.send(poise::CreateReply::default().embed(embed)).await?;
+            Ok(())
+        }
+        Err(e) => {
+            warn!(error = %e, repo = full_name, "Failed to fetch GitHub issues");
+            send_error(
+                ctx,
+                &format!(
+                    "Failed to fetch issues from GitHub for `{}`. Check that the token has access.",
+                    full_name
+                ),
+            )
+            .await
+        }
+    }
+}
+
+// ── /github issues ──────────────────────────────────────────────────
+
+/// List open issues for a repository.
+#[poise::command(slash_command)]
+async fn issues(
+    ctx: Context<'_>,
+    #[description = "Repository (owner/repo, default: KBVE/kbve)"] repo: Option<String>,
+    #[description = "Max results (default: 10, max: 25)"] limit: Option<u8>,
+) -> Result<(), Error> {
+    ctx.defer().await?;
+
+    let gh = match get_github_client(ctx).await {
+        Ok(c) => c,
+        Err(msg) => return send_error(ctx, &msg).await,
+    };
+
+    let (owner, repo_name) = parse_repo(&repo);
+    let full_name = format!("{}/{}", owner, repo_name);
+    let count = limit.unwrap_or(10).min(25);
+
+    match gh
+        .list_issues(owner, repo_name, Some("open"), Some(count))
+        .await
+    {
+        Ok(issues) => {
+            let mut embed = poise::serenity_prelude::CreateEmbed::new()
+                .title(format!("Open Issues — {}", full_name))
+                .color(0x238636);
+
+            if issues.is_empty() {
+                embed = embed.description("No open issues!");
+            } else {
+                for issue in &issues {
+                    let labels = issue
+                        .labels
+                        .iter()
+                        .map(|l| format!("`{}`", l.name))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let label_str = if labels.is_empty() {
+                        String::new()
+                    } else {
+                        format!("\n{}", labels)
+                    };
+                    embed = embed.field(
+                        format!("#{} {}", issue.number, truncate(&issue.title, 80)),
+                        format!(
+                            "by `{}` | [view]({}){label_str}",
+                            issue.user.login, issue.html_url
+                        ),
+                        false,
+                    );
+                }
+            }
+
+            ctx.send(poise::CreateReply::default().embed(embed)).await?;
+            Ok(())
+        }
+        Err(e) => {
+            warn!(error = %e, repo = full_name, "Failed to fetch issues");
+            send_error(ctx, &format!("Failed to fetch issues for `{}`.", full_name)).await
+        }
+    }
+}
+
+// ── /github pulls ───────────────────────────────────────────────────
+
+/// List open pull requests for a repository.
+#[poise::command(slash_command)]
+async fn pulls(
+    ctx: Context<'_>,
+    #[description = "Repository (owner/repo, default: KBVE/kbve)"] repo: Option<String>,
+    #[description = "Max results (default: 10, max: 25)"] limit: Option<u8>,
+) -> Result<(), Error> {
+    ctx.defer().await?;
+
+    let gh = match get_github_client(ctx).await {
+        Ok(c) => c,
+        Err(msg) => return send_error(ctx, &msg).await,
+    };
+
+    let (owner, repo_name) = parse_repo(&repo);
+    let full_name = format!("{}/{}", owner, repo_name);
+    let count = limit.unwrap_or(10).min(25);
+
+    match gh
+        .list_pulls(owner, repo_name, Some("open"), Some(count))
+        .await
+    {
+        Ok(pulls) => {
+            let mut embed = poise::serenity_prelude::CreateEmbed::new()
+                .title(format!("Open PRs — {}", full_name))
+                .color(0x8957E5);
+
+            if pulls.is_empty() {
+                embed = embed.description("No open pull requests!");
+            } else {
+                for pr in &pulls {
+                    let draft = if pr.draft { " (draft)" } else { "" };
+                    embed = embed.field(
+                        format!("#{} {}{}", pr.number, truncate(&pr.title, 80), draft),
+                        format!(
+                            "by `{}` → `{}` | [view]({})",
+                            pr.user.login, pr.head.ref_name, pr.html_url
+                        ),
+                        false,
+                    );
+                }
+            }
+
+            ctx.send(poise::CreateReply::default().embed(embed)).await?;
+            Ok(())
+        }
+        Err(e) => {
+            warn!(error = %e, repo = full_name, "Failed to fetch PRs");
+            send_error(ctx, &format!("Failed to fetch PRs for `{}`.", full_name)).await
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max - 1])
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/commands/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/mod.rs
@@ -1,5 +1,6 @@
 mod admin;
 mod dungeon;
+mod github_board;
 mod health;
 mod ping;
 mod status;
@@ -15,5 +16,6 @@ pub fn all() -> Vec<poise::Command<Data, Error>> {
         admin::restart(),
         admin::cleanup(),
         dungeon::dungeon(),
+        github_board::github(),
     ]
 }


### PR DESCRIPTION
## Summary
- Add `/github` parent command with 4 subcommands wiring the full vault → GitHub API → embed pipeline
- `/github noticeboard [repo] [stale_days]` — shows blockers and stale issues/PRs with priority colors
- `/github taskboard [repo] [phase]` — shows task progress grouped by department labels
- `/github issues [repo] [limit]` — lists open issues with labels
- `/github pulls [repo] [limit]` — lists open PRs with branch info and draft status
- All commands default to `KBVE/kbve`, accept `owner/repo` override
- Token resolved via `resolve_github_token(guild_id)` from env vars or Supabase Vault

## Test plan
- [x] `cargo check -p axum-discordsh` passes
- [ ] Deploy and verify `/github issues` returns embed with real data
- [ ] Verify `/github noticeboard` shows stale items
- [ ] Verify missing token returns graceful error message
- [ ] Verify DM usage returns "must be used in a server"

Ref: #7855