### PR TITLE
feat(astro-kbve): add Unreal Engine page and gdd MDX collection

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -96,6 +96,11 @@ export default defineConfig({
 					autogenerate: { directory: 'project' },
 				},
 				{
+					label: 'GDD',
+					collapsed: true,
+					autogenerate: { directory: 'gdd' },
+				},
+				{
 					label: 'Memes',
 					autogenerate: { directory: 'memes' },
 				},

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -46,6 +46,13 @@ const application = defineCollection({
 	}),
 });
 
+const gdd = defineCollection({
+	loader: glob({
+		pattern: '**/*.mdx',
+		base: './src/content/docs/gdd',
+	}),
+});
+
 const project = defineCollection({
 	loader: glob({
 		pattern: '**/*.mdx',
@@ -105,6 +112,7 @@ export const collections = {
 	questdb,
 	npcdb,
 	application,
+	gdd,
 	project,
 	mapdb,
 };

--- a/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
@@ -1,0 +1,91 @@
+---
+title: Unreal Engine
+description: |
+    Unreal Engine is a powerful real-time 3D creation platform developed by Epic Games, widely used for building high-fidelity games, simulations, and interactive experiences.
+    The engine offers advanced rendering capabilities, including Nanite virtualized geometry and Lumen global illumination, alongside robust tools for animation, physics, and AI.
+    With support for C++ and Blueprints visual scripting, Unreal Engine provides flexibility for both programmers and designers across industries including gaming, film, architecture, and automotive.
+sidebar:
+    label: Unreal Engine
+    order: 1302
+unsplash: 1542751371-adc38448a05e
+img: https://images.unsplash.com/photo-1542751371-adc38448a05e?fit=crop&w=1400&h=700&q=75
+tags:
+    - game-engine
+    - software
+---
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+	Code,
+	FileTree,
+} from '@astrojs/starlight/components';
+
+import { Giscus, Adsense } from '@/components/astropad';
+
+## Information
+
+Unreal Engine is a leading real-time 3D creation platform developed by Epic Games, powering some of the most visually stunning games and interactive experiences in the industry.
+Originally launched in 1998, the engine has evolved through multiple generations, with Unreal Engine 5 introducing groundbreaking features like Nanite virtualized geometry for film-quality assets and Lumen for fully dynamic global illumination and reflections.
+The engine supports development across PC, consoles, mobile, VR, and AR platforms, making it a versatile choice for a wide range of projects.
+
+Unreal Engine uses C++ as its primary programming language, offering direct access to the engine's source code for deep customization.
+For rapid prototyping and designer-friendly workflows, the Blueprints visual scripting system allows logic creation without writing code.
+The engine also includes a comprehensive suite of tools for animation (Sequencer, Control Rig), audio (MetaSounds), world building (World Partition, PCG), and multiplayer networking.
+
+<Adsense />
+
+---
+
+## Getting Started
+
+To begin developing with Unreal Engine, download the Epic Games Launcher and install the desired engine version.
+Projects can be created from templates covering common game genres and application types.
+The editor provides a viewport for scene composition, a content browser for asset management, and a details panel for property editing.
+
+<Aside>
+Unreal Engine is free to use with a 5% royalty on gross revenue after the first $1 million USD per product. Review the EULA for full licensing terms.
+</Aside>
+
+---
+
+## Blueprints
+
+Blueprints is Unreal Engine's visual scripting system that allows designers and developers to create gameplay logic, UI interactions, and procedural content without writing C++ code.
+Blueprint graphs use nodes connected by wires to define execution flow and data relationships.
+Blueprints can be used standalone or in conjunction with C++ classes for hybrid workflows.
+
+---
+
+## C++ Development
+
+Unreal Engine's C++ framework uses a custom build system (Unreal Build Tool) and a reflection system powered by macros like `UCLASS`, `UPROPERTY`, and `UFUNCTION`.
+These macros expose C++ types to the editor, Blueprints, and the garbage collector.
+The Gameplay Framework provides base classes such as `AActor`, `APawn`, `ACharacter`, and `AGameModeBase` for structuring game logic.
+
+---
+
+## Rendering
+
+Unreal Engine 5 introduced Nanite and Lumen as core rendering technologies.
+Nanite enables the use of film-quality source art with millions of polygons directly in scenes, automatically handling LOD and streaming.
+Lumen provides real-time global illumination and reflections without baking, adapting dynamically to scene changes.
+
+---
+
+## Multiplayer
+
+Unreal Engine includes a built-in networking framework with server-authoritative replication, RPCs (Remote Procedure Calls), and relevancy management.
+The engine supports dedicated servers, listen servers, and peer-to-peer topologies.
+For large-scale multiplayer, Epic provides tools and integrations for session management and matchmaking.
+
+---
+
+## Plugins
+
+Unreal Engine supports a plugin architecture for extending editor and runtime functionality.
+Plugins can be written in C++ or Blueprints and distributed via the Unreal Marketplace or as source.
+
+<Giscus />

--- a/apps/kbve/astro-kbve/src/content/docs/gdd/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/gdd/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Game Design Documents
+description: |
+    A collection of Game Design Documents (GDDs) covering game mechanics, systems design, narrative structures, and technical specifications.
+    GDDs serve as the foundational blueprint for game development projects, aligning teams on vision, scope, and implementation details.
+unsplash: 1511512578047-dfb367046420
+img: https://images.unsplash.com/photo-1511512578047-dfb367046420?fit=crop&w=1400&h=700&q=75
+sidebar:
+    label: GDD Navigator
+    order: 1
+---
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+	Code,
+	FileTree,
+} from '@astrojs/starlight/components';
+
+import { Giscus, Adsense } from '@/components/astropad';
+
+## Introduction
+
+A Game Design Document (GDD) is a comprehensive reference that describes the vision, mechanics, systems, and scope of a game project.
+It serves as a living blueprint that keeps designers, engineers, artists, and stakeholders aligned throughout the development lifecycle.
+
+GDDs typically cover:
+
+- **Core Concept** - The elevator pitch, genre, target audience, and unique selling points.
+- **Gameplay Mechanics** - Player actions, controls, progression systems, and game loops.
+- **Systems Design** - Economy, inventory, combat, AI behavior, and multiplayer architecture.
+- **Narrative** - Story structure, characters, dialogue systems, and world-building.
+- **Technical Specifications** - Engine choice, platform targets, performance budgets, and tooling.
+- **Art and Audio Direction** - Visual style, animation guidelines, sound design, and music.
+- **Milestones and Scope** - Feature prioritization, development phases, and deliverables.
+
+<Aside>
+GDDs are living documents. Update them as the project evolves to keep them useful rather than letting them become stale artifacts.
+</Aside>
+
+<Adsense />
+
+<Giscus />


### PR DESCRIPTION
## Summary
- Adds `application/unreal.mdx` covering UE5 fundamentals (Blueprints, C++, Nanite/Lumen rendering, multiplayer, plugins)
- Creates new `gdd` content collection for Game Design Documents with `gdd/index.mdx` as the navigator page
- Wires `gdd` collection into `content.config.ts` and adds sidebar entry in `astro.config.mjs`

## Test plan
- [ ] Verify `application/unreal` page renders correctly on the site
- [ ] Verify `gdd/index` page renders and appears in the sidebar under "GDD"
- [ ] Confirm no build errors with `npx nx run astro-kbve:build`