### PR TITLE
fix(kube/kubevirt): update KEDA labels + add UE5 Win setup workflow

### DIFF
--- a/.github/workflows/ci-ue-win-setup.yml
+++ b/.github/workflows/ci-ue-win-setup.yml
@@ -1,0 +1,126 @@
+name: UE Win Setup
+
+on:
+    workflow_dispatch:
+        inputs:
+            install_vs_buildtools:
+                description: 'Install Visual Studio Build Tools'
+                type: boolean
+                default: true
+            install_python:
+                description: 'Install Python 3'
+                type: boolean
+                default: true
+            install_dotnet:
+                description: 'Install .NET SDK 8.0'
+                type: boolean
+                default: true
+            install_directx:
+                description: 'Install DirectX Runtime'
+                type: boolean
+                default: true
+            install_cmake:
+                description: 'Install CMake'
+                type: boolean
+                default: true
+
+jobs:
+    setup:
+        name: Setup UE5 Windows Builder
+        runs-on: UE5-Win
+        steps:
+            - name: System Info
+              run: |
+                  Write-Host "=== System Info ==="
+                  Write-Host "OS: $([System.Environment]::OSVersion)"
+                  Write-Host "CPU: $((Get-CimInstance Win32_Processor).Name)"
+                  Write-Host "RAM: $([math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB, 1)) GB"
+                  Write-Host "Disk: $([math]::Round((Get-CimInstance Win32_LogicalDisk -Filter 'DeviceID=''C:''').FreeSpace / 1GB, 1)) GB free"
+                  Write-Host "Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss UTC')"
+                  git --version
+
+            - name: Install Visual Studio 2022 Build Tools
+              if: inputs.install_vs_buildtools
+              run: |
+                  if (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools") {
+                      Write-Host "VS Build Tools already installed, skipping."
+                      exit 0
+                  }
+                  Write-Host "Downloading VS Build Tools..."
+                  curl.exe -L -o C:\vs_buildtools.exe "https://aka.ms/vs/17/release/vs_buildtools.exe"
+                  Write-Host "Installing VS Build Tools (this takes 10-15 minutes)..."
+                  Start-Process C:\vs_buildtools.exe -ArgumentList @(
+                      '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                      '--add', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+                      '--add', 'Microsoft.VisualStudio.Component.Windows11SDK.26100',
+                      '--add', 'Microsoft.Component.MSBuild',
+                      '--includeRecommended',
+                      '--quiet', '--wait', '--norestart'
+                  ) -Wait
+                  Write-Host "VS Build Tools installed."
+
+            - name: Install Python 3
+              if: inputs.install_python
+              run: |
+                  if (Get-Command python -ErrorAction SilentlyContinue) {
+                      Write-Host "Python already installed: $(python --version)"
+                      exit 0
+                  }
+                  Write-Host "Downloading Python..."
+                  curl.exe -L -o C:\python-install.exe "https://www.python.org/ftp/python/3.15.0/python-3.15.0-amd64.exe"
+                  Start-Process C:\python-install.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
+                  Write-Host "Python installed."
+
+            - name: Install .NET SDK 8.0
+              if: inputs.install_dotnet
+              run: |
+                  if (Get-Command dotnet -ErrorAction SilentlyContinue) {
+                      Write-Host ".NET already installed: $(dotnet --version)"
+                      exit 0
+                  }
+                  Write-Host "Downloading .NET install script..."
+                  Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile C:\dotnet-install.ps1 -UseBasicParsing
+                  & C:\dotnet-install.ps1 -Channel 8.0
+                  Write-Host ".NET SDK 8.0 installed."
+
+            - name: Install DirectX Runtime
+              if: inputs.install_directx
+              run: |
+                  Write-Host "Downloading DirectX Runtime..."
+                  curl.exe -L -o C:\dxsetup.exe "https://download.microsoft.com/download/1/7/1/1718CCC4-6315-4D8E-9543-8E28A4E18C4C/dxwebsetup.exe"
+                  Start-Process C:\dxsetup.exe -ArgumentList '/Q' -Wait
+                  Write-Host "DirectX Runtime installed."
+
+            - name: Install CMake
+              if: inputs.install_cmake
+              run: |
+                  if (Get-Command cmake -ErrorAction SilentlyContinue) {
+                      Write-Host "CMake already installed: $(cmake --version | Select-Object -First 1)"
+                      exit 0
+                  }
+                  Write-Host "Downloading CMake..."
+                  curl.exe -L -o C:\cmake-install.msi "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-windows-x86_64.msi"
+                  Start-Process msiexec.exe -ArgumentList '/i C:\cmake-install.msi /quiet /norestart ADD_CMAKE_TO_PATH=System' -Wait
+                  Write-Host "CMake installed."
+
+            - name: Verify Installation
+              run: |
+                  Write-Host "=== Installed Tools ==="
+                  $tools = @{
+                      'git' = { git --version }
+                      'python' = { python --version }
+                      'dotnet' = { dotnet --version }
+                      'cmake' = { cmake --version | Select-Object -First 1 }
+                      'cl.exe' = {
+                          $cl = Get-ChildItem "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\*\bin\Hostx64\x64\cl.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+                          if ($cl) { "$($cl.FullName)" } else { "NOT FOUND" }
+                      }
+                  }
+                  foreach ($tool in $tools.GetEnumerator()) {
+                      try {
+                          $result = & $tool.Value 2>&1
+                          Write-Host "  $($tool.Key): $result"
+                      } catch {
+                          Write-Host "  $($tool.Key): NOT INSTALLED" -ForegroundColor Yellow
+                      }
+                  }

--- a/apps/kube/kubevirt/keda/idle-shutdown-cronjob.yaml
+++ b/apps/kube/kubevirt/keda/idle-shutdown-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
                     restartPolicy: OnFailure
                     containers:
                         - name: idle-checker
-                          image: bitnami/kubectl:1.32
+                          image: registry.k8s.io/kubectl:v1.33.2
                           command:
                               - /bin/sh
                               - -c

--- a/apps/kube/kubevirt/keda/scaled-jobs.yaml
+++ b/apps/kube/kubevirt/keda/scaled-jobs.yaml
@@ -5,7 +5,7 @@
 # The GitHub PAT needs workflow + admin:org scope for the KEDA GitHub runner scaler.
 # Uses the same github-arc-token secret as the ARC runners.
 ---
-# Windows VM — starts when jobs target 'ue-win-builder' label
+# Windows VM — starts when jobs target 'UE5-Win' label
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
@@ -23,7 +23,7 @@ spec:
                 restartPolicy: OnFailure
                 containers:
                     - name: scaler
-                      image: bitnami/kubectl:1.32
+                      image: registry.k8s.io/kubectl:v1.33.2
                       command: ['/bin/sh', '/scripts/scale.sh']
                       env:
                           - name: VM_NAME
@@ -49,14 +49,13 @@ spec:
         - type: github-runner
           metadata:
               owner: KBVE
-              repos: UnrealEngine-Angelscript
-              runnerScope: repo
-              labels: ue-win-builder
+              runnerScope: org
+              labels: UE5-Win
               targetWorkflowQueueLength: '1'
           authenticationRef:
               name: github-runner-auth
 ---
-# macOS VM — starts when jobs target 'ue-mac-builder' label
+# macOS VM — starts when jobs target 'UE5-Mac' label
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
@@ -74,7 +73,7 @@ spec:
                 restartPolicy: OnFailure
                 containers:
                     - name: scaler
-                      image: bitnami/kubectl:1.32
+                      image: registry.k8s.io/kubectl:v1.33.2
                       command: ['/bin/sh', '/scripts/scale.sh']
                       env:
                           - name: VM_NAME
@@ -100,9 +99,8 @@ spec:
         - type: github-runner
           metadata:
               owner: KBVE
-              repos: UnrealEngine-Angelscript
-              runnerScope: repo
-              labels: ue-mac-builder
+              runnerScope: org
+              labels: UE5-Mac
               targetWorkflowQueueLength: '1'
           authenticationRef:
               name: github-runner-auth


### PR DESCRIPTION
## Summary
- Update KEDA ScaledJob runner labels to match actual runner names (`UE5-Win`, `UE5-Mac`)
- Change runner scope from `repo` to `org` (runners registered at org level)
- Switch container image from `bitnami/kubectl:1.32` to `registry.k8s.io/kubectl:v1.33.2`
- Add `ci-ue-win-setup.yml` workflow_dispatch for installing build tools on the Windows VM

## KEDA flow
1. GitHub Actions job queued with `runs-on: UE5-Win`
2. KEDA detects queued job → ScaledJob starts the VM
3. Runner agent inside VM picks up the job
4. CronJob stops VM after 30min idle

## Test plan
- [ ] KEDA ScaledJob triggers on `UE5-Win` label
- [ ] Dispatch `ci-ue-win-setup` workflow → installs run on Windows VM
- [ ] Idle shutdown CronJob uses correct kubectl image