### PR TITLE
fix(kube/rabbitmq): set /manager command for upstream operator images

### DIFF
--- a/apps/kube/rabbitmq/manifests/values.yaml
+++ b/apps/kube/rabbitmq/manifests/values.yaml
@@ -15,6 +15,8 @@ clusterOperator:
         registry: docker.io
         repository: rabbitmqoperator/cluster-operator
         tag: '2.16.1'
+    command:
+        - /manager
     resources:
         requests:
             memory: '128Mi'
@@ -43,6 +45,8 @@ msgTopologyOperator:
         registry: docker.io
         repository: rabbitmqoperator/messaging-topology-operator
         tag: '1.17.4'
+    command:
+        - /manager
     resources:
         requests:
             memory: '128Mi'


### PR DESCRIPTION
## Summary
- Bitnami chart hardcodes `command: ["manager"]` (relative path) in the deployment template
- Upstream `rabbitmqoperator/*` images have the binary at `/manager` (absolute path), causing `StartError: executable file not found in $PATH`
- Override `command: ["/manager"]` for both cluster operator and messaging topology operator

## Test plan
- [ ] Both operator pods start without `CrashLoopBackOff` / `RunContainerError`
- [ ] Operator pods reach Running/Ready state
- [ ] RabbitmqCluster CR reconciles successfully