### PR TITLE
fix(kube/kubevirt): align with Talos docs, bump to v1.7.2 + v1.64.0

### DIFF
--- a/apps/kube/angelscript/manifest/vm-macos-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-macos-builder.yaml
@@ -79,6 +79,7 @@ spec:
                 component: macos-builder
                 kubevirt.io/domain: macos-builder
         spec:
+            evictionStrategy: LiveMigrate
             domain:
                 cpu:
                     cores: 8
@@ -118,7 +119,7 @@ spec:
                               bus: sata
                     interfaces:
                         - name: default
-                          bridge: {}
+                          masquerade: {}
                     inputs:
                         - type: tablet
                           bus: usb

--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -72,6 +72,7 @@ spec:
                 component: windows-builder
                 kubevirt.io/domain: windows-builder
         spec:
+            evictionStrategy: LiveMigrate
             domain:
                 cpu:
                     cores: 8
@@ -100,7 +101,7 @@ spec:
                               bus: virtio
                     interfaces:
                         - name: default
-                          bridge: {}
+                          masquerade: {}
                     inputs:
                         - type: tablet
                           bus: usb
@@ -146,7 +147,7 @@ spec:
                       claimName: windows-builder-iso
                 - name: virtio-drivers
                   containerDisk:
-                      image: quay.io/kubevirt/virtio-container-disk:v1.5.0
+                      image: quay.io/kubevirt/virtio-container-disk:v1.7.2
                 - name: shared-storage
                   persistentVolumeClaim:
                       claimName: builder-shared-storage

--- a/apps/kube/kubevirt/cdi/bootstrap-job.yaml
+++ b/apps/kube/kubevirt/cdi/bootstrap-job.yaml
@@ -1,14 +1,16 @@
-# One-shot Job to apply the upstream CDI operator + CR.
-# CDI enables importing disk images (ISOs, qcow2) into PVCs for KubeVirt VMs.
+# One-shot Job to apply the upstream CDI operator manifest.
+# Only installs the operator — the CDI CR is managed separately by ArgoCD.
+# Latest version: curl -sI https://github.com/kubevirt/containerized-data-importer/releases/latest
+# Bump the Job name suffix when upgrading to force a re-run.
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: cdi-operator-bootstrap
+    name: cdi-operator-bootstrap-v1-64-0
     namespace: cdi
     annotations:
         argocd.argoproj.io/sync-wave: '-1'
 spec:
-    backoffLimit: 3
+    backoffLimit: 5
     ttlSecondsAfterFinished: 600
     template:
         metadata:
@@ -25,9 +27,9 @@ spec:
                       - -c
                       - |
                           set -e
-                          CDI_VERSION="v1.61.0"
+                          CDI_VERSION="v1.64.0"
                           echo "Applying CDI operator ${CDI_VERSION}..."
                           kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-operator.yaml"
-                          echo "Applying CDI CR..."
-                          kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-cr.yaml"
-                          echo "CDI deployed."
+                          echo "Waiting for CRDs to register..."
+                          kubectl wait --for=condition=Established crd/cdis.cdi.kubevirt.io --timeout=120s
+                          echo "CDI operator ${CDI_VERSION} applied and CRDs registered."

--- a/apps/kube/kubevirt/cdi/cdi-cr.yaml
+++ b/apps/kube/kubevirt/cdi/cdi-cr.yaml
@@ -1,0 +1,18 @@
+# CDI Custom Resource — configures the data importer.
+# Based on Talos docs: https://docs.siderolabs.com/talos/v1.12/advanced-guides/install-kubevirt
+# Uses Longhorn for scratch space (Talos docs default to local-path).
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+metadata:
+    name: cdi
+    namespace: cdi
+spec:
+    config:
+        scratchSpaceStorageClass: longhorn
+        podResourceRequirements:
+            requests:
+                cpu: 100m
+                memory: 60M
+            limits:
+                cpu: 750m
+                memory: 2Gi

--- a/apps/kube/kubevirt/cr/kubevirt.yaml
+++ b/apps/kube/kubevirt/cr/kubevirt.yaml
@@ -1,31 +1,25 @@
-# KubeVirt operator — deployed via upstream release manifest
-# Talos ships with KVM in the kernel; no extensions or machine config patches needed.
-# Update the URL version to upgrade KubeVirt.
-#
-# Upstream source (pinned):
-#   https://github.com/kubevirt/kubevirt/releases/download/v1.5.0/kubevirt-operator.yaml
-#
-# We inline the KubeVirt CR here so ArgoCD manages the full lifecycle.
-# The operator YAML is too large to inline — apply it once manually or
-# use a Job to bootstrap. This file contains the KubeVirt CR that tells
-# the operator what to deploy.
----
+# KubeVirt CR — configures the operator deployment.
+# Based on Talos docs: https://docs.siderolabs.com/talos/v1.12/advanced-guides/install-kubevirt
 apiVersion: kubevirt.io/v1
 kind: KubeVirt
 metadata:
     name: kubevirt
     namespace: kubevirt
 spec:
-    certificateRotateStrategy: {}
     configuration:
         developerConfiguration:
             featureGates:
                 - LiveMigration
-                - Sidecar
                 - HotplugVolumes
+                - NetworkBindingPlugins
+        smbios:
+            sku: TalosCloud
+            version: v0.1.0
+            manufacturer: Talos Virtualization
+            product: talosvm
+            family: ccio
         network:
             permitBridgeInterfaceOnPodNetwork: true
-    customizeComponents: {}
     imagePullPolicy: IfNotPresent
     workloadUpdateStrategy:
         workloadUpdateMethods:

--- a/apps/kube/kubevirt/manifests/bootstrap-job.yaml
+++ b/apps/kube/kubevirt/manifests/bootstrap-job.yaml
@@ -1,15 +1,15 @@
 # One-shot Job to apply the upstream KubeVirt operator manifest.
-# The operator YAML is ~10k lines and changes per release, so we pull it
-# at deploy time rather than vendoring it into the repo.
+# Latest stable check: curl https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt
+# Bump the Job name suffix when upgrading to force a re-run.
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: kubevirt-operator-bootstrap
+    name: kubevirt-operator-bootstrap-v1-7-2
     namespace: kubevirt
     annotations:
         argocd.argoproj.io/sync-wave: '-1'
 spec:
-    backoffLimit: 3
+    backoffLimit: 5
     ttlSecondsAfterFinished: 600
     template:
         metadata:
@@ -26,7 +26,9 @@ spec:
                       - -c
                       - |
                           set -e
-                          KUBEVIRT_VERSION="v1.5.0"
+                          KUBEVIRT_VERSION="v1.7.2"
                           echo "Applying KubeVirt operator ${KUBEVIRT_VERSION}..."
                           kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
-                          echo "KubeVirt operator applied."
+                          echo "Waiting for CRDs to register..."
+                          kubectl wait --for=condition=Established crd/kubevirts.kubevirt.io --timeout=120s
+                          echo "KubeVirt operator ${KUBEVIRT_VERSION} applied and CRDs registered."


### PR DESCRIPTION
## Summary
Aligns KubeVirt setup with [Talos docs](https://docs.siderolabs.com/talos/v1.12/advanced-guides/install-kubevirt).

- **KubeVirt** v1.5.0 -> v1.7.2, **CDI** v1.61.0 -> v1.64.0
- KubeVirt CR: Talos SMBIOS config, `NetworkBindingPlugins` feature gate
- CDI CR: split out of bootstrap Job into ArgoCD-managed manifest, `scratchSpaceStorageClass: longhorn`
- Bootstrap Jobs: add `kubectl wait --for=condition=Established` for CRDs, versioned Job names
- VMs: `bridge` -> `masquerade` interfaces, `evictionStrategy: LiveMigrate`, virtio-container-disk v1.7.2

## Test plan
- [ ] kubevirt-operator Job runs, installs CRDs, waits for registration
- [ ] kubevirt-cr syncs KubeVirt CR with Talos SMBIOS config
- [ ] kubevirt-cdi Job installs CDI operator, CDI CR syncs with Longhorn scratch space
- [ ] VM specs valid with masquerade networking