### PR TITLE
fix(sql): wrap auth.uid() in subquery for RLS performance #7761

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260318210000_rls_subquery_auth_uid.sql
+++ b/packages/data/sql/dbmate/migrations/20260318210000_rls_subquery_auth_uid.sql
@@ -1,0 +1,317 @@
+-- migrate:up
+-- ============================================================
+-- RLS Performance: auth.uid() → (select auth.uid())
+--
+-- Wrapping auth.uid() in a subquery forces PostgreSQL to evaluate
+-- it once per query instead of once per row, reducing overhead
+-- from seconds to microseconds on large tables.
+--
+-- Ref: https://github.com/KBVE/kbve/issues/7761
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- MEME SCHEMA — meme.memes (4 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_select_published_and_own" ON meme.memes
+    USING (status = 3 OR author_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_insert_own" ON meme.memes
+    WITH CHECK (author_id = (select auth.uid()) AND status = 1);
+
+ALTER POLICY "authenticated_update_own" ON meme.memes
+    USING (author_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own" ON meme.memes
+    WITH CHECK (author_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_reactions (4 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_insert_own_reaction" ON meme.meme_reactions
+    WITH CHECK (user_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_reaction" ON meme.meme_reactions
+    USING (user_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_reaction" ON meme.meme_reactions
+    WITH CHECK (user_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_delete_own_reaction" ON meme.meme_reactions
+    USING (user_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_comments (4 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_insert_own_comment" ON meme.meme_comments
+    WITH CHECK (author_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_comment" ON meme.meme_comments
+    USING (author_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_comment" ON meme.meme_comments
+    WITH CHECK (author_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_delete_own_comment" ON meme.meme_comments
+    USING (author_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_decks (5 policy clauses)
+-- ===========================================
+
+ALTER POLICY "authenticated_select_own_decks" ON meme.meme_decks
+    USING (owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_insert_own_deck" ON meme.meme_decks
+    WITH CHECK (owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_deck" ON meme.meme_decks
+    USING (owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_deck" ON meme.meme_decks
+    WITH CHECK (owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_delete_own_deck" ON meme.meme_decks
+    USING (owner_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_deck_cards (3 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_select_own_deck_cards" ON meme.meme_deck_cards
+    USING (EXISTS (
+        SELECT 1 FROM meme.meme_decks d
+        WHERE d.id = deck_id AND d.owner_id = (select auth.uid())
+    ));
+
+ALTER POLICY "authenticated_insert_own_deck_cards" ON meme.meme_deck_cards
+    WITH CHECK (EXISTS (
+        SELECT 1 FROM meme.meme_decks d
+        WHERE d.id = deck_id AND d.owner_id = (select auth.uid())
+    ));
+
+ALTER POLICY "authenticated_delete_own_deck_cards" ON meme.meme_deck_cards
+    USING (EXISTS (
+        SELECT 1 FROM meme.meme_decks d
+        WHERE d.id = deck_id AND d.owner_id = (select auth.uid())
+    ));
+
+-- ===========================================
+-- MEME SCHEMA — meme.battle_results (1 policy)
+-- ===========================================
+
+ALTER POLICY "authenticated_select_own_battles" ON meme.battle_results
+    USING (player_a_id = (select auth.uid()) OR player_b_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_user_profiles (1 policy, 2 clauses)
+-- ===========================================
+
+ALTER POLICY "authenticated_update_own_profile" ON meme.meme_user_profiles
+    USING (user_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_profile" ON meme.meme_user_profiles
+    WITH CHECK (user_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_follows (2 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_insert_own_follow" ON meme.meme_follows
+    WITH CHECK (follower_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_delete_own_follow" ON meme.meme_follows
+    USING (follower_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_collections (4 policies, 6 clauses)
+-- ===========================================
+
+ALTER POLICY "authenticated_select_public_and_own" ON meme.meme_collections
+    USING (is_public = true OR owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_insert_own_collection" ON meme.meme_collections
+    WITH CHECK (owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_collection" ON meme.meme_collections
+    USING (owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_update_own_collection" ON meme.meme_collections
+    WITH CHECK (owner_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_delete_own_collection" ON meme.meme_collections
+    USING (owner_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_saves (3 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_select_own_saves" ON meme.meme_saves
+    USING (user_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_insert_own_save" ON meme.meme_saves
+    WITH CHECK (user_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_delete_own_save" ON meme.meme_saves
+    USING (user_id = (select auth.uid()));
+
+-- ===========================================
+-- MEME SCHEMA — meme.meme_reports (2 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_insert_own_report" ON meme.meme_reports
+    WITH CHECK (reporter_id = (select auth.uid()));
+
+ALTER POLICY "authenticated_select_own_reports" ON meme.meme_reports
+    USING (reporter_id = (select auth.uid()));
+
+-- ===========================================
+-- REALTIME — public.realtime_messages (3 policies)
+-- ===========================================
+
+ALTER POLICY "authenticated_users_insert_messages" ON public.realtime_messages
+    WITH CHECK ((select auth.uid()) = user_id);
+
+ALTER POLICY "users_update_own_messages" ON public.realtime_messages
+    USING ((select auth.uid()) = user_id);
+
+ALTER POLICY "users_update_own_messages" ON public.realtime_messages
+    WITH CHECK ((select auth.uid()) = user_id);
+
+ALTER POLICY "users_delete_own_messages" ON public.realtime_messages
+    USING ((select auth.uid()) = user_id);
+
+-- ===========================================
+-- DISCORDSH — discordsh.servers (1 policy)
+-- ===========================================
+
+ALTER POLICY "authenticated_select_active_and_own" ON discordsh.servers
+    USING (status = 1 OR owner_id = (select auth.uid()));
+
+COMMIT;
+
+-- migrate:down
+-- Revert all policies back to bare auth.uid() calls
+
+BEGIN;
+
+-- meme.memes
+ALTER POLICY "authenticated_select_published_and_own" ON meme.memes
+    USING (status = 3 OR author_id = auth.uid());
+ALTER POLICY "authenticated_insert_own" ON meme.memes
+    WITH CHECK (author_id = auth.uid() AND status = 1);
+ALTER POLICY "authenticated_update_own" ON meme.memes
+    USING (author_id = auth.uid());
+ALTER POLICY "authenticated_update_own" ON meme.memes
+    WITH CHECK (author_id = auth.uid());
+
+-- meme.meme_reactions
+ALTER POLICY "authenticated_insert_own_reaction" ON meme.meme_reactions
+    WITH CHECK (user_id = auth.uid());
+ALTER POLICY "authenticated_update_own_reaction" ON meme.meme_reactions
+    USING (user_id = auth.uid());
+ALTER POLICY "authenticated_update_own_reaction" ON meme.meme_reactions
+    WITH CHECK (user_id = auth.uid());
+ALTER POLICY "authenticated_delete_own_reaction" ON meme.meme_reactions
+    USING (user_id = auth.uid());
+
+-- meme.meme_comments
+ALTER POLICY "authenticated_insert_own_comment" ON meme.meme_comments
+    WITH CHECK (author_id = auth.uid());
+ALTER POLICY "authenticated_update_own_comment" ON meme.meme_comments
+    USING (author_id = auth.uid());
+ALTER POLICY "authenticated_update_own_comment" ON meme.meme_comments
+    WITH CHECK (author_id = auth.uid());
+ALTER POLICY "authenticated_delete_own_comment" ON meme.meme_comments
+    USING (author_id = auth.uid());
+
+-- meme.meme_decks
+ALTER POLICY "authenticated_select_own_decks" ON meme.meme_decks
+    USING (owner_id = auth.uid());
+ALTER POLICY "authenticated_insert_own_deck" ON meme.meme_decks
+    WITH CHECK (owner_id = auth.uid());
+ALTER POLICY "authenticated_update_own_deck" ON meme.meme_decks
+    USING (owner_id = auth.uid());
+ALTER POLICY "authenticated_update_own_deck" ON meme.meme_decks
+    WITH CHECK (owner_id = auth.uid());
+ALTER POLICY "authenticated_delete_own_deck" ON meme.meme_decks
+    USING (owner_id = auth.uid());
+
+-- meme.meme_deck_cards
+ALTER POLICY "authenticated_select_own_deck_cards" ON meme.meme_deck_cards
+    USING (EXISTS (
+        SELECT 1 FROM meme.meme_decks d
+        WHERE d.id = deck_id AND d.owner_id = auth.uid()
+    ));
+ALTER POLICY "authenticated_insert_own_deck_cards" ON meme.meme_deck_cards
+    WITH CHECK (EXISTS (
+        SELECT 1 FROM meme.meme_decks d
+        WHERE d.id = deck_id AND d.owner_id = auth.uid()
+    ));
+ALTER POLICY "authenticated_delete_own_deck_cards" ON meme.meme_deck_cards
+    USING (EXISTS (
+        SELECT 1 FROM meme.meme_decks d
+        WHERE d.id = deck_id AND d.owner_id = auth.uid()
+    ));
+
+-- meme.battle_results
+ALTER POLICY "authenticated_select_own_battles" ON meme.battle_results
+    USING (player_a_id = auth.uid() OR player_b_id = auth.uid());
+
+-- meme.meme_user_profiles
+ALTER POLICY "authenticated_update_own_profile" ON meme.meme_user_profiles
+    USING (user_id = auth.uid());
+ALTER POLICY "authenticated_update_own_profile" ON meme.meme_user_profiles
+    WITH CHECK (user_id = auth.uid());
+
+-- meme.meme_follows
+ALTER POLICY "authenticated_insert_own_follow" ON meme.meme_follows
+    WITH CHECK (follower_id = auth.uid());
+ALTER POLICY "authenticated_delete_own_follow" ON meme.meme_follows
+    USING (follower_id = auth.uid());
+
+-- meme.meme_collections
+ALTER POLICY "authenticated_select_public_and_own" ON meme.meme_collections
+    USING (is_public = true OR owner_id = auth.uid());
+ALTER POLICY "authenticated_insert_own_collection" ON meme.meme_collections
+    WITH CHECK (owner_id = auth.uid());
+ALTER POLICY "authenticated_update_own_collection" ON meme.meme_collections
+    USING (owner_id = auth.uid());
+ALTER POLICY "authenticated_update_own_collection" ON meme.meme_collections
+    WITH CHECK (owner_id = auth.uid());
+ALTER POLICY "authenticated_delete_own_collection" ON meme.meme_collections
+    USING (owner_id = auth.uid());
+
+-- meme.meme_saves
+ALTER POLICY "authenticated_select_own_saves" ON meme.meme_saves
+    USING (user_id = auth.uid());
+ALTER POLICY "authenticated_insert_own_save" ON meme.meme_saves
+    WITH CHECK (user_id = auth.uid());
+ALTER POLICY "authenticated_delete_own_save" ON meme.meme_saves
+    USING (user_id = auth.uid());
+
+-- meme.meme_reports
+ALTER POLICY "authenticated_insert_own_report" ON meme.meme_reports
+    WITH CHECK (reporter_id = auth.uid());
+ALTER POLICY "authenticated_select_own_reports" ON meme.meme_reports
+    USING (reporter_id = auth.uid());
+
+-- public.realtime_messages
+ALTER POLICY "authenticated_users_insert_messages" ON public.realtime_messages
+    WITH CHECK (auth.uid() = user_id);
+ALTER POLICY "users_update_own_messages" ON public.realtime_messages
+    USING (auth.uid() = user_id);
+ALTER POLICY "users_update_own_messages" ON public.realtime_messages
+    WITH CHECK (auth.uid() = user_id);
+ALTER POLICY "users_delete_own_messages" ON public.realtime_messages
+    USING (auth.uid() = user_id);
+
+-- discordsh.servers
+ALTER POLICY "authenticated_select_active_and_own" ON discordsh.servers
+    USING (status = 1 OR owner_id = auth.uid());
+
+COMMIT;

--- a/packages/data/sql/schema/discordsh/discordsh_servers.sql
+++ b/packages/data/sql/schema/discordsh/discordsh_servers.sql
@@ -386,7 +386,7 @@ CREATE POLICY "anon_select_active" ON discordsh.servers
 
 CREATE POLICY "authenticated_select_active_and_own" ON discordsh.servers
     FOR SELECT TO authenticated
-    USING (status = 1 OR owner_id = auth.uid());
+    USING (status = 1 OR owner_id = (select auth.uid()));
 
 -- No INSERT or UPDATE policy for authenticated — all writes gated through proxy functions
 -- INSERT via proxy_submit_server, UPDATE via proxy_update_server

--- a/packages/data/sql/schema/meme/meme_cards.sql
+++ b/packages/data/sql/schema/meme/meme_cards.sql
@@ -142,20 +142,20 @@ CREATE POLICY "service_role_full_access" ON meme.meme_decks
 
 CREATE POLICY "authenticated_select_own_decks" ON meme.meme_decks
     FOR SELECT TO authenticated
-    USING (owner_id = auth.uid());
+    USING (owner_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_insert_own_deck" ON meme.meme_decks
     FOR INSERT TO authenticated
-    WITH CHECK (owner_id = auth.uid());
+    WITH CHECK (owner_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_update_own_deck" ON meme.meme_decks
     FOR UPDATE TO authenticated
-    USING (owner_id = auth.uid())
-    WITH CHECK (owner_id = auth.uid());
+    USING (owner_id = (select auth.uid()))
+    WITH CHECK (owner_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_delete_own_deck" ON meme.meme_decks
     FOR DELETE TO authenticated
-    USING (owner_id = auth.uid());
+    USING (owner_id = (select auth.uid()));
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON meme.meme_decks TO authenticated;
 
@@ -192,21 +192,21 @@ CREATE POLICY "authenticated_select_own_deck_cards" ON meme.meme_deck_cards
     FOR SELECT TO authenticated
     USING (EXISTS (
         SELECT 1 FROM meme.meme_decks d
-        WHERE d.id = deck_id AND d.owner_id = auth.uid()
+        WHERE d.id = deck_id AND d.owner_id = (select auth.uid())
     ));
 
 CREATE POLICY "authenticated_insert_own_deck_cards" ON meme.meme_deck_cards
     FOR INSERT TO authenticated
     WITH CHECK (EXISTS (
         SELECT 1 FROM meme.meme_decks d
-        WHERE d.id = deck_id AND d.owner_id = auth.uid()
+        WHERE d.id = deck_id AND d.owner_id = (select auth.uid())
     ));
 
 CREATE POLICY "authenticated_delete_own_deck_cards" ON meme.meme_deck_cards
     FOR DELETE TO authenticated
     USING (EXISTS (
         SELECT 1 FROM meme.meme_decks d
-        WHERE d.id = deck_id AND d.owner_id = auth.uid()
+        WHERE d.id = deck_id AND d.owner_id = (select auth.uid())
     ));
 
 GRANT SELECT, INSERT, DELETE ON meme.meme_deck_cards TO authenticated;
@@ -311,7 +311,7 @@ CREATE POLICY "service_role_full_access" ON meme.battle_results
 
 CREATE POLICY "authenticated_select_own_battles" ON meme.battle_results
     FOR SELECT TO authenticated
-    USING (player_a_id = auth.uid() OR player_b_id = auth.uid());
+    USING (player_a_id = (select auth.uid()) OR player_b_id = (select auth.uid()));
 
 CREATE POLICY "anon_select_completed_battles" ON meme.battle_results
     FOR SELECT TO anon

--- a/packages/data/sql/schema/meme/meme_core.sql
+++ b/packages/data/sql/schema/meme/meme_core.sql
@@ -428,16 +428,16 @@ CREATE POLICY "anon_select_published" ON meme.memes
 
 CREATE POLICY "authenticated_select_published_and_own" ON meme.memes
     FOR SELECT TO authenticated
-    USING (status = 3 OR author_id = auth.uid());
+    USING (status = 3 OR author_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_insert_own" ON meme.memes
     FOR INSERT TO authenticated
-    WITH CHECK (author_id = auth.uid() AND status = 1);
+    WITH CHECK (author_id = (select auth.uid()) AND status = 1);
 
 CREATE POLICY "authenticated_update_own" ON meme.memes
     FOR UPDATE TO authenticated
-    USING (author_id = auth.uid())
-    WITH CHECK (author_id = auth.uid());
+    USING (author_id = (select auth.uid()))
+    WITH CHECK (author_id = (select auth.uid()));
 
 GRANT SELECT ON meme.memes TO anon;
 GRANT SELECT, INSERT, UPDATE ON meme.memes TO authenticated;

--- a/packages/data/sql/schema/meme/meme_engagement.sql
+++ b/packages/data/sql/schema/meme/meme_engagement.sql
@@ -81,16 +81,16 @@ CREATE POLICY "authenticated_select_reactions" ON meme.meme_reactions
 
 CREATE POLICY "authenticated_insert_own_reaction" ON meme.meme_reactions
     FOR INSERT TO authenticated
-    WITH CHECK (user_id = auth.uid());
+    WITH CHECK (user_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_update_own_reaction" ON meme.meme_reactions
     FOR UPDATE TO authenticated
-    USING (user_id = auth.uid())
-    WITH CHECK (user_id = auth.uid());
+    USING (user_id = (select auth.uid()))
+    WITH CHECK (user_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_delete_own_reaction" ON meme.meme_reactions
     FOR DELETE TO authenticated
-    USING (user_id = auth.uid());
+    USING (user_id = (select auth.uid()));
 
 GRANT SELECT ON meme.meme_reactions TO anon;
 GRANT SELECT, INSERT, UPDATE, DELETE ON meme.meme_reactions TO authenticated;
@@ -214,16 +214,16 @@ CREATE POLICY "authenticated_select_comments" ON meme.meme_comments
 
 CREATE POLICY "authenticated_insert_own_comment" ON meme.meme_comments
     FOR INSERT TO authenticated
-    WITH CHECK (author_id = auth.uid());
+    WITH CHECK (author_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_update_own_comment" ON meme.meme_comments
     FOR UPDATE TO authenticated
-    USING (author_id = auth.uid())
-    WITH CHECK (author_id = auth.uid());
+    USING (author_id = (select auth.uid()))
+    WITH CHECK (author_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_delete_own_comment" ON meme.meme_comments
     FOR DELETE TO authenticated
-    USING (author_id = auth.uid());
+    USING (author_id = (select auth.uid()));
 
 GRANT SELECT ON meme.meme_comments TO anon;
 GRANT SELECT, INSERT, UPDATE, DELETE ON meme.meme_comments TO authenticated;

--- a/packages/data/sql/schema/meme/meme_moderation.sql
+++ b/packages/data/sql/schema/meme/meme_moderation.sql
@@ -71,11 +71,11 @@ CREATE POLICY "service_role_full_access" ON meme.meme_reports
 
 CREATE POLICY "authenticated_insert_own_report" ON meme.meme_reports
     FOR INSERT TO authenticated
-    WITH CHECK (reporter_id = auth.uid());
+    WITH CHECK (reporter_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_select_own_reports" ON meme.meme_reports
     FOR SELECT TO authenticated
-    USING (reporter_id = auth.uid());
+    USING (reporter_id = (select auth.uid()));
 
 -- No anon access, no UPDATE/DELETE for authenticated (moderation is service_role only)
 GRANT SELECT, INSERT ON meme.meme_reports TO authenticated;

--- a/packages/data/sql/schema/meme/meme_social.sql
+++ b/packages/data/sql/schema/meme/meme_social.sql
@@ -102,8 +102,8 @@ CREATE POLICY "authenticated_select_profiles" ON meme.meme_user_profiles
 
 CREATE POLICY "authenticated_update_own_profile" ON meme.meme_user_profiles
     FOR UPDATE TO authenticated
-    USING (user_id = auth.uid())
-    WITH CHECK (user_id = auth.uid());
+    USING (user_id = (select auth.uid()))
+    WITH CHECK (user_id = (select auth.uid()));
 
 -- Profile INSERT is service_role only (auto-created on first login)
 GRANT SELECT ON meme.meme_user_profiles TO anon;
@@ -180,11 +180,11 @@ CREATE POLICY "authenticated_select_follows" ON meme.meme_follows
 
 CREATE POLICY "authenticated_insert_own_follow" ON meme.meme_follows
     FOR INSERT TO authenticated
-    WITH CHECK (follower_id = auth.uid());
+    WITH CHECK (follower_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_delete_own_follow" ON meme.meme_follows
     FOR DELETE TO authenticated
-    USING (follower_id = auth.uid());
+    USING (follower_id = (select auth.uid()));
 
 GRANT SELECT ON meme.meme_follows TO anon;
 GRANT SELECT, INSERT, DELETE ON meme.meme_follows TO authenticated;
@@ -264,20 +264,20 @@ CREATE POLICY "anon_select_public_collections" ON meme.meme_collections
 
 CREATE POLICY "authenticated_select_public_and_own" ON meme.meme_collections
     FOR SELECT TO authenticated
-    USING (is_public = true OR owner_id = auth.uid());
+    USING (is_public = true OR owner_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_insert_own_collection" ON meme.meme_collections
     FOR INSERT TO authenticated
-    WITH CHECK (owner_id = auth.uid());
+    WITH CHECK (owner_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_update_own_collection" ON meme.meme_collections
     FOR UPDATE TO authenticated
-    USING (owner_id = auth.uid())
-    WITH CHECK (owner_id = auth.uid());
+    USING (owner_id = (select auth.uid()))
+    WITH CHECK (owner_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_delete_own_collection" ON meme.meme_collections
     FOR DELETE TO authenticated
-    USING (owner_id = auth.uid());
+    USING (owner_id = (select auth.uid()));
 
 GRANT SELECT ON meme.meme_collections TO anon;
 GRANT SELECT, INSERT, UPDATE, DELETE ON meme.meme_collections TO authenticated;
@@ -357,15 +357,15 @@ CREATE POLICY "service_role_full_access" ON meme.meme_saves
 
 CREATE POLICY "authenticated_select_own_saves" ON meme.meme_saves
     FOR SELECT TO authenticated
-    USING (user_id = auth.uid());
+    USING (user_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_insert_own_save" ON meme.meme_saves
     FOR INSERT TO authenticated
-    WITH CHECK (user_id = auth.uid());
+    WITH CHECK (user_id = (select auth.uid()));
 
 CREATE POLICY "authenticated_delete_own_save" ON meme.meme_saves
     FOR DELETE TO authenticated
-    USING (user_id = auth.uid());
+    USING (user_id = (select auth.uid()));
 
 GRANT SELECT, INSERT, DELETE ON meme.meme_saves TO authenticated;
 

--- a/packages/data/sql/schema/realtime/realtime_rls.sql
+++ b/packages/data/sql/schema/realtime/realtime_rls.sql
@@ -100,7 +100,7 @@ BEGIN
         ON public.realtime_messages
         FOR INSERT
         TO authenticated
-        WITH CHECK (auth.uid() = user_id)';
+        WITH CHECK ((select auth.uid()) = user_id)';
     END IF;
 END $$;
 

--- a/packages/data/sql/schema/realtime/realtime_schema.sql
+++ b/packages/data/sql/schema/realtime/realtime_schema.sql
@@ -128,7 +128,7 @@ ON public.realtime_messages
 FOR INSERT
 TO authenticated
 WITH CHECK (
-    auth.uid() = user_id
+    (select auth.uid()) = user_id
 );
 
 -- Users can update their own messages
@@ -137,10 +137,10 @@ ON public.realtime_messages
 FOR UPDATE
 TO authenticated
 USING (
-    auth.uid() = user_id
+    (select auth.uid()) = user_id
 )
 WITH CHECK (
-    auth.uid() = user_id
+    (select auth.uid()) = user_id
 );
 
 -- Users can delete their own messages
@@ -149,7 +149,7 @@ ON public.realtime_messages
 FOR DELETE
 TO authenticated
 USING (
-    auth.uid() = user_id
+    (select auth.uid()) = user_id
 );
 
 -- Admin override policy (for system messages)


### PR DESCRIPTION
## Summary
- Wrap all `auth.uid()` calls in RLS policies with `(select auth.uid())` so PostgreSQL evaluates the function once per query instead of once per row
- Update 7 source-of-truth SQL schema files (meme, realtime, discordsh)
- Add dbmate migration `20260318210000_rls_subquery_auth_uid.sql` for production rollout with full `migrate:down` support

## Scope
- **39 RLS policies** across 3 schemas: `meme` (34), `realtime` (4), `discordsh` (1)
- Purely a performance optimization — no functional or API contract changes
- Function body `auth.uid()` calls (e.g. discordsh proxy functions) left as-is since they already execute once

Closes #7761

## Test plan
- [ ] Verify migration applies cleanly against local postgres (`dbmate up`)
- [ ] Verify migration rolls back cleanly (`dbmate down`)
- [ ] Spot-check feed, reactions, saves, comments still work via edge functions
- [ ] Confirm no RLS errors in Supabase logs after deploy