### PR TITLE
chore(ows): bump all OWS services to 0.10.2

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_characterpersistence
 pipeline: docker
 app_name: ows-characterpersistence
-version: "0.10.1"
+version: "0.10.2"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_globaldata
 pipeline: docker
 app_name: ows-globaldata
-version: "0.10.1"
+version: "0.10.2"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancelauncher
 pipeline: docker
 app_name: ows-instancelauncher
-version: "0.10.1"
+version: "0.10.2"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancemanagement
 pipeline: docker
 app_name: ows-instancemanagement
-version: "0.10.1"
+version: "0.10.2"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_management
 pipeline: docker
 app_name: ows-management
-version: "0.10.1"
+version: "0.10.2"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_publicapi
 pipeline: docker
 app_name: ows-publicapi
-version: "0.10.1"
+version: "0.10.2"
 source_path: apps/ows
 version_toml: apps/ows/version.toml
 version_target: apps/ows/version.toml

--- a/apps/ows/version.toml
+++ b/apps/ows/version.toml
@@ -1,2 +1,2 @@
-version = "0.10.1"
+version = "0.10.2"
 publish = true


### PR DESCRIPTION
## Summary
- Bump OWS version from 0.10.1 to 0.10.2
- Updated `apps/ows/version.toml` + 6 MDX frontmatter files (publicapi, characterpersistence, instancemanagement, globaldata, management, instancelauncher)