### PR TITLE
fix(kbve): address CodeQL security findings

### DIFF
--- a/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
@@ -316,6 +316,15 @@ function getWebSocketStatus() {
 
 // Handle incoming messages
 self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
+	// Validate message origin to prevent cross-origin attacks (CodeQL CWE-020)
+	if (e.origin && e.origin !== self.location.origin) {
+		console.warn(
+			'[WebSocket Worker] Rejected message from unexpected origin:',
+			e.origin,
+		);
+		return;
+	}
+
 	const msg = e.data;
 	const { id, type } = msg;
 

--- a/packages/rust/kbve/src/entity/response/header_response.rs
+++ b/packages/rust/kbve/src/entity/response/header_response.rs
@@ -43,6 +43,7 @@ impl HeaderResponse {
             .max_age(duration)
             .same_site(same_site)
             .http_only(http_only)
+            .secure(true)
             .build();
 
         let cookie_value = cookie.to_string();

--- a/packages/rust/kbve/src/spellbook.rs
+++ b/packages/rust/kbve/src/spellbook.rs
@@ -34,6 +34,7 @@ macro_rules! spellbook_create_cookie {
             .max_age(time::Duration::hours($duration))
             .same_site(axum_extra::extract::cookie::SameSite::Lax)
             .http_only(true)
+            .secure(true)
             .build()
     };
 }

--- a/packages/rust/kbve/src/sys/system_diagnostics.rs
+++ b/packages/rust/kbve/src/sys/system_diagnostics.rs
@@ -97,6 +97,14 @@ pub async fn call_n8n_service() -> impl IntoResponse {
     let n8n_url = std::env::var("N8N_WORKFLOWS_URL")
         .unwrap_or_else(|_| "https://automation.kbve.com/workflows".to_string());
 
+    // Enforce HTTPS to prevent cleartext transmission (CodeQL CWE-319)
+    if !n8n_url.starts_with("https://") {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "N8N_WORKFLOWS_URL must use HTTPS"})),
+        );
+    }
+
     // Attempt to call the primary service
     if let Ok(resp) = client.get(&n8n_url).send().await {
         if let Ok(json) = resp.json::<Value>().await {


### PR DESCRIPTION
## Summary
- **Insecure cookies (#261, #262, #263)**: Added `Secure` attribute to `spellbook_create_cookie!` macro and `HeaderResponse::with_cookie` to ensure cookies are only sent over HTTPS
- **Cleartext transmission (#264)**: Added HTTPS enforcement for `N8N_WORKFLOWS_URL` env var in `system_diagnostics.rs` to prevent accidental HTTP usage
- **Missing origin check (#253)**: Added origin validation to WebSocket worker `onmessage` handler to reject cross-origin messages

## Test plan
- [ ] Verify `cargo check -p kbve` passes (confirmed locally)
- [ ] Verify cookie-dependent auth flows still work (Secure flag is a no-op on localhost HTTP, production is HTTPS)
- [ ] Verify n8n health endpoint still responds when `N8N_WORKFLOWS_URL` is HTTPS or unset