### PR TITLE
fix(ci): fan out Docker builds — run-name + remove workflow concurrency

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,5 +1,7 @@
 name: CI - Docker
 
+run-name: 'CI - Docker / ${{ inputs.app_name }}'
+
 on:
     workflow_dispatch:
         inputs:
@@ -16,12 +18,10 @@ on:
                 required: true
                 type: string
 
-# Per-app concurrency — never cancel in-progress runs.
-# GitHub Actions keeps one pending slot: if two runs queue for the same app,
-# the latest pending replaces the older pending, but the running job is safe.
-concurrency:
-    group: ci-docker-${{ inputs.app_name }}
-    cancel-in-progress: false
+# No workflow-level concurrency — each app fans out independently.
+# Per-app serialization is handled by the queue_guard job (stale deploy
+# protection) rather than GitHub's concurrency groups, which can collapse
+# dispatches into one group when inputs aren't resolved for pending runs.
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Add `run-name: CI - Docker / ${{ inputs.app_name }}` so each dispatch is identifiable in the Actions UI instead of 16 identical "CI - Docker" entries
- Remove workflow-level `concurrency` group — when `inputs.app_name` is not yet resolved for pending runs, all CI-Docker dispatches collapse into a single group, blocking unrelated apps from starting
- Queue guard already handles stale deploy protection per-app, so the workflow-level concurrency was redundant and harmful

## Root cause
Run 23431458847 was stuck in `pending` with 0 jobs because the concurrency group `ci-docker-${{ inputs.app_name }}` evaluated to `ci-docker-` (empty input) before the workflow started, colliding with the in-progress run 23429989109.

## Test plan
- [ ] Dispatch two different apps simultaneously — verify they run in parallel
- [ ] Verify Actions UI shows "CI - Docker / axum-kbve" instead of "CI - Docker"
- [ ] Dispatch same app twice — verify second run starts immediately (no concurrency block)