### PR TITLE
fix(ci): has_test=false treated as truthy by jq alternative operator

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -178,7 +178,7 @@ jobs:
                   echo "e2e_name=$(echo "$ENTRY" | jq -r '.e2e_name // empty')"              >> "$GITHUB_OUTPUT"
                   echo "cargo_toml=$(echo "$ENTRY" | jq -r '.version_source // empty')"      >> "$GITHUB_OUTPUT"
                   echo "deployment_yaml=$(echo "$ENTRY" | jq -r '.deployment_yaml // empty')" >> "$GITHUB_OUTPUT"
-                  echo "has_test=$(echo "$ENTRY" | jq -r '.has_test // true')"               >> "$GITHUB_OUTPUT"
+                  echo "has_test=$(echo "$ENTRY" | jq -r 'if .has_test == false then "false" else "true" end')" >> "$GITHUB_OUTPUT"
                   echo "version_toml=$(echo "$ENTRY" | jq -r '.version_toml // empty')"      >> "$GITHUB_OUTPUT"
                   echo "version_source=$(echo "$ENTRY" | jq -r '.version_source // empty')"  >> "$GITHUB_OUTPUT"
                   echo "version_target=$(echo "$ENTRY" | jq -r '.version_target // empty')"  >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
`jq -r '.has_test // true'` returns `true` even when `has_test` is `false` because jq's `//` operator treats `false` as falsy (same as `null`). This caused OWS to run the test step despite `has_test: false` in the manifest.

Fix: `jq -r 'if .has_test == false then "false" else "true" end'`

Closes #8598

## Test plan
- [ ] After merge to main, trigger ci-docker for OWS
- [ ] Test step should be skipped
- [ ] Publish step should proceed