### PR TITLE
fix(unreal): resolve UE 5.7.4 compile errors in KBVEUnrealMCP

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
@@ -379,16 +379,18 @@ Targets UE 5.7+.
 **Architecture:**
 
 ```
-[AI Client] --MCP--> [External Bridge] --WebSocket--> [KBVEUnrealMCP Plugin]
-                                                           |
-                                               TMap<FString, Handler> dispatch
-                                                           |
-                                               GameThread UE API execution
+[AI Client] --MCP--> [External Bridge] --TCP (JSON\n)--> [KBVEUnrealMCP Plugin]
+                                                              |
+                                                  TMap<FString, Handler> dispatch
+                                                              |
+                                                  GameThread UE API execution
 ```
 
-The plugin runs a WebSocket server on port `9777` (configurable in Project Settings under KBVE Unreal MCP).
+The plugin runs a TCP server on port `9777` (configurable in Project Settings under KBVE Unreal MCP).
+Clients connect via TCP and send newline-delimited JSON (`\n` terminated).
 All handler methods are dispatched via a `TMap`-based registry for O(1) lookup.
 Every UE API call is marshaled to the GameThread via `AsyncTask` for thread safety.
+Verified compiling on UE 5.7.4 (Mac, universal binary).
 
 **JSON Protocol:**
 

--- a/packages/unreal/KBVEUnrealMCP/Config/FilterPlugin.ini
+++ b/packages/unreal/KBVEUnrealMCP/Config/FilterPlugin.ini
@@ -1,0 +1,8 @@
+[FilterPlugin]
+; This section lists additional files which will be packaged along with your plugin. Paths should be listed relative to the root plugin directory, and
+; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
+;
+; Examples:
+;    /README.txt
+;    /Extras/...
+;    /Binaries/ThirdParty/*.dll

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/KBVEUnrealMCP.Build.cs
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/KBVEUnrealMCP.Build.cs
@@ -25,8 +25,7 @@ public class KBVEUnrealMCP : ModuleRules
 			"SlateCore",
 			"InputCore",
 			"LevelEditor",
-			// WebSocket server
-			"WebSockets",
+			// TCP server
 			"Networking",
 			"Sockets",
 			// Blueprint editing
@@ -42,6 +41,7 @@ public class KBVEUnrealMCP : ModuleRules
 			"EnhancedInput",
 			// UMG
 			"UMG",
+			"UMGEditor",
 			// Landscape
 			"Landscape",
 			// AI
@@ -50,6 +50,8 @@ public class KBVEUnrealMCP : ModuleRules
 			"GameplayTags",
 			// Niagara (runtime component access)
 			"Niagara",
+			// RHI (GPU adapter info)
+			"RHI",
 			// Settings
 			"DeveloperSettings"
 		});

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPBlueprintHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPBlueprintHandlers.cpp
@@ -13,6 +13,9 @@
 #include "AssetToolsModule.h"
 #include "UObject/SavePackage.h"
 #include "Factories/BlueprintFactory.h"
+#include "Engine/SimpleConstructionScript.h"
+#include "Engine/SCS_Node.h"
+#include "Kismet/KismetMathLibrary.h"
 #include "Components/SceneComponent.h"
 
 void FMCPBlueprintHandlers::Register(FMCPHandlerRegistry& Registry)
@@ -419,7 +422,8 @@ void FMCPBlueprintHandlers::HandleConnectNodes(const TSharedPtr<FJsonObject>& Pa
 		return;
 	}
 
-	bool bConnected = SourcePin->MakeLinkTo(TargetPin);
+	SourcePin->MakeLinkTo(TargetPin);
+	bool bConnected = SourcePin->LinkedTo.Contains(TargetPin);
 
 	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
 

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPNavigationHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPNavigationHandlers.cpp
@@ -77,7 +77,7 @@ void FMCPNavigationHandlers::HandleGetInfo(const TSharedPtr<FJsonObject>& Params
 	Result->SetBoolField(TEXT("nav_system_present"), NavSys != nullptr);
 	if (NavSys)
 	{
-		Result->SetBoolField(TEXT("is_navigation_built"), NavSys->IsNavigationBuilt(FNavigationSystem::GetDefaultNavDataConfig()));
+		Result->SetBoolField(TEXT("is_navigation_built"), NavSys->IsNavigationBuilt(World->GetWorldSettings()));
 	}
 	MCPProtocolHelpers::Succeed(OnComplete, Result);
 }

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPNetworkHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPNetworkHandlers.cpp
@@ -67,6 +67,8 @@ void FMCPNetworkHandlers::HandleGetInfo(const TSharedPtr<FJsonObject>& Params, F
 	Result->SetNumberField(TEXT("total_actors"), TotalActors);
 	Result->SetNumberField(TEXT("replicated_actors"), ReplicatedActors.Num());
 	Result->SetArrayField(TEXT("replicated"), ReplicatedActors);
-	Result->SetStringField(TEXT("net_mode"), StaticEnum<ENetMode>()->GetNameStringByValue((int64)World->GetNetMode()));
+	ENetMode NetMode = World->GetNetMode();
+	FString NetModeStr = NetMode == NM_Standalone ? TEXT("Standalone") : NetMode == NM_DedicatedServer ? TEXT("DedicatedServer") : NetMode == NM_ListenServer ? TEXT("ListenServer") : TEXT("Client");
+	Result->SetStringField(TEXT("net_mode"), NetModeStr);
 	MCPProtocolHelpers::Succeed(OnComplete, Result);
 }

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPViewportHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPViewportHandlers.cpp
@@ -7,6 +7,7 @@
 #include "LevelEditor.h"
 #include "Misc/FileHelper.h"
 #include "ImageUtils.h"
+#include "EngineUtils.h"
 
 void FMCPViewportHandlers::Register(FMCPHandlerRegistry& Registry)
 {

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/KBVEUnrealMCPModule.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/KBVEUnrealMCPModule.cpp
@@ -1,6 +1,7 @@
 #include "KBVEUnrealMCPModule.h"
 #include "KBVEUnrealMCPSettings.h"
 #include "Registry/MCPHandlerRegistry.h"
+#include "Registry/MCPSafetyValidator.h"
 #include "Server/MCPWebSocketServer.h"
 
 // Phase 1 — Fully implemented handlers

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Server/MCPConnection.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Server/MCPConnection.cpp
@@ -1,6 +1,6 @@
 #include "Server/MCPConnection.h"
 
-FMCPConnection::FMCPConnection(INetworkingWebSocket* InSocket)
+FMCPConnection::FMCPConnection(FSocket* InSocket)
 	: Socket(InSocket)
 	, LastHeartbeatTime(FPlatformTime::Seconds())
 {

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Server/MCPWebSocketServer.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Server/MCPWebSocketServer.cpp
@@ -1,10 +1,12 @@
 #include "Server/MCPWebSocketServer.h"
 #include "Server/MCPProtocol.h"
 #include "Registry/MCPHandlerRegistry.h"
-#include "IWebSocketServer.h"
-#include "IWebSocketNetworkingModule.h"
+#include "Common/TcpListener.h"
+#include "Sockets.h"
+#include "SocketSubsystem.h"
 #include "HAL/RunnableThread.h"
 #include "Async/Async.h"
+#include "IPAddress.h"
 
 DEFINE_LOG_CATEGORY(LogMCPServer);
 
@@ -26,29 +28,31 @@ void FMCPWebSocketServer::StartServer()
 		return;
 	}
 
-	FWebSocketClientConnectedCallBack ConnectedCallback;
-	ConnectedCallback.BindRaw(this, &FMCPWebSocketServer::OnClientConnected);
+	FIPv4Endpoint Endpoint(FIPv4Address::Any, Port);
+	Listener = MakeShared<FTcpListener>(Endpoint);
+	Listener->OnConnectionAccepted().BindRaw(this, &FMCPWebSocketServer::OnConnectionAccepted);
 
-	IWebSocketServer* RawServer = FModuleManager::Get().IsModuleLoaded(TEXT("WebSockets"))
-		? FModuleManager::Get().LoadModuleChecked<IWebSocketNetworkingModule>(TEXT("WebSockets")).CreateServer(Port, ConnectedCallback)
-		: nullptr;
-
-	if (!RawServer)
+	if (!Listener->Init())
 	{
-		UE_LOG(LogMCPServer, Error, TEXT("Failed to create WebSocket server on port %d"), Port);
+		UE_LOG(LogMCPServer, Error, TEXT("Failed to start TCP listener on port %d"), Port);
+		Listener.Reset();
 		return;
 	}
 
-	WebSocketServer = TSharedPtr<IWebSocketServer>(RawServer);
 	bShouldRun = true;
-	Thread = FRunnableThread::Create(this, TEXT("MCPWebSocketServer"), 0, TPri_Normal);
+	Thread = FRunnableThread::Create(this, TEXT("MCPTCPServer"), 0, TPri_Normal);
 
-	UE_LOG(LogMCPServer, Log, TEXT("MCP WebSocket server started on port %d"), Port);
+	UE_LOG(LogMCPServer, Log, TEXT("MCP TCP server started on port %d"), Port);
 }
 
 void FMCPWebSocketServer::StopServer()
 {
 	bShouldRun = false;
+
+	if (Listener.IsValid())
+	{
+		Listener->Stop();
+	}
 
 	if (Thread)
 	{
@@ -59,12 +63,20 @@ void FMCPWebSocketServer::StopServer()
 
 	{
 		FScopeLock Lock(&ConnectionsLock);
+		for (TSharedPtr<FMCPConnection>& Conn : Connections)
+		{
+			if (Conn->Socket)
+			{
+				Conn->Socket->Close();
+				ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(Conn->Socket);
+			}
+		}
 		Connections.Empty();
 	}
 
-	WebSocketServer.Reset();
+	Listener.Reset();
 
-	UE_LOG(LogMCPServer, Log, TEXT("MCP WebSocket server stopped"));
+	UE_LOG(LogMCPServer, Log, TEXT("MCP TCP server stopped"));
 }
 
 bool FMCPWebSocketServer::Init()
@@ -76,10 +88,22 @@ uint32 FMCPWebSocketServer::Run()
 {
 	while (bShouldRun)
 	{
-		if (WebSocketServer.IsValid())
+		// Move pending sockets to connections
 		{
-			WebSocketServer->Tick();
+			FScopeLock Lock(&PendingLock);
+			for (FSocket* PendingSocket : PendingSockets)
+			{
+				TSharedPtr<FMCPConnection> NewConn = MakeShared<FMCPConnection>(PendingSocket);
+				PendingSocket->SetNoDelay(true);
+
+				FScopeLock ConnLock(&ConnectionsLock);
+				Connections.Add(NewConn);
+				UE_LOG(LogMCPServer, Log, TEXT("MCP client connected: %s"), *NewConn->ClientId);
+			}
+			PendingSockets.Empty();
 		}
+
+		ProcessConnections();
 		FPlatformProcess::Sleep(0.01f);
 	}
 	return 0;
@@ -90,53 +114,68 @@ void FMCPWebSocketServer::Stop()
 	bShouldRun = false;
 }
 
+bool FMCPWebSocketServer::OnConnectionAccepted(FSocket* ClientSocket, const FIPv4Endpoint& Endpoint)
+{
+	FScopeLock Lock(&PendingLock);
+	PendingSockets.Add(ClientSocket);
+	return true;
+}
+
+void FMCPWebSocketServer::ProcessConnections()
+{
+	FScopeLock Lock(&ConnectionsLock);
+
+	for (int32 i = Connections.Num() - 1; i >= 0; --i)
+	{
+		TSharedPtr<FMCPConnection>& Conn = Connections[i];
+		if (!Conn->Socket || Conn->Socket->GetConnectionState() != SCS_Connected)
+		{
+			UE_LOG(LogMCPServer, Log, TEXT("MCP client disconnected: %s"), *Conn->ClientId);
+			if (Conn->Socket)
+			{
+				Conn->Socket->Close();
+				ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(Conn->Socket);
+			}
+			Connections.RemoveAt(i);
+			continue;
+		}
+
+		uint32 PendingDataSize = 0;
+		if (Conn->Socket->HasPendingData(PendingDataSize) && PendingDataSize > 0)
+		{
+			TArray<uint8> Buffer;
+			Buffer.SetNumUninitialized(FMath::Min(PendingDataSize, (uint32)65536));
+			int32 BytesRead = 0;
+
+			if (Conn->Socket->Recv(Buffer.GetData(), Buffer.Num(), BytesRead))
+			{
+				FString Received = FString(BytesRead, UTF8_TO_TCHAR(reinterpret_cast<const char*>(Buffer.GetData())));
+				Conn->ReceiveBuffer += Received;
+
+				// Process newline-delimited messages
+				int32 NewlineIdx;
+				while (Conn->ReceiveBuffer.FindChar(TEXT('\n'), NewlineIdx))
+				{
+					FString Message = Conn->ReceiveBuffer.Left(NewlineIdx).TrimStartAndEnd();
+					Conn->ReceiveBuffer.RightChopInline(NewlineIdx + 1);
+
+					if (!Message.IsEmpty())
+					{
+						ProcessMessage(Message, Conn);
+					}
+				}
+			}
+		}
+	}
+}
+
 int32 FMCPWebSocketServer::GetConnectionCount() const
 {
 	FScopeLock Lock(const_cast<FCriticalSection*>(&ConnectionsLock));
 	return Connections.Num();
 }
 
-void FMCPWebSocketServer::OnClientConnected(INetworkingWebSocket* ClientSocket)
-{
-	if (!ClientSocket)
-	{
-		return;
-	}
-
-	TSharedPtr<FMCPConnection> Connection = MakeShared<FMCPConnection>(ClientSocket);
-
-	FWebSocketPacketRecievedCallBack ReceiveCallback;
-	ReceiveCallback.BindRaw(this, &FMCPWebSocketServer::OnMessage, ClientSocket);
-	ClientSocket->SetReceiveCallBack(ReceiveCallback);
-
-	FWebSocketInfoCallBack ClosedCallback;
-	ClosedCallback.BindRaw(this, &FMCPWebSocketServer::OnClientDisconnected, ClientSocket);
-	ClientSocket->SetSocketClosedCallBack(ClosedCallback);
-
-	{
-		FScopeLock Lock(&ConnectionsLock);
-		Connections.Add(ClientSocket, Connection);
-	}
-
-	UE_LOG(LogMCPServer, Log, TEXT("MCP client connected: %s"), *Connection->ClientId);
-}
-
-void FMCPWebSocketServer::OnMessage(void* Data, int32 Count, INetworkingWebSocket* Client)
-{
-	if (!Data || Count <= 0)
-	{
-		return;
-	}
-
-	TArray<uint8> RawData;
-	RawData.Append(static_cast<uint8*>(Data), Count);
-	FString Message = FString(UTF8_TO_TCHAR(reinterpret_cast<const char*>(RawData.GetData())));
-	Message = Message.Left(Count);
-
-	OnRawMessage(Message, Client);
-}
-
-void FMCPWebSocketServer::OnRawMessage(const FString& RawMessage, INetworkingWebSocket* Client)
+void FMCPWebSocketServer::ProcessMessage(const FString& RawMessage, TSharedPtr<FMCPConnection> Connection)
 {
 	FString Id, Method;
 	TSharedPtr<FJsonObject> Params;
@@ -146,36 +185,26 @@ void FMCPWebSocketServer::OnRawMessage(const FString& RawMessage, INetworkingWeb
 		FString ErrorResponse = MCPProtocol::FormatResponse(
 			TEXT("unknown"), false,
 			MCPProtocolHelpers::MakeError(TEXT("PARSE_ERROR"), TEXT("Invalid JSON request")));
-		SendToClient(Client, ErrorResponse);
+		SendToClient(Connection, ErrorResponse);
 		return;
 	}
 
-	// Handle heartbeat locally
+	// Handle heartbeat locally on the network thread
 	if (Method == TEXT("mcp.ping"))
 	{
 		TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
 		Result->SetStringField(TEXT("status"), TEXT("ok"));
 		Result->SetNumberField(TEXT("timestamp"), FPlatformTime::Seconds());
-		SendToClient(Client, MCPProtocol::FormatResponse(Id, true, Result));
+		SendToClient(Connection, MCPProtocol::FormatResponse(Id, true, Result));
 		return;
 	}
 
 	// Dispatch to handler on GameThread
-	TWeakPtr<FMCPConnection> WeakConn;
-	{
-		FScopeLock Lock(&ConnectionsLock);
-		TSharedPtr<FMCPConnection>* Found = Connections.Find(Client);
-		if (Found)
-		{
-			WeakConn = *Found;
-		}
-	}
-
-	INetworkingWebSocket* ClientCapture = Client;
+	TWeakPtr<FMCPConnection> WeakConn = Connection;
 	FMCPHandlerRegistry* RegistryPtr = &Registry;
 	FMCPWebSocketServer* Self = this;
 
-	AsyncTask(ENamedThreads::GameThread, [RegistryPtr, Method, Params, Id, ClientCapture, Self, WeakConn]()
+	AsyncTask(ENamedThreads::GameThread, [RegistryPtr, Method, Params, Id, Self, WeakConn]()
 	{
 		TSharedPtr<FMCPConnection> Conn = WeakConn.Pin();
 		if (!Conn.IsValid())
@@ -184,10 +213,10 @@ void FMCPWebSocketServer::OnRawMessage(const FString& RawMessage, INetworkingWeb
 		}
 
 		FMCPResponseDelegate OnComplete;
-		OnComplete.BindLambda([Self, ClientCapture, Id](bool bSuccess, TSharedPtr<FJsonObject> ResultOrError)
+		OnComplete.BindLambda([Self, Conn, Id](bool bSuccess, TSharedPtr<FJsonObject> ResultOrError)
 		{
 			FString Response = MCPProtocol::FormatResponse(Id, bSuccess, ResultOrError);
-			Self->SendToClient(ClientCapture, Response);
+			Self->SendToClient(Conn, Response);
 		});
 
 		if (!RegistryPtr->Dispatch(Method, Params, OnComplete))
@@ -195,33 +224,20 @@ void FMCPWebSocketServer::OnRawMessage(const FString& RawMessage, INetworkingWeb
 			FString Response = MCPProtocol::FormatResponse(Id, false,
 				MCPProtocolHelpers::MakeError(TEXT("METHOD_NOT_FOUND"),
 					FString::Printf(TEXT("Unknown method: %s"), *Method)));
-			Self->SendToClient(ClientCapture, Response);
+			Self->SendToClient(Conn, Response);
 		}
 	});
 }
 
-void FMCPWebSocketServer::OnClientDisconnected(INetworkingWebSocket* Client)
+void FMCPWebSocketServer::SendToClient(TSharedPtr<FMCPConnection> Connection, const FString& Message)
 {
-	FScopeLock Lock(&ConnectionsLock);
-	TSharedPtr<FMCPConnection>* Found = Connections.Find(Client);
-	if (Found)
-	{
-		UE_LOG(LogMCPServer, Log, TEXT("MCP client disconnected: %s"), *(*Found)->ClientId);
-		Connections.Remove(Client);
-	}
-}
-
-void FMCPWebSocketServer::SendToClient(INetworkingWebSocket* Client, const FString& Message)
-{
-	if (!Client)
+	if (!Connection.IsValid() || !Connection->Socket)
 	{
 		return;
 	}
 
-	FTCHARToUTF8 Converter(*Message);
-	FScopeLock Lock(&ConnectionsLock);
-	if (Connections.Contains(Client))
-	{
-		Client->Send(reinterpret_cast<const uint8*>(Converter.Get()), Converter.Length(), false);
-	}
+	FString MessageWithNewline = Message + TEXT("\n");
+	FTCHARToUTF8 Converter(*MessageWithNewline);
+	int32 BytesSent = 0;
+	Connection->Socket->Send(reinterpret_cast<const uint8*>(Converter.Get()), Converter.Length(), BytesSent);
 }

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Server/MCPConnection.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Server/MCPConnection.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include "CoreMinimal.h"
-
-class INetworkingWebSocket;
+#include "Sockets.h"
 
 struct FMCPConnection
 {
 	FString ClientId;
-	INetworkingWebSocket* Socket = nullptr;
+	FSocket* Socket = nullptr;
 	double LastHeartbeatTime = 0.0;
+	FString ReceiveBuffer;
 
 	FMCPConnection() = default;
-	explicit FMCPConnection(INetworkingWebSocket* InSocket);
+	explicit FMCPConnection(FSocket* InSocket);
 };

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Server/MCPWebSocketServer.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Server/MCPWebSocketServer.h
@@ -3,11 +3,12 @@
 #include "CoreMinimal.h"
 #include "HAL/Runnable.h"
 #include "HAL/ThreadSafeBool.h"
+#include "Interfaces/IPv4/IPv4Endpoint.h"
 #include "Server/MCPConnection.h"
 
 class FMCPHandlerRegistry;
-class IWebSocketServer;
-class INetworkingWebSocket;
+class FTcpListener;
+class FSocket;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogMCPServer, Log, All);
 
@@ -29,19 +30,20 @@ public:
 	virtual void Stop() override;
 
 private:
-	void OnClientConnected(INetworkingWebSocket* ClientSocket);
-	void OnMessage(void* Data, int32 Count, INetworkingWebSocket* Client);
-	void OnRawMessage(const FString& RawMessage, INetworkingWebSocket* Client);
-	void OnClientDisconnected(INetworkingWebSocket* Client);
+	bool OnConnectionAccepted(FSocket* ClientSocket, const FIPv4Endpoint& Endpoint);
+	void ProcessConnections();
+	void ProcessMessage(const FString& RawMessage, TSharedPtr<FMCPConnection> Connection);
 
-	void SendToClient(INetworkingWebSocket* Client, const FString& Message);
+	void SendToClient(TSharedPtr<FMCPConnection> Connection, const FString& Message);
 
 	FMCPHandlerRegistry& Registry;
 	int32 Port;
 
-	TSharedPtr<IWebSocketServer> WebSocketServer;
-	TMap<INetworkingWebSocket*, TSharedPtr<FMCPConnection>> Connections;
+	TSharedPtr<FTcpListener> Listener;
+	TArray<TSharedPtr<FMCPConnection>> Connections;
+	TArray<FSocket*> PendingSockets;
 	FCriticalSection ConnectionsLock;
+	FCriticalSection PendingLock;
 
 	FRunnableThread* Thread = nullptr;
 	FThreadSafeBool bShouldRun;


### PR DESCRIPTION
## Summary
Verified KBVEUnrealMCP compiles cleanly via `RunUAT BuildPlugin` on **UE 5.7.4** (Mac universal binary).

### Fixes
- **TCP server rewrite** — replaced `IWebSocketServer` with `FTcpListener` + `FSocket` (UE 5.7 removed the WebSocket server networking module). Now uses newline-delimited JSON over TCP, matching the protocol used by chongdashu/unreal-mcp
- **Missing includes** — `SimpleConstructionScript.h`, `SCS_Node.h`, `KismetMathLibrary.h`, `EngineUtils.h`, `MCPSafetyValidator.h`
- **UMGEditor module** — added to Build.cs for `WidgetBlueprint.h`
- **RHI module** — added to Build.cs for `GRHIAdapterName`
- **API fixes** — `IsNavigationBuilt` takes `AWorldSettings*` in 5.7; `MakeLinkTo` returns void; `StaticEnum<ENetMode>` replaced with manual conversion

### Build verification
```
RunUAT BuildPlugin -Plugin=KBVEUnrealMCP.uplugin -Package=/tmp/Build -TargetPlatforms=Mac -Rocket
Result: Succeeded
BUILD SUCCESSFUL
```

## Test plan
- [x] `RunUAT BuildPlugin` succeeds on UE 5.7.4 Mac
- [ ] Load plugin in UE 5.7 editor, verify TCP server starts on port 9777
- [ ] Connect via `nc localhost 9777` and test `{"method":"mcp.ping","id":"1"}\n`