### PR TITLE
feat(ows): wire RabbitMQ secrets, health probes, KEDA trigger auth

### DIFF
--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -62,13 +62,13 @@ spec:
                           cpu: '500m'
                   livenessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 30
                       periodSeconds: 15
                   readinessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 10
                       periodSeconds: 5
@@ -133,6 +133,16 @@ spec:
                             configMapKeyRef:
                                 name: ows-config
                                 key: RabbitMQPort
+                      - name: RabbitMQOptions__RabbitMQUserName
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-rabbitmq-credentials
+                                key: username
+                      - name: RabbitMQOptions__RabbitMQPassword
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-rabbitmq-credentials
+                                key: password
                   ports:
                       - name: http
                         containerPort: 80
@@ -146,13 +156,13 @@ spec:
                           cpu: '500m'
                   livenessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 30
                       periodSeconds: 15
                   readinessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 10
                       periodSeconds: 5
@@ -217,6 +227,16 @@ spec:
                             configMapKeyRef:
                                 name: ows-config
                                 key: RabbitMQPort
+                      - name: RabbitMQOptions__RabbitMQUserName
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-rabbitmq-credentials
+                                key: username
+                      - name: RabbitMQOptions__RabbitMQPassword
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-rabbitmq-credentials
+                                key: password
                   ports:
                       - name: http
                         containerPort: 80
@@ -230,13 +250,13 @@ spec:
                           cpu: '500m'
                   livenessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 30
                       periodSeconds: 15
                   readinessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 10
                       periodSeconds: 5
@@ -301,6 +321,16 @@ spec:
                             configMapKeyRef:
                                 name: ows-config
                                 key: RabbitMQPort
+                      - name: RabbitMQOptions__RabbitMQUserName
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-rabbitmq-credentials
+                                key: username
+                      - name: RabbitMQOptions__RabbitMQPassword
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-rabbitmq-credentials
+                                key: password
                   ports:
                       - name: http
                         containerPort: 80
@@ -314,13 +344,13 @@ spec:
                           cpu: '500m'
                   livenessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 30
                       periodSeconds: 15
                   readinessProbe:
                       httpGet:
-                          path: /swagger
+                          path: /health
                           port: http
                       initialDelaySeconds: 10
                       periodSeconds: 5

--- a/apps/kube/ows/manifest/externalsecret.yaml
+++ b/apps/kube/ows/manifest/externalsecret.yaml
@@ -41,3 +41,52 @@ spec:
           remoteRef:
               key: supabase-postgres
               property: password
+---
+# RabbitMQ credentials — pulled from operator-managed secret in rabbitmq-system
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: rabbitmq-remote-secret-store
+    namespace: ows
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rabbitmq-system
+            auth:
+                serviceAccount:
+                    name: ows-external-secrets
+                    namespace: ows
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-rabbitmq-secrets
+    namespace: ows
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: rabbitmq-remote-secret-store
+        kind: SecretStore
+    target:
+        name: ows-rabbitmq-credentials
+        creationPolicy: Owner
+    data:
+        - secretKey: username
+          remoteRef:
+              key: rabbitmq-default-user
+              property: username
+        - secretKey: password
+          remoteRef:
+              key: rabbitmq-default-user
+              property: password
+        - secretKey: host
+          remoteRef:
+              key: rabbitmq-default-user
+              property: host

--- a/apps/kube/ows/manifest/keda-trigger-auth.yaml
+++ b/apps/kube/ows/manifest/keda-trigger-auth.yaml
@@ -1,0 +1,19 @@
+---
+# KEDA TriggerAuthentication — RabbitMQ credentials from ExternalSecret
+# Used by ScaledObjects to authenticate against the RabbitMQ cluster
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+    name: ows-rabbitmq-auth
+    namespace: ows
+spec:
+    secretTargetRef:
+        - parameter: host
+          name: ows-rabbitmq-credentials
+          key: host
+        - parameter: username
+          name: ows-rabbitmq-credentials
+          key: username
+        - parameter: password
+          name: ows-rabbitmq-credentials
+          key: password

--- a/apps/kube/rabbitmq/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/rabbitmq/manifests/cross-namespace-rbac.yaml
@@ -1,0 +1,26 @@
+---
+# Cross-namespace RBAC for OWS to access RabbitMQ operator-generated secrets
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: rabbitmq-secrets-reader
+    namespace: rabbitmq-system
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['rabbitmq-default-user']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ows-read-rabbitmq-secrets
+    namespace: rabbitmq-system
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rabbitmq-secrets-reader
+subjects:
+    - kind: ServiceAccount
+      name: ows-external-secrets
+      namespace: ows

--- a/apps/ows/ows-character-persistence/Startup.cs
+++ b/apps/ows/ows-character-persistence/Startup.cs
@@ -112,6 +112,12 @@ namespace OWSCharacterPersistence
 
             //app.UseAuthorization();
 
+            app.Map("/health", a => a.Run(async ctx =>
+            {
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync("{\"status\":\"ok\"}");
+            }));
+
             app.UseMvc();
 
             app.UseSwagger(/*c =>

--- a/apps/ows/ows-global-data/Startup.cs
+++ b/apps/ows/ows-global-data/Startup.cs
@@ -107,6 +107,12 @@ namespace OWSGlobalData
 
             //app.UseAuthorization();
 
+            app.Map("/health", a => a.Run(async ctx =>
+            {
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync("{\"status\":\"ok\"}");
+            }));
+
             app.UseMvc();
 
             app.UseSwagger(/*c =>

--- a/apps/ows/ows-instance-management/Startup.cs
+++ b/apps/ows/ows-instance-management/Startup.cs
@@ -112,6 +112,12 @@ namespace OWSInstanceManagement
 
             //app.UseAuthorization();
 
+            app.Map("/health", a => a.Run(async ctx =>
+            {
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync("{\"status\":\"ok\"}");
+            }));
+
             app.UseMvc();
 
             app.UseSwagger(/*c =>

--- a/apps/ows/ows-public-api/Startup.cs
+++ b/apps/ows/ows-public-api/Startup.cs
@@ -145,6 +145,12 @@ namespace OWSPublicAPI
             //app.UseStaticFiles();
             app.UseRouting();
 
+            app.Map("/health", a => a.Run(async ctx =>
+            {
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync("{\"status\":\"ok\"}");
+            }));
+
             app.UseMvc();
 
             app.UseSwagger(/*c =>


### PR DESCRIPTION
## Summary
- **RabbitMQ credentials via ExternalSecret** — pulls username/password/host from operator-managed `rabbitmq-default-user` secret in `rabbitmq-system` into `ows` namespace. No more hardcoded `dev/test` in production.
- **Cross-namespace RBAC** — `ows-external-secrets` SA can now read RabbitMQ secrets
- **Health probes** — all 4 API services get `/health` endpoint (simple JSON `{"status":"ok"}`), replacing fragile `/swagger` liveness/readiness probes
- **RabbitMQ env vars** — `RabbitMQOptions__RabbitMQUserName` and `RabbitMQOptions__RabbitMQPassword` wired from secret into instancemanagement, characterpersistence, globaldata deployments
- **KEDA TriggerAuthentication** — `ows-rabbitmq-auth` ready for ScaledObject use with secret-based RabbitMQ auth

## Test plan
- [ ] ArgoCD syncs OWS namespace successfully
- [ ] ExternalSecret creates `ows-rabbitmq-credentials` in OWS namespace
- [ ] All 5 deployments start and pass health probes
- [ ] `curl http://ows-publicapi.ows.svc.cluster.local/health` returns `{"status":"ok"}`