### PR TITLE
fix(ows): convert blocking async to await and add typed Agones errors

### DIFF
--- a/apps/ows/ows-instance-launcher/Services/AgonesAllocator.cs
+++ b/apps/ows/ows-instance-launcher/Services/AgonesAllocator.cs
@@ -8,12 +8,28 @@ using System.Threading.Tasks;
 
 namespace OWSInstanceLauncher.Services
 {
+    public enum AgonesErrorCode
+    {
+        None,
+        FleetExhausted,
+        FleetNotFound,
+        ApiTimeout,
+        AuthFailure,
+        Unknown
+    }
+
     public class AgonesAllocationResult
     {
+        public bool Success { get; set; }
+        public AgonesErrorCode ErrorCode { get; set; } = AgonesErrorCode.None;
+        public string ErrorMessage { get; set; } = "";
         public string GameServerName { get; set; } = "";
         public string Address { get; set; } = "";
         public int Port { get; set; }
         public string State { get; set; } = "";
+
+        public static AgonesAllocationResult Fail(AgonesErrorCode code, string message) =>
+            new() { Success = false, ErrorCode = code, ErrorMessage = message };
     }
 
     public class AgonesAllocator : IDisposable
@@ -38,7 +54,7 @@ namespace OWSInstanceLauncher.Services
         /// Allocate a GameServer from the Agones Fleet.
         /// Creates a GameServerAllocation CR via the Kubernetes API.
         /// </summary>
-        public async Task<AgonesAllocationResult?> AllocateAsync(string mapName, int zoneInstanceId)
+        public async Task<AgonesAllocationResult> AllocateAsync(string mapName, int zoneInstanceId)
         {
             var allocation = new Dictionary<string, object>
             {
@@ -85,10 +101,18 @@ namespace OWSInstanceLauncher.Services
 
                 var state = root.GetProperty("status").GetProperty("state").GetString() ?? "";
 
+                if (state == "UnAllocated")
+                {
+                    Log.Warning("GameServerAllocation state is {State} — fleet exhausted, no ready servers", state);
+                    return AgonesAllocationResult.Fail(AgonesErrorCode.FleetExhausted,
+                        $"No ready GameServers in fleet {_fleetName}");
+                }
+
                 if (state != "Allocated")
                 {
-                    Log.Warning("GameServerAllocation state is {State}, not Allocated. No servers available?", state);
-                    return null;
+                    Log.Warning("GameServerAllocation state is {State}, expected Allocated", state);
+                    return AgonesAllocationResult.Fail(AgonesErrorCode.Unknown,
+                        $"Unexpected allocation state: {state}");
                 }
 
                 var address = root.GetProperty("status").GetProperty("address").GetString() ?? "";
@@ -108,6 +132,7 @@ namespace OWSInstanceLauncher.Services
 
                 var result = new AgonesAllocationResult
                 {
+                    Success = true,
                     GameServerName = gsName,
                     Address = address,
                     Port = port,
@@ -119,10 +144,28 @@ namespace OWSInstanceLauncher.Services
 
                 return result;
             }
+            catch (k8s.Autorest.HttpOperationException ex) when (ex.Response?.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                Log.Error(ex, "Fleet or namespace not found for map {Map} zone {Zone}", mapName, zoneInstanceId);
+                return AgonesAllocationResult.Fail(AgonesErrorCode.FleetNotFound,
+                    $"Fleet {_fleetName} not found in namespace {_namespace}");
+            }
+            catch (k8s.Autorest.HttpOperationException ex) when (ex.Response?.StatusCode == System.Net.HttpStatusCode.Unauthorized || ex.Response?.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                Log.Error(ex, "K8s auth failure for map {Map} zone {Zone}", mapName, zoneInstanceId);
+                return AgonesAllocationResult.Fail(AgonesErrorCode.AuthFailure,
+                    $"K8s API auth failure: {ex.Response?.StatusCode}");
+            }
+            catch (TaskCanceledException ex)
+            {
+                Log.Error(ex, "K8s API timeout for map {Map} zone {Zone}", mapName, zoneInstanceId);
+                return AgonesAllocationResult.Fail(AgonesErrorCode.ApiTimeout,
+                    "K8s API request timed out");
+            }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to create GameServerAllocation for map {Map} zone {Zone}", mapName, zoneInstanceId);
-                return null;
+                return AgonesAllocationResult.Fail(AgonesErrorCode.Unknown, ex.Message);
             }
         }
 

--- a/apps/ows/ows-instance-launcher/Services/ServerLauncherHealthMonitoring.cs
+++ b/apps/ows/ows-instance-launcher/Services/ServerLauncherHealthMonitoring.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Serilog;
 
 namespace OWSInstanceLauncher.Services
@@ -31,7 +32,7 @@ namespace OWSInstanceLauncher.Services
             _owsInstanceLauncherDataRepository = owsInstanceLauncherDataRepository;
         }
 
-        public void DoWork()
+        public async void DoWork()
         {
             Log.Information("Server Health Monitoring is checking for broken Zone Server Instances...");
 
@@ -46,7 +47,7 @@ namespace OWSInstanceLauncher.Services
             Log.Information("Server Health Monitoring is getting a list of Zone Server Instances...");
 
             //Get a list of ZoneInstances from api/Instance/GetZoneInstancesForWorldServer
-            List<GetZoneInstancesForWorldServer> zoneInstances = GetZoneInstancesForWorldServer(worldServerID);
+            List<GetZoneInstancesForWorldServer> zoneInstances = await GetZoneInstancesForWorldServerAsync(worldServerID);
 
             foreach (var zoneInstance in zoneInstances)
             {
@@ -63,10 +64,8 @@ namespace OWSInstanceLauncher.Services
             Log.Information("Shutting Down OWS Server Health Monitoring...");
         }
 
-        private List<GetZoneInstancesForWorldServer> GetZoneInstancesForWorldServer(int worldServerId)
+        private async Task<List<GetZoneInstancesForWorldServer>> GetZoneInstancesForWorldServerAsync(int worldServerId)
         {
-            List<GetZoneInstancesForWorldServer> output;
-
             var instanceManagementHttpClient = _httpClientFactory.CreateClient("OWSInstanceManagement");
 
             var worldServerIDRequestPayload = new
@@ -79,21 +78,16 @@ namespace OWSInstanceLauncher.Services
 
             var getZoneInstancesForWorldServerRequest = new StringContent(JsonSerializer.Serialize(worldServerIDRequestPayload), Encoding.UTF8, "application/json");
 
-            var responseMessageTask = instanceManagementHttpClient.PostAsync("api/Instance/GetZoneInstancesForWorldServer", getZoneInstancesForWorldServerRequest);
-            var responseMessage = responseMessageTask.Result;
+            var responseMessage = await instanceManagementHttpClient.PostAsync("api/Instance/GetZoneInstancesForWorldServer", getZoneInstancesForWorldServerRequest);
 
             if (responseMessage.IsSuccessStatusCode)
             {
-                var responseContentAsync = responseMessage.Content.ReadAsStringAsync();
-                string responseContentString = responseContentAsync.Result;
-                output = JsonSerializer.Deserialize<List<GetZoneInstancesForWorldServer>>(responseContentString);
-            }
-            else
-            {
-                output = new List<GetZoneInstancesForWorldServer>();
+                string responseContentString = await responseMessage.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<List<GetZoneInstancesForWorldServer>>(responseContentString)
+                    ?? new List<GetZoneInstancesForWorldServer>();
             }
 
-            return output;
+            return new List<GetZoneInstancesForWorldServer>();
         }
     }
 }

--- a/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
+++ b/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
@@ -80,10 +80,10 @@ namespace OWSInstanceLauncher.Services
             InitRabbitMQ();
         }
 
-        public void RegisterLauncher()
+        public async void RegisterLauncher()
         {
             Log.Information($"Attempting to register Launcher GUID: {_launcherGUID}");
-            var isregistered = RegisterInstanceLauncherRequest();
+            var isregistered = await RegisterInstanceLauncherRequestAsync();
 
             if (isregistered == 1)
             {
@@ -108,7 +108,7 @@ namespace OWSInstanceLauncher.Services
 
             if (worldServerID < 1)
             {
-                worldServerID = StartInstanceLauncherRequest();
+                worldServerID = StartInstanceLauncherRequestAsync().GetAwaiter().GetResult();
                 _owsInstanceLauncherDataRepository.SetWorldServerID(worldServerID);
             }
 
@@ -194,14 +194,14 @@ namespace OWSInstanceLauncher.Services
             //Server Spin Up
             var serverSpinUpConsumer = new AsyncEventingBasicConsumer(serverSpinUpChannel);
 
-            serverSpinUpConsumer.Received += (model, ea) =>
+            serverSpinUpConsumer.Received += async (model, ea) =>
             {
                 try
                 {
                     var body = ea.Body;
                     MQSpinUpServerMessage serverSpinUpMessage = MQSpinUpServerMessage.Deserialize(body.ToArray());
                     Log.Information($"Server Spin Up Message Received: {serverSpinUpMessage.CustomerGUID} WorldServerID: {serverSpinUpMessage.WorldServerID} ZoneInstanceID: {serverSpinUpMessage.ZoneInstanceID} MapName: {serverSpinUpMessage.MapName} Port: {serverSpinUpMessage.Port}");
-                    HandleServerSpinUpMessage(
+                    await HandleServerSpinUpMessageAsync(
                         serverSpinUpMessage.CustomerGUID,
                         serverSpinUpMessage.WorldServerID,
                         serverSpinUpMessage.ZoneInstanceID,
@@ -215,8 +215,6 @@ namespace OWSInstanceLauncher.Services
                     Log.Error(ex, "Failed to process server spin-up message");
                     serverSpinUpChannel.BasicNack(ea.DeliveryTag, multiple: false, requeue: true);
                 }
-
-                return Task.CompletedTask;
             };
 
             serverSpinUpConsumer.Shutdown += OnServerSpinUpConsumerShutdown;
@@ -231,14 +229,14 @@ namespace OWSInstanceLauncher.Services
             //Server Shut Down
             var serverShutDownConsumer = new AsyncEventingBasicConsumer(serverShutDownChannel);
 
-            serverShutDownConsumer.Received += (model, ea) =>
+            serverShutDownConsumer.Received += async (model, ea) =>
             {
                 try
                 {
                     Log.Information("Server Shut Down Message Received");
                     var body = ea.Body;
                     MQShutDownServerMessage serverShutDownMessage = MQShutDownServerMessage.Deserialize(body.ToArray());
-                    HandleServerShutDownMessage(
+                    await HandleServerShutDownMessageAsync(
                         serverShutDownMessage.CustomerGUID,
                         serverShutDownMessage.ZoneInstanceID
                     );
@@ -250,8 +248,6 @@ namespace OWSInstanceLauncher.Services
                     Log.Error(ex, "Failed to process server shut-down message");
                     serverShutDownChannel.BasicNack(ea.DeliveryTag, multiple: false, requeue: true);
                 }
-
-                return Task.CompletedTask;
             };
 
             serverShutDownConsumer.Shutdown += OnServerShutDownConsumerShutdown;
@@ -266,7 +262,7 @@ namespace OWSInstanceLauncher.Services
             //return Task.CompletedTask;
         }
 
-        private void HandleServerSpinUpMessage(Guid customerGUID, int worldServerID, int zoneInstanceID, string mapName, int port)
+        private async Task HandleServerSpinUpMessageAsync(Guid customerGUID, int worldServerID, int zoneInstanceID, string mapName, int port)
         {
             Log.Information($"Starting up {customerGUID} : {worldServerID} : {mapName} : {port}");
 
@@ -278,12 +274,11 @@ namespace OWSInstanceLauncher.Services
             }
 
             // Allocate a GameServer from Agones Fleet
-            var allocationTask = _agonesAllocator.AllocateAsync(mapName, zoneInstanceID);
-            var allocation = allocationTask.GetAwaiter().GetResult();
+            var allocation = await _agonesAllocator.AllocateAsync(mapName, zoneInstanceID);
 
-            if (allocation == null)
+            if (!allocation.Success)
             {
-                Log.Error($"Failed to allocate GameServer for map {mapName} zone {zoneInstanceID}. No servers available in fleet.");
+                Log.Error($"Failed to allocate GameServer for map {mapName} zone {zoneInstanceID}. Error: {allocation.ErrorCode} — {allocation.ErrorMessage}");
                 return;
             }
 
@@ -302,7 +297,7 @@ namespace OWSInstanceLauncher.Services
             Log.Information($"{customerGUID} : {worldServerID} : {mapName} : {allocation.Port} allocated via Agones. GameServer: {allocation.GameServerName} at {allocation.Address}:{allocation.Port}");
         }
 
-        private void HandleServerShutDownMessage(Guid customerGUID, int zoneInstanceID)
+        private async Task HandleServerShutDownMessageAsync(Guid customerGUID, int zoneInstanceID)
         {
             Log.Information($"Shutting down {customerGUID} : {zoneInstanceID}");
 
@@ -315,7 +310,7 @@ namespace OWSInstanceLauncher.Services
 
             if (_zoneToGameServer.TryGetValue(zoneInstanceID, out var gameServerName))
             {
-                var result = _agonesAllocator.DeallocateAsync(gameServerName).GetAwaiter().GetResult();
+                var result = await _agonesAllocator.DeallocateAsync(gameServerName);
                 if (result)
                 {
                     _zoneToGameServer.Remove(zoneInstanceID);
@@ -328,19 +323,19 @@ namespace OWSInstanceLauncher.Services
             }
         }
 
-        private void ShutDownAllZoneServerInstances()
+        private async Task ShutDownAllZoneServerInstancesAsync()
         {
             Log.Information("Shutting down all Server Instances via Agones...");
 
             foreach (var kvp in _zoneToGameServer)
             {
-                _agonesAllocator.DeallocateAsync(kvp.Value).GetAwaiter().GetResult();
+                await _agonesAllocator.DeallocateAsync(kvp.Value);
                 Log.Information($"Deallocated GameServer {kvp.Value} for zone {kvp.Key}");
             }
             _zoneToGameServer.Clear();
         }
 
-        private int RegisterInstanceLauncherRequest()
+        private async Task<int> RegisterInstanceLauncherRequestAsync()
         {
             try
             {
@@ -360,23 +355,15 @@ namespace OWSInstanceLauncher.Services
 
                 var RegisterLauncherPayloadRequest = new StringContent(JsonSerializer.Serialize(RegisterLauncherPayload), Encoding.UTF8, "application/json");
 
-                var responseMessageAsync = instanceManagementHttpClient.PostAsync("api/Instance/RegisterLauncher", RegisterLauncherPayloadRequest);
-                var responseMessage = responseMessageAsync.Result;
-                var responseContentAsync = responseMessage.Content.ReadAsStringAsync();
+                var responseMessage = await instanceManagementHttpClient.PostAsync("api/Instance/RegisterLauncher", RegisterLauncherPayloadRequest);
 
-                if (responseMessage == null)
-                {
-                    return -1;
-                }
-
-                if (!responseMessage.IsSuccessStatusCode)
+                if (responseMessage == null || !responseMessage.IsSuccessStatusCode)
                 {
                     return -1;
                 }
 
                 return 1;
             }
-
             catch (Exception ex)
             {
                 Log.Error($"Error connecting to Instance Management API: {ex.Message} - {ex.InnerException}");
@@ -385,7 +372,7 @@ namespace OWSInstanceLauncher.Services
             return -1;
         }
 
-        private int StartInstanceLauncherRequest()
+        private async Task<int> StartInstanceLauncherRequestAsync()
         {
             try
             {
@@ -397,24 +384,16 @@ namespace OWSInstanceLauncher.Services
                     Method = HttpMethod.Get
                 };
                 request.Headers.Add("X-LauncherGUID", _launcherGUID.ToString());
-                var responseMessageAsync = instanceManagementHttpClient.SendAsync(request);
-                var responseMessage = responseMessageAsync.Result;
+                var responseMessage = await instanceManagementHttpClient.SendAsync(request);
 
-                if (responseMessage == null)
+                if (responseMessage == null || !responseMessage.IsSuccessStatusCode)
                 {
                     return -1;
                 }
 
-                if (!responseMessage.IsSuccessStatusCode)
-                {
-                    return -1;
-                }
+                string responseContentString = await responseMessage.Content.ReadAsStringAsync();
 
-                var responseContentAsync = responseMessage.Content.ReadAsStringAsync();
-                string responseContentString = responseContentAsync.Result;
-
-                int worldServerID = -1;
-                if (Int32.TryParse(responseContentString, out worldServerID))
+                if (Int32.TryParse(responseContentString, out int worldServerID))
                 {
                     return worldServerID;
                 }
@@ -493,11 +472,8 @@ namespace OWSInstanceLauncher.Services
 
             if (_worldServerId > 0)
             {
-                var shutDownTask = ShutDownInstanceLauncherRequest(_worldServerId);
-
-                shutDownTask.Wait();
-
-                ShutDownAllZoneServerInstances();
+                ShutDownInstanceLauncherRequest(_worldServerId).GetAwaiter().GetResult();
+                ShutDownAllZoneServerInstancesAsync().GetAwaiter().GetResult();
             }
 
             if (serverSpinUpChannel != null)


### PR DESCRIPTION
## Summary

- Convert all `.Result` and `.GetAwaiter().GetResult()` blocking patterns to proper `await` in OWS Instance Launcher
- Make RabbitMQ message handlers fully async
- Add `AgonesErrorCode` enum and typed `AgonesAllocationResult` with `Success`/`ErrorCode`/`ErrorMessage` instead of returning `null`
- Categorize K8s API failures: `FleetExhausted`, `FleetNotFound`, `AuthFailure`, `ApiTimeout`, `Unknown`

## Test plan

- [x] `dotnet build apps/ows/OWS.sln -c Release` passes (0 errors)

Closes #8930