### PR TITLE
refactor(ci): use MDX as source of truth for edge version

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -82,7 +82,7 @@ jobs:
                     irc-gateway)  SRC="apps/irc/irc-gateway/Cargo.toml";            VTOML="apps/irc/version.toml" ;;
                     discordsh)    SRC="apps/discordsh/axum-discordsh/Cargo.toml";   VTOML="apps/discordsh/version.toml" ;;
                     mc)           SRC="apps/mc/plugins/kbve-mc-plugin/Cargo.toml";  VTOML="apps/mc/version.toml" ;;
-                    edge)         SRC="apps/kbve/edge/deno.json";                   VTOML="apps/kbve/edge/version.toml" ;;
+                    edge)         SRC="apps/kbve/astro-kbve/src/content/docs/project/edge.mdx"; VTOML="apps/kbve/edge/version.toml" ;;
                     cryptothrone) SRC="apps/cryptothrone/axum-cryptothrone/Cargo.toml"; VTOML="apps/cryptothrone/version.toml" ;;
                     kilobase)     SRC=""; VTOML="" ;;
                     *)
@@ -224,10 +224,12 @@ jobs:
                       echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
                       echo "image=kbve/edge"                                                               >> "$GITHUB_OUTPUT"
                       echo "e2e_name=edge"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/kbve/edge/deno.json"                                          >> "$GITHUB_OUTPUT"
+                      echo "cargo_toml=apps/kbve/astro-kbve/src/content/docs/project/edge.mdx"            >> "$GITHUB_OUTPUT"
                       echo "deployment_yaml=apps/kube/functions/manifests/functions-deployment.yaml"      >> "$GITHUB_OUTPUT"
                       echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
                       echo "version_toml=apps/kbve/edge/version.toml"                                      >> "$GITHUB_OUTPUT"
+                      echo "version_source=apps/kbve/astro-kbve/src/content/docs/project/edge.mdx"        >> "$GITHUB_OUTPUT"
+                      echo "version_target=apps/kbve/edge/deno.json"                                      >> "$GITHUB_OUTPUT"
                       ;;
                     cryptothrone)
                       echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -59,7 +59,10 @@ jobs:
                     *) VER="" ;;
                   esac
                   if [ -n "$VER" ]; then
-                    sed -i "s/^version = .*/version = \"${VER}\"/" "$TGT"
+                    case "$TGT" in
+                      *.json) jq --arg v "$VER" '.version = $v' "$TGT" > "${TGT}.tmp" && mv "${TGT}.tmp" "$TGT" ;;
+                      *)      sed -i "s/^version = .*/version = \"${VER}\"/" "$TGT" ;;
+                    esac
                     echo "Synced version ${VER} → ${TGT}"
                   fi
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.16"
+version: "0.1.20"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 author: h0lybyte


### PR DESCRIPTION
## Summary
- Switches edge version gate from `deno.json` to `project/edge.mdx` (matching axum-kbve pattern)
- Adds `version_source`/`version_target` to edge config so `docker-test-app` syncs MDX version into `deno.json` at build time
- Updates version sync step to handle JSON targets via `jq` (was only handling TOML/Cargo format)
- Bumps edge to `0.1.20`

## Test plan
- [ ] Verify edge CI Docker reads version from MDX and passes version gate
- [ ] Verify `deno.json` gets synced to `0.1.20` during build
- [ ] Verify publish + kube manifest update runs after tests pass