### PR TITLE
fix(ci): allow square brackets in auto-merge sanitizer

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -87,7 +87,7 @@ jobs:
                       const sanitize = (s) => {
                         const asciiOnly = s.replace(/[^\x20-\x7E]/g, '');
                         const stripped = asciiOnly.replace(/[\u0000-\u001F\u007F-\u009F]/g, '');
-                        return stripped.replace(/[^a-zA-Z0-9\-_.\/@: ()]/g, '');
+                        return stripped.replace(/[^a-zA-Z0-9\-_.\/@: ()\[\]]/g, '');
                       };
 
                       // Sanitize and verify every field — reject if ANY field


### PR DESCRIPTION
## Summary
- Add `[ ]` to the allowlist in `ci-auto-merge-bot-prs.yml`
- `github-actions[bot]` was being rejected because `[` and `]` were stripped by the sanitizer
- This caused PR #9093 to fail auto-merge

Fixes #9093