### PR TITLE
fix(kube/angelscript): remove ISO PVCs, use CDI DataVolumes for uploads

### DIFF
--- a/apps/kube/angelscript/manifest/vm-macos-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-macos-builder.yaml
@@ -6,42 +6,26 @@
 # per Apple's EULA. Only deploy this on Apple-branded physical hosts.
 #
 # Provisioning steps (one-time, after KubeVirt + CDI are running):
-#   1. Prepare a macOS install image (qcow2 or raw) using OSX-KVM tools:
+#   1. Prepare a macOS install image using OSX-KVM tools:
 #        - Clone https://github.com/kholia/OSX-KVM
 #        - Run fetch-macOS-v2.py to download the BaseSystem.dmg
 #        - Convert to raw: qemu-img convert BaseSystem.dmg -O raw BaseSystem.img
-#   2. Upload the install image into the PVC via virtctl:
-#        virtctl image-upload pvc macos-builder-iso \
+#   2. Port-forward the CDI upload proxy:
+#        kubectl port-forward -n cdi svc/cdi-uploadproxy 8443:443
+#   3. Upload the install image via virtctl DataVolume:
+#        virtctl image-upload dv macos-tahoe-builder-iso \
 #          --size=16Gi \
-#          --image-path=./BaseSystem.img \
+#          --image-path=/Users/alappatel/Downloads/BaseSystem-tahoe.img \
 #          --storage-class=longhorn \
 #          --namespace=angelscript \
+#          --uploadproxy-url=https://localhost:8443 \
 #          --insecure
-#   3. Start the VM (ArgoCD sets running: false by default — manual start):
-#        virtctl start macos-builder -n angelscript
-#   4. Connect via VNC and install macOS:
-#        virtctl vnc macos-builder -n angelscript
-#   5. Inside macOS, install:
+#   4. Start the VM: virtctl start macos-builder -n angelscript
+#   5. Connect via VNC: virtctl vnc macos-builder -n angelscript
+#   6. Inside macOS, install:
 #      - Xcode + Command Line Tools
 #      - GitHub Actions runner (configured for KBVE/UnrealEngine-Angelscript)
-#   6. After setup, set running: true and the VM becomes a persistent runner.
----
-# ISO PVC — created empty, then populated via virtctl image-upload.
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-    name: macos-builder-iso
-    namespace: angelscript
-    labels:
-        app: angelscript
-        component: macos-builder
-spec:
-    accessModes:
-        - ReadWriteOnce
-    storageClassName: longhorn
-    resources:
-        requests:
-            storage: 16Gi
+#   7. After setup, set running: true and the VM becomes a persistent runner.
 ---
 # Root disk — blank Longhorn volume for the macOS installation
 apiVersion: v1
@@ -108,7 +92,7 @@ spec:
                           disk:
                               bus: sata
                           bootOrder: 1
-                        # macOS install image — used for initial install
+                        # macOS install image — uploaded via virtctl, managed by CDI DataVolume
                         - name: iso
                           cdrom:
                               bus: sata
@@ -149,8 +133,8 @@ spec:
                   persistentVolumeClaim:
                       claimName: macos-builder-rootdisk
                 - name: iso
-                  persistentVolumeClaim:
-                      claimName: macos-builder-iso
+                  dataVolume:
+                      name: macos-tahoe-builder-iso
                 - name: shared-storage
                   persistentVolumeClaim:
                       claimName: builder-shared-storage

--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -2,39 +2,24 @@
 # Requires: KubeVirt operator + CDI deployed in the cluster.
 #
 # Provisioning steps (one-time, after KubeVirt + CDI are running):
-#   1. Upload Windows ISO directly into the PVC via virtctl:
-#        virtctl image-upload pvc windows-builder-iso \
+#   1. Port-forward the CDI upload proxy:
+#        kubectl port-forward -n cdi svc/cdi-uploadproxy 8443:443
+#   2. Upload Windows ISO via virtctl DataVolume:
+#        virtctl image-upload dv windows-server-builder-iso \
 #          --size=8Gi \
-#          --image-path=./windows-server-2022.iso \
+#          --image-path=/Users/alappatel/Downloads/win_server.iso \
 #          --storage-class=longhorn \
 #          --namespace=angelscript \
+#          --uploadproxy-url=https://localhost:8443 \
 #          --insecure
-#   2. Start the VM (ArgoCD sets running: true, or use virtctl start)
-#   3. Connect via VNC and install Windows:
+#   3. Start the VM: virtctl start windows-builder -n angelscript
+#   4. Connect via VNC and install Windows:
 #        virtctl vnc windows-builder -n angelscript
-#   4. Inside Windows, install:
+#   5. Inside Windows, install:
 #      - virtio-win drivers (from the virtio CD-ROM attached below)
 #      - Visual Studio Build Tools (MSVC)
 #      - GitHub Actions runner (configured for KBVE/UnrealEngine-Angelscript)
-#   5. After setup, the VM runs as a persistent self-hosted runner.
----
-# ISO PVC — created empty, then populated via virtctl image-upload.
-# This avoids needing an HTTP-accessible URL for the ISO.
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-    name: windows-builder-iso
-    namespace: angelscript
-    labels:
-        app: angelscript
-        component: windows-builder
-spec:
-    accessModes:
-        - ReadWriteOnce
-    storageClassName: longhorn
-    resources:
-        requests:
-            storage: 8Gi
+#   6. After setup, the VM runs as a persistent self-hosted runner.
 ---
 # Root disk — blank Longhorn volume for the Windows installation
 apiVersion: v1
@@ -63,8 +48,8 @@ metadata:
         app: angelscript
         component: windows-builder
 spec:
-    # Keep the VM running — it acts as a persistent self-hosted runner
-    running: true
+    # Default to stopped — start manually after ISO upload
+    running: false
     template:
         metadata:
             labels:
@@ -85,7 +70,7 @@ spec:
                           disk:
                               bus: virtio
                           bootOrder: 1
-                        # Windows ISO — used for initial install, can be removed after
+                        # Windows ISO — uploaded via virtctl, managed by CDI DataVolume
                         - name: iso
                           cdrom:
                               bus: sata
@@ -143,8 +128,8 @@ spec:
                   persistentVolumeClaim:
                       claimName: windows-builder-rootdisk
                 - name: iso
-                  persistentVolumeClaim:
-                      claimName: windows-builder-iso
+                  dataVolume:
+                      name: windows-server-builder-iso
                 - name: virtio-drivers
                   containerDisk:
                       image: quay.io/kubevirt/virtio-container-disk:v1.7.2


### PR DESCRIPTION
## Summary
- Remove ArgoCD-managed ISO PVCs (`windows-builder-iso`, `macos-builder-iso`) — they conflicted with virtctl uploads
- VM volumes now reference CDI DataVolumes (`windows-server-builder-iso`, `macos-tahoe-builder-iso`)
- Windows VM defaults to `running: false` (start after ISO upload)
- Updated provisioning docs with port-forward + uploadproxy workflow

## Upload flow (after merge)
```bash
kubectl port-forward -n cdi svc/cdi-uploadproxy 8443:443

# Windows
virtctl image-upload dv windows-server-builder-iso \
  --size=8Gi --image-path=/Users/alappatel/Downloads/win_server.iso \
  --storage-class=longhorn --namespace=angelscript \
  --uploadproxy-url=https://localhost:8443 --insecure

# macOS
virtctl image-upload dv macos-tahoe-builder-iso \
  --size=16Gi --image-path=/Users/alappatel/Downloads/BaseSystem-tahoe.img \
  --storage-class=longhorn --namespace=angelscript \
  --uploadproxy-url=https://localhost:8443 --insecure
```

## Test plan
- [ ] Old ISO PVCs pruned by ArgoCD
- [ ] virtctl upload succeeds via port-forward
- [ ] VM starts and mounts the DataVolume ISO