### PR TITLE
fix(edge): separate version source of truth from published marker

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -82,7 +82,7 @@ jobs:
                     irc-gateway)  SRC="apps/irc/irc-gateway/Cargo.toml";            VTOML="apps/irc/version.toml" ;;
                     discordsh)    SRC="apps/discordsh/axum-discordsh/Cargo.toml";   VTOML="apps/discordsh/version.toml" ;;
                     mc)           SRC="apps/mc/plugins/kbve-mc-plugin/Cargo.toml";  VTOML="apps/mc/version.toml" ;;
-                    edge)         SRC="apps/kbve/edge/version.toml";                VTOML="apps/kbve/edge/version.toml" ;;
+                    edge)         SRC="apps/kbve/edge/deno.json";                   VTOML="apps/kbve/edge/version.toml" ;;
                     cryptothrone) SRC="apps/cryptothrone/axum-cryptothrone/Cargo.toml"; VTOML="apps/cryptothrone/version.toml" ;;
                     kilobase)     SRC=""; VTOML="" ;;
                     *)
@@ -98,7 +98,10 @@ jobs:
                     exit 0
                   fi
 
-                  LOCAL=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || echo "0.0.0")
+                  case "$SRC" in
+                    *.json) LOCAL=$(jq -r '.version // "0.0.0"' "$SRC" 2>/dev/null || echo "0.0.0") ;;
+                    *)      LOCAL=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || echo "0.0.0") ;;
+                  esac
                   PUBLISHED="0.0.0"
                   PUBLISH_FLAG="true"
                   if [ -f "$VTOML" ]; then
@@ -216,7 +219,7 @@ jobs:
                       echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
                       echo "image=kbve/edge"                                                               >> "$GITHUB_OUTPUT"
                       echo "e2e_name=edge"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/kbve/edge/version.toml"                                       >> "$GITHUB_OUTPUT"
+                      echo "cargo_toml=apps/kbve/edge/deno.json"                                          >> "$GITHUB_OUTPUT"
                       echo "deployment_yaml=apps/kube/functions/manifests/functions-deployment.yaml"      >> "$GITHUB_OUTPUT"
                       echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
                       echo "version_toml=apps/kbve/edge/version.toml"                                      >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -186,7 +186,7 @@ jobs:
                       irc-gateway)  SRC="apps/irc/irc-gateway/Cargo.toml";            VTOML="apps/irc/version.toml" ;;
                       discordsh)    SRC="apps/discordsh/axum-discordsh/Cargo.toml";   VTOML="apps/discordsh/version.toml" ;;
                       mc)           SRC="apps/mc/plugins/kbve-mc-plugin/Cargo.toml";  VTOML="apps/mc/version.toml" ;;
-                      edge)         SRC="apps/kbve/edge/version.toml";                VTOML="apps/kbve/edge/version.toml" ;;
+                      edge)         SRC="apps/kbve/edge/deno.json";                   VTOML="apps/kbve/edge/version.toml" ;;
                       cryptothrone) SRC="apps/cryptothrone/axum-cryptothrone/Cargo.toml"; VTOML="apps/cryptothrone/version.toml" ;;
                       kilobase)     SRC=""; VTOML="" ;;
                       *)            SRC=""; VTOML="" ;;

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -263,6 +263,7 @@ jobs:
                           - 'apps/kbve/edge/functions/**'
                           - 'apps/kbve/edge/Dockerfile'
                           - 'apps/kbve/edge/project.json'
+                          - 'apps/kbve/edge/deno.json'
                           - 'apps/kbve/edge/version.toml'
                       isometric:
                           - 'apps/kbve/isometric/src/**'

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -51,9 +51,12 @@ jobs:
               id: version_check
               if: ${{ inputs.image != '' && inputs.cargo_toml != '' }}
               run: |
-                  LOCAL_VERSION=$(grep -m1 '^version' "${{ inputs.cargo_toml }}" \
-                    | sed 's/version = "\(.*\)"/\1/')
-                  echo "Local version from Cargo.toml: $LOCAL_VERSION"
+                  CARGO_TOML="${{ inputs.cargo_toml }}"
+                  case "$CARGO_TOML" in
+                    *.json) LOCAL_VERSION=$(jq -r '.version // "0.0.0"' "$CARGO_TOML" 2>/dev/null) ;;
+                    *)      LOCAL_VERSION=$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/') ;;
+                  esac
+                  echo "Local version: $LOCAL_VERSION"
 
                   STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
                     "https://hub.docker.com/v2/repositories/${{ inputs.image }}/tags/$LOCAL_VERSION")
@@ -87,8 +90,11 @@ jobs:
                   echo "Attempting to pull CI image: ${CI_IMAGE}"
                   if docker pull "${CI_IMAGE}" 2>/dev/null; then
                     echo "found=true" >> "$GITHUB_OUTPUT"
-                    LOCAL_VERSION=$(grep -m1 '^version' "${{ inputs.cargo_toml }}" \
-                      | sed 's/version = "\(.*\)"/\1/')
+                    CARGO_TOML="${{ inputs.cargo_toml }}"
+                    case "$CARGO_TOML" in
+                      *.json) LOCAL_VERSION=$(jq -r '.version // "0.0.0"' "$CARGO_TOML" 2>/dev/null) ;;
+                      *)      LOCAL_VERSION=$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/') ;;
+                    esac
 
                     docker tag "${CI_IMAGE}" "${{ inputs.image }}:latest"
                     docker tag "${CI_IMAGE}" "${{ inputs.image }}:${LOCAL_VERSION}"

--- a/.github/workflows/utils-update-kube-manifest.yml
+++ b/.github/workflows/utils-update-kube-manifest.yml
@@ -35,11 +35,14 @@ jobs:
                   ref: main
                   path: main-ref
 
-            - name: Extract version from Cargo.toml
+            - name: Extract version from source file
               id: version
               run: |
-                  NEW_VER=$(grep -m1 '^version' "main-ref/${{ inputs.cargo_toml }}" \
-                    | sed 's/version = "\(.*\)"/\1/')
+                  SRC="main-ref/${{ inputs.cargo_toml }}"
+                  case "$SRC" in
+                    *.json) NEW_VER=$(jq -r '.version // "0.0.0"' "$SRC" 2>/dev/null) ;;
+                    *)      NEW_VER=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/') ;;
+                  esac
                   echo "new_version=$NEW_VER" >> "$GITHUB_OUTPUT"
                   echo "Resolved version: $NEW_VER"
 

--- a/.github/workflows/utils-update-version-toml.yml
+++ b/.github/workflows/utils-update-version-toml.yml
@@ -39,13 +39,13 @@ jobs:
                   VTOML="${{ inputs.version_toml_path }}"
                   VERSION="${{ inputs.version }}"
 
-                  # Preserve publish flag if it exists
-                  PUBLISH_FLAG="true"
-                  if [ -f "$VTOML" ]; then
-                    PUBLISH_FLAG=$(grep -m1 '^publish' "$VTOML" | sed 's/publish = //' | tr -d ' "' 2>/dev/null || echo "true")
+                  if [ -f "$VTOML" ] && grep -q '^version' "$VTOML"; then
+                    # In-place update preserves all other content (e.g. function registry)
+                    sed -i "s/^version = .*/version = \"${VERSION}\"/" "$VTOML"
+                  else
+                    # Fresh file — simple two-line version.toml
+                    printf 'version = "%s"\npublish = true\n' "$VERSION" > "$VTOML"
                   fi
-
-                  printf 'version = "%s"\npublish = %s\n' "$VERSION" "$PUBLISH_FLAG" > "$VTOML"
                   echo "Updated $VTOML:"
                   cat "$VTOML"
 

--- a/apps/kbve/edge/.dockerignore
+++ b/apps/kbve/edge/.dockerignore
@@ -8,7 +8,6 @@ pnpm-lock.yaml
 .DS_Store
 package.json
 tsconfig.json
-deno.json
 functions/types.d.ts
 .env
 edge-runtime/

--- a/apps/kbve/edge/Dockerfile
+++ b/apps/kbve/edge/Dockerfile
@@ -1,14 +1,17 @@
-# Stage 1: Bake version.toml into a TypeScript module.
+# Stage 1: Bake version + function registry into a TypeScript module.
 # Worker isolates run in a sandbox that blocks Deno.readTextFile outside
 # the service path, so the manifest must be an importable module.
+# Version comes from deno.json (developer source of truth).
+# Function registry comes from version.toml.
 FROM alpine:3.21 AS baker
 
+COPY ./deno.json /tmp/deno.json
 COPY ./version.toml /tmp/version.toml
 
 RUN set -eu; \
     TOML="/tmp/version.toml"; \
     OUT="/tmp/manifest.ts"; \
-    VERSION=$(grep '^version' "$TOML" | head -1 | sed 's/.*"\(.*\)"/\1/'); \
+    VERSION=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' /tmp/deno.json | head -1); \
     FUNCS="["; FIRST=true; NAME=""; LABEL=""; DESC=""; \
     while IFS= read -r line; do \
       case "$line" in \

--- a/apps/kbve/edge/deno.json
+++ b/apps/kbve/edge/deno.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.1.16",
   "compilerOptions": {
     "lib": ["deno.window"],
     "strict": true

--- a/apps/kbve/edge/project.json
+++ b/apps/kbve/edge/project.json
@@ -14,13 +14,13 @@
 				"local": {
 					"commands": [
 						"./kbve.sh -nx edge:containerx",
-						"VERSION=$(grep '^version' apps/kbve/edge/version.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/edge:latest kbve/edge:$VERSION && echo \"Tagged kbve/edge:$VERSION\""
+						"VERSION=$(grep '\"version\"' apps/kbve/edge/deno.json | head -1 | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1) && docker tag kbve/edge:latest kbve/edge:$VERSION && echo \"Tagged kbve/edge:$VERSION\""
 					]
 				},
 				"production": {
 					"commands": [
 						"./kbve.sh -nx edge:containerx --configuration=production",
-						"VERSION=$(grep '^version' apps/kbve/edge/version.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/edge:latest kbve/edge:$VERSION && docker tag ghcr.io/kbve/edge:latest ghcr.io/kbve/edge:$VERSION && echo \"Tagged kbve/edge:$VERSION\""
+						"VERSION=$(grep '\"version\"' apps/kbve/edge/deno.json | head -1 | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1) && docker tag kbve/edge:latest kbve/edge:$VERSION && docker tag ghcr.io/kbve/edge:latest ghcr.io/kbve/edge:$VERSION && echo \"Tagged kbve/edge:$VERSION\""
 					]
 				},
 				"ci": {

--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -1,4 +1,4 @@
-version = "0.1.16"
+version = "0.1.15"
 
 [[functions]]
 name = "health"


### PR DESCRIPTION
## Summary
- Edge CI version gate had `SRC` and `VTOML` both pointing to `version.toml`, so `LOCAL == PUBLISHED` always and publish was permanently skipped (dashboard stuck at v0.1.15 despite v0.1.16 being built)
- `deno.json` is now the developer version source of truth; `version.toml` becomes the CI-managed published marker
- All CI workflows updated to handle JSON extraction via `jq` for edge
- `utils-update-version-toml.yml` now uses `sed` in-place update instead of overwriting the file, preserving edge's function registry
- Dockerfile reads version from `deno.json`, function registry from `version.toml`

## Test plan
- [ ] CI lint/test passes on this PR
- [ ] Merge to dev, then verify ci-main dispatches ci-docker for edge
- [ ] Confirm version_gate sees LOCAL=0.1.16 (deno.json) > PUBLISHED=0.1.15 (version.toml) and sets should_publish=true
- [ ] After publish, verify version.toml is updated to 0.1.16 via PR without destroying function registry
- [ ] Dashboard reflects v0.1.16