### PR TITLE
fix(kube): register OWS in root kustomization + wire missing env vars

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -52,6 +52,8 @@ resources:
     - memes/application.yaml
     - n8n/application.yaml
     - rabbitmq/application.yaml
+    # OWS — Open World Server .NET microservices (5 services + ValKey)
+    - ows/application.yaml
     - rentearth/application.yaml
     - cryptothrone/application.yaml
     # AngelScript UE dedicated server

--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -49,6 +49,21 @@ spec:
                             configMapKeyRef:
                                 name: ows-config
                                 key: InternalCharacterPersistenceApiURL
+                      - name: OWSAPIPathConfig__InternalGlobalDataApiURL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: ows-config
+                                key: InternalGlobalDataApiURL
+                      - name: UserSessionCacheOptions__HostName
+                        valueFrom:
+                            configMapKeyRef:
+                                name: ows-config
+                                key: UserSessionCacheHostName
+                      - name: UserSessionCacheOptions__Port
+                        valueFrom:
+                            configMapKeyRef:
+                                name: ows-config
+                                key: UserSessionCachePort
                   ports:
                       - name: http
                         containerPort: 80
@@ -143,6 +158,11 @@ spec:
                             secretKeyRef:
                                 name: ows-rabbitmq-credentials
                                 key: password
+                      - name: OWSAPIPathConfig__InternalGlobalDataApiURL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: ows-config
+                                key: InternalGlobalDataApiURL
                   ports:
                       - name: http
                         containerPort: 80
@@ -237,6 +257,11 @@ spec:
                             secretKeyRef:
                                 name: ows-rabbitmq-credentials
                                 key: password
+                      - name: OWSAPIPathConfig__InternalGlobalDataApiURL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: ows-config
+                                key: InternalGlobalDataApiURL
                   ports:
                       - name: http
                         containerPort: 80
@@ -331,6 +356,11 @@ spec:
                             secretKeyRef:
                                 name: ows-rabbitmq-credentials
                                 key: password
+                      - name: OWSAPIPathConfig__InternalGlobalDataApiURL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: ows-config
+                                key: InternalGlobalDataApiURL
                   ports:
                       - name: http
                         containerPort: 80


### PR DESCRIPTION
## Summary
- **OWS missing from root kustomization** — ArgoCD couldn't discover the OWS namespace. Added `ows/application.yaml` to `apps/kube/kustomization.yaml`
- **InternalGlobalDataApiURL** wired to all 4 API deployments (was only in management)
- **ValKey session cache** env vars (`UserSessionCacheOptions__HostName/Port`) wired to publicapi (main session consumer)

## Audit findings addressed
| Issue | Fix |
|-------|-----|
| OWS not in kustomization | Added to root kustomization.yaml |
| GlobalDataApiURL missing from 4 deployments | Added to publicapi, instancemanagement, characterpersistence, globaldata |
| ValKey not wired | Session cache host/port injected into publicapi |

## Test plan
- [ ] ArgoCD discovers and syncs OWS namespace
- [ ] All 5 deployments have correct env vars
- [ ] ValKey pod starts with health probes passing