### PR TITLE
fix(kube/forgejo): add namespace to ExternalSecret remoteRef

### DIFF
--- a/apps/kube/forgejo/manifest/forgejo-db-external-secret.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-db-external-secret.yaml
@@ -11,9 +11,11 @@ spec:
     target:
         name: forgejo-db
         creationPolicy: Owner
+    dataFrom: []
     data:
         - secretKey: password
           remoteRef:
               key: supabase-cluster-app
+              namespace: kilobase
               property: password
               metadataPolicy: None

--- a/apps/kube/forgejo/manifest/forgejo-redis-external-secret.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-redis-external-secret.yaml
@@ -11,9 +11,11 @@ spec:
     target:
         name: forgejo-redis
         creationPolicy: Owner
+    dataFrom: []
     data:
         - secretKey: password
           remoteRef:
               key: redis-auth
+              namespace: redis
               property: redis-password
               metadataPolicy: None


### PR DESCRIPTION
Fixes `ExternalSecret` sync failures:

```
an empty namespace may not be set when a resource name is provided
```

The `ClusterSecretStore` kubernetes provider requires an explicit `namespace` in `remoteRef` when fetching secrets cross-namespace. Added:
- `namespace: kilobase` for `forgejo-db` (pulls from `supabase-cluster-app`)
- `namespace: redis` for `forgejo-redis` (pulls from `redis-auth`)