### PR TITLE
test(rows): scaffold rows-e2e project with vitest + Docker

### DIFF
--- a/apps/ows/rows-e2e/e2e/api.spec.ts
+++ b/apps/ows/rows-e2e/e2e/api.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+const VALID_GUID = 'be92671d-af96-4a6b-bdf7-6a3b6270dae6';
+
+describe('ROWS API — System', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('GET /api/System/Status returns true', async () => {
+		const res = await fetch(`${BASE_URL}/api/System/Status`, {
+			headers: { 'X-Customer-GUID': VALID_GUID },
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('ROWS API — Auth guard', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('rejects requests without X-Customer-GUID', async () => {
+		const res = await fetch(`${BASE_URL}/api/System/Status`);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects empty GUID', async () => {
+		const res = await fetch(`${BASE_URL}/api/System/Status`, {
+			headers: {
+				'X-Customer-GUID': '00000000-0000-0000-0000-000000000000',
+			},
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects invalid GUID format', async () => {
+		const res = await fetch(`${BASE_URL}/api/System/Status`, {
+			headers: { 'X-Customer-GUID': 'not-a-guid' },
+		});
+		expect(res.status).toBe(401);
+	});
+});
+
+describe('ROWS API — Users (no DB)', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('POST /api/Users/LoginAndCreateSession returns error without DB', async () => {
+		const res = await fetch(`${BASE_URL}/api/Users/LoginAndCreateSession`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-Customer-GUID': VALID_GUID,
+			},
+			body: JSON.stringify({
+				email: 'test@example.com',
+				password: 'testpass123',
+			}),
+		});
+		// Without a DB, should return 500 or 503 — not 401 or panic
+		expect(res.status).toBeGreaterThanOrEqual(400);
+	});
+
+	it('POST /api/Users/RegisterUser returns error without DB', async () => {
+		const res = await fetch(`${BASE_URL}/api/Users/RegisterUser`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-Customer-GUID': VALID_GUID,
+			},
+			body: JSON.stringify({
+				email: 'newuser@example.com',
+				password: 'password123',
+				first_name: 'Test',
+				last_name: 'User',
+			}),
+		});
+		expect(res.status).toBeGreaterThanOrEqual(400);
+	});
+});
+
+describe('ROWS API — CORS', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('OPTIONS returns CORS headers', async () => {
+		const res = await fetch(`${BASE_URL}/health`, {
+			method: 'OPTIONS',
+			headers: {
+				Origin: 'https://kbve.com',
+				'Access-Control-Request-Method': 'GET',
+			},
+		});
+		// Should not reject the preflight
+		expect(res.status).toBeLessThan(400);
+	});
+});

--- a/apps/ows/rows-e2e/e2e/health.spec.ts
+++ b/apps/ows/rows-e2e/e2e/health.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+describe('ROWS Health', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('GET /health returns 200 with JSON', async () => {
+		const res = await fetch(`${BASE_URL}/health`);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('status', 'healthy');
+		expect(body).toHaveProperty('service', 'rows');
+	});
+
+	it('GET /health responds within 500ms', async () => {
+		const start = performance.now();
+		const res = await fetch(`${BASE_URL}/health`);
+		const elapsed = performance.now() - start;
+		expect(res.ok).toBe(true);
+		expect(elapsed).toBeLessThan(500);
+	});
+
+	it('GET /ready returns readiness status', async () => {
+		const res = await fetch(`${BASE_URL}/ready`);
+		// May return 200 (all deps up) or 503 (DB missing in e2e) — both are valid responses
+		expect([200, 503]).toContain(res.status);
+		const body = await res.json();
+		expect(body).toHaveProperty('status');
+	});
+});

--- a/apps/ows/rows-e2e/e2e/helpers/http.ts
+++ b/apps/ows/rows-e2e/e2e/helpers/http.ts
@@ -1,0 +1,23 @@
+export const BASE_URL = process.env.ROWS_E2E_URL ?? 'http://localhost:4325';
+
+const POLL_INTERVAL_MS = 500;
+const MAX_WAIT_MS = 30_000;
+
+/**
+ * Poll the /health endpoint until the server is ready or timeout.
+ */
+export async function waitForReady(): Promise<void> {
+	const deadline = Date.now() + MAX_WAIT_MS;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${BASE_URL}/health`);
+			if (res.ok) return;
+		} catch {
+			// server not up yet
+		}
+		await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+	}
+	throw new Error(
+		`ROWS server at ${BASE_URL} did not become ready within ${MAX_WAIT_MS}ms`,
+	);
+}

--- a/apps/ows/rows-e2e/project.json
+++ b/apps/ows/rows-e2e/project.json
@@ -1,0 +1,35 @@
+{
+	"name": "rows-e2e",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"implicitDependencies": ["rows"],
+	"targets": {
+		"test": {
+			"executor": "nx:noop",
+			"cache": false
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"dependsOn": [
+				{
+					"target": "container",
+					"projects": ["rows"],
+					"params": "forward"
+				}
+			],
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker rm -f rows-e2e 2>/dev/null || true",
+					"docker run -d --name rows-e2e -p 4325:4322 -e HTTP_HOST=0.0.0.0 -e HTTP_PORT=4322 -e RUST_LOG=info -e DATABASE_URL='' kbve/rows:latest",
+					"npx vitest run; EC=$?; docker rm -f rows-e2e 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false,
+				"cwd": "apps/ows/rows-e2e"
+			},
+			"configurations": {
+				"ci": {}
+			}
+		}
+	}
+}

--- a/apps/ows/rows-e2e/tsconfig.json
+++ b/apps/ows/rows-e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"target": "ESNext"
+	},
+	"include": ["e2e/**/*.ts"]
+}

--- a/apps/ows/rows-e2e/vitest.config.ts
+++ b/apps/ows/rows-e2e/vitest.config.ts
@@ -1,0 +1,7 @@
+export default {
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 30_000,
+		hookTimeout: 60_000,
+	},
+};


### PR DESCRIPTION
## Summary
Scaffold `rows-e2e` Nx project following the same pattern as `axum-kbve-e2e` and `axum-chuckrpg-e2e`:

- **project.json**: e2e target spins up ROWS Docker container on `localhost:4325`, runs vitest, tears down
- **health.spec.ts**: `/health` (200 + JSON), `/ready` (probes deps), latency check
- **api.spec.ts**: `X-Customer-GUID` auth guard (missing/empty/invalid → 401), `System/Status`, Users endpoints fail gracefully without DB (no panic), CORS preflight
- **helpers/http.ts**: `waitForReady()` polls `/health` with 30s deadline

## Next steps
- Wire `rows-e2e` as `e2e_name` in CI dispatch manifest when ROWS gets a Docker entry
- Add DB-connected tests once a test Postgres container is in the e2e compose
- Add gRPC endpoint tests

## Test plan
- [ ] `npx nx e2e rows-e2e` runs after `npx nx container rows` builds the image
- [ ] Health tests pass against running ROWS container
- [ ] Auth guard tests verify 401 for missing/empty/invalid GUID