### PR TITLE
fix(agones): add arc-runners to gameserver namespaces

### DIFF
--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -57,9 +57,10 @@ agones:
 
 # Game server defaults
 gameservers:
-    # Namespace for game servers — use OWS namespace
+    # Namespaces for game servers
     namespaces:
         - ows
+        - arc-runners
 
     # Port range for game server host ports (UDP)
     minPort: 7000


### PR DESCRIPTION
## Summary
Agones only manages GameServers in namespaces listed in `gameservers.namespaces`. The OWS Fleet is in `arc-runners` (co-located with the `ows-server-build` PVC), but Agones wasn't configured for that namespace.

This caused: `serviceaccount "agones-sdk" not found` when creating GameServer pods.

## Fix
Add `arc-runners` to `gameservers.namespaces` in Agones Helm values.

## Test plan
- [ ] Agones creates `agones-sdk` SA in `arc-runners`
- [ ] GameServer pods start without SA error