### PR TITLE
fix(kube/kbve): add forgejo-deploy-keys ExternalSecret and GAME_SERVER_HOST

### DIFF
--- a/apps/kube/forgejo/manifest/rbac.yaml
+++ b/apps/kube/forgejo/manifest/rbac.yaml
@@ -79,6 +79,32 @@ subjects:
       name: arc-runners-external-secrets
       namespace: arc-runners
 ---
+# Role: Allow kbve ExternalSecrets SA to read forgejo-deploy-keys secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: kbve-forgejo-access
+    namespace: forgejo
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['forgejo-deploy-keys']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-forgejo-access-binding
+    namespace: forgejo
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: kbve-forgejo-access
+subjects:
+    - kind: ServiceAccount
+      name: kbve-external-secrets
+      namespace: kbve
+---
 # NetworkPolicy: Allow forgejo pods to reach Redis on port 6379
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/apps/kube/kbve/manifest/forgejo-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/forgejo-externalsecret.yaml
@@ -1,0 +1,45 @@
+# SecretStore: pull secrets from forgejo namespace via kbve-external-secrets SA
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: forgejo-remote-secret-store
+    namespace: kbve
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: forgejo
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: sync forgejo api-token into kbve namespace
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: kbve-forgejo-deploy-keys
+    namespace: kbve
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: forgejo-remote-secret-store
+        kind: SecretStore
+    target:
+        name: forgejo-deploy-keys
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                api-token: '{{ .apitoken }}'
+    data:
+        - secretKey: apitoken
+          remoteRef:
+              key: forgejo-deploy-keys
+              property: api-token

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -114,6 +114,8 @@ spec:
                             secretKeyRef:
                                 name: forgejo-deploy-keys
                                 key: api-token
+                      - name: GAME_SERVER_HOST
+                        value: 'wt.kbve.com'
                       - name: GAME_WT_CERT
                         value: '/etc/ssl/webtransport/tls.crt'
                       - name: GAME_WT_KEY

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
     - kbve-serviceaccount.yaml
     - kbve-externalsecret.yaml
     - mc-rcon-externalsecret.yaml
+    - forgejo-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml
     - kbve-wt-cert.yaml


### PR DESCRIPTION
## Summary
- Fixes degraded `kbve-deployment` pod — `CreateContainerConfigError: secret "forgejo-deploy-keys" not found`
- The secret exists in `forgejo` namespace but deployment references it in `kbve` namespace
- Adds RBAC (Role + RoleBinding) in `forgejo` namespace for `kbve-external-secrets` SA to read the secret
- Adds SecretStore (`forgejo-remote-secret-store`) + ExternalSecret to sync `api-token` into `kbve` namespace as `forgejo-deploy-keys`
- Adds `GAME_SERVER_HOST=wt.kbve.com` env var for WebTransport token resolution (bypasses Cloudflare for QUIC)

## Test plan
- [ ] Verify ExternalSecret syncs and `forgejo-deploy-keys` secret appears in `kbve` namespace
- [ ] Verify pod starts successfully after rollout
- [ ] Verify `/api/v1/auth/game-token` resolves to origin IP for WebTransport