### PR TITLE
chore(ci): sync manifest with OWS entry (28 tracked items)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.70",
+			"version": "1.0.71",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -31,7 +31,7 @@
 		{
 			"key": "discordsh",
 			"app_name": "discordsh",
-			"version": "0.1.33",
+			"version": "0.1.34",
 			"version_toml": "apps/discordsh/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx",
 			"version_target": "apps/discordsh/axum-discordsh/Cargo.toml",
@@ -125,12 +125,13 @@
 		{
 			"key": "ows",
 			"app_name": "ows",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "apps/ows/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows.mdx",
 			"source_path": "apps/ows",
 			"runner": "ubuntu-latest",
-			"image": "kbve/ows",
+			"image": "kbve/ows-publicapi",
+			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
 			"has_test": false
 		}
 	],


### PR DESCRIPTION
## Summary
- Rebuild Astro site and sync `ci-dispatch-manifest.json`
- OWS now included with correct fields: `has_test: false`, `image: kbve/ows-publicapi`, `deployment_yaml`, `version: 0.1.1`
- Fixes the empty project name bug that caused OWS docker test to fail

## Test plan
- [ ] After merge to main, trigger `ci-docker.yml` for OWS
- [ ] Version gate should see `0.1.1` and test should be skipped (`has_test: false`)
- [ ] Publish should proceed directly