### PR TITLE
fix(ows): add missing using for HttpResponse.WriteAsync

### DIFF
--- a/apps/ows/ows-management/Startup.cs
+++ b/apps/ows/ows-management/Startup.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
## Summary
- Add `using Microsoft.AspNetCore.Http;` to `ows-management/Startup.cs`
- The `/health` endpoint uses `HttpResponse.WriteAsync()` which requires this namespace in .NET 8
- Without it, Docker build fails with `CS1061: HttpResponse does not contain a definition for WriteAsync`

Closes #8796