### PR TITLE
chore(kube): upgrade Cilium from 1.18.0 to 1.19.1

### DIFF
--- a/apps/kube/cilium/application.yaml
+++ b/apps/kube/cilium/application.yaml
@@ -7,7 +7,7 @@ spec:
     project: default
     sources:
         - repoURL: https://helm.cilium.io
-          targetRevision: 1.18.0
+          targetRevision: 1.19.1
           chart: cilium
           helm:
               releaseName: cilium


### PR DESCRIPTION
## Summary
- Bump Cilium Helm chart from 1.18.0 to 1.19.1
- Release notes: https://github.com/cilium/cilium/releases/tag/v1.19.1

## Test plan
- [ ] ArgoCD syncs Cilium upgrade successfully
- [ ] Verify pods in kube-system restart cleanly
- [ ] Verify Gateway API routes still function (forgejo, kbve)
- [ ] Verify Hubble UI accessible
- [ ] Verify WireGuard encryption still active