### PR TITLE
Atomic: axum-chuckrpg v0.1.3 post-publish sync

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Cargo.toml
+++ b/apps/chuckrpg/axum-chuckrpg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-chuckrpg"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 

--- a/apps/chuckrpg/axum-chuckrpg/version.toml
+++ b/apps/chuckrpg/axum-chuckrpg/version.toml
@@ -1,1 +1,1 @@
-version = "0.1.2"
+version = "0.1.3"

--- a/apps/kube/chuckrpg/manifest/deployment.yaml
+++ b/apps/kube/chuckrpg/manifest/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         spec:
             containers:
                 - name: chuckrpg
-                  image: ghcr.io/kbve/chuckrpg:0.1.2
+                  image: ghcr.io/kbve/chuckrpg:0.1.3
                   imagePullPolicy: Always
                   ports:
                       - name: http


### PR DESCRIPTION
## Post-publish sync for axum-chuckrpg v0.1.3

- `apps/chuckrpg/axum-chuckrpg/Cargo.toml`
- `apps/chuckrpg/axum-chuckrpg/version.toml`
- `apps/kube/chuckrpg/manifest/deployment.yaml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*