### PR TITLE
fix(ci): install dotnet 8.0 + 10.0 SDKs for @nx/dotnet analyzer

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -83,7 +83,9 @@ jobs:
             - name: Setup .NET SDK
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      10.0.x
 
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Fixes #8478 — `@nx/dotnet` v22.6.1 ships an msbuild-analyzer compiled for .NET 10 runtime
- The self-hosted runner had .NET 10 runtime preinstalled but we only installed SDK 8.0.x
- Error: `Current runtime: .NET 10 / Available SDKs: .NET 8.0.419` → "No compatible .NET SDK found"
- Now installs both `8.0.x` (for OWS `net8.0` project builds) and `10.0.x` (for the analyzer binary)

## Test plan
- [ ] Re-run CI Docker / axum-kbve and verify project graph processes successfully