### PR TITLE
Atomic: rows v0.1.8 post-publish sync

### DIFF
--- a/apps/kube/ows/manifest/rows-deployment.yaml
+++ b/apps/kube/ows/manifest/rows-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             serviceAccountName: ows-instancelauncher
             containers:
                 - name: rows
-                  image: ghcr.io/kbve/rows:0.1.7
+                  image: ghcr.io/kbve/rows:0.1.8
                   imagePullPolicy: Always
                   env:
                       - name: HTTP_HOST

--- a/apps/ows/rows/Cargo.toml
+++ b/apps/ows/rows/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rows"
 authors = ["kbve", "h0lybyte"]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 description = "Rust OWS — single-binary game backend (REST + gRPC)"

--- a/apps/ows/rows/version.toml
+++ b/apps/ows/rows/version.toml
@@ -1,2 +1,2 @@
-version = "0.1.7"
+version = "0.1.8"
 publish = true


### PR DESCRIPTION
## Post-publish sync for rows v0.1.8

- `apps/kube/ows/manifest/rows-deployment.yaml`
- `apps/ows/rows/Cargo.toml`
- `apps/ows/rows/version.toml`

All version references updated in a single atomic commit to prevent race conditions.

---
*Auto-generated by utils-post-publish.yml*