### PR TITLE
fix(kbve): allow clippy::too_many_arguments on SocialMeta::meme()

### DIFF
--- a/packages/rust/kbve/src/social.rs
+++ b/packages/rust/kbve/src/social.rs
@@ -409,6 +409,7 @@ impl SocialMetaBuilder {
 /// Presets for common social meta configurations.
 impl SocialMeta {
     /// Meme page preset — OG type "article", large image card, Meme.sh branding.
+    #[allow(clippy::too_many_arguments)]
     pub fn meme(
         title: impl Into<Cow<'static, str>>,
         description: impl Into<Cow<'static, str>>,


### PR DESCRIPTION
## Summary
`rows:lint` fails because `cargo clippy -p rows -- -D warnings` checks the `kbve` dependency which has `SocialMeta::meme()` with 8 args (clippy max is 7).

One-line fix: `#[allow(clippy::too_many_arguments)]` on the function.

Verified: `cargo clippy -p rows -- -D warnings` passes with zero errors.