### PR TITLE
fix(ci): prevent empty grep alternation in Docker push step

### DIFF
--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -229,22 +229,31 @@ jobs:
                     docker tag "${IMAGE}:${VERSION}" "${IMAGE}:latest"
                   fi
 
-                  # Also tag for Docker Hub if image is on GHCR
-                  DOCKERHUB_IMAGE=""
+                  # Derive both GHCR and Docker Hub image names regardless of input format
                   if echo "${IMAGE}" | grep -q "ghcr.io/"; then
+                    GHCR_IMAGE="${IMAGE}"
                     DOCKERHUB_IMAGE=$(echo "${IMAGE}" | sed 's|ghcr.io/||')
-                    for TAG in "${VERSION}" "latest"; do
-                      if docker image inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
-                        docker tag "${IMAGE}:${TAG}" "${DOCKERHUB_IMAGE}:${TAG}"
-                      fi
-                    done
+                  else
+                    DOCKERHUB_IMAGE="${IMAGE}"
+                    GHCR_IMAGE="ghcr.io/${IMAGE}"
                   fi
 
-                  GREP_PATTERN="${IMAGE}"
-                  if [ -n "${DOCKERHUB_IMAGE}" ]; then
-                    GREP_PATTERN="${IMAGE}|${DOCKERHUB_IMAGE}"
-                  fi
-                  IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E "^(${GREP_PATTERN}):" | sort -u || true)
+                  # Ensure both registries have version + latest tags
+                  for REPO in "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"; do
+                    for TAG in "${VERSION}" "latest"; do
+                      if ! docker image inspect "${REPO}:${TAG}" >/dev/null 2>&1; then
+                        # Try to create the tag from whichever source exists
+                        for SRC in "${IMAGE}:${TAG}" "${IMAGE}:latest" "${GHCR_IMAGE}:${TAG}" "${DOCKERHUB_IMAGE}:${TAG}"; do
+                          if docker image inspect "${SRC}" >/dev/null 2>&1; then
+                            docker tag "${SRC}" "${REPO}:${TAG}"
+                            break
+                          fi
+                        done
+                      fi
+                    done
+                  done
+
+                  IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E "^(${GHCR_IMAGE}|${DOCKERHUB_IMAGE}):" | sort -u || true)
                   if [ -z "$IMAGES" ]; then
                     echo "::error::No images found matching '${IMAGE}'. Listing all images:"
                     docker images


### PR DESCRIPTION
## Summary
- OWS Docker pushes failed with `denied: permission_denied` because the image grep matched runner system images
- Root cause: when `DOCKERHUB_IMAGE` is empty, `grep -E "${IMAGE}|"` matches everything
- Fix: conditionally build grep pattern + anchor with `^(pattern):`

Fixes #8864 #8865 #8866 #8867 #8868 #8869