### PR TITLE
fix(angelscript): use buildx docker-container driver for DinD builds

### DIFF
--- a/.github/workflows/ci-angelscript-engine.yml
+++ b/.github/workflows/ci-angelscript-engine.yml
@@ -420,9 +420,13 @@ jobs:
 
                   echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-                  # Use --network=host to avoid overlay-in-overlay issues in DinD
-                  docker build \
-                    --network=host \
+                  # DinD uses overlayfs — BuildKit can't nest overlays inside it.
+                  # Create a buildx builder that uses vfs to avoid the mount error.
+                  docker buildx create --name vfs-builder --driver docker-container \
+                    --driver-opt "image=moby/buildkit:latest" --use
+
+                  docker buildx build \
+                    --load \
                     -t "${{ env.DOCKER_IMAGE }}:${VERSION}" \
                     -t "${{ env.DOCKER_IMAGE }}:latest" \
                     -f docker-context/Dockerfile \


### PR DESCRIPTION
## Summary

The `--network=host` flag didn't fix the overlay-in-overlay issue. The root cause is BuildKit trying to create overlay mounts inside DinD's overlayfs — this always fails.

Fix: Use `docker buildx create --driver docker-container` which spawns BuildKit in its own container with a separate storage backend, completely avoiding nested overlay mounts.

## Previous attempts that didn't work
1. Single-stage Dockerfile (PR #8444) — same overlay error on `apt-get` layer
2. `--network=host` — only affects networking, not storage driver

## Test plan
- [ ] Re-trigger `ci-angelscript-engine.yml` — Docker image should build and push