### PR TITLE
feat(rows): wire integrations, gRPC→repo, structured tracing

### DIFF
--- a/apps/ows/rows/src/grpc.rs
+++ b/apps/ows/rows/src/grpc.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
 use tonic::{Request, Response, Status};
-use tracing::info;
+use tracing::{error, info};
+use uuid::Uuid;
 
 use crate::proto::rows::character_persistence_server::{
     CharacterPersistence, CharacterPersistenceServer,
@@ -10,27 +12,81 @@ use crate::proto::rows::instance_management_server::{
 };
 use crate::proto::rows::public_api_server::{PublicApi, PublicApiServer};
 use crate::proto::rows::*;
+use crate::repo::*;
+use crate::state::AppState;
 
 // ──────────────────────────────────────────────
 // Public API
 // ──────────────────────────────────────────────
 
-#[derive(Debug, Default)]
-pub struct PublicApiService;
+pub struct PublicApiService {
+    state: Arc<AppState>,
+}
 
 #[tonic::async_trait]
 impl PublicApi for PublicApiService {
     async fn login(&self, req: Request<LoginRequest>) -> Result<Response<LoginResponse>, Status> {
-        info!("Login request for: {}", req.get_ref().email);
-        Err(Status::unimplemented("Login not yet implemented"))
+        let r = req.get_ref();
+        info!(email = %r.email, "gRPC Login");
+        let repo = UsersRepo(&self.state.db);
+
+        match repo.login(&r.email, &r.password).await {
+            Ok(result) => Ok(Response::new(LoginResponse {
+                success: result.authenticated,
+                user_session_guid: result
+                    .user_session_guid
+                    .map(|u| u.to_string())
+                    .unwrap_or_default(),
+                error: if result.error_message.is_empty() {
+                    None
+                } else {
+                    Some(result.error_message)
+                },
+            })),
+            Err(e) => {
+                error!(error = %e, "gRPC Login failed");
+                Err(e.into_tonic())
+            }
+        }
     }
 
     async fn register(
         &self,
         req: Request<RegisterRequest>,
     ) -> Result<Response<RegisterResponse>, Status> {
-        info!("Register request for: {}", req.get_ref().email);
-        Err(Status::unimplemented("Register not yet implemented"))
+        let r = req.get_ref();
+        info!(email = %r.email, "gRPC Register");
+
+        use argon2::{
+            Argon2, PasswordHasher,
+            password_hash::{SaltString, rand_core::OsRng},
+        };
+        let salt = SaltString::generate(&mut OsRng);
+        let hash = Argon2::default()
+            .hash_password(r.password.as_bytes(), &salt)
+            .map_err(|e| Status::internal(format!("Hash error: {e}")))?
+            .to_string();
+
+        let repo = UsersRepo(&self.state.db);
+        match repo
+            .register(
+                self.state.config.customer_guid,
+                &r.email,
+                &hash,
+                &r.first_name,
+                &r.last_name,
+            )
+            .await
+        {
+            Ok(_) => Ok(Response::new(RegisterResponse {
+                success: true,
+                error: None,
+            })),
+            Err(e) => {
+                error!(error = %e, "gRPC Register failed");
+                Err(e.into_tonic())
+            }
+        }
     }
 
     async fn get_characters(
@@ -77,8 +133,9 @@ impl PublicApi for PublicApiService {
 // Instance Management
 // ──────────────────────────────────────────────
 
-#[derive(Debug, Default)]
-pub struct InstanceManagementService;
+pub struct InstanceManagementService {
+    state: Arc<AppState>,
+}
 
 #[tonic::async_trait]
 impl InstanceManagement for InstanceManagementService {
@@ -120,11 +177,21 @@ impl InstanceManagement for InstanceManagementService {
 
     async fn set_zone_instance_status(
         &self,
-        _req: Request<SetZoneInstanceStatusRequest>,
+        req: Request<SetZoneInstanceStatusRequest>,
     ) -> Result<Response<SetZoneInstanceStatusResponse>, Status> {
-        Err(Status::unimplemented(
-            "SetZoneInstanceStatus not yet implemented",
-        ))
+        let r = req.get_ref();
+        let repo = InstanceRepo(&self.state.db);
+        repo.set_zone_status(
+            self.state.config.customer_guid,
+            r.zone_instance_id,
+            r.instance_status,
+        )
+        .await
+        .map_err(|e| e.into_tonic())?;
+
+        Ok(Response::new(SetZoneInstanceStatusResponse {
+            success: true,
+        }))
     }
 
     async fn spin_up_instance(
@@ -148,8 +215,9 @@ impl InstanceManagement for InstanceManagementService {
 // Character Persistence
 // ──────────────────────────────────────────────
 
-#[derive(Debug, Default)]
-pub struct CharacterPersistenceService;
+pub struct CharacterPersistenceService {
+    state: Arc<AppState>,
+}
 
 #[tonic::async_trait]
 impl CharacterPersistence for CharacterPersistenceService {
@@ -162,9 +230,24 @@ impl CharacterPersistence for CharacterPersistenceService {
 
     async fn update_position(
         &self,
-        _req: Request<UpdatePositionRequest>,
+        req: Request<UpdatePositionRequest>,
     ) -> Result<Response<UpdatePositionResponse>, Status> {
-        Err(Status::unimplemented("UpdatePosition not yet implemented"))
+        let r = req.get_ref();
+        let repo = CharsRepo(&self.state.db);
+        repo.update_position(
+            self.state.config.customer_guid,
+            &r.character_name,
+            r.x,
+            r.y,
+            r.z,
+            r.rx,
+            r.ry,
+            r.rz,
+        )
+        .await
+        .map_err(|e| e.into_tonic())?;
+
+        Ok(Response::new(UpdatePositionResponse { success: true }))
     }
 
     async fn update_stats(
@@ -176,9 +259,19 @@ impl CharacterPersistence for CharacterPersistenceService {
 
     async fn player_logout(
         &self,
-        _req: Request<PlayerLogoutRequest>,
+        req: Request<PlayerLogoutRequest>,
     ) -> Result<Response<PlayerLogoutResponse>, Status> {
-        Err(Status::unimplemented("PlayerLogout not yet implemented"))
+        let r = req.get_ref();
+        let session_guid = Uuid::parse_str(&r.user_session_guid)
+            .map_err(|_| Status::invalid_argument("Invalid session GUID"))?;
+
+        let repo = UsersRepo(&self.state.db);
+        repo.logout(session_guid)
+            .await
+            .map_err(|e| e.into_tonic())?;
+
+        info!(character = %r.character_name, "gRPC PlayerLogout");
+        Ok(Response::new(PlayerLogoutResponse { success: true }))
     }
 
     async fn join_map(
@@ -200,33 +293,65 @@ impl CharacterPersistence for CharacterPersistenceService {
 // Global Data
 // ──────────────────────────────────────────────
 
-#[derive(Debug, Default)]
-pub struct GlobalDataServiceImpl;
+pub struct GlobalDataServiceImpl {
+    state: Arc<AppState>,
+}
 
 #[tonic::async_trait]
 impl GlobalDataService for GlobalDataServiceImpl {
     async fn get_global_data(
         &self,
-        _req: Request<GetGlobalDataRequest>,
+        req: Request<GetGlobalDataRequest>,
     ) -> Result<Response<GetGlobalDataResponse>, Status> {
-        Err(Status::unimplemented("GetGlobalData not yet implemented"))
+        let r = req.get_ref();
+        let repo = GlobalDataRepo(&self.state.db);
+
+        let data = repo
+            .get(self.state.config.customer_guid, &r.global_data_key)
+            .await
+            .map_err(|e| e.into_tonic())?;
+
+        Ok(Response::new(GetGlobalDataResponse {
+            global_data_value: data.and_then(|d| d.global_data_value),
+        }))
     }
 
     async fn set_global_data(
         &self,
-        _req: Request<SetGlobalDataRequest>,
+        req: Request<SetGlobalDataRequest>,
     ) -> Result<Response<SetGlobalDataResponse>, Status> {
-        Err(Status::unimplemented("SetGlobalData not yet implemented"))
+        let r = req.get_ref();
+        let repo = GlobalDataRepo(&self.state.db);
+
+        repo.set(
+            self.state.config.customer_guid,
+            &r.global_data_key,
+            &r.global_data_value,
+        )
+        .await
+        .map_err(|e| e.into_tonic())?;
+
+        Ok(Response::new(SetGlobalDataResponse { success: true }))
     }
 }
 
 // ──────────────────────────────────────────────
-// Router — combines all gRPC services
+// Router — combines all gRPC services with shared state
 // ──────────────────────────────────────────────
 
-pub fn router() -> tonic::service::Routes {
-    tonic::service::Routes::new(PublicApiServer::new(PublicApiService))
-        .add_service(InstanceManagementServer::new(InstanceManagementService))
-        .add_service(CharacterPersistenceServer::new(CharacterPersistenceService))
-        .add_service(GlobalDataServiceServer::new(GlobalDataServiceImpl))
+pub fn router(state: Arc<AppState>) -> tonic::service::Routes {
+    tonic::service::Routes::new(PublicApiServer::new(PublicApiService {
+        state: state.clone(),
+    }))
+    .add_service(InstanceManagementServer::new(InstanceManagementService {
+        state: state.clone(),
+    }))
+    .add_service(CharacterPersistenceServer::new(
+        CharacterPersistenceService {
+            state: state.clone(),
+        },
+    ))
+    .add_service(GlobalDataServiceServer::new(GlobalDataServiceImpl {
+        state,
+    }))
 }

--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -8,6 +8,7 @@ mod mq;
 mod repo;
 mod rest;
 mod state;
+mod trace;
 
 use std::net::SocketAddr;
 use tracing::info;
@@ -30,14 +31,21 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "rows=info,tower_http=info".into()),
+                .unwrap_or_else(|_| "rows=info,tower_http=debug".into()),
         )
         .json()
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .init();
 
     let database_url = std::env::var("DATABASE_URL")
         .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/ows".into());
     let api_key = std::env::var("OWS_API_KEY").unwrap_or_else(|_| Uuid::new_v4().to_string());
+    let rabbitmq_url =
+        std::env::var("RABBITMQ_URL").unwrap_or_else(|_| "amqp://dev:test@localhost:5672".into());
+    let agones_ns = std::env::var("AGONES_NAMESPACE").unwrap_or_else(|_| "ows".into());
+    let agones_fleet = std::env::var("AGONES_FLEET").unwrap_or_else(|_| "ows-hubworld".into());
 
     let host = std::env::var("HTTP_HOST").unwrap_or_else(|_| "0.0.0.0".into());
     let port: u16 = std::env::var("HTTP_PORT")
@@ -49,28 +57,39 @@ async fn main() -> anyhow::Result<()> {
     let pool = db::connect(&database_url).await?;
     info!("Database connected");
 
+    // RabbitMQ (non-fatal if unavailable)
+    let mq_producer = mq::try_connect(&rabbitmq_url).await;
+    info!(
+        available = mq_producer.is_some(),
+        "RabbitMQ initialization complete"
+    );
+
+    // Agones (non-fatal if not in-cluster)
+    let agones_client = agones::AgonesClient::try_new(&agones_ns, &agones_fleet).await;
+    info!(
+        available = agones_client.is_some(),
+        "Agones initialization complete"
+    );
+
     // Build shared state — single Arc allocation
     let app_state = state::AppState::builder()
         .db(pool)
         .customer_guid(Uuid::parse_str(&api_key)?)
-        .agones(
-            std::env::var("AGONES_NAMESPACE").unwrap_or_else(|_| "ows".into()),
-            std::env::var("AGONES_FLEET").unwrap_or_else(|_| "ows-hubworld".into()),
-        )
-        .rabbitmq(
-            std::env::var("RABBITMQ_URL")
-                .unwrap_or_else(|_| "amqp://dev:test@localhost:5672".into()),
-        )
+        .agones_config(&agones_ns, &agones_fleet)
+        .mq(mq_producer)
+        .agones(agones_client)
         .build()?;
 
     // gRPC services (tonic) — shares Arc<AppState>
-    let grpc_router = grpc::router();
+    let grpc_router = grpc::router(app_state.clone());
 
     // REST routes (axum) — backward-compat with C# OWS API paths
     let rest_router = rest::router(app_state);
 
     // Multiplex: gRPC (content-type: application/grpc) + REST on single port
-    let app = rest_router.merge(grpc_router.into_axum_router());
+    let app = rest_router
+        .merge(grpc_router.into_axum_router())
+        .layer(axum::middleware::from_fn(trace::request_trace));
 
     info!("ROWS listening on {addr} (REST + gRPC multiplexed)");
 

--- a/apps/ows/rows/src/state.rs
+++ b/apps/ows/rows/src/state.rs
@@ -1,10 +1,11 @@
+use crate::agones::AgonesClient;
 use crate::db::DbPool;
+use crate::mq::MqProducer;
 use dashmap::DashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
 /// Shared application state — single Arc allocation, no Clone on inner fields.
-/// Passed via axum `State<Arc<AppState>>` and tonic interceptors.
 pub struct AppState {
     pub db: DbPool,
     /// In-memory session cache: user_session_guid → customer_guid
@@ -12,13 +13,16 @@ pub struct AppState {
     /// Zone instance → GameServer name tracking (Agones)
     pub zone_servers: DashMap<i32, String>,
     pub config: AppConfig,
+    /// RabbitMQ producer (None if unavailable — non-fatal)
+    pub mq: Option<MqProducer>,
+    /// Agones allocator (None if not in-cluster — non-fatal)
+    pub agones: Option<AgonesClient>,
 }
 
 pub struct AppConfig {
     pub customer_guid: Uuid,
     pub agones_namespace: String,
     pub agones_fleet: String,
-    pub rabbitmq_url: String,
 }
 
 impl AppState {
@@ -33,7 +37,8 @@ pub struct AppStateBuilder {
     customer_guid: Option<Uuid>,
     agones_namespace: Option<String>,
     agones_fleet: Option<String>,
-    rabbitmq_url: Option<String>,
+    mq: Option<MqProducer>,
+    agones: Option<AgonesClient>,
 }
 
 impl AppStateBuilder {
@@ -47,14 +52,19 @@ impl AppStateBuilder {
         self
     }
 
-    pub fn agones(mut self, namespace: impl Into<String>, fleet: impl Into<String>) -> Self {
+    pub fn agones_config(mut self, namespace: impl Into<String>, fleet: impl Into<String>) -> Self {
         self.agones_namespace = Some(namespace.into());
         self.agones_fleet = Some(fleet.into());
         self
     }
 
-    pub fn rabbitmq(mut self, url: impl Into<String>) -> Self {
-        self.rabbitmq_url = Some(url.into());
+    pub fn mq(mut self, producer: Option<MqProducer>) -> Self {
+        self.mq = producer;
+        self
+    }
+
+    pub fn agones(mut self, client: Option<AgonesClient>) -> Self {
+        self.agones = client;
         self
     }
 
@@ -69,10 +79,9 @@ impl AppStateBuilder {
                     .ok_or_else(|| anyhow::anyhow!("OWS_API_KEY required"))?,
                 agones_namespace: self.agones_namespace.unwrap_or_else(|| "ows".into()),
                 agones_fleet: self.agones_fleet.unwrap_or_else(|| "ows-hubworld".into()),
-                rabbitmq_url: self
-                    .rabbitmq_url
-                    .unwrap_or_else(|| "amqp://dev:test@localhost:5672".into()),
             },
+            mq: self.mq,
+            agones: self.agones,
         }))
     }
 }

--- a/apps/ows/rows/src/trace.rs
+++ b/apps/ows/rows/src/trace.rs
@@ -1,0 +1,75 @@
+use axum::{extract::Request, middleware::Next, response::Response};
+use tracing::{Span, info_span};
+use uuid::Uuid;
+
+/// Middleware that creates a per-request span with a unique request ID.
+/// Vector/ClickHouse can correlate all log lines from the same request.
+pub async fn request_trace(req: Request, next: Next) -> Response {
+    let request_id = Uuid::new_v4();
+    let method = req.method().clone();
+    let uri = req.uri().path().to_string();
+    let customer_guid = req
+        .headers()
+        .get("x-customerguid")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-");
+
+    let span = info_span!(
+        "request",
+        id = %request_id,
+        method = %method,
+        path = %uri,
+        customer = %customer_guid,
+        status = tracing::field::Empty,
+        latency_ms = tracing::field::Empty,
+    );
+
+    let start = std::time::Instant::now();
+    let resp = {
+        let _guard = span.enter();
+        next.run(req).await
+    };
+
+    let latency = start.elapsed().as_millis();
+    span.record("status", resp.status().as_u16());
+    span.record("latency_ms", latency);
+
+    // Emit a structured log line that ClickHouse can index
+    tracing::info!(
+        parent: &span,
+        status = resp.status().as_u16(),
+        latency_ms = latency,
+        "request completed"
+    );
+
+    resp
+}
+
+/// Macro for tracing errors from repo/service calls.
+/// Logs the error with context and converts to the appropriate response type.
+#[macro_export]
+macro_rules! trace_err {
+    ($result:expr, $context:expr) => {
+        match $result {
+            Ok(val) => Ok(val),
+            Err(e) => {
+                tracing::error!(error = %e, context = $context, "operation failed");
+                Err(e)
+            }
+        }
+    };
+}
+
+/// Macro for wrapping a handler result into a SuccessResponse JSON.
+#[macro_export]
+macro_rules! success_or_err {
+    ($result:expr) => {
+        match $result {
+            Ok(_) => axum::Json($crate::error::SuccessResponse::ok()),
+            Err(e) => {
+                tracing::error!(error = %e, "handler error");
+                axum::Json($crate::error::SuccessResponse::err(e.to_string()))
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Summary

### State wiring
- `AppState` now holds `Option<MqProducer>` and `Option<AgonesClient>` — both init non-fatally
- main.rs initializes RabbitMQ + Agones at startup, logs availability

### gRPC → repo wiring
- All 4 gRPC services now hold `Arc<AppState>` (no more `Default`)
- Fully wired: Login, Register, SetZoneInstanceStatus, UpdatePosition, PlayerLogout, GetGlobalData, SetGlobalData
- Remaining methods stay `unimplemented` (contract preserved)

### Structured tracing
- `trace.rs`: per-request span middleware — `request_id` (UUID), method, path, customer_guid, status, latency_ms
- JSON structured logs with target, thread_id, span close events
- `trace_err!` and `success_or_err!` macros for zero-boilerplate error logging
- All fields indexable by ClickHouse/Vector pipeline

## Test plan

- [x] `cargo check -p rows` passes (0 errors)