### PR TITLE
feat(rows): CI manifest + full project.json targets

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -17,7 +17,7 @@
 		{
 			"key": "chuckrpg",
 			"app_name": "axum-chuckrpg",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"version_toml": "apps/chuckrpg/axum-chuckrpg/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx",
 			"version_target": "apps/chuckrpg/axum-chuckrpg/Cargo.toml",
@@ -139,7 +139,7 @@
 		{
 			"key": "ows_characterpersistence",
 			"app_name": "ows-characterpersistence",
-			"version": "0.10.4",
+			"version": "0.10.6",
 			"version_toml": "apps/ows/ows-character-persistence/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-characterpersistence.mdx",
 			"version_target": "apps/ows/ows-character-persistence/OWSCharacterPersistence.csproj",
@@ -154,7 +154,7 @@
 		{
 			"key": "ows_globaldata",
 			"app_name": "ows-globaldata",
-			"version": "0.10.4",
+			"version": "0.10.6",
 			"version_toml": "apps/ows/ows-global-data/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-globaldata.mdx",
 			"version_target": "apps/ows/ows-global-data/OWSGlobalData.csproj",
@@ -169,7 +169,7 @@
 		{
 			"key": "ows_instancelauncher",
 			"app_name": "ows-instancelauncher",
-			"version": "0.10.4",
+			"version": "0.10.8",
 			"version_toml": "apps/ows/ows-instance-launcher/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-instancelauncher.mdx",
 			"version_target": "apps/ows/ows-instance-launcher/OWSInstanceLauncher.csproj",
@@ -184,7 +184,7 @@
 		{
 			"key": "ows_instancemanagement",
 			"app_name": "ows-instancemanagement",
-			"version": "0.10.4",
+			"version": "0.10.6",
 			"version_toml": "apps/ows/ows-instance-management/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-instancemanagement.mdx",
 			"version_target": "apps/ows/ows-instance-management/OWSInstanceManagement.csproj",
@@ -199,7 +199,7 @@
 		{
 			"key": "ows_management",
 			"app_name": "ows-management",
-			"version": "0.10.4",
+			"version": "0.10.6",
 			"version_toml": "apps/ows/ows-management/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-management.mdx",
 			"version_target": "apps/ows/ows-management/OWSManagement.csproj",
@@ -214,7 +214,7 @@
 		{
 			"key": "ows_publicapi",
 			"app_name": "ows-publicapi",
-			"version": "0.10.4",
+			"version": "0.10.6",
 			"version_toml": "apps/ows/ows-public-api/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/ows-publicapi.mdx",
 			"version_target": "apps/ows/ows-public-api/OWSPublicAPI.csproj",
@@ -225,6 +225,19 @@
 			"has_test": false,
 			"target": "container-publicapi",
 			"nx_project": "ows"
+		},
+		{
+			"key": "rows",
+			"app_name": "rows",
+			"version": "0.1.0",
+			"version_toml": "apps/ows/rows/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rows.mdx",
+			"version_target": "apps/ows/rows/Cargo.toml",
+			"source_path": "apps/ows/rows",
+			"runner": "ubuntu-latest",
+			"image": "kbve/rows",
+			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
+			"has_test": false
 		}
 	],
 	"npm": [
@@ -354,11 +367,11 @@
 		}
 	],
 	"summary": {
-		"docker": 16,
+		"docker": 17,
 		"npm": 4,
 		"crates": 6,
 		"python": 2,
 		"unreal": 6,
-		"total": 34
+		"total": 35
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
@@ -22,7 +22,7 @@ deployment_yaml: apps/kube/ows/manifest/deployment.yaml
 has_test: false
 author: h0lybyte
 license: KBVE
-status: alpha
+status: beta
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/apps/ows/rows/project.json
+++ b/apps/ows/rows/project.json
@@ -5,19 +5,99 @@
 	"sourceRoot": "apps/ows/rows/src",
 	"targets": {
 		"build": {
-			"executor": "nx:run-commands",
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
 			"options": {
-				"commands": ["cargo build --release -p rows"],
-				"cwd": "{workspaceRoot}"
+				"target-dir": "dist/target/rows"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/rows"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/rows"
+			}
+		},
+		"run": {
+			"executor": "@monodon/rust:run",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/rows"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
 			}
 		},
 		"container": {
 			"executor": "nx:run-commands",
+			"dependsOn": [],
+			"defaultConfiguration": "local",
 			"options": {
-				"commands": [
-					"docker buildx build --platform linux/amd64 -f apps/ows/rows/Dockerfile -t kbve/rows:latest --load ."
-				],
-				"cwd": "{workspaceRoot}"
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx rows:containerx",
+						"VERSION=$(grep '^version' apps/ows/rows/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/rows:latest kbve/rows:$VERSION && echo \"Tagged kbve/rows:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx rows:containerx --configuration=production",
+						"VERSION=$(grep '^version' apps/ows/rows/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/rows:latest kbve/rows:$VERSION && docker tag kbve/rows:latest ghcr.io/kbve/rows:latest && docker tag kbve/rows:latest ghcr.io/kbve/rows:$VERSION && echo \"Tagged kbve/rows:$VERSION and ghcr.io/kbve/rows:$VERSION\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/ows/rows/Dockerfile",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/rows:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"metadata": {
+						"images": ["ghcr.io/kbve/rows", "kbve/rows"],
+						"tags": ["latest"]
+					},
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/rows:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/rows:buildcache,mode=max"
+					]
+				}
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
- Regenerate `ci-dispatch-manifest.json` — ROWS now included (17 tracked Docker items)
- Fix `rows.mdx` status: `alpha` → `beta` (schema only allows active/beta/deprecated/archived)
- Upgrade `project.json` to match other Rust projects:
  - `@monodon/rust` executors for build/test/lint/run
  - `container` + `containerx` with local/production configs
  - GHCR buildx cache-from/cache-to
  - Auto version tagging from Cargo.toml

Ref: #8404