### PR TITLE
test(discordsh,jedi): unit tests for GitHub pipeline

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/embeds/notice_board_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/notice_board_embed.rs
@@ -259,3 +259,226 @@ fn days_since_update(updated_at: &str) -> Option<u64> {
     let diff: chrono::TimeDelta = chrono::Utc::now() - dt;
     Some(diff.num_days().max(0) as u64)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jedi::entity::github::{GitHubLabel, GitHubPull, GitHubRef, GitHubUser};
+
+    fn days_ago(days: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::days(days))
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    }
+
+    fn make_issue(number: u64, updated_at: &str, labels: Vec<&str>) -> GitHubIssue {
+        GitHubIssue {
+            number,
+            title: format!("Issue #{number}"),
+            state: "open".to_string(),
+            user: GitHubUser {
+                login: "tester".to_string(),
+            },
+            labels: labels
+                .into_iter()
+                .map(|n| GitHubLabel {
+                    name: n.to_string(),
+                    color: None,
+                })
+                .collect(),
+            created_at: updated_at.to_string(),
+            updated_at: updated_at.to_string(),
+            html_url: format!("https://github.com/test/repo/issues/{number}"),
+            pull_request: None,
+        }
+    }
+
+    fn make_pull(number: u64, updated_at: &str) -> GitHubPull {
+        GitHubPull {
+            number,
+            title: format!("PR #{number}"),
+            state: "open".to_string(),
+            user: GitHubUser {
+                login: "tester".to_string(),
+            },
+            head: GitHubRef {
+                ref_name: "feat".to_string(),
+                sha: "abc".to_string(),
+            },
+            created_at: updated_at.to_string(),
+            updated_at: updated_at.to_string(),
+            html_url: format!("https://github.com/test/repo/pull/{number}"),
+            draft: false,
+        }
+    }
+
+    // ── NoticePriority ───────────────────────────────────────────────
+
+    #[test]
+    fn priority_from_labels_critical() {
+        let labels = vec![GitHubLabel {
+            name: "Critical".to_string(),
+            color: None,
+        }];
+        assert_eq!(
+            NoticePriority::from_labels(&labels),
+            NoticePriority::Critical
+        );
+    }
+
+    #[test]
+    fn priority_from_labels_blocker() {
+        let labels = vec![GitHubLabel {
+            name: "blocker".to_string(),
+            color: None,
+        }];
+        assert_eq!(
+            NoticePriority::from_labels(&labels),
+            NoticePriority::Critical
+        );
+    }
+
+    #[test]
+    fn priority_from_labels_high() {
+        let labels = vec![GitHubLabel {
+            name: "priority:high".to_string(),
+            color: None,
+        }];
+        assert_eq!(NoticePriority::from_labels(&labels), NoticePriority::High);
+    }
+
+    #[test]
+    fn priority_from_labels_urgent() {
+        let labels = vec![GitHubLabel {
+            name: "URGENT".to_string(),
+            color: None,
+        }];
+        assert_eq!(NoticePriority::from_labels(&labels), NoticePriority::High);
+    }
+
+    #[test]
+    fn priority_from_labels_medium() {
+        let labels = vec![GitHubLabel {
+            name: "medium".to_string(),
+            color: None,
+        }];
+        assert_eq!(NoticePriority::from_labels(&labels), NoticePriority::Medium);
+    }
+
+    #[test]
+    fn priority_from_labels_low() {
+        let labels = vec![GitHubLabel {
+            name: "low-priority".to_string(),
+            color: None,
+        }];
+        assert_eq!(NoticePriority::from_labels(&labels), NoticePriority::Low);
+    }
+
+    #[test]
+    fn priority_from_labels_default_medium() {
+        let labels = vec![GitHubLabel {
+            name: "enhancement".to_string(),
+            color: None,
+        }];
+        assert_eq!(NoticePriority::from_labels(&labels), NoticePriority::Medium);
+    }
+
+    #[test]
+    fn priority_from_empty_labels() {
+        assert_eq!(NoticePriority::from_labels(&[]), NoticePriority::Medium);
+    }
+
+    // ── NoticeItem ───────────────────────────────────────────────────
+
+    #[test]
+    fn notice_from_issue_fields() {
+        let issue = make_issue(42, "2026-01-01T00:00:00Z", vec!["critical"]);
+        let notice = NoticeItem::from_issue(&issue, Some(10));
+        assert_eq!(notice.number, 42);
+        assert_eq!(notice.reporter, "tester");
+        assert_eq!(notice.priority, NoticePriority::Critical);
+        assert_eq!(notice.stale_days, Some(10));
+    }
+
+    #[test]
+    fn notice_from_pull_fields() {
+        let pull = make_pull(99, "2026-01-01T00:00:00Z");
+        let notice = NoticeItem::from_pull(&pull, Some(5));
+        assert_eq!(notice.number, 99);
+        assert!(notice.title.starts_with("PR:"));
+        assert_eq!(notice.priority, NoticePriority::High);
+    }
+
+    // ── notices_from_stale ───────────────────────────────────────────
+
+    #[test]
+    fn notices_from_stale_filters_and_sorts() {
+        let issues = vec![
+            make_issue(1, &days_ago(10), vec!["low"]),
+            make_issue(2, &days_ago(1), vec![]),
+            make_issue(3, &days_ago(5), vec!["critical"]),
+        ];
+        let pulls = vec![make_pull(4, &days_ago(8))];
+
+        let notices = notices_from_stale(&issues, &pulls, 3);
+
+        // Issue 2 is recent (1 day), should be excluded
+        assert!(!notices.iter().any(|n| n.number == 2));
+        // Critical sorts first
+        assert_eq!(notices[0].number, 3);
+        assert_eq!(notices[0].priority, NoticePriority::Critical);
+    }
+
+    #[test]
+    fn notices_from_stale_empty_inputs() {
+        let notices = notices_from_stale(&[], &[], 3);
+        assert!(notices.is_empty());
+    }
+
+    // ── build_notice_board_summary ───────────────────────────────────
+
+    #[test]
+    fn summary_embed_empty_shows_all_clear() {
+        let embed = build_notice_board_summary(&[], "KBVE/kbve");
+        let json = serde_json::to_string(&embed).unwrap();
+        assert!(json.contains("All clear"));
+    }
+
+    #[test]
+    fn summary_embed_critical_is_red() {
+        let issue = make_issue(1, &days_ago(10), vec!["critical"]);
+        let notices = vec![NoticeItem::from_issue(&issue, Some(10))];
+        let embed = build_notice_board_summary(&notices, "test/repo");
+        let json = serde_json::to_string(&embed).unwrap();
+        // 0xE74C3C = 15158332
+        assert!(json.contains("15158332"));
+    }
+
+    // ── days_since_update ────────────────────────────────────────────
+
+    #[test]
+    fn days_since_valid_date() {
+        let ts = days_ago(5);
+        let result = days_since_update(&ts);
+        assert!(result.is_some());
+        assert!(result.unwrap() >= 4 && result.unwrap() <= 6);
+    }
+
+    #[test]
+    fn days_since_invalid_date() {
+        assert_eq!(days_since_update("not-a-date"), None);
+    }
+
+    // ── truncate ─────────────────────────────────────────────────────
+
+    #[test]
+    fn truncate_short_string() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string() {
+        let result = truncate("hello world this is long", 10);
+        assert!(result.len() <= 12); // 9 chars + "…"
+        assert!(result.ends_with('…'));
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/task_board_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/task_board_embed.rs
@@ -188,3 +188,178 @@ fn add_footer(embed: serenity::CreateEmbed, repo_url: &str) -> serenity::CreateE
         .field("Repository", repo_url, false)
         .footer(serenity::CreateEmbedFooter::new("Task Board"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jedi::entity::github::{GitHubLabel, GitHubUser};
+
+    fn make_issue(number: u64, state: &str, labels: Vec<&str>) -> GitHubIssue {
+        GitHubIssue {
+            number,
+            title: format!("Task #{number}"),
+            state: state.to_string(),
+            user: GitHubUser {
+                login: "dev".to_string(),
+            },
+            labels: labels
+                .into_iter()
+                .map(|n| GitHubLabel {
+                    name: n.to_string(),
+                    color: None,
+                })
+                .collect(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-02T00:00:00Z".to_string(),
+            html_url: format!("https://github.com/test/repo/issues/{number}"),
+            pull_request: None,
+        }
+    }
+
+    // ── TaskStatus ───────────────────────────────────────────────────
+
+    #[test]
+    fn status_open() {
+        let issue = make_issue(1, "open", vec![]);
+        assert!(matches!(TaskStatus::from_issue(&issue), TaskStatus::Open));
+    }
+
+    #[test]
+    fn status_closed() {
+        let issue = make_issue(1, "closed", vec![]);
+        assert!(matches!(TaskStatus::from_issue(&issue), TaskStatus::Closed));
+    }
+
+    // ── Department extraction ────────────────────────────────────────
+
+    #[test]
+    fn extract_dept_programming() {
+        let labels = vec![GitHubLabel {
+            name: "programming".to_string(),
+            color: None,
+        }];
+        assert_eq!(extract_department(&labels), "Programming");
+    }
+
+    #[test]
+    fn extract_dept_3d_art() {
+        let labels = vec![GitHubLabel {
+            name: "3d art".to_string(),
+            color: None,
+        }];
+        assert_eq!(extract_department(&labels), "3d art");
+    }
+
+    #[test]
+    fn extract_dept_devops_case_insensitive() {
+        let labels = vec![GitHubLabel {
+            name: "DevOps".to_string(),
+            color: None,
+        }];
+        assert_eq!(extract_department(&labels), "Devops");
+    }
+
+    #[test]
+    fn extract_dept_fallback_general() {
+        let labels = vec![GitHubLabel {
+            name: "enhancement".to_string(),
+            color: None,
+        }];
+        assert_eq!(extract_department(&labels), "General");
+    }
+
+    #[test]
+    fn extract_dept_empty_labels() {
+        assert_eq!(extract_department(&[]), "General");
+    }
+
+    // ── TaskItem ─────────────────────────────────────────────────────
+
+    #[test]
+    fn task_from_issue_fields() {
+        let issue = make_issue(42, "open", vec!["programming"]);
+        let task = TaskItem::from_issue(&issue);
+        assert_eq!(task.number, 42);
+        assert_eq!(task.assignee, "dev");
+        assert_eq!(task.department, "Programming");
+        assert!(matches!(task.status, TaskStatus::Open));
+    }
+
+    // ── tasks_from_issues ────────────────────────────────────────────
+
+    #[test]
+    fn tasks_from_issues_maps_all() {
+        let issues = vec![
+            make_issue(1, "open", vec!["programming"]),
+            make_issue(2, "closed", vec!["qa"]),
+            make_issue(3, "open", vec![]),
+        ];
+        let tasks = tasks_from_issues(&issues);
+        assert_eq!(tasks.len(), 3);
+        assert!(matches!(tasks[1].status, TaskStatus::Closed));
+        assert_eq!(tasks[2].department, "General");
+    }
+
+    // ── build_task_board_embed ────────────────────────────────────────
+
+    #[test]
+    fn task_board_empty_shows_no_tasks() {
+        let embed = build_task_board_embed(&[], "Phase 0", "", "https://github.com/t/r");
+        let json = serde_json::to_string(&embed).unwrap();
+        assert!(json.contains("No Tasks") || json.contains("No tasks"));
+    }
+
+    #[test]
+    fn task_board_groups_by_department() {
+        let issues = vec![
+            make_issue(1, "open", vec!["programming"]),
+            make_issue(2, "open", vec!["qa"]),
+            make_issue(3, "closed", vec!["programming"]),
+        ];
+        let tasks = tasks_from_issues(&issues);
+        let embed = build_task_board_embed(&tasks, "Phase 1", "", "https://github.com/t/r");
+        let json = serde_json::to_string(&embed).unwrap();
+        assert!(json.contains("Programming"));
+        assert!(json.contains("Qa"));
+        assert!(json.contains("Progress"));
+    }
+
+    #[test]
+    fn task_board_shows_correct_progress() {
+        let issues = vec![
+            make_issue(1, "open", vec![]),
+            make_issue(2, "closed", vec![]),
+            make_issue(3, "closed", vec![]),
+        ];
+        let tasks = tasks_from_issues(&issues);
+        let embed = build_task_board_embed(&tasks, "Test", "", "https://github.com/t/r");
+        let json = serde_json::to_string(&embed).unwrap();
+        // 2 closed out of 3 total
+        assert!(json.contains("2/3 completed"));
+    }
+
+    // ── truncate helpers ─────────────────────────────────────────────
+
+    #[test]
+    fn truncate_short() {
+        assert_eq!(truncate("short", 100), "short");
+    }
+
+    #[test]
+    fn truncate_long() {
+        let long = "a".repeat(100);
+        let result = truncate(&long, 50);
+        assert!(result.len() <= 52);
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_value_respects_limit() {
+        let long = (0..50)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let result = truncate_value(&long, 100);
+        assert!(result.len() <= 120);
+    }
+}

--- a/packages/rust/jedi/src/entity/github/client.rs
+++ b/packages/rust/jedi/src/entity/github/client.rs
@@ -247,3 +247,230 @@ impl GitHubClient {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Fixture helpers ──────────────────────────────────────────────
+
+    fn make_issue(number: u64, updated_at: &str, labels: Vec<&str>) -> GitHubIssue {
+        GitHubIssue {
+            number,
+            title: format!("Issue #{number}"),
+            state: "open".to_string(),
+            user: GitHubUser {
+                login: "testuser".to_string(),
+            },
+            labels: labels
+                .into_iter()
+                .map(|n| GitHubLabel {
+                    name: n.to_string(),
+                    color: None,
+                })
+                .collect(),
+            created_at: updated_at.to_string(),
+            updated_at: updated_at.to_string(),
+            html_url: format!("https://github.com/test/repo/issues/{number}"),
+            pull_request: None,
+        }
+    }
+
+    fn make_pull(number: u64, updated_at: &str, draft: bool) -> GitHubPull {
+        GitHubPull {
+            number,
+            title: format!("PR #{number}"),
+            state: "open".to_string(),
+            user: GitHubUser {
+                login: "testuser".to_string(),
+            },
+            head: GitHubRef {
+                ref_name: "feature-branch".to_string(),
+                sha: "abc123".to_string(),
+            },
+            created_at: updated_at.to_string(),
+            updated_at: updated_at.to_string(),
+            html_url: format!("https://github.com/test/repo/pull/{number}"),
+            draft,
+        }
+    }
+
+    fn days_ago(days: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::days(days))
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    }
+
+    // ── Type deserialization ─────────────────────────────────────────
+
+    #[test]
+    fn deserialize_issue_json() {
+        let json = r#"{
+            "number": 42,
+            "title": "Test issue",
+            "state": "open",
+            "user": {"login": "octocat"},
+            "labels": [{"name": "bug", "color": "d73a4a"}],
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-02T00:00:00Z",
+            "html_url": "https://github.com/test/repo/issues/42"
+        }"#;
+        let issue: GitHubIssue = serde_json::from_str(json).unwrap();
+        assert_eq!(issue.number, 42);
+        assert_eq!(issue.title, "Test issue");
+        assert_eq!(issue.user.login, "octocat");
+        assert_eq!(issue.labels.len(), 1);
+        assert_eq!(issue.labels[0].name, "bug");
+        assert!(!issue.is_pull_request());
+    }
+
+    #[test]
+    fn deserialize_issue_with_pr_field() {
+        let json = r#"{
+            "number": 10,
+            "title": "PR as issue",
+            "state": "open",
+            "user": {"login": "octocat"},
+            "labels": [],
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-02T00:00:00Z",
+            "html_url": "https://github.com/test/repo/issues/10",
+            "pull_request": {"url": "https://api.github.com/repos/test/repo/pulls/10"}
+        }"#;
+        let issue: GitHubIssue = serde_json::from_str(json).unwrap();
+        assert!(issue.is_pull_request());
+    }
+
+    #[test]
+    fn deserialize_pull_json() {
+        let json = r#"{
+            "number": 99,
+            "title": "Add feature",
+            "state": "open",
+            "user": {"login": "dev"},
+            "head": {"ref": "feat/new", "sha": "deadbeef"},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-03T00:00:00Z",
+            "html_url": "https://github.com/test/repo/pull/99",
+            "draft": true
+        }"#;
+        let pull: GitHubPull = serde_json::from_str(json).unwrap();
+        assert_eq!(pull.number, 99);
+        assert_eq!(pull.head.ref_name, "feat/new");
+        assert!(pull.draft);
+    }
+
+    #[test]
+    fn deserialize_commit_json() {
+        let json = r#"{
+            "sha": "abc123def",
+            "commit": {
+                "message": "fix: resolve bug",
+                "author": {"name": "Dev", "date": "2026-01-01T12:00:00Z"}
+            },
+            "html_url": "https://github.com/test/repo/commit/abc123def"
+        }"#;
+        let commit: GitHubCommit = serde_json::from_str(json).unwrap();
+        assert_eq!(commit.sha, "abc123def");
+        assert_eq!(commit.commit.message, "fix: resolve bug");
+        assert_eq!(commit.commit.author.name, "Dev");
+    }
+
+    #[test]
+    fn deserialize_repo_json() {
+        let json = r#"{
+            "name": "kbve",
+            "full_name": "KBVE/kbve",
+            "description": "A monorepo",
+            "html_url": "https://github.com/KBVE/kbve",
+            "default_branch": "main",
+            "open_issues_count": 150
+        }"#;
+        let repo: GitHubRepo = serde_json::from_str(json).unwrap();
+        assert_eq!(repo.full_name, "KBVE/kbve");
+        assert_eq!(repo.default_branch, "main");
+        assert_eq!(repo.open_issues_count, 150);
+    }
+
+    #[test]
+    fn deserialize_branch_protection_json() {
+        let json = r#"{
+            "required_status_checks": {"strict": true, "contexts": ["ci/build"]},
+            "enforce_admins": {"enabled": true}
+        }"#;
+        let bp: GitHubBranchProtection = serde_json::from_str(json).unwrap();
+        assert!(bp.required_status_checks.unwrap().strict);
+        assert!(bp.enforce_admins.unwrap().enabled);
+    }
+
+    #[test]
+    fn deserialize_issue_missing_optional_labels() {
+        let json = r#"{
+            "number": 1,
+            "title": "No labels",
+            "state": "open",
+            "user": {"login": "u"},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com/1"
+        }"#;
+        let issue: GitHubIssue = serde_json::from_str(json).unwrap();
+        assert!(issue.labels.is_empty());
+    }
+
+    // ── Stale filtering ──────────────────────────────────────────────
+
+    #[test]
+    fn stale_issues_filters_by_threshold() {
+        let issues = vec![
+            make_issue(1, &days_ago(10), vec![]),
+            make_issue(2, &days_ago(2), vec![]),
+            make_issue(3, &days_ago(5), vec![]),
+        ];
+        let stale = GitHubClient::stale_issues(&issues, 3);
+        assert_eq!(stale.len(), 2);
+        assert!(stale.iter().any(|i| i.number == 1));
+        assert!(stale.iter().any(|i| i.number == 3));
+    }
+
+    #[test]
+    fn stale_issues_empty_when_all_recent() {
+        let issues = vec![
+            make_issue(1, &days_ago(0), vec![]),
+            make_issue(2, &days_ago(1), vec![]),
+        ];
+        let stale = GitHubClient::stale_issues(&issues, 7);
+        assert!(stale.is_empty());
+    }
+
+    #[test]
+    fn stale_pulls_filters_by_threshold() {
+        let pulls = vec![
+            make_pull(1, &days_ago(15), false),
+            make_pull(2, &days_ago(1), true),
+        ];
+        let stale = GitHubClient::stale_pulls(&pulls, 7);
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].number, 1);
+    }
+
+    #[test]
+    fn stale_issues_handles_invalid_dates() {
+        let issues = vec![make_issue(1, "not-a-date", vec![])];
+        let stale = GitHubClient::stale_issues(&issues, 1);
+        assert!(stale.is_empty());
+    }
+
+    #[test]
+    fn stale_issues_empty_input() {
+        let stale = GitHubClient::stale_issues(&[], 1);
+        assert!(stale.is_empty());
+    }
+
+    // ── Client construction ──────────────────────────────────────────
+
+    #[test]
+    fn with_base_url_trims_trailing_slash() {
+        let client = GitHubClient::new("tok").with_base_url("https://gh.example.com/");
+        assert_eq!(client.base_url, "https://gh.example.com");
+    }
+}


### PR DESCRIPTION
## Summary
- 13 unit tests for jedi `GitHubClient`: type deserialization (issues, PRs, commits, repos, branch protection), stale filtering by threshold, invalid date handling, `with_base_url` trimming
- 18 unit tests for notice board embeds: `NoticePriority::from_labels()` mapping (critical, blocker, high, urgent, medium, low, default), `NoticeItem` field extraction from issues/PRs, `notices_from_stale()` filtering and sorting, summary embed structure, `days_since_update` helper, truncation
- 15 unit tests for task board embeds: `TaskStatus` mapping, department extraction from labels (programming, 3d art, devops, fallback), `tasks_from_issues()`, embed grouping by department, progress counts, truncation helpers

## Test plan
- [x] `cargo test -p jedi --lib github` — 13 passed
- [x] `cargo test -p axum-discordsh --bin axum-discordsh -- notice_board_embed` — 18 passed
- [x] `cargo test -p axum-discordsh --bin axum-discordsh -- task_board_embed` — 15 passed

Partial #8150, partial #7856