### PR TITLE
fix(axum-kbve): strip hop-by-hop headers in proxy to fix premature connection close

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.60"
+version = "1.0.61"
 edition = "2021"
 publish = false
 

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -50,8 +50,19 @@ impl ServiceProxy {
 
         let method = req.method().clone();
         let mut headers = req_headers;
+
+        // Strip hop-by-hop and content-negotiation headers before forwarding
+        // upstream. These must not cross proxy boundaries per RFC 7230 §6.1.
+        // accept-encoding is removed so upstream never compresses — we buffer
+        // the full body and re-serve it, so we need the raw bytes.
         headers.remove(header::HOST);
         headers.remove(header::AUTHORIZATION);
+        headers.remove(header::ACCEPT_ENCODING);
+        headers.remove(header::CONNECTION);
+        headers.remove("te");
+        headers.remove("trailers");
+        headers.remove("upgrade");
+        headers.remove("proxy-connection");
 
         // Inject upstream auth token if configured
         if let Some(token) = &self.upstream_token {
@@ -123,14 +134,38 @@ impl ServiceProxy {
         let status =
             StatusCode::from_u16(upstream_status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
-        // Collect headers before consuming the body
+        // Collect headers before consuming the body.
+        // Use `append` to preserve multi-value headers (e.g. Set-Cookie, Vary).
         let mut resp_headers = HeaderMap::new();
         for (k, v) in upstream_resp.headers() {
             if let Ok(name) = axum::http::HeaderName::from_bytes(k.as_str().as_bytes()) {
                 if let Ok(val) = HeaderValue::from_bytes(v.as_bytes()) {
-                    resp_headers.insert(name, val);
+                    resp_headers.append(name, val);
                 }
             }
+        }
+
+        // Strip hop-by-hop headers from the upstream response — they must not
+        // be forwarded to the downstream client (RFC 7230 §6.1). In particular:
+        //   transfer-encoding — body is already fully buffered; axum sets the
+        //                        correct content-length automatically.
+        //   connection        — forwarding "close" would make hyper close the
+        //                        nginx keep-alive connection prematurely, which
+        //                        nginx logs as "upstream prematurely closed".
+        //   content-encoding  — reqwest may have decoded the body; forwarding
+        //                        the original encoding header would mismatch.
+        const HOP_BY_HOP: &[&str] = &[
+            "transfer-encoding",
+            "connection",
+            "keep-alive",
+            "content-encoding",
+            "upgrade",
+            "proxy-connection",
+            "te",
+            "trailers",
+        ];
+        for h in HOP_BY_HOP {
+            resp_headers.remove(*h);
         }
 
         let resp_body = match upstream_resp.bytes().await {
@@ -428,7 +463,8 @@ fn reqwest_headers(headers: &HeaderMap) -> reqwest::header::HeaderMap {
     for (k, v) in headers {
         if let Ok(name) = reqwest::header::HeaderName::from_bytes(k.as_str().as_bytes()) {
             if let Ok(val) = reqwest::header::HeaderValue::from_bytes(v.as_bytes()) {
-                out.insert(name, val);
+                // Use append to preserve multi-value headers (Accept, Cookie, etc.)
+                out.append(name, val);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Strips hop-by-hop headers (`transfer-encoding`, `connection`, `keep-alive`, `content-encoding`, `upgrade`, `proxy-connection`, `te`, `trailers`) from upstream responses before forwarding — the most impactful fix: forwarding `Connection: close` from ArgoCD caused hyper to tear down the nginx keep-alive TCP connection immediately, which nginx logged as *"upstream prematurely closed connection while reading response header"*
- Strips `accept-encoding` and hop-by-hop headers from upstream requests so ArgoCD/Grafana never compress responses (body is fully buffered; raw bytes are needed to avoid content-encoding mismatches in the nginx pipeline)
- Switches from `insert` to `append` when building reqwest header maps so multi-value headers (`Accept`, `Cookie`, `Set-Cookie`, `Vary`) are no longer silently truncated

Bumps axum-kbve to v1.0.61.

## Test plan

- [ ] Deploy v1.0.61 and navigate to `https://kbve.com/dashboard/argo`
- [ ] Confirm `/dashboard/argo/proxy/api/v1/applications` returns 200 without nginx logging "upstream prematurely closed connection"
- [ ] Verify Grafana proxy still works (same code path)