### PR TITLE
fix(ci): add actions:write permission for auto-merge dispatch

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -255,6 +255,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
+            actions: write
         uses: KBVE/kbve/.github/workflows/utils-update-kube-manifest.yml@main
         with:
             app_name: ${{ inputs.app_name }}
@@ -277,6 +278,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
+            actions: write
         uses: KBVE/kbve/.github/workflows/utils-update-version-toml.yml@dev
         with:
             package_type: docker

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -293,6 +293,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
+            actions: write
         uses: KBVE/kbve/.github/workflows/utils-update-version-toml.yml@dev
         with:
             package_type: npm
@@ -307,6 +308,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
+            actions: write
         uses: KBVE/kbve/.github/workflows/utils-update-version-toml.yml@dev
         with:
             package_type: crates
@@ -321,6 +323,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
+            actions: write
         uses: KBVE/kbve/.github/workflows/utils-update-version-toml.yml@dev
         with:
             package_type: python


### PR DESCRIPTION
## Summary
- Auto-merge bot PRs (#8798–#8805) were stuck at "Review required" because `gh workflow run ci-auto-merge-bot-prs.yml` silently failed — the calling jobs lacked `actions: write` permission on `GITHUB_TOKEN`
- Added `actions: write` to 5 jobs across `ci-docker.yml` (2 jobs) and `ci-publish.yml` (3 jobs) that dispatch the auto-merge workflow

## Root Cause
`utils-update-version-toml.yml` and `utils-update-kube-manifest.yml` call `gh workflow run` to dispatch the auto-merge workflow. The GitHub API requires `actions: write` for `workflow_dispatch` triggers. The `|| true` at the end swallowed the 403 error, so the failure was invisible.

## Test Plan
- [ ] Verify CI passes on this PR
- [ ] Next Docker/npm/crates publish should auto-merge its bot PRs

Fixes #8798 #8799 #8800 #8801 #8802 #8803 #8804 #8805