### PR TITLE
fix(axum-kbve): add CORP headers to static assets for COEP compatibility

### DIFF
--- a/apps/kbve/axum-kbve-e2e/e2e/static.spec.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/static.spec.ts
@@ -62,6 +62,22 @@ describe('Static file serving', () => {
 		}
 	});
 
+	it('returns CORP header on /_astro/ assets for COEP compatibility', async () => {
+		// Fetch the arcade page to discover an _astro asset path
+		const page = await fetch(`${BASE_URL}/arcade/isometric/`);
+		if (page.status !== 200) return;
+		const html = await page.text();
+		const match = html.match(/\/_astro\/[^"'\s]+\.js/);
+		if (!match) return;
+		const astroAsset = match[0];
+		const res = await fetch(`${BASE_URL}${astroAsset}`);
+		if (res.status === 200) {
+			expect(res.headers.get('cross-origin-resource-policy')).toBe(
+				'same-origin',
+			);
+		}
+	});
+
 	it('supports precompressed content via Accept-Encoding', async () => {
 		const res = await fetch(`${BASE_URL}/health`, {
 			headers: { 'Accept-Encoding': 'gzip, deflate, br' },

--- a/apps/kbve/axum-kbve/src/astro/mod.rs
+++ b/apps/kbve/axum-kbve/src/astro/mod.rs
@@ -100,6 +100,8 @@ pub fn build_static_router(config: &StaticConfig) -> Router {
         // Isometric game requires cross-origin isolation for SharedArrayBuffer (WASM pthreads).
         // Scoped to /isometric/ paths only to avoid breaking other pages.
         .layer(axum::middleware::from_fn(coop_coep_isometric))
+        // Mark /_astro/ assets with CORP so they satisfy COEP when loaded by the isometric page.
+        .layer(axum::middleware::from_fn(corp_astro_assets))
 }
 
 /// Middleware that adds COOP/COEP headers to /isometric/ responses,
@@ -117,6 +119,25 @@ async fn coop_coep_isometric(req: axum::extract::Request, next: Next) -> impl In
         headers.insert(
             header::HeaderName::from_static("cross-origin-embedder-policy"),
             HeaderValue::from_static("require-corp"),
+        );
+    }
+    resp
+}
+
+/// Middleware that adds Cross-Origin-Resource-Policy to /_astro/ and /assets/
+/// responses so they are loadable under COEP: require-corp from the isometric page.
+async fn corp_astro_assets(req: axum::extract::Request, next: Next) -> impl IntoResponse {
+    let path = req.uri().path();
+    let needs_corp = path.starts_with("/_astro")
+        || path.starts_with("/assets")
+        || path.starts_with("/pagefind")
+        || path.starts_with("/chunks")
+        || path.starts_with("/images");
+    let mut resp = next.run(req).await;
+    if needs_corp {
+        resp.headers_mut().insert(
+            header::HeaderName::from_static("cross-origin-resource-policy"),
+            HeaderValue::from_static("same-origin"),
         );
     }
     resp


### PR DESCRIPTION
## Summary
- `/_astro/` assets (and `/assets/`, `/pagefind/`, `/chunks/`, `/images/`) were blocked by the browser when loaded from `/arcade/isometric/` because that page has `COEP: require-corp` but the assets lacked `Cross-Origin-Resource-Policy` headers
- Adds `CORP: same-origin` middleware for all static asset paths so they satisfy COEP
- Adds e2e test verifying `/_astro/` assets return the CORP header

## Test plan
- [ ] `/arcade/isometric/` no longer blocks `/_astro/*.js` assets in browser console
- [ ] `supabase.db-*.js` loads successfully on the isometric page
- [ ] E2e test `returns CORP header on /_astro/ assets` passes