### PR TITLE
feat(ows): v0.1.1 — InstanceLauncher secrets, management fix, image bump

### DIFF
--- a/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
+++ b/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
@@ -22,14 +22,25 @@ spec:
                 app: ows-instance-launcher
                 app.kubernetes.io/part-of: ows
         spec:
+            serviceAccountName: ows-launcher-external-secrets
             containers:
                 - name: ows-instance-launcher
-                  image: ghcr.io/kbve/ows-instance-launcher:0.1.0
+                  image: ghcr.io/kbve/ows-instance-launcher:0.1.1
                   env:
                       - name: RabbitMQOptions__RabbitMQHostName
                         value: 'rabbitmq.rabbitmq-system.svc.cluster.local'
                       - name: RabbitMQOptions__RabbitMQPort
                         value: '5672'
+                      - name: RabbitMQOptions__RabbitMQUserName
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-launcher-rabbitmq-credentials
+                                key: username
+                      - name: RabbitMQOptions__RabbitMQPassword
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-launcher-rabbitmq-credentials
+                                key: password
                       - name: OWSInstanceLauncherOptions__PathToDedicatedServer
                         value: '/server/latest/OWSHubWorldMMOServer'
                       - name: OWSInstanceLauncherOptions__PathToUProject

--- a/apps/kube/github/runners/manifests/ows-launcher-secrets.yaml
+++ b/apps/kube/github/runners/manifests/ows-launcher-secrets.yaml
@@ -1,0 +1,53 @@
+---
+# ServiceAccount for InstanceLauncher to access RabbitMQ secrets
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ows-launcher-external-secrets
+    namespace: arc-runners
+---
+# SecretStore pointing to rabbitmq-system namespace
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: rabbitmq-remote-store
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rabbitmq-system
+            auth:
+                serviceAccount:
+                    name: ows-launcher-external-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret to sync RabbitMQ credentials into arc-runners
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-launcher-rabbitmq
+    namespace: arc-runners
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: rabbitmq-remote-store
+        kind: SecretStore
+    target:
+        name: ows-launcher-rabbitmq-credentials
+        creationPolicy: Owner
+    data:
+        - secretKey: username
+          remoteRef:
+              key: rabbitmq-default-user
+              property: username
+        - secretKey: password
+          remoteRef:
+              key: rabbitmq-default-user
+              property: password

--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
             containers:
                 - name: ows-publicapi
-                  image: ghcr.io/kbve/ows-publicapi:0.1.0
+                  image: ghcr.io/kbve/ows-publicapi:0.1.1
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -95,7 +95,7 @@ spec:
         spec:
             containers:
                 - name: ows-instancemanagement
-                  image: ghcr.io/kbve/ows-instancemanagement:0.1.0
+                  image: ghcr.io/kbve/ows-instancemanagement:0.1.1
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -189,7 +189,7 @@ spec:
         spec:
             containers:
                 - name: ows-characterpersistence
-                  image: ghcr.io/kbve/ows-characterpersistence:0.1.0
+                  image: ghcr.io/kbve/ows-characterpersistence:0.1.1
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -283,7 +283,7 @@ spec:
         spec:
             containers:
                 - name: ows-globaldata
-                  image: ghcr.io/kbve/ows-globaldata:0.1.0
+                  image: ghcr.io/kbve/ows-globaldata:0.1.1
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -377,7 +377,7 @@ spec:
         spec:
             containers:
                 - name: ows-management
-                  image: ghcr.io/kbve/ows-management:0.1.0
+                  image: ghcr.io/kbve/ows-management:0.1.1
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -405,6 +405,11 @@ spec:
                             configMapKeyRef:
                                 name: ows-config
                                 key: InternalCharacterPersistenceApiURL
+                      - name: OWSAPIPathConfig__InternalGlobalDataApiURL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: ows-config
+                                key: InternalGlobalDataApiURL
                   ports:
                       - name: http
                         containerPort: 80

--- a/apps/kube/rabbitmq/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/rabbitmq/manifests/cross-namespace-rbac.yaml
@@ -24,3 +24,6 @@ subjects:
     - kind: ServiceAccount
       name: ows-external-secrets
       namespace: ows
+    - kind: ServiceAccount
+      name: ows-launcher-external-secrets
+      namespace: arc-runners

--- a/apps/ows/version.toml
+++ b/apps/ows/version.toml
@@ -1,2 +1,2 @@
-version = "0.1.0"
+version = "0.1.1"
 publish = true


### PR DESCRIPTION
## Summary
- **Version bump** to `0.1.1` — all 5 OWS deployment image tags updated
- **InstanceLauncher RabbitMQ secrets** — new SA, SecretStore, ExternalSecret in `arc-runners` namespace; RabbitMQ credentials wired via `ows-launcher-rabbitmq-credentials` secret
- **RabbitMQ RBAC** — `ows-launcher-external-secrets` SA added to cross-namespace role binding
- **Management fix** — added missing `InternalGlobalDataApiURL` env var

## Changes by file
| File | Change |
|------|--------|
| `version.toml` | `0.1.0` → `0.1.1` |
| `deployment.yaml` | Image tags bumped, management gets GlobalData URL |
| `ows-instance-launcher.yaml` | RabbitMQ creds from secret, SA reference |
| `ows-launcher-secrets.yaml` | New: SA + SecretStore + ExternalSecret |
| `cross-namespace-rbac.yaml` | Add arc-runners SA |

## Test plan
- [ ] CI builds OWS 0.1.1 images (trigger ci-ue5-ows after merge to main)
- [ ] ArgoCD syncs both `ows` and `arc-runners` namespaces
- [ ] ExternalSecrets create `ows-launcher-rabbitmq-credentials` in arc-runners
- [ ] All deployments start with `/health` probes passing