### PR TITLE
test(chuckrpg): add e2e test suite for axum-chuckrpg

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg-e2e/e2e/health.spec.ts
+++ b/apps/chuckrpg/axum-chuckrpg-e2e/e2e/health.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+describe('Health endpoint', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('GET /health returns 200 with JSON', async () => {
+		const res = await fetch(`${BASE_URL}/health`);
+		expect(res.status).toBe(200);
+
+		const body = await res.json();
+		expect(body).toHaveProperty('status', 'ok');
+		expect(body).toHaveProperty('service', 'axum-chuckrpg');
+		expect(body).toHaveProperty('version');
+		expect(typeof body.version).toBe('string');
+	});
+
+	it('GET /health responds within 500ms', async () => {
+		const start = Date.now();
+		const res = await fetch(`${BASE_URL}/health`);
+		const elapsed = Date.now() - start;
+
+		expect(res.status).toBe(200);
+		expect(elapsed).toBeLessThan(500);
+	});
+});

--- a/apps/chuckrpg/axum-chuckrpg-e2e/e2e/helpers/http.ts
+++ b/apps/chuckrpg/axum-chuckrpg-e2e/e2e/helpers/http.ts
@@ -1,0 +1,24 @@
+const HOST = process.env['AXUM_HOST'] ?? '127.0.0.1';
+const PORT = Number(process.env['AXUM_PORT'] ?? 4324);
+
+export const BASE_URL = `http://${HOST}:${PORT}`;
+
+export async function waitForReady(timeoutMs = 30_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${BASE_URL}/health`, {
+				signal: AbortSignal.timeout(2_000),
+			});
+			if (res.status > 0) return;
+		} catch {
+			// Connection refused or reset — keep trying
+		}
+		await new Promise((r) => setTimeout(r, 500));
+	}
+
+	throw new Error(
+		`axum-chuckrpg server not ready at ${BASE_URL} after ${timeoutMs}ms`,
+	);
+}

--- a/apps/chuckrpg/axum-chuckrpg-e2e/e2e/root.spec.ts
+++ b/apps/chuckrpg/axum-chuckrpg-e2e/e2e/root.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+describe('Root endpoint', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('GET / returns 200 with text', async () => {
+		const res = await fetch(`${BASE_URL}/`);
+		expect(res.status).toBe(200);
+
+		const body = await res.text();
+		expect(body).toContain('ChuckRPG');
+	});
+
+	it('GET /nonexistent returns 404', async () => {
+		const res = await fetch(`${BASE_URL}/nonexistent-route-12345`);
+		expect(res.status).toBe(404);
+	});
+});

--- a/apps/chuckrpg/axum-chuckrpg-e2e/package.json
+++ b/apps/chuckrpg/axum-chuckrpg-e2e/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "axum-chuckrpg-e2e",
+	"private": true,
+	"version": "0.0.0"
+}

--- a/apps/chuckrpg/axum-chuckrpg-e2e/project.json
+++ b/apps/chuckrpg/axum-chuckrpg-e2e/project.json
@@ -1,0 +1,36 @@
+{
+	"name": "axum-chuckrpg-e2e",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"implicitDependencies": ["axum-chuckrpg"],
+	"targets": {
+		"test": {
+			"executor": "nx:noop",
+			"cache": false
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"dependsOn": [
+				{
+					"target": "container",
+					"projects": ["axum-chuckrpg"],
+					"params": "forward"
+				}
+			],
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker rm -f axum-chuckrpg-e2e 2>/dev/null || true",
+					"docker run -d --name axum-chuckrpg-e2e -p 4324:4322 -e HTTP_HOST=0.0.0.0 -e HTTP_PORT=4322 -e RUST_LOG=info kbve/chuckrpg:latest",
+					"npx vitest run; EC=$?; docker rm -f axum-chuckrpg-e2e 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false,
+				"cwd": "apps/chuckrpg/axum-chuckrpg-e2e"
+			},
+			"configurations": {
+				"ci": {}
+			}
+		}
+	},
+	"tags": []
+}

--- a/apps/chuckrpg/axum-chuckrpg-e2e/tsconfig.json
+++ b/apps/chuckrpg/axum-chuckrpg-e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true
+	},
+	"include": ["e2e/**/*.ts"]
+}

--- a/apps/chuckrpg/axum-chuckrpg-e2e/vitest.config.ts
+++ b/apps/chuckrpg/axum-chuckrpg-e2e/vitest.config.ts
@@ -1,0 +1,7 @@
+export default {
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 30_000,
+		hookTimeout: 60_000,
+	},
+};

--- a/apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx
@@ -18,7 +18,8 @@ version_target: apps/chuckrpg/axum-chuckrpg/Cargo.toml
 runner: ubuntu-latest
 image: kbve/chuckrpg
 deployment_yaml: apps/kube/chuckrpg/manifest/deployment.yaml
-has_test: false
+e2e_name: axum-chuckrpg-e2e
+has_test: true
 author: h0lybyte
 license: KBVE
 status: beta


### PR DESCRIPTION
## Summary
- E2e tests at `apps/chuckrpg/axum-chuckrpg-e2e/`
- Health endpoint: status, service name, version string, latency < 500ms
- Root endpoint: response contains "ChuckRPG", 404 for unknown routes
- Docker-based test runner matching axum-kbve-e2e pattern
- MDX updated: `has_test: true`, `e2e_name: axum-chuckrpg-e2e`

## Test plan
- [ ] `npx vitest run` passes against running container
- [ ] CI docker test step runs e2e before publish