### PR TITLE
feat(kube/rabbitmq): add RabbitMQ cluster operator and broker instance

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -49,6 +49,7 @@ resources:
     - herbmail/application.yaml
     - memes/application.yaml
     - n8n/application.yaml
+    - rabbitmq/application.yaml
     - rentearth/application.yaml
     - cryptothrone/application.yaml
     # GitHub Actions Runner Controller (ARC)

--- a/apps/kube/rabbitmq/application.yaml
+++ b/apps/kube/rabbitmq/application.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: rabbitmq
+    namespace: argocd
+spec:
+    project: default
+    sources:
+        - repoURL: https://charts.bitnami.com/bitnami
+          targetRevision: 4.4.34
+          chart: rabbitmq-cluster-operator
+          helm:
+              releaseName: rabbitmq-cluster-operator
+              valueFiles:
+                  - $values/apps/kube/rabbitmq/manifests/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          path: apps/kube/rabbitmq/manifests
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: rabbitmq-system
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m

--- a/apps/kube/rabbitmq/manifests/kustomization.yaml
+++ b/apps/kube/rabbitmq/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+    - rabbitmq-cluster.yaml

--- a/apps/kube/rabbitmq/manifests/rabbitmq-cluster.yaml
+++ b/apps/kube/rabbitmq/manifests/rabbitmq-cluster.yaml
@@ -1,0 +1,24 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+    name: rabbitmq
+    namespace: rabbitmq-system
+spec:
+    replicas: 1
+    resources:
+        requests:
+            memory: '256Mi'
+            cpu: '100m'
+        limits:
+            memory: '512Mi'
+            cpu: '500m'
+    persistence:
+        storageClassName: longhorn
+        storage: 10Gi
+    rabbitmq:
+        additionalConfig: |
+            default_user_tags.administrator = true
+            disk_free_limit.absolute = 1GB
+            log.console.level = warning
+    service:
+        type: ClusterIP

--- a/apps/kube/rabbitmq/manifests/values.yaml
+++ b/apps/kube/rabbitmq/manifests/values.yaml
@@ -1,0 +1,28 @@
+# RabbitMQ Cluster Operator configuration
+# Chart: bitnami/rabbitmq-cluster-operator
+
+# -- Cluster Operator settings
+clusterOperator:
+    replicaCount: 1
+    resources:
+        requests:
+            memory: '128Mi'
+            cpu: '100m'
+        limits:
+            memory: '256Mi'
+            cpu: '250m'
+
+# -- Messaging Topology Operator (manages queues, exchanges, bindings, users, etc. via CRDs)
+msgTopologyOperator:
+    enabled: true
+    replicaCount: 1
+    resources:
+        requests:
+            memory: '128Mi'
+            cpu: '100m'
+        limits:
+            memory: '256Mi'
+            cpu: '250m'
+
+# -- Install CRDs (RabbitmqCluster, Queue, Exchange, Binding, User, etc.)
+useCRDs: true


### PR DESCRIPTION
## Summary
- Add Bitnami `rabbitmq-cluster-operator` Helm chart (v4.4.34) as ArgoCD Application
- Enable messaging topology operator for declarative queue/exchange/binding management via CRDs
- Include `RabbitmqCluster` CR for single-replica broker with Longhorn persistence (10Gi)
- Operator auto-generates `rabbitmq-default-user` secret with connection credentials

## Test plan
- [ ] Verify ArgoCD syncs the rabbitmq Application successfully
- [ ] Confirm operator pods are running in `rabbitmq-system` namespace
- [ ] Confirm `RabbitmqCluster` CR creates a broker pod with ready status
- [ ] Verify `rabbitmq-default-user` secret is auto-generated with credentials