### PR TITLE
fix(ci): remove [skip ci] from post-publish commit message

### DIFF
--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -142,7 +142,7 @@ jobs:
                   fi
 
                   git checkout -b "$BRANCH"
-                  git commit -m "chore(${APP}): post-publish sync to v${VERSION} [skip ci]"
+                  git commit -m "chore(${APP}): post-publish sync to v${VERSION}"
                   git push -u origin "$BRANCH"
 
                   CHANGED=$(git diff --name-only HEAD~1 | sed 's/^/- `/' | sed 's/$/`/')


### PR DESCRIPTION
## Summary
Post-publish atomic PRs (#8892-#8897) were stuck at "Review required" because `[skip ci]` in the commit message prevented `ci-atom.yml` from triggering. ci-atom handles auto-approve + auto-merge for atom branches.

One-line fix: remove `[skip ci]` from the commit message in `utils-post-publish.yml`.

## Test plan
- [ ] Next post-publish creates atom branch → ci-atom triggers → auto-merges