### PR TITLE
test(ows): expand test suite — middleware, options, validation, query tests

### DIFF
--- a/apps/ows/ows-tests/Data/AdditionalQueryTests.cs
+++ b/apps/ows/ows-tests/Data/AdditionalQueryTests.cs
@@ -1,0 +1,169 @@
+using OWSData.SQL;
+using Xunit;
+
+namespace OWSTests.Data
+{
+    public class AdditionalQueryTests
+    {
+        // ── Abilities ──────────────────────────────────────────────────
+
+        [Fact]
+        public void GetAbilities_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetAbilities);
+        }
+
+        [Fact]
+        public void GetCharacterAbilities_Requires_CustomerGUID_And_CharName()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetCharacterAbilities);
+            Assert.Contains("@CharName", GenericQueries.GetCharacterAbilities);
+        }
+
+        [Fact]
+        public void GetCharacterAbilityBars_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetCharacterAbilityBars);
+            Assert.Contains("@CharName", GenericQueries.GetCharacterAbilityBars);
+        }
+
+        // ── Characters ─────────────────────────────────────────────────
+
+        [Fact]
+        public void GetCharByCharName_Requires_CustomerGUID_And_CharName()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetCharByCharName);
+            Assert.Contains("@CharName", GenericQueries.GetCharByCharName);
+        }
+
+        [Fact]
+        public void AddCharacterToInstance_Requires_All_IDs()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.AddCharacterToInstance);
+            Assert.Contains("@MapInstanceID", GenericQueries.AddCharacterToInstance);
+            Assert.Contains("@CharacterID", GenericQueries.AddCharacterToInstance);
+        }
+
+        [Fact]
+        public void UpdateCharacterStats_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.UpdateCharacterStats);
+        }
+
+        [Fact]
+        public void UpdateCharacterPosition_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.UpdateCharacterPosition);
+            Assert.Contains("@CharacterID", GenericQueries.UpdateCharacterPosition);
+        }
+
+        [Fact]
+        public void GetCharacterByName_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetCharacterByName);
+            Assert.Contains("@CharacterName", GenericQueries.GetCharacterByName);
+        }
+
+        // ── Global Data ────────────────────────────────────────────────
+
+        [Fact]
+        public void AddGlobalData_Requires_Key_And_Value()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.AddGlobalData);
+            Assert.Contains("@GlobalDataKey", GenericQueries.AddGlobalData);
+            Assert.Contains("@GlobalDataValue", GenericQueries.AddGlobalData);
+        }
+
+        [Fact]
+        public void GetGlobalDataByKey_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetGlobalDataByGlobalDataKey);
+            Assert.Contains("@GlobalDataKey", GenericQueries.GetGlobalDataByGlobalDataKey);
+        }
+
+        [Fact]
+        public void UpdateGlobalData_Requires_Key_And_Value()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.UpdateGlobalData);
+            Assert.Contains("@GlobalDataKey", GenericQueries.UpdateGlobalData);
+            Assert.Contains("@GlobalDataValue", GenericQueries.UpdateGlobalData);
+        }
+
+        // ── Sessions ───────────────────────────────────────────────────
+
+        [Fact]
+        public void GetUserSession_Requires_UserSessionGUID()
+        {
+            Assert.Contains("@UserSessionGUID", GenericQueries.GetUserSession);
+        }
+
+        [Fact]
+        public void UserSessionSetSelectedCharacter_Requires_Session_And_Character()
+        {
+            Assert.Contains("@UserSessionGUID", GenericQueries.UserSessionSetSelectedCharacter);
+            Assert.Contains("@SelectedCharacterID", GenericQueries.UserSessionSetSelectedCharacter);
+        }
+
+        // ── Map Instances ──────────────────────────────────────────────
+
+        [Fact]
+        public void GetMapInstance_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetMapInstance);
+        }
+
+        [Fact]
+        public void UpdateMapInstanceStatus_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.UpdateMapInstanceStatus);
+            Assert.Contains("@MapInstanceID", GenericQueries.UpdateMapInstanceStatus);
+        }
+
+        [Fact]
+        public void GetMapByZoneName_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetMapByZoneName);
+            Assert.Contains("@ZoneName", GenericQueries.GetMapByZoneName);
+        }
+
+        // ── World Servers ──────────────────────────────────────────────
+
+        [Fact]
+        public void GetActiveWorldServersByLoad_Requires_CustomerGUID()
+        {
+            Assert.Contains("@CustomerGUID", GenericQueries.GetActiveWorldServersByLoad);
+        }
+
+        [Fact]
+        public void UpdateWorldServerStatus_Requires_WorldServerID()
+        {
+            Assert.Contains("@WorldServerID", GenericQueries.UpdateWorldServerStatus);
+            Assert.Contains("@CustomerGUID", GenericQueries.UpdateWorldServerStatus);
+        }
+
+        // ── Security: no hardcoded values in additional queries ────────
+
+        [Fact]
+        public void Additional_Queries_Do_Not_Contain_Hardcoded_GUIDs()
+        {
+            var queries = new[]
+            {
+                GenericQueries.GetAbilities,
+                GenericQueries.GetCustomer,
+                GenericQueries.AddCharacterToInstance,
+                GenericQueries.AddGlobalData,
+                GenericQueries.GetGlobalDataByGlobalDataKey,
+                GenericQueries.UpdateGlobalData,
+                GenericQueries.GetUserSession,
+                GenericQueries.GetMapInstance,
+                GenericQueries.UpdateMapInstanceStatus,
+                GenericQueries.GetActiveWorldServersByLoad,
+            };
+
+            foreach (var query in queries)
+            {
+                Assert.DoesNotMatch(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", query);
+            }
+        }
+    }
+}

--- a/apps/ows/ows-tests/Middleware/StoreCustomerGUIDMiddlewareTests.cs
+++ b/apps/ows/ows-tests/Middleware/StoreCustomerGUIDMiddlewareTests.cs
@@ -1,8 +1,133 @@
 using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using OWSShared.Implementations;
+using OWSShared.Middleware;
 using Xunit;
 
 namespace OWSTests.Middleware
 {
+    public class StoreCustomerGUIDMiddlewareTests
+    {
+        private readonly HeaderCustomerGUID _headerGuid;
+        private readonly StoreCustomerGUIDMiddleware _middleware;
+
+        public StoreCustomerGUIDMiddlewareTests()
+        {
+            _headerGuid = new HeaderCustomerGUID();
+            _middleware = new StoreCustomerGUIDMiddleware(_headerGuid);
+        }
+
+        private static DefaultHttpContext CreateContext(string path, string guidHeader = null)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = path;
+            if (guidHeader != null)
+                ctx.Request.Headers["X-CustomerGUID"] = guidHeader;
+            return ctx;
+        }
+
+        [Fact]
+        public async Task Health_Endpoint_Bypasses_Auth()
+        {
+            var ctx = CreateContext("/health");
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.True(nextCalled);
+            Assert.Equal(200, ctx.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Missing_Header_Returns_401()
+        {
+            var ctx = CreateContext("/api/users");
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.False(nextCalled);
+            Assert.Equal(401, ctx.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Empty_String_Header_Returns_401()
+        {
+            var ctx = CreateContext("/api/users", "");
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.False(nextCalled);
+            Assert.Equal(401, ctx.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Invalid_GUID_Format_Returns_401()
+        {
+            var ctx = CreateContext("/api/users", "not-a-guid");
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.False(nextCalled);
+            Assert.Equal(401, ctx.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Empty_GUID_Returns_401()
+        {
+            var ctx = CreateContext("/api/users", "00000000-0000-0000-0000-000000000000");
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.False(nextCalled);
+            Assert.Equal(401, ctx.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Valid_GUID_Sets_CustomerGUID_And_Calls_Next()
+        {
+            var guid = "be92671d-af96-4a6b-bdf7-6a3b6270dae6";
+            var ctx = CreateContext("/api/users", guid);
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.True(nextCalled);
+            Assert.Equal(Guid.Parse(guid), _headerGuid.CustomerGUID);
+        }
+
+        [Fact]
+        public async Task Valid_GUID_Uppercase_Works()
+        {
+            var guid = "BE92671D-AF96-4A6B-BDF7-6A3B6270DAE6";
+            var ctx = CreateContext("/api/users", guid);
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.True(nextCalled);
+            Assert.Equal(Guid.Parse(guid), _headerGuid.CustomerGUID);
+        }
+
+        [Fact]
+        public async Task Header_Name_Is_Case_Insensitive()
+        {
+            var guid = "be92671d-af96-4a6b-bdf7-6a3b6270dae6";
+            var ctx = CreateContext("/api/users");
+            ctx.Request.Headers["x-customerguid"] = guid;
+            bool nextCalled = false;
+
+            await _middleware.InvokeAsync(ctx, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.True(nextCalled);
+            Assert.Equal(Guid.Parse(guid), _headerGuid.CustomerGUID);
+        }
+    }
+
     public class CustomerGUIDValidationTests
     {
         [Theory]
@@ -22,8 +147,6 @@ namespace OWSTests.Middleware
         [Fact]
         public void Empty_GUID_Should_Be_Rejected()
         {
-            // The middleware currently allows Guid.Empty through — this test
-            // documents the expected behavior after the fix in issue #8664 item #2
             var emptyGuid = Guid.Parse("00000000-0000-0000-0000-000000000000");
             Assert.Equal(Guid.Empty, emptyGuid);
         }

--- a/apps/ows/ows-tests/Options/APIPathOptionsTests.cs
+++ b/apps/ows/ows-tests/Options/APIPathOptionsTests.cs
@@ -1,0 +1,38 @@
+using OWSShared.Options;
+using Xunit;
+
+namespace OWSTests.Options
+{
+    public class APIPathOptionsTests
+    {
+        [Fact]
+        public void SectionName_Is_Correct()
+        {
+            Assert.Equal("OWSAPIPathConfig", APIPathOptions.SectionName);
+        }
+
+        [Fact]
+        public void Can_Set_All_URLs()
+        {
+            var opts = new APIPathOptions
+            {
+                InternalPublicApiURL = "http://publicapi:80",
+                InternalInstanceManagementApiURL = "http://instancemgmt:80",
+                InternalCharacterPersistenceApiURL = "http://charpersist:80"
+            };
+
+            Assert.Equal("http://publicapi:80", opts.InternalPublicApiURL);
+            Assert.Equal("http://instancemgmt:80", opts.InternalInstanceManagementApiURL);
+            Assert.Equal("http://charpersist:80", opts.InternalCharacterPersistenceApiURL);
+        }
+
+        [Fact]
+        public void Default_Values_Are_Null()
+        {
+            var opts = new APIPathOptions();
+            Assert.Null(opts.InternalPublicApiURL);
+            Assert.Null(opts.InternalInstanceManagementApiURL);
+            Assert.Null(opts.InternalCharacterPersistenceApiURL);
+        }
+    }
+}

--- a/apps/ows/ows-tests/Options/PublicAPIOptionsTests.cs
+++ b/apps/ows/ows-tests/Options/PublicAPIOptionsTests.cs
@@ -1,0 +1,40 @@
+using OWSShared.Options;
+using Xunit;
+
+namespace OWSTests.Options
+{
+    public class PublicAPIOptionsTests
+    {
+        [Fact]
+        public void SectionName_Is_Correct()
+        {
+            Assert.Equal("OWSPublicAPIConfig", PublicAPIOptions.SectionName);
+        }
+
+        [Fact]
+        public void Can_Set_Timing_Options()
+        {
+            var opts = new PublicAPIOptions
+            {
+                SecondsToWaitForServerSpinUp = 180,
+                SecondsToWaitInBetweenSpinUpPolling = 3,
+                SecondsToWaitBeforeFirstPollForSpinUp = 5,
+                OWSInstanceMangementBaseAddress = "http://instancemgmt:80"
+            };
+
+            Assert.Equal(180, opts.SecondsToWaitForServerSpinUp);
+            Assert.Equal(3, opts.SecondsToWaitInBetweenSpinUpPolling);
+            Assert.Equal(5, opts.SecondsToWaitBeforeFirstPollForSpinUp);
+            Assert.Equal("http://instancemgmt:80", opts.OWSInstanceMangementBaseAddress);
+        }
+
+        [Fact]
+        public void Default_Timing_Values_Are_Zero()
+        {
+            var opts = new PublicAPIOptions();
+            Assert.Equal(0, opts.SecondsToWaitForServerSpinUp);
+            Assert.Equal(0, opts.SecondsToWaitInBetweenSpinUpPolling);
+            Assert.Equal(0, opts.SecondsToWaitBeforeFirstPollForSpinUp);
+        }
+    }
+}

--- a/apps/ows/ows-tests/Options/RabbitMQOptionsTests.cs
+++ b/apps/ows/ows-tests/Options/RabbitMQOptionsTests.cs
@@ -1,0 +1,47 @@
+using OWSShared.Options;
+using Xunit;
+
+namespace OWSTests.Options
+{
+    public class RabbitMQOptionsTests
+    {
+        [Fact]
+        public void SectionName_Is_Correct()
+        {
+            Assert.Equal("RabbitMQOptions", RabbitMQOptions.SectionName);
+        }
+
+        [Fact]
+        public void Can_Set_All_Properties()
+        {
+            var opts = new RabbitMQOptions
+            {
+                RabbitMQHostName = "rabbitmq.svc.cluster.local",
+                RabbitMQPort = 5672,
+                RabbitMQUserName = "guest",
+                RabbitMQPassword = "guest"
+            };
+
+            Assert.Equal("rabbitmq.svc.cluster.local", opts.RabbitMQHostName);
+            Assert.Equal(5672, opts.RabbitMQPort);
+            Assert.Equal("guest", opts.RabbitMQUserName);
+            Assert.Equal("guest", opts.RabbitMQPassword);
+        }
+
+        [Fact]
+        public void Default_Port_Is_Zero()
+        {
+            var opts = new RabbitMQOptions();
+            Assert.Equal(0, opts.RabbitMQPort);
+        }
+
+        [Fact]
+        public void Default_Strings_Are_Null()
+        {
+            var opts = new RabbitMQOptions();
+            Assert.Null(opts.RabbitMQHostName);
+            Assert.Null(opts.RabbitMQUserName);
+            Assert.Null(opts.RabbitMQPassword);
+        }
+    }
+}

--- a/apps/ows/ows-tests/Options/StorageOptionsTests.cs
+++ b/apps/ows/ows-tests/Options/StorageOptionsTests.cs
@@ -1,0 +1,43 @@
+using OWSShared.Options;
+using Xunit;
+
+namespace OWSTests.Options
+{
+    public class StorageOptionsTests
+    {
+        [Fact]
+        public void SectionName_Is_Correct()
+        {
+            Assert.Equal("OWSStorageConfig", StorageOptions.SectionName);
+        }
+
+        [Theory]
+        [InlineData("postgres")]
+        [InlineData("mysql")]
+        [InlineData("mssql")]
+        public void OWSDBBackend_Accepts_Valid_Backends(string backend)
+        {
+            var opts = new StorageOptions { OWSDBBackend = backend };
+            Assert.Equal(backend, opts.OWSDBBackend);
+        }
+
+        [Fact]
+        public void OWSDBConnectionString_Can_Be_Set()
+        {
+            var opts = new StorageOptions
+            {
+                OWSDBBackend = "postgres",
+                OWSDBConnectionString = "Host=localhost;Database=ows;Username=ows;Password=test"
+            };
+            Assert.Contains("Host=localhost", opts.OWSDBConnectionString);
+        }
+
+        [Fact]
+        public void Default_Values_Are_Null()
+        {
+            var opts = new StorageOptions();
+            Assert.Null(opts.OWSDBBackend);
+            Assert.Null(opts.OWSDBConnectionString);
+        }
+    }
+}

--- a/apps/ows/ows-tests/Validation/InputValidationTests.cs
+++ b/apps/ows/ows-tests/Validation/InputValidationTests.cs
@@ -1,0 +1,88 @@
+using System;
+using OWSShared.Implementations;
+using Xunit;
+
+namespace OWSTests.Validation
+{
+    public class InputValidationTests
+    {
+        private readonly DefaultPublicAPIInputValidation _validator;
+
+        public InputValidationTests()
+        {
+            _validator = new DefaultPublicAPIInputValidation();
+        }
+
+        // ── ValidateCharacterName ──────────────────────────────────────
+
+        [Theory]
+        [InlineData("Hero", "")]
+        [InlineData("TestChar", "")]
+        [InlineData("Player1", "")]
+        [InlineData("ABCD", "")]
+        [InlineData("a1b2c3", "")]
+        public void ValidateCharacterName_Accepts_Valid_Names(string name, string expected)
+        {
+            Assert.Equal(expected, _validator.ValidateCharacterName(name));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("A")]
+        [InlineData("AB")]
+        [InlineData("ABC")]
+        public void ValidateCharacterName_Rejects_Short_Names(string name)
+        {
+            var result = _validator.ValidateCharacterName(name);
+            Assert.NotEmpty(result);
+            Assert.Contains("at least 4 characters", result);
+        }
+
+        [Theory]
+        [InlineData("Hero!")]
+        [InlineData("Player Name")]
+        [InlineData("test@char")]
+        [InlineData("my-char")]
+        [InlineData("char.name")]
+        public void ValidateCharacterName_Rejects_Special_Characters(string name)
+        {
+            var result = _validator.ValidateCharacterName(name);
+            Assert.NotEmpty(result);
+            Assert.Contains("only contains letters and numbers", result);
+        }
+
+        [Fact]
+        public void ValidateCharacterName_Allows_Underscores()
+        {
+            // \w matches [a-zA-Z0-9_] so underscores are allowed
+            Assert.Equal("", _validator.ValidateCharacterName("Hero_Name"));
+        }
+
+        // ── Unimplemented methods ──────────────────────────────────────
+
+        [Fact]
+        public void ValidateEmail_Throws_NotImplemented()
+        {
+            Assert.Throws<NotImplementedException>(() => _validator.ValidateEmail("test@example.com"));
+        }
+
+        [Fact]
+        public void ValidatePassword_Throws_NotImplemented()
+        {
+            Assert.Throws<NotImplementedException>(() => _validator.ValidatePassword("password123"));
+        }
+
+        [Fact]
+        public void ValidateFirstName_Throws_NotImplemented()
+        {
+            Assert.Throws<NotImplementedException>(() => _validator.ValidateFirstName("John"));
+        }
+
+        [Fact]
+        public void ValidateLastName_Throws_NotImplemented()
+        {
+            Assert.Throws<NotImplementedException>(() => _validator.ValidateLastName("Doe"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Expands OWS test coverage from 3 files (19 tests) to 10 files (~55 tests):

- **Middleware**: `StoreCustomerGUIDMiddleware` — health bypass, missing/invalid/empty GUID, case insensitivity (8 tests)
- **Options**: `StorageOptions`, `RabbitMQOptions`, `APIPathOptions`, `PublicAPIOptions` — section names, defaults, property binding (15 tests)
- **Validation**: `DefaultPublicAPIInputValidation` — valid names, short names, special chars, underscores, unimplemented methods (11 tests)
- **SQL Queries**: abilities, characters, global data, sessions, map instances, world servers, hardcoded GUID check (17 tests)

## Build verification
- `dotnet build apps/ows/OWS.sln` — 0 errors, 34 warnings (all pre-existing)
- Test execution requires net8.0 runtime (CI has it)

## Next steps (future PRs)
- Integration tests with test database
- Per-service Startup.cs configuration tests
- Repository implementation tests (Postgres/MySQL/MSSQL backends)