### PR TITLE
fix(ci): use GITHUB_TOKEN for post-publish PR creation

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -79,18 +79,35 @@ jobs:
                         pull_number: prNumber,
                       });
 
-                      // Two-pass sanitizer:
-                      // Pass 1 (blocklist): strip known-dangerous Unicode — RTL overrides,
-                      //   zero-width chars, bidi embeddings, control characters.
-                      // Pass 2 (allowlist): strip anything not in the safe character set.
+                      // Three-pass sanitizer (English ASCII only):
+                      // Pass 1: reject non-ASCII entirely (Unicode homoglyphs, Arabic,
+                      //         Cyrillic, CJK, RTL overrides, zero-width, punycode xn--)
+                      // Pass 2 (blocklist): strip known-dangerous control characters
+                      // Pass 3 (allowlist): strip anything not in the safe ASCII set
                       const sanitize = (s) => {
-                        const stripped = s.replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202F\u2060-\u206F\uFEFF\uFFF0-\uFFFF]/g, '');
+                        const asciiOnly = s.replace(/[^\x20-\x7E]/g, '');
+                        const stripped = asciiOnly.replace(/[\u0000-\u001F\u007F-\u009F]/g, '');
                         return stripped.replace(/[^a-zA-Z0-9\-_.\/@: ()]/g, '');
                       };
 
                       // Sanitize and verify every field — reject if ANY field
-                      // contained characters that were stripped.
+                      // contained characters that were stripped. Also reject punycode.
                       const verifiedSanitize = (raw, fieldName) => {
+                        // Reject punycode / IDN attacks
+                        if (/xn--/i.test(raw)) {
+                          core.setFailed(
+                            `Field '${fieldName}' contains punycode/IDN pattern (xn--) — aborting.`
+                          );
+                          return null;
+                        }
+                        // Reject any non-ASCII (homoglyphs, RTL, zero-width, etc.)
+                        if (/[^\x20-\x7E]/.test(raw)) {
+                          core.setFailed(
+                            `Field '${fieldName}' contains non-ASCII characters — only English ASCII allowed. ` +
+                            `Raw bytes: ${JSON.stringify(raw)}`
+                          );
+                          return null;
+                        }
                         const clean = sanitize(raw);
                         if (clean !== raw) {
                           core.setFailed(

--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -56,6 +56,24 @@ jobs:
                   IMAGE="${{ inputs.image_name }}"
                   DYAML="${{ inputs.deployment_yaml }}"
 
+                  # ASCII-only check — reject any non-ASCII character in ALL inputs.
+                  # Blocks Unicode homoglyphs, RTL overrides, punycode (xn--),
+                  # Arabic/Cyrillic/CJK substitutions, zero-width chars, etc.
+                  for VAL in "$APP" "$VERSION" "$VTOML" "$VTARGET" "$IMAGE" "$DYAML"; do
+                    if echo "$VAL" | grep -qP '[^\x20-\x7E]'; then
+                      echo "::error::Non-ASCII characters detected in input: '$VAL' — only English ASCII allowed"
+                      exit 1
+                    fi
+                  done
+
+                  # Punycode / IDN attack check — reject xn-- anywhere
+                  for VAL in "$APP" "$VERSION" "$VTOML" "$VTARGET" "$IMAGE" "$DYAML"; do
+                    if echo "$VAL" | grep -qi 'xn--'; then
+                      echo "::error::Punycode/IDN pattern (xn--) detected in input: '$VAL'"
+                      exit 1
+                    fi
+                  done
+
                   # Semver check — must be x.y.z with optional pre-release
                   if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
                     echo "::error::Invalid version format: '$VERSION' — must be semver (x.y.z)"


### PR DESCRIPTION
## Summary
- Split post-publish step: `TRIGGER_PAT` for git push, `GITHUB_TOKEN` for PR creation
- PR author becomes `github-actions[bot]` instead of PAT owner
- Auto-merge bot can now approve + merge post-publish PRs automatically

Fixes the issue where post-publish PRs (like #9084) had to be manually merged because the author was `h0lybyte` not `github-actions[bot]`.