### PR TITLE
fix(kube): Talos-compatible Multus + bridge NAD + Cilium cni.exclusive

### DIFF
--- a/apps/kube/angelscript/manifest/hetzner-bridge-nad.yaml
+++ b/apps/kube/angelscript/manifest/hetzner-bridge-nad.yaml
@@ -1,6 +1,8 @@
-# NetworkAttachmentDefinition — macvlan on Hetzner dedicated server.
-# Uses the Hetzner-assigned virtual MAC (00:50:56:00:BA:57) for IP 142.132.206.71.
+# NetworkAttachmentDefinition — bridge on Hetzner dedicated server.
+# KubeVirt requires bridge type (macvlan/ipvlan are incompatible).
+# Uses br0 bridge interface configured in Talos machine config.
 # VMs get direct internet access — no masquerade NAT, no connection drops.
+# Ref: https://docs.siderolabs.com/kubernetes-guides/cni/multus
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
@@ -10,9 +12,8 @@ spec:
     config: |-
         {
             "cniVersion": "0.3.1",
-            "type": "macvlan",
-            "master": "enp195s0",
-            "mode": "bridge",
+            "type": "bridge",
+            "bridge": "br0",
             "ipam": {
                 "type": "static",
                 "addresses": [

--- a/apps/kube/cilium/values.yaml
+++ b/apps/kube/cilium/values.yaml
@@ -1,6 +1,10 @@
 ## Cilium Helm values for Talos Linux (v1.8.0+)
 ## Reference: https://docs.siderolabs.com/kubernetes-guides/cni/deploying-cilium
 
+# CNI — allow Multus to coexist with Cilium
+cni:
+    exclusive: false
+
 ipam:
     mode: kubernetes
 

--- a/apps/kube/multus/application.yaml
+++ b/apps/kube/multus/application.yaml
@@ -1,7 +1,9 @@
 # Multus CNI — enables multiple network interfaces on pods/VMs.
-# Required for KubeVirt VMs to get direct network access via macvlan.
-# Installs the Multus DaemonSet + CRDs via upstream manifest.
-# Our NetworkAttachmentDefinitions are in a separate app.
+# Vendored from upstream v4.2.1 with Talos-specific fixes:
+#   - /run/netns → /var/run/netns/ (volume mount)
+#   - install_multus thick mode (init container)
+#   - Increased resource limits (prevent OOM)
+# Ref: https://docs.siderolabs.com/kubernetes-guides/cni/multus
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -14,11 +16,9 @@ metadata:
 spec:
     project: default
     source:
-        repoURL: https://github.com/k8snetworkplumbingwg/multus-cni
-        targetRevision: v4.2.1
-        path: deployments
-        directory:
-            include: 'multus-daemonset-thick.yml'
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: main
+        path: apps/kube/multus/manifests
     destination:
         server: https://kubernetes.default.svc
         namespace: kube-system

--- a/apps/kube/multus/manifests/multus-daemonset.yaml
+++ b/apps/kube/multus/manifests/multus-daemonset.yaml
@@ -1,0 +1,259 @@
+# Note:
+#   This deployment file is designed for 'quickstart' of multus, easy installation to test it,
+#   hence this deployment yaml does not care about following things intentionally.
+#     - various configuration options
+#     - minor deployment scenario
+#     - upgrade/update/uninstall scenario
+#   Multus team understand users deployment scenarios are diverse, hence we do not cover
+#   comprehensive deployment scenario. We expect that it is covered by each platform deployment.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+    group: k8s.cni.cncf.io
+    scope: Namespaced
+    names:
+        plural: network-attachment-definitions
+        singular: network-attachment-definition
+        kind: NetworkAttachmentDefinition
+        shortNames:
+            - net-attach-def
+    versions:
+        - name: v1
+          served: true
+          storage: true
+          schema:
+              openAPIV3Schema:
+                  description:
+                      'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+                      Working Group to express the intent for attaching pods to one or more logical or physical
+                      networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+                  type: object
+                  properties:
+                      apiVersion:
+                          description:
+                              'APIVersion defines the versioned schema of this represen
+                              tation of an object. Servers should convert recognized schemas to the
+                              latest internal value, and may reject unrecognized values. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                      kind:
+                          description:
+                              'Kind is a string value representing the REST resource this
+                              object represents. Servers may infer this from the endpoint the client
+                              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                      metadata:
+                          type: object
+                      spec:
+                          description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
+                          type: object
+                          properties:
+                              config:
+                                  description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
+                                  type: string
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+    name: multus
+rules:
+    - apiGroups: ['k8s.cni.cncf.io']
+      resources:
+          - '*'
+      verbs:
+          - '*'
+    - apiGroups:
+          - ''
+      resources:
+          - pods
+          - pods/status
+      verbs:
+          - get
+          - list
+          - update
+          - watch
+    - apiGroups:
+          - ''
+          - events.k8s.io
+      resources:
+          - events
+      verbs:
+          - create
+          - patch
+          - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+    name: multus
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: multus
+subjects:
+    - kind: ServiceAccount
+      name: multus
+      namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: multus
+    namespace: kube-system
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+    name: multus-daemon-config
+    namespace: kube-system
+    labels:
+        tier: node
+        app: multus
+data:
+    daemon-config.json: |
+        {
+            "chrootDir": "/hostroot",
+            "cniVersion": "0.3.1",
+            "logLevel": "verbose",
+            "logToStderr": true,
+            "cniConfigDir": "/host/etc/cni/net.d",
+            "multusAutoconfigDir": "/host/etc/cni/net.d",
+            "multusConfigFile": "auto",
+            "socketDir": "/host/run/multus/"
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+    name: kube-multus-ds
+    namespace: kube-system
+    labels:
+        tier: node
+        app: multus
+        name: multus
+spec:
+    selector:
+        matchLabels:
+            name: multus
+    updateStrategy:
+        type: RollingUpdate
+    template:
+        metadata:
+            labels:
+                tier: node
+                app: multus
+                name: multus
+        spec:
+            hostNetwork: true
+            hostPID: true
+            tolerations:
+                - operator: Exists
+                  effect: NoSchedule
+                - operator: Exists
+                  effect: NoExecute
+            serviceAccountName: multus
+            containers:
+                - name: kube-multus
+                  image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+                  command: ['/usr/src/multus-cni/bin/multus-daemon']
+                  resources:
+                      requests:
+                          cpu: '200m'
+                          memory: '100Mi'
+                      limits:
+                          cpu: '300m'
+                          memory: '150Mi'
+                  securityContext:
+                      privileged: true
+                  terminationMessagePolicy: FallbackToLogsOnError
+                  volumeMounts:
+                      - name: cni
+                        mountPath: /host/etc/cni/net.d
+                      # multus-daemon expects that cnibin path must be identical between pod and container host.
+                      # e.g. if the cni bin is in '/opt/cni/bin' on the container host side, then it should be mount to '/opt/cni/bin' in multus-daemon,
+                      # not to any other directory, like '/opt/bin' or '/usr/bin'.
+                      - name: cnibin
+                        mountPath: /opt/cni/bin
+                      - name: host-run
+                        mountPath: /host/run
+                      - name: host-var-lib-cni-multus
+                        mountPath: /var/lib/cni/multus
+                      - name: host-var-lib-kubelet
+                        mountPath: /var/lib/kubelet
+                        mountPropagation: HostToContainer
+                      - name: host-run-k8s-cni-cncf-io
+                        mountPath: /run/k8s.cni.cncf.io
+                      - name: host-run-netns
+                        mountPath: /run/netns
+                        mountPropagation: HostToContainer
+                      - name: multus-daemon-config
+                        mountPath: /etc/cni/net.d/multus.d
+                        readOnly: true
+                      - name: hostroot
+                        mountPath: /hostroot
+                        mountPropagation: HostToContainer
+                      - mountPath: /etc/cni/multus/net.d
+                        name: multus-conf-dir
+                  env:
+                      - name: MULTUS_NODE_NAME
+                        valueFrom:
+                            fieldRef:
+                                fieldPath: spec.nodeName
+            initContainers:
+                - name: install-multus-binary
+                  image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+                  command:
+                      - '/usr/src/multus-cni/bin/install_multus'
+                      - '-d'
+                      - '/host/opt/cni/bin'
+                      - '-t'
+                      - 'thick'
+                  resources:
+                      requests:
+                          cpu: '10m'
+                          memory: '15Mi'
+                  securityContext:
+                      privileged: true
+                  terminationMessagePolicy: FallbackToLogsOnError
+                  volumeMounts:
+                      - name: cnibin
+                        mountPath: /host/opt/cni/bin
+                        mountPropagation: Bidirectional
+            terminationGracePeriodSeconds: 10
+            volumes:
+                - name: cni
+                  hostPath:
+                      path: /etc/cni/net.d
+                - name: cnibin
+                  hostPath:
+                      path: /opt/cni/bin
+                - name: hostroot
+                  hostPath:
+                      path: /
+                - name: multus-daemon-config
+                  configMap:
+                      name: multus-daemon-config
+                      items:
+                          - key: daemon-config.json
+                            path: daemon-config.json
+                - name: host-run
+                  hostPath:
+                      path: /run
+                - name: host-var-lib-cni-multus
+                  hostPath:
+                      path: /var/lib/cni/multus
+                - name: host-var-lib-kubelet
+                  hostPath:
+                      path: /var/lib/kubelet
+                - name: host-run-k8s-cni-cncf-io
+                  hostPath:
+                      path: /run/k8s.cni.cncf.io
+                - name: host-run-netns
+                  hostPath:
+                      path: /var/run/netns/
+                - name: multus-conf-dir
+                  hostPath:
+                      path: /etc/cni/multus/net.d


### PR DESCRIPTION
## Summary
- Cilium `cni.exclusive: false` to allow Multus coexistence
- Vendored Multus DaemonSet with Talos fixes (/var/run/netns, thick install, bumped resources)
- Switch NAD from macvlan to bridge (KubeVirt requires bridge type per Talos docs)
- Ref: https://docs.siderolabs.com/kubernetes-guides/cni/multus

## Still needed (after merge)
- Talos machine config: create br0 bridge on enp195s0