### PR TITLE
fix(kube): redirect argo.kbve.com to kbve.com/dashboard

### DIFF
--- a/apps/kube/argocd/manifests/httproute.yaml
+++ b/apps/kube/argocd/manifests/httproute.yaml
@@ -14,6 +14,12 @@ spec:
               - path:
                     type: PathPrefix
                     value: /
-          backendRefs:
-              - name: argocd-server
-                port: 443
+          filters:
+              - type: RequestRedirect
+                requestRedirect:
+                    scheme: https
+                    hostname: kbve.com
+                    path:
+                        type: ReplaceFullPath
+                        replaceFullPath: /dashboard
+                    statusCode: 301

--- a/apps/kube/argocd/manifests/ingress.yaml
+++ b/apps/kube/argocd/manifests/ingress.yaml
@@ -1,27 +1,27 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: argocd-ingress
-  namespace: argocd
-  annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-http"
+    name: argocd-ingress
+    namespace: argocd
+    annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+        nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+        nginx.ingress.kubernetes.io/permanent-redirect: 'https://kbve.com/dashboard'
+        cert-manager.io/cluster-issuer: 'letsencrypt-http'
 spec:
-  ingressClassName: nginx
-  rules:
-    - host: argo.kbve.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: argocd-server
-                port:
-                  number: 443
-  tls:
-    - hosts:
-        - argo.kbve.com
-      secretName: argocd-tls
+    ingressClassName: nginx
+    rules:
+        - host: argo.kbve.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: argocd-server
+                            port:
+                                number: 443
+    tls:
+        - hosts:
+              - argo.kbve.com
+          secretName: argocd-tls


### PR DESCRIPTION
## Summary
- `argo.kbve.com` now returns 301 redirect to `https://kbve.com/dashboard`
- Nginx Ingress: `permanent-redirect` annotation
- Gateway API HTTPRoute: `RequestRedirect` filter with `ReplaceFullPath`
- ArgoCD server unchanged — still accessible internally via cluster DNS

## Test plan
- [ ] `curl -I https://argo.kbve.com` returns `301` with `Location: https://kbve.com/dashboard`
- [ ] ArgoCD CLI / internal access via `argocd-server.argocd.svc` still works