### PR TITLE
feat(ows): manifest sync (32 items) + ValKey session cache

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -123,16 +123,74 @@
 			"has_test": true
 		},
 		{
-			"key": "ows",
-			"app_name": "ows",
-			"version": "0.1.1",
+			"key": "ows_characterpersistence",
+			"app_name": "ows-characterpersistence",
+			"version": "0.1.2",
 			"version_toml": "apps/ows/version.toml",
-			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows.mdx",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx",
+			"source_path": "apps/ows",
+			"runner": "ubuntu-latest",
+			"image": "kbve/ows-characterpersistence",
+			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
+			"has_test": false,
+			"target": "container-characterpersistence",
+			"nx_project": "ows"
+		},
+		{
+			"key": "ows_globaldata",
+			"app_name": "ows-globaldata",
+			"version": "0.1.2",
+			"version_toml": "apps/ows/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx",
+			"source_path": "apps/ows",
+			"runner": "ubuntu-latest",
+			"image": "kbve/ows-globaldata",
+			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
+			"has_test": false,
+			"target": "container-globaldata",
+			"nx_project": "ows"
+		},
+		{
+			"key": "ows_instancemanagement",
+			"app_name": "ows-instancemanagement",
+			"version": "0.1.2",
+			"version_toml": "apps/ows/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx",
+			"source_path": "apps/ows",
+			"runner": "ubuntu-latest",
+			"image": "kbve/ows-instancemanagement",
+			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
+			"has_test": false,
+			"target": "container-instancemanagement",
+			"nx_project": "ows"
+		},
+		{
+			"key": "ows_management",
+			"app_name": "ows-management",
+			"version": "0.1.2",
+			"version_toml": "apps/ows/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx",
+			"source_path": "apps/ows",
+			"runner": "ubuntu-latest",
+			"image": "kbve/ows-management",
+			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
+			"has_test": false,
+			"target": "container-management",
+			"nx_project": "ows"
+		},
+		{
+			"key": "ows_publicapi",
+			"app_name": "ows-publicapi",
+			"version": "0.1.2",
+			"version_toml": "apps/ows/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx",
 			"source_path": "apps/ows",
 			"runner": "ubuntu-latest",
 			"image": "kbve/ows-publicapi",
 			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
-			"has_test": false
+			"has_test": false,
+			"target": "container-publicapi",
+			"nx_project": "ows"
 		}
 	],
 	"npm": [
@@ -262,11 +320,11 @@
 		}
 	],
 	"summary": {
-		"docker": 10,
+		"docker": 14,
 		"npm": 4,
 		"crates": 6,
 		"python": 2,
 		"unreal": 6,
-		"total": 28
+		"total": 32
 	}
 }

--- a/apps/kube/ows/manifest/configmap.yaml
+++ b/apps/kube/ows/manifest/configmap.yaml
@@ -11,3 +11,5 @@ data:
     InternalGlobalDataApiURL: 'http://ows-globaldata.ows.svc.cluster.local/'
     RabbitMQHostName: 'rabbitmq.rabbitmq-system.svc.cluster.local'
     RabbitMQPort: '5672'
+    UserSessionCacheHostName: 'ows-valkey.ows.svc.cluster.local'
+    UserSessionCachePort: '6379'

--- a/apps/kube/ows/manifest/valkey.yaml
+++ b/apps/kube/ows/manifest/valkey.yaml
@@ -1,0 +1,70 @@
+---
+# ValKey — user session cache for OWS (Redis-compatible)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: ows-valkey
+    namespace: ows
+    labels:
+        app: ows-valkey
+        app.kubernetes.io/part-of: ows
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: ows-valkey
+    template:
+        metadata:
+            labels:
+                app: ows-valkey
+                app.kubernetes.io/part-of: ows
+        spec:
+            containers:
+                - name: valkey
+                  image: valkey/valkey:8-alpine
+                  command: ['valkey-server', '--appendonly', 'yes']
+                  ports:
+                      - name: valkey
+                        containerPort: 6379
+                        protocol: TCP
+                  resources:
+                      requests:
+                          memory: '64Mi'
+                          cpu: '50m'
+                      limits:
+                          memory: '256Mi'
+                          cpu: '250m'
+                  livenessProbe:
+                      exec:
+                          command: ['valkey-cli', 'ping']
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+                  readinessProbe:
+                      exec:
+                          command: ['valkey-cli', 'ping']
+                      initialDelaySeconds: 5
+                      periodSeconds: 5
+                  volumeMounts:
+                      - name: data
+                        mountPath: /data
+            volumes:
+                - name: data
+                  emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: ows-valkey
+    namespace: ows
+    labels:
+        app: ows-valkey
+        app.kubernetes.io/part-of: ows
+spec:
+    type: ClusterIP
+    selector:
+        app: ows-valkey
+    ports:
+        - name: valkey
+          port: 6379
+          targetPort: 6379
+          protocol: TCP


### PR DESCRIPTION
## Summary
- **Manifest sync** — 32 tracked items. All 5 OWS services included with `target`, `nx_project`, `image` fields for independent ci-docker dispatch
- **ValKey deployment** — Redis-compatible user session cache (`valkey/valkey:8-alpine`) in OWS namespace
- **ConfigMap** — added `UserSessionCacheHostName` and `UserSessionCachePort`

## OWS services in manifest
| app_name | target | nx_project | image |
|----------|--------|------------|-------|
| ows-publicapi | container-publicapi | ows | kbve/ows-publicapi |
| ows-instancemanagement | container-instancemanagement | ows | kbve/ows-instancemanagement |
| ows-characterpersistence | container-characterpersistence | ows | kbve/ows-characterpersistence |
| ows-globaldata | container-globaldata | ows | kbve/ows-globaldata |
| ows-management | container-management | ows | kbve/ows-management |

## Test plan
- [ ] After merge to main, trigger ci-docker for each OWS service
- [ ] Version gate sees 0.1.2 > version.toml 0.1.1 → publish
- [ ] ArgoCD syncs ValKey deployment to OWS namespace