### PR TITLE
chore(kube): update axum-kbve to v1.0.71

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.70"
+version: "1.0.71"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 version_target: apps/kbve/axum-kbve/Cargo.toml


### PR DESCRIPTION
## Summary
- Bump axum-kbve version from 1.0.70 to 1.0.71
- Includes: Forgejo proxy + dashboard, KubeVirt VM dashboard with start/stop/restart/VNC, Kanban/Report/Graph home dashboard cards

## Test plan
- [ ] CI builds and publishes v1.0.71 Docker image
- [ ] Deployment updates to new image