### PR TITLE
fix(kube/angelscript): use runStrategy Manual for Windows VM

### DIFF
--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -48,8 +48,7 @@ metadata:
         app: angelscript
         component: windows-builder
 spec:
-    # Default to stopped — start manually after ISO upload
-    running: false
+    runStrategy: Manual
     template:
         metadata:
             labels:


### PR DESCRIPTION
## Summary
- Replace `running: false` with `runStrategy: Manual` on Windows builder VM
- ArgoCD selfHeal was reverting `virtctl start` commands back to stopped state
- `Manual` lets virtctl control start/stop without ArgoCD interference

## Test plan
- [ ] `virtctl start windows-builder -n angelscript` works and VM stays running