### PR TITLE
feat(python-kbve,python-fudster): CLI invocability, utils module, Nx targets

### DIFF
--- a/packages/python/fudster/fudster/cli.py
+++ b/packages/python/fudster/fudster/cli.py
@@ -73,6 +73,48 @@ def main() -> None:
     """Fudster CLI — workspace tooling powered by kbve core."""
 
 
+# ── version ──────────────────────────────────────────────────────────
+
+@main.command()
+def version() -> None:
+    """Show fudster and kbve versions."""
+    import fudster as _fudster
+    import kbve as _kbve
+    click.echo(f"fudster {_fudster.__version__}")
+    click.echo(f"kbve    {_kbve.__version__}")
+
+
+# ── info ─────────────────────────────────────────────────────────────
+
+@main.command()
+@click.option(
+    "--json", "as_json", is_flag=True, default=False,
+    help="Output as JSON instead of a table.",
+)
+def info(as_json: bool) -> None:
+    """Show available kbve modules and their status."""
+    from kbve.utils.module_info import list_modules
+
+    modules = list_modules()
+
+    if as_json:
+        import json as _json
+        data = [
+            {"name": m.name, "description": m.description,
+             "available": m.available}
+            for m in modules
+        ]
+        click.echo(_json.dumps(data, indent=2))
+    else:
+        click.echo("kbve modules:\n")
+        for m in modules:
+            status = click.style("ok", fg="green") if m.available \
+                else click.style("missing", fg="red")
+            click.echo(f"  [{status}] {m.name}")
+            click.echo(f"         {m.description}")
+        click.echo()
+
+
 # ── nx sub-group ─────────────────────────────────────────────────────
 
 @main.group()

--- a/packages/python/fudster/project.json
+++ b/packages/python/fudster/project.json
@@ -45,7 +45,9 @@
 		},
 		"lint": {
 			"executor": "@nxlv/python:flake8",
-			"outputs": ["{workspaceRoot}/reports/packages/python/fudster/pylint.txt"],
+			"outputs": [
+				"{workspaceRoot}/reports/packages/python/fudster/pylint.txt"
+			],
 			"options": {
 				"outputFile": "reports/packages/python/fudster/pylint.txt"
 			}
@@ -65,6 +67,27 @@
 			],
 			"options": {
 				"command": "uv run pytest tests/",
+				"cwd": "packages/python/fudster"
+			}
+		},
+		"cli": {
+			"executor": "@nxlv/python:run-commands",
+			"options": {
+				"command": "uv run fudster",
+				"cwd": "packages/python/fudster"
+			}
+		},
+		"graph-to-mdx": {
+			"executor": "@nxlv/python:run-commands",
+			"options": {
+				"command": "uv run fudster nx graph-to-mdx",
+				"cwd": "packages/python/fudster"
+			}
+		},
+		"security-to-mdx": {
+			"executor": "@nxlv/python:run-commands",
+			"options": {
+				"command": "uv run fudster nx security-to-mdx",
 				"cwd": "packages/python/fudster"
 			}
 		}

--- a/packages/python/fudster/tests/test_cli.py
+++ b/packages/python/fudster/tests/test_cli.py
@@ -379,3 +379,51 @@ def test_security_to_mdx_dependabot_tab(tmp_path):
     content = mdx_out.read_text()
     assert "axios" in content
     assert "SSRF" in content
+
+
+# ── version ──────────────────────────────────────────────────────────
+
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(main, ["version"])
+    assert result.exit_code == 0
+    assert "fudster" in result.output
+    assert "kbve" in result.output
+    assert "0.1.0" in result.output
+
+
+# ── info ─────────────────────────────────────────────────────────────
+
+def test_info():
+    runner = CliRunner()
+    result = runner.invoke(main, ["info"])
+    assert result.exit_code == 0
+    assert "kbve modules" in result.output
+    assert "kbve.server" in result.output
+    assert "kbve.nx.graph" in result.output
+    assert "kbve.mdx" in result.output
+    assert "kbve.utils" in result.output
+
+
+def test_info_json():
+    runner = CliRunner()
+    result = runner.invoke(main, ["info", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    names = [m["name"] for m in data]
+    assert "kbve.server" in names
+    assert "kbve.nx.graph" in names
+    assert all("available" in m for m in data)
+    assert all("description" in m for m in data)
+
+
+def test_info_json_all_available():
+    runner = CliRunner()
+    result = runner.invoke(main, ["info", "--json"])
+    data = json.loads(result.output)
+    for m in data:
+        assert m["available"] is True, (
+            f"{m['name']} should be available"
+        )

--- a/packages/python/kbve/kbve/utils/__init__.py
+++ b/packages/python/kbve/kbve/utils/__init__.py
@@ -1,0 +1,11 @@
+"""KBVE utilities — JSON, file, and data helpers."""
+
+from .json_utils import (  # noqa: F401
+    load_json,
+    write_json,
+    merge_dicts,
+)
+from .module_info import (  # noqa: F401
+    get_module_info,
+    list_modules,
+)

--- a/packages/python/kbve/kbve/utils/json_utils.py
+++ b/packages/python/kbve/kbve/utils/json_utils.py
@@ -1,0 +1,55 @@
+"""JSON and file I/O helpers for kbve core.
+
+Provides safe loading, writing, and merging of JSON data — useful as
+building blocks for CLI commands and microservice endpoints.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(source: str | Path) -> Any:
+    """Load JSON from a file path.
+
+    Raises ``FileNotFoundError`` if the path doesn't exist,
+    ``json.JSONDecodeError`` on malformed JSON.
+    """
+    with open(source) as f:
+        return json.load(f)
+
+
+def write_json(
+    data: Any,
+    path: str | Path,
+    indent: int = 2,
+) -> None:
+    """Write *data* as formatted JSON to *path*."""
+    with open(path, "w") as f:
+        json.dump(data, f, indent=indent)
+
+
+def merge_dicts(
+    base: dict,
+    override: dict,
+    deep: bool = True,
+) -> dict:
+    """Merge *override* into *base*, returning a new dict.
+
+    When *deep* is True (default), nested dicts are merged recursively
+    rather than replaced wholesale.
+    """
+    merged = dict(base)
+    for key, val in override.items():
+        if (
+            deep
+            and key in merged
+            and isinstance(merged[key], dict)
+            and isinstance(val, dict)
+        ):
+            merged[key] = merge_dicts(merged[key], val, deep=True)
+        else:
+            merged[key] = val
+    return merged

--- a/packages/python/kbve/kbve/utils/module_info.py
+++ b/packages/python/kbve/kbve/utils/module_info.py
@@ -1,0 +1,64 @@
+"""Introspection helpers for kbve module capabilities.
+
+Used by the ``fudster info`` CLI command to report which kbve modules
+are available and what they provide.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ModuleInfo:
+    """Metadata about a kbve module."""
+
+    name: str
+    description: str
+    available: bool
+
+
+_MODULES = [
+    ("kbve.server", "Async HTTP + gRPC server framework"),
+    ("kbve.models", "Pydantic data models"),
+    ("kbve.proto", "gRPC protobuf bindings"),
+    ("kbve.nx.graph", "Nx project graph parsing and analysis"),
+    ("kbve.nx.security", "Multi-ecosystem security audit parsing"),
+    ("kbve.mdx", "Starlight MDX rendering primitives"),
+    ("kbve.mdx.escape", "MDX/JSX text escaping"),
+    ("kbve.utils", "JSON, file, and data helpers"),
+    ("kbve.api", "API clients and utilities"),
+]
+
+
+def _check_available(module_name: str) -> bool:
+    """Check if a module can be imported."""
+    try:
+        __import__(module_name)
+        return True
+    except ImportError:
+        return False
+
+
+def get_module_info(module_name: str) -> ModuleInfo | None:
+    """Get info for a specific module, or None if unknown."""
+    for name, desc in _MODULES:
+        if name == module_name:
+            return ModuleInfo(
+                name=name,
+                description=desc,
+                available=_check_available(name),
+            )
+    return None
+
+
+def list_modules() -> list[ModuleInfo]:
+    """List all known kbve modules with availability status."""
+    return [
+        ModuleInfo(
+            name=name,
+            description=desc,
+            available=_check_available(name),
+        )
+        for name, desc in _MODULES
+    ]

--- a/packages/python/kbve/tests/test_utils.py
+++ b/packages/python/kbve/tests/test_utils.py
@@ -1,0 +1,161 @@
+"""Tests for kbve.utils module."""
+
+import json
+
+from kbve.utils.json_utils import load_json, merge_dicts, write_json
+from kbve.utils.module_info import (
+    ModuleInfo,
+    get_module_info,
+    list_modules,
+)
+
+
+# ── load_json ────────────────────────────────────────────────────────
+
+def test_load_json(tmp_path):
+    path = tmp_path / "data.json"
+    path.write_text('{"key": "value"}')
+    result = load_json(path)
+    assert result == {"key": "value"}
+
+
+def test_load_json_string_path(tmp_path):
+    path = tmp_path / "data.json"
+    path.write_text("[1, 2, 3]")
+    result = load_json(str(path))
+    assert result == [1, 2, 3]
+
+
+def test_load_json_file_not_found():
+    import pytest
+    with pytest.raises(FileNotFoundError):
+        load_json("/nonexistent/file.json")
+
+
+def test_load_json_malformed(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{invalid json")
+    import pytest
+    with pytest.raises(json.JSONDecodeError):
+        load_json(path)
+
+
+# ── write_json ───────────────────────────────────────────────────────
+
+def test_write_json(tmp_path):
+    path = tmp_path / "out.json"
+    write_json({"a": 1}, path)
+    result = json.loads(path.read_text())
+    assert result == {"a": 1}
+
+
+def test_write_json_indent(tmp_path):
+    path = tmp_path / "out.json"
+    write_json({"a": 1}, path, indent=4)
+    text = path.read_text()
+    assert "    " in text
+
+
+def test_write_json_overwrites(tmp_path):
+    path = tmp_path / "out.json"
+    path.write_text("old")
+    write_json({"new": True}, path)
+    assert "old" not in path.read_text()
+    assert json.loads(path.read_text()) == {"new": True}
+
+
+def test_write_json_list(tmp_path):
+    path = tmp_path / "out.json"
+    write_json([1, 2, 3], path)
+    assert json.loads(path.read_text()) == [1, 2, 3]
+
+
+# ── merge_dicts ──────────────────────────────────────────────────────
+
+def test_merge_dicts_flat():
+    result = merge_dicts({"a": 1}, {"b": 2})
+    assert result == {"a": 1, "b": 2}
+
+
+def test_merge_dicts_override():
+    result = merge_dicts({"a": 1}, {"a": 2})
+    assert result == {"a": 2}
+
+
+def test_merge_dicts_deep():
+    base = {"nested": {"a": 1, "b": 2}}
+    override = {"nested": {"b": 3, "c": 4}}
+    result = merge_dicts(base, override)
+    assert result == {"nested": {"a": 1, "b": 3, "c": 4}}
+
+
+def test_merge_dicts_deep_preserves_originals():
+    base = {"nested": {"a": 1}}
+    override = {"nested": {"b": 2}}
+    merge_dicts(base, override)
+    assert base == {"nested": {"a": 1}}  # not mutated
+
+
+def test_merge_dicts_shallow():
+    base = {"nested": {"a": 1, "b": 2}}
+    override = {"nested": {"c": 3}}
+    result = merge_dicts(base, override, deep=False)
+    assert result == {"nested": {"c": 3}}  # replaced, not merged
+
+
+def test_merge_dicts_empty():
+    assert merge_dicts({}, {"a": 1}) == {"a": 1}
+    assert merge_dicts({"a": 1}, {}) == {"a": 1}
+    assert merge_dicts({}, {}) == {}
+
+
+def test_merge_dicts_nested_multi_level():
+    base = {"a": {"b": {"c": 1}}}
+    override = {"a": {"b": {"d": 2}}}
+    result = merge_dicts(base, override)
+    assert result == {"a": {"b": {"c": 1, "d": 2}}}
+
+
+def test_merge_dicts_non_dict_override():
+    base = {"a": {"nested": True}}
+    override = {"a": "flat now"}
+    result = merge_dicts(base, override)
+    assert result == {"a": "flat now"}
+
+
+# ── module_info ──────────────────────────────────────────────────────
+
+def test_list_modules():
+    modules = list_modules()
+    assert len(modules) > 0
+    assert all(isinstance(m, ModuleInfo) for m in modules)
+    names = [m.name for m in modules]
+    assert "kbve.server" in names
+    assert "kbve.nx.graph" in names
+    assert "kbve.mdx" in names
+    assert "kbve.utils" in names
+
+
+def test_list_modules_availability():
+    modules = list_modules()
+    core_modules = [m for m in modules if m.name == "kbve.server"]
+    assert core_modules[0].available is True
+
+
+def test_get_module_info_known():
+    info = get_module_info("kbve.nx.graph")
+    assert info is not None
+    assert info.name == "kbve.nx.graph"
+    assert info.available is True
+    assert "graph" in info.description.lower()
+
+
+def test_get_module_info_unknown():
+    info = get_module_info("kbve.nonexistent")
+    assert info is None
+
+
+def test_module_info_descriptions():
+    modules = list_modules()
+    for m in modules:
+        assert m.description, f"{m.name} has empty description"


### PR DESCRIPTION
## Summary
- Add `kbve.utils` module with `load_json`, `write_json`, `merge_dicts` (JSON/file helpers) and `list_modules`, `get_module_info` (module introspection)
- Add `fudster version` command — shows fudster and kbve package versions
- Add `fudster info` command — lists all kbve modules with availability status, supports `--json` output
- Add Nx targets in fudster `project.json`: `cli` (generic runner), `graph-to-mdx`, `security-to-mdx` — enables `pnpm nx run python-fudster:cli -- version` etc.
- 178 total tests passing (142 kbve + 36 fudster)

## Test plan
- [x] `pnpm nx run python-kbve:lint` passes
- [x] `pnpm nx run python-kbve:test` passes (142/142)
- [x] `pnpm nx run python-fudster:lint` passes
- [x] `pnpm nx run python-fudster:test` passes (36/36)