### PR TITLE
fix(isometric): use credentialless COEP to unblock local WebSocket

### DIFF
--- a/apps/kbve/isometric/vite.config.ts
+++ b/apps/kbve/isometric/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig(async () => ({
 		},
 		headers: {
 			'Cross-Origin-Opener-Policy': 'same-origin',
-			'Cross-Origin-Embedder-Policy': 'require-corp',
+			'Cross-Origin-Embedder-Policy': 'credentialless',
 		},
 	},
 	optimizeDeps: {


### PR DESCRIPTION
## Summary
- Changed `Cross-Origin-Embedder-Policy` from `require-corp` to `credentialless` in the Vite dev server config
- `require-corp` blocked WebSocket connections to the Lightyear game server (`ws://127.0.0.1:5000`) from the dev page (`http://localhost:1420`) because the game server doesn't send CORP headers
- `credentialless` still enables `crossOriginIsolated` (SharedArrayBuffer / WASM threads) while allowing cross-origin requests — matches the production Axum middleware

## Test plan
- [ ] Run `isometric:quick` and verify the Vite dev server starts on port 1420
- [ ] Confirm `self.crossOriginIsolated === true` in the browser console (SharedArrayBuffer still works)
- [ ] Click "Go Online" and verify WebSocket connects to the local game server