### PR TITLE
fix(ci): retry label application on dev→main PR creation

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -188,15 +188,29 @@ jobs:
                           draft: false
                         });
                         prNumber = pr.data.number;
-
-                        await github.rest.issues.addLabels({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: prNumber,
-                          labels: ['auto-pr', 'dev→main']
-                        });
-
                         console.log(`Created PR #${prNumber}`);
+
+                        // Retry label application — GitHub's graph index
+                        // can lag behind PR creation, causing a 422 if the
+                        // node ID isn't resolvable yet.
+                        for (let attempt = 1; attempt <= 3; attempt++) {
+                          try {
+                            await github.rest.issues.addLabels({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: prNumber,
+                              labels: ['auto-pr', 'dev→main']
+                            });
+                            break;
+                          } catch (labelErr) {
+                            if (attempt === 3) {
+                              console.warn(`Failed to add labels after ${attempt} attempts: ${labelErr.message}`);
+                            } else {
+                              console.log(`Label attempt ${attempt} failed, retrying in 2s...`);
+                              await new Promise(r => setTimeout(r, 2000));
+                            }
+                          }
+                        }
                       }
 
                       // Always update title and body to reflect latest commits


### PR DESCRIPTION
## Summary
- GitHub's graph index can lag behind PR creation, causing a 422 `"Could not resolve to a node"` error when `addLabels` runs immediately after `pulls.create`
- Wrap label application in a retry loop (3 attempts, 2s delay between retries)
- Non-fatal: if all 3 attempts fail, logs a warning but doesn't fail the job

## Test plan
- [ ] Merge to dev, verify dev→main PR is created with labels
- [ ] If labels fail transiently, retry succeeds on subsequent attempt

Closes #8597