### PR TITLE
fix(ows): add instance launcher secrets to kustomization

### DIFF
--- a/apps/kube/github/runners/manifests/kustomization.yaml
+++ b/apps/kube/github/runners/manifests/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
     - dind-cache-pvc.yaml
     - engine-cache-pvc.yaml
     - ows-server-build-pvc.yaml
+    - ows-launcher-secrets.yaml
     - ows-instance-launcher.yaml
     - cache-cleanup-cronjob.yaml


### PR DESCRIPTION
## Summary
`ows-launcher-secrets.yaml` (SA + SecretStore + ExternalSecret) was in the repo but not listed in the kustomization resources. This caused the instance launcher to fail with:

```
error looking up service account arc-runners/ows-launcher-external-secrets: serviceaccount not found
```

## Fix
Add `ows-launcher-secrets.yaml` to `kustomization.yaml` resources.

## Test plan
- [ ] SA created in arc-runners namespace
- [ ] ExternalSecret syncs RabbitMQ credentials
- [ ] Instance launcher pod starts