### PR TITLE
fix(deps): patch fast-xml-parser CVE and bump verdaccio

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"ts-node": "10.9.1",
 		"twin.macro": "^3.4.1",
 		"typescript": "5.9.3",
-		"verdaccio": "6.0.5",
+		"verdaccio": "6.3.2",
 		"vite": "7.3.1",
 		"vite-plugin-dts": "4.5.3",
 		"vite-plugin-top-level-await": "^1.6.0",
@@ -214,6 +214,9 @@
 		"prepare": "husky"
 	},
 	"pnpm": {
+		"overrides": {
+			"fast-xml-parser": ">=5.5.8"
+		},
 		"onlyBuiltDependencies": [
 			"@parcel/watcher",
 			"@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
     autoInstallPeers: true
     excludeLinksFromLockfile: false
 
+overrides:
+    fast-xml-parser: '>=5.5.8'
+
 importers:
     .:
         dependencies:
@@ -274,7 +277,7 @@ importers:
                 version: 1.0.0(nanostores@1.1.0)(react@19.2.4)
             '@nx-tools/nx-container':
                 specifier: ^7.2.1
-                version: 7.2.1(@nx/devkit@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))))(@nx/js@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0)))(dotenv@16.4.7)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(tslib@2.8.1)
+                version: 7.2.1(@nx/devkit@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))))(@nx/js@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0)))(dotenv@16.4.7)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(tslib@2.8.1)
             '@nx/devkit':
                 specifier: 22.6.1
                 version: 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -283,37 +286,37 @@ importers:
                 version: 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
             '@nx/esbuild':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/eslint':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/eslint-plugin':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@8.57.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@8.57.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/js':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/node':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/playwright':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@playwright/test@1.51.1)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@playwright/test@1.51.1)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/react':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.0)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)(vue-tsc@1.8.27(typescript@5.9.3))
+                version: 22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.0)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)(vue-tsc@1.8.27(typescript@5.9.3))
             '@nx/vite':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
             '@nx/vitest':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
             '@nx/web':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/webpack':
                 specifier: 22.6.1
-                version: 22.6.1(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.30.2)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+                version: 22.6.1(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.30.2)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@nx/workspace':
                 specifier: 22.6.1
                 version: 22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
@@ -525,8 +528,8 @@ importers:
                 specifier: 5.9.3
                 version: 5.9.3
             verdaccio:
-                specifier: 6.0.5
-                version: 6.0.5(encoding@0.1.13)(typanion@3.14.0)
+                specifier: 6.3.2
+                version: 6.3.2(encoding@0.1.13)(typanion@3.14.0)
             vite:
                 specifier: 7.3.1
                 version: 7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2)
@@ -2241,10 +2244,10 @@ packages:
             }
         engines: { node: '>=14' }
 
-    '@cypress/request@3.0.7':
+    '@cypress/request@3.0.10':
         resolution:
             {
-                integrity: sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==,
+                integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==,
             }
         engines: { node: '>= 6' }
 
@@ -5891,6 +5894,12 @@ packages:
         peerDependencies:
             typescript: ^3 || ^4 || ^5
 
+    '@pinojs/redact@0.4.0':
+        resolution:
+            {
+                integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
+            }
+
     '@pkgjs/parseargs@0.11.0':
         resolution:
             {
@@ -7492,6 +7501,13 @@ packages:
             }
         engines: { node: '>=6' }
 
+    '@sindresorhus/is@4.6.0':
+        resolution:
+            {
+                integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==,
+            }
+        engines: { node: '>=10' }
+
     '@sindresorhus/is@5.6.0':
         resolution:
             {
@@ -7874,6 +7890,13 @@ packages:
                 integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==,
             }
         engines: { node: '>=6' }
+
+    '@szmarczak/http-timer@4.0.6':
+        resolution:
+            {
+                integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==,
+            }
+        engines: { node: '>=10' }
 
     '@szmarczak/http-timer@5.0.1':
         resolution:
@@ -8763,6 +8786,12 @@ packages:
                 integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==,
             }
 
+    '@types/responselike@1.0.0':
+        resolution:
+            {
+                integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==,
+            }
+
     '@types/responselike@1.0.3':
         resolution:
             {
@@ -9247,38 +9276,31 @@ packages:
         peerDependencies:
             react: '>= 16.8.0'
 
-    '@verdaccio/auth@8.0.0-next-8.7':
+    '@verdaccio/auth@8.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-CSLBAsCJT1oOpJ4OWnVGmN6o/ZilDNa7Aa5+AU1LI2lbRblqgr4BVRn07GFqimJ//6+tPzl8BHgyiCbBhh1ZiA==,
+                integrity: sha512-HRIqEj9J7t95ZG3pCVpaCJoXCNVPB0R2DpkEXfG19TXsapf/mv5vMnBYG6O1C/ShNagHMA7z+Z6NwFZXHUzm9g==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/commons-api@10.2.0':
+    '@verdaccio/config@8.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-F/YZANu4DmpcEV0jronzI7v2fGVWkQ5Mwi+bVmV+ACJ+EzR0c9Jbhtbe5QyLUuzR97t8R5E/Xe53O0cc2LukdQ==,
-            }
-        engines: { node: '>=8' }
-
-    '@verdaccio/config@8.0.0-next-8.7':
-        resolution:
-            {
-                integrity: sha512-pA0WCWvvWY6vPRav+X0EuFmuK6M08zIpRzTKkqSriCWk6JUCZ07TDnN054AS8TSSOy6EaWgHxnUw3nTd34Z4Sg==,
+                integrity: sha512-6/n/qcVMbNTK8oFY8l6vlJMeG6zor/aOFcR2Wd6yCoKcehITigmLn8MFziZPriYivzxYJJRjlaKO9+HuuQSKCA==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/core@8.0.0-next-8.1':
+    '@verdaccio/core@8.0.0-next-8.21':
         resolution:
             {
-                integrity: sha512-kQRCB2wgXEh8H88G51eQgAFK9IxmnBtkQ8sY5FbmB6PbBkyHrbGcCp+2mtRqqo36j0W1VAlfM3XzoknMy6qQnw==,
+                integrity: sha512-n3Y8cqf84cwXxUUdTTfEJc8fV55PONPKijCt2YaC0jilb5qp1ieB3d4brqTOdCdXuwkmnG2uLCiGpUd/RuSW0Q==,
             }
-        engines: { node: '>=14' }
+        engines: { node: '>=18' }
 
-    '@verdaccio/core@8.0.0-next-8.7':
+    '@verdaccio/core@8.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-pf8M2Z5EI/5Zdhdcm3aadb9Q9jiDsIredPD3+cIoDum8x3di2AIYvQD7i5BEramfzZlLXVICmFAulU7nUY11qg==,
+                integrity: sha512-ndPAfZVyN677y/EZX+USkL0/aOcU5rvnzS99nRCIHarZB44WMno9jl6FdX5Ax3b3exGo9GsxhEdbYHgOYaRlLQ==,
             }
         engines: { node: '>=18' }
 
@@ -9289,66 +9311,73 @@ packages:
             }
         engines: { node: '>=12' }
 
-    '@verdaccio/file-locking@13.0.0-next-8.2':
+    '@verdaccio/file-locking@13.0.0-next-8.6':
         resolution:
             {
-                integrity: sha512-TcHgN3I/N28WBSvtukpGrJhBljl4jyIXq0vEv94vXAG6nUE3saK+vtgo8PfYA3Ueo88v/1zyAbiZM4uxwojCmQ==,
+                integrity: sha512-F6xQWvsZnEyGjugrYfe+D/ChSVudXmBFWi8xuTIX6PAdp7dk9x9biOGQFW8O3GSAK8UhJ6WlRisQKJeYRa6vWQ==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/loaders@8.0.0-next-8.4':
+    '@verdaccio/hooks@8.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-Powlqb4SuMbe6RVgxyyOXaCjuHCcK7oZA+lygaKZDpV9NSHJtbkkV4L+rXyCfTX3b0tKsBh7FzaIdgWc1rDeGQ==,
+                integrity: sha512-8xP6kVOCufjaZWriFtaxP3HEmvYTIBhcxWldui4eCG7dzBdZzPlCkRbYKWP8LMnOEIxbJNbeFkokOaI1nho1jg==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/local-storage-legacy@11.0.2':
+    '@verdaccio/loaders@8.0.0-next-8.23':
         resolution:
             {
-                integrity: sha512-7AXG7qlcVFmF+Nue2oKaraprGRtaBvrQIOvc/E89+7hAe399V01KnZI6E/ET56u7U9fq0MSlp92HBcdotlpUXg==,
-            }
-        engines: { node: '>=12' }
-
-    '@verdaccio/logger-commons@8.0.0-next-8.7':
-        resolution:
-            {
-                integrity: sha512-sXNx57G1LVp81xF4qHer3AOcMEZ90W4FjxtYF0vmULcVg3ybdtStKAT/9ocZtVMvLWTPAauhqylfnXoRZYf32A==,
+                integrity: sha512-UruK7pFz7aRKkR41/Hg/cPFSqX5Oxbx9rKGWK5ql3mvg2+xaWleRwknmnNjbVod7QK6cWsYA6cKnttRBTQuPkQ==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/logger-prettify@8.0.0-next-8.1':
+    '@verdaccio/local-storage-legacy@11.1.1':
         resolution:
             {
-                integrity: sha512-vLhaGq0q7wtMCcqa0aQY6QOsMNarhTu/l4e6Z8mG/5LUH95GGLsBwpXLnKS94P3deIjsHhc9ycnEmG39txbQ1w==,
+                integrity: sha512-P6ahH2W6/KqfJFKP+Eid7P134FHDLNvHa+i8KVgRVBeo2/IXb6FEANpM1mCVNvPANu0LCAmNJBOXweoUKViaoA==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/logger@8.0.0-next-8.7':
+    '@verdaccio/logger-commons@8.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-5EMPdZhz2V08BP2rjhtN/Fz5KxCfPJBkYDitbk/eo+FCZ9nVdMCQE3WRbHEaXyJQcIso/LJ6RnL/zKN20E/rPg==,
+                integrity: sha512-WmMq/6HyRliKWus3sQR9Pgodopzbp84dl/h/E0tnxuOmzc/eDwYCEiQMfFhIBaOlpVJdsdLYqNAM9+YkoSDK0g==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/middleware@8.0.0-next-8.7':
+    '@verdaccio/logger-prettify@8.0.0-next-8.4':
         resolution:
             {
-                integrity: sha512-Zad7KcdOsI1DUBt1TjQb08rIi/IFFaJKdPhj7M6oy5BX9l/4OM0TtbBueHFNS1+aU+t5eo8ue7ZHbqmjDY/6VQ==,
+                integrity: sha512-gjI/JW29fyalutn/X1PQ0iNuGvzeVWKXRmnLa7gXVKhdi4p37l/j7YZ7n44XVbbiLIKAK0pbavEg9Yr66QrYaA==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/search-indexer@8.0.0-next-8.2':
+    '@verdaccio/logger@8.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-sWliVN5BkAGbZ3e/GD0CsZMfPJdRMRuN0tEKQFsvEJifxToq5UkfCw6vKaVvhezsTWqb+Rp5y+2d4n5BDOA49w==,
+                integrity: sha512-8nR3hreOcINIbMIOohhxZNUL3l0uvgGYQecl8WJvR4XizYTp1vPHv4qz1CPyuaI5bKj1QFRqHkKvvtEnD1A0rw==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/signature@8.0.0-next-8.1':
+    '@verdaccio/middleware@8.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-lHD/Z2FoPQTtDYz6ZlXhj/lrg0SFirHrwCGt/cibl1GlePpx78WPdo03tgAyl0Qf+I35n484/gR1l9eixBQqYw==,
+                integrity: sha512-iMzE3stUp/qocHzFX2+xkzUe6L89vWZ/J4a4v7IxPu6KqBH39XCg4gI8Qu0xXRIFeYSTpZNzRUO+FTkeZRhJ1A==,
+            }
+        engines: { node: '>=18' }
+
+    '@verdaccio/search-indexer@8.0.0-next-8.5':
+        resolution:
+            {
+                integrity: sha512-0GC2tJKstbPg/W2PZl2yE+hoAxffD2ZWilEnEYSEo2e9UQpNIy2zg7KE/uMUq2P72Vf5EVfVzb8jdaH4KV4QeA==,
+            }
+        engines: { node: '>=18' }
+
+    '@verdaccio/signature@8.0.0-next-8.25':
+        resolution:
+            {
+                integrity: sha512-3qMHZ9uXgNmRQDw7Bz3coCbXJAfI3q+bWRXQ0/fKg03LgSV6pbMD0HinGKcIBn0Kni+e8IsXxBfrs5ga4FF+Rg==,
             }
         engines: { node: '>=18' }
 
@@ -9359,39 +9388,32 @@ packages:
             }
         engines: { node: '>=12', npm: '>=5' }
 
-    '@verdaccio/tarball@13.0.0-next-8.7':
+    '@verdaccio/tarball@13.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-EWRuEOLgb3UETxUsYg6+Mml6DDRiwQqKIEsE4Ys6y6rcH2vgW6XMnTt+s/v5pFI+zlbi6fxjOgQB1e6IJAwxVA==,
+                integrity: sha512-VQZ8I5Fs6INxO1cY6Lpk4Wx3sD0Uy7YIzTY9qWrZNRPGDxGcZu2fyFMUfoNc1+ygJP0r5TTqdVAY74z0iQnsWg==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/ui-theme@8.0.0-next-8.7':
+    '@verdaccio/ui-theme@8.0.0-next-8.30':
         resolution:
             {
-                integrity: sha512-+7f7XqqIU+TVCHjsP6lWzCdsD4sM7MEhn4cu3mLW1kJZ7eenWKEltoqixQnoXJzaBjCiz+yXW1WkjMyEFLNbpg==,
+                integrity: sha512-MSvFnYeocTWp6hqtIqtwp7Zm920UNhO3zQkKTPT6qGNjarkhxCCWRcSOAz7oJZhpbyLXc85zuxOLkTezCl4KUg==,
             }
 
-    '@verdaccio/url@13.0.0-next-8.7':
+    '@verdaccio/url@13.0.0-next-8.33':
         resolution:
             {
-                integrity: sha512-biFvwH3zIXYicA+SXNGvjMAe8oIQ5VddsfbO0ZXWlFs0lIz8cgI7QYPeSiCkU2VKpGzZ8pEKgqkxFsfFkU5kGA==,
+                integrity: sha512-26LzQTCuUFFcNasAdzayBqsYWBheQy+D4tSWnVtmj4kKQnVhufBvHLjpEjK1gqphOMx6/Mju0IQe0LsjRc1zdg==,
             }
         engines: { node: '>=18' }
 
-    '@verdaccio/utils@7.0.1-next-8.1':
+    '@verdaccio/utils@8.1.0-next-8.33':
         resolution:
             {
-                integrity: sha512-cyJdRrVa+8CS7UuIQb3K3IJFjMe64v38tYiBnohSmhRbX7dX9IT3jWbjrwkqWh4KeS1CS6BYENrGG1evJ2ggrQ==,
+                integrity: sha512-WLE8qTBgzuZPa+gq/nKPWtF4MTMayaeOD3Qy6yfChxNvFXY+6yPFkS0QocXL7CdB2A+w+ylgTOOzKr0tWvyTpQ==,
             }
-        engines: { node: '>=12' }
-
-    '@verdaccio/utils@8.1.0-next-8.7':
-        resolution:
-            {
-                integrity: sha512-4eqPCnPAJsL6gdVs0/oqZNgs2PnQW3HHBMgBHyEbb5A/ESI10TvRp+B7MRl9glUmy/aR5B6YSI68rgXvAFjdxA==,
-            }
-        engines: { node: '>=12' }
+        engines: { node: '>=18' }
 
     '@vite-pwa/astro@1.2.0':
         resolution:
@@ -10567,12 +10589,6 @@ packages:
                 integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==,
             }
 
-    async@3.2.4:
-        resolution:
-            {
-                integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==,
-            }
-
     async@3.2.6:
         resolution:
             {
@@ -11190,6 +11206,13 @@ packages:
             }
         engines: { node: '>= 0.8' }
 
+    cacheable-lookup@6.1.0:
+        resolution:
+            {
+                integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==,
+            }
+        engines: { node: '>=10.6.0' }
+
     cacheable-lookup@7.0.0:
         resolution:
             {
@@ -11208,6 +11231,13 @@ packages:
         resolution:
             {
                 integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==,
+            }
+        engines: { node: '>=8' }
+
+    cacheable-request@7.0.2:
+        resolution:
+            {
+                integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==,
             }
         engines: { node: '>=8' }
 
@@ -11898,13 +11928,6 @@ packages:
             }
         engines: { node: '>= 0.6' }
 
-    compression@1.7.5:
-        resolution:
-            {
-                integrity: sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==,
-            }
-        engines: { node: '>= 0.8.0' }
-
     compression@1.8.1:
         resolution:
             {
@@ -12043,12 +12066,6 @@ packages:
                 integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==,
             }
 
-    core-js@3.37.1:
-        resolution:
-            {
-                integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==,
-            }
-
     core-util-is@1.0.2:
         resolution:
             {
@@ -12061,10 +12078,10 @@ packages:
                 integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
             }
 
-    cors@2.8.5:
+    cors@2.8.6:
         resolution:
             {
-                integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==,
+                integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==,
             }
         engines: { node: '>= 0.10' }
 
@@ -12808,18 +12825,6 @@ packages:
             supports-color:
                 optional: true
 
-    debug@4.3.4:
-        resolution:
-            {
-                integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==,
-            }
-        engines: { node: '>=6.0' }
-        peerDependencies:
-            supports-color: '*'
-        peerDependenciesMeta:
-            supports-color:
-                optional: true
-
     debug@4.3.7:
         resolution:
             {
@@ -12836,6 +12841,18 @@ packages:
         resolution:
             {
                 integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==,
+            }
+        engines: { node: '>=6.0' }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+
+    debug@4.4.1:
+        resolution:
+            {
+                integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==,
             }
         engines: { node: '>=6.0' }
         peerDependencies:
@@ -13556,14 +13573,6 @@ packages:
             }
         engines: { node: '>=6' }
 
-    envinfo@7.14.0:
-        resolution:
-            {
-                integrity: sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==,
-            }
-        engines: { node: '>=4' }
-        hasBin: true
-
     envinfo@7.21.0:
         resolution:
             {
@@ -14238,6 +14247,13 @@ packages:
             }
         engines: { node: '>= 0.10.0' }
 
+    express@4.22.1:
+        resolution:
+            {
+                integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==,
+            }
+        engines: { node: '>= 0.10.0' }
+
     expressive-code@0.41.7:
         resolution:
             {
@@ -14341,19 +14357,6 @@ packages:
                 integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
             }
 
-    fast-redact@3.5.0:
-        resolution:
-            {
-                integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==,
-            }
-        engines: { node: '>=6' }
-
-    fast-safe-stringify@2.1.1:
-        resolution:
-            {
-                integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
-            }
-
     fast-string-truncated-width@3.0.3:
         resolution:
             {
@@ -14378,10 +14381,16 @@ packages:
                 integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==,
             }
 
-    fast-xml-parser@4.5.4:
+    fast-xml-builder@1.1.4:
         resolution:
             {
-                integrity: sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==,
+                integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==,
+            }
+
+    fast-xml-parser@5.5.8:
+        resolution:
+            {
+                integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==,
             }
         hasBin: true
 
@@ -14691,6 +14700,12 @@ packages:
         peerDependencies:
             typescript: '>3.6.0'
             webpack: ^5.11.0
+
+    form-data-encoder@1.7.2:
+        resolution:
+            {
+                integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==,
+            }
 
     form-data-encoder@2.1.4:
         resolution:
@@ -15143,6 +15158,13 @@ packages:
                 integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
             }
         engines: { node: '>= 0.4' }
+
+    got-cjs@12.5.4:
+        resolution:
+            {
+                integrity: sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==,
+            }
+        engines: { node: '>=12' }
 
     got@13.0.0:
         resolution:
@@ -15717,12 +15739,6 @@ packages:
                 integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==,
             }
         engines: { node: '>=0.10' }
-
-    http-status-codes@2.2.0:
-        resolution:
-            {
-                integrity: sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==,
-            }
 
     http-status-codes@2.3.0:
         resolution:
@@ -17184,10 +17200,10 @@ packages:
             }
         engines: { node: '>=0.10.0' }
 
-    jsonwebtoken@9.0.2:
+    jsonwebtoken@9.0.3:
         resolution:
             {
-                integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==,
+                integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==,
             }
         engines: { node: '>=12', npm: '>=6' }
 
@@ -17205,16 +17221,16 @@ packages:
             }
         engines: { node: '>=4.0' }
 
-    jwa@1.4.1:
+    jwa@2.0.1:
         resolution:
             {
-                integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==,
+                integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==,
             }
 
-    jws@3.2.2:
+    jws@4.0.1:
         resolution:
             {
-                integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==,
+                integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==,
             }
 
     kapsule@1.16.3:
@@ -19051,6 +19067,13 @@ packages:
             }
         engines: { node: '>=10' }
 
+    minimatch@7.4.9:
+        resolution:
+            {
+                integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==,
+            }
+        engines: { node: '>=10' }
+
     minimatch@9.0.3:
         resolution:
             {
@@ -19469,6 +19492,13 @@ packages:
             }
         engines: { node: '>=8' }
 
+    normalize-url@6.1.0:
+        resolution:
+            {
+                integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==,
+            }
+        engines: { node: '>=10' }
+
     normalize-url@8.0.1:
         resolution:
             {
@@ -19665,13 +19695,6 @@ packages:
             }
         engines: { node: '>= 0.8' }
 
-    on-headers@1.0.2:
-        resolution:
-            {
-                integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==,
-            }
-        engines: { node: '>= 0.8' }
-
     on-headers@1.1.0:
         resolution:
             {
@@ -19819,6 +19842,13 @@ packages:
                 integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==,
             }
         engines: { node: '>=6' }
+
+    p-cancelable@2.1.1:
+        resolution:
+            {
+                integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==,
+            }
+        engines: { node: '>=8' }
 
     p-cancelable@3.0.0:
         resolution:
@@ -20091,6 +20121,13 @@ packages:
             }
         engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
+    path-expression-matcher@1.2.0:
+        resolution:
+            {
+                integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==,
+            }
+        engines: { node: '>=14.0.0' }
+
     path-is-absolute@1.0.1:
         resolution:
             {
@@ -20268,10 +20305,10 @@ packages:
                 integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==,
             }
 
-    pino@9.5.0:
+    pino@9.14.0:
         resolution:
             {
-                integrity: sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==,
+                integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==,
             }
         hasBin: true
 
@@ -20313,13 +20350,6 @@ packages:
             {
                 integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==,
             }
-
-    pkginfo@0.4.1:
-        resolution:
-            {
-                integrity: sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==,
-            }
-        engines: { node: '>= 0.4.0' }
 
     playwright-core@1.51.1:
         resolution:
@@ -20870,10 +20900,10 @@ packages:
                 integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==,
             }
 
-    process-warning@4.0.1:
+    process-warning@5.0.0:
         resolution:
             {
-                integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==,
+                integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
             }
 
     process@0.11.10:
@@ -21010,17 +21040,17 @@ packages:
             }
         engines: { node: '>=0.6' }
 
-    qs@6.13.1:
-        resolution:
-            {
-                integrity: sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==,
-            }
-        engines: { node: '>=0.6' }
-
     qs@6.14.0:
         resolution:
             {
                 integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==,
+            }
+        engines: { node: '>=0.6' }
+
+    qs@6.14.2:
+        resolution:
+            {
+                integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==,
             }
         engines: { node: '>=0.6' }
 
@@ -21966,6 +21996,12 @@ packages:
         resolution:
             {
                 integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==,
+            }
+
+    responselike@2.0.1:
+        resolution:
+            {
+                integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==,
             }
 
     responselike@3.0.0:
@@ -23333,10 +23369,10 @@ packages:
             }
         engines: { node: '>=8' }
 
-    strnum@1.1.2:
+    strnum@2.2.1:
         resolution:
             {
-                integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==,
+                integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==,
             }
 
     strtok3@9.1.1:
@@ -24838,10 +24874,10 @@ packages:
             }
         engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
 
-    validator@13.12.0:
+    validator@13.15.26:
         resolution:
             {
-                integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==,
+                integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==,
             }
         engines: { node: '>= 0.10' }
 
@@ -24867,24 +24903,24 @@ packages:
             react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
             react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
-    verdaccio-audit@13.0.0-next-8.7:
+    verdaccio-audit@13.0.0-next-8.33:
         resolution:
             {
-                integrity: sha512-kd6YdrDztkP1/GDZT7Ue2u41iGPvM9y+5aaUbIBUPvTY/YVv57K6MaCMfn9C/I+ZL4R7XOTSxTtWvz3JK4QrNg==,
+                integrity: sha512-qBMN0b4cbSbo6RbOke0QtVy/HuSzmxgRXIjnXM3C86ZhjN6DlhdeAoQYcZUfbXM8BklRXtObAnMoTlgeJ7BJLA==,
             }
         engines: { node: '>=18' }
 
-    verdaccio-htpasswd@13.0.0-next-8.7:
+    verdaccio-htpasswd@13.0.0-next-8.33:
         resolution:
             {
-                integrity: sha512-znyFnwt59mLKTAu6eHJrfWP07iaHUlYiQN7QoBo8KMAOT1AecUYreBqs93oKHdIOzjTI8j6tQLg57DpeVS5vgg==,
+                integrity: sha512-ZYqvF/EuA4W4idfv2O1ZN8YhSI2xreFbGdrcWgOd+QBedDin7NzMhgypbafutm9mPhkI6Xv/+3syee1u1cEL8g==,
             }
         engines: { node: '>=18' }
 
-    verdaccio@6.0.5:
+    verdaccio@6.3.2:
         resolution:
             {
-                integrity: sha512-hv+v4mtG/rcNidGUHXAtNuVySiPE3/PM+7dYye5jCDrhCUmRJYOtnvDe/Ym1ZE/twti39g6izVRxEkjnSp52gA==,
+                integrity: sha512-9BmfrGlakdAW1QNBrD2GgO8hOhwIp6ogbAhaaDgtDsK3/94qXwS6n2PM1/gG2V/zFC5JH1rWbLia390i0xbodA==,
             }
         engines: { node: '>=18' }
         hasBin: true
@@ -28075,7 +28111,7 @@ snapshots:
 
     '@ctrl/tinycolor@4.1.0': {}
 
-    '@cypress/request@3.0.7':
+    '@cypress/request@3.0.10':
         dependencies:
             aws-sign2: 0.7.0
             aws4: 1.13.2
@@ -28083,14 +28119,14 @@ snapshots:
             combined-stream: 1.0.8
             extend: 3.0.2
             forever-agent: 0.6.1
-            form-data: 4.0.2
+            form-data: 4.0.5
             http-signature: 1.4.0
             is-typedarray: 1.0.0
             isstream: 0.1.2
             json-stringify-safe: 5.0.1
             mime-types: 2.1.35
             performance-now: 2.1.0
-            qs: 6.13.1
+            qs: 6.14.2
             safe-buffer: 5.2.1
             tough-cookie: 5.1.2
             tunnel-agent: 0.6.0
@@ -30261,12 +30297,12 @@ snapshots:
             tinyrainbow: 3.0.3
             tslib: 2.8.1
 
-    '@nx-tools/nx-container@7.2.1(@nx/devkit@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))))(@nx/js@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0)))(dotenv@16.4.7)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(tslib@2.8.1)':
+    '@nx-tools/nx-container@7.2.1(@nx/devkit@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))))(@nx/js@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0)))(dotenv@16.4.7)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(tslib@2.8.1)':
         dependencies:
             '@nx-tools/container-metadata': 7.2.1(@nx/devkit@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))))(tslib@2.8.1)
             '@nx-tools/core': 7.2.1(@nx/devkit@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))))(tslib@2.8.1)
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             csv-parse: 5.6.0
             dotenv: 16.4.7
             handlebars: 4.7.8
@@ -30314,10 +30350,10 @@ snapshots:
         transitivePeerDependencies:
             - nx
 
-    '@nx/esbuild@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/esbuild@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             picocolors: 1.1.1
             tinyglobby: 0.2.15
             tsconfig-paths: 4.2.0
@@ -30333,10 +30369,10 @@ snapshots:
             - supports-color
             - verdaccio
 
-    '@nx/eslint-plugin@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@8.57.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/eslint-plugin@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@8.57.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
             '@typescript-eslint/parser': 7.18.0(eslint@8.57.0)(typescript@5.9.3)
             '@typescript-eslint/type-utils': 8.11.0(eslint@8.57.0)(typescript@5.9.3)
@@ -30360,10 +30396,10 @@ snapshots:
             - typescript
             - verdaccio
 
-    '@nx/eslint@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/eslint@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             eslint: 8.57.0
             semver: 7.7.4
             tslib: 2.8.1
@@ -30379,12 +30415,12 @@ snapshots:
             - supports-color
             - verdaccio
 
-    '@nx/jest@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/jest@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@jest/reporters': 30.2.0
             '@jest/test-result': 30.2.0
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
             identity-obj-proxy: 3.0.0
             jest-config: 30.2.0(@types/node@18.19.17)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))
@@ -30411,7 +30447,7 @@ snapshots:
             - typescript
             - verdaccio
 
-    '@nx/js@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/js@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@babel/core': 7.29.0
             '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -30440,7 +30476,7 @@ snapshots:
             tinyglobby: 0.2.15
             tslib: 2.8.1
         optionalDependencies:
-            verdaccio: 6.0.5(encoding@0.1.13)(typanion@3.14.0)
+            verdaccio: 6.3.2(encoding@0.1.13)(typanion@3.14.0)
         transitivePeerDependencies:
             - '@babel/traverse'
             - '@swc-node/register'
@@ -30449,14 +30485,14 @@ snapshots:
             - nx
             - supports-color
 
-    '@nx/module-federation@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vue-tsc@1.8.27(typescript@5.9.3))':
+    '@nx/module-federation@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vue-tsc@1.8.27(typescript@5.9.3))':
         dependencies:
             '@module-federation/enhanced': 2.2.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0))
             '@module-federation/node': 2.7.31(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0))
             '@module-federation/sdk': 2.2.3
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/web': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/web': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
             express: 4.21.2
             http-proxy-middleware: 3.0.5
@@ -30483,13 +30519,13 @@ snapshots:
             - vue-tsc
             - webpack-cli
 
-    '@nx/node@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/node@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
             '@nx/docker': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/eslint': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/jest': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/eslint': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/jest': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.17)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/wasm@1.15.18)(@types/node@18.19.17)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             kill-port: 1.6.1
             tcp-port-used: 1.0.2
             tslib: 2.8.1
@@ -30540,11 +30576,11 @@ snapshots:
     '@nx/nx-win32-x64-msvc@22.6.1':
         optional: true
 
-    '@nx/playwright@22.6.1(@babel/traverse@7.29.0)(@playwright/test@1.51.1)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/playwright@22.6.1(@babel/traverse@7.29.0)(@playwright/test@1.51.1)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/eslint': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/eslint': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             minimatch: 10.2.4
             tslib: 2.8.1
         optionalDependencies:
@@ -30560,14 +30596,14 @@ snapshots:
             - supports-color
             - verdaccio
 
-    '@nx/react@22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.0)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)(vue-tsc@1.8.27(typescript@5.9.3))':
+    '@nx/react@22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.25.0)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)(vue-tsc@1.8.27(typescript@5.9.3))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/eslint': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/module-federation': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vue-tsc@1.8.27(typescript@5.9.3))
-            '@nx/rollup': 22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/web': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/eslint': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/module-federation': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vue-tsc@1.8.27(typescript@5.9.3))
+            '@nx/rollup': 22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/web': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
             '@svgr/webpack': 8.1.0(typescript@5.9.3)
             express: 4.21.2
@@ -30577,7 +30613,7 @@ snapshots:
             semver: 7.7.4
             tslib: 2.8.1
         optionalDependencies:
-            '@nx/vite': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
+            '@nx/vite': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
         transitivePeerDependencies:
             - '@babel/core'
             - '@babel/traverse'
@@ -30604,10 +30640,10 @@ snapshots:
             - vue-tsc
             - webpack-cli
 
-    '@nx/rollup@22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/rollup@22.6.1(@babel/core@7.26.10)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@rollup/plugin-babel': 6.1.0(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@4.57.1)
             '@rollup/plugin-commonjs': 25.0.8(rollup@4.57.1)
             '@rollup/plugin-image': 3.0.3(rollup@4.57.1)
@@ -30635,11 +30671,11 @@ snapshots:
             - typescript
             - verdaccio
 
-    '@nx/vite@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)':
+    '@nx/vite@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-            '@nx/vitest': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/vitest': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)
             '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
             ajv: 8.18.0
             enquirer: 2.3.6
@@ -30659,10 +30695,10 @@ snapshots:
             - typescript
             - verdaccio
 
-    '@nx/vitest@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)':
+    '@nx/vitest@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.9)':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
             semver: 7.7.4
             tslib: 2.8.1
@@ -30679,10 +30715,10 @@ snapshots:
             - typescript
             - verdaccio
 
-    '@nx/web@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/web@22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             detect-port: 1.6.1
             http-server: 14.1.1
             picocolors: 1.1.1
@@ -30696,11 +30732,11 @@ snapshots:
             - supports-color
             - verdaccio
 
-    '@nx/webpack@22.6.1(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.30.2)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+    '@nx/webpack@22.6.1(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.30.2)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
         dependencies:
             '@babel/core': 7.29.0
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+            '@nx/js': 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
             '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
             ajv: 8.18.0
             autoprefixer: 10.4.25(postcss@8.5.6)
@@ -31076,6 +31112,8 @@ snapshots:
             '@types/esquery': 1.5.4
             esquery: 1.6.0
             typescript: 5.9.3
+
+    '@pinojs/redact@0.4.0': {}
 
     '@pkgjs/parseargs@0.11.0':
         optional: true
@@ -31462,7 +31500,7 @@ snapshots:
             '@react-native-community/cli-tools': 15.1.3
             chalk: 4.1.2
             fast-glob: 3.3.3
-            fast-xml-parser: 4.5.4
+            fast-xml-parser: 5.5.8
         optional: true
 
     '@react-native-community/cli-config-apple@15.1.3':
@@ -31529,7 +31567,7 @@ snapshots:
             '@react-native-community/cli-tools': 15.1.3
             chalk: 4.1.2
             execa: 5.1.1
-            fast-xml-parser: 4.5.4
+            fast-xml-parser: 5.5.8
         optional: true
 
     '@react-native-community/cli-platform-ios@15.1.3':
@@ -32398,6 +32436,8 @@ snapshots:
 
     '@sindresorhus/is@0.14.0': {}
 
+    '@sindresorhus/is@4.6.0': {}
+
     '@sindresorhus/is@5.6.0': {}
 
     '@sinonjs/commons@3.0.1':
@@ -32660,6 +32700,10 @@ snapshots:
     '@szmarczak/http-timer@1.1.2':
         dependencies:
             defer-to-connect: 1.1.3
+
+    '@szmarczak/http-timer@4.0.6':
+        dependencies:
+            defer-to-connect: 2.0.1
 
     '@szmarczak/http-timer@5.0.1':
         dependencies:
@@ -33180,6 +33224,10 @@ snapshots:
 
     '@types/resolve@1.20.2': {}
 
+    '@types/responselike@1.0.0':
+        dependencies:
+            '@types/node': 18.19.17
+
     '@types/responselike@1.0.3':
         dependencies:
             '@types/node': 18.19.17
@@ -33487,167 +33535,160 @@ snapshots:
             '@use-gesture/core': 10.3.1
             react: 19.2.4
 
-    '@verdaccio/auth@8.0.0-next-8.7':
+    '@verdaccio/auth@8.0.0-next-8.33':
         dependencies:
-            '@verdaccio/config': 8.0.0-next-8.7
-            '@verdaccio/core': 8.0.0-next-8.7
-            '@verdaccio/loaders': 8.0.0-next-8.4
-            '@verdaccio/signature': 8.0.0-next-8.1
-            '@verdaccio/utils': 8.1.0-next-8.7
-            debug: 4.4.0
-            lodash: 4.17.21
-            verdaccio-htpasswd: 13.0.0-next-8.7
+            '@verdaccio/config': 8.0.0-next-8.33
+            '@verdaccio/core': 8.0.0-next-8.33
+            '@verdaccio/loaders': 8.0.0-next-8.23
+            '@verdaccio/signature': 8.0.0-next-8.25
+            debug: 4.4.3(supports-color@5.5.0)
+            lodash: 4.17.23
+            verdaccio-htpasswd: 13.0.0-next-8.33
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/commons-api@10.2.0':
+    '@verdaccio/config@8.0.0-next-8.33':
         dependencies:
-            http-errors: 2.0.0
-            http-status-codes: 2.2.0
+            '@verdaccio/core': 8.0.0-next-8.33
+            debug: 4.4.3(supports-color@5.5.0)
+            js-yaml: 4.1.1
+            lodash: 4.17.23
+        transitivePeerDependencies:
+            - supports-color
 
-    '@verdaccio/config@8.0.0-next-8.7':
+    '@verdaccio/core@8.0.0-next-8.21':
         dependencies:
-            '@verdaccio/core': 8.0.0-next-8.7
-            '@verdaccio/utils': 8.1.0-next-8.7
-            debug: 4.4.0
-            js-yaml: 4.1.0
-            lodash: 4.17.21
+            ajv: 8.17.1
+            http-errors: 2.0.0
+            http-status-codes: 2.3.0
             minimatch: 7.4.6
-        transitivePeerDependencies:
-            - supports-color
-
-    '@verdaccio/core@8.0.0-next-8.1':
-        dependencies:
-            ajv: 8.17.1
-            core-js: 3.37.1
-            http-errors: 2.0.0
-            http-status-codes: 2.3.0
             process-warning: 1.0.0
-            semver: 7.6.3
+            semver: 7.7.2
 
-    '@verdaccio/core@8.0.0-next-8.7':
+    '@verdaccio/core@8.0.0-next-8.33':
         dependencies:
-            ajv: 8.17.1
-            core-js: 3.37.1
-            http-errors: 2.0.0
+            ajv: 8.18.0
+            http-errors: 2.0.1
             http-status-codes: 2.3.0
+            minimatch: 7.4.9
             process-warning: 1.0.0
-            semver: 7.6.3
+            semver: 7.7.4
 
     '@verdaccio/file-locking@10.3.1':
         dependencies:
             lockfile: 1.0.4
 
-    '@verdaccio/file-locking@13.0.0-next-8.2':
+    '@verdaccio/file-locking@13.0.0-next-8.6':
         dependencies:
             lockfile: 1.0.4
 
-    '@verdaccio/loaders@8.0.0-next-8.4':
+    '@verdaccio/hooks@8.0.0-next-8.33':
         dependencies:
-            debug: 4.3.7(supports-color@5.5.0)
-            lodash: 4.17.21
+            '@verdaccio/core': 8.0.0-next-8.33
+            '@verdaccio/logger': 8.0.0-next-8.33
+            debug: 4.4.3(supports-color@5.5.0)
+            got-cjs: 12.5.4
+            handlebars: 4.7.8
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/local-storage-legacy@11.0.2':
+    '@verdaccio/loaders@8.0.0-next-8.23':
         dependencies:
-            '@verdaccio/commons-api': 10.2.0
+            '@verdaccio/core': 8.0.0-next-8.33
+            debug: 4.4.3(supports-color@5.5.0)
+            lodash: 4.17.23
+        transitivePeerDependencies:
+            - supports-color
+
+    '@verdaccio/local-storage-legacy@11.1.1':
+        dependencies:
+            '@verdaccio/core': 8.0.0-next-8.21
             '@verdaccio/file-locking': 10.3.1
             '@verdaccio/streams': 10.2.1
-            async: 3.2.4
-            debug: 4.3.4
+            async: 3.2.6
+            debug: 4.4.1
             lodash: 4.17.21
             lowdb: 1.0.0
             mkdirp: 1.0.4
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/logger-commons@8.0.0-next-8.7':
+    '@verdaccio/logger-commons@8.0.0-next-8.33':
         dependencies:
-            '@verdaccio/core': 8.0.0-next-8.7
-            '@verdaccio/logger-prettify': 8.0.0-next-8.1
+            '@verdaccio/core': 8.0.0-next-8.33
+            '@verdaccio/logger-prettify': 8.0.0-next-8.4
             colorette: 2.0.20
-            debug: 4.4.0
+            debug: 4.4.3(supports-color@5.5.0)
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/logger-prettify@8.0.0-next-8.1':
+    '@verdaccio/logger-prettify@8.0.0-next-8.4':
         dependencies:
             colorette: 2.0.20
             dayjs: 1.11.13
             lodash: 4.17.21
+            on-exit-leak-free: 2.1.2
             pino-abstract-transport: 1.2.0
             sonic-boom: 3.8.1
 
-    '@verdaccio/logger@8.0.0-next-8.7':
+    '@verdaccio/logger@8.0.0-next-8.33':
         dependencies:
-            '@verdaccio/logger-commons': 8.0.0-next-8.7
-            pino: 9.5.0
+            '@verdaccio/logger-commons': 8.0.0-next-8.33
+            pino: 9.14.0
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/middleware@8.0.0-next-8.7':
+    '@verdaccio/middleware@8.0.0-next-8.33':
         dependencies:
-            '@verdaccio/config': 8.0.0-next-8.7
-            '@verdaccio/core': 8.0.0-next-8.7
-            '@verdaccio/url': 13.0.0-next-8.7
-            '@verdaccio/utils': 8.1.0-next-8.7
-            debug: 4.4.0
-            express: 4.21.2
+            '@verdaccio/config': 8.0.0-next-8.33
+            '@verdaccio/core': 8.0.0-next-8.33
+            '@verdaccio/url': 13.0.0-next-8.33
+            debug: 4.4.3(supports-color@5.5.0)
+            express: 4.22.1
             express-rate-limit: 5.5.1
-            lodash: 4.17.21
+            lodash: 4.17.23
             lru-cache: 7.18.3
-            mime: 2.6.0
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/search-indexer@8.0.0-next-8.2': {}
+    '@verdaccio/search-indexer@8.0.0-next-8.5': {}
 
-    '@verdaccio/signature@8.0.0-next-8.1':
+    '@verdaccio/signature@8.0.0-next-8.25':
         dependencies:
-            debug: 4.3.7(supports-color@5.5.0)
-            jsonwebtoken: 9.0.2
+            '@verdaccio/config': 8.0.0-next-8.33
+            '@verdaccio/core': 8.0.0-next-8.33
+            debug: 4.4.3(supports-color@5.5.0)
+            jsonwebtoken: 9.0.3
         transitivePeerDependencies:
             - supports-color
 
     '@verdaccio/streams@10.2.1': {}
 
-    '@verdaccio/tarball@13.0.0-next-8.7':
+    '@verdaccio/tarball@13.0.0-next-8.33':
         dependencies:
-            '@verdaccio/core': 8.0.0-next-8.7
-            '@verdaccio/url': 13.0.0-next-8.7
-            '@verdaccio/utils': 8.1.0-next-8.7
-            debug: 4.4.0
+            '@verdaccio/core': 8.0.0-next-8.33
+            '@verdaccio/url': 13.0.0-next-8.33
+            debug: 4.4.3(supports-color@5.5.0)
             gunzip-maybe: 1.4.2
-            lodash: 4.17.21
             tar-stream: 3.1.7
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/ui-theme@8.0.0-next-8.7': {}
+    '@verdaccio/ui-theme@8.0.0-next-8.30': {}
 
-    '@verdaccio/url@13.0.0-next-8.7':
+    '@verdaccio/url@13.0.0-next-8.33':
         dependencies:
-            '@verdaccio/core': 8.0.0-next-8.7
-            debug: 4.4.0
-            lodash: 4.17.21
-            validator: 13.12.0
+            '@verdaccio/core': 8.0.0-next-8.33
+            debug: 4.4.3(supports-color@5.5.0)
+            validator: 13.15.26
         transitivePeerDependencies:
             - supports-color
 
-    '@verdaccio/utils@7.0.1-next-8.1':
+    '@verdaccio/utils@8.1.0-next-8.33':
         dependencies:
-            '@verdaccio/core': 8.0.0-next-8.1
-            lodash: 4.17.21
-            minimatch: 7.4.6
-            semver: 7.6.3
-
-    '@verdaccio/utils@8.1.0-next-8.7':
-        dependencies:
-            '@verdaccio/core': 8.0.0-next-8.7
-            lodash: 4.17.21
-            minimatch: 7.4.6
-            semver: 7.6.3
+            '@verdaccio/core': 8.0.0-next-8.33
+            lodash: 4.17.23
+            minimatch: 7.4.9
 
     '@vite-pwa/astro@1.2.0(astro@6.0.6(@planetscale/database@1.19.0)(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(rollup@4.57.1)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(vite-plugin-pwa@1.0.0(vite@7.3.1(@types/node@18.19.17)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.2)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.44.1)(yaml@2.8.2))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))':
         dependencies:
@@ -34678,8 +34719,6 @@ snapshots:
         dependencies:
             lodash: 4.17.23
 
-    async@3.2.4: {}
-
     async@3.2.6: {}
 
     asynckit@0.4.0: {}
@@ -35199,6 +35238,8 @@ snapshots:
 
     bytes@3.1.2: {}
 
+    cacheable-lookup@6.1.0: {}
+
     cacheable-lookup@7.0.0: {}
 
     cacheable-request@10.2.14:
@@ -35220,6 +35261,16 @@ snapshots:
             lowercase-keys: 2.0.0
             normalize-url: 4.5.1
             responselike: 1.0.2
+
+    cacheable-request@7.0.2:
+        dependencies:
+            clone-response: 1.0.3
+            get-stream: 5.2.0
+            http-cache-semantics: 4.2.0
+            keyv: 4.5.4
+            lowercase-keys: 2.0.0
+            normalize-url: 6.1.0
+            responselike: 2.0.1
 
     call-bind-apply-helpers@1.0.2:
         dependencies:
@@ -35587,18 +35638,6 @@ snapshots:
         dependencies:
             mime-db: 1.54.0
 
-    compression@1.7.5:
-        dependencies:
-            bytes: 3.1.2
-            compressible: 2.0.18
-            debug: 2.6.9
-            negotiator: 0.6.4
-            on-headers: 1.0.2
-            safe-buffer: 5.2.1
-            vary: 1.1.2
-        transitivePeerDependencies:
-            - supports-color
-
     compression@1.8.1:
         dependencies:
             bytes: 3.1.2
@@ -35677,13 +35716,11 @@ snapshots:
         dependencies:
             browserslist: 4.28.1
 
-    core-js@3.37.1: {}
-
     core-util-is@1.0.2: {}
 
     core-util-is@1.0.3: {}
 
-    cors@2.8.5:
+    cors@2.8.6:
         dependencies:
             object-assign: 4.1.1
             vary: 1.1.2
@@ -36224,10 +36261,6 @@ snapshots:
         dependencies:
             ms: 2.1.2
 
-    debug@4.3.4:
-        dependencies:
-            ms: 2.1.2
-
     debug@4.3.7(supports-color@5.5.0):
         dependencies:
             ms: 2.1.3
@@ -36235,6 +36268,10 @@ snapshots:
             supports-color: 5.5.0
 
     debug@4.4.0:
+        dependencies:
+            ms: 2.1.3
+
+    debug@4.4.1:
         dependencies:
             ms: 2.1.3
 
@@ -36566,10 +36603,7 @@ snapshots:
     env-paths@2.2.1:
         optional: true
 
-    envinfo@7.14.0: {}
-
-    envinfo@7.21.0:
-        optional: true
+    envinfo@7.21.0: {}
 
     environment@1.1.0: {}
 
@@ -37313,6 +37347,42 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
+    express@4.22.1:
+        dependencies:
+            accepts: 1.3.8
+            array-flatten: 1.1.1
+            body-parser: 1.20.3
+            content-disposition: 0.5.4
+            content-type: 1.0.5
+            cookie: 0.7.1
+            cookie-signature: 1.0.6
+            debug: 2.6.9
+            depd: 2.0.0
+            encodeurl: 2.0.0
+            escape-html: 1.0.3
+            etag: 1.8.1
+            finalhandler: 1.3.1
+            fresh: 0.5.2
+            http-errors: 2.0.1
+            merge-descriptors: 1.0.3
+            methods: 1.1.2
+            on-finished: 2.4.1
+            parseurl: 1.3.3
+            path-to-regexp: 0.1.12
+            proxy-addr: 2.0.7
+            qs: 6.14.0
+            range-parser: 1.2.1
+            safe-buffer: 5.2.1
+            send: 0.19.2
+            serve-static: 1.16.3
+            setprototypeof: 1.2.0
+            statuses: 2.0.2
+            type-is: 1.6.18
+            utils-merge: 1.0.1
+            vary: 1.1.2
+        transitivePeerDependencies:
+            - supports-color
+
     expressive-code@0.41.7:
         dependencies:
             '@expressive-code/core': 0.41.7
@@ -37363,10 +37433,6 @@ snapshots:
 
     fast-levenshtein@2.0.6: {}
 
-    fast-redact@3.5.0: {}
-
-    fast-safe-stringify@2.1.1: {}
-
     fast-string-truncated-width@3.0.3: {}
 
     fast-string-width@3.0.2:
@@ -37379,9 +37445,16 @@ snapshots:
         dependencies:
             fast-string-width: 3.0.2
 
-    fast-xml-parser@4.5.4:
+    fast-xml-builder@1.1.4:
         dependencies:
-            strnum: 1.1.2
+            path-expression-matcher: 1.2.0
+        optional: true
+
+    fast-xml-parser@5.5.8:
+        dependencies:
+            fast-xml-builder: 1.1.4
+            path-expression-matcher: 1.2.0
+            strnum: 2.2.1
         optional: true
 
     fastq@1.17.1:
@@ -37588,6 +37661,8 @@ snapshots:
             tapable: 2.3.0
             typescript: 5.9.3
             webpack: 5.105.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)
+
+    form-data-encoder@1.7.2: {}
 
     form-data-encoder@2.1.4: {}
 
@@ -37884,6 +37959,21 @@ snapshots:
             get-intrinsic: 1.3.0
 
     gopd@1.2.0: {}
+
+    got-cjs@12.5.4:
+        dependencies:
+            '@sindresorhus/is': 4.6.0
+            '@szmarczak/http-timer': 4.0.6
+            '@types/responselike': 1.0.0
+            cacheable-lookup: 6.1.0
+            cacheable-request: 7.0.2
+            decompress-response: 6.0.0
+            form-data-encoder: 1.7.2
+            get-stream: 6.0.1
+            http2-wrapper: 2.2.1
+            lowercase-keys: 2.0.0
+            p-cancelable: 2.1.1
+            responselike: 2.0.1
 
     got@13.0.0:
         dependencies:
@@ -38436,8 +38526,6 @@ snapshots:
             assert-plus: 1.0.0
             jsprim: 2.0.2
             sshpk: 1.18.0
-
-    http-status-codes@2.2.0: {}
 
     http-status-codes@2.3.0: {}
 
@@ -39422,9 +39510,9 @@ snapshots:
 
     jsonpointer@5.0.1: {}
 
-    jsonwebtoken@9.0.2:
+    jsonwebtoken@9.0.3:
         dependencies:
-            jws: 3.2.2
+            jws: 4.0.1
             lodash.includes: 4.3.0
             lodash.isboolean: 3.0.3
             lodash.isinteger: 4.0.4
@@ -39449,15 +39537,15 @@ snapshots:
             object.assign: 4.1.7
             object.values: 1.2.1
 
-    jwa@1.4.1:
+    jwa@2.0.1:
         dependencies:
             buffer-equal-constant-time: 1.0.1
             ecdsa-sig-formatter: 1.0.11
             safe-buffer: 5.2.1
 
-    jws@3.2.2:
+    jws@4.0.1:
         dependencies:
-            jwa: 1.4.1
+            jwa: 2.0.1
             safe-buffer: 5.2.1
 
     kapsule@1.16.3:
@@ -40919,7 +41007,8 @@ snapshots:
 
     mime@1.6.0: {}
 
-    mime@2.6.0: {}
+    mime@2.6.0:
+        optional: true
 
     mime@3.0.0: {}
 
@@ -40974,6 +41063,10 @@ snapshots:
             brace-expansion: 2.0.2
 
     minimatch@7.4.6:
+        dependencies:
+            brace-expansion: 2.0.2
+
+    minimatch@7.4.9:
         dependencies:
             brace-expansion: 2.0.2
 
@@ -41169,6 +41262,8 @@ snapshots:
 
     normalize-url@4.5.1: {}
 
+    normalize-url@6.1.0: {}
+
     normalize-url@8.0.1: {}
 
     nosleep.js@0.7.0: {}
@@ -41335,8 +41430,6 @@ snapshots:
         dependencies:
             ee-first: 1.1.1
 
-    on-headers@1.0.2: {}
-
     on-headers@1.1.0: {}
 
     once@1.3.3:
@@ -41474,6 +41567,8 @@ snapshots:
             '@oxc-resolver/binding-win32-x64-msvc': 11.17.1
 
     p-cancelable@1.1.0: {}
+
+    p-cancelable@2.1.1: {}
 
     p-cancelable@3.0.0: {}
 
@@ -41632,6 +41727,9 @@ snapshots:
 
     path-exists@5.0.0: {}
 
+    path-expression-matcher@1.2.0:
+        optional: true
+
     path-is-absolute@1.0.1: {}
 
     path-key@3.1.1: {}
@@ -41710,14 +41808,14 @@ snapshots:
 
     pino-std-serializers@7.0.0: {}
 
-    pino@9.5.0:
+    pino@9.14.0:
         dependencies:
+            '@pinojs/redact': 0.4.0
             atomic-sleep: 1.0.0
-            fast-redact: 3.5.0
             on-exit-leak-free: 2.1.2
             pino-abstract-transport: 2.0.0
             pino-std-serializers: 7.0.0
-            process-warning: 4.0.1
+            process-warning: 5.0.0
             quick-format-unescaped: 4.0.4
             real-require: 0.2.0
             safe-stable-stringify: 2.5.0
@@ -41749,8 +41847,6 @@ snapshots:
             confbox: 0.2.2
             exsolve: 1.0.7
             pathe: 2.0.3
-
-    pkginfo@0.4.1: {}
 
     playwright-core@1.51.1: {}
 
@@ -42240,7 +42336,7 @@ snapshots:
 
     process-warning@1.0.0: {}
 
-    process-warning@4.0.1: {}
+    process-warning@5.0.0: {}
 
     process@0.11.10: {}
 
@@ -42316,11 +42412,11 @@ snapshots:
         dependencies:
             side-channel: 1.1.0
 
-    qs@6.13.1:
+    qs@6.14.0:
         dependencies:
             side-channel: 1.1.0
 
-    qs@6.14.0:
+    qs@6.14.2:
         dependencies:
             side-channel: 1.1.0
 
@@ -43096,6 +43192,10 @@ snapshots:
     responselike@1.0.2:
         dependencies:
             lowercase-keys: 1.0.1
+
+    responselike@2.0.1:
+        dependencies:
+            lowercase-keys: 2.0.0
 
     responselike@3.0.0:
         dependencies:
@@ -44034,7 +44134,7 @@ snapshots:
 
     strip-json-comments@3.1.1: {}
 
-    strnum@1.1.2:
+    strnum@2.2.1:
         optional: true
 
     strtok3@9.1.1:
@@ -44959,7 +45059,7 @@ snapshots:
     validate-npm-package-name@5.0.1:
         optional: true
 
-    validator@13.12.0: {}
+    validator@13.15.26: {}
 
     varint@6.0.0: {}
 
@@ -44974,69 +45074,61 @@ snapshots:
             - '@types/react'
             - '@types/react-dom'
 
-    verdaccio-audit@13.0.0-next-8.7(encoding@0.1.13):
+    verdaccio-audit@13.0.0-next-8.33(encoding@0.1.13):
         dependencies:
-            '@verdaccio/config': 8.0.0-next-8.7
-            '@verdaccio/core': 8.0.0-next-8.7
-            express: 4.21.2
+            '@verdaccio/config': 8.0.0-next-8.33
+            '@verdaccio/core': 8.0.0-next-8.33
+            express: 4.22.1
             https-proxy-agent: 5.0.1
             node-fetch: 2.6.7(encoding@0.1.13)
         transitivePeerDependencies:
             - encoding
             - supports-color
 
-    verdaccio-htpasswd@13.0.0-next-8.7:
+    verdaccio-htpasswd@13.0.0-next-8.33:
         dependencies:
-            '@verdaccio/core': 8.0.0-next-8.7
-            '@verdaccio/file-locking': 13.0.0-next-8.2
+            '@verdaccio/core': 8.0.0-next-8.33
+            '@verdaccio/file-locking': 13.0.0-next-8.6
             apache-md5: 1.1.8
             bcryptjs: 2.4.3
-            core-js: 3.37.1
-            debug: 4.4.0
-            http-errors: 2.0.0
+            debug: 4.4.3(supports-color@5.5.0)
+            http-errors: 2.0.1
             unix-crypt-td-js: 1.1.4
         transitivePeerDependencies:
             - supports-color
 
-    verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0):
+    verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0):
         dependencies:
-            '@cypress/request': 3.0.7
-            '@verdaccio/auth': 8.0.0-next-8.7
-            '@verdaccio/config': 8.0.0-next-8.7
-            '@verdaccio/core': 8.0.0-next-8.7
-            '@verdaccio/local-storage-legacy': 11.0.2
-            '@verdaccio/logger': 8.0.0-next-8.7
-            '@verdaccio/middleware': 8.0.0-next-8.7
-            '@verdaccio/search-indexer': 8.0.0-next-8.2
-            '@verdaccio/signature': 8.0.0-next-8.1
+            '@cypress/request': 3.0.10
+            '@verdaccio/auth': 8.0.0-next-8.33
+            '@verdaccio/config': 8.0.0-next-8.33
+            '@verdaccio/core': 8.0.0-next-8.33
+            '@verdaccio/hooks': 8.0.0-next-8.33
+            '@verdaccio/loaders': 8.0.0-next-8.23
+            '@verdaccio/local-storage-legacy': 11.1.1
+            '@verdaccio/logger': 8.0.0-next-8.33
+            '@verdaccio/middleware': 8.0.0-next-8.33
+            '@verdaccio/search-indexer': 8.0.0-next-8.5
+            '@verdaccio/signature': 8.0.0-next-8.25
             '@verdaccio/streams': 10.2.1
-            '@verdaccio/tarball': 13.0.0-next-8.7
-            '@verdaccio/ui-theme': 8.0.0-next-8.7
-            '@verdaccio/url': 13.0.0-next-8.7
-            '@verdaccio/utils': 7.0.1-next-8.1
+            '@verdaccio/tarball': 13.0.0-next-8.33
+            '@verdaccio/ui-theme': 8.0.0-next-8.30
+            '@verdaccio/url': 13.0.0-next-8.33
+            '@verdaccio/utils': 8.1.0-next-8.33
             JSONStream: 1.3.5
             async: 3.2.6
             clipanion: 4.0.0-rc.4(typanion@3.14.0)
-            compression: 1.7.5
-            cors: 2.8.5
-            debug: 4.4.0
-            envinfo: 7.14.0
-            express: 4.21.2
-            express-rate-limit: 5.5.1
-            fast-safe-stringify: 2.1.1
-            handlebars: 4.7.8
-            js-yaml: 4.1.0
-            jsonwebtoken: 9.0.2
-            kleur: 4.1.5
-            lodash: 4.17.21
+            compression: 1.8.1
+            cors: 2.8.6
+            debug: 4.4.3(supports-color@5.5.0)
+            envinfo: 7.21.0
+            express: 4.22.1
+            lodash: 4.17.23
             lru-cache: 7.18.3
             mime: 3.0.0
-            mkdirp: 1.0.4
-            pkginfo: 0.4.1
-            semver: 7.6.3
-            validator: 13.12.0
-            verdaccio-audit: 13.0.0-next-8.7(encoding@0.1.13)
-            verdaccio-htpasswd: 13.0.0-next-8.7
+            semver: 7.7.4
+            verdaccio-audit: 13.0.0-next-8.33(encoding@0.1.13)
+            verdaccio-htpasswd: 13.0.0-next-8.33
         transitivePeerDependencies:
             - encoding
             - supports-color


### PR DESCRIPTION
## Summary
- Override `fast-xml-parser` to `>=5.5.8` — fixes numeric entity expansion bypass (high severity, CVE-2026-26278 incomplete fix)
- Bump `verdaccio` from 6.0.5 to 6.3.2 (supersedes #8756)

## Test plan
- [ ] Dependency review check passes (no high+ vulns)
- [ ] pnpm install succeeds
- [ ] CI lint/test pass

Ref: #8756