### PR TITLE
fix(droid): add missing event schemas and improve test coverage

### DIFF
--- a/packages/npm/droid/src/lib/state/auth.spec.ts
+++ b/packages/npm/droid/src/lib/state/auth.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { $auth, setAuth, resetAuth } from './auth';
+
+beforeEach(() => {
+	resetAuth();
+	// resetAuth sets tone to 'anon', restore to default 'loading' for clean tests
+	$auth.set({
+		tone: 'loading',
+		name: '',
+		avatar: undefined,
+		id: '',
+		error: undefined,
+	});
+});
+
+describe('Auth state', () => {
+	it('starts with loading tone', () => {
+		expect($auth.get().tone).toBe('loading');
+	});
+
+	it('setAuth merges partial state', () => {
+		setAuth({ tone: 'auth', name: 'Alice', id: 'u1' });
+
+		const state = $auth.get();
+		expect(state.tone).toBe('auth');
+		expect(state.name).toBe('Alice');
+		expect(state.id).toBe('u1');
+		expect(state.avatar).toBeUndefined();
+	});
+
+	it('setAuth preserves existing fields', () => {
+		setAuth({ tone: 'auth', name: 'Alice', id: 'u1' });
+		setAuth({ avatar: 'https://example.com/avatar.png' });
+
+		const state = $auth.get();
+		expect(state.name).toBe('Alice');
+		expect(state.avatar).toBe('https://example.com/avatar.png');
+	});
+
+	it('setAuth can set error state', () => {
+		setAuth({ tone: 'error', error: 'Token expired' });
+
+		expect($auth.get().tone).toBe('error');
+		expect($auth.get().error).toBe('Token expired');
+	});
+
+	it('resetAuth clears to anon defaults', () => {
+		setAuth({ tone: 'auth', name: 'Alice', id: 'u1', avatar: 'img.png' });
+		resetAuth();
+
+		const state = $auth.get();
+		expect(state.tone).toBe('anon');
+		expect(state.name).toBe('');
+		expect(state.id).toBe('');
+		expect(state.avatar).toBeUndefined();
+		expect(state.error).toBeUndefined();
+	});
+});

--- a/packages/npm/droid/src/lib/state/toasts.spec.ts
+++ b/packages/npm/droid/src/lib/state/toasts.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { $toasts, addToast, removeToast } from './toasts';
+import { DroidEvents } from '../workers/events';
+import type { ToastPayload } from '../types/ui-event-types';
+
+beforeEach(() => {
+	$toasts.set({});
+	// Reset the toast queue
+	(window as Record<string, unknown>).__kbveToastQueue = undefined;
+});
+
+const makeToast = (
+	id: string,
+	overrides?: Partial<ToastPayload>,
+): ToastPayload => ({
+	id,
+	message: `Toast ${id}`,
+	severity: 'info',
+	...overrides,
+});
+
+describe('addToast', () => {
+	it('adds toast to the nanostore', () => {
+		addToast(makeToast('t1'));
+		expect($toasts.get()).toHaveProperty('t1');
+		expect($toasts.get()['t1'].message).toBe('Toast t1');
+	});
+
+	it('adds multiple toasts', () => {
+		addToast(makeToast('t1'));
+		addToast(makeToast('t2', { severity: 'error' }));
+
+		const state = $toasts.get();
+		expect(Object.keys(state)).toHaveLength(2);
+		expect(state['t2'].severity).toBe('error');
+	});
+
+	it('emits toast-added event', () => {
+		const handler = vi.fn();
+		DroidEvents.on('toast-added', handler);
+
+		const toast = makeToast('t1');
+		addToast(toast);
+
+		expect(handler).toHaveBeenCalledWith(toast);
+		DroidEvents.off('toast-added', handler);
+	});
+
+	it('pushes to the pre-mount queue', () => {
+		addToast(makeToast('t1'));
+
+		const queue = (window as Record<string, unknown>)
+			.__kbveToastQueue as ToastPayload[];
+		expect(queue).toHaveLength(1);
+		expect(queue[0].id).toBe('t1');
+	});
+
+	it('does not push to queue when queue is drained (null)', () => {
+		(window as Record<string, unknown>).__kbveToastQueue = null;
+
+		addToast(makeToast('t1'));
+
+		expect((window as Record<string, unknown>).__kbveToastQueue).toBeNull();
+		// But the nanostore should still have it
+		expect($toasts.get()).toHaveProperty('t1');
+	});
+});
+
+describe('removeToast', () => {
+	it('removes toast from the nanostore', () => {
+		addToast(makeToast('t1'));
+		addToast(makeToast('t2'));
+
+		removeToast('t1');
+
+		expect($toasts.get()).not.toHaveProperty('t1');
+		expect($toasts.get()).toHaveProperty('t2');
+	});
+
+	it('emits toast-removed event', () => {
+		const handler = vi.fn();
+		DroidEvents.on('toast-removed', handler);
+
+		addToast(makeToast('t1'));
+		removeToast('t1');
+
+		expect(handler).toHaveBeenCalledWith({ id: 't1' });
+		DroidEvents.off('toast-removed', handler);
+	});
+
+	it('removes toast from the pre-mount queue', () => {
+		addToast(makeToast('t1'));
+		addToast(makeToast('t2'));
+
+		removeToast('t1');
+
+		const queue = (window as Record<string, unknown>)
+			.__kbveToastQueue as ToastPayload[];
+		expect(queue).toHaveLength(1);
+		expect(queue[0].id).toBe('t2');
+	});
+
+	it('handles removing a non-existent toast gracefully', () => {
+		expect(() => removeToast('non-existent')).not.toThrow();
+	});
+});

--- a/packages/npm/droid/src/lib/state/ui.spec.ts
+++ b/packages/npm/droid/src/lib/state/ui.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+	$activeTooltip,
+	$drawerOpen,
+	$modalId,
+	openTooltip,
+	closeTooltip,
+	openDrawer,
+	closeDrawer,
+	openModal,
+	closeModal,
+} from './ui';
+import { DroidEvents } from '../workers/events';
+
+beforeEach(() => {
+	$activeTooltip.set(null);
+	$drawerOpen.set(false);
+	$modalId.set(null);
+});
+
+describe('Tooltip state', () => {
+	it('openTooltip sets the active tooltip', () => {
+		openTooltip('tip-1');
+		expect($activeTooltip.get()).toBe('tip-1');
+	});
+
+	it('openTooltip emits tooltip-opened event', () => {
+		const handler = vi.fn();
+		DroidEvents.on('tooltip-opened', handler);
+
+		openTooltip('tip-2');
+
+		expect(handler).toHaveBeenCalledWith({ id: 'tip-2' });
+		DroidEvents.off('tooltip-opened', handler);
+	});
+
+	it('closeTooltip clears the active tooltip', () => {
+		openTooltip('tip-1');
+		closeTooltip();
+		expect($activeTooltip.get()).toBeNull();
+	});
+
+	it('closeTooltip emits tooltip-closed event', () => {
+		const handler = vi.fn();
+		DroidEvents.on('tooltip-closed', handler);
+
+		openTooltip('tip-1');
+		closeTooltip();
+
+		expect(handler).toHaveBeenCalledWith({ id: 'tip-1' });
+		DroidEvents.off('tooltip-closed', handler);
+	});
+
+	it('closeTooltip with mismatched id does nothing', () => {
+		openTooltip('tip-1');
+		closeTooltip('tip-2');
+		expect($activeTooltip.get()).toBe('tip-1');
+	});
+
+	it('closeTooltip with matching id clears tooltip', () => {
+		openTooltip('tip-1');
+		closeTooltip('tip-1');
+		expect($activeTooltip.get()).toBeNull();
+	});
+
+	it('closeTooltip does not emit when no tooltip is active', () => {
+		const handler = vi.fn();
+		DroidEvents.on('tooltip-closed', handler);
+
+		closeTooltip();
+
+		expect(handler).not.toHaveBeenCalled();
+		DroidEvents.off('tooltip-closed', handler);
+	});
+});
+
+describe('Drawer state', () => {
+	it('openDrawer sets drawer open and clears tooltip', () => {
+		openTooltip('tip-1');
+		openDrawer();
+		expect($drawerOpen.get()).toBe(true);
+		expect($activeTooltip.get()).toBeNull();
+	});
+
+	it('closeDrawer sets drawer closed', () => {
+		openDrawer();
+		closeDrawer();
+		expect($drawerOpen.get()).toBe(false);
+	});
+});
+
+describe('Modal state', () => {
+	it('openModal sets the modal id', () => {
+		openModal('modal-1');
+		expect($modalId.get()).toBe('modal-1');
+	});
+
+	it('openModal closes drawer and tooltip', () => {
+		openDrawer();
+		openTooltip('tip-1');
+		openModal('modal-1');
+		expect($drawerOpen.get()).toBe(false);
+		expect($activeTooltip.get()).toBeNull();
+	});
+
+	it('openModal emits modal-opened event', () => {
+		const handler = vi.fn();
+		DroidEvents.on('modal-opened', handler);
+
+		openModal('modal-1');
+
+		expect(handler).toHaveBeenCalledWith({ id: 'modal-1' });
+		DroidEvents.off('modal-opened', handler);
+	});
+
+	it('closeModal clears the modal id', () => {
+		openModal('modal-1');
+		closeModal();
+		expect($modalId.get()).toBeNull();
+	});
+
+	it('closeModal emits modal-closed event', () => {
+		const handler = vi.fn();
+		DroidEvents.on('modal-closed', handler);
+
+		openModal('modal-1');
+		closeModal();
+
+		expect(handler).toHaveBeenCalledWith({ id: 'modal-1' });
+		DroidEvents.off('modal-closed', handler);
+	});
+
+	it('closeModal with mismatched id does nothing', () => {
+		openModal('modal-1');
+		closeModal('modal-2');
+		expect($modalId.get()).toBe('modal-1');
+	});
+
+	it('closeModal does not emit when no modal is active', () => {
+		const handler = vi.fn();
+		DroidEvents.on('modal-closed', handler);
+
+		closeModal();
+
+		expect(handler).not.toHaveBeenCalled();
+		DroidEvents.off('modal-closed', handler);
+	});
+});

--- a/packages/npm/droid/src/lib/types/bento.spec.ts
+++ b/packages/npm/droid/src/lib/types/bento.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+	BentoTileSchema,
+	BENTO_VARIANT_CLASS_MAP,
+	BENTO_ANIMATION_CLASS_MAP,
+	BENTO_BADGE_CLASS_MAP,
+} from './bento';
+
+const validTile = {
+	title: 'Test Tile',
+	primaryColor: 'blue-500',
+	secondaryColor: 'red-300',
+};
+
+describe('BentoTileSchema', () => {
+	it('accepts a minimal valid tile', () => {
+		const result = BentoTileSchema.safeParse(validTile);
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects empty title', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			title: '',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects invalid primary color format', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			primaryColor: 'invalid',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts valid ULID id', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects invalid ULID id', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			id: 'not-a-ulid',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts valid span format', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			span: 'col-span-2',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('requires target when href is provided', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			href: 'https://example.com',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts href with target', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			href: 'https://example.com',
+			target: '_blank',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('requires badge text when badgeType is set', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			badgeType: 'success',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts badge with badgeType', () => {
+		const result = BentoTileSchema.safeParse({
+			...validTile,
+			badge: 'New',
+			badgeType: 'success',
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('Bento class maps', () => {
+	it('BENTO_VARIANT_CLASS_MAP has all variants', () => {
+		expect(BENTO_VARIANT_CLASS_MAP).toHaveProperty('default');
+		expect(BENTO_VARIANT_CLASS_MAP).toHaveProperty('minimal');
+		expect(BENTO_VARIANT_CLASS_MAP).toHaveProperty('image-heavy');
+	});
+
+	it('BENTO_ANIMATION_CLASS_MAP has all animations', () => {
+		expect(BENTO_ANIMATION_CLASS_MAP).toHaveProperty('fade-in');
+		expect(BENTO_ANIMATION_CLASS_MAP).toHaveProperty('slide-up');
+		expect(BENTO_ANIMATION_CLASS_MAP).toHaveProperty('none');
+		expect(BENTO_ANIMATION_CLASS_MAP['none']).toBe('');
+	});
+
+	it('BENTO_BADGE_CLASS_MAP has all badge types', () => {
+		expect(BENTO_BADGE_CLASS_MAP).toHaveProperty('default');
+		expect(BENTO_BADGE_CLASS_MAP).toHaveProperty('success');
+		expect(BENTO_BADGE_CLASS_MAP).toHaveProperty('warning');
+		expect(BENTO_BADGE_CLASS_MAP).toHaveProperty('error');
+	});
+});

--- a/packages/npm/droid/src/lib/types/event-types.spec.ts
+++ b/packages/npm/droid/src/lib/types/event-types.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+	DroidEventSchemas,
+	DroidReadySchema,
+	DroidFirstConnectSchema,
+	DroidDownscaleSchema,
+	DroidUpscaleSchema,
+} from './event-types';
+
+describe('DroidEventSchemas', () => {
+	it('has all expected event keys', () => {
+		const keys = Object.keys(DroidEventSchemas);
+		expect(keys).toContain('droid-first-connect');
+		expect(keys).toContain('droid-ready');
+		expect(keys).toContain('droid-mod-ready');
+		expect(keys).toContain('droid-downscale');
+		expect(keys).toContain('droid-upscale');
+		expect(keys).toContain('panel-open');
+		expect(keys).toContain('panel-close');
+		expect(keys).toContain('toast-added');
+		expect(keys).toContain('toast-removed');
+		expect(keys).toContain('tooltip-opened');
+		expect(keys).toContain('tooltip-closed');
+		expect(keys).toContain('modal-opened');
+		expect(keys).toContain('modal-closed');
+	});
+
+	it('has exactly 13 event types', () => {
+		expect(Object.keys(DroidEventSchemas)).toHaveLength(13);
+	});
+});
+
+describe('DroidReadySchema', () => {
+	it('accepts valid payload', () => {
+		const result = DroidReadySchema.safeParse({ timestamp: 123 });
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects missing timestamp', () => {
+		const result = DroidReadySchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects non-number timestamp', () => {
+		const result = DroidReadySchema.safeParse({ timestamp: 'now' });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('DroidFirstConnectSchema', () => {
+	it('accepts valid payload', () => {
+		const result = DroidFirstConnectSchema.safeParse({
+			timestamp: 1,
+			workersFirst: { db: true, ws: false },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects missing workersFirst', () => {
+		const result = DroidFirstConnectSchema.safeParse({ timestamp: 1 });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('DroidDownscaleSchema', () => {
+	it('accepts valid payload', () => {
+		const result = DroidDownscaleSchema.safeParse({
+			timestamp: 1,
+			level: 'minimal',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects missing level', () => {
+		const result = DroidDownscaleSchema.safeParse({ timestamp: 1 });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('DroidUpscaleSchema', () => {
+	it('accepts valid payload', () => {
+		const result = DroidUpscaleSchema.safeParse({
+			timestamp: 1,
+			level: 'full',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects missing timestamp', () => {
+		const result = DroidUpscaleSchema.safeParse({ level: 'full' });
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/npm/droid/src/lib/types/event-types.ts
+++ b/packages/npm/droid/src/lib/types/event-types.ts
@@ -33,10 +33,22 @@ export const DroidFirstConnectSchema = z.object({
 	}),
 });
 
+export const DroidDownscaleSchema = z.object({
+	timestamp: z.number(),
+	level: z.string(),
+});
+
+export const DroidUpscaleSchema = z.object({
+	timestamp: z.number(),
+	level: z.string(),
+});
+
 export const DroidEventSchemas = {
 	'droid-first-connect': DroidFirstConnectSchema,
 	'droid-ready': DroidReadySchema,
 	'droid-mod-ready': DroidModReadySchema,
+	'droid-downscale': DroidDownscaleSchema,
+	'droid-upscale': DroidUpscaleSchema,
 	'panel-open': PanelEventSchema,
 	'panel-close': PanelEventSchema,
 	'toast-added': ToastPayloadSchema,

--- a/packages/npm/droid/src/lib/workers/events.spec.ts
+++ b/packages/npm/droid/src/lib/workers/events.spec.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We need a fresh DroidEventBus for each test, so import the class-creating module
+// and re-instantiate. Since the module exports a singleton, we'll test via dynamic import.
+// Actually, let's just test the singleton and reset between tests.
+
+// The module exports a singleton `DroidEvents`. We can still test it
+// by carefully managing listener cleanup.
+
+import { DroidEvents } from './events';
+
+beforeEach(() => {
+	// Remove all listeners by re-creating internal state isn't possible
+	// with the singleton, so we rely on off() in each test.
+});
+
+describe('DroidEventBus', () => {
+	it('should register and fire a listener via on/emit', () => {
+		const handler = vi.fn();
+		DroidEvents.on('droid-ready', handler);
+
+		DroidEvents.emit('droid-ready', { timestamp: 123 });
+
+		expect(handler).toHaveBeenCalledOnce();
+		expect(handler).toHaveBeenCalledWith({ timestamp: 123 });
+
+		DroidEvents.off('droid-ready', handler);
+	});
+
+	it('should unregister a listener via off', () => {
+		const handler = vi.fn();
+		DroidEvents.on('droid-ready', handler);
+		DroidEvents.off('droid-ready', handler);
+
+		DroidEvents.emit('droid-ready', { timestamp: 1 });
+
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it('should support multiple listeners on the same event', () => {
+		const h1 = vi.fn();
+		const h2 = vi.fn();
+		DroidEvents.on('droid-ready', h1);
+		DroidEvents.on('droid-ready', h2);
+
+		DroidEvents.emit('droid-ready', { timestamp: 1 });
+
+		expect(h1).toHaveBeenCalledOnce();
+		expect(h2).toHaveBeenCalledOnce();
+
+		DroidEvents.off('droid-ready', h1);
+		DroidEvents.off('droid-ready', h2);
+	});
+
+	it('should not fail when removing a listener that was never added', () => {
+		const handler = vi.fn();
+		expect(() => DroidEvents.off('droid-ready', handler)).not.toThrow();
+	});
+
+	it('should validate payload via Zod and reject invalid payloads', () => {
+		const handler = vi.fn();
+		DroidEvents.on('droid-ready', handler);
+
+		const consoleSpy = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => undefined);
+
+		// @ts-expect-error intentionally passing invalid payload
+		DroidEvents.emit('droid-ready', { timestamp: 'not-a-number' });
+
+		expect(handler).not.toHaveBeenCalled();
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining('[DroidEventBus] Invalid payload'),
+			expect.anything(),
+		);
+
+		consoleSpy.mockRestore();
+		DroidEvents.off('droid-ready', handler);
+	});
+
+	it('should dispatch a CustomEvent on window', () => {
+		const windowHandler = vi.fn();
+		window.addEventListener('droid-ready', windowHandler);
+
+		DroidEvents.emit('droid-ready', { timestamp: 42 });
+
+		expect(windowHandler).toHaveBeenCalledOnce();
+		const event = windowHandler.mock.calls[0][0] as CustomEvent;
+		expect(event.detail).toEqual({ timestamp: 42 });
+
+		window.removeEventListener('droid-ready', windowHandler);
+	});
+
+	it('should catch and log listener errors without breaking other listeners', () => {
+		const badHandler = vi.fn(() => {
+			throw new Error('boom');
+		});
+		const goodHandler = vi.fn();
+
+		DroidEvents.on('droid-ready', badHandler);
+		DroidEvents.on('droid-ready', goodHandler);
+
+		const consoleSpy = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => undefined);
+
+		DroidEvents.emit('droid-ready', { timestamp: 1 });
+
+		expect(badHandler).toHaveBeenCalledOnce();
+		expect(goodHandler).toHaveBeenCalledOnce();
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining('[DroidEventBus] Listener error'),
+			expect.anything(),
+		);
+
+		consoleSpy.mockRestore();
+		DroidEvents.off('droid-ready', badHandler);
+		DroidEvents.off('droid-ready', goodHandler);
+	});
+
+	it('should resolve wait() when the event fires', async () => {
+		const promise = DroidEvents.wait('droid-ready');
+
+		DroidEvents.emit('droid-ready', { timestamp: 999 });
+
+		const result = await promise;
+		expect(result).toEqual({ timestamp: 999 });
+	});
+
+	it('wait() should auto-unregister after resolving', async () => {
+		const promise = DroidEvents.wait('droid-ready');
+		DroidEvents.emit('droid-ready', { timestamp: 1 });
+		await promise;
+
+		// Emit again — the wait handler should not fire again
+		// (no way to directly test, but ensures no memory leak)
+		const handler = vi.fn();
+		DroidEvents.on('droid-ready', handler);
+		DroidEvents.emit('droid-ready', { timestamp: 2 });
+		expect(handler).toHaveBeenCalledOnce();
+		DroidEvents.off('droid-ready', handler);
+	});
+
+	it('should emit droid-downscale event with level payload', () => {
+		const handler = vi.fn();
+		DroidEvents.on('droid-downscale', handler);
+
+		DroidEvents.emit('droid-downscale', {
+			timestamp: Date.now(),
+			level: 'minimal',
+		});
+
+		expect(handler).toHaveBeenCalledOnce();
+		expect(handler.mock.calls[0][0].level).toBe('minimal');
+
+		DroidEvents.off('droid-downscale', handler);
+	});
+
+	it('should emit droid-upscale event with level payload', () => {
+		const handler = vi.fn();
+		DroidEvents.on('droid-upscale', handler);
+
+		DroidEvents.emit('droid-upscale', {
+			timestamp: Date.now(),
+			level: 'full',
+		});
+
+		expect(handler).toHaveBeenCalledOnce();
+		expect(handler.mock.calls[0][0].level).toBe('full');
+
+		DroidEvents.off('droid-upscale', handler);
+	});
+
+	it('should emit panel-open and panel-close events', () => {
+		const openHandler = vi.fn();
+		const closeHandler = vi.fn();
+		DroidEvents.on('panel-open', openHandler);
+		DroidEvents.on('panel-close', closeHandler);
+
+		DroidEvents.emit('panel-open', { id: 'left' });
+		DroidEvents.emit('panel-close', { id: 'right' });
+
+		expect(openHandler).toHaveBeenCalledWith({ id: 'left' });
+		expect(closeHandler).toHaveBeenCalledWith({ id: 'right' });
+
+		DroidEvents.off('panel-open', openHandler);
+		DroidEvents.off('panel-close', closeHandler);
+	});
+
+	it('should emit toast events', () => {
+		const handler = vi.fn();
+		DroidEvents.on('toast-added', handler);
+
+		DroidEvents.emit('toast-added', {
+			id: 'toast-1',
+			message: 'Hello',
+			severity: 'info',
+		});
+
+		expect(handler).toHaveBeenCalledWith({
+			id: 'toast-1',
+			message: 'Hello',
+			severity: 'info',
+		});
+
+		DroidEvents.off('toast-added', handler);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `DroidDownscaleSchema` and `DroidUpscaleSchema` to `DroidEventSchemas` — fixes TS2345 build errors in `main.ts` that caused the `discordsh:e2e` CI job to fail
- Add 67 new tests across event bus, UI state, toast state, auth state, event type schemas, and bento tile validation
- Coverage for `events.ts`, `ui.ts`, `toasts.ts`, `auth.ts`, `event-types.ts`, `bento.ts` all at 100%

## Test plan
- [x] `nx droid:coverage` — 72/72 tests pass
- [x] `nx droid:build` — builds cleanly
- [x] `nx astro-discordsh:build` — builds cleanly (no more TS2345 errors)