### PR TITLE
fix(ows): skip PathToDedicatedServer in Agones mode + add /health endpoint

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancelauncher
 pipeline: docker
 app_name: ows-instancelauncher
-version: "0.10.5"
+version: "0.10.6"
 source_path: apps/ows
 version_toml: apps/ows/ows-instance-launcher/version.toml
 version_target: apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj

--- a/apps/kube/ows/manifest/instance-launcher.yaml
+++ b/apps/kube/ows/manifest/instance-launcher.yaml
@@ -21,12 +21,19 @@ spec:
                 app: ows-instancelauncher
                 app.kubernetes.io/part-of: ows
         spec:
+            serviceAccountName: ows-instancelauncher
             containers:
                 - name: ows-instancelauncher
                   image: ghcr.io/kbve/ows-instancelauncher:0.10.5
                   env:
                       - name: ASPNETCORE_ENVIRONMENT
                         value: 'Production'
+                      - name: OWS_USE_AGONES
+                        value: 'true'
+                      - name: AGONES_NAMESPACE
+                        value: 'arc-runners'
+                      - name: AGONES_FLEET
+                        value: 'ows-hubworld'
                       - name: OWSInstanceLauncherOptions__OWSAPIKey
                         valueFrom:
                             secretKeyRef:

--- a/apps/kube/ows/manifest/launcher-agones-rbac.yaml
+++ b/apps/kube/ows/manifest/launcher-agones-rbac.yaml
@@ -1,0 +1,34 @@
+# ServiceAccount + RBAC for OWS Instance Launcher to create Agones GameServerAllocations
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ows-instancelauncher
+    namespace: ows
+---
+# Allow creating GameServerAllocations in arc-runners namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: agones-allocator-for-ows
+    namespace: arc-runners
+rules:
+    - apiGroups: ['allocation.agones.dev']
+      resources: ['gameserverallocations']
+      verbs: ['create']
+    - apiGroups: ['agones.dev']
+      resources: ['gameservers']
+      verbs: ['get', 'list', 'delete']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ows-launcher-agones-allocator
+    namespace: arc-runners
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: agones-allocator-for-ows
+subjects:
+    - kind: ServiceAccount
+      name: ows-instancelauncher
+      namespace: ows

--- a/apps/ows/ows-instance-launcher/Startup.cs
+++ b/apps/ows/ows-instance-launcher/Startup.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,6 +54,11 @@ namespace OWSInstanceLauncher
                 thereWasAStartupError = true;
                 Log.Error("Please enter a valid OWSAPIKey in appsettings.json!");
             }
+            //Skip PathToDedicatedServer checks when using Agones (K8s-native game server management)
+            else if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("OWS_USE_AGONES")))
+            {
+                Log.Information("Agones mode enabled (OWS_USE_AGONES set) — skipping PathToDedicatedServer validation.");
+            }
             //Abort if there is not a valid PathToDedicatedServer in appsettings.json
             else if (String.IsNullOrEmpty(owsInstanceLauncherOptions.PathToDedicatedServer))
             {
@@ -68,7 +74,7 @@ namespace OWSInstanceLauncher
             //If using the UE4 editor, make sure there is a project path in Path To UProject
             else
             {
-                if (OperatingSystem.IsWindows() && owsInstanceLauncherOptions.PathToDedicatedServer.Contains("Editor.exe") || 
+                if (OperatingSystem.IsWindows() && owsInstanceLauncherOptions.PathToDedicatedServer.Contains("Editor.exe") ||
                     OperatingSystem.IsMacOS() && owsInstanceLauncherOptions.PathToDedicatedServer.EndsWith("UnrealEditor") ||
                     OperatingSystem.IsLinux() && owsInstanceLauncherOptions.PathToDedicatedServer.EndsWith("Editor"))
                 {
@@ -89,7 +95,7 @@ namespace OWSInstanceLauncher
                         thereWasAStartupError = true;
                         Log.Error("Because you are using UE4Editor.exe or UnrealEditor.exe, your PathToUProject in appsettings.json must contain a path to the uproject file.  Be sure to use escaped (double) backslashes in the path!");
                     }
-                }  
+                }
             }
 
             //If there was a startup error, don't continue any further.  Wait for shutdown.
@@ -157,6 +163,13 @@ namespace OWSInstanceLauncher
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+
+            app.Map("/health", a => a.Run(async ctx =>
+            {
+                ctx.Response.ContentType = "application/json";
+                ctx.Response.StatusCode = 200;
+                await ctx.Response.WriteAsync("{\"status\":\"healthy\",\"service\":\"instancelauncher\"}");
+            }));
 
             app.UseRouting();
 


### PR DESCRIPTION
## Summary
Two fixes for the instance launcher:

1. **Agones mode bypass** — `OWS_USE_AGONES=true` env var skips the `PathToDedicatedServer` file check that was crashing the launcher on startup. Agones manages game servers, no local binary needed.

2. **Health endpoint** — added `/health` returning 200 JSON so readiness/liveness probes work.

## Test plan
- [ ] Launcher starts without crash
- [ ] Health probe passes
- [ ] RabbitMQ connection established