### PR TITLE
fix(ows): switch to alpine runtime to fix CVE-2021-24112

### DIFF
--- a/apps/ows/Dockerfile
+++ b/apps/ows/Dockerfile
@@ -86,12 +86,9 @@ RUN npm run build
 # ============================================================================
 # Runtime base — HTTP only (no HTTPS certs in containers)
 # ============================================================================
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime-base
 ENV ASPNETCORE_URLS=http://+:80
 EXPOSE 80
-# Remove vulnerable System.Drawing.Common 4.7.0 from the shared framework (CVE-2021-24112).
-# Our apps ship 8.0.0 via Directory.Build.props, but Trivy flags the base image copy.
-RUN find /usr/share/dotnet -name 'System.Drawing.Common.dll' -delete 2>/dev/null || true
 
 # ============================================================================
 # Final service images


### PR DESCRIPTION
## Summary
Switch OWS Docker runtime from `aspnet:8.0` to `aspnet:8.0-alpine`.

Alpine doesn't ship `System.Drawing.Common` in the shared framework, eliminating CVE-2021-24112 at the source. Also reduces image size.

Closes #8702 #8703 #8704 #8705 #8706

## Test plan
- [ ] Docker build succeeds with alpine base
- [ ] Trivy scan passes (no System.Drawing.Common 4.7.0)
- [ ] OWS services start correctly on alpine