### PR TITLE
feat(edge): dual-mode health checks (proxy + direct) with retry

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeStatusGrid.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeStatusGrid.tsx
@@ -1,21 +1,79 @@
 import { useStore } from '@nanostores/react';
 import { edgeService, type FunctionHealth } from './edgeService';
-import { CheckCircle, XCircle, Loader2, Zap, Clock } from 'lucide-react';
+import {
+	CheckCircle,
+	XCircle,
+	Loader2,
+	Zap,
+	Clock,
+	Server,
+	Globe,
+} from 'lucide-react';
 
-function StatusCard({ fn }: { fn: FunctionHealth }) {
-	const statusColor =
-		fn.status === 'ok'
+type Status = 'ok' | 'error' | 'pending';
+
+function StatusBadge({
+	label,
+	icon,
+	status,
+	latencyMs,
+	error,
+}: {
+	label: string;
+	icon: React.ReactNode;
+	status: Status;
+	latencyMs?: number;
+	error?: string;
+}) {
+	const color =
+		status === 'ok'
 			? '#22c55e'
-			: fn.status === 'error'
+			: status === 'error'
 				? '#ef4444'
-				: 'var(--sl-color-gray-3, #8b949e)';
+				: 'var(--sl-color-gray-4, #6b7280)';
 
 	const StatusIcon =
-		fn.status === 'ok'
-			? CheckCircle
-			: fn.status === 'error'
-				? XCircle
-				: Loader2;
+		status === 'ok' ? CheckCircle : status === 'error' ? XCircle : Loader2;
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: '0.4rem',
+				padding: '4px 8px',
+				borderRadius: '6px',
+				background: `${color}12`,
+				border: `1px solid ${color}30`,
+				fontSize: '0.72rem',
+			}}>
+			{icon}
+			<StatusIcon size={12} style={{ color, flexShrink: 0 }} />
+			<span style={{ color, fontWeight: 600 }}>{label}</span>
+			{latencyMs != null && (
+				<span
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontVariantNumeric: 'tabular-nums',
+					}}>
+					{latencyMs}ms
+				</span>
+			)}
+			{error && status === 'error' && (
+				<span style={{ color: '#fca5a5', marginLeft: 2 }}>{error}</span>
+			)}
+		</div>
+	);
+}
+
+function StatusCard({ fn }: { fn: FunctionHealth }) {
+	// Overall status: ok if either passes, error if both fail
+	const overall =
+		fn.proxyStatus === 'ok' || fn.directStatus === 'ok' ? 'ok' : 'error';
+	const borderColor =
+		overall === 'ok'
+			? 'var(--sl-color-gray-5, #262626)'
+			: 'rgba(239, 68, 68, 0.3)';
 
 	return (
 		<div
@@ -25,16 +83,30 @@ function StatusCard({ fn }: { fn: FunctionHealth }) {
 				gap: '0.5rem',
 				padding: '1.25rem',
 				borderRadius: '12px',
-				border: '1px solid var(--sl-color-gray-5, #262626)',
+				border: `1px solid ${borderColor}`,
 				background: 'var(--sl-color-bg-nav, #111)',
 			}}>
+			{/* Header */}
 			<div
 				style={{
 					display: 'flex',
 					alignItems: 'center',
 					gap: '0.5rem',
 				}}>
-				<StatusIcon size={18} style={{ color: statusColor }} />
+				<span
+					style={{
+						display: 'inline-block',
+						width: 8,
+						height: 8,
+						borderRadius: '50%',
+						background: overall === 'ok' ? '#22c55e' : '#ef4444',
+						boxShadow:
+							overall === 'ok'
+								? '0 0 6px #22c55e'
+								: '0 0 6px #ef4444',
+						flexShrink: 0,
+					}}
+				/>
 				<span
 					style={{
 						color: 'var(--sl-color-text, #e6edf3)',
@@ -44,21 +116,9 @@ function StatusCard({ fn }: { fn: FunctionHealth }) {
 					}}>
 					{fn.label}
 				</span>
-				{fn.latencyMs != null && (
-					<span
-						style={{
-							padding: '2px 6px',
-							borderRadius: '4px',
-							background: 'var(--sl-color-gray-6, #1c1c1c)',
-							color: 'var(--sl-color-gray-3, #8b949e)',
-							fontSize: '0.7rem',
-							fontWeight: 500,
-							fontVariantNumeric: 'tabular-nums',
-						}}>
-						{fn.latencyMs}ms
-					</span>
-				)}
 			</div>
+
+			{/* Description */}
 			<div
 				style={{
 					color: 'var(--sl-color-gray-3, #8b949e)',
@@ -66,6 +126,31 @@ function StatusCard({ fn }: { fn: FunctionHealth }) {
 				}}>
 				{fn.description}
 			</div>
+
+			{/* Dual status badges */}
+			<div
+				style={{
+					display: 'flex',
+					gap: '0.5rem',
+					flexWrap: 'wrap',
+				}}>
+				<StatusBadge
+					label="Proxy"
+					icon={<Server size={11} style={{ color: '#8b949e' }} />}
+					status={fn.proxyStatus}
+					latencyMs={fn.proxyLatencyMs}
+					error={fn.proxyError}
+				/>
+				<StatusBadge
+					label="Direct"
+					icon={<Globe size={11} style={{ color: '#8b949e' }} />}
+					status={fn.directStatus}
+					latencyMs={fn.directLatencyMs}
+					error={fn.directError}
+				/>
+			</div>
+
+			{/* Version + timestamp (from health only) */}
 			{fn.version && (
 				<div
 					style={{
@@ -98,18 +183,6 @@ function StatusCard({ fn }: { fn: FunctionHealth }) {
 					</span>
 				</div>
 			)}
-			{fn.error && (
-				<div
-					style={{
-						color: '#fca5a5',
-						fontSize: '0.75rem',
-						padding: '4px 8px',
-						borderRadius: '4px',
-						background: 'rgba(239,68,68,0.1)',
-					}}>
-					{fn.error}
-				</div>
-			)}
 		</div>
 	);
 }
@@ -121,7 +194,7 @@ export default function ReactEdgeStatusGrid() {
 		<div
 			style={{
 				display: 'grid',
-				gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+				gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
 				gap: '1rem',
 			}}>
 			{functions.map((fn) => (

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactEdgeSummary.tsx
@@ -1,17 +1,41 @@
 import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
 import { edgeService } from './edgeService';
-import { Activity, XCircle, Clock, AlertCircle } from 'lucide-react';
+import { initSupa, getSupa } from '@/lib/supa';
+import {
+	Activity,
+	XCircle,
+	Clock,
+	AlertCircle,
+	Server,
+	Globe,
+} from 'lucide-react';
 
 export default function ReactEdgeSummary() {
 	const okCount = useStore(edgeService.$okCount);
 	const errorCount = useStore(edgeService.$errorCount);
 	const totalCount = useStore(edgeService.$totalCount);
+	const proxyOk = useStore(edgeService.$proxyOkCount);
+	const directOk = useStore(edgeService.$directOkCount);
 	const lastChecked = useStore(edgeService.$lastChecked);
 	const error = useStore(edgeService.$error);
 
 	useEffect(() => {
-		edgeService.fetchHealth();
+		(async () => {
+			// Try to get auth token for proxy checks
+			try {
+				await initSupa();
+				const supa = getSupa();
+				const result = await supa.getSession().catch(() => null);
+				const token = result?.session?.access_token ?? null;
+				if (token) {
+					edgeService.$accessToken.set(token as string);
+				}
+			} catch {
+				// No auth — proxy checks will show as pending
+			}
+			edgeService.fetchHealth();
+		})();
 	}, []);
 
 	return (
@@ -41,6 +65,40 @@ export default function ReactEdgeSummary() {
 						{okCount}/{totalCount} operational
 					</span>
 				</div>
+				{totalCount > 0 && (
+					<>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '0.4rem',
+								color:
+									proxyOk === totalCount
+										? '#22c55e'
+										: '#f59e0b',
+							}}>
+							<Server size={14} />
+							<span>
+								Proxy {proxyOk}/{totalCount}
+							</span>
+						</div>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '0.4rem',
+								color:
+									directOk === totalCount
+										? '#22c55e'
+										: '#f59e0b',
+							}}>
+							<Globe size={14} />
+							<span>
+								Direct {directOk}/{totalCount}
+							</span>
+						</div>
+					</>
+				)}
 				{errorCount > 0 && (
 					<div
 						style={{
@@ -50,9 +108,7 @@ export default function ReactEdgeSummary() {
 							color: '#fca5a5',
 						}}>
 						<XCircle size={16} />
-						<span>
-							{errorCount} {errorCount === 1 ? 'issue' : 'issues'}
-						</span>
+						<span>{errorCount} both-fail</span>
 					</div>
 				)}
 				{lastChecked && (

--- a/apps/kbve/astro-kbve/src/components/dashboard/edgeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/edgeService.ts
@@ -11,15 +11,20 @@ export interface EdgeFunctionDef {
 	description: string;
 }
 
+export type CheckMode = 'proxy' | 'direct';
+
 export interface FunctionHealth {
 	name: string;
 	label: string;
 	description: string;
-	status: 'ok' | 'error' | 'pending';
+	proxyStatus: 'ok' | 'error' | 'pending';
+	proxyLatencyMs?: number;
+	proxyError?: string;
+	directStatus: 'ok' | 'error' | 'pending';
+	directLatencyMs?: number;
+	directError?: string;
 	version?: string;
-	latencyMs?: number;
 	timestamp?: string;
-	error?: string;
 }
 
 interface CachedHealth {
@@ -31,9 +36,11 @@ interface CachedHealth {
 // Constants
 // ---------------------------------------------------------------------------
 
-const EDGE_CACHE_KEY = 'cache:edge:health';
+const EDGE_CACHE_KEY = 'cache:edge:health-v2';
 const CACHE_TTL_MS = 30 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
+const RETRY_DELAY_MS = 2000;
+const PROXY_BASE = '/dashboard/edge/proxy';
 
 // ---------------------------------------------------------------------------
 // Cache helpers
@@ -60,56 +67,90 @@ function setCachedHealth(data: CachedHealth): void {
 }
 
 // ---------------------------------------------------------------------------
-// API helpers
+// Fetch with retry
 // ---------------------------------------------------------------------------
 
-async function checkFunctionHealth(
+async function fetchWithRetry(
+	url: string,
+	opts: RequestInit,
+	retries = 1,
+): Promise<Response> {
+	for (let i = 0; i <= retries; i++) {
+		try {
+			const controller = new AbortController();
+			const timeout = setTimeout(
+				() => controller.abort(),
+				FETCH_TIMEOUT_MS,
+			);
+			const resp = await fetch(url, {
+				...opts,
+				signal: controller.signal,
+			});
+			clearTimeout(timeout);
+			return resp;
+		} catch (e) {
+			if (i < retries) {
+				await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+				continue;
+			}
+			throw e;
+		}
+	}
+	throw new Error('unreachable');
+}
+
+// ---------------------------------------------------------------------------
+// Check helpers — one for proxy, one for direct
+// ---------------------------------------------------------------------------
+
+async function checkViaProxy(
 	fn: EdgeFunctionDef,
-): Promise<FunctionHealth> {
-	const url = `${SUPABASE_URL}/functions/v1/${fn.name}`;
+	token: string,
+): Promise<
+	Pick<
+		FunctionHealth,
+		| 'proxyStatus'
+		| 'proxyLatencyMs'
+		| 'proxyError'
+		| 'version'
+		| 'timestamp'
+	>
+> {
+	const url = `${PROXY_BASE}/${fn.name}`;
 	const start = performance.now();
 
 	try {
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 		const method = fn.name === 'health' ? 'GET' : 'OPTIONS';
-
-		const resp = await fetch(url, {
+		const resp = await fetchWithRetry(url, {
 			method,
-			signal: controller.signal,
+			headers: { Authorization: `Bearer ${token}` },
 		});
-		clearTimeout(timeout);
-
 		const latencyMs = Math.round(performance.now() - start);
 
 		if (fn.name === 'health' && resp.ok) {
 			const data = await resp.json();
 			return {
-				...fn,
-				status: 'ok',
+				proxyStatus: 'ok',
+				proxyLatencyMs: latencyMs,
 				version: data.version,
 				timestamp: data.timestamp,
-				latencyMs,
 			};
 		}
 
-		if (method === 'OPTIONS' && resp.ok) {
-			return { ...fn, status: 'ok', latencyMs };
+		if (resp.ok) {
+			return { proxyStatus: 'ok', proxyLatencyMs: latencyMs };
 		}
 
 		return {
-			...fn,
-			status: 'error',
-			latencyMs,
-			error: `HTTP ${resp.status}`,
+			proxyStatus: 'error',
+			proxyLatencyMs: latencyMs,
+			proxyError: `HTTP ${resp.status}`,
 		};
 	} catch (e: unknown) {
-		const latencyMs = Math.round(performance.now() - start);
 		return {
-			...fn,
-			status: 'error',
-			latencyMs,
-			error:
+			proxyStatus: 'error',
+			proxyLatencyMs: Math.round(performance.now() - start),
+			proxyError:
 				e instanceof Error
 					? e.name === 'AbortError'
 						? 'Timeout'
@@ -119,23 +160,82 @@ async function checkFunctionHealth(
 	}
 }
 
-async function fetchManifest(): Promise<EdgeFunctionDef[]> {
-	const url = `${SUPABASE_URL}/functions/v1/health`;
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+async function checkViaDirect(
+	fn: EdgeFunctionDef,
+): Promise<
+	Pick<FunctionHealth, 'directStatus' | 'directLatencyMs' | 'directError'>
+> {
+	const url = `${SUPABASE_URL}/functions/v1/${fn.name}`;
+	const start = performance.now();
 
 	try {
-		const resp = await fetch(url, { signal: controller.signal });
-		clearTimeout(timeout);
+		const method = fn.name === 'health' ? 'GET' : 'OPTIONS';
+		const resp = await fetchWithRetry(url, { method });
+		const latencyMs = Math.round(performance.now() - start);
 
-		if (!resp.ok) return [];
+		if (resp.ok) {
+			return { directStatus: 'ok', directLatencyMs: latencyMs };
+		}
 
-		const data = await resp.json();
-		if (Array.isArray(data.functions) && data.functions.length > 0) {
-			return data.functions;
+		return {
+			directStatus: 'error',
+			directLatencyMs: latencyMs,
+			directError: `HTTP ${resp.status}`,
+		};
+	} catch (e: unknown) {
+		return {
+			directStatus: 'error',
+			directLatencyMs: Math.round(performance.now() - start),
+			directError:
+				e instanceof Error
+					? e.name === 'AbortError'
+						? 'Timeout'
+						: e.message
+					: 'Unknown error',
+		};
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manifest fetcher — try proxy first, fallback to direct
+// ---------------------------------------------------------------------------
+
+async function fetchManifest(token: string | null): Promise<EdgeFunctionDef[]> {
+	// Try proxy first (more reliable, cluster-internal)
+	if (token) {
+		try {
+			const resp = await fetchWithRetry(`${PROXY_BASE}/health`, {
+				method: 'GET',
+				headers: { Authorization: `Bearer ${token}` },
+			});
+			if (resp.ok) {
+				const data = await resp.json();
+				if (
+					Array.isArray(data.functions) &&
+					data.functions.length > 0
+				) {
+					return data.functions;
+				}
+			}
+		} catch {
+			// fall through to direct
+		}
+	}
+
+	// Direct fallback
+	try {
+		const resp = await fetchWithRetry(
+			`${SUPABASE_URL}/functions/v1/health`,
+			{ method: 'GET' },
+		);
+		if (resp.ok) {
+			const data = await resp.json();
+			if (Array.isArray(data.functions) && data.functions.length > 0) {
+				return data.functions;
+			}
 		}
 	} catch {
-		// Health unreachable
+		// both failed
 	}
 
 	return [];
@@ -152,21 +252,37 @@ class EdgeService {
 	public readonly $refreshing = atom<boolean>(false);
 	public readonly $error = atom<string | null>(null);
 	public readonly $lastChecked = atom<Date | null>(null);
+	public readonly $accessToken = atom<string | null>(null);
 
-	// Computed
+	// Computed — overall status uses proxy as primary, direct as secondary
 	public readonly $okCount = computed(
 		[this.$functions],
-		(fns) => fns.filter((f) => f.status === 'ok').length,
+		(fns) =>
+			fns.filter((f) => f.proxyStatus === 'ok' || f.directStatus === 'ok')
+				.length,
 	);
 
 	public readonly $errorCount = computed(
 		[this.$functions],
-		(fns) => fns.filter((f) => f.status === 'error').length,
+		(fns) =>
+			fns.filter(
+				(f) => f.proxyStatus === 'error' && f.directStatus === 'error',
+			).length,
 	);
 
 	public readonly $totalCount = computed(
 		[this.$functions],
 		(fns) => fns.length,
+	);
+
+	public readonly $proxyOkCount = computed(
+		[this.$functions],
+		(fns) => fns.filter((f) => f.proxyStatus === 'ok').length,
+	);
+
+	public readonly $directOkCount = computed(
+		[this.$functions],
+		(fns) => fns.filter((f) => f.directStatus === 'ok').length,
 	);
 
 	// --- Actions ---
@@ -186,8 +302,10 @@ class EdgeService {
 		this.$error.set(null);
 		this.$fromCache.set(false);
 
+		const token = this.$accessToken.get();
+
 		try {
-			const manifest = await fetchManifest();
+			const manifest = await fetchManifest(token);
 
 			if (manifest.length === 0) {
 				this.$error.set(
@@ -198,9 +316,27 @@ class EdgeService {
 				return;
 			}
 
+			// Run proxy and direct checks in parallel for each function
 			const results = await Promise.all(
-				manifest.map(checkFunctionHealth),
+				manifest.map(async (fn) => {
+					const [proxyResult, directResult] = await Promise.all([
+						token
+							? checkViaProxy(fn, token)
+							: Promise.resolve({
+									proxyStatus: 'pending' as const,
+									proxyError: 'Not authenticated',
+								}),
+						checkViaDirect(fn),
+					]);
+
+					return {
+						...fn,
+						...proxyResult,
+						...directResult,
+					} as FunctionHealth;
+				}),
 			);
+
 			this.$functions.set(results);
 			this.$lastChecked.set(new Date());
 

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -127,6 +127,13 @@ async fn main() -> anyhow::Result<()> {
         info!("Forgejo proxy not configured (FORGEJO_UPSTREAM_URL not set)");
     }
 
+    // Initialize Edge Functions proxy (optional - for /dashboard/edge)
+    if transport::proxy::init_edge_proxy() {
+        info!("Edge proxy initialized - /dashboard/edge/proxy enabled");
+    } else {
+        info!("Edge proxy not configured (SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set)");
+    }
+
     // Initialize KubeVirt proxy (optional - for /dashboard/vm)
     if transport::proxy::init_kubevirt_proxy() {
         info!("KubeVirt proxy initialized - /dashboard/vm/proxy enabled");

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -230,6 +230,14 @@ fn router(state: AppState) -> Router {
         .route(
             "/dashboard/vm/proxy",
             any(super::proxy::kubevirt_proxy_handler),
+        )
+        .route(
+            "/dashboard/edge/proxy/{*path}",
+            any(super::proxy::edge_proxy_handler),
+        )
+        .route(
+            "/dashboard/edge/proxy",
+            any(super::proxy::edge_proxy_handler),
         );
 
     // Game server WebSocket is now handled by lightyear on a separate port

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -582,6 +582,52 @@ pub async fn kubevirt_proxy_handler(path: Option<Path<String>>, req: Request<Bod
 }
 
 // ---------------------------------------------------------------------------
+// Edge Functions proxy singleton (Supabase → internal Kong)
+// ---------------------------------------------------------------------------
+
+static EDGE: OnceLock<ServiceProxy> = OnceLock::new();
+
+pub fn init_edge_proxy() -> bool {
+    let supabase_url = match std::env::var("SUPABASE_URL") {
+        Ok(u) => u.trim_end_matches('/').to_string(),
+        Err(_) => return false,
+    };
+    // Proxy to the Supabase functions base — callers append /health, /meme, etc.
+    let upstream = format!("{supabase_url}/functions/v1");
+
+    let service_role_key = match std::env::var("SUPABASE_SERVICE_ROLE_KEY") {
+        Ok(k) => k,
+        Err(_) => return false,
+    };
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("failed to build reqwest client for edge proxy");
+
+    EDGE.set(ServiceProxy {
+        name: "Edge",
+        client,
+        upstream,
+        upstream_token: Some(service_role_key),
+    })
+    .is_ok()
+}
+
+pub async fn edge_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
+    match EDGE.get() {
+        Some(proxy) => proxy.handle(path, req).await,
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Edge proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Convert axum HeaderMap to reqwest HeaderMap
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add Edge Functions reverse proxy in axum (reuses existing `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`, no new env vars)
- Edge dashboard now checks each function via **both** paths in parallel:
  - **Proxy**: server-side through axum -> internal Kong (JWT-authed, cluster-internal, more reliable)
  - **Direct**: browser -> supabase.kbve.com (public, tests client connectivity)
- `fetchWithRetry`: 1 automatic retry after 2s delay on network failures
- Summary bar shows Proxy X/N and Direct X/N independently; "both-fail" count for total failures
- Each status card shows dual badges with separate latency and error info
- Manifest fetch tries proxy first, falls back to direct

## Test plan
- [ ] Verify `/dashboard/edge/proxy/health` returns health JSON when authenticated
- [ ] Verify edge dashboard loads with dual Proxy/Direct badges per function
- [ ] Verify summary bar shows separate proxy and direct counts
- [ ] Kill browser network briefly — verify retry recovers on direct checks
- [ ] Verify unauthenticated users see proxy as "pending" but direct still works