### PR TITLE
fix(chuckrpg): add content.config.ts + pin Node 22 (#8986)

### DIFF
--- a/apps/chuckrpg/astro-chuckrpg/src/content.config.ts
+++ b/apps/chuckrpg/astro-chuckrpg/src/content.config.ts
@@ -1,0 +1,10 @@
+import { defineCollection } from 'astro:content';
+import { docsSchema } from '@astrojs/starlight/schema';
+import { docsLoader } from '@astrojs/starlight/loaders';
+
+export const collections = {
+	docs: defineCollection({
+		loader: docsLoader(),
+		schema: docsSchema(),
+	}),
+};


### PR DESCRIPTION
## Summary
Two fixes for chuckrpg.com returning 404:

1. **Missing `content.config.ts`** — Starlight needs this to register the docs collection. Without it, zero pages built (only 404.html).
2. **Pin Dockerfile to Node 22** — Astro `astro:` protocol imports break on Node 24.

Verified locally: 4 pages built, all e2e tests pass (4/4).

Closes #8986