### PR TITLE
fix(ci): add dotnet compile-check gate before Docker publish

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -157,6 +157,7 @@ jobs:
             version_target: ${{ steps.resolve.outputs.version_target }}
             target: ${{ steps.resolve.outputs.target }}
             nx_project: ${{ steps.resolve.outputs.nx_project }}
+            source_path: ${{ steps.resolve.outputs.source_path }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -186,6 +187,7 @@ jobs:
                   echo "version_target=$(echo "$ENTRY" | jq -r '.version_target // empty')"  >> "$GITHUB_OUTPUT"
                   echo "target=$(echo "$ENTRY" | jq -r '.target // "container"')"              >> "$GITHUB_OUTPUT"
                   echo "nx_project=$(echo "$ENTRY" | jq -r '.nx_project // empty')"            >> "$GITHUB_OUTPUT"
+                  echo "source_path=$(echo "$ENTRY" | jq -r '.source_path // empty')"          >> "$GITHUB_OUTPUT"
 
     # ---------------------------------------------------------------------------
     # Test — builds the app image, tags as ci-{sha} in GHCR, runs e2e tests.
@@ -212,19 +214,59 @@ jobs:
             version_target: ${{ needs.config.outputs.version_target }}
 
     # ---------------------------------------------------------------------------
+    # Compile Check — runs `dotnet restore + test` via Nx for dotnet projects.
+    # Catches compilation errors before the Docker publish stage.
+    # Only runs when a .sln file exists in source_path (i.e. dotnet projects).
+    # ---------------------------------------------------------------------------
+    compile_check:
+        name: Compile Check
+        needs: [config]
+        if: |
+            always() &&
+            needs.config.result == 'success' &&
+            needs.config.outputs.source_path != '' &&
+            !cancelled()
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            - name: Check for .sln file
+              id: detect
+              run: |
+                  SLN=$(find "${{ needs.config.outputs.source_path }}" -maxdepth 1 -name '*.sln' -print -quit 2>/dev/null)
+                  if [ -n "$SLN" ]; then
+                    echo "is_dotnet=true" >> "$GITHUB_OUTPUT"
+                    echo "sln_path=$SLN" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "is_dotnet=false" >> "$GITHUB_OUTPUT"
+                  fi
+            - name: Setup .NET SDK
+              if: steps.detect.outputs.is_dotnet == 'true'
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: '8.0.x'
+            - name: Dotnet restore and build
+              if: steps.detect.outputs.is_dotnet == 'true'
+              run: |
+                  dotnet restore "${{ steps.detect.outputs.sln_path }}"
+                  dotnet build "${{ steps.detect.outputs.sln_path }}" --no-restore -c Release
+
+    # ---------------------------------------------------------------------------
     # Publish — promotes the ci-{sha} tag built in test to the release tag.
     # Falls back to a full rebuild only if the ci-{sha} image is not in GHCR.
     # For apps without a test step (kilobase) this is the primary build path.
     # ---------------------------------------------------------------------------
     publish:
         name: Publish Docker
-        needs: [config, test, version_gate]
+        needs: [config, test, compile_check, version_gate]
         if: |
             always() &&
             !cancelled() &&
             needs.config.result == 'success' &&
             needs.version_gate.outputs.should_publish == 'true' &&
-            (needs.test.result == 'success' || needs.test.result == 'skipped')
+            (needs.test.result == 'success' || needs.test.result == 'skipped') &&
+            (needs.compile_check.result == 'success' || needs.compile_check.result == 'skipped')
         permissions:
             contents: read
             packages: write

--- a/apps/ows/ows-tests/OWSTests.csproj
+++ b/apps/ows/ows-tests/OWSTests.csproj
@@ -17,6 +17,12 @@
   <ItemGroup>
     <ProjectReference Include="../ows-shared/OWSShared.csproj" />
     <ProjectReference Include="../ows-data/OWSData.csproj" />
+    <ProjectReference Include="../ows-management/OWSManagement.csproj" />
+    <ProjectReference Include="../ows-instance-management/OWSInstanceManagement.csproj" />
+    <ProjectReference Include="../ows-public-api/OWSPublicAPI.csproj" />
+    <ProjectReference Include="../ows-character-persistence/OWSCharacterPersistence.csproj" />
+    <ProjectReference Include="../ows-global-data/OWSGlobalData.csproj" />
+    <ProjectReference Include="../ows-instance-launcher/OWSInstanceLauncher.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">


### PR DESCRIPTION
## Summary
- Add **Compile Check** job in `ci-docker.yml` that auto-detects `.sln` files and runs `dotnet restore + build` before publish
- Publish job now requires `compile_check` to pass (or skip for non-dotnet projects)
- Add all OWS service projects as references in `ows-tests/OWSTests.csproj` so the solution build compiles every service
- Non-dotnet projects (Rust, Node) skip the check automatically — zero impact on existing pipelines

## Root cause (#8796)
OWS had `has_test: false` and no pre-Docker compilation step. The `dotnet build` only happened inside the Dockerfile during publish, so compilation errors were never caught before deployment.

## Test plan
- [ ] Verify compile-check runs for OWS services (detects `OWS.sln`)
- [ ] Verify compile-check is skipped for Rust/Node projects (no `.sln`)
- [ ] Verify publish still requires compile-check to pass
- [ ] Introduce a deliberate compilation error in OWS and verify it fails at compile-check, not publish