### PR TITLE
feat(chuckrpg): align Dockerfile with axum-kbve pattern

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
+++ b/apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml
@@ -1,0 +1,16 @@
+[workspace]
+resolver = "2"
+members = [
+    "apps/chuckrpg/axum-chuckrpg",
+    "packages/rust/jedi",
+    "packages/rust/kbve",
+    "packages/rust/bevy/bevy_kbve_net",
+    "packages/rust/bevy/bevy_npc",
+]
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /app/apps/chuckrpg/astro-chuckrpg
 RUN --mount=type=cache,target=/tmp/astro-cache,id=astro-chuckrpg-cache \
     cp -a /tmp/astro-cache/. .astro/ 2>/dev/null || true && \
     npx astro sync && \
-    npx astro build && \
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=8192" npx astro build && \
     cp -a .astro/. /tmp/astro-cache/ 2>/dev/null || true
 
 # ============================================================================
@@ -49,10 +49,11 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) -exec sh -c ' \
+    \) ! -path "*/askama/*" -exec sh -c ' \
         gzip -9 -k "$1" && \
         brotli --best --keep "$1" \
-    ' _ {} \;
+    ' _ {} \; && \
+    echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
 # [STAGE C] - Rust Base Image
@@ -63,6 +64,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         pkg-config \
         libssl-dev \
+        protobuf-compiler \
+        libprotobuf-dev \
         mold && \
     rm -rf /var/lib/apt/lists/*
 
@@ -74,44 +77,84 @@ WORKDIR /app
 # [STAGE D] - Cargo Chef Planner
 FROM rust-base AS planner
 
-COPY apps/chuckrpg/axum-chuckrpg/Cargo.toml apps/chuckrpg/axum-chuckrpg/Cargo.toml
-RUN mkdir -p apps/chuckrpg/axum-chuckrpg/src && \
-    echo "fn main() {}" > apps/chuckrpg/axum-chuckrpg/src/main.rs
+COPY apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
 
-# Create workspace Cargo.toml
-RUN printf '[workspace]\nmembers = ["apps/chuckrpg/axum-chuckrpg"]\nresolver = "2"\n' > Cargo.toml
+COPY apps/chuckrpg/axum-chuckrpg/Cargo.toml apps/chuckrpg/axum-chuckrpg/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+COPY packages/rust/bevy/bevy_kbve_net/Cargo.toml packages/rust/bevy/bevy_kbve_net/Cargo.toml
+COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
+
+COPY packages/data/proto packages/data/proto
+
+RUN mkdir -p apps/chuckrpg/axum-chuckrpg/src && echo "fn main() {}" > apps/chuckrpg/axum-chuckrpg/src/main.rs && \
+    mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_kbve_net/src && echo "" > packages/rust/bevy/bevy_kbve_net/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
-# [STAGE E] - Cargo Chef Cook (Cache Dependencies)
+# [STAGE E] - Cargo Chef Cook (Cache External Dependencies)
 FROM rust-base AS builder-deps
 
 COPY --from=planner /app/recipe.json recipe.json
-COPY --from=planner /app/Cargo.toml ./
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef cook --release --recipe-path recipe.json -p axum-chuckrpg
 
-# ============================================================================
-# [STAGE F] - Build Application
-# ============================================================================
-FROM rust-base AS builder
+# [STAGE E2] - Foundation Layer (Compile kbve + jedi from real source)
+FROM rust-base AS foundation
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
 
-# Workspace Cargo.toml
-RUN printf '[workspace]\nmembers = ["apps/chuckrpg/axum-chuckrpg"]\nresolver = "2"\n' > Cargo.toml
+COPY --from=planner /app/Cargo.toml ./
+COPY Cargo.lock ./
+
+COPY apps/chuckrpg/axum-chuckrpg/Cargo.toml apps/chuckrpg/axum-chuckrpg/Cargo.toml
+RUN mkdir -p apps/chuckrpg/axum-chuckrpg/src && \
+    echo "fn main() {}" > apps/chuckrpg/axum-chuckrpg/src/main.rs
+
+COPY packages/data/proto packages/data/proto
+
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/bevy/bevy_kbve_net packages/rust/bevy/bevy_kbve_net
+COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p kbve -p jedi -p bevy_kbve_net -p bevy_npc
+
+# ============================================================================
+# [STAGE F] - Build Application
+# ============================================================================
+FROM foundation AS builder
 
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
-# Copy source first, then overlay Astro output (source has empty templates/dist)
+# Astro build output (precompressed) -> placed into templates/dist
+COPY --from=astro-precompressor /static /app/apps/chuckrpg/axum-chuckrpg/templates/dist
+
+# Foundation crate source (cargo needs source to verify fingerprints)
+COPY packages/data/proto packages/data/proto
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/bevy/bevy_kbve_net packages/rust/bevy/bevy_kbve_net
+COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
+
+# Application source (most frequently changing — placed last for cache)
 COPY apps/chuckrpg/axum-chuckrpg apps/chuckrpg/axum-chuckrpg
 
-# Overlay precompressed Astro output AFTER source copy
-COPY --from=astro-precompressor /static /app/apps/chuckrpg/axum-chuckrpg/templates/dist
+# Copy Askama templates, then overwrite with Astro-generated versions
+COPY apps/chuckrpg/axum-chuckrpg/templates/askama /app/apps/chuckrpg/axum-chuckrpg/templates/askama
+RUN cp -a /app/apps/chuckrpg/axum-chuckrpg/templates/dist/askama/. /app/apps/chuckrpg/axum-chuckrpg/templates/askama/
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -147,17 +190,34 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
     mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
 
 # ============================================================================
-# [STAGE Z] - Runtime Image
+# [STAGE H] - Jemalloc
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc-dev && \
+    apt-get autoremove -y && \
+    apt-get purge -y --auto-remove && \
+    rm -rf /var/lib/apt/lists/*
+
+# ============================================================================
+# [STAGE Z] - Runtime Image (Scratch + Chisel + Jemalloc)
 # ============================================================================
 FROM --platform=linux/amd64 scratch AS runtime
 
 COPY --from=chisel-builder /rootfs /
 
+COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 WORKDIR /app
 
 COPY --from=builder --chown=10001:10001 /app/target/release/axum-chuckrpg /app/axum-chuckrpg
-COPY --from=builder --chown=10001:10001 /app/apps/chuckrpg/axum-chuckrpg/templates/dist /app/templates/dist
 
+COPY --from=builder --chown=10001:10001 /app/apps/chuckrpg/axum-chuckrpg/templates/dist /app/templates/dist
+COPY --from=builder --chown=10001:10001 /app/apps/chuckrpg/axum-chuckrpg/templates/askama /app/templates/askama
+
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=4322
 ENV RUST_LOG=info


### PR DESCRIPTION
## Summary
- Align `axum-chuckrpg` Dockerfile with the standard monorepo pattern used by `axum-kbve`
- Add `Cargo.workspace.toml` with foundation crates (kbve, jedi, bevy_kbve_net, bevy_npc) and release profile (LTO, strip, codegen-units=1, panic=abort)
- Add foundation layer (Stage E2) for shared crate compilation
- Add jemalloc runtime with `LD_PRELOAD` and tuned `MALLOC_CONF`
- Add protobuf-compiler/libprotobuf-dev to rust-base
- Add Askama template overlay pattern (dist/askama → templates/askama)
- Use root `Cargo.lock` instead of standalone workspace
- Add `UV_THREADPOOL_SIZE` + `NODE_OPTIONS` for Astro build stability

## Test plan
- [ ] `npx nx run axum-chuckrpg:docker` builds successfully
- [ ] Container starts and `/health` returns 200
- [ ] Static assets served with brotli/gzip precompression