### PR TITLE
fix(chuckrpg): fix Dockerfile layer order — Astro output was overwritten (#8986)

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -107,9 +107,11 @@ RUN printf '[workspace]\nmembers = ["apps/chuckrpg/axum-chuckrpg"]\nresolver = "
 
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
-COPY --from=astro-precompressor /static /app/apps/chuckrpg/axum-chuckrpg/templates/dist
-
+# Copy source first, then overlay Astro output (source has empty templates/dist)
 COPY apps/chuckrpg/axum-chuckrpg apps/chuckrpg/axum-chuckrpg
+
+# Overlay precompressed Astro output AFTER source copy
+COPY --from=astro-precompressor /static /app/apps/chuckrpg/axum-chuckrpg/templates/dist
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
## Summary
`GET /` returned 404 because `templates/dist` was empty in the Docker image.

**Root cause**: Dockerfile line 110 copied precompressed Astro output into `templates/dist`, but line 112 then copied the entire source directory (with an empty `templates/dist`) which overwrote it.

**Fix**: Swap the order — copy source first, then overlay Astro output.

Closes #8986

## Test plan
- [ ] Docker build produces non-empty `templates/dist`
- [ ] `GET /` returns 200 with HTML containing "ChuckRPG"
- [ ] E2E tests pass (health + root + 404)