### PR TITLE
fix(ows): remove CodeGeneration.Design CVE + bump to 0.1.4

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_characterpersistence
 pipeline: docker
 app_name: ows-characterpersistence
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_globaldata
 pipeline: docker
 app_name: ows-globaldata
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancemanagement
 pipeline: docker
 app_name: ows-instancemanagement
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_management
 pipeline: docker
 app_name: ows-management
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_publicapi
 pipeline: docker
 app_name: ows-publicapi
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 runner: ubuntu-latest

--- a/apps/ows/ows-character-persistence/OWSCharacterPersistence.csproj
+++ b/apps/ows/ows-character-persistence/OWSCharacterPersistence.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../ows-data/OWSData.csproj" />

--- a/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
+++ b/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.5.0" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../ows-data/OWSData.csproj" />

--- a/apps/ows/ows-instance-management/OWSInstanceManagement.csproj
+++ b/apps/ows/ows-instance-management/OWSInstanceManagement.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../ows-data/OWSData.csproj" />


### PR DESCRIPTION
## Summary
- Remove `Microsoft.VisualStudio.Web.CodeGeneration.Design 8.0.2` from 3 csproj files
  - Transitive dep `Microsoft.Build 17.8.3` has CVE-2025-55247 (HIGH: DoS)
  - This package is dev-time scaffolding only — not needed at runtime
- Bump all 5 OWS services to `0.1.4` for clean rebuild
- Build verified locally: `dotnet build OWS.sln` passes

## Affected services
| Service | Had CodeGen.Design | Trivy blocked 0.1.3? |
|---------|-------------------|---------------------|
| ows-instancemanagement | Yes (removed) | Yes |
| ows-characterpersistence | Yes (removed) | Yes |
| ows-instance-launcher | Yes (removed) | N/A (not Docker published) |
| ows-publicapi | No | Published OK |
| ows-globaldata | No | Published OK |
| ows-management | No | Published OK |

## Test plan
- [ ] All 5 OWS services publish at 0.1.4 without Trivy blocks