### PR TITLE
fix(ci): fan out publish + UE workflows, add run-names

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,5 +1,7 @@
 name: CI - E2E
 
+run-name: 'CI - E2E / ${{ inputs.branch || github.ref_name }}'
+
 on:
     schedule:
         - cron: '0 6 * * 1' # Weekly Monday 06:00 UTC

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,5 +1,7 @@
 name: CI - Publish
 
+run-name: 'CI - Publish / ${{ inputs.package_type }} / ${{ inputs.package_name }}'
+
 on:
     workflow_dispatch:
         inputs:
@@ -46,11 +48,8 @@ on:
                 required: true
                 type: string
 
-# Per-package concurrency — never cancel in-progress runs.
-# The queue guard enforces a 2h stale-run limit; the running job is always safe.
-concurrency:
-    group: ci-publish-${{ inputs.package_type }}-${{ inputs.package_name }}
-    cancel-in-progress: false
+# No workflow-level concurrency — each package fans out independently.
+# Queue guard handles stale deploy protection per-package.
 
 permissions: {}
 

--- a/.github/workflows/ci-ue.yml
+++ b/.github/workflows/ci-ue.yml
@@ -1,5 +1,7 @@
 name: CI - Unreal Engine
 
+run-name: 'CI - UE / ${{ inputs.task }}'
+
 on:
     workflow_dispatch:
         inputs:
@@ -27,9 +29,7 @@ on:
                 type: boolean
                 default: false
 
-concurrency:
-    group: ci-ue-${{ inputs.task }}
-    cancel-in-progress: false
+# No workflow-level concurrency — tasks fan out independently.
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
Apply the same fan-out fix from #8839 (ci-docker) to remaining dispatch-based workflows:

- **ci-publish.yml**: remove workflow-level concurrency (`ci-publish-${{ inputs.package_type }}-${{ inputs.package_name }}`), add `run-name: CI - Publish / {type} / {name}`
- **ci-ue.yml**: remove workflow-level concurrency (`ci-ue-${{ inputs.task }}`), add `run-name: CI - UE / {task}`
- **ci-e2e.yml**: add `run-name: CI - E2E / {branch}` for visibility (existing concurrency is fine — uses `github.workflow`)
- **ci-ue5-ows.yml**: left as-is — static `ci-ue5-ows-server` group is intentional (shared 300Gi engine cache, only one build at a time)

## Why
Same root cause as #8839: `inputs.*` expressions in workflow-level `concurrency.group` are not resolved for pending runs, causing all dispatches to collapse into one group and block each other.

## Test plan
- [ ] Dispatch two different packages via ci-publish — verify they run in parallel
- [ ] Verify Actions UI shows "CI - Publish / npm / droid" instead of "CI - Publish"
- [ ] Verify "CI - UE / ows-server" shows correctly