### PR TITLE
fix(kube): switch forgejo helm chart to OCI registry

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -7,7 +7,7 @@ spec:
     project: default
     sources:
         - chart: forgejo
-          repoURL: https://code.forgejo.org/forgejo-helm
+          repoURL: oci://code.forgejo.org/forgejo-helm/forgejo
           targetRevision: 13.0.1
           helm:
               valuesObject:


### PR DESCRIPTION
The old HTTP chart repo (`https://code.forgejo.org/forgejo-helm`) returns 404 — Forgejo migrated to OCI format.

Updates `repoURL` to `oci://code.forgejo.org/forgejo-helm/forgejo` so ArgoCD can pull the chart.

Currently the forgejo namespace exists but has zero resources deployed due to this `ComparisonError`.