### PR TITLE
refactor(ci): MDX single source of truth for all docker CI config

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -156,102 +156,27 @@ jobs:
             version_source: ${{ steps.resolve.outputs.version_source }}
             version_target: ${{ steps.resolve.outputs.version_target }}
         steps:
-            - name: Resolve config for ${{ inputs.app_name }}
+            - name: Resolve config from manifest
               id: resolve
               run: |
-                  case "${{ inputs.app_name }}" in
-                    axum-kbve)
-                      echo "runner=arc-runner-set"                                                         >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/kbve"                                                               >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=axum-kbve-e2e"                                                        >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/kbve/astro-kbve/src/content/docs/project/api.mdx"              >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/kbve/manifest/kbve-deployment.yaml"                 >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/kbve/axum-kbve/version.toml"                                >> "$GITHUB_OUTPUT"
-                      echo "version_source=apps/kbve/astro-kbve/src/content/docs/project/api.mdx"         >> "$GITHUB_OUTPUT"
-                      echo "version_target=apps/kbve/axum-kbve/Cargo.toml"                                >> "$GITHUB_OUTPUT"
-                      ;;
-                    herbmail)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/herbmail"                                                           >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=herbmail"                                                             >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/herbmail/axum-herbmail/Cargo.toml"                             >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/herbmail/manifest/herbmail-deployment.yaml"          >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/herbmail/version.toml"                                       >> "$GITHUB_OUTPUT"
-                      ;;
-                    memes)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/memes"                                                              >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=memes"                                                                >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/memes/axum-memes/Cargo.toml"                                   >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/memes/manifest/memes-deployment.yaml"               >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/memes/version.toml"                                          >> "$GITHUB_OUTPUT"
-                      ;;
-                    irc-gateway)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/irc-gateway"                                                        >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=irc"                                                                  >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/irc/irc-gateway/Cargo.toml"                                   >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/irc/manifests/irc-gateway-deployment.yaml"          >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/irc/version.toml"                                            >> "$GITHUB_OUTPUT"
-                      ;;
-                    discordsh)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/discordsh"                                                          >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=discordsh"                                                            >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx"       >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/discordsh/manifest/deployment.yaml"                 >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/discordsh/version.toml"                                      >> "$GITHUB_OUTPUT"
-                      echo "version_source=apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx"   >> "$GITHUB_OUTPUT"
-                      echo "version_target=apps/discordsh/axum-discordsh/Cargo.toml"                      >> "$GITHUB_OUTPUT"
-                      ;;
-                    mc)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/mc"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=mc"                                                                   >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/mc/plugins/kbve-mc-plugin/Cargo.toml"                         >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/mc/manifest/deployment.yaml"                        >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/mc/version.toml"                                             >> "$GITHUB_OUTPUT"
-                      ;;
-                    edge)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/edge"                                                               >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=edge"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/kbve/astro-kbve/src/content/docs/project/edge.mdx"            >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/functions/manifests/functions-deployment.yaml"      >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/kbve/edge/version.toml"                                      >> "$GITHUB_OUTPUT"
-                      echo "version_source=apps/kbve/astro-kbve/src/content/docs/project/edge.mdx"        >> "$GITHUB_OUTPUT"
-                      echo "version_target=apps/kbve/edge/deno.json"                                      >> "$GITHUB_OUTPUT"
-                      ;;
-                    cryptothrone)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/cryptothrone"                                                       >> "$GITHUB_OUTPUT"
-                      echo "e2e_name=cryptothrone"                                                         >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml=apps/cryptothrone/axum-cryptothrone/Cargo.toml"                    >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml=apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml" >> "$GITHUB_OUTPUT"
-                      echo "has_test=true"                                                                 >> "$GITHUB_OUTPUT"
-                      echo "version_toml=apps/cryptothrone/version.toml"                                   >> "$GITHUB_OUTPUT"
-                      ;;
-                    kilobase)
-                      echo "runner=ubuntu-latest"                                                          >> "$GITHUB_OUTPUT"
-                      echo "image=kbve/kilobase"                                                           >> "$GITHUB_OUTPUT"
-                      echo "e2e_name="                                                                     >> "$GITHUB_OUTPUT"
-                      echo "cargo_toml="                                                                   >> "$GITHUB_OUTPUT"
-                      echo "deployment_yaml="                                                              >> "$GITHUB_OUTPUT"
-                      echo "has_test=false"                                                                >> "$GITHUB_OUTPUT"
-                      echo "version_toml="                                                                 >> "$GITHUB_OUTPUT"
-                      ;;
-                    *)
-                      echo "::error::Unknown app_name: ${{ inputs.app_name }}"
-                      exit 1
-                      ;;
-                  esac
+                  APP="${{ inputs.app_name }}"
+                  MANIFEST=".github/ci-dispatch-manifest.json"
+
+                  ENTRY=$(jq -c --arg app "$APP" '.docker[] | select(.app_name == $app)' "$MANIFEST" 2>/dev/null)
+                  if [ -z "$ENTRY" ]; then
+                    echo "::error::App '$APP' not found in manifest"
+                    exit 1
+                  fi
+
+                  echo "runner=$(echo "$ENTRY" | jq -r '.runner // "ubuntu-latest"')"       >> "$GITHUB_OUTPUT"
+                  echo "image=$(echo "$ENTRY" | jq -r '.image // empty')"                   >> "$GITHUB_OUTPUT"
+                  echo "e2e_name=$(echo "$ENTRY" | jq -r '.e2e_name // empty')"              >> "$GITHUB_OUTPUT"
+                  echo "cargo_toml=$(echo "$ENTRY" | jq -r '.version_source // empty')"      >> "$GITHUB_OUTPUT"
+                  echo "deployment_yaml=$(echo "$ENTRY" | jq -r '.deployment_yaml // empty')" >> "$GITHUB_OUTPUT"
+                  echo "has_test=$(echo "$ENTRY" | jq -r '.has_test // true')"               >> "$GITHUB_OUTPUT"
+                  echo "version_toml=$(echo "$ENTRY" | jq -r '.version_toml // empty')"      >> "$GITHUB_OUTPUT"
+                  echo "version_source=$(echo "$ENTRY" | jq -r '.version_source // empty')"  >> "$GITHUB_OUTPUT"
+                  echo "version_target=$(echo "$ENTRY" | jq -r '.version_target // empty')"  >> "$GITHUB_OUTPUT"
 
     # ---------------------------------------------------------------------------
     # Test — builds the app image, tags as ci-{sha} in GHCR, runs e2e tests.

--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -15,6 +15,12 @@ app_name: axum-kbve
 version: "1.0.70"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
+version_target: apps/kbve/axum-kbve/Cargo.toml
+runner: arc-runner-set
+image: kbve/kbve
+e2e_name: axum-kbve-e2e
+deployment_yaml: apps/kube/kbve/manifest/kbve-deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -18,6 +18,12 @@ app_name: cryptothrone
 version: "0.1.4"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
+version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml
+runner: ubuntu-latest
+image: kbve/cryptothrone
+e2e_name: cryptothrone
+deployment_yaml: apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx
@@ -16,6 +16,12 @@ app_name: discordsh
 version: "0.1.33"
 source_path: apps/discordsh
 version_toml: apps/discordsh/version.toml
+version_target: apps/discordsh/axum-discordsh/Cargo.toml
+runner: ubuntu-latest
+image: kbve/discordsh
+e2e_name: discordsh
+deployment_yaml: apps/kube/discordsh/manifest/deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -14,6 +14,12 @@ app_name: edge
 version: "0.1.20"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
+version_target: apps/kbve/edge/deno.json
+runner: ubuntu-latest
+image: kbve/edge
+e2e_name: edge
+deployment_yaml: apps/kube/functions/manifests/functions-deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/herbmail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/herbmail.mdx
@@ -16,6 +16,12 @@ app_name: herbmail
 version: "0.1.0"
 source_path: apps/herbmail
 version_toml: apps/herbmail/version.toml
+version_target: apps/herbmail/axum-herbmail/Cargo.toml
+runner: ubuntu-latest
+image: kbve/herbmail
+e2e_name: herbmail
+deployment_yaml: apps/kube/herbmail/manifest/herbmail-deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
@@ -14,6 +14,12 @@ app_name: irc-gateway
 version: "0.1.2"
 source_path: apps/irc
 version_toml: apps/irc/version.toml
+version_target: apps/irc/irc-gateway/Cargo.toml
+runner: ubuntu-latest
+image: kbve/irc-gateway
+e2e_name: irc
+deployment_yaml: apps/kube/irc/manifests/irc-gateway-deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/kilobase.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kilobase.mdx
@@ -13,6 +13,9 @@ pipeline: docker
 app_name: kilobase
 version: "17.4.1"
 source_path: apps/kbve/kilobase
+runner: ubuntu-latest
+image: kbve/kilobase
+has_test: false
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -14,6 +14,12 @@ app_name: mc
 version: "0.1.14"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
+version_target: apps/mc/plugins/kbve-mc-plugin/Cargo.toml
+runner: ubuntu-latest
+image: kbve/mc
+e2e_name: mc
+deployment_yaml: apps/kube/mc/manifest/deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
@@ -14,6 +14,12 @@ app_name: memes
 version: "0.1.7"
 source_path: apps/memes
 version_toml: apps/memes/version.toml
+version_target: apps/memes/axum-memes/Cargo.toml
+runner: ubuntu-latest
+image: kbve/memes
+e2e_name: memes
+deployment_yaml: apps/kube/memes/manifest/memes-deployment.yaml
+has_test: true
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
@@ -26,6 +26,13 @@ export type {
 const AstroProjectExtensions = z.object({
 	unsplash: z.string().optional(),
 	img: z.string().url().optional(),
+	// CI deployment config — drives ci-docker.yml without case statements
+	runner: z.string().max(64).optional(),
+	image: z.string().max(128).optional(),
+	e2e_name: z.string().max(64).optional(),
+	deployment_yaml: z.string().max(256).optional(),
+	version_target: z.string().max(256).optional(),
+	has_test: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
@@ -18,7 +18,13 @@ interface DockerEntry {
 	version?: string;
 	version_toml?: string;
 	version_source?: string;
+	version_target?: string;
 	source_path?: string;
+	runner?: string;
+	image?: string;
+	e2e_name?: string;
+	deployment_yaml?: string;
+	has_test?: boolean;
 }
 
 interface NpmEntry {
@@ -76,16 +82,21 @@ function toManifestEntry(d: ICiProject, mdxPath?: string): ManifestEntry | null 
 	const ver = d.version;
 	switch (d.pipeline) {
 		case 'docker':
-			return d.app_name
-				? {
-						key: d.key!,
-						app_name: d.app_name,
-						...(ver && { version: ver }),
-						...(vt && { version_toml: vt }),
-						...(mdxPath && { version_source: mdxPath }),
-						...(d.source_path && { source_path: d.source_path }),
-					}
-				: null;
+			if (!d.app_name) return null;
+			return {
+				key: d.key!,
+				app_name: d.app_name,
+				...(ver && { version: ver }),
+				...(vt && { version_toml: vt }),
+				...(mdxPath && { version_source: mdxPath }),
+				...(d.version_target && { version_target: d.version_target }),
+				...(d.source_path && { source_path: d.source_path }),
+				...(d.runner && { runner: d.runner }),
+				...(d.image && { image: d.image }),
+				...(d.e2e_name && { e2e_name: d.e2e_name }),
+				...(d.deployment_yaml && { deployment_yaml: d.deployment_yaml }),
+				...(d.has_test !== undefined && { has_test: d.has_test }),
+			};
 		case 'npm':
 		case 'crates':
 			return d.package_name


### PR DESCRIPTION
## Summary

Eliminates all hardcoded case statements from the docker CI pipeline. Every per-app field now lives in MDX frontmatter and flows through the manifest.

### Data flow
```
MDX frontmatter → ci-registry.json API → ci-dispatch-manifest.json → CI workflows
```

### Changes
- **Schema** — added `runner`, `image`, `e2e_name`, `deployment_yaml`, `version_target`, `has_test` to `ICiProjectSchema` (Astro extension)
- **9 MDX files** — all docker project pages now carry full CI deployment config in frontmatter
- **API endpoint** — `ci-registry.json.ts` emits all new fields in docker manifest entries
- **ci-docker.yml** — config job case statement (~100 lines) replaced with manifest `jq` lookup (~10 lines)

### Before
Adding/modifying a docker app required editing case statements in `ci-main.yml`, `ci-docker.yml` version gate, and `ci-docker.yml` config — 3 places, 2 files.

### After
Edit one MDX file, re-sync the manifest. No workflow changes needed.

### Next step
Re-sync manifest after merge: `npx nx run astro-kbve:build && npx nx run astro-kbve:sync:ci-manifest`

## Test plan
- [ ] Build astro-kbve to verify schema validates all MDX frontmatter
- [ ] Re-sync manifest and verify all docker entries have new fields
- [ ] Trigger a docker CI run and verify config resolves from manifest