### PR TITLE
feat(rows): add k8s deployment to ows namespace

### DIFF
--- a/apps/kube/ows/manifest/externalsecret.yaml
+++ b/apps/kube/ows/manifest/externalsecret.yaml
@@ -77,6 +77,13 @@ spec:
     target:
         name: ows-rabbitmq-credentials
         creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                username: '{{ .username }}'
+                password: '{{ .password }}'
+                host: '{{ .host }}'
+                amqp-url: 'amqp://{{ .username }}:{{ .password }}@{{ .host }}:5672'
     data:
         - secretKey: username
           remoteRef:

--- a/apps/kube/ows/manifest/rows-deployment.yaml
+++ b/apps/kube/ows/manifest/rows-deployment.yaml
@@ -1,0 +1,109 @@
+---
+# ROWS — Rust OWS single-binary game backend (REST + gRPC)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: rows
+    namespace: ows
+    labels:
+        app: rows
+        app.kubernetes.io/part-of: ows
+spec:
+    replicas: 1
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
+    selector:
+        matchLabels:
+            app: rows
+    template:
+        metadata:
+            labels:
+                app: rows
+                app.kubernetes.io/part-of: ows
+        spec:
+            serviceAccountName: ows-external-secrets
+            containers:
+                - name: rows
+                  image: ghcr.io/kbve/rows:0.1.0
+                  imagePullPolicy: Always
+                  env:
+                      - name: HTTP_HOST
+                        value: '0.0.0.0'
+                      - name: HTTP_PORT
+                        value: '4322'
+                      - name: RUST_LOG
+                        value: 'info'
+                      - name: DATABASE_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-db-credentials
+                                key: db-connection-string
+                      - name: RABBITMQ_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-rabbitmq-credentials
+                                key: amqp-url
+                      - name: OWS_API_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: ows-customer-guid
+                                key: customer-guid
+                      - name: AGONES_NAMESPACE
+                        value: 'ows'
+                      - name: AGONES_FLEET
+                        value: 'ows-hubworld'
+                  ports:
+                      - name: http
+                        containerPort: 4322
+                        protocol: TCP
+                      - name: grpc
+                        containerPort: 50051
+                        protocol: TCP
+                  resources:
+                      requests:
+                          memory: '128Mi'
+                          cpu: '100m'
+                      limits:
+                          memory: '512Mi'
+                          cpu: '500m'
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: http
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                      timeoutSeconds: 3
+                      failureThreshold: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /ready
+                          port: http
+                      initialDelaySeconds: 3
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: rows
+    namespace: ows
+    labels:
+        app: rows
+        app.kubernetes.io/part-of: ows
+spec:
+    type: ClusterIP
+    selector:
+        app: rows
+    ports:
+        - name: http
+          port: 4322
+          targetPort: 4322
+          protocol: TCP
+        - name: grpc
+          port: 50051
+          targetPort: 50051
+          protocol: TCP


### PR DESCRIPTION
## Summary
- Add ROWS deployment + service to `apps/kube/ows/manifest/`
- REST on port 4322, gRPC on port 50051
- Shares ows namespace secrets: DB, RabbitMQ, customer GUID
- Add `amqp-url` template to RabbitMQ ExternalSecret (ROWS needs single connection string)
- Agones fleet config via env vars
- Image: `ghcr.io/kbve/rows:0.1.0` (will update once first publish completes)

## Note
ROWS runs alongside the .NET OWS services. Traffic routing to ROWS will be configured separately via HTTPRoute once validated.

Ref: #8404