### PR TITLE
feat(ows): set game.chuckrpg.com as external game server hostname

### DIFF
--- a/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
+++ b/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
@@ -40,9 +40,7 @@ spec:
                                 name: ows-launcher-rabbitmq-credentials
                                 key: password
                       - name: OWSInstanceLauncherOptions__ServerIP
-                        valueFrom:
-                            fieldRef:
-                                fieldPath: status.podIP
+                        value: 'game.chuckrpg.com'
                       - name: OWSInstanceLauncherOptions__InternalServerIP
                         valueFrom:
                             fieldRef:

--- a/apps/kube/ows/manifest/configmap.yaml
+++ b/apps/kube/ows/manifest/configmap.yaml
@@ -13,3 +13,5 @@ data:
     RabbitMQPort: '5672'
     UserSessionCacheHostName: 'ows-valkey.ows.svc.cluster.local'
     UserSessionCachePort: '6379'
+    # External hostname for game clients connecting to dedicated servers
+    GameServerExternalHost: 'game.chuckrpg.com'


### PR DESCRIPTION
## Summary
Configure OWS to tell game clients to connect to `game.chuckrpg.com` for UDP game traffic.

### Game client flow
```
Client → api.chuckrpg.com:443 (HTTPS) → OWS PublicAPI
  ↓ returns game.chuckrpg.com:<port>
Client → game.chuckrpg.com:<port> (UDP) → UE5 Dedicated Server
```

### Changes
- InstanceLauncher `ServerIP` → `game.chuckrpg.com` (was pod IP)
- OWS configmap adds `GameServerExternalHost`
- `InternalServerIP` stays pod IP for cluster comms

### DNS required
- `api.chuckrpg.com` A → `142.132.206.74` (PublicAPI, already set up)
- `game.chuckrpg.com` A → `142.132.206.74` (UDP game servers, Agones ports 7000-8000)

## Test plan
- [ ] DNS pointed
- [ ] OWS returns game.chuckrpg.com in server connection info
- [ ] Game client connects via UDP to allocated port