### PR TITLE
feat(ows): bump all OWS services to 0.1.6

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_characterpersistence
 pipeline: docker
 app_name: ows-characterpersistence
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_globaldata
 pipeline: docker
 app_name: ows-globaldata
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancemanagement
 pipeline: docker
 app_name: ows-instancemanagement
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_management
 pipeline: docker
 app_name: ows-management
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_publicapi
 pipeline: docker
 app_name: ows-publicapi
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml


### PR DESCRIPTION
## Summary
Bump all 5 OWS services from 0.1.5 → 0.1.6 to trigger GHCR republish.

Previous versions published to Docker Hub instead of GHCR, causing `ImagePullBackOff` in cluster.

## Services bumped
- ows-characterpersistence
- ows-globaldata
- ows-instancemanagement
- ows-management
- ows-publicapi

## Test plan
- [ ] CI publishes all 5 images to GHCR
- [ ] Pods recover from ImagePullBackOff