### PR TITLE
feat(kube): secondary IP + MetalLB pool + Cilium ArgoCD registration

### DIFF
--- a/apps/kube/kbve/manifest/kbve-wt-lb.yaml
+++ b/apps/kube/kbve/manifest/kbve-wt-lb.yaml
@@ -6,7 +6,7 @@ metadata:
     labels:
         app: kbve
     annotations:
-        metallb.io/allow-shared-ip: 'shared-public-ip'
+        metallb.io/loadBalancerIPs: '142.132.206.71'
 spec:
     type: LoadBalancer
     externalTrafficPolicy: Local

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -56,3 +56,7 @@ resources:
     # Consolidated: runners includes helm chart + ExternalSecret/SecretStore
     - github/controller/application.yaml
     - github/runners/application.yaml
+
+    # Cilium CNI + WireGuard (Phase 0 — ArgoCD discovers the app,
+    # but CNI swap requires Talos machine config patch in Phase 1)
+    - cilium/application.yaml

--- a/apps/kube/metallb/manifests/ip-pool.yaml
+++ b/apps/kube/metallb/manifests/ip-pool.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
     addresses:
         - 142.132.206.74/32
+        - 142.132.206.71/32
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement


### PR DESCRIPTION
## Summary
- Add Hetzner secondary IP `142.132.206.71/32` to MetalLB IP pool
- Assign `kbve-wt-lb` (WebTransport UDP 5001) to the new IP via `metallb.io/loadBalancerIPs` — fixes pending LB from PR #8299
- Register `cilium/application.yaml` in root kustomization so ArgoCD discovers the Cilium Helm chart

## IP allocation plan
| IP | Purpose |
|---|---|
| `142.132.206.74` | nginx ingress (current production) |
| `142.132.206.71` | Cilium (future ingress) + WebTransport LB |

## Test plan
- [ ] MetalLB assigns `142.132.206.71` to `kbve-wt-lb` (status moves from `<pending>` to assigned)
- [ ] ArgoCD discovers and syncs the Cilium Application
- [ ] Existing nginx ingress on `142.132.206.74` unaffected
- [ ] WebTransport reachable on `142.132.206.71:5001`