### PR TITLE
chore(ows): bump version to 0.1.2 for first ci-docker publish

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
@@ -12,7 +12,7 @@ tags:
 key: ows
 pipeline: docker
 app_name: ows
-version: "0.1.1"
+version: "0.1.2"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary
- Bump OWS MDX version to `0.1.2`
- MDX `0.1.2` > version.toml `0.1.1` → publish gate triggers
- First actual publish of OWS .NET services through the regular ci-docker pipeline

## Test plan
- [ ] After merge to main + manifest sync, ci-docker dispatches OWS
- [ ] Test skipped (`has_test: false`)
- [ ] Publish builds all 5 services and pushes to GHCR + Docker Hub
- [ ] version.toml updated to 0.1.2 post-publish
- [ ] Kube manifest PR created with 0.1.2 image tags