### PR TITLE
feat(python-kbve,python-fudster): add kbve.grpc module and fudster grpc CLI

### DIFF
--- a/packages/python/fudster/fudster/cli.py
+++ b/packages/python/fudster/fudster/cli.py
@@ -201,6 +201,82 @@ def config_cmd(
         click.echo()
 
 
+# ── grpc sub-group ───────────────────────────────────────────────────
+
+@main.group("grpc")
+def grpc_group() -> None:
+    """gRPC utilities — health check, proto compilation."""
+
+
+@grpc_group.command("health")
+@click.argument("target", default="localhost:50051")
+@click.option("--timeout", default=5.0, type=float, help="Timeout in seconds.")
+def grpc_health(target: str, timeout: float) -> None:
+    """Check gRPC health of a remote server."""
+    import asyncio
+    from kbve.grpc.client import check_health
+
+    result = asyncio.get_event_loop().run_until_complete(
+        check_health(target, timeout=timeout)
+    )
+    if result["healthy"]:
+        click.secho(
+            f"  {target} -> {result['status']}", fg="green",
+        )
+    else:
+        err = result.get("error", "")
+        msg = f"  {target} -> {result['status']}"
+        if err:
+            msg += f" ({err})"
+        click.secho(msg, fg="red")
+    raise SystemExit(0 if result["healthy"] else 1)
+
+
+@grpc_group.command("compile")
+@click.argument("proto_files", nargs=-1, required=True)
+@click.option(
+    "--proto-path", default=".", type=click.Path(exists=True),
+    help="Directory to search for imports.",
+)
+@click.option(
+    "--python-out", default=".", type=click.Path(),
+    help="Output directory for _pb2.py files.",
+)
+@click.option(
+    "--grpc-out", default=None, type=click.Path(),
+    help="Output directory for _pb2_grpc.py files.",
+)
+@click.option(
+    "--pyi-out", default=None, type=click.Path(),
+    help="Output directory for .pyi type stubs.",
+)
+def grpc_compile(
+    proto_files: tuple[str, ...],
+    proto_path: str,
+    python_out: str,
+    grpc_out: str | None,
+    pyi_out: str | None,
+) -> None:
+    """Compile .proto files to Python."""
+    from kbve.grpc.compiler import compile_proto
+
+    exit_code = compile_proto(
+        proto_files=list(proto_files),
+        proto_path=proto_path,
+        python_out=python_out,
+        grpc_out=grpc_out,
+        pyi_out=pyi_out,
+    )
+    if exit_code == 0:
+        click.secho(
+            f"Compiled {len(proto_files)} proto file(s)", fg="green",
+        )
+    else:
+        msg = "Proto compilation failed (exit " + str(exit_code) + ")"
+        click.secho(msg, fg="red")
+    raise SystemExit(exit_code)
+
+
 # ── nx sub-group ─────────────────────────────────────────────────────
 
 @main.group()

--- a/packages/python/fudster/tests/test_cli.py
+++ b/packages/python/fudster/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import json
 
+import pytest
 from click.testing import CliRunner
 
 from fudster.cli import main
@@ -489,3 +490,82 @@ def test_config_json(tmp_path):
     data = json.loads(result.output)
     assert data["a"] == "1"
     assert data["b"] == "two"
+
+
+# ── grpc subgroup ────────────────────────────────────────────────────
+
+def test_grpc_help():
+    runner = CliRunner()
+    result = runner.invoke(main, ["grpc", "--help"])
+    assert result.exit_code == 0
+    assert "health" in result.output
+    assert "compile" in result.output
+
+
+def test_grpc_health_unreachable():
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "grpc", "health", "localhost:1", "--timeout", "0.5",
+    ])
+    assert result.exit_code != 0
+    assert "UNREACHABLE" in result.output or "ERROR" in result.output
+
+
+def _has_grpc_tools():
+    try:
+        import grpc_tools  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _has_grpc_tools(),
+    reason="grpcio-tools not installed",
+)
+def test_grpc_compile_success(tmp_path):
+    proto_file = tmp_path / "cli_test.proto"
+    proto_file.write_text(
+        'syntax = "proto3";\n'
+        "package clipkg;\n"
+        "message CliMsg { string v = 1; }\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "grpc", "compile",
+        str(proto_file),
+        "--proto-path", str(tmp_path),
+        "--python-out", str(tmp_path),
+    ])
+    assert result.exit_code == 0
+    assert "Compiled" in result.output
+    assert (tmp_path / "cli_test_pb2.py").exists()
+
+
+@pytest.mark.skipif(
+    not _has_grpc_tools(),
+    reason="grpcio-tools not installed",
+)
+def test_grpc_compile_bad_proto(tmp_path):
+    proto_file = tmp_path / "bad.proto"
+    proto_file.write_text("invalid proto")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "grpc", "compile",
+        str(proto_file),
+        "--proto-path", str(tmp_path),
+        "--python-out", str(tmp_path),
+    ])
+    assert result.exit_code != 0
+    assert "failed" in result.output
+
+
+def test_grpc_compile_help():
+    runner = CliRunner()
+    result = runner.invoke(main, ["grpc", "compile", "--help"])
+    assert result.exit_code == 0
+    assert "--proto-path" in result.output
+    assert "--grpc-out" in result.output
+    assert "--pyi-out" in result.output

--- a/packages/python/kbve/kbve/grpc/__init__.py
+++ b/packages/python/kbve/kbve/grpc/__init__.py
@@ -1,0 +1,16 @@
+"""KBVE gRPC utilities — client factory, interceptors, and proto helpers."""
+
+from .client import (  # noqa: F401
+    GrpcClient,
+    create_channel,
+    check_health,
+)
+from .interceptors import (  # noqa: F401
+    LoggingInterceptor,
+)
+from .compiler import (  # noqa: F401
+    compile_proto,
+)
+from .reflection import (  # noqa: F401
+    enable_reflection,
+)

--- a/packages/python/kbve/kbve/grpc/client.py
+++ b/packages/python/kbve/kbve/grpc/client.py
@@ -1,0 +1,122 @@
+"""gRPC client factory with channel management and health checking.
+
+Provides ``GrpcClient`` as a context manager for typed gRPC stub
+usage, and ``check_health`` for remote health probes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Type
+
+import grpc
+from grpc import aio
+
+logger = logging.getLogger(__name__)
+
+
+def create_channel(
+    target: str,
+    secure: bool = False,
+    options: list[tuple[str, Any]] | None = None,
+) -> aio.Channel:
+    """Create a gRPC async channel.
+
+    Returns an insecure channel by default. Pass ``secure=True``
+    for a TLS channel (uses default credentials).
+    """
+    opts = options or []
+    if secure:
+        credentials = grpc.ssl_channel_credentials()
+        return aio.secure_channel(target, credentials, options=opts)
+    return aio.insecure_channel(target, options=opts)
+
+
+class GrpcClient:
+    """Async gRPC client with automatic channel lifecycle.
+
+    Usage::
+
+        async with GrpcClient("localhost:50051") as client:
+            stub = client.stub(MyServiceStub)
+            response = await stub.MyMethod(request)
+    """
+
+    def __init__(
+        self,
+        target: str,
+        secure: bool = False,
+        options: list[tuple[str, Any]] | None = None,
+    ):
+        self.target = target
+        self._secure = secure
+        self._options = options
+        self._channel: aio.Channel | None = None
+
+    async def __aenter__(self) -> "GrpcClient":
+        self._channel = create_channel(
+            self.target,
+            secure=self._secure,
+            options=self._options,
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    def stub(self, stub_class: Type) -> Any:
+        """Create a gRPC stub from a generated stub class."""
+        if self._channel is None:
+            raise RuntimeError(
+                "Channel not open. Use GrpcClient as a context manager."
+            )
+        return stub_class(self._channel)
+
+    async def close(self) -> None:
+        """Close the underlying channel."""
+        if self._channel is not None:
+            await self._channel.close()
+            self._channel = None
+
+
+async def check_health(
+    target: str,
+    timeout: float = 5.0,
+) -> dict[str, Any]:
+    """Check the gRPC health of a remote server.
+
+    Uses the standard kbve Health.Check RPC. Returns a dict with
+    ``status`` and ``healthy`` keys.
+    """
+    from kbve.proto import kbve_pb2, kbve_pb2_grpc
+
+    try:
+        async with GrpcClient(target) as client:
+            stub = client.stub(kbve_pb2_grpc.HealthStub)
+            request = kbve_pb2.HealthCheckRequest()
+            response = await stub.Check(
+                request,
+                timeout=timeout,
+            )
+            status_name = kbve_pb2.HealthCheckResponse.ServingStatus.Name(
+                response.status,
+            )
+            return {
+                "target": target,
+                "status": status_name,
+                "healthy": status_name == "SERVING",
+            }
+    except grpc.aio.AioRpcError as exc:
+        return {
+            "target": target,
+            "status": "UNREACHABLE",
+            "healthy": False,
+            "error": str(exc.code()),
+        }
+    except Exception as exc:
+        return {
+            "target": target,
+            "status": "ERROR",
+            "healthy": False,
+            "error": str(exc),
+        }

--- a/packages/python/kbve/kbve/grpc/compiler.py
+++ b/packages/python/kbve/kbve/grpc/compiler.py
@@ -1,0 +1,66 @@
+"""Programmatic proto compilation wrapper.
+
+Wraps ``grpc_tools.protoc`` so you don't need to remember the flags.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def compile_proto(
+    proto_files: str | Sequence[str],
+    proto_path: str | Path = ".",
+    python_out: str | Path = ".",
+    grpc_out: str | Path | None = None,
+    pyi_out: str | Path | None = None,
+) -> int:
+    """Compile ``.proto`` files to Python using grpc_tools.protoc.
+
+    Args:
+        proto_files: One or more ``.proto`` file paths.
+        proto_path: Directory to search for imports (``--proto_path``).
+        python_out: Output directory for ``_pb2.py`` files.
+        grpc_out: Output directory for ``_pb2_grpc.py`` files (optional).
+        pyi_out: Output directory for ``.pyi`` type stubs (optional).
+
+    Returns:
+        protoc exit code (0 = success).
+    """
+    from grpc_tools import protoc
+
+    if isinstance(proto_files, str):
+        proto_files = [proto_files]
+
+    args = [
+        "grpc_tools.protoc",
+        f"--proto_path={proto_path}",
+        f"--python_out={python_out}",
+    ]
+
+    if grpc_out is not None:
+        args.append(f"--grpc_python_out={grpc_out}")
+
+    if pyi_out is not None:
+        args.append(f"--pyi_out={pyi_out}")
+
+    args.extend(proto_files)
+
+    logger.info("Compiling protos: %s", " ".join(args))
+    exit_code = protoc.main(args)
+
+    if exit_code == 0:
+        logger.info(
+            "Proto compilation succeeded for %d file(s)",
+            len(proto_files),
+        )
+    else:
+        logger.error(
+            "Proto compilation failed with exit code %d", exit_code,
+        )
+
+    return exit_code

--- a/packages/python/kbve/kbve/grpc/interceptors.py
+++ b/packages/python/kbve/kbve/grpc/interceptors.py
@@ -1,0 +1,41 @@
+"""gRPC server interceptors for logging and observability."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable
+
+import grpc
+from grpc import aio
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingInterceptor(aio.ServerInterceptor):
+    """Server interceptor that logs each RPC call with duration.
+
+    Usage::
+
+        server = grpc.aio.server(
+            interceptors=[LoggingInterceptor()],
+        )
+    """
+
+    async def intercept_service(
+        self,
+        continuation: Callable,
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> Any:
+        method = handler_call_details.method
+        start = time.monotonic()
+
+        handler = await continuation(handler_call_details)
+
+        elapsed_ms = round((time.monotonic() - start) * 1000, 2)
+        logger.info(
+            "gRPC %s resolved in %.2fms",
+            method, elapsed_ms,
+        )
+
+        return handler

--- a/packages/python/kbve/kbve/grpc/reflection.py
+++ b/packages/python/kbve/kbve/grpc/reflection.py
@@ -1,0 +1,46 @@
+"""gRPC reflection enablement for server introspection.
+
+Enables ``grpcurl`` and other tools to discover services at runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def enable_reflection(
+    server,
+    service_names: Sequence[str] | None = None,
+) -> None:
+    """Enable gRPC Server Reflection on an ``aio.Server``.
+
+    If *service_names* is None, enables reflection with just the
+    reflection service itself. Pass fully-qualified service names
+    (e.g., ``["kbve.Health", "kbve.Echo"]``) to advertise them.
+
+    Requires ``grpcio-reflection`` to be installed.
+    """
+    try:
+        from grpc_reflection.v1alpha import reflection as grpc_reflection
+        from grpc_reflection.v1alpha import reflection_pb2
+    except ImportError:
+        logger.warning(
+            "grpcio-reflection not installed; "
+            "skipping gRPC reflection setup"
+        )
+        return
+
+    names = list(service_names or [])
+    names.append(
+        reflection_pb2.FILE_DESCRIPTOR_RESPONSE
+        if hasattr(reflection_pb2, "FILE_DESCRIPTOR_RESPONSE")
+        else reflection_pb2.DESCRIPTOR.services_by_name[
+            "ServerReflection"
+        ].full_name
+    )
+
+    grpc_reflection.enable_server_reflection(names, server)
+    logger.info("gRPC reflection enabled for %d service(s)", len(names))

--- a/packages/python/kbve/kbve/server/grpc_server.py
+++ b/packages/python/kbve/kbve/server/grpc_server.py
@@ -1,7 +1,7 @@
 """Async gRPC server wrapper."""
 
 import logging
-from typing import Callable
+from typing import Callable, Sequence
 
 from grpc import aio
 
@@ -11,28 +11,55 @@ logger = logging.getLogger(__name__)
 class GrpcServer:
     """Manages an async gRPC server lifecycle."""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 50051):
+    def __init__(
+        self,
+        host: str = "0.0.0.0",
+        port: int = 50051,
+        interceptors: list | None = None,
+    ):
         self.host = host
         self.port = port
+        self._interceptors = interceptors or []
         self._server: aio.Server | None = None
         self._service_registrars: list[Callable] = []
+        self._service_names: list[str] = []
+        self._reflection_enabled = False
 
-    def add_service(self, registrar: Callable) -> None:
+    def add_service(
+        self, registrar: Callable, name: str | None = None,
+    ) -> None:
         """Register a gRPC service adder callable.
 
-        The registrar should accept (servicer_instance, server) and call
-        the generated add_*Servicer_to_server function.
+        The registrar should accept a server and call the generated
+        ``add_*Servicer_to_server`` function. Optionally pass *name*
+        (fully-qualified service name) for reflection advertisement.
         """
         self._service_registrars.append(registrar)
+        if name:
+            self._service_names.append(name)
+
+    def enable_reflection(
+        self, extra_names: Sequence[str] | None = None,
+    ) -> None:
+        """Mark this server for gRPC reflection on start."""
+        self._reflection_enabled = True
+        if extra_names:
+            self._service_names.extend(extra_names)
 
     async def start(self) -> None:
         """Create the gRPC server, bind port, and start serving."""
-        self._server = aio.server()
+        self._server = aio.server(
+            interceptors=self._interceptors or None,
+        )
 
         for registrar in self._service_registrars:
             registrar(self._server)
 
-        bind_address = f"{self.host}:{self.port}"  # noqa: E231
+        if self._reflection_enabled:
+            from kbve.grpc.reflection import enable_reflection
+            enable_reflection(self._server, self._service_names)
+
+        bind_address = self.host + ":" + str(self.port)
         self._server.add_insecure_port(bind_address)
         await self._server.start()
         logger.info("gRPC server started on %s", bind_address)

--- a/packages/python/kbve/kbve/utils/module_info.py
+++ b/packages/python/kbve/kbve/utils/module_info.py
@@ -30,6 +30,7 @@ _MODULES = [
     ("kbve.config", "Environment-aware configuration loader"),
     ("kbve.health", "Health check primitives for microservices"),
     ("kbve.tasks", "Async task runner for background work"),
+    ("kbve.grpc", "gRPC client factory, interceptors, and proto helpers"),
     ("kbve.api", "API clients and utilities"),
 ]
 

--- a/packages/python/kbve/tests/test_grpc.py
+++ b/packages/python/kbve/tests/test_grpc.py
@@ -1,0 +1,232 @@
+"""Tests for kbve.grpc module."""
+
+import pytest
+
+from kbve.grpc.client import GrpcClient, create_channel
+from kbve.grpc.compiler import compile_proto
+from kbve.grpc.interceptors import LoggingInterceptor
+
+
+# ── create_channel ───────────────────────────────────────────────────
+
+def test_create_channel_insecure():
+    channel = create_channel("localhost:50051")
+    assert channel is not None
+
+
+def test_create_channel_with_options():
+    channel = create_channel(
+        "localhost:50051",
+        options=[("grpc.max_receive_message_length", 1024)],
+    )
+    assert channel is not None
+
+
+# ── GrpcClient ───────────────────────────────────────────────────────
+
+def test_grpc_client_init():
+    client = GrpcClient("localhost:50051")
+    assert client.target == "localhost:50051"
+    assert client._channel is None
+
+
+def test_grpc_client_stub_without_channel():
+    client = GrpcClient("localhost:50051")
+    with pytest.raises(RuntimeError, match="Channel not open"):
+        client.stub(object)
+
+
+@pytest.mark.asyncio
+async def test_grpc_client_context_manager():
+    async with GrpcClient("localhost:50051") as client:
+        assert client._channel is not None
+    assert client._channel is None
+
+
+@pytest.mark.asyncio
+async def test_grpc_client_close_no_channel():
+    client = GrpcClient("localhost:50051")
+    await client.close()  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_grpc_client_stub_creation():
+    class FakeStub:
+        def __init__(self, channel):
+            self.channel = channel
+
+    async with GrpcClient("localhost:50051") as client:
+        stub = client.stub(FakeStub)
+        assert stub.channel is client._channel
+
+
+# ── check_health (unreachable target) ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_check_health_unreachable():
+    from kbve.grpc.client import check_health
+    result = await check_health("localhost:1", timeout=0.5)
+    assert result["healthy"] is False
+    assert result["target"] == "localhost:1"
+    assert result["status"] in ("UNREACHABLE", "ERROR")
+
+
+# ── LoggingInterceptor ───────────────────────────────────────────────
+
+def test_logging_interceptor_init():
+    interceptor = LoggingInterceptor()
+    assert interceptor is not None
+
+
+def test_logging_interceptor_is_server_interceptor():
+    from grpc import aio
+    interceptor = LoggingInterceptor()
+    assert isinstance(interceptor, aio.ServerInterceptor)
+
+
+# ── compile_proto ────────────────────────────────────────────────────
+
+def test_compile_proto_success(tmp_path):
+    proto_file = tmp_path / "test.proto"
+    proto_file.write_text(
+        'syntax = "proto3";\n'
+        "package testpkg;\n"
+        "message TestMsg { string value = 1; }\n"
+    )
+
+    exit_code = compile_proto(
+        proto_files=str(proto_file),
+        proto_path=str(tmp_path),
+        python_out=str(tmp_path),
+    )
+    assert exit_code == 0
+    assert (tmp_path / "test_pb2.py").exists()
+
+
+def test_compile_proto_with_grpc(tmp_path):
+    proto_file = tmp_path / "svc.proto"
+    proto_file.write_text(
+        'syntax = "proto3";\n'
+        "package svcpkg;\n"
+        "message Req { string id = 1; }\n"
+        "message Res { string data = 1; }\n"
+        "service TestSvc { rpc Get(Req) returns (Res); }\n"
+    )
+
+    exit_code = compile_proto(
+        proto_files=str(proto_file),
+        proto_path=str(tmp_path),
+        python_out=str(tmp_path),
+        grpc_out=str(tmp_path),
+    )
+    assert exit_code == 0
+    assert (tmp_path / "svc_pb2.py").exists()
+    assert (tmp_path / "svc_pb2_grpc.py").exists()
+
+
+def test_compile_proto_with_pyi(tmp_path):
+    proto_file = tmp_path / "typed.proto"
+    proto_file.write_text(
+        'syntax = "proto3";\n'
+        "package typedpkg;\n"
+        "message TypedMsg { int32 count = 1; }\n"
+    )
+
+    exit_code = compile_proto(
+        proto_files=str(proto_file),
+        proto_path=str(tmp_path),
+        python_out=str(tmp_path),
+        pyi_out=str(tmp_path),
+    )
+    assert exit_code == 0
+    assert (tmp_path / "typed_pb2.pyi").exists()
+
+
+def _simple_proto(pkg, msg):
+    semi = ";"
+    lb = "{"
+    rb = "}"
+    return (
+        f'syntax = "proto3"{semi}\n'
+        f"package {pkg}{semi}\n"
+        f"message {msg} {lb} string v = 1{semi} {rb}\n"
+    )
+
+
+def test_compile_proto_multiple_files(tmp_path):
+    for name in ("a", "b"):
+        f = tmp_path / f"{name}.proto"
+        f.write_text(_simple_proto(f"{name}pkg", f"{name.upper()}Msg"))
+
+    exit_code = compile_proto(
+        proto_files=[
+            str(tmp_path / "a.proto"),
+            str(tmp_path / "b.proto"),
+        ],
+        proto_path=str(tmp_path),
+        python_out=str(tmp_path),
+    )
+    assert exit_code == 0
+    assert (tmp_path / "a_pb2.py").exists()
+    assert (tmp_path / "b_pb2.py").exists()
+
+
+def test_compile_proto_bad_file(tmp_path):
+    proto_file = tmp_path / "bad.proto"
+    proto_file.write_text("not valid proto content")
+
+    exit_code = compile_proto(
+        proto_files=str(proto_file),
+        proto_path=str(tmp_path),
+        python_out=str(tmp_path),
+    )
+    assert exit_code != 0
+
+
+# ── GrpcServer with interceptors ─────────────────────────────────────
+
+def test_grpc_server_interceptors():
+    from kbve.server.grpc_server import GrpcServer
+    interceptor = LoggingInterceptor()
+    server = GrpcServer(interceptors=[interceptor])
+    assert server._interceptors == [interceptor]
+
+
+def test_grpc_server_add_service_with_name():
+    from kbve.server.grpc_server import GrpcServer
+    server = GrpcServer()
+    server.add_service(lambda s: None, name="test.Service")
+    assert "test.Service" in server._service_names
+
+
+def test_grpc_server_enable_reflection():
+    from kbve.server.grpc_server import GrpcServer
+    server = GrpcServer()
+    server.enable_reflection(extra_names=["kbve.Health"])
+    assert server._reflection_enabled is True
+    assert "kbve.Health" in server._service_names
+
+
+def test_grpc_server_reflection_default_off():
+    from kbve.server.grpc_server import GrpcServer
+    server = GrpcServer()
+    assert server._reflection_enabled is False
+
+
+# ── Module imports ───────────────────────────────────────────────────
+
+def test_grpc_module_imports():
+    from kbve.grpc import (
+        GrpcClient,
+        LoggingInterceptor,
+        check_health,
+        compile_proto,
+        create_channel,
+        enable_reflection,
+    )
+    assert GrpcClient is not None
+    assert LoggingInterceptor is not None
+    assert callable(check_health)
+    assert callable(compile_proto)
+    assert callable(create_channel)
+    assert callable(enable_reflection)


### PR DESCRIPTION
## Summary
- Add `kbve.grpc` module with:
  - `GrpcClient` — async context manager with typed stub factory and channel lifecycle
  - `create_channel` — insecure/secure channel factory with options
  - `check_health` — remote gRPC health probe using kbve Health service
  - `LoggingInterceptor` — server interceptor logging each RPC with duration
  - `compile_proto` — programmatic `grpc_tools.protoc` wrapper (no flag memorization)
  - `enable_reflection` — opt-in gRPC Server Reflection for `grpcurl` support
- Refactor `GrpcServer` to support interceptors and opt-in reflection (`server.enable_reflection()`)
- Add `fudster grpc` CLI subgroup:
  - `fudster grpc health <target>` — check remote gRPC health
  - `fudster grpc compile <files> --proto-path --python-out --grpc-out --pyi-out`
- Update module registry with `kbve.grpc`
- 291 tests (230 kbve + 61 fudster, 2 skipped where grpcio-tools unavailable)

## Test plan
- [x] `python-kbve:lint` passes
- [x] `python-kbve:test` passes (230/230)
- [x] `python-fudster:lint` passes
- [x] `python-fudster:test` passes (61 passed, 2 skipped)