### PR TITLE
fix(desktop-kbve): add eslint config and resolve lint errors

### DIFF
--- a/apps/kbve/desktop-kbve/.eslintrc.json
+++ b/apps/kbve/desktop-kbve/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+	"extends": ["plugin:@nx/react", "../../../.eslintrc.base.json"],
+	"ignorePatterns": [
+		"!**/*",
+		"**/vite.config.*.timestamp*",
+		"**/vitest.config.*.timestamp*",
+		"src-tauri/**"
+	],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/apps/kbve/desktop-kbve/src/components/ToggleSwitch.tsx
+++ b/apps/kbve/desktop-kbve/src/components/ToggleSwitch.tsx
@@ -13,14 +13,6 @@ export function ToggleSwitch({ checked = false, onChange }: ToggleSwitchProps) {
 	const dotRef = useRef<HTMLSpanElement>(null);
 	const stateRef = useRef(checked);
 
-	useEffect(() => {
-		// Sync if parent changes the prop
-		if (stateRef.current !== checked) {
-			stateRef.current = checked;
-			applyVisual(checked);
-		}
-	}, [checked]);
-
 	function applyVisual(on: boolean) {
 		if (btnRef.current) {
 			btnRef.current.style.backgroundColor = on
@@ -33,6 +25,14 @@ export function ToggleSwitch({ checked = false, onChange }: ToggleSwitchProps) {
 				: 'translateX(2px)';
 		}
 	}
+
+	useEffect(() => {
+		// Sync if parent changes the prop
+		if (stateRef.current !== checked) {
+			stateRef.current = checked;
+			applyVisual(checked);
+		}
+	}, [checked]);
 
 	function handleClick() {
 		const next = !stateRef.current;

--- a/apps/kbve/desktop-kbve/src/engine/slot.tsx
+++ b/apps/kbve/desktop-kbve/src/engine/slot.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/refs */
 import { useRef, useEffect, createElement, type CSSProperties } from 'react';
 
 type Subscribable<S> = {

--- a/apps/kbve/desktop-kbve/src/main.tsx
+++ b/apps/kbve/desktop-kbve/src/main.tsx
@@ -7,6 +7,7 @@ import './app.css';
 // Register all views before React mounts — registry is populated synchronously
 initViews();
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<React.StrictMode>
 		<App />


### PR DESCRIPTION
## Summary
- **Root cause**: desktop-kbve was missing a project-level `.eslintrc.json`. The root config uses `ignorePatterns: ["**/*"]`, so without a project override with `"!**/*"`, ESLint rejects all files with "all files are ignored"
- Added `.eslintrc.json` extending `plugin:@nx/react` (matching the isometric project pattern)
- Fixed 10 errors / 1 warning exposed by the new config:
  - `ToggleSwitch.tsx`: moved `applyVisual` declaration above its `useEffect` usage
  - `slot.tsx`: disabled `react-hooks/refs` — intentional render-time ref update pattern for zero-rerender store subscribers
  - `main.tsx`: suppressed non-null assertion on `getElementById('root')`

Ref #8266

## Test plan
- [x] `nx run desktop-kbve:lint` passes locally
- [ ] CI lint step passes