### PR TITLE
fix(axum-kbve): use COEP credentialless for supabase compatibility

### DIFF
--- a/apps/kbve/axum-kbve-e2e/e2e/static.spec.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/static.spec.ts
@@ -45,7 +45,7 @@ describe('Static file serving', () => {
 				'same-origin',
 			);
 			expect(res.headers.get('cross-origin-embedder-policy')).toBe(
-				'require-corp',
+				'credentialless',
 			);
 		}
 	});
@@ -57,7 +57,7 @@ describe('Static file serving', () => {
 				'same-origin',
 			);
 			expect(res.headers.get('cross-origin-embedder-policy')).toBe(
-				'require-corp',
+				'credentialless',
 			);
 		}
 	});

--- a/apps/kbve/axum-kbve/src/astro/mod.rs
+++ b/apps/kbve/axum-kbve/src/astro/mod.rs
@@ -106,6 +106,12 @@ pub fn build_static_router(config: &StaticConfig) -> Router {
 
 /// Middleware that adds COOP/COEP headers to /isometric/ responses,
 /// enabling SharedArrayBuffer for WASM pthreads.
+///
+/// Uses `credentialless` instead of `require-corp` for COEP so that
+/// cross-origin fetches (e.g. Supabase SDK → supabase.kbve.com) are
+/// allowed without requiring the remote server to send CORP headers.
+/// `credentialless` still enables SharedArrayBuffer while permitting
+/// cross-origin requests that don't use cookies.
 async fn coop_coep_isometric(req: axum::extract::Request, next: Next) -> impl IntoResponse {
     let path = req.uri().path();
     let is_isometric = path.starts_with("/isometric") || path.starts_with("/arcade/isometric");
@@ -118,7 +124,7 @@ async fn coop_coep_isometric(req: axum::extract::Request, next: Next) -> impl In
         );
         headers.insert(
             header::HeaderName::from_static("cross-origin-embedder-policy"),
-            HeaderValue::from_static("require-corp"),
+            HeaderValue::from_static("credentialless"),
         );
     }
     resp


### PR DESCRIPTION
## Summary
- Change `Cross-Origin-Embedder-Policy` from `require-corp` to `credentialless` on isometric pages
- `require-corp` blocked Supabase SDK cross-origin fetches to `supabase.kbve.com` because the remote server doesn't send CORP headers
- `credentialless` still enables `SharedArrayBuffer` for WASM pthreads while allowing cross-origin requests that don't use cookies
- Updated e2e tests to match new header value

## Test plan
- [ ] Visit `https://kbve.com/arcade/isometric/` and verify Supabase auth/SDK calls work
- [ ] Verify SharedArrayBuffer is still available (WASM workers spawn)
- [ ] e2e tests pass with updated COEP assertion