### PR TITLE
feat(forgejo): dashboard proxy + redirect to kbve.com/dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -1,0 +1,67 @@
+---
+import ReactForgejoAuth from './ReactForgejoAuth';
+import ReactForgejoHeader from './ReactForgejoHeader';
+import ReactForgejoSummary from './ReactForgejoSummary';
+import ReactForgejoRepoTable from './ReactForgejoRepoTable';
+---
+
+<section
+	id="forgejo-dashboard-wrapper"
+	class="forgejo-dashboard-wrapper"
+	aria-label="Forgejo repository dashboard">
+	<div id="dashboard-content" class="dashboard-content">
+		<ReactForgejoAuth client:only="react">
+			<div class="not-content forgejo-dashboard">
+				<!-- Island: Header (title, last updated, refresh) -->
+				<div id="forgejo-header">
+					<ReactForgejoHeader client:only="react" />
+				</div>
+
+				<!-- Island: Error banner + summary stat cards + loading state -->
+				<div id="forgejo-summary">
+					<ReactForgejoSummary client:only="react" />
+				</div>
+
+				<!-- Island: Repository table -->
+				<div id="forgejo-repo-table">
+					<ReactForgejoRepoTable client:only="react" />
+				</div>
+			</div>
+		</ReactForgejoAuth>
+	</div>
+</section>
+
+<style>
+	.forgejo-dashboard-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100vw;
+		margin-left: calc(-50vw + 50%);
+	}
+
+	.dashboard-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.dashboard-content {
+			padding: 2rem 1.5rem;
+		}
+	}
+
+	.forgejo-dashboard {
+		display: flex;
+		flex-direction: column;
+		color: var(--sl-color-text, #e6edf3);
+		min-height: 60vh;
+	}
+
+	:global(@keyframes spin) {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoAuth.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoAuth.tsx
@@ -1,0 +1,122 @@
+import { useEffect, type ReactNode } from 'react';
+import { useStore } from '@nanostores/react';
+import { forgejoService } from './forgejoService';
+import { Loader2, LogIn, ShieldOff } from 'lucide-react';
+
+const fullCenter: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'center',
+	justifyContent: 'center',
+	minHeight: '40vh',
+	textAlign: 'center',
+};
+
+export default function ReactForgejoAuth({
+	children,
+}: {
+	children: ReactNode;
+}) {
+	const authState = useStore(forgejoService.$authState);
+
+	useEffect(() => {
+		forgejoService.initAuth();
+	}, []);
+
+	if (authState === 'loading') {
+		return (
+			<div className="not-content" style={fullCenter}>
+				<Loader2
+					size={28}
+					style={{
+						animation: 'spin 1s linear infinite',
+						color: 'var(--sl-color-accent, #06b6d4)',
+					}}
+				/>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						marginTop: 12,
+					}}>
+					Authenticating...
+				</p>
+			</div>
+		);
+	}
+
+	if (authState === 'unauthenticated') {
+		return (
+			<div className="not-content" style={fullCenter}>
+				<div
+					style={{
+						width: 56,
+						height: 56,
+						borderRadius: 14,
+						background: 'rgba(139, 92, 246, 0.1)',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						marginBottom: '0.5rem',
+					}}>
+					<LogIn size={24} style={{ color: '#8b5cf6' }} />
+				</div>
+				<h2
+					style={{
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0.5rem 0 0.25rem',
+						fontSize: '1.25rem',
+						fontWeight: 600,
+					}}>
+					Sign In Required
+				</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						margin: 0,
+						fontSize: '0.85rem',
+					}}>
+					Authentication is required to access the Forgejo dashboard.
+				</p>
+			</div>
+		);
+	}
+
+	if (authState === 'forbidden') {
+		return (
+			<div className="not-content" style={fullCenter}>
+				<div
+					style={{
+						width: 56,
+						height: 56,
+						borderRadius: 14,
+						background: 'rgba(239, 68, 68, 0.1)',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						marginBottom: '0.5rem',
+					}}>
+					<ShieldOff size={24} style={{ color: '#ef4444' }} />
+				</div>
+				<h2
+					style={{
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0.5rem 0 0.25rem',
+						fontSize: '1.25rem',
+						fontWeight: 600,
+					}}>
+					Access Restricted
+				</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						margin: 0,
+						fontSize: '0.85rem',
+					}}>
+					You do not have permission to view this dashboard.
+				</p>
+			</div>
+		);
+	}
+
+	return <>{children}</>;
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoHeader.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoHeader.tsx
@@ -1,0 +1,69 @@
+import { useStore } from '@nanostores/react';
+import { forgejoService } from './forgejoService';
+import { RefreshCw } from 'lucide-react';
+
+export default function ReactForgejoHeader() {
+	const lastUpdated = useStore(forgejoService.$lastUpdated);
+	const loading = useStore(forgejoService.$loading);
+
+	return (
+		<div
+			className="not-content"
+			style={{
+				display: 'flex',
+				justifyContent: 'space-between',
+				alignItems: 'center',
+				marginBottom: '1.5rem',
+				flexWrap: 'wrap',
+				gap: '0.5rem',
+			}}>
+			<div>
+				<h2
+					style={{
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: 0,
+						fontSize: '1.5rem',
+						fontWeight: 700,
+					}}>
+					Forgejo
+				</h2>
+				{lastUpdated && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							margin: '0.25rem 0 0',
+							fontSize: '0.75rem',
+						}}>
+						Last updated: {lastUpdated.toLocaleTimeString()}
+					</p>
+				)}
+			</div>
+			<button
+				onClick={() => forgejoService.refresh()}
+				disabled={loading}
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 6,
+					padding: '0.4rem 0.8rem',
+					borderRadius: 8,
+					border: '1px solid var(--sl-color-gray-5, #30363d)',
+					background: 'var(--sl-color-gray-6, #161b22)',
+					color: 'var(--sl-color-text, #e6edf3)',
+					cursor: loading ? 'not-allowed' : 'pointer',
+					opacity: loading ? 0.6 : 1,
+					fontSize: '0.8rem',
+				}}>
+				<RefreshCw
+					size={14}
+					style={
+						loading
+							? { animation: 'spin 1s linear infinite' }
+							: undefined
+					}
+				/>
+				Refresh
+			</button>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
@@ -1,0 +1,220 @@
+import { useStore } from '@nanostores/react';
+import { forgejoService, type ForgejoRepo } from './forgejoService';
+import { Lock, GitFork, Star, AlertCircle, Copy } from 'lucide-react';
+
+function timeAgo(dateStr: string): string {
+	const diff = Date.now() - new Date(dateStr).getTime();
+	const mins = Math.floor(diff / 60000);
+	if (mins < 60) return `${mins}m ago`;
+	const hrs = Math.floor(mins / 60);
+	if (hrs < 24) return `${hrs}h ago`;
+	const days = Math.floor(hrs / 24);
+	if (days < 30) return `${days}d ago`;
+	return `${Math.floor(days / 30)}mo ago`;
+}
+
+function RepoRow({ repo }: { repo: ForgejoRepo }) {
+	return (
+		<tr
+			style={{
+				borderBottom: '1px solid var(--sl-color-gray-5, #30363d)',
+			}}>
+			<td style={{ padding: '0.6rem 0.75rem' }}>
+				<div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+					<span
+						style={{
+							color: 'var(--sl-color-text, #e6edf3)',
+							fontWeight: 500,
+							fontSize: '0.85rem',
+						}}>
+						{repo.full_name}
+					</span>
+					{repo.private && (
+						<Lock
+							size={12}
+							style={{ color: '#f59e0b', flexShrink: 0 }}
+						/>
+					)}
+					{repo.mirror && (
+						<Copy
+							size={12}
+							style={{ color: '#8b5cf6', flexShrink: 0 }}
+						/>
+					)}
+					{repo.fork && (
+						<GitFork
+							size={12}
+							style={{ color: '#6b7280', flexShrink: 0 }}
+						/>
+					)}
+				</div>
+				{repo.description && (
+					<div
+						style={{
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.75rem',
+							marginTop: 2,
+							maxWidth: 400,
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+						}}>
+						{repo.description}
+					</div>
+				)}
+			</td>
+			<td
+				style={{
+					padding: '0.6rem 0.75rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.8rem',
+				}}>
+				{repo.default_branch}
+			</td>
+			<td
+				style={{
+					padding: '0.6rem 0.75rem',
+					textAlign: 'center',
+				}}>
+				<span
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: 3,
+						color: '#f59e0b',
+						fontSize: '0.8rem',
+					}}>
+					<Star size={12} />
+					{repo.stars_count}
+				</span>
+			</td>
+			<td
+				style={{
+					padding: '0.6rem 0.75rem',
+					textAlign: 'center',
+				}}>
+				{repo.open_issues_count > 0 && (
+					<span
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: 3,
+							color: '#22c55e',
+							fontSize: '0.8rem',
+						}}>
+						<AlertCircle size={12} />
+						{repo.open_issues_count}
+					</span>
+				)}
+			</td>
+			<td
+				style={{
+					padding: '0.6rem 0.75rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.75rem',
+					whiteSpace: 'nowrap',
+				}}>
+				{timeAgo(repo.updated_at)}
+			</td>
+		</tr>
+	);
+}
+
+export default function ReactForgejoRepoTable() {
+	const repos = useStore(forgejoService.$repos);
+
+	if (repos.length === 0) return null;
+
+	return (
+		<div className="not-content">
+			<div
+				style={{
+					borderRadius: 10,
+					border: '1px solid var(--sl-color-gray-5, #30363d)',
+					overflow: 'hidden',
+				}}>
+				<table
+					style={{
+						width: '100%',
+						borderCollapse: 'collapse',
+						fontSize: '0.85rem',
+					}}>
+					<thead>
+						<tr
+							style={{
+								background: 'var(--sl-color-gray-6, #161b22)',
+								borderBottom:
+									'1px solid var(--sl-color-gray-5, #30363d)',
+							}}>
+							<th
+								style={{
+									padding: '0.6rem 0.75rem',
+									textAlign: 'left',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+									fontWeight: 600,
+									fontSize: '0.75rem',
+									textTransform: 'uppercase',
+									letterSpacing: '0.05em',
+								}}>
+								Repository
+							</th>
+							<th
+								style={{
+									padding: '0.6rem 0.75rem',
+									textAlign: 'left',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+									fontWeight: 600,
+									fontSize: '0.75rem',
+									textTransform: 'uppercase',
+									letterSpacing: '0.05em',
+								}}>
+								Branch
+							</th>
+							<th
+								style={{
+									padding: '0.6rem 0.75rem',
+									textAlign: 'center',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+									fontWeight: 600,
+									fontSize: '0.75rem',
+									textTransform: 'uppercase',
+									letterSpacing: '0.05em',
+								}}>
+								Stars
+							</th>
+							<th
+								style={{
+									padding: '0.6rem 0.75rem',
+									textAlign: 'center',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+									fontWeight: 600,
+									fontSize: '0.75rem',
+									textTransform: 'uppercase',
+									letterSpacing: '0.05em',
+								}}>
+								Issues
+							</th>
+							<th
+								style={{
+									padding: '0.6rem 0.75rem',
+									textAlign: 'left',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+									fontWeight: 600,
+									fontSize: '0.75rem',
+									textTransform: 'uppercase',
+									letterSpacing: '0.05em',
+								}}>
+								Updated
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{repos.map((repo) => (
+							<RepoRow key={repo.id} repo={repo} />
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -1,0 +1,133 @@
+import { useEffect } from 'react';
+import { useStore } from '@nanostores/react';
+import { forgejoService } from './forgejoService';
+import { Loader2, AlertTriangle } from 'lucide-react';
+
+function formatSize(kb: number): string {
+	if (kb < 1024) return `${kb} KB`;
+	const mb = kb / 1024;
+	if (mb < 1024) return `${mb.toFixed(1)} MB`;
+	return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+function StatCard({
+	label,
+	value,
+	color,
+}: {
+	label: string;
+	value: string | number;
+	color: string;
+}) {
+	return (
+		<div
+			style={{
+				flex: '1 1 140px',
+				padding: '1rem',
+				borderRadius: 10,
+				background: 'var(--sl-color-gray-6, #161b22)',
+				border: '1px solid var(--sl-color-gray-5, #30363d)',
+				textAlign: 'center',
+			}}>
+			<div
+				style={{
+					fontSize: '1.75rem',
+					fontWeight: 700,
+					color,
+					lineHeight: 1.2,
+				}}>
+				{value}
+			</div>
+			<div
+				style={{
+					fontSize: '0.75rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					marginTop: 4,
+				}}>
+				{label}
+			</div>
+		</div>
+	);
+}
+
+export default function ReactForgejoSummary() {
+	const loading = useStore(forgejoService.$loading);
+	const error = useStore(forgejoService.$error);
+	const totalRepos = useStore(forgejoService.$totalRepos);
+	const privateCount = useStore(forgejoService.$privateCount);
+	const mirrorCount = useStore(forgejoService.$mirrorCount);
+	const totalUsers = useStore(forgejoService.$totalUsers);
+	const totalSize = useStore(forgejoService.$totalSize);
+
+	useEffect(() => {
+		forgejoService.loadCacheAndFetch();
+	}, []);
+
+	if (loading && totalRepos === 0) {
+		return (
+			<div
+				className="not-content"
+				style={{
+					display: 'flex',
+					justifyContent: 'center',
+					padding: '2rem',
+				}}>
+				<Loader2
+					size={24}
+					style={{
+						animation: 'spin 1s linear infinite',
+						color: 'var(--sl-color-accent, #06b6d4)',
+					}}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="not-content">
+			{error && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 8,
+						padding: '0.75rem 1rem',
+						borderRadius: 8,
+						background: 'rgba(239, 68, 68, 0.1)',
+						border: '1px solid rgba(239, 68, 68, 0.3)',
+						marginBottom: '1rem',
+						fontSize: '0.85rem',
+						color: '#ef4444',
+					}}>
+					<AlertTriangle size={16} />
+					{error}
+				</div>
+			)}
+			<div
+				style={{
+					display: 'flex',
+					gap: '0.75rem',
+					flexWrap: 'wrap',
+					marginBottom: '1.5rem',
+				}}>
+				<StatCard
+					label="Repositories"
+					value={totalRepos}
+					color="#06b6d4"
+				/>
+				<StatCard
+					label="Private"
+					value={privateCount}
+					color="#f59e0b"
+				/>
+				<StatCard label="Mirrors" value={mirrorCount} color="#8b5cf6" />
+				<StatCard label="Users" value={totalUsers} color="#22c55e" />
+				<StatCard
+					label="Total Size"
+					value={formatSize(totalSize)}
+					color="#06b6d4"
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -1,0 +1,288 @@
+import { atom, computed } from 'nanostores';
+import { initSupa, getSupa } from '@/lib/supa';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AuthState =
+	| 'loading'
+	| 'authenticated'
+	| 'unauthenticated'
+	| 'forbidden';
+
+export interface ForgejoRepo {
+	id: number;
+	name: string;
+	full_name: string;
+	description: string;
+	html_url: string;
+	clone_url: string;
+	private: boolean;
+	fork: boolean;
+	mirror: boolean;
+	empty: boolean;
+	size: number;
+	stars_count: number;
+	forks_count: number;
+	open_issues_count: number;
+	default_branch: string;
+	created_at: string;
+	updated_at: string;
+	has_pull_requests: boolean;
+	owner: {
+		login: string;
+		avatar_url: string;
+	};
+}
+
+export interface ForgejoUser {
+	id: number;
+	login: string;
+	full_name: string;
+	email: string;
+	avatar_url: string;
+	is_admin: boolean;
+	created: string;
+	last_login: string;
+}
+
+interface CachedData {
+	ts: number;
+	repos: ForgejoRepo[];
+	users: ForgejoUser[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'cache:forgejo:data';
+const CACHE_TTL_MS = 60 * 1000;
+const PROXY_BASE = '/dashboard/forgejo/proxy';
+const REFRESH_INTERVAL_MS = 30 * 1000;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+class AccessRestrictedError extends Error {
+	constructor() {
+		super('Access restricted');
+		this.name = 'AccessRestrictedError';
+	}
+}
+
+class UpstreamUnavailableError extends Error {
+	reason: string;
+	detail: string;
+	constructor(reason: string, detail: string) {
+		super(`Forgejo upstream unreachable: ${reason}`);
+		this.name = 'UpstreamUnavailableError';
+		this.reason = reason;
+		this.detail = detail;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function fetchRepos(token: string): Promise<ForgejoRepo[]> {
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/repos/search?limit=50&sort=updated`,
+		{
+			headers: { Authorization: `Bearer ${token}` },
+			signal: AbortSignal.timeout(10000),
+		},
+	);
+
+	if (resp.status === 403) throw new AccessRestrictedError();
+	if (resp.status === 502) {
+		try {
+			const body = await resp.json();
+			throw new UpstreamUnavailableError(
+				body.reason ?? 'unknown',
+				body.detail ?? '',
+			);
+		} catch (e) {
+			if (e instanceof UpstreamUnavailableError) throw e;
+			throw new UpstreamUnavailableError('unknown', 'Bad gateway');
+		}
+	}
+	if (!resp.ok) throw new Error(`Forgejo API error: ${resp.status}`);
+
+	const data = await resp.json();
+	return data.data ?? data ?? [];
+}
+
+async function fetchUsers(token: string): Promise<ForgejoUser[]> {
+	const resp = await fetch(`${PROXY_BASE}/api/v1/admin/users?limit=50`, {
+		headers: { Authorization: `Bearer ${token}` },
+		signal: AbortSignal.timeout(10000),
+	});
+
+	if (resp.status === 403) return [];
+	if (resp.status === 502) return [];
+	if (!resp.ok) return [];
+
+	return await resp.json();
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+function loadCache(): CachedData | null {
+	try {
+		const raw = localStorage.getItem(CACHE_KEY);
+		if (!raw) return null;
+		const parsed: CachedData = JSON.parse(raw);
+		if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+function saveCache(repos: ForgejoRepo[], users: ForgejoUser[]): void {
+	try {
+		const data: CachedData = { ts: Date.now(), repos, users };
+		localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+	} catch {
+		// ignore quota errors
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+class ForgejoService {
+	// Auth
+	public readonly $authState = atom<AuthState>('loading');
+	public readonly $accessToken = atom<string | null>(null);
+
+	// Data
+	public readonly $repos = atom<ForgejoRepo[]>([]);
+	public readonly $users = atom<ForgejoUser[]>([]);
+	public readonly $loading = atom<boolean>(true);
+	public readonly $error = atom<string | null>(null);
+	public readonly $errorReason = atom<string | null>(null);
+	public readonly $lastUpdated = atom<Date | null>(null);
+
+	// Computed
+	public readonly $totalRepos = computed(
+		[this.$repos],
+		(repos) => repos.length,
+	);
+
+	public readonly $privateCount = computed(
+		[this.$repos],
+		(repos) => repos.filter((r) => r.private).length,
+	);
+
+	public readonly $mirrorCount = computed(
+		[this.$repos],
+		(repos) => repos.filter((r) => r.mirror).length,
+	);
+
+	public readonly $totalUsers = computed(
+		[this.$users],
+		(users) => users.length,
+	);
+
+	public readonly $totalSize = computed([this.$repos], (repos) =>
+		repos.reduce((sum, r) => sum + r.size, 0),
+	);
+
+	private _refreshInterval: ReturnType<typeof setInterval> | undefined;
+
+	// --- Auth ---
+
+	public async initAuth(): Promise<void> {
+		try {
+			await initSupa();
+			const supa = getSupa();
+			const sessionResult = await supa.getSession().catch(() => null);
+			const session = sessionResult?.session ?? null;
+
+			if (!session?.access_token) {
+				this.$authState.set('unauthenticated');
+				return;
+			}
+
+			this.$accessToken.set(session.access_token as string);
+			this.$authState.set('authenticated');
+		} catch {
+			this.$authState.set('unauthenticated');
+		}
+	}
+
+	// --- Data fetching ---
+
+	public async fetchData(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+
+		try {
+			this.$error.set(null);
+			this.$errorReason.set(null);
+			const [repos, users] = await Promise.all([
+				fetchRepos(token),
+				fetchUsers(token),
+			]);
+			this.$repos.set(repos);
+			this.$users.set(users);
+			this.$lastUpdated.set(new Date());
+			saveCache(repos, users);
+		} catch (e: unknown) {
+			if (e instanceof AccessRestrictedError) {
+				this.$authState.set('forbidden');
+				return;
+			}
+			if (e instanceof UpstreamUnavailableError) {
+				this.$error.set(e.message);
+				this.$errorReason.set(e.reason);
+				return;
+			}
+			this.$error.set(e instanceof Error ? e.message : 'Unknown error');
+		} finally {
+			this.$loading.set(false);
+		}
+	}
+
+	public loadCacheAndFetch(): void {
+		const token = this.$accessToken.get();
+		if (!token) return;
+
+		const cached = loadCache();
+		if (cached) {
+			this.$repos.set(cached.repos);
+			this.$users.set(cached.users);
+			this.$lastUpdated.set(new Date(cached.ts));
+			this.$loading.set(false);
+		}
+
+		this.fetchData();
+		this._startAutoRefresh();
+	}
+
+	public refresh(): void {
+		const token = this.$accessToken.get();
+		if (token) {
+			this.$loading.set(true);
+			this.fetchData();
+		}
+	}
+
+	private _startAutoRefresh(): void {
+		if (this._refreshInterval) clearInterval(this._refreshInterval);
+		this._refreshInterval = setInterval(
+			() => this.fetchData(),
+			REFRESH_INTERVAL_MS,
+		);
+	}
+}
+
+export const forgejoService = new ForgejoService();

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/forgejo/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/forgejo/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Forgejo Dashboard
+description: KBVE Forgejo Repository Dashboard
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: Forgejo
+    order: 4
+unsplash: 1558494949-ef010cbdcc31
+img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - forgejo
+---
+
+import AstroForgejoDashboard from '@/components/dashboard/AstroForgejoDashboard.astro';
+
+<AstroForgejoDashboard />

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -120,6 +120,13 @@ async fn main() -> anyhow::Result<()> {
         info!("ClickHouse logs proxy not configured (CLICKHOUSE_LOGS_UPSTREAM_URL not set)");
     }
 
+    // Initialize Forgejo reverse proxy (optional - for /dashboard/forgejo)
+    if transport::proxy::init_forgejo_proxy() {
+        info!("Forgejo proxy initialized - /dashboard/forgejo/proxy enabled");
+    } else {
+        info!("Forgejo proxy not configured (FORGEJO_UPSTREAM_URL not set)");
+    }
+
     // Initialize game server (headless Bevy + lightyear + avian3d)
     // Runs in its own thread; lightyear binds WebSocket on GAME_WS_ADDR (default :5000)
     gameserver::init_gameserver();

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -214,6 +214,14 @@ fn router(state: AppState) -> Router {
         .route(
             "/dashboard/clickhouse/proxy",
             any(super::proxy::clickhouse_logs_proxy_handler),
+        )
+        .route(
+            "/dashboard/forgejo/proxy/{*path}",
+            any(super::proxy::forgejo_proxy_handler),
+        )
+        .route(
+            "/dashboard/forgejo/proxy",
+            any(super::proxy::forgejo_proxy_handler),
         );
 
     // Game server WebSocket is now handled by lightyear on a separate port

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -455,6 +455,51 @@ pub async fn clickhouse_logs_proxy_handler(
 }
 
 // ---------------------------------------------------------------------------
+// Forgejo proxy singleton
+// ---------------------------------------------------------------------------
+
+static FORGEJO: OnceLock<ServiceProxy> = OnceLock::new();
+
+pub fn init_forgejo_proxy() -> bool {
+    let upstream = match std::env::var("FORGEJO_UPSTREAM_URL") {
+        Ok(u) => u.trim_end_matches('/').to_string(),
+        Err(_) => return false,
+    };
+
+    let auth_token = match std::env::var("FORGEJO_AUTH_TOKEN") {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("failed to build reqwest client for forgejo proxy");
+
+    FORGEJO
+        .set(ServiceProxy {
+            name: "Forgejo",
+            client,
+            upstream,
+            upstream_token: Some(auth_token),
+        })
+        .is_ok()
+}
+
+pub async fn forgejo_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
+    match FORGEJO.get() {
+        Some(proxy) => proxy.handle(path, req).await,
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Forgejo proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Convert axum HeaderMap to reqwest HeaderMap
 // ---------------------------------------------------------------------------
 

--- a/apps/kube/forgejo/manifest/httproute.yaml
+++ b/apps/kube/forgejo/manifest/httproute.yaml
@@ -10,10 +10,48 @@ spec:
     hostnames:
         - forgejo.kbve.com
     rules:
+        # Forgejo REST API (token auth, CI, deploy keys)
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /api/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
+        # Container registry API
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /v2/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
+        # Internal Forgejo routes (avatars, assets, webhooks)
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /-/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
+        # Git HTTP traffic for KBVE org repos (clone, push, fetch, LFS)
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /KBVE/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
+        # Redirect everything else to kbve.com/dashboard
         - matches:
               - path:
                     type: PathPrefix
                     value: /
-          backendRefs:
-              - name: forgejo-http
-                port: 3000
+          filters:
+              - type: RequestRedirect
+                requestRedirect:
+                    hostname: kbve.com
+                    path:
+                        type: ReplaceFullPath
+                        replaceFullPath: /dashboard
+                    statusCode: 302

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -107,6 +107,13 @@ spec:
                                 key: argocd-auth-token
                       - name: ARGOCD_CA_CERT_PATH
                         value: '/etc/ssl/argocd/ca.crt'
+                      - name: FORGEJO_UPSTREAM_URL
+                        value: 'http://forgejo-http.forgejo.svc.cluster.local:3000'
+                      - name: FORGEJO_AUTH_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: forgejo-deploy-keys
+                                key: api-token
                       - name: GAME_WT_CERT
                         value: '/etc/ssl/webtransport/tls.crt'
                       - name: GAME_WT_KEY


### PR DESCRIPTION
## Summary
- Add Forgejo reverse proxy in axum following the Grafana/ArgoCD/ClickHouse ServiceProxy pattern
- HTTPRoute: passthrough `/api/`, `/v2/`, `/-/`, `/KBVE/` for Git/API/LFS token integrations; 302 redirect everything else to `kbve.com/dashboard`
- Frontend dashboard at `/dashboard/forgejo` with auth gate, repo table, stat cards (repos, private, mirrors, users, storage size)
- K8s deployment wired with `FORGEJO_UPSTREAM_URL` + `FORGEJO_AUTH_TOKEN` from `forgejo-deploy-keys` secret

## Test plan
- [ ] Verify `git clone https://forgejo.kbve.com/KBVE/<repo>.git` still works with token auth
- [ ] Verify `/api/v1/` endpoints still respond to token-authenticated requests
- [ ] Verify browsing `forgejo.kbve.com` in a browser redirects to `kbve.com/dashboard`
- [ ] Verify `/dashboard/forgejo` loads behind JWT auth gate
- [ ] Verify repo list populates via proxy with correct stats

Closes #8418