### PR TITLE
feat(chuckrpg): scaffold astro-chuckrpg with Starlight

### DIFF
--- a/apps/chuckrpg/astro-chuckrpg/astro.config.mjs
+++ b/apps/chuckrpg/astro-chuckrpg/astro.config.mjs
@@ -1,0 +1,40 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+	site: 'https://chuckrpg.com',
+	output: 'static',
+	trailingSlash: 'always',
+	outDir: '../../../dist/apps/astro-chuckrpg',
+	prefetch: true,
+	integrations: [
+		starlight({
+			title: 'ChuckRPG',
+			defaultLocale: 'root',
+			locales: {
+				root: {
+					label: 'English',
+					lang: 'en',
+				},
+			},
+			sidebar: [
+				{
+					label: 'Getting Started',
+					autogenerate: { directory: 'guides' },
+				},
+				{
+					label: 'Game',
+					autogenerate: { directory: 'game' },
+				},
+			],
+		}),
+		react(),
+		sitemap(),
+	],
+	vite: {
+		plugins: [tailwindcss()],
+	},
+});

--- a/apps/chuckrpg/astro-chuckrpg/project.json
+++ b/apps/chuckrpg/astro-chuckrpg/project.json
@@ -1,0 +1,43 @@
+{
+	"name": "astro-chuckrpg",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/chuckrpg/astro-chuckrpg/src",
+	"tags": [],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/chuckrpg/astro-chuckrpg",
+				"commands": [
+					"rm -rf .astro",
+					"nx exec -- astro sync",
+					"nx exec -- astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-chuckrpg"],
+			"options": {
+				"cwd": "apps/chuckrpg/astro-chuckrpg",
+				"commands": [
+					"rm -rf .astro",
+					"nx exec -- astro sync",
+					"nx exec -- astro build"
+				],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"preview": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/chuckrpg/astro-chuckrpg",
+				"commands": ["nx exec -- astro preview"]
+			},
+			"dependsOn": ["build"]
+		}
+	}
+}

--- a/apps/chuckrpg/astro-chuckrpg/src/content/docs/game/overview.mdx
+++ b/apps/chuckrpg/astro-chuckrpg/src/content/docs/game/overview.mdx
@@ -1,0 +1,6 @@
+---
+title: Game Overview
+description: ChuckRPG game systems and architecture
+---
+
+Game systems documentation will go here.

--- a/apps/chuckrpg/astro-chuckrpg/src/content/docs/guides/introduction.mdx
+++ b/apps/chuckrpg/astro-chuckrpg/src/content/docs/guides/introduction.mdx
@@ -1,0 +1,6 @@
+---
+title: Introduction
+description: Welcome to ChuckRPG
+---
+
+ChuckRPG is an open world multiplayer RPG built on Unreal Engine with the Open World Server (OWS) backend.

--- a/apps/chuckrpg/astro-chuckrpg/src/content/docs/index.mdx
+++ b/apps/chuckrpg/astro-chuckrpg/src/content/docs/index.mdx
@@ -1,0 +1,11 @@
+---
+title: ChuckRPG
+description: Open world multiplayer RPG powered by Unreal Engine and OWS
+template: splash
+hero:
+    tagline: Open world multiplayer RPG
+    actions:
+        - text: Get Started
+          link: /guides/introduction/
+          icon: right-arrow
+---

--- a/apps/chuckrpg/astro-chuckrpg/tailwind.config.mjs
+++ b/apps/chuckrpg/astro-chuckrpg/tailwind.config.mjs
@@ -1,0 +1,7 @@
+import starlightPlugin from '@astrojs/starlight-tailwind';
+
+/** @type {import('tailwindcss').Config} */
+export default {
+	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+	plugins: [starlightPlugin()],
+};

--- a/apps/chuckrpg/astro-chuckrpg/tsconfig.json
+++ b/apps/chuckrpg/astro-chuckrpg/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "astro/tsconfigs/strict",
+	"include": [".astro/types.d.ts", "**/*"],
+	"exclude": ["dist"],
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "react",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"],
+			"@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
+			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
+			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"]
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New Astro Starlight app at `apps/chuckrpg/astro-chuckrpg/`
- Configured for `chuckrpg.com` with static output
- Starlight sidebar: guides + game sections
- React, Tailwind, sitemap integrations
- Nx targets: dev, build, preview
- Build verified locally

## Test plan
- [ ] `npx nx run astro-chuckrpg:build` passes
- [ ] `npx nx run astro-chuckrpg:dev` launches dev server