### PR TITLE
feat(kube): add Multus CNI + macvlan for KubeVirt direct internet

### DIFF
--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -86,6 +86,10 @@ spec:
                     interfaces:
                         - name: default
                           masquerade: {}
+                        # Direct internet via Hetzner additional IP + virtual MAC
+                        - name: hetzner
+                          bridge: {}
+                          macAddress: '00:50:56:00:BA:57'
                     inputs:
                         - type: tablet
                           bus: usb
@@ -121,6 +125,9 @@ spec:
             networks:
                 - name: default
                   pod: {}
+                - name: hetzner
+                  multus:
+                      networkName: angelscript/hetzner-direct
             terminationGracePeriodSeconds: 3600
             volumes:
                 - name: rootdisk

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -76,6 +76,9 @@ resources:
     # Forgejo — Git LFS server + Actions runner, UE asset storage on sdb
     - forgejo/application.yaml
 
+    # Multus CNI — multiple network interfaces for KubeVirt VMs
+    - multus/application.yaml
+
     # KubeVirt — VM workloads on Talos (KVM in kernel, no extensions needed)
     # Operators installed manually: kubectl apply -f <upstream-operator.yaml>
     # ArgoCD manages namespace + KubeVirt CR + shared storage

--- a/apps/kube/multus/application.yaml
+++ b/apps/kube/multus/application.yaml
@@ -1,0 +1,38 @@
+# Multus CNI — enables multiple network interfaces on pods/VMs.
+# Required for KubeVirt VMs to get direct network access via macvlan.
+# Installs the Multus DaemonSet + CRDs via upstream manifest.
+# Our NetworkAttachmentDefinitions are in a separate app.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: multus
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '0'
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/k8snetworkplumbingwg/multus-cni
+        targetRevision: v4.2.1
+        path: deployments
+        directory:
+            include: 'multus-daemonset-thick.yml'
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: kube-system
+    syncPolicy:
+        automated:
+            prune: false
+            selfHeal: true
+        syncOptions:
+            - ServerSideApply=true
+            - CreateNamespace=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 10s
+                factor: 2
+                maxDuration: 5m
+    revisionHistoryLimit: 3

--- a/apps/kube/multus/manifests/hetzner-macvlan-nad.yaml
+++ b/apps/kube/multus/manifests/hetzner-macvlan-nad.yaml
@@ -1,0 +1,31 @@
+# NetworkAttachmentDefinition — macvlan on Hetzner dedicated server.
+# Uses the Hetzner-assigned virtual MAC (00:50:56:00:BA:57) for IP 142.132.206.71.
+# VMs get direct internet access — no masquerade NAT, no connection drops.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+    name: hetzner-direct
+    namespace: angelscript
+spec:
+    config: |-
+        {
+            "cniVersion": "0.3.1",
+            "type": "macvlan",
+            "master": "enp195s0",
+            "mode": "bridge",
+            "ipam": {
+                "type": "static",
+                "addresses": [
+                    {
+                        "address": "142.132.206.71/26",
+                        "gateway": "142.132.206.65"
+                    }
+                ],
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0",
+                        "gw": "142.132.206.65"
+                    }
+                ]
+            }
+        }


### PR DESCRIPTION
## Summary
Fix KubeVirt masquerade NAT dropping long-lived TCP connections by adding a second NIC via Multus macvlan.

**Root cause**: KubeVirt masquerade NAT (double NAT + VXLAN + WireGuard) drops sustained TCP connections after ~2.5 min. Regular pods unaffected.

**Fix**: Dual-NIC VM — keep masquerade for cluster services, add macvlan for direct internet via Hetzner additional IP.

## Architecture
```
VM NIC1 (masquerade) → pod network → cluster DNS/services
VM NIC2 (macvlan)    → enp195s0 → Hetzner network → internet
                       MAC: 00:50:56:00:BA:57
                       IP:  142.132.206.71/26
                       GW:  142.132.206.65
```

## Components
- `multus/application.yaml` — ArgoCD app pointing at upstream thick plugin DaemonSet
- `multus/manifests/hetzner-macvlan-nad.yaml` — NetworkAttachmentDefinition with static IP
- Windows VM updated with second interface (`bridge` + Hetzner virtual MAC)

## Test plan
- [ ] Multus DaemonSet deploys on node
- [ ] NetworkAttachmentDefinition created in angelscript namespace
- [ ] VM gets second NIC with `142.132.206.71`
- [ ] Large downloads work from inside VM (VS Build Tools, etc.)
- [ ] Cluster services still reachable via first NIC