### PR TITLE
feat(ows): colocate InstanceLauncher with build PVC in arc-runners

### DIFF
--- a/.github/workflows/ci-ue5-ows.yml
+++ b/.github/workflows/ci-ue5-ows.yml
@@ -308,8 +308,7 @@ jobs:
                     -utf8output \
                     -NoP4
 
-            - name: Locate server output
-              id: locate
+            - name: Deploy server to PVC
               run: |
                   VERSION="${{ needs.version_gate.outputs.version }}"
                   SERVER_DIR=$(find /tmp/ue5-build-output -name "LinuxServer" -type d | head -1)
@@ -318,56 +317,20 @@ jobs:
                     find /tmp/ue5-build-output -maxdepth 3 -type d
                     exit 1
                   fi
-                  echo "server_dir=${SERVER_DIR}" >> "$GITHUB_OUTPUT"
-                  echo "::notice::Server v${VERSION} built ($(du -sh ${SERVER_DIR} | cut -f1))"
 
-            - name: Configure kubectl
-              run: |
-                  mkdir -p ~/.kube
-                  echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+                  # Copy to versioned directory on the PVC (mounted at /mnt/longhorn/ows-server)
+                  DEST="/mnt/longhorn/ows-server/${VERSION}"
+                  mkdir -p "${DEST}"
+                  cp -r "${SERVER_DIR}/." "${DEST}/"
+                  chmod -R 755 "${DEST}"
+                  ln -sfn "${DEST}" /mnt/longhorn/ows-server/latest
 
-            - name: Deploy server to OWS PVC
-              run: |
-                  VERSION="${{ needs.version_gate.outputs.version }}"
-                  SERVER_DIR="${{ steps.locate.outputs.server_dir }}"
-
-                  # Spin up a temp pod in ows namespace with the PVC mounted
-                  kubectl apply -f - <<EOF
-                  apiVersion: v1
-                  kind: Pod
-                  metadata:
-                    name: ows-server-sync
-                    namespace: ows
-                  spec:
-                    containers:
-                      - name: sync
-                        image: busybox:1.37
-                        command: ["sleep", "600"]
-                        volumeMounts:
-                          - name: server-binary
-                            mountPath: /server
-                    volumes:
-                      - name: server-binary
-                        persistentVolumeClaim:
-                          claimName: ows-server-binary
-                    restartPolicy: Never
-                  EOF
-
-                  kubectl wait --for=condition=Ready pod/ows-server-sync -n ows --timeout=120s
-
-                  # Copy server files into versioned directory on PVC
-                  kubectl exec -n ows ows-server-sync -- mkdir -p "/server/${VERSION}"
-                  cd "${SERVER_DIR}" && tar cf - . | kubectl exec -i -n ows ows-server-sync -- tar xf - -C "/server/${VERSION}/"
-                  kubectl exec -n ows ows-server-sync -- ln -sfn "/server/${VERSION}" /server/latest
-                  kubectl exec -n ows ows-server-sync -- ls -la "/server/${VERSION}/" | head -10
-
-                  echo "::notice::Server v${VERSION} deployed to ows-server-binary PVC"
+                  echo "::notice::Server v${VERSION} deployed to ows-server-build PVC ($(du -sh ${DEST} | cut -f1))"
+                  ls -la "${DEST}/" | head -10
 
             - name: Cleanup
               if: always()
               run: |
-                  kubectl delete pod ows-server-sync -n ows --ignore-not-found --grace-period=0 2>/dev/null || true
-                  rm -f ~/.kube/config 2>/dev/null || true
                   cd "${{ env.ENGINE_CACHE_PATH }}" 2>/dev/null && \
                     git remote set-url origin "https://github.com/KBVE/UnrealEngine-Angelscript.git" || true
                   rm -rf /tmp/chuck /tmp/ue5-build-output 2>/dev/null || true

--- a/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
+++ b/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
@@ -1,0 +1,77 @@
+---
+# OWSInstanceLauncher — spawns UE5 dedicated server instances via RabbitMQ.
+# Lives in arc-runners namespace alongside the ows-server-build PVC
+# so it can directly access the cooked server binary without
+# cross-namespace volume mounts.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: ows-instance-launcher
+    namespace: arc-runners
+    labels:
+        app: ows-instance-launcher
+        app.kubernetes.io/part-of: ows
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: ows-instance-launcher
+    template:
+        metadata:
+            labels:
+                app: ows-instance-launcher
+                app.kubernetes.io/part-of: ows
+        spec:
+            containers:
+                - name: ows-instance-launcher
+                  image: ghcr.io/kbve/ows-instance-launcher:0.1.0
+                  env:
+                      - name: RabbitMQOptions__RabbitMQHostName
+                        value: 'rabbitmq.rabbitmq-system.svc.cluster.local'
+                      - name: RabbitMQOptions__RabbitMQPort
+                        value: '5672'
+                      - name: OWSInstanceLauncherOptions__PathToDedicatedServer
+                        value: '/server/latest/OWSHubWorldMMOServer'
+                      - name: OWSInstanceLauncherOptions__PathToUProject
+                        value: '/server/latest/OWSHubWorldMMO.uproject'
+                      - name: OWSInstanceLauncherOptions__IsServerEditor
+                        value: 'false'
+                      - name: OWSInstanceLauncherOptions__StartingInstancePort
+                        value: '7778'
+                  ports:
+                      - name: http
+                        containerPort: 8181
+                        protocol: TCP
+                  volumeMounts:
+                      - name: server-binary
+                        mountPath: /server
+                        readOnly: true
+                  resources:
+                      requests:
+                          memory: '128Mi'
+                          cpu: '100m'
+                      limits:
+                          memory: '512Mi'
+                          cpu: '500m'
+            volumes:
+                - name: server-binary
+                  persistentVolumeClaim:
+                      claimName: ows-server-build
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: ows-instance-launcher
+    namespace: arc-runners
+    labels:
+        app: ows-instance-launcher
+        app.kubernetes.io/part-of: ows
+spec:
+    type: ClusterIP
+    selector:
+        app: ows-instance-launcher
+    ports:
+        - name: http
+          port: 8181
+          targetPort: 8181
+          protocol: TCP

--- a/apps/kube/github/runners/manifests/ows-server-build-pvc.yaml
+++ b/apps/kube/github/runners/manifests/ows-server-build-pvc.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-    name: ows-server-binary
-    namespace: ows
+    name: ows-server-build
+    namespace: arc-runners
     labels:
         app.kubernetes.io/part-of: ows
         app.kubernetes.io/component: dedicated-server

--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -76,6 +76,9 @@ template:
                   # Persistent engine source cache for AngelScript builds
                   - name: engine-cache
                     mountPath: /mnt/longhorn/angelscript-engine
+                  # OWS cooked server output
+                  - name: ows-server-build
+                    mountPath: /mnt/longhorn/ows-server
             # Docker-in-Docker sidecar with persistent image cache
             - name: dind
               image: docker:29.3.0-dind
@@ -115,6 +118,9 @@ template:
             - name: engine-cache
               persistentVolumeClaim:
                   claimName: arc-engine-cache
+            - name: ows-server-build
+              persistentVolumeClaim:
+                  claimName: ows-server-build
 
 listenerTemplate:
     spec:


### PR DESCRIPTION
## Summary

Simplest secure approach for UE5 dedicated server deployment:

- **Build PVC** (`ows-server-build`, 50Gi RWX) in `arc-runners` namespace
- **CI build** writes cooked server directly to PVC — versioned directories + `latest` symlink
- **OWSInstanceLauncher** deployment in `arc-runners` mounts same PVC (read-only)
- No cross-namespace PVC mounts, no kubectl on runners, no ServiceAccount RBAC

OWSInstanceLauncher is the only component that needs the server binary. All other OWS services stay in `ows` namespace.

Removes old `ows-server-binary` PVC from `ows` namespace and strips kubectl/sync steps from CI workflow.

Ref: #8404

## Test plan

- [ ] Verify PVC created by ArgoCD in arc-runners namespace
- [ ] Run ci-ue5-ows.yml with build_ue5_server=true
- [ ] Verify server files appear at /mnt/longhorn/ows-server/{version}/
- [ ] Verify OWSInstanceLauncher pod mounts the PVC