### PR TITLE
fix(kube/forgejo): use direct DB connection + correct postgres secret

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -54,7 +54,7 @@ spec:
                               LFS_JWT_SECRET: ''
                           database:
                               DB_TYPE: postgres
-                              HOST: supabase-cluster-pooler-rw.kilobase.svc.cluster.local:5432
+                              HOST: supabase-cluster-rw.kilobase.svc.cluster.local:5432
                               NAME: supabase
                               USER: postgres
                               SSL_MODE: require

--- a/apps/kube/forgejo/manifest/forgejo-externalsecret.yaml
+++ b/apps/kube/forgejo/manifest/forgejo-externalsecret.yaml
@@ -5,7 +5,7 @@ metadata:
     name: forgejo-external-secrets
     namespace: forgejo
 ---
-# SecretStore: Kilobase namespace (for supabase-cluster-app password)
+# SecretStore: Kilobase namespace (for supabase-postgres password)
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
@@ -44,7 +44,7 @@ spec:
     data:
         - secretKey: password
           remoteRef:
-              key: supabase-cluster-app
+              key: supabase-postgres
               property: password
 ---
 # SecretStore: Redis namespace (for redis-auth password)

--- a/apps/kube/forgejo/manifest/rbac.yaml
+++ b/apps/kube/forgejo/manifest/rbac.yaml
@@ -1,4 +1,4 @@
-# Role: Allow forgejo ExternalSecrets SA to read supabase-cluster-app secret
+# Role: Allow forgejo ExternalSecrets SA to read supabase-postgres secret
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -7,7 +7,7 @@ metadata:
 rules:
     - apiGroups: ['']
       resources: ['secrets']
-      resourceNames: ['supabase-cluster-app']
+      resourceNames: ['supabase-postgres']
       verbs: ['get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Forgejo init container was failing with `pq: server login has been failing, cached error: server conn crashed?`

**Root cause**: Two mismatches vs the working n8n pattern:
1. Using pooler (`supabase-cluster-pooler-rw`) which blocks `postgres` superuser connections — switched to direct (`supabase-cluster-rw`)
2. Pulling password from `supabase-cluster-app` (user: `supabase_admin`) but Helm values had `USER: postgres` — switched to `supabase-postgres` secret

Now matches n8n exactly: direct connection + postgres user + supabase-postgres secret.