### PR TITLE
fix(ows): remove CVE-2021-24112 System.Drawing.Common from Docker image (#8695)

### DIFF
--- a/apps/ows/Dockerfile
+++ b/apps/ows/Dockerfile
@@ -89,6 +89,9 @@ RUN npm run build
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime-base
 ENV ASPNETCORE_URLS=http://+:80
 EXPOSE 80
+# Remove vulnerable System.Drawing.Common 4.7.0 from the shared framework (CVE-2021-24112).
+# Our apps ship 8.0.0 via Directory.Build.props, but Trivy flags the base image copy.
+RUN find /usr/share/dotnet -name 'System.Drawing.Common.dll' -delete 2>/dev/null || true
 
 # ============================================================================
 # Final service images


### PR DESCRIPTION
## Summary
Remove `System.Drawing.Common 4.7.0` from the aspnet:8.0 shared framework in the Docker runtime image. Trivy blocks publish due to CVE-2021-24112 (CRITICAL RCE).

Our apps already bundle `8.0.0` via `Directory.Build.props` — the base image copy at `/usr/share/dotnet/shared/` is unused but Trivy scans the full image.

Closes #8695

## Test plan
- [ ] Docker publish passes Trivy scan
- [ ] OWS services start correctly (System.Drawing.Common 8.0.0 from app takes precedence)