### PR TITLE
fix(ows): switch to chiseled runtime image to fix CVE scan

### DIFF
--- a/apps/ows/.trivyignore
+++ b/apps/ows/.trivyignore
@@ -1,5 +1,0 @@
-# False positive: Trivy reports System.Drawing.Common 4.7.0 but the actual
-# published DLL is 8.0.0 (pinned via Directory.Build.props). The deps.json
-# and file version both confirm 8.0.0. Trivy misidentifies the version.
-# See: https://github.com/aquasecurity/trivy/issues/7073
-CVE-2021-24112


### PR DESCRIPTION
## Summary
Switch OWS Docker runtime from `aspnet:8.0` to `aspnet:8.0-jammy-chiseled`.

Chiseled images are the most minimal .NET runtime — no shell, no package manager, smallest attack surface. Testing if this resolves the Trivy false positive for System.Drawing.Common CVE-2021-24112.

The actual published DLL is 8.0.0 (verified via deps.json and file version) but Trivy reports 4.7.0.

Closes #8702 #8703 #8704 #8705 #8706 #8709

## Test plan
- [ ] Docker build succeeds with chiseled base
- [ ] Trivy scan passes
- [ ] OWS services start correctly