### PR TITLE
fix(ci): exclude generated WASM assets from CodeQL scanning

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -50,6 +50,7 @@ jobs:
                           - 'apps/mc/pumpkin'
                           - 'apps/irc/ergo'
                           - 'apps/postgres'
+                          - 'apps/kbve/astro-kbve/public/isometric/assets'
 
             - name: Auto-build
               uses: github/codeql-action/autobuild@v4
@@ -84,6 +85,7 @@ jobs:
                           - 'apps/mc/pumpkin'
                           - 'apps/irc/ergo'
                           - 'apps/postgres'
+                          - 'apps/kbve/astro-kbve/public/isometric/assets'
 
             - name: Auto-build
               uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
## Summary
- Adds `apps/kbve/astro-kbve/public/isometric/assets` to `paths-ignore` in both CodeQL init steps (JS/TS+Python job and Rust job)

## Why
These files are machine-generated (wasm-bindgen → Vite bundle, auto-deployed by the bevy WASM build job). CodeQL was producing 27 false positive alerts against this output — `js/trivial-conditional`, `js/comparison-between-incompatible-types`, etc. None are actionable since the code is not human-authored.

The actual game source in `apps/kbve/isometric/src/` remains fully scanned.

Closes #8183