### PR TITLE
Atomic: ows-instancelauncher v0.10.4 post-publish sync

### DIFF
--- a/apps/ows/ows-instance-launcher/version.toml
+++ b/apps/ows/ows-instance-launcher/version.toml
@@ -1,2 +1,2 @@
-version = "0.10.2"
+version = "0.10.4"
 publish = true


### PR DESCRIPTION
## Post-publish sync for ows-instancelauncher v0.10.4

- `apps/ows/ows-instance-launcher/version.toml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*