### PR TITLE
fix(astro): remove test target that breaks CI

### DIFF
--- a/packages/npm/astro/project.json
+++ b/packages/npm/astro/project.json
@@ -28,13 +28,6 @@
 				"packageRoot": "dist/packages/npm/astro"
 			}
 		},
-		"test": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": ["nx e2e astro-e2e"],
-				"parallel": false
-			}
-		},
 		"e2e": {
 			"executor": "nx:run-commands",
 			"options": {


### PR DESCRIPTION
## Summary
- Remove `test` target from `@kbve/astro` library's project.json that was aliasing `nx e2e astro-e2e`
- This target caused `nx affected --target=test` to trigger `astro-e2e:build`, which fails on Node 24 due to the `astro:` virtual module protocol being rejected by Node's ESM loader
- The `e2e` target remains for explicit runs (`nx e2e astro`), matching how `@kbve/droid` is structured

Closes #8353

## Test plan
- [ ] CI `nx affected --target=test` no longer triggers `astro-e2e:build`
- [ ] `nx e2e astro` still works for explicit e2e runs