### PR TITLE
fix(kube/kubevirt): remove ArgoCD hook annotations from bootstrap resources

### DIFF
--- a/apps/kube/kubevirt/cdi/bootstrap-job.yaml
+++ b/apps/kube/kubevirt/cdi/bootstrap-job.yaml
@@ -7,11 +7,9 @@ metadata:
     namespace: cdi
     annotations:
         argocd.argoproj.io/sync-wave: '-1'
-        argocd.argoproj.io/hook: Sync
-        argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
     backoffLimit: 3
-    ttlSecondsAfterFinished: 300
+    ttlSecondsAfterFinished: 600
     template:
         metadata:
             labels:

--- a/apps/kube/kubevirt/cdi/bootstrap-rbac.yaml
+++ b/apps/kube/kubevirt/cdi/bootstrap-rbac.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
     name: cdi-bootstrap
     namespace: cdi
+    annotations:
+        argocd.argoproj.io/sync-wave: '-2'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -11,8 +13,6 @@ metadata:
     name: cdi-bootstrap
     annotations:
         argocd.argoproj.io/sync-wave: '-2'
-        argocd.argoproj.io/hook: Sync
-        argocd.argoproj.io/hook-delete-policy: HookSucceeded
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole

--- a/apps/kube/kubevirt/manifests/bootstrap-job.yaml
+++ b/apps/kube/kubevirt/manifests/bootstrap-job.yaml
@@ -1,8 +1,6 @@
 # One-shot Job to apply the upstream KubeVirt operator manifest.
 # The operator YAML is ~10k lines and changes per release, so we pull it
 # at deploy time rather than vendoring it into the repo.
-# After the operator pods are running, the KubeVirt CR in operator.yaml
-# tells it what features to enable.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,11 +8,9 @@ metadata:
     namespace: kubevirt
     annotations:
         argocd.argoproj.io/sync-wave: '-1'
-        argocd.argoproj.io/hook: Sync
-        argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
     backoffLimit: 3
-    ttlSecondsAfterFinished: 300
+    ttlSecondsAfterFinished: 600
     template:
         metadata:
             labels:

--- a/apps/kube/kubevirt/manifests/bootstrap-rbac.yaml
+++ b/apps/kube/kubevirt/manifests/bootstrap-rbac.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
     name: kubevirt-bootstrap
     namespace: kubevirt
+    annotations:
+        argocd.argoproj.io/sync-wave: '-2'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -11,8 +13,6 @@ metadata:
     name: kubevirt-bootstrap
     annotations:
         argocd.argoproj.io/sync-wave: '-2'
-        argocd.argoproj.io/hook: Sync
-        argocd.argoproj.io/hook-delete-policy: HookSucceeded
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole


### PR DESCRIPTION
## Summary
- Remove `argocd.argoproj.io/hook: Sync` and `hook-delete-policy: HookSucceeded` from all bootstrap Jobs and RBAC
- Root cause: ArgoCD hooks have a separate lifecycle — the ServiceAccount was a regular resource but the ClusterRoleBinding was a hook, so the SA didn't exist when the Job pod tried to start
- Replace with plain `sync-wave` ordering: wave -2 for RBAC, wave -1 for Jobs

## What changed
- `manifests/bootstrap-rbac.yaml` — removed hook annotations, added sync-wave to SA
- `manifests/bootstrap-job.yaml` — removed hook annotations, kept sync-wave
- `cdi/bootstrap-rbac.yaml` — same
- `cdi/bootstrap-job.yaml` — same

## Test plan
- [ ] ArgoCD syncs kubevirt-operator: SA + CRB created at wave -2, Job runs at wave -1
- [ ] Bootstrap Job pod starts successfully (SA exists)
- [ ] Operator CRDs installed, kubevirt-cr app syncs