### PR TITLE
feat(agones): add OWS HubWorldMMO game server Fleet (#8699)

### DIFF
--- a/apps/kube/agones/ows/application.yaml
+++ b/apps/kube/agones/ows/application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: agones-ows
+    namespace: argocd
+    labels:
+        app.kubernetes.io/part-of: ows
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: main
+        path: apps/kube/agones/ows
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: arc-runners
+    syncPolicy:
+        automated:
+            prune: true
+        syncOptions:
+            - CreateNamespace=false
+            - ServerSideApply=true

--- a/apps/kube/agones/ows/fleet-autoscaler.yaml
+++ b/apps/kube/agones/ows/fleet-autoscaler.yaml
@@ -1,0 +1,19 @@
+# OWS Fleet Autoscaler — maintains a buffer of ready servers
+# When a GameServerAllocation claims a server, the scaler creates a new one
+# to maintain the buffer. Keeps 0 ready servers by default (scale from zero).
+apiVersion: autoscaling.agones.dev/v1
+kind: FleetAutoscaler
+metadata:
+    name: ows-hubworld-autoscaler
+    namespace: arc-runners
+    labels:
+        app: ows-gameserver
+        app.kubernetes.io/part-of: ows
+spec:
+    fleetName: ows-hubworld
+    policy:
+        type: Buffer
+        buffer:
+            bufferSize: 0
+            minReplicas: 0
+            maxReplicas: 5

--- a/apps/kube/agones/ows/fleet.yaml
+++ b/apps/kube/agones/ows/fleet.yaml
@@ -1,0 +1,91 @@
+# OWS Game Server Fleet — managed by Agones
+# Spawns UE5 dedicated server instances from the ows-server-build PVC.
+# Fleet starts at 0 replicas — FleetAutoscaler or manual allocation spins up servers.
+#
+# Server binary: /server/latest/LinuxServer/OWSHubWorldMMOServer.sh
+# UDP port: allocated by Agones (7777-7900 range)
+# Health: game server reports to OWS InstanceManagement API
+apiVersion: agones.dev/v1
+kind: Fleet
+metadata:
+    name: ows-hubworld
+    namespace: arc-runners
+    labels:
+        app: ows-gameserver
+        app.kubernetes.io/part-of: ows
+spec:
+    replicas: 0
+    scheduling: Packed
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 25%
+            maxUnavailable: 25%
+    template:
+        metadata:
+            labels:
+                app: ows-gameserver
+                app.kubernetes.io/part-of: ows
+        spec:
+            ports:
+                - name: game
+                  portPolicy: Dynamic
+                  containerPort: 7777
+                  protocol: UDP
+            health:
+                disabled: false
+                initialDelaySeconds: 30
+                periodSeconds: 15
+                failureThreshold: 5
+            template:
+                spec:
+                    containers:
+                        - name: ue5-server
+                          image: ubuntu:24.04
+                          command:
+                              - /bin/bash
+                              - -c
+                              - |
+                                  SERVER_DIR="/server/latest/LinuxServer"
+                                  SERVER_BIN="${SERVER_DIR}/OWSHubWorldMMOServer.sh"
+
+                                  if [ ! -f "${SERVER_BIN}" ]; then
+                                    echo "ERROR: Server binary not found at ${SERVER_BIN}"
+                                    ls -la /server/ 2>/dev/null
+                                    exit 1
+                                  fi
+
+                                  chmod +x "${SERVER_BIN}"
+
+                                  # Agones SDK sets AGONES_SDK_GRPC_PORT
+                                  # OWS uses command-line args for zone/port config
+                                  exec "${SERVER_BIN}" \
+                                    -server \
+                                    -log \
+                                    -nosteam \
+                                    -unattended \
+                                    -port=${GAME_PORT:-7777} \
+                                    ${OWS_EXTRA_ARGS:-}
+                          env:
+                              - name: GAME_PORT
+                                value: '7777'
+                              - name: OWS_API_URL
+                                value: http://ows-publicapi.ows.svc.cluster.local
+                              - name: OWS_INSTANCE_MGMT_URL
+                                value: http://ows-instancemanagement.ows.svc.cluster.local
+                          resources:
+                              requests:
+                                  memory: 2Gi
+                                  cpu: '1'
+                              limits:
+                                  memory: 4Gi
+                                  cpu: '2'
+                          volumeMounts:
+                              - name: server-binary
+                                mountPath: /server
+                                readOnly: true
+                    volumes:
+                        - name: server-binary
+                          persistentVolumeClaim:
+                              claimName: ows-server-build
+                              readOnly: true

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -54,6 +54,8 @@ resources:
     - rabbitmq/application.yaml
     # Agones — game server operator (GameServer/Fleet/Allocator CRDs)
     - agones/application.yaml
+    # Agones OWS — HubWorldMMO game server fleet
+    - agones/ows/application.yaml
     # OWS — Open World Server .NET microservices (5 services + ValKey)
     - ows/application.yaml
     # ChuckRPG — game website + API


### PR DESCRIPTION
## Summary
Agones Fleet for OWS HubWorldMMO dedicated servers.

- **Fleet**: `ows-hubworld` in `arc-runners` namespace, 0 replicas (scale from zero)
- **Binary**: mounts `ows-server-build` PVC at `/server` (927MB UE5 dedicated server)
- **Autoscaler**: buffer policy, 0 min / 5 max replicas
- **Resources**: 2Gi-4Gi RAM, 1-2 CPU per game server
- **Networking**: dynamic UDP port via Agones

When OWS InstanceManagement sends a RabbitMQ spin-up message, a `GameServerAllocation` claims a ready server from the fleet. The autoscaler replaces it.

Ref: #8699

## Test plan
- [ ] Fleet syncs via ArgoCD (0 replicas)
- [ ] Manual allocation creates a GameServer pod
- [ ] Server binary found at /server/latest/LinuxServer/
- [ ] Game server connects to OWS InstanceManagement API