### PR TITLE
feat(ci): roll out failure tracker to all main workflows

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -563,3 +563,35 @@ jobs:
                   else
                     echo "### Auto-Merge: ${{ needs.auto_merge.result }}"
                   fi
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Atomic branch failures silently break branch state without alerting.
+    # ---------------------------------------------------------------------------
+    track-run-tests:
+        name: Track Run Tests
+        if: always()
+        needs: [run_tests]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Atomic Branches'
+            job_name: 'Run Tests'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.run_tests.result }}
+
+    track-auto-merge:
+        name: Track Auto Merge
+        if: always()
+        needs: [auto_merge]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Atomic Branches'
+            job_name: 'Auto-Merge Authorized PRs'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.auto_merge.result }}

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -340,3 +340,49 @@ jobs:
             base-ref: origin/main
             head-ref: origin/dev
             check-conflicts: true
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Dev branch orchestrator — failures here break PR creation and Docker builds.
+    # ---------------------------------------------------------------------------
+    track-dev-to-main-pr:
+        name: Track Dev to Main PR
+        if: always()
+        needs: [dev_to_main_pr]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Dev'
+            job_name: 'Create/Update Dev to Main PR'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.dev_to_main_pr.result }}
+
+    track-dev-docker-mc:
+        name: Track Dev Docker MC
+        if: always()
+        needs: [dev_docker_mc]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Dev'
+            job_name: 'Dev Docker Build — MC'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.dev_docker_mc.result }}
+
+    track-validate-pr:
+        name: Track Validate PR
+        if: always()
+        needs: [validate_pr]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Dev'
+            job_name: 'Validate Dev→Main PR'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.validate_pr.result }}

--- a/.github/workflows/ci-docker-smoke-test.yml
+++ b/.github/workflows/ci-docker-smoke-test.yml
@@ -257,35 +257,47 @@ jobs:
 
     # ---------------------------------------------------------------------------
     # Failure tracker — surfaces failures as GitHub issues (#8186).
-    # Scheduled workflows are easy to miss without this; failures go unnoticed
-    # until the weekly digest pin silently stops working.
+    # Uses always() + status pass-through so the tracker can both create
+    # issues on failure AND auto-close them when the job recovers.
     # ---------------------------------------------------------------------------
-    track_resolve_failure:
-        name: Track Resolve Failure
-        if: ${{ always() && needs.resolve_digests.result == 'failure' }}
+    track-resolve-digests:
+        name: Track Resolve Digests
+        if: always()
         needs: [resolve_digests]
         permissions:
             issues: write
-            contents: read
-        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
         with:
             workflow_name: 'CI - Docker Smoke Test'
-            job_name: 'resolve_digests'
+            job_name: 'Resolve Base Image Digests'
             run_id: ${{ github.run_id }}
             run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             status: ${{ needs.resolve_digests.result }}
 
-    track_smoke_failure:
-        name: Track Smoke Build Failure
-        if: ${{ always() && needs.smoke_build.result == 'failure' }}
+    track-smoke-build:
+        name: Track Smoke Build
+        if: always()
         needs: [smoke_build]
         permissions:
             issues: write
-            contents: read
-        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
         with:
             workflow_name: 'CI - Docker Smoke Test'
-            job_name: 'smoke_build'
+            job_name: 'Smoke Build'
             run_id: ${{ github.run_id }}
             run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             status: ${{ needs.smoke_build.result }}
+
+    track-create-pr:
+        name: Track Create PR
+        if: always()
+        needs: [create_pr]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Docker Smoke Test'
+            job_name: 'Create Digest Update PR'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.create_pr.result }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -181,3 +181,79 @@ jobs:
                   [ "${{ needs.alter.outputs.py_lib_kbve }}"    = "true" ] && dispatch_python "python-kbve"    "kbve"
 
                   echo "All publish dispatches complete"
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Release pipeline — failures here block deploys. Grouped by phase:
+    #   - Infrastructure (globals, sync, alter)
+    #   - Dispatch (docker, publish)
+    # ---------------------------------------------------------------------------
+    track-globals:
+        name: Track Globals
+        if: always()
+        needs: [globals]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Main'
+            job_name: 'Global Variables'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.globals.result }}
+
+    track-call-sync:
+        name: Track Call Sync
+        if: always()
+        needs: [call_sync]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Main'
+            job_name: 'Call Sync Workflow'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.call_sync.result }}
+
+    track-alter:
+        name: Track Alter
+        if: always()
+        needs: [alter]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Main'
+            job_name: 'Alpha Alters'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.alter.result }}
+
+    track-dispatch-docker:
+        name: Track Dispatch Docker
+        if: always()
+        needs: [dispatch_docker]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Main'
+            job_name: 'Dispatch Docker Apps'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.dispatch_docker.result }}
+
+    track-dispatch-publish:
+        name: Track Dispatch Publish
+        if: always()
+        needs: [dispatch_publish]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Main'
+            job_name: 'Dispatch Publish Packages'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.dispatch_publish.result }}

--- a/.github/workflows/ci-mc-headless-e2e.yml
+++ b/.github/workflows/ci-mc-headless-e2e.yml
@@ -275,3 +275,21 @@ jobs:
             - name: Cleanup
               if: always()
               run: docker rm -f mc-e2e-pumpkin 2>/dev/null || true
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Manual trigger — caller usually watches, but tracker ensures nothing slips.
+    # ---------------------------------------------------------------------------
+    track-headless-e2e:
+        name: Track Headless E2E
+        if: always()
+        needs: [headless-e2e]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'MC - Headless E2E'
+            job_name: 'MC Headless Client E2E'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.headless-e2e.result }}

--- a/.github/workflows/ci-monday-e2e.yml
+++ b/.github/workflows/ci-monday-e2e.yml
@@ -173,3 +173,49 @@ jobs:
                     echo ""
                     echo "::warning::Monday E2E: $PASSED/$TOTAL projects passed"
                   fi
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Scheduled workflows are easy to miss; failures go unnoticed until Monday.
+    # ---------------------------------------------------------------------------
+    track-discover:
+        name: Track Discover
+        if: always()
+        needs: [discover]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Monday E2E'
+            job_name: 'Discover E2E Projects'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.discover.result }}
+
+    track-e2e:
+        name: Track E2E
+        if: always()
+        needs: [e2e]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Monday E2E'
+            job_name: 'E2E'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.e2e.result }}
+
+    track-summary:
+        name: Track Summary
+        if: always()
+        needs: [summary]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Monday E2E'
+            job_name: 'Monday E2E Summary'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.summary.result }}

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -87,6 +87,38 @@ jobs:
               with:
                   category: /language:rust
 
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Security scanning — failures should not go unnoticed.
+    # ---------------------------------------------------------------------------
+    track-codeql:
+        name: Track CodeQL Analysis
+        if: always()
+        needs: [codeql]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Security (CodeQL)'
+            job_name: 'CodeQL Analysis'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.codeql.result }}
+
+    track-codeql-rust:
+        name: Track CodeQL Rust Analysis
+        if: always()
+        needs: [codeql-rust]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Security (CodeQL)'
+            job_name: 'CodeQL Rust Analysis'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.codeql-rust.result }}
+
     dependency-review:
         name: Dependency Review
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -213,6 +213,38 @@ jobs:
                         }
                       }
 
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Sync automation — failures can leave branches in inconsistent state.
+    # ---------------------------------------------------------------------------
+    track-sync:
+        name: Track Sync
+        if: always()
+        needs: [sync_dev_with_main]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Sync Branches'
+            job_name: 'Sync Dev with Main (Safe)'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.sync_dev_with_main.result }}
+
+    track-cleanup:
+        name: Track Cleanup
+        if: always()
+        needs: [cleanup_orphaned_atomic_branches]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Sync Branches'
+            job_name: 'Cleanup Orphaned Atomic Branches'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.cleanup_orphaned_atomic_branches.result }}
+
     close_explicit_keyword_issues:
         name: 'Close Issues with Explicit Keywords'
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-weekly-nx-report.yml
+++ b/.github/workflows/ci-weekly-nx-report.yml
@@ -462,3 +462,21 @@ jobs:
                   echo "Cleaning up workspace..."
                   rm -f /tmp/nx-report-raw.txt /tmp/nx-graph.json /tmp/loc-stats.txt /tmp/coverage-report.txt /tmp/pr-body.md /tmp/pr-body-clean.md
                   rm -rf "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.[!.]* 2>/dev/null || true
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Weekly scheduled workflow — failures go unnoticed for an entire week.
+    # ---------------------------------------------------------------------------
+    track-generate:
+        name: Track Generate Job
+        if: always()
+        needs: [generate]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Weekly NX Report'
+            job_name: 'Generate NX Report & Graph'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.generate.result }}

--- a/.github/workflows/i-label.yml
+++ b/.github/workflows/i-label.yml
@@ -234,3 +234,39 @@ jobs:
                   key: 'Matrix'
                   value: '6'
                   idref: ${{ github.event.issue.node_id }}
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # Event-driven label automation — low risk but tracked for completeness.
+    # Only tracks jobs that actually ran (each label job is conditional).
+    # ---------------------------------------------------------------------------
+    track-label-jobs:
+        name: Track Label Automation
+        if: always()
+        needs:
+            [
+                assign_ai,
+                assign_concepts,
+                assign_update,
+                assign_media,
+                assign_bug,
+                assign_todo,
+                assign_backlog,
+                assign_support,
+                assign_matrix_0,
+                assign_matrix_1,
+                assign_matrix_2,
+                assign_matrix_3,
+                assign_matrix_4,
+                assign_matrix_5,
+                assign_matrix_6,
+            ]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'Organize Labels'
+            job_name: 'Label Automation'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ (needs.assign_ai.result == 'failure' || needs.assign_concepts.result == 'failure' || needs.assign_update.result == 'failure' || needs.assign_media.result == 'failure' || needs.assign_bug.result == 'failure' || needs.assign_todo.result == 'failure' || needs.assign_backlog.result == 'failure' || needs.assign_support.result == 'failure' || needs.assign_matrix_0.result == 'failure' || needs.assign_matrix_1.result == 'failure' || needs.assign_matrix_2.result == 'failure' || needs.assign_matrix_3.result == 'failure' || needs.assign_matrix_4.result == 'failure' || needs.assign_matrix_5.result == 'failure' || needs.assign_matrix_6.result == 'failure') && 'failure' || 'success' }}

--- a/.github/workflows/transfer-scripts.yml
+++ b/.github/workflows/transfer-scripts.yml
@@ -8,5 +8,22 @@ jobs:
         name: Transfer Scripts
         runs-on: ubuntu-latest
         steps:
-            -   name: Checkout the repository using git
-                uses: actions/checkout@v6
+            - name: Checkout the repository using git
+              uses: actions/checkout@v6
+
+    # ---------------------------------------------------------------------------
+    # Failure tracker — surfaces failures as GitHub issues (#8186).
+    # ---------------------------------------------------------------------------
+    track-release:
+        name: Track Transfer Scripts
+        if: always()
+        needs: [release]
+        permissions:
+            issues: write
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'Transfer Scripts'
+            job_name: 'Transfer Scripts'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.release.result }}


### PR DESCRIPTION
## Summary
- Wires `utils-ci-failure-tracker` into all 11 remaining workflows per the rollout plan in #8186
- Normalizes existing `ci-docker-smoke-test.yml` trackers to use `always()` + status pass-through (enables auto-close on recovery)
- Uses consistent pattern across all workflows: `if: always()`, `needs: [job]`, `status: ${{ needs.job.result }}`

## Rollout coverage

| Phase | Workflow | Jobs tracked |
|-------|----------|-------------|
| 1 - Scheduled | `ci-docker-smoke-test.yml` | resolve_digests, smoke_build, create_pr (fixed existing) |
| 1 - Scheduled | `ci-monday-e2e.yml` | discover, e2e, summary |
| 1 - Scheduled | `ci-weekly-nx-report.yml` | generate |
| 1 - Scheduled | `ci-security.yml` | codeql, codeql-rust |
| 2 - Dev/Atom | `ci-atom.yml` | run_tests, auto_merge |
| 2 - Dev/Atom | `ci-dev.yml` | dev_to_main_pr, dev_docker_mc, validate_pr |
| 3 - Main | `ci-main.yml` | globals, call_sync, alter, dispatch_docker, dispatch_publish |
| 4 - Remaining | `ci-sync.yml` | sync_dev_with_main, cleanup_orphaned_atomic_branches |
| 4 - Remaining | `ci-mc-headless-e2e.yml` | headless-e2e |
| 4 - Remaining | `transfer-scripts.yml` | release |
| 4 - Remaining | `i-label.yml` | all label jobs (aggregated) |

## Test plan
- [ ] Verify YAML syntax is valid (validated locally with js-yaml)
- [ ] Confirm tracker jobs appear in workflow run UI after merge
- [ ] Trigger a workflow_dispatch on a scheduled workflow to verify tracker fires

Closes #8186