### PR TITLE
feat(ci): wire axum-kbve version gate to MDX frontmatter

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -76,7 +76,7 @@ jobs:
                   SRC="" VTOML=""
 
                   case "$APP" in
-                    axum-kbve)    SRC="apps/kbve/axum-kbve/Cargo.toml";            VTOML="apps/kbve/axum-kbve/version.toml" ;;
+                    axum-kbve)    SRC="apps/kbve/astro-kbve/src/content/docs/project/api.mdx"; VTOML="apps/kbve/axum-kbve/version.toml" ;;
                     herbmail)     SRC="apps/herbmail/axum-herbmail/Cargo.toml";     VTOML="apps/herbmail/version.toml" ;;
                     memes)        SRC="apps/memes/axum-memes/Cargo.toml";           VTOML="apps/memes/version.toml" ;;
                     irc-gateway)  SRC="apps/irc/irc-gateway/Cargo.toml";            VTOML="apps/irc/version.toml" ;;
@@ -100,6 +100,7 @@ jobs:
 
                   case "$SRC" in
                     *.json) LOCAL=$(jq -r '.version // "0.0.0"' "$SRC" 2>/dev/null || echo "0.0.0") ;;
+                    *.mdx)  LOCAL=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$SRC" | head -1); [ -z "$LOCAL" ] && LOCAL="0.0.0" ;;
                     *)      LOCAL=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || echo "0.0.0") ;;
                   esac
                   PUBLISHED="0.0.0"
@@ -165,7 +166,7 @@ jobs:
                       echo "runner=arc-runner-set"                                                         >> "$GITHUB_OUTPUT"
                       echo "image=kbve/kbve"                                                               >> "$GITHUB_OUTPUT"
                       echo "e2e_name=axum-kbve-e2e"                                                        >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/kbve/axum-kbve/Cargo.toml"                                    >> "$GITHUB_OUTPUT"
+                      echo "cargo_toml=apps/kbve/astro-kbve/src/content/docs/project/api.mdx"              >> "$GITHUB_OUTPUT"
                       echo "deployment_yaml=apps/kube/kbve/manifest/kbve-deployment.yaml"                 >> "$GITHUB_OUTPUT"
                       echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
                       echo "version_toml=apps/kbve/axum-kbve/version.toml"                                >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -144,6 +144,7 @@ jobs:
                       case "$source_file" in
                         *.json)    local_v=$(jq -r '.version // "0.0.0"' "$source_file" 2>/dev/null || echo "0.0.0") ;;
                         *.uplugin) local_v=$(jq -r '.VersionName // "0.0.0"' "$source_file" 2>/dev/null || echo "0.0.0") ;;
+                        *.mdx)     local_v=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$source_file" | head -1); [ -z "$local_v" ] && local_v="0.0.0" ;;
                         *)         local_v=$(grep -m1 '^version' "$source_file" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || echo "0.0.0") ;;
                       esac
                     fi
@@ -180,7 +181,7 @@ jobs:
                   resolve_docker_paths() {
                     local app="$1"
                     case "$app" in
-                      axum-kbve)    SRC="apps/kbve/axum-kbve/Cargo.toml";            VTOML="apps/kbve/axum-kbve/version.toml" ;;
+                      axum-kbve)    SRC="apps/kbve/astro-kbve/src/content/docs/project/api.mdx"; VTOML="apps/kbve/axum-kbve/version.toml" ;;
                       herbmail)     SRC="apps/herbmail/axum-herbmail/Cargo.toml";     VTOML="apps/herbmail/version.toml" ;;
                       memes)        SRC="apps/memes/axum-memes/Cargo.toml";           VTOML="apps/memes/version.toml" ;;
                       irc-gateway)  SRC="apps/irc/irc-gateway/Cargo.toml";            VTOML="apps/irc/version.toml" ;;

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -54,6 +54,7 @@ jobs:
                   CARGO_TOML="${{ inputs.cargo_toml }}"
                   case "$CARGO_TOML" in
                     *.json) LOCAL_VERSION=$(jq -r '.version // "0.0.0"' "$CARGO_TOML" 2>/dev/null) ;;
+                    *.mdx)  LOCAL_VERSION=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$CARGO_TOML" | head -1) ;;
                     *)      LOCAL_VERSION=$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/') ;;
                   esac
                   echo "Local version: $LOCAL_VERSION"
@@ -93,6 +94,7 @@ jobs:
                     CARGO_TOML="${{ inputs.cargo_toml }}"
                     case "$CARGO_TOML" in
                       *.json) LOCAL_VERSION=$(jq -r '.version // "0.0.0"' "$CARGO_TOML" 2>/dev/null) ;;
+                      *.mdx)  LOCAL_VERSION=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$CARGO_TOML" | head -1) ;;
                       *)      LOCAL_VERSION=$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/') ;;
                     esac
 

--- a/.github/workflows/utils-update-kube-manifest.yml
+++ b/.github/workflows/utils-update-kube-manifest.yml
@@ -41,6 +41,7 @@ jobs:
                   SRC="main-ref/${{ inputs.cargo_toml }}"
                   case "$SRC" in
                     *.json) NEW_VER=$(jq -r '.version // "0.0.0"' "$SRC" 2>/dev/null) ;;
+                    *.mdx)  NEW_VER=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$SRC" | head -1) ;;
                     *)      NEW_VER=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/') ;;
                   esac
                   echo "new_version=$NEW_VER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- axum-kbve version gate now reads from `api.mdx` frontmatter instead of `Cargo.toml`
- Add `*.mdx` extraction (sed-based YAML frontmatter parsing) to all CI version extraction case blocks
- version.toml remains the published marker — no change there
- Other Docker apps unchanged — will migrate incrementally after validation

## Test plan
- [ ] CI lint passes
- [ ] Version gate correctly reads `version: "1.0.66"` from api.mdx
- [ ] Bumping version in api.mdx triggers publish (after merge to main)