### PR TITLE
fix(ows): add /health endpoint to management service

### DIFF
--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -453,13 +453,13 @@ spec:
                           cpu: '500m'
                   livenessProbe:
                       httpGet:
-                          path: /
+                          path: /health
                           port: http
                       initialDelaySeconds: 30
                       periodSeconds: 15
                   readinessProbe:
                       httpGet:
-                          path: /
+                          path: /health
                           port: http
                       initialDelaySeconds: 10
                       periodSeconds: 5

--- a/apps/ows/ows-management/Startup.cs
+++ b/apps/ows/ows-management/Startup.cs
@@ -105,6 +105,13 @@ namespace OWSManagement
                 c.SwaggerEndpoint("./v1/swagger.json", "Open World Server Management API");
             });
 
+            app.Map("/health", a => a.Run(async ctx =>
+            {
+                ctx.Response.ContentType = "application/json";
+                ctx.Response.StatusCode = 200;
+                await ctx.Response.WriteAsync("{\"status\":\"healthy\"}");
+            }));
+
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
 


### PR DESCRIPTION
## Summary
Management service had no `/health` endpoint. Readiness/liveness probes hit `/` which serves the Vue SPA — fails on chiseled alpine image causing CrashLoopBackOff.

- Added `/health` endpoint returning `200 {"status":"healthy"}`
- Updated deployment probes from `/` to `/health`

## Test plan
- [ ] Management pod passes readiness/liveness probes
- [ ] Management pod reaches 1/1 Running