### PR TITLE
fix(edge): bake version.toml into importable TS module via multi-stage Docker build

### DIFF
--- a/apps/kbve/edge/Dockerfile
+++ b/apps/kbve/edge/Dockerfile
@@ -1,4 +1,40 @@
+# Stage 1: Bake version.toml into a TypeScript module.
+# Worker isolates run in a sandbox that blocks Deno.readTextFile outside
+# the service path, so the manifest must be an importable module.
+FROM alpine:3.21 AS baker
+
+COPY ./version.toml /tmp/version.toml
+
+RUN set -eu; \
+    TOML="/tmp/version.toml"; \
+    OUT="/tmp/manifest.ts"; \
+    VERSION=$(grep '^version' "$TOML" | head -1 | sed 's/.*"\(.*\)"/\1/'); \
+    FUNCS="["; FIRST=true; NAME=""; LABEL=""; DESC=""; \
+    while IFS= read -r line; do \
+      case "$line" in \
+        "[[functions]]") \
+          if [ -n "$NAME" ]; then \
+            $FIRST || FUNCS="${FUNCS},"; \
+            FUNCS="${FUNCS}{\"name\":\"${NAME}\",\"label\":\"${LABEL}\",\"description\":\"${DESC}\"}"; \
+            FIRST=false; \
+          fi; \
+          NAME=""; LABEL=""; DESC=""; ;; \
+        name\ =\ *)   NAME=$(echo "$line" | sed 's/.*"\(.*\)"/\1/') ;; \
+        label\ =\ *)  LABEL=$(echo "$line" | sed 's/.*"\(.*\)"/\1/') ;; \
+        description\ =\ *) DESC=$(echo "$line" | sed 's/.*"\(.*\)"/\1/') ;; \
+      esac; \
+    done < "$TOML"; \
+    if [ -n "$NAME" ]; then \
+      $FIRST || FUNCS="${FUNCS},"; \
+      FUNCS="${FUNCS}{\"name\":\"${NAME}\",\"label\":\"${LABEL}\",\"description\":\"${DESC}\"}"; \
+    fi; \
+    FUNCS="${FUNCS}]"; \
+    printf '// Auto-generated from version.toml — do not edit.\nexport const VERSION = "%s";\nexport const FUNCTIONS: { name: string; label: string; description: string }[] = %s;\n' \
+      "$VERSION" "$FUNCS" > "$OUT"
+
+# Stage 2: Production edge-runtime image.
 FROM supabase/edge-runtime:v1.70.5
 
-COPY --chown=deno:deno ./version.toml /home/deno/version.toml
+COPY ./version.toml /home/deno/version.toml
 COPY ./functions /home/deno/functions
+COPY --from=baker /tmp/manifest.ts /home/deno/functions/_shared/manifest.ts

--- a/apps/kbve/edge/functions/health/index.ts
+++ b/apps/kbve/edge/functions/health/index.ts
@@ -1,49 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
+import { VERSION, FUNCTIONS } from "../_shared/manifest.ts";
 
-interface EdgeFunction {
-  name: string;
-  label: string;
-  description: string;
-}
-
-interface EdgeManifest {
-  version: string;
-  functions: EdgeFunction[];
-}
-
-async function loadManifest(): Promise<EdgeManifest> {
-  const fallback: EdgeManifest = { version: "0.1.11", functions: [] };
-
-  const envVersion = Deno.env.get("EDGE_VERSION");
-
-  try {
-    const toml = await Deno.readTextFile("/home/deno/version.toml");
-
-    // Parse version
-    const versionMatch = toml.match(/^version\s*=\s*"([^"]+)"/m);
-    const version = envVersion ?? versionMatch?.[1] ?? fallback.version;
-
-    // Parse [[functions]] blocks
-    const functions: EdgeFunction[] = [];
-    const blocks = toml.split(/\[\[functions\]\]/g).slice(1);
-
-    for (const block of blocks) {
-      const name = block.match(/^name\s*=\s*"([^"]+)"/m)?.[1];
-      const label = block.match(/^label\s*=\s*"([^"]+)"/m)?.[1];
-      const description = block.match(/^description\s*=\s*"([^"]+)"/m)?.[1];
-      if (name && label && description) {
-        functions.push({ name, label, description });
-      }
-    }
-
-    return { version, functions };
-  } catch {
-    return { ...fallback, version: envVersion ?? fallback.version };
-  }
-}
-
-const manifest = await loadManifest();
+const manifest = { version: VERSION, functions: FUNCTIONS };
 
 serve((req) => {
   if (req.method === "OPTIONS") {


### PR DESCRIPTION
## Summary
- Fixes #8230
- Worker isolates in `supabase/edge-runtime` run in a Deno sandbox that blocks `Deno.readTextFile` outside the service path — health function silently fell back to hardcoded `v0.1.11` with empty functions array
- Add an `alpine` baker stage that parses `version.toml` into `_shared/manifest.ts`, then `COPY --from=baker` into the final image
- Health function now imports `VERSION` and `FUNCTIONS` directly as a module

## Test plan
- [x] Built locally, verified `/health` returns `v0.1.15` with all 9 functions
- [ ] CI e2e tests should pass — version and functions array now match `version.toml`