### PR TITLE
Atomic: ows-characterpersistence v0.10.6 post-publish sync

### DIFF
--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -209,7 +209,7 @@ spec:
         spec:
             containers:
                 - name: ows-characterpersistence
-                  image: ghcr.io/kbve/ows-characterpersistence:0.10.5
+                  image: ghcr.io/kbve/ows-characterpersistence:0.10.6
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend

--- a/apps/ows/ows-character-persistence/version.toml
+++ b/apps/ows/ows-character-persistence/version.toml
@@ -1,2 +1,2 @@
-version = "0.10.5"
+version = "0.10.6"
 publish = true


### PR DESCRIPTION
## Post-publish sync for ows-characterpersistence v0.10.6

- `apps/kube/ows/manifest/deployment.yaml`
- `apps/ows/ows-character-persistence/version.toml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*