### PR TITLE
feat(jedi,axum-discordsh): GitHub repo policy guard + permission system + new commands

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/commands/github_board.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/github_board.rs
@@ -1,5 +1,5 @@
-//! `/github` slash commands — notice board and task board embeds
-//! powered by the guild's GitHub PAT from Supabase Vault.
+//! `/github` slash commands — notice board, task board, repo info, commits,
+//! issues, and pull request embeds powered by the guild's GitHub PAT.
 
 use jedi::entity::github::GitHubClient;
 use tracing::{info, warn};
@@ -8,6 +8,7 @@ use crate::discord::bot::{Context, Error};
 use crate::discord::embeds::notice_board_embed::{build_notice_board_summary, notices_from_stale};
 use crate::discord::embeds::task_board_embed::{build_task_board_embed, tasks_from_issues};
 use crate::discord::github::resolve_github_token;
+use crate::discord::github_permissions::github_permission_check;
 
 /// Maximum time for the entire slash command operation (token resolve + API calls).
 /// Discord allows 15 minutes after defer, but we want fast feedback.
@@ -26,7 +27,8 @@ async fn get_github_client(ctx: Context<'_>) -> Result<GitHubClient, String> {
             "No GitHub token configured for this server. A server admin can store one at <https://kbve.com>.".to_string()
         })?;
 
-    let client = GitHubClient::new(&token);
+    let policy = ctx.data().app.github_repo_policy.clone();
+    let client = GitHubClient::new(&token).with_policy(policy);
     let client = match std::env::var("GITHUB_API_BASE_URL") {
         Ok(url) if !url.is_empty() => client.with_base_url(&url),
         _ => client,
@@ -53,12 +55,30 @@ fn parse_repo(repo: &Option<String>, default: &(String, String)) -> (String, Str
     }
 }
 
+/// Format assignees list for embed display.
+fn format_assignees(assignees: &[jedi::entity::github::GitHubUser]) -> String {
+    if assignees.is_empty() {
+        return String::new();
+    }
+    let names: Vec<_> = assignees.iter().map(|a| format!("`{}`", a.login)).collect();
+    format!(" | assigned: {}", names.join(", "))
+}
+
+/// Parse a hex color string (e.g. "d73a4a") to a u32 for Discord embeds.
+fn parse_label_color(labels: &[jedi::entity::github::GitHubLabel]) -> Option<u32> {
+    labels
+        .first()
+        .and_then(|l| l.color.as_deref())
+        .and_then(|c| u32::from_str_radix(c, 16).ok())
+}
+
 // ── Parent command ──────────────────────────────────────────────────
 
 /// GitHub project boards — notice board and task board embeds.
 #[poise::command(
     slash_command,
-    subcommands("noticeboard", "taskboard", "issues", "pulls")
+    check = "github_permission_check",
+    subcommands("noticeboard", "taskboard", "issues", "pulls", "repo", "commits")
 )]
 pub async fn github(_ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
@@ -215,9 +235,14 @@ async fn issues(
             .await
         {
             Ok(issues) => {
+                let color = issues
+                    .first()
+                    .and_then(|i| parse_label_color(&i.labels))
+                    .unwrap_or(0x238636);
+
                 let mut embed = poise::serenity_prelude::CreateEmbed::new()
                     .title(format!("Open Issues — {}", full_name))
-                    .color(0x238636);
+                    .color(color);
 
                 if issues.is_empty() {
                     embed = embed.description("No open issues!");
@@ -234,10 +259,11 @@ async fn issues(
                         } else {
                             format!("\n{}", labels)
                         };
+                        let assignees = format_assignees(&issue.assignees);
                         embed = embed.field(
                             format!("#{} {}", issue.number, truncate(&issue.title, 80)),
                             format!(
-                                "by `{}` | [view]({}){label_str}",
+                                "by `{}`{assignees} | [view]({}){label_str}",
                                 issue.user.login, issue.html_url
                             ),
                             false,
@@ -301,11 +327,23 @@ async fn pulls(
                     embed = embed.description("No open pull requests!");
                 } else {
                     for pr in &pulls {
-                        let draft = if pr.draft { " (draft)" } else { "" };
+                        let draft = if pr.draft { " [DRAFT]" } else { "" };
+                        let labels = pr
+                            .labels
+                            .iter()
+                            .map(|l| format!("`{}`", l.name))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let label_str = if labels.is_empty() {
+                            String::new()
+                        } else {
+                            format!("\n{}", labels)
+                        };
+                        let assignees = format_assignees(&pr.assignees);
                         embed = embed.field(
-                            format!("#{} {}{}", pr.number, truncate(&pr.title, 80), draft),
+                            format!("#{} {}{}", pr.number, truncate(&pr.title, 70), draft),
                             format!(
-                                "by `{}` → `{}` | [view]({})",
+                                "by `{}` → `{}`{assignees} | [view]({}){label_str}",
                                 pr.user.login, pr.head.ref_name, pr.html_url
                             ),
                             false,
@@ -335,6 +373,125 @@ async fn pulls(
                 "The request timed out. The vault or GitHub API may be slow — please try again.",
             )
             .await
+        }
+    }
+}
+
+// ── /github repo ────────────────────────────────────────────────────
+
+/// Show repository info.
+#[poise::command(slash_command)]
+async fn repo(
+    ctx: Context<'_>,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+
+        match gh.get_repo(&owner, &repo_name).await {
+            Ok(info) => {
+                let desc = info.description.as_deref().unwrap_or("No description");
+
+                let embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(&info.full_name)
+                    .url(&info.html_url)
+                    .description(desc)
+                    .field("Default Branch", &info.default_branch, true)
+                    .field("Open Issues", info.open_issues_count.to_string(), true)
+                    .color(0x0d1117)
+                    .footer(poise::serenity_prelude::CreateEmbedFooter::new(
+                        "Repository Info",
+                    ));
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to fetch repo info");
+                Err(format!(
+                    "Failed to fetch repo info for `{}/{}`: {}",
+                    owner, repo_name, e
+                ))
+            }
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => {
+            warn!("repo command timed out");
+            send_error(ctx, "The request timed out — please try again.").await
+        }
+    }
+}
+
+// ── /github commits ─────────────────────────────────────────────────
+
+/// Show recent commits for a repository.
+#[poise::command(slash_command)]
+async fn commits(
+    ctx: Context<'_>,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+    #[description = "Max results (default: 10, max: 25)"] limit: Option<u8>,
+) -> Result<(), Error> {
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+        let full_name = format!("{}/{}", owner, repo_name);
+        let count = limit.unwrap_or(10).min(25);
+
+        match gh.list_commits(&owner, &repo_name, None, Some(count)).await {
+            Ok(commits) => {
+                let mut embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(format!("Recent Commits — {}", full_name))
+                    .color(0x2EA043);
+
+                if commits.is_empty() {
+                    embed = embed.description("No commits found.");
+                } else {
+                    for c in &commits {
+                        let first_line = c.commit.message.lines().next().unwrap_or("");
+                        let short_sha = &c.sha[..7.min(c.sha.len())];
+                        embed = embed.field(
+                            truncate(first_line, 80),
+                            format!(
+                                "by `{}` | `{}` | [view]({})",
+                                c.commit.author.name, short_sha, c.html_url
+                            ),
+                            false,
+                        );
+                    }
+                }
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => {
+                warn!(error = %e, repo = full_name, "Failed to fetch commits");
+                Err(format!(
+                    "Failed to fetch commits for `{}`: {}",
+                    full_name, e
+                ))
+            }
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => {
+            warn!("commits command timed out");
+            send_error(ctx, "The request timed out — please try again.").await
         }
     }
 }

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/notice_board_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/notice_board_embed.rs
@@ -289,6 +289,7 @@ mod tests {
             updated_at: updated_at.to_string(),
             html_url: format!("https://github.com/test/repo/issues/{number}"),
             pull_request: None,
+            assignees: Vec::new(),
         }
     }
 
@@ -308,6 +309,8 @@ mod tests {
             updated_at: updated_at.to_string(),
             html_url: format!("https://github.com/test/repo/pull/{number}"),
             draft: false,
+            labels: Vec::new(),
+            assignees: Vec::new(),
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/embeds/task_board_embed.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/embeds/task_board_embed.rs
@@ -213,6 +213,7 @@ mod tests {
             updated_at: "2026-01-02T00:00:00Z".to_string(),
             html_url: format!("https://github.com/test/repo/issues/{number}"),
             pull_request: None,
+            assignees: Vec::new(),
         }
     }
 

--- a/apps/discordsh/axum-discordsh/src/discord/github_permissions.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/github_permissions.rs
@@ -1,0 +1,234 @@
+//! Discord-specific permission guards for `/github` commands.
+//!
+//! Complements the repo-level `RepoPolicy` in the jedi crate with
+//! Discord role checks and per-user command rate limiting.
+
+use std::time::Instant;
+
+use dashmap::DashMap;
+use poise::serenity_prelude as serenity;
+use tracing::info;
+
+use crate::discord::bot::{Context, Error};
+
+// ── Command Rate Limiter ─────────────────────────────────────────────
+
+/// Sliding-window rate limiter keyed by Discord user ID.
+pub struct CommandRateLimiter {
+    buckets: DashMap<u64, (Instant, u32)>,
+    max_requests: u32,
+    window_secs: u64,
+}
+
+impl CommandRateLimiter {
+    pub fn new(max_requests: u32, window_secs: u64) -> Self {
+        Self {
+            buckets: DashMap::new(),
+            max_requests,
+            window_secs,
+        }
+    }
+
+    /// Returns `true` if the request is allowed.
+    pub fn check_user(&self, user_id: u64) -> bool {
+        let now = Instant::now();
+        let mut entry = self.buckets.entry(user_id).or_insert((now, 0));
+        let (ref mut window_start, ref mut count) = *entry;
+
+        if now.duration_since(*window_start).as_secs() >= self.window_secs {
+            *window_start = now;
+            *count = 1;
+            return true;
+        }
+
+        if *count >= self.max_requests {
+            return false;
+        }
+
+        *count += 1;
+        true
+    }
+
+    /// Prune entries older than 2x the window.
+    pub fn prune(&self) {
+        let now = Instant::now();
+        let cutoff = self.window_secs * 2;
+        self.buckets
+            .retain(|_, (start, _)| now.duration_since(*start).as_secs() < cutoff);
+    }
+}
+
+// ── GitHub Command Guard ─────────────────────────────────────────────
+
+/// Bundles per-user rate limiting + optional Discord permission requirement
+/// for all `/github` subcommands.
+pub struct GitHubCommandGuard {
+    pub rate_limiter: CommandRateLimiter,
+    required_permissions: Option<serenity::Permissions>,
+}
+
+impl GitHubCommandGuard {
+    /// Build from environment variables:
+    ///
+    /// - `GITHUB_CMD_RATE_LIMIT` — max commands per user per window (default: 5)
+    /// - `GITHUB_CMD_RATE_WINDOW` — window in seconds (default: 60)
+    /// - `GITHUB_REQUIRED_PERMISSIONS` — comma-separated Discord permission
+    ///   flags (e.g. `MANAGE_MESSAGES,SEND_MESSAGES`). Unset = unrestricted.
+    pub fn from_env() -> Self {
+        let max = std::env::var("GITHUB_CMD_RATE_LIMIT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(5);
+        let window = std::env::var("GITHUB_CMD_RATE_WINDOW")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(60);
+
+        let required_permissions = std::env::var("GITHUB_REQUIRED_PERMISSIONS")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| parse_permissions(&s));
+
+        if let Some(perms) = &required_permissions {
+            info!(permissions = ?perms, "GitHub commands require Discord permissions");
+        }
+
+        Self {
+            rate_limiter: CommandRateLimiter::new(max, window),
+            required_permissions,
+        }
+    }
+
+    /// Check if the member has the required Discord permissions.
+    pub fn has_permission(&self, member_permissions: serenity::Permissions) -> bool {
+        match &self.required_permissions {
+            None => true,
+            Some(required) => member_permissions.contains(*required),
+        }
+    }
+}
+
+/// Parse comma-separated permission flag names into a `Permissions` bitfield.
+fn parse_permissions(s: &str) -> serenity::Permissions {
+    let mut perms = serenity::Permissions::empty();
+    for flag in s.split(',').map(str::trim) {
+        let p = match flag.to_uppercase().as_str() {
+            "ADMINISTRATOR" => serenity::Permissions::ADMINISTRATOR,
+            "MANAGE_GUILD" => serenity::Permissions::MANAGE_GUILD,
+            "MANAGE_MESSAGES" => serenity::Permissions::MANAGE_MESSAGES,
+            "MANAGE_CHANNELS" => serenity::Permissions::MANAGE_CHANNELS,
+            "MANAGE_ROLES" => serenity::Permissions::MANAGE_ROLES,
+            "SEND_MESSAGES" => serenity::Permissions::SEND_MESSAGES,
+            "VIEW_CHANNEL" => serenity::Permissions::VIEW_CHANNEL,
+            "MODERATE_MEMBERS" => serenity::Permissions::MODERATE_MEMBERS,
+            other => {
+                tracing::warn!(flag = other, "Unknown Discord permission flag, skipping");
+                serenity::Permissions::empty()
+            }
+        };
+        perms |= p;
+    }
+    perms
+}
+
+// ── Poise Check Function ─────────────────────────────────────────────
+
+/// Pre-command check applied to all `/github` subcommands.
+///
+/// Enforces per-user rate limiting and optional Discord permissions.
+pub async fn github_permission_check(ctx: Context<'_>) -> Result<bool, Error> {
+    let guard = &ctx.data().app.github_guard;
+    let user_id = ctx.author().id.get();
+
+    // Rate limit
+    if !guard.rate_limiter.check_user(user_id) {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("You're using GitHub commands too quickly. Please wait a moment.")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(false);
+    }
+
+    // Discord permissions (skip in DMs — guild-only commands will catch this later)
+    if let Some(member) = ctx.author_member().await {
+        let member_perms = member
+            .permissions
+            .unwrap_or_else(serenity::Permissions::empty);
+        if !guard.has_permission(member_perms) {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("You don't have permission to use GitHub commands in this server.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limiter_allows_up_to_limit() {
+        let limiter = CommandRateLimiter::new(3, 60);
+        assert!(limiter.check_user(1));
+        assert!(limiter.check_user(1));
+        assert!(limiter.check_user(1));
+        assert!(!limiter.check_user(1));
+    }
+
+    #[test]
+    fn rate_limiter_users_independent() {
+        let limiter = CommandRateLimiter::new(1, 60);
+        assert!(limiter.check_user(1));
+        assert!(!limiter.check_user(1));
+        assert!(limiter.check_user(2));
+    }
+
+    #[test]
+    fn rate_limiter_prune() {
+        let limiter = CommandRateLimiter::new(10, 0);
+        limiter.check_user(1);
+        assert_eq!(limiter.buckets.len(), 1);
+        limiter.prune();
+        assert_eq!(limiter.buckets.len(), 0);
+    }
+
+    #[test]
+    fn parse_permissions_valid() {
+        let perms = parse_permissions("ADMINISTRATOR,MANAGE_MESSAGES");
+        assert!(perms.contains(serenity::Permissions::ADMINISTRATOR));
+        assert!(perms.contains(serenity::Permissions::MANAGE_MESSAGES));
+    }
+
+    #[test]
+    fn parse_permissions_unknown_ignored() {
+        let perms = parse_permissions("NONEXISTENT,ADMINISTRATOR");
+        assert!(perms.contains(serenity::Permissions::ADMINISTRATOR));
+    }
+
+    #[test]
+    fn guard_no_perms_allows_all() {
+        let guard = GitHubCommandGuard {
+            rate_limiter: CommandRateLimiter::new(100, 60),
+            required_permissions: None,
+        };
+        assert!(guard.has_permission(serenity::Permissions::empty()));
+    }
+
+    #[test]
+    fn guard_with_perms_blocks_missing() {
+        let guard = GitHubCommandGuard {
+            rate_limiter: CommandRateLimiter::new(100, 60),
+            required_permissions: Some(serenity::Permissions::MANAGE_MESSAGES),
+        };
+        assert!(!guard.has_permission(serenity::Permissions::SEND_MESSAGES));
+        assert!(guard.has_permission(serenity::Permissions::MANAGE_MESSAGES));
+    }
+}

--- a/apps/discordsh/axum-discordsh/src/discord/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/mod.rs
@@ -5,4 +5,5 @@ pub mod embeds;
 pub mod game;
 #[allow(dead_code)]
 pub mod github;
+pub mod github_permissions;
 pub mod scheduler;

--- a/apps/discordsh/axum-discordsh/src/state.rs
+++ b/apps/discordsh/axum-discordsh/src/state.rs
@@ -9,6 +9,7 @@ use kbve::{FontDb, MemberCache};
 
 use crate::api::rate_limit::RateLimiter;
 use crate::discord::game::{ProfileStore, SessionStore};
+use crate::discord::github_permissions::GitHubCommandGuard;
 use crate::health::HealthMonitor;
 use crate::tracker::ShardTracker;
 
@@ -71,6 +72,12 @@ pub struct AppState {
     /// Default GitHub repo (owner, name) resolved once from
     /// `GITHUB_DEFAULT_REPO` → `GH_REPO` → `KBVE/kbve`.
     pub default_repo: (String, String),
+
+    /// GitHub repo access policy (allowlist resolved from `GITHUB_ALLOWED_REPOS`).
+    pub github_repo_policy: jedi::entity::github::RepoPolicy,
+
+    /// Discord-level guard for `/github` commands (rate limit + permissions).
+    pub github_guard: GitHubCommandGuard,
 }
 
 /// Resolve the default GitHub repo from env vars (checked once at startup).
@@ -139,6 +146,8 @@ impl AppState {
             http_client,
             submit_limiter: RateLimiter::new(5, 60),
             default_repo: resolve_default_repo(),
+            github_repo_policy: jedi::entity::github::RepoPolicy::from_env(),
+            github_guard: GitHubCommandGuard::from_env(),
         }
     }
 }

--- a/packages/rust/jedi/src/entity/github/client.rs
+++ b/packages/rust/jedi/src/entity/github/client.rs
@@ -13,6 +13,7 @@ use reqwest::{Client, Response, StatusCode};
 use std::borrow::Cow;
 use tracing::warn;
 
+use super::policy::RepoPolicy;
 use super::types::*;
 use crate::entity::error::JediError;
 
@@ -24,6 +25,7 @@ pub struct GitHubClient {
     client: Client,
     token: String,
     base_url: String,
+    policy: RepoPolicy,
 }
 
 impl GitHubClient {
@@ -38,12 +40,20 @@ impl GitHubClient {
             client,
             token: token.to_string(),
             base_url: DEFAULT_BASE_URL.to_string(),
+            policy: RepoPolicy::open(),
         }
     }
 
     /// Override the base URL (useful for GitHub Enterprise or testing).
     pub fn with_base_url(mut self, url: &str) -> Self {
         self.base_url = url.trim_end_matches('/').to_string();
+        self
+    }
+
+    /// Attach a repo access policy. Requests to repos not in the policy
+    /// are rejected before any HTTP call is made.
+    pub fn with_policy(mut self, policy: RepoPolicy) -> Self {
+        self.policy = policy;
         self
     }
 
@@ -57,6 +67,7 @@ impl GitHubClient {
         state: Option<&str>,
         per_page: Option<u8>,
     ) -> Result<Vec<GitHubIssue>, JediError> {
+        self.policy.check(owner, repo)?;
         let url = format!("{}/repos/{}/{}/issues", self.base_url, owner, repo);
         let mut req = self.client.get(&url).bearer_auth(&self.token);
 
@@ -88,6 +99,7 @@ impl GitHubClient {
         state: Option<&str>,
         per_page: Option<u8>,
     ) -> Result<Vec<GitHubPull>, JediError> {
+        self.policy.check(owner, repo)?;
         let url = format!("{}/repos/{}/{}/pulls", self.base_url, owner, repo);
         let mut req = self.client.get(&url).bearer_auth(&self.token);
 
@@ -113,6 +125,7 @@ impl GitHubClient {
         since: Option<&str>,
         per_page: Option<u8>,
     ) -> Result<Vec<GitHubCommit>, JediError> {
+        self.policy.check(owner, repo)?;
         let url = format!("{}/repos/{}/{}/commits", self.base_url, owner, repo);
         let mut req = self.client.get(&url).bearer_auth(&self.token);
 
@@ -137,6 +150,7 @@ impl GitHubClient {
         repo: &str,
         branch: &str,
     ) -> Result<GitHubBranchProtection, JediError> {
+        self.policy.check(owner, repo)?;
         let url = format!(
             "{}/repos/{}/{}/branches/{}/protection",
             self.base_url, owner, repo, branch
@@ -156,6 +170,7 @@ impl GitHubClient {
 
     /// Fetch repository metadata.
     pub async fn get_repo(&self, owner: &str, repo: &str) -> Result<GitHubRepo, JediError> {
+        self.policy.check(owner, repo)?;
         let url = format!("{}/repos/{}/{}", self.base_url, owner, repo);
 
         let resp = self
@@ -273,6 +288,7 @@ mod tests {
             updated_at: updated_at.to_string(),
             html_url: format!("https://github.com/test/repo/issues/{number}"),
             pull_request: None,
+            assignees: Vec::new(),
         }
     }
 
@@ -292,6 +308,8 @@ mod tests {
             updated_at: updated_at.to_string(),
             html_url: format!("https://github.com/test/repo/pull/{number}"),
             draft,
+            labels: Vec::new(),
+            assignees: Vec::new(),
         }
     }
 

--- a/packages/rust/jedi/src/entity/github/mod.rs
+++ b/packages/rust/jedi/src/entity/github/mod.rs
@@ -1,5 +1,7 @@
 mod client;
+mod policy;
 mod types;
 
 pub use client::*;
+pub use policy::*;
 pub use types::*;

--- a/packages/rust/jedi/src/entity/github/policy.rs
+++ b/packages/rust/jedi/src/entity/github/policy.rs
@@ -1,0 +1,134 @@
+//! Repository access policy for the GitHub client.
+//!
+//! `RepoPolicy` controls which repositories the client is allowed to query.
+//! When an allowlist is configured, API calls to unlisted repos are rejected
+//! before any HTTP request is made.
+//!
+//! # Configuration
+//!
+//! Set `GITHUB_ALLOWED_REPOS` to a comma-separated list of `owner/repo` entries:
+//!
+//! ```text
+//! GITHUB_ALLOWED_REPOS=KBVE/kbve,KBVE/kbve.com
+//! ```
+//!
+//! If the variable is unset or empty, all repos are allowed (open mode).
+
+use std::collections::HashSet;
+
+use tracing::info;
+
+use crate::entity::error::JediError;
+
+/// Controls which repositories the GitHub client may access.
+#[derive(Debug, Clone)]
+pub struct RepoPolicy {
+    /// Lowercased `"owner/repo"` entries. `None` = all repos allowed.
+    allowed_repos: Option<HashSet<String>>,
+}
+
+impl RepoPolicy {
+    /// No restrictions — every repo is allowed.
+    pub fn open() -> Self {
+        Self {
+            allowed_repos: None,
+        }
+    }
+
+    /// Build from an explicit set of `"owner/repo"` strings.
+    pub fn from_allowed(repos: &[&str]) -> Self {
+        let set: HashSet<String> = repos.iter().map(|r| r.to_lowercase()).collect();
+        Self {
+            allowed_repos: if set.is_empty() { None } else { Some(set) },
+        }
+    }
+
+    /// Build from the `GITHUB_ALLOWED_REPOS` environment variable.
+    ///
+    /// Unset or empty → open mode (all repos allowed).
+    pub fn from_env() -> Self {
+        let raw = match std::env::var("GITHUB_ALLOWED_REPOS") {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => {
+                info!("GITHUB_ALLOWED_REPOS not set — all repos allowed");
+                return Self::open();
+            }
+        };
+
+        let repos: HashSet<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| s.contains('/'))
+            .collect();
+
+        if repos.is_empty() {
+            info!("GITHUB_ALLOWED_REPOS contained no valid entries — all repos allowed");
+            return Self::open();
+        }
+
+        info!(count = repos.len(), "GitHub repo allowlist configured");
+        Self {
+            allowed_repos: Some(repos),
+        }
+    }
+
+    /// Returns `true` if the repo is permitted by this policy.
+    pub fn is_allowed(&self, owner: &str, repo: &str) -> bool {
+        match &self.allowed_repos {
+            None => true,
+            Some(set) => {
+                let key = format!("{}/{}", owner.to_lowercase(), repo.to_lowercase());
+                set.contains(&key)
+            }
+        }
+    }
+
+    /// Returns `Ok(())` if allowed, `Err(JediError::Forbidden)` otherwise.
+    pub fn check(&self, owner: &str, repo: &str) -> Result<(), JediError> {
+        if self.is_allowed(owner, repo) {
+            Ok(())
+        } else {
+            Err(JediError::Forbidden)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_allows_everything() {
+        let policy = RepoPolicy::open();
+        assert!(policy.is_allowed("anything", "goes"));
+        assert!(policy.check("foo", "bar").is_ok());
+    }
+
+    #[test]
+    fn allowlist_permits_listed_repos() {
+        let policy = RepoPolicy::from_allowed(&["KBVE/kbve", "KBVE/kbve.com"]);
+        assert!(policy.is_allowed("KBVE", "kbve"));
+        assert!(policy.is_allowed("kbve", "KBVE")); // case insensitive
+        assert!(policy.is_allowed("KBVE", "kbve.com"));
+    }
+
+    #[test]
+    fn allowlist_blocks_unlisted_repos() {
+        let policy = RepoPolicy::from_allowed(&["KBVE/kbve"]);
+        assert!(!policy.is_allowed("evil", "repo"));
+        assert!(policy.check("evil", "repo").is_err());
+    }
+
+    #[test]
+    fn empty_allowlist_becomes_open() {
+        let policy = RepoPolicy::from_allowed(&[]);
+        assert!(policy.is_allowed("any", "repo"));
+    }
+
+    #[test]
+    fn check_returns_forbidden() {
+        let policy = RepoPolicy::from_allowed(&["only/this"]);
+        let err = policy.check("not", "this").unwrap_err();
+        assert!(matches!(err, JediError::Forbidden));
+    }
+}

--- a/packages/rust/jedi/src/entity/github/types.rs
+++ b/packages/rust/jedi/src/entity/github/types.rs
@@ -18,6 +18,8 @@ pub struct GitHubIssue {
     pub updated_at: String,
     pub html_url: String,
     pub pull_request: Option<serde_json::Value>,
+    #[serde(default)]
+    pub assignees: Vec<GitHubUser>,
 }
 
 impl GitHubIssue {
@@ -41,6 +43,10 @@ pub struct GitHubPull {
     pub html_url: String,
     #[serde(default)]
     pub draft: bool,
+    #[serde(default)]
+    pub labels: Vec<GitHubLabel>,
+    #[serde(default)]
+    pub assignees: Vec<GitHubUser>,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Summary
- Add **RepoPolicy** to jedi crate — configurable repo allowlist (`GITHUB_ALLOWED_REPOS`), enforced at the `GitHubClient` level before any HTTP request. Reusable by any project consuming the jedi GitHub module.
- Add **GitHubCommandGuard** in discordsh — per-user command rate limiting (`GITHUB_CMD_RATE_LIMIT`/`GITHUB_CMD_RATE_WINDOW`) + optional Discord permission requirements (`GITHUB_REQUIRED_PERMISSIONS`). Applied as poise check on `/github` parent command.
- New `/github repo` subcommand — shows repository info (description, default branch, open issues count)
- New `/github commits` subcommand — shows recent commits with author + short SHA
- Improved `/github issues` embed — assignees display, first label color for sidebar
- Improved `/github pulls` embed — labels, assignees, prominent `[DRAFT]` marker
- Added `assignees` field to `GitHubIssue` and `labels`/`assignees` to `GitHubPull` (all `#[serde(default)]`, backward compatible)

## New Environment Variables
| Variable | Default | Description |
|---|---|---|
| `GITHUB_ALLOWED_REPOS` | (unset = all) | Comma-separated `owner/repo` allowlist |
| `GITHUB_REQUIRED_PERMISSIONS` | (unset = none) | Discord permission flags for `/github` commands |
| `GITHUB_CMD_RATE_LIMIT` | `5` | Max GitHub commands per user per window |
| `GITHUB_CMD_RATE_WINDOW` | `60` | Rate limit window in seconds |

All env vars are optional — existing deployments with no new vars behave identically.

## Test plan
- [x] 29 jedi GitHub tests pass (including 5 new policy tests)
- [x] 730 axum-discordsh tests pass (including 7 new guard tests)
- [ ] Manual: set `GITHUB_ALLOWED_REPOS=KBVE/kbve`, test `/github issues` with unlisted repo returns forbidden
- [ ] Manual: unset all new env vars, verify identical behavior to current