### PR TITLE
fix(agones): set bufferSize to 1 (Agones rejects 0)

### DIFF
--- a/apps/kube/agones/ows/fleet-autoscaler.yaml
+++ b/apps/kube/agones/ows/fleet-autoscaler.yaml
@@ -1,6 +1,7 @@
 # OWS Fleet Autoscaler — maintains a buffer of ready servers
 # When a GameServerAllocation claims a server, the scaler creates a new one
-# to maintain the buffer. Keeps 0 ready servers by default (scale from zero).
+# to maintain the buffer. bufferSize=1 keeps one warm server ready.
+# minReplicas=0 allows full scale-down when no servers are allocated.
 apiVersion: autoscaling.agones.dev/v1
 kind: FleetAutoscaler
 metadata:
@@ -14,6 +15,6 @@ spec:
     policy:
         type: Buffer
         buffer:
-            bufferSize: 0
+            bufferSize: 1
             minReplicas: 0
             maxReplicas: 5


### PR DESCRIPTION
## Summary
Agones webhook rejects `bufferSize: 0`. Set to 1 so the autoscaler is valid. `minReplicas: 0` still allows full scale-down.

## Test plan
- [ ] FleetAutoscaler syncs without webhook rejection
- [ ] Fleet stays at 0 replicas when no allocations