### PR TITLE
fix(astro-kbve): fix collapsible sidebars and add right sidebar toggle

### DIFF
--- a/apps/kbve/astro-kbve/src/components/pagesidebar/PageSidebar.astro
+++ b/apps/kbve/astro-kbve/src/components/pagesidebar/PageSidebar.astro
@@ -1,8 +1,37 @@
 ---
 import Default from '@astrojs/starlight/components/PageSidebar.astro';
+import SidebarToggle from '../sidebar/SidebarToggle';
 // TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
 // import { PageGraph, PageBacklinks } from 'starlight-site-graph/components';
 ---
+
+<div class="sl-right-sidebar-toggle-wrap">
+	<button
+		id="sl-right-sidebar-collapse-btn"
+		class="sl-sidebar-collapse-btn"
+		aria-label="Toggle right sidebar"
+		title="Toggle right sidebar">
+		<svg
+			class="sl-sidebar-collapse-icon"
+			xmlns="http://www.w3.org/2000/svg"
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round">
+			<polyline points="9 18 15 12 9 6"></polyline>
+		</svg>
+	</button>
+</div>
+
+<SidebarToggle
+	client:load
+	side="right"
+	targetId="sl-right-sidebar-collapse-btn"
+/>
 
 <div class="mx-auto p-3">
 	<a

--- a/apps/kbve/astro-kbve/src/components/sidebar/Sidebar.astro
+++ b/apps/kbve/astro-kbve/src/components/sidebar/Sidebar.astro
@@ -2,6 +2,7 @@
 import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
 import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
 import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
+import SidebarToggle from './SidebarToggle';
 
 const { sidebar } = Astro.locals.starlightRoute;
 ---
@@ -28,6 +29,8 @@ const { sidebar } = Astro.locals.starlightRoute;
 	</button>
 </div>
 
+<SidebarToggle client:load side="left" targetId="sl-sidebar-collapse-btn" />
+
 <SidebarPersister>
 	<SidebarSublist sublist={sidebar} />
 </SidebarPersister>
@@ -35,30 +38,3 @@ const { sidebar } = Astro.locals.starlightRoute;
 <div class="md:sl-hidden">
 	<MobileMenuFooter />
 </div>
-
-<script>
-	const btn = document.getElementById('sl-sidebar-collapse-btn');
-	const STORAGE_KEY = 'sl-sidebar-collapsed';
-
-	function applyState(collapsed: boolean) {
-		document.documentElement.setAttribute(
-			'data-sidebar-collapsed',
-			String(collapsed),
-		);
-	}
-
-	// Restore saved state on load
-	const saved = localStorage.getItem(STORAGE_KEY);
-	if (saved === 'true') {
-		applyState(true);
-	}
-
-	btn?.addEventListener('click', () => {
-		const isCollapsed =
-			document.documentElement.getAttribute('data-sidebar-collapsed') ===
-			'true';
-		const next = !isCollapsed;
-		applyState(next);
-		localStorage.setItem(STORAGE_KEY, String(next));
-	});
-</script>

--- a/apps/kbve/astro-kbve/src/components/sidebar/SidebarToggle.tsx
+++ b/apps/kbve/astro-kbve/src/components/sidebar/SidebarToggle.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { restoreSavedState, toggleSidebar } from './sidebar-state';
+
+interface Props {
+	side: 'left' | 'right';
+	targetId: string;
+}
+
+export default function SidebarToggle({ side, targetId }: Props) {
+	useEffect(() => {
+		restoreSavedState(side);
+
+		const btn = document.getElementById(targetId);
+		if (!btn) return;
+
+		const handler = () => toggleSidebar(side);
+		btn.addEventListener('click', handler);
+		return () => btn.removeEventListener('click', handler);
+	}, [side, targetId]);
+
+	return null;
+}

--- a/apps/kbve/astro-kbve/src/components/sidebar/sidebar-state.ts
+++ b/apps/kbve/astro-kbve/src/components/sidebar/sidebar-state.ts
@@ -1,0 +1,39 @@
+import { DroidEvents } from '@kbve/droid';
+
+const LEFT_STORAGE_KEY = 'sl-sidebar-collapsed';
+const RIGHT_STORAGE_KEY = 'sl-right-sidebar-collapsed';
+
+type Side = 'left' | 'right';
+
+function getAttr(side: Side): string {
+	return side === 'left'
+		? 'data-sidebar-collapsed'
+		: 'data-right-sidebar-collapsed';
+}
+
+function getStorageKey(side: Side): string {
+	return side === 'left' ? LEFT_STORAGE_KEY : RIGHT_STORAGE_KEY;
+}
+
+export function isCollapsed(side: Side): boolean {
+	return document.documentElement.getAttribute(getAttr(side)) === 'true';
+}
+
+export function applyState(side: Side, collapsed: boolean) {
+	document.documentElement.setAttribute(getAttr(side), String(collapsed));
+	localStorage.setItem(getStorageKey(side), String(collapsed));
+	DroidEvents.emit(collapsed ? 'panel-close' : 'panel-open', {
+		id: side,
+	});
+}
+
+export function toggleSidebar(side: Side) {
+	applyState(side, !isCollapsed(side));
+}
+
+export function restoreSavedState(side: Side) {
+	const saved = localStorage.getItem(getStorageKey(side));
+	if (saved === 'true') {
+		document.documentElement.setAttribute(getAttr(side), 'true');
+	}
+}

--- a/apps/kbve/astro-kbve/src/styles/global.css
+++ b/apps/kbve/astro-kbve/src/styles/global.css
@@ -121,9 +121,9 @@
 	}
 }
 
-/* Collapsible sidebar toggle */
+/* Collapsible sidebar toggles (left + right) */
 @layer my-overrides {
-	/* Toggle button */
+	/* Shared toggle-button styles */
 	.sl-sidebar-toggle-wrap {
 		display: none;
 	}
@@ -153,15 +153,21 @@
 		transition: transform 0.2s ease;
 	}
 
-	/* Desktop only: show toggle + enable collapse */
+	/* Right-sidebar toggle wrapper (inside PageSidebar) */
+	.sl-right-sidebar-toggle-wrap {
+		display: none;
+	}
+
+	/* Desktop only: show toggles + enable collapse */
 	@media (min-width: 50rem) {
+		/* --- Left sidebar toggle --- */
 		.sl-sidebar-toggle-wrap {
 			display: flex;
 			justify-content: flex-end;
 			padding: 0.5rem 0.75rem 0;
 		}
 
-		/* Smooth sidebar width transition */
+		/* Smooth transitions */
 		.sidebar-pane,
 		.sidebar {
 			transition: width 0.2s ease;
@@ -170,36 +176,86 @@
 			transition: padding-inline-start 0.2s ease;
 		}
 
-		/* Collapsed state */
+		/* Left-sidebar collapsed: target elements directly instead of --sl-sidebar-width
+		   so the right sidebar is NOT affected */
 		:root[data-sidebar-collapsed='true'] {
-			--sl-sidebar-width: 3.5rem;
+			--sl-content-inline-start: 3.5rem;
+		}
+		:root[data-sidebar-collapsed='true'] .sidebar-pane {
+			width: 3.5rem;
+		}
+		:root[data-sidebar-collapsed='true'] .sidebar {
+			width: 3.5rem;
 		}
 
-		/* Rotate chevron when collapsed */
 		:root[data-sidebar-collapsed='true'] .sl-sidebar-collapse-icon {
 			transform: rotate(180deg);
 		}
 
-		/* Center the toggle button when collapsed */
 		:root[data-sidebar-collapsed='true'] .sl-sidebar-toggle-wrap {
 			justify-content: center;
 			padding: 0.5rem 0;
 		}
 
-		/* Hide sidebar text content when collapsed */
 		:root[data-sidebar-collapsed='true'] .sidebar-content ul {
 			display: none;
 		}
 
-		/* Hide mobile menu footer in collapsed state */
 		:root[data-sidebar-collapsed='true'] .sidebar-content > div {
 			display: none;
 		}
 
-		/* Reduce sidebar padding when collapsed */
 		:root[data-sidebar-collapsed='true'] .sidebar-content {
 			padding-inline: 0.25rem;
 			overflow: hidden;
+		}
+	}
+
+	/* Right sidebar: only visible at the ≥72rem breakpoint (matches Starlight) */
+	@media (min-width: 72rem) {
+		.sl-right-sidebar-toggle-wrap {
+			display: flex;
+			justify-content: flex-start;
+			padding: 0.5rem 0.75rem;
+		}
+
+		.right-sidebar-container {
+			transition:
+				width 0.2s ease,
+				opacity 0.2s ease;
+		}
+		.right-sidebar {
+			transition: opacity 0.2s ease;
+		}
+
+		/* Right-sidebar collapsed */
+		:root[data-right-sidebar-collapsed='true'] .right-sidebar-container {
+			width: 3rem;
+			min-width: 3rem;
+		}
+
+		:root[data-right-sidebar-collapsed='true'] .right-sidebar {
+			width: 3rem;
+		}
+
+		:root[data-right-sidebar-collapsed='true'] .right-sidebar-panel,
+		:root[data-right-sidebar-collapsed='true']
+			.right-sidebar
+			.sl-right-sidebar-toggle-wrap
+			~ * {
+			display: none;
+		}
+
+		:root[data-right-sidebar-collapsed='true']
+			.sl-right-sidebar-toggle-wrap {
+			justify-content: center;
+			padding: 0.5rem 0;
+		}
+
+		:root[data-right-sidebar-collapsed='true']
+			.sl-right-sidebar-toggle-wrap
+			.sl-sidebar-collapse-icon {
+			transform: rotate(180deg);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fixed left sidebar collapse breaking the right sidebar by targeting `.sidebar-pane` width and `--sl-content-inline-start` directly instead of overriding `--sl-sidebar-width` globally
- Added independent right sidebar collapse toggle in PageSidebar
- Extracted sidebar state logic from inline `<script>` tags into `sidebar-state.ts` (core logic) and `SidebarToggle.tsx` (React island)
- Both sidebars emit `panel-open`/`panel-close` events via `DroidEvents` from `@kbve/droid`
- Collapse state persisted per-sidebar in localStorage

## Test plan
- [ ] Verify left sidebar collapses/expands without affecting right sidebar width
- [ ] Verify right sidebar collapses/expands independently
- [ ] Verify collapse state persists across page navigation (localStorage)
- [ ] Verify toggle buttons hidden on mobile, visible on desktop breakpoints
- [ ] Verify smooth CSS transitions on both sidebars