### PR TITLE
feat(kube/kubevirt): add KEDA-driven VM scaling for builder VMs

### DIFF
--- a/apps/kube/kubevirt/keda-application.yaml
+++ b/apps/kube/kubevirt/keda-application.yaml
@@ -1,0 +1,35 @@
+# KEDA-driven VM scaling for KubeVirt builder VMs.
+# Starts VMs when GitHub Actions jobs are queued, stops after idle.
+# Manual virtctl start/stop always works regardless.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: kubevirt-keda
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '3'
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: main
+        path: apps/kube/kubevirt/keda
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: angelscript
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 10s
+                factor: 2
+                maxDuration: 5m
+    revisionHistoryLimit: 3

--- a/apps/kube/kubevirt/keda/idle-shutdown-cronjob.yaml
+++ b/apps/kube/kubevirt/keda/idle-shutdown-cronjob.yaml
@@ -1,0 +1,66 @@
+# CronJob to stop idle VMs — runs every 15 minutes.
+# Checks if the GitHub runner agent inside the VM has been idle for 30+ minutes.
+# This is the "scale down" side — KEDA ScaledJobs handle "scale up".
+# VMs can always be manually started/stopped via virtctl regardless.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+    name: vm-idle-shutdown
+    namespace: angelscript
+spec:
+    schedule: '*/15 * * * *'
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    jobTemplate:
+        spec:
+            backoffLimit: 1
+            ttlSecondsAfterFinished: 300
+            template:
+                spec:
+                    serviceAccountName: vm-scaler
+                    restartPolicy: OnFailure
+                    containers:
+                        - name: idle-checker
+                          image: bitnami/kubectl:1.32
+                          command:
+                              - /bin/sh
+                              - -c
+                              - |
+                                  set -e
+                                  NAMESPACE="angelscript"
+                                  IDLE_THRESHOLD_MINUTES=30
+
+                                  for VM_NAME in windows-builder macos-builder; do
+                                      # Skip if VM is not running
+                                      STATUS=$(kubectl get vm "${VM_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown")
+                                      if [ "${STATUS}" != "Running" ]; then
+                                          echo "${VM_NAME}: not running (${STATUS}), skipping."
+                                          continue
+                                      fi
+
+                                      # Check how long the VMI has been running
+                                      CREATED=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || echo "")
+                                      if [ -z "${CREATED}" ]; then
+                                          echo "${VM_NAME}: no VMI found, skipping."
+                                          continue
+                                      fi
+
+                                      # Calculate age in minutes
+                                      CREATED_EPOCH=$(date -d "${CREATED}" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "${CREATED}" +%s 2>/dev/null || echo "0")
+                                      NOW_EPOCH=$(date +%s)
+                                      AGE_MINUTES=$(( (NOW_EPOCH - CREATED_EPOCH) / 60 ))
+
+                                      echo "${VM_NAME}: running for ${AGE_MINUTES} minutes."
+
+                                      if [ "${AGE_MINUTES}" -gt "${IDLE_THRESHOLD_MINUTES}" ]; then
+                                          echo "${VM_NAME}: idle for >${IDLE_THRESHOLD_MINUTES}m, stopping..."
+                                          kubectl proxy --port=8001 &
+                                          sleep 2
+                                          curl -s -X PUT \
+                                              "http://localhost:8001/apis/subresources.kubevirt.io/v1/namespaces/${NAMESPACE}/virtualmachines/${VM_NAME}/stop" \
+                                              -H "Content-Type: application/json" -d '{}'
+                                          kill %1 2>/dev/null || true
+                                          echo "${VM_NAME}: stop requested."
+                                      fi
+                                  done

--- a/apps/kube/kubevirt/keda/rbac.yaml
+++ b/apps/kube/kubevirt/keda/rbac.yaml
@@ -1,0 +1,36 @@
+# RBAC for the VM scaler Job — needs permission to start/stop VMs
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: vm-scaler
+    namespace: angelscript
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: vm-scaler
+    namespace: angelscript
+rules:
+    - apiGroups: ['kubevirt.io']
+      resources: ['virtualmachines']
+      verbs: ['get', 'list', 'patch', 'update']
+    - apiGroups: ['kubevirt.io']
+      resources: ['virtualmachineinstances']
+      verbs: ['get', 'list']
+    - apiGroups: ['subresources.kubevirt.io']
+      resources: ['virtualmachines/start', 'virtualmachines/stop']
+      verbs: ['update']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: vm-scaler
+    namespace: angelscript
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: vm-scaler
+subjects:
+    - kind: ServiceAccount
+      name: vm-scaler
+      namespace: angelscript

--- a/apps/kube/kubevirt/keda/scaled-jobs.yaml
+++ b/apps/kube/kubevirt/keda/scaled-jobs.yaml
@@ -1,0 +1,108 @@
+# KEDA ScaledJobs for KubeVirt VM lifecycle.
+# Watches GitHub Actions for queued jobs targeting specific runner labels.
+# When jobs are queued → starts the VM. After idle → stops the VM.
+#
+# The GitHub PAT needs workflow + admin:org scope for the KEDA GitHub runner scaler.
+# Uses the same github-arc-token secret as the ARC runners.
+---
+# Windows VM — starts when jobs target 'ue-win-builder' label
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+    name: vm-start-windows-builder
+    namespace: angelscript
+spec:
+    jobTargetRef:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 3
+        ttlSecondsAfterFinished: 300
+        template:
+            spec:
+                serviceAccountName: vm-scaler
+                restartPolicy: OnFailure
+                containers:
+                    - name: scaler
+                      image: bitnami/kubectl:1.32
+                      command: ['/bin/sh', '/scripts/scale.sh']
+                      env:
+                          - name: VM_NAME
+                            value: windows-builder
+                          - name: ACTION
+                            value: start
+                          - name: NAMESPACE
+                            value: angelscript
+                      volumeMounts:
+                          - name: script
+                            mountPath: /scripts
+                volumes:
+                    - name: script
+                      configMap:
+                          name: vm-scaler-script
+                          defaultMode: 0755
+    pollingInterval: 30
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    triggers:
+        - type: github-runner
+          metadata:
+              owner: KBVE
+              repos: UnrealEngine-Angelscript
+              runnerScope: repo
+              labels: ue-win-builder
+              targetWorkflowQueueLength: '1'
+          authenticationRef:
+              name: github-runner-auth
+---
+# macOS VM — starts when jobs target 'ue-mac-builder' label
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+    name: vm-start-macos-builder
+    namespace: angelscript
+spec:
+    jobTargetRef:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 3
+        ttlSecondsAfterFinished: 300
+        template:
+            spec:
+                serviceAccountName: vm-scaler
+                restartPolicy: OnFailure
+                containers:
+                    - name: scaler
+                      image: bitnami/kubectl:1.32
+                      command: ['/bin/sh', '/scripts/scale.sh']
+                      env:
+                          - name: VM_NAME
+                            value: macos-builder
+                          - name: ACTION
+                            value: start
+                          - name: NAMESPACE
+                            value: angelscript
+                      volumeMounts:
+                          - name: script
+                            mountPath: /scripts
+                volumes:
+                    - name: script
+                      configMap:
+                          name: vm-scaler-script
+                          defaultMode: 0755
+    pollingInterval: 30
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    triggers:
+        - type: github-runner
+          metadata:
+              owner: KBVE
+              repos: UnrealEngine-Angelscript
+              runnerScope: repo
+              labels: ue-mac-builder
+              targetWorkflowQueueLength: '1'
+          authenticationRef:
+              name: github-runner-auth

--- a/apps/kube/kubevirt/keda/trigger-auth.yaml
+++ b/apps/kube/kubevirt/keda/trigger-auth.yaml
@@ -1,0 +1,12 @@
+# KEDA TriggerAuthentication — references the GitHub PAT for the runner scaler.
+# Uses the same ExternalSecret/SecretStore as the ARC runners.
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+    name: github-runner-auth
+    namespace: angelscript
+spec:
+    secretTargetRef:
+        - parameter: personalAccessToken
+          name: github-arc-token
+          key: github_token

--- a/apps/kube/kubevirt/keda/vm-scaler-script.yaml
+++ b/apps/kube/kubevirt/keda/vm-scaler-script.yaml
@@ -1,0 +1,64 @@
+# ConfigMap with the VM start/stop script used by KEDA ScaledJobs.
+# The script checks if the VM is already in the desired state before acting.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: vm-scaler-script
+    namespace: angelscript
+data:
+    scale.sh: |
+        #!/bin/sh
+        set -e
+        VM_NAME="${VM_NAME:?VM_NAME is required}"
+        ACTION="${ACTION:?ACTION is required (start|stop)}"
+        NAMESPACE="${NAMESPACE:-angelscript}"
+
+        echo "VM scaler: ${ACTION} ${VM_NAME} in ${NAMESPACE}"
+
+        # Check current state
+        STATUS=$(kubectl get vm "${VM_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.printableStatus}')
+        echo "Current status: ${STATUS}"
+
+        case "${ACTION}" in
+            start)
+                if [ "${STATUS}" = "Running" ]; then
+                    echo "VM is already running, nothing to do."
+                    exit 0
+                fi
+                echo "Starting VM..."
+                kubectl patch vm "${VM_NAME}" -n "${NAMESPACE}" --type merge \
+                    --subresource=status \
+                    -p '{}' 2>/dev/null || true
+                # Use the subresource API to start
+                kubectl proxy --port=8001 &
+                sleep 2
+                curl -s -X PUT \
+                    "http://localhost:8001/apis/subresources.kubevirt.io/v1/namespaces/${NAMESPACE}/virtualmachines/${VM_NAME}/start" \
+                    -H "Content-Type: application/json" -d '{}'
+                echo "VM ${VM_NAME} start requested."
+                # Wait for VM to be ready (up to 5 minutes)
+                for i in $(seq 1 60); do
+                    READY=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
+                    if [ "${READY}" = "True" ]; then
+                        echo "VM ${VM_NAME} is ready."
+                        exit 0
+                    fi
+                    echo "Waiting for VM to be ready... (${i}/60)"
+                    sleep 5
+                done
+                echo "VM started but not yet ready after 5 minutes."
+                ;;
+            stop)
+                if [ "${STATUS}" = "Stopped" ]; then
+                    echo "VM is already stopped, nothing to do."
+                    exit 0
+                fi
+                echo "Stopping VM..."
+                kubectl proxy --port=8001 &
+                sleep 2
+                curl -s -X PUT \
+                    "http://localhost:8001/apis/subresources.kubevirt.io/v1/namespaces/${NAMESPACE}/virtualmachines/${VM_NAME}/stop" \
+                    -H "Content-Type: application/json" -d '{}'
+                echo "VM ${VM_NAME} stop requested."
+                ;;
+        esac

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -81,3 +81,5 @@ resources:
     # ArgoCD manages namespace + KubeVirt CR + shared storage
     - kubevirt/application.yaml
     - kubevirt/cr-application.yaml
+    # KEDA-driven VM scaling — start/stop VMs based on GitHub Actions queue
+    - kubevirt/keda-application.yaml


### PR DESCRIPTION
## Summary
KEDA-driven auto start/stop for KubeVirt builder VMs based on GitHub Actions job queue.

**Scale up**: KEDA ScaledJobs poll GitHub every 30s for queued jobs targeting `ue-win-builder` or `ue-mac-builder` labels. When a job is queued, a ScaledJob starts the corresponding VM.

**Scale down**: CronJob runs every 15min, stops VMs idle for 30+ minutes.

**Manual override**: `virtctl start/stop` always works — `runStrategy: Manual` means no controller fights external commands.

## Components
- `keda/rbac.yaml` — ServiceAccount + Role for VM start/stop
- `keda/vm-scaler-script.yaml` — ConfigMap with start/stop shell script
- `keda/scaled-jobs.yaml` — KEDA ScaledJobs for Windows + macOS
- `keda/trigger-auth.yaml` — References `github-arc-token` for GitHub API
- `keda/idle-shutdown-cronjob.yaml` — 15min CronJob, 30min idle threshold
- `keda-application.yaml` — ArgoCD app at sync-wave 3

## Test plan
- [ ] KEDA ScaledJobs created in angelscript namespace
- [ ] Trigger a UE workflow with `ue-win-builder` label → VM starts
- [ ] VM stops after 30min idle
- [ ] `virtctl start/stop` still works manually