### PR TITLE
fix(ows): correct image tags and add RabbitMQ RBAC

### DIFF
--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
             containers:
                 - name: ows-publicapi
-                  image: ghcr.io/kbve/ows-publicapi:0.1.1
+                  image: ghcr.io/kbve/ows-publicapi:0.1.0
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -95,7 +95,7 @@ spec:
         spec:
             containers:
                 - name: ows-instancemanagement
-                  image: ghcr.io/kbve/ows-instancemanagement:0.1.1
+                  image: ghcr.io/kbve/ows-instancemanagement:0.1.0
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -189,7 +189,7 @@ spec:
         spec:
             containers:
                 - name: ows-characterpersistence
-                  image: ghcr.io/kbve/ows-characterpersistence:0.1.1
+                  image: ghcr.io/kbve/ows-characterpersistence:0.1.0
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -283,7 +283,7 @@ spec:
         spec:
             containers:
                 - name: ows-globaldata
-                  image: ghcr.io/kbve/ows-globaldata:0.1.1
+                  image: ghcr.io/kbve/ows-globaldata:0.1.0
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -377,7 +377,7 @@ spec:
         spec:
             containers:
                 - name: ows-management
-                  image: ghcr.io/kbve/ows-management:0.1.1
+                  image: ghcr.io/kbve/ows-management:0.1.0
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend

--- a/apps/kube/ows/manifest/rbac.yaml
+++ b/apps/kube/ows/manifest/rbac.yaml
@@ -1,0 +1,33 @@
+---
+# Cross-namespace RBAC — allow ows-external-secrets SA to read
+# RabbitMQ operator-managed credentials in rabbitmq-system namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: rabbitmq-secrets-reader-for-ows
+    namespace: rabbitmq-system
+    labels:
+        app.kubernetes.io/name: ows
+        app.kubernetes.io/component: rbac
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['rabbitmq-default-user']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ows-read-rabbitmq-secrets
+    namespace: rabbitmq-system
+    labels:
+        app.kubernetes.io/name: ows
+        app.kubernetes.io/component: rbac
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rabbitmq-secrets-reader-for-ows
+subjects:
+    - kind: ServiceAccount
+      name: ows-external-secrets
+      namespace: ows


### PR DESCRIPTION
## Summary
- Fix image tags 0.1.1 → 0.1.0 (only 0.1.0 exists on GHCR)
- Add cross-namespace RBAC for `ows-external-secrets` SA to read `rabbitmq-default-user` secret in `rabbitmq-system` namespace
- kilobase RBAC already existed via `cross-namespace-rbac.yaml`

## What's needed after merge
1. Apply the ArgoCD Application: `kubectl apply -f apps/kube/ows/application.yaml`
2. ArgoCD will bootstrap the entire `ows` namespace (namespace, SA, configmap, externalsecrets, deployments, services)
3. Verify ExternalSecrets populate: `kubectl get externalsecret -n ows`
4. Verify pods start: `kubectl get pods -n ows`

Ref: #8404