### PR TITLE
feat(astro-kbve): consolidate sidebar and add collapsible toggle

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -72,6 +72,7 @@ export default defineConfig({
 				SiteTitle: './src/components/navigation/SiteTitle.astro',
 				PageSidebar: './src/components/pagesidebar/PageSidebar.astro',
 				Footer: './src/components/footer/AstroFooter.astro',
+				Sidebar: './src/components/sidebar/Sidebar.astro',
 			},
 			// TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
 			// plugins: [starlightSiteGraph({ ... })],
@@ -79,10 +80,22 @@ export default defineConfig({
 				{
 					label: 'Dashboard',
 					collapsed: false,
-					autogenerate: { directory: 'dashboard' },
+					items: [
+						{ label: 'Overview', slug: 'dashboard' },
+						{ label: 'Kanban', slug: 'dashboard/kanban' },
+						{ label: 'Report', slug: 'dashboard/report' },
+						{ label: 'Graph', slug: 'dashboard/graph' },
+						{ label: 'Security', slug: 'dashboard/security' },
+						{ label: 'ArgoCD', slug: 'dashboard/argo' },
+						{ label: 'ClickHouse', slug: 'dashboard/clickhouse' },
+						{ label: 'Edge', slug: 'dashboard/edge' },
+						{ label: 'Forgejo', slug: 'dashboard/forgejo' },
+						{ label: 'Grafana', slug: 'dashboard/grafana' },
+					],
 				},
 				{
 					label: 'Guides',
+					collapsed: true,
 					autogenerate: { directory: 'guides' },
 				},
 				{
@@ -96,17 +109,13 @@ export default defineConfig({
 					autogenerate: { directory: 'project' },
 				},
 				{
-					label: 'GDD',
-					collapsed: true,
-					autogenerate: { directory: 'gdd' },
-				},
-				{
 					label: 'Memes',
+					collapsed: true,
 					autogenerate: { directory: 'memes' },
 				},
 				{
 					label: 'Minecraft',
-					collapsed: false,
+					collapsed: true,
 					autogenerate: { directory: 'mc' },
 				},
 				{
@@ -134,32 +143,39 @@ export default defineConfig({
 					],
 				},
 				{
+					label: 'Game Data',
+					collapsed: true,
+					items: [
+						{
+							label: 'GDD',
+							autogenerate: { directory: 'gdd' },
+						},
+						{
+							label: 'ItemDB',
+							autogenerate: { directory: 'itemdb' },
+						},
+						{
+							label: 'QuestDB',
+							autogenerate: { directory: 'questdb' },
+						},
+						{
+							label: 'MapDB',
+							autogenerate: { directory: 'mapdb' },
+						},
+						{
+							label: 'NpcDB',
+							autogenerate: { directory: 'npcdb' },
+						},
+					],
+				},
+				{
 					label: 'Theory',
 					collapsed: true,
 					autogenerate: { directory: 'theory' },
 				},
 				{
-					label: 'ItemDB',
-					collapsed: true,
-					autogenerate: { directory: 'itemdb' },
-				},
-				{
-					label: 'QuestDB',
-					collapsed: true,
-					autogenerate: { directory: 'questdb' },
-				},
-				{
-					label: 'MapDB',
-					collapsed: true,
-					autogenerate: { directory: 'mapdb' },
-				},
-				{
-					label: 'NpcDB',
-					collapsed: true,
-					autogenerate: { directory: 'npcdb' },
-				},
-				{
 					label: 'Blog',
+					collapsed: true,
 					autogenerate: { directory: 'blog' },
 				},
 				{

--- a/apps/kbve/astro-kbve/src/components/sidebar/Sidebar.astro
+++ b/apps/kbve/astro-kbve/src/components/sidebar/Sidebar.astro
@@ -1,0 +1,64 @@
+---
+import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
+import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
+import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
+
+const { sidebar } = Astro.locals.starlightRoute;
+---
+
+<div class="sl-sidebar-toggle-wrap">
+	<button
+		id="sl-sidebar-collapse-btn"
+		class="sl-sidebar-collapse-btn"
+		aria-label="Toggle sidebar"
+		title="Toggle sidebar">
+		<svg
+			class="sl-sidebar-collapse-icon"
+			xmlns="http://www.w3.org/2000/svg"
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round">
+			<polyline class="chevron-left" points="15 18 9 12 15 6"></polyline>
+		</svg>
+	</button>
+</div>
+
+<SidebarPersister>
+	<SidebarSublist sublist={sidebar} />
+</SidebarPersister>
+
+<div class="md:sl-hidden">
+	<MobileMenuFooter />
+</div>
+
+<script>
+	const btn = document.getElementById('sl-sidebar-collapse-btn');
+	const STORAGE_KEY = 'sl-sidebar-collapsed';
+
+	function applyState(collapsed: boolean) {
+		document.documentElement.setAttribute(
+			'data-sidebar-collapsed',
+			String(collapsed),
+		);
+	}
+
+	// Restore saved state on load
+	const saved = localStorage.getItem(STORAGE_KEY);
+	if (saved === 'true') {
+		applyState(true);
+	}
+
+	btn?.addEventListener('click', () => {
+		const isCollapsed =
+			document.documentElement.getAttribute('data-sidebar-collapsed') ===
+			'true';
+		const next = !isCollapsed;
+		applyState(next);
+		localStorage.setItem(STORAGE_KEY, String(next));
+	});
+</script>

--- a/apps/kbve/astro-kbve/src/styles/global.css
+++ b/apps/kbve/astro-kbve/src/styles/global.css
@@ -120,3 +120,86 @@
 		@apply px-2 py-1 bg-cyan-100 dark:bg-cyan-900/30 hover:bg-cyan-200 dark:hover:bg-cyan-800/50 text-cyan-700 dark:text-cyan-300 rounded transition-colors;
 	}
 }
+
+/* Collapsible sidebar toggle */
+@layer my-overrides {
+	/* Toggle button */
+	.sl-sidebar-toggle-wrap {
+		display: none;
+	}
+
+	.sl-sidebar-collapse-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		border: 1px solid var(--sl-color-hairline-shade);
+		border-radius: 0.375rem;
+		background: var(--sl-color-bg-sidebar);
+		color: var(--sl-color-text);
+		cursor: pointer;
+		transition:
+			background-color 0.15s,
+			color 0.15s;
+	}
+
+	.sl-sidebar-collapse-btn:hover {
+		background: var(--sl-color-bg-accent);
+		color: var(--sl-color-text-accent);
+	}
+
+	.sl-sidebar-collapse-icon {
+		transition: transform 0.2s ease;
+	}
+
+	/* Desktop only: show toggle + enable collapse */
+	@media (min-width: 50rem) {
+		.sl-sidebar-toggle-wrap {
+			display: flex;
+			justify-content: flex-end;
+			padding: 0.5rem 0.75rem 0;
+		}
+
+		/* Smooth sidebar width transition */
+		.sidebar-pane,
+		.sidebar {
+			transition: width 0.2s ease;
+		}
+		.main-frame {
+			transition: padding-inline-start 0.2s ease;
+		}
+
+		/* Collapsed state */
+		:root[data-sidebar-collapsed='true'] {
+			--sl-sidebar-width: 3.5rem;
+		}
+
+		/* Rotate chevron when collapsed */
+		:root[data-sidebar-collapsed='true'] .sl-sidebar-collapse-icon {
+			transform: rotate(180deg);
+		}
+
+		/* Center the toggle button when collapsed */
+		:root[data-sidebar-collapsed='true'] .sl-sidebar-toggle-wrap {
+			justify-content: center;
+			padding: 0.5rem 0;
+		}
+
+		/* Hide sidebar text content when collapsed */
+		:root[data-sidebar-collapsed='true'] .sidebar-content ul {
+			display: none;
+		}
+
+		/* Hide mobile menu footer in collapsed state */
+		:root[data-sidebar-collapsed='true'] .sidebar-content > div {
+			display: none;
+		}
+
+		/* Reduce sidebar padding when collapsed */
+		:root[data-sidebar-collapsed='true'] .sidebar-content {
+			padding-inline: 0.25rem;
+			overflow: hidden;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Consolidate sidebar from 19 to 14 top-level groups by merging GDD, ItemDB, QuestDB, MapDB, NpcDB into a "Game Data" parent
- Convert Dashboard from autogenerate to manual links for explicit ordering control
- Collapse all sidebar sections by default
- Add a desktop sidebar toggle button (chevron icon) that collapses the sidebar to a narrow 3.5rem rail, with state persisted in localStorage

## Test plan
- [ ] `npx nx run astro-kbve:build` passes
- [ ] Dashboard shows manual links in correct order
- [ ] Game Data group contains GDD, ItemDB, QuestDB, MapDB, NpcDB
- [ ] Sidebar toggle button collapses/expands the sidebar on desktop
- [ ] Collapsed state persists on page reload
- [ ] Mobile sidebar menu still works normally