### PR TITLE
fix(ows): disable RabbitMQ autoAck to prevent message loss on crash

### DIFF
--- a/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
+++ b/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
@@ -187,15 +187,25 @@ namespace OWSInstanceLauncher.Services
 
             serverSpinUpConsumer.Received += (model, ea) =>
             {
-                var body = ea.Body;
-                MQSpinUpServerMessage serverSpinUpMessage = MQSpinUpServerMessage.Deserialize(body.ToArray());
-                Log.Information($"Server Spin Up Message Received: {serverSpinUpMessage.CustomerGUID} WorldServerID: {serverSpinUpMessage.WorldServerID} ZoneInstanceID: {serverSpinUpMessage.ZoneInstanceID} MapName: {serverSpinUpMessage.MapName} Port: {serverSpinUpMessage.Port}");
-                HandleServerSpinUpMessage(
-                    serverSpinUpMessage.CustomerGUID,
-                    serverSpinUpMessage.WorldServerID,
-                    serverSpinUpMessage.ZoneInstanceID,
-                    serverSpinUpMessage.MapName,
-                    serverSpinUpMessage.Port);
+                try
+                {
+                    var body = ea.Body;
+                    MQSpinUpServerMessage serverSpinUpMessage = MQSpinUpServerMessage.Deserialize(body.ToArray());
+                    Log.Information($"Server Spin Up Message Received: {serverSpinUpMessage.CustomerGUID} WorldServerID: {serverSpinUpMessage.WorldServerID} ZoneInstanceID: {serverSpinUpMessage.ZoneInstanceID} MapName: {serverSpinUpMessage.MapName} Port: {serverSpinUpMessage.Port}");
+                    HandleServerSpinUpMessage(
+                        serverSpinUpMessage.CustomerGUID,
+                        serverSpinUpMessage.WorldServerID,
+                        serverSpinUpMessage.ZoneInstanceID,
+                        serverSpinUpMessage.MapName,
+                        serverSpinUpMessage.Port);
+
+                    serverSpinUpChannel.BasicAck(ea.DeliveryTag, multiple: false);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to process server spin-up message");
+                    serverSpinUpChannel.BasicNack(ea.DeliveryTag, multiple: false, requeue: true);
+                }
 
                 return Task.CompletedTask;
             };
@@ -206,7 +216,7 @@ namespace OWSInstanceLauncher.Services
             serverSpinUpConsumer.ConsumerCancelled += OnServerSpinUpConsumerConsumerCancelled;
 
             serverSpinUpChannel.BasicConsume(queue: serverSpinUpQueueNameGUID.ToString(),
-                                         autoAck: true,
+                                         autoAck: false,
                                          consumer: serverSpinUpConsumer);
 
             //Server Shut Down
@@ -214,13 +224,23 @@ namespace OWSInstanceLauncher.Services
 
             serverShutDownConsumer.Received += (model, ea) =>
             {
-                Log.Information("Message Received");
-                var body = ea.Body;
-                MQShutDownServerMessage serverShutDownMessage = MQShutDownServerMessage.Deserialize(body.ToArray());
-                HandleServerShutDownMessage(
-                    serverShutDownMessage.CustomerGUID,
-                    serverShutDownMessage.ZoneInstanceID
-                );
+                try
+                {
+                    Log.Information("Server Shut Down Message Received");
+                    var body = ea.Body;
+                    MQShutDownServerMessage serverShutDownMessage = MQShutDownServerMessage.Deserialize(body.ToArray());
+                    HandleServerShutDownMessage(
+                        serverShutDownMessage.CustomerGUID,
+                        serverShutDownMessage.ZoneInstanceID
+                    );
+
+                    serverShutDownChannel.BasicAck(ea.DeliveryTag, multiple: false);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to process server shut-down message");
+                    serverShutDownChannel.BasicNack(ea.DeliveryTag, multiple: false, requeue: true);
+                }
 
                 return Task.CompletedTask;
             };
@@ -231,7 +251,7 @@ namespace OWSInstanceLauncher.Services
             serverShutDownConsumer.ConsumerCancelled += OnServerShutDownConsumerConsumerCancelled;
 
             serverShutDownChannel.BasicConsume(queue: serverShutDownQueueNameGUID.ToString(),
-                                         autoAck: true,
+                                         autoAck: false,
                                          consumer: serverShutDownConsumer);
 
             //return Task.CompletedTask;


### PR DESCRIPTION
## Summary
Addresses item #3 from #8664.

Both RabbitMQ consumers (`serverSpinUp` and `serverShutDown`) used `autoAck: true`, meaning messages were dequeued before processing completed. A crash during handling permanently lost the message.

- Set `autoAck: false` on both consumers
- Add `BasicAck` after successful processing
- Add `BasicNack` with `requeue: true` on failure with error logging

## Test plan
- [ ] OWS instance launcher builds successfully
- [ ] Server spin-up messages are processed and acked
- [ ] Simulated failure results in message requeue, not loss