### PR TITLE
chore(ci): sync manifest with full MDX CI fields

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -2,137 +2,270 @@
 	"docker": [
 		{
 			"key": "astro_kbve",
-			"app_name": "axum-kbve"
+			"app_name": "axum-kbve",
+			"version": "1.0.70",
+			"version_toml": "apps/kbve/axum-kbve/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
+			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
+			"source_path": "apps/kbve/astro-kbve",
+			"runner": "arc-runner-set",
+			"image": "kbve/kbve",
+			"e2e_name": "axum-kbve-e2e",
+			"deployment_yaml": "apps/kube/kbve/manifest/kbve-deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "cryptothrone",
-			"app_name": "cryptothrone"
+			"app_name": "cryptothrone",
+			"version": "0.1.4",
+			"version_toml": "apps/cryptothrone/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
+			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
+			"source_path": "apps/cryptothrone",
+			"runner": "ubuntu-latest",
+			"image": "kbve/cryptothrone",
+			"e2e_name": "cryptothrone",
+			"deployment_yaml": "apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "discordsh",
-			"app_name": "discordsh"
+			"app_name": "discordsh",
+			"version": "0.1.33",
+			"version_toml": "apps/discordsh/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx",
+			"version_target": "apps/discordsh/axum-discordsh/Cargo.toml",
+			"source_path": "apps/discordsh",
+			"runner": "ubuntu-latest",
+			"image": "kbve/discordsh",
+			"e2e_name": "discordsh",
+			"deployment_yaml": "apps/kube/discordsh/manifest/deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "edge",
-			"app_name": "edge"
+			"app_name": "edge",
+			"version": "0.1.20",
+			"version_toml": "apps/kbve/edge/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
+			"version_target": "apps/kbve/edge/deno.json",
+			"source_path": "apps/kbve/edge",
+			"runner": "ubuntu-latest",
+			"image": "kbve/edge",
+			"e2e_name": "edge",
+			"deployment_yaml": "apps/kube/functions/manifests/functions-deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "herbmail",
-			"app_name": "herbmail"
+			"app_name": "herbmail",
+			"version": "0.1.0",
+			"version_toml": "apps/herbmail/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/herbmail.mdx",
+			"version_target": "apps/herbmail/axum-herbmail/Cargo.toml",
+			"source_path": "apps/herbmail",
+			"runner": "ubuntu-latest",
+			"image": "kbve/herbmail",
+			"e2e_name": "herbmail",
+			"deployment_yaml": "apps/kube/herbmail/manifest/herbmail-deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "irc_gateway",
-			"app_name": "irc-gateway"
+			"app_name": "irc-gateway",
+			"version": "0.1.2",
+			"version_toml": "apps/irc/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
+			"version_target": "apps/irc/irc-gateway/Cargo.toml",
+			"source_path": "apps/irc",
+			"runner": "ubuntu-latest",
+			"image": "kbve/irc-gateway",
+			"e2e_name": "irc",
+			"deployment_yaml": "apps/kube/irc/manifests/irc-gateway-deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "kilobase",
-			"app_name": "kilobase"
+			"app_name": "kilobase",
+			"version": "17.4.1",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kilobase.mdx",
+			"source_path": "apps/kbve/kilobase",
+			"runner": "ubuntu-latest",
+			"image": "kbve/kilobase",
+			"has_test": false
 		},
 		{
 			"key": "mc",
-			"app_name": "mc"
+			"app_name": "mc",
+			"version": "0.1.14",
+			"version_toml": "apps/mc/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
+			"version_target": "apps/mc/plugins/kbve-mc-plugin/Cargo.toml",
+			"source_path": "apps/mc",
+			"runner": "ubuntu-latest",
+			"image": "kbve/mc",
+			"e2e_name": "mc",
+			"deployment_yaml": "apps/kube/mc/manifest/deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "memes",
-			"app_name": "memes"
+			"app_name": "memes",
+			"version": "0.1.7",
+			"version_toml": "apps/memes/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/memes.mdx",
+			"version_target": "apps/memes/axum-memes/Cargo.toml",
+			"source_path": "apps/memes",
+			"runner": "ubuntu-latest",
+			"image": "kbve/memes",
+			"e2e_name": "memes",
+			"deployment_yaml": "apps/kube/memes/manifest/memes-deployment.yaml",
+			"has_test": true
+		},
+		{
+			"key": "ows",
+			"app_name": "ows",
+			"version": "0.1.0",
+			"version_toml": "apps/ows/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows.mdx",
+			"source_path": "apps/ows",
+			"runner": "ubuntu-latest",
+			"image": "kbve/ows",
+			"has_test": false
 		}
 	],
 	"npm": [
 		{
 			"key": "devops",
-			"package_name": "devops"
+			"package_name": "devops",
+			"version": "0.0.19",
+			"version_toml": "packages/npm/devops/version.toml"
 		},
 		{
 			"key": "droid",
-			"package_name": "droid"
+			"package_name": "droid",
+			"version": "0.1.1",
+			"version_toml": "packages/npm/droid/version.toml"
 		},
 		{
 			"key": "khashvault",
-			"package_name": "khashvault"
+			"package_name": "khashvault",
+			"version": "1.0.12",
+			"version_toml": "packages/npm/khashvault/version.toml"
 		},
 		{
 			"key": "laser",
-			"package_name": "laser"
+			"package_name": "laser",
+			"version": "0.1.0",
+			"version_toml": "packages/npm/laser/version.toml"
 		}
 	],
 	"crates": [
 		{
 			"key": "erust_crate",
-			"package_name": "erust"
+			"package_name": "erust",
+			"version": "0.1.7",
+			"version_toml": "packages/rust/erust/version.toml"
 		},
 		{
 			"key": "holy_crate",
-			"package_name": "holy"
+			"package_name": "holy",
+			"version": "0.2.0",
+			"version_toml": "packages/rust/holy/version.toml"
 		},
 		{
 			"key": "jedi_crate",
-			"package_name": "jedi"
+			"package_name": "jedi",
+			"version": "0.2.1",
+			"version_toml": "packages/rust/jedi/version.toml"
 		},
 		{
 			"key": "kbve_crate",
-			"package_name": "kbve"
+			"package_name": "kbve",
+			"version": "0.1.26",
+			"version_toml": "packages/rust/kbve/version.toml"
 		},
 		{
 			"key": "q_crate",
-			"package_name": "q"
+			"package_name": "q",
+			"version": "0.1.1",
+			"version_toml": "packages/rust/q/version.toml"
 		},
 		{
 			"key": "soul_crate",
-			"package_name": "soul"
+			"package_name": "soul",
+			"version": "0.1.1",
+			"version_toml": "packages/rust/soul/version.toml"
 		}
 	],
 	"python": [
 		{
 			"key": "py_lib_fudster",
 			"package_name": "python-fudster",
-			"pypi_name": "fudster"
+			"pypi_name": "fudster",
+			"version": "1.0.3",
+			"version_toml": "packages/python/fudster/version.toml"
 		},
 		{
 			"key": "py_lib_kbve",
 			"package_name": "python-kbve",
-			"pypi_name": "kbve"
+			"pypi_name": "kbve",
+			"version": "1.0.13",
+			"version_toml": "packages/python/kbve/version.toml"
 		}
 	],
 	"unreal": [
 		{
 			"key": "ue_kbvesqlite",
 			"plugin_name": "KBVESQLite",
-			"plugin_path": "packages/unreal/KBVESQLite"
+			"plugin_path": "packages/unreal/KBVESQLite",
+			"version": "3.51.3",
+			"version_toml": "packages/unreal/KBVESQLite/version.toml"
 		},
 		{
 			"key": "ue_kbvewasm",
 			"plugin_name": "KBVEWASM",
-			"plugin_path": "packages/unreal/KBVEWASM"
+			"plugin_path": "packages/unreal/KBVEWASM",
+			"version": "2.2.0",
+			"version_toml": "packages/unreal/KBVEWASM/version.toml"
 		},
 		{
 			"key": "ue_kbvexxhash",
 			"plugin_name": "KBVEXXHash",
-			"plugin_path": "packages/unreal/KBVEXXHash"
+			"plugin_path": "packages/unreal/KBVEXXHash",
+			"version": "0.8.3",
+			"version_toml": "packages/unreal/KBVEXXHash/version.toml"
 		},
 		{
 			"key": "ue_kbveyyjson",
 			"plugin_name": "KBVEYYJson",
-			"plugin_path": "packages/unreal/KBVEYYJson"
+			"plugin_path": "packages/unreal/KBVEYYJson",
+			"version": "0.12.0",
+			"version_toml": "packages/unreal/KBVEYYJson/version.toml"
 		},
 		{
 			"key": "ue_kbvezstd",
 			"plugin_name": "KBVEZstd",
-			"plugin_path": "packages/unreal/KBVEZstd"
+			"plugin_path": "packages/unreal/KBVEZstd",
+			"version": "1.5.7",
+			"version_toml": "packages/unreal/KBVEZstd/version.toml"
 		},
 		{
 			"key": "ue_devops",
 			"plugin_name": "UEDevOps",
 			"plugin_path": "packages/unreal/UEDevOps",
 			"dependency_plugins": "packages/unreal/KBVEYYJson packages/unreal/KBVEXXHash packages/unreal/KBVEZstd",
-			"itch_game_id": "uedevops"
+			"itch_game_id": "uedevops",
+			"version": "0.1.0",
+			"version_toml": "packages/unreal/UEDevOps/version.toml"
 		}
 	],
 	"summary": {
-		"docker": 9,
+		"docker": 10,
 		"npm": 4,
 		"crates": 6,
 		"python": 2,
 		"unreal": 6,
-		"total": 27
+		"total": 28
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
@@ -15,6 +15,9 @@ app_name: ows
 version: "0.1.0"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
+runner: ubuntu-latest
+image: kbve/ows
+has_test: false
 author: h0lybyte
 license: MIT
 status: active


### PR DESCRIPTION
## Summary
- Re-syncs `ci-dispatch-manifest.json` with all new CI fields from MDX frontmatter
- All 10 docker entries now include: `runner`, `image`, `e2e_name`, `deployment_yaml`, `version_source`, `version_target`, `has_test`
- Adds missing CI fields to OWS project MDX (`runner`, `image`, `has_test`)
- This is the companion to #8540 — the manifest now has the data the workflows need

## Test plan
- [ ] Verify ci-docker.yml config job resolves all fields from manifest
- [ ] Verify ci-main.yml dispatch reads version_source from manifest