### PR TITLE
fix(ows): grant extensions schema access for pgcrypto login

### DIFF
--- a/apps/kube/ows/manifest/externalsecret.yaml
+++ b/apps/kube/ows/manifest/externalsecret.yaml
@@ -35,7 +35,7 @@ spec:
         template:
             engineVersion: v2
             data:
-                db-connection-string: 'Host=supabase-cluster-rw.kilobase.svc.cluster.local;Port=5432;Database=supabase;Username=ows;Password={{ .dbpassword }};Search Path=ows,public;Maximum Pool Size=6;'
+                db-connection-string: 'Host=supabase-cluster-rw.kilobase.svc.cluster.local;Port=5432;Database=supabase;Username=ows;Password={{ .dbpassword }};Search Path=ows,extensions,public;Maximum Pool Size=6;'
     data:
         - secretKey: dbpassword
           remoteRef:

--- a/packages/data/sql/dbmate/migrations/20260323230000_ows_extensions_access.sql
+++ b/packages/data/sql/dbmate/migrations/20260323230000_ows_extensions_access.sql
@@ -1,0 +1,19 @@
+-- migrate:up
+
+-- Grant ows role access to the extensions schema.
+-- pgcrypto (crypt/gen_salt) lives in extensions, not public.
+-- Without this, OWS login fails because the crypt() function
+-- is not found in the ows,public search path.
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.role_usage_grants
+        WHERE grantee = 'ows' AND object_schema = 'extensions'
+    ) THEN
+        GRANT USAGE ON SCHEMA extensions TO ows;
+    END IF;
+END $$;
+
+-- migrate:down
+
+REVOKE USAGE ON SCHEMA extensions FROM ows;


### PR DESCRIPTION
## Summary
OWS login returns 500 because `crypt()`/`gen_salt()` (pgcrypto) live in the `extensions` schema, which the `ows` role couldn't access.

### Changes
- **dbmate migration**: `GRANT USAGE ON SCHEMA extensions TO ows` (idempotent)
- **ExternalSecret**: search path `ows,extensions,public` (was `ows,public`)

### After merge
1. Apply migration: `dbmate up` (grants schema access)
2. ArgoCD syncs ExternalSecret → new connection string → pods restart
3. Login works

## Test plan
- [ ] `POST /api/Users/LoginAndCreateSession` returns 200
- [ ] `crypt()` function accessible in ows search path