### PR TITLE
Atomic: ows-management v0.10.4 post-publish sync

### DIFF
--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -407,7 +407,7 @@ spec:
         spec:
             containers:
                 - name: ows-management
-                  image: ghcr.io/kbve/ows-management:0.10.0
+                  image: ghcr.io/kbve/ows-management:0.10.4
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend

--- a/apps/ows/ows-management/version.toml
+++ b/apps/ows/ows-management/version.toml
@@ -1,2 +1,2 @@
-version = "0.10.2"
+version = "0.10.4"
 publish = true


### PR DESCRIPTION
## Post-publish sync for ows-management v0.10.4

- `apps/kube/ows/manifest/deployment.yaml`
- `apps/ows/ows-management/version.toml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*