### PR TITLE
Atomic: ows-instancelauncher v0.10.5 post-publish sync

### DIFF
--- a/apps/kube/ows/manifest/instance-launcher.yaml
+++ b/apps/kube/ows/manifest/instance-launcher.yaml
@@ -23,7 +23,7 @@ spec:
         spec:
             containers:
                 - name: ows-instancelauncher
-                  image: ghcr.io/kbve/ows-instancelauncher:0.10.4
+                  image: ghcr.io/kbve/ows-instancelauncher:0.10.5
                   env:
                       - name: ASPNETCORE_ENVIRONMENT
                         value: 'Production'

--- a/apps/ows/ows-instance-launcher/version.toml
+++ b/apps/ows/ows-instance-launcher/version.toml
@@ -1,2 +1,2 @@
-version = "0.10.4"
+version = "0.10.5"
 publish = true


### PR DESCRIPTION
## Post-publish sync for ows-instancelauncher v0.10.5

- `apps/kube/ows/manifest/instance-launcher.yaml`
- `apps/ows/ows-instance-launcher/version.toml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*