### PR TITLE
fix(ows): platform flag + stream docker output in deploy script

### DIFF
--- a/apps/ows/scripts/deploy-server.sh
+++ b/apps/ows/scripts/deploy-server.sh
@@ -83,7 +83,8 @@ if [ "${SKIP_BUILD}" = false ]; then
 
     # Mount source as read-only, copy to writable location inside container.
     # UE5 BuildCookRun writes to the project's Intermediate/ directory.
-    docker run --rm \
+    docker run --rm -t \
+        --platform linux/amd64 \
         -v "${CHUCK_DIR}:/tmp/chuck-src:ro" \
         -v "${OUTPUT_DIR}:/tmp/ows-server-output" \
         "${UE_IMAGE}" \


### PR DESCRIPTION
## Summary
- `--platform linux/amd64` — fixes ARM Mac warning
- `-t` flag — streams docker build output live instead of buffering

## Test plan
- [ ] `./kbve.sh -ue chuck` shows build output in real-time
- [ ] No platform mismatch warning on ARM Mac