### PR TITLE
fix(angelscript): use git reset to preserve cached engine deps

### DIFF
--- a/.github/workflows/ci-angelscript-engine.yml
+++ b/.github/workflows/ci-angelscript-engine.yml
@@ -165,8 +165,7 @@ jobs:
                     Push-Location $CachePath
                     git remote set-url origin "https://x-access-token:${env:UNITY_PAT}@github.com/${{ env.ENGINE_REPO }}.git"
                     git fetch origin ${{ inputs.engine_ref }}
-                    git checkout FETCH_HEAD
-                    git clean -fdx -e "Engine/Binaries" -e "Engine/Intermediate" -e ".ue4dependencies" -e ".git/ue4-gitdeps"
+                    git reset --hard FETCH_HEAD
                     Pop-Location
                   } else {
                     # Clear non-git directory if it exists (e.g. empty PVC mount)
@@ -271,8 +270,7 @@ jobs:
                     cd "${CACHE}"
                     git remote set-url origin "https://x-access-token:${UNITY_PAT}@github.com/${{ env.ENGINE_REPO }}.git"
                     git fetch origin ${{ inputs.engine_ref }}
-                    git checkout FETCH_HEAD
-                    git clean -fdx -e "Engine/Binaries" -e "Engine/Intermediate" -e ".ue4dependencies" -e ".git/ue4-gitdeps"
+                    git reset --hard FETCH_HEAD
                   else
                     # Clear non-git directory if it exists (e.g. empty PVC mount)
                     if [ -d "${CACHE}" ]; then
@@ -376,8 +374,7 @@ jobs:
                     cd "${CACHE}"
                     git remote set-url origin "https://x-access-token:${UNITY_PAT}@github.com/${{ env.ENGINE_REPO }}.git"
                     git fetch origin ${{ inputs.engine_ref }}
-                    git checkout FETCH_HEAD
-                    git clean -fdx -e "Engine/Binaries" -e "Engine/Intermediate" -e ".ue4dependencies" -e ".git/ue4-gitdeps"
+                    git reset --hard FETCH_HEAD
                   else
                     # Clear non-git directory if it exists (e.g. empty PVC mount)
                     if [ -d "${CACHE}" ]; then


### PR DESCRIPTION
## Summary

Replaced `git clean -fdx` with `git reset --hard FETCH_HEAD` on cache hit for all three platforms.

`git clean -fdx` was deleting all untracked files — including the ~29GB of engine dependencies that `Setup.sh` downloads. This forced a full re-download on every build, defeating the Longhorn cache entirely.

`git reset --hard` only resets tracked source files to match the ref, leaving downloaded dependencies and build intermediates intact.

## Test plan

- [ ] Re-trigger build — Setup.sh should skip most dependency downloads on cache hit