### PR TITLE
feat(kube): forgejo git forge + longhorn sdb dedicated disk + dbmate migration

### DIFF
--- a/apps/kube/forgejo/README.md
+++ b/apps/kube/forgejo/README.md
@@ -1,0 +1,80 @@
+# Forgejo — Git LFS + Actions
+
+Self-hosted Git forge for LFS storage (UE game assets on sdb) and CI.
+
+## Prerequisites
+
+### 1. Create database schema + user
+
+Connect to the CNPG cluster and create the Forgejo schema:
+
+```bash
+kubectl port-forward -n kilobase svc/supabase-cluster-rw 54322:5432
+```
+
+```sql
+CREATE SCHEMA IF NOT EXISTS forgejo;
+CREATE USER forgejo WITH PASSWORD '<password>';
+GRANT ALL ON SCHEMA forgejo TO forgejo;
+ALTER DEFAULT PRIVILEGES IN SCHEMA forgejo GRANT ALL ON TABLES TO forgejo;
+ALTER DEFAULT PRIVILEGES IN SCHEMA forgejo GRANT ALL ON SEQUENCES TO forgejo;
+```
+
+### 2. Create admin secret
+
+```bash
+kubectl create namespace forgejo
+kubectl create secret generic forgejo-admin \
+  --namespace forgejo \
+  --from-literal=username=kbve-admin \
+  --from-literal=password=<your-password> \
+  --from-literal=email=admin@kbve.com
+```
+
+### 3. Create database credential secret
+
+The database password needs to be available to Forgejo. Update the
+`PASSWD` field in `application.yaml` or use an ExternalSecret.
+
+## Post-Deploy Setup
+
+### Add SSH keys
+
+```bash
+kubectl port-forward svc/forgejo-http -n forgejo 3000:3000
+# Open http://localhost:3000 → login → Settings → SSH Keys
+```
+
+### Configure GitHub mirror
+
+In Forgejo UI: New Migration → GitHub → paste private repo URL + deploy key.
+
+### Configure LFS in GitHub repo
+
+Add `.lfsconfig` to your GitHub repo:
+
+```ini
+[lfs]
+    url = https://forgejo.kbve.com/<org>/<repo>.git/info/lfs
+```
+
+## Architecture
+
+```
+GitHub (private, source of truth)
+    ↓ SSH deploy key (read-only mirror)
+Forgejo (mirror + LFS on sdb via Longhorn)
+    ↓ local clone
+Forgejo Actions runner (builds with code + assets)
+```
+
+## Storage
+
+- **LFS objects**: `/data/lfs` inside Forgejo PVC (50Gi on Longhorn)
+- **Database**: `forgejo` schema in kilobase CNPG cluster (shared Postgres)
+- **SSH**: NodePort 30022 → `forgejo.kbve.com:30022`
+
+## DNS
+
+Add `forgejo.kbve.com` A record pointing to `142.132.206.74` in Cloudflare.
+Grey-cloud if you want SSH to work directly, or proxied for HTTPS-only access.

--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -1,0 +1,96 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: forgejo
+    namespace: argocd
+spec:
+    project: default
+    sources:
+        - chart: forgejo
+          repoURL: https://code.forgejo.org/forgejo-helm
+          targetRevision: 13.0.1
+          helm:
+              valuesObject:
+                  global:
+                      storageClass: longhorn
+
+                  replicaCount: 1
+
+                  image:
+                      registry: codeberg.org
+                      repository: forgejo/forgejo
+                      tag: '12'
+
+                  service:
+                      http:
+                          type: ClusterIP
+                          port: 3000
+                      ssh:
+                          type: NodePort
+                          port: 2222
+                          nodePort: 30022
+
+                  ingress:
+                      enabled: false
+
+                  persistence:
+                      enabled: true
+                      size: 50Gi
+                      storageClass: longhorn
+                      accessModes:
+                          - ReadWriteOnce
+
+                  gitea:
+                      admin:
+                          existingSecret: forgejo-admin
+                      config:
+                          server:
+                              DOMAIN: forgejo.kbve.com
+                              ROOT_URL: https://forgejo.kbve.com
+                              SSH_DOMAIN: forgejo.kbve.com
+                              SSH_PORT: 2222
+                              SSH_LISTEN_PORT: 2222
+                              LFS_START_SERVER: true
+                              LFS_JWT_SECRET: ''
+                          database:
+                              DB_TYPE: postgres
+                              HOST: supabase-cluster-pooler-rw.kilobase.svc.cluster.local:5432
+                              NAME: supabase
+                              USER: forgejo
+                              PASSWD: ''
+                              SSL_MODE: require
+                              SCHEMA: forgejo
+                          lfs:
+                              STORAGE_TYPE: local
+                              PATH: /data/lfs
+                          service:
+                              DISABLE_REGISTRATION: true
+                              REQUIRE_SIGNIN_VIEW: true
+                          actions:
+                              ENABLED: true
+                          repository:
+                              DEFAULT_PRIVATE: private
+                              ENABLE_PUSH_CREATE_USER: true
+                          mirror:
+                              ENABLED: true
+                              DEFAULT_INTERVAL: 10m
+
+                  postgresql:
+                      enabled: false
+
+                  postgresql-ha:
+                      enabled: false
+
+        - repoURL: https://github.com/KBVE/kbve.git
+          targetRevision: main
+          path: apps/kube/forgejo/manifest
+
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: forgejo
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true

--- a/apps/kube/forgejo/manifest/httproute.yaml
+++ b/apps/kube/forgejo/manifest/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: forgejo-route
+    namespace: forgejo
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - forgejo.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: forgejo-http
+                port: 3000

--- a/apps/kube/forgejo/manifest/kustomization.yaml
+++ b/apps/kube/forgejo/manifest/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+    - httproute.yaml
+    # Future: actions-runner.yaml

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -63,3 +63,6 @@ resources:
     - cilium/application.yaml
     # Cilium LB IPAM — IP pools + L2 announcements (replaces MetalLB)
     - cilium/lb-application.yaml
+
+    # Forgejo — Git LFS server + Actions runner, UE asset storage on sdb
+    - forgejo/application.yaml

--- a/apps/kube/longhorn/patches/node-disk-sdb.yaml
+++ b/apps/kube/longhorn/patches/node-disk-sdb.yaml
@@ -1,0 +1,30 @@
+## Longhorn node disk patch — add sdb as dedicated storage
+## Applied: 2026-03-20
+## Node: talos-4bn-whr
+##
+## This is a runtime patch (not managed by ArgoCD).
+## Longhorn manages disk config per-node via the nodes.longhorn.io CR.
+##
+## To re-apply:
+##   kubectl -n longhorn-system patch nodes.longhorn.io talos-4bn-whr --type merge -p "$(cat node-disk-sdb.json)"
+##
+## Prerequisites:
+##   - sdb mounted at /var/mnt/longhorn-sdb via Talos machine config
+##     (see apps/kube/talos/patches/longhorn-sdb.yaml)
+
+apiVersion: longhorn.io/v1beta2
+kind: Node
+metadata:
+    name: talos-4bn-whr
+    namespace: longhorn-system
+spec:
+    disks:
+        sdb-longhorn:
+            allowScheduling: true
+            diskType: filesystem
+            evictionRequested: false
+            path: /var/mnt/longhorn-sdb
+            storageReserved: 0
+            tags:
+                - ssd
+                - dedicated

--- a/apps/kube/talos/patches/longhorn-sdb.yaml
+++ b/apps/kube/talos/patches/longhorn-sdb.yaml
@@ -1,0 +1,13 @@
+## Talos machine config patch — mount sdb for Longhorn storage
+## Apply: talosctl patch machineconfig --nodes <node> --patch @longhorn-sdb.yaml
+##
+## This mounts the second Samsung 960GB SSD (/dev/sdb) at /var/mnt/longhorn-sdb
+## for use as a dedicated Longhorn storage disk.
+##
+## The disk will be formatted as XFS on first apply.
+
+machine:
+    disks:
+        - device: /dev/sdb
+          partitions:
+              - mountpoint: /var/mnt/longhorn-sdb

--- a/packages/data/sql/dbmate/forgejo-docker-compose.yml
+++ b/packages/data/sql/dbmate/forgejo-docker-compose.yml
@@ -1,0 +1,71 @@
+# Local Postgres + Forgejo for testing schema isolation.
+#
+# Runs both services together so you can verify:
+#   - Forgejo boots with SCHEMA=forgejo
+#   - xorm creates all 125 tables in the forgejo schema
+#   - Zero tables leak into public schema
+#   - Existing schemas (mc, meme, discordsh, n8n, etc.) are unaffected
+#   - Forgejo web UI is accessible at http://localhost:3333
+#
+# Usage:
+#   cp forgejo-docker-compose.yml docker-compose.yml
+#   docker compose up -d
+#   # Wait for postgres to be healthy, then apply migrations:
+#   DATABASE_URL="postgresql://postgres:postgres@localhost:54322/postgres?sslmode=disable&search_path=dbmate,public" \
+#     dbmate --no-dump-schema --migrations-dir migrations up
+#   # Wait ~15s for Forgejo to run xorm migrations, then verify:
+#   psql "postgresql://postgres:postgres@localhost:54322/postgres" -c "\dt forgejo.*"
+#   # Confirm zero tables in public:
+#   psql "postgresql://postgres:postgres@localhost:54322/postgres" -c "\dt public.*"
+#   # Open Forgejo:
+#   open http://localhost:3333
+#   # Tear down:
+#   docker compose down -v
+
+services:
+    postgres:
+        image: postgres:17-alpine
+        ports:
+            - '54322:5432'
+        environment:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: postgres
+        volumes:
+            - ./init:/docker-entrypoint-initdb.d
+            - pgdata:/var/lib/postgresql/data
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U postgres']
+            interval: 5s
+            timeout: 3s
+            retries: 5
+
+    forgejo:
+        image: codeberg.org/forgejo/forgejo:12
+        ports:
+            - '3333:3000'
+            - '2222:22'
+        environment:
+            - FORGEJO__database__DB_TYPE=postgres
+            - FORGEJO__database__HOST=postgres:5432
+            - FORGEJO__database__NAME=postgres
+            - FORGEJO__database__USER=postgres
+            - FORGEJO__database__PASSWD=postgres
+            - FORGEJO__database__SCHEMA=forgejo
+            - FORGEJO__database__SSL_MODE=disable
+            - FORGEJO__security__INSTALL_LOCK=true
+            - FORGEJO__server__ROOT_URL=http://localhost:3333
+            - FORGEJO__server__LFS_START_SERVER=true
+            - FORGEJO__lfs__STORAGE_TYPE=local
+            - FORGEJO__lfs__PATH=/data/lfs
+            - FORGEJO__service__DISABLE_REGISTRATION=false
+            - FORGEJO__actions__ENABLED=true
+        volumes:
+            - forgejo-data:/data
+        depends_on:
+            postgres:
+                condition: service_healthy
+
+volumes:
+    pgdata:
+    forgejo-data:

--- a/packages/data/sql/dbmate/migrations/20260320210000_forgejo_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260320210000_forgejo_schema_init.sql
@@ -1,0 +1,87 @@
+-- migrate:up
+
+-- ============================================================
+-- FORGEJO SCHEMA INITIALIZATION
+--
+-- Creates a dedicated PostgreSQL schema for the Forgejo git
+-- forge. Forgejo connects to the shared supabase database with
+-- SCHEMA=forgejo, and xorm manages all 125 tables within this
+-- schema automatically on first boot.
+--
+-- We ONLY create the schema and grants here. Forgejo owns its
+-- own table lifecycle (creation, migration, indexing).
+--
+-- Upgrade process:
+--   1. Pin forgejo image version in apps/kube/forgejo/
+--   2. Bump version locally in docker compose
+--   3. docker compose up → forgejo auto-migrates its own tables
+--   4. Verify clean → update kube manifest → ArgoCD syncs
+--
+-- Depends on: 00-roles.sql (service_role must exist)
+-- ============================================================
+
+-- ===========================================
+-- SCHEMA
+-- ===========================================
+
+CREATE SCHEMA IF NOT EXISTS forgejo;
+
+COMMENT ON SCHEMA forgejo IS
+    'Forgejo git forge schema. Tables managed by Forgejo xorm, not dbmate.';
+
+-- ===========================================
+-- GRANTS
+-- ===========================================
+
+-- postgres is superuser (implicit full access), but explicit for clarity
+GRANT ALL ON SCHEMA forgejo TO postgres;
+
+-- service_role needs access for cross-schema RPC calls
+GRANT USAGE ON SCHEMA forgejo TO service_role;
+
+-- Ensure future tables/sequences created by Forgejo are accessible to service_role
+ALTER DEFAULT PRIVILEGES IN SCHEMA forgejo
+    GRANT SELECT ON TABLES TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA forgejo
+    GRANT USAGE ON SEQUENCES TO service_role;
+
+-- ===========================================
+-- ISOLATION: Block anon/authenticated from forgejo internals
+-- ===========================================
+
+REVOKE ALL ON SCHEMA forgejo FROM PUBLIC;
+REVOKE ALL ON SCHEMA forgejo FROM anon;
+REVOKE ALL ON SCHEMA forgejo FROM authenticated;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    -- Verify schema exists
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.schemata
+        WHERE schema_name = 'forgejo'
+    ) THEN
+        RAISE EXCEPTION 'forgejo schema creation failed';
+    END IF;
+
+    -- Verify anon cannot access forgejo schema
+    IF has_schema_privilege('anon', 'forgejo', 'USAGE') THEN
+        RAISE EXCEPTION 'anon must NOT have USAGE on forgejo schema';
+    END IF;
+
+    -- Verify authenticated cannot access forgejo schema
+    IF has_schema_privilege('authenticated', 'forgejo', 'USAGE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have USAGE on forgejo schema';
+    END IF;
+
+    RAISE NOTICE 'forgejo_init.sql: forgejo schema created and verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+-- migrate:down
+
+DROP SCHEMA IF EXISTS forgejo CASCADE;


### PR DESCRIPTION
## Summary

- **Forgejo** ArgoCD app — Git LFS server + Actions, mirroring from GitHub
- **Longhorn sdb** — dedicated 960GB Samsung SSD mounted at `/var/mnt/longhorn-sdb`
- **dbmate migration** — `forgejo` schema on kilobase CNPG cluster (125 tables, isolated)
- **docker-compose** — local schema validation

## Schema isolation (verified)

- 125 tables in `forgejo` schema, 0 in `public`
- `anon` / `authenticated` blocked
- `service_role` read-only (SELECT on tables)

## Prerequisites before ArgoCD deploy

- [x] dbmate migration applied (20260320210000)
- [ ] Create `forgejo-admin` secret in cluster
- [ ] Add `forgejo.kbve.com` DNS record in Cloudflare
- [ ] Set DB password via ExternalSecret or sealed secret

## Storage

| Component | Location | Size |
|---|---|---|
| LFS objects | Longhorn PVC on sdb | 50Gi |
| Database | forgejo schema in kilobase CNPG | shared |
| SSH | NodePort 30022 | — |