### PR TITLE
fix(astro): remove unused variables and imports flagged by CodeQL

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/GameStoreContext.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/GameStoreContext.tsx
@@ -2,8 +2,6 @@ import {
 	createContext,
 	useContext,
 	useReducer,
-	useCallback,
-	useMemo,
 	type Dispatch,
 	type ReactNode,
 } from 'react';

--- a/apps/kbve/astro-kbve/src/components/twitch/ReactTwitchChat.tsx
+++ b/apps/kbve/astro-kbve/src/components/twitch/ReactTwitchChat.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { useStore } from '@nanostores/react';
-import { twitchService } from './ServiceTwitch';
 
 export interface ReactTwitchChatProps {
 	channel: string;

--- a/apps/kbve/astro-kbve/src/components/twitch/ReactTwitchEmbed.tsx
+++ b/apps/kbve/astro-kbve/src/components/twitch/ReactTwitchEmbed.tsx
@@ -35,7 +35,6 @@ const ReactTwitchEmbed: React.FC<ReactTwitchEmbedProps> = ({
 	const streamFrameRef = useRef<HTMLIFrameElement | null>(null);
 	const chatFrameRef = useRef<HTMLIFrameElement | null>(null);
 
-	const isLoading = useStore(twitchService.isLoadingAtom);
 	const error = useStore(twitchService.errorAtom);
 	const embedUrl = useStore(twitchService.embedUrlAtom);
 	const chatUrl = useStore(twitchService.chatUrlAtom);
@@ -45,7 +44,6 @@ const ReactTwitchEmbed: React.FC<ReactTwitchEmbedProps> = ({
 
 	const [streamLoaded, setStreamLoaded] = useState(false);
 	const [chatLoaded, setChatLoaded] = useState(false);
-	const [activeTheme, setActiveTheme] = useState<'dark' | 'light'>('dark');
 
 	// Initialize service on mount
 	useEffect(() => {
@@ -57,24 +55,7 @@ const ReactTwitchEmbed: React.FC<ReactTwitchEmbedProps> = ({
 			muted,
 		});
 
-		// Set initial theme
-		const resolvedTheme =
-			theme === 'auto'
-				? window.matchMedia('(prefers-color-scheme: dark)').matches
-					? 'dark'
-					: 'light'
-				: theme;
-		setActiveTheme(resolvedTheme);
-
-		// Subscribe to theme changes
-		const unsubscribe = twitchService.subscribeToThemeChanges(
-			(newTheme) => {
-				setActiveTheme(newTheme);
-			},
-		);
-
 		return () => {
-			unsubscribe();
 			twitchService.reset();
 		};
 	}, [channel, type, theme, autoplay, muted]);

--- a/apps/kbve/astro-kbve/src/components/twitch/ReactTwitchProfile.tsx
+++ b/apps/kbve/astro-kbve/src/components/twitch/ReactTwitchProfile.tsx
@@ -1,17 +1,7 @@
-import { useEffect, useState } from 'react';
-
 export interface ReactTwitchProfileProps {
 	username: string;
 	avatarUrl?: string;
 	isLive?: boolean;
-}
-
-function formatDate(dateStr: string): string {
-	const date = new Date(dateStr);
-	return date.toLocaleDateString('en-US', {
-		month: 'short',
-		year: 'numeric',
-	});
 }
 
 const ReactTwitchProfile = ({

--- a/apps/kbve/astro-kbve/src/lib/storage-migration.ts
+++ b/apps/kbve/astro-kbve/src/lib/storage-migration.ts
@@ -3,7 +3,6 @@
 
 const MIGRATION_KEY = 'sb-auth-migrated';
 const OLD_DB_NAME = 'sb-auth';
-const NEW_DB_NAME = 'sb-auth-v2';
 
 /**
  * Migrates data from old sb-auth database to new sb-auth-v2 database


### PR DESCRIPTION
## Summary
- Remove unused `useCallback`, `useMemo` imports from GameStoreContext (#269)
- Remove unused `useEffect`, `useState` imports and `formatDate` function from ReactTwitchProfile (#244, #245)
- Remove unused `useStore`, `twitchService` imports from ReactTwitchChat (#242, #243)
- Remove unused `isLoading` store binding and `activeTheme` state from ReactTwitchEmbed (#246, #247)
- Remove unused `NEW_DB_NAME` constant from storage-migration (#249)

## Test plan
- [ ] Verify lint passes (confirmed via pre-commit hooks)
- [ ] Verify Twitch embed/chat/profile components render correctly (no runtime behavior changed)
- [ ] Verify CryptoThrone game store context still works (only removed unused imports)