### PR TITLE
fix(isometric): Safari WebGPU crashes — setBindGroup SharedArrayBuffer shim + winit resize defer

### DIFF
--- a/apps/kbve/astro-kbve/public/isometric/index.html
+++ b/apps/kbve/astro-kbve/public/isometric/index.html
@@ -42,49 +42,7 @@
             }
             /* pointer-events managed per-component via Tailwind pointer-events-auto */
         </style>
-      <script>
-        // Safari WebGPU shim — must execute before the WASM module loads.
-        // See apps/kbve/isometric/index.html for full explanation.
-        (function() {
-            if (typeof GPURenderPassEncoder !== 'undefined') {
-                var _origR = GPURenderPassEncoder.prototype.setBindGroup;
-                GPURenderPassEncoder.prototype.setBindGroup = function(index, bg, offsets, start, len) {
-                    if (offsets instanceof Uint32Array && offsets.buffer instanceof SharedArrayBuffer) {
-                        var s = start !== undefined ? start : 0;
-                        var l = len !== undefined ? len : offsets.length;
-                        var copy = new Uint32Array(l);
-                        copy.set(offsets.subarray(s, s + l));
-                        return _origR.call(this, index, bg, copy, 0, l);
-                    }
-                    return _origR.call(this, index, bg, offsets, start, len);
-                };
-            }
-            if (typeof GPUComputePassEncoder !== 'undefined') {
-                var _origC = GPUComputePassEncoder.prototype.setBindGroup;
-                GPUComputePassEncoder.prototype.setBindGroup = function(index, bg, offsets, start, len) {
-                    if (offsets instanceof Uint32Array && offsets.buffer instanceof SharedArrayBuffer) {
-                        var s = start !== undefined ? start : 0;
-                        var l = len !== undefined ? len : offsets.length;
-                        var copy = new Uint32Array(l);
-                        copy.set(offsets.subarray(s, s + l));
-                        return _origC.call(this, index, bg, copy, 0, l);
-                    }
-                    return _origC.call(this, index, bg, offsets, start, len);
-                };
-            }
-            if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
-                var _origAEL = EventTarget.prototype.addEventListener;
-                var DEFER = { resize: true, orientationchange: true };
-                EventTarget.prototype.addEventListener = function(type, listener, options) {
-                    if (DEFER[type] && typeof listener === 'function') {
-                        var deferred = function(evt) { setTimeout(function() { listener(evt); }, 0); };
-                        return _origAEL.call(this, type, deferred, options);
-                    }
-                    return _origAEL.call(this, type, listener, options);
-                };
-            }
-        })();
-      </script>
+      <script src="/isometric/safari-shim.js"></script>
       <script type="module" crossorigin src="/isometric/assets/index.js"></script>
       <link rel="stylesheet" crossorigin href="/isometric/assets/index.css">
     </head>

--- a/apps/kbve/astro-kbve/public/isometric/safari-shim.js
+++ b/apps/kbve/astro-kbve/public/isometric/safari-shim.js
@@ -1,0 +1,74 @@
+/* global GPURenderPassEncoder, GPUComputePassEncoder */
+/**
+ * safari-shim.js — Safari WebGPU compatibility fixes for wgpu 27.x + winit 0.30.x
+ *
+ * Must be loaded as a plain <script> (not type="module") BEFORE the WASM module.
+ *
+ * Bug 1 — setBindGroup SharedArrayBuffer rejection (wgpu 27.x + Safari)
+ * -----------------------------------------------------------------------
+ * The WASM binary is compiled with +atomics / --shared-memory, so the WASM heap
+ * is a SharedArrayBuffer. wgpu creates Uint32Array *views* into that shared heap
+ * and passes them to GPURenderPassEncoder/GPUComputePassEncoder.setBindGroup() as
+ * the dynamicOffsetsData argument. Safari's WebGPU enforces the spec and rejects
+ * SharedArrayBuffer-backed TypedArrays here; Chrome is lenient.
+ * Fix: intercept setBindGroup and copy any SharedArrayBuffer-backed view into a
+ * fresh ArrayBuffer-backed Uint32Array before forwarding to the native method.
+ *
+ * Bug 2 — winit RefCell re-entrant borrow (winit 0.30.x + Safari)
+ * -----------------------------------------------------------------------
+ * Safari fires resize/orientationchange events synchronously inside
+ * requestAnimationFrame callbacks, causing winit's web event-loop runner to
+ * re-borrow an already-borrowed RefCell and panic.
+ * Fix: on Safari only, defer resize/orientationchange listeners via setTimeout(0)
+ * so they always arrive between frames, never re-entrantly.
+ */
+(function () {
+	function patchSetBindGroup(proto) {
+		if (!proto || typeof proto.setBindGroup !== 'function') return;
+		var orig = proto.setBindGroup;
+		proto.setBindGroup = function (index, bg, offsets, start, len) {
+			if (
+				offsets instanceof Uint32Array &&
+				offsets.buffer instanceof SharedArrayBuffer
+			) {
+				var s = start !== undefined ? start : 0;
+				var l = len !== undefined ? len : offsets.length;
+				var copy = new Uint32Array(l);
+				copy.set(offsets.subarray(s, s + l));
+				return orig.call(this, index, bg, copy, 0, l);
+			}
+			return orig.call(this, index, bg, offsets, start, len);
+		};
+	}
+
+	patchSetBindGroup(
+		typeof GPURenderPassEncoder !== 'undefined'
+			? GPURenderPassEncoder.prototype
+			: null,
+	);
+	patchSetBindGroup(
+		typeof GPUComputePassEncoder !== 'undefined'
+			? GPUComputePassEncoder.prototype
+			: null,
+	);
+
+	if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+		var origAEL = EventTarget.prototype.addEventListener;
+		var DEFER = { resize: true, orientationchange: true };
+		EventTarget.prototype.addEventListener = function (
+			type,
+			listener,
+			options,
+		) {
+			if (DEFER[type] && typeof listener === 'function') {
+				var deferred = function (evt) {
+					setTimeout(function () {
+						listener(evt);
+					}, 0);
+				};
+				return origAEL.call(this, type, deferred, options);
+			}
+			return origAEL.call(this, type, listener, options);
+		};
+	}
+})();

--- a/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
+++ b/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
@@ -36,77 +36,7 @@
 	<canvas id="bevy-canvas" style="display: none;"></canvas>
 	<div id="root" style="display: none;"></div>
 	<link rel="stylesheet" crossorigin href="/isometric/assets/index.css" />
-	<script is:inline>
-		// ---------------------------------------------------------------------------
-		// Safari WebGPU shim — runs before index.js is injected.
-		// See apps/kbve/isometric/index.html for full explanation.
-		// ---------------------------------------------------------------------------
-		(function () {
-			if (typeof GPURenderPassEncoder !== 'undefined') {
-				var _origR = GPURenderPassEncoder.prototype.setBindGroup;
-				GPURenderPassEncoder.prototype.setBindGroup = function (
-					index,
-					bg,
-					offsets,
-					start,
-					len,
-				) {
-					if (
-						offsets instanceof Uint32Array &&
-						offsets.buffer instanceof SharedArrayBuffer
-					) {
-						var s = start !== undefined ? start : 0;
-						var l = len !== undefined ? len : offsets.length;
-						var copy = new Uint32Array(l);
-						copy.set(offsets.subarray(s, s + l));
-						return _origR.call(this, index, bg, copy, 0, l);
-					}
-					return _origR.call(this, index, bg, offsets, start, len);
-				};
-			}
-			if (typeof GPUComputePassEncoder !== 'undefined') {
-				var _origC = GPUComputePassEncoder.prototype.setBindGroup;
-				GPUComputePassEncoder.prototype.setBindGroup = function (
-					index,
-					bg,
-					offsets,
-					start,
-					len,
-				) {
-					if (
-						offsets instanceof Uint32Array &&
-						offsets.buffer instanceof SharedArrayBuffer
-					) {
-						var s = start !== undefined ? start : 0;
-						var l = len !== undefined ? len : offsets.length;
-						var copy = new Uint32Array(l);
-						copy.set(offsets.subarray(s, s + l));
-						return _origC.call(this, index, bg, copy, 0, l);
-					}
-					return _origC.call(this, index, bg, offsets, start, len);
-				};
-			}
-			if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
-				var _origAEL = EventTarget.prototype.addEventListener;
-				var DEFER = { resize: true, orientationchange: true };
-				EventTarget.prototype.addEventListener = function (
-					type,
-					listener,
-					options,
-				) {
-					if (DEFER[type] && typeof listener === 'function') {
-						var deferred = function (evt) {
-							setTimeout(function () {
-								listener(evt);
-							}, 0);
-						};
-						return _origAEL.call(this, type, deferred, options);
-					}
-					return _origAEL.call(this, type, listener, options);
-				};
-			}
-		})();
-	</script>
+	<script is:inline src="/isometric/safari-shim.js"></script>
 	<script is:inline>
 		(function () {
 			// Downscale droid workers to free threads for WASM pthreads

--- a/apps/kbve/isometric/index.html
+++ b/apps/kbve/isometric/index.html
@@ -46,84 +46,8 @@
     <body>
         <canvas id="bevy-canvas" tabindex="0"></canvas>
         <div id="root"></div>
+        <script src="/isometric/safari-shim.js"></script>
         <script>
-            // ---------------------------------------------------------------------------
-            // Safari WebGPU shim — must run before the WASM module initialises.
-            //
-            // Bug 1 — setBindGroup SharedArrayBuffer rejection (wgpu 27.x + Safari)
-            // -----------------------------------------------------------------------
-            // The WASM binary is compiled with +atomics / --shared-memory, so the
-            // WASM heap is a SharedArrayBuffer.  wgpu builds Uint32Array *views* into
-            // that shared heap and passes them to GPURenderPassEncoder.setBindGroup()
-            // as the dynamicOffsetsData argument.  Safari's WebGPU implementation
-            // rejects SharedArrayBuffer-backed TypedArrays here (spec §GPUBuffer
-            // requires regular ArrayBuffer); Chrome is lenient.  The fix: intercept
-            // the call and copy any SharedArrayBuffer-backed view into a fresh
-            // ArrayBuffer-backed Uint32Array before forwarding to the native method.
-            //
-            // Bug 2 — winit RefCell re-entrant borrow (winit 0.30.x + Safari)
-            // -----------------------------------------------------------------------
-            // Safari fires resize / visualViewport events synchronously inside a
-            // requestAnimationFrame callback, causing winit's web event-loop runner
-            // to re-borrow an already-borrowed RefCell and panic.  The fix: queue
-            // these events with a zero-timeout so they always arrive between frames,
-            // never re-entrantly.
-            // ---------------------------------------------------------------------------
-
-            (function() {
-                // ── Bug 1: setBindGroup SharedArrayBuffer shim ──────────────────────
-                if (typeof GPURenderPassEncoder !== 'undefined') {
-                    var _origRenderSetBindGroup = GPURenderPassEncoder.prototype.setBindGroup;
-                    GPURenderPassEncoder.prototype.setBindGroup = function(index, bindGroup, dynamicOffsets, start, length) {
-                        if (dynamicOffsets instanceof Uint32Array &&
-                                dynamicOffsets.buffer instanceof SharedArrayBuffer) {
-                            // Copy from shared memory into a plain ArrayBuffer slice.
-                            // start/length select the relevant sub-range when wgpu uses
-                            // a subarray view — copy only that window.
-                            var s = (start !== undefined) ? start : 0;
-                            var l = (length !== undefined) ? length : dynamicOffsets.length;
-                            var copy = new Uint32Array(l);
-                            copy.set(dynamicOffsets.subarray(s, s + l));
-                            return _origRenderSetBindGroup.call(this, index, bindGroup, copy, 0, l);
-                        }
-                        return _origRenderSetBindGroup.call(this, index, bindGroup, dynamicOffsets, start, length);
-                    };
-                }
-                if (typeof GPUComputePassEncoder !== 'undefined') {
-                    var _origComputeSetBindGroup = GPUComputePassEncoder.prototype.setBindGroup;
-                    GPUComputePassEncoder.prototype.setBindGroup = function(index, bindGroup, dynamicOffsets, start, length) {
-                        if (dynamicOffsets instanceof Uint32Array &&
-                                dynamicOffsets.buffer instanceof SharedArrayBuffer) {
-                            var s = (start !== undefined) ? start : 0;
-                            var l = (length !== undefined) ? length : dynamicOffsets.length;
-                            var copy = new Uint32Array(l);
-                            copy.set(dynamicOffsets.subarray(s, s + l));
-                            return _origComputeSetBindGroup.call(this, index, bindGroup, copy, 0, l);
-                        }
-                        return _origComputeSetBindGroup.call(this, index, bindGroup, dynamicOffsets, start, length);
-                    };
-                }
-
-                // ── Bug 2: winit RefCell re-entrant borrow guard ────────────────────
-                // Defer resize / viewport events so they never fire synchronously
-                // inside a rAF callback (which would re-enter winit's RefCell).
-                // Only apply on Safari (avoid unnecessary overhead on Chrome/Firefox).
-                var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-                if (isSafari) {
-                    var _origAddEventListener = EventTarget.prototype.addEventListener;
-                    var DEFER_TYPES = { 'resize': true, 'orientationchange': true };
-                    EventTarget.prototype.addEventListener = function(type, listener, options) {
-                        if (DEFER_TYPES[type] && typeof listener === 'function') {
-                            var deferred = function(evt) {
-                                setTimeout(function() { listener(evt); }, 0);
-                            };
-                            return _origAddEventListener.call(this, type, deferred, options);
-                        }
-                        return _origAddEventListener.call(this, type, listener, options);
-                    };
-                }
-            })();
-
             // Auto-focus the Bevy canvas so keyboard events reach winit.
             // Re-focus after any click on the page (React buttons steal focus).
             document.addEventListener('pointerup', function() {

--- a/apps/kbve/isometric/public/safari-shim.js
+++ b/apps/kbve/isometric/public/safari-shim.js
@@ -1,0 +1,74 @@
+/* global GPURenderPassEncoder, GPUComputePassEncoder */
+/**
+ * safari-shim.js — Safari WebGPU compatibility fixes for wgpu 27.x + winit 0.30.x
+ *
+ * Must be loaded as a plain <script> (not type="module") BEFORE the WASM module.
+ *
+ * Bug 1 — setBindGroup SharedArrayBuffer rejection (wgpu 27.x + Safari)
+ * -----------------------------------------------------------------------
+ * The WASM binary is compiled with +atomics / --shared-memory, so the WASM heap
+ * is a SharedArrayBuffer. wgpu creates Uint32Array *views* into that shared heap
+ * and passes them to GPURenderPassEncoder/GPUComputePassEncoder.setBindGroup() as
+ * the dynamicOffsetsData argument. Safari's WebGPU enforces the spec and rejects
+ * SharedArrayBuffer-backed TypedArrays here; Chrome is lenient.
+ * Fix: intercept setBindGroup and copy any SharedArrayBuffer-backed view into a
+ * fresh ArrayBuffer-backed Uint32Array before forwarding to the native method.
+ *
+ * Bug 2 — winit RefCell re-entrant borrow (winit 0.30.x + Safari)
+ * -----------------------------------------------------------------------
+ * Safari fires resize/orientationchange events synchronously inside
+ * requestAnimationFrame callbacks, causing winit's web event-loop runner to
+ * re-borrow an already-borrowed RefCell and panic.
+ * Fix: on Safari only, defer resize/orientationchange listeners via setTimeout(0)
+ * so they always arrive between frames, never re-entrantly.
+ */
+(function () {
+	function patchSetBindGroup(proto) {
+		if (!proto || typeof proto.setBindGroup !== 'function') return;
+		var orig = proto.setBindGroup;
+		proto.setBindGroup = function (index, bg, offsets, start, len) {
+			if (
+				offsets instanceof Uint32Array &&
+				offsets.buffer instanceof SharedArrayBuffer
+			) {
+				var s = start !== undefined ? start : 0;
+				var l = len !== undefined ? len : offsets.length;
+				var copy = new Uint32Array(l);
+				copy.set(offsets.subarray(s, s + l));
+				return orig.call(this, index, bg, copy, 0, l);
+			}
+			return orig.call(this, index, bg, offsets, start, len);
+		};
+	}
+
+	patchSetBindGroup(
+		typeof GPURenderPassEncoder !== 'undefined'
+			? GPURenderPassEncoder.prototype
+			: null,
+	);
+	patchSetBindGroup(
+		typeof GPUComputePassEncoder !== 'undefined'
+			? GPUComputePassEncoder.prototype
+			: null,
+	);
+
+	if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+		var origAEL = EventTarget.prototype.addEventListener;
+		var DEFER = { resize: true, orientationchange: true };
+		EventTarget.prototype.addEventListener = function (
+			type,
+			listener,
+			options,
+		) {
+			if (DEFER[type] && typeof listener === 'function') {
+				var deferred = function (evt) {
+					setTimeout(function () {
+						listener(evt);
+					}, 0);
+				};
+				return origAEL.call(this, type, deferred, options);
+			}
+			return origAEL.call(this, type, listener, options);
+		};
+	}
+})();


### PR DESCRIPTION
## Summary

Two Safari-specific crashes fixed via JS shim in `index.html` (no Rust/wgpu changes needed):

### Bug 1 — Fatal render crash: `setBindGroup must be an instance of Uint32Array`
- **Root cause**: WASM compiled with `+atomics/--shared-memory` means the WASM heap is a `SharedArrayBuffer`. wgpu 27.x creates `Uint32Array` views directly into that shared heap and passes them to `GPURenderPassEncoder.setBindGroup()`. Safari's WebGPU enforces the spec and rejects `SharedArrayBuffer`-backed typed arrays; Chrome is lenient.
- **Fix**: Intercept `setBindGroup` on both `GPURenderPassEncoder` and `GPUComputePassEncoder`. If the `dynamicOffsets` argument is backed by `SharedArrayBuffer`, copy the relevant slice into a fresh `ArrayBuffer`-backed `Uint32Array` before forwarding.

### Bug 2 — Startup panic: `RefCell already borrowed` (winit 0.30.13)
- **Root cause**: Safari fires `resize`/`orientationchange` events synchronously inside `requestAnimationFrame` callbacks. This re-enters winit's web event-loop runner and double-borrows its internal `RefCell`, causing a panic.
- **Fix**: On Safari only, wrap `addEventListener` to defer `resize` and `orientationchange` listeners via `setTimeout(0)`, ensuring they always arrive between frames rather than re-entrantly.

## Test plan
- [ ] Open `kbve.com/isometric` in Safari 18+ — game should load and render without crashing
- [ ] Confirm no regression in Chrome/Firefox (shims are either no-ops or Safari-gated)
- [ ] Resize the Safari window while the game runs — no RefCell panic