### PR TITLE
fix(kube/elk): bump ECK to 3.3.1, ES+Kibana to 8.19.13, add kbve meta tags

### DIFF
--- a/apps/kube/elk/application.yaml
+++ b/apps/kube/elk/application.yaml
@@ -3,13 +3,17 @@ kind: Application
 metadata:
     name: eck-operator
     namespace: argocd
+    labels:
+        kbve.sh/app: elk
+        kbve.sh/component: operator
     annotations:
         argocd.argoproj.io/sync-wave: '2'
+        kbve.sh/last-updated: '2026-03-20'
 spec:
     project: default
     sources:
         - repoURL: https://helm.elastic.co
-          targetRevision: 2.16.1
+          targetRevision: 3.3.1
           chart: eck-operator
           helm:
               releaseName: eck-operator

--- a/apps/kube/elk/manifests/elasticsearch.yaml
+++ b/apps/kube/elk/manifests/elasticsearch.yaml
@@ -3,8 +3,14 @@ kind: Elasticsearch
 metadata:
     name: elasticsearch
     namespace: elastic-stack
+    labels:
+        kbve.sh/app: elk
+        kbve.sh/component: elasticsearch
+    annotations:
+        kbve.sh/last-updated: '2026-03-20'
+        kbve.sh/rollout-restart: '2026-03-20T00:00:00Z'
 spec:
-    version: 8.17.3
+    version: 8.19.13
     nodeSets:
         - name: default
           count: 1

--- a/apps/kube/elk/manifests/kibana.yaml
+++ b/apps/kube/elk/manifests/kibana.yaml
@@ -3,8 +3,14 @@ kind: Kibana
 metadata:
     name: kibana
     namespace: elastic-stack
+    labels:
+        kbve.sh/app: elk
+        kbve.sh/component: kibana
+    annotations:
+        kbve.sh/last-updated: '2026-03-20'
+        kbve.sh/rollout-restart: '2026-03-20T00:00:00Z'
 spec:
-    version: 8.17.3
+    version: 8.19.13
     count: 1
     elasticsearchRef:
         name: elasticsearch

--- a/apps/kube/elk/manifests/values.yaml
+++ b/apps/kube/elk/manifests/values.yaml
@@ -1,8 +1,8 @@
-# ECK Operator Helm values
+# ECK Operator Helm values (v3.3.1)
 # https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-operator
 
-# Manage CRDs with the operator chart
-manageCrds: true
+# Install CRDs with the operator chart
+installCRDs: true
 
 # Resource limits for the operator
 resources:
@@ -11,7 +11,7 @@ resources:
         memory: 256Mi
     requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 150Mi
 
 # Restrict operator to watch only the elastic-stack namespace
 managedNamespaces:

--- a/apps/kube/elk/stack-application.yaml
+++ b/apps/kube/elk/stack-application.yaml
@@ -3,8 +3,12 @@ kind: Application
 metadata:
     name: elk-stack
     namespace: argocd
+    labels:
+        kbve.sh/app: elk
+        kbve.sh/component: stack
     annotations:
         argocd.argoproj.io/sync-wave: '3'
+        kbve.sh/last-updated: '2026-03-20'
 spec:
     project: default
     sources:


### PR DESCRIPTION
## Summary
- Bump ECK operator `2.16.1` -> `3.3.1` (fix `manageCrds` -> `installCRDs` for v3 schema)
- Bump Elasticsearch + Kibana `8.17.3` -> `8.19.13` (8.17 is EOL)
- Add `kbve.sh/app`, `kbve.sh/component` labels for kubectl/ArgoCD filtering
- Add `kbve.sh/last-updated`, `kbve.sh/rollout-restart` annotations for restart/sync triggers
- Align operator memory request to upstream default (150Mi)

## Test plan
- [ ] Verify ECK operator v3.3.1 syncs and CRDs install correctly
- [ ] Verify Elasticsearch 8.19.13 rolls out with Longhorn PVC
- [ ] Verify Kibana 8.19.13 connects to Elasticsearch
- [ ] Confirm `kubectl get app -l kbve.sh/app=elk` returns both ArgoCD applications