### PR TITLE
fix(chuckrpg): remove askama template refs from Dockerfile #9081

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -152,10 +152,6 @@ COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
 # Application source (most frequently changing — placed last for cache)
 COPY apps/chuckrpg/axum-chuckrpg apps/chuckrpg/axum-chuckrpg
 
-# Copy Askama templates, then overwrite with Astro-generated versions
-COPY apps/chuckrpg/axum-chuckrpg/templates/askama /app/apps/chuckrpg/axum-chuckrpg/templates/askama
-RUN cp -a /app/apps/chuckrpg/axum-chuckrpg/templates/dist/askama/. /app/apps/chuckrpg/axum-chuckrpg/templates/askama/
-
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo build --release -p axum-chuckrpg && \
@@ -214,7 +210,6 @@ WORKDIR /app
 COPY --from=builder --chown=10001:10001 /app/target/release/axum-chuckrpg /app/axum-chuckrpg
 
 COPY --from=builder --chown=10001:10001 /app/apps/chuckrpg/axum-chuckrpg/templates/dist /app/templates/dist
-COPY --from=builder --chown=10001:10001 /app/apps/chuckrpg/axum-chuckrpg/templates/askama /app/templates/askama
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"


### PR DESCRIPTION
## Summary
- Remove 3 askama-related lines from the Dockerfile that reference a non-existent `templates/askama/` directory
- `axum-chuckrpg` is a pure static file server (no askama dependency) — these lines were copy-pasted from the CryptoThrone Dockerfile template

Closes #9081

## Test plan
- [ ] CI Docker build + e2e test passes for `axum-chuckrpg`