### PR TITLE
feat(kube/elk): add ECK operator and Elasticsearch + Kibana stack

### DIFF
--- a/apps/kube/elk/application.yaml
+++ b/apps/kube/elk/application.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: eck-operator
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '2'
+spec:
+    project: default
+    sources:
+        - repoURL: https://helm.elastic.co
+          targetRevision: 2.16.1
+          chart: eck-operator
+          helm:
+              releaseName: eck-operator
+              valueFiles:
+                  - $values/apps/kube/elk/manifests/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: elastic-system
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true

--- a/apps/kube/elk/manifests/elasticsearch.yaml
+++ b/apps/kube/elk/manifests/elasticsearch.yaml
@@ -1,0 +1,33 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+    name: elasticsearch
+    namespace: elastic-stack
+spec:
+    version: 8.17.3
+    nodeSets:
+        - name: default
+          count: 1
+          config:
+              node.store.allow_mmap: false
+          podTemplate:
+              spec:
+                  containers:
+                      - name: elasticsearch
+                        resources:
+                            limits:
+                                cpu: '2'
+                                memory: 4Gi
+                            requests:
+                                cpu: 500m
+                                memory: 2Gi
+          volumeClaimTemplates:
+              - metadata:
+                    name: elasticsearch-data
+                spec:
+                    accessModes:
+                        - ReadWriteOnce
+                    resources:
+                        requests:
+                            storage: 50Gi
+                    storageClassName: longhorn

--- a/apps/kube/elk/manifests/kibana.yaml
+++ b/apps/kube/elk/manifests/kibana.yaml
@@ -1,0 +1,21 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+    name: kibana
+    namespace: elastic-stack
+spec:
+    version: 8.17.3
+    count: 1
+    elasticsearchRef:
+        name: elasticsearch
+    podTemplate:
+        spec:
+            containers:
+                - name: kibana
+                  resources:
+                      limits:
+                          cpu: '1'
+                          memory: 1Gi
+                      requests:
+                          cpu: 250m
+                          memory: 512Mi

--- a/apps/kube/elk/manifests/kustomization.yaml
+++ b/apps/kube/elk/manifests/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+    - elasticsearch.yaml
+    - kibana.yaml

--- a/apps/kube/elk/manifests/values.yaml
+++ b/apps/kube/elk/manifests/values.yaml
@@ -1,0 +1,18 @@
+# ECK Operator Helm values
+# https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-operator
+
+# Manage CRDs with the operator chart
+manageCrds: true
+
+# Resource limits for the operator
+resources:
+    limits:
+        cpu: 200m
+        memory: 256Mi
+    requests:
+        cpu: 100m
+        memory: 128Mi
+
+# Restrict operator to watch only the elastic-stack namespace
+managedNamespaces:
+    - elastic-stack

--- a/apps/kube/elk/stack-application.yaml
+++ b/apps/kube/elk/stack-application.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: elk-stack
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '3'
+spec:
+    project: default
+    sources:
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          path: apps/kube/elk/manifests
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: elastic-stack
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -69,5 +69,9 @@ resources:
     # Cilium LB IPAM — IP pools + L2 announcements (replaces MetalLB)
     - cilium/lb-application.yaml
 
+    # ECK (Elastic Cloud on Kubernetes) — operator + Elasticsearch + Kibana
+    - elk/application.yaml
+    - elk/stack-application.yaml
+
     # Forgejo — Git LFS server + Actions runner, UE asset storage on sdb
     - forgejo/application.yaml


### PR DESCRIPTION
## Summary
- Add ECK (Elastic Cloud on Kubernetes) operator via Helm chart (v2.16.1) in `elastic-system` namespace
- Deploy single-node Elasticsearch 8.17.3 with 50Gi Longhorn PVC and Kibana 8.17.3 in `elastic-stack` namespace
- ArgoCD applications with sync-wave ordering (operator wave 2, stack wave 3)
- No S3 backup configured — Longhorn-only storage as requested

## Test plan
- [ ] Verify ECK operator syncs successfully in ArgoCD
- [ ] Verify Elasticsearch pod comes up healthy with Longhorn PVC bound
- [ ] Verify Kibana connects to Elasticsearch and is accessible
- [ ] Confirm no impact on existing ArgoCD applications