### PR TITLE
Atomic: ows-globaldata v0.10.5 post-publish sync

### DIFF
--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -308,7 +308,7 @@ spec:
         spec:
             containers:
                 - name: ows-globaldata
-                  image: ghcr.io/kbve/ows-globaldata:0.10.4
+                  image: ghcr.io/kbve/ows-globaldata:0.10.5
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend

--- a/apps/ows/ows-global-data/version.toml
+++ b/apps/ows/ows-global-data/version.toml
@@ -1,2 +1,2 @@
-version = "0.10.4"
+version = "0.10.5"
 publish = true


### PR DESCRIPTION
## Post-publish sync for ows-globaldata v0.10.5

- `apps/kube/ows/manifest/deployment.yaml`
- `apps/ows/ows-global-data/version.toml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*