### PR TITLE
feat(edge): add OWS admin edge function

### DIFF
--- a/apps/kbve/edge/functions/ows/_shared.ts
+++ b/apps/kbve/edge/functions/ows/_shared.ts
@@ -1,0 +1,54 @@
+import {
+  createServiceClient,
+  extractToken,
+  jsonResponse,
+  parseJwt,
+  requireServiceRole,
+  type JwtClaims,
+} from "../_shared/supabase.ts";
+
+export { createServiceClient, extractToken, jsonResponse, parseJwt };
+
+// ---------------------------------------------------------------------------
+// OWS Edge Function — Shared Types & Helpers
+// ---------------------------------------------------------------------------
+
+export interface OwsRequest {
+  token: string;
+  claims: JwtClaims;
+  body: Record<string, unknown>;
+  action: string;
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function validateUuid(value: unknown, field: string): Response | null {
+  if (typeof value !== "string" || !UUID_RE.test(value)) {
+    return jsonResponse({ error: `${field} must be a valid UUID` }, 400);
+  }
+  return null;
+}
+
+export function validateCharName(
+  value: unknown,
+  field: string,
+): Response | null {
+  if (typeof value !== "string" || value.length < 1 || value.length > 50) {
+    return jsonResponse(
+      { error: `${field} must be a string between 1 and 50 characters` },
+      400,
+    );
+  }
+  if (/[<>"'\\%;]/.test(value)) {
+    return jsonResponse(
+      { error: `${field} contains illegal characters` },
+      400,
+    );
+  }
+  return null;
+}
+
+export function requireAdmin(claims: JwtClaims): Response | null {
+  return requireServiceRole(claims);
+}

--- a/apps/kbve/edge/functions/ows/character.ts
+++ b/apps/kbve/edge/functions/ows/character.ts
@@ -1,0 +1,692 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  requireAdmin,
+  validateCharName,
+  validateUuid,
+  type OwsRequest,
+} from "./_shared.ts";
+
+export const CHARACTER_ACTIONS = [
+  "unstuck",
+  "reset_stats",
+  "lookup",
+  "list",
+  "create",
+  "delete",
+  "set_admin",
+];
+
+export async function handleCharacter(req: OwsRequest): Promise<Response> {
+  const adminErr = requireAdmin(req.claims);
+  if (adminErr) return adminErr;
+
+  switch (req.action) {
+    case "unstuck":
+      return unstuck(req);
+    case "reset_stats":
+      return resetStats(req);
+    case "lookup":
+      return lookup(req);
+    case "list":
+      return list(req);
+    case "create":
+      return create(req);
+    case "delete":
+      return remove(req);
+    case "set_admin":
+      return setAdmin(req);
+    default:
+      return jsonResponse(
+        {
+          error: `Unknown action: ${req.action}. Available: ${CHARACTER_ACTIONS.join(", ")}`,
+        },
+        400,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// character.unstuck
+//
+// Moves a character back to the default spawn point for their map.
+// Clears CharOnMapInstance so OWS reassigns them on next login.
+//
+// Body: { customer_guid, char_name }
+// ---------------------------------------------------------------------------
+async function unstuck(req: OwsRequest): Promise<Response> {
+  const { customer_guid, char_name } = req.body as {
+    customer_guid?: string;
+    char_name?: string;
+  };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+  const nameErr = validateCharName(char_name, "char_name");
+  if (nameErr) return nameErr;
+
+  const sb = createServiceClient();
+
+  const { data: character, error: charErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .select("characterid, mapname, x, y, z")
+    .eq("customerguid", customer_guid!)
+    .eq("charname", char_name!)
+    .single();
+
+  if (charErr || !character) {
+    return jsonResponse(
+      { error: `Character '${char_name}' not found` },
+      404,
+    );
+  }
+
+  const { data: defaults, error: defErr } = await sb
+    .schema("ows")
+    .from("defaultcharactervalues")
+    .select("startingmapname, x, y, z, rx, ry, rz")
+    .eq("customerguid", customer_guid!)
+    .limit(1)
+    .single();
+
+  if (defErr || !defaults) {
+    return jsonResponse(
+      { error: "No default spawn point configured for this customer" },
+      404,
+    );
+  }
+
+  const { error: updateErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .update({
+      mapname: defaults.startingmapname,
+      x: defaults.x,
+      y: defaults.y,
+      z: defaults.z,
+      rx: defaults.rx,
+      ry: defaults.ry,
+      rz: defaults.rz,
+      serverip: null,
+      lastactivity: new Date().toISOString(),
+    })
+    .eq("customerguid", customer_guid!)
+    .eq("characterid", character.characterid);
+
+  if (updateErr) {
+    console.error("unstuck update error:", updateErr.message);
+    return jsonResponse({ error: "Failed to update character position" }, 500);
+  }
+
+  // Clear CharOnMapInstance so OWS reassigns on next login
+  const { error: clearErr } = await sb
+    .schema("ows")
+    .from("charonmapinstance")
+    .delete()
+    .eq("customerguid", customer_guid!)
+    .eq("characterid", character.characterid);
+
+  if (clearErr) {
+    console.error("unstuck clear map instance error:", clearErr.message);
+  }
+
+  return jsonResponse({
+    ok: true,
+    character: char_name,
+    moved_to: {
+      map: defaults.startingmapname,
+      x: defaults.x,
+      y: defaults.y,
+      z: defaults.z,
+    },
+    previous: {
+      map: character.mapname,
+      x: character.x,
+      y: character.y,
+      z: character.z,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// character.reset_stats
+//
+// Resets a character's combat/resource stats to zero defaults.
+// Does NOT touch position, inventory, or custom data.
+//
+// Body: { customer_guid, char_name }
+// ---------------------------------------------------------------------------
+async function resetStats(req: OwsRequest): Promise<Response> {
+  const { customer_guid, char_name } = req.body as {
+    customer_guid?: string;
+    char_name?: string;
+  };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+  const nameErr = validateCharName(char_name, "char_name");
+  if (nameErr) return nameErr;
+
+  const sb = createServiceClient();
+
+  const { data: character, error: charErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .select("characterid")
+    .eq("customerguid", customer_guid!)
+    .eq("charname", char_name!)
+    .single();
+
+  if (charErr || !character) {
+    return jsonResponse(
+      { error: `Character '${char_name}' not found` },
+      404,
+    );
+  }
+
+  const { error: updateErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .update({
+      health: 0,
+      maxhealth: 0,
+      mana: 0,
+      maxmana: 0,
+      energy: 0,
+      maxenergy: 0,
+      stamina: 0,
+      maxstamina: 0,
+      endurance: 0,
+      maxendurance: 0,
+      fatigue: 0,
+      maxfatigue: 0,
+      wounds: 0,
+      gold: 0,
+      silver: 0,
+      copper: 0,
+      xp: 0,
+      characterlevel: 0,
+      lastactivity: new Date().toISOString(),
+    })
+    .eq("customerguid", customer_guid!)
+    .eq("characterid", character.characterid);
+
+  if (updateErr) {
+    console.error("reset_stats error:", updateErr.message);
+    return jsonResponse({ error: "Failed to reset character stats" }, 500);
+  }
+
+  return jsonResponse({
+    ok: true,
+    character: char_name,
+    message: "Stats reset to defaults. Position and inventory unchanged.",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// character.lookup
+//
+// Returns full character info + custom data + map instance for admin inspection.
+//
+// Body: { customer_guid, char_name }
+// ---------------------------------------------------------------------------
+async function lookup(req: OwsRequest): Promise<Response> {
+  const { customer_guid, char_name } = req.body as {
+    customer_guid?: string;
+    char_name?: string;
+  };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+  const nameErr = validateCharName(char_name, "char_name");
+  if (nameErr) return nameErr;
+
+  const sb = createServiceClient();
+
+  const { data: character, error: charErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .select(
+      "characterid, charname, userguid, email, mapname, x, y, z, rx, ry, rz, health, maxhealth, mana, maxmana, gold, silver, copper, xp, characterlevel, classid, lastactivity, createdate, isadmin, ismoderator, serverip",
+    )
+    .eq("customerguid", customer_guid!)
+    .eq("charname", char_name!)
+    .single();
+
+  if (charErr || !character) {
+    return jsonResponse(
+      { error: `Character '${char_name}' not found` },
+      404,
+    );
+  }
+
+  const [mapInstanceRes, customDataRes] = await Promise.all([
+    sb
+      .schema("ows")
+      .from("charonmapinstance")
+      .select("mapinstanceid")
+      .eq("customerguid", customer_guid!)
+      .eq("characterid", character.characterid),
+    sb
+      .schema("ows")
+      .from("customcharacterdata")
+      .select("customfieldname, fieldvalue")
+      .eq("customerguid", customer_guid!)
+      .eq("characterid", character.characterid),
+  ]);
+
+  return jsonResponse({
+    ok: true,
+    character,
+    custom_data: customDataRes.data ?? [],
+    map_instances: mapInstanceRes.data ?? [],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// character.list
+//
+// Lists all characters for a given user (by user_guid or email).
+//
+// Body: { customer_guid, user_guid?, email? }
+// ---------------------------------------------------------------------------
+async function list(req: OwsRequest): Promise<Response> {
+  const { customer_guid, user_guid, email } = req.body as {
+    customer_guid?: string;
+    user_guid?: string;
+    email?: string;
+  };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+
+  if (!user_guid && !email) {
+    return jsonResponse(
+      { error: "Either user_guid or email is required" },
+      400,
+    );
+  }
+
+  if (user_guid) {
+    const userGuidErr = validateUuid(user_guid, "user_guid");
+    if (userGuidErr) return userGuidErr;
+  }
+
+  const sb = createServiceClient();
+
+  let query = sb
+    .schema("ows")
+    .from("characters")
+    .select(
+      "characterid, charname, userguid, email, mapname, x, y, z, characterlevel, classid, lastactivity, createdate, isadmin, ismoderator",
+    )
+    .eq("customerguid", customer_guid!);
+
+  if (user_guid) {
+    query = query.eq("userguid", user_guid);
+  } else if (email) {
+    query = query.eq("email", email);
+  }
+
+  const { data: characters, error: charErr } = await query.order(
+    "createdate",
+    { ascending: true },
+  );
+
+  if (charErr) {
+    console.error("list error:", charErr.message);
+    return jsonResponse({ error: "Failed to list characters" }, 500);
+  }
+
+  return jsonResponse({
+    ok: true,
+    count: characters?.length ?? 0,
+    characters: characters ?? [],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// character.create
+//
+// Admin-creates a character for a user, using DefaultCharacterValues for
+// starting position and seeding default CustomCharacterData.
+//
+// Body: { customer_guid, user_guid, char_name, class_id? }
+// ---------------------------------------------------------------------------
+async function create(req: OwsRequest): Promise<Response> {
+  const { customer_guid, user_guid, char_name, class_id } = req.body as {
+    customer_guid?: string;
+    user_guid?: string;
+    char_name?: string;
+    class_id?: number;
+  };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+  const userGuidErr = validateUuid(user_guid, "user_guid");
+  if (userGuidErr) return userGuidErr;
+  const nameErr = validateCharName(char_name, "char_name");
+  if (nameErr) return nameErr;
+
+  const sb = createServiceClient();
+
+  // 1. Verify user exists
+  const { data: user, error: userErr } = await sb
+    .schema("ows")
+    .from("users")
+    .select("userguid, email")
+    .eq("customerguid", customer_guid!)
+    .eq("userguid", user_guid!)
+    .single();
+
+  if (userErr || !user) {
+    return jsonResponse({ error: "User not found" }, 404);
+  }
+
+  // 2. Check char_name not already taken
+  const { data: existing } = await sb
+    .schema("ows")
+    .from("characters")
+    .select("characterid")
+    .eq("customerguid", customer_guid!)
+    .eq("charname", char_name!)
+    .maybeSingle();
+
+  if (existing) {
+    return jsonResponse(
+      { error: `Character name '${char_name}' is already taken` },
+      409,
+    );
+  }
+
+  // 3. Get default spawn values
+  const { data: defaults, error: defErr } = await sb
+    .schema("ows")
+    .from("defaultcharactervalues")
+    .select("defaultcharactervaluesid, startingmapname, x, y, z, rx, ry, rz")
+    .eq("customerguid", customer_guid!)
+    .limit(1)
+    .single();
+
+  if (defErr || !defaults) {
+    return jsonResponse(
+      { error: "No default character values configured" },
+      404,
+    );
+  }
+
+  // 4. Insert character
+  const { data: newChar, error: insertErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .insert({
+      customerguid: customer_guid,
+      userguid: user_guid,
+      email: user.email,
+      charname: char_name,
+      mapname: defaults.startingmapname,
+      x: defaults.x,
+      y: defaults.y,
+      z: defaults.z,
+      rx: defaults.rx,
+      ry: defaults.ry,
+      rz: defaults.rz,
+      perception: 0,
+      acrobatics: 0,
+      climb: 0,
+      stealth: 0,
+      classid: class_id ?? 0,
+    })
+    .select("characterid")
+    .single();
+
+  if (insertErr || !newChar) {
+    console.error("create character error:", insertErr?.message);
+    return jsonResponse({ error: "Failed to create character" }, 500);
+  }
+
+  // 5. Seed default custom character data from DefaultCustomCharacterData
+  const { data: defaultCustom } = await sb
+    .schema("ows")
+    .from("defaultcustomcharacterdata")
+    .select("customfieldname, fieldvalue")
+    .eq("customerguid", customer_guid!)
+    .eq("defaultcharactervaluesid", defaults.defaultcharactervaluesid);
+
+  if (defaultCustom && defaultCustom.length > 0) {
+    const customRows = defaultCustom.map((d) => ({
+      customerguid: customer_guid,
+      characterid: newChar.characterid,
+      customfieldname: d.customfieldname,
+      fieldvalue: d.fieldvalue,
+    }));
+
+    const { error: customErr } = await sb
+      .schema("ows")
+      .from("customcharacterdata")
+      .insert(customRows);
+
+    if (customErr) {
+      console.error("create custom data error:", customErr.message);
+      // Non-fatal — character exists, custom data can be added later
+    }
+  }
+
+  return jsonResponse({
+    ok: true,
+    character_id: newChar.characterid,
+    char_name,
+    map: defaults.startingmapname,
+    position: { x: defaults.x, y: defaults.y, z: defaults.z },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// character.delete
+//
+// Permanently deletes a character and all associated FK data.
+// Deletion order respects FK constraints:
+//   CharAbilityBarAbilities → CharAbilityBars → CharHasAbilities
+//   CharInventoryItems → CharInventory
+//   CharHasItems, CustomCharacterData, CharOnMapInstance,
+//   PlayerGroupCharacters → Characters
+//
+// Body: { customer_guid, char_name, confirm: true }
+// ---------------------------------------------------------------------------
+async function remove(req: OwsRequest): Promise<Response> {
+  const { customer_guid, char_name, confirm } = req.body as {
+    customer_guid?: string;
+    char_name?: string;
+    confirm?: boolean;
+  };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+  const nameErr = validateCharName(char_name, "char_name");
+  if (nameErr) return nameErr;
+
+  if (confirm !== true) {
+    return jsonResponse(
+      { error: "Set confirm: true to permanently delete this character" },
+      400,
+    );
+  }
+
+  const sb = createServiceClient();
+
+  const { data: character, error: charErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .select("characterid")
+    .eq("customerguid", customer_guid!)
+    .eq("charname", char_name!)
+    .single();
+
+  if (charErr || !character) {
+    return jsonResponse(
+      { error: `Character '${char_name}' not found` },
+      404,
+    );
+  }
+
+  const charId = character.characterid;
+  const cg = customer_guid!;
+  const deleted: Record<string, number> = {};
+
+  // Helper: delete from a table and track count
+  async function deleteFrom(
+    table: string,
+    filters: Record<string, unknown>,
+  ): Promise<void> {
+    let query = sb.schema("ows").from(table).delete({ count: "exact" });
+    for (const [col, val] of Object.entries(filters)) {
+      query = query.eq(col, val);
+    }
+    const { count, error } = await query;
+    if (error) {
+      console.error(`delete ${table} error:`, error.message);
+    }
+    deleted[table] = count ?? 0;
+  }
+
+  // 1. Get ability bar IDs for this character (needed for CharAbilityBarAbilities)
+  const { data: bars } = await sb
+    .schema("ows")
+    .from("charabilitybars")
+    .select("charabilitybarid")
+    .eq("customerguid", cg)
+    .eq("characterid", charId);
+
+  if (bars && bars.length > 0) {
+    const barIds = bars.map((b) => b.charabilitybarid);
+    // Delete abilities in those bars
+    const { count: barAbilCount, error: barAbilErr } = await sb
+      .schema("ows")
+      .from("charabilitybarabilities")
+      .delete({ count: "exact" })
+      .eq("customerguid", cg)
+      .in("charabilitybarid", barIds);
+
+    if (barAbilErr) {
+      console.error("delete charabilitybarabilities error:", barAbilErr.message);
+    }
+    deleted["charabilitybarabilities"] = barAbilCount ?? 0;
+  }
+
+  // 2. Get inventory IDs for this character (needed for CharInventoryItems)
+  const { data: invs } = await sb
+    .schema("ows")
+    .from("charinventory")
+    .select("charinventoryid")
+    .eq("customerguid", cg)
+    .eq("characterid", charId);
+
+  if (invs && invs.length > 0) {
+    const invIds = invs.map((i) => i.charinventoryid);
+    const { count: invItemCount, error: invItemErr } = await sb
+      .schema("ows")
+      .from("charinventoryitems")
+      .delete({ count: "exact" })
+      .eq("customerguid", cg)
+      .in("charinventoryid", invIds);
+
+    if (invItemErr) {
+      console.error("delete charinventoryitems error:", invItemErr.message);
+    }
+    deleted["charinventoryitems"] = invItemCount ?? 0;
+  }
+
+  // 3. Delete remaining FK children in dependency order
+  await deleteFrom("charabilitybars", { customerguid: cg, characterid: charId });
+  await deleteFrom("charhasabilities", { customerguid: cg, characterid: charId });
+  await deleteFrom("charhasitems", { customerguid: cg, characterid: charId });
+  await deleteFrom("charinventory", { customerguid: cg, characterid: charId });
+  await deleteFrom("customcharacterdata", { customerguid: cg, characterid: charId });
+  await deleteFrom("charonmapinstance", { customerguid: cg, characterid: charId });
+  await deleteFrom("playergroupcharacters", { customerguid: cg, characterid: charId });
+
+  // 4. Delete the character itself
+  await deleteFrom("characters", { customerguid: cg, characterid: charId });
+
+  return jsonResponse({
+    ok: true,
+    character: char_name,
+    character_id: charId,
+    deleted,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// character.set_admin
+//
+// Toggles IsAdmin and/or IsModerator flags on a character.
+//
+// Body: { customer_guid, char_name, is_admin?: boolean, is_moderator?: boolean }
+// ---------------------------------------------------------------------------
+async function setAdmin(req: OwsRequest): Promise<Response> {
+  const { customer_guid, char_name, is_admin, is_moderator } = req.body as {
+    customer_guid?: string;
+    char_name?: string;
+    is_admin?: boolean;
+    is_moderator?: boolean;
+  };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+  const nameErr = validateCharName(char_name, "char_name");
+  if (nameErr) return nameErr;
+
+  if (is_admin === undefined && is_moderator === undefined) {
+    return jsonResponse(
+      { error: "At least one of is_admin or is_moderator must be provided" },
+      400,
+    );
+  }
+
+  const sb = createServiceClient();
+
+  const { data: character, error: charErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .select("characterid, isadmin, ismoderator")
+    .eq("customerguid", customer_guid!)
+    .eq("charname", char_name!)
+    .single();
+
+  if (charErr || !character) {
+    return jsonResponse(
+      { error: `Character '${char_name}' not found` },
+      404,
+    );
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (is_admin !== undefined) updates.isadmin = is_admin;
+  if (is_moderator !== undefined) updates.ismoderator = is_moderator;
+
+  const { error: updateErr } = await sb
+    .schema("ows")
+    .from("characters")
+    .update(updates)
+    .eq("customerguid", customer_guid!)
+    .eq("characterid", character.characterid);
+
+  if (updateErr) {
+    console.error("set_admin error:", updateErr.message);
+    return jsonResponse({ error: "Failed to update admin flags" }, 500);
+  }
+
+  return jsonResponse({
+    ok: true,
+    character: char_name,
+    previous: {
+      is_admin: character.isadmin,
+      is_moderator: character.ismoderator,
+    },
+    current: {
+      is_admin: is_admin ?? character.isadmin,
+      is_moderator: is_moderator ?? character.ismoderator,
+    },
+  });
+}

--- a/apps/kbve/edge/functions/ows/index.ts
+++ b/apps/kbve/edge/functions/ows/index.ts
@@ -1,0 +1,102 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import { requireJsonContentType } from "../_shared/validators.ts";
+import { extractToken, jsonResponse, parseJwt } from "./_shared.ts";
+import { CHARACTER_ACTIONS, handleCharacter } from "./character.ts";
+import { handleMaintenance, MAINTENANCE_ACTIONS } from "./maintenance.ts";
+
+// ---------------------------------------------------------------------------
+// OWS Edge Function — Admin Router
+//
+// All actions require service_role JWT (admin-only).
+//
+// Command format: "module.action"
+//   character:    unstuck, reset_stats, lookup, list, create, delete, set_admin
+//   maintenance:  cleanup_worldservers, cleanup_map_instances, status
+// ---------------------------------------------------------------------------
+
+const MODULES: Record<
+  string,
+  {
+    handler: (req: import("./_shared.ts").OwsRequest) => Promise<Response>;
+    actions: string[];
+  }
+> = {
+  character: { handler: handleCharacter, actions: CHARACTER_ACTIONS },
+  maintenance: { handler: handleMaintenance, actions: MAINTENANCE_ACTIONS },
+};
+
+function buildHelpText(): string {
+  const commands: string[] = [];
+  for (const [mod, { actions }] of Object.entries(MODULES)) {
+    for (const action of actions) {
+      commands.push(`${mod}.${action}`);
+    }
+  }
+  return commands.join(", ");
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+  }
+
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+
+  try {
+    const token = extractToken(req);
+    const claims = await parseJwt(token);
+    const body = await req.json();
+    const { command } = body;
+
+    if (!command || typeof command !== "string") {
+      return jsonResponse(
+        {
+          error: `command is required (format: "module.action"). Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const dotIndex = command.indexOf(".");
+    if (dotIndex === -1) {
+      return jsonResponse(
+        {
+          error: `Invalid command format. Use "module.action". Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const moduleName = command.slice(0, dotIndex);
+    const action = command.slice(dotIndex + 1);
+
+    const mod = MODULES[moduleName];
+    if (!mod) {
+      return jsonResponse(
+        {
+          error: `Unknown module: ${moduleName}. Available: ${Object.keys(MODULES).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    return mod.handler({ token, claims, body, action });
+  } catch (err) {
+    console.error("ows error:", err);
+    const rawMessage = err instanceof Error
+      ? err.message
+      : "Internal server error";
+    const isAuthError =
+      rawMessage.includes("authorization") || rawMessage.includes("JWT");
+    if (isAuthError) {
+      return jsonResponse({ error: rawMessage }, 401);
+    }
+    return jsonResponse({ error: "Internal server error" }, 500);
+  }
+});

--- a/apps/kbve/edge/functions/ows/maintenance.ts
+++ b/apps/kbve/edge/functions/ows/maintenance.ts
@@ -1,0 +1,198 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  requireAdmin,
+  validateUuid,
+  type OwsRequest,
+} from "./_shared.ts";
+
+export const MAINTENANCE_ACTIONS = [
+  "cleanup_worldservers",
+  "cleanup_map_instances",
+  "status",
+];
+
+export async function handleMaintenance(req: OwsRequest): Promise<Response> {
+  const adminErr = requireAdmin(req.claims);
+  if (adminErr) return adminErr;
+
+  switch (req.action) {
+    case "cleanup_worldservers":
+      return cleanupWorldServers(req);
+    case "cleanup_map_instances":
+      return cleanupMapInstances(req);
+    case "status":
+      return status(req);
+    default:
+      return jsonResponse(
+        {
+          error: `Unknown action: ${req.action}. Available: ${MAINTENANCE_ACTIONS.join(", ")}`,
+        },
+        400,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// maintenance.cleanup_worldservers
+//
+// Removes duplicate WorldServer rows (keeps lowest ID) and ensures the
+// remaining server is marked active (ServerStatus=1).
+//
+// Body: { customer_guid }
+// ---------------------------------------------------------------------------
+async function cleanupWorldServers(req: OwsRequest): Promise<Response> {
+  const { customer_guid } = req.body as { customer_guid?: string };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+
+  const sb = createServiceClient();
+
+  // Get all world servers for this customer
+  const { data: servers, error: fetchErr } = await sb
+    .schema("ows")
+    .from("worldservers")
+    .select("worldserverid, serverip, serverstatus, zonserverguid")
+    .eq("customerguid", customer_guid!)
+    .order("worldserverid", { ascending: true });
+
+  if (fetchErr) {
+    console.error("cleanup_worldservers fetch error:", fetchErr.message);
+    return jsonResponse({ error: "Failed to fetch world servers" }, 500);
+  }
+
+  if (!servers || servers.length === 0) {
+    return jsonResponse({ ok: true, message: "No world servers found", deleted: 0 });
+  }
+
+  // Keep the first (lowest ID), delete the rest
+  const keepId = servers[0].worldserverid;
+  const duplicateIds = servers
+    .slice(1)
+    .map((s) => s.worldserverid);
+
+  let deleted = 0;
+  if (duplicateIds.length > 0) {
+    const { error: delErr, count } = await sb
+      .schema("ows")
+      .from("worldservers")
+      .delete({ count: "exact" })
+      .eq("customerguid", customer_guid!)
+      .in("worldserverid", duplicateIds);
+
+    if (delErr) {
+      console.error("cleanup_worldservers delete error:", delErr.message);
+      return jsonResponse({ error: "Failed to delete duplicate servers" }, 500);
+    }
+    deleted = count ?? duplicateIds.length;
+  }
+
+  // Ensure the remaining server is active
+  const { error: activateErr } = await sb
+    .schema("ows")
+    .from("worldservers")
+    .update({
+      serverstatus: 1,
+      activestarttime: new Date().toISOString(),
+    })
+    .eq("customerguid", customer_guid!)
+    .eq("worldserverid", keepId);
+
+  if (activateErr) {
+    console.error("cleanup_worldservers activate error:", activateErr.message);
+  }
+
+  return jsonResponse({
+    ok: true,
+    kept_server_id: keepId,
+    deleted,
+    activated: !activateErr,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// maintenance.cleanup_map_instances
+//
+// Removes stale MapInstances (status != 2, no update in > 1 hour).
+//
+// Body: { customer_guid }
+// ---------------------------------------------------------------------------
+async function cleanupMapInstances(req: OwsRequest): Promise<Response> {
+  const { customer_guid } = req.body as { customer_guid?: string };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+
+  const sb = createServiceClient();
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+  const { error: delErr, count } = await sb
+    .schema("ows")
+    .from("mapinstances")
+    .delete({ count: "exact" })
+    .eq("customerguid", customer_guid!)
+    .neq("status", 2)
+    .lt("lastupdatefromserver", oneHourAgo);
+
+  if (delErr) {
+    console.error("cleanup_map_instances error:", delErr.message);
+    return jsonResponse({ error: "Failed to clean map instances" }, 500);
+  }
+
+  return jsonResponse({
+    ok: true,
+    deleted: count ?? 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// maintenance.status
+//
+// Returns a snapshot of OWS infrastructure state for a customer:
+// world servers, active map instances, online characters.
+//
+// Body: { customer_guid }
+// ---------------------------------------------------------------------------
+async function status(req: OwsRequest): Promise<Response> {
+  const { customer_guid } = req.body as { customer_guid?: string };
+
+  const guidErr = validateUuid(customer_guid, "customer_guid");
+  if (guidErr) return guidErr;
+
+  const sb = createServiceClient();
+
+  const [serversRes, mapsRes, instancesRes, onlineRes] = await Promise.all([
+    sb
+      .schema("ows")
+      .from("worldservers")
+      .select("worldserverid, serverip, serverstatus, activestarttime, port")
+      .eq("customerguid", customer_guid!),
+    sb
+      .schema("ows")
+      .from("maps")
+      .select("mapid, mapname, zonename, softplayercap, hardplayercap")
+      .eq("customerguid", customer_guid!),
+    sb
+      .schema("ows")
+      .from("mapinstances")
+      .select(
+        "mapinstanceid, worldserverid, mapid, port, status, numberofreportedplayers, lastupdatefromserver",
+      )
+      .eq("customerguid", customer_guid!),
+    sb
+      .schema("ows")
+      .from("characters")
+      .select("characterid, charname, mapname, serverip, lastactivity")
+      .eq("customerguid", customer_guid!)
+      .not("serverip", "is", null),
+  ]);
+
+  return jsonResponse({
+    ok: true,
+    world_servers: serversRes.data ?? [],
+    maps: mapsRes.data ?? [],
+    map_instances: instancesRes.data ?? [],
+    online_characters: onlineRes.data ?? [],
+  });
+}

--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -45,3 +45,8 @@ name = "logs"
 label = "Logs"
 description = "ClickHouse observability logs"
 publish = true
+
+[[functions]]
+name = "ows"
+label = "OWS"
+description = "OWS admin operations (unstuck, maintenance, status)"


### PR DESCRIPTION
## Summary
- Add new `ows` edge function with service_role-only admin access
- **character** module: `unstuck`, `reset_stats`, `lookup`, `list`, `create`, `delete`, `set_admin`
- **maintenance** module: `cleanup_worldservers`, `cleanup_map_instances`, `status`
- Uses existing `_shared/supabase.ts` helpers (`createServiceClient`, `requireServiceRole`)
- All queries target the `ows` schema via `.schema("ows")`
- Delete cascade respects FK order (ability bars → abilities → inventory → items → character)
- Registered in `version.toml` (version unchanged at 0.1.21)

## Test plan
- [ ] Deploy edge image and call `POST /ows` with service_role JWT + `{"command": "maintenance.status", "customer_guid": "..."}`
- [ ] Test `character.unstuck` moves character to default spawn
- [ ] Test `character.create` seeds default custom data
- [ ] Test `character.delete` with `confirm: true` cascades all FK rows
- [ ] Verify anon/authenticated JWTs are rejected (403)