### PR TITLE
fix(rows): add missing From<serde_json::Error> to AgonesError (#9018)

### DIFF
--- a/apps/ows/rows/src/agones.rs
+++ b/apps/ows/rows/src/agones.rs
@@ -33,6 +33,8 @@ pub enum AgonesError {
     NotAllocated { state: String },
     #[error("K8s API error: {0}")]
     ApiError(#[from] kube::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
     #[error("{0}")]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
## Summary
`rows:containerx:production` failed with:
```
error[E0277]: `?` couldnt convert the error to `AgonesError`
  --> apps/ows/rows/src/agones.rs:187:50
     .body(serde_json::to_vec(&allocation)?)
```

`AgonesError` was missing `From<serde_json::Error>`. Added `Json` variant.

Closes #9018