### PR TITLE
feat(ci): move OWS .NET services into regular ci-docker flow

### DIFF
--- a/.github/workflows/ci-ue5-ows.yml
+++ b/.github/workflows/ci-ue5-ows.yml
@@ -1,185 +1,30 @@
-name: CI - OWS Stack
+name: CI - OWS UE5 Server
 
 on:
     workflow_dispatch:
         inputs:
-            build_services:
-                description: 'Build OWS .NET microservices'
-                required: false
-                type: boolean
-                default: true
-            build_ue5_server:
-                description: 'Build HubWorldMMO UE5 dedicated server'
-                required: false
-                type: boolean
-                default: false
             engine_ref:
                 description: 'Engine git branch/tag (KBVE/UnrealEngine-Angelscript)'
                 required: false
                 type: string
                 default: 'angelscript-master'
-            skip_version_gate:
-                description: 'Skip version gate (force rebuild)'
-                required: false
-                type: boolean
-                default: false
 
 concurrency:
-    group: ci-ue5-ows-${{ github.ref }}
+    group: ci-ue5-ows-server
     cancel-in-progress: false
 
 permissions: {}
 
-env:
-    VERSION_TOML: apps/ows/version.toml
-
 jobs:
-    # ── Version Gate ─────────────────────────────────────────
-    version_gate:
-        name: Version Gate
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        permissions:
-            contents: read
-        outputs:
-            version: ${{ steps.check.outputs.version }}
-            should_publish: ${{ steps.check.outputs.should_publish }}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-
-            - name: Read version and check GHCR
-              id: check
-              run: |
-                  VERSION=$(grep -m1 '^version' "${{ env.VERSION_TOML }}" | sed 's/version = "\(.*\)"/\1/')
-                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-                  echo "OWS version: ${VERSION}"
-
-                  if [ "${{ inputs.skip_version_gate }}" = "true" ]; then
-                    echo "Version gate skipped by input."
-                    echo "should_publish=true" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
-
-                  # Check if any OWS service image already exists at this version
-                  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-                    -H "Authorization: Bearer $(echo ${{ github.token }} | base64)" \
-                    "https://ghcr.io/v2/kbve/ows-publicapi/manifests/${VERSION}" 2>/dev/null || echo "000")
-
-                  if [ "$STATUS" = "200" ]; then
-                    echo "OWS v${VERSION} already published — skipping."
-                    echo "should_publish=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "OWS v${VERSION} not found (HTTP ${STATUS}) — will publish."
-                    echo "should_publish=true" >> "$GITHUB_OUTPUT"
-                  fi
-
-    # ── Build OWS .NET Services (matrix) ─────────────────────
-    build_services:
-        name: Build ${{ matrix.service }}
-        needs: [version_gate]
-        if: |
-            inputs.build_services &&
-            needs.version_gate.outputs.should_publish == 'true'
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        permissions:
-            contents: read
-            packages: write
-        strategy:
-            fail-fast: false
-            matrix:
-                service:
-                    - publicapi
-                    - instancemanagement
-                    - characterpersistence
-                    - globaldata
-                    - management
-        env:
-            NX_NO_CLOUD: true
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-
-            - name: Setup Node v24
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-
-            - name: Setup pnpm v10
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 10
-                  run_install: false
-
-            - name: Get pnpm Store
-              id: pnpm-store
-              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm Cache
-              uses: actions/cache@v5
-              with:
-                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install pnpm Dependencies
-              run: pnpm install
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4
-
-            - name: Login to GHCR
-              uses: docker/login-action@v4
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ github.token }}
-
-            - name: Login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-            - name: Build OWS ${{ matrix.service }}
-              env:
-                  INPUT_GITHUB_TOKEN: ${{ github.token }}
-              run: |
-                  pnpm nx run ows:container-${{ matrix.service }} --configuration=production --no-cloud
-
-            - name: Tag with version
-              run: |
-                  VERSION="${{ needs.version_gate.outputs.version }}"
-                  IMAGE="kbve/ows-${{ matrix.service }}"
-
-                  docker tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"
-                  docker tag "${IMAGE}:latest" "ghcr.io/${IMAGE}:latest"
-                  docker tag "${IMAGE}:latest" "ghcr.io/${IMAGE}:${VERSION}"
-
-                  echo "Tagged ${IMAGE}:{latest,${VERSION}} and ghcr.io/${IMAGE}:{latest,${VERSION}}"
-
-            - name: Push to GHCR and Docker Hub
-              run: |
-                  VERSION="${{ needs.version_gate.outputs.version }}"
-                  IMAGE="kbve/ows-${{ matrix.service }}"
-
-                  docker push "${IMAGE}:latest"
-                  docker push "${IMAGE}:${VERSION}"
-                  docker push "ghcr.io/${IMAGE}:latest"
-                  docker push "ghcr.io/${IMAGE}:${VERSION}"
-
     # ── Build HubWorldMMO UE5 Dedicated Server ───────────────
     # Builds on-host using the cached engine source at ENGINE_CACHE_PATH.
-    # Output is saved to a Longhorn RWX PVC (ows-server-binary) so
+    # Output is saved to a Longhorn RWX PVC (ows-server-build) so
     # OWSInstanceLauncher pods can mount and spawn server instances
     # without baking the binary into a Docker image.
+    #
+    # .NET microservices are now built via ci-docker.yml (regular flow).
     build_ue5_server:
         name: Build HubWorldMMO Dedicated Server
-        needs: [version_gate]
-        if: inputs.build_ue5_server
         runs-on: arc-runner-ue
         timeout-minutes: 480
         permissions:
@@ -191,6 +36,13 @@ jobs:
         steps:
             - name: Checkout monorepo
               uses: actions/checkout@v6
+
+            - name: Read version
+              id: version
+              run: |
+                  VERSION=$(grep -m1 '^version' apps/ows/version.toml | sed 's/version = "\(.*\)"/\1/')
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "OWS version: ${VERSION}"
 
             - name: Install build dependencies
               run: |
@@ -217,91 +69,43 @@ jobs:
                     libcairo2 \
                     libglib2.0-0 \
                     libgdk-pixbuf-2.0-0 \
-                    libfontconfig1 \
-                    libfreetype6 \
-                    libx11-6 \
-                    libx11-xcb1 \
-                    libxcb1 \
-                    libxext6 \
-                    libxfixes3 \
-                    libxi6 \
-                    libxrender1 \
-                    libxtst6 \
                     libasound2t64
-                  # Ensure runner user can sudo for setup scripts
-                  echo 'runner ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/runner
 
-            - name: Configure git safe directories
+            - name: Setup engine source
               run: |
-                  git config --global --add safe.directory /mnt/longhorn/angelscript-engine
-                  git config --global --add safe.directory /tmp/chuck
-
-            - name: Clone or update engine source
-              env:
-                  UNITY_PAT: ${{ secrets.UNITY_PAT }}
-              run: |
-                  CACHE="${{ env.ENGINE_CACHE_PATH }}"
-
-                  if [ -d "${CACHE}/.git" ]; then
-                    echo "::notice::Using cached engine source at ${CACHE}"
-                    cd "${CACHE}"
-                    git remote set-url origin "https://x-access-token:${UNITY_PAT}@github.com/KBVE/UnrealEngine-Angelscript.git"
-                    git fetch origin ${{ inputs.engine_ref || 'angelscript-master' }}
-                    git reset --hard FETCH_HEAD
+                  ENGINE="${{ env.ENGINE_CACHE_PATH }}"
+                  if [ -d "${ENGINE}/.git" ]; then
+                    echo "Updating existing engine clone..."
+                    cd "${ENGINE}"
+                    git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/KBVE/UnrealEngine-Angelscript.git"
+                    git fetch origin ${{ inputs.engine_ref }} --depth=1
+                    git checkout FETCH_HEAD
                   else
-                    if [ -d "${CACHE}" ]; then
-                      rm -rf "${CACHE:?}"/*
-                    fi
-                    echo "::notice::Fresh clone of engine source"
-                    git clone --depth 1 --branch ${{ inputs.engine_ref || 'angelscript-master' }} \
-                      "https://x-access-token:${UNITY_PAT}@github.com/KBVE/UnrealEngine-Angelscript.git" \
-                      "${CACHE}"
+                    echo "Fresh engine clone..."
+                    git clone --depth=1 --branch=${{ inputs.engine_ref }} \
+                      "https://x-access-token:${{ github.token }}@github.com/KBVE/UnrealEngine-Angelscript.git" \
+                      "${ENGINE}"
+                    cd "${ENGINE}"
                   fi
 
             - name: Run engine setup
               run: |
                   cd "${{ env.ENGINE_CACHE_PATH }}"
-                  ENGINE_REF="${{ inputs.engine_ref || 'angelscript-master' }}"
-                  MARKER=".setup-done-${ENGINE_REF}"
-                  if [ -f "${MARKER}" ]; then
-                    echo "::notice::Setup already completed for ${ENGINE_REF} — skipping"
-                  else
-                    chmod +x Setup.sh
-                    ./Setup.sh
-                    touch "${MARKER}"
-                  fi
-
-            - name: Generate project files
-              run: |
-                  cd "${{ env.ENGINE_CACHE_PATH }}"
-                  ENGINE_REF="${{ inputs.engine_ref || 'angelscript-master' }}"
-                  MARKER=".genproj-done-${ENGINE_REF}"
-                  if [ -f "${MARKER}" ]; then
-                    echo "::notice::Project files already generated for ${ENGINE_REF} — skipping"
-                  else
-                    chmod +x GenerateProjectFiles.sh
-                    ./GenerateProjectFiles.sh
-                    touch "${MARKER}"
-                  fi
+                  ./Setup.sh 2>&1 | tail -20
+                  ./GenerateProjectFiles.sh 2>&1 | tail -20
 
             - name: Clone HubWorldMMO
               run: |
-                  git lfs install
-
-                  # Clone from GitHub (skip LFS smudge — LFS is on Forgejo)
-                  GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 \
-                    "https://x-access-token:${{ secrets.UNITY_PAT }}@github.com/${{ env.CHUCK_REPO }}.git" \
+                  rm -rf /tmp/chuck
+                  git clone --depth=1 \
+                    "https://x-access-token:${{ github.token }}@github.com/${{ env.CHUCK_REPO }}.git" \
                     /tmp/chuck
 
+            - name: Fetch LFS objects
+              run: |
                   cd /tmp/chuck
-
-                  # Point LFS to internal Forgejo HTTPS with token inline (LFS objects live on Forgejo, not GitHub)
-                  git config lfs.url "http://x-access-token:${FORGEJO_API_TOKEN}@forgejo-http.forgejo.svc.cluster.local:3000/KBVE/chuck.git/info/lfs"
-
+                  git lfs install
                   git lfs pull
-
-            - name: Prepare build output
-              run: mkdir -p /tmp/ue5-build-output
 
             - name: Build dedicated server
               run: |
@@ -325,7 +129,7 @@ jobs:
 
             - name: Deploy server to PVC
               run: |
-                  VERSION="${{ needs.version_gate.outputs.version }}"
+                  VERSION="${{ steps.version.outputs.version }}"
                   SERVER_DIR=$(find /tmp/ue5-build-output -name "LinuxServer" -type d | head -1)
                   if [ -z "${SERVER_DIR}" ]; then
                     echo "::error::LinuxServer output not found"
@@ -333,7 +137,6 @@ jobs:
                     exit 1
                   fi
 
-                  # Copy to versioned directory on the PVC (mounted at /mnt/longhorn/ows-server)
                   DEST="/mnt/longhorn/ows-server/${VERSION}"
                   mkdir -p "${DEST}"
                   cp -r "${SERVER_DIR}/." "${DEST}/"
@@ -350,84 +153,18 @@ jobs:
                     git remote set-url origin "https://github.com/KBVE/UnrealEngine-Angelscript.git" || true
                   rm -rf /tmp/chuck /tmp/ue5-build-output 2>/dev/null || true
 
-    # ── Update Kube Manifests ────────────────────────────────
-    update_kube:
-        name: Update Kube Manifests
-        needs: [version_gate, build_services]
-        if: |
-            always() &&
-            needs.build_services.result == 'success'
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        permissions:
-            contents: write
-            pull-requests: write
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-
-            - name: Update deployment image tags
-              run: |
-                  VERSION="${{ needs.version_gate.outputs.version }}"
-                  DEPLOY="apps/kube/ows/manifest/deployment.yaml"
-
-                  for SERVICE in publicapi instancemanagement characterpersistence globaldata management; do
-                    sed -i "s|ghcr.io/kbve/ows-${SERVICE}:.*|ghcr.io/kbve/ows-${SERVICE}:${VERSION}|g" "$DEPLOY"
-                    echo "Updated ows-${SERVICE} to ${VERSION}"
-                  done
-
-            - name: Create PR for kube manifest update
-              uses: peter-evans/create-pull-request@v7
-              with:
-                  token: ${{ github.token }}
-                  commit-message: 'chore(kube): update OWS images to v${{ needs.version_gate.outputs.version }}'
-                  title: 'chore(kube): update OWS images to v${{ needs.version_gate.outputs.version }}'
-                  body: |
-                      Updates all 5 OWS service deployment images to v${{ needs.version_gate.outputs.version }}.
-
-                      Triggered by CI - OWS Stack workflow.
-                  branch: auto/ows-kube-${{ needs.version_gate.outputs.version }}
-                  base: dev
-                  labels: automated
-
-    # ── Update version.toml ──────────────────────────────────
-    update_version:
-        name: Update version.toml
-        needs: [version_gate, build_services]
-        if: |
-            always() &&
-            needs.build_services.result == 'success' &&
-            needs.version_gate.outputs.should_publish == 'true'
-        permissions:
-            contents: write
-            pull-requests: write
-        uses: KBVE/kbve/.github/workflows/utils-update-version-toml.yml@dev
-        with:
-            package_type: docker
-            package_name: ows
-            version: ${{ needs.version_gate.outputs.version }}
-            version_toml_path: apps/ows/version.toml
-
     # ── Failure Tracker ──────────────────────────────────────
     track_failure:
         name: Track Failures
         if: ${{ always() && contains(needs.*.result, 'failure') }}
-        needs:
-            [
-                version_gate,
-                build_services,
-                build_ue5_server,
-                update_kube,
-                update_version,
-            ]
+        needs: [build_ue5_server]
         permissions:
             issues: write
             contents: read
-        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
         with:
-            workflow_name: 'CI - OWS Stack'
-            job_name: 'ows'
+            workflow_name: 'CI - OWS UE5 Server'
+            job_name: 'Build HubWorldMMO'
             run_id: ${{ github.run_id }}
             run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             status: 'failure'

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -265,6 +265,9 @@ jobs:
                           - 'apps/kbve/edge/project.json'
                           - 'apps/kbve/edge/deno.json'
                           - 'apps/kbve/edge/version.toml'
+                      ows:
+                          - 'apps/ows/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/ows.mdx'
                       isometric:
                           - 'apps/kbve/isometric/src/**'
                           - 'apps/kbve/isometric/public/**'

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
@@ -12,14 +12,16 @@ tags:
 key: ows
 pipeline: docker
 app_name: ows
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest
-image: kbve/ows
+image: kbve/ows-publicapi
+e2e_name: ""
+deployment_yaml: apps/kube/ows/manifest/deployment.yaml
 has_test: false
 author: h0lybyte
-license: MIT
+license: KBVE
 status: active
 ---
 

--- a/apps/ows/project.json
+++ b/apps/ows/project.json
@@ -4,17 +4,31 @@
 	"projectType": "application",
 	"sourceRoot": "apps/ows",
 	"targets": {
-		"container-all": {
+		"container": {
 			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
 			"options": {
-				"commands": [
-					"./kbve.sh -nx ows:container-publicapi --no-cloud",
-					"./kbve.sh -nx ows:container-instancemanagement --no-cloud",
-					"./kbve.sh -nx ows:container-characterpersistence --no-cloud",
-					"./kbve.sh -nx ows:container-globaldata --no-cloud",
-					"./kbve.sh -nx ows:container-management --no-cloud"
-				],
-				"parallel": true
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx ows:container-publicapi --no-cloud",
+						"./kbve.sh -nx ows:container-instancemanagement --no-cloud",
+						"./kbve.sh -nx ows:container-characterpersistence --no-cloud",
+						"./kbve.sh -nx ows:container-globaldata --no-cloud",
+						"./kbve.sh -nx ows:container-management --no-cloud"
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx ows:container-publicapi --configuration=production --no-cloud",
+						"./kbve.sh -nx ows:container-instancemanagement --configuration=production --no-cloud",
+						"./kbve.sh -nx ows:container-characterpersistence --configuration=production --no-cloud",
+						"./kbve.sh -nx ows:container-globaldata --configuration=production --no-cloud",
+						"./kbve.sh -nx ows:container-management --configuration=production --no-cloud"
+					]
+				}
 			}
 		},
 		"container-publicapi": {


### PR DESCRIPTION
## Summary
- OWS .NET microservices now follow the standard `ci-main → ci-docker` pipeline
- MDX page (`ows.mdx`) drives the version gate, file alterations trigger dispatch
- `container` target in `project.json` wraps all 5 services (publicapi, instancemanagement, characterpersistence, globaldata, management)
- `ci-ue5-ows.yml` stripped down to UE5 dedicated server build only (manual dispatch)
- Version gate, kube manifest update, and version.toml sync all handled by existing ci-docker infrastructure

## Before → After
| Aspect | Before | After |
|--------|--------|-------|
| .NET service builds | `ci-ue5-ows.yml` (manual dispatch) | `ci-docker.yml` (auto on file changes) |
| Version gate | Custom GHCR check | Standard manifest-driven gate |
| Kube update | Custom PR step | `utils-update-kube-manifest.yml` |
| UE5 server build | Mixed in same workflow | Dedicated `ci-ue5-ows.yml` |
| File alteration trigger | None | `apps/ows/**` tracked |

## Test plan
- [ ] CI passes (MDX validates, manifest generates)
- [ ] After merge to main + manifest sync, OWS appears in ci-docker dispatch
- [ ] `ci-ue5-ows.yml` still works for manual UE5 server builds