### PR TITLE
feat(kube): cilium phase 0 — ArgoCD app, helm values, talos patches

### DIFF
--- a/apps/kube/cilium/MIGRATION.md
+++ b/apps/kube/cilium/MIGRATION.md
@@ -58,15 +58,19 @@ Cluster: Talos Linux, Kubernetes 1.32.1, single /32 external IP (142.132.206.74)
 
 **Goal:** Validate Cilium compatibility with Talos and establish rollback plan.
 
-- [ ] Confirm Talos version supports Cilium CNI swap (Talos 1.6+ has native Cilium support via machine config)
-- [ ] Document current pod CIDR (10.244.0.0/16) and service CIDR (10.96.0.0/12)
+- [x] Confirm Talos version supports Cilium CNI swap — **Talos v1.8.0** (installer: `ghcr.io/siderolabs/installer:v1.8.0`), well above 1.6+ requirement
+- [x] Document current pod CIDR (10.244.0.0/16) and service CIDR (10.96.0.0/12) — confirmed in `talos-worker.yaml`
+- [x] KubePrism already enabled on port 7445 — no machine config change needed for this
+- [x] WireGuard tools system extension already installed (`siderolabs/wireguard-tools`) — kernel module available
+- [x] Infra-level WireGuard (wg0, port 51820, 10.0.0.0/24) already connects NUC workers to Hetzner control plane — Cilium WireGuard (port 51871) is a separate layer for pod traffic
+- [ ] `cluster.proxy.disabled` is currently `false` — must flip to `true` during Phase 1 cutover
 - [ ] Snapshot current MetalLB IP assignments: `kubectl get svc -A -o wide | grep LoadBalancer`
 - [ ] Back up all Ingress resources: `kubectl get ingress -A -o yaml > ingress-backup.yaml`
 - [ ] Back up MetalLB config: `kubectl get ipaddresspool,l2advertisement -n metallb-system -o yaml`
-- [ ] Verify cert-manager has no hard dependency on nginx (it doesn't — HTTP01 solver uses any ingress class)
-- [ ] Create `apps/kube/cilium/` ArgoCD Application structure (this directory)
+- [x] cert-manager check — `letsencrypt-dns` and `internal-ca-issuer` are nginx-independent. **However**, `letsencrypt-http` ClusterIssuer has `ingressClassName: nginx` hardcoded in all 5 HTTP01 solvers (kbve.com, discord.sh, herbmail.com, meme.sh, cryptothrone.com). Must update to `cilium` during Phase 2 ingress migration.
+- [x] Create `apps/kube/cilium/` ArgoCD Application structure — `application.yaml`, `values.yaml`, `patches/`
 
-**Rollback plan:** Talos machine config can revert CNI. Keep flannel config in version control.
+**Rollback plan:** `patches/cilium-rollback.yaml` reverts to flannel + kube-proxy. Apply per-node via `talosctl patch machineconfig`, then remove Cilium ArgoCD Application.
 
 ---
 

--- a/apps/kube/cilium/application.yaml
+++ b/apps/kube/cilium/application.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: cilium
+    namespace: argocd
+spec:
+    project: default
+    sources:
+        - repoURL: https://helm.cilium.io
+          targetRevision: 1.18.0
+          chart: cilium
+          helm:
+              releaseName: cilium
+              valueFiles:
+                  - $values/apps/kube/cilium/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: kube-system
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=false
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m

--- a/apps/kube/cilium/patches/cilium-enable.yaml
+++ b/apps/kube/cilium/patches/cilium-enable.yaml
@@ -1,0 +1,32 @@
+## Talos machine config patch — enable Cilium CNI
+## Apply: talosctl patch machineconfig --nodes <node> --patch @cilium-enable.yaml
+##
+## Prerequisites:
+##   1. Cilium Helm chart deployed via ArgoCD (application.yaml)
+##   2. Maintenance window scheduled (CNI swap disrupts pod networking)
+##
+## This patch:
+##   - Disables the default flannel CNI
+##   - Disables kube-proxy (Cilium replaces it via eBPF)
+##   - KubePrism is already enabled (port 7445) in current config
+##   - Disables forwardKubeDNSToHost to avoid CoreDNS conflict with BPF masquerade
+##
+## Apply to each node one at a time (rolling upgrade):
+##   talosctl patch machineconfig --nodes <control-plane> --patch @cilium-enable.yaml
+##   # wait for node to come back and cilium agent to be Running
+##   talosctl patch machineconfig --nodes <worker-1> --patch @cilium-enable.yaml
+##   # repeat for each worker
+
+cluster:
+    network:
+        cni:
+            name: none
+    proxy:
+        disabled: true
+machine:
+    features:
+        kubePrism:
+            enabled: true
+            port: 7445
+    sysctls:
+        net.core.bpf_jit_enable: '1'

--- a/apps/kube/cilium/patches/cilium-rollback.yaml
+++ b/apps/kube/cilium/patches/cilium-rollback.yaml
@@ -1,0 +1,15 @@
+## Talos machine config patch — rollback to flannel + kube-proxy
+## Apply: talosctl patch machineconfig --nodes <node> --patch @cilium-rollback.yaml
+##
+## Use this if Cilium fails to start or causes networking issues.
+## After applying to all nodes:
+##   1. Delete the Cilium ArgoCD Application (or disable auto-sync)
+##   2. kubectl delete ds cilium -n kube-system
+##   3. Pods will reconnect via flannel once nodes finish reconfiguring
+
+cluster:
+    network:
+        cni:
+            name: flannel
+    proxy:
+        disabled: false

--- a/apps/kube/cilium/values.yaml
+++ b/apps/kube/cilium/values.yaml
@@ -1,0 +1,62 @@
+## Cilium Helm values for Talos Linux (v1.8.0+)
+## Reference: https://docs.siderolabs.com/kubernetes-guides/cni/deploying-cilium
+
+ipam:
+    mode: kubernetes
+
+# Replace kube-proxy (requires cluster.proxy.disabled=true in Talos machine config)
+kubeProxyReplacement: true
+k8sServiceHost: localhost # KubePrism (already enabled on port 7445)
+k8sServicePort: 7445
+
+# Talos cgroup v2 — do not auto-mount, use host path
+cgroup:
+    autoMount:
+        enabled: false
+    hostRoot: /sys/fs/cgroup
+
+# Talos security — SYS_MODULE not allowed, must be explicitly excluded
+securityContext:
+    capabilities:
+        ciliumAgent:
+            - CHOWN
+            - KILL
+            - NET_ADMIN
+            - NET_RAW
+            - IPC_LOCK
+            - SYS_ADMIN
+            - SYS_RESOURCE
+            - DAC_OVERRIDE
+            - FOWNER
+            - SETGID
+            - SETUID
+        cleanCiliumState:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_RESOURCE
+
+# WireGuard encryption — pod-to-pod + node-to-node
+# This is separate from the infra-level WireGuard (wg0) that connects
+# NUC workers to the Hetzner control plane. Cilium WireGuard encrypts
+# all east-west pod traffic across nodes using per-node keys on UDP 51871.
+encryption:
+    enabled: true
+    type: wireguard
+    nodeEncryption: true
+
+# Observability — Hubble network flow visibility
+hubble:
+    enabled: true
+    relay:
+        enabled: true
+    ui:
+        enabled: true
+
+# Gateway API — enabled now so CRDs are installed, ready for Phase 2/5
+gatewayAPI:
+    enabled: true
+    enableAlpn: true
+    enableAppProtocol: true
+
+operator:
+    replicas: 1


### PR DESCRIPTION
## Summary
- Cilium ArgoCD Application (`application.yaml`) — Helm chart v1.18.0 with multi-source pattern matching existing ingress-nginx setup
- Helm values (`values.yaml`) — Talos-specific config: KubePrism localhost:7445, cgroup v2 host mount, SYS_MODULE exclusion, WireGuard pod-to-pod + node-to-node encryption, Hubble observability, Gateway API CRDs
- Talos machine config patches (`patches/`) — `cilium-enable.yaml` for CNI swap, `cilium-rollback.yaml` to revert to flannel
- Updated MIGRATION.md Phase 0 checklist with verified findings from `talos-worker.yaml`

## Key findings
- Talos v1.8.0 confirmed (above 1.6+ requirement)
- KubePrism already enabled on port 7445
- Infra-level WireGuard (wg0, port 51820) already in place for NUC↔Hetzner; Cilium WireGuard (port 51871) is a separate pod-traffic layer
- `letsencrypt-http` ClusterIssuer has `ingressClassName: nginx` in 5 HTTP01 solvers — needs updating during Phase 2

## Test plan
- [ ] Review Helm values against Siderolabs guide
- [ ] Verify ArgoCD Application YAML is valid (dry-run sync)
- [ ] No cluster changes in this PR — Phase 0 is prep only