### PR TITLE
feat(kube/angelscript): virtctl ISO upload + macOS VM + shared storage

### DIFF
--- a/apps/kube/angelscript/manifest/vm-macos-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-macos-builder.yaml
@@ -112,6 +112,10 @@ spec:
                           cdrom:
                               bus: sata
                           bootOrder: 2
+                        # Shared storage — ISOs, Xcode .xip, installers staging
+                        - name: shared-storage
+                          disk:
+                              bus: sata
                     interfaces:
                         - name: default
                           bridge: {}
@@ -146,3 +150,6 @@ spec:
                 - name: iso
                   persistentVolumeClaim:
                       claimName: macos-builder-iso
+                - name: shared-storage
+                  persistentVolumeClaim:
+                      claimName: builder-shared-storage

--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -94,6 +94,10 @@ spec:
                           cdrom:
                               bus: sata
                           bootOrder: 3
+                        # Shared storage — ISOs, installers, Xcode .xip staging
+                        - name: shared-storage
+                          disk:
+                              bus: virtio
                     interfaces:
                         - name: default
                           bridge: {}
@@ -143,3 +147,6 @@ spec:
                 - name: virtio-drivers
                   containerDisk:
                       image: quay.io/kubevirt/virtio-container-disk:v1.5.0
+                - name: shared-storage
+                  persistentVolumeClaim:
+                      claimName: builder-shared-storage

--- a/apps/kube/kubevirt/manifests/iso-storage-pvc.yaml
+++ b/apps/kube/kubevirt/manifests/iso-storage-pvc.yaml
@@ -1,19 +1,20 @@
-# Dedicated Longhorn PVC for storing ISO images (Windows, virtio-win, etc.)
-# CDI DataVolumes can reference this as a source, or ISOs can be uploaded
-# directly via virtctl image-upload.
+# Shared Longhorn PVC for staging ISOs, Xcode .xip, installers, etc.
+# Mounted as a data disk on both Windows and macOS builder VMs.
+# Upload files via virtctl or kubectl cp, then access from inside each VM.
+# RWX so both VMs can mount simultaneously.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-    name: kubevirt-iso-storage
-    namespace: kubevirt
+    name: builder-shared-storage
+    namespace: angelscript
     labels:
-        app: kubevirt
-        component: iso-storage
+        app: angelscript
+        component: shared-storage
 spec:
     accessModes:
-        - ReadWriteOnce
+        - ReadWriteMany
     storageClassName: longhorn
     resources:
         requests:
-            # 50Gi: Windows Server ~6Gi + virtio-win ~0.5Gi + headroom for additional ISOs
+            # 50Gi: Windows ISO ~6Gi + Xcode .xip ~12Gi + misc installers
             storage: 50Gi


### PR DESCRIPTION
## Summary
- Switch Windows ISO from CDI DataVolume (HTTP URL) to `virtctl image-upload` PVC approach
- Add macOS Tahoe builder VM spec (OSX-KVM, Penryn CPU, 256Gi disk)
- Add shared 50Gi RWX Longhorn PVC (`builder-shared-storage`) mounted on both VMs for staging ISOs, Xcode .xip, and installers

## Architecture
- `builder-shared-storage` — RWX PVC in angelscript namespace, attached as data disk to both VMs
- Windows VM: virtio bus for shared disk (drivers available)
- macOS VM: SATA bus for shared disk (no virtio support)
- Upload files to shared storage, both VMs see them immediately

## Upload workflow
```bash
# Windows ISO
virtctl image-upload pvc windows-builder-iso \
  --size=8Gi --image-path=/Users/alappatel/Downloads/win_server.iso \
  --storage-class=longhorn --namespace=angelscript --insecure

# macOS Tahoe image (already prepared locally)
virtctl image-upload pvc macos-builder-iso \
  --size=16Gi --image-path=/Users/alappatel/Downloads/BaseSystem-tahoe.img \
  --storage-class=longhorn --namespace=angelscript --insecure
```

## Test plan
- [ ] Verify shared PVC creates as RWX in angelscript namespace
- [ ] Confirm both VMs can mount shared storage simultaneously
- [ ] Upload Windows ISO and boot Windows VM
- [ ] Upload macOS image and boot macOS VM