### PR TITLE
Atomic: axum-kbve v1.0.74 post-publish sync

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-kbve"
 authors = ["kbve", "h0lybyte"]
-version = "1.0.73"
+version = "1.0.74"
 edition = "2021"
 publish = false
 

--- a/apps/kbve/axum-kbve/version.toml
+++ b/apps/kbve/axum-kbve/version.toml
@@ -1,2 +1,2 @@
-version = "1.0.73"
+version = "1.0.74"
 publish = true

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -35,7 +35,7 @@ spec:
                               topologyKey: kubernetes.io/hostname
             containers:
                 - name: kbve
-                  image: ghcr.io/kbve/kbve:1.0.73
+                  image: ghcr.io/kbve/kbve:1.0.74
                   imagePullPolicy: Always
                   ports:
                       - name: http


### PR DESCRIPTION
## Post-publish sync for axum-kbve v1.0.74

- `apps/kbve/axum-kbve/Cargo.toml`
- `apps/kbve/axum-kbve/version.toml`
- `apps/kube/kbve/manifest/kbve-deployment.yaml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*