### PR TITLE
chore(ows): bump all 5 services to 0.1.3 for first full publish

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_characterpersistence
 pipeline: docker
 app_name: ows-characterpersistence
-version: "0.1.2"
+version: "0.1.3"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_globaldata
 pipeline: docker
 app_name: ows-globaldata
-version: "0.1.2"
+version: "0.1.3"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancemanagement
 pipeline: docker
 app_name: ows-instancemanagement
-version: "0.1.2"
+version: "0.1.3"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_management
 pipeline: docker
 app_name: ows-management
-version: "0.1.2"
+version: "0.1.3"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_publicapi
 pipeline: docker
 app_name: ows-publicapi
-version: "0.1.2"
+version: "0.1.3"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary
Bump all 5 OWS service MDX pages to `0.1.3`. Previous versions were never fully published:
- `ows-publicapi` had `0.1.1` on GHCR
- Other 4 services only had `buildcache` layers (never tagged/pushed)

MDX `0.1.3` > version.toml `0.1.2` → version gate triggers for all 5.

## Test plan
- [ ] After merge to main, ci-main dispatches all 5 OWS services
- [ ] All 5 images published to GHCR as `0.1.3` + `latest`
- [ ] version.toml updated to 0.1.3 post-publish
- [ ] ArgoCD picks up new image tags