### PR TITLE
chore(ows): spin down .NET services — ROWS replaces them

### DIFF
--- a/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
+++ b/apps/kube/github/runners/manifests/ows-instance-launcher.yaml
@@ -12,7 +12,7 @@ metadata:
         app: ows-instance-launcher
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     selector:
         matchLabels:
             app: ows-instance-launcher

--- a/apps/kube/ows/manifest/deployment.yaml
+++ b/apps/kube/ows/manifest/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
         app: ows-publicapi
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     selector:
         matchLabels:
             app: ows-publicapi
@@ -98,7 +98,7 @@ metadata:
         app: ows-instancemanagement
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     selector:
         matchLabels:
             app: ows-instancemanagement
@@ -197,7 +197,7 @@ metadata:
         app: ows-characterpersistence
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     selector:
         matchLabels:
             app: ows-characterpersistence
@@ -296,7 +296,7 @@ metadata:
         app: ows-globaldata
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     selector:
         matchLabels:
             app: ows-globaldata
@@ -395,7 +395,7 @@ metadata:
         app: ows-management
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     selector:
         matchLabels:
             app: ows-management

--- a/apps/kube/ows/manifest/instance-launcher.yaml
+++ b/apps/kube/ows/manifest/instance-launcher.yaml
@@ -11,7 +11,7 @@ metadata:
         app: ows-instancelauncher
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     selector:
         matchLabels:
             app: ows-instancelauncher


### PR DESCRIPTION
## Summary
- Scale all 7 .NET OWS deployments to `replicas: 0`
- ROWS is running and covers 48/49 OWS endpoints
- Manifests preserved for rollback (just set replicas back to 1)
- ValKey stays running (shared by ROWS)

Ref: #8404