### PR TITLE
feat(unreal): add foliage, placement, streaming, and blueprint snapshot MCP domains

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
@@ -405,12 +405,12 @@ Verified compiling on UE 5.7.4 (Mac, universal binary).
 { "id": "uuid", "success": false, "error": { "code": "NOT_FOUND", "message": "Actor not found" } }
 ```
 
-**Implemented Handler Domains (25 domains, 150+ methods):**
+**Implemented Handler Domains (28 domains, 170+ methods):**
 
 | Domain | Methods | Status |
 |--------|---------|--------|
 | `actor.*` | spawn, delete, find, list, get/set_transform, get/set_property, duplicate, batch_transform, attach, detach, add_component | Complete |
-| `blueprint.*` | create, add/remove_component, list_components, set_component_property, add/remove_variable, add_function_node, add_event_node, connect_nodes, disconnect_pin, set_pin_default, delete_node, set_default, reparent, validate, compile, get_graph | Complete |
+| `blueprint.*` | create, add/remove_component, list_components, set_component_property, add/remove_variable, add_function_node, add_event_node, connect_nodes, disconnect_pin, set_pin_default, delete_node, set_default, reparent, validate, compile, get_graph, snapshot_graph, diff_graph, restore_graph | Complete |
 | `asset.*` | search, get_info, get_references, get_dependents, list, validate | Complete |
 | `level.*` | get_info, list_levels, open, save, get_world_outliner | Complete |
 | `console.*` | execute (with safety validation), get_log | Complete |
@@ -432,6 +432,9 @@ Verified compiling on UE 5.7.4 (Mac, universal binary).
 | `niagara.*` | create_system, activate, deactivate, set_parameter, get_info | Complete |
 | `gameplay.*` | create_interaction, get_info (tags, GAS, trigger volumes) | Complete |
 | `editor.*` | undo, redo, select, get_selection, rename_asset, delete_asset, find_in_radius, raycast, set_label, set_folder, add/remove_tag, find_by_tag | Complete |
+| `foliage.*` | paint (radial scatter with ground snap), remove (area clear), get_info (type/instance counts) | Complete |
+| `placement.*` | grid (rows x cols), circle (radial with face_center), scatter (random with ground snap + scale), along_spline (evenly distributed) | Complete |
+| `streaming.*` | list_levels (persistent + streaming), load_level, unload_level, set_visibility | Complete |
 | `landscape.*` | sculpt, flatten, smooth, get_info | Partial |
 | `widget.*` | create, set_property, get_info | Partial |
 | `mcp.*` | ping, list_methods, server_info | Complete |

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPBlueprintHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPBlueprintHandlers.cpp
@@ -39,6 +39,10 @@ void FMCPBlueprintHandlers::Register(FMCPHandlerRegistry& Registry)
 	Registry.RegisterHandler(TEXT("blueprint.reparent"), &HandleReparent);
 	Registry.RegisterHandler(TEXT("blueprint.validate"), &HandleValidate);
 	Registry.RegisterHandler(TEXT("blueprint.list_components"), &HandleListComponents);
+	// Phase 9 — snapshot/diff/restore
+	Registry.RegisterHandler(TEXT("blueprint.snapshot_graph"), &HandleSnapshotGraph);
+	Registry.RegisterHandler(TEXT("blueprint.diff_graph"), &HandleDiffGraph);
+	Registry.RegisterHandler(TEXT("blueprint.restore_graph"), &HandleRestoreGraph);
 }
 
 void FMCPBlueprintHandlers::HandleCreate(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
@@ -725,5 +729,288 @@ void FMCPBlueprintHandlers::HandleListComponents(const TSharedPtr<FJsonObject>& 
 	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
 	Result->SetArrayField(TEXT("components"), Components);
 	Result->SetNumberField(TEXT("count"), Components.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+// ---- Phase 9: Snapshot/Diff/Restore ----
+
+TMap<FString, FMCPBlueprintHandlers::FGraphSnapshot> FMCPBlueprintHandlers::Snapshots;
+
+TSharedPtr<FJsonObject> FMCPBlueprintHandlers::CaptureGraphState(UEdGraph* Graph)
+{
+	TSharedPtr<FJsonObject> State = MakeShared<FJsonObject>();
+	TArray<TSharedPtr<FJsonValue>> Nodes;
+
+	for (UEdGraphNode* Node : Graph->Nodes)
+	{
+		TSharedPtr<FJsonObject> NObj = MakeShared<FJsonObject>();
+		NObj->SetStringField(TEXT("id"), Node->GetName());
+		NObj->SetStringField(TEXT("class"), Node->GetClass()->GetName());
+		NObj->SetStringField(TEXT("title"), Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+		NObj->SetNumberField(TEXT("x"), Node->NodePosX);
+		NObj->SetNumberField(TEXT("y"), Node->NodePosY);
+		NObj->SetStringField(TEXT("comment"), Node->NodeComment);
+
+		TArray<TSharedPtr<FJsonValue>> Pins;
+		for (UEdGraphPin* Pin : Node->Pins)
+		{
+			TSharedPtr<FJsonObject> PObj = MakeShared<FJsonObject>();
+			PObj->SetStringField(TEXT("name"), Pin->PinName.ToString());
+			PObj->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input ? TEXT("input") : TEXT("output"));
+			PObj->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
+			PObj->SetStringField(TEXT("default_value"), Pin->DefaultValue);
+			PObj->SetNumberField(TEXT("connections"), Pin->LinkedTo.Num());
+
+			TArray<TSharedPtr<FJsonValue>> Links;
+			for (UEdGraphPin* Linked : Pin->LinkedTo)
+			{
+				TSharedPtr<FJsonObject> LObj = MakeShared<FJsonObject>();
+				LObj->SetStringField(TEXT("node"), Linked->GetOwningNode()->GetName());
+				LObj->SetStringField(TEXT("pin"), Linked->PinName.ToString());
+				Links.Add(MakeShared<FJsonValueObject>(LObj));
+			}
+			PObj->SetArrayField(TEXT("links"), Links);
+			Pins.Add(MakeShared<FJsonValueObject>(PObj));
+		}
+		NObj->SetArrayField(TEXT("pins"), Pins);
+		Nodes.Add(MakeShared<FJsonValueObject>(NObj));
+	}
+
+	State->SetArrayField(TEXT("nodes"), Nodes);
+	State->SetNumberField(TEXT("node_count"), Graph->Nodes.Num());
+	return State;
+}
+
+void FMCPBlueprintHandlers::HandleSnapshotGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString Name = Params->GetStringField(TEXT("name"));
+	if (Name.IsEmpty()) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'name' is required")); return; }
+
+	FString BPPath = FString::Printf(TEXT("/Game/%s.%s"), *Name, *Name);
+	UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *BPPath);
+	if (!BP) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Blueprint not found: %s"), *Name)); return; }
+
+	FString GraphName = Params->GetStringField(TEXT("graph"));
+
+	UEdGraph* Graph = nullptr;
+	if (GraphName.IsEmpty())
+	{
+		TArray<UEdGraph*> Graphs;
+		BP->GetAllGraphs(Graphs);
+		if (Graphs.Num() > 0) Graph = Graphs[0];
+	}
+	else
+	{
+		TArray<UEdGraph*> Graphs;
+		BP->GetAllGraphs(Graphs);
+		for (UEdGraph* G : Graphs)
+			if (G->GetName() == GraphName) { Graph = G; break; }
+	}
+
+	if (!Graph) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Graph not found")); return; }
+
+	FString SnapshotKey = Params->GetStringField(TEXT("snapshot_id"));
+	if (SnapshotKey.IsEmpty())
+		SnapshotKey = FString::Printf(TEXT("%s_%s_%s"), *Name, *Graph->GetName(), *FDateTime::Now().ToString());
+
+	FGraphSnapshot Snap;
+	Snap.BlueprintName = Name;
+	Snap.GraphName = Graph->GetName();
+	Snap.Data = CaptureGraphState(Graph);
+	Snap.Timestamp = FDateTime::Now();
+	Snapshots.Add(SnapshotKey, Snap);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("snapshot_id"), SnapshotKey);
+	Result->SetStringField(TEXT("blueprint"), Name);
+	Result->SetStringField(TEXT("graph"), Graph->GetName());
+	Result->SetNumberField(TEXT("node_count"), Graph->Nodes.Num());
+	Result->SetStringField(TEXT("timestamp"), Snap.Timestamp.ToString());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleDiffGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString SnapshotKey = Params->GetStringField(TEXT("snapshot_id"));
+	if (SnapshotKey.IsEmpty()) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'snapshot_id' is required")); return; }
+
+	FGraphSnapshot* Snap = Snapshots.Find(SnapshotKey);
+	if (!Snap) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Snapshot not found: %s"), *SnapshotKey)); return; }
+
+	FString BPPath = FString::Printf(TEXT("/Game/%s.%s"), *Snap->BlueprintName, *Snap->BlueprintName);
+	UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *BPPath);
+	if (!BP) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint no longer exists")); return; }
+
+	UEdGraph* Graph = nullptr;
+	TArray<UEdGraph*> Graphs;
+	BP->GetAllGraphs(Graphs);
+	for (UEdGraph* G : Graphs)
+		if (G->GetName() == Snap->GraphName) { Graph = G; break; }
+	if (!Graph) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Graph no longer exists")); return; }
+
+	TSharedPtr<FJsonObject> CurrentState = CaptureGraphState(Graph);
+
+	// Compare node counts
+	const TArray<TSharedPtr<FJsonValue>>* SnapNodes;
+	const TArray<TSharedPtr<FJsonValue>>* CurNodes;
+	Snap->Data->TryGetArrayField(TEXT("nodes"), SnapNodes);
+	CurrentState->TryGetArrayField(TEXT("nodes"), CurNodes);
+
+	TSet<FString> SnapNodeIds, CurNodeIds;
+	TMap<FString, TSharedPtr<FJsonObject>> SnapNodeMap, CurNodeMap;
+
+	if (SnapNodes)
+		for (auto& V : *SnapNodes)
+		{
+			auto Obj = V->AsObject();
+			FString Id = Obj->GetStringField(TEXT("id"));
+			SnapNodeIds.Add(Id);
+			SnapNodeMap.Add(Id, Obj);
+		}
+
+	if (CurNodes)
+		for (auto& V : *CurNodes)
+		{
+			auto Obj = V->AsObject();
+			FString Id = Obj->GetStringField(TEXT("id"));
+			CurNodeIds.Add(Id);
+			CurNodeMap.Add(Id, Obj);
+		}
+
+	TArray<TSharedPtr<FJsonValue>> Added, Removed, Modified;
+
+	for (const FString& Id : CurNodeIds)
+		if (!SnapNodeIds.Contains(Id))
+			Added.Add(MakeShared<FJsonValueString>(Id));
+
+	for (const FString& Id : SnapNodeIds)
+		if (!CurNodeIds.Contains(Id))
+			Removed.Add(MakeShared<FJsonValueString>(Id));
+
+	for (const FString& Id : CurNodeIds.Intersect(SnapNodeIds))
+	{
+		auto* S = SnapNodeMap.Find(Id);
+		auto* C = CurNodeMap.Find(Id);
+		if (S && C)
+		{
+			bool bDiff = false;
+			// Check position
+			if ((*S)->GetNumberField(TEXT("x")) != (*C)->GetNumberField(TEXT("x")) ||
+				(*S)->GetNumberField(TEXT("y")) != (*C)->GetNumberField(TEXT("y")))
+				bDiff = true;
+
+			// Check pin connections count change
+			const TArray<TSharedPtr<FJsonValue>>* SPins; const TArray<TSharedPtr<FJsonValue>>* CPins;
+			if ((*S)->TryGetArrayField(TEXT("pins"), SPins) && (*C)->TryGetArrayField(TEXT("pins"), CPins))
+			{
+				if (SPins->Num() != CPins->Num()) bDiff = true;
+			}
+
+			if (bDiff)
+				Modified.Add(MakeShared<FJsonValueString>(Id));
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("snapshot_id"), SnapshotKey);
+	Result->SetArrayField(TEXT("added_nodes"), Added);
+	Result->SetArrayField(TEXT("removed_nodes"), Removed);
+	Result->SetArrayField(TEXT("modified_nodes"), Modified);
+	Result->SetNumberField(TEXT("snapshot_node_count"), SnapNodeIds.Num());
+	Result->SetNumberField(TEXT("current_node_count"), CurNodeIds.Num());
+	Result->SetBoolField(TEXT("has_changes"), Added.Num() > 0 || Removed.Num() > 0 || Modified.Num() > 0);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPBlueprintHandlers::HandleRestoreGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	FString SnapshotKey = Params->GetStringField(TEXT("snapshot_id"));
+	if (SnapshotKey.IsEmpty()) { MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'snapshot_id' is required")); return; }
+
+	FGraphSnapshot* Snap = Snapshots.Find(SnapshotKey);
+	if (!Snap) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Snapshot not found: %s"), *SnapshotKey)); return; }
+
+	FString BPPath = FString::Printf(TEXT("/Game/%s.%s"), *Snap->BlueprintName, *Snap->BlueprintName);
+	UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *BPPath);
+	if (!BP) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Blueprint no longer exists")); return; }
+
+	UEdGraph* Graph = nullptr;
+	TArray<UEdGraph*> Graphs;
+	BP->GetAllGraphs(Graphs);
+	for (UEdGraph* G : Graphs)
+		if (G->GetName() == Snap->GraphName) { Graph = G; break; }
+	if (!Graph) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), TEXT("Graph no longer exists")); return; }
+
+	// Restore pin connections from snapshot
+	const TArray<TSharedPtr<FJsonValue>>* SnapNodes;
+	if (!Snap->Data->TryGetArrayField(TEXT("nodes"), SnapNodes))
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("CORRUPT"), TEXT("Snapshot data is corrupt"));
+		return;
+	}
+
+	int32 RestoredConnections = 0;
+
+	// Build map of current nodes
+	TMap<FString, UEdGraphNode*> NodeMap;
+	for (UEdGraphNode* Node : Graph->Nodes)
+		NodeMap.Add(Node->GetName(), Node);
+
+	// Rewire connections from snapshot
+	for (auto& NodeVal : *SnapNodes)
+	{
+		auto NodeObj = NodeVal->AsObject();
+		FString NodeId = NodeObj->GetStringField(TEXT("id"));
+		UEdGraphNode** NodePtr = NodeMap.Find(NodeId);
+		if (!NodePtr) continue;
+
+		const TArray<TSharedPtr<FJsonValue>>* PinsArr;
+		if (!NodeObj->TryGetArrayField(TEXT("pins"), PinsArr)) continue;
+
+		for (auto& PinVal : *PinsArr)
+		{
+			auto PinObj = PinVal->AsObject();
+			FString PinName = PinObj->GetStringField(TEXT("name"));
+			FString Dir = PinObj->GetStringField(TEXT("direction"));
+			if (Dir != TEXT("output")) continue; // Only restore from output side
+
+			UEdGraphPin* SrcPin = nullptr;
+			for (UEdGraphPin* P : (*NodePtr)->Pins)
+				if (P->PinName.ToString() == PinName && P->Direction == EGPD_Output) { SrcPin = P; break; }
+			if (!SrcPin) continue;
+
+			const TArray<TSharedPtr<FJsonValue>>* LinksArr;
+			if (!PinObj->TryGetArrayField(TEXT("links"), LinksArr)) continue;
+
+			for (auto& LinkVal : *LinksArr)
+			{
+				auto LinkObj = LinkVal->AsObject();
+				FString TargetNodeId = LinkObj->GetStringField(TEXT("node"));
+				FString TargetPinName = LinkObj->GetStringField(TEXT("pin"));
+
+				UEdGraphNode** TargetNodePtr = NodeMap.Find(TargetNodeId);
+				if (!TargetNodePtr) continue;
+
+				UEdGraphPin* TgtPin = nullptr;
+				for (UEdGraphPin* P : (*TargetNodePtr)->Pins)
+					if (P->PinName.ToString() == TargetPinName && P->Direction == EGPD_Input) { TgtPin = P; break; }
+				if (!TgtPin) continue;
+
+				// Check if already connected
+				if (!SrcPin->LinkedTo.Contains(TgtPin))
+				{
+					SrcPin->MakeLinkTo(TgtPin);
+					RestoredConnections++;
+				}
+			}
+		}
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsModified(BP);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("snapshot_id"), SnapshotKey);
+	Result->SetNumberField(TEXT("restored_connections"), RestoredConnections);
+	Result->SetBoolField(TEXT("restored"), true);
 	MCPProtocolHelpers::Succeed(OnComplete, Result);
 }

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPFoliageHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPFoliageHandlers.cpp
@@ -1,0 +1,183 @@
+#include "Handlers/MCPFoliageHandlers.h"
+#include "Registry/MCPHandlerRegistry.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "InstancedFoliageActor.h"
+#include "FoliageType.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+
+void FMCPFoliageHandlers::Register(FMCPHandlerRegistry& Registry)
+{
+	Registry.RegisterHandler(TEXT("foliage.paint"), &HandlePaint);
+	Registry.RegisterHandler(TEXT("foliage.remove"), &HandleRemove);
+	Registry.RegisterHandler(TEXT("foliage.get_info"), &HandleGetInfo);
+}
+
+void FMCPFoliageHandlers::HandlePaint(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString FoliageTypePath = Params->GetStringField(TEXT("foliage_type"));
+	if (FoliageTypePath.IsEmpty())
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'foliage_type' asset path is required"));
+		return;
+	}
+
+	UFoliageType* FoliageType = LoadObject<UFoliageType>(nullptr, *FoliageTypePath);
+	if (!FoliageType)
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Foliage type not found: %s"), *FoliageTypePath));
+		return;
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
+	if (!Params->TryGetArrayField(TEXT("center"), CenterArr) || CenterArr->Num() < 3)
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'center' [x,y,z] array is required"));
+		return;
+	}
+	FVector Center((*CenterArr)[0]->AsNumber(), (*CenterArr)[1]->AsNumber(), (*CenterArr)[2]->AsNumber());
+
+	double Radius = Params->GetNumberField(TEXT("radius"));
+	if (Radius <= 0) Radius = 500.0;
+
+	int32 Count = (int32)Params->GetNumberField(TEXT("count"));
+	if (Count <= 0) Count = 10;
+
+	double MinScale = 1.0, MaxScale = 1.0;
+	Params->TryGetNumberField(TEXT("min_scale"), MinScale);
+	Params->TryGetNumberField(TEXT("max_scale"), MaxScale);
+	if (MaxScale < MinScale) MaxScale = MinScale;
+
+	AInstancedFoliageActor* IFA = AInstancedFoliageActor::GetInstancedFoliageActorForCurrentLevel(World, true);
+	if (!IFA)
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("FOLIAGE_ERROR"), TEXT("Failed to get InstancedFoliageActor"));
+		return;
+	}
+
+	FFoliageInfo* FoliageInfo = IFA->FindOrAddMesh(FoliageType);
+	if (!FoliageInfo)
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("FOLIAGE_ERROR"), TEXT("Failed to create foliage mesh info"));
+		return;
+	}
+
+	int32 Placed = 0;
+	for (int32 i = 0; i < Count; i++)
+	{
+		float Angle = FMath::FRandRange(0.f, 2.f * PI);
+		float Dist = FMath::FRandRange(0.f, (float)Radius);
+		FVector Loc = Center + FVector(FMath::Cos(Angle) * Dist, FMath::Sin(Angle) * Dist, 0);
+
+		// Raycast down to find ground
+		FHitResult Hit;
+		FVector Start = Loc + FVector(0, 0, 10000);
+		FVector End = Loc - FVector(0, 0, 10000);
+		if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic))
+		{
+			Loc = Hit.ImpactPoint;
+		}
+
+		float Scale = FMath::FRandRange((float)MinScale, (float)MaxScale);
+		float Yaw = FMath::FRandRange(0.f, 360.f);
+
+		FFoliageInstance Instance;
+		Instance.Location = Loc;
+		Instance.Rotation = FRotator(0, Yaw, 0);
+		Instance.DrawScale3D = FVector3f(Scale);
+
+		FoliageInfo->AddInstance(FoliageType, Instance);
+		Placed++;
+	}
+
+	IFA->MarkPackageDirty();
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetNumberField(TEXT("placed"), Placed);
+	Result->SetStringField(TEXT("foliage_type"), FoliageTypePath);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPFoliageHandlers::HandleRemove(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
+	if (!Params->TryGetArrayField(TEXT("center"), CenterArr) || CenterArr->Num() < 3)
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'center' [x,y,z] array is required"));
+		return;
+	}
+	FVector Center((*CenterArr)[0]->AsNumber(), (*CenterArr)[1]->AsNumber(), (*CenterArr)[2]->AsNumber());
+
+	double Radius = Params->GetNumberField(TEXT("radius"));
+	if (Radius <= 0) Radius = 500.0;
+
+	FString FoliageTypeFilter = Params->GetStringField(TEXT("foliage_type"));
+
+	int32 Removed = 0;
+
+	for (TActorIterator<AInstancedFoliageActor> It(World); It; ++It)
+	{
+		AInstancedFoliageActor* IFA = *It;
+		TMap<UFoliageType*, FFoliageInfo*> FoliageInfos = IFA->GetAllInstancesFoliageType();
+
+		for (auto& Pair : FoliageInfos)
+		{
+			if (!FoliageTypeFilter.IsEmpty() && !Pair.Key->GetPathName().Contains(FoliageTypeFilter))
+				continue;
+
+			TArray<int32> InstancesToRemove;
+			FSphere Sphere(Center, (float)Radius);
+			Pair.Value->GetInstancesInsideSphere(Sphere, InstancesToRemove);
+
+			if (InstancesToRemove.Num() > 0)
+			{
+				Removed += InstancesToRemove.Num();
+				Pair.Value->RemoveInstances(InstancesToRemove, true);
+			}
+		}
+
+		IFA->MarkPackageDirty();
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetNumberField(TEXT("removed"), Removed);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPFoliageHandlers::HandleGetInfo(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	TArray<TSharedPtr<FJsonValue>> Types;
+	int32 TotalInstances = 0;
+
+	for (TActorIterator<AInstancedFoliageActor> It(World); It; ++It)
+	{
+		TMap<UFoliageType*, FFoliageInfo*> FoliageInfos = It->GetAllInstancesFoliageType();
+		for (auto& Pair : FoliageInfos)
+		{
+			int32 InstanceCount = Pair.Value->Instances.Num();
+			TotalInstances += InstanceCount;
+
+			TSharedPtr<FJsonObject> TypeObj = MakeShared<FJsonObject>();
+			TypeObj->SetStringField(TEXT("type"), Pair.Key->GetPathName());
+			TypeObj->SetStringField(TEXT("name"), Pair.Key->GetName());
+			TypeObj->SetNumberField(TEXT("instance_count"), InstanceCount);
+			Types.Add(MakeShared<FJsonValueObject>(TypeObj));
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("foliage_types"), Types);
+	Result->SetNumberField(TEXT("total_instances"), TotalInstances);
+	Result->SetNumberField(TEXT("type_count"), Types.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPPlacementHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPPlacementHandlers.cpp
@@ -1,0 +1,263 @@
+#include "Handlers/MCPPlacementHandlers.h"
+#include "Registry/MCPHandlerRegistry.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "Engine/StaticMeshActor.h"
+#include "Components/SplineComponent.h"
+#include "Engine/PointLight.h"
+#include "Engine/SpotLight.h"
+
+void FMCPPlacementHandlers::Register(FMCPHandlerRegistry& Registry)
+{
+	Registry.RegisterHandler(TEXT("placement.grid"), &HandlePlaceInGrid);
+	Registry.RegisterHandler(TEXT("placement.circle"), &HandlePlaceInCircle);
+	Registry.RegisterHandler(TEXT("placement.scatter"), &HandleScatterInArea);
+	Registry.RegisterHandler(TEXT("placement.along_spline"), &HandlePlaceAlongSpline);
+}
+
+AActor* FMCPPlacementHandlers::SpawnActorByType(UWorld* World, const FString& ActorType, const FVector& Location, const FRotator& Rotation)
+{
+	UClass* ActorClass = nullptr;
+
+	if (ActorType.Equals(TEXT("StaticMeshActor"), ESearchCase::IgnoreCase))
+		ActorClass = AStaticMeshActor::StaticClass();
+	else if (ActorType.Equals(TEXT("PointLight"), ESearchCase::IgnoreCase))
+		ActorClass = APointLight::StaticClass();
+	else if (ActorType.Equals(TEXT("SpotLight"), ESearchCase::IgnoreCase))
+		ActorClass = ASpotLight::StaticClass();
+	else
+	{
+		ActorClass = FindObject<UClass>(nullptr, *ActorType);
+		if (!ActorClass)
+			ActorClass = LoadClass<AActor>(nullptr, *ActorType);
+	}
+
+	if (!ActorClass)
+		ActorClass = AActor::StaticClass();
+
+	return World->SpawnActor<AActor>(ActorClass, Location, Rotation);
+}
+
+void FMCPPlacementHandlers::HandlePlaceInGrid(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString ActorType = Params->GetStringField(TEXT("actor_type"));
+	if (ActorType.IsEmpty()) ActorType = TEXT("StaticMeshActor");
+
+	const TArray<TSharedPtr<FJsonValue>>* OriginArr;
+	FVector Origin = FVector::ZeroVector;
+	if (Params->TryGetArrayField(TEXT("origin"), OriginArr) && OriginArr->Num() >= 3)
+		Origin = FVector((*OriginArr)[0]->AsNumber(), (*OriginArr)[1]->AsNumber(), (*OriginArr)[2]->AsNumber());
+
+	int32 Rows = (int32)Params->GetNumberField(TEXT("rows"));
+	int32 Cols = (int32)Params->GetNumberField(TEXT("columns"));
+	if (Rows <= 0) Rows = 3;
+	if (Cols <= 0) Cols = 3;
+
+	double SpacingX = Params->GetNumberField(TEXT("spacing_x"));
+	double SpacingY = Params->GetNumberField(TEXT("spacing_y"));
+	if (SpacingX <= 0) SpacingX = 200.0;
+	if (SpacingY <= 0) SpacingY = 200.0;
+
+	FString LabelPrefix = Params->GetStringField(TEXT("label_prefix"));
+	if (LabelPrefix.IsEmpty()) LabelPrefix = TEXT("GridActor");
+
+	TArray<TSharedPtr<FJsonValue>> Spawned;
+	for (int32 R = 0; R < Rows; R++)
+	{
+		for (int32 C = 0; C < Cols; C++)
+		{
+			FVector Loc = Origin + FVector(C * SpacingX, R * SpacingY, 0);
+			AActor* Actor = SpawnActorByType(World, ActorType, Loc, FRotator::ZeroRotator);
+			if (Actor)
+			{
+				FString Label = FString::Printf(TEXT("%s_%d_%d"), *LabelPrefix, R, C);
+				Actor->SetActorLabel(Label);
+				Spawned.Add(MakeShared<FJsonValueString>(Actor->GetName()));
+			}
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("actors"), Spawned);
+	Result->SetNumberField(TEXT("count"), Spawned.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPPlacementHandlers::HandlePlaceInCircle(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString ActorType = Params->GetStringField(TEXT("actor_type"));
+	if (ActorType.IsEmpty()) ActorType = TEXT("StaticMeshActor");
+
+	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
+	FVector Center = FVector::ZeroVector;
+	if (Params->TryGetArrayField(TEXT("center"), CenterArr) && CenterArr->Num() >= 3)
+		Center = FVector((*CenterArr)[0]->AsNumber(), (*CenterArr)[1]->AsNumber(), (*CenterArr)[2]->AsNumber());
+
+	double Radius = Params->GetNumberField(TEXT("radius"));
+	if (Radius <= 0) Radius = 500.0;
+
+	int32 Count = (int32)Params->GetNumberField(TEXT("count"));
+	if (Count <= 0) Count = 8;
+
+	bool bFaceCenter = true;
+	Params->TryGetBoolField(TEXT("face_center"), bFaceCenter);
+
+	FString LabelPrefix = Params->GetStringField(TEXT("label_prefix"));
+	if (LabelPrefix.IsEmpty()) LabelPrefix = TEXT("CircleActor");
+
+	TArray<TSharedPtr<FJsonValue>> Spawned;
+	for (int32 i = 0; i < Count; i++)
+	{
+		float Angle = (2.f * PI * i) / Count;
+		FVector Loc = Center + FVector(FMath::Cos(Angle) * Radius, FMath::Sin(Angle) * Radius, 0);
+		FRotator Rot = FRotator::ZeroRotator;
+		if (bFaceCenter)
+		{
+			FVector Dir = (Center - Loc).GetSafeNormal();
+			Rot = Dir.Rotation();
+		}
+
+		AActor* Actor = SpawnActorByType(World, ActorType, Loc, Rot);
+		if (Actor)
+		{
+			Actor->SetActorLabel(FString::Printf(TEXT("%s_%d"), *LabelPrefix, i));
+			Spawned.Add(MakeShared<FJsonValueString>(Actor->GetName()));
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("actors"), Spawned);
+	Result->SetNumberField(TEXT("count"), Spawned.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPPlacementHandlers::HandleScatterInArea(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString ActorType = Params->GetStringField(TEXT("actor_type"));
+	if (ActorType.IsEmpty()) ActorType = TEXT("StaticMeshActor");
+
+	const TArray<TSharedPtr<FJsonValue>>* CenterArr;
+	FVector Center = FVector::ZeroVector;
+	if (Params->TryGetArrayField(TEXT("center"), CenterArr) && CenterArr->Num() >= 3)
+		Center = FVector((*CenterArr)[0]->AsNumber(), (*CenterArr)[1]->AsNumber(), (*CenterArr)[2]->AsNumber());
+
+	double Radius = Params->GetNumberField(TEXT("radius"));
+	if (Radius <= 0) Radius = 1000.0;
+
+	int32 Count = (int32)Params->GetNumberField(TEXT("count"));
+	if (Count <= 0) Count = 20;
+
+	bool bSnapToGround = true;
+	Params->TryGetBoolField(TEXT("snap_to_ground"), bSnapToGround);
+
+	bool bRandomYaw = true;
+	Params->TryGetBoolField(TEXT("random_yaw"), bRandomYaw);
+
+	double MinScale = 1.0, MaxScale = 1.0;
+	Params->TryGetNumberField(TEXT("min_scale"), MinScale);
+	Params->TryGetNumberField(TEXT("max_scale"), MaxScale);
+
+	FString LabelPrefix = Params->GetStringField(TEXT("label_prefix"));
+	if (LabelPrefix.IsEmpty()) LabelPrefix = TEXT("ScatterActor");
+
+	TArray<TSharedPtr<FJsonValue>> Spawned;
+	for (int32 i = 0; i < Count; i++)
+	{
+		float Angle = FMath::FRandRange(0.f, 2.f * PI);
+		float Dist = FMath::FRandRange(0.f, (float)Radius);
+		FVector Loc = Center + FVector(FMath::Cos(Angle) * Dist, FMath::Sin(Angle) * Dist, 0);
+
+		if (bSnapToGround)
+		{
+			FHitResult Hit;
+			if (World->LineTraceSingleByChannel(Hit, Loc + FVector(0, 0, 10000), Loc - FVector(0, 0, 10000), ECC_WorldStatic))
+				Loc = Hit.ImpactPoint;
+		}
+
+		float Yaw = bRandomYaw ? FMath::FRandRange(0.f, 360.f) : 0.f;
+		AActor* Actor = SpawnActorByType(World, ActorType, Loc, FRotator(0, Yaw, 0));
+		if (Actor)
+		{
+			if (MaxScale > MinScale)
+			{
+				float S = FMath::FRandRange((float)MinScale, (float)MaxScale);
+				Actor->SetActorScale3D(FVector(S));
+			}
+			Actor->SetActorLabel(FString::Printf(TEXT("%s_%d"), *LabelPrefix, i));
+			Spawned.Add(MakeShared<FJsonValueString>(Actor->GetName()));
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("actors"), Spawned);
+	Result->SetNumberField(TEXT("count"), Spawned.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPPlacementHandlers::HandlePlaceAlongSpline(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString SplineName = Params->GetStringField(TEXT("spline_actor"));
+	if (SplineName.IsEmpty())
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'spline_actor' name is required"));
+		return;
+	}
+
+	AActor* SplineActor = nullptr;
+	for (TActorIterator<AActor> It(World); It; ++It)
+		if (It->GetActorLabel() == SplineName || It->GetName() == SplineName) { SplineActor = *It; break; }
+	if (!SplineActor) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Spline actor not found: %s"), *SplineName)); return; }
+
+	USplineComponent* Spline = SplineActor->FindComponentByClass<USplineComponent>();
+	if (!Spline) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_SPLINE"), TEXT("Actor has no spline component")); return; }
+
+	FString ActorType = Params->GetStringField(TEXT("actor_type"));
+	if (ActorType.IsEmpty()) ActorType = TEXT("StaticMeshActor");
+
+	int32 Count = (int32)Params->GetNumberField(TEXT("count"));
+	if (Count <= 0) Count = 10;
+
+	bool bAlignToSpline = true;
+	Params->TryGetBoolField(TEXT("align_to_spline"), bAlignToSpline);
+
+	FString LabelPrefix = Params->GetStringField(TEXT("label_prefix"));
+	if (LabelPrefix.IsEmpty()) LabelPrefix = TEXT("SplineActor");
+
+	float SplineLen = Spline->GetSplineLength();
+
+	TArray<TSharedPtr<FJsonValue>> Spawned;
+	for (int32 i = 0; i < Count; i++)
+	{
+		float Dist = (SplineLen * i) / FMath::Max(Count - 1, 1);
+		FVector Loc = Spline->GetLocationAtDistanceAlongSpline(Dist, ESplineCoordinateSpace::World);
+		FRotator Rot = FRotator::ZeroRotator;
+		if (bAlignToSpline)
+			Rot = Spline->GetRotationAtDistanceAlongSpline(Dist, ESplineCoordinateSpace::World);
+
+		AActor* Actor = SpawnActorByType(World, ActorType, Loc, Rot);
+		if (Actor)
+		{
+			Actor->SetActorLabel(FString::Printf(TEXT("%s_%d"), *LabelPrefix, i));
+			Spawned.Add(MakeShared<FJsonValueString>(Actor->GetName()));
+		}
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("actors"), Spawned);
+	Result->SetNumberField(TEXT("count"), Spawned.Num());
+	Result->SetNumberField(TEXT("spline_length"), SplineLen);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPStreamingHandlers.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/Handlers/MCPStreamingHandlers.cpp
@@ -1,0 +1,156 @@
+#include "Handlers/MCPStreamingHandlers.h"
+#include "Registry/MCPHandlerRegistry.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "Engine/LevelStreaming.h"
+#include "Engine/LevelStreamingDynamic.h"
+#include "EditorLevelUtils.h"
+
+void FMCPStreamingHandlers::Register(FMCPHandlerRegistry& Registry)
+{
+	Registry.RegisterHandler(TEXT("streaming.list_levels"), &HandleListLevels);
+	Registry.RegisterHandler(TEXT("streaming.load_level"), &HandleLoadLevel);
+	Registry.RegisterHandler(TEXT("streaming.unload_level"), &HandleUnloadLevel);
+	Registry.RegisterHandler(TEXT("streaming.set_visibility"), &HandleSetVisibility);
+}
+
+void FMCPStreamingHandlers::HandleListLevels(const TSharedPtr<FJsonObject>& /*Params*/, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	TArray<TSharedPtr<FJsonValue>> Levels;
+
+	// Persistent level
+	{
+		TSharedPtr<FJsonObject> PL = MakeShared<FJsonObject>();
+		PL->SetStringField(TEXT("name"), World->GetMapName());
+		PL->SetBoolField(TEXT("persistent"), true);
+		PL->SetBoolField(TEXT("loaded"), true);
+		PL->SetBoolField(TEXT("visible"), true);
+		Levels.Add(MakeShared<FJsonValueObject>(PL));
+	}
+
+	// Streaming levels
+	const TArray<ULevelStreaming*>& StreamingLevels = World->GetStreamingLevels();
+	for (ULevelStreaming* SL : StreamingLevels)
+	{
+		if (!SL) continue;
+
+		TSharedPtr<FJsonObject> LObj = MakeShared<FJsonObject>();
+		LObj->SetStringField(TEXT("name"), SL->GetWorldAssetPackageName());
+		LObj->SetBoolField(TEXT("persistent"), false);
+		LObj->SetBoolField(TEXT("loaded"), SL->GetLoadedLevel() != nullptr);
+		LObj->SetBoolField(TEXT("visible"), SL->GetShouldBeVisibleInEditor());
+		LObj->SetStringField(TEXT("package"), SL->GetWorldAssetPackageFName().ToString());
+		Levels.Add(MakeShared<FJsonValueObject>(LObj));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetArrayField(TEXT("levels"), Levels);
+	Result->SetNumberField(TEXT("count"), Levels.Num());
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPStreamingHandlers::HandleLoadLevel(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString LevelPath = Params->GetStringField(TEXT("level"));
+	if (LevelPath.IsEmpty())
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'level' path is required"));
+		return;
+	}
+
+	ULevelStreaming* StreamingLevel = EditorLevelUtils::AddLevelToWorld(
+		World, *LevelPath, ULevelStreamingDynamic::StaticClass());
+
+	if (!StreamingLevel)
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("LOAD_FAILED"), FString::Printf(TEXT("Failed to load level: %s"), *LevelPath));
+		return;
+	}
+
+	StreamingLevel->SetShouldBeVisibleInEditor(true);
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("level"), LevelPath);
+	Result->SetBoolField(TEXT("loaded"), true);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPStreamingHandlers::HandleUnloadLevel(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString LevelName = Params->GetStringField(TEXT("level"));
+	if (LevelName.IsEmpty())
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'level' name is required"));
+		return;
+	}
+
+	const TArray<ULevelStreaming*>& StreamingLevels = World->GetStreamingLevels();
+	ULevelStreaming* Target = nullptr;
+	for (ULevelStreaming* SL : StreamingLevels)
+	{
+		if (SL && (SL->GetWorldAssetPackageName().Contains(LevelName) || SL->GetWorldAssetPackageFName().ToString().Contains(LevelName)))
+		{
+			Target = SL;
+			break;
+		}
+	}
+
+	if (!Target)
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Streaming level not found: %s"), *LevelName));
+		return;
+	}
+
+	ULevel* LoadedLevel = Target->GetLoadedLevel();
+	if (LoadedLevel)
+	{
+		EditorLevelUtils::RemoveLevelFromWorld(LoadedLevel);
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+	Result->SetStringField(TEXT("level"), LevelName);
+	Result->SetBoolField(TEXT("unloaded"), true);
+	MCPProtocolHelpers::Succeed(OnComplete, Result);
+}
+
+void FMCPStreamingHandlers::HandleSetVisibility(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World) { MCPProtocolHelpers::Fail(OnComplete, TEXT("NO_WORLD"), TEXT("No editor world available")); return; }
+
+	FString LevelName = Params->GetStringField(TEXT("level"));
+	if (LevelName.IsEmpty())
+	{
+		MCPProtocolHelpers::Fail(OnComplete, TEXT("INVALID_PARAMS"), TEXT("'level' name is required"));
+		return;
+	}
+
+	bool bVisible = true;
+	Params->TryGetBoolField(TEXT("visible"), bVisible);
+
+	const TArray<ULevelStreaming*>& StreamingLevels = World->GetStreamingLevels();
+	for (ULevelStreaming* SL : StreamingLevels)
+	{
+		if (SL && (SL->GetWorldAssetPackageName().Contains(LevelName) || SL->GetWorldAssetPackageFName().ToString().Contains(LevelName)))
+		{
+			SL->SetShouldBeVisibleInEditor(bVisible);
+
+			TSharedPtr<FJsonObject> Result = MCPProtocolHelpers::MakeResult();
+			Result->SetStringField(TEXT("level"), LevelName);
+			Result->SetBoolField(TEXT("visible"), bVisible);
+			MCPProtocolHelpers::Succeed(OnComplete, Result);
+			return;
+		}
+	}
+
+	MCPProtocolHelpers::Fail(OnComplete, TEXT("NOT_FOUND"), FString::Printf(TEXT("Streaming level not found: %s"), *LevelName));
+}

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/KBVEUnrealMCPModule.cpp
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Private/KBVEUnrealMCPModule.cpp
@@ -32,6 +32,9 @@
 #include "Handlers/MCPGeometryHandlers.h"
 #include "Handlers/MCPCodeAnalysisHandlers.h"
 #include "Handlers/MCPEditorHandlers.h"
+#include "Handlers/MCPFoliageHandlers.h"
+#include "Handlers/MCPPlacementHandlers.h"
+#include "Handlers/MCPStreamingHandlers.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogKBVEUnrealMCP, Log, All);
 
@@ -140,6 +143,11 @@ void FKBVEUnrealMCPModule::RegisterAllHandlers()
 
 	// Phase 8 — Editor utilities
 	FMCPEditorHandlers::Register(*Registry);
+
+	// Phase 9 — Foliage, Placement, Streaming
+	FMCPFoliageHandlers::Register(*Registry);
+	FMCPPlacementHandlers::Register(*Registry);
+	FMCPStreamingHandlers::Register(*Registry);
 }
 
 IMPLEMENT_MODULE(FKBVEUnrealMCPModule, KBVEUnrealMCP)

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPBlueprintHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPBlueprintHandlers.h
@@ -31,4 +31,20 @@ private:
 	static void HandleReparent(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 	static void HandleValidate(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
 	static void HandleListComponents(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	// Phase 9 — snapshot/diff/restore
+	static void HandleSnapshotGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleDiffGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleRestoreGraph(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	// In-memory snapshot storage
+	struct FGraphSnapshot
+	{
+		FString BlueprintName;
+		FString GraphName;
+		TSharedPtr<FJsonObject> Data;
+		FDateTime Timestamp;
+	};
+	static TMap<FString, FGraphSnapshot> Snapshots;
+	static TSharedPtr<FJsonObject> CaptureGraphState(UEdGraph* Graph);
 };

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPFoliageHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPFoliageHandlers.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Registry/MCPHandlerTypes.h"
+
+class FMCPHandlerRegistry;
+
+class FMCPFoliageHandlers
+{
+public:
+	static void Register(FMCPHandlerRegistry& Registry);
+
+private:
+	static void HandlePaint(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleRemove(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleGetInfo(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+};

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPPlacementHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPPlacementHandlers.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Registry/MCPHandlerTypes.h"
+
+class FMCPHandlerRegistry;
+
+class FMCPPlacementHandlers
+{
+public:
+	static void Register(FMCPHandlerRegistry& Registry);
+
+private:
+	static void HandlePlaceInGrid(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandlePlaceInCircle(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleScatterInArea(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandlePlaceAlongSpline(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+
+	static AActor* SpawnActorByType(UWorld* World, const FString& ActorType, const FVector& Location, const FRotator& Rotation);
+};

--- a/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPStreamingHandlers.h
+++ b/packages/unreal/KBVEUnrealMCP/Source/KBVEUnrealMCP/Public/Handlers/MCPStreamingHandlers.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Registry/MCPHandlerTypes.h"
+
+class FMCPHandlerRegistry;
+
+class FMCPStreamingHandlers
+{
+public:
+	static void Register(FMCPHandlerRegistry& Registry);
+
+private:
+	static void HandleListLevels(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleLoadLevel(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleUnloadLevel(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+	static void HandleSetVisibility(const TSharedPtr<FJsonObject>& Params, FMCPResponseDelegate OnComplete);
+};


### PR DESCRIPTION
## Summary
Phase 9 adds **14 new methods** across 3 new domains + blueprint snapshot system.

### New Domains

**Foliage (3 methods)**
- `foliage.paint` — radial scatter with ground raycasting, random yaw/scale, configurable count/radius
- `foliage.remove` — area-based instance removal with optional type filter via FSphere query
- `foliage.get_info` — enumerate all foliage types with instance counts

**Placement (4 methods)** — inspired by SpecialAgentPlugin's 71+ tools
- `placement.grid` — NxM grid arrangement with configurable spacing
- `placement.circle` — radial placement with optional `face_center` rotation
- `placement.scatter` — random scatter with ground snap, random yaw, min/max scale
- `placement.along_spline` — evenly distributed actors along a spline component

**Streaming (4 methods)** — level streaming management
- `streaming.list_levels` — persistent + streaming sub-levels with load/visibility state
- `streaming.load_level` — add streaming level via `EditorLevelUtils`
- `streaming.unload_level` — remove streaming level
- `streaming.set_visibility` — toggle sub-level editor visibility

### Blueprint Snapshot System (3 methods) — ported from ue5-mcp concept
- `blueprint.snapshot_graph` — capture full node/pin/connection state to in-memory snapshot
- `blueprint.diff_graph` — compare current graph vs snapshot (lists added/removed/modified nodes)
- `blueprint.restore_graph` — rewire severed pin connections from snapshot data

## Totals
- **28 domains, ~170 implemented methods**
- [x] `RunUAT BuildPlugin` passes on UE 5.7.4 Mac

## Test plan
- [x] Build verified on UE 5.7.4
- [ ] Test `foliage.paint` with a FoliageType asset path
- [ ] Test `placement.grid` spawns correct NxM arrangement
- [ ] Test `blueprint.snapshot_graph` → modify → `blueprint.diff_graph` detects changes