### PR TITLE
chore(unreal): sync version.toml for WIP plugins

### DIFF
--- a/packages/unreal/KBVESQLite/version.toml
+++ b/packages/unreal/KBVESQLite/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "3.51.3"

--- a/packages/unreal/KBVEWASM/version.toml
+++ b/packages/unreal/KBVEWASM/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "2.2.0"

--- a/packages/unreal/KBVEXXHash/version.toml
+++ b/packages/unreal/KBVEXXHash/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "0.8.3"

--- a/packages/unreal/KBVEYYJson/version.toml
+++ b/packages/unreal/KBVEYYJson/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "0.12.0"

--- a/packages/unreal/KBVEZstd/version.toml
+++ b/packages/unreal/KBVEZstd/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "1.5.7"


### PR DESCRIPTION
## Summary
- Set `version.toml` to match `.uplugin` `VersionName` for 5 WIP plugins: KBVEWASM, KBVEXXHash, KBVEYYJson, KBVEZstd, KBVESQLite
- This tells the manifest-driven dispatch version gate these versions are "already handled" — no dispatch fires
- UEDevOps left at `0.0.0` since it has an active publish pipeline
- When a WIP plugin is ready to publish, bump its `.uplugin` VersionName and the pipeline kicks in automatically

## Current state
| Plugin | .uplugin | version.toml | Dispatches? |
|--------|----------|-------------|-------------|
| UEDevOps | 0.1.0 | 0.0.0 | Yes (new version) |
| KBVEWASM | 2.2.0 | 2.2.0 | No (synced) |
| KBVEXXHash | 0.8.3 | 0.8.3 | No (synced) |
| KBVEYYJson | 0.12.0 | 0.12.0 | No (synced) |
| KBVEZstd | 1.5.7 | 1.5.7 | No (synced) |
| KBVESQLite | 3.51.3 | 3.51.3 | No (synced) |