### PR TITLE
fix(ci): use dotnet SDK 8.0.x for OWS net8.0 target

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -83,7 +83,7 @@ jobs:
             - name: Setup .NET SDK
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '9.0.x'
+                  dotnet-version: '8.0.x'
 
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Fixes #8464 — previous fix installed dotnet 9.0.x but OWS projects target `net8.0`, causing `No compatible .NET SDK found` during Nx project graph analysis
- Changed `setup-dotnet` to SDK `8.0.x` to match the OWS `TargetFramework`

## Test plan
- [ ] Re-run CI Docker / axum-kbve and verify project graph processes successfully