### PR TITLE
fix(soul,bevy): resolve clippy lint failures

### DIFF
--- a/packages/rust/bevy/bevy_battle/src/snapshot.rs
+++ b/packages/rust/bevy/bevy_battle/src/snapshot.rs
@@ -80,7 +80,7 @@ fn capture_players(world: &mut World) -> Vec<PlayerSnapshot> {
             armor: armor.value,
             defending: stats.defending,
             effects: snapshot_effects(effects),
-            class: class.0.clone(),
+            class: class.0,
             alive: !is_dead,
         });
     }
@@ -123,7 +123,7 @@ fn snapshot_effects(effects: &ActiveEffects) -> Vec<EffectSnapshot> {
         .0
         .iter()
         .map(|e| EffectSnapshot {
-            kind: e.kind.clone(),
+            kind: e.kind,
             stacks: e.stacks,
             turns_left: e.turns_left,
         })

--- a/packages/rust/bevy/bevy_battle/src/system/attack.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/attack.rs
@@ -9,6 +9,7 @@ use crate::resource::*;
 use crate::types::*;
 
 /// Resolve player attack intents.
+#[allow(clippy::type_complexity)]
 pub fn attack_system(
     mut intents: MessageReader<AttackIntent>,
     mut outcomes: MessageWriter<CombatOutcome>,
@@ -302,17 +303,17 @@ pub fn use_item_system(
                 }
             }
             UseEffect::DamageEnemy { amount } => {
-                if let Some(target) = intent.target {
-                    if let Ok((_name, mut hp, _effects)) = combatants.get_mut(target) {
-                        hp.take_damage(*amount);
-                        outcomes.write(CombatOutcome::Attack {
-                            attacker: intent.user,
-                            target,
-                            damage: *amount,
-                            crit: false,
-                            overkill: hp.is_dead(),
-                        });
-                    }
+                if let Some(target) = intent.target
+                    && let Ok((_name, mut hp, _effects)) = combatants.get_mut(target)
+                {
+                    hp.take_damage(*amount);
+                    outcomes.write(CombatOutcome::Attack {
+                        attacker: intent.user,
+                        target,
+                        damage: *amount,
+                        crit: false,
+                        overkill: hp.is_dead(),
+                    });
                 }
             }
             UseEffect::ApplyEffect {
@@ -356,28 +357,28 @@ pub fn use_item_system(
                 stacks,
                 turns,
             } => {
-                if let Some(target) = intent.target {
-                    if let Ok((_name, mut hp, mut effects)) = combatants.get_mut(target) {
-                        hp.take_damage(*damage);
-                        effects.add(EffectInstance {
-                            kind: *kind,
-                            stacks: *stacks,
-                            turns_left: *turns,
-                        });
-                        outcomes.write(CombatOutcome::Attack {
-                            attacker: intent.user,
-                            target,
-                            damage: *damage,
-                            crit: false,
-                            overkill: hp.is_dead(),
-                        });
-                        outcomes.write(CombatOutcome::EffectApplied {
-                            target,
-                            effect: *kind,
-                            stacks: *stacks,
-                            turns: *turns,
-                        });
-                    }
+                if let Some(target) = intent.target
+                    && let Ok((_name, mut hp, mut effects)) = combatants.get_mut(target)
+                {
+                    hp.take_damage(*damage);
+                    effects.add(EffectInstance {
+                        kind: *kind,
+                        stacks: *stacks,
+                        turns_left: *turns,
+                    });
+                    outcomes.write(CombatOutcome::Attack {
+                        attacker: intent.user,
+                        target,
+                        damage: *damage,
+                        crit: false,
+                        overkill: hp.is_dead(),
+                    });
+                    outcomes.write(CombatOutcome::EffectApplied {
+                        target,
+                        effect: *kind,
+                        stacks: *stacks,
+                        turns: *turns,
+                    });
                 }
             }
             // Session-level effects handled by bridge: GuaranteedFlee, CampfireRest, TeleportCity, ReviveAlly

--- a/packages/rust/bevy/bevy_battle/src/system/death.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/death.rs
@@ -6,6 +6,7 @@ use crate::component::*;
 use crate::event::*;
 
 /// Check all combatants for death (HP <= 0) and emit `CombatOutcome::Death`.
+#[allow(clippy::type_complexity)]
 pub fn death_check_system(
     mut commands: Commands,
     mut outcomes: MessageWriter<CombatOutcome>,
@@ -15,6 +16,7 @@ pub fn death_check_system(
 }
 
 /// Same check, runs again after effects tick to catch DoT kills.
+#[allow(clippy::type_complexity)]
 pub fn final_death_check_system(
     mut commands: Commands,
     mut outcomes: MessageWriter<CombatOutcome>,
@@ -23,6 +25,7 @@ pub fn final_death_check_system(
     check_deaths(&mut commands, &mut outcomes, &combatants);
 }
 
+#[allow(clippy::type_complexity)]
 fn check_deaths(
     commands: &mut Commands,
     outcomes: &mut MessageWriter<CombatOutcome>,

--- a/packages/rust/bevy/bevy_battle/src/system/defend.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/defend.rs
@@ -9,6 +9,7 @@ use crate::resource::*;
 use crate::types::*;
 
 /// Process defend intents — set defending flag and handle Cleric prayer proc.
+#[allow(clippy::type_complexity)]
 pub fn defend_system(
     mut intents: MessageReader<DefendIntent>,
     mut outcomes: MessageWriter<CombatOutcome>,

--- a/packages/rust/bevy/bevy_battle/src/system/effects.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/effects.rs
@@ -6,6 +6,7 @@ use crate::component::*;
 use crate::event::*;
 
 /// Tick all active effects on all combatants.
+#[allow(clippy::type_complexity)]
 pub fn tick_effects_system(
     mut requests: MessageReader<TickEffectsRequest>,
     mut outcomes: MessageWriter<CombatOutcome>,

--- a/packages/rust/bevy/bevy_battle/src/system/enemy_turn.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/enemy_turn.rs
@@ -9,6 +9,7 @@ use crate::resource::*;
 use crate::types::*;
 
 /// Execute all enemy turns when `EnemyTurnRequest` is received.
+#[allow(clippy::type_complexity)]
 pub fn enemy_turn_system(
     mut requests: MessageReader<EnemyTurnRequest>,
     mut outcomes: MessageWriter<CombatOutcome>,
@@ -159,14 +160,14 @@ pub fn enemy_turn_system(
                 if let Ok((_, _, _, _, _, effects, _)) = players.get(*target_entity) {
                     let effect_thorns = effects.stacks(&EffectKind::Thorns) as i32;
                     let total = *target_thorns_gear + effect_thorns;
-                    if total > 0 {
-                        if let Ok((_, _, mut ehp, _, _, _, _)) = enemies.get_mut(*enemy_entity) {
-                            ehp.take_damage(total);
-                            outcomes.write(CombatOutcome::Thorns {
-                                target: *enemy_entity,
-                                reflected: total,
-                            });
-                        }
+                    if total > 0
+                        && let Ok((_, _, mut ehp, _, _, _, _)) = enemies.get_mut(*enemy_entity)
+                    {
+                        ehp.take_damage(total);
+                        outcomes.write(CombatOutcome::Thorns {
+                            target: *enemy_entity,
+                            reflected: total,
+                        });
                     }
                 }
             }

--- a/packages/rust/bevy/bevy_cam/src/lib.rs
+++ b/packages/rust/bevy/bevy_cam/src/lib.rs
@@ -185,6 +185,7 @@ pub struct CameraUpdate;
 
 // ── Plugin ──────────────────────────────────────────────────────────────
 
+#[derive(Default)]
 pub struct IsometricCameraPlugin {
     config: CameraConfig,
 }
@@ -192,14 +193,6 @@ pub struct IsometricCameraPlugin {
 impl IsometricCameraPlugin {
     pub fn new(config: CameraConfig) -> Self {
         Self { config }
-    }
-}
-
-impl Default for IsometricCameraPlugin {
-    fn default() -> Self {
-        Self {
-            config: CameraConfig::default(),
-        }
     }
 }
 

--- a/packages/rust/bevy/bevy_inventory/src/lib.rs
+++ b/packages/rust/bevy/bevy_inventory/src/lib.rs
@@ -1087,10 +1087,10 @@ fn process_move_action<K: ItemKind>(
 
 #[cfg(feature = "snapshot")]
 fn snapshot_inventory<K: ItemKind>(inventory: Res<Inventory<K>>) {
-    if inventory.is_changed() {
-        if let Ok(json) = serde_json::to_string(inventory.as_ref()) {
-            snapshot_store::write(json);
-        }
+    if inventory.is_changed()
+        && let Ok(json) = serde_json::to_string(inventory.as_ref())
+    {
+        snapshot_store::write(json);
     }
 }
 

--- a/packages/rust/bevy/bevy_player/src/plugin.rs
+++ b/packages/rust/bevy/bevy_player/src/plugin.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 
 use crate::config::{DirectionMap, PlayerConfig};
 use crate::ground::detect_ground;
-use crate::movement::{move_player, PlayerMovement};
+use crate::movement::{PlayerMovement, move_player};
 
 /// Bevy plugin that registers the player character controller systems.
 ///
@@ -24,6 +24,7 @@ use crate::movement::{move_player, PlayerMovement};
 ///         ..default()
 ///     }));
 /// ```
+#[derive(Default)]
 pub struct PlayerPlugin {
     config: PlayerConfig,
 }
@@ -32,14 +33,6 @@ impl PlayerPlugin {
     /// Create a player plugin with the given configuration.
     pub fn new(config: PlayerConfig) -> Self {
         Self { config }
-    }
-}
-
-impl Default for PlayerPlugin {
-    fn default() -> Self {
-        Self {
-            config: PlayerConfig::default(),
-        }
     }
 }
 

--- a/packages/rust/bevy/bevy_skills/src/profile.rs
+++ b/packages/rust/bevy/bevy_skills/src/profile.rs
@@ -5,21 +5,12 @@ use bevy::prelude::*;
 use crate::registry::SkillId;
 
 /// A single skill's state on an entity.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct SkillEntry {
     /// Total accumulated XP.
     pub total_xp: u64,
     /// Current computed level (cached, updated by the XP system).
     pub level: u32,
-}
-
-impl Default for SkillEntry {
-    fn default() -> Self {
-        Self {
-            total_xp: 0,
-            level: 0,
-        }
-    }
 }
 
 /// Component holding all skill data for a single entity (player, NPC, etc.).
@@ -66,11 +57,6 @@ impl SkillProfile {
         if let Some(entry) = self.skills.get_mut(&id) {
             entry.level = level;
         }
-    }
-
-    /// Get a mutable reference to a skill entry, creating it if needed.
-    pub(crate) fn entry_mut(&mut self, id: SkillId) -> &mut SkillEntry {
-        self.skills.entry(id).or_default()
     }
 
     /// Iterate over all trained skills.

--- a/packages/rust/soul/src/error.rs
+++ b/packages/rust/soul/src/error.rs
@@ -1,17 +1,21 @@
-use thiserror::Error;
-use axum::{http::StatusCode, response::{IntoResponse, Response}, Json};
-use solana_client::client_error::ClientError;
-use tracing::error;
-use std::sync::Arc;
-use std::error::Error;
-use std::borrow::Cow;
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
 use serde::Serialize;
+use solana_client::client_error::ClientError;
+use std::borrow::Cow;
+use std::error::Error;
 use std::io;
+use std::sync::Arc;
+use thiserror::Error;
+use tracing::error;
 
 #[derive(Error, Debug)]
 pub enum AppError {
     #[error("Solana RPC error: {0}")]
-    SolanaClientError(#[from] ClientError),
+    SolanaClientError(#[from] Box<ClientError>),
 
     #[error("Invalid input: {0}")]
     InvalidInput(Cow<'static, str>),
@@ -36,14 +40,36 @@ struct ErrorResponse<'a> {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, code, message) = match &self {
-            AppError::SolanaClientError(err) => (StatusCode::BAD_REQUEST, "SOLANA_RPC_ERROR", err.to_string()),
-            AppError::InvalidInput(msg) => (StatusCode::UNPROCESSABLE_ENTITY, "INVALID_INPUT", msg.as_ref().to_string()),
-            AppError::Unexpected(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "UNEXPECTED_ERROR", msg.as_ref().to_string()),
-            AppError::IoError(err) => (StatusCode::INTERNAL_SERVER_ERROR, "IO_ERROR", err.to_string()),
-            AppError::Custom(err) => (StatusCode::INTERNAL_SERVER_ERROR, "CUSTOM_ERROR", err.to_string()),
+            AppError::SolanaClientError(err) => {
+                (StatusCode::BAD_REQUEST, "SOLANA_RPC_ERROR", err.to_string())
+            }
+            AppError::InvalidInput(msg) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "INVALID_INPUT",
+                msg.as_ref().to_string(),
+            ),
+            AppError::Unexpected(msg) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "UNEXPECTED_ERROR",
+                msg.as_ref().to_string(),
+            ),
+            AppError::IoError(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "IO_ERROR",
+                err.to_string(),
+            ),
+            AppError::Custom(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "CUSTOM_ERROR",
+                err.to_string(),
+            ),
         };
 
-        let response = ErrorResponse { error: &message, code, status: status.as_u16() };
+        let response = ErrorResponse {
+            error: &message,
+            code,
+            status: status.as_u16(),
+        };
         (status, Json(response)).into_response()
     }
 }


### PR DESCRIPTION
## Summary
- Box `ClientError` in `soul::AppError` to fix `clippy::large_enum_variant` (264 bytes → pointer-sized)
- Fix clippy warnings across `bevy_battle`, `bevy_cam`, `bevy_inventory`, `bevy_player`, `bevy_skills`: derivable Default impls, collapsible nested ifs, clone on Copy types, type_complexity, dead code

Closes #8253