### PR TITLE
Atomic: discordsh v0.1.36 post-publish sync

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-discordsh"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.34"
+version = "0.1.36"
 edition = "2024"
 publish = false
 

--- a/apps/discordsh/version.toml
+++ b/apps/discordsh/version.toml
@@ -1,2 +1,2 @@
-version = "0.1.35"
+version = "0.1.36"
 publish = true

--- a/apps/kube/discordsh/manifest/deployment.yaml
+++ b/apps/kube/discordsh/manifest/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             serviceAccountName: discordsh-sa
             containers:
                 - name: discordsh
-                  image: ghcr.io/kbve/discordsh:0.1.35
+                  image: ghcr.io/kbve/discordsh:0.1.36
                   imagePullPolicy: Always
                   ports:
                       - name: http


### PR DESCRIPTION
## Post-publish sync for discordsh v0.1.36

- `apps/discordsh/axum-discordsh/Cargo.toml`
- `apps/discordsh/version.toml`
- `apps/kube/discordsh/manifest/deployment.yaml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*