### PR TITLE
feat(unreal): implement landscape flatten and smooth MCP handlers

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
@@ -431,7 +431,7 @@ Verified compiling on UE 5.7.4 (Mac, universal binary).
 | `animation.*` | create_anim_bp, set_sequence, add_notify, get_tracks | Complete |
 | `niagara.*` | create_system, activate, deactivate, set_parameter, get_info | Complete |
 | `gameplay.*` | create_interaction, get_info (tags, GAS, trigger volumes) | Complete |
-| `landscape.*` | sculpt, get_info | Partial |
+| `landscape.*` | sculpt, flatten, smooth, get_info | Partial |
 | `widget.*` | create, set_property, get_info | Partial |
 | `mcp.*` | ping, list_methods, server_info | Complete |
 
@@ -447,7 +447,7 @@ The following methods are registered but return `NOT_IMPLEMENTED`. Each is track
 
 | Domain | Stubbed Methods | Reason |
 |--------|----------------|--------|
-| `landscape.*` | flatten, smooth, paint_layer | Variants of sculpt with different blend modes |
+| `landscape.*` | paint_layer | Weight map painting requires layer info setup |
 | `widget.*` | add_element, bind_event, add_to_viewport, remove | UMG widget tree manipulation + PIE-only viewport ops |
 | `animation.*` | add_state, add_transition | AnimGraph state machine node manipulation is version-sensitive |
 | `gameplay.*` | add_ability, add_attribute | GAS is an optional plugin; needs conditional loading |

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPLandscapeHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPLandscapeHandlers.cpp
@@ -11,12 +11,21 @@
 void FMCPLandscapeHandlers::Register(FMCPHandlerRegistry& Registry)
 {
 	Registry.RegisterHandler(TEXT("landscape.sculpt"), &HandleSculpt);
-	// flatten, smooth, paint_layer use the same heightmap API but with
-	// different blend modes — can be added later as variants of sculpt.
-	Registry.RegisterHandler(TEXT("landscape.flatten"), MCPProtocolHelpers::MakeStub(TEXT("landscape.flatten")));
-	Registry.RegisterHandler(TEXT("landscape.smooth"), MCPProtocolHelpers::MakeStub(TEXT("landscape.smooth")));
+	Registry.RegisterHandler(TEXT("landscape.flatten"), &HandleFlatten);
+	Registry.RegisterHandler(TEXT("landscape.smooth"), &HandleSmooth);
+	// paint_layer requires weight map manipulation with specific layer info
 	Registry.RegisterHandler(TEXT("landscape.paint_layer"), MCPProtocolHelpers::MakeStub(TEXT("landscape.paint_layer")));
 	Registry.RegisterHandler(TEXT("landscape.get_info"), &HandleGetInfo);
+}
+
+ALandscapeProxy* FMCPLandscapeHandlers::FindLandscape(UWorld* World, const FString& Name)
+{
+	for (TActorIterator<ALandscapeProxy> It(World); It; ++It)
+	{
+		if (Name.IsEmpty() || It->GetActorLabel() == Name || It->GetName() == Name)
+			return *It;
+	}
+	return nullptr;
 }
 
 void FMCPLandscapeHandlers::HandleSculpt(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
@@ -24,100 +33,185 @@ void FMCPLandscapeHandlers::HandleSculpt(const TSharedPtr<FJsonObject>& Params, 
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
 	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
 
-	// Find the landscape
-	ALandscapeProxy* Landscape = nullptr;
-	FString LandscapeName = Params->GetStringField(TEXT("landscape_name"));
-	for (TActorIterator<ALandscapeProxy> It(World); It; ++It)
-	{
-		if (LandscapeName.IsEmpty() || It->GetActorLabel() == LandscapeName || It->GetName() == LandscapeName)
-		{
-			Landscape = *It;
-			break;
-		}
-	}
+	ALandscapeProxy* Landscape = FindLandscape(World, Params->GetStringField(TEXT("landscape_name")));
+	if (!Landscape) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("No landscape found")); return; }
 
-	if (!Landscape)
-	{
-		MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("No landscape found in the level"));
-		return;
-	}
-
-	// Get sculpt parameters
 	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
 	if (!Params->TryGetArrayField(TEXT("center"), CenterArr) || CenterArr->Num() < 2)
-	{
-		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'center' [x,y] array is required"));
-		return;
-	}
+	{ MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'center' [x,y] required")); return; }
 
-	double CenterX = (*CenterArr)[0]->AsNumber();
-	double CenterY = (*CenterArr)[1]->AsNumber();
+	double CenterX = (*CenterArr)[0]->AsNumber(), CenterY = (*CenterArr)[1]->AsNumber();
 	double Radius = Params->GetNumberField(TEXT("radius"));
 	double Strength = Params->GetNumberField(TEXT("strength"));
-
 	if (Radius <= 0) Radius = 500.0;
 	if (Strength == 0) Strength = 100.0;
 
-	// Use the landscape edit data interface to modify heightmap
-	ULandscapeInfo* LandscapeInfo = Landscape->GetLandscapeInfo();
-	if (!LandscapeInfo)
-	{
-		MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_INFO"), TEXT("Landscape has no LandscapeInfo"));
-		return;
-	}
+	ULandscapeInfo* Info = Landscape->GetLandscapeInfo();
+	if (!Info) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_INFO"), TEXT("No LandscapeInfo")); return; }
 
-	// Calculate the region to modify in landscape-local coordinates
-	FVector LandscapePos = Landscape->GetActorLocation();
-	FVector LandscapeScale = Landscape->GetActorScale3D();
+	FVector Pos = Landscape->GetActorLocation(), Scale = Landscape->GetActorScale3D();
+	int32 MinX = FMath::FloorToInt((CenterX - Radius - Pos.X) / Scale.X);
+	int32 MaxX = FMath::CeilToInt((CenterX + Radius - Pos.X) / Scale.X);
+	int32 MinY = FMath::FloorToInt((CenterY - Radius - Pos.Y) / Scale.Y);
+	int32 MaxY = FMath::CeilToInt((CenterY + Radius - Pos.Y) / Scale.Y);
+	int32 Width = MaxX - MinX + 1, Height = MaxY - MinY + 1;
+	if (Width <= 0 || Height <= 0) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_REGION"), TEXT("Region empty")); return; }
 
-	int32 MinX = FMath::FloorToInt((CenterX - Radius - LandscapePos.X) / LandscapeScale.X);
-	int32 MaxX = FMath::CeilToInt((CenterX + Radius - LandscapePos.X) / LandscapeScale.X);
-	int32 MinY = FMath::FloorToInt((CenterY - Radius - LandscapePos.Y) / LandscapeScale.Y);
-	int32 MaxY = FMath::CeilToInt((CenterY + Radius - LandscapePos.Y) / LandscapeScale.Y);
-
-	FLandscapeEditDataInterface EditData(LandscapeInfo);
+	FLandscapeEditDataInterface EditData(Info);
 	TArray<uint16> HeightData;
-	int32 Width = MaxX - MinX + 1;
-	int32 Height = MaxY - MinY + 1;
-
-	if (Width <= 0 || Height <= 0)
-	{
-		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_REGION"), TEXT("Sculpt region is empty"));
-		return;
-	}
-
 	HeightData.SetNumUninitialized(Width * Height);
 	EditData.GetHeightDataFast(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
 
-	// Apply radial sculpt
 	int32 ModifiedCount = 0;
 	for (int32 Y = MinY; Y <= MaxY; Y++)
 	{
 		for (int32 X = MinX; X <= MaxX; X++)
 		{
-			double WorldX = X * LandscapeScale.X + LandscapePos.X;
-			double WorldY = Y * LandscapeScale.Y + LandscapePos.Y;
+			double WorldX = X * Scale.X + Pos.X, WorldY = Y * Scale.Y + Pos.Y;
 			double Dist = FMath::Sqrt(FMath::Square(WorldX - CenterX) + FMath::Square(WorldY - CenterY));
-
 			if (Dist <= Radius)
 			{
-				double Falloff = 1.0 - (Dist / Radius);
-				Falloff = FMath::Square(Falloff); // Smooth falloff
+				double Falloff = FMath::Square(1.0 - Dist / Radius);
 				int32 Idx = (Y - MinY) * Width + (X - MinX);
-				int32 Delta = FMath::RoundToInt(Strength * Falloff);
-				HeightData[Idx] = FMath::Clamp((int32)HeightData[Idx] + Delta, 0, 65535);
+				HeightData[Idx] = FMath::Clamp((int32)HeightData[Idx] + FMath::RoundToInt(Strength * Falloff), 0, 65535);
 				ModifiedCount++;
 			}
 		}
 	}
-
 	EditData.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 
 	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
 	Result->SetStringField(TEXT("landscape"), Landscape->GetActorLabel());
+	Result->SetStringField(TEXT("operation"), TEXT("sculpt"));
 	Result->SetNumberField(TEXT("modified_vertices"), ModifiedCount);
-	Result->SetNumberField(TEXT("radius"), Radius);
-	Result->SetNumberField(TEXT("strength"), Strength);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPLandscapeHandlers::HandleFlatten(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	ALandscapeProxy* Landscape = FindLandscape(World, Params->GetStringField(TEXT("landscape_name")));
+	if (!Landscape) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("No landscape found")); return; }
+
+	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
+	if (!Params->TryGetArrayField(TEXT("center"), CenterArr) || CenterArr->Num() < 2)
+	{ MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'center' [x,y] required")); return; }
+
+	double CenterX = (*CenterArr)[0]->AsNumber(), CenterY = (*CenterArr)[1]->AsNumber();
+	double Radius = Params->GetNumberField(TEXT("radius"));
+	double TargetHeight = Params->GetNumberField(TEXT("target_height"));
+	if (Radius <= 0) Radius = 500.0;
+
+	// Convert target height to uint16 landscape space (32768 = sea level)
+	uint16 TargetH = (uint16)FMath::Clamp(FMath::RoundToInt(TargetHeight + 32768.0), 0, 65535);
+
+	ULandscapeInfo* Info = Landscape->GetLandscapeInfo();
+	if (!Info) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_INFO"), TEXT("No LandscapeInfo")); return; }
+
+	FVector Pos = Landscape->GetActorLocation(), Scale = Landscape->GetActorScale3D();
+	int32 MinX = FMath::FloorToInt((CenterX - Radius - Pos.X) / Scale.X);
+	int32 MaxX = FMath::CeilToInt((CenterX + Radius - Pos.X) / Scale.X);
+	int32 MinY = FMath::FloorToInt((CenterY - Radius - Pos.Y) / Scale.Y);
+	int32 MaxY = FMath::CeilToInt((CenterY + Radius - Pos.Y) / Scale.Y);
+	int32 Width = MaxX - MinX + 1, Height = MaxY - MinY + 1;
+	if (Width <= 0 || Height <= 0) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_REGION"), TEXT("Region empty")); return; }
+
+	FLandscapeEditDataInterface EditData(Info);
+	TArray<uint16> HeightData;
+	HeightData.SetNumUninitialized(Width * Height);
+	EditData.GetHeightDataFast(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
+
+	int32 ModifiedCount = 0;
+	for (int32 Y = MinY; Y <= MaxY; Y++)
+	{
+		for (int32 X = MinX; X <= MaxX; X++)
+		{
+			double WorldX = X * Scale.X + Pos.X, WorldY = Y * Scale.Y + Pos.Y;
+			double Dist = FMath::Sqrt(FMath::Square(WorldX - CenterX) + FMath::Square(WorldY - CenterY));
+			if (Dist <= Radius)
+			{
+				double Falloff = FMath::Square(1.0 - Dist / Radius);
+				int32 Idx = (Y - MinY) * Width + (X - MinX);
+				int32 Current = HeightData[Idx];
+				HeightData[Idx] = (uint16)FMath::Lerp((double)Current, (double)TargetH, Falloff);
+				ModifiedCount++;
+			}
+		}
+	}
+	EditData.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("landscape"), Landscape->GetActorLabel());
+	Result->SetStringField(TEXT("operation"), TEXT("flatten"));
+	Result->SetNumberField(TEXT("modified_vertices"), ModifiedCount);
+	Result->SetNumberField(TEXT("target_height"), TargetHeight);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPLandscapeHandlers::HandleSmooth(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	ALandscapeProxy* Landscape = FindLandscape(World, Params->GetStringField(TEXT("landscape_name")));
+	if (!Landscape) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("No landscape found")); return; }
+
+	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
+	if (!Params->TryGetArrayField(TEXT("center"), CenterArr) || CenterArr->Num() < 2)
+	{ MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'center' [x,y] required")); return; }
+
+	double CenterX = (*CenterArr)[0]->AsNumber(), CenterY = (*CenterArr)[1]->AsNumber();
+	double Radius = Params->GetNumberField(TEXT("radius"));
+	double Strength = Params->GetNumberField(TEXT("strength"));
+	if (Radius <= 0) Radius = 500.0;
+	if (Strength <= 0 || Strength > 1.0) Strength = 0.5;
+
+	ULandscapeInfo* Info = Landscape->GetLandscapeInfo();
+	if (!Info) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_INFO"), TEXT("No LandscapeInfo")); return; }
+
+	FVector Pos = Landscape->GetActorLocation(), Scale = Landscape->GetActorScale3D();
+	// Expand region by 1 for neighbor sampling
+	int32 MinX = FMath::FloorToInt((CenterX - Radius - Pos.X) / Scale.X) - 1;
+	int32 MaxX = FMath::CeilToInt((CenterX + Radius - Pos.X) / Scale.X) + 1;
+	int32 MinY = FMath::FloorToInt((CenterY - Radius - Pos.Y) / Scale.Y) - 1;
+	int32 MaxY = FMath::CeilToInt((CenterY + Radius - Pos.Y) / Scale.Y) + 1;
+	int32 Width = MaxX - MinX + 1, Height = MaxY - MinY + 1;
+	if (Width <= 2 || Height <= 2) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_REGION"), TEXT("Region too small")); return; }
+
+	FLandscapeEditDataInterface EditData(Info);
+	TArray<uint16> HeightData, SmoothedData;
+	HeightData.SetNumUninitialized(Width * Height);
+	SmoothedData.SetNumUninitialized(Width * Height);
+	EditData.GetHeightDataFast(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
+	FMemory::Memcpy(SmoothedData.GetData(), HeightData.GetData(), Width * Height * sizeof(uint16));
+
+	int32 ModifiedCount = 0;
+	for (int32 Y = MinY + 1; Y < MaxY; Y++)
+	{
+		for (int32 X = MinX + 1; X < MaxX; X++)
+		{
+			double WorldX = X * Scale.X + Pos.X, WorldY = Y * Scale.Y + Pos.Y;
+			double Dist = FMath::Sqrt(FMath::Square(WorldX - CenterX) + FMath::Square(WorldY - CenterY));
+			if (Dist <= Radius)
+			{
+				int32 Idx = (Y - MinY) * Width + (X - MinX);
+				// Average of 4 neighbors
+				double Avg = ((double)HeightData[Idx - 1] + HeightData[Idx + 1] +
+					HeightData[Idx - Width] + HeightData[Idx + Width]) * 0.25;
+				double Falloff = FMath::Square(1.0 - Dist / Radius) * Strength;
+				SmoothedData[Idx] = (uint16)FMath::Lerp((double)HeightData[Idx], Avg, Falloff);
+				ModifiedCount++;
+			}
+		}
+	}
+	EditData.SetHeightData(MinX, MinY, MaxX, MaxY, SmoothedData.GetData(), 0, true);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("landscape"), Landscape->GetActorLabel());
+	Result->SetStringField(TEXT("operation"), TEXT("smooth"));
+	Result->SetNumberField(TEXT("modified_vertices"), ModifiedCount);
 	MCPProtocolHelpers::Succeed(OnComplete, Result);
 }
 
@@ -134,14 +228,11 @@ void FMCPLandscapeHandlers::HandleGetInfo(const TSharedPtr<FJsonObject>& Params,
 		L->SetStringField(TEXT("name"), Proxy->GetName());
 		L->SetStringField(TEXT("label"), Proxy->GetActorLabel());
 		L->SetStringField(TEXT("class"), Proxy->GetClass()->GetName());
-
 		FVector Origin, Extent;
 		Proxy->GetActorBounds(false, Origin, Extent);
 		L->SetArrayField(TEXT("origin"), { MakeShared<FJsonValueNumber>(Origin.X), MakeShared<FJsonValueNumber>(Origin.Y), MakeShared<FJsonValueNumber>(Origin.Z) });
 		L->SetArrayField(TEXT("extent"), { MakeShared<FJsonValueNumber>(Extent.X), MakeShared<FJsonValueNumber>(Extent.Y), MakeShared<FJsonValueNumber>(Extent.Z) });
-
 		L->SetNumberField(TEXT("component_count"), Proxy->LandscapeComponents.Num());
-
 		Landscapes.Add(MakeShared<FJsonValueObject>(L));
 	}
 

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPLandscapeHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPLandscapeHandlers.h
@@ -4,6 +4,7 @@
 #include "Registry/MCPHandlerTypes.h"
 
 class FMCPHandlerRegistry;
+class ALandscapeProxy;
 
 class FMCPLandscapeHandlers
 {
@@ -12,5 +13,9 @@ public:
 
 private:
 	static void HandleSculpt(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleFlatten(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleSmooth(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 	static void HandleGetInfo(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	static ALandscapeProxy* FindLandscape(UWorld* World, const FString& Name);
 };


### PR DESCRIPTION
## Summary
- **landscape.flatten** — lerps heightmap toward a target height with radial falloff (32768 = sea level)
- **landscape.smooth** — 4-neighbor average smoothing with configurable strength and radial falloff
- Both use `FLandscapeEditDataInterface` for direct heightmap manipulation
- Verified: `RunUAT BuildPlugin` passes on UE 5.7.4 Mac

## Current totals
- **~125 implemented methods** across 24 domains
- **12 remaining stubs** — landscape paint_layer, widget tree ops (4), animation state machines (2), GAS (2), network sessions, geometry vertices, AI task nodes

## Test plan
- [x] `RunUAT BuildPlugin` succeeds on UE 5.7.4 Mac
- [ ] Test `landscape.flatten` with target_height on a landscape
- [ ] Test `landscape.smooth` with varying strength values