### PR TITLE
fix(rows): install rustls crypto provider before kube-rs TLS

### DIFF
--- a/apps/ows/rows/Cargo.toml
+++ b/apps/ows/rows/Cargo.toml
@@ -61,6 +61,7 @@ chrono = { version = "0.4", features = ["serde"] }
 async-trait = "0.1"
 futures-lite = "2"
 tokio-stream = "0.1"
+rustls = { version = "0.23", features = ["ring"] }
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi" }

--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -39,6 +39,12 @@ pub mod proto {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Install rustls crypto provider before any TLS operations (kube-rs, sqlx).
+    // Required since rustls 0.23+ no longer auto-selects a provider.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     dotenvy::dotenv().ok();
 
     tracing_subscriber::fmt()


### PR DESCRIPTION
## Summary

Fixes panic on startup: `Could not automatically determine the process-level CryptoProvider from Rustls crate features.`

### Root cause
rustls 0.23+ no longer auto-selects a crypto provider. kube-rs (Agones client) tries to create an in-cluster TLS connection and panics.

### Fix
- Install `ring::default_provider()` at the start of `main()` before any TLS operations
- Add `rustls = { version = "0.23", features = ["ring"] }` to Cargo.toml

### Previous logs showed
```
Database connected ✓
RabbitMQ connected ✓
→ panic at rustls CryptoProvider
```

After this fix, Agones client initialization should succeed.

## Test plan

- [x] `cargo check -p rows` passes
- [ ] ROWS pod starts without panic after merge + image rebuild