### PR TITLE
fix(ci): align versions across all sources after MDX migration

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.32"
+version = "0.1.34"
 edition = "2024"
 publish = false
 

--- a/apps/discordsh/version.toml
+++ b/apps/discordsh/version.toml
@@ -1,2 +1,2 @@
-version = "0.1.32"
+version = "0.1.34"
 publish = true

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.68"
+version = "1.0.70"
 edition = "2021"
 publish = false
 

--- a/apps/kbve/axum-kbve/version.toml
+++ b/apps/kbve/axum-kbve/version.toml
@@ -1,2 +1,2 @@
-version = "unknown"
+version = "1.0.70"
 publish = true

--- a/apps/kbve/edge/deno.json
+++ b/apps/kbve/edge/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.17",
+  "version": "0.1.20",
   "compilerOptions": {
     "lib": ["deno.window"],
     "strict": true

--- a/apps/kube/memes/manifest/memes-deployment.yaml
+++ b/apps/kube/memes/manifest/memes-deployment.yaml
@@ -16,11 +16,11 @@ spec:
         rollout-restart: "2026-03-05T05:12:54Z"
       labels:
         app: memes
-        version: "0.1.6"
+        version: "0.1.7"
     spec:
       containers:
       - name: memes
-        image: ghcr.io/kbve/memes:0.1.6
+        image: ghcr.io/kbve/memes:0.1.7
         imagePullPolicy: Always
         ports:
         - containerPort: 4321


### PR DESCRIPTION
## Summary

Version audit after the MDX single-source-of-truth migration found 6 misalignments:

| File | Was | Now | Issue |
|------|-----|-----|-------|
| `axum-kbve/version.toml` | `"unknown"` | `1.0.70` | Corrupted by version gate before manifest sync |
| `axum-kbve/Cargo.toml` | `1.0.68` | `1.0.70` | Never committed back after build-time sync |
| `discordsh/version.toml` | `0.1.32` | `0.1.34` | Post-publish update didn't run |
| `discordsh/Cargo.toml` | `0.1.32` | `0.1.34` | Source drift |
| `edge/deno.json` | `0.1.17` | `0.1.20` | Source drift |
| `memes kube deployment` | `0.1.6` | `0.1.7` | Kube manifest update missed |

All versions now align with their MDX source of truth.

## Test plan
- [ ] Verify version gate passes for axum-kbve (no longer comparing against "unknown")
- [ ] Verify memes deployment rolls out to 0.1.7