### PR TITLE
fix(discordsh): e2e preflight — testIgnore fixes and README docs

### DIFF
--- a/apps/discordsh/axum-discordsh/README.md
+++ b/apps/discordsh/axum-discordsh/README.md
@@ -41,11 +41,12 @@ Discord bot + HTTP server for the KBVE ecosystem. Combines a [poise](https://git
 
 ### GitHub Integration
 
-| Variable           | Required | Default | Description                                                    |
-| ------------------ | -------- | ------- | -------------------------------------------------------------- |
-| `GITHUB_TOKEN`     | No       | —       | GitHub PAT for API calls. Checked first.                       |
-| `GITHUB_TOKEN_API` | No       | —       | Alternative GitHub token (checked if `GITHUB_TOKEN` is empty). |
-| `GITHUB_TOKEN_PAT` | No       | —       | Alternative GitHub token (checked last before Vault fallback). |
+| Variable              | Required | Default                  | Description                                                          |
+| --------------------- | -------- | ------------------------ | -------------------------------------------------------------------- |
+| `GITHUB_TOKEN`        | No       | —                        | GitHub PAT for API calls. Checked first.                             |
+| `GITHUB_TOKEN_API`    | No       | —                        | Alternative GitHub token (checked if `GITHUB_TOKEN` is empty).       |
+| `GITHUB_TOKEN_PAT`    | No       | —                        | Alternative GitHub token (checked last before Vault fallback).       |
+| `GITHUB_API_BASE_URL` | No       | `https://api.github.com` | Override GitHub REST API base URL (for testing with Mockoon or GHE). |
 
 > Token resolution order: `GITHUB_TOKEN` → `GITHUB_TOKEN_API` → `GITHUB_TOKEN_PAT` → Supabase Vault (tag `github_pat:<guild_id>`).
 
@@ -94,3 +95,47 @@ DISCORD_TOKEN=... GUILD_ID=... HTTP_PORT=4321 cargo run -p axum-discordsh
 cargo test -p axum-discordsh --bin axum-discordsh
 cargo test -p jedi --lib github
 ```
+
+## E2E Testing
+
+The full e2e pipeline runs via `nx e2e discordsh`:
+
+1. **Unit tests** — `cargo test -p axum-discordsh`
+2. **Docker build** — `nx container axum-discordsh`
+3. **Docker e2e** — Playwright against the bare container (`nx e2e:docker discordsh-e2e`)
+4. **Mock e2e** — Playwright against the Mockoon mock stack (`nx e2e:mock discordsh-e2e`)
+
+### E2E Environment Variables
+
+| Variable          | Used By  | Default              | Description                                                                                                                     |
+| ----------------- | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `DISCORDSH_IMAGE` | e2e:mock | —                    | Pre-built Docker image tag (e.g. `kbve/discordsh:0.1.31`). When set, the mock docker-compose skips rebuilding.                  |
+| `DISCORD_TOKEN`   | e2e:mock | `mock-discord-token` | Bot token for the mock stack. A real test bot token enables full gateway connection; the mock fallback tests GitHub-only paths. |
+| `CI`              | all e2e  | —                    | Set automatically in CI. Adjusts Playwright retries (2) and workers (1).                                                        |
+
+### Running E2E Locally
+
+```bash
+# Full pipeline (unit tests → docker build → docker e2e → mock e2e)
+./kbve.sh -nx e2e discordsh
+
+# Individual steps
+cargo test -p axum-discordsh                    # unit tests
+./kbve.sh -nx container axum-discordsh          # docker build
+./kbve.sh -nx e2e:docker discordsh-e2e          # playwright vs container
+./kbve.sh -nx e2e:mock discordsh-e2e            # playwright vs mockoon stack
+
+# Mock stack only (without Nx)
+docker compose -f apps/discordsh/poc/docker-compose-poc-dev.yaml up
+```
+
+### Mock Stack Architecture
+
+```
+docker-compose-poc-dev.yaml
+├── mockoon-github    (port 4010) — GitHub REST API mock
+├── mockoon-discord   (port 4011) — Discord REST API mock
+└── discordsh         (port 4321) — bot with GITHUB_API_BASE_URL → mockoon
+```
+
+See [poc/README.md](../poc/README.md) for mock route details and CI integration guide.

--- a/apps/discordsh/discordsh-e2e/playwright.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'dev',
-			testIgnore: /toast-welcome/,
+			testIgnore: /toast-welcome|mock-api/,
 			use: {
 				...devices['Desktop Chrome'],
 				baseURL,

--- a/apps/discordsh/discordsh-e2e/playwright.docker.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.docker.config.ts
@@ -6,7 +6,10 @@ const workspaceRoot = resolve(__dirname, '../../..');
 const port = 4321;
 const baseURL = `http://localhost:${port}`;
 
-const cargoToml = readFileSync(resolve(workspaceRoot, 'apps/discordsh/axum-discordsh/Cargo.toml'), 'utf-8');
+const cargoToml = readFileSync(
+	resolve(workspaceRoot, 'apps/discordsh/axum-discordsh/Cargo.toml'),
+	'utf-8',
+);
 const version = cargoToml.match(/^version\s*=\s*"(.+)"/m)?.[1] ?? '0.1.0';
 
 const killPort = `lsof -ti:${port} | xargs kill -9 2>/dev/null; sleep 1;`;
@@ -24,6 +27,7 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'docker',
+			testIgnore: /mock-api/,
 			use: {
 				...devices['Desktop Chrome'],
 				baseURL,


### PR DESCRIPTION
## Summary
- Add `testIgnore: /mock-api/` to `playwright.docker.config.ts` and update `playwright.config.ts` to exclude `mock-api.spec.ts` from non-mock Playwright configs — prevents failures when Mockoon is not running
- Document `GITHUB_API_BASE_URL` env var in README GitHub Integration table
- Add full E2E Testing section to README with env vars, local run commands, and mock stack architecture

## Preflight validation
- e2e:docker: 37/44 passed (7 pre-existing failures unrelated to these changes)
- e2e:mock: 15/15 passed

## Test plan
- [x] `e2e:mock` — all 15 tests pass with Mockoon docker-compose stack
- [x] `e2e:docker` — mock-api.spec.ts correctly excluded via testIgnore
- [x] Dev config (`playwright.config.ts`) — mock-api.spec.ts correctly excluded