### PR TITLE
feat(clickhouse): reduce data retention TTL from 90 to 45 days

### DIFF
--- a/packages/data/ch/schemas/logs.sql
+++ b/packages/data/ch/schemas/logs.sql
@@ -7,7 +7,7 @@
 --
 -- Engine: MergeTree (default). Logflare config overrides for production:
 --   config :logflare, :clickhouse_backend_adaptor, engine: "ReplicatedMergeTree"
--- TTL: 90 days
+-- TTL: 45 days
 -- Partition: daily by timestamp
 -- =============================================================================
 
@@ -44,7 +44,7 @@ ENGINE = MergeTree
 PARTITION BY toDate(timestamp)
 PRIMARY KEY (project, source_name, toDateTime(timestamp))
 ORDER BY (project, source_name, toDateTime(timestamp), timestamp)
-TTL toDateTime(timestamp) + INTERVAL 90 DAY
+TTL toDateTime(timestamp) + INTERVAL 45 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 
@@ -82,5 +82,5 @@ CREATE TABLE IF NOT EXISTS logflare.simple_otel_logs_template (
 ENGINE = MergeTree
 PARTITION BY toDate(timestamp)
 ORDER BY (source_name, project, timestamp_hour)
-TTL toDateTime(timestamp) + INTERVAL 90 DAY
+TTL toDateTime(timestamp) + INTERVAL 45 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/packages/data/ch/schemas/metrics.sql
+++ b/packages/data/ch/schemas/metrics.sql
@@ -5,7 +5,7 @@
 -- OTEL-aligned metrics tables.
 --
 -- Engine: MergeTree (default)
--- TTL: 90 days
+-- TTL: 45 days
 -- Partition: daily by timestamp
 -- =============================================================================
 
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS logflare.otel_metrics_template (
 ENGINE = MergeTree
 PARTITION BY toDate(timestamp)
 ORDER BY (source_name, metric_name, project, timestamp_hour)
-TTL toDateTime(timestamp) + INTERVAL 90 DAY
+TTL toDateTime(timestamp) + INTERVAL 45 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 
@@ -121,5 +121,5 @@ CREATE TABLE IF NOT EXISTS logflare.simple_otel_metrics_template (
 ENGINE = MergeTree
 PARTITION BY toDate(timestamp)
 ORDER BY (source_name, metric_name, project, timestamp_hour)
-TTL toDateTime(timestamp) + INTERVAL 90 DAY
+TTL toDateTime(timestamp) + INTERVAL 45 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/packages/data/ch/schemas/observability.sql
+++ b/packages/data/ch/schemas/observability.sql
@@ -1,6 +1,6 @@
 -- observability.logs_raw — single raw log table for Vector → ClickHouse direct pipeline
 -- All services (kong, auth, rest, realtime, storage, functions, db, analytics, meta, studio)
--- land in one table, partitioned by day, 90-day TTL.
+-- land in one table, partitioned by day, 45-day TTL.
 
 CREATE DATABASE IF NOT EXISTS observability ON CLUSTER 'cluster';
 
@@ -18,4 +18,4 @@ CREATE TABLE IF NOT EXISTS observability.logs_raw ON CLUSTER 'cluster'
 ENGINE = MergeTree
 ORDER BY (service, timestamp)
 PARTITION BY toYYYYMMDD(timestamp)
-TTL toDateTime(timestamp) + INTERVAL 90 DAY;
+TTL toDateTime(timestamp) + INTERVAL 45 DAY;

--- a/packages/data/ch/schemas/traces.sql
+++ b/packages/data/ch/schemas/traces.sql
@@ -5,7 +5,7 @@
 -- OTEL-aligned traces tables.
 --
 -- Engine: MergeTree (default)
--- TTL: 90 days
+-- TTL: 45 days
 -- Partition: daily by timestamp
 -- =============================================================================
 
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS logflare.otel_traces_template (
 ENGINE = MergeTree
 PARTITION BY toDate(timestamp)
 ORDER BY (source_name, span_name, project, timestamp_hour)
-TTL toDateTime(timestamp) + INTERVAL 90 DAY
+TTL toDateTime(timestamp) + INTERVAL 45 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 
@@ -93,5 +93,5 @@ CREATE TABLE IF NOT EXISTS logflare.simple_otel_traces_template (
 ENGINE = MergeTree
 PARTITION BY toDate(timestamp)
 ORDER BY (source_name, span_name, project, timestamp_hour)
-TTL toDateTime(timestamp) + INTERVAL 90 DAY
+TTL toDateTime(timestamp) + INTERVAL 45 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;


### PR DESCRIPTION
## Summary
- Halves ClickHouse data retention from 90 days to 45 days across all 7 tables (observability + logflare logs/metrics/traces)
- Reduces storage pressure from excessive data accumulation
- Updates both TTL definitions and matching SQL comments

## Note
Live production tables still need `ALTER TABLE ... MODIFY TTL` applied manually for the change to take effect on existing data.

## Test plan
- [x] Grep `packages/data/ch/schemas/` for `90` returns zero hits
- [ ] After merge, run `ALTER TABLE <table> MODIFY TTL toDateTime(timestamp) + INTERVAL 45 DAY` on each production table