### PR TITLE
feat(ci): add Unreal plugin fan-out to ci-publish dispatch (#8254)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -180,6 +180,34 @@ jobs:
                   [ "${{ needs.alter.outputs.py_lib_fudster }}" = "true" ] && dispatch_python "python-fudster" "fudster"
                   [ "${{ needs.alter.outputs.py_lib_kbve }}"    = "true" ] && dispatch_python "python-kbve"    "kbve"
 
+                  dispatch_unreal() {
+                    local plugin_name="$1"
+                    local plugin_path="$2"
+                    local dep_plugins="${3:-}"
+                    local itch_game="${4:-}"
+                    local deploy_itch="false"
+                    if [ -n "$itch_game" ]; then deploy_itch="true"; fi
+                    echo "Dispatching ci-publish.yml unreal/$plugin_name"
+                    gh workflow run ci-publish.yml \
+                      --repo "${{ github.repository }}" \
+                      --ref main \
+                      --field package_type="unreal" \
+                      --field package_name="$plugin_name" \
+                      --field unreal_plugin_path="$plugin_path" \
+                      --field deploy_to_itch="$deploy_itch" \
+                      --field itch_game_id="$itch_game" \
+                      --field unreal_dependency_plugins="$dep_plugins" \
+                      --field dispatched_at="$DISPATCHED_AT"
+                  }
+
+                  # Unreal Plugins
+                  [ "${{ needs.alter.outputs.ue_kbvexxhash }}"  = "true" ] && dispatch_unreal "KBVEXXHash"  "packages/unreal/KBVEXXHash"
+                  [ "${{ needs.alter.outputs.ue_kbveyyjson }}"  = "true" ] && dispatch_unreal "KBVEYYJson"  "packages/unreal/KBVEYYJson"
+                  [ "${{ needs.alter.outputs.ue_kbvezstd }}"    = "true" ] && dispatch_unreal "KBVEZstd"    "packages/unreal/KBVEZstd"
+                  [ "${{ needs.alter.outputs.ue_kbvesqlite }}"  = "true" ] && dispatch_unreal "KBVESQLite"  "packages/unreal/KBVESQLite"
+                  [ "${{ needs.alter.outputs.ue_kbvewasm }}"    = "true" ] && dispatch_unreal "KBVEWASM"    "packages/unreal/KBVEWASM"
+                  [ "${{ needs.alter.outputs.ue_devops }}"      = "true" ] && dispatch_unreal "UEDevOps"    "packages/unreal/UEDevOps" "packages/unreal/KBVEYYJson packages/unreal/KBVEXXHash packages/unreal/KBVEZstd" "uedevops"
+
                   echo "All publish dispatches complete"
 
     # ---------------------------------------------------------------------------

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -102,10 +102,29 @@ on:
             edge:
                 description: 'Edge functions changed'
                 value: ${{ jobs.alter.outputs.edge }}
-            # ? Tauri
+            # ? Bevy
             isometric:
                 description: 'Isometric game changed'
                 value: ${{ jobs.alter.outputs.isometric }}
+            # ? Unreal
+            ue_devops:
+                description: 'UEDevOps plugin changed'
+                value: ${{ jobs.alter.outputs.ue_devops }}
+            ue_kbvewasm:
+                description: 'KBVEWASM plugin changed'
+                value: ${{ jobs.alter.outputs.ue_kbvewasm }}
+            ue_kbvexxhash:
+                description: 'KBVEXXHash plugin changed'
+                value: ${{ jobs.alter.outputs.ue_kbvexxhash }}
+            ue_kbveyyjson:
+                description: 'KBVEYYJson plugin changed'
+                value: ${{ jobs.alter.outputs.ue_kbveyyjson }}
+            ue_kbvezstd:
+                description: 'KBVEZstd plugin changed'
+                value: ${{ jobs.alter.outputs.ue_kbvezstd }}
+            ue_kbvesqlite:
+                description: 'KBVESQLite plugin changed'
+                value: ${{ jobs.alter.outputs.ue_kbvesqlite }}
 
 jobs:
     alter:
@@ -144,6 +163,12 @@ jobs:
             mc_plugin: ${{ steps.delta.outputs.mc_plugin_any_changed }}
             edge: ${{ steps.delta.outputs.edge_any_changed }}
             isometric: ${{ steps.delta.outputs.isometric_any_changed }}
+            ue_devops: ${{ steps.delta.outputs.ue_devops_any_changed }}
+            ue_kbvewasm: ${{ steps.delta.outputs.ue_kbvewasm_any_changed }}
+            ue_kbvexxhash: ${{ steps.delta.outputs.ue_kbvexxhash_any_changed }}
+            ue_kbveyyjson: ${{ steps.delta.outputs.ue_kbveyyjson_any_changed }}
+            ue_kbvezstd: ${{ steps.delta.outputs.ue_kbvezstd_any_changed }}
+            ue_kbvesqlite: ${{ steps.delta.outputs.ue_kbvesqlite_any_changed }}
 
         steps:
             - name: Checkout the repository
@@ -250,3 +275,21 @@ jobs:
                           - 'apps/kbve/isometric/package.json'
                           - 'apps/kbve/isometric/vite.config.ts'
                           - 'packages/rust/bevy/bevy_tasker/**'
+                      ue_devops:
+                          - 'packages/unreal/UEDevOps/Source/**'
+                          - 'packages/unreal/UEDevOps/UEDevOps.uplugin'
+                      ue_kbvewasm:
+                          - 'packages/unreal/KBVEWASM/Source/**'
+                          - 'packages/unreal/KBVEWASM/KBVEWASM.uplugin'
+                      ue_kbvexxhash:
+                          - 'packages/unreal/KBVEXXHash/Source/**'
+                          - 'packages/unreal/KBVEXXHash/KBVEXXHash.uplugin'
+                      ue_kbveyyjson:
+                          - 'packages/unreal/KBVEYYJson/Source/**'
+                          - 'packages/unreal/KBVEYYJson/KBVEYYJson.uplugin'
+                      ue_kbvezstd:
+                          - 'packages/unreal/KBVEZstd/Source/**'
+                          - 'packages/unreal/KBVEZstd/KBVEZstd.uplugin'
+                      ue_kbvesqlite:
+                          - 'packages/unreal/KBVESQLite/Source/**'
+                          - 'packages/unreal/KBVESQLite/KBVESQLite.uplugin'


### PR DESCRIPTION
## Summary
- Add file alteration detection for all 6 Unreal plugins (`UEDevOps`, `KBVEWASM`, `KBVEXXHash`, `KBVEYYJson`, `KBVEZstd`, `KBVESQLite`) to `utils-file-alterations.yml`
- Add `dispatch_unreal()` helper in `ci-main.yml` that fans out per changed plugin with correct `dependency_plugin_paths` and itch.io config
- Rename `# ? Tauri` section comment to `# ? Bevy`

Closes #8254

## Test plan
- [ ] Merge to `main` and verify altered Unreal plugin files trigger `ci-publish.yml` with `package_type=unreal`
- [ ] Confirm `UEDevOps` dispatch includes dependency plugin paths and itch.io game ID
- [ ] Confirm standalone plugins (e.g. `KBVEWASM`) dispatch without dependencies