### PR TITLE
fix(kube/kubevirt): add SkipDryRunOnMissingResource for CRD ordering

### DIFF
--- a/apps/kube/kubevirt/application.yaml
+++ b/apps/kube/kubevirt/application.yaml
@@ -1,4 +1,7 @@
 # KubeVirt operator — enables VM workloads on Talos (KVM built into kernel)
+# Bootstrap Job (sync-wave -1) applies upstream operator YAML to install CRDs,
+# then the KubeVirt CR (sync-wave 0) configures the deployment.
+# SkipDryRunOnMissingResource lets ArgoCD handle the CRD chicken-and-egg.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -25,12 +28,13 @@ spec:
             - CreateNamespace=true
             - ServerSideApply=true
             - PruneLast=true
+            - SkipDryRunOnMissingResource=true
         retry:
-            limit: 5
+            limit: 10
             backoff:
-                duration: 5s
+                duration: 15s
                 factor: 2
-                maxDuration: 3m
+                maxDuration: 10m
     ignoreDifferences:
         - group: admissionregistration.k8s.io
           kind: ValidatingWebhookConfiguration

--- a/apps/kube/kubevirt/cdi-application.yaml
+++ b/apps/kube/kubevirt/cdi-application.yaml
@@ -1,4 +1,6 @@
 # CDI (Containerized Data Importer) — imports disk images (Windows ISO) into PVCs
+# Bootstrap Job applies upstream CDI operator + CR YAML.
+# SkipDryRunOnMissingResource handles CRD chicken-and-egg ordering.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -25,10 +27,11 @@ spec:
             - CreateNamespace=true
             - ServerSideApply=true
             - PruneLast=true
+            - SkipDryRunOnMissingResource=true
         retry:
-            limit: 5
+            limit: 10
             backoff:
-                duration: 5s
+                duration: 15s
                 factor: 2
-                maxDuration: 3m
+                maxDuration: 10m
     revisionHistoryLimit: 3


### PR DESCRIPTION
## Summary
- Add `SkipDryRunOnMissingResource=true` to both kubevirt-operator and kubevirt-cdi ArgoCD applications
- Fixes CRD chicken-and-egg: bootstrap Job installs operator CRDs at sync-wave -1, but ArgoCD's dry-run rejects the KubeVirt CR because the CRD doesn't exist yet
- Bump retry limits (10 retries, 10m max) to give operator pods time to start

## Root cause
ArgoCD validates all resources in the application before syncing. The KubeVirt CR (`kubevirt.io/v1/KubeVirt`) fails dry-run because the CRD only gets installed by the bootstrap Job during sync. `SkipDryRunOnMissingResource` tells ArgoCD to skip validation for unknown resource types.

## Test plan
- [ ] ArgoCD syncs kubevirt-operator successfully
- [ ] Bootstrap Job runs, operator pods come up in kubevirt namespace
- [ ] KubeVirt CR applies after CRDs are registered
- [ ] CDI follows the same pattern