### PR TITLE
chore(kube): bump ARC runner images (runner 2.333.0, dind 29.3.0)

### DIFF
--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -17,7 +17,11 @@ controllerServiceAccount:
 minRunners: 0
 maxRunners: 3
 
+# Bump RESTART_TRIGGER to force a pod rollout without changing images.
 template:
+    metadata:
+        annotations:
+            kbve.com/restart-trigger: '20260320-image-bump'
     spec:
         initContainers:
             - name: init-dind-externals

--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -27,7 +27,11 @@ maxRunners: 10
 # runnerGroup: "default"
 
 # Runner container configuration with Docker-in-Docker support
+# Bump RESTART_TRIGGER to force a pod rollout without changing images.
 template:
+    metadata:
+        annotations:
+            kbve.com/restart-trigger: '20260320-image-bump'
     spec:
         # Init container to copy externals for DinD
         initContainers:


### PR DESCRIPTION
## Summary
- Bump `actions-runner` 2.332.0 → 2.333.0
- Bump `docker:dind` 29.2.1 → 29.3.0
- Both `arc-runner-set` and `arc-runner-ue` values updated

Argo watches these values files and will auto-sync on merge, triggering new runner pods with the updated images.

## Test plan
- [ ] Verify Argo detects OutOfSync after merge
- [ ] Confirm new runner pods pull updated images
- [ ] Run a Docker build to validate dind 29.3.0 compatibility