### PR TITLE
feat(kube): wire ARC runners to Forgejo LFS credentials via ExternalSecret

### DIFF
--- a/apps/kube/forgejo/manifest/rbac.yaml
+++ b/apps/kube/forgejo/manifest/rbac.yaml
@@ -53,6 +53,32 @@ subjects:
       name: forgejo-external-secrets
       namespace: forgejo
 ---
+# Role: Allow ARC runners to read forgejo-deploy-keys secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: arc-runners-forgejo-access
+    namespace: forgejo
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['forgejo-deploy-keys']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: arc-runners-forgejo-access-binding
+    namespace: forgejo
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: arc-runners-forgejo-access
+subjects:
+    - kind: ServiceAccount
+      name: arc-runners-external-secrets
+      namespace: arc-runners
+---
 # NetworkPolicy: Allow forgejo pods to reach Redis on port 6379
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/apps/kube/github/runners/manifests/github-arc-externalsecret.yaml
+++ b/apps/kube/github/runners/manifests/github-arc-externalsecret.yaml
@@ -3,50 +3,99 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: arc-runners-external-secrets
-  namespace: arc-runners
+    name: arc-runners-external-secrets
+    namespace: arc-runners
 ---
 # SecretStore to pull the GitHub PAT from arc-systems namespace
 # Uses local SA in arc-runners namespace (not cross-namespace SA reference)
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
-  name: arc-systems-secret-store
-  namespace: arc-runners
+    name: arc-systems-secret-store
+    namespace: arc-runners
 spec:
-  provider:
-    kubernetes:
-      remoteNamespace: arc-systems
-      auth:
-        serviceAccount:
-          name: arc-runners-external-secrets
-      server:
-        url: https://kubernetes.default.svc
-        caProvider:
-          type: ConfigMap
-          name: kube-root-ca.crt
-          key: ca.crt
-          namespace: kube-system
+    provider:
+        kubernetes:
+            remoteNamespace: arc-systems
+            auth:
+                serviceAccount:
+                    name: arc-runners-external-secrets
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: github-arc-token
-  namespace: arc-runners
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: arc-systems-secret-store
-    kind: SecretStore
-  target:
     name: github-arc-token
-    creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        github_token: "{{ .token }}"
-  data:
-    - secretKey: token
-      remoteRef:
-        key: github-arc-token
-        property: github_token
+    namespace: arc-runners
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: arc-systems-secret-store
+        kind: SecretStore
+    target:
+        name: github-arc-token
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                github_token: '{{ .token }}'
+    data:
+        - secretKey: token
+          remoteRef:
+              key: github-arc-token
+              property: github_token
+---
+# SecretStore to pull Forgejo deploy keys from forgejo namespace
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: forgejo-secret-store
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: forgejo
+            auth:
+                serviceAccount:
+                    name: arc-runners-external-secrets
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: Pull Forgejo deploy keys (SSH key + API token for LFS)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: forgejo-lfs-credentials
+    namespace: arc-runners
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: forgejo-secret-store
+        kind: SecretStore
+    target:
+        name: forgejo-lfs-credentials
+        creationPolicy: Owner
+    data:
+        - secretKey: api-token
+          remoteRef:
+              key: forgejo-deploy-keys
+              property: api-token
+        - secretKey: ssh-private-key
+          remoteRef:
+              key: forgejo-deploy-keys
+              property: ssh-private-key
+        - secretKey: ssh-public-key
+          remoteRef:
+              key: forgejo-deploy-keys
+              property: ssh-public-key


### PR DESCRIPTION
Enables UE build runners to access Forgejo LFS for the `chuck` repo via SSH.

**arc-runners namespace:**
- New `forgejo-secret-store` SecretStore pointing at `forgejo` namespace
- New `forgejo-lfs-credentials` ExternalSecret mirroring `forgejo-deploy-keys` (ssh-private-key, ssh-public-key, api-token)
- Reuses existing `arc-runners-external-secrets` ServiceAccount

**forgejo namespace:**
- RBAC Role + RoleBinding granting `arc-runners-external-secrets` SA scoped read access to `forgejo-deploy-keys` secret

**Workflow usage (SSH — chuck uses `ssh://git@forgejo.kbve.com` for LFS):**
```yaml
- name: Configure Forgejo SSH for LFS
  run: |
    mkdir -p ~/.ssh
    echo "${{ secrets.FORGEJO_SSH_KEY }}" > ~/.ssh/forgejo_deploy
    chmod 600 ~/.ssh/forgejo_deploy
    ssh-keyscan -p 30022 forgejo.kbve.com >> ~/.ssh/known_hosts
    cat >> ~/.ssh/config << EOF
    Host forgejo.kbve.com
        HostName forgejo.kbve.com
        Port 30022
        User git
        IdentityFile ~/.ssh/forgejo_deploy
        StrictHostKeyChecking no
    EOF
```

The `forgejo-lfs-credentials` secret in `arc-runners` namespace provides the SSH private key for this setup.