### PR TITLE
fix(kube): move WebTransport UDP 5001 LB to kbve manifest

### DIFF
--- a/apps/kube/isometric/manifest/kustomization.yaml
+++ b/apps/kube/isometric/manifest/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kbve
 
-resources:
-    - isometric-wt-lb.yaml
+resources: []

--- a/apps/kube/kbve/manifest/kbve-wt-lb.yaml
+++ b/apps/kube/kbve/manifest/kbve-wt-lb.yaml
@@ -1,10 +1,11 @@
-## Dedicated LoadBalancer for WebTransport (QUIC/UDP) on wt.kbve.com:5001.
-## Bypasses the Cilium Gateway / nginx L4 proxy — QUIC needs direct
+## Dedicated LoadBalancer for WebTransport (QUIC/UDP) on port 5001.
+## Bypasses the Cilium Gateway / L7 proxy — QUIC needs direct
 ## UDP path with connection-ID awareness that L7 proxies lack.
+## Shares the public IP with other kbve LoadBalancers via Cilium LB-IPAM.
 apiVersion: v1
 kind: Service
 metadata:
-    name: isometric-wt-lb
+    name: kbve-wt-lb
     namespace: kbve
     labels:
         app: kbve

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
     - kubevirt-rbac.yaml
     - kbve-deployment.yaml
     - kbve-gateway.yaml
+    - kbve-wt-lb.yaml


### PR DESCRIPTION
## Summary
- Move `isometric-wt-lb` → `kbve-wt-lb` under kbve ArgoCD app (was managed by isometric app but selects `app: kbve` pods)
- Adds `kbve-wt-lb.yaml` to kbve kustomization so it syncs with the main deployment
- Cilium LB-IPAM assigns public IP via `sharing-key: kbve-shared`
- `externalTrafficPolicy: Local` preserves source IP for QUIC connections

## Context
- **WebTransport (QUIC/UDP 5001)**: needs dedicated LoadBalancer — Gateway API is HTTP-only, cannot proxy UDP
- **Agones game servers (UDP 7000-8000)**: use hostPort via Dynamic port policy — no LB needed, Agones handles it natively
- The old `isometric-wt-lb` was functionally correct but misplaced under the isometric ArgoCD app

## Test plan
- [ ] Verify `kbve-wt-lb` gets external IP from Cilium LB-IPAM
- [ ] Verify UDP 5001 reaches axum-kbve container
- [ ] Verify ArgoCD prunes old `isometric-wt-lb` from cluster