### PR TITLE
feat(kube): Phase 2 prep — Cilium Gateway API, anti-affinity, nodeIP fix

### DIFF
--- a/apps/kube/cilium/MIGRATION.md
+++ b/apps/kube/cilium/MIGRATION.md
@@ -74,7 +74,16 @@ Cluster: Talos Linux, Kubernetes 1.32.1, single /32 external IP (142.132.206.74)
 
 ---
 
-## Phase 1: Cilium as CNI + WireGuard (replace flannel)
+## Phase 1: Cilium as CNI + WireGuard (replace flannel) — COMPLETED 2026-03-19
+
+**Status:** COMPLETE. Cilium is the active CNI with kubeProxyReplacement and WireGuard encryption.
+
+### Lessons Learned
+
+1. **Do NOT set `kubeProxyReplacement: true` before the CNI swap.** Cilium and kube-proxy both try to bind the same health check NodePorts, causing cluster-wide DNS failures. Deploy Cilium with `kubeProxyReplacement: false` first, then flip to `true` at the same time as the Talos patch.
+2. **Pin `kubelet.nodeIP.validSubnets` when adding secondary IPs.** Without this, kubelet advertises the secondary IP as InternalIP. The API server can't reach kubelet on the wrong IP, breaking logs/exec/port-forward and causing pods to get stuck in Pending/ContainerCreating.
+3. **Cilium attaches eBPF programs to all interfaces even when flannel is the active CNI.** This can interfere with flannel's routing. The ideal sequence is: deploy Cilium → apply Talos CNI patch → restart all pods.
+4. **Restart all pods after the CNI swap.** Existing pods keep stale flannel networking. A rolling restart of all deployments/statefulsets is required.
 
 **Goal:** Swap the CNI to Cilium with WireGuard pod-to-pod encryption. No ingress changes. nginx stays.
 

--- a/apps/kube/cilium/patches/cilium-enable.yaml
+++ b/apps/kube/cilium/patches/cilium-enable.yaml
@@ -9,7 +9,16 @@
 ##   - Disables the default flannel CNI
 ##   - Disables kube-proxy (Cilium replaces it via eBPF)
 ##   - KubePrism is already enabled (port 7445) in current config
-##   - Disables forwardKubeDNSToHost to avoid CoreDNS conflict with BPF masquerade
+##   - Pins kubelet nodeIP to the primary address (prevents secondary
+##     IP from being advertised as InternalIP, which breaks kubelet
+##     API server communication)
+##
+## IMPORTANT: If you have added secondary IPs to the node, you MUST
+## include kubelet.nodeIP.validSubnets to pin the primary IP. Without
+## this, kubelet may pick the secondary IP and the API server won't
+## be able to reach it for logs/exec/port-forward.
+##
+## Applied to production 2026-03-19.
 ##
 ## Apply to each node one at a time (rolling upgrade):
 ##   talosctl patch machineconfig --nodes <control-plane> --patch @cilium-enable.yaml
@@ -24,6 +33,10 @@ cluster:
     proxy:
         disabled: true
 machine:
+    kubelet:
+        nodeIP:
+            validSubnets:
+                - 142.132.206.74/32
     features:
         kubePrism:
             enabled: true

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -23,6 +23,15 @@ spec:
                 app: kbve
                 version: '1.0.22'
         spec:
+            affinity:
+                podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 100
+                          podAffinityTerm:
+                              labelSelector:
+                                  matchLabels:
+                                      app: kbve
+                              topologyKey: kubernetes.io/hostname
             containers:
                 - name: kbve
                   image: ghcr.io/kbve/kbve:1.0.64

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -1,0 +1,62 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+    name: kbve-gateway
+    namespace: kbve
+    annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-dns
+spec:
+    gatewayClassName: cilium
+    # Pin the Envoy proxy pod to dedicated-server nodes only.
+    # Edge/IoT/dev workers should not handle external ingress traffic.
+    infrastructure:
+        labels:
+            node.kbve.com/type: dedicated-server
+    listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          hostname: kbve.com
+          allowedRoutes:
+              namespaces:
+                  from: Same
+        - name: https
+          protocol: HTTPS
+          port: 443
+          hostname: kbve.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - name: kbve-gateway-tls
+          allowedRoutes:
+              namespaces:
+                  from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: kbve-routes
+    namespace: kbve
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - kbve.com
+    rules:
+        # WebSocket route — must come before the catch-all
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /ws
+          backendRefs:
+              - name: kbve-service
+                port: 5000
+        # Default route — HTTP API + Astro frontend
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: kbve-service
+                port: 4321

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
     - kbve-wt-cert.yaml
     - kbve-deployment.yaml
     - kbve-wt-lb.yaml
+    - kbve-gateway.yaml
     - nginx-ingress.yaml
     - kbve-ws-ingress.yaml


### PR DESCRIPTION
## Summary
- **Gateway API:** `kbve-gateway.yaml` — Cilium Gateway + HTTPRoute for kbve.com (Wave 1). HTTPS with cert-manager DNS01, WebSocket on `/ws`, catch-all on `/`
- **Anti-affinity:** Soft pod anti-affinity on kbve-deployment — no-op on single node, spreads when NUC workers join
- **nodeIP fix:** Pin `kubelet.nodeIP.validSubnets` to `142.132.206.74/32` in cilium-enable.yaml — prevents secondary IP from being advertised as InternalIP
- **Phase 1 docs:** MIGRATION.md updated with completion status and lessons learned

## Note on migration strategy
The Gateway + HTTPRoute coexists with the existing nginx Ingress resources. Both route to the same backend. Once validated, the nginx Ingress resources can be removed in a follow-up PR. No DNS changes needed — both ingress controllers are on the same node.

## Test plan
- [ ] ArgoCD syncs Gateway + HTTPRoute without errors
- [ ] Cilium creates an Envoy listener for the Gateway
- [ ] `kubectl get gateway kbve-gateway -n kbve` shows Accepted/Programmed
- [ ] cert-manager provisions `kbve-gateway-tls` secret via DNS01
- [ ] kbve.com still serves via nginx (existing path unaffected)