### PR TITLE
perf(rows): eliminate unwrap panics, optimize hot paths, typed errors

### DIFF
--- a/apps/ows/rows/src/error.rs
+++ b/apps/ows/rows/src/error.rs
@@ -1,6 +1,7 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use serde_json::json;
+use serde::Serialize;
+use std::borrow::Cow;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RowsError {
@@ -29,6 +30,17 @@ impl RowsError {
         }
     }
 
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::Unauthorized => "UNAUTHORIZED",
+            Self::BadRequest(_) => "BAD_REQUEST",
+            Self::Conflict(_) => "CONFLICT",
+            Self::Database(_) => "DATABASE_ERROR",
+            Self::Internal(_) => "INTERNAL_ERROR",
+        }
+    }
+
     pub fn into_tonic(self) -> tonic::Status {
         match &self {
             Self::NotFound(m) => tonic::Status::not_found(m),
@@ -41,19 +53,28 @@ impl RowsError {
     }
 }
 
+#[derive(Serialize)]
+struct ApiErrorBody<'a> {
+    success: bool,
+    code: &'a str,
+    #[serde(rename = "errorMessage")]
+    error_message: Cow<'a, str>,
+}
+
 impl IntoResponse for RowsError {
     fn into_response(self) -> Response {
         let status = self.status();
-        let body = axum::Json(json!({
-            "success": false,
-            "errorMessage": self.to_string(),
-        }));
-        (status, body).into_response()
+        let body = ApiErrorBody {
+            success: false,
+            code: self.code(),
+            error_message: Cow::Owned(self.to_string()),
+        };
+        (status, axum::Json(body)).into_response()
     }
 }
 
-/// OWS-compatible success/error response
-#[derive(serde::Serialize)]
+/// OWS-compatible success/error response.
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SuccessResponse {
     pub success: bool,
@@ -72,6 +93,25 @@ impl SuccessResponse {
         Self {
             success: false,
             error_message: msg.into(),
+        }
+    }
+}
+
+pub type ApiResult<T> = Result<axum::Json<T>, RowsError>;
+
+/// Serialize a value to Json response. Returns error JSON on failure instead of panicking.
+/// Uses to_value (single pass through serde) — safe replacement for .unwrap().
+pub fn json_or_500<T: Serialize>(val: &T) -> axum::Json<serde_json::Value> {
+    match serde_json::to_value(val) {
+        Ok(v) => axum::Json(v),
+        Err(e) => {
+            tracing::error!(error = %e, "JSON serialization failed");
+            axum::Json(serde_json::Value::Object({
+                let mut m = serde_json::Map::with_capacity(2);
+                m.insert("success".into(), false.into());
+                m.insert("errorMessage".into(), "Internal serialization error".into());
+                m
+            }))
         }
     }
 }

--- a/apps/ows/rows/src/repo.rs
+++ b/apps/ows/rows/src/repo.rs
@@ -300,30 +300,36 @@ impl<'a> CharsRepo<'a> {
             .as_object()
             .ok_or_else(|| RowsError::BadRequest("Stats must be a JSON object".into()))?;
 
-        // Build SET clause from allowlisted keys only (SQL injection safe)
-        let mut sets = Vec::new();
-        let mut vals: Vec<f64> = Vec::new();
+        // Build SET clause from allowlisted keys only (SQL injection safe).
+        // Pre-allocate with capacity to avoid realloc.
+        use std::fmt::Write;
+        let mut sql = String::with_capacity(256);
+        sql.push_str("UPDATE characters SET ");
+        let mut vals: Vec<f64> = Vec::with_capacity(obj.len().min(Self::STAT_COLUMNS.len()));
         let mut idx = 3u32; // $1 = customer_guid, $2 = charname
+        let mut first = true;
 
         for (key, val) in obj {
             let col = key.to_lowercase();
             if Self::STAT_COLUMNS.contains(&col.as_str()) {
                 if let Some(n) = val.as_f64() {
-                    sets.push(format!("{col} = ${idx}"));
+                    if !first {
+                        sql.push_str(", ");
+                    }
+                    // write! into pre-allocated String — no extra allocation
+                    let _ = write!(sql, "{col} = ${idx}");
                     vals.push(n);
                     idx += 1;
+                    first = false;
                 }
             }
         }
 
-        if sets.is_empty() {
-            return Ok(());
+        if first {
+            return Ok(()); // no valid columns
         }
 
-        let sql = format!(
-            "UPDATE characters SET {} WHERE customerguid = $1 AND charname = $2",
-            sets.join(", ")
-        );
+        sql.push_str(" WHERE customerguid = $1 AND charname = $2");
 
         let mut q = sqlx::query(&sql).bind(customer_guid).bind(char_name);
         for v in &vals {

--- a/apps/ows/rows/src/rest.rs
+++ b/apps/ows/rows/src/rest.rs
@@ -1,4 +1,4 @@
-use crate::error::SuccessResponse;
+use crate::error::{SuccessResponse, json_or_500};
 use crate::middleware::{extract_customer_guid, require_customer_guid};
 use crate::repo::*;
 use crate::state::AppState;
@@ -70,7 +70,7 @@ async fn login(
 ) -> Json<serde_json::Value> {
     let repo = UsersRepo(&state.db);
     match repo.login(&body.email, &body.password).await {
-        Ok(result) => Json(serde_json::to_value(result).unwrap()),
+        Ok(result) => json_or_500(&result),
         Err(e) => Json(json!({
             "authenticated": false,
             "userSessionGuid": null,
@@ -93,7 +93,7 @@ async fn get_user_session(
 
     let repo = UsersRepo(&state.db);
     match repo.get_session(session_guid).await {
-        Ok(Some(session)) => Json(serde_json::to_value(session).unwrap()),
+        Ok(Some(session)) => json_or_500(&session),
         Ok(None) => Json(json!({"success": false, "errorMessage": "Session not found"})),
         Err(e) => Json(json!({"success": false, "errorMessage": e.to_string()})),
     }
@@ -124,7 +124,7 @@ async fn get_all_characters(
     };
 
     match repo.get_all_characters(customer_guid, user_guid).await {
-        Ok(chars) => Json(serde_json::to_value(chars).unwrap()),
+        Ok(chars) => json_or_500(&chars),
         Err(_) => Json(json!([])),
     }
 }
@@ -166,7 +166,7 @@ async fn get_server_to_connect_to(
                     }
                 }
             }
-            Json(serde_json::to_value(result).unwrap())
+            json_or_500(&result)
         }
         Err(e) => Json(json!({"success": false, "errorMessage": e.to_string()})),
     }
@@ -189,7 +189,7 @@ async fn get_char_by_name_public(
     let repo = CharsRepo(&state.db);
 
     match repo.get_by_name(customer_guid, &body.character_name).await {
-        Ok(Some(ch)) => Json(serde_json::to_value(ch).unwrap()),
+        Ok(Some(ch)) => json_or_500(&ch),
         Ok(None) => Json(json!({"success": false, "errorMessage": "Character not found"})),
         Err(e) => Json(json!({"success": false, "errorMessage": e.to_string()})),
     }
@@ -399,7 +399,7 @@ async fn get_zone_instances(
         .get_zone_instances(customer_guid, body.request.world_server_id)
         .await
     {
-        Ok(zones) => Json(serde_json::to_value(zones).unwrap()),
+        Ok(zones) => json_or_500(&zones),
         Err(e) => Json(json!({"success": false, "errorMessage": e.to_string()})),
     }
 }
@@ -452,7 +452,7 @@ async fn get_char_by_name(
     let repo = CharsRepo(&state.db);
 
     match repo.get_by_name(customer_guid, &body.character_name).await {
-        Ok(Some(ch)) => Json(serde_json::to_value(ch).unwrap()),
+        Ok(Some(ch)) => json_or_500(&ch),
         Ok(None) => Json(json!({"success": false, "errorMessage": "Character not found"})),
         Err(e) => Json(json!({"success": false, "errorMessage": e.to_string()})),
     }
@@ -492,28 +492,28 @@ async fn update_all_positions(
     let repo = CharsRepo(&state.db);
 
     // Parse pipe-separated format: CharName:X:Y:Z:RX:RY:RZ|CharName2:...
+    // Zero-alloc: use split iterator instead of collecting into Vec
     for entry in body.serialized_player_location_data.split('|') {
-        let parts: Vec<&str> = entry.split(':').collect();
-        if parts.len() < 7 {
-            continue;
-        }
-        let char_name = parts[0];
-        let Ok(x) = parts[1].parse::<f64>() else {
-            continue;
-        };
-        let Ok(y) = parts[2].parse::<f64>() else {
-            continue;
-        };
-        let Ok(z) = parts[3].parse::<f64>() else {
+        let mut it = entry.splitn(8, ':'); // max 7 fields + remainder
+        let Some(char_name) = it.next() else { continue };
+        let (Some(sx), Some(sy), Some(sz), Some(srx), Some(sry), Some(srz)) = (
+            it.next(),
+            it.next(),
+            it.next(),
+            it.next(),
+            it.next(),
+            it.next(),
+        ) else {
             continue;
         };
-        let Ok(rx) = parts[4].parse::<f64>() else {
-            continue;
-        };
-        let Ok(ry) = parts[5].parse::<f64>() else {
-            continue;
-        };
-        let Ok(rz) = parts[6].parse::<f64>() else {
+        let (Ok(x), Ok(y), Ok(z), Ok(rx), Ok(ry), Ok(rz)) = (
+            sx.parse::<f64>(),
+            sy.parse::<f64>(),
+            sz.parse::<f64>(),
+            srx.parse::<f64>(),
+            sry.parse::<f64>(),
+            srz.parse::<f64>(),
+        ) else {
             continue;
         };
 
@@ -521,7 +521,7 @@ async fn update_all_positions(
             .update_position(customer_guid, char_name, x, y, z, rx, ry, rz)
             .await
         {
-            tracing::warn!("Failed to update position for {char_name}: {e}");
+            tracing::warn!(char_name, error = %e, "position update failed");
         }
     }
 
@@ -634,7 +634,7 @@ async fn get_character_abilities(
         .get_character_abilities(customer_guid, &body.character_name)
         .await
     {
-        Ok(abilities) => Json(serde_json::to_value(abilities).unwrap()),
+        Ok(abilities) => json_or_500(&abilities),
         Err(e) => Json(json!({"success": false, "errorMessage": e.to_string()})),
     }
 }
@@ -801,7 +801,7 @@ async fn get_global_data(
     let repo = GlobalDataRepo(&state.db);
 
     match repo.get(customer_guid, &key).await {
-        Ok(Some(data)) => Json(serde_json::to_value(data).unwrap()),
+        Ok(Some(data)) => json_or_500(&data),
         Ok(None) => Json(json!(null)),
         Err(e) => Json(json!({"success": false, "errorMessage": e.to_string()})),
     }

--- a/apps/ows/rows/src/trace.rs
+++ b/apps/ows/rows/src/trace.rs
@@ -1,25 +1,30 @@
 use axum::{extract::Request, middleware::Next, response::Response};
-use tracing::{Span, info_span};
+use tracing::info_span;
 use uuid::Uuid;
 
 /// Middleware that creates a per-request span with a unique request ID.
 /// Vector/ClickHouse can correlate all log lines from the same request.
+///
+/// Zero-copy: method is Display'd into the span (no clone), path is
+/// borrowed from the request URI (no String allocation).
 pub async fn request_trace(req: Request, next: Next) -> Response {
     let request_id = Uuid::new_v4();
-    let method = req.method().clone();
-    let uri = req.uri().path().to_string();
-    let customer_guid = req
+    let method = req.method().as_str();
+    let path = req.uri().path();
+    let customer = req
         .headers()
         .get("x-customerguid")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("-");
 
+    // info_span! captures the &str references before req is moved.
+    // Fields are recorded eagerly, so no allocation after this point.
     let span = info_span!(
         "request",
         id = %request_id,
-        method = %method,
-        path = %uri,
-        customer = %customer_guid,
+        %method,
+        %path,
+        %customer,
         status = tracing::field::Empty,
         latency_ms = tracing::field::Empty,
     );
@@ -30,11 +35,10 @@ pub async fn request_trace(req: Request, next: Next) -> Response {
         next.run(req).await
     };
 
-    let latency = start.elapsed().as_millis();
+    let latency = start.elapsed().as_millis() as u64;
     span.record("status", resp.status().as_u16());
     span.record("latency_ms", latency);
 
-    // Emit a structured log line that ClickHouse can index
     tracing::info!(
         parent: &span,
         status = resp.status().as_u16(),
@@ -45,8 +49,6 @@ pub async fn request_trace(req: Request, next: Next) -> Response {
     resp
 }
 
-/// Macro for tracing errors from repo/service calls.
-/// Logs the error with context and converts to the appropriate response type.
 #[macro_export]
 macro_rules! trace_err {
     ($result:expr, $context:expr) => {
@@ -60,7 +62,6 @@ macro_rules! trace_err {
     };
 }
 
-/// Macro for wrapping a handler result into a SuccessResponse JSON.
 #[macro_export]
 macro_rules! success_or_err {
     ($result:expr) => {


### PR DESCRIPTION
## Summary

### Safety
- Replace 9x `serde_json::to_value().unwrap()` with `json_or_500()` — never panics
- `ApiErrorBody` with `Cow<str>` + `&'static str` code — no `json!` macro allocation
- `RowsError::code()` for machine-readable error codes

### Hot-path optimizations
- **update_all_positions**: `Vec<&str> collect` → zero-alloc `splitn()` iterator
- **update_stats**: pre-allocated `String::with_capacity(256)` + `write!` instead of `format!` per-column
- **trace.rs**: borrow `&str` from request instead of cloning `Method` enum and allocating path `String`

## Test plan

- [x] `cargo check -p rows` passes (0 errors)