### PR TITLE
fix(discordsh): kill Docker container between e2e steps to free port 4321

### DIFF
--- a/apps/discordsh/discordsh-e2e/docker-teardown.ts
+++ b/apps/discordsh/discordsh-e2e/docker-teardown.ts
@@ -1,0 +1,11 @@
+import { execSync } from 'child_process';
+
+export default function globalTeardown() {
+	try {
+		execSync('docker rm -f discordsh-e2e-test 2>/dev/null', {
+			stdio: 'ignore',
+		});
+	} catch {
+		// container already gone
+	}
+}

--- a/apps/discordsh/discordsh-e2e/playwright.docker.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.docker.config.ts
@@ -12,7 +12,7 @@ const cargoToml = readFileSync(
 );
 const version = cargoToml.match(/^version\s*=\s*"(.+)"/m)?.[1] ?? '0.1.0';
 
-const killPort = `lsof -ti:${port} | xargs kill -9 2>/dev/null; sleep 1;`;
+const killPort = `docker rm -f discordsh-e2e-test 2>/dev/null; lsof -ti:${port} | xargs kill -9 2>/dev/null; sleep 1;`;
 
 export default defineConfig({
 	testDir: './e2e',
@@ -40,4 +40,5 @@ export default defineConfig({
 		reuseExistingServer: false,
 		timeout: 30_000,
 	},
+	globalTeardown: resolve(__dirname, 'docker-teardown.ts'),
 });

--- a/apps/discordsh/project.json
+++ b/apps/discordsh/project.json
@@ -11,6 +11,7 @@
 					"nx test axum-discordsh",
 					"nx container axum-discordsh",
 					"nx e2e:docker discordsh-e2e",
+					"docker rm -f discordsh-e2e-test 2>/dev/null; lsof -ti:4321 | xargs kill -9 2>/dev/null; sleep 1; echo 'port 4321 released'",
 					"nx e2e:mock discordsh-e2e"
 				],
 				"parallel": false


### PR DESCRIPTION
## Summary
- Fixes #8232
- Playwright's webServer teardown kills the `docker run` process but the container can linger on CI, leaving port 4321 occupied — `e2e:mock` then fails with "port already used"
- Add explicit `docker rm -f discordsh-e2e-test` cleanup step between `e2e:docker` and `e2e:mock` in the orchestrator
- Harden docker config's `killPort` prefix to also remove the named container before starting
- Add `globalTeardown` to docker Playwright config for belt-and-suspenders cleanup

## Test plan
- [ ] CI `discordsh:e2e` pipeline should pass both `e2e:docker` and `e2e:mock` sequentially without port conflict