### PR TITLE
feat(rows): wire gRPC through OWSService + add WebSocket adapter

### DIFF
--- a/apps/ows/rows/src/grpc.rs
+++ b/apps/ows/rows/src/grpc.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
-use tracing::{error, info};
+use tracing::info;
 use uuid::Uuid;
 
 use crate::convert::to_proto_characters;
-
 use crate::proto::rows::character_persistence_server::{
     CharacterPersistence, CharacterPersistenceServer,
 };
@@ -14,42 +13,47 @@ use crate::proto::rows::instance_management_server::{
 };
 use crate::proto::rows::public_api_server::{PublicApi, PublicApiServer};
 use crate::proto::rows::*;
-use crate::repo::*;
-use crate::state::AppState;
+use crate::service::OWSService;
+
+/// Helper: parse session GUID from string, return gRPC InvalidArgument on failure.
+fn parse_session(s: &str) -> Result<Uuid, Status> {
+    Uuid::parse_str(s).map_err(|_| Status::invalid_argument("Invalid session GUID"))
+}
+
+/// Helper: convert RowsError to tonic::Status.
+fn to_status(e: crate::error::RowsError) -> Status {
+    e.into_tonic()
+}
 
 // ──────────────────────────────────────────────
 // Public API
 // ──────────────────────────────────────────────
 
 pub struct PublicApiService {
-    state: Arc<AppState>,
+    svc: Arc<OWSService>,
 }
 
 #[tonic::async_trait]
 impl PublicApi for PublicApiService {
     async fn login(&self, req: Request<LoginRequest>) -> Result<Response<LoginResponse>, Status> {
         let r = req.get_ref();
-        info!(email = %r.email, "gRPC Login");
-        let repo = UsersRepo(&self.state.db);
-
-        match repo.login(&r.email, &r.password).await {
-            Ok(result) => Ok(Response::new(LoginResponse {
-                success: result.authenticated,
-                user_session_guid: result
-                    .user_session_guid
-                    .map(|u| u.to_string())
-                    .unwrap_or_default(),
-                error: if result.error_message.is_empty() {
-                    None
-                } else {
-                    Some(result.error_message)
-                },
-            })),
-            Err(e) => {
-                error!(error = %e, "gRPC Login failed");
-                Err(e.into_tonic())
-            }
-        }
+        let result = self
+            .svc
+            .login(&r.email, &r.password)
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(LoginResponse {
+            success: result.authenticated,
+            user_session_guid: result
+                .user_session_guid
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            error: if result.error_message.is_empty() {
+                None
+            } else {
+                Some(result.error_message)
+            },
+        }))
     }
 
     async fn register(
@@ -57,8 +61,6 @@ impl PublicApi for PublicApiService {
         req: Request<RegisterRequest>,
     ) -> Result<Response<RegisterResponse>, Status> {
         let r = req.get_ref();
-        info!(email = %r.email, "gRPC Register");
-
         use argon2::{
             Argon2, PasswordHasher,
             password_hash::{SaltString, rand_core::OsRng},
@@ -69,52 +71,27 @@ impl PublicApi for PublicApiService {
             .map_err(|e| Status::internal(format!("Hash error: {e}")))?
             .to_string();
 
-        let repo = UsersRepo(&self.state.db);
-        match repo
-            .register(
-                self.state.config.customer_guid,
-                &r.email,
-                &hash,
-                &r.first_name,
-                &r.last_name,
-            )
+        self.svc
+            .register(&r.email, &hash, &r.first_name, &r.last_name)
             .await
-        {
-            Ok(_) => Ok(Response::new(RegisterResponse {
-                success: true,
-                error: None,
-            })),
-            Err(e) => {
-                error!(error = %e, "gRPC Register failed");
-                Err(e.into_tonic())
-            }
-        }
+            .map_err(to_status)?;
+        Ok(Response::new(RegisterResponse {
+            success: true,
+            error: None,
+        }))
     }
 
     async fn get_characters(
         &self,
         req: Request<GetCharactersRequest>,
     ) -> Result<Response<GetCharactersResponse>, Status> {
-        let r = req.get_ref();
-        let session_guid = Uuid::parse_str(&r.user_session_guid)
-            .map_err(|_| Status::invalid_argument("Invalid session GUID"))?;
-
-        let repo = UsersRepo(&self.state.db);
-        let session = repo
-            .get_session(session_guid)
+        let session_guid = parse_session(&req.get_ref().user_session_guid)?;
+        let guid = self.svc.state().config.customer_guid;
+        let chars = self
+            .svc
+            .get_all_characters(session_guid, guid)
             .await
-            .map_err(|e| e.into_tonic())?
-            .ok_or_else(|| Status::not_found("Session not found"))?;
-
-        let user_guid = session
-            .user_guid
-            .ok_or_else(|| Status::not_found("No user in session"))?;
-
-        let chars = repo
-            .get_all_characters(self.state.config.customer_guid, user_guid)
-            .await
-            .map_err(|e| e.into_tonic())?;
-
+            .map_err(to_status)?;
         Ok(Response::new(GetCharactersResponse {
             characters: to_proto_characters(&chars),
         }))
@@ -125,31 +102,12 @@ impl PublicApi for PublicApiService {
         req: Request<CreateCharacterRequest>,
     ) -> Result<Response<CreateCharacterResponse>, Status> {
         let r = req.get_ref();
-        let session_guid = Uuid::parse_str(&r.user_session_guid)
-            .map_err(|_| Status::invalid_argument("Invalid session GUID"))?;
-
-        let users = UsersRepo(&self.state.db);
-        let session = users
-            .get_session(session_guid)
+        let session_guid = parse_session(&r.user_session_guid)?;
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .create_character(session_guid, guid, &r.character_name, &r.class_name)
             .await
-            .map_err(|e| e.into_tonic())?
-            .ok_or_else(|| Status::not_found("Session not found"))?;
-
-        let user_guid = session
-            .user_guid
-            .ok_or_else(|| Status::not_found("No user in session"))?;
-
-        let chars = CharsRepo(&self.state.db);
-        chars
-            .create_character(
-                self.state.config.customer_guid,
-                user_guid,
-                &r.character_name,
-                &r.class_name,
-            )
-            .await
-            .map_err(|e| e.into_tonic())?;
-
+            .map_err(to_status)?;
         info!(character = %r.character_name, "gRPC CreateCharacter");
         Ok(Response::new(CreateCharacterResponse {
             success: true,
@@ -162,13 +120,11 @@ impl PublicApi for PublicApiService {
         req: Request<RemoveCharacterRequest>,
     ) -> Result<Response<RemoveCharacterResponse>, Status> {
         let r = req.get_ref();
-        let chars = CharsRepo(&self.state.db);
-        chars
-            .remove_character(self.state.config.customer_guid, &r.character_name)
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .remove_character(guid, &r.character_name)
             .await
-            .map_err(|e| e.into_tonic())?;
-
-        info!(character = %r.character_name, "gRPC RemoveCharacter");
+            .map_err(to_status)?;
         Ok(Response::new(RemoveCharacterResponse {
             success: true,
             error: None,
@@ -180,16 +136,12 @@ impl PublicApi for PublicApiService {
         req: Request<GetServerToConnectToRequest>,
     ) -> Result<Response<GetServerToConnectToResponse>, Status> {
         let r = req.get_ref();
-        let repo = InstanceRepo(&self.state.db);
-        let result = repo
-            .join_map_by_char_name(
-                self.state.config.customer_guid,
-                &r.character_name,
-                &r.character_name, // zone_name from zone_id lookup — simplified
-            )
+        let guid = self.svc.state().config.customer_guid;
+        let result = self
+            .svc
+            .get_server_to_connect_to(guid, &r.character_name, &r.character_name)
             .await
-            .map_err(|e| e.into_tonic())?;
-
+            .map_err(to_status)?;
         if !result.success {
             return Ok(Response::new(GetServerToConnectToResponse {
                 server_ip: String::new(),
@@ -197,7 +149,6 @@ impl PublicApi for PublicApiService {
                 error: Some(result.error_message),
             }));
         }
-
         Ok(Response::new(GetServerToConnectToResponse {
             server_ip: result.server_ip,
             port: result.port,
@@ -209,26 +160,13 @@ impl PublicApi for PublicApiService {
         &self,
         req: Request<GetAllCharactersRequest>,
     ) -> Result<Response<GetAllCharactersResponse>, Status> {
-        let r = req.get_ref();
-        let session_guid = Uuid::parse_str(&r.user_session_guid)
-            .map_err(|_| Status::invalid_argument("Invalid session GUID"))?;
-
-        let repo = UsersRepo(&self.state.db);
-        let session = repo
-            .get_session(session_guid)
+        let session_guid = parse_session(&req.get_ref().user_session_guid)?;
+        let guid = self.svc.state().config.customer_guid;
+        let chars = self
+            .svc
+            .get_all_characters(session_guid, guid)
             .await
-            .map_err(|e| e.into_tonic())?
-            .ok_or_else(|| Status::not_found("Session not found"))?;
-
-        let user_guid = session
-            .user_guid
-            .ok_or_else(|| Status::not_found("No user in session"))?;
-
-        let chars = repo
-            .get_all_characters(self.state.config.customer_guid, user_guid)
-            .await
-            .map_err(|e| e.into_tonic())?;
-
+            .map_err(to_status)?;
         Ok(Response::new(GetAllCharactersResponse {
             characters: to_proto_characters(&chars),
         }))
@@ -240,7 +178,7 @@ impl PublicApi for PublicApiService {
 // ──────────────────────────────────────────────
 
 pub struct InstanceManagementService {
-    state: Arc<AppState>,
+    svc: Arc<OWSService>,
 }
 
 #[tonic::async_trait]
@@ -286,15 +224,11 @@ impl InstanceManagement for InstanceManagementService {
         req: Request<SetZoneInstanceStatusRequest>,
     ) -> Result<Response<SetZoneInstanceStatusResponse>, Status> {
         let r = req.get_ref();
-        let repo = InstanceRepo(&self.state.db);
-        repo.set_zone_status(
-            self.state.config.customer_guid,
-            r.zone_instance_id,
-            r.instance_status,
-        )
-        .await
-        .map_err(|e| e.into_tonic())?;
-
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .set_zone_status(guid, r.zone_instance_id, r.instance_status)
+            .await
+            .map_err(to_status)?;
         Ok(Response::new(SetZoneInstanceStatusResponse {
             success: true,
         }))
@@ -322,16 +256,23 @@ impl InstanceManagement for InstanceManagementService {
 // ──────────────────────────────────────────────
 
 pub struct CharacterPersistenceService {
-    state: Arc<AppState>,
+    svc: Arc<OWSService>,
 }
 
 #[tonic::async_trait]
 impl CharacterPersistence for CharacterPersistenceService {
     async fn get_by_name(
         &self,
-        _req: Request<GetCharacterByNameRequest>,
+        req: Request<GetCharacterByNameRequest>,
     ) -> Result<Response<crate::proto::ows::Character>, Status> {
-        Err(Status::unimplemented("GetByName not yet implemented"))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        let ch = self
+            .svc
+            .get_character_by_name(guid, &r.character_name)
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(crate::proto::ows::Character::from(&ch)))
     }
 
     async fn update_position(
@@ -339,28 +280,25 @@ impl CharacterPersistence for CharacterPersistenceService {
         req: Request<UpdatePositionRequest>,
     ) -> Result<Response<UpdatePositionResponse>, Status> {
         let r = req.get_ref();
-        let repo = CharsRepo(&self.state.db);
-        repo.update_position(
-            self.state.config.customer_guid,
-            &r.character_name,
-            r.x,
-            r.y,
-            r.z,
-            r.rx,
-            r.ry,
-            r.rz,
-        )
-        .await
-        .map_err(|e| e.into_tonic())?;
-
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .update_position(guid, &r.character_name, r.x, r.y, r.z, r.rx, r.ry, r.rz)
+            .await
+            .map_err(to_status)?;
         Ok(Response::new(UpdatePositionResponse { success: true }))
     }
 
     async fn update_stats(
         &self,
-        _req: Request<UpdateStatsRequest>,
+        req: Request<UpdateStatsRequest>,
     ) -> Result<Response<UpdateStatsResponse>, Status> {
-        Err(Status::unimplemented("UpdateStats not yet implemented"))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .update_stats(guid, &r.character_name, &r.update_stats_json)
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(UpdateStatsResponse { success: true }))
     }
 
     async fn player_logout(
@@ -368,30 +306,51 @@ impl CharacterPersistence for CharacterPersistenceService {
         req: Request<PlayerLogoutRequest>,
     ) -> Result<Response<PlayerLogoutResponse>, Status> {
         let r = req.get_ref();
-        let session_guid = Uuid::parse_str(&r.user_session_guid)
-            .map_err(|_| Status::invalid_argument("Invalid session GUID"))?;
-
-        let repo = UsersRepo(&self.state.db);
-        repo.logout(session_guid)
+        let session_guid = parse_session(&r.user_session_guid)?;
+        self.svc.logout(session_guid).await.map_err(to_status)?;
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .player_logout(guid, &r.character_name)
             .await
-            .map_err(|e| e.into_tonic())?;
-
+            .map_err(to_status)?;
         info!(character = %r.character_name, "gRPC PlayerLogout");
         Ok(Response::new(PlayerLogoutResponse { success: true }))
     }
 
     async fn join_map(
         &self,
-        _req: Request<JoinMapRequest>,
+        req: Request<JoinMapRequest>,
     ) -> Result<Response<JoinMapResponse>, Status> {
-        Err(Status::unimplemented("JoinMap not yet implemented"))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        let result = self
+            .svc
+            .get_server_to_connect_to(guid, &r.character_name, &r.zone_name)
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(JoinMapResponse {
+            success: result.success,
+            server_ip: result.server_ip,
+            port: result.port,
+            error: if result.error_message.is_empty() {
+                None
+            } else {
+                Some(result.error_message)
+            },
+        }))
     }
 
     async fn leave_map(
         &self,
-        _req: Request<LeaveMapRequest>,
+        req: Request<LeaveMapRequest>,
     ) -> Result<Response<LeaveMapResponse>, Status> {
-        Err(Status::unimplemented("LeaveMap not yet implemented"))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .player_logout(guid, &r.character_name)
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(LeaveMapResponse { success: true }))
     }
 }
 
@@ -400,7 +359,7 @@ impl CharacterPersistence for CharacterPersistenceService {
 // ──────────────────────────────────────────────
 
 pub struct GlobalDataServiceImpl {
-    state: Arc<AppState>,
+    svc: Arc<OWSService>,
 }
 
 #[tonic::async_trait]
@@ -410,13 +369,12 @@ impl GlobalDataService for GlobalDataServiceImpl {
         req: Request<GetGlobalDataRequest>,
     ) -> Result<Response<GetGlobalDataResponse>, Status> {
         let r = req.get_ref();
-        let repo = GlobalDataRepo(&self.state.db);
-
-        let data = repo
-            .get(self.state.config.customer_guid, &r.global_data_key)
+        let guid = self.svc.state().config.customer_guid;
+        let data = self
+            .svc
+            .get_global_data(guid, &r.global_data_key)
             .await
-            .map_err(|e| e.into_tonic())?;
-
+            .map_err(to_status)?;
         Ok(Response::new(GetGlobalDataResponse {
             global_data_value: data.and_then(|d| d.global_data_value),
         }))
@@ -427,40 +385,26 @@ impl GlobalDataService for GlobalDataServiceImpl {
         req: Request<SetGlobalDataRequest>,
     ) -> Result<Response<SetGlobalDataResponse>, Status> {
         let r = req.get_ref();
-        let repo = GlobalDataRepo(&self.state.db);
-
-        repo.set(
-            self.state.config.customer_guid,
-            &r.global_data_key,
-            &r.global_data_value,
-        )
-        .await
-        .map_err(|e| e.into_tonic())?;
-
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .set_global_data(guid, &r.global_data_key, &r.global_data_value)
+            .await
+            .map_err(to_status)?;
         Ok(Response::new(SetGlobalDataResponse { success: true }))
     }
 }
 
 // ──────────────────────────────────────────────
-// Router — combines all gRPC services with shared state
+// Router
 // ──────────────────────────────────────────────
 
-pub fn router(
-    state: Arc<AppState>,
-    _svc: Arc<crate::service::OWSService>,
-) -> tonic::service::Routes {
-    tonic::service::Routes::new(PublicApiServer::new(PublicApiService {
-        state: state.clone(),
-    }))
-    .add_service(InstanceManagementServer::new(InstanceManagementService {
-        state: state.clone(),
-    }))
-    .add_service(CharacterPersistenceServer::new(
-        CharacterPersistenceService {
-            state: state.clone(),
-        },
-    ))
-    .add_service(GlobalDataServiceServer::new(GlobalDataServiceImpl {
-        state,
-    }))
+pub fn router(svc: Arc<OWSService>) -> tonic::service::Routes {
+    tonic::service::Routes::new(PublicApiServer::new(PublicApiService { svc: svc.clone() }))
+        .add_service(InstanceManagementServer::new(InstanceManagementService {
+            svc: svc.clone(),
+        }))
+        .add_service(CharacterPersistenceServer::new(
+            CharacterPersistenceService { svc: svc.clone() },
+        ))
+        .add_service(GlobalDataServiceServer::new(GlobalDataServiceImpl { svc }))
 }

--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -11,6 +11,7 @@ mod rest;
 pub mod service;
 mod state;
 mod trace;
+mod ws;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -86,14 +87,18 @@ async fn main() -> anyhow::Result<()> {
     // Transport-agnostic service layer — shared across REST, gRPC, WebSocket
     let svc = Arc::new(service::OWSService::new(app_state.clone()));
 
-    // gRPC services (tonic)
-    let grpc_router = grpc::router(app_state.clone(), svc.clone());
+    // gRPC services (tonic) — uses OWSService only
+    let grpc_router = grpc::router(svc.clone());
 
     // REST routes (axum) — backward-compat with C# OWS API paths
-    let rest_router = rest::router(app_state, svc);
+    let rest_router = rest::router(app_state, svc.clone());
 
-    // Multiplex: gRPC (content-type: application/grpc) + REST on single port
+    // WebSocket routes
+    let ws_router = ws::router(svc);
+
+    // Multiplex: gRPC + REST + WebSocket on single port
     let app = rest_router
+        .merge(ws_router)
         .merge(grpc_router.into_axum_router())
         .layer(axum::middleware::from_fn(trace::request_trace));
 

--- a/apps/ows/rows/src/ws.rs
+++ b/apps/ows/rows/src/ws.rs
@@ -1,0 +1,225 @@
+use axum::{
+    Router,
+    extract::{
+        State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    response::Response,
+    routing::get,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::service::OWSService;
+
+/// WebSocket adapter — third transport alongside REST and gRPC.
+/// Clients send JSON-RPC-style messages, server responds with JSON.
+///
+/// Protocol:
+/// ```json
+/// { "method": "login", "id": 1, "params": { "email": "...", "password": "..." } }
+/// → { "id": 1, "result": { "authenticated": true, ... } }
+/// → { "id": 1, "error": { "code": "NOT_FOUND", "message": "..." } }
+/// ```
+
+pub fn router(svc: Arc<OWSService>) -> Router {
+    Router::new().route("/ws", get(ws_upgrade)).with_state(svc)
+}
+
+async fn ws_upgrade(State(svc): State<Arc<OWSService>>, ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(move |socket| handle_ws(socket, svc))
+}
+
+#[derive(Deserialize)]
+struct WsRequest {
+    method: String,
+    id: Option<u64>,
+    #[serde(default)]
+    params: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct WsResponse {
+    id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<WsError>,
+}
+
+#[derive(Serialize)]
+struct WsError {
+    code: String,
+    message: String,
+}
+
+impl WsResponse {
+    fn ok(id: Option<u64>, result: impl Serialize) -> Self {
+        Self {
+            id,
+            result: serde_json::to_value(result).ok(),
+            error: None,
+        }
+    }
+
+    fn err(id: Option<u64>, code: &str, message: impl Into<String>) -> Self {
+        Self {
+            id,
+            result: None,
+            error: Some(WsError {
+                code: code.to_string(),
+                message: message.into(),
+            }),
+        }
+    }
+}
+
+async fn handle_ws(mut socket: WebSocket, svc: Arc<OWSService>) {
+    info!("WebSocket client connected");
+
+    while let Some(msg) = socket.recv().await {
+        let msg = match msg {
+            Ok(Message::Text(text)) => text,
+            Ok(Message::Close(_)) => break,
+            Ok(_) => continue, // ignore binary/ping/pong
+            Err(e) => {
+                warn!(error = %e, "WebSocket receive error");
+                break;
+            }
+        };
+
+        let req: WsRequest = match serde_json::from_str(&msg) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = WsResponse::err(None, "PARSE_ERROR", format!("Invalid JSON: {e}"));
+                let _ = socket
+                    .send(Message::Text(serde_json::to_string(&resp).unwrap().into()))
+                    .await;
+                continue;
+            }
+        };
+
+        let resp = dispatch(&svc, &req).await;
+        let json = serde_json::to_string(&resp).unwrap();
+        if socket.send(Message::Text(json.into())).await.is_err() {
+            break;
+        }
+    }
+
+    info!("WebSocket client disconnected");
+}
+
+async fn dispatch(svc: &OWSService, req: &WsRequest) -> WsResponse {
+    let id = req.id;
+    let guid = svc.state().config.customer_guid;
+
+    match req.method.as_str() {
+        "login" => {
+            let email = req
+                .params
+                .get("email")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let password = req
+                .params
+                .get("password")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match svc.login(email, password).await {
+                Ok(result) => WsResponse::ok(id, result),
+                Err(e) => WsResponse::err(id, e.code(), e.to_string()),
+            }
+        }
+
+        "get_session" => {
+            let session_str = req
+                .params
+                .get("session_guid")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let session_guid = match Uuid::parse_str(session_str) {
+                Ok(g) => g,
+                Err(_) => return WsResponse::err(id, "BAD_REQUEST", "Invalid session_guid"),
+            };
+            match svc.get_session(session_guid).await {
+                Ok(session) => WsResponse::ok(id, session),
+                Err(e) => WsResponse::err(id, e.code(), e.to_string()),
+            }
+        }
+
+        "get_all_characters" => {
+            let session_str = req
+                .params
+                .get("session_guid")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let session_guid = match Uuid::parse_str(session_str) {
+                Ok(g) => g,
+                Err(_) => return WsResponse::err(id, "BAD_REQUEST", "Invalid session_guid"),
+            };
+            match svc.get_all_characters(session_guid, guid).await {
+                Ok(chars) => WsResponse::ok(id, chars),
+                Err(e) => WsResponse::err(id, e.code(), e.to_string()),
+            }
+        }
+
+        "get_character" => {
+            let name = req
+                .params
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match svc.get_character_by_name(guid, name).await {
+                Ok(ch) => WsResponse::ok(id, ch),
+                Err(e) => WsResponse::err(id, e.code(), e.to_string()),
+            }
+        }
+
+        "update_position" => {
+            let name = req
+                .params
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let x = req.params.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let y = req.params.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let z = req.params.get("z").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let rx = req.params.get("rx").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let ry = req.params.get("ry").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let rz = req.params.get("rz").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            match svc.update_position(guid, name, x, y, z, rx, ry, rz).await {
+                Ok(()) => WsResponse::ok(id, serde_json::json!({"success": true})),
+                Err(e) => WsResponse::err(id, e.code(), e.to_string()),
+            }
+        }
+
+        "get_global_data" => {
+            let key = req.params.get("key").and_then(|v| v.as_str()).unwrap_or("");
+            match svc.get_global_data(guid, key).await {
+                Ok(data) => WsResponse::ok(id, data),
+                Err(e) => WsResponse::err(id, e.code(), e.to_string()),
+            }
+        }
+
+        "set_global_data" => {
+            let key = req.params.get("key").and_then(|v| v.as_str()).unwrap_or("");
+            let value = req
+                .params
+                .get("value")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match svc.set_global_data(guid, key, value).await {
+                Ok(()) => WsResponse::ok(id, serde_json::json!({"success": true})),
+                Err(e) => WsResponse::err(id, e.code(), e.to_string()),
+            }
+        }
+
+        _ => WsResponse::err(
+            id,
+            "METHOD_NOT_FOUND",
+            format!("Unknown method: {}", req.method),
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

All three transports now share one service layer — zero code duplication.

### gRPC → OWSService migration
- All 4 gRPC services use `Arc<OWSService>` (removed `Arc<AppState>`)
- Removed `use crate::repo::*` from grpc.rs
- `grpc::router()` takes `Arc<OWSService>` only
- Previously stubbed methods now wired: get_by_name, update_stats, join_map, leave_map

### WebSocket adapter (`ws.rs`)
- JSON-RPC-style protocol on `/ws` endpoint
- 7 methods: login, get_session, get_all_characters, get_character, update_position, get/set_global_data
- Uses same `Arc<OWSService>` — identical business logic as REST/gRPC

### Architecture
```
HTTP  (axum)  ──┐
gRPC  (tonic) ──┤──→ OWSService ──→ Repos ──→ DB
WebSocket     ──┘       ↕
                   DashMap cache
```

## Test plan

- [x] `cargo check -p rows` passes (0 errors)