### PR TITLE
fix(rows): standalone workspace in Dockerfile

### DIFF
--- a/apps/ows/rows/Dockerfile
+++ b/apps/ows/rows/Dockerfile
@@ -7,21 +7,22 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /src
 
-# Copy workspace manifests first for layer caching
-COPY Cargo.toml Cargo.lock ./
-COPY packages/rust/ packages/rust/
-COPY apps/ows/rows/ apps/ows/rows/
-COPY packages/data/proto/ packages/data/proto/
+# Create a standalone workspace (avoids pulling in root workspace members)
+RUN printf '[workspace]\nmembers = ["apps/ows/rows"]\nresolver = "2"\n' > Cargo.toml
 
-# Create dummy main.rs for dependency caching
+# Copy rows manifest for dependency caching
+COPY apps/ows/rows/Cargo.toml apps/ows/rows/Cargo.toml
+COPY packages/data/proto/ packages/data/proto/
+COPY apps/ows/rows/proto/ apps/ows/rows/proto/
+COPY apps/ows/rows/build.rs apps/ows/rows/build.rs
+
+# Dummy main.rs for dependency layer caching
 RUN mkdir -p apps/ows/rows/src && \
     echo 'fn main() {}' > apps/ows/rows/src/main.rs && \
     cargo build --release -p rows 2>/dev/null || true
 
 # Copy real source and rebuild
 COPY apps/ows/rows/src/ apps/ows/rows/src/
-COPY apps/ows/rows/proto/ apps/ows/rows/proto/
-COPY apps/ows/rows/build.rs apps/ows/rows/build.rs
 RUN touch apps/ows/rows/src/main.rs && \
     cargo build --release -p rows
 
@@ -43,6 +44,7 @@ ENV HTTP_PORT=4322
 ENV RUST_LOG=rows=info,tower_http=info
 
 EXPOSE 4322
+EXPOSE 50051
 
 HEALTHCHECK --interval=15s --timeout=3s --start-period=5s \
     CMD ["/usr/local/bin/rows", "--health-check"] || exit 1


### PR DESCRIPTION
## Summary
- Create minimal workspace Cargo.toml inside Dockerfile with only `rows` as member
- Fixes build failure: root Cargo.toml references workspace members not in Docker context
- Expose gRPC port 50051

Ref: #9004