### PR TITLE
fix(ci): add checkout step before reading ci-dispatch-manifest.json

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -156,6 +156,11 @@ jobs:
             version_source: ${{ steps.resolve.outputs.version_source }}
             version_target: ${{ steps.resolve.outputs.version_target }}
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  sparse-checkout: .github/ci-dispatch-manifest.json
+                  sparse-checkout-cone-mode: false
             - name: Resolve config from manifest
               id: resolve
               run: |


### PR DESCRIPTION
## Summary
Closes #8545

The `config` job in `ci-docker.yml` reads `.github/ci-dispatch-manifest.json` via `jq` but never checks out the repository, causing `exit code 2` (file not found on the runner).

- Add `actions/checkout@v4` with sparse checkout of just the manifest file before the resolve step

## Test plan
- [ ] Re-run the CI - Docker workflow for `axum-kbve` and verify the config job passes