### PR TITLE
feat(ows): replace Process.Start with Agones GameServerAllocation (#8911)

### DIFF
--- a/apps/kube/github/runners/manifests/ows-agones-rbac.yaml
+++ b/apps/kube/github/runners/manifests/ows-agones-rbac.yaml
@@ -1,0 +1,40 @@
+---
+# ServiceAccount for the InstanceLauncher pod
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ows-instance-launcher
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/part-of: ows
+---
+# ClusterRole to create GameServerAllocations and manage GameServers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ows-agones-allocator
+    labels:
+        app.kubernetes.io/part-of: ows
+rules:
+    - apiGroups: ['allocation.agones.dev']
+      resources: ['gameserverallocations']
+      verbs: ['create']
+    - apiGroups: ['agones.dev']
+      resources: ['gameservers']
+      verbs: ['get', 'list', 'delete']
+---
+# Bind the role to the InstanceLauncher ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ows-agones-allocator-binding
+    labels:
+        app.kubernetes.io/part-of: ows
+subjects:
+    - kind: ServiceAccount
+      name: ows-instance-launcher
+      namespace: arc-runners
+roleRef:
+    kind: ClusterRole
+    name: ows-agones-allocator
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
+++ b/apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.5.0" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="KubernetesClient" Version="15.0.1" />
 
   </ItemGroup>
   <ItemGroup>

--- a/apps/ows/ows-instance-launcher/Services/AgonesAllocator.cs
+++ b/apps/ows/ows-instance-launcher/Services/AgonesAllocator.cs
@@ -1,0 +1,159 @@
+using k8s;
+using k8s.Models;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace OWSInstanceLauncher.Services
+{
+    public class AgonesAllocationResult
+    {
+        public string GameServerName { get; set; } = "";
+        public string Address { get; set; } = "";
+        public int Port { get; set; }
+        public string State { get; set; } = "";
+    }
+
+    public class AgonesAllocator : IDisposable
+    {
+        private readonly IKubernetes _client;
+        private readonly string _namespace;
+        private readonly string _fleetName;
+
+        public AgonesAllocator(string fleetNamespace = "ows", string fleetName = "ows-hubworld")
+        {
+            _namespace = fleetNamespace;
+            _fleetName = fleetName;
+
+            // In-cluster config (ServiceAccount token)
+            var config = KubernetesClientConfiguration.InClusterConfig();
+            _client = new Kubernetes(config);
+
+            Log.Information("AgonesAllocator initialized for fleet {Fleet} in namespace {Namespace}", _fleetName, _namespace);
+        }
+
+        /// <summary>
+        /// Allocate a GameServer from the Agones Fleet.
+        /// Creates a GameServerAllocation CR via the Kubernetes API.
+        /// </summary>
+        public async Task<AgonesAllocationResult?> AllocateAsync(string mapName, int zoneInstanceId)
+        {
+            var allocation = new Dictionary<string, object>
+            {
+                ["apiVersion"] = "allocation.agones.dev/v1",
+                ["kind"] = "GameServerAllocation",
+                ["metadata"] = new Dictionary<string, object>
+                {
+                    ["namespace"] = _namespace
+                },
+                ["spec"] = new Dictionary<string, object>
+                {
+                    ["required"] = new Dictionary<string, object>
+                    {
+                        ["matchLabels"] = new Dictionary<string, string>
+                        {
+                            ["agones.dev/fleet"] = _fleetName
+                        }
+                    },
+                    ["metadata"] = new Dictionary<string, object>
+                    {
+                        ["labels"] = new Dictionary<string, string>
+                        {
+                            ["ows.kbve.com/map"] = mapName,
+                            ["ows.kbve.com/zone-instance"] = zoneInstanceId.ToString()
+                        }
+                    }
+                }
+            };
+
+            try
+            {
+                var json = JsonSerializer.Serialize(allocation);
+                var response = await _client.CustomObjects.CreateNamespacedCustomObjectAsync(
+                    body: JsonSerializer.Deserialize<object>(json),
+                    group: "allocation.agones.dev",
+                    version: "v1",
+                    namespaceParameter: _namespace,
+                    plural: "gameserverallocations"
+                );
+
+                var responseJson = JsonSerializer.Serialize(response);
+                var responseDoc = JsonDocument.Parse(responseJson);
+                var root = responseDoc.RootElement;
+
+                var state = root.GetProperty("status").GetProperty("state").GetString() ?? "";
+
+                if (state != "Allocated")
+                {
+                    Log.Warning("GameServerAllocation state is {State}, not Allocated. No servers available?", state);
+                    return null;
+                }
+
+                var address = root.GetProperty("status").GetProperty("address").GetString() ?? "";
+                var ports = root.GetProperty("status").GetProperty("ports");
+                int port = 0;
+                if (ports.GetArrayLength() > 0)
+                {
+                    port = ports[0].GetProperty("port").GetInt32();
+                }
+
+                var gsName = root.GetProperty("status").GetProperty("nodeName").GetString() ?? "";
+                // Try to get the actual GameServer name
+                if (root.GetProperty("status").TryGetProperty("gameServerName", out var gsNameProp))
+                {
+                    gsName = gsNameProp.GetString() ?? gsName;
+                }
+
+                var result = new AgonesAllocationResult
+                {
+                    GameServerName = gsName,
+                    Address = address,
+                    Port = port,
+                    State = state
+                };
+
+                Log.Information("Allocated GameServer {Name} at {Address}:{Port} for map {Map} zone {Zone}",
+                    result.GameServerName, result.Address, result.Port, mapName, zoneInstanceId);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to create GameServerAllocation for map {Map} zone {Zone}", mapName, zoneInstanceId);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Delete a GameServer by name (shutdown).
+        /// </summary>
+        public async Task<bool> DeallocateAsync(string gameServerName)
+        {
+            try
+            {
+                await _client.CustomObjects.DeleteNamespacedCustomObjectAsync(
+                    group: "agones.dev",
+                    version: "v1",
+                    namespaceParameter: _namespace,
+                    plural: "gameservers",
+                    name: gameServerName
+                );
+
+                Log.Information("Deleted GameServer {Name}", gameServerName);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to delete GameServer {Name}", gameServerName);
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            _client?.Dispose();
+        }
+    }
+}

--- a/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
+++ b/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
@@ -9,6 +9,7 @@ using OWSShared.RequestPayloads;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -38,6 +39,9 @@ namespace OWSInstanceLauncher.Services
         private readonly int _MaxNumberOfInstances;
         private readonly string _InternalServerIP;
         private readonly int _StartingInstancePort;
+        private readonly AgonesAllocator _agonesAllocator;
+        // Maps zoneInstanceId → Agones GameServer name for shutdown
+        private readonly Dictionary<int, string> _zoneToGameServer = new();
 
         public ServerLauncherMQListener(IWritableOptions<OWSInstanceLauncherOptions> owsInstanceLauncherOptions, IOptions<APIPathOptions> owsAPIPathOptions, IOptions<RabbitMQOptions> rabbitMQOptions, IHttpClientFactory httpClientFactory, IZoneServerProcessesRepository zoneServerProcessesRepository,
             IOWSInstanceLauncherDataRepository owsInstanceLauncherDataRepository)
@@ -63,6 +67,11 @@ namespace OWSInstanceLauncher.Services
             _MaxNumberOfInstances = owsInstanceLauncherOptions.Value.MaxNumberOfInstances;
             _InternalServerIP = owsInstanceLauncherOptions.Value.InternalServerIP;
             _StartingInstancePort = owsInstanceLauncherOptions.Value.StartingInstancePort;
+
+            // Initialize Agones allocator for GameServer lifecycle
+            var agonesNamespace = Environment.GetEnvironmentVariable("AGONES_NAMESPACE") ?? "ows";
+            var agonesFleet = Environment.GetEnvironmentVariable("AGONES_FLEET") ?? "ows-hubworld";
+            _agonesAllocator = new AgonesAllocator(agonesNamespace, agonesFleet);
 
             RegisterLauncher();
 
@@ -268,44 +277,29 @@ namespace OWSInstanceLauncher.Services
                 return;
             }
 
-            //string PathToDedicatedServer = "E:\\Program Files\\Epic Games\\UE_4.25\\Engine\\Binaries\\Win64\\UE4Editor.exe";
-            //string ServerArguments = "\"C:\\OWS\\OpenWorldStarterPlugin\\OpenWorldStarter.uproject\" {0}?listen -server -log -nosteam -messaging -port={1}";
+            // Allocate a GameServer from Agones Fleet
+            var allocationTask = _agonesAllocator.AllocateAsync(mapName, zoneInstanceID);
+            var allocation = allocationTask.GetAwaiter().GetResult();
 
-            string serverArguments = (_owsInstanceLauncherOptions.Value.IsServerEditor ? "\"" + _owsInstanceLauncherOptions.Value.PathToUProject + "\" " : "")
-                + "{0}?listen -server "
-                + (_owsInstanceLauncherOptions.Value.UseServerLog ? "-log " : "")
-                + (_owsInstanceLauncherOptions.Value.UseNoSteam ? "-nosteam " : "")
-                + "-port={1} "
-                + "-zoneinstanceid={2}";
-
-            System.Diagnostics.Process proc = new System.Diagnostics.Process
+            if (allocation == null)
             {
-                StartInfo = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = _owsInstanceLauncherOptions.Value.PathToDedicatedServer,
-                    Arguments = Encoding.Default.GetString(Encoding.UTF8.GetBytes(String.Format(serverArguments, mapName, port, zoneInstanceID))),
-                    UseShellExecute = false,
-                    RedirectStandardOutput = false,
-                    CreateNoWindow = false
-                }
-            };
+                Log.Error($"Failed to allocate GameServer for map {mapName} zone {zoneInstanceID}. No servers available in fleet.");
+                return;
+            }
 
-            proc.Start();
-            //proc.WaitForInputIdle();
+            // Track the GameServer name for shutdown
+            _zoneToGameServer[zoneInstanceID] = allocation.GameServerName;
 
             _zoneServerProcessesRepository.AddZoneServerProcess(new ZoneServerProcess
             {
                 ZoneInstanceId = zoneInstanceID,
                 MapName = mapName,
-                Port = port,
-                ProcessId = proc.Id,
-                ProcessName = proc.ProcessName
+                Port = allocation.Port,
+                ProcessId = 0, // No OS process — Agones manages the pod
+                ProcessName = allocation.GameServerName
             });
 
-            Log.Information($"{customerGUID} : {worldServerID} : {mapName} : {port} has started.  ProcessId: {proc.Id}, ProcessName: {proc.ProcessName}");
-
-            //The server has finished spinning up.  Set the status to 2.
-            //_ = UpdateZoneServerStatusReady(zoneInstanceID);
+            Log.Information($"{customerGUID} : {worldServerID} : {mapName} : {allocation.Port} allocated via Agones. GameServer: {allocation.GameServerName} at {allocation.Address}:{allocation.Port}");
         }
 
         private void HandleServerShutDownMessage(Guid customerGUID, int zoneInstanceID)
@@ -319,35 +313,31 @@ namespace OWSInstanceLauncher.Services
                 return;
             }
 
-            int foundProcessId = _zoneServerProcessesRepository.FindZoneServerProcessId(zoneInstanceID);
-
-            if (foundProcessId > 0)
+            if (_zoneToGameServer.TryGetValue(zoneInstanceID, out var gameServerName))
             {
-                System.Diagnostics.Process procToKill = System.Diagnostics.Process.GetProcessById(foundProcessId);
-
-                if (procToKill != null)
+                var result = _agonesAllocator.DeallocateAsync(gameServerName).GetAwaiter().GetResult();
+                if (result)
                 {
-                    procToKill.Kill();
+                    _zoneToGameServer.Remove(zoneInstanceID);
+                    Log.Information($"Deallocated GameServer {gameServerName} for zone {zoneInstanceID}");
                 }
+            }
+            else
+            {
+                Log.Warning($"No tracked GameServer for zone {zoneInstanceID} — may have already been cleaned up");
             }
         }
 
         private void ShutDownAllZoneServerInstances()
         {
-            Log.Information("Shutting down all Server Instances...");
+            Log.Information("Shutting down all Server Instances via Agones...");
 
-            foreach (var zoneServerInstance in _zoneServerProcessesRepository.GetZoneServerProcesses())
+            foreach (var kvp in _zoneToGameServer)
             {
-                if (zoneServerInstance.ProcessId > 0)
-                {
-                    System.Diagnostics.Process procToKill = System.Diagnostics.Process.GetProcessById(zoneServerInstance.ProcessId);
-
-                    if (procToKill != null)
-                    {
-                        procToKill.Kill();
-                    }
-                }
+                _agonesAllocator.DeallocateAsync(kvp.Value).GetAwaiter().GetResult();
+                Log.Information($"Deallocated GameServer {kvp.Value} for zone {kvp.Key}");
             }
+            _zoneToGameServer.Clear();
         }
 
         private int RegisterInstanceLauncherRequest()
@@ -522,6 +512,8 @@ namespace OWSInstanceLauncher.Services
             {
                 connection.Close();
             }
+
+            _agonesAllocator?.Dispose();
 
             Log.Information("Done!");
         }


### PR DESCRIPTION
## Summary
Replace `Process.Start()` in InstanceLauncher with Agones `GameServerAllocation` via the Kubernetes API.

**Spin up**: RabbitMQ message → `AgonesAllocator.AllocateAsync()` → creates GameServerAllocation CR → Agones returns IP:Port
**Shut down**: `AgonesAllocator.DeallocateAsync()` → deletes GameServer resource
**RBAC**: ServiceAccount `ows-instance-launcher` in `arc-runners` with ClusterRole to create allocations and manage GameServers

### Files changed
- `ows-instance-launcher/Services/AgonesAllocator.cs` — new K8s client wrapper
- `ows-instance-launcher/Services/ServerLauncherMQListener.cs` — Process.Start → Agones
- `ows-instance-launcher/OWSInstanceLauncher.csproj` — add KubernetesClient 15.0.1
- `apps/kube/github/runners/manifests/ows-agones-rbac.yaml` — RBAC

Closes #8911

## Test plan
- [ ] Compiles cleanly (verified locally)
- [ ] RBAC allows GameServerAllocation creation from arc-runners namespace
- [ ] Allocation returns IP:Port from Agones Fleet