### PR TITLE
fix(kube/cilium): revert to enp195s0, disable Hubble

### DIFF
--- a/apps/kube/cilium/values.yaml
+++ b/apps/kube/cilium/values.yaml
@@ -5,15 +5,14 @@
 cni:
     exclusive: false
 
-# Device — pin Cilium external/native device to br0 after bridge setup.
-# br0 holds the node IP (142.132.206.74) and default route.
-# Without this, Cilium auto-detects flannel.1 (legacy) which can't serve external LB traffic.
+# Device — pin Cilium to the external-facing interface.
+# Without this, Cilium auto-detects flannel.1 (legacy).
 devices:
-    - br0
+    - enp195s0
 
 # NodePort direct routing device — must match the external-facing interface.
 nodePort:
-    directRoutingDevice: br0
+    directRoutingDevice: enp195s0
 
 ipam:
     mode: kubernetes


### PR DESCRIPTION
## Summary
- Revert Cilium devices from br0 to enp195s0 — bridge breaks BPF TPROXY path in tunnel mode
- Disable Hubble — nil pointer crash in observer affects both 1.18.0 and 1.19.x
- Site is back up

## Root cause
Cilium tunnel mode doesn't attach BPF programs to bridge interfaces. The Gateway LB path requires: BPF mark → iptables TPROXY → Envoy. Without BPF on the external interface, packets never get marked and TPROXY never fires.

## What's reverted
- Bridge removed from Talos machine config (done manually)
- Cilium devices back to enp195s0
- VM networking still on masquerade (file-server proxy for large downloads)