### PR TITLE
feat(ci): unified CI - Unreal Engine dispatcher

### DIFF
--- a/.github/workflows/ci-angelscript-engine.yml
+++ b/.github/workflows/ci-angelscript-engine.yml
@@ -1,6 +1,24 @@
 name: AngelScript Engine Build
 
 on:
+    workflow_call:
+        inputs:
+            platforms:
+                required: false
+                type: string
+                default: 'linux'
+            engine_ref:
+                required: false
+                type: string
+                default: 'angelscript-master'
+            skip_version_gate:
+                required: false
+                type: boolean
+                default: false
+            build_dedicated_server:
+                required: false
+                type: boolean
+                default: true
     workflow_dispatch:
         inputs:
             platforms:

--- a/.github/workflows/ci-ue-win-setup.yml
+++ b/.github/workflows/ci-ue-win-setup.yml
@@ -1,6 +1,7 @@
 name: UE Win Setup
 
 on:
+    workflow_call: {}
     workflow_dispatch:
         inputs:
             install_vs_buildtools:

--- a/.github/workflows/ci-ue.yml
+++ b/.github/workflows/ci-ue.yml
@@ -1,0 +1,78 @@
+name: CI - Unreal Engine
+
+on:
+    workflow_dispatch:
+        inputs:
+            task:
+                description: 'Which UE task to run'
+                required: true
+                type: choice
+                options:
+                    - ows-server
+                    - win-setup
+                    - engine-build
+            engine_ref:
+                description: 'Engine git branch/tag (for ows-server and engine-build)'
+                required: false
+                type: string
+                default: 'angelscript-master'
+            platforms:
+                description: 'Engine build platforms (comma-separated: windows,mac,linux)'
+                required: false
+                type: string
+                default: 'linux'
+            skip_version_gate:
+                description: 'Skip version gate for engine build'
+                required: false
+                type: boolean
+                default: false
+
+concurrency:
+    group: ci-ue-${{ inputs.task }}
+    cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+    # ── OWS UE5 Dedicated Server Build ─────────────────────────
+    ows_server:
+        name: OWS Server
+        if: inputs.task == 'ows-server'
+        uses: KBVE/kbve/.github/workflows/ci-ue5-ows.yml@dev
+        with:
+            engine_ref: ${{ inputs.engine_ref }}
+        secrets: inherit
+
+    # ── Windows VM Setup ───────────────────────────────────────
+    win_setup:
+        name: Win Setup
+        if: inputs.task == 'win-setup'
+        uses: KBVE/kbve/.github/workflows/ci-ue-win-setup.yml@dev
+        secrets: inherit
+
+    # ── AngelScript Engine Build ───────────────────────────────
+    engine_build:
+        name: Engine Build
+        if: inputs.task == 'engine-build'
+        uses: KBVE/kbve/.github/workflows/ci-angelscript-engine.yml@dev
+        with:
+            platforms: ${{ inputs.platforms }}
+            engine_ref: ${{ inputs.engine_ref }}
+            skip_version_gate: ${{ inputs.skip_version_gate }}
+        secrets: inherit
+
+    # ── Failure Tracker ────────────────────────────────────────
+    track_failure:
+        name: Track Failures
+        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        needs: [ows_server, win_setup, engine_build]
+        permissions:
+            issues: write
+            contents: read
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@dev
+        with:
+            workflow_name: 'CI - Unreal Engine'
+            job_name: ${{ inputs.task }}
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: 'failure'

--- a/.github/workflows/ci-ue5-ows.yml
+++ b/.github/workflows/ci-ue5-ows.yml
@@ -1,6 +1,12 @@
 name: CI - OWS UE5 Server
 
 on:
+    workflow_call:
+        inputs:
+            engine_ref:
+                required: false
+                type: string
+                default: 'angelscript-master'
     workflow_dispatch:
         inputs:
             engine_ref:


### PR DESCRIPTION
## Summary
- New `ci-ue.yml` — single Actions entry point with task dropdown:
  - `ows-server` → calls `ci-ue5-ows.yml` (HubWorldMMO dedicated server)
  - `win-setup` → calls `ci-ue-win-setup.yml` (Windows VM toolchain)
  - `engine-build` → calls `ci-angelscript-engine.yml` (multi-platform engine)
- All three existing workflows get `workflow_call` triggers (additive — standalone dispatch still works)
- Shared inputs: `engine_ref`, `platforms`, `skip_version_gate`
- Unified failure tracking under `CI - Unreal Engine`

## Approach
Additive — no workflows deleted. `ci-ue.yml` is a thin dispatcher that fans out via `workflow_call`. You can still trigger each workflow individually.

## Test plan
- [ ] `CI - Unreal Engine` appears in Actions with task dropdown
- [ ] Each task option dispatches to the correct underlying workflow
- [ ] Individual workflows still work via direct dispatch