### PR TITLE
fix(agones): auto-discover server binary path on PVC

### DIFF
--- a/apps/kube/agones/ows/fleet.yaml
+++ b/apps/kube/agones/ows/fleet.yaml
@@ -46,12 +46,18 @@ spec:
                               - /bin/bash
                               - -c
                               - |
-                                  SERVER_DIR="/server/latest/LinuxServer"
+                                  # Find latest version directory (symlink may be broken due to mount path)
+                                  SERVER_DIR=$(find /server -maxdepth 2 -name "LinuxServer" -type d | head -1)
+                                  if [ -z "${SERVER_DIR}" ]; then
+                                    echo "ERROR: LinuxServer directory not found on PVC"
+                                    ls -la /server/ 2>/dev/null
+                                    exit 1
+                                  fi
                                   SERVER_BIN="${SERVER_DIR}/OWSHubWorldMMOServer.sh"
 
                                   if [ ! -f "${SERVER_BIN}" ]; then
                                     echo "ERROR: Server binary not found at ${SERVER_BIN}"
-                                    ls -la /server/ 2>/dev/null
+                                    ls -la "${SERVER_DIR}/" 2>/dev/null
                                     exit 1
                                   fi
 


### PR DESCRIPTION
## Summary
The `latest` symlink on the PVC points to `/mnt/ows-server/0.1.0` (the path used by `deploy-server.sh`) but the Fleet mounts the PVC at `/server`. Broken symlink → server binary not found → pod exits immediately.

## Fix
Use `find` to discover the `LinuxServer` directory on the PVC instead of relying on the symlink.

## Test plan
- [ ] GameServer pod finds binary at `/server/0.1.0/LinuxServer/`
- [ ] Server starts (may still fail on other issues but past the path problem)