### PR TITLE
fix(ows): skip appsettings.json write in Agones mode + add tests

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx
@@ -11,7 +11,7 @@ tags:
 key: ows_instancelauncher
 pipeline: docker
 app_name: ows-instancelauncher
-version: "0.10.6"
+version: "0.10.7"
 source_path: apps/ows
 version_toml: apps/ows/ows-instance-launcher/version.toml
 version_target: apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj

--- a/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
+++ b/apps/ows/ows-instance-launcher/Services/ServerLauncherMQListener.cs
@@ -56,7 +56,12 @@ namespace OWSInstanceLauncher.Services
             if (String.IsNullOrEmpty(owsInstanceLauncherOptions.Value.LauncherGuid))
             {
                 _launcherGUID = Guid.NewGuid();
-                _owsInstanceLauncherOptions.Update(x => x.LauncherGuid = _launcherGUID.ToString());
+                // In Agones mode, appsettings.json is read-only (chiseled image).
+                // Only persist the GUID if not in Agones mode.
+                if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("OWS_USE_AGONES")))
+                {
+                    _owsInstanceLauncherOptions.Update(x => x.LauncherGuid = _launcherGUID.ToString());
+                }
                 Log.Information($"New Launcher GUID Generated: {_launcherGUID}");
             }
             else

--- a/apps/ows/ows-tests/Validation/AgonesConfigTests.cs
+++ b/apps/ows/ows-tests/Validation/AgonesConfigTests.cs
@@ -1,0 +1,56 @@
+using System;
+using Xunit;
+
+namespace OWSTests.Validation
+{
+    public class AgonesConfigTests
+    {
+        [Fact]
+        public void AgonesModeDetected_WhenEnvVarSet()
+        {
+            Environment.SetEnvironmentVariable("OWS_USE_AGONES", "true");
+            var value = Environment.GetEnvironmentVariable("OWS_USE_AGONES");
+            Assert.False(String.IsNullOrEmpty(value));
+            Environment.SetEnvironmentVariable("OWS_USE_AGONES", null);
+        }
+
+        [Fact]
+        public void AgonesModeNotDetected_WhenEnvVarUnset()
+        {
+            Environment.SetEnvironmentVariable("OWS_USE_AGONES", null);
+            var value = Environment.GetEnvironmentVariable("OWS_USE_AGONES");
+            Assert.True(String.IsNullOrEmpty(value));
+        }
+
+        [Theory]
+        [InlineData("arc-runners", "ows-hubworld")]
+        [InlineData("ows", "chuck-fleet")]
+        public void AgonesNamespaceAndFleet_FromEnvVars(string ns, string fleet)
+        {
+            Environment.SetEnvironmentVariable("AGONES_NAMESPACE", ns);
+            Environment.SetEnvironmentVariable("AGONES_FLEET", fleet);
+
+            var agonesNs = Environment.GetEnvironmentVariable("AGONES_NAMESPACE") ?? "ows";
+            var agonesFl = Environment.GetEnvironmentVariable("AGONES_FLEET") ?? "ows-hubworld";
+
+            Assert.Equal(ns, agonesNs);
+            Assert.Equal(fleet, agonesFl);
+
+            Environment.SetEnvironmentVariable("AGONES_NAMESPACE", null);
+            Environment.SetEnvironmentVariable("AGONES_FLEET", null);
+        }
+
+        [Fact]
+        public void AgonesDefaults_WhenEnvVarsUnset()
+        {
+            Environment.SetEnvironmentVariable("AGONES_NAMESPACE", null);
+            Environment.SetEnvironmentVariable("AGONES_FLEET", null);
+
+            var agonesNs = Environment.GetEnvironmentVariable("AGONES_NAMESPACE") ?? "ows";
+            var agonesFl = Environment.GetEnvironmentVariable("AGONES_FLEET") ?? "ows-hubworld";
+
+            Assert.Equal("ows", agonesNs);
+            Assert.Equal("ows-hubworld", agonesFl);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Instance launcher crashed with `Permission denied` writing to `/app/appsettings.json` — chiseled image is read-only. In Agones mode, the LauncherGuid is held in-memory only.

## Changes
- `ServerLauncherMQListener.cs`: skip `WritableOptions.Update()` when `OWS_USE_AGONES` is set
- `AgonesConfigTests.cs`: 4 tests for env var detection and defaults
- Bump: `ows-instancelauncher` 0.10.6 → 0.10.7

## Test plan
- [ ] Launcher starts without permission error
- [ ] Connects to RabbitMQ
- [ ] Health check returns 200
- [ ] Agones config tests pass in CI