### PR TITLE
feat(rows): production hardening — graceful shutdown, deep health, CORS, body limits

### DIFF
--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -15,6 +15,9 @@ mod ws;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
+use tower_http::cors::CorsLayer;
+use tower_http::limit::RequestBodyLimitLayer;
 use tracing::info;
 use uuid::Uuid;
 
@@ -57,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
         .parse()?;
     let addr: SocketAddr = format!("{host}:{port}").parse()?;
 
-    // Database
+    // Database with retry
     let pool = db::connect(&database_url).await?;
     info!("Database connected");
 
@@ -75,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
         "Agones initialization complete"
     );
 
-    // Build shared state — single Arc allocation
+    // Build shared state
     let app_state = state::AppState::builder()
         .db(pool)
         .customer_guid(Uuid::parse_str(&api_key)?)
@@ -84,13 +87,13 @@ async fn main() -> anyhow::Result<()> {
         .agones(agones_client)
         .build()?;
 
-    // Transport-agnostic service layer — shared across REST, gRPC, WebSocket
+    // Transport-agnostic service layer
     let svc = Arc::new(service::OWSService::new(app_state.clone()));
 
-    // gRPC services (tonic) — uses OWSService only
+    // gRPC services
     let grpc_router = grpc::router(svc.clone());
 
-    // REST routes (axum) — backward-compat with C# OWS API paths
+    // REST routes (backward-compat)
     let rest_router = rest::router(app_state, svc.clone());
 
     // WebSocket routes
@@ -100,12 +103,42 @@ async fn main() -> anyhow::Result<()> {
     let app = rest_router
         .merge(ws_router)
         .merge(grpc_router.into_axum_router())
-        .layer(axum::middleware::from_fn(trace::request_trace));
+        .layer(axum::middleware::from_fn(trace::request_trace))
+        .layer(RequestBodyLimitLayer::new(10 * 1024 * 1024)) // 10MB max body
+        .layer(CorsLayer::permissive());
 
-    info!("ROWS listening on {addr} (REST + gRPC multiplexed)");
+    info!("ROWS listening on {addr} (REST + gRPC + WS multiplexed)");
 
+    // Graceful shutdown: drain in-flight requests on SIGTERM/SIGINT
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
 
+    info!("ROWS shutdown complete");
     Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => info!("Received Ctrl+C, shutting down..."),
+        _ = terminate => info!("Received SIGTERM, shutting down..."),
+    }
 }

--- a/apps/ows/rows/src/rest.rs
+++ b/apps/ows/rows/src/rest.rs
@@ -8,6 +8,7 @@ use axum::{
     extract::{Path, State},
     http::HeaderMap,
     middleware,
+    response::IntoResponse,
     routing::{get, post},
 };
 use serde::Deserialize;
@@ -32,6 +33,7 @@ pub fn router(app: Arc<AppState>, svc: Arc<OWSService>) -> Router {
 
     Router::new()
         .route("/health", get(health))
+        .route("/ready", get(readiness).with_state(hs.clone()))
         .merge(public)
         .merge(instance)
         .merge(character)
@@ -45,6 +47,28 @@ async fn health() -> Json<HealthResponse> {
         status: "healthy",
         service: "rows",
     })
+}
+
+/// Deep readiness check — probes DB pool. Returns 503 if database is unavailable.
+async fn readiness(State(hs): State<HandlerState>) -> axum::response::Response {
+    let db_ok = sqlx::query("SELECT 1").execute(&hs.app.db).await.is_ok();
+
+    let status = if db_ok { "ready" } else { "degraded" };
+    let http_status = if db_ok {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    let body = serde_json::json!({
+        "status": status,
+        "service": "rows",
+        "database": db_ok,
+        "sessions_cached": hs.app.sessions.len(),
+        "zones_tracked": hs.app.zone_servers.len(),
+    });
+
+    (http_status, Json(body)).into_response()
 }
 
 // ─── Public API ──────────────────────────────────────────────
@@ -349,14 +373,65 @@ async fn get_zone_instances(
     Ok(Json(zones))
 }
 
-async fn register_launcher() -> Json<SuccessResponse> {
-    // TODO: persist launcher registration
-    Json(SuccessResponse::ok())
+#[derive(Deserialize)]
+struct RegisterLauncherWrapper {
+    #[serde(rename = "Request")]
+    request: RegisterLauncherPayload,
 }
 
-async fn start_instance_launcher() -> String {
-    // TODO: return world server ID
-    "-1".to_string()
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct RegisterLauncherPayload {
+    #[serde(rename = "launcherGUID")]
+    launcher_guid: String,
+    server_ip: String,
+    max_number_of_instances: i32,
+    internal_server_ip: String,
+    starting_instance_port: i32,
+}
+
+async fn register_launcher(
+    State(hs): State<HandlerState>,
+    headers: HeaderMap,
+    Json(body): Json<RegisterLauncherWrapper>,
+) -> Json<SuccessResponse> {
+    let customer_guid = extract_customer_guid(&headers);
+    let r = &body.request;
+    let repo = crate::repo::InstanceRepo(&hs.app.db);
+    match repo
+        .register_launcher(
+            customer_guid,
+            &r.launcher_guid,
+            &r.server_ip,
+            r.max_number_of_instances,
+            &r.internal_server_ip,
+            r.starting_instance_port,
+        )
+        .await
+    {
+        Ok(id) => {
+            tracing::info!(world_server_id = id, "Launcher registered");
+            Json(SuccessResponse::ok())
+        }
+        Err(e) => Json(SuccessResponse::err(e.to_string())),
+    }
+}
+
+async fn start_instance_launcher(State(hs): State<HandlerState>, headers: HeaderMap) -> String {
+    let customer_guid = extract_customer_guid(&headers);
+    let launcher_guid = headers
+        .get("x-launcherguid")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    let repo = crate::repo::InstanceRepo(&hs.app.db);
+    match repo
+        .register_launcher(customer_guid, launcher_guid, "", 10, "", 7778)
+        .await
+    {
+        Ok(id) => id.to_string(),
+        Err(_) => "-1".to_string(),
+    }
 }
 
 // ─── Character Persistence ───────────────────────────────────


### PR DESCRIPTION
## Summary

Production-readiness improvements to make ROWS a proper OWS replacement.

### Graceful shutdown
- SIGTERM + SIGINT handlers via `tokio::signal`
- `axum::serve().with_graceful_shutdown()` — drains in-flight requests before exit

### Deep health check
- `/health` — fast liveness probe (static, no I/O)
- `/ready` — k8s readiness probe with live `SELECT 1` against DB pool
  - Returns `503 SERVICE_UNAVAILABLE` if database unreachable
  - Includes `sessions_cached` + `zones_tracked` counts for observability

### Middleware
- `RequestBodyLimitLayer` — 10MB max body (prevents upload DoS)
- `CorsLayer::permissive()` — enables cross-origin for web/UE5 clients

### Stub completions
- `register_launcher` — parses full `RegisterLauncherRequest`, persists via `InstanceRepo`
- `start_instance_launcher` — reads `X-LauncherGUID` header, creates world server record

## Test plan

- [x] `cargo check -p rows` passes (0 errors)