### PR TITLE
fix(ci): allow dots in atom branch name validation

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -62,11 +62,11 @@ jobs:
 
                   echo "Validating branch: $BRANCH_NAME"
 
-                  # Strict validation: atom- prefix + alphanumeric/hyphens only
-                  if [[ ! "$BRANCH_NAME" =~ ^atom-[a-zA-Z0-9-]+$ ]]; then
+                  # Strict validation: atom- prefix + alphanumeric/hyphens/dots only
+                  if [[ ! "$BRANCH_NAME" =~ ^atom-[a-zA-Z0-9.-]+$ ]]; then
                       echo "Invalid branch name: $BRANCH_NAME"
-                      echo "Valid format: atom-[a-zA-Z0-9-]+"
-                      echo "Examples: atom-12151430-fix-login, atom-12151430-update-docs"
+                      echo "Valid format: atom-[a-zA-Z0-9.-]+"
+                      echo "Examples: atom-12151430-fix-login, atom-post-publish-app-v1.0.0"
                       exit 1
                   fi
 


### PR DESCRIPTION
## Summary

- Update `ci-atom.yml` branch validation regex from `^atom-[a-zA-Z0-9-]+$` to `^atom-[a-zA-Z0-9.-]+$`

## Context

Post-publish and kube-manifest workflows generate atom branches with semver versions containing dots (e.g. `atom-post-publish-axum-chuckrpg-v0.1.1`). The regex rejected these, causing Validate Branch to fail and blocking auto-merge on PRs #8917-#8923.

## Test plan

- [ ] Re-run `ci-atom.yml` on the blocked PRs after merge — Validate Branch should pass