### PR TITLE
chore(axum-kbve): bump version to 1.0.70

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.69"
+version: "1.0.70"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 author: h0lybyte


### PR DESCRIPTION
## Summary
- Bumps axum-kbve to 1.0.70
- Triggers Docker build with forgejo-deploy-keys ExternalSecret fix and GAME_SERVER_HOST env var