### PR TITLE
fix(ci): add .trivyignore for CVE-2021-24112 Trivy false positive (#8727)

### DIFF
--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -197,6 +197,7 @@ jobs:
                   exit-code: 1
                   severity: CRITICAL,HIGH
                   ignore-unfixed: true
+                  trivyignores: .trivyignore
 
             - name: Push Docker Images
               if: ${{ steps.version_check.outputs.should_publish != 'false' && inputs.image != '' }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,16 @@
+# Trivy false positive — System.Drawing.Common CVE-2021-24112
+#
+# Trivy reports System.Drawing.Common 4.7.0 but the actual shipped version
+# is 8.0.0, verified by:
+#   1. Directory.Build.props pins PackageReference to 8.0.0
+#   2. deps.json in published output contains only 8.0.0 references
+#   3. DLL file version is 8.0.9.3103
+#   4. dotnet list --include-transitive resolves to 8.0.0
+#   5. Persists across aspnet:8.0, aspnet:8.0-alpine, aspnet:8.0-jammy-chiseled
+#
+# Trivy reads the .NET assembly metadata version (4.7.x) which Microsoft
+# reuses across major releases for binary compatibility. This does not
+# reflect the NuGet package version (8.0.0) which contains the fix.
+#
+# Ref: https://github.com/aquasecurity/trivy/issues/7073
+CVE-2021-24112


### PR DESCRIPTION
## Summary
Add `.trivyignore` at repo root for CVE-2021-24112 (System.Drawing.Common).

This is a confirmed Trivy false positive:
- **Trivy reports**: `System.Drawing.Common 4.7.0`
- **Actually shipped**: `8.0.0` (pinned via `Directory.Build.props`)
- **Verified via**: deps.json (all refs = 8.0.0), DLL file version (8.0.9.3103), `dotnet list --include-transitive` (8.0.0)
- **Tested on**: aspnet:8.0, aspnet:8.0-alpine, aspnet:8.0-jammy-chiseled — all report 4.7.0
- **Root cause**: Trivy reads .NET assembly metadata version (4.7.x) which Microsoft reuses across major releases for compatibility

Also wires `trivyignores: .trivyignore` into the Docker publish workflow.

Closes #8727

## Test plan
- [ ] Docker publish passes Trivy scan
- [ ] All OWS images publish successfully