### PR TITLE
chore(ows): bump all OWS services to 0.10.4

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_characterpersistence
 pipeline: docker
 app_name: ows-characterpersistence
-version: "0.10.3"
+version: "0.10.4"
 source_path: apps/ows
 version_toml: apps/ows/ows-character-persistence/version.toml
 version_target: apps/ows/ows-character-persistence/OWSCharacterPersistence.csproj

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_globaldata
 pipeline: docker
 app_name: ows-globaldata
-version: "0.10.3"
+version: "0.10.4"
 source_path: apps/ows
 version_toml: apps/ows/ows-global-data/version.toml
 version_target: apps/ows/ows-global-data/OWSGlobalData.csproj

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancelauncher
 pipeline: docker
 app_name: ows-instancelauncher
-version: "0.10.3"
+version: "0.10.4"
 source_path: apps/ows
 version_toml: apps/ows/ows-instance-launcher/version.toml
 version_target: apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancemanagement
 pipeline: docker
 app_name: ows-instancemanagement
-version: "0.10.3"
+version: "0.10.4"
 source_path: apps/ows
 version_toml: apps/ows/ows-instance-management/version.toml
 version_target: apps/ows/ows-instance-management/OWSInstanceManagement.csproj

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_management
 pipeline: docker
 app_name: ows-management
-version: "0.10.3"
+version: "0.10.4"
 source_path: apps/ows
 version_toml: apps/ows/ows-management/version.toml
 version_target: apps/ows/ows-management/OWSManagement.csproj

--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_publicapi
 pipeline: docker
 app_name: ows-publicapi
-version: "0.10.3"
+version: "0.10.4"
 source_path: apps/ows
 version_toml: apps/ows/ows-public-api/version.toml
 version_target: apps/ows/ows-public-api/OWSPublicAPI.csproj


### PR DESCRIPTION
MDX-only version bump. CI will sync .csproj and version.toml post-publish.