### PR TITLE
fix(chuckrpg): route api.chuckrpg.com to OWS, fix TLS

### DIFF
--- a/apps/kube/chuckrpg/manifest/certificate.yaml
+++ b/apps/kube/chuckrpg/manifest/certificate.yaml
@@ -1,12 +1,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-    name: chuckrpg-api-tls
+    name: chuckrpg-tls
     namespace: chuckrpg
 spec:
-    secretName: chuckrpg-api-tls
+    secretName: chuckrpg-tls
     dnsNames:
-        - api.chuckrpg.com
+        - chuckrpg.com
     issuerRef:
         name: letsencrypt-http
         kind: ClusterIssuer
@@ -15,12 +15,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-    name: chuckrpg-tls
+    name: chuckrpg-api-tls
     namespace: chuckrpg
 spec:
-    secretName: chuckrpg-tls
+    secretName: chuckrpg-api-tls
     dnsNames:
-        - chuckrpg.com
+        - api.chuckrpg.com
     issuerRef:
         name: letsencrypt-http
         kind: ClusterIssuer

--- a/apps/kube/chuckrpg/manifest/httproute.yaml
+++ b/apps/kube/chuckrpg/manifest/httproute.yaml
@@ -1,30 +1,4 @@
 ---
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-    name: chuckrpg-tls
-    namespace: chuckrpg
-spec:
-    secretName: chuckrpg-tls
-    issuerRef:
-        name: letsencrypt-dns
-        kind: ClusterIssuer
-    dnsNames:
-        - chuckrpg.com
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-    name: chuckrpg-api-tls
-    namespace: chuckrpg
-spec:
-    secretName: chuckrpg-api-tls
-    issuerRef:
-        name: letsencrypt-dns
-        kind: ClusterIssuer
-    dnsNames:
-        - api.chuckrpg.com
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -49,7 +23,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
     name: chuckrpg-api-routes
-    namespace: chuckrpg
+    namespace: ows
 spec:
     parentRefs:
         - name: kbve-gateway
@@ -62,5 +36,5 @@ spec:
                     type: PathPrefix
                     value: /
           backendRefs:
-              - name: chuckrpg-service
-                port: 4322
+              - name: ows-publicapi
+                port: 80


### PR DESCRIPTION
## Summary
- `chuckrpg.com` → `chuckrpg-service:4322` (Astro+Axum site)
- `api.chuckrpg.com` → `ows-publicapi:80` (OWS game server API in ows namespace)
- Switch certs from `letsencrypt-dns` to `letsencrypt-http` (no Cloudflare access for chuckrpg.com)
- Add ReferenceGrant for Gateway cross-namespace TLS secret access
- Remove stale nginx ingress

Ref: #8404