### PR TITLE
fix(ci): export local_version from version_check in Docker publish

### DIFF
--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -72,6 +72,8 @@ jobs:
                   STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
                     "https://hub.docker.com/v2/repositories/${{ inputs.image }}/tags/$LOCAL_VERSION")
 
+                  echo "local_version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+
                   if [ "$STATUS" = "200" ]; then
                     echo "Tag $LOCAL_VERSION already exists on Docker Hub — skipping."
                     echo "should_publish=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- All OWS Docker pushes failed with `"kbve/ows-publicapi:" is not a valid repository/tag`
- Root cause: `version_check` step computed `LOCAL_VERSION=0.10.4` but never wrote `local_version` to `$GITHUB_OUTPUT`
- The push step read `steps.version_check.outputs.local_version` → empty string → empty tag

One-line fix: add `echo "local_version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"` 

Fixes #8881 #8882 #8883 #8884 #8885