### PR TITLE
fix(chuckrpg): initialize version.toml and add to CI registry

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/version.toml
+++ b/apps/chuckrpg/axum-chuckrpg/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "0.1.0"

--- a/packages/npm/devops/src/lib/ci/registry.ts
+++ b/packages/npm/devops/src/lib/ci/registry.ts
@@ -141,6 +141,23 @@ export const CI_PROJECTS: CiProject[] = ProjectArraySchema.parse([
 		status: 'active',
 		tags: ['docker', 'database'],
 	},
+	{
+		key: 'chuckrpg',
+		name: 'ChuckRPG',
+		pipeline: 'docker',
+		app_name: 'axum-chuckrpg',
+		test_framework: 'rust',
+		description: 'ChuckRPG game backend (Axum)',
+		source_path: 'apps/chuckrpg/axum-chuckrpg',
+		version_toml: 'apps/chuckrpg/axum-chuckrpg/version.toml',
+		runner: 'ubuntu-latest',
+		image: 'kbve/chuckrpg',
+		deployment_yaml: 'apps/kube/chuckrpg/manifest/deployment.yaml',
+		author: 'h0lybyte',
+		license: 'KBVE',
+		status: 'active',
+		tags: ['docker', 'gaming'],
+	},
 
 	// ── OWS (C# / .NET) Docker Apps ───────────────────────────
 	{


### PR DESCRIPTION
## Summary

- Initialized `apps/chuckrpg/axum-chuckrpg/version.toml` from `0.0.0` to `0.1.0` — the version gate in `ci-docker.yml` treats `0.0.0` as "not initialized" and skips publish
- Added chuckrpg entry to `@kbve/devops` CI registry (`registry.ts`) with all required dispatch fields (`app_name`, `image`, `deployment_yaml`, `version_toml`, etc.)

## Context

The chuckrpg namespace exists in k8s (ArgoCD auto-created it) but the Docker image `ghcr.io/kbve/chuckrpg:0.1.0` was never published because:
1. `version.toml` was `0.0.0` → version gate blocked publish
2. chuckrpg was missing from the `@kbve/devops` CI registry

## Test plan

- [x] `devops:typecheck` passes
- [x] `devops:build` passes (Zod validates the new registry entry at import time)