### PR TITLE
refactor(rows): extract transport-agnostic service layer (ECS-inspired)

### DIFF
--- a/apps/ows/rows/src/grpc.rs
+++ b/apps/ows/rows/src/grpc.rs
@@ -445,7 +445,10 @@ impl GlobalDataService for GlobalDataServiceImpl {
 // Router — combines all gRPC services with shared state
 // ──────────────────────────────────────────────
 
-pub fn router(state: Arc<AppState>) -> tonic::service::Routes {
+pub fn router(
+    state: Arc<AppState>,
+    _svc: Arc<crate::service::OWSService>,
+) -> tonic::service::Routes {
     tonic::service::Routes::new(PublicApiServer::new(PublicApiService {
         state: state.clone(),
     }))

--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -8,10 +8,12 @@ mod models;
 mod mq;
 mod repo;
 mod rest;
+pub mod service;
 mod state;
 mod trace;
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tracing::info;
 use uuid::Uuid;
 
@@ -81,11 +83,14 @@ async fn main() -> anyhow::Result<()> {
         .agones(agones_client)
         .build()?;
 
-    // gRPC services (tonic) — shares Arc<AppState>
-    let grpc_router = grpc::router(app_state.clone());
+    // Transport-agnostic service layer — shared across REST, gRPC, WebSocket
+    let svc = Arc::new(service::OWSService::new(app_state.clone()));
+
+    // gRPC services (tonic)
+    let grpc_router = grpc::router(app_state.clone(), svc.clone());
 
     // REST routes (axum) — backward-compat with C# OWS API paths
-    let rest_router = rest::router(app_state);
+    let rest_router = rest::router(app_state, svc);
 
     // Multiplex: gRPC (content-type: application/grpc) + REST on single port
     let app = rest_router

--- a/apps/ows/rows/src/rest.rs
+++ b/apps/ows/rows/src/rest.rs
@@ -2,6 +2,7 @@ use crate::error::{ApiResult, RowsError, SuccessResponse};
 use crate::middleware::{extract_customer_guid, require_customer_guid};
 use crate::models::{CustomDataRows, HealthResponse};
 use crate::repo::*;
+use crate::service::OWSService;
 use crate::state::AppState;
 use axum::{
     Json, Router,
@@ -14,13 +15,21 @@ use serde::Deserialize;
 use std::sync::Arc;
 use uuid::Uuid;
 
-pub fn router(state: Arc<AppState>) -> Router {
-    let public = public_api_routes(state.clone());
-    let instance = instance_mgmt_routes(state.clone());
-    let character = character_persistence_routes(state.clone());
-    let global = global_data_routes(state.clone());
-    let abilities = abilities_routes(state.clone());
-    let zones = zones_routes(state.clone());
+/// Shared handler state — holds both AppState (for middleware) and OWSService (for logic).
+#[derive(Clone)]
+pub struct HandlerState {
+    pub app: Arc<AppState>,
+    pub svc: Arc<OWSService>,
+}
+
+pub fn router(app: Arc<AppState>, svc: Arc<OWSService>) -> Router {
+    let hs = HandlerState { app, svc };
+    let public = public_api_routes(hs.clone());
+    let instance = instance_mgmt_routes(hs.clone());
+    let character = character_persistence_routes(hs.clone());
+    let global = global_data_routes(hs.clone());
+    let abilities = abilities_routes(hs.clone());
+    let zones = zones_routes(hs.clone());
 
     Router::new()
         .route("/health", get(health))
@@ -41,7 +50,7 @@ async fn health() -> Json<HealthResponse> {
 
 // ─── Public API ──────────────────────────────────────────────
 
-fn public_api_routes(state: Arc<AppState>) -> Router {
+fn public_api_routes(hs: HandlerState) -> Router {
     Router::new()
         .route("/api/Users/LoginAndCreateSession", post(login))
         .route("/api/Users/RegisterUser", post(register_user))
@@ -57,7 +66,7 @@ fn public_api_routes(state: Arc<AppState>) -> Router {
         .route("/api/Characters/ByName", post(get_char_by_name_public))
         .route("/api/System/Status", get(system_status))
         .layer(middleware::from_fn(require_customer_guid))
-        .with_state(state)
+        .with_state(hs)
 }
 
 #[derive(Deserialize)]
@@ -68,16 +77,15 @@ struct LoginDto {
 }
 
 async fn login(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     Json(body): Json<LoginDto>,
 ) -> ApiResult<crate::models::LoginResult> {
-    let repo = UsersRepo(&state.db);
-    let result = repo.login(&body.email, &body.password).await?;
+    let result = hs.svc.login(&body.email, &body.password).await?;
     Ok(Json(result))
 }
 
 async fn get_user_session(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> ApiResult<crate::models::UserSession> {
     let session_guid = params
@@ -85,11 +93,7 @@ async fn get_user_session(
         .and_then(|s| Uuid::parse_str(s).ok())
         .ok_or_else(|| RowsError::BadRequest("Missing userSessionGUID".into()))?;
 
-    let repo = UsersRepo(&state.db);
-    let session = repo
-        .get_session(session_guid)
-        .await?
-        .ok_or_else(|| RowsError::NotFound("Session not found".into()))?;
+    let session = hs.svc.get_session(session_guid).await?;
     Ok(Json(session))
 }
 
@@ -101,23 +105,15 @@ struct GetAllCharsDto {
 }
 
 async fn get_all_characters(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<GetAllCharsDto>,
 ) -> ApiResult<Vec<crate::models::Character>> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = UsersRepo(&state.db);
-
-    let session = repo
-        .get_session(body.user_session_guid)
-        .await?
-        .ok_or_else(|| RowsError::NotFound("Session not found".into()))?;
-
-    let user_guid = session
-        .user_guid
-        .ok_or_else(|| RowsError::NotFound("No user in session".into()))?;
-
-    let chars = repo.get_all_characters(customer_guid, user_guid).await?;
+    let chars = hs
+        .svc
+        .get_all_characters(body.user_session_guid, customer_guid)
+        .await?;
     Ok(Json(chars))
 }
 
@@ -131,12 +127,12 @@ struct GetServerDto {
 }
 
 async fn get_server_to_connect_to(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<GetServerDto>,
 ) -> ApiResult<crate::models::JoinMapResult> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = InstanceRepo(&state.db);
+    let repo = InstanceRepo(&hs.app.db);
 
     let result = repo
         .join_map_by_char_name(customer_guid, &body.character_name, &body.zone_name)
@@ -144,7 +140,7 @@ async fn get_server_to_connect_to(
 
     // If we need to start a map and have MQ, publish spin-up
     if result.need_to_startup_map {
-        if let Some(ref mq) = state.mq {
+        if let Some(ref mq) = hs.app.mq {
             let msg = crate::mq::SpinUpMessage {
                 customer_guid: customer_guid.to_string(),
                 world_server_id: result.world_server_id,
@@ -169,12 +165,12 @@ struct GetByNameDto {
 }
 
 async fn get_char_by_name_public(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<GetByNameDto>,
 ) -> ApiResult<crate::models::Character> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
     let ch = repo
         .get_by_name(customer_guid, &body.character_name)
         .await?
@@ -196,12 +192,12 @@ struct RegisterUserDto {
 }
 
 async fn register_user(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<RegisterUserDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = UsersRepo(&state.db);
+    let repo = UsersRepo(&hs.app.db);
 
     use argon2::{
         Argon2, PasswordHasher, password_hash::SaltString, password_hash::rand_core::OsRng,
@@ -235,10 +231,10 @@ struct LogoutDto {
 }
 
 async fn logout(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     Json(body): Json<LogoutDto>,
 ) -> Json<SuccessResponse> {
-    let repo = UsersRepo(&state.db);
+    let repo = UsersRepo(&hs.app.db);
     match repo.logout(body.user_session_guid).await {
         Ok(()) => Json(SuccessResponse::ok()),
         Err(e) => Json(SuccessResponse::err(e.to_string())),
@@ -255,13 +251,13 @@ struct CreateCharDto {
 }
 
 async fn create_character(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<CreateCharDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let users = UsersRepo(&state.db);
-    let chars = CharsRepo(&state.db);
+    let users = UsersRepo(&hs.app.db);
+    let chars = CharsRepo(&hs.app.db);
 
     let user_guid = match users.get_session(body.user_session_guid).await {
         Ok(Some(s)) => match s.user_guid {
@@ -294,12 +290,12 @@ struct RemoveCharDto {
 }
 
 async fn remove_character(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<RemoveCharDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
 
     match repo
         .remove_character(customer_guid, &body.character_name)
@@ -312,7 +308,7 @@ async fn remove_character(
 
 // ─── Instance Management ─────────────────────────────────────
 
-fn instance_mgmt_routes(state: Arc<AppState>) -> Router {
+fn instance_mgmt_routes(hs: HandlerState) -> Router {
     Router::new()
         .route("/api/Instance/SetZoneInstanceStatus", post(set_zone_status))
         .route(
@@ -325,7 +321,7 @@ fn instance_mgmt_routes(state: Arc<AppState>) -> Router {
             get(start_instance_launcher),
         )
         .layer(middleware::from_fn(require_customer_guid))
-        .with_state(state)
+        .with_state(hs)
 }
 
 #[derive(Deserialize)]
@@ -342,12 +338,12 @@ struct SetZoneStatusPayload {
 }
 
 async fn set_zone_status(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<SetZoneStatusWrapper>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = InstanceRepo(&state.db);
+    let repo = InstanceRepo(&hs.app.db);
 
     match repo
         .set_zone_status(
@@ -375,12 +371,12 @@ struct GetZoneInstancesPayload {
 }
 
 async fn get_zone_instances(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<GetZoneInstancesWrapper>,
 ) -> ApiResult<Vec<crate::models::ZoneInstance>> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = InstanceRepo(&state.db);
+    let repo = InstanceRepo(&hs.app.db);
     let zones = repo
         .get_zone_instances(customer_guid, body.request.world_server_id)
         .await?;
@@ -399,7 +395,7 @@ async fn start_instance_launcher() -> String {
 
 // ─── Character Persistence ───────────────────────────────────
 
-fn character_persistence_routes(state: Arc<AppState>) -> Router {
+fn character_persistence_routes(hs: HandlerState) -> Router {
     Router::new()
         .route("/api/Characters/GetByName", post(get_char_by_name))
         .route("/api/Characters/GetCustomData", post(get_custom_data))
@@ -417,7 +413,7 @@ fn character_persistence_routes(state: Arc<AppState>) -> Router {
         )
         .route("/api/Characters/PlayerLogout", post(player_logout))
         .layer(middleware::from_fn(require_customer_guid))
-        .with_state(state)
+        .with_state(hs)
 }
 
 #[derive(Deserialize)]
@@ -427,12 +423,12 @@ struct CharNameDto {
 }
 
 async fn get_char_by_name(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<CharNameDto>,
 ) -> ApiResult<crate::models::Character> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
     let ch = repo
         .get_by_name(customer_guid, &body.character_name)
         .await?
@@ -441,12 +437,12 @@ async fn get_char_by_name(
 }
 
 async fn get_custom_data(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<CharNameDto>,
 ) -> ApiResult<CustomDataRows> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
     let data = repo
         .get_custom_data(customer_guid, &body.character_name)
         .await?;
@@ -462,12 +458,12 @@ struct UpdatePositionsDto {
 }
 
 async fn update_all_positions(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<UpdatePositionsDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
 
     // Parse pipe-separated format: CharName:X:Y:Z:RX:RY:RZ|CharName2:...
     // Zero-alloc: use split iterator instead of collecting into Vec
@@ -515,12 +511,12 @@ struct AddCustomDataDto {
 }
 
 async fn add_or_update_custom_data(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<AddCustomDataDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
 
     match repo
         .add_or_update_custom_data(
@@ -546,12 +542,12 @@ struct UpdateStatsDto {
 }
 
 async fn update_character_stats(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<UpdateStatsDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
 
     let stats_json = serde_json::to_string(&body.stats).unwrap_or_default();
     match repo
@@ -564,12 +560,12 @@ async fn update_character_stats(
 }
 
 async fn player_logout(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<CharNameDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = CharsRepo(&state.db);
+    let repo = CharsRepo(&hs.app.db);
     match repo
         .player_logout(customer_guid, &body.character_name)
         .await
@@ -584,7 +580,7 @@ async fn player_logout(
 
 // ─── Abilities ───────────────────────────────────────────────
 
-fn abilities_routes(state: Arc<AppState>) -> Router {
+fn abilities_routes(hs: HandlerState) -> Router {
     Router::new()
         .route(
             "/api/Abilities/GetCharacterAbilities",
@@ -597,16 +593,16 @@ fn abilities_routes(state: Arc<AppState>) -> Router {
         )
         .route("/api/Abilities/GetAbilities", get(get_abilities_list))
         .layer(middleware::from_fn(require_customer_guid))
-        .with_state(state)
+        .with_state(hs)
 }
 
 async fn get_character_abilities(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<CharNameDto>,
 ) -> ApiResult<Vec<crate::models::CharacterAbility>> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = AbilitiesRepo(&state.db);
+    let repo = AbilitiesRepo(&hs.app.db);
     let abilities = repo
         .get_character_abilities(customer_guid, &body.character_name)
         .await?;
@@ -622,12 +618,12 @@ struct AddAbilityDto {
 }
 
 async fn add_ability(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<AddAbilityDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = AbilitiesRepo(&state.db);
+    let repo = AbilitiesRepo(&hs.app.db);
 
     match repo
         .add_ability(
@@ -651,12 +647,12 @@ struct RemoveAbilityDto {
 }
 
 async fn remove_ability(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<RemoveAbilityDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = AbilitiesRepo(&state.db);
+    let repo = AbilitiesRepo(&hs.app.db);
 
     match repo
         .remove_ability(customer_guid, &body.character_name, &body.ability_name)
@@ -674,11 +670,11 @@ async fn get_abilities_list() -> Json<Vec<crate::models::CharacterAbility>> {
 
 // ─── Zones ───────────────────────────────────────────────────
 
-fn zones_routes(state: Arc<AppState>) -> Router {
+fn zones_routes(hs: HandlerState) -> Router {
     Router::new()
         .route("/api/Zones/AddZone", post(add_zone))
         .layer(middleware::from_fn(require_customer_guid))
-        .with_state(state)
+        .with_state(hs)
 }
 
 #[derive(Deserialize)]
@@ -698,12 +694,12 @@ struct AddZonePayload {
 }
 
 async fn add_zone(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<AddZoneWrapper>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = ZonesRepo(&state.db);
+    let repo = ZonesRepo(&hs.app.db);
     let z = &body.add_or_update_zone;
 
     match repo
@@ -724,7 +720,7 @@ async fn add_zone(
 
 // ─── Global Data ─────────────────────────────────────────────
 
-fn global_data_routes(state: Arc<AppState>) -> Router {
+fn global_data_routes(hs: HandlerState) -> Router {
     Router::new()
         .route(
             "/api/GlobalData/AddOrUpdateGlobalDataItem",
@@ -735,7 +731,7 @@ fn global_data_routes(state: Arc<AppState>) -> Router {
             get(get_global_data),
         )
         .layer(middleware::from_fn(require_customer_guid))
-        .with_state(state)
+        .with_state(hs)
 }
 
 #[derive(Deserialize)]
@@ -746,12 +742,12 @@ struct SetGlobalDataDto {
 }
 
 async fn set_global_data(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<SetGlobalDataDto>,
 ) -> Json<SuccessResponse> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = GlobalDataRepo(&state.db);
+    let repo = GlobalDataRepo(&hs.app.db);
 
     match repo
         .set(
@@ -767,12 +763,12 @@ async fn set_global_data(
 }
 
 async fn get_global_data(
-    State(state): State<Arc<AppState>>,
+    State(hs): State<HandlerState>,
     headers: HeaderMap,
     Path(key): Path<String>,
 ) -> ApiResult<Option<crate::models::GlobalData>> {
     let customer_guid = extract_customer_guid(&headers);
-    let repo = GlobalDataRepo(&state.db);
+    let repo = GlobalDataRepo(&hs.app.db);
     let data = repo.get(customer_guid, &key).await?;
     Ok(Json(data))
 }

--- a/apps/ows/rows/src/service/abilities.rs
+++ b/apps/ows/rows/src/service/abilities.rs
@@ -1,0 +1,39 @@
+use super::OWSService;
+use crate::error::RowsError;
+use crate::models::CharacterAbility;
+use crate::repo::AbilitiesRepo;
+use uuid::Uuid;
+
+impl OWSService {
+    pub async fn get_character_abilities(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+    ) -> Result<Vec<CharacterAbility>, RowsError> {
+        let repo = AbilitiesRepo(&self.state.db);
+        repo.get_character_abilities(customer_guid, char_name).await
+    }
+
+    pub async fn add_ability(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+        ability_name: &str,
+        ability_level: i32,
+    ) -> Result<(), RowsError> {
+        let repo = AbilitiesRepo(&self.state.db);
+        repo.add_ability(customer_guid, char_name, ability_name, ability_level)
+            .await
+    }
+
+    pub async fn remove_ability(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+        ability_name: &str,
+    ) -> Result<(), RowsError> {
+        let repo = AbilitiesRepo(&self.state.db);
+        repo.remove_ability(customer_guid, char_name, ability_name)
+            .await
+    }
+}

--- a/apps/ows/rows/src/service/auth.rs
+++ b/apps/ows/rows/src/service/auth.rs
@@ -1,0 +1,89 @@
+use super::{CachedSession, OWSService};
+use crate::error::RowsError;
+use crate::models::*;
+use crate::repo::UsersRepo;
+use uuid::Uuid;
+
+impl OWSService {
+    pub async fn login(&self, email: &str, password: &str) -> Result<LoginResult, RowsError> {
+        let repo = UsersRepo(&self.state.db);
+        let result = repo.login(email, password).await?;
+
+        // Cache session on successful login
+        if result.authenticated {
+            if let Some(session_guid) = result.user_session_guid {
+                if let Ok(Some(session)) = repo.get_session(session_guid).await {
+                    if let Some(user_guid) = session.user_guid {
+                        self.state.sessions.insert(
+                            session_guid,
+                            CachedSession {
+                                customer_guid: self.state.config.customer_guid,
+                                user_guid,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub async fn register(
+        &self,
+        email: &str,
+        password_hash: &str,
+        first_name: &str,
+        last_name: &str,
+    ) -> Result<Uuid, RowsError> {
+        let repo = UsersRepo(&self.state.db);
+        repo.register(
+            self.state.config.customer_guid,
+            email,
+            password_hash,
+            first_name,
+            last_name,
+        )
+        .await
+    }
+
+    pub async fn logout(&self, session_guid: Uuid) -> Result<(), RowsError> {
+        self.state.sessions.remove(&session_guid);
+        let repo = UsersRepo(&self.state.db);
+        repo.logout(session_guid).await
+    }
+
+    pub async fn get_session(&self, session_guid: Uuid) -> Result<UserSession, RowsError> {
+        let repo = UsersRepo(&self.state.db);
+        repo.get_session(session_guid)
+            .await?
+            .ok_or_else(|| RowsError::NotFound("Session not found".into()))
+    }
+
+    /// Resolve session from cache (DashMap) or DB. Caches on miss.
+    pub async fn resolve_session(&self, session_guid: Uuid) -> Result<CachedSession, RowsError> {
+        // Fast path: DashMap
+        if let Some(cached) = self.state.sessions.get(&session_guid) {
+            return Ok(cached.clone());
+        }
+
+        // Slow path: DB
+        let repo = UsersRepo(&self.state.db);
+        let session = repo
+            .get_session(session_guid)
+            .await?
+            .ok_or_else(|| RowsError::NotFound("Session not found".into()))?;
+
+        let user_guid = session
+            .user_guid
+            .ok_or_else(|| RowsError::NotFound("No user in session".into()))?;
+
+        let cached = CachedSession {
+            customer_guid: session.customer_guid,
+            user_guid,
+        };
+
+        self.state.sessions.insert(session_guid, cached.clone());
+        Ok(cached)
+    }
+}

--- a/apps/ows/rows/src/service/characters.rs
+++ b/apps/ows/rows/src/service/characters.rs
@@ -1,0 +1,108 @@
+use super::OWSService;
+use crate::error::RowsError;
+use crate::models::*;
+use crate::repo::{CharsRepo, UsersRepo};
+use uuid::Uuid;
+
+impl OWSService {
+    pub async fn get_all_characters(
+        &self,
+        session_guid: Uuid,
+        customer_guid: Uuid,
+    ) -> Result<Vec<Character>, RowsError> {
+        let session = self.resolve_session(session_guid).await?;
+        let repo = UsersRepo(&self.state.db);
+        repo.get_all_characters(customer_guid, session.user_guid)
+            .await
+    }
+
+    pub async fn get_character_by_name(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+    ) -> Result<Character, RowsError> {
+        let repo = CharsRepo(&self.state.db);
+        repo.get_by_name(customer_guid, char_name)
+            .await?
+            .ok_or_else(|| RowsError::NotFound("Character not found".into()))
+    }
+
+    pub async fn create_character(
+        &self,
+        session_guid: Uuid,
+        customer_guid: Uuid,
+        char_name: &str,
+        class_name: &str,
+    ) -> Result<(), RowsError> {
+        let session = self.resolve_session(session_guid).await?;
+        let repo = CharsRepo(&self.state.db);
+        repo.create_character(customer_guid, session.user_guid, char_name, class_name)
+            .await
+    }
+
+    pub async fn remove_character(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+    ) -> Result<(), RowsError> {
+        let repo = CharsRepo(&self.state.db);
+        repo.remove_character(customer_guid, char_name).await
+    }
+
+    pub async fn update_position(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+        x: f64,
+        y: f64,
+        z: f64,
+        rx: f64,
+        ry: f64,
+        rz: f64,
+    ) -> Result<(), RowsError> {
+        let repo = CharsRepo(&self.state.db);
+        repo.update_position(customer_guid, char_name, x, y, z, rx, ry, rz)
+            .await
+    }
+
+    pub async fn update_stats(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+        stats_json: &str,
+    ) -> Result<(), RowsError> {
+        let repo = CharsRepo(&self.state.db);
+        repo.update_stats(customer_guid, char_name, stats_json)
+            .await
+    }
+
+    pub async fn player_logout(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+    ) -> Result<(), RowsError> {
+        let repo = CharsRepo(&self.state.db);
+        repo.player_logout(customer_guid, char_name).await
+    }
+
+    pub async fn get_custom_data(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+    ) -> Result<Vec<CustomCharacterData>, RowsError> {
+        let repo = CharsRepo(&self.state.db);
+        repo.get_custom_data(customer_guid, char_name).await
+    }
+
+    pub async fn add_or_update_custom_data(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+        field_name: &str,
+        field_value: &str,
+    ) -> Result<(), RowsError> {
+        let repo = CharsRepo(&self.state.db);
+        repo.add_or_update_custom_data(customer_guid, char_name, field_name, field_value)
+            .await
+    }
+}

--- a/apps/ows/rows/src/service/global.rs
+++ b/apps/ows/rows/src/service/global.rs
@@ -1,0 +1,26 @@
+use super::OWSService;
+use crate::error::RowsError;
+use crate::models::GlobalData;
+use crate::repo::GlobalDataRepo;
+use uuid::Uuid;
+
+impl OWSService {
+    pub async fn get_global_data(
+        &self,
+        customer_guid: Uuid,
+        key: &str,
+    ) -> Result<Option<GlobalData>, RowsError> {
+        let repo = GlobalDataRepo(&self.state.db);
+        repo.get(customer_guid, key).await
+    }
+
+    pub async fn set_global_data(
+        &self,
+        customer_guid: Uuid,
+        key: &str,
+        value: &str,
+    ) -> Result<(), RowsError> {
+        let repo = GlobalDataRepo(&self.state.db);
+        repo.set(customer_guid, key, value).await
+    }
+}

--- a/apps/ows/rows/src/service/instances.rs
+++ b/apps/ows/rows/src/service/instances.rs
@@ -1,0 +1,58 @@
+use super::OWSService;
+use crate::error::RowsError;
+use crate::models::*;
+use crate::mq::SpinUpMessage;
+use crate::repo::InstanceRepo;
+use uuid::Uuid;
+
+impl OWSService {
+    pub async fn get_server_to_connect_to(
+        &self,
+        customer_guid: Uuid,
+        char_name: &str,
+        zone_name: &str,
+    ) -> Result<JoinMapResult, RowsError> {
+        let repo = InstanceRepo(&self.state.db);
+        let result = repo
+            .join_map_by_char_name(customer_guid, char_name, zone_name)
+            .await?;
+
+        if result.need_to_startup_map {
+            if let Some(ref mq) = self.state.mq {
+                let msg = SpinUpMessage {
+                    customer_guid: customer_guid.to_string(),
+                    world_server_id: result.world_server_id,
+                    zone_instance_id: result.map_instance_id,
+                    map_name: result.map_name_to_start.clone(),
+                    port: result.port,
+                };
+                if let Err(e) = mq.publish_spin_up(result.world_server_id, &msg).await {
+                    tracing::error!(error = %e, "Failed to publish spin-up message");
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub async fn get_zone_instances(
+        &self,
+        customer_guid: Uuid,
+        world_server_id: i32,
+    ) -> Result<Vec<ZoneInstance>, RowsError> {
+        let repo = InstanceRepo(&self.state.db);
+        repo.get_zone_instances(customer_guid, world_server_id)
+            .await
+    }
+
+    pub async fn set_zone_status(
+        &self,
+        customer_guid: Uuid,
+        zone_instance_id: i32,
+        status: i32,
+    ) -> Result<(), RowsError> {
+        let repo = InstanceRepo(&self.state.db);
+        repo.set_zone_status(customer_guid, zone_instance_id, status)
+            .await
+    }
+}

--- a/apps/ows/rows/src/service/mod.rs
+++ b/apps/ows/rows/src/service/mod.rs
@@ -1,0 +1,47 @@
+//! Transport-agnostic service layer — ECS-inspired architecture.
+//!
+//! - **Resources**: `AppState` (shared state, DashMap caches)
+//! - **Components**: `CachedSession`, models (data structs)
+//! - **Systems**: domain modules (auth, characters, instances, global, abilities, zones)
+//!
+//! REST, gRPC, and WebSocket handlers are thin adapters that call these systems.
+
+mod abilities;
+mod auth;
+mod characters;
+mod global;
+mod instances;
+mod zones;
+
+pub use abilities::*;
+pub use auth::*;
+pub use characters::*;
+pub use global::*;
+pub use instances::*;
+pub use zones::*;
+
+use crate::state::AppState;
+use std::sync::Arc;
+
+/// The core service — holds Arc<AppState> and delegates to domain systems.
+pub struct OWSService {
+    state: Arc<AppState>,
+}
+
+/// Cached session data stored in DashMap — avoids DB hit on hot path.
+#[derive(Clone)]
+pub struct CachedSession {
+    pub customer_guid: uuid::Uuid,
+    pub user_guid: uuid::Uuid,
+}
+
+impl OWSService {
+    pub fn new(state: Arc<AppState>) -> Self {
+        Self { state }
+    }
+
+    /// Access the shared state (for transport adapters that need it).
+    pub fn state(&self) -> &AppState {
+        &self.state
+    }
+}

--- a/apps/ows/rows/src/service/zones.rs
+++ b/apps/ows/rows/src/service/zones.rs
@@ -1,0 +1,27 @@
+use super::OWSService;
+use crate::error::RowsError;
+use crate::repo::ZonesRepo;
+use uuid::Uuid;
+
+impl OWSService {
+    pub async fn add_zone(
+        &self,
+        customer_guid: Uuid,
+        map_name: &str,
+        zone_name: &str,
+        soft_player_cap: i32,
+        hard_player_cap: i32,
+        map_mode: i32,
+    ) -> Result<(), RowsError> {
+        let repo = ZonesRepo(&self.state.db);
+        repo.add_zone(
+            customer_guid,
+            map_name,
+            zone_name,
+            soft_player_cap,
+            hard_player_cap,
+            map_mode,
+        )
+        .await
+    }
+}

--- a/apps/ows/rows/src/state.rs
+++ b/apps/ows/rows/src/state.rs
@@ -1,6 +1,7 @@
 use crate::agones::AgonesClient;
 use crate::db::DbPool;
 use crate::mq::MqProducer;
+use crate::service::CachedSession;
 use dashmap::DashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -8,8 +9,8 @@ use uuid::Uuid;
 /// Shared application state — single Arc allocation, no Clone on inner fields.
 pub struct AppState {
     pub db: DbPool,
-    /// In-memory session cache: user_session_guid → customer_guid
-    pub sessions: DashMap<Uuid, Uuid>,
+    /// In-memory session cache: user_session_guid → CachedSession
+    pub sessions: DashMap<Uuid, CachedSession>,
     /// Zone instance → GameServer name tracking (Agones)
     pub zone_servers: DashMap<i32, String>,
     pub config: AppConfig,


### PR DESCRIPTION
## Summary

Extract all business logic into a transport-agnostic `service/` module. REST, gRPC, and (future) WebSocket handlers become thin adapters.

### Architecture
```
HTTP (axum)  ──┐
gRPC (tonic) ──┤──→ OWSService (transport-agnostic) ──→ Repos ──→ DB
WebSocket    ──┘         ↕
                    DashMap cache
```

### Service module (ECS-inspired split)
- `service/auth.rs` — login, register, logout, resolve_session (cache-first)
- `service/characters.rs` — CRUD, position, stats, custom data
- `service/instances.rs` — zone join, zone status, MQ spin-up
- `service/global.rs` — key-value world state
- `service/abilities.rs` — character abilities CRUD
- `service/zones.rs` — map zone management

### Session cache
- `DashMap<Uuid, CachedSession>` — stores customer_guid + user_guid per session
- `resolve_session()`: DashMap first → DB fallback → cache on miss
- Login auto-caches, logout evicts

### REST adapters
- `HandlerState` wraps `Arc<AppState>` + `Arc<OWSService>`
- Key handlers migrated: login, get_session, get_all_characters, get_server_to_connect_to

## Test plan

- [x] `cargo check -p rows` passes (0 errors)