### PR TITLE
fix(kube/rabbitmq): bypass Bitnami image security gate and add sync-wave

### DIFF
--- a/apps/kube/rabbitmq/application.yaml
+++ b/apps/kube/rabbitmq/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
     name: rabbitmq
     namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '3'
 spec:
     project: default
     sources:

--- a/apps/kube/rabbitmq/manifests/values.yaml
+++ b/apps/kube/rabbitmq/manifests/values.yaml
@@ -3,6 +3,11 @@
 # Note: Bitnami chart references non-existent bitnami/* images on Docker Hub.
 #       We override to use the official rabbitmqoperator/* images instead.
 
+# -- Allow non-Bitnami images (required to bypass Bitnami's NOTES.txt security gate)
+global:
+    security:
+        allowInsecureImages: true
+
 # -- Cluster Operator settings
 clusterOperator:
     replicaCount: 1


### PR DESCRIPTION
## Summary
- Bitnami chart NOTES.txt hard-errors when non-Bitnami images are used — ArgoCD manifest generation fails with `execution error`
- Set `global.security.allowInsecureImages: true` to allow official `rabbitmqoperator/*` images
- Add `argocd.argoproj.io/sync-wave: '3'` annotation for proper ArgoCD ordering

## Test plan
- [ ] ArgoCD manifest generation succeeds (no more `execution error`)
- [ ] ArgoCD syncs the rabbitmq Application automatically
- [ ] Operator pods pull images and reach Running state
- [ ] RabbitmqCluster CR reconciles and broker pod comes up