### PR TITLE
fix(ows): patch Serilog CVE + fix zero GUID test (#8673)

### DIFF
--- a/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
+++ b/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.0.3" />
+    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.1.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/apps/ows/ows-tests/Middleware/StoreCustomerGUIDMiddlewareTests.cs
+++ b/apps/ows/ows-tests/Middleware/StoreCustomerGUIDMiddlewareTests.cs
@@ -7,7 +7,7 @@ namespace OWSTests.Middleware
     {
         [Theory]
         [InlineData("be92671d-af96-4a6b-bdf7-6a3b6270dae6", true)]
-        [InlineData("00000000-0000-0000-0000-000000000000", true)]
+        [InlineData("00000000-0000-0000-0000-000000000000", false)]
         [InlineData("not-a-guid", false)]
         [InlineData("", false)]
         [InlineData(null, false)]
@@ -15,13 +15,8 @@ namespace OWSTests.Middleware
         [InlineData("BE92671D-AF96-4A6B-BDF7-6A3B6270DAE6", true)]
         public void CustomerGUID_TryParse_Validation(string input, bool expectedValid)
         {
-            bool isValid = Guid.TryParse(input, out Guid result);
+            bool isValid = Guid.TryParse(input, out Guid result) && result != Guid.Empty;
             Assert.Equal(expectedValid, isValid);
-
-            if (isValid)
-            {
-                Assert.NotEqual(Guid.Empty, result);
-            }
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- Bump `Serilog.Enrichers.ClientInfo` 2.0.3 → 2.1.0 (fixes IP spoofing CVE GHSA-5x5q-cqf6-gj8r)
- Fix zero GUID test: `00000000-0000-0000-0000-000000000000` should be rejected as invalid
- Combines `Guid.TryParse` + `!= Guid.Empty` check in one expression

Closes #8673

## Test plan
- [ ] `dotnet test` passes (zero GUID now correctly expected as `false`)
- [ ] No NU1902 warning for Serilog.Enrichers.ClientInfo