### PR TITLE
fix(rows): handle both postgres:// URL and Npgsql connection string formats

### DIFF
--- a/apps/kube/ows/manifest/externalsecret.yaml
+++ b/apps/kube/ows/manifest/externalsecret.yaml
@@ -36,6 +36,7 @@ spec:
             engineVersion: v2
             data:
                 db-connection-string: 'Host=supabase-cluster-rw.kilobase.svc.cluster.local;Port=5432;Database=supabase;Username=ows;Password={{ .dbpassword }};Options=-c search_path=ows,extensions,public;Maximum Pool Size=6;'
+                db-url: 'postgres://ows:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
     data:
         - secretKey: dbpassword
           remoteRef:

--- a/apps/kube/ows/manifest/rows-deployment.yaml
+++ b/apps/kube/ows/manifest/rows-deployment.yaml
@@ -40,7 +40,7 @@ spec:
                         valueFrom:
                             secretKeyRef:
                                 name: ows-db-credentials
-                                key: db-connection-string
+                                key: db-url
                       - name: RABBITMQ_URL
                         valueFrom:
                             secretKeyRef:

--- a/apps/ows/rows/src/db.rs
+++ b/apps/ows/rows/src/db.rs
@@ -1,19 +1,28 @@
-use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
 use std::str::FromStr;
 use std::time::Duration;
-use tracing::info;
+use tracing::{info, warn};
 
 pub type DbPool = PgPool;
 
 pub async fn connect(database_url: &str) -> anyhow::Result<DbPool> {
-    // Parse the URL and ensure search_path is set for OWS schema resolution.
-    // sqlx respects PgConnectOptions which supports options=-c search_path=...
-    let mut opts = PgConnectOptions::from_str(database_url)?;
+    // Auto-detect format: postgres:// URL or Npgsql semicolon-delimited
+    let opts =
+        if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") {
+            info!("Parsing DATABASE_URL as postgres:// URL");
+            PgConnectOptions::from_str(database_url)?
+        } else if database_url.contains('=') && database_url.contains(';') {
+            info!("Parsing DATABASE_URL as Npgsql/ADO.NET connection string");
+            parse_npgsql(database_url)?
+        } else {
+            anyhow::bail!(
+                "DATABASE_URL must be a postgres:// URL or Npgsql connection string. Got: {}...",
+                &database_url[..database_url.len().min(40)]
+            );
+        };
 
-    // If the URL doesn't already contain options with search_path, set it.
-    // OWS tables live in the 'ows' schema, crypt()/gen_salt() in 'extensions'.
-    opts = opts.options([("search_path", "ows,extensions,public")]);
-
+    // Set search_path for OWS schema resolution
+    let opts = opts.options([("search_path", "ows,extensions,public")]);
     info!("Database search_path set to: ows,extensions,public");
 
     let pool = PgPoolOptions::new()
@@ -24,4 +33,71 @@ pub async fn connect(database_url: &str) -> anyhow::Result<DbPool> {
         .connect_with(opts)
         .await?;
     Ok(pool)
+}
+
+/// Parse an Npgsql/ADO.NET connection string into PgConnectOptions.
+///
+/// Format: `Host=host;Port=5432;Database=db;Username=user;Password=pass;...`
+///
+/// Supported keys (case-insensitive):
+///   Host, Server → hostname
+///   Port → port
+///   Database → database
+///   Username, User ID, User → username
+///   Password → password
+///   SSL Mode, SslMode → ssl mode
+///   Search Path → search_path (applied via options)
+fn parse_npgsql(conn_str: &str) -> anyhow::Result<PgConnectOptions> {
+    let mut opts = PgConnectOptions::new();
+
+    for part in conn_str.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (key, value) = part
+            .split_once('=')
+            .ok_or_else(|| anyhow::anyhow!("Invalid key=value in connection string: {part}"))?;
+
+        let key_lower = key.trim().to_lowercase();
+        let value = value.trim();
+
+        match key_lower.as_str() {
+            "host" | "server" => {
+                opts = opts.host(value);
+            }
+            "port" => {
+                opts = opts.port(value.parse::<u16>().unwrap_or(5432));
+            }
+            "database" => {
+                opts = opts.database(value);
+            }
+            "username" | "user id" | "user" => {
+                opts = opts.username(value);
+            }
+            "password" => {
+                opts = opts.password(value);
+            }
+            "ssl mode" | "sslmode" => match value.to_lowercase().as_str() {
+                "disable" | "none" => opts = opts.ssl_mode(PgSslMode::Disable),
+                "prefer" => opts = opts.ssl_mode(PgSslMode::Prefer),
+                "require" => opts = opts.ssl_mode(PgSslMode::Require),
+                "verify-ca" | "verifyca" => opts = opts.ssl_mode(PgSslMode::VerifyCa),
+                "verify-full" | "verifyfull" => opts = opts.ssl_mode(PgSslMode::VerifyFull),
+                _ => warn!(ssl_mode = value, "Unknown SSL mode, using default"),
+            },
+            "search path" => {
+                // Will be overridden by our explicit options() call, but log it
+                info!(
+                    search_path = value,
+                    "Npgsql search_path found (overridden by ROWS)"
+                );
+            }
+            _ => {
+                // Skip unknown keys (Pooling, Timeout, CommandTimeout, etc.)
+            }
+        }
+    }
+
+    Ok(opts)
 }


### PR DESCRIPTION
## Summary

Fixes CrashLoopBackOff caused by ROWS receiving an Npgsql connection string when sqlx expects a postgres:// URL.

### Belt (code)
- `db.rs` auto-detects format: postgres:// URL or Npgsql semicolon-delimited
- `parse_npgsql()` extracts Host, Port, Database, Username, Password, SSL Mode
- Both formats work — ROWS won't crash regardless of which secret format is provided

### Suspenders (infra)
- ExternalSecret: added `db-url` key with `postgres://` format
- ROWS deployment: uses `db-url` (preferred URL format)
- C# OWS still uses `db-connection-string` (Npgsql format) — both coexist

## Root cause

The `ows-db-credentials` secret only had the Npgsql format (`Host=...;Port=...;`). sqlx tried to parse it as a URL and got "relative URL without a base."

## Test plan

- [x] `cargo check -p rows` passes (0 errors)
- [ ] ROWS pod should start after merge + ArgoCD sync