### PR TITLE
feat(desktop-kbve): make dev target launch full Tauri app

### DIFF
--- a/apps/kbve/desktop-kbve/project.json
+++ b/apps/kbve/desktop-kbve/project.json
@@ -14,7 +14,16 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"lsof -ti:1421 | xargs kill 2>/dev/null; export PATH=\"$HOME/.cargo/bin:$PATH\" && pnpm dev"
+					"lsof -ti:1421 | xargs kill 2>/dev/null; export PATH=\"$HOME/.cargo/bin:$PATH\" && cargo tauri dev"
+				],
+				"cwd": "apps/kbve/desktop-kbve"
+			}
+		},
+		"dev:web": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"lsof -ti:1421 | xargs kill 2>/dev/null; pnpm dev"
 				],
 				"cwd": "apps/kbve/desktop-kbve"
 			}


### PR DESCRIPTION
## Summary
- `dev` target now runs `cargo tauri dev` — launches both Vite dev server and Rust backend with hot reload
- Added `dev:web` target for frontend-only Vite development (what `dev` used to do)

## Usage
```bash
npx nx run desktop-kbve:dev       # Full Tauri desktop app with hot reload
npx nx run desktop-kbve:dev:web   # Vite frontend only (browser)
```

## Test plan
- [ ] Verify `npx nx run desktop-kbve:dev` opens the Tauri window
- [ ] Verify `npx nx run desktop-kbve:dev:web` starts Vite on port 1421