### PR TITLE
chore(axum-kbve): bump version to 1.0.69

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.68"
+version: "1.0.69"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 author: h0lybyte


### PR DESCRIPTION
## Summary
- Bumps axum-kbve version to 1.0.69 in the MDX source of truth
- Triggers a new Docker build including the path-based WebSocket URL fix (`wss://kbve.com/ws`) and CI dotnet SDK fixes

## Test plan
- [ ] Version gate should detect 1.0.69 > 1.0.68 and allow publish
- [ ] Docker image should build and deploy with the /ws URL fix