### PR TITLE
fix(nx): scope @nx/dotnet plugin to apps/ows/**

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -114,7 +114,10 @@
 				"testTargetName": "test"
 			}
 		},
-		"@nx/dotnet"
+		{
+			"plugin": "@nx/dotnet",
+			"include": ["apps/ows/**"]
+		}
 	],
 	"defaultProject": "kbve.com",
 	"generators": {


### PR DESCRIPTION
## Summary
- `@nx/dotnet` was registered globally in `nx.json` without an `include` filter
- Runners without .NET SDK fail with `spawnSync dotnet ENOENT`, killing the Nx project graph
- This blocked all Docker builds including axum-kbve
- Scope the plugin to `apps/ows/**` so it only activates for OWS projects

Closes #8440

## Test plan
- [ ] CI lint passes (project graph resolves without dotnet)
- [ ] axum-kbve Docker build succeeds