### PR TITLE
chore(ows): bump all OWS services to 0.10.3

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -145,6 +145,7 @@ jobs:
                         *.json)    local_v=$(jq -r '.version // "0.0.0"' "$source_file" 2>/dev/null || echo "0.0.0") ;;
                         *.uplugin) local_v=$(jq -r '.VersionName // "0.0.0"' "$source_file" 2>/dev/null || echo "0.0.0") ;;
                         *.mdx)     local_v=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$source_file" | head -1); [ -z "$local_v" ] && local_v="0.0.0" ;;
+                        *.csproj)  local_v=$(sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' "$source_file" | head -1); [ -z "$local_v" ] && local_v="0.0.0" ;;
                         *)         local_v=$(grep -m1 '^version' "$source_file" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || echo "0.0.0") ;;
                       esac
                     fi

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -60,8 +60,9 @@ jobs:
                   esac
                   if [ -n "$VER" ]; then
                     case "$TGT" in
-                      *.json) jq --arg v "$VER" '.version = $v' "$TGT" > "${TGT}.tmp" && mv "${TGT}.tmp" "$TGT" ;;
-                      *)      sed -i "s/^version = .*/version = \"${VER}\"/" "$TGT" ;;
+                      *.json)   jq --arg v "$VER" '.version = $v' "$TGT" > "${TGT}.tmp" && mv "${TGT}.tmp" "$TGT" ;;
+                      *.csproj) sed -i "s|<Version>[^<]*</Version>|<Version>${VER}</Version>|" "$TGT" ;;
+                      *)        sed -i "s/^version = .*/version = \"${VER}\"/" "$TGT" ;;
                     esac
                     echo "Synced version ${VER} → ${TGT}"
                   fi

--- a/.github/workflows/utils-update-kube-manifest.yml
+++ b/.github/workflows/utils-update-kube-manifest.yml
@@ -41,9 +41,10 @@ jobs:
               run: |
                   SRC="main-ref/${{ inputs.cargo_toml }}"
                   case "$SRC" in
-                    *.json) NEW_VER=$(jq -r '.version // "0.0.0"' "$SRC" 2>/dev/null) ;;
-                    *.mdx)  NEW_VER=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$SRC" | head -1) ;;
-                    *)      NEW_VER=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/') ;;
+                    *.json)   NEW_VER=$(jq -r '.version // "0.0.0"' "$SRC" 2>/dev/null) ;;
+                    *.mdx)    NEW_VER=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$SRC" | head -1) ;;
+                    *.csproj) NEW_VER=$(sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' "$SRC" | head -1) ;;
+                    *)        NEW_VER=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/') ;;
                   esac
                   echo "new_version=$NEW_VER" >> "$GITHUB_OUTPUT"
                   echo "Resolved version: $NEW_VER"

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -14,7 +14,7 @@ app_name: ows-characterpersistence
 version: "0.10.3"
 source_path: apps/ows
 version_toml: apps/ows/ows-character-persistence/version.toml
-version_target: apps/ows/ows-character-persistence/version.toml
+version_target: apps/ows/ows-character-persistence/OWSCharacterPersistence.csproj
 runner: ubuntu-latest
 image: kbve/ows-characterpersistence
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -14,7 +14,7 @@ app_name: ows-globaldata
 version: "0.10.3"
 source_path: apps/ows
 version_toml: apps/ows/ows-global-data/version.toml
-version_target: apps/ows/ows-global-data/version.toml
+version_target: apps/ows/ows-global-data/OWSGlobalData.csproj
 runner: ubuntu-latest
 image: kbve/ows-globaldata
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
@@ -14,7 +14,7 @@ app_name: ows-instancelauncher
 version: "0.10.3"
 source_path: apps/ows
 version_toml: apps/ows/ows-instance-launcher/version.toml
-version_target: apps/ows/ows-instance-launcher/version.toml
+version_target: apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
 runner: ubuntu-latest
 image: kbve/ows-instancelauncher
 deployment_yaml: apps/kube/github/runners/manifests/ows-instance-launcher.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -14,7 +14,7 @@ app_name: ows-instancemanagement
 version: "0.10.3"
 source_path: apps/ows
 version_toml: apps/ows/ows-instance-management/version.toml
-version_target: apps/ows/ows-instance-management/version.toml
+version_target: apps/ows/ows-instance-management/OWSInstanceManagement.csproj
 runner: ubuntu-latest
 image: kbve/ows-instancemanagement
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -14,7 +14,7 @@ app_name: ows-management
 version: "0.10.3"
 source_path: apps/ows
 version_toml: apps/ows/ows-management/version.toml
-version_target: apps/ows/ows-management/version.toml
+version_target: apps/ows/ows-management/OWSManagement.csproj
 runner: ubuntu-latest
 image: kbve/ows-management
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -14,7 +14,7 @@ app_name: ows-publicapi
 version: "0.10.3"
 source_path: apps/ows
 version_toml: apps/ows/ows-public-api/version.toml
-version_target: apps/ows/ows-public-api/version.toml
+version_target: apps/ows/ows-public-api/OWSPublicAPI.csproj
 runner: ubuntu-latest
 image: kbve/ows-publicapi
 deployment_yaml: apps/kube/ows/manifest/deployment.yaml

--- a/apps/ows/ows-character-persistence/OWSCharacterPersistence.csproj
+++ b/apps/ows/ows-character-persistence/OWSCharacterPersistence.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Version>0.10.3</Version>
     <UserSecretsId>f3bb93df-33d8-4372-b1d5-43a2c186459a</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/apps/ows/ows-global-data/OWSGlobalData.csproj
+++ b/apps/ows/ows-global-data/OWSGlobalData.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Version>0.10.3</Version>
     <UserSecretsId>f2bb93df-33d8-4372-b1d5-43a2c186459a</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
+++ b/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Version>0.10.3</Version>
     <StartupObject>OWSInstanceLauncher.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>

--- a/apps/ows/ows-instance-management/OWSInstanceManagement.csproj
+++ b/apps/ows/ows-instance-management/OWSInstanceManagement.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Version>0.10.3</Version>
     <UserSecretsId>e3bb93df-33d8-4372-b1d5-43a2c1864599</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/apps/ows/ows-management/OWSManagement.csproj
+++ b/apps/ows/ows-management/OWSManagement.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Version>0.10.3</Version>
     <UserSecretsId>9805f064-639a-42e6-9e13-a99860a79187</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/apps/ows/ows-public-api/OWSPublicAPI.csproj
+++ b/apps/ows/ows-public-api/OWSPublicAPI.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Version>0.10.3</Version>
     <UserSecretsId>5f287243-b8be-4d52-a0d5-8c329ba8d881</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Bump version in all 6 OWS MDX frontmatter files from 0.10.2 to 0.10.3
- version.toml files untouched — CI will update them post-publish