### PR TITLE
chore(axum-kbve): bump version to 1.0.68 via MDX

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.66"
+version: "1.0.68"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 author: h0lybyte

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.67"
+version = "1.0.68"
 edition = "2021"
 publish = false
 

--- a/packages/npm/devops/src/lib/ci/registry.ts
+++ b/packages/npm/devops/src/lib/ci/registry.ts
@@ -28,7 +28,7 @@ export const CI_PROJECTS: CiProject[] = ProjectArraySchema.parse([
 		name: 'Axum KBVE',
 		pipeline: 'docker',
 		app_name: 'axum-kbve',
-		version: '1.0.66',
+		version: '1.0.68',
 		description: 'Main KBVE website (Astro + Axum)',
 		source_path: 'apps/kbve/astro-kbve',
 		author: 'h0lybyte',


### PR DESCRIPTION
## Summary
- Bump axum-kbve to `1.0.68` — first publish driven by MDX frontmatter
- MDX `1.0.68` > version.toml `1.0.67` will trigger the publish gate
- Cargo.toml and registry.ts synced to match

## Test plan
- [ ] CI version_gate reads `1.0.68` from api.mdx frontmatter
- [ ] `should_publish=true` since `1.0.68 > 1.0.67`
- [ ] Docker image tagged and pushed as `1.0.68`
- [ ] version.toml updated to `1.0.68` post-publish