### PR TITLE
fix(desktop-kbve): mock Tauri APIs at vitest config level for CI #8330

### DIFF
--- a/apps/kbve/desktop-kbve/src/__mocks__/tauri-api-core.ts
+++ b/apps/kbve/desktop-kbve/src/__mocks__/tauri-api-core.ts
@@ -1,0 +1,4 @@
+// Mock for @tauri-apps/api/core — used in tests and CI where Tauri is not available.
+export async function invoke(_cmd: string, _args?: unknown): Promise<unknown> {
+	return undefined;
+}

--- a/apps/kbve/desktop-kbve/src/__mocks__/tauri-api-event.ts
+++ b/apps/kbve/desktop-kbve/src/__mocks__/tauri-api-event.ts
@@ -1,0 +1,14 @@
+// Mock for @tauri-apps/api/event — used in tests and CI where Tauri is not available.
+export type UnlistenFn = () => void;
+
+export async function listen<T>(
+	_event: string,
+	_handler: (event: { payload: T }) => void,
+): Promise<UnlistenFn> {
+	// no-op in test environment
+	return () => undefined;
+}
+
+export async function emit(_event: string, _payload?: unknown): Promise<void> {
+	// no-op in test environment
+}

--- a/apps/kbve/desktop-kbve/src/engine/registry.test.ts
+++ b/apps/kbve/desktop-kbve/src/engine/registry.test.ts
@@ -40,7 +40,7 @@ describe('View Registry', () => {
 	it('retrieves a view by id', () => {
 		const view = getView('test-view');
 		expect(view).toBeDefined();
-		expect(view!.label).toBe('Test');
+		expect(view?.label).toBe('Test');
 	});
 
 	it('returns undefined for unknown id', () => {

--- a/apps/kbve/desktop-kbve/src/test-setup.ts
+++ b/apps/kbve/desktop-kbve/src/test-setup.ts
@@ -1,0 +1,2 @@
+// Global test setup for desktop-kbve.
+// Tauri API mocks are handled via vitest.config.ts resolve aliases.

--- a/apps/kbve/desktop-kbve/vitest.config.ts
+++ b/apps/kbve/desktop-kbve/vitest.config.ts
@@ -1,9 +1,25 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
 	test: {
 		include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
 		environment: 'jsdom',
 		globals: true,
+		setupFiles: ['src/test-setup.ts'],
+	},
+	resolve: {
+		alias: {
+			// Mock Tauri APIs at resolution level so tests work in CI
+			// where @tauri-apps/api is not installed.
+			'@tauri-apps/api/core': path.resolve(
+				__dirname,
+				'src/__mocks__/tauri-api-core.ts',
+			),
+			'@tauri-apps/api/event': path.resolve(
+				__dirname,
+				'src/__mocks__/tauri-api-event.ts',
+			),
+		},
 	},
 });


### PR DESCRIPTION
## Summary
- Add `@tauri-apps/api/core` and `@tauri-apps/api/event` mock stubs under `src/__mocks__/`
- Wire vitest resolve aliases to use mocks instead of real Tauri packages
- Tests now pass in CI where `@tauri-apps/api` is not installed in the monorepo root

Fixes #8330

## Test plan
- [ ] Verify `vitest run` passes locally
- [ ] Verify `vitest run` passes without `node_modules/@tauri-apps/api` present (simulates CI)
- [ ] Verify CI pipeline passes on this PR