### PR TITLE
fix(q): resolve clippy lint warnings (#8247)

### DIFF
--- a/packages/rust/q/src/core/bridge.rs
+++ b/packages/rust/q/src/core/bridge.rs
@@ -116,10 +116,10 @@ impl EventBridge {
         match request_type {
             "spawn_entity" => {
                 let parts: Vec<&str> = payload.split(',').collect();
-                if parts.len() == 2 {
-                    if let (Ok(x), Ok(y)) = (parts[0].trim().parse(), parts[1].trim().parse()) {
-                        return GameRequest::SpawnEntity { x, y };
-                    }
+                if parts.len() == 2
+                    && let (Ok(x), Ok(y)) = (parts[0].trim().parse(), parts[1].trim().parse())
+                {
+                    return GameRequest::SpawnEntity { x, y };
                 }
                 GameRequest::Custom(request_type.to_string(), payload.to_string())
             }
@@ -128,14 +128,14 @@ impl EventBridge {
             },
             "update_position" => {
                 let parts: Vec<&str> = payload.split(',').collect();
-                if parts.len() == 3 {
-                    if let (Ok(x), Ok(y)) = (parts[1].trim().parse(), parts[2].trim().parse()) {
-                        return GameRequest::UpdatePosition {
-                            id: parts[0].trim().to_string(),
-                            x,
-                            y,
-                        };
-                    }
+                if parts.len() == 3
+                    && let (Ok(x), Ok(y)) = (parts[1].trim().parse(), parts[2].trim().parse())
+                {
+                    return GameRequest::UpdatePosition {
+                        id: parts[0].trim().to_string(),
+                        x,
+                        y,
+                    };
                 }
                 GameRequest::Custom(request_type.to_string(), payload.to_string())
             }

--- a/packages/rust/q/src/data/abstract_data_map.rs
+++ b/packages/rust/q/src/data/abstract_data_map.rs
@@ -41,8 +41,6 @@ pub trait AbstractDataMap: Serialize + for<'de> Deserialize<'de> + Sized {
                 Value::Number(serde_json::Number::from(i))
             } else if let Ok(b) = entry.value().try_to::<bool>() {
                 Value::Bool(b)
-            } else if entry.value().is_nil() {
-                Value::Null
             } else {
                 Value::Null
             };

--- a/packages/rust/q/src/data/cache.rs
+++ b/packages/rust/q/src/data/cache.rs
@@ -66,7 +66,7 @@ pub struct CacheManager {
 #[godot_api]
 impl INode for CacheManager {
     fn init(base: Base<Self::Base>) -> Self {
-        let shader_cache = Gd::from_init_fn(|base| ShaderCache::init(base));
+        let shader_cache = Gd::from_init_fn(ShaderCache::init);
 
         Self {
             base,

--- a/packages/rust/q/src/data/user_data.rs
+++ b/packages/rust/q/src/data/user_data.rs
@@ -19,6 +19,7 @@ pub struct UserData {
 impl AbstractDataMap for UserData {}
 
 impl UserData {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         username: &str,
         email: &str,

--- a/packages/rust/q/src/data/uxui_data.rs
+++ b/packages/rust/q/src/data/uxui_data.rs
@@ -55,7 +55,7 @@ impl TryFrom<UxUiElement> for MenuButtonData {
         let params = props
             .get("params")
             .and_then(|v| v.as_array())
-            .map(|arr| arr.iter().cloned().collect())
+            .map(|arr| arr.to_vec())
             .unwrap_or_else(Vec::new);
 
         Ok(MenuButtonData {

--- a/packages/rust/q/src/lib.rs
+++ b/packages/rust/q/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use godot::prelude::*;
 
 mod core;
@@ -18,32 +20,26 @@ unsafe impl ExtensionLibrary for Q {
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
     fn on_level_init(level: InitLevel) {
         use crate::threads::runtime::RuntimeManager;
-        match level {
-            InitLevel::Scene => {
-                let mut engine = godot::classes::Engine::singleton();
-                engine.register_singleton(RuntimeManager::SINGLETON, &RuntimeManager::new_alloc());
-            }
-            _ => (),
+        if level == InitLevel::Scene {
+            let mut engine = godot::classes::Engine::singleton();
+            engine.register_singleton(RuntimeManager::SINGLETON, &RuntimeManager::new_alloc());
         }
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
     fn on_level_deinit(level: InitLevel) {
         use crate::threads::runtime::RuntimeManager;
-        match level {
-            InitLevel::Scene => {
-                let mut engine = godot::classes::Engine::singleton();
-                if let Some(singleton) = engine.get_singleton(RuntimeManager::SINGLETON) {
-                    engine.unregister_singleton(RuntimeManager::SINGLETON);
-                    singleton.free();
-                } else {
-                    godot_warn!(
-                        "Failed to find & free singleton -> {}",
-                        RuntimeManager::SINGLETON
-                    );
-                }
+        if level == InitLevel::Scene {
+            let mut engine = godot::classes::Engine::singleton();
+            if let Some(singleton) = engine.get_singleton(RuntimeManager::SINGLETON) {
+                engine.unregister_singleton(RuntimeManager::SINGLETON);
+                singleton.free();
+            } else {
+                godot_warn!(
+                    "Failed to find & free singleton -> {}",
+                    RuntimeManager::SINGLETON
+                );
             }
-            _ => (),
         }
     }
 

--- a/packages/rust/q/src/macros.rs
+++ b/packages/rust/q/src/macros.rs
@@ -37,32 +37,31 @@ macro_rules! connect_signal {
 #[macro_export]
 macro_rules! find_game_manager {
     ($self:ident) => {
-        match $self.base().get_parent() {
-            Some(parent) => {
-                let game_manager: Gd<GameManager> = parent.cast::<GameManager>();
-                if game_manager.clone().upcast::<Node>().is_instance_valid() {
-                    $self.game_manager = Some(game_manager);
-                    debug_print!(
-                        "[{}:{}] [{}] Successfully linked with GameManager.",
-                        file!(),
-                        line!(),
-                        module_path!()
-                    );
-                } else {
-                    godot_warn!(
-                        "[{}:{}] [{}] Failed to initialize: GameManager is invalid.",
-                        file!(),
-                        line!(),
-                        module_path!()
-                    );
-                }
+        if let Some(parent) = $self.base().get_parent() {
+            let game_manager: Gd<GameManager> = parent.cast::<GameManager>();
+            if game_manager.clone().upcast::<Node>().is_instance_valid() {
+                $self.game_manager = Some(game_manager);
+                debug_print!(
+                    "[{}:{}] [{}] Successfully linked with GameManager.",
+                    file!(),
+                    line!(),
+                    module_path!()
+                );
+            } else {
+                godot_warn!(
+                    "[{}:{}] [{}] Failed to initialize: GameManager is invalid.",
+                    file!(),
+                    line!(),
+                    module_path!()
+                );
             }
-            None => godot_warn!(
+        } else {
+            godot_warn!(
                 "[{}:{}] [{}] Failed to initialize: No parent node found.",
                 file!(),
                 line!(),
                 module_path!()
-            ),
+            );
         }
     };
 }

--- a/packages/rust/q/src/manager/browser_manager.rs
+++ b/packages/rust/q/src/manager/browser_manager.rs
@@ -63,24 +63,24 @@ impl ICanvasLayer for BrowserManager {
 
         {
             let base = self.base_mut();
-            if let Some(tree) = base.get_tree() {
-                if let Some(mut root) = tree.get_root() {
-                    let callable = Callable::from_object_method(
-                        &base.clone().upcast::<Node>(),
-                        "on_window_resize",
-                    );
+            if let Some(tree) = base.get_tree()
+                && let Some(mut root) = tree.get_root()
+            {
+                let callable = Callable::from_object_method(
+                    &base.clone().upcast::<Node>(),
+                    "on_window_resize",
+                );
 
-                    let error = root.connect("size_changed", &callable);
-                    if error != godot::global::Error::OK {
-                        godot_error!(
-                            "[BrowserManager] Failed to connect root size_changed: {:?}",
-                            error
-                        );
-                    } else {
-                        godot_print!(
-                            "[BrowserManager] Connected root size_changed to on_window_resize."
-                        );
-                    }
+                let error = root.connect("size_changed", &callable);
+                if error != godot::global::Error::OK {
+                    godot_error!(
+                        "[BrowserManager] Failed to connect root size_changed: {:?}",
+                        error
+                    );
+                } else {
+                    godot_print!(
+                        "[BrowserManager] Connected root size_changed to on_window_resize."
+                    );
                 }
             }
         }

--- a/packages/rust/q/src/manager/game_manager.rs
+++ b/packages/rust/q/src/manager/game_manager.rs
@@ -32,13 +32,13 @@ impl INode for GameManager {
 
         let user_data_cache = Some(UserDataCache::new());
 
-        let clock_master = Gd::from_init_fn(|base| ClockMaster::init(base));
-        let cache_manager = Gd::from_init_fn(|base| CacheManager::init(base));
-        let music_manager = Gd::from_init_fn(|base| MusicManager::init(base));
-        let gui_manager = Gd::from_init_fn(|base| GUIManager::init(base));
-        let browser_manager = Gd::from_init_fn(|base| BrowserManager::init(base));
-        let entity_manager = Gd::from_init_fn(|base| EntityManager::init(base));
-        let event_bridge = Gd::from_init_fn(|base| EventBridge::init(base));
+        let clock_master = Gd::from_init_fn(ClockMaster::init);
+        let cache_manager = Gd::from_init_fn(CacheManager::init);
+        let music_manager = Gd::from_init_fn(MusicManager::init);
+        let gui_manager = Gd::from_init_fn(GUIManager::init);
+        let browser_manager = Gd::from_init_fn(BrowserManager::init);
+        let entity_manager = Gd::from_init_fn(EntityManager::init);
+        let event_bridge = Gd::from_init_fn(EventBridge::init);
 
         Self {
             base,

--- a/packages/rust/q/src/manager/gui_manager.rs
+++ b/packages/rust/q/src/manager/gui_manager.rs
@@ -81,10 +81,11 @@ impl ICanvasLayer for GUIManager {
     }
 
     fn input(&mut self, event: Gd<InputEvent>) {
-        if let Ok(key_event) = event.try_cast::<InputEventKey>() {
-            if key_event.is_pressed() && key_event.get_keycode() == Key::QUOTELEFT {
-                self.toggle_mouse_passthrough();
-            }
+        if let Ok(key_event) = event.try_cast::<InputEventKey>()
+            && key_event.is_pressed()
+            && key_event.get_keycode() == Key::QUOTELEFT
+        {
+            self.toggle_mouse_passthrough();
         }
     }
 }

--- a/packages/rust/q/src/manager/music_manager.rs
+++ b/packages/rust/q/src/manager/music_manager.rs
@@ -338,8 +338,8 @@ impl MusicManager {
         }
 
         self.blend_state = Some(BlendState {
-            active_name: active_name.into(),
-            idle_name: idle_name.into(),
+            active_name,
+            idle_name,
             start_volume: self.global_music_volume,
             target_volume: self.global_music_volume,
             duration: blend_duration,

--- a/packages/rust/q/src/platform/browser.rs
+++ b/packages/rust/q/src/platform/browser.rs
@@ -93,13 +93,13 @@ impl IControl for GodotBrowser {
                 });
 
             if !self.user_agent.is_empty() {
-                builder = builder.with_user_agent(&self.user_agent.to_string());
+                builder = builder.with_user_agent(self.user_agent.to_string());
             }
 
             if self.html.is_empty() && !self.url.is_empty() {
-                builder = builder.with_url(&self.url.to_string());
+                builder = builder.with_url(self.url.to_string());
             } else if !self.html.is_empty() && self.url.is_empty() {
-                builder = builder.with_html(&self.html.to_string());
+                builder = builder.with_html(self.html.to_string());
             }
 
             let webview_builder = builder;

--- a/packages/rust/q/src/platform/macos.rs
+++ b/packages/rust/q/src/platform/macos.rs
@@ -46,8 +46,6 @@ pub fn enable_mac_always_on_top() {
 #[cfg(target_os = "macos")]
 use std::ffi::c_void;
 #[cfg(target_os = "macos")]
-use std::mem::transmute;
-#[cfg(target_os = "macos")]
 use std::ptr::NonNull;
 
 #[cfg(target_os = "macos")]
@@ -73,7 +71,8 @@ impl MacOSWryBrowserOptions {
         unsafe {
             Ok(WindowHandle::borrow_raw(RawWindowHandle::AppKit(
                 AppKitWindowHandle::new({
-                    let ptr: *mut c_void = transmute(window_handle);
+                    let ptr: *mut c_void =
+                        std::ptr::with_exposed_provenance_mut(window_handle as usize);
                     NonNull::new(ptr).expect("Id<T> should never be null")
                 }),
             )))

--- a/packages/rust/q/src/threads/runtime.rs
+++ b/packages/rust/q/src/threads/runtime.rs
@@ -121,10 +121,10 @@ impl RuntimeManager {
     }
 
     pub fn send_map_message(&self, message: MapMessage) {
-        if let Some(sender) = &self.sender {
-            if sender.send(message).is_err() {
-                godot_print!("[Q] -> Failed to send message to global map handler");
-            }
+        if let Some(sender) = &self.sender
+            && sender.send(message).is_err()
+        {
+            godot_print!("[Q] -> Failed to send message to global map handler");
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix 56 clippy warnings in the `q` crate that were failing CI lint
- Replace `match` with `if let`/`if ==` for single-arm matches
- Replace redundant closures with function references (`Gd::from_init_fn(Foo::init)`)
- Collapse nested `if` statements using `let` chains
- Remove useless `.into()` conversions and needless borrows
- Replace `transmute` with `std::ptr::with_exposed_provenance_mut`
- Replace `iter().cloned().collect()` with `to_vec()`
- Add `#![allow(dead_code)]` at crate level (GDExtension items are called by engine at runtime)

## Test plan
- [x] `npx nx run q:lint` passes with zero code warnings

Closes #8247