### PR TITLE
fix(discordsh-e2e): prevent cleanup xargs exit 123 from skipping compose start

### DIFF
--- a/apps/discordsh/discordsh-e2e/playwright.mock.config.ts
+++ b/apps/discordsh/discordsh-e2e/playwright.mock.config.ts
@@ -21,11 +21,15 @@ const composePath = 'apps/discordsh/poc/docker-compose-poc-dev.yaml';
 // Kill any leftover containers and ports from previous runs, then start
 // the full mock stack. The discordsh service in compose uses the
 // already-built local image (kbve/discordsh:{version}).
+// Each command uses `|| true` so cleanup always exits 0 — the startCmd
+// joins cleanup to docker-compose with `&&`, so a non-zero exit here
+// would skip the compose start entirely (xargs returns 123 when kill
+// is invoked with no arguments from empty lsof output).
 const cleanup = [
-	`docker compose -f ${composePath} down --remove-orphans 2>/dev/null`,
-	`lsof -ti:${port} | xargs kill -9 2>/dev/null`,
-	`lsof -ti:${GITHUB_MOCK_PORT} | xargs kill -9 2>/dev/null`,
-	`lsof -ti:${DISCORD_MOCK_PORT} | xargs kill -9 2>/dev/null`,
+	`docker compose -f ${composePath} down --remove-orphans 2>/dev/null || true`,
+	`lsof -ti:${port} | xargs kill -9 2>/dev/null || true`,
+	`lsof -ti:${GITHUB_MOCK_PORT} | xargs kill -9 2>/dev/null || true`,
+	`lsof -ti:${DISCORD_MOCK_PORT} | xargs kill -9 2>/dev/null || true`,
 ].join('; ');
 
 // Override the discordsh image tag via env so docker-compose uses the

--- a/apps/discordsh/project.json
+++ b/apps/discordsh/project.json
@@ -11,7 +11,7 @@
 					"nx test axum-discordsh",
 					"nx container axum-discordsh",
 					"E2E_PORT=4322 nx e2e:docker discordsh-e2e",
-					"docker rm -f discordsh-e2e-test 2>/dev/null; lsof -ti:4322 | xargs kill -9 2>/dev/null; sleep 1; echo 'port 4322 released'",
+					"docker rm -f discordsh-e2e-test 2>/dev/null || true; lsof -ti:4322 | xargs kill -9 2>/dev/null || true; sleep 1; echo 'port 4322 released'",
 					"E2E_PORT=4323 nx e2e:mock discordsh-e2e"
 				],
 				"parallel": false


### PR DESCRIPTION
## Summary
- Mock e2e cleanup commands (`lsof | xargs kill -9`) return exit 123 when no process occupies the target port — GNU xargs invokes `kill -9` with no arguments, which fails
- Due to shell operator precedence, the last cleanup command is `&&`-chained to `docker compose up`, so exit 123 short-circuits and compose never starts
- Added `|| true` to all cleanup commands in `playwright.mock.config.ts` and `project.json` so the chain always reaches the compose start

Closes #8232

## Test plan
- [ ] Re-run CI Docker / discordsh workflow — `e2e:mock` target should reach docker-compose startup
- [ ] Verify `e2e:docker` cleanup step also succeeds cleanly between test phases