### PR TITLE
Atomic: ows-instancemanagement v0.10.6 post-publish sync

### DIFF
--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -110,7 +110,7 @@ spec:
         spec:
             containers:
                 - name: ows-instancemanagement
-                  image: ghcr.io/kbve/ows-instancemanagement:0.10.5
+                  image: ghcr.io/kbve/ows-instancemanagement:0.10.6
                   imagePullPolicy: Always
                   env:
                       - name: OWSStorageConfig__OWSDBBackend

--- a/apps/ows/ows-instance-management/version.toml
+++ b/apps/ows/ows-instance-management/version.toml
@@ -1,2 +1,2 @@
-version = "0.10.5"
+version = "0.10.6"
 publish = true


### PR DESCRIPTION
## Post-publish sync for ows-instancemanagement v0.10.6

- `apps/kube/ows/manifest/deployment.yaml`
- `apps/ows/ows-instance-management/version.toml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*