### PR TITLE
feat(kube): add Valkey as secondary key-value store

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -24,6 +24,8 @@ resources:
     - external-secrets/application.yaml
     - monitoring/application.yaml
     - redis/application.yaml
+    # Valkey — open-source Redis fork (Linux Foundation), secondary key-value store
+    - valkey/application.yaml
     - storage/application.yaml
     - irc/application.yaml
     - kilobase/application.yaml

--- a/apps/kube/valkey/application.yaml
+++ b/apps/kube/valkey/application.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: valkey
+    namespace: argocd
+spec:
+    project: default
+    sources:
+        - repoURL: https://charts.bitnami.com/bitnami
+          targetRevision: 3.0.5
+          chart: valkey
+          helm:
+              releaseName: valkey
+              valueFiles:
+                  - $values/apps/kube/valkey/manifests/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          path: apps/kube/valkey/manifests
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: valkey
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true

--- a/apps/kube/valkey/manifests/kustomization.yaml
+++ b/apps/kube/valkey/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+    - valkey-auth-sealedsecret.yaml

--- a/apps/kube/valkey/manifests/valkey-auth-sealedsecret.yaml
+++ b/apps/kube/valkey/manifests/valkey-auth-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: valkey-auth
+    namespace: valkey
+spec:
+    encryptedData:
+        valkey-password: AgAwZY3UHO4xUPnbYBokn/fJc2VfB5dBESIjhPqd6PPutPl8dv6ziMYBcugci5+SwrS96qNcBgqT716oeBSyAbTozf6rryRT6j+TZVvu6xNTOv0KwmCD5Qkv4EpjI0kSVYVNqF/BY1dsHPxoSnjy/6ho64F3wUqcKp+bvokH1H4HvZnjmoEcUL2hoClldSIcldFqTjss1f7Dc+t1I+Jn1xfQK45v9NLhVaG2RjtB88S8HXJFIWO5Ac61cqueWDmRIaxdzw2ir/8CjG2+A7Hlg+/76i/TnIzdC/+dAqpG65M92mm0iDliaUZugqXT4DeBys6vTNqYPr2DjX6WCEoETWqMp+1d80ORWIohKM7C6exSESX9okcB80CnUUSJ9bPlHM4WlZtt3v5OqZx1pMW8+J0ptebAJjiNctYP/+vsnsuQIgMJuBNelQ/fcDx1pJ4aEG8lwOgBpmFWGuehoApUvoL3A589AhRldLOV7DFS6g4UhhYNhz9RsJGRiNUeE7lB30rUvuVSJ6sc3agr/JETo30lo+g8pU+KJ9UMzxoCtVQC+cIJDHBpBEV0lbcwjWr4uY3GPvcp5NBr632QOfhyKj5Pgud+iPzFpOM2nWLaXo64DuH7hgT0HIf092t7tvpaiPvR/pKgLGEr6D9ZL3GvnuwFQ6qggGawjam1QPMnV3b6ymiyOOT0ybOxB3YxDQSSRMDSAHsLaPST9vKps+wG2PkVob4WNve2VLfwTG7eFzPFgbCUvQfyJ1zEJ7D8LLVwmjEvgMXzdA0JLtba6QU1ClVn
+    template:
+        metadata:
+            name: valkey-auth
+            namespace: valkey

--- a/apps/kube/valkey/manifests/values.yaml
+++ b/apps/kube/valkey/manifests/values.yaml
@@ -1,0 +1,37 @@
+# Valkey configuration — secondary key-value store alongside Redis
+# Valkey is an open-source Redis fork maintained by the Linux Foundation
+architecture: standalone
+
+auth:
+    enabled: true
+    existingSecret: valkey-auth
+    existingSecretPasswordKey: valkey-password
+
+master:
+    service:
+        type: ClusterIP
+        ports:
+            valkey: 6379
+    persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: 'longhorn'
+    resources:
+        requests:
+            memory: '256Mi'
+            cpu: '100m'
+        limits:
+            memory: '512Mi'
+            cpu: '500m'
+
+metrics:
+    enabled: true
+    serviceMonitor:
+        enabled: true
+        namespace: valkey
+
+networkPolicy:
+    enabled: true
+    allowExternal: true
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}

--- a/apps/kube/valkey/seal-valkey-password.sh
+++ b/apps/kube/valkey/seal-valkey-password.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# seal-valkey-password.sh — Seal the Valkey auth password
+#
+# Pipeline that:
+#   1. Prompts for (or reads from env) the Valkey password
+#   2. Wraps it in a Kubernetes Secret (kubectl --dry-run)
+#   3. Encrypts it via kubeseal (cluster public key)
+#   4. Writes ONLY the SealedSecret YAML to the repo
+#
+# The plaintext password exists only in memory between pipe stages.
+# It never touches disk, shell history, or git.
+#
+# Prerequisites:
+#   - kubectl configured with cluster access
+#   - kubeseal installed (brew install kubeseal)
+#   - sealed-secrets-controller running in kube-system
+#
+# Usage:
+#   ./seal-valkey-password.sh
+#   # or: VALKEY_PASSWORD=<value> ./seal-valkey-password.sh
+#   # Output: apps/kube/valkey/manifests/valkey-auth-sealedsecret.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_FILE="${SCRIPT_DIR}/manifests/valkey-auth-sealedsecret.yaml"
+TARGET_NS="valkey"
+
+# --- Preflight checks ---
+
+for cmd in kubectl kubeseal; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is not installed or not in PATH" >&2
+        exit 1
+    fi
+done
+
+if ! kubectl cluster-info &>/dev/null; then
+    echo "Error: Cannot connect to Kubernetes cluster" >&2
+    exit 1
+fi
+
+if ! kubectl get deployment sealed-secrets-controller -n kube-system &>/dev/null; then
+    echo "Error: sealed-secrets-controller not found in kube-system namespace" >&2
+    exit 1
+fi
+
+# --- Get password ---
+
+if [[ -z "${VALKEY_PASSWORD:-}" ]]; then
+    echo -n "Enter Valkey password: "
+    read -rs VALKEY_PASSWORD
+    echo
+fi
+
+if [[ -z "${VALKEY_PASSWORD}" ]]; then
+    echo "Error: Valkey password cannot be empty" >&2
+    exit 1
+fi
+
+# --- Seal the password ---
+
+echo "Sealing Valkey password..."
+
+echo -n "${VALKEY_PASSWORD}" \
+| kubectl create secret generic valkey-auth \
+    --namespace="${TARGET_NS}" \
+    --from-file=valkey-password=/dev/stdin \
+    --dry-run=client \
+    -o yaml \
+| kubeseal \
+    --controller-name=sealed-secrets-controller \
+    --controller-namespace=kube-system \
+    --format=yaml \
+> "${OUTPUT_FILE}"
+
+echo ""
+echo "Sealed secret written to: ${OUTPUT_FILE}"
+echo "Plaintext password was never written to disk."
+echo ""
+echo "Next steps:"
+echo "  1. git add ${OUTPUT_FILE}"
+echo "  2. Commit and push — ArgoCD will sync the SealedSecret"
+echo "  3. Services can reference valkey-auth secret via ExternalSecret"


### PR DESCRIPTION
## Summary
- Adds Valkey (open-source Redis fork, Linux Foundation) as a secondary key-value store alongside existing Redis
- Deployed via Bitnami Helm chart (v3.0.5) with standalone architecture, Longhorn persistence (8Gi), sealed secret auth, and Prometheus ServiceMonitor
- Includes `seal-valkey-password.sh` for secure password sealing via kubeseal (same pattern as mc/clickhouse seal scripts)
- Registered in root kustomization for ArgoCD sync

## Files
- `apps/kube/valkey/application.yaml` — ArgoCD Application
- `apps/kube/valkey/manifests/values.yaml` — Helm values
- `apps/kube/valkey/manifests/kustomization.yaml` — Kustomize resources
- `apps/kube/valkey/manifests/valkey-auth-sealedsecret.yaml` — Sealed auth secret
- `apps/kube/valkey/seal-valkey-password.sh` — Secure password seal script
- `apps/kube/kustomization.yaml` — Updated root kustomization

## Test plan
- [ ] Verify ArgoCD picks up the new Valkey application
- [ ] Confirm sealed secret decrypts correctly in-cluster
- [ ] Validate Valkey pod starts and is reachable on port 6379
- [ ] Check Prometheus ServiceMonitor scrapes metrics