### PR TITLE
fix(axum-kbve-e2e): align COEP header assertions with require-corp policy

### DIFF
--- a/apps/kbve/axum-kbve-e2e/e2e/static.spec.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/static.spec.ts
@@ -44,8 +44,9 @@ describe('Static file serving', () => {
 			expect(res.headers.get('cross-origin-opener-policy')).toBe(
 				'same-origin',
 			);
+			// require-corp used instead of credentialless for Safari SharedArrayBuffer support
 			expect(res.headers.get('cross-origin-embedder-policy')).toBe(
-				'credentialless',
+				'require-corp',
 			);
 		}
 	});
@@ -56,8 +57,9 @@ describe('Static file serving', () => {
 			expect(res.headers.get('cross-origin-opener-policy')).toBe(
 				'same-origin',
 			);
+			// require-corp used instead of credentialless for Safari SharedArrayBuffer support
 			expect(res.headers.get('cross-origin-embedder-policy')).toBe(
-				'credentialless',
+				'require-corp',
 			);
 		}
 	});


### PR DESCRIPTION
## Summary
- E2e tests in `static.spec.ts` expected `credentialless` for `cross-origin-embedder-policy`, but the axum server uses `require-corp` for Safari SharedArrayBuffer compatibility
- Updated both COEP assertions to expect `require-corp`, matching the server's intentional behavior

Closes #8260

## Test plan
- [ ] `npx nx run axum-kbve-e2e:e2e` passes with the updated assertions
- [ ] CI Docker / axum-kbve job passes