### PR TITLE
feat(python-kbve,python-fudster): add config, health, tasks modules and serve/config CLI

### DIFF
--- a/packages/python/fudster/fudster/cli.py
+++ b/packages/python/fudster/fudster/cli.py
@@ -115,6 +115,92 @@ def info(as_json: bool) -> None:
         click.echo()
 
 
+# ── serve ─────────────────────────────────────────────────────────────
+
+@main.command()
+@click.option("--host", default="0.0.0.0", help="Bind host.")
+@click.option("--port", default=8000, type=int, help="HTTP port.")
+@click.option("--grpc-port", default=50051, type=int, help="gRPC port.")
+@click.option("--log-level", default="info", help="Log level.")
+@click.option(
+    "--env-file", type=click.Path(), default=None,
+    help="Path to .env file for config.",
+)
+def serve(
+    host: str, port: int, grpc_port: int,
+    log_level: str, env_file: str | None,
+) -> None:
+    """Start a kbve microservice with health checks."""
+    import asyncio
+    from kbve import AppServer, ServerConfig
+    from kbve.config import apply_env_file
+    from kbve.health import HealthCheck, create_health_router
+
+    if env_file:
+        loaded = apply_env_file(env_file)
+        click.echo(f"Loaded {loaded} vars from {env_file}")
+
+    config = ServerConfig(
+        http_host=host,
+        http_port=port,
+        grpc_host=host,
+        grpc_port=grpc_port,
+        log_level=log_level,
+    )
+
+    hc = HealthCheck()
+    hc.add("self", lambda: True)
+
+    server = AppServer(config=config)
+    router = create_health_router(hc)
+    server.http.app.include_router(router)
+
+    addr = host + ":" + str(port)
+    click.echo(
+        f"Starting kbve server on {addr}"
+        f" (gRPC: {grpc_port})"
+    )
+    asyncio.run(server.serve())
+
+
+# ── config ───────────────────────────────────────────────────────────
+
+@main.command("config")
+@click.option(
+    "--env-file", type=click.Path(exists=True), default=None,
+    help="Path to .env file.",
+)
+@click.option("--prefix", default="", help="Env var prefix to filter.")
+@click.option(
+    "--json", "as_json", is_flag=True, default=False,
+    help="Output as JSON.",
+)
+def config_cmd(
+    env_file: str | None, prefix: str, as_json: bool,
+) -> None:
+    """Show resolved configuration from environment and .env files."""
+    from kbve.config import EnvConfig
+
+    cfg = EnvConfig.from_env(
+        prefix=prefix,
+        env_file=env_file,
+    )
+
+    if as_json:
+        click.echo(json.dumps(cfg.as_dict(), indent=2))
+    else:
+        values = cfg.as_dict()
+        if not values:
+            click.echo("No configuration values found.")
+            return
+        pfx = f" (prefix: {prefix})" if prefix else ""
+        header = "Configuration" + pfx
+        click.echo(header + ":\n")
+        for key, val in sorted(values.items()):
+            click.echo(f"  {key} = {val}")
+        click.echo()
+
+
 # ── nx sub-group ─────────────────────────────────────────────────────
 
 @main.group()

--- a/packages/python/fudster/tests/test_cli.py
+++ b/packages/python/fudster/tests/test_cli.py
@@ -427,3 +427,65 @@ def test_info_json_all_available():
         assert m["available"] is True, (
             f"{m['name']} should be available"
         )
+
+
+def test_info_includes_new_modules():
+    runner = CliRunner()
+    result = runner.invoke(main, ["info", "--json"])
+    data = json.loads(result.output)
+    names = [m["name"] for m in data]
+    assert "kbve.config" in names
+    assert "kbve.health" in names
+    assert "kbve.tasks" in names
+
+
+# ── serve ────────────────────────────────────────────────────────────
+
+def test_serve_help():
+    runner = CliRunner()
+    result = runner.invoke(main, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "--host" in result.output
+    assert "--port" in result.output
+    assert "--grpc-port" in result.output
+    assert "--env-file" in result.output
+
+
+# ── config ───────────────────────────────────────────────────────────
+
+def test_config_empty():
+    runner = CliRunner()
+    result = runner.invoke(main, ["config"])
+    assert result.exit_code == 0
+
+
+def test_config_with_env_file(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("TESTCLI_PORT=9090\nTESTCLI_HOST=127.0.0.1\n")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "config",
+        "--env-file", str(f),
+        "--prefix", "TESTCLI",
+    ])
+    assert result.exit_code == 0
+    assert "port" in result.output
+    assert "9090" in result.output
+
+
+def test_config_json(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("JSONCFG_A=1\nJSONCFG_B=two\n")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "config",
+        "--env-file", str(f),
+        "--prefix", "JSONCFG",
+        "--json",
+    ])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["a"] == "1"
+    assert data["b"] == "two"

--- a/packages/python/kbve/kbve/config/__init__.py
+++ b/packages/python/kbve/kbve/config/__init__.py
@@ -1,0 +1,7 @@
+"""KBVE configuration — env-aware config with .env file support."""
+
+from .env_config import (  # noqa: F401
+    EnvConfig,
+    load_env_file,
+    get_env,
+)

--- a/packages/python/kbve/kbve/config/env_config.py
+++ b/packages/python/kbve/kbve/config/env_config.py
@@ -1,0 +1,144 @@
+"""Environment-aware configuration loader.
+
+Reads configuration from environment variables with optional .env file
+support and typed defaults. Designed as a lightweight alternative to
+pydantic-settings for microservice deployments.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def load_env_file(path: str | Path) -> dict[str, str]:
+    """Parse a .env file into a dict of key-value pairs.
+
+    Supports ``KEY=VALUE``, quoted values, ``#`` comments, and blank lines.
+    Does NOT modify ``os.environ`` — use ``apply_env_file`` for that.
+    """
+    env_path = Path(path)
+    if not env_path.is_file():
+        return {}
+
+    result: dict[str, str] = {}
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in (
+                '"', "'"
+            ):
+                value = value[1:-1]
+            result[key] = value
+    return result
+
+
+def apply_env_file(path: str | Path, override: bool = False) -> int:
+    """Load a .env file and apply its values to ``os.environ``.
+
+    When *override* is False (default), existing env vars take precedence.
+    Returns the number of variables set.
+    """
+    pairs = load_env_file(path)
+    count = 0
+    for key, value in pairs.items():
+        if override or key not in os.environ:
+            os.environ[key] = value
+            count += 1
+    return count
+
+
+def get_env(
+    key: str,
+    default: str | None = None,
+    required: bool = False,
+) -> str | None:
+    """Get an environment variable with optional default and validation.
+
+    Raises ``ValueError`` if *required* is True and the variable is unset.
+    """
+    value = os.environ.get(key, default)
+    if required and value is None:
+        raise ValueError(f"Required environment variable '{key}' is not set")
+    return value
+
+
+@dataclass
+class EnvConfig:
+    """Typed configuration populated from environment variables.
+
+    Usage::
+
+        config = EnvConfig.from_env(
+            prefix="MYAPP",
+            defaults={"port": "8000", "log_level": "info"},
+        )
+        port = config.get_int("port")
+        host = config.get("host", "0.0.0.0")
+    """
+
+    values: dict[str, str] = field(default_factory=dict)
+    prefix: str = ""
+
+    @classmethod
+    def from_env(
+        cls,
+        prefix: str = "",
+        defaults: dict[str, str] | None = None,
+        env_file: str | Path | None = None,
+    ) -> "EnvConfig":
+        """Create an EnvConfig from environment variables.
+
+        If *env_file* is provided, loads it first (existing env vars
+        take precedence). Variables are matched by ``{PREFIX}_{KEY}``
+        when a prefix is given.
+        """
+        if env_file:
+            apply_env_file(env_file, override=False)
+
+        values = dict(defaults or {})
+        env_prefix = f"{prefix}_" if prefix else ""
+
+        for key in list(values.keys()):
+            env_key = f"{env_prefix}{key}".upper()
+            env_val = os.environ.get(env_key)
+            if env_val is not None:
+                values[key] = env_val
+
+        for key, val in os.environ.items():
+            if env_prefix and key.upper().startswith(env_prefix.upper()):
+                short_key = key[len(env_prefix):].lower()
+                if short_key not in values:
+                    values[short_key] = val
+
+        return cls(values=values, prefix=prefix)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Get a string config value."""
+        return self.values.get(key, default)
+
+    def get_int(self, key: str, default: int = 0) -> int:
+        """Get an integer config value."""
+        raw = self.values.get(key)
+        if raw is None:
+            return default
+        return int(raw)
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        """Get a boolean config value."""
+        raw = self.values.get(key)
+        if raw is None:
+            return default
+        return raw.lower() in ("true", "1", "yes", "on")
+
+    def as_dict(self) -> dict[str, str]:
+        """Return all config values as a dict."""
+        return dict(self.values)

--- a/packages/python/kbve/kbve/health/__init__.py
+++ b/packages/python/kbve/kbve/health/__init__.py
@@ -1,0 +1,8 @@
+"""KBVE health check primitives for microservice deployments."""
+
+from .checker import (  # noqa: F401
+    HealthCheck,
+    HealthStatus,
+    CheckResult,
+    create_health_router,
+)

--- a/packages/python/kbve/kbve/health/checker.py
+++ b/packages/python/kbve/kbve/health/checker.py
@@ -1,0 +1,141 @@
+"""Health check primitives for liveness and readiness probes.
+
+Provides a composable ``HealthCheck`` that aggregates named checks
+and exposes results as dicts (for JSON APIs) or as a FastAPI router.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable
+
+
+class HealthStatus(str, Enum):
+    """Overall health status."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+
+
+@dataclass
+class CheckResult:
+    """Result of a single health check."""
+
+    name: str
+    healthy: bool
+    message: str = ""
+    duration_ms: float = 0.0
+
+
+class HealthCheck:
+    """Aggregates named health checks for liveness/readiness.
+
+    Usage::
+
+        hc = HealthCheck()
+        hc.add("database", lambda: db.ping())
+        hc.add("redis", lambda: redis.ping())
+
+        result = await hc.run()
+        # {"status": "healthy", "checks": [...], "uptime_s": 123.4}
+    """
+
+    def __init__(self) -> None:
+        self._checks: list[tuple[str, Callable]] = []
+        self._start_time = time.monotonic()
+
+    def add(self, name: str, check_fn: Callable) -> "HealthCheck":
+        """Register a named check function.
+
+        *check_fn* should return True/truthy for healthy, or raise
+        an exception for unhealthy. It can be sync or async.
+        """
+        self._checks.append((name, check_fn))
+        return self
+
+    async def run(self) -> dict[str, Any]:
+        """Execute all checks and return an aggregate result."""
+        import asyncio
+
+        results: list[CheckResult] = []
+        for name, fn in self._checks:
+            start = time.monotonic()
+            try:
+                ret = fn()
+                if asyncio.iscoroutine(ret):
+                    ret = await ret
+                healthy = bool(ret) if ret is not None else True
+                msg = ""
+            except Exception as exc:
+                healthy = False
+                msg = str(exc)
+            elapsed = (time.monotonic() - start) * 1000
+            results.append(CheckResult(
+                name=name,
+                healthy=healthy,
+                message=msg,
+                duration_ms=round(elapsed, 2),
+            ))
+
+        all_healthy = all(r.healthy for r in results)
+        any_healthy = any(r.healthy for r in results)
+
+        if all_healthy:
+            status = HealthStatus.HEALTHY
+        elif any_healthy:
+            status = HealthStatus.DEGRADED
+        else:
+            status = HealthStatus.UNHEALTHY
+
+        uptime = round(time.monotonic() - self._start_time, 1)
+
+        return {
+            "status": status.value,
+            "uptime_s": uptime,
+            "checks": [
+                {
+                    "name": r.name,
+                    "healthy": r.healthy,
+                    "message": r.message,
+                    "duration_ms": r.duration_ms,
+                }
+                for r in results
+            ],
+        }
+
+    def uptime_seconds(self) -> float:
+        """Return seconds since this HealthCheck was created."""
+        return round(time.monotonic() - self._start_time, 1)
+
+
+def create_health_router(
+    health_check: HealthCheck,
+    path: str = "/health",
+    liveness_path: str = "/health/live",
+) -> Any:
+    """Create a FastAPI APIRouter with health endpoints.
+
+    - ``GET {path}`` — full health check with all probes
+    - ``GET {liveness_path}`` — simple liveness (always 200)
+
+    Returns an ``APIRouter`` instance ready to include in a FastAPI app.
+    """
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    @router.get(path)
+    async def health():
+        return await health_check.run()
+
+    @router.get(liveness_path)
+    async def liveness():
+        return {
+            "status": "alive",
+            "uptime_s": health_check.uptime_seconds(),
+        }
+
+    return router

--- a/packages/python/kbve/kbve/tasks/__init__.py
+++ b/packages/python/kbve/kbve/tasks/__init__.py
@@ -1,0 +1,7 @@
+"""KBVE async task runner for lightweight background work."""
+
+from .runner import (  # noqa: F401
+    TaskRunner,
+    TaskState,
+    TaskResult,
+)

--- a/packages/python/kbve/kbve/tasks/runner.py
+++ b/packages/python/kbve/kbve/tasks/runner.py
@@ -1,0 +1,119 @@
+"""Lightweight async task runner.
+
+Runs named async callables with timeout, error capture, and status
+tracking. Designed for microservice startup jobs, periodic checks,
+and one-shot background work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Coroutine
+
+
+class TaskState(str, Enum):
+    """Lifecycle state of a task."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+
+
+@dataclass
+class TaskResult:
+    """Outcome of a single task execution."""
+
+    name: str
+    state: TaskState
+    result: Any = None
+    error: str | None = None
+    duration_ms: float = 0.0
+
+
+class TaskRunner:
+    """Run named async tasks with timeout and error capture.
+
+    Usage::
+
+        runner = TaskRunner()
+        runner.add("migrate", migrate_db, timeout=30.0)
+        runner.add("cache-warm", warm_cache)
+
+        results = await runner.run_all()
+        # [TaskResult(name="migrate", state=COMPLETED, ...), ...]
+
+        # Or run sequentially:
+        results = await runner.run_sequential()
+    """
+
+    def __init__(self) -> None:
+        self._tasks: list[tuple[str, Callable, float | None]] = []
+
+    def add(
+        self,
+        name: str,
+        fn: Callable[[], Coroutine],
+        timeout: float | None = None,
+    ) -> "TaskRunner":
+        """Register a named async callable.
+
+        *timeout* is in seconds. None means no timeout.
+        """
+        self._tasks.append((name, fn, timeout))
+        return self
+
+    async def run_all(self) -> list[TaskResult]:
+        """Run all tasks concurrently and return results."""
+        coros = [self._execute(name, fn, timeout)
+                 for name, fn, timeout in self._tasks]
+        return await asyncio.gather(*coros)
+
+    async def run_sequential(self) -> list[TaskResult]:
+        """Run all tasks one-by-one in registration order."""
+        results: list[TaskResult] = []
+        for name, fn, timeout in self._tasks:
+            result = await self._execute(name, fn, timeout)
+            results.append(result)
+        return results
+
+    def task_names(self) -> list[str]:
+        """Return registered task names."""
+        return [name for name, _, _ in self._tasks]
+
+    async def _execute(
+        self, name: str, fn: Callable, timeout: float | None,
+    ) -> TaskResult:
+        start = time.monotonic()
+        try:
+            if timeout is not None:
+                ret = await asyncio.wait_for(fn(), timeout=timeout)
+            else:
+                ret = await fn()
+            elapsed = (time.monotonic() - start) * 1000
+            return TaskResult(
+                name=name,
+                state=TaskState.COMPLETED,
+                result=ret,
+                duration_ms=round(elapsed, 2),
+            )
+        except asyncio.TimeoutError:
+            elapsed = (time.monotonic() - start) * 1000
+            return TaskResult(
+                name=name,
+                state=TaskState.TIMEOUT,
+                error=f"Timed out after {timeout}s",
+                duration_ms=round(elapsed, 2),
+            )
+        except Exception as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            return TaskResult(
+                name=name,
+                state=TaskState.FAILED,
+                error=str(exc),
+                duration_ms=round(elapsed, 2),
+            )

--- a/packages/python/kbve/kbve/utils/module_info.py
+++ b/packages/python/kbve/kbve/utils/module_info.py
@@ -27,6 +27,9 @@ _MODULES = [
     ("kbve.mdx", "Starlight MDX rendering primitives"),
     ("kbve.mdx.escape", "MDX/JSX text escaping"),
     ("kbve.utils", "JSON, file, and data helpers"),
+    ("kbve.config", "Environment-aware configuration loader"),
+    ("kbve.health", "Health check primitives for microservices"),
+    ("kbve.tasks", "Async task runner for background work"),
     ("kbve.api", "API clients and utilities"),
 ]
 

--- a/packages/python/kbve/tests/test_config.py
+++ b/packages/python/kbve/tests/test_config.py
@@ -1,0 +1,178 @@
+"""Tests for kbve.config module."""
+
+import os
+
+import pytest
+
+from kbve.config.env_config import (
+    EnvConfig,
+    apply_env_file,
+    get_env,
+    load_env_file,
+)
+
+
+# ── load_env_file ────────────────────────────────────────────────────
+
+def test_load_env_file(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("KEY=value\nOTHER=123\n")
+    result = load_env_file(f)
+    assert result == {"KEY": "value", "OTHER": "123"}
+
+
+def test_load_env_file_comments_and_blanks(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("# comment\n\nKEY=val\n  # another\nB=2\n")
+    result = load_env_file(f)
+    assert result == {"KEY": "val", "B": "2"}
+
+
+def test_load_env_file_quoted_values(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text('A="hello world"\nB=\'single\'\n')
+    result = load_env_file(f)
+    assert result["A"] == "hello world"
+    assert result["B"] == "single"
+
+
+def test_load_env_file_no_equals(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("NOEQUALS\nKEY=val\n")
+    result = load_env_file(f)
+    assert result == {"KEY": "val"}
+
+
+def test_load_env_file_missing():
+    result = load_env_file("/nonexistent/.env")
+    assert result == {}
+
+
+def test_load_env_file_equals_in_value(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("URL=postgres://user:pass@host/db?opt=1\n")
+    result = load_env_file(f)
+    assert result["URL"] == "postgres://user:pass@host/db?opt=1"
+
+
+# ── apply_env_file ───────────────────────────────────────────────────
+
+def test_apply_env_file(tmp_path, monkeypatch):
+    f = tmp_path / ".env"
+    f.write_text("TEST_APPLY_VAR=hello\n")
+    monkeypatch.delenv("TEST_APPLY_VAR", raising=False)
+
+    count = apply_env_file(f)
+    assert count == 1
+    assert os.environ["TEST_APPLY_VAR"] == "hello"
+
+    monkeypatch.delenv("TEST_APPLY_VAR")
+
+
+def test_apply_env_file_no_override(tmp_path, monkeypatch):
+    f = tmp_path / ".env"
+    f.write_text("TEST_NOOVER=from_file\n")
+    monkeypatch.setenv("TEST_NOOVER", "from_env")
+
+    apply_env_file(f, override=False)
+    assert os.environ["TEST_NOOVER"] == "from_env"
+
+
+def test_apply_env_file_override(tmp_path, monkeypatch):
+    f = tmp_path / ".env"
+    f.write_text("TEST_OVER=from_file\n")
+    monkeypatch.setenv("TEST_OVER", "from_env")
+
+    apply_env_file(f, override=True)
+    assert os.environ["TEST_OVER"] == "from_file"
+
+
+# ── get_env ──────────────────────────────────────────────────────────
+
+def test_get_env(monkeypatch):
+    monkeypatch.setenv("TEST_GET_ENV", "val")
+    assert get_env("TEST_GET_ENV") == "val"
+
+
+def test_get_env_default():
+    assert get_env("NONEXISTENT_VAR_XYZ", default="fallback") == "fallback"
+
+
+def test_get_env_required(monkeypatch):
+    monkeypatch.delenv("REQUIRED_MISSING", raising=False)
+    with pytest.raises(ValueError, match="REQUIRED_MISSING"):
+        get_env("REQUIRED_MISSING", required=True)
+
+
+def test_get_env_required_present(monkeypatch):
+    monkeypatch.setenv("REQUIRED_PRESENT", "ok")
+    assert get_env("REQUIRED_PRESENT", required=True) == "ok"
+
+
+# ── EnvConfig ────────────────────────────────────────────────────────
+
+def test_env_config_defaults():
+    cfg = EnvConfig.from_env(defaults={"port": "8000", "host": "localhost"})
+    assert cfg.get("port") == "8000"
+    assert cfg.get("host") == "localhost"
+
+
+def test_env_config_env_override(monkeypatch):
+    monkeypatch.setenv("MYAPP_PORT", "9090")
+    cfg = EnvConfig.from_env(
+        prefix="MYAPP",
+        defaults={"port": "8000"},
+    )
+    assert cfg.get("port") == "9090"
+
+
+def test_env_config_from_file(tmp_path, monkeypatch):
+    f = tmp_path / ".env"
+    f.write_text("TESTCFG_PORT=3000\n")
+    monkeypatch.delenv("TESTCFG_PORT", raising=False)
+
+    cfg = EnvConfig.from_env(
+        prefix="TESTCFG",
+        defaults={"port": "8000"},
+        env_file=f,
+    )
+    assert cfg.get("port") == "3000"
+
+    monkeypatch.delenv("TESTCFG_PORT", raising=False)
+
+
+def test_env_config_get_int():
+    cfg = EnvConfig(values={"port": "8080"})
+    assert cfg.get_int("port") == 8080
+    assert cfg.get_int("missing") == 0
+    assert cfg.get_int("missing", default=42) == 42
+
+
+def test_env_config_get_bool():
+    cfg = EnvConfig(values={"debug": "true", "verbose": "0"})
+    assert cfg.get_bool("debug") is True
+    assert cfg.get_bool("verbose") is False
+    assert cfg.get_bool("missing") is False
+    assert cfg.get_bool("missing", default=True) is True
+
+
+def test_env_config_get_bool_variants():
+    for truthy in ("true", "1", "yes", "on", "True", "YES"):
+        cfg = EnvConfig(values={"v": truthy})
+        assert cfg.get_bool("v") is True
+    for falsy in ("false", "0", "no", "off"):
+        cfg = EnvConfig(values={"v": falsy})
+        assert cfg.get_bool("v") is False
+
+
+def test_env_config_as_dict():
+    cfg = EnvConfig(values={"a": "1", "b": "2"})
+    assert cfg.as_dict() == {"a": "1", "b": "2"}
+
+
+def test_env_config_auto_discover(monkeypatch):
+    monkeypatch.setenv("SVC_CUSTOM_KEY", "discovered")
+    cfg = EnvConfig.from_env(prefix="SVC")
+    assert cfg.get("custom_key") == "discovered"
+
+    monkeypatch.delenv("SVC_CUSTOM_KEY")

--- a/packages/python/kbve/tests/test_health.py
+++ b/packages/python/kbve/tests/test_health.py
@@ -1,0 +1,117 @@
+"""Tests for kbve.health module."""
+
+import asyncio
+
+import pytest
+
+from kbve.health.checker import (
+    CheckResult,
+    HealthCheck,
+    HealthStatus,
+)
+
+
+@pytest.fixture
+def hc():
+    return HealthCheck()
+
+
+# ── HealthCheck basics ───────────────────────────────────────────────
+
+def test_health_check_empty(hc):
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["status"] == "healthy"
+    assert result["checks"] == []
+    assert "uptime_s" in result
+
+
+def test_health_check_all_healthy(hc):
+    hc.add("a", lambda: True)
+    hc.add("b", lambda: True)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["status"] == "healthy"
+    assert len(result["checks"]) == 2
+    assert all(c["healthy"] for c in result["checks"])
+
+
+def test_health_check_one_unhealthy(hc):
+    hc.add("ok", lambda: True)
+    hc.add("bad", lambda: False)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["status"] == "degraded"
+
+
+def test_health_check_all_unhealthy(hc):
+    hc.add("bad1", lambda: False)
+    hc.add("bad2", lambda: False)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["status"] == "unhealthy"
+
+
+def test_health_check_exception(hc):
+    def failing():
+        raise ConnectionError("db down")
+
+    hc.add("db", failing)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["status"] == "unhealthy"
+    assert result["checks"][0]["healthy"] is False
+    assert "db down" in result["checks"][0]["message"]
+
+
+def test_health_check_async_fn(hc):
+    async def async_check():
+        return True
+
+    hc.add("async", async_check)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["status"] == "healthy"
+    assert result["checks"][0]["name"] == "async"
+
+
+def test_health_check_async_exception(hc):
+    async def async_fail():
+        raise RuntimeError("timeout")
+
+    hc.add("fail", async_fail)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["checks"][0]["healthy"] is False
+    assert "timeout" in result["checks"][0]["message"]
+
+
+def test_health_check_none_return(hc):
+    hc.add("none", lambda: None)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["checks"][0]["healthy"] is True
+
+
+def test_health_check_duration(hc):
+    hc.add("fast", lambda: True)
+    result = asyncio.get_event_loop().run_until_complete(hc.run())
+    assert result["checks"][0]["duration_ms"] >= 0
+
+
+def test_health_check_chaining(hc):
+    result = hc.add("a", lambda: True).add("b", lambda: True)
+    assert result is hc
+
+
+def test_uptime_seconds(hc):
+    uptime = hc.uptime_seconds()
+    assert uptime >= 0
+
+
+# ── HealthStatus enum ────────────────────────────────────────────────
+
+def test_health_status_values():
+    assert HealthStatus.HEALTHY.value == "healthy"
+    assert HealthStatus.DEGRADED.value == "degraded"
+    assert HealthStatus.UNHEALTHY.value == "unhealthy"
+
+
+# ── CheckResult ──────────────────────────────────────────────────────
+
+def test_check_result_defaults():
+    cr = CheckResult(name="test", healthy=True)
+    assert cr.message == ""
+    assert cr.duration_ms == 0.0

--- a/packages/python/kbve/tests/test_tasks.py
+++ b/packages/python/kbve/tests/test_tasks.py
@@ -1,0 +1,152 @@
+"""Tests for kbve.tasks module."""
+
+import asyncio
+
+import pytest
+
+from kbve.tasks.runner import TaskResult, TaskRunner, TaskState
+
+
+@pytest.fixture
+def runner():
+    return TaskRunner()
+
+
+# ── TaskRunner basics ────────────────────────────────────────────────
+
+def test_task_runner_empty(runner):
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_all()
+    )
+    assert results == []
+
+
+def test_task_runner_single(runner):
+    async def job():
+        return 42
+
+    runner.add("calc", job)
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_all()
+    )
+    assert len(results) == 1
+    assert results[0].name == "calc"
+    assert results[0].state == TaskState.COMPLETED
+    assert results[0].result == 42
+
+
+def test_task_runner_multiple(runner):
+    async def a():
+        return "a"
+
+    async def b():
+        return "b"
+
+    runner.add("a", a).add("b", b)
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_all()
+    )
+    assert len(results) == 2
+    assert all(r.state == TaskState.COMPLETED for r in results)
+
+
+def test_task_runner_failure(runner):
+    async def failing():
+        raise ValueError("broken")
+
+    runner.add("fail", failing)
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_all()
+    )
+    assert results[0].state == TaskState.FAILED
+    assert "broken" in results[0].error
+
+
+def test_task_runner_timeout(runner):
+    async def slow():
+        await asyncio.sleep(10)
+
+    runner.add("slow", slow, timeout=0.01)
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_all()
+    )
+    assert results[0].state == TaskState.TIMEOUT
+    assert "Timed out" in results[0].error
+
+
+def test_task_runner_sequential(runner):
+    order = []
+
+    async def first():
+        order.append("first")
+
+    async def second():
+        order.append("second")
+
+    runner.add("first", first).add("second", second)
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_sequential()
+    )
+    assert order == ["first", "second"]
+    assert all(r.state == TaskState.COMPLETED for r in results)
+
+
+def test_task_runner_sequential_continues_on_failure(runner):
+    async def failing():
+        raise RuntimeError("oops")
+
+    async def ok():
+        return "fine"
+
+    runner.add("fail", failing).add("ok", ok)
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_sequential()
+    )
+    assert results[0].state == TaskState.FAILED
+    assert results[1].state == TaskState.COMPLETED
+
+
+def test_task_runner_names(runner):
+    async def noop():
+        pass
+
+    runner.add("a", noop).add("b", noop)
+    assert runner.task_names() == ["a", "b"]
+
+
+def test_task_runner_duration(runner):
+    async def job():
+        return True
+
+    runner.add("job", job)
+    results = asyncio.get_event_loop().run_until_complete(
+        runner.run_all()
+    )
+    assert results[0].duration_ms >= 0
+
+
+def test_task_runner_chaining(runner):
+    async def noop():
+        pass
+
+    result = runner.add("a", noop).add("b", noop)
+    assert result is runner
+
+
+# ── TaskState enum ───────────────────────────────────────────────────
+
+def test_task_state_values():
+    assert TaskState.PENDING.value == "pending"
+    assert TaskState.RUNNING.value == "running"
+    assert TaskState.COMPLETED.value == "completed"
+    assert TaskState.FAILED.value == "failed"
+    assert TaskState.TIMEOUT.value == "timeout"
+
+
+# ── TaskResult ───────────────────────────────────────────────────────
+
+def test_task_result_defaults():
+    tr = TaskResult(name="test", state=TaskState.PENDING)
+    assert tr.result is None
+    assert tr.error is None
+    assert tr.duration_ms == 0.0


### PR DESCRIPTION
## Summary
- Add `kbve.config` module — `EnvConfig` with `.env` file parsing, prefixed env var loading, typed getters (`get_int`, `get_bool`), and `apply_env_file` for env injection
- Add `kbve.health` module — composable `HealthCheck` with sync/async probe support, `HealthStatus` enum (healthy/degraded/unhealthy), duration tracking, and `create_health_router()` FastAPI factory for `/health` + `/health/live` endpoints
- Add `kbve.tasks` module — `TaskRunner` with named async tasks, timeout support, error capture, concurrent (`run_all`) and sequential (`run_sequential`) execution modes
- Add `fudster serve` command — quick-start a kbve microservice with health check endpoints, env file loading, configurable host/port/grpc-port
- Add `fudster config` command — show resolved configuration from env vars and .env files, supports `--prefix` filtering and `--json` output
- Update module registry with new modules
- 229 total tests passing (188 kbve + 41 fudster)

## Test plan
- [x] `python-kbve:lint` passes
- [x] `python-kbve:test` passes (188/188)
- [x] `python-fudster:lint` passes
- [x] `python-fudster:test` passes (41/41)