### PR TITLE
feat(kube): add Gateway + HTTPRoute for chuckrpg.com

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -45,7 +45,7 @@ spec:
                       - name: GOTRUE_SITE_URL
                         value: 'https://kbve.com'
                       - name: GOTRUE_URI_ALLOW_LIST
-                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**'
+                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,https://chuckrpg.com/**,https://*.chuckrpg.com/**,https://api.chuckrpg.com/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**'
                       - name: GOTRUE_DISABLE_SIGNUP
                         value: 'false'
 

--- a/apps/kube/chuckrpg/manifest/httproute.yaml
+++ b/apps/kube/chuckrpg/manifest/httproute.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: chuckrpg-tls
+    namespace: chuckrpg
+spec:
+    secretName: chuckrpg-tls
+    issuerRef:
+        name: letsencrypt-dns
+        kind: ClusterIssuer
+    dnsNames:
+        - chuckrpg.com
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: chuckrpg-api-tls
+    namespace: chuckrpg
+spec:
+    secretName: chuckrpg-api-tls
+    issuerRef:
+        name: letsencrypt-dns
+        kind: ClusterIssuer
+    dnsNames:
+        - api.chuckrpg.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: chuckrpg-routes
+    namespace: chuckrpg
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - chuckrpg.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: chuckrpg-service
+                port: 4322
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: chuckrpg-api-routes
+    namespace: chuckrpg
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - api.chuckrpg.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: chuckrpg-service
+                port: 4322

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -33,12 +33,24 @@ spec:
         - name: https-chuckrpg
           protocol: HTTPS
           port: 443
+          hostname: chuckrpg.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - name: chuckrpg-tls
+                    namespace: chuckrpg
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-chuckrpg-api
+          protocol: HTTPS
+          port: 443
           hostname: api.chuckrpg.com
           tls:
               mode: Terminate
               certificateRefs:
                   - name: chuckrpg-api-tls
-                    namespace: ows
+                    namespace: chuckrpg
           allowedRoutes:
               namespaces:
                   from: All


### PR DESCRIPTION
## Summary
ChuckRPG returns 404 because there was no Gateway listener or HTTPRoute for `chuckrpg.com`.

- Add HTTPS listeners on Gateway for `chuckrpg.com` and `api.chuckrpg.com`
- Create HTTPRoutes in `chuckrpg` namespace routing to `chuckrpg-service:4322`
- TLS certs via cert-manager ClusterIssuer `letsencrypt-dns`
- Add `chuckrpg.com` + `*.chuckrpg.com` + `api.chuckrpg.com` to GoTrue URI allow list

## Test plan
- [ ] ArgoCD syncs Gateway + HTTPRoute
- [ ] cert-manager issues TLS certs
- [ ] `curl https://chuckrpg.com/health` returns 200
- [ ] GoTrue allows auth redirects to chuckrpg.com