### PR TITLE
chore(chuckrpg): bump to 0.1.1 for first publish

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx
@@ -11,7 +11,7 @@ tags:
 key: chuckrpg
 pipeline: docker
 app_name: axum-chuckrpg
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/chuckrpg/axum-chuckrpg
 version_toml: apps/chuckrpg/axum-chuckrpg/version.toml
 version_target: apps/chuckrpg/axum-chuckrpg/Cargo.toml


### PR DESCRIPTION
## Summary
Bump MDX version to `0.1.1`. CI will handle the rest:
1. Version gate: MDX `0.1.1` > version.toml `0.0.0` → publish
2. Cargo.toml synced to `0.1.1` pre-build
3. Docker image built + pushed to GHCR as `kbve/chuckrpg:0.1.1`
4. version.toml updated to `0.1.1` post-publish
5. Kube deployment image tag updated → ArgoCD deploys