### PR TITLE
feat(fudster): add gdrive pdf-to-md command

### DIFF
--- a/packages/python/fudster/fudster/apps/gdrive_pdf.py
+++ b/packages/python/fudster/fudster/apps/gdrive_pdf.py
@@ -1,0 +1,251 @@
+"""Google Drive view-only PDF extractor.
+
+Opens a Google Drive PDF link in a headless browser, scrolls through
+all pages to force rendering, captures each page image from the DOM,
+and converts the result to Markdown (with OCR when available).
+
+Requires the ``browser`` optional dependency group::
+
+    pip install fudster[browser]
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import re
+import tempfile
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_GDRIVE_FILE_RE = re.compile(
+    r"https?://drive\.google\.com/file/d/([a-zA-Z0-9_-]+)",
+)
+
+_GDRIVE_PREVIEW_TPL = (
+    "https://drive.google.com/file/d/{file_id}/preview"
+)
+
+# JS that converts every blob: <img> on the page to a base64 data-URL
+# via an offscreen canvas.  Returns a JSON array of base64 JPEG strings.
+_CAPTURE_JS = """
+return (function() {
+    var imgs = document.querySelectorAll('img[src^="blob:"]');
+    var results = [];
+    for (var i = 0; i < imgs.length; i++) {
+        var img = imgs[i];
+        if (img.naturalWidth === 0) continue;
+        var c = document.createElement('canvas');
+        c.width = img.naturalWidth;
+        c.height = img.naturalHeight;
+        var ctx = c.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        try {
+            results.push(c.toDataURL('image/png').split(',')[1]);
+        } catch(e) {
+            // tainted canvas — skip
+        }
+    }
+    return results;
+})();
+"""
+
+# Fallback: screenshot-based capture for each page role element
+_PAGE_COUNT_JS = """
+return document.querySelectorAll('div[role="listitem"]').length;
+"""
+
+
+def _parse_file_id(url: str) -> str:
+    """Extract the Google Drive file ID from a URL."""
+    m = _GDRIVE_FILE_RE.search(url)
+    if m:
+        return m.group(1)
+    raise ValueError(
+        f"Could not extract Google Drive file ID from: {url}"
+    )
+
+
+def _build_viewer_url(url: str) -> str:
+    """Normalise a Google Drive URL to the embeddable viewer."""
+    file_id = _parse_file_id(url)
+    return _GDRIVE_PREVIEW_TPL.format(file_id=file_id)
+
+
+def _scroll_all_pages(sb, *, pause: float = 0.6, max_scrolls: int = 300):
+    """Scroll the Google Drive PDF viewer to load every page."""
+    last_height = 0
+    stable_count = 0
+    for _ in range(max_scrolls):
+        sb.execute_script(
+            "document.querySelector('div.ndfHFb-c4YZDc-cYSp0e-DARUcf')"
+            "?.scrollBy(0, window.innerHeight);"
+        )
+        time.sleep(pause)
+        new_height = sb.execute_script(
+            "var el = document.querySelector("
+            "'div.ndfHFb-c4YZDc-cYSp0e-DARUcf');"
+            "return el ? el.scrollTop : 0;"
+        )
+        if new_height == last_height:
+            stable_count += 1
+            if stable_count >= 3:
+                break
+        else:
+            stable_count = 0
+        last_height = new_height
+
+
+def _capture_blob_images(sb) -> list[bytes]:
+    """Capture all blob: images from the viewer as PNG bytes."""
+    raw = sb.execute_script(_CAPTURE_JS)
+    if not raw:
+        return []
+    images: list[bytes] = []
+    for b64 in raw:
+        if b64:
+            images.append(base64.b64decode(b64))
+    return images
+
+
+def _try_ocr(image_bytes: bytes) -> str | None:
+    """Attempt OCR on a single image. Returns text or None."""
+    try:
+        import pytesseract
+        from PIL import Image
+    except ImportError:
+        return None
+    img = Image.open(io.BytesIO(image_bytes))
+    text = pytesseract.image_to_string(img)
+    return text.strip() if text.strip() else None
+
+
+def _images_to_markdown(
+    images: list[bytes],
+    *,
+    output_dir: Path | None = None,
+    use_ocr: bool = True,
+) -> str:
+    """Convert captured page images to Markdown.
+
+    If *use_ocr* is True and pytesseract + Pillow are available, each
+    page is OCR'd and the recognised text is emitted.  Otherwise the
+    images are saved to *output_dir* and referenced as Markdown images.
+    """
+    parts: list[str] = []
+    ocr_available = use_ocr
+    if ocr_available:
+        try:
+            import pytesseract  # noqa: F401
+            from PIL import Image  # noqa: F401
+        except ImportError:
+            ocr_available = False
+
+    if output_dir is None:
+        output_dir = Path(tempfile.mkdtemp(prefix="fudster_gdrive_"))
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for idx, img_bytes in enumerate(images, 1):
+        page_label = f"Page {idx}"
+        parts.append(f"## {page_label}\n")
+
+        if ocr_available:
+            text = _try_ocr(img_bytes)
+            if text:
+                parts.append(text)
+                parts.append("")
+                continue
+
+        # Fallback: save image and reference it
+        img_path = output_dir / f"page_{idx:03d}.png"
+        img_path.write_bytes(img_bytes)
+        parts.append(f"![{page_label}]({img_path})\n")
+
+    return "\n".join(parts)
+
+
+def extract_gdrive_pdf(
+    url: str,
+    *,
+    headless: bool = True,
+    output_dir: str | None = None,
+    scroll_pause: float = 0.6,
+    use_ocr: bool = True,
+) -> str:
+    """Extract a view-only Google Drive PDF and return Markdown.
+
+    Parameters
+    ----------
+    url:
+        Google Drive share / view link containing ``/file/d/<id>``.
+    headless:
+        Run the browser without a visible window.
+    output_dir:
+        Directory to save page images.  Created if absent.
+    scroll_pause:
+        Seconds to wait between scroll steps.
+    use_ocr:
+        Attempt OCR via pytesseract when available.
+
+    Returns
+    -------
+    str
+        Markdown representation of the PDF content.
+    """
+    try:
+        from seleniumbase import SB
+    except ImportError:
+        raise ImportError(
+            "seleniumbase is required. "
+            "Install with: pip install fudster[browser]"
+        )
+
+    viewer_url = _build_viewer_url(url)
+    logger.info("Opening viewer: %s", viewer_url)
+
+    out = Path(output_dir) if output_dir else None
+
+    with SB(
+        uc=True,
+        headless=headless,
+        browser="chrome",
+    ) as sb:
+        sb.open(viewer_url)
+        # Wait for the PDF viewer to render at least one page image
+        try:
+            sb.wait_for_element(
+                'img[src^="blob:"]', timeout=20,
+            )
+        except Exception:
+            logger.warning(
+                "No blob images found — the PDF may require "
+                "sign-in or the link may be invalid."
+            )
+            return (
+                "# Error\n\n"
+                "Could not load the PDF. Ensure the link is a "
+                "publicly shared Google Drive PDF.\n"
+            )
+
+        logger.info("First page loaded, scrolling through document…")
+        _scroll_all_pages(sb, pause=scroll_pause)
+
+        # Brief extra pause for final images to render
+        time.sleep(1.0)
+
+        images = _capture_blob_images(sb)
+        logger.info("Captured %d page image(s)", len(images))
+
+    if not images:
+        return (
+            "# Error\n\n"
+            "No page images could be captured from the viewer.\n"
+        )
+
+    header = f"# Google Drive PDF — {len(images)} page(s)\n\n"
+    body = _images_to_markdown(images, output_dir=out, use_ocr=use_ocr)
+    return header + body

--- a/packages/python/fudster/fudster/cli.py
+++ b/packages/python/fudster/fudster/cli.py
@@ -379,6 +379,81 @@ def grpc_compile(
     raise SystemExit(exit_code)
 
 
+# ── gdrive sub-group ────────────────────────────────────────────────
+
+@main.group("gdrive")
+def gdrive_group() -> None:
+    """Google Drive utilities — PDF extraction, conversion."""
+
+
+@gdrive_group.command("pdf-to-md")
+@click.argument("url")
+@click.option(
+    "--output", "-o", type=click.Path(), default=None,
+    help="Write Markdown to a file instead of stdout.",
+)
+@click.option(
+    "--image-dir", type=click.Path(), default=None,
+    help="Directory to save extracted page images.",
+)
+@click.option(
+    "--no-ocr", is_flag=True, default=False,
+    help="Skip OCR even if pytesseract is available.",
+)
+@click.option(
+    "--headed", is_flag=True, default=False,
+    help="Run the browser with a visible window.",
+)
+@click.option(
+    "--scroll-pause", type=float, default=0.6,
+    help="Seconds between scroll steps (default: 0.6).",
+)
+def gdrive_pdf_to_md(
+    url: str,
+    output: str | None,
+    image_dir: str | None,
+    no_ocr: bool,
+    headed: bool,
+    scroll_pause: float,
+) -> None:
+    """Extract a view-only Google Drive PDF and convert to Markdown.
+
+    Accepts a Google Drive share/view link, opens it in a headless
+    browser, captures every rendered page image, and produces Markdown
+    output (with OCR text when pytesseract is installed).
+
+    \b
+    Example:
+        fudster gdrive pdf-to-md "https://drive.google.com/file/d/ABC123/view"
+        fudster gdrive pdf-to-md URL -o output.md --image-dir ./pages
+    """
+    from fudster.apps.gdrive_pdf import extract_gdrive_pdf
+
+    click.echo(f"Extracting PDF from: {url}")
+
+    try:
+        md = extract_gdrive_pdf(
+            url,
+            headless=not headed,
+            output_dir=image_dir,
+            scroll_pause=scroll_pause,
+            use_ocr=not no_ocr,
+        )
+    except ValueError as exc:
+        click.secho(f"Error: {exc}", fg="red")
+        raise SystemExit(1)
+    except ImportError as exc:
+        click.secho(f"Missing dependency: {exc}", fg="red")
+        raise SystemExit(1)
+
+    if output:
+        from pathlib import Path
+        Path(output).write_text(md, encoding="utf-8")
+        click.secho(f"Markdown written to {output}", fg="green")
+    else:
+        click.echo(md)
+
+
 # ── nx sub-group ─────────────────────────────────────────────────────
 
 @main.group()

--- a/packages/python/fudster/pyproject.toml
+++ b/packages/python/fudster/pyproject.toml
@@ -33,6 +33,10 @@ automation = [
 browser = [
     "seleniumbase>=4.32,<5.0",
 ]
+ocr = [
+    "pytesseract>=0.3.10,<1.0",
+    "pillow>=10.0,<12.0",
+]
 vnc = [
     "websockify>=0.11,<1.0",
     "websockets>=12.0",
@@ -44,6 +48,7 @@ all = [
     "pillow>=10.0,<12.0",
     "numpy>=1.26,<3.0",
     "seleniumbase>=4.32,<5.0",
+    "pytesseract>=0.3.10,<1.0",
     "websockify>=0.11,<1.0",
     "websockets>=12.0",
 ]

--- a/packages/python/fudster/uv.lock
+++ b/packages/python/fudster/uv.lock
@@ -543,6 +543,7 @@ all = [
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pyautogui" },
+    { name = "pytesseract" },
     { name = "seleniumbase" },
     { name = "websockets" },
     { name = "websockify" },
@@ -556,6 +557,10 @@ automation = [
 ]
 browser = [
     { name = "seleniumbase" },
+]
+ocr = [
+    { name = "pillow" },
+    { name = "pytesseract" },
 ]
 vnc = [
     { name = "websockets" },
@@ -592,9 +597,12 @@ requires-dist = [
     { name = "opencv-python", marker = "extra == 'automation'", specifier = ">=4.9,<5.0" },
     { name = "pillow", marker = "extra == 'all'", specifier = ">=10.0,<12.0" },
     { name = "pillow", marker = "extra == 'automation'", specifier = ">=10.0,<12.0" },
+    { name = "pillow", marker = "extra == 'ocr'", specifier = ">=10.0,<12.0" },
     { name = "pyautogui", marker = "extra == 'all'", specifier = ">=0.9,<1.0" },
     { name = "pyautogui", marker = "extra == 'automation'", specifier = ">=0.9,<1.0" },
     { name = "pydantic", specifier = ">=1.10,<3.0" },
+    { name = "pytesseract", marker = "extra == 'all'", specifier = ">=0.3.10,<1.0" },
+    { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.10,<1.0" },
     { name = "requests", specifier = ">=2.28,<3.0" },
     { name = "seleniumbase", marker = "extra == 'all'", specifier = ">=4.32,<5.0" },
     { name = "seleniumbase", marker = "extra == 'browser'", specifier = ">=4.32,<5.0" },
@@ -603,7 +611,7 @@ requires-dist = [
     { name = "websockify", marker = "extra == 'all'", specifier = ">=0.11,<1.0" },
     { name = "websockify", marker = "extra == 'vnc'", specifier = ">=0.11,<1.0" },
 ]
-provides-extras = ["automation", "browser", "vnc", "all"]
+provides-extras = ["automation", "browser", "ocr", "vnc", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1511,6 +1519,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
+name = "pytesseract"
+version = "0.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a6/7d679b83c285974a7cb94d739b461fa7e7a9b17a3abfd7bf6cbc5c2394b0/pytesseract-0.3.13.tar.gz", hash = "sha256:4bf5f880c99406f52a3cfc2633e42d9dc67615e69d8a509d74867d3baddb5db9", size = 17689, upload-time = "2024-08-16T02:33:56.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/33/8312d7ce74670c9d39a532b2c246a853861120486be9443eebf048043637/pytesseract-0.3.13-py3-none-any.whl", hash = "sha256:7a99c6c2ac598360693d83a416e36e0b33a67638bb9d77fdcac094a3589d4b34", size = 14705, upload-time = "2024-08-16T02:36:10.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `fudster gdrive pdf-to-md` CLI command that extracts view-only Google Drive PDFs to Markdown
- Uses SeleniumBase to open the PDF viewer, scroll all pages, and capture rendered images via JS canvas
- Supports OCR text extraction via optional `pytesseract` dependency, falls back to image-based Markdown
- Adds `ocr` optional dependency group (`pytesseract` + `pillow`) to `pyproject.toml`

## Test plan
- [ ] `uv run fudster gdrive pdf-to-md --help` shows correct usage
- [ ] Run against a publicly shared Google Drive PDF link with `--headed` to verify scrolling + capture
- [ ] Verify `--no-ocr` flag saves page images and outputs image-reference Markdown
- [ ] Verify `-o output.md` writes file correctly