### PR TITLE
feat(kube): dedicated LB for WebTransport UDP

### DIFF
--- a/apps/kube/ingress/manifests/values.yaml
+++ b/apps/kube/ingress/manifests/values.yaml
@@ -89,5 +89,8 @@ tcp:
     6667: 'irc/ergo-irc-service:6667'
     6697: 'irc/ergo-irc-service:6697'
 
-udp:
-    5001: 'kbve/kbve-service:5001'
+udp: {}
+# WebTransport (UDP 5001) is exposed via a dedicated LoadBalancer
+# Service (kbve-wt-lb) to bypass nginx's L4 stream proxy, which
+# lacks QUIC connection-ID awareness and has aggressive UDP
+# session timeouts that break long-lived QUIC connections.

--- a/apps/kube/kbve/manifest/kbve-wt-lb.yaml
+++ b/apps/kube/kbve/manifest/kbve-wt-lb.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: kbve-wt-lb
+    namespace: kbve
+    labels:
+        app: kbve
+    annotations:
+        metallb.io/allow-shared-ip: 'shared-public-ip'
+spec:
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    selector:
+        app: kbve
+    ports:
+        - name: wt
+          port: 5001
+          targetPort: 5001
+          protocol: UDP

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
     - kbve-internal-ca-cert.yaml
     - kbve-wt-cert.yaml
     - kbve-deployment.yaml
+    - kbve-wt-lb.yaml
     - nginx-ingress.yaml
     - kbve-ws-ingress.yaml


### PR DESCRIPTION
## Summary
- Replace nginx stream UDP proxy with a dedicated MetalLB LoadBalancer Service (`kbve-wt-lb`) for WebTransport QUIC on port 5001
- Nginx's L4 stream module lacks QUIC connection-ID awareness and has aggressive UDP session timeouts that break long-lived QUIC connections
- Direct LB path gives clients a clean UDP path to the server, which already handles its own TLS via lightyear/wtransport

## Changes
- **New:** `apps/kube/kbve/manifest/kbve-wt-lb.yaml` — LoadBalancer Service (UDP 5001) with MetalLB `shared-public-ip` annotation + `externalTrafficPolicy: Local`
- **Modified:** `apps/kube/ingress/manifests/values.yaml` — removed `udp: 5001` from nginx stream proxy
- **Modified:** `apps/kube/kbve/manifest/kustomization.yaml` — added `kbve-wt-lb.yaml` to resources

## Test plan
- [ ] Verify ArgoCD syncs the new `kbve-wt-lb` Service in the `kbve` namespace
- [ ] Confirm MetalLB assigns the shared public IP to the new LB Service
- [ ] Test WebTransport connection from Chrome to `https://kbve.com:5001`
- [ ] Verify WebSocket fallback on `/ws` still works (Safari)