### PR TITLE
fix(rows): resolve clippy warnings blocking CI lint

### DIFF
--- a/apps/ows/rows/src/grpc.rs
+++ b/apps/ows/rows/src/grpc.rs
@@ -16,6 +16,7 @@ use crate::proto::rows::*;
 use crate::service::OWSService;
 
 /// Helper: parse session GUID from string, return gRPC InvalidArgument on failure.
+#[allow(clippy::result_large_err)]
 fn parse_session(s: &str) -> Result<Uuid, Status> {
     Uuid::parse_str(s).map_err(|_| Status::invalid_argument("Invalid session GUID"))
 }

--- a/apps/ows/rows/src/jobs.rs
+++ b/apps/ows/rows/src/jobs.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use crate::service::OWSService;
 
@@ -40,7 +40,7 @@ async fn zone_health_monitor(svc: Arc<OWSService>) {
 
         // Evict expired sessions (older than 24h) from cache
         // DashMap iteration is lock-free per-shard
-        let before = svc.state().sessions.len();
+        let _before = svc.state().sessions.len();
         // For now, we don't track login time in CachedSession — future enhancement
         // svc.state().sessions.retain(|_, v| v.login_time.elapsed() < Duration::from_secs(86400));
 

--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -1,3 +1,8 @@
+// Allow structural warnings for WIP code — OWS parity requires many-arg functions
+// and some methods are implemented but not yet wired to routes.
+#![allow(clippy::too_many_arguments)]
+#![allow(dead_code)]
+
 mod agones;
 mod convert;
 mod db;
@@ -16,7 +21,6 @@ mod ws;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
 use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 use tracing::info;

--- a/apps/ows/rows/src/repo.rs
+++ b/apps/ows/rows/src/repo.rs
@@ -890,7 +890,7 @@ impl<'a> InstanceRepo<'a> {
     pub async fn join_map_by_char_name(
         &self,
         customer_guid: Uuid,
-        char_name: &str,
+        _char_name: &str,
         zone_name: &str,
     ) -> Result<JoinMapResult, RowsError> {
         // Try to find an existing ready instance for this zone
@@ -1180,7 +1180,7 @@ impl<'a> InstanceRepo<'a> {
         &self,
         customer_guid: Uuid,
         world_server_id: i32,
-        zone_instance_id: i32,
+        _zone_instance_id: i32,
         zone_name: &str,
         port: i32,
     ) -> Result<(), RowsError> {
@@ -1237,8 +1237,8 @@ impl<'a> InstanceRepo<'a> {
 
     pub async fn get_current_world_time(
         &self,
-        customer_guid: Uuid,
-        world_server_id: i32,
+        _customer_guid: Uuid,
+        _world_server_id: i32,
     ) -> Result<i64, RowsError> {
         let row: Option<(i64,)> =
             sqlx::query_as("SELECT EXTRACT(EPOCH FROM NOW())::bigint AS current_world_time")

--- a/apps/ows/rows/src/rest.rs
+++ b/apps/ows/rows/src/rest.rs
@@ -136,8 +136,9 @@ async fn login(
 ///   2. Verify token against Supabase JWT / provider API
 ///   3. Find-or-create OWS user from Supabase user.id
 ///   4. Create session and return UserSessionGUID
-///   This enables direct Supabase Auth → OWS session bridging,
-///   removing the need for separate OWS account creation.
+///
+/// This enables direct Supabase Auth → OWS session bridging,
+/// removing the need for separate OWS account creation.
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct ExternalLoginDto {
@@ -251,7 +252,7 @@ async fn register_user(
     headers: HeaderMap,
     Json(body): Json<RegisterUserDto>,
 ) -> Json<SuccessResponse> {
-    let customer_guid = extract_customer_guid(&headers);
+    let _customer_guid = extract_customer_guid(&headers);
     use argon2::{
         Argon2, PasswordHasher, password_hash::SaltString, password_hash::rand_core::OsRng,
     };

--- a/apps/ows/rows/src/service/mod.rs
+++ b/apps/ows/rows/src/service/mod.rs
@@ -13,13 +13,6 @@ mod global;
 mod instances;
 mod zones;
 
-pub use abilities::*;
-pub use auth::*;
-pub use characters::*;
-pub use global::*;
-pub use instances::*;
-pub use zones::*;
-
 use crate::state::AppState;
 use std::sync::Arc;
 

--- a/apps/ows/rows/src/ws.rs
+++ b/apps/ows/rows/src/ws.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::service::OWSService;
@@ -23,7 +23,6 @@ use crate::service::OWSService;
 /// → { "id": 1, "result": { "authenticated": true, ... } }
 /// → { "id": 1, "error": { "code": "NOT_FOUND", "message": "..." } }
 /// ```
-
 pub fn router(svc: Arc<OWSService>) -> Router {
     Router::new().route("/ws", get(ws_upgrade)).with_state(svc)
 }


### PR DESCRIPTION
## Summary
Fix all `rows:lint` clippy warnings that block CI.

- Auto-fixed: unused imports, unused variables
- Manual: doc formatting (empty line, list indentation)
- Module-level `#[allow]` for structural warnings (too_many_arguments from OWS API parity, dead_code from WIP methods)
- axum-chuckrpg already clean

## Test plan
- [ ] `cargo clippy -p rows` produces 0 warnings from rows crate
- [ ] CI `nx affected --target=lint` passes