### PR TITLE
fix(bevy_cam): remove bevy_winit to fix CI lint on headless Linux

### DIFF
--- a/packages/rust/bevy/bevy_cam/Cargo.toml
+++ b/packages/rust/bevy/bevy_cam/Cargo.toml
@@ -15,5 +15,4 @@ bevy = { version = "0.18", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_pbr",
-    "bevy_winit",
 ] }


### PR DESCRIPTION
## Summary
- `bevy_cam` enabled `bevy_winit` which pulls in the winit windowing backend — requires X11/Wayland dev libs not available on headless CI runners
- Removed the `bevy_winit` feature; `bevy_input` and `bevy_window` types (PrimaryWindow, MouseWheel) are always compiled as non-optional deps of `bevy_internal`
- As a library plugin, bevy_cam should not depend on the platform windowing backend — that's the consuming application's responsibility

Closes #8266

## Test plan
- [x] `nx run bevy_cam:lint` passes locally (macOS)
- [ ] CI lint step passes on Linux (no winit platform error)