### PR TITLE
feat(desktop-kbve): wire frontend views to backend actors

### DIFF
--- a/apps/kbve/desktop-kbve/src/components/ViewStatus.tsx
+++ b/apps/kbve/desktop-kbve/src/components/ViewStatus.tsx
@@ -1,0 +1,58 @@
+import { useRef, useEffect } from 'react';
+import type { ViewStatus } from '../engine/bridge';
+
+const STATUS_COLORS: Record<ViewStatus, string> = {
+	idle: '#8888a0',
+	running: '#22c55e',
+	paused: '#f59e0b',
+	stopped: '#ef4444',
+};
+
+const STATUS_LABELS: Record<ViewStatus, string> = {
+	idle: 'Idle',
+	running: 'Connected',
+	paused: 'Paused',
+	stopped: 'Disconnected',
+};
+
+interface ViewStatusBadgeProps {
+	status: ViewStatus;
+}
+
+/**
+ * Small dot + label badge showing backend actor status.
+ * Updates via direct DOM patch when status prop changes.
+ */
+export function ViewStatusBadge({ status }: ViewStatusBadgeProps) {
+	const dotRef = useRef<HTMLSpanElement>(null);
+	const labelRef = useRef<HTMLSpanElement>(null);
+
+	useEffect(() => {
+		if (dotRef.current) {
+			dotRef.current.style.backgroundColor =
+				STATUS_COLORS[status] ?? STATUS_COLORS.idle;
+		}
+		if (labelRef.current) {
+			labelRef.current.textContent = STATUS_LABELS[status] ?? status;
+		}
+	}, [status]);
+
+	return (
+		<div className="flex items-center gap-1.5">
+			<span
+				ref={dotRef}
+				className="inline-block h-2 w-2 rounded-full"
+				style={{
+					backgroundColor:
+						STATUS_COLORS[status] ?? STATUS_COLORS.idle,
+				}}
+			/>
+			<span
+				ref={labelRef}
+				className="text-xs"
+				style={{ color: 'var(--color-text-muted)' }}>
+				{STATUS_LABELS[status] ?? status}
+			</span>
+		</div>
+	);
+}

--- a/apps/kbve/desktop-kbve/src/engine/index.ts
+++ b/apps/kbve/desktop-kbve/src/engine/index.ts
@@ -14,3 +14,4 @@ export {
 	onViewConfigAck,
 } from './bridge';
 export type { ViewStatus, ViewSnapshot, ViewEvent } from './bridge';
+export { useViewBridge } from './use-view-bridge';

--- a/apps/kbve/desktop-kbve/src/engine/registry.test.ts
+++ b/apps/kbve/desktop-kbve/src/engine/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 // We need to test registry in isolation, so import the module functions directly.
 // The registry is module-scoped mutable state, so tests reflect cumulative state.

--- a/apps/kbve/desktop-kbve/src/engine/use-view-bridge.ts
+++ b/apps/kbve/desktop-kbve/src/engine/use-view-bridge.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+	viewStart,
+	viewSnapshot,
+	onViewStatusChange,
+	onViewConfigAck,
+	type ViewStatus,
+} from './bridge';
+
+interface ViewBridgeState {
+	status: ViewStatus;
+	data: Record<string, unknown>;
+	loading: boolean;
+	error: string | null;
+}
+
+/**
+ * Hook that connects a frontend view to its backend actor.
+ *
+ * On mount:
+ * 1. Sends a Start command to the actor
+ * 2. Fetches the actor's snapshot to hydrate initial state
+ * 3. Subscribes to status + config events for live updates
+ *
+ * Returns the current actor state which updates via direct event
+ * subscriptions — no polling.
+ */
+export function useViewBridge(viewId: string): ViewBridgeState {
+	const [state, setState] = useState<ViewBridgeState>({
+		status: 'idle',
+		data: {},
+		loading: true,
+		error: null,
+	});
+	const mountedRef = useRef(true);
+
+	useEffect(() => {
+		mountedRef.current = true;
+		const cleanups: (() => void)[] = [];
+
+		async function init() {
+			try {
+				// Start the actor
+				await viewStart(viewId);
+
+				// Fetch initial snapshot
+				const snap = await viewSnapshot(viewId);
+				if (mountedRef.current) {
+					setState({
+						status: snap.status,
+						data: snap.data,
+						loading: false,
+						error: null,
+					});
+				}
+
+				// Subscribe to status changes
+				const unStatus = await onViewStatusChange(viewId, (status) => {
+					if (mountedRef.current) {
+						setState((prev) => ({ ...prev, status }));
+					}
+				});
+				cleanups.push(unStatus);
+
+				// Subscribe to config acknowledgements
+				const unConfig = await onViewConfigAck(viewId, (config) => {
+					if (mountedRef.current) {
+						setState((prev) => ({
+							...prev,
+							data: { ...prev.data, ...config },
+						}));
+					}
+				});
+				cleanups.push(unConfig);
+			} catch (err) {
+				// In dev mode without Tauri, invoke() throws — handle gracefully
+				if (mountedRef.current) {
+					setState((prev) => ({
+						...prev,
+						loading: false,
+						error:
+							err instanceof Error
+								? err.message
+								: 'Bridge unavailable',
+					}));
+				}
+			}
+		}
+
+		init();
+
+		return () => {
+			mountedRef.current = false;
+			cleanups.forEach((fn) => fn());
+		};
+	}, [viewId]);
+
+	return state;
+}

--- a/apps/kbve/desktop-kbve/src/engine/view-host.tsx
+++ b/apps/kbve/desktop-kbve/src/engine/view-host.tsx
@@ -262,13 +262,22 @@ function CardPanel({
 					</button>
 				</div>
 			</div>
-			<div className="card-body">
-				<p
-					className="text-xs"
-					style={{ color: 'var(--color-text-muted)' }}>
-					{getView(viewId)?.label ?? viewId} view content
-				</p>
-			</div>
+			<CardContent viewId={viewId} />
+		</div>
+	);
+}
+
+// ─── CardContent ─────────────────────────────────────────────────────────────
+// Renders the actual view component inside a card panel.
+
+function CardContent({ viewId }: { viewId: string }) {
+	const view = getView(viewId);
+	if (!view) return null;
+
+	const Component = view.component;
+	return (
+		<div className="card-body">
+			<Component />
 		</div>
 	);
 }

--- a/apps/kbve/desktop-kbve/src/views/general.tsx
+++ b/apps/kbve/desktop-kbve/src/views/general.tsx
@@ -1,12 +1,27 @@
 import { SettingsCard } from '../components/SettingsCard';
 import { SettingsRow } from '../components/SettingsRow';
 import { ToggleSwitch } from '../components/ToggleSwitch';
+import { ViewStatusBadge } from '../components/ViewStatus';
 import { Slot } from '../engine';
+import { useViewBridge } from '../engine/use-view-bridge';
 import { useSettingsStore } from '../stores/settings';
 
 export function GeneralView() {
+	const bridge = useViewBridge('general');
+
 	return (
 		<div className="flex max-w-2xl flex-col gap-6">
+			<div className="flex items-center justify-between">
+				<ViewStatusBadge status={bridge.status} />
+				{bridge.loading && (
+					<span
+						className="text-xs"
+						style={{ color: 'var(--color-text-muted)' }}>
+						Connecting...
+					</span>
+				)}
+			</div>
+
 			<SettingsCard title="Appearance">
 				<SettingsRow
 					label="Theme"


### PR DESCRIPTION
## Summary
- `useViewBridge` hook connects React views to Rust actors on mount — sends Start, fetches snapshot, subscribes to status/config events
- Card panels now render actual view components via `CardContent` instead of placeholder text
- `ViewStatusBadge` component shows color-coded backend connection state (green=Connected, yellow=Paused, red=Disconnected)
- GeneralView wired to backend with live status indicator

## Test plan
- [ ] Verify `tsc --noEmit` passes
- [ ] Verify vitest (26 tests) passes
- [ ] Verify `cargo test` (12 tests) passes
- [ ] Confirm GeneralView shows status badge on mount
- [ ] Confirm card panels render real view content when opened