### PR TITLE
fix(ows): remove --no-build from dotnet test

### DIFF
--- a/apps/ows/project.json
+++ b/apps/ows/project.json
@@ -341,9 +341,7 @@
 		"test": {
 			"executor": "nx:run-commands",
 			"options": {
-				"commands": [
-					"dotnet test apps/ows/OWS.sln --no-build --verbosity normal"
-				],
+				"commands": ["dotnet test apps/ows/OWS.sln --verbosity normal"],
 				"parallel": false
 			}
 		}


### PR DESCRIPTION
## Summary
Remove `--no-build` from `dotnet test` in Nx project.json. CI runs `dotnet restore` but not `dotnet build`, so `--no-build` causes the test DLL to not exist.

## Test plan
- [ ] `nx run ows:test` passes in CI