### PR TITLE
feat(unreal): add 26 new MCP methods — blueprint graph, editor utils, class introspection

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
@@ -405,12 +405,12 @@ Verified compiling on UE 5.7.4 (Mac, universal binary).
 { "id": "uuid", "success": false, "error": { "code": "NOT_FOUND", "message": "Actor not found" } }
 ```
 
-**Implemented Handler Domains (24 domains, 100+ methods):**
+**Implemented Handler Domains (25 domains, 150+ methods):**
 
 | Domain | Methods | Status |
 |--------|---------|--------|
 | `actor.*` | spawn, delete, find, list, get/set_transform, get/set_property, duplicate, batch_transform, attach, detach, add_component | Complete |
-| `blueprint.*` | create, add_component, set_component_property, add_variable, add_function_node, add_event_node, connect_nodes, compile | Complete |
+| `blueprint.*` | create, add/remove_component, list_components, set_component_property, add/remove_variable, add_function_node, add_event_node, connect_nodes, disconnect_pin, set_pin_default, delete_node, set_default, reparent, validate, compile, get_graph | Complete |
 | `asset.*` | search, get_info, get_references, get_dependents, list, validate | Complete |
 | `level.*` | get_info, list_levels, open, save, get_world_outliner | Complete |
 | `console.*` | execute (with safety validation), get_log | Complete |
@@ -424,13 +424,14 @@ Verified compiling on UE 5.7.4 (Mac, universal binary).
 | `audio.*` | spawn_source, set_properties, play, stop, get_info | Complete |
 | `input.*` | create_action, create_mapping, bind_action, get_info | Complete |
 | `spline.*` | create, add_point, set_properties, get_info | Complete |
-| `codeanalysis.*` | analyze_class, find_references, search_code, get_hierarchy | Complete |
+| `codeanalysis.*` | analyze_class, find_references, search_code, get_hierarchy, list_classes, list_functions, list_properties | Complete |
 | `network.*` | set_replication, get_info | Complete |
 | `geometry.*` | create_procedural_mesh (basic shapes), get_info | Complete |
 | `ai.*` | create_behavior_tree, set_blackboard, get_info | Complete |
 | `animation.*` | create_anim_bp, set_sequence, add_notify, get_tracks | Complete |
 | `niagara.*` | create_system, activate, deactivate, set_parameter, get_info | Complete |
 | `gameplay.*` | create_interaction, get_info (tags, GAS, trigger volumes) | Complete |
+| `editor.*` | undo, redo, select, get_selection, rename_asset, delete_asset, find_in_radius, raycast, set_label, set_folder, add/remove_tag, find_by_tag | Complete |
 | `landscape.*` | sculpt, flatten, smooth, get_info | Partial |
 | `widget.*` | create, set_property, get_info | Partial |
 | `mcp.*` | ping, list_methods, server_info | Complete |

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPBlueprintHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPBlueprintHandlers.cpp
@@ -28,6 +28,17 @@ void FMCPBlueprintHandlers::Register(FMCPHandlerRegistry& Registry)
 	Registry.RegisterHandler(TEXT("blueprint.add_event_node"), &HandleAddEventNode);
 	Registry.RegisterHandler(TEXT("blueprint.connect_nodes"), &HandleConnectNodes);
 	Registry.RegisterHandler(TEXT("blueprint.compile"), &HandleCompile);
+	// Phase 8
+	Registry.RegisterHandler(TEXT("blueprint.get_graph"), &HandleGetGraph);
+	Registry.RegisterHandler(TEXT("blueprint.delete_node"), &HandleDeleteNode);
+	Registry.RegisterHandler(TEXT("blueprint.disconnect_pin"), &HandleDisconnectPin);
+	Registry.RegisterHandler(TEXT("blueprint.set_pin_default"), &HandleSetPinDefault);
+	Registry.RegisterHandler(TEXT("blueprint.set_default"), &HandleSetDefault);
+	Registry.RegisterHandler(TEXT("blueprint.remove_variable"), &HandleRemoveVariable);
+	Registry.RegisterHandler(TEXT("blueprint.remove_component"), &HandleRemoveComponent);
+	Registry.RegisterHandler(TEXT("blueprint.reparent"), &HandleReparent);
+	Registry.RegisterHandler(TEXT("blueprint.validate"), &HandleValidate);
+	Registry.RegisterHandler(TEXT("blueprint.list_components"), &HandleListComponents);
 }
 
 void FMCPBlueprintHandlers::HandleCreate(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
@@ -449,5 +460,270 @@ void FMCPBlueprintHandlers::HandleCompile(const TSharedPtr<FJsonObject>& Params,
 	Result->SetStringField(TEXT("blueprint"), Blueprint->GetName());
 	Result->SetBoolField(TEXT("compiled"), Blueprint->Status == BS_UpToDate);
 	Result->SetStringField(TEXT("status"), Blueprint->Status == BS_UpToDate ? TEXT("success") : TEXT("error"));
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+// ─── Phase 8: Graph introspection + manipulation ────────────────────────────
+
+void FMCPBlueprintHandlers::HandleGetGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintPath)); return; }
+
+	UEdGraph* EventGraph = FBlueprintEditorUtils::FindEventGraph(Blueprint);
+	if (!EventGraph) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_GRAPH"), TEXT("No event graph")); return; }
+
+	TArray<TSharedPtr<FJsonValue>> Nodes;
+	for (UEdGraphNode* Node : EventGraph->Nodes)
+	{
+		TSharedPtr<FJsonObject> N = MakeShared<FJsonObject>();
+		N->SetStringField(TEXT("node_id"), Node->NodeGuid.ToString());
+		N->SetStringField(TEXT("class"), Node->GetClass()->GetName());
+		N->SetStringField(TEXT("title"), Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+		N->SetNumberField(TEXT("pos_x"), Node->NodePosX);
+		N->SetNumberField(TEXT("pos_y"), Node->NodePosY);
+		N->SetStringField(TEXT("comment"), Node->NodeComment);
+
+		TArray<TSharedPtr<FJsonValue>> Pins;
+		for (UEdGraphPin* Pin : Node->Pins)
+		{
+			TSharedPtr<FJsonObject> P = MakeShared<FJsonObject>();
+			P->SetStringField(TEXT("name"), Pin->PinName.ToString());
+			P->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
+			P->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input ? TEXT("input") : TEXT("output"));
+			P->SetStringField(TEXT("default_value"), Pin->DefaultValue);
+			P->SetNumberField(TEXT("connections"), Pin->LinkedTo.Num());
+			Pins.Add(MakeShared<FJsonValueObject>(P));
+		}
+		N->SetArrayField(TEXT("pins"), Pins);
+		Nodes.Add(MakeShared<FJsonValueObject>(N));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("blueprint"), Blueprint->GetName());
+	Result->SetStringField(TEXT("graph"), EventGraph->GetName());
+	Result->SetArrayField(TEXT("nodes"), Nodes);
+	Result->SetNumberField(TEXT("node_count"), Nodes.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleDeleteNode(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	FString NodeId = Params->GetStringField(TEXT("node_id"));
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	UEdGraph* EventGraph = FBlueprintEditorUtils::FindEventGraph(Blueprint);
+	if (!EventGraph) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_GRAPH"), TEXT("No event graph")); return; }
+
+	FGuid TargetGuid;
+	FGuid::Parse(NodeId, TargetGuid);
+	UEdGraphNode* TargetNode = nullptr;
+	for (UEdGraphNode* Node : EventGraph->Nodes)
+		if (Node->NodeGuid == TargetGuid) { TargetNode = Node; break; }
+
+	if (!TargetNode) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Node not found")); return; }
+
+	TargetNode->BreakAllNodeLinks();
+	EventGraph->RemoveNode(TargetNode);
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("deleted_node"), NodeId);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleDisconnectPin(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	FString NodeId = Params->GetStringField(TEXT("node_id"));
+	FString PinName = Params->GetStringField(TEXT("pin_name"));
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	UEdGraph* EventGraph = FBlueprintEditorUtils::FindEventGraph(Blueprint);
+	if (!EventGraph) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_GRAPH"), TEXT("No event graph")); return; }
+
+	FGuid TargetGuid;
+	FGuid::Parse(NodeId, TargetGuid);
+	UEdGraphNode* Node = nullptr;
+	for (UEdGraphNode* N : EventGraph->Nodes)
+		if (N->NodeGuid == TargetGuid) { Node = N; break; }
+
+	if (!Node) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Node not found")); return; }
+
+	UEdGraphPin* Pin = nullptr;
+	for (UEdGraphPin* P : Node->Pins)
+		if (P->PinName.ToString() == PinName) { Pin = P; break; }
+
+	if (!Pin) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Pin not found")); return; }
+
+	int32 BrokenCount = Pin->LinkedTo.Num();
+	Pin->BreakAllPinLinks();
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetNumberField(TEXT("disconnected"), BrokenCount);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleSetPinDefault(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	FString NodeId = Params->GetStringField(TEXT("node_id"));
+	FString PinName = Params->GetStringField(TEXT("pin_name"));
+	FString DefaultValue = Params->GetStringField(TEXT("default_value"));
+
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	UEdGraph* EventGraph = FBlueprintEditorUtils::FindEventGraph(Blueprint);
+	if (!EventGraph) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_GRAPH"), TEXT("No event graph")); return; }
+
+	FGuid TargetGuid;
+	FGuid::Parse(NodeId, TargetGuid);
+	UEdGraphNode* Node = nullptr;
+	for (UEdGraphNode* N : EventGraph->Nodes)
+		if (N->NodeGuid == TargetGuid) { Node = N; break; }
+	if (!Node) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Node not found")); return; }
+
+	UEdGraphPin* Pin = nullptr;
+	for (UEdGraphPin* P : Node->Pins)
+		if (P->PinName.ToString() == PinName) { Pin = P; break; }
+	if (!Pin) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Pin not found")); return; }
+
+	Pin->DefaultValue = DefaultValue;
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("pin"), PinName);
+	Result->SetStringField(TEXT("default_value"), DefaultValue);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleSetDefault(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	FString PropertyName = Params->GetStringField(TEXT("property_name"));
+	FString PropertyValue = Params->GetStringField(TEXT("property_value"));
+
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	UObject* CDO = Blueprint->GeneratedClass ? Blueprint->GeneratedClass->GetDefaultObject() : nullptr;
+	if (!CDO) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_CDO"), TEXT("No CDO available — compile first")); return; }
+
+	FProperty* Prop = Blueprint->GeneratedClass->FindPropertyByName(*PropertyName);
+	if (!Prop) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PROPERTY"), FString::Printf(TEXT("Property not found: %s"), *PropertyName)); return; }
+
+	void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(CDO);
+	if (!Prop->ImportText_Direct(*PropertyValue, ValuePtr, CDO, PPF_None))
+	{ MCPProtocolHelpers::Fail(OnComplete, TEXT("SET_FAILED"), TEXT("Failed to set default value")); return; }
+
+	Blueprint->MarkPackageDirty();
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("blueprint"), Blueprint->GetName());
+	Result->SetStringField(TEXT("property"), PropertyName);
+	Result->SetBoolField(TEXT("updated"), true);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleRemoveVariable(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	FString VariableName = Params->GetStringField(TEXT("variable_name"));
+
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	FBlueprintEditorUtils::RemoveMemberVariable(Blueprint, FName(*VariableName));
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("removed"), VariableName);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleRemoveComponent(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	FString ComponentName = Params->GetStringField(TEXT("component_name"));
+
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	USCS_Node* FoundNode = nullptr;
+	for (USCS_Node* Node : Blueprint->SimpleConstructionScript->GetAllNodes())
+		if (Node->GetVariableName().ToString() == ComponentName) { FoundNode = Node; break; }
+
+	if (!FoundNode) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Component not found: %s"), *ComponentName)); return; }
+
+	Blueprint->SimpleConstructionScript->RemoveNode(FoundNode);
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("removed"), ComponentName);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleReparent(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	FString NewParentPath = Params->GetStringField(TEXT("new_parent_class"));
+
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	UClass* NewParent = FindObject<UClass>(nullptr, *NewParentPath);
+	if (!NewParent) NewParent = LoadObject<UClass>(nullptr, *NewParentPath);
+	if (!NewParent) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_CLASS"), FString::Printf(TEXT("Class not found: %s"), *NewParentPath)); return; }
+
+	Blueprint->ParentClass = NewParent;
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("blueprint"), Blueprint->GetName());
+	Result->SetStringField(TEXT("new_parent"), NewParent->GetName());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleValidate(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("blueprint"), Blueprint->GetName());
+	Result->SetBoolField(TEXT("valid"), Blueprint->Status == BS_UpToDate);
+	Result->SetStringField(TEXT("status"), Blueprint->Status == BS_UpToDate ? TEXT("up_to_date") :
+		Blueprint->Status == BS_Error ? TEXT("error") : TEXT("dirty"));
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleListComponents(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString BlueprintPath = Params->GetStringField(TEXT("blueprint_path"));
+	UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+	if (!Blueprint) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint not found")); return; }
+
+	TArray<TSharedPtr<FJsonValue>> Components;
+	for (USCS_Node* Node : Blueprint->SimpleConstructionScript->GetAllNodes())
+	{
+		TSharedPtr<FJsonObject> C = MakeShared<FJsonObject>();
+		C->SetStringField(TEXT("name"), Node->GetVariableName().ToString());
+		C->SetStringField(TEXT("class"), Node->ComponentClass ? Node->ComponentClass->GetName() : TEXT("unknown"));
+		C->SetBoolField(TEXT("is_root"), Node == Blueprint->SimpleConstructionScript->GetDefaultSceneRootNode());
+		Components.Add(MakeShared<FJsonValueObject>(C));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("components"), Components);
+	Result->SetNumberField(TEXT("count"), Components.Num());
 	MCPProtocolHelpers::Succeed(OnComplete, Result);
 }

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPCodeAnalysisHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPCodeAnalysisHandlers.cpp
@@ -10,6 +10,9 @@ void FMCPCodeAnalysisHandlers::Register(FMCPHandlerRegistry& Registry)
 	Registry.RegisterHandler(TEXT("codeanalysis.find_references"), &HandleFindReferences);
 	Registry.RegisterHandler(TEXT("codeanalysis.search_code"), &HandleSearchCode);
 	Registry.RegisterHandler(TEXT("codeanalysis.get_hierarchy"), &HandleGetHierarchy);
+	Registry.RegisterHandler(TEXT("codeanalysis.list_classes"), &HandleListClasses);
+	Registry.RegisterHandler(TEXT("codeanalysis.list_functions"), &HandleListFunctions);
+	Registry.RegisterHandler(TEXT("codeanalysis.list_properties"), &HandleListProperties);
 }
 
 void FMCPCodeAnalysisHandlers::HandleAnalyzeClass(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
@@ -168,5 +171,103 @@ void FMCPCodeAnalysisHandlers::HandleGetHierarchy(const TSharedPtr<FJsonObject>&
 	Result->SetArrayField(TEXT("hierarchy"), Ancestors);
 	Result->SetArrayField(TEXT("interfaces"), Interfaces);
 	Result->SetNumberField(TEXT("depth"), Ancestors.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPCodeAnalysisHandlers::HandleListClasses(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString ParentFilter = Params->GetStringField(TEXT("parent_class"));
+	int32 MaxResults = (int32)Params->GetNumberField(TEXT("max_results"));
+	if (MaxResults <= 0) MaxResults = 100;
+
+	UClass* ParentClass = nullptr;
+	if (!ParentFilter.IsEmpty())
+	{
+		for (TObjectIterator<UClass> It; It; ++It)
+			if (It->GetName() == ParentFilter) { ParentClass = *It; break; }
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Classes;
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		if (ParentClass && !It->IsChildOf(ParentClass)) continue;
+		TSharedPtr<FJsonObject> C = MakeShared<FJsonObject>();
+		C->SetStringField(TEXT("name"), It->GetName());
+		C->SetStringField(TEXT("parent"), It->GetSuperClass() ? It->GetSuperClass()->GetName() : TEXT("none"));
+		C->SetBoolField(TEXT("abstract"), It->HasAnyClassFlags(CLASS_Abstract));
+		Classes.Add(MakeShared<FJsonValueObject>(C));
+		if (Classes.Num() >= MaxResults) break;
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("classes"), Classes);
+	Result->SetNumberField(TEXT("count"), Classes.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPCodeAnalysisHandlers::HandleListFunctions(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString ClassName = Params->GetStringField(TEXT("class_name"));
+	if (ClassName.IsEmpty()) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'class_name' is required")); return; }
+
+	UClass* FoundClass = nullptr;
+	for (TObjectIterator<UClass> It; It; ++It)
+		if (It->GetName() == ClassName) { FoundClass = *It; break; }
+	if (!FoundClass) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Class not found: %s"), *ClassName)); return; }
+
+	bool bIncludeInherited = Params->GetBoolField(TEXT("include_inherited"));
+
+	TArray<TSharedPtr<FJsonValue>> Funcs;
+	EFieldIteratorFlags::SuperClassFlags SuperFlag = bIncludeInherited ? EFieldIteratorFlags::IncludeSuper : EFieldIteratorFlags::ExcludeSuper;
+	for (TFieldIterator<UFunction> It(FoundClass, SuperFlag); It; ++It)
+	{
+		TSharedPtr<FJsonObject> F = MakeShared<FJsonObject>();
+		F->SetStringField(TEXT("name"), It->GetName());
+		F->SetBoolField(TEXT("blueprint_callable"), It->HasAnyFunctionFlags(FUNC_BlueprintCallable));
+		F->SetBoolField(TEXT("blueprint_pure"), It->HasAnyFunctionFlags(FUNC_BlueprintPure));
+		F->SetBoolField(TEXT("is_event"), It->HasAnyFunctionFlags(FUNC_Event));
+		F->SetBoolField(TEXT("is_static"), It->HasAnyFunctionFlags(FUNC_Static));
+		F->SetNumberField(TEXT("param_count"), It->NumParms);
+		F->SetStringField(TEXT("owner"), It->GetOwnerClass() ? It->GetOwnerClass()->GetName() : TEXT("unknown"));
+		Funcs.Add(MakeShared<FJsonValueObject>(F));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("class"), FoundClass->GetName());
+	Result->SetArrayField(TEXT("functions"), Funcs);
+	Result->SetNumberField(TEXT("count"), Funcs.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPCodeAnalysisHandlers::HandleListProperties(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString ClassName = Params->GetStringField(TEXT("class_name"));
+	if (ClassName.IsEmpty()) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'class_name' is required")); return; }
+
+	UClass* FoundClass = nullptr;
+	for (TObjectIterator<UClass> It; It; ++It)
+		if (It->GetName() == ClassName) { FoundClass = *It; break; }
+	if (!FoundClass) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Class not found: %s"), *ClassName)); return; }
+
+	bool bIncludeInherited = Params->GetBoolField(TEXT("include_inherited"));
+
+	TArray<TSharedPtr<FJsonValue>> Props;
+	EFieldIteratorFlags::SuperClassFlags SuperFlag = bIncludeInherited ? EFieldIteratorFlags::IncludeSuper : EFieldIteratorFlags::ExcludeSuper;
+	for (TFieldIterator<FProperty> It(FoundClass, SuperFlag); It; ++It)
+	{
+		TSharedPtr<FJsonObject> P = MakeShared<FJsonObject>();
+		P->SetStringField(TEXT("name"), It->GetName());
+		P->SetStringField(TEXT("type"), It->GetCPPType());
+		P->SetBoolField(TEXT("blueprint_visible"), It->HasAnyPropertyFlags(CPF_BlueprintVisible));
+		P->SetBoolField(TEXT("edit_anywhere"), It->HasAnyPropertyFlags(CPF_Edit));
+		P->SetBoolField(TEXT("replicated"), It->HasAnyPropertyFlags(CPF_Net));
+		P->SetStringField(TEXT("category"), It->GetMetaData(TEXT("Category")));
+		Props.Add(MakeShared<FJsonValueObject>(P));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("class"), FoundClass->GetName());
+	Result->SetArrayField(TEXT("properties"), Props);
+	Result->SetNumberField(TEXT("count"), Props.Num());
 	MCPProtocolHelpers::Succeed(OnComplete, Result);
 }

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPEditorHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPEditorHandlers.cpp
@@ -1,0 +1,334 @@
+#include "Handlers/MCPEditorHandlers.h"
+#include "Registry/MCPHandlerRegistry.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "Engine/Selection.h"
+#include "AssetToolsModule.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "ObjectTools.h"
+#include "CollisionQueryParams.h"
+
+void FMCPEditorHandlers::Register(FMCPHandlerRegistry& Registry)
+{
+	Registry.RegisterHandler(TEXT("editor.undo"), &HandleUndo);
+	Registry.RegisterHandler(TEXT("editor.redo"), &HandleRedo);
+	Registry.RegisterHandler(TEXT("editor.select"), &HandleSelect);
+	Registry.RegisterHandler(TEXT("editor.get_selection"), &HandleGetSelection);
+	Registry.RegisterHandler(TEXT("editor.rename_asset"), &HandleRenameAsset);
+	Registry.RegisterHandler(TEXT("editor.delete_asset"), &HandleDeleteAsset);
+	Registry.RegisterHandler(TEXT("editor.find_in_radius"), &HandleFindInRadius);
+	Registry.RegisterHandler(TEXT("editor.raycast"), &HandleRaycast);
+	Registry.RegisterHandler(TEXT("editor.set_label"), &HandleSetLabel);
+	Registry.RegisterHandler(TEXT("editor.set_folder"), &HandleSetFolder);
+	Registry.RegisterHandler(TEXT("editor.add_tag"), &HandleAddTag);
+	Registry.RegisterHandler(TEXT("editor.remove_tag"), &HandleRemoveTag);
+	Registry.RegisterHandler(TEXT("editor.find_by_tag"), &HandleFindByTag);
+}
+
+void FMCPEditorHandlers::HandleUndo(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	int32 Steps = (int32)Params->GetNumberField(TEXT("steps"));
+	if (Steps <= 0) Steps = 1;
+
+	for (int32 i = 0; i < Steps; i++)
+	{
+		GEditor->UndoTransaction();
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetNumberField(TEXT("steps_undone"), Steps);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleRedo(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	int32 Steps = (int32)Params->GetNumberField(TEXT("steps"));
+	if (Steps <= 0) Steps = 1;
+
+	for (int32 i = 0; i < Steps; i++)
+	{
+		GEditor->RedoTransaction();
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetNumberField(TEXT("steps_redone"), Steps);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleSelect(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	FString Name = Params->GetStringField(TEXT("name"));
+	bool bAdditive = Params->GetBoolField(TEXT("additive"));
+
+	if (!bAdditive)
+	{
+		GEditor->SelectNone(true, true);
+	}
+
+	AActor* Actor = nullptr;
+	for (TActorIterator<AActor> It(World); It; ++It)
+		if (It->GetActorLabel() == Name || It->GetName() == Name) { Actor = *It; break; }
+
+	if (!Actor) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Actor not found: %s"), *Name)); return; }
+
+	GEditor->SelectActor(Actor, true, true);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("selected"), Actor->GetActorLabel());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleGetSelection(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	TArray<TSharedPtr<FJsonValue>> Selected;
+	for (FSelectionIterator It(GEditor->GetSelectedActorIterator()); It; ++It)
+	{
+		AActor* Actor = Cast<AActor>(*It);
+		if (!Actor) continue;
+		TSharedPtr<FJsonObject> A = MakeShared<FJsonObject>();
+		A->SetStringField(TEXT("name"), Actor->GetName());
+		A->SetStringField(TEXT("label"), Actor->GetActorLabel());
+		A->SetStringField(TEXT("class"), Actor->GetClass()->GetName());
+		Selected.Add(MakeShared<FJsonValueObject>(A));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("selected"), Selected);
+	Result->SetNumberField(TEXT("count"), Selected.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleRenameAsset(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	FString NewName = Params->GetStringField(TEXT("new_name"));
+
+	if (AssetPath.IsEmpty() || NewName.IsEmpty())
+	{ MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'asset_path' and 'new_name' are required")); return; }
+
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+
+	TArray<FAssetRenameData> RenameData;
+	FString PackagePath = FPackageName::GetLongPackagePath(AssetPath);
+	FString OldName = FPackageName::GetShortName(AssetPath);
+
+	FAssetRenameData Rename;
+	Rename.OldObjectPath = FSoftObjectPath(AssetPath);
+	Rename.NewName = NewName;
+	Rename.NewPackagePath = PackagePath;
+	RenameData.Add(Rename);
+
+	bool bSuccess = AssetTools.RenameAssets(RenameData);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("old_path"), AssetPath);
+	Result->SetStringField(TEXT("new_name"), NewName);
+	Result->SetBoolField(TEXT("renamed"), bSuccess);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleDeleteAsset(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	if (AssetPath.IsEmpty()) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'asset_path' is required")); return; }
+
+	UObject* Asset = LoadObject<UObject>(nullptr, *AssetPath);
+	if (!Asset) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Asset not found: %s"), *AssetPath)); return; }
+
+	TArray<UObject*> AssetsToDelete;
+	AssetsToDelete.Add(Asset);
+	int32 Deleted = ObjectTools::DeleteObjects(AssetsToDelete, false);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+	Result->SetBoolField(TEXT("deleted"), Deleted > 0);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleFindInRadius(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
+	if (!Params->TryGetArrayField(TEXT("center"), CenterArr) || CenterArr->Num() < 3)
+	{ MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'center' [x,y,z] required")); return; }
+
+	FVector Center((*CenterArr)[0]->AsNumber(), (*CenterArr)[1]->AsNumber(), (*CenterArr)[2]->AsNumber());
+	double Radius = Params->GetNumberField(TEXT("radius"));
+	if (Radius <= 0) Radius = 1000.0;
+
+	FString ClassFilter = Params->GetStringField(TEXT("class_filter"));
+	double RadiusSq = Radius * Radius;
+
+	TArray<TSharedPtr<FJsonValue>> Found;
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		if (!ClassFilter.IsEmpty() && !It->GetClass()->GetName().Contains(ClassFilter)) continue;
+
+		double DistSq = FVector::DistSquared(It->GetActorLocation(), Center);
+		if (DistSq <= RadiusSq)
+		{
+			TSharedPtr<FJsonObject> A = MakeShared<FJsonObject>();
+			A->SetStringField(TEXT("label"), It->GetActorLabel());
+			A->SetStringField(TEXT("class"), It->GetClass()->GetName());
+			A->SetNumberField(TEXT("distance"), FMath::Sqrt(DistSq));
+			Found.Add(MakeShared<FJsonValueObject>(A));
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("actors"), Found);
+	Result->SetNumberField(TEXT("count"), Found.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleRaycast(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	const TArray<TSharedPtr<FJsonValue>>* StartArr;
+	const TArray<TSharedPtr<FJsonValue>>* EndArr;
+	if (!Params->TryGetArrayField(TEXT("start"), StartArr) || StartArr->Num() < 3 ||
+		!Params->TryGetArrayField(TEXT("end"), EndArr) || EndArr->Num() < 3)
+	{ MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'start' and 'end' [x,y,z] required")); return; }
+
+	FVector Start((*StartArr)[0]->AsNumber(), (*StartArr)[1]->AsNumber(), (*StartArr)[2]->AsNumber());
+	FVector End((*EndArr)[0]->AsNumber(), (*EndArr)[1]->AsNumber(), (*EndArr)[2]->AsNumber());
+
+	FHitResult Hit;
+	FCollisionQueryParams QueryParams;
+	QueryParams.bTraceComplex = true;
+
+	bool bHit = World->LineTraceSingleByChannel(Hit, Start, End, ECC_Visibility, QueryParams);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetBoolField(TEXT("hit"), bHit);
+	if (bHit)
+	{
+		Result->SetArrayField(TEXT("location"), { MakeShared<FJsonValueNumber>(Hit.Location.X), MakeShared<FJsonValueNumber>(Hit.Location.Y), MakeShared<FJsonValueNumber>(Hit.Location.Z) });
+		Result->SetArrayField(TEXT("normal"), { MakeShared<FJsonValueNumber>(Hit.Normal.X), MakeShared<FJsonValueNumber>(Hit.Normal.Y), MakeShared<FJsonValueNumber>(Hit.Normal.Z) });
+		Result->SetNumberField(TEXT("distance"), Hit.Distance);
+		if (Hit.GetActor())
+		{
+			Result->SetStringField(TEXT("actor"), Hit.GetActor()->GetActorLabel());
+			Result->SetStringField(TEXT("component"), Hit.GetComponent() ? Hit.GetComponent()->GetName() : TEXT("none"));
+		}
+	}
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleSetLabel(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	FString Name = Params->GetStringField(TEXT("name"));
+	FString NewLabel = Params->GetStringField(TEXT("new_label"));
+
+	AActor* Actor = nullptr;
+	for (TActorIterator<AActor> It(World); It; ++It)
+		if (It->GetActorLabel() == Name || It->GetName() == Name) { Actor = *It; break; }
+	if (!Actor) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Actor not found: %s"), *Name)); return; }
+
+	Actor->SetActorLabel(NewLabel);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("old_label"), Name);
+	Result->SetStringField(TEXT("new_label"), NewLabel);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleSetFolder(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	FString Name = Params->GetStringField(TEXT("name"));
+	FString FolderPath = Params->GetStringField(TEXT("folder"));
+
+	AActor* Actor = nullptr;
+	for (TActorIterator<AActor> It(World); It; ++It)
+		if (It->GetActorLabel() == Name || It->GetName() == Name) { Actor = *It; break; }
+	if (!Actor) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Actor not found: %s"), *Name)); return; }
+
+	Actor->SetFolderPath(FName(*FolderPath));
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("actor"), Actor->GetActorLabel());
+	Result->SetStringField(TEXT("folder"), FolderPath);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleAddTag(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	FString Name = Params->GetStringField(TEXT("name"));
+	FString Tag = Params->GetStringField(TEXT("tag"));
+
+	AActor* Actor = nullptr;
+	for (TActorIterator<AActor> It(World); It; ++It)
+		if (It->GetActorLabel() == Name || It->GetName() == Name) { Actor = *It; break; }
+	if (!Actor) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Actor not found: %s"), *Name)); return; }
+
+	Actor->Tags.AddUnique(FName(*Tag));
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("actor"), Actor->GetActorLabel());
+	Result->SetStringField(TEXT("tag"), Tag);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleRemoveTag(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	FString Name = Params->GetStringField(TEXT("name"));
+	FString Tag = Params->GetStringField(TEXT("tag"));
+
+	AActor* Actor = nullptr;
+	for (TActorIterator<AActor> It(World); It; ++It)
+		if (It->GetActorLabel() == Name || It->GetName() == Name) { Actor = *It; break; }
+	if (!Actor) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Actor not found: %s"), *Name)); return; }
+
+	Actor->Tags.Remove(FName(*Tag));
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("actor"), Actor->GetActorLabel());
+	Result->SetStringField(TEXT("removed_tag"), Tag);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPEditorHandlers::HandleFindByTag(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world")); return; }
+
+	FString Tag = Params->GetStringField(TEXT("tag"));
+	FName TagName(*Tag);
+
+	TArray<TSharedPtr<FJsonValue>> Found;
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		if (It->Tags.Contains(TagName))
+		{
+			TSharedPtr<FJsonObject> A = MakeShared<FJsonObject>();
+			A->SetStringField(TEXT("label"), It->GetActorLabel());
+			A->SetStringField(TEXT("class"), It->GetClass()->GetName());
+			Found.Add(MakeShared<FJsonValueObject>(A));
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("actors"), Found);
+	Result->SetNumberField(TEXT("count"), Found.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/KBVEUnrealMCPModule.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/KBVEUnrealMCPModule.cpp
@@ -31,6 +31,7 @@
 #include "Handlers/MCPSplineHandlers.h"
 #include "Handlers/MCPGeometryHandlers.h"
 #include "Handlers/MCPCodeAnalysisHandlers.h"
+#include "Handlers/MCPEditorHandlers.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogKBVEUnrealMCP, Log, All);
 
@@ -136,6 +137,9 @@ void FKBVEUnrealMCPModule::RegisterAllHandlers()
 	FMCPSplineHandlers::Register(*Registry);
 	FMCPGeometryHandlers::Register(*Registry);
 	FMCPCodeAnalysisHandlers::Register(*Registry);
+
+	// Phase 8 — Editor utilities
+	FMCPEditorHandlers::Register(*Registry);
 }
 
 IMPLEMENT_MODULE(FKBVEUnrealMCPModule, KBVEUnrealMCP)

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPBlueprintHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPBlueprintHandlers.h
@@ -19,4 +19,16 @@ private:
 	static void HandleAddEventNode(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 	static void HandleConnectNodes(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 	static void HandleCompile(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	// Phase 8 — graph introspection + manipulation
+	static void HandleGetGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleDeleteNode(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleDisconnectPin(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleSetPinDefault(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleSetDefault(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleRemoveVariable(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleRemoveComponent(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleReparent(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleValidate(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleListComponents(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 };

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPCodeAnalysisHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPCodeAnalysisHandlers.h
@@ -15,4 +15,7 @@ private:
 	static void HandleFindReferences(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 	static void HandleSearchCode(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 	static void HandleGetHierarchy(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleListClasses(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleListFunctions(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleListProperties(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 };

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPEditorHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPEditorHandlers.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Registry/MCPHandlerTypes.h"
+
+class FMCPHandlerRegistry;
+
+class FMCPEditorHandlers
+{
+public:
+	static void Register(FMCPHandlerRegistry& Registry);
+
+private:
+	// Undo/Redo
+	static void HandleUndo(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleRedo(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	// Selection
+	static void HandleSelect(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleGetSelection(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	// Asset management
+	static void HandleRenameAsset(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleDeleteAsset(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	// Spatial queries
+	static void HandleFindInRadius(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleRaycast(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	// Actor organization
+	static void HandleSetLabel(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleSetFolder(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleAddTag(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleRemoveTag(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleFindByTag(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+};


### PR DESCRIPTION
## Summary
Phase 8 adds **26 new methods** across 3 domains, closing the biggest feature gaps vs mirno-ehf/ue5-mcp, SpecialAgentPlugin, and UnrealClaude.

### Blueprint (10 new methods)
- **get_graph** — full node/pin introspection (node ID, class, title, position, all pins with types, default values, connection counts)
- **delete_node** — remove nodes with automatic link cleanup
- **disconnect_pin** — break all connections on a specific pin
- **set_pin_default** — set default value on unconnected pins
- **set_default** — set CDO (Class Default Object) property values
- **remove_variable** / **remove_component** — structure cleanup
- **reparent** — change Blueprint parent class
- **validate** — compile and report status (up_to_date/error/dirty)
- **list_components** — enumerate SCS component tree

### Editor (13 new methods — new domain)
- **undo** / **redo** — with step count
- **select** / **get_selection** — editor selection management
- **rename_asset** / **delete_asset** — asset lifecycle with reference updates
- **find_in_radius** — spatial sphere query with class filter and distance
- **raycast** — line trace returning hit location, normal, distance, actor, component
- **set_label** / **set_folder** — actor organization
- **add_tag** / **remove_tag** / **find_by_tag** — actor tagging

### CodeAnalysis (3 new methods)
- **list_classes** — enumerate UClasses with parent class filter
- **list_functions** — list UFunctions with callable/pure/event/static/param flags
- **list_properties** — list FProperties with type, category, visibility, replication

## Totals
- **25 domains, ~150 implemented methods**
- **12 remaining stubs** (landscape paint, widget tree, anim state machines, GAS, network sessions)
- [x] `RunUAT BuildPlugin` passes on UE 5.7.4 Mac

## Test plan
- [x] Build verified on UE 5.7.4
- [ ] Test `blueprint.get_graph` returns full node/pin structure
- [ ] Test `editor.raycast` returns hit data
- [ ] Test `editor.undo`/`editor.redo` with step counts
- [ ] Test `codeanalysis.list_classes` with parent filter