### PR TITLE
chore(discordsh): bump version to 0.1.34

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx
@@ -13,7 +13,7 @@ tags:
 key: discordsh
 pipeline: docker
 app_name: discordsh
-version: "0.1.33"
+version: "0.1.34"
 source_path: apps/discordsh
 version_toml: apps/discordsh/version.toml
 version_target: apps/discordsh/axum-discordsh/Cargo.toml


### PR DESCRIPTION
## Summary
- Bump discordsh version to `0.1.34` in project MDX (source of truth)
- Pipeline handles Cargo.toml, version.toml, and deployment.yaml propagation
- Includes bot_get_guild_token vault integration and vault-reader get_by_guild/get_by_tag support