### PR TITLE
test(astro-memes): vitest setup + media and feed store test suites (53 tests)

### DIFF
--- a/apps/memes/astro-memes/project.json
+++ b/apps/memes/astro-memes/project.json
@@ -70,6 +70,13 @@
 				"commands": ["nx exec -- astro sync"],
 				"parallel": false
 			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/memes/astro-memes",
+				"command": "vitest run --config vitest.config.ts"
+			}
 		}
 	}
 }

--- a/apps/memes/astro-memes/src/lib/media.test.ts
+++ b/apps/memes/astro-memes/src/lib/media.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import {
+	parseYouTubeUrl,
+	youTubeThumbnail,
+	youTubeEmbedUrl,
+	resolveMediaKind,
+	gridThumbnail,
+	showPlayOverlay,
+} from './media';
+
+// ── parseYouTubeUrl ──────────────────────────────────────────────────
+
+describe('parseYouTubeUrl', () => {
+	it('parses youtube.com/watch?v= URLs', () => {
+		const result = parseYouTubeUrl(
+			'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		);
+		expect(result).toEqual({ videoId: 'dQw4w9WgXcQ' });
+	});
+
+	it('parses youtube.com/watch with extra params', () => {
+		const result = parseYouTubeUrl(
+			'https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmE',
+		);
+		expect(result?.videoId).toBe('dQw4w9WgXcQ');
+	});
+
+	it('parses youtu.be short URLs', () => {
+		const result = parseYouTubeUrl('https://youtu.be/dQw4w9WgXcQ');
+		expect(result).toEqual({ videoId: 'dQw4w9WgXcQ' });
+	});
+
+	it('parses youtube.com/embed/ URLs', () => {
+		const result = parseYouTubeUrl(
+			'https://www.youtube.com/embed/dQw4w9WgXcQ',
+		);
+		expect(result).toEqual({ videoId: 'dQw4w9WgXcQ' });
+	});
+
+	it('parses youtube.com/shorts/ URLs', () => {
+		const result = parseYouTubeUrl(
+			'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+		);
+		expect(result).toEqual({ videoId: 'dQw4w9WgXcQ' });
+	});
+
+	it('extracts start time from ?t= param', () => {
+		const result = parseYouTubeUrl('https://youtu.be/dQw4w9WgXcQ?t=42');
+		expect(result).toEqual({ videoId: 'dQw4w9WgXcQ', startTime: '42' });
+	});
+
+	it('extracts start time from &t= param', () => {
+		const result = parseYouTubeUrl(
+			'https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120',
+		);
+		expect(result).toEqual({
+			videoId: 'dQw4w9WgXcQ',
+			startTime: '120',
+		});
+	});
+
+	it('returns null for non-YouTube URLs', () => {
+		expect(parseYouTubeUrl('https://example.com/video.mp4')).toBeNull();
+		expect(parseYouTubeUrl('https://vimeo.com/123456')).toBeNull();
+		expect(parseYouTubeUrl('https://picsum.photos/800/600')).toBeNull();
+	});
+
+	it('returns null for malformed YouTube URLs', () => {
+		expect(parseYouTubeUrl('https://youtube.com/watch')).toBeNull();
+		expect(parseYouTubeUrl('https://youtube.com/watch?v=short')).toBeNull();
+	});
+
+	it('handles video IDs with hyphens and underscores', () => {
+		const result = parseYouTubeUrl('https://youtu.be/abc-def_123');
+		expect(result?.videoId).toBe('abc-def_123');
+	});
+});
+
+// ── youTubeThumbnail ─────────────────────────────────────────────────
+
+describe('youTubeThumbnail', () => {
+	it('returns hq thumbnail by default', () => {
+		expect(youTubeThumbnail('dQw4w9WgXcQ')).toBe(
+			'https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+		);
+	});
+
+	it('returns maxres thumbnail', () => {
+		expect(youTubeThumbnail('dQw4w9WgXcQ', 'maxres')).toBe(
+			'https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg',
+		);
+	});
+
+	it('returns default quality thumbnail', () => {
+		expect(youTubeThumbnail('dQw4w9WgXcQ', 'default')).toBe(
+			'https://img.youtube.com/vi/dQw4w9WgXcQ/default.jpg',
+		);
+	});
+
+	it('returns sd thumbnail', () => {
+		expect(youTubeThumbnail('dQw4w9WgXcQ', 'sd')).toBe(
+			'https://img.youtube.com/vi/dQw4w9WgXcQ/sddefault.jpg',
+		);
+	});
+
+	it('returns mq thumbnail', () => {
+		expect(youTubeThumbnail('dQw4w9WgXcQ', 'mq')).toBe(
+			'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
+		);
+	});
+});
+
+// ── youTubeEmbedUrl ──────────────────────────────────────────────────
+
+describe('youTubeEmbedUrl', () => {
+	it('builds privacy-enhanced embed URL', () => {
+		expect(youTubeEmbedUrl({ videoId: 'dQw4w9WgXcQ' })).toBe(
+			'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0&modestbranding=1',
+		);
+	});
+
+	it('includes start time when provided', () => {
+		expect(
+			youTubeEmbedUrl({ videoId: 'dQw4w9WgXcQ', startTime: '42' }),
+		).toBe(
+			'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0&modestbranding=1&start=42',
+		);
+	});
+
+	it('omits start param when undefined', () => {
+		const url = youTubeEmbedUrl({ videoId: 'abc-def_123' });
+		expect(url).not.toContain('&start=');
+	});
+});
+
+// ── resolveMediaKind ─────────────────────────────────────────────────
+
+describe('resolveMediaKind', () => {
+	it('detects YouTube URLs regardless of format field', () => {
+		expect(resolveMediaKind('https://youtu.be/dQw4w9WgXcQ', 1)).toBe(
+			'youtube',
+		);
+		expect(
+			resolveMediaKind('https://youtube.com/watch?v=dQw4w9WgXcQ', 3),
+		).toBe('youtube');
+	});
+
+	it('maps format 1 to image', () => {
+		expect(resolveMediaKind('https://cdn.example.com/m.jpg', 1)).toBe(
+			'image',
+		);
+	});
+
+	it('maps format 2 to gif', () => {
+		expect(resolveMediaKind('https://cdn.example.com/m.gif', 2)).toBe(
+			'gif',
+		);
+	});
+
+	it('maps format 3 to video', () => {
+		expect(resolveMediaKind('https://cdn.example.com/m.mp4', 3)).toBe(
+			'video',
+		);
+	});
+
+	it('maps format 4 (webp_anim) to image', () => {
+		expect(resolveMediaKind('https://cdn.example.com/m.webp', 4)).toBe(
+			'image',
+		);
+	});
+
+	it('maps format 0 to unknown', () => {
+		expect(resolveMediaKind('https://cdn.example.com/m', 0)).toBe(
+			'unknown',
+		);
+	});
+
+	it('maps unknown format to unknown', () => {
+		expect(resolveMediaKind('https://cdn.example.com/m', 99)).toBe(
+			'unknown',
+		);
+	});
+});
+
+// ── gridThumbnail ────────────────────────────────────────────────────
+
+describe('gridThumbnail', () => {
+	it('returns YouTube thumbnail for YouTube URLs', () => {
+		const thumb = gridThumbnail('https://youtu.be/dQw4w9WgXcQ', null);
+		expect(thumb).toBe(
+			'https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+		);
+	});
+
+	it('prefers thumbnail_url over asset_url for non-YouTube', () => {
+		expect(
+			gridThumbnail(
+				'https://cdn.example.com/m.jpg',
+				'https://cdn.example.com/t.jpg',
+			),
+		).toBe('https://cdn.example.com/t.jpg');
+	});
+
+	it('falls back to asset_url when thumbnail_url is null', () => {
+		expect(gridThumbnail('https://cdn.example.com/m.jpg', null)).toBe(
+			'https://cdn.example.com/m.jpg',
+		);
+	});
+
+	it('ignores thumbnail_url for YouTube (uses YT thumbnail API)', () => {
+		const thumb = gridThumbnail(
+			'https://youtu.be/dQw4w9WgXcQ',
+			'https://cdn.example.com/custom-thumb.jpg',
+		);
+		expect(thumb).toContain('img.youtube.com');
+	});
+});
+
+// ── showPlayOverlay ──────────────────────────────────────────────────
+
+describe('showPlayOverlay', () => {
+	it('returns true for video', () => {
+		expect(showPlayOverlay('video')).toBe(true);
+	});
+
+	it('returns true for youtube', () => {
+		expect(showPlayOverlay('youtube')).toBe(true);
+	});
+
+	it('returns false for image', () => {
+		expect(showPlayOverlay('image')).toBe(false);
+	});
+
+	it('returns false for gif', () => {
+		expect(showPlayOverlay('gif')).toBe(false);
+	});
+
+	it('returns false for unknown', () => {
+		expect(showPlayOverlay('unknown')).toBe(false);
+	});
+});

--- a/apps/memes/astro-memes/src/lib/stores/feed.test.ts
+++ b/apps/memes/astro-memes/src/lib/stores/feed.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Provide window.location for apiGet URL construction
+if (typeof globalThis.window === 'undefined') {
+	(globalThis as Record<string, unknown>).window = {
+		location: { origin: 'http://localhost:4321' },
+	};
+}
+
+// Mock @kbve/astro before importing feed store
+vi.mock('@kbve/astro', () => ({
+	$auth: {
+		get: () => ({ tone: 'auth', name: 'test', id: 'user-1' }),
+	},
+}));
+
+// Mock supa.ts authBridge
+vi.mock('../supa', () => ({
+	authBridge: {
+		getSession: vi.fn().mockResolvedValue({ access_token: 'test-jwt' }),
+	},
+}));
+
+import {
+	$feedMemes,
+	$feedCursor,
+	$feedHasMore,
+	$feedLoading,
+	$userReactions,
+	$userSaves,
+	loadFeed,
+	loadMore,
+	reactToMeme,
+	saveMeme,
+	unsaveMeme,
+	trackView,
+	trackShare,
+} from './feed';
+import type { FeedMeme } from '../memeService';
+
+// ── Test helpers ─────────────────────────────────────────────────────
+
+function makeMeme(id: string, overrides?: Partial<FeedMeme>): FeedMeme {
+	return {
+		id,
+		title: `Meme ${id}`,
+		format: 1,
+		asset_url: `https://cdn.test/${id}.jpg`,
+		thumbnail_url: null,
+		width: 800,
+		height: 600,
+		tags: [],
+		view_count: 0,
+		reaction_count: 0,
+		comment_count: 0,
+		save_count: 0,
+		share_count: 0,
+		created_at: '2026-01-01T00:00:00Z',
+		author_name: null,
+		author_avatar: null,
+		...overrides,
+	};
+}
+
+function mockFetch(response: unknown, ok = true) {
+	return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+		ok,
+		status: ok ? 200 : 500,
+		json: () => Promise.resolve(response),
+	} as Response);
+}
+
+// ── Reset stores between tests ───────────────────────────────────────
+
+beforeEach(() => {
+	$feedMemes.set([]);
+	$feedCursor.set(null);
+	$feedHasMore.set(true);
+	$feedLoading.set('idle');
+	$userReactions.set({});
+	$userSaves.set(new Set());
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ── loadFeed ─────────────────────────────────────────────────────────
+
+describe('loadFeed', () => {
+	it('populates $feedMemes from API response', async () => {
+		const memes = [makeMeme('m1'), makeMeme('m2')];
+		mockFetch({ memes, next_cursor: 'cur1' });
+
+		await loadFeed();
+
+		expect($feedMemes.get()).toHaveLength(2);
+		expect($feedMemes.get()[0].id).toBe('m1');
+		expect($feedCursor.get()).toBe('cur1');
+	});
+
+	it('sets hasMore false when fewer than FEED_LIMIT memes returned', async () => {
+		mockFetch({ memes: [makeMeme('m1')], next_cursor: null });
+
+		await loadFeed();
+
+		expect($feedHasMore.get()).toBe(false);
+	});
+
+	it('returns to idle loading state after completion', async () => {
+		mockFetch({ memes: [], next_cursor: null });
+
+		await loadFeed();
+
+		expect($feedLoading.get()).toBe('idle');
+	});
+
+	it('handles API errors gracefully', async () => {
+		mockFetch({ error: 'Server error' }, false);
+
+		await loadFeed();
+
+		expect($feedMemes.get()).toHaveLength(0);
+		expect($feedHasMore.get()).toBe(false);
+		expect($feedLoading.get()).toBe('idle');
+	});
+
+	it('prevents concurrent loads', async () => {
+		const fetchSpy = mockFetch({
+			memes: [makeMeme('m1')],
+			next_cursor: null,
+		});
+
+		// Start two loads simultaneously
+		const p1 = loadFeed();
+		const p2 = loadFeed();
+		await Promise.all([p1, p2]);
+
+		// Only one fetch should have been made
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ── loadMore ─────────────────────────────────────────────────────────
+
+describe('loadMore', () => {
+	it('appends memes to existing feed', async () => {
+		$feedMemes.set([makeMeme('m1')]);
+		$feedCursor.set('cur1');
+		mockFetch({ memes: [makeMeme('m2')], next_cursor: 'cur2' });
+
+		await loadMore();
+
+		expect($feedMemes.get()).toHaveLength(2);
+		expect($feedMemes.get()[1].id).toBe('m2');
+		expect($feedCursor.get()).toBe('cur2');
+	});
+
+	it('does nothing when hasMore is false', async () => {
+		$feedHasMore.set(false);
+		const fetchSpy = mockFetch({ memes: [], next_cursor: null });
+
+		await loadMore();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});
+
+// ── reactToMeme (optimistic) ─────────────────────────────────────────
+
+describe('reactToMeme', () => {
+	it('optimistically adds reaction', () => {
+		$feedMemes.set([makeMeme('m1', { reaction_count: 5 })]);
+		mockFetch({ success: true });
+
+		reactToMeme('m1', 3);
+
+		expect($userReactions.get()['m1']).toBe(3);
+		expect($feedMemes.get()[0].reaction_count).toBe(6);
+	});
+
+	it('toggles off when same reaction is sent', () => {
+		$feedMemes.set([makeMeme('m1', { reaction_count: 5 })]);
+		$userReactions.set({ m1: 3 });
+		mockFetch({ success: true });
+
+		reactToMeme('m1', 3);
+
+		expect($userReactions.get()['m1']).toBeUndefined();
+		expect($feedMemes.get()[0].reaction_count).toBe(4);
+	});
+
+	it('changes reaction without changing count', () => {
+		$feedMemes.set([makeMeme('m1', { reaction_count: 5 })]);
+		$userReactions.set({ m1: 1 });
+		mockFetch({ success: true });
+
+		reactToMeme('m1', 3);
+
+		expect($userReactions.get()['m1']).toBe(3);
+		// Count stays same — replacing existing reaction
+		expect($feedMemes.get()[0].reaction_count).toBe(5);
+	});
+
+	it('rolls back on API failure', async () => {
+		$feedMemes.set([makeMeme('m1', { reaction_count: 5 })]);
+		mockFetch({ error: 'fail' }, false);
+
+		reactToMeme('m1', 3);
+
+		// Wait for the promise to reject and rollback
+		await vi.waitFor(() => {
+			expect($userReactions.get()['m1']).toBeUndefined();
+			expect($feedMemes.get()[0].reaction_count).toBe(5);
+		});
+	});
+});
+
+// ── saveMeme / unsaveMeme (optimistic) ───────────────────────────────
+
+describe('saveMeme', () => {
+	it('optimistically adds save', () => {
+		$feedMemes.set([makeMeme('m1', { save_count: 10 })]);
+		mockFetch({ success: true });
+
+		saveMeme('m1');
+
+		expect($userSaves.get().has('m1')).toBe(true);
+		expect($feedMemes.get()[0].save_count).toBe(11);
+	});
+
+	it('rolls back on API failure', async () => {
+		$feedMemes.set([makeMeme('m1', { save_count: 10 })]);
+		mockFetch({ error: 'fail' }, false);
+
+		saveMeme('m1');
+
+		await vi.waitFor(() => {
+			expect($userSaves.get().has('m1')).toBe(false);
+			expect($feedMemes.get()[0].save_count).toBe(10);
+		});
+	});
+});
+
+describe('unsaveMeme', () => {
+	it('optimistically removes save', () => {
+		$feedMemes.set([makeMeme('m1', { save_count: 10 })]);
+		$userSaves.set(new Set(['m1']));
+		mockFetch({ success: true });
+
+		unsaveMeme('m1');
+
+		expect($userSaves.get().has('m1')).toBe(false);
+		expect($feedMemes.get()[0].save_count).toBe(9);
+	});
+
+	it('rolls back on API failure', async () => {
+		$feedMemes.set([makeMeme('m1', { save_count: 10 })]);
+		$userSaves.set(new Set(['m1']));
+		mockFetch({ error: 'fail' }, false);
+
+		unsaveMeme('m1');
+
+		await vi.waitFor(() => {
+			expect($userSaves.get().has('m1')).toBe(true);
+			expect($feedMemes.get()[0].save_count).toBe(10);
+		});
+	});
+});
+
+// ── trackView ────────────────────────────────────────────────────────
+
+describe('trackView', () => {
+	it('fires API call for first view', async () => {
+		const fetchSpy = mockFetch({ success: true });
+
+		trackView('tv-1');
+
+		// Wait for the fire-and-forget async chain to settle
+		await vi.waitFor(() => {
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it('deduplicates — second call for same ID does not fetch', async () => {
+		const fetchSpy = mockFetch({ success: true });
+
+		trackView('tv-dedup');
+		trackView('tv-dedup');
+
+		await vi.waitFor(() => {
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+});
+
+// ── trackShare ───────────────────────────────────────────────────────
+
+describe('trackShare', () => {
+	it('optimistically increments share count', () => {
+		$feedMemes.set([makeMeme('m1', { share_count: 5 })]);
+		mockFetch({ success: true });
+
+		trackShare('m1');
+
+		expect($feedMemes.get()[0].share_count).toBe(6);
+	});
+
+	it('rolls back on API failure', async () => {
+		$feedMemes.set([makeMeme('m1', { share_count: 5 })]);
+		mockFetch({ error: 'fail' }, false);
+
+		trackShare('m1');
+
+		await vi.waitFor(() => {
+			expect($feedMemes.get()[0].share_count).toBe(5);
+		});
+	});
+});

--- a/apps/memes/astro-memes/vitest.config.ts
+++ b/apps/memes/astro-memes/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+	},
+	resolve: {
+		alias: {
+			'@kbve/astro': path.resolve(
+				__dirname,
+				'../../../packages/npm/astro/src/index.ts',
+			),
+		},
+	},
+});


### PR DESCRIPTION
## Summary
- Set up vitest for `astro-memes` with test target in `project.json`
- **media.test.ts** (34 tests): Full coverage of `parseYouTubeUrl` (watch, youtu.be, embed, shorts, start time, edge cases), `youTubeThumbnail` (all quality levels), `youTubeEmbedUrl`, `resolveMediaKind` (all formats + YT override), `gridThumbnail`, `showPlayOverlay`
- **feed.test.ts** (19 tests): `loadFeed` (populate, hasMore, idle state, error handling, concurrency guard), `loadMore` (append, guard), `reactToMeme` (add, toggle, change, API rollback), `saveMeme`/`unsaveMeme` (optimistic + rollback), `trackView` (fire + dedup), `trackShare` (optimistic + rollback)

## Test plan
- [x] All 53 tests pass (`vitest run`)
- [x] `npx nx run astro-memes:test` works via project.json target