### PR TITLE
fix(kube): add br0 to Cilium L2 announcements, revert VM to masquerade

### DIFF
--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -86,10 +86,6 @@ spec:
                     interfaces:
                         - name: default
                           masquerade: {}
-                        # Direct internet via Hetzner additional IP + virtual MAC
-                        - name: hetzner
-                          bridge: {}
-                          macAddress: '00:50:56:00:BA:57'
                     inputs:
                         - type: tablet
                           bus: usb
@@ -125,9 +121,6 @@ spec:
             networks:
                 - name: default
                   pod: {}
-                - name: hetzner
-                  multus:
-                      networkName: angelscript/hetzner-direct
             terminationGracePeriodSeconds: 3600
             volumes:
                 - name: rootdisk

--- a/apps/kube/cilium/manifests/lb-ipam.yaml
+++ b/apps/kube/cilium/manifests/lb-ipam.yaml
@@ -15,6 +15,7 @@ spec:
     loadBalancerIPs: true
     interfaces:
         - ^enp.*
+        - ^br.*
     nodeSelector:
         matchLabels:
             node.kbve.com/type: dedicated-server


### PR DESCRIPTION
## URGENT — Site down

Cilium L2 announcement policy only matches `^enp.*` but node IP moved to `br0` bridge. Site returning 521.

## Fixes
- Add `^br.*` to L2 announcement interfaces so Cilium announces on the bridge
- Revert Windows VM to masquerade-only (remove broken Multus NIC) so it can start

## Test plan
- [ ] kbve.com responds after ArgoCD syncs
- [ ] Windows VM starts with masquerade networking