### PR TITLE
fix(kube): switch Valkey to official valkey-io helm chart

### DIFF
--- a/apps/kube/valkey/application.yaml
+++ b/apps/kube/valkey/application.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
     project: default
     sources:
-        - repoURL: https://charts.bitnami.com/bitnami
-          targetRevision: 3.0.5
+        - repoURL: https://valkey-io.github.io/valkey-helm/
+          targetRevision: 0.9.3
           chart: valkey
           helm:
               releaseName: valkey

--- a/apps/kube/valkey/manifests/values.yaml
+++ b/apps/kube/valkey/manifests/values.yaml
@@ -1,37 +1,30 @@
 # Valkey configuration — secondary key-value store alongside Redis
-# Valkey is an open-source Redis fork maintained by the Linux Foundation
-architecture: standalone
+# Official valkey-io/valkey-helm chart (not Bitnami)
 
 auth:
     enabled: true
-    existingSecret: valkey-auth
-    existingSecretPasswordKey: valkey-password
+    aclUsers:
+        default:
+            permissions: '~* &* +@all'
+            passwordKey: valkey-password
+    usersExistingSecret: valkey-auth
 
-master:
-    service:
-        type: ClusterIP
-        ports:
-            valkey: 6379
-    persistence:
-        enabled: true
-        size: 8Gi
-        storageClass: 'longhorn'
-    resources:
-        requests:
-            memory: '256Mi'
-            cpu: '100m'
-        limits:
-            memory: '512Mi'
-            cpu: '500m'
+dataStorage:
+    enabled: true
+    requestedSize: 8Gi
+    className: longhorn
+    accessModes:
+        - ReadWriteOnce
+
+resources:
+    requests:
+        memory: '256Mi'
+        cpu: '100m'
+    limits:
+        memory: '512Mi'
+        cpu: '500m'
 
 metrics:
     enabled: true
     serviceMonitor:
         enabled: true
-        namespace: valkey
-
-networkPolicy:
-    enabled: true
-    allowExternal: true
-    ingressNSMatchLabels: {}
-    ingressNSPodMatchLabels: {}


### PR DESCRIPTION
## Summary
- Bitnami Valkey chart 3.0.5 references Docker images that no longer exist (`valkey:8.1.1-debian-12-r0`, `redis-exporter:1.72.0-debian-12-r0`), causing `ImagePullBackOff`
- Migrates to the official `valkey-io/valkey-helm` chart (v0.9.3, app v9.0.1) using `valkey/valkey` images from Docker Hub
- Updates values to match the official chart structure: ACL-based auth, `dataStorage` for persistence, top-level `resources`

## Test plan
- [ ] Verify ArgoCD syncs the updated Valkey application
- [ ] Confirm `valkey-primary-0` pod pulls images successfully and reaches Running state
- [ ] Validate auth works with the existing sealed secret
- [ ] Check Prometheus ServiceMonitor scrapes metrics