### PR TITLE
fix(axum-kbve): remove local docker cache from CI config

### DIFF
--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -91,8 +91,7 @@
 				},
 				"ci": {
 					"commands": [
-						"echo '=== Pre-build diagnostics ===' && df -h 2>/dev/null && echo '--- cgroup memory ---' && cat /sys/fs/cgroup/memory.max 2>/dev/null && cat /sys/fs/cgroup/memory.current 2>/dev/null || true && docker system df 2>/dev/null || true && docker buildx ls 2>/dev/null || true",
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --cache-from type=local,src=/home/runner/_cache/docker/axum-kbve --cache-to type=local,dest=/home/runner/_cache/docker/axum-kbve,mode=max --file apps/kbve/axum-kbve/Dockerfile .",
+						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile .",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
 					]
 				}
@@ -131,13 +130,7 @@
 				"ci": {
 					"load": true,
 					"push": false,
-					"tags": ["kbve/kbve:latest"],
-					"cache-from": [
-						"type=local,src=/home/runner/_cache/docker/axum-kbve"
-					],
-					"cache-to": [
-						"type=local,dest=/home/runner/_cache/docker/axum-kbve,mode=max"
-					]
+					"tags": ["kbve/kbve:latest"]
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Remove `type=local,mode=max` Docker buildx cache from axum-kbve `ci` configurations (`container` and `containerx` targets)

## Context

[CI run #23433704678](https://github.com/KBVE/kbve/actions/runs/23433704678) — the Rust build completed successfully (53 min) but failed at the cache export step when writing all intermediate layers to `/home/runner/_cache/docker/axum-kbve/ingest/` filled the disk. `mode=max` exports every layer from the multi-stage build, easily 10GB+ for Rust compilation. The production config uses `type=gha` + `type=registry` (external storage) which works correctly.

## Test plan

- [ ] Next axum-kbve Docker test run completes without disk space errors