### PR TITLE
fix(discordsh): configurable e2e port to prevent CI port conflicts

### DIFF
--- a/apps/discordsh/discordsh-e2e/e2e/smoke.spec.ts
+++ b/apps/discordsh/discordsh-e2e/e2e/smoke.spec.ts
@@ -87,7 +87,9 @@ test.describe('Smoke: Cache-Control Headers', () => {
 // Sitemap-driven route sampling
 // ---------------------------------------------------------------------------
 
-const BASE_URL = process.env['BASE_URL'] || 'http://localhost:4321';
+const BASE_URL =
+	process.env['BASE_URL'] ||
+	`http://localhost:${process.env['E2E_PORT'] || '4321'}`;
 
 test.describe('Smoke: Sitemap Routes', () => {
 	test('sitemap exists and is parseable', async ({ request }) => {

--- a/apps/discordsh/discordsh-e2e/playwright.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 import { resolve } from 'path';
 
 const workspaceRoot = resolve(__dirname, '../../..');
-const port = 4321;
+const port = Number(process.env['E2E_PORT']) || 4321;
 const baseURL = `http://localhost:${port}`;
 
 export default defineConfig({
@@ -26,7 +26,7 @@ export default defineConfig({
 		},
 	],
 	webServer: {
-		command: './kbve.sh -nx axum-discordsh:dev',
+		command: `HTTP_PORT=${port} ./kbve.sh -nx axum-discordsh:dev`,
 		cwd: workspaceRoot,
 		url: `${baseURL}/health`,
 		reuseExistingServer: false,

--- a/apps/discordsh/discordsh-e2e/playwright.docker.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.docker.config.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 const workspaceRoot = resolve(__dirname, '../../..');
-const port = 4321;
+const port = Number(process.env['E2E_PORT']) || 4321;
 const baseURL = `http://localhost:${port}`;
 
 const cargoToml = readFileSync(
@@ -35,7 +35,7 @@ export default defineConfig({
 		},
 	],
 	webServer: {
-		command: `${killPort} docker run --rm --name discordsh-e2e-test -p ${port}:${port} kbve/discordsh:${version}`,
+		command: `${killPort} docker run --rm --name discordsh-e2e-test -e HTTP_PORT=${port} -p ${port}:${port} kbve/discordsh:${version}`,
 		url: `${baseURL}/health`,
 		reuseExistingServer: false,
 		timeout: 30_000,

--- a/apps/discordsh/discordsh-e2e/playwright.mock.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.mock.config.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 const workspaceRoot = resolve(__dirname, '../../..');
-const port = 4321;
+const port = Number(process.env['E2E_PORT']) || 4321;
 const baseURL = `http://localhost:${port}`;
 
 // Mockoon ports — must match docker-compose-poc-dev.yaml
@@ -33,7 +33,7 @@ const cleanup = [
 const startCmd = [
 	cleanup,
 	'sleep 1',
-	`DISCORDSH_IMAGE=kbve/discordsh:${version} docker compose -f ${composePath} up --abort-on-container-exit`,
+	`DISCORDSH_IMAGE=kbve/discordsh:${version} DISCORDSH_PORT=${port} docker compose -f ${composePath} up --abort-on-container-exit`,
 ].join(' && ');
 
 export default defineConfig({

--- a/apps/discordsh/poc/docker-compose-poc-dev.yaml
+++ b/apps/discordsh/poc/docker-compose-poc-dev.yaml
@@ -84,7 +84,7 @@ services:
             context: ../../../
             dockerfile: apps/discordsh/axum-discordsh/Dockerfile
         ports:
-            - '4321:4321'
+            - '${DISCORDSH_PORT:-4321}:${DISCORDSH_PORT:-4321}'
         environment:
             # ── GitHub mock redirect ──────────────────────────────────────
             GITHUB_API_BASE_URL: 'http://mockoon-github:4010'
@@ -105,7 +105,7 @@ services:
 
             # ── Runtime ───────────────────────────────────────────────────
             HTTP_HOST: '0.0.0.0'
-            HTTP_PORT: '4321'
+            HTTP_PORT: '${DISCORDSH_PORT:-4321}'
             RUST_LOG: 'axum_discordsh=debug,tower_http=debug,kbve=debug,jedi=debug'
         depends_on:
             mockoon-github:

--- a/apps/discordsh/project.json
+++ b/apps/discordsh/project.json
@@ -10,9 +10,9 @@
 				"commands": [
 					"nx test axum-discordsh",
 					"nx container axum-discordsh",
-					"nx e2e:docker discordsh-e2e",
-					"docker rm -f discordsh-e2e-test 2>/dev/null; lsof -ti:4321 | xargs kill -9 2>/dev/null; sleep 1; echo 'port 4321 released'",
-					"nx e2e:mock discordsh-e2e"
+					"E2E_PORT=4322 nx e2e:docker discordsh-e2e",
+					"docker rm -f discordsh-e2e-test 2>/dev/null; lsof -ti:4322 | xargs kill -9 2>/dev/null; sleep 1; echo 'port 4322 released'",
+					"E2E_PORT=4323 nx e2e:mock discordsh-e2e"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
## Summary
- Makes all discordsh e2e Playwright configs read `E2E_PORT` env var (default 4321) instead of hardcoding port 4321
- Orchestrator assigns distinct ports per e2e step: `e2e:docker` → 4322, `e2e:mock` → 4323
- Docker-compose uses `DISCORDSH_PORT` env var for flexible port mapping
- Eliminates the root cause of the CI failure — even if Docker cleanup fails between steps, ports never collide

Closes #8232