### PR TITLE
feat(rows): bump to 0.1.1, fix deployment path, regen manifest

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -229,14 +229,14 @@
 		{
 			"key": "rows",
 			"app_name": "rows",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "apps/ows/rows/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rows.mdx",
 			"version_target": "apps/ows/rows/Cargo.toml",
 			"source_path": "apps/ows/rows",
 			"runner": "ubuntu-latest",
 			"image": "kbve/rows",
-			"deployment_yaml": "apps/kube/ows/manifest/deployment.yaml",
+			"deployment_yaml": "apps/kube/ows/manifest/rows-deployment.yaml",
 			"has_test": false
 		}
 	],

--- a/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
@@ -12,13 +12,13 @@ tags:
 key: rows
 pipeline: docker
 app_name: rows
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/ows/rows
 version_toml: apps/ows/rows/version.toml
 version_target: apps/ows/rows/Cargo.toml
 runner: ubuntu-latest
 image: kbve/rows
-deployment_yaml: apps/kube/ows/manifest/deployment.yaml
+deployment_yaml: apps/kube/ows/manifest/rows-deployment.yaml
 has_test: false
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
## Summary
- Bump ROWS version 0.1.0 → 0.1.1 to trigger first CI Docker publish
- Fix `deployment_yaml` to `rows-deployment.yaml` (was pointing to shared .NET deployment)
- Regenerate `ci-dispatch-manifest.json` with correct ROWS entry

## Pipeline flow
1. MDX bump triggers `ci-docker.yml` for `rows`
2. Builds `ghcr.io/kbve/rows:0.1.1`
3. `utils-update-kube-manifest.yml` updates `rows-deployment.yaml` image tag
4. Auto-merge bot merges the kube manifest PR

Ref: #8404