### PR TITLE
feat(forgejo): storage-focused dashboard with expandable repo detail

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -3,6 +3,8 @@ import ReactForgejoAuth from './ReactForgejoAuth';
 import ReactForgejoHeader from './ReactForgejoHeader';
 import ReactForgejoSummary from './ReactForgejoSummary';
 import ReactForgejoRepoTable from './ReactForgejoRepoTable';
+import ReactForgejoOrgCards from './ReactForgejoOrgCards';
+import ReactForgejoUserGrid from './ReactForgejoUserGrid';
 ---
 
 <section
@@ -17,14 +19,24 @@ import ReactForgejoRepoTable from './ReactForgejoRepoTable';
 					<ReactForgejoHeader client:only="react" />
 				</div>
 
-				<!-- Island: Error banner + summary stat cards + loading state -->
+				<!-- Island: Summary stat cards + language breakdown -->
 				<div id="forgejo-summary">
 					<ReactForgejoSummary client:only="react" />
 				</div>
 
-				<!-- Island: Repository table -->
+				<!-- Island: Repository table with expandable detail rows -->
 				<div id="forgejo-repo-table">
 					<ReactForgejoRepoTable client:only="react" />
+				</div>
+
+				<!-- Island: Organization cards -->
+				<div id="forgejo-orgs">
+					<ReactForgejoOrgCards client:only="react" />
+				</div>
+
+				<!-- Island: User grid -->
+				<div id="forgejo-users">
+					<ReactForgejoUserGrid client:only="react" />
 				</div>
 			</div>
 		</ReactForgejoAuth>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgCards.tsx
@@ -1,0 +1,115 @@
+import { useStore } from '@nanostores/react';
+import { forgejoService, type ForgejoOrg } from './forgejoService';
+import { Building2, Eye, EyeOff } from 'lucide-react';
+
+function OrgCard({ org }: { org: ForgejoOrg }) {
+	const isPublic = org.visibility === 'public';
+
+	return (
+		<div
+			style={{
+				padding: '0.75rem',
+				borderRadius: 10,
+				background: 'var(--sl-color-gray-6, #161b22)',
+				border: '1px solid var(--sl-color-gray-5, #30363d)',
+				display: 'flex',
+				gap: 10,
+				alignItems: 'center',
+			}}>
+			<img
+				src={org.avatar_url}
+				alt={org.username}
+				style={{
+					width: 36,
+					height: 36,
+					borderRadius: 8,
+					flexShrink: 0,
+					background: 'var(--sl-color-gray-5, #30363d)',
+				}}
+			/>
+			<div style={{ flex: 1, minWidth: 0 }}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 4,
+					}}>
+					<span
+						style={{
+							color: 'var(--sl-color-text, #e6edf3)',
+							fontWeight: 600,
+							fontSize: '0.8rem',
+						}}>
+						{org.username}
+					</span>
+					{isPublic ? (
+						<Eye
+							size={11}
+							style={{
+								color: '#22c55e',
+								flexShrink: 0,
+							}}
+						/>
+					) : (
+						<EyeOff
+							size={11}
+							style={{
+								color: '#f59e0b',
+								flexShrink: 0,
+							}}
+						/>
+					)}
+				</div>
+				{org.description && (
+					<div
+						style={{
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.7rem',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+						}}>
+						{org.description}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export default function ReactForgejoOrgCards() {
+	const orgs = useStore(forgejoService.$orgs);
+
+	if (orgs.length === 0) return null;
+
+	return (
+		<div className="not-content" style={{ marginTop: '1.5rem' }}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 4,
+					fontSize: '0.75rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+					marginBottom: 10,
+				}}>
+				<Building2 size={12} />
+				Organizations
+			</div>
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns:
+						'repeat(auto-fill, minmax(240px, 1fr))',
+					gap: '0.6rem',
+				}}>
+				{orgs.map((o) => (
+					<OrgCard key={o.id} org={o} />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
@@ -1,127 +1,590 @@
 import { useStore } from '@nanostores/react';
-import { forgejoService, type ForgejoRepo } from './forgejoService';
-import { Lock, GitFork, Star, AlertCircle, Copy } from 'lucide-react';
+import {
+	forgejoService,
+	formatSize,
+	timeAgo,
+	langColor,
+	type ForgejoRepo,
+	type RepoDetail,
+} from './forgejoService';
+import {
+	Lock,
+	GitFork,
+	Copy,
+	ChevronDown,
+	ChevronRight,
+	GitBranch,
+	GitCommit,
+	Tag,
+	Download,
+	Shield,
+	Archive,
+	Loader2,
+	HardDrive,
+} from 'lucide-react';
 
-function timeAgo(dateStr: string): string {
-	const diff = Date.now() - new Date(dateStr).getTime();
-	const mins = Math.floor(diff / 60000);
-	if (mins < 60) return `${mins}m ago`;
-	const hrs = Math.floor(mins / 60);
-	if (hrs < 24) return `${hrs}h ago`;
-	const days = Math.floor(hrs / 24);
-	if (days < 30) return `${days}d ago`;
-	return `${Math.floor(days / 30)}mo ago`;
+// ---------------------------------------------------------------------------
+// Shared styles
+// ---------------------------------------------------------------------------
+
+const sectionHeader: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: 4,
+	fontSize: '0.7rem',
+	fontWeight: 600,
+	color: 'var(--sl-color-gray-3, #8b949e)',
+	textTransform: 'uppercase',
+	letterSpacing: '0.05em',
+	marginBottom: 6,
+};
+
+function pillStyle(color: string): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		padding: '1px 6px',
+		borderRadius: 4,
+		fontSize: '0.6rem',
+		fontWeight: 600,
+		background: `${color}18`,
+		border: `1px solid ${color}30`,
+		color,
+		textTransform: 'uppercase',
+		letterSpacing: '0.05em',
+	};
 }
 
-function RepoRow({ repo }: { repo: ForgejoRepo }) {
+const thStyle: React.CSSProperties = {
+	padding: '0.6rem 0.75rem',
+	textAlign: 'left',
+	color: 'var(--sl-color-gray-3, #8b949e)',
+	fontWeight: 600,
+	fontSize: '0.75rem',
+	textTransform: 'uppercase',
+	letterSpacing: '0.05em',
+};
+
+// ---------------------------------------------------------------------------
+// Repo detail expansion panel
+// ---------------------------------------------------------------------------
+
+function LanguageBreakdown({
+	languages,
+}: {
+	languages: Record<string, number>;
+}) {
+	const entries = Object.entries(languages).sort((a, b) => b[1] - a[1]);
+	if (entries.length === 0) return null;
+
+	const total = entries.reduce((s, [, v]) => s + v, 0);
+
 	return (
-		<tr
-			style={{
-				borderBottom: '1px solid var(--sl-color-gray-5, #30363d)',
-			}}>
-			<td style={{ padding: '0.6rem 0.75rem' }}>
-				<div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-					<span
-						style={{
-							color: 'var(--sl-color-text, #e6edf3)',
-							fontWeight: 500,
-							fontSize: '0.85rem',
-						}}>
-						{repo.full_name}
-					</span>
-					{repo.private && (
-						<Lock
-							size={12}
-							style={{ color: '#f59e0b', flexShrink: 0 }}
-						/>
-					)}
-					{repo.mirror && (
-						<Copy
-							size={12}
-							style={{ color: '#8b5cf6', flexShrink: 0 }}
-						/>
-					)}
-					{repo.fork && (
-						<GitFork
-							size={12}
-							style={{ color: '#6b7280', flexShrink: 0 }}
-						/>
-					)}
-				</div>
-				{repo.description && (
+		<div>
+			<div style={sectionHeader}>Languages</div>
+			<div
+				style={{
+					display: 'flex',
+					height: 6,
+					borderRadius: 3,
+					overflow: 'hidden',
+					background: 'var(--sl-color-gray-5, #30363d)',
+					marginBottom: 6,
+				}}>
+				{entries.map(([lang, bytes]) => (
 					<div
+						key={lang}
+						title={`${lang}: ${((bytes / total) * 100).toFixed(1)}%`}
 						style={{
-							color: 'var(--sl-color-gray-3, #8b949e)',
-							fontSize: '0.75rem',
-							marginTop: 2,
-							maxWidth: 400,
-							overflow: 'hidden',
-							textOverflow: 'ellipsis',
-							whiteSpace: 'nowrap',
-						}}>
-						{repo.description}
-					</div>
-				)}
-			</td>
-			<td
+							width: `${(bytes / total) * 100}%`,
+							background: langColor(lang),
+							minWidth: 2,
+						}}
+					/>
+				))}
+			</div>
+			<div
 				style={{
-					padding: '0.6rem 0.75rem',
-					color: 'var(--sl-color-gray-3, #8b949e)',
-					fontSize: '0.8rem',
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '0.4rem 0.8rem',
 				}}>
-				{repo.default_branch}
-			</td>
-			<td
-				style={{
-					padding: '0.6rem 0.75rem',
-					textAlign: 'center',
-				}}>
-				<span
-					style={{
-						display: 'inline-flex',
-						alignItems: 'center',
-						gap: 3,
-						color: '#f59e0b',
-						fontSize: '0.8rem',
-					}}>
-					<Star size={12} />
-					{repo.stars_count}
-				</span>
-			</td>
-			<td
-				style={{
-					padding: '0.6rem 0.75rem',
-					textAlign: 'center',
-				}}>
-				{repo.open_issues_count > 0 && (
+				{entries.slice(0, 8).map(([lang, bytes]) => (
 					<span
+						key={lang}
 						style={{
 							display: 'inline-flex',
 							alignItems: 'center',
-							gap: 3,
-							color: '#22c55e',
-							fontSize: '0.8rem',
+							gap: 4,
+							fontSize: '0.7rem',
+							color: 'var(--sl-color-gray-3, #8b949e)',
 						}}>
-						<AlertCircle size={12} />
-						{repo.open_issues_count}
+						<span
+							style={{
+								width: 7,
+								height: 7,
+								borderRadius: '50%',
+								background: langColor(lang),
+							}}
+						/>
+						{lang}{' '}
+						<span style={{ opacity: 0.6 }}>
+							{((bytes / total) * 100).toFixed(1)}%
+						</span>
 					</span>
-				)}
-			</td>
-			<td
-				style={{
-					padding: '0.6rem 0.75rem',
-					color: 'var(--sl-color-gray-3, #8b949e)',
-					fontSize: '0.75rem',
-					whiteSpace: 'nowrap',
-				}}>
-				{timeAgo(repo.updated_at)}
-			</td>
-		</tr>
+				))}
+			</div>
+		</div>
 	);
 }
 
+function BranchList({ detail }: { detail: RepoDetail }) {
+	if (detail.branches.length === 0) return null;
+	return (
+		<div>
+			<div style={sectionHeader}>
+				<GitBranch size={12} /> Branches ({detail.branches.length})
+			</div>
+			<div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+				{detail.branches.map((b) => (
+					<span
+						key={b.name}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: 4,
+							padding: '2px 8px',
+							borderRadius: 6,
+							background: b.protected
+								? 'rgba(34, 197, 94, 0.1)'
+								: 'var(--sl-color-gray-5, #21262d)',
+							border: b.protected
+								? '1px solid rgba(34, 197, 94, 0.3)'
+								: '1px solid var(--sl-color-gray-5, #30363d)',
+							fontSize: '0.7rem',
+							color: 'var(--sl-color-text, #e6edf3)',
+						}}>
+						{b.protected && (
+							<Shield size={10} style={{ color: '#22c55e' }} />
+						)}
+						{b.name}
+					</span>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function CommitList({ detail }: { detail: RepoDetail }) {
+	if (detail.commits.length === 0) return null;
+	return (
+		<div>
+			<div style={sectionHeader}>
+				<GitCommit size={12} /> Recent Commits
+			</div>
+			<div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+				{detail.commits.slice(0, 5).map((c) => (
+					<div
+						key={c.sha}
+						style={{
+							display: 'flex',
+							gap: 8,
+							alignItems: 'baseline',
+							fontSize: '0.75rem',
+						}}>
+						<code
+							style={{
+								color: '#06b6d4',
+								fontFamily: 'monospace',
+								fontSize: '0.7rem',
+								flexShrink: 0,
+							}}>
+							{c.sha.slice(0, 7)}
+						</code>
+						<span
+							style={{
+								color: 'var(--sl-color-text, #e6edf3)',
+								overflow: 'hidden',
+								textOverflow: 'ellipsis',
+								whiteSpace: 'nowrap',
+								flex: 1,
+							}}>
+							{c.commit.message.split('\n')[0]}
+						</span>
+						<span
+							style={{
+								color: 'var(--sl-color-gray-3, #8b949e)',
+								fontSize: '0.65rem',
+								flexShrink: 0,
+							}}>
+							{timeAgo(c.commit.author.date)}
+						</span>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function ReleaseList({ detail }: { detail: RepoDetail }) {
+	if (detail.releases.length === 0) return null;
+
+	const totalAssetSize = detail.releases
+		.flatMap((r) => r.assets)
+		.reduce((s, a) => s + a.size, 0);
+	const totalDownloads = detail.releases
+		.flatMap((r) => r.assets)
+		.reduce((s, a) => s + a.download_count, 0);
+	const totalAssets = detail.releases.flatMap((r) => r.assets).length;
+
+	return (
+		<div>
+			<div style={sectionHeader}>
+				<Tag size={12} /> Releases ({detail.releases.length})
+				{totalAssets > 0 && (
+					<span
+						style={{
+							marginLeft: 8,
+							fontSize: '0.65rem',
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontWeight: 400,
+						}}>
+						{totalAssets} assets ·{' '}
+						<HardDrive
+							size={10}
+							style={{ verticalAlign: 'middle' }}
+						/>{' '}
+						{formatSize(Math.round(totalAssetSize / 1024))}
+						{totalDownloads > 0 && (
+							<>
+								{' · '}
+								<Download
+									size={10}
+									style={{ verticalAlign: 'middle' }}
+								/>{' '}
+								{totalDownloads}
+							</>
+						)}
+					</span>
+				)}
+			</div>
+			<div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+				{detail.releases.slice(0, 5).map((r) => (
+					<div
+						key={r.id}
+						style={{
+							padding: '0.5rem 0.75rem',
+							borderRadius: 8,
+							background: 'var(--sl-color-gray-6, #161b22)',
+							border: '1px solid var(--sl-color-gray-5, #30363d)',
+						}}>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 6,
+								marginBottom: r.assets.length > 0 ? 4 : 0,
+							}}>
+							<span
+								style={{
+									color: 'var(--sl-color-text, #e6edf3)',
+									fontWeight: 600,
+									fontSize: '0.8rem',
+								}}>
+								{r.tag_name}
+							</span>
+							{r.name && r.name !== r.tag_name && (
+								<span
+									style={{
+										color: 'var(--sl-color-gray-3, #8b949e)',
+										fontSize: '0.75rem',
+									}}>
+									{r.name}
+								</span>
+							)}
+							{r.prerelease && (
+								<span style={pillStyle('#f59e0b')}>
+									pre-release
+								</span>
+							)}
+							{r.draft && (
+								<span style={pillStyle('#6b7280')}>draft</span>
+							)}
+							<span
+								style={{
+									marginLeft: 'auto',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+									fontSize: '0.65rem',
+								}}>
+								{timeAgo(r.published_at || r.created_at)}
+							</span>
+						</div>
+						{r.assets.length > 0 && (
+							<div
+								style={{
+									display: 'flex',
+									flexWrap: 'wrap',
+									gap: 4,
+								}}>
+								{r.assets.map((a) => (
+									<span
+										key={a.id}
+										style={{
+											display: 'inline-flex',
+											alignItems: 'center',
+											gap: 4,
+											padding: '2px 6px',
+											borderRadius: 4,
+											background:
+												'var(--sl-color-gray-5, #21262d)',
+											fontSize: '0.65rem',
+											color: 'var(--sl-color-gray-3, #8b949e)',
+										}}>
+										<Download size={9} />
+										{a.name}
+										<span style={{ opacity: 0.6 }}>
+											{formatSize(
+												Math.round(a.size / 1024),
+											)}
+										</span>
+										{a.download_count > 0 && (
+											<span style={{ color: '#06b6d4' }}>
+												({a.download_count})
+											</span>
+										)}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function RepoDetailPanel({ detail }: { detail: RepoDetail }) {
+	if (detail.loading) {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					justifyContent: 'center',
+					padding: '1.5rem',
+				}}>
+				<Loader2
+					size={20}
+					style={{
+						animation: 'spin 1s linear infinite',
+						color: 'var(--sl-color-accent, #06b6d4)',
+					}}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			style={{
+				padding: '1rem 1.25rem',
+				background: 'var(--sl-color-bg-nav, #111)',
+				borderTop: '1px solid var(--sl-color-gray-5, #30363d)',
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '1rem',
+			}}>
+			<LanguageBreakdown languages={detail.languages} />
+			<BranchList detail={detail} />
+			<CommitList detail={detail} />
+			<ReleaseList detail={detail} />
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Row component
+// ---------------------------------------------------------------------------
+
+function RepoRow({
+	repo,
+	expanded,
+	detail,
+}: {
+	repo: ForgejoRepo;
+	expanded: boolean;
+	detail?: RepoDetail;
+}) {
+	return (
+		<>
+			<tr
+				onClick={() =>
+					forgejoService.toggleExpandedRepo(repo.full_name)
+				}
+				style={{
+					borderBottom: expanded
+						? 'none'
+						: '1px solid var(--sl-color-gray-5, #30363d)',
+					cursor: 'pointer',
+					background: expanded
+						? 'var(--sl-color-gray-6, #161b22)'
+						: 'transparent',
+					transition: 'background 0.15s',
+				}}>
+				<td style={{ padding: '0.6rem 0.5rem', width: 24 }}>
+					{expanded ? (
+						<ChevronDown
+							size={14}
+							style={{
+								color: 'var(--sl-color-gray-3, #8b949e)',
+							}}
+						/>
+					) : (
+						<ChevronRight
+							size={14}
+							style={{
+								color: 'var(--sl-color-gray-3, #8b949e)',
+							}}
+						/>
+					)}
+				</td>
+				<td style={{ padding: '0.6rem 0.75rem' }}>
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 6,
+						}}>
+						{repo.language && (
+							<span
+								style={{
+									width: 8,
+									height: 8,
+									borderRadius: '50%',
+									background: langColor(repo.language),
+									flexShrink: 0,
+								}}
+							/>
+						)}
+						<span
+							style={{
+								color: 'var(--sl-color-text, #e6edf3)',
+								fontWeight: 500,
+								fontSize: '0.85rem',
+							}}>
+							{repo.full_name}
+						</span>
+						{repo.private && (
+							<Lock
+								size={11}
+								style={{ color: '#f59e0b', flexShrink: 0 }}
+							/>
+						)}
+						{repo.mirror && (
+							<Copy
+								size={11}
+								style={{ color: '#8b5cf6', flexShrink: 0 }}
+							/>
+						)}
+						{repo.fork && (
+							<GitFork
+								size={11}
+								style={{ color: '#6b7280', flexShrink: 0 }}
+							/>
+						)}
+						{repo.archived && (
+							<Archive
+								size={11}
+								style={{ color: '#6b7280', flexShrink: 0 }}
+							/>
+						)}
+					</div>
+					{repo.description && (
+						<div
+							style={{
+								color: 'var(--sl-color-gray-3, #8b949e)',
+								fontSize: '0.72rem',
+								marginTop: 2,
+								maxWidth: 400,
+								overflow: 'hidden',
+								textOverflow: 'ellipsis',
+								whiteSpace: 'nowrap',
+							}}>
+							{repo.description}
+						</div>
+					)}
+				</td>
+				<td
+					style={{
+						padding: '0.6rem 0.75rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.8rem',
+					}}>
+					{repo.default_branch}
+				</td>
+				<td
+					style={{
+						padding: '0.6rem 0.75rem',
+						textAlign: 'right',
+						fontFamily: 'monospace',
+						fontSize: '0.8rem',
+						color:
+							repo.size > 100 * 1024
+								? '#f59e0b'
+								: repo.size > 10 * 1024
+									? '#06b6d4'
+									: 'var(--sl-color-gray-3, #8b949e)',
+						fontWeight: repo.size > 100 * 1024 ? 600 : 400,
+					}}>
+					{formatSize(repo.size)}
+				</td>
+				<td
+					style={{
+						padding: '0.6rem 0.75rem',
+						textAlign: 'center',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.75rem',
+					}}>
+					{(repo.release_counter ?? 0) > 0 && (
+						<span
+							style={{
+								display: 'inline-flex',
+								alignItems: 'center',
+								gap: 3,
+								color: '#8b5cf6',
+							}}>
+							<Tag size={11} />
+							{repo.release_counter}
+						</span>
+					)}
+				</td>
+				<td
+					style={{
+						padding: '0.6rem 0.75rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.72rem',
+						whiteSpace: 'nowrap',
+					}}>
+					{timeAgo(repo.updated_at)}
+				</td>
+			</tr>
+			{expanded && detail && (
+				<tr>
+					<td colSpan={6} style={{ padding: 0 }}>
+						<RepoDetailPanel detail={detail} />
+					</td>
+				</tr>
+			)}
+		</>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Main table
+// ---------------------------------------------------------------------------
+
 export default function ReactForgejoRepoTable() {
 	const repos = useStore(forgejoService.$repos);
+	const expandedRepo = useStore(forgejoService.$expandedRepo);
+	const repoDetails = useStore(forgejoService.$repoDetails);
 
 	if (repos.length === 0) return null;
 
@@ -148,69 +611,30 @@ export default function ReactForgejoRepoTable() {
 							}}>
 							<th
 								style={{
-									padding: '0.6rem 0.75rem',
-									textAlign: 'left',
-									color: 'var(--sl-color-gray-3, #8b949e)',
-									fontWeight: 600,
-									fontSize: '0.75rem',
-									textTransform: 'uppercase',
-									letterSpacing: '0.05em',
-								}}>
-								Repository
+									...thStyle,
+									width: 24,
+									padding: '0.6rem 0.5rem',
+								}}
+							/>
+							<th style={thStyle}>Repository</th>
+							<th style={thStyle}>Branch</th>
+							<th style={{ ...thStyle, textAlign: 'right' }}>
+								Size
 							</th>
-							<th
-								style={{
-									padding: '0.6rem 0.75rem',
-									textAlign: 'left',
-									color: 'var(--sl-color-gray-3, #8b949e)',
-									fontWeight: 600,
-									fontSize: '0.75rem',
-									textTransform: 'uppercase',
-									letterSpacing: '0.05em',
-								}}>
-								Branch
+							<th style={{ ...thStyle, textAlign: 'center' }}>
+								Releases
 							</th>
-							<th
-								style={{
-									padding: '0.6rem 0.75rem',
-									textAlign: 'center',
-									color: 'var(--sl-color-gray-3, #8b949e)',
-									fontWeight: 600,
-									fontSize: '0.75rem',
-									textTransform: 'uppercase',
-									letterSpacing: '0.05em',
-								}}>
-								Stars
-							</th>
-							<th
-								style={{
-									padding: '0.6rem 0.75rem',
-									textAlign: 'center',
-									color: 'var(--sl-color-gray-3, #8b949e)',
-									fontWeight: 600,
-									fontSize: '0.75rem',
-									textTransform: 'uppercase',
-									letterSpacing: '0.05em',
-								}}>
-								Issues
-							</th>
-							<th
-								style={{
-									padding: '0.6rem 0.75rem',
-									textAlign: 'left',
-									color: 'var(--sl-color-gray-3, #8b949e)',
-									fontWeight: 600,
-									fontSize: '0.75rem',
-									textTransform: 'uppercase',
-									letterSpacing: '0.05em',
-								}}>
-								Updated
-							</th>
+							<th style={thStyle}>Updated</th>
 						</tr>
 					</thead>
 					<tbody>
 						{repos.map((repo) => (
-							<RepoRow key={repo.id} repo={repo} />
+							<RepoRow
+								key={repo.id}
+								repo={repo}
+								expanded={expandedRepo === repo.full_name}
+								detail={repoDetails[repo.full_name]}
+							/>
 						))}
 					</tbody>
 				</table>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -1,34 +1,56 @@
 import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
-import { forgejoService } from './forgejoService';
-import { Loader2, AlertTriangle } from 'lucide-react';
-
-function formatSize(kb: number): string {
-	if (kb < 1024) return `${kb} KB`;
-	const mb = kb / 1024;
-	if (mb < 1024) return `${mb.toFixed(1)} MB`;
-	return `${(mb / 1024).toFixed(2)} GB`;
-}
+import { forgejoService, formatSize, langColor } from './forgejoService';
+import {
+	Loader2,
+	AlertTriangle,
+	HardDrive,
+	BookOpen,
+	Users,
+	Tag,
+	Lock,
+	Archive,
+} from 'lucide-react';
 
 function StatCard({
+	icon,
 	label,
 	value,
 	color,
+	sub,
 }: {
+	icon: React.ReactNode;
 	label: string;
 	value: string | number;
 	color: string;
+	sub?: string;
 }) {
 	return (
 		<div
 			style={{
-				flex: '1 1 140px',
-				padding: '1rem',
+				flex: '1 1 180px',
+				padding: '1rem 1.1rem',
 				borderRadius: 10,
 				background: 'var(--sl-color-gray-6, #161b22)',
 				border: '1px solid var(--sl-color-gray-5, #30363d)',
-				textAlign: 'center',
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 6,
 			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 6,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.7rem',
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+					fontWeight: 600,
+				}}>
+				{icon}
+				{label}
+			</div>
 			<div
 				style={{
 					fontSize: '1.75rem',
@@ -38,13 +60,181 @@ function StatCard({
 				}}>
 				{value}
 			</div>
+			{sub && (
+				<div
+					style={{
+						fontSize: '0.7rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+					}}>
+					{sub}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function StorageBreakdown() {
+	const repos = useStore(forgejoService.$repos);
+
+	if (repos.length === 0) return null;
+
+	const sorted = [...repos].sort((a, b) => b.size - a.size);
+	const totalSize = sorted.reduce((s, r) => s + r.size, 0);
+	const top = sorted.slice(0, 8);
+
+	return (
+		<div style={{ marginBottom: '1.5rem' }}>
 			<div
 				style={{
 					fontSize: '0.75rem',
+					fontWeight: 600,
 					color: 'var(--sl-color-gray-3, #8b949e)',
-					marginTop: 4,
+					marginBottom: 8,
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 4,
 				}}>
-				{label}
+				<HardDrive size={12} />
+				Storage by Repository
+			</div>
+			{/* Stacked bar */}
+			<div
+				style={{
+					display: 'flex',
+					height: 10,
+					borderRadius: 5,
+					overflow: 'hidden',
+					background: 'var(--sl-color-gray-5, #30363d)',
+					marginBottom: 8,
+				}}>
+				{top.map((repo, i) => {
+					const pct =
+						totalSize > 0 ? (repo.size / totalSize) * 100 : 0;
+					const hue = [200, 160, 280, 30, 340, 120, 50, 240][i % 8];
+					return (
+						<div
+							key={repo.id}
+							title={`${repo.full_name}: ${formatSize(repo.size)}`}
+							style={{
+								width: `${pct}%`,
+								background: `hsl(${hue}, 60%, 55%)`,
+								minWidth: pct > 0 ? 3 : 0,
+							}}
+						/>
+					);
+				})}
+			</div>
+			{/* Legend */}
+			<div
+				style={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '0.4rem 1rem',
+				}}>
+				{top.map((repo, i) => {
+					const hue = [200, 160, 280, 30, 340, 120, 50, 240][i % 8];
+					return (
+						<div
+							key={repo.id}
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 4,
+								fontSize: '0.72rem',
+								color: 'var(--sl-color-gray-3, #8b949e)',
+							}}>
+							<span
+								style={{
+									width: 8,
+									height: 8,
+									borderRadius: '50%',
+									background: `hsl(${hue}, 60%, 55%)`,
+									flexShrink: 0,
+								}}
+							/>
+							{repo.name}
+							<span style={{ opacity: 0.6, fontSize: '0.65rem' }}>
+								{formatSize(repo.size)}
+							</span>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+function LanguageBar() {
+	const langs = useStore(forgejoService.$languageBreakdown);
+	const totalRepos = useStore(forgejoService.$totalRepos);
+
+	if (langs.length === 0) return null;
+
+	return (
+		<div style={{ marginBottom: '1.5rem' }}>
+			<div
+				style={{
+					fontSize: '0.75rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					marginBottom: 8,
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+				}}>
+				Languages
+			</div>
+			<div
+				style={{
+					display: 'flex',
+					height: 8,
+					borderRadius: 4,
+					overflow: 'hidden',
+					background: 'var(--sl-color-gray-5, #30363d)',
+				}}>
+				{langs.map(([lang, count]) => (
+					<div
+						key={lang}
+						title={`${lang}: ${count} repo${count > 1 ? 's' : ''}`}
+						style={{
+							width: `${(count / totalRepos) * 100}%`,
+							background: langColor(lang),
+							minWidth: 3,
+						}}
+					/>
+				))}
+			</div>
+			<div
+				style={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '0.4rem 1rem',
+					marginTop: 8,
+				}}>
+				{langs.map(([lang, count]) => (
+					<div
+						key={lang}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 4,
+							fontSize: '0.72rem',
+							color: 'var(--sl-color-gray-3, #8b949e)',
+						}}>
+						<span
+							style={{
+								width: 8,
+								height: 8,
+								borderRadius: '50%',
+								background: langColor(lang),
+								flexShrink: 0,
+							}}
+						/>
+						{lang}
+						<span style={{ opacity: 0.6 }}>{count}</span>
+					</div>
+				))}
 			</div>
 		</div>
 	);
@@ -55,9 +245,11 @@ export default function ReactForgejoSummary() {
 	const error = useStore(forgejoService.$error);
 	const totalRepos = useStore(forgejoService.$totalRepos);
 	const privateCount = useStore(forgejoService.$privateCount);
-	const mirrorCount = useStore(forgejoService.$mirrorCount);
+	const publicCount = useStore(forgejoService.$publicCount);
+	const archivedCount = useStore(forgejoService.$archivedCount);
 	const totalUsers = useStore(forgejoService.$totalUsers);
 	const totalSize = useStore(forgejoService.$totalSize);
+	const totalReleases = useStore(forgejoService.$totalReleases);
 
 	useEffect(() => {
 		forgejoService.loadCacheAndFetch();
@@ -103,6 +295,8 @@ export default function ReactForgejoSummary() {
 					{error}
 				</div>
 			)}
+
+			{/* Primary stats — storage focused */}
 			<div
 				style={{
 					display: 'flex',
@@ -111,23 +305,39 @@ export default function ReactForgejoSummary() {
 					marginBottom: '1.5rem',
 				}}>
 				<StatCard
-					label="Repositories"
-					value={totalRepos}
-					color="#06b6d4"
-				/>
-				<StatCard
-					label="Private"
-					value={privateCount}
-					color="#f59e0b"
-				/>
-				<StatCard label="Mirrors" value={mirrorCount} color="#8b5cf6" />
-				<StatCard label="Users" value={totalUsers} color="#22c55e" />
-				<StatCard
-					label="Total Size"
+					icon={<HardDrive size={12} />}
+					label="Total Storage"
 					value={formatSize(totalSize)}
 					color="#06b6d4"
+					sub={`across ${totalRepos} repositories`}
+				/>
+				<StatCard
+					icon={<BookOpen size={12} />}
+					label="Repositories"
+					value={totalRepos}
+					color="#22c55e"
+					sub={`${publicCount} public · ${privateCount} private${archivedCount > 0 ? ` · ${archivedCount} archived` : ''}`}
+				/>
+				<StatCard
+					icon={<Tag size={12} />}
+					label="Releases"
+					value={totalReleases}
+					color="#8b5cf6"
+					sub="build artifacts & assets"
+				/>
+				<StatCard
+					icon={<Users size={12} />}
+					label="Users"
+					value={totalUsers}
+					color="#f59e0b"
 				/>
 			</div>
+
+			{/* Storage breakdown by repo */}
+			<StorageBreakdown />
+
+			{/* Language breakdown */}
+			<LanguageBar />
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserGrid.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserGrid.tsx
@@ -1,0 +1,125 @@
+import { useStore } from '@nanostores/react';
+import { forgejoService, timeAgo, type ForgejoUser } from './forgejoService';
+import { Shield, UserX, Clock } from 'lucide-react';
+
+function UserCard({ user }: { user: ForgejoUser }) {
+	const inactive = !user.active || user.prohibit_login;
+
+	return (
+		<div
+			style={{
+				padding: '0.75rem',
+				borderRadius: 10,
+				background: 'var(--sl-color-gray-6, #161b22)',
+				border: `1px solid ${inactive ? 'rgba(239, 68, 68, 0.2)' : 'var(--sl-color-gray-5, #30363d)'}`,
+				display: 'flex',
+				gap: 10,
+				alignItems: 'center',
+				opacity: inactive ? 0.6 : 1,
+			}}>
+			<img
+				src={user.avatar_url}
+				alt={user.login}
+				style={{
+					width: 36,
+					height: 36,
+					borderRadius: 8,
+					flexShrink: 0,
+					background: 'var(--sl-color-gray-5, #30363d)',
+				}}
+			/>
+			<div style={{ flex: 1, minWidth: 0 }}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 4,
+					}}>
+					<span
+						style={{
+							color: 'var(--sl-color-text, #e6edf3)',
+							fontWeight: 600,
+							fontSize: '0.8rem',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+						}}>
+						{user.login}
+					</span>
+					{user.is_admin && (
+						<Shield
+							size={11}
+							style={{ color: '#f59e0b', flexShrink: 0 }}
+						/>
+					)}
+					{user.prohibit_login && (
+						<UserX
+							size={11}
+							style={{ color: '#ef4444', flexShrink: 0 }}
+						/>
+					)}
+				</div>
+				{user.full_name && user.full_name !== user.login && (
+					<div
+						style={{
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.7rem',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+						}}>
+						{user.full_name}
+					</div>
+				)}
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 3,
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.65rem',
+						marginTop: 2,
+					}}>
+					<Clock size={9} />
+					{user.last_login &&
+					user.last_login !== '1970-01-01T00:00:00Z'
+						? timeAgo(user.last_login)
+						: 'never'}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default function ReactForgejoUserGrid() {
+	const users = useStore(forgejoService.$users);
+
+	if (users.length === 0) return null;
+
+	return (
+		<div className="not-content" style={{ marginTop: '1.5rem' }}>
+			<div
+				style={{
+					fontSize: '0.75rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+					marginBottom: 10,
+				}}>
+				Users
+			</div>
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns:
+						'repeat(auto-fill, minmax(220px, 1fr))',
+					gap: '0.6rem',
+				}}>
+				{users.map((u) => (
+					<UserCard key={u.id} user={u} />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -21,18 +21,28 @@ export interface ForgejoRepo {
 	private: boolean;
 	fork: boolean;
 	mirror: boolean;
+	archived: boolean;
 	empty: boolean;
 	size: number;
 	stars_count: number;
 	forks_count: number;
 	open_issues_count: number;
+	open_pr_counter: number;
+	release_counter: number;
 	default_branch: string;
 	created_at: string;
 	updated_at: string;
 	has_pull_requests: boolean;
+	language: string;
+	languages_url: string;
 	owner: {
 		login: string;
 		avatar_url: string;
+	};
+	internal_tracker?: {
+		enable_time_tracker: boolean;
+		allow_only_contributors_to_track_time: boolean;
+		enable_issue_dependencies: boolean;
 	};
 }
 
@@ -45,12 +55,90 @@ export interface ForgejoUser {
 	is_admin: boolean;
 	created: string;
 	last_login: string;
+	active: boolean;
+	prohibit_login: boolean;
+}
+
+export interface ForgejoBranch {
+	name: string;
+	commit: {
+		id: string;
+		message: string;
+		timestamp: string;
+		author: {
+			name: string;
+			email: string;
+		};
+	};
+	protected: boolean;
+}
+
+export interface ForgejoCommit {
+	sha: string;
+	commit: {
+		message: string;
+		author: {
+			name: string;
+			email: string;
+			date: string;
+		};
+	};
+	html_url: string;
+}
+
+export interface ForgejoRelease {
+	id: number;
+	tag_name: string;
+	name: string;
+	body: string;
+	draft: boolean;
+	prerelease: boolean;
+	created_at: string;
+	published_at: string;
+	author: {
+		login: string;
+		avatar_url: string;
+	};
+	assets: ForgejoReleaseAsset[];
+}
+
+export interface ForgejoReleaseAsset {
+	id: number;
+	name: string;
+	size: number;
+	download_count: number;
+	created_at: string;
+	browser_download_url: string;
+}
+
+export interface ForgejoLFSObject {
+	oid: string;
+	size: number;
+	created_at: string;
+}
+
+export interface ForgejoOrg {
+	id: number;
+	username: string;
+	full_name: string;
+	avatar_url: string;
+	description: string;
+	visibility: string;
+}
+
+export interface RepoDetail {
+	branches: ForgejoBranch[];
+	commits: ForgejoCommit[];
+	releases: ForgejoRelease[];
+	languages: Record<string, number>;
+	loading: boolean;
 }
 
 interface CachedData {
 	ts: number;
 	repos: ForgejoRepo[];
 	users: ForgejoUser[];
+	orgs: ForgejoOrg[];
 }
 
 // ---------------------------------------------------------------------------
@@ -88,17 +176,22 @@ class UpstreamUnavailableError extends Error {
 // API helpers
 // ---------------------------------------------------------------------------
 
-async function fetchRepos(token: string): Promise<ForgejoRepo[]> {
-	const resp = await fetch(
-		`${PROXY_BASE}/api/v1/repos/search?limit=50&sort=updated`,
-		{
-			headers: { Authorization: `Bearer ${token}` },
-			signal: AbortSignal.timeout(10000),
-		},
-	);
+async function apiFetch<T>(
+	token: string,
+	path: string,
+	fallback?: T,
+): Promise<T> {
+	const resp = await fetch(`${PROXY_BASE}${path}`, {
+		headers: { Authorization: `Bearer ${token}` },
+		signal: AbortSignal.timeout(10000),
+	});
 
-	if (resp.status === 403) throw new AccessRestrictedError();
+	if (resp.status === 403) {
+		if (fallback !== undefined) return fallback;
+		throw new AccessRestrictedError();
+	}
 	if (resp.status === 502) {
+		if (fallback !== undefined) return fallback;
 		try {
 			const body = await resp.json();
 			throw new UpstreamUnavailableError(
@@ -110,23 +203,77 @@ async function fetchRepos(token: string): Promise<ForgejoRepo[]> {
 			throw new UpstreamUnavailableError('unknown', 'Bad gateway');
 		}
 	}
-	if (!resp.ok) throw new Error(`Forgejo API error: ${resp.status}`);
+	if (!resp.ok) {
+		if (fallback !== undefined) return fallback;
+		throw new Error(`Forgejo API error: ${resp.status}`);
+	}
 
-	const data = await resp.json();
-	return data.data ?? data ?? [];
+	return await resp.json();
+}
+
+async function fetchRepos(token: string): Promise<ForgejoRepo[]> {
+	const data = await apiFetch<{ data?: ForgejoRepo[] } | ForgejoRepo[]>(
+		token,
+		'/api/v1/repos/search?limit=50&sort=updated',
+	);
+	if (Array.isArray(data)) return data;
+	return data.data ?? [];
 }
 
 async function fetchUsers(token: string): Promise<ForgejoUser[]> {
-	const resp = await fetch(`${PROXY_BASE}/api/v1/admin/users?limit=50`, {
-		headers: { Authorization: `Bearer ${token}` },
-		signal: AbortSignal.timeout(10000),
-	});
+	return apiFetch(token, '/api/v1/admin/users?limit=50', [] as ForgejoUser[]);
+}
 
-	if (resp.status === 403) return [];
-	if (resp.status === 502) return [];
-	if (!resp.ok) return [];
+async function fetchOrgs(token: string): Promise<ForgejoOrg[]> {
+	return apiFetch(token, '/api/v1/admin/orgs?limit=50', [] as ForgejoOrg[]);
+}
 
-	return await resp.json();
+// ---------------------------------------------------------------------------
+// Repo detail API helpers
+// ---------------------------------------------------------------------------
+
+async function fetchRepoBranches(
+	token: string,
+	fullName: string,
+): Promise<ForgejoBranch[]> {
+	return apiFetch(
+		token,
+		`/api/v1/repos/${fullName}/branches?limit=20`,
+		[] as ForgejoBranch[],
+	);
+}
+
+async function fetchRepoCommits(
+	token: string,
+	fullName: string,
+): Promise<ForgejoCommit[]> {
+	return apiFetch(
+		token,
+		`/api/v1/repos/${fullName}/commits?limit=10`,
+		[] as ForgejoCommit[],
+	);
+}
+
+async function fetchRepoReleases(
+	token: string,
+	fullName: string,
+): Promise<ForgejoRelease[]> {
+	return apiFetch(
+		token,
+		`/api/v1/repos/${fullName}/releases?limit=10`,
+		[] as ForgejoRelease[],
+	);
+}
+
+async function fetchRepoLanguages(
+	token: string,
+	fullName: string,
+): Promise<Record<string, number>> {
+	return apiFetch(
+		token,
+		`/api/v1/repos/${fullName}/languages`,
+		{} as Record<string, number>,
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -145,13 +292,72 @@ function loadCache(): CachedData | null {
 	}
 }
 
-function saveCache(repos: ForgejoRepo[], users: ForgejoUser[]): void {
+function saveCache(
+	repos: ForgejoRepo[],
+	users: ForgejoUser[],
+	orgs: ForgejoOrg[],
+): void {
 	try {
-		const data: CachedData = { ts: Date.now(), repos, users };
+		const data: CachedData = { ts: Date.now(), repos, users, orgs };
 		localStorage.setItem(CACHE_KEY, JSON.stringify(data));
 	} catch {
 		// ignore quota errors
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function formatSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} KB`;
+	const mb = bytes / 1024;
+	if (mb < 1024) return `${mb.toFixed(1)} MB`;
+	return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+export function timeAgo(dateStr: string): string {
+	const diff = Date.now() - new Date(dateStr).getTime();
+	const mins = Math.floor(diff / 60000);
+	if (mins < 1) return 'just now';
+	if (mins < 60) return `${mins}m ago`;
+	const hrs = Math.floor(mins / 60);
+	if (hrs < 24) return `${hrs}h ago`;
+	const days = Math.floor(hrs / 24);
+	if (days < 30) return `${days}d ago`;
+	return `${Math.floor(days / 30)}mo ago`;
+}
+
+const LANG_COLORS: Record<string, string> = {
+	Go: '#00ADD8',
+	Rust: '#DEA584',
+	TypeScript: '#3178C6',
+	JavaScript: '#F7DF1E',
+	Python: '#3572A5',
+	Shell: '#89E051',
+	Dockerfile: '#384D54',
+	HTML: '#E34C26',
+	CSS: '#563D7C',
+	SCSS: '#C6538C',
+	Makefile: '#427819',
+	C: '#555555',
+	'C++': '#F34B7D',
+	Java: '#B07219',
+	Kotlin: '#A97BFF',
+	Swift: '#F05138',
+	Markdown: '#083FA1',
+	YAML: '#CB171E',
+	JSON: '#292929',
+	TOML: '#9C4221',
+	Astro: '#FF5A03',
+	MDX: '#FCB32C',
+	Nix: '#7E7EFF',
+	Lua: '#000080',
+	Zig: '#EC915C',
+};
+
+export function langColor(lang: string): string {
+	return LANG_COLORS[lang] ?? '#6b7280';
 }
 
 // ---------------------------------------------------------------------------
@@ -166,15 +372,25 @@ class ForgejoService {
 	// Data
 	public readonly $repos = atom<ForgejoRepo[]>([]);
 	public readonly $users = atom<ForgejoUser[]>([]);
+	public readonly $orgs = atom<ForgejoOrg[]>([]);
 	public readonly $loading = atom<boolean>(true);
 	public readonly $error = atom<string | null>(null);
 	public readonly $errorReason = atom<string | null>(null);
 	public readonly $lastUpdated = atom<Date | null>(null);
 
+	// Expanded repo detail
+	public readonly $expandedRepo = atom<string | null>(null);
+	public readonly $repoDetails = atom<Record<string, RepoDetail>>({});
+
 	// Computed
 	public readonly $totalRepos = computed(
 		[this.$repos],
 		(repos) => repos.length,
+	);
+
+	public readonly $publicCount = computed(
+		[this.$repos],
+		(repos) => repos.filter((r) => !r.private).length,
 	);
 
 	public readonly $privateCount = computed(
@@ -187,14 +403,57 @@ class ForgejoService {
 		(repos) => repos.filter((r) => r.mirror).length,
 	);
 
+	public readonly $archivedCount = computed(
+		[this.$repos],
+		(repos) => repos.filter((r) => r.archived).length,
+	);
+
 	public readonly $totalUsers = computed(
 		[this.$users],
 		(users) => users.length,
 	);
 
+	public readonly $activeUsers = computed(
+		[this.$users],
+		(users) => users.filter((u) => u.active && !u.prohibit_login).length,
+	);
+
+	public readonly $adminCount = computed(
+		[this.$users],
+		(users) => users.filter((u) => u.is_admin).length,
+	);
+
 	public readonly $totalSize = computed([this.$repos], (repos) =>
 		repos.reduce((sum, r) => sum + r.size, 0),
 	);
+
+	public readonly $totalStars = computed([this.$repos], (repos) =>
+		repos.reduce((sum, r) => sum + r.stars_count, 0),
+	);
+
+	public readonly $totalOpenIssues = computed([this.$repos], (repos) =>
+		repos.reduce((sum, r) => sum + r.open_issues_count, 0),
+	);
+
+	public readonly $totalOpenPRs = computed([this.$repos], (repos) =>
+		repos.reduce((sum, r) => sum + (r.open_pr_counter ?? 0), 0),
+	);
+
+	public readonly $totalReleases = computed([this.$repos], (repos) =>
+		repos.reduce((sum, r) => sum + (r.release_counter ?? 0), 0),
+	);
+
+	public readonly $languageBreakdown = computed([this.$repos], (repos) => {
+		const counts: Record<string, number> = {};
+		for (const r of repos) {
+			if (r.language) {
+				counts[r.language] = (counts[r.language] ?? 0) + 1;
+			}
+		}
+		return Object.entries(counts)
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, 10);
+	});
 
 	private _refreshInterval: ReturnType<typeof setInterval> | undefined;
 
@@ -228,14 +487,16 @@ class ForgejoService {
 		try {
 			this.$error.set(null);
 			this.$errorReason.set(null);
-			const [repos, users] = await Promise.all([
+			const [repos, users, orgs] = await Promise.all([
 				fetchRepos(token),
 				fetchUsers(token),
+				fetchOrgs(token),
 			]);
 			this.$repos.set(repos);
 			this.$users.set(users);
+			this.$orgs.set(orgs);
 			this.$lastUpdated.set(new Date());
-			saveCache(repos, users);
+			saveCache(repos, users, orgs);
 		} catch (e: unknown) {
 			if (e instanceof AccessRestrictedError) {
 				this.$authState.set('forbidden');
@@ -260,6 +521,7 @@ class ForgejoService {
 		if (cached) {
 			this.$repos.set(cached.repos);
 			this.$users.set(cached.users);
+			this.$orgs.set(cached.orgs ?? []);
 			this.$lastUpdated.set(new Date(cached.ts));
 			this.$loading.set(false);
 		}
@@ -274,6 +536,50 @@ class ForgejoService {
 			this.$loading.set(true);
 			this.fetchData();
 		}
+	}
+
+	// --- Repo detail expansion ---
+
+	public toggleExpandedRepo(fullName: string): void {
+		const current = this.$expandedRepo.get();
+		if (current === fullName) {
+			this.$expandedRepo.set(null);
+		} else {
+			this.$expandedRepo.set(fullName);
+			this._fetchRepoDetail(fullName);
+		}
+	}
+
+	private async _fetchRepoDetail(fullName: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+
+		const details = { ...this.$repoDetails.get() };
+		details[fullName] = {
+			branches: [],
+			commits: [],
+			releases: [],
+			languages: {},
+			loading: true,
+		};
+		this.$repoDetails.set(details);
+
+		const [branches, commits, releases, languages] = await Promise.all([
+			fetchRepoBranches(token, fullName),
+			fetchRepoCommits(token, fullName),
+			fetchRepoReleases(token, fullName),
+			fetchRepoLanguages(token, fullName),
+		]);
+
+		const updated = { ...this.$repoDetails.get() };
+		updated[fullName] = {
+			branches,
+			commits,
+			releases,
+			languages,
+			loading: false,
+		};
+		this.$repoDetails.set(updated);
 	}
 
 	private _startAutoRefresh(): void {


### PR DESCRIPTION
## Summary
- Refocus dashboard for code + Unreal asset storage use case — storage breakdown bar, size-coded repo table, release/asset detail
- Expandable repo rows: click to see branches, recent commits, releases with full asset listing (file names, sizes, download counts)
- Language breakdown bar across repos
- New org cards + user grid islands with avatars, admin badges, last login
- De-emphasize stars/issues/PRs in favor of Size/Releases columns

## Test plan
- [ ] Verify `/dashboard/forgejo` loads with storage-focused stat cards
- [ ] Verify storage breakdown bar renders repos sorted by size
- [ ] Verify clicking a repo row expands to show branches, commits, releases
- [ ] Verify release assets show file names, sizes, and download counts
- [ ] Verify org cards and user grid render with correct data