### PR TITLE
fix(ci): add dotnet restore before nx affected test

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -104,6 +104,9 @@ jobs:
                   mkdir -p ~/.pgrx
                   printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
 
+            - name: Restore .NET dependencies
+              run: dotnet restore apps/ows/OWS.sln || true
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud
 


### PR DESCRIPTION
## Summary
Closes #8670

The `@nx/dotnet` plugin infers `dotnet build --no-restore` for all .NET projects, expecting a prior `restore` target to have run. But `nx affected --target=test` doesn't trigger `restore` in the dependency graph — the plugin's inferred `dependsOn` can't be overridden via `project.json`.

Add `dotnet restore apps/ows/OWS.sln` as a CI step before running affected tests. Uses `|| true` so non-dotnet PRs aren't affected.

## Why not Option A (project.json dependency override)?
The `@nx/dotnet` plugin's C# analyzer generates `build` targets with hardcoded `dependsOn: ['^build']`. Neither `project.json` overrides, `targetDefaults`, nor plugin `options.build.dependsOn` can inject `restore` into the inferred graph — the analyzer output always wins.

## Test plan
- [ ] CI passes for PRs touching OWS .NET code
- [ ] CI still passes for non-.NET PRs (dotnet restore || true)