### PR TITLE
refactor(ows): split into 5 MDX projects + add target/nx_project to manifest

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -155,6 +155,8 @@ jobs:
             version_toml: ${{ steps.resolve.outputs.version_toml }}
             version_source: ${{ steps.resolve.outputs.version_source }}
             version_target: ${{ steps.resolve.outputs.version_target }}
+            target: ${{ steps.resolve.outputs.target }}
+            nx_project: ${{ steps.resolve.outputs.nx_project }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -182,6 +184,8 @@ jobs:
                   echo "version_toml=$(echo "$ENTRY" | jq -r '.version_toml // empty')"      >> "$GITHUB_OUTPUT"
                   echo "version_source=$(echo "$ENTRY" | jq -r '.version_source // empty')"  >> "$GITHUB_OUTPUT"
                   echo "version_target=$(echo "$ENTRY" | jq -r '.version_target // empty')"  >> "$GITHUB_OUTPUT"
+                  echo "target=$(echo "$ENTRY" | jq -r '.target // "container"')"              >> "$GITHUB_OUTPUT"
+                  echo "nx_project=$(echo "$ENTRY" | jq -r '.nx_project // empty')"            >> "$GITHUB_OUTPUT"
 
     # ---------------------------------------------------------------------------
     # Test — builds the app image, tags as ci-{sha} in GHCR, runs e2e tests.
@@ -226,8 +230,8 @@ jobs:
             packages: write
         uses: KBVE/kbve/.github/workflows/utils-publish-docker-image.yml@main
         with:
-            project: ${{ inputs.app_name }}
-            target: container
+            project: ${{ needs.config.outputs.nx_project || inputs.app_name }}
+            target: ${{ needs.config.outputs.target }}
             image: ${{ needs.config.outputs.image }}
             cargo_toml: ${{ needs.config.outputs.cargo_toml }}
             version_source: ${{ needs.config.outputs.version_source }}

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -265,9 +265,21 @@ jobs:
                           - 'apps/kbve/edge/project.json'
                           - 'apps/kbve/edge/deno.json'
                           - 'apps/kbve/edge/version.toml'
-                      ows:
+                      ows_publicapi:
                           - 'apps/ows/**'
-                          - 'apps/kbve/astro-kbve/src/content/docs/project/ows.mdx'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx'
+                      ows_instancemanagement:
+                          - 'apps/ows/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx'
+                      ows_characterpersistence:
+                          - 'apps/ows/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx'
+                      ows_globaldata:
+                          - 'apps/ows/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx'
+                      ows_management:
+                          - 'apps/ows/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx'
                       isometric:
                           - 'apps/kbve/isometric/src/**'
                           - 'apps/kbve/isometric/public/**'

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -1,0 +1,30 @@
+---
+title: OWS CharacterPersistence
+description: |
+    OWS Character Persistence — character stats, abilities, inventory.
+sidebar:
+    label: OWS CharPersist
+    order: 63
+tags:
+    - docker
+    - dotnet
+key: ows_characterpersistence
+pipeline: docker
+app_name: ows-characterpersistence
+version: "0.1.2"
+source_path: apps/ows
+version_toml: apps/ows/version.toml
+runner: ubuntu-latest
+image: kbve/ows-characterpersistence
+deployment_yaml: apps/kube/ows/manifest/deployment.yaml
+has_test: false
+target: container-characterpersistence
+nx_project: ows
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+OWS Character Persistence handles character state management — stats, abilities, inventory, and custom character data for the HubWorldMMO backend.

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -1,0 +1,30 @@
+---
+title: OWS GlobalData
+description: |
+    OWS Global Data — distributed key/value world state store.
+sidebar:
+    label: OWS GlobalData
+    order: 64
+tags:
+    - docker
+    - dotnet
+key: ows_globaldata
+pipeline: docker
+app_name: ows-globaldata
+version: "0.1.2"
+source_path: apps/ows
+version_toml: apps/ows/version.toml
+runner: ubuntu-latest
+image: kbve/ows-globaldata
+deployment_yaml: apps/kube/ows/manifest/deployment.yaml
+has_test: false
+target: container-globaldata
+nx_project: ows
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+OWS Global Data provides a distributed key/value store for world state, shared across all game server instances in the HubWorldMMO backend.

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -1,0 +1,30 @@
+---
+title: OWS InstanceManagement
+description: |
+    OWS Instance Management — zone/server instance orchestration via RabbitMQ.
+sidebar:
+    label: OWS InstanceMgmt
+    order: 62
+tags:
+    - docker
+    - dotnet
+key: ows_instancemanagement
+pipeline: docker
+app_name: ows-instancemanagement
+version: "0.1.2"
+source_path: apps/ows
+version_toml: apps/ows/version.toml
+runner: ubuntu-latest
+image: kbve/ows-instancemanagement
+deployment_yaml: apps/kube/ows/manifest/deployment.yaml
+has_test: false
+target: container-instancemanagement
+nx_project: ows
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+OWS Instance Management orchestrates zone and server instances, coordinating with the InstanceLauncher via RabbitMQ to spawn UE5 dedicated servers on demand.

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -1,0 +1,30 @@
+---
+title: OWS Management
+description: |
+    OWS Management — admin web dashboard (Vue 3) for server operators.
+sidebar:
+    label: OWS Management
+    order: 65
+tags:
+    - docker
+    - dotnet
+key: ows_management
+pipeline: docker
+app_name: ows-management
+version: "0.1.2"
+source_path: apps/ows
+version_toml: apps/ows/version.toml
+runner: ubuntu-latest
+image: kbve/ows-management
+deployment_yaml: apps/kube/ows/manifest/deployment.yaml
+has_test: false
+target: container-management
+nx_project: ows
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+OWS Management is the admin web dashboard (Vue 3 + ASP.NET Core) for server operators to manage players, zones, and global configuration.

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -1,0 +1,30 @@
+---
+title: OWS PublicAPI
+description: |
+    OWS Public API — player login, registration, character creation.
+sidebar:
+    label: OWS PublicAPI
+    order: 61
+tags:
+    - docker
+    - dotnet
+key: ows_publicapi
+pipeline: docker
+app_name: ows-publicapi
+version: "0.1.2"
+source_path: apps/ows
+version_toml: apps/ows/version.toml
+runner: ubuntu-latest
+image: kbve/ows-publicapi
+deployment_yaml: apps/kube/ows/manifest/deployment.yaml
+has_test: false
+target: container-publicapi
+nx_project: ows
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+OWS Public API handles player authentication, registration, and character creation for the HubWorldMMO multiplayer backend.

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows.mdx
@@ -9,17 +9,6 @@ tags:
     - docker
     - dotnet
     - game
-key: ows
-pipeline: docker
-app_name: ows
-version: "0.1.2"
-source_path: apps/ows
-version_toml: apps/ows/version.toml
-runner: ubuntu-latest
-image: kbve/ows-publicapi
-e2e_name: ""
-deployment_yaml: apps/kube/ows/manifest/deployment.yaml
-has_test: false
 author: h0lybyte
 license: KBVE
 status: active

--- a/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
@@ -33,6 +33,8 @@ const AstroProjectExtensions = z.object({
 	deployment_yaml: z.string().max(256).optional(),
 	version_target: z.string().max(256).optional(),
 	has_test: z.boolean().optional(),
+	target: z.string().max(64).optional(),
+	nx_project: z.string().max(64).optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
@@ -25,6 +25,8 @@ interface DockerEntry {
 	e2e_name?: string;
 	deployment_yaml?: string;
 	has_test?: boolean;
+	target?: string;
+	nx_project?: string;
 }
 
 interface NpmEntry {
@@ -77,7 +79,10 @@ interface DispatchManifest {
 }
 
 /** Build a typed manifest entry from the frontmatter data, or null if required fields are missing. */
-function toManifestEntry(d: ICiProject, mdxPath?: string): ManifestEntry | null {
+function toManifestEntry(
+	d: ICiProject,
+	mdxPath?: string,
+): ManifestEntry | null {
 	const vt = d.version_toml;
 	const ver = d.version;
 	switch (d.pipeline) {
@@ -94,8 +99,12 @@ function toManifestEntry(d: ICiProject, mdxPath?: string): ManifestEntry | null 
 				...(d.runner && { runner: d.runner }),
 				...(d.image && { image: d.image }),
 				...(d.e2e_name && { e2e_name: d.e2e_name }),
-				...(d.deployment_yaml && { deployment_yaml: d.deployment_yaml }),
+				...(d.deployment_yaml && {
+					deployment_yaml: d.deployment_yaml,
+				}),
 				...(d.has_test !== undefined && { has_test: d.has_test }),
+				...(d.target && { target: d.target }),
+				...(d.nx_project && { nx_project: d.nx_project }),
 			};
 		case 'npm':
 		case 'crates':

--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -95,7 +95,7 @@ spec:
         spec:
             containers:
                 - name: ows-instancemanagement
-                  image: ghcr.io/kbve/ows-instancemanagement:0.1.0
+                  image: ghcr.io/kbve/ows-instancemanagement:0.1.2
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -189,7 +189,7 @@ spec:
         spec:
             containers:
                 - name: ows-characterpersistence
-                  image: ghcr.io/kbve/ows-characterpersistence:0.1.0
+                  image: ghcr.io/kbve/ows-characterpersistence:0.1.2
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -283,7 +283,7 @@ spec:
         spec:
             containers:
                 - name: ows-globaldata
-                  image: ghcr.io/kbve/ows-globaldata:0.1.0
+                  image: ghcr.io/kbve/ows-globaldata:0.1.2
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend
@@ -377,7 +377,7 @@ spec:
         spec:
             containers:
                 - name: ows-management
-                  image: ghcr.io/kbve/ows-management:0.1.0
+                  image: ghcr.io/kbve/ows-management:0.1.2
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend


### PR DESCRIPTION
## Summary
- Split single OWS MDX into 5 service-specific pages — each is a first-class ci-docker entry
- Add `target` field to manifest (defaults to `container`, OWS uses `container-{service}`)
- Add `nx_project` field for apps where the Nx project name differs from app_name (OWS: project=`ows`, app_name=`ows-publicapi`)
- ci-docker.yml reads both from manifest — no more hardcoded `container` target
- File alterations track all 5 OWS services independently
- Fix deployment.yaml: all 5 images at `0.1.2`

## New MDX pages
| Page | app_name | image | target |
|------|----------|-------|--------|
| ows-publicapi.mdx | ows-publicapi | kbve/ows-publicapi | container-publicapi |
| ows-instancemanagement.mdx | ows-instancemanagement | kbve/ows-instancemanagement | container-instancemanagement |
| ows-characterpersistence.mdx | ows-characterpersistence | kbve/ows-characterpersistence | container-characterpersistence |
| ows-globaldata.mdx | ows-globaldata | kbve/ows-globaldata | container-globaldata |
| ows-management.mdx | ows-management | kbve/ows-management | container-management |

## Test plan
- [ ] Astro build succeeds with 5 new MDX pages
- [ ] Manifest includes all 5 OWS services with correct fields
- [ ] ci-docker dispatches each service independently
- [ ] Kube manifest update hits all 5 image tags