### PR TITLE
feat(kube): add Agones game server operator (v1.56.0)

### DIFF
--- a/apps/kube/agones/application.yaml
+++ b/apps/kube/agones/application.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: agones
+    namespace: argocd
+spec:
+    project: default
+    sources:
+        - repoURL: https://agones.dev/chart/stable
+          targetRevision: 1.56.0
+          chart: agones
+          helm:
+              releaseName: agones
+              valueFiles:
+                  - $values/apps/kube/agones/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: agones-system
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m

--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -1,0 +1,70 @@
+## Agones Helm values for Talos Linux + Cilium
+## Reference: https://agones.dev/site/docs/installation/install-agones/helm/
+
+# CRDs — let Helm manage them
+agones:
+    crds:
+        install: true
+        cleanupOnDelete: false
+
+    # Controller — manages GameServer/Fleet lifecycle
+    controller:
+        replicas: 2
+        resources:
+            requests:
+                cpu: 100m
+                memory: 128Mi
+            limits:
+                cpu: 500m
+                memory: 256Mi
+
+    # Extensions — webhooks and API extensions
+    extensions:
+        replicas: 2
+        resources:
+            requests:
+                cpu: 50m
+                memory: 64Mi
+            limits:
+                cpu: 200m
+                memory: 128Mi
+
+    # Allocator — handles GameServerAllocation requests
+    allocator:
+        replicas: 2
+        resources:
+            requests:
+                cpu: 50m
+                memory: 64Mi
+            limits:
+                cpu: 200m
+                memory: 128Mi
+        # Disable external allocator service for now — internal only
+        service:
+            serviceType: ClusterIP
+
+    # Ping — latency testing (disabled for now, enable when needed)
+    ping:
+        install: false
+
+    # Metrics — Prometheus integration
+    metrics:
+        prometheusEnabled: true
+        prometheusServiceDiscovery: true
+
+    # Feature gates
+    featureGates: ''
+
+# Game server defaults
+gameservers:
+    # Namespace for game servers — use OWS namespace
+    namespaces:
+        - ows
+
+    # Port range for game server host ports (UDP)
+    minPort: 7000
+    maxPort: 8000
+
+    # Node selector — only run game servers on dedicated-server nodes
+    nodeSelector:
+        node.kbve.com/type: dedicated-server

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -52,6 +52,8 @@ resources:
     - memes/application.yaml
     - n8n/application.yaml
     - rabbitmq/application.yaml
+    # Agones — game server operator (GameServer/Fleet/Allocator CRDs)
+    - agones/application.yaml
     # OWS — Open World Server .NET microservices (5 services + ValKey)
     - ows/application.yaml
     - rentearth/application.yaml


### PR DESCRIPTION
## Summary
- Add Agones as a Helm-based ArgoCD application at `apps/kube/agones/`
- Chart version 1.56.0 from `https://agones.dev/chart/stable`
- Configured for Talos + Cilium: host port range 7000-8000, dedicated-server node selector
- Game servers scoped to `ows` namespace
- Prometheus metrics enabled, allocator internal-only (ClusterIP), ping disabled
- Added to `kustomization.yaml` before OWS entry

## Test plan
- [ ] ArgoCD syncs Agones to `agones-system` namespace
- [ ] CRDs installed: GameServer, Fleet, FleetAutoscaler, GameServerAllocation
- [ ] Controller and allocator pods running
- [ ] GameServer CR can be created in `ows` namespace