### PR TITLE
chore(edge): bump deno.json version to 0.1.17

### DIFF
--- a/apps/kbve/edge/deno.json
+++ b/apps/kbve/edge/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "compilerOptions": {
     "lib": ["deno.window"],
     "strict": true


### PR DESCRIPTION
## Summary
- Bump edge version in `deno.json` to `0.1.17` (source of truth for versioning)
- Reflects vault-reader `get_by_guild` and `get_by_tag` commands deployed with the `bot_get_guild_token` migration