### PR TITLE
fix(ows): add version_target for correct GHCR tags + bump 0.1.5

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -11,9 +11,10 @@ tags:
 key: ows_characterpersistence
 pipeline: docker
 app_name: ows-characterpersistence
-version: "0.1.4"
+version: "0.1.5"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
+version_target: apps/ows/version.toml
 runner: ubuntu-latest
 image: kbve/ows-characterpersistence
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -11,9 +11,10 @@ tags:
 key: ows_globaldata
 pipeline: docker
 app_name: ows-globaldata
-version: "0.1.4"
+version: "0.1.5"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
+version_target: apps/ows/version.toml
 runner: ubuntu-latest
 image: kbve/ows-globaldata
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -11,9 +11,10 @@ tags:
 key: ows_instancemanagement
 pipeline: docker
 app_name: ows-instancemanagement
-version: "0.1.4"
+version: "0.1.5"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
+version_target: apps/ows/version.toml
 runner: ubuntu-latest
 image: kbve/ows-instancemanagement
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -11,9 +11,10 @@ tags:
 key: ows_management
 pipeline: docker
 app_name: ows-management
-version: "0.1.4"
+version: "0.1.5"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
+version_target: apps/ows/version.toml
 runner: ubuntu-latest
 image: kbve/ows-management
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -11,9 +11,10 @@ tags:
 key: ows_publicapi
 pipeline: docker
 app_name: ows-publicapi
-version: "0.1.4"
+version: "0.1.5"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
+version_target: apps/ows/version.toml
 runner: ubuntu-latest
 image: kbve/ows-publicapi
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml


### PR DESCRIPTION
## Summary
- **Root cause:** GHCR images tagged `0.1.3` instead of `0.1.4` because `version_target` was missing from OWS MDX pages. The CI version sync step couldn't write the MDX version into `version.toml`, so the Nx wrapper read the stale `version.toml` value for image tagging.
- **Fix:** Add `version_target: apps/ows/version.toml` to all 5 OWS MDX pages
- **Bump to 0.1.5** for clean rebuild with correct version tags on GHCR

## Test plan
- [ ] All 5 OWS images published as `0.1.5` on GHCR (not just `latest`)
- [ ] ArgoCD deployment uses matching `0.1.5` tags