### PR TITLE
fix(ci): simplify UE5-Win setup to single job with pre-staged files

### DIFF
--- a/.github/workflows/ci-ue-win-setup.yml
+++ b/.github/workflows/ci-ue-win-setup.yml
@@ -24,66 +24,24 @@ on:
                 type: boolean
                 default: true
 
+# Pre-requisite: stage installers on the file-server pod before dispatching.
+# From your local machine (with kubectl access):
+#   kubectl scale deploy file-server -n angelscript --replicas=1
+#   kubectl wait --for=condition=ready pod -l app=file-server -n angelscript --timeout=120s
+#   POD=$(kubectl get pods -n angelscript -l app=file-server -o jsonpath='{.items[0].metadata.name}')
+#   kubectl exec -n angelscript $POD -- wget -q -O /shared/vs_buildtools.exe "https://aka.ms/vs/17/release/vs_buildtools.exe"
+#   kubectl exec -n angelscript $POD -- wget -q -O /shared/python-install.exe "https://www.python.org/ftp/python/3.12.8/python-3.12.8-amd64.exe"
+#   kubectl exec -n angelscript $POD -- wget -q -O /shared/cmake-install.msi "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-windows-x86_64.msi"
+#   kubectl exec -n angelscript $POD -- wget -q -O /shared/dotnet-install.ps1 "https://dot.net/v1/dotnet-install.ps1"
+#   kubectl exec -n angelscript $POD -- wget -q -O /shared/dxsetup.exe "https://download.microsoft.com/download/1/7/1/1718CCC4-6315-4D8E-9543-8E28A4E18C4C/dxwebsetup.exe"
+#
+# Files are already staged if file-server pod has files in /shared/.
+# Scale down when done: kubectl scale deploy file-server -n angelscript --replicas=0
+
 jobs:
-    # Job 1: Download installers on a Linux pod (fast internet, no NAT issues)
-    # and stage them on the file-server shared storage
-    stage-downloads:
-        name: Stage Installers
-        runs-on: arc-runner-set
-        steps:
-            - name: Scale up file server
-              id: fileserver
-              run: |
-                  kubectl scale deploy file-server -n angelscript --replicas=1
-                  echo "Waiting for file server pod..."
-                  kubectl wait --for=condition=ready pod -l app=file-server -n angelscript --timeout=120s
-                  POD=$(kubectl get pods -n angelscript -l app=file-server -o jsonpath='{.items[0].metadata.name}')
-                  echo "pod=${POD}" >> "$GITHUB_OUTPUT"
-
-            - name: Download VS Build Tools bootstrapper
-              if: inputs.install_vs_buildtools
-              run: |
-                  kubectl exec -n angelscript ${{ steps.fileserver.outputs.pod }} -- \
-                    wget -q -O /shared/vs_buildtools.exe "https://aka.ms/vs/17/release/vs_buildtools.exe"
-                  echo "VS Build Tools bootstrapper staged."
-
-            - name: Download Python installer
-              if: inputs.install_python
-              run: |
-                  kubectl exec -n angelscript ${{ steps.fileserver.outputs.pod }} -- \
-                    wget -q -O /shared/python-install.exe "https://www.python.org/ftp/python/3.12.8/python-3.12.8-amd64.exe"
-                  echo "Python installer staged."
-
-            - name: Download .NET install script
-              if: inputs.install_dotnet
-              run: |
-                  kubectl exec -n angelscript ${{ steps.fileserver.outputs.pod }} -- \
-                    wget -q -O /shared/dotnet-install.ps1 "https://dot.net/v1/dotnet-install.ps1"
-                  echo ".NET install script staged."
-
-            - name: Download DirectX Runtime
-              if: inputs.install_directx
-              run: |
-                  kubectl exec -n angelscript ${{ steps.fileserver.outputs.pod }} -- \
-                    wget -q -O /shared/dxsetup.exe "https://download.microsoft.com/download/1/7/1/1718CCC4-6315-4D8E-9543-8E28A4E18C4C/dxwebsetup.exe"
-                  echo "DirectX Runtime staged."
-
-            - name: Download CMake installer
-              if: inputs.install_cmake
-              run: |
-                  kubectl exec -n angelscript ${{ steps.fileserver.outputs.pod }} -- \
-                    wget -q -O /shared/cmake-install.msi "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-windows-x86_64.msi"
-                  echo "CMake installer staged."
-
-            - name: List staged files
-              run: |
-                  kubectl exec -n angelscript ${{ steps.fileserver.outputs.pod }} -- ls -lh /shared/
-
-    # Job 2: Install from cluster-internal HTTP server (no internet needed)
     install:
         name: Install on UE5-Win
         runs-on: UE5-Win
-        needs: stage-downloads
         env:
             FILE_SERVER: http://file-server.angelscript.svc:8080
         steps:
@@ -96,6 +54,16 @@ jobs:
                   Write-Host "Disk: $([math]::Round((Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace / 1GB, 1)) GB free"
                   git --version
 
+            - name: Check file server reachable
+              run: |
+                  $response = curl.exe -s -o NUL -w "%{http_code}" "$env:FILE_SERVER/"
+                  if ($response -ne "200") {
+                      Write-Host "ERROR: File server not reachable (HTTP $response)" -ForegroundColor Red
+                      Write-Host "Make sure file-server is scaled up: kubectl scale deploy file-server -n angelscript --replicas=1"
+                      exit 1
+                  }
+                  Write-Host "File server reachable."
+
             - name: Install Visual Studio 2022 Build Tools
               if: inputs.install_vs_buildtools
               timeout-minutes: 30
@@ -106,6 +74,10 @@ jobs:
                   }
                   Write-Host "Downloading from file server..."
                   curl.exe -o C:\vs_buildtools.exe "$env:FILE_SERVER/vs_buildtools.exe"
+                  if (!(Test-Path C:\vs_buildtools.exe)) {
+                      Write-Host "ERROR: Download failed. Stage vs_buildtools.exe on the file server first." -ForegroundColor Red
+                      exit 1
+                  }
                   Write-Host "Installing VS Build Tools (this takes 10-15 minutes)..."
                   $p = Start-Process C:\vs_buildtools.exe -ArgumentList @(
                       '--add', 'Microsoft.VisualStudio.Workload.VCTools',
@@ -179,21 +151,11 @@ jobs:
                       catch { Write-Host "  $($check.Name): NOT INSTALLED" }
                   }
 
-    # Job 3: Scale down file server
-    cleanup:
-        name: Cleanup
-        runs-on: arc-runner-set
-        needs: install
-        if: always()
-        steps:
-            - name: Scale down file server
-              run: kubectl scale deploy file-server -n angelscript --replicas=0
-
     # ── Failure tracker ──────────────────────────────────────
     track-failure:
         name: Track Failures
         if: ${{ always() && contains(needs.*.result, 'failure') }}
-        needs: [install, cleanup]
+        needs: [install]
         permissions:
             issues: write
             contents: read


### PR DESCRIPTION
## Summary
- Remove multi-job approach that needed ARC runners with kubectl access
- Single job on `UE5-Win` downloads from pre-staged file-server pod
- Files already staged — staging done via kubectl before dispatching

## Pre-dispatch (from local machine with kubectl)
```bash
kubectl scale deploy file-server -n angelscript --replicas=1
kubectl wait --for=condition=ready pod -l app=file-server -n angelscript --timeout=120s
POD=$(kubectl get pods -n angelscript -l app=file-server -o jsonpath='{.items[0].metadata.name}')
kubectl exec -n angelscript $POD -- wget -q -O /shared/vs_buildtools.exe "https://aka.ms/vs/17/release/vs_buildtools.exe"
# ... (full list in workflow comments)
```

## Test plan
- [ ] File server scaled up with files staged
- [ ] Dispatch workflow — installs from internal HTTP
- [ ] VS Build Tools, Python, .NET, DirectX, CMake all install