### PR TITLE
fix(kube/cilium): Gateway API host-network mode for 1.19.x regression

### DIFF
--- a/apps/kube/cilium/values.yaml
+++ b/apps/kube/cilium/values.yaml
@@ -57,11 +57,14 @@ hubble:
     ui:
         enabled: true
 
-# Gateway API — enabled now so CRDs are installed, ready for Phase 2/5
+# Gateway API — host-network mode to work around 1.19.x external access regression
+# Ref: https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/#host-network-mode
 gatewayAPI:
     enabled: true
     enableAlpn: true
     enableAppProtocol: true
+    hostNetwork:
+        enabled: true
 
 # L2 announcements — replaces MetalLB
 l2announcements:


### PR DESCRIPTION
## URGENT — Site down

Cilium 1.19.x Gateway API external access regression. Gateway is Programmed, Envoy has listeners, L2 lease acquired, but eBPF TPROXY path to Envoy is broken for external traffic.

## Fix
Enable `gatewayAPI.hostNetwork.enabled: true` — runs Gateway Envoy directly on host network, bypassing the broken TPROXY path.

Also includes L2 announcement `^br.*` interface pattern from previous commit.

## Test plan
- [ ] kbve.com responds after ArgoCD syncs
- [ ] All HTTPRoutes accessible externally