### PR TITLE
feat(ows): add api.chuckrpg.com route + TLS

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -68,6 +68,17 @@ spec:
                           metadata:
                               annotations:
                                   cert-manager.io/http01-ingress-path-type: 'Prefix'
+
+            # --- Solver 6: CHUCKRPG.COM domains (Gateway API HTTP-01) ---
+            - selector:
+                  dnsZones:
+                      - chuckrpg.com
+              http01:
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -30,6 +30,18 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-chuckrpg
+          protocol: HTTPS
+          port: 443
+          hostname: api.chuckrpg.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - name: chuckrpg-api-tls
+                    namespace: ows
+          allowedRoutes:
+              namespaces:
+                  from: All
 ---
 ## kbve.com routes
 apiVersion: gateway.networking.k8s.io/v1

--- a/apps/kube/ows/manifest/certificate.yaml
+++ b/apps/kube/ows/manifest/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: chuckrpg-api-tls
+    namespace: ows
+spec:
+    secretName: chuckrpg-api-tls
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+    dnsNames:
+        - api.chuckrpg.com

--- a/apps/kube/ows/manifest/httproute.yaml
+++ b/apps/kube/ows/manifest/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: ows-publicapi-route
+    namespace: ows
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - api.chuckrpg.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: ows-publicapi
+                port: 80


### PR DESCRIPTION
## Summary
Expose OWS PublicAPI externally at `api.chuckrpg.com` for UE5 game client connections.

- HTTPRoute: `api.chuckrpg.com` -> `ows-publicapi:80`
- TLS Certificate via cert-manager (Let's Encrypt HTTP-01 with Gateway API solver)
- Gateway listener: dedicated HTTPS listener for `api.chuckrpg.com`
- ClusterIssuer: added `chuckrpg.com` solver using `gatewayHTTPRoute`

## Prerequisites
- `api.chuckrpg.com` A record must point to `142.132.206.74`
- Port 80 must be reachable for ACME HTTP-01 challenge

## Test plan
- [ ] DNS pointed
- [ ] Certificate issued by Let's Encrypt
- [ ] `curl https://api.chuckrpg.com/health` returns 200