### PR TITLE
fix(chuckrpg): cleanup SSL — Cloudflare edge + game.chuckrpg.com cert

### DIFF
--- a/apps/kube/chuckrpg/manifest/certificate.yaml
+++ b/apps/kube/chuckrpg/manifest/certificate.yaml
@@ -1,26 +1,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-    name: chuckrpg-tls
+    name: game-chuckrpg-tls
     namespace: chuckrpg
 spec:
-    secretName: chuckrpg-tls
+    secretName: game-chuckrpg-tls
     dnsNames:
-        - chuckrpg.com
-    issuerRef:
-        name: letsencrypt-http
-        kind: ClusterIssuer
-        group: cert-manager.io
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-    name: chuckrpg-api-tls
-    namespace: chuckrpg
-spec:
-    secretName: chuckrpg-api-tls
-    dnsNames:
-        - api.chuckrpg.com
+        - game.chuckrpg.com
     issuerRef:
         name: letsencrypt-http
         kind: ClusterIssuer

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -30,26 +30,14 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
-        - name: https-chuckrpg
+        - name: https-game-chuckrpg
           protocol: HTTPS
           port: 443
-          hostname: chuckrpg.com
+          hostname: game.chuckrpg.com
           tls:
               mode: Terminate
               certificateRefs:
-                  - name: chuckrpg-tls
-                    namespace: chuckrpg
-          allowedRoutes:
-              namespaces:
-                  from: All
-        - name: https-chuckrpg-api
-          protocol: HTTPS
-          port: 443
-          hostname: api.chuckrpg.com
-          tls:
-              mode: Terminate
-              certificateRefs:
-                  - name: chuckrpg-api-tls
+                  - name: game-chuckrpg-tls
                     namespace: chuckrpg
           allowedRoutes:
               namespaces:


### PR DESCRIPTION
## Summary
- Remove `https-chuckrpg` and `https-chuckrpg-api` Gateway listeners (Cloudflare handles TLS)
- Remove Let's Encrypt certs for `chuckrpg.com` and `api.chuckrpg.com`
- Add `game.chuckrpg.com` HTTPS listener + Let's Encrypt cert (grey-clouded, HTTP-01 works)
- Agones will handle UDP game traffic separately

Ref: #8404