### PR TITLE
fix(rows): SetSelectedChar field alias + PascalCase session response with character data

### DIFF
--- a/apps/ows/rows/src/models.rs
+++ b/apps/ows/rows/src/models.rs
@@ -133,6 +133,57 @@ pub struct UserSession {
     pub role: String,
 }
 
+/// User session with selected character data — matches C# GetUserSession stored proc.
+/// UE OWS plugin reads these fields with PascalCase GetStringField/GetNumberField.
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct UserSessionWithCharacter {
+    #[sqlx(rename = "customerguid")]
+    #[serde(rename = "CustomerGUID")]
+    pub customer_guid: Uuid,
+    #[sqlx(rename = "userguid")]
+    #[serde(rename = "UserGUID")]
+    pub user_guid: Option<Uuid>,
+    #[sqlx(rename = "usersessionguid")]
+    #[serde(rename = "UserSessionGUID")]
+    pub user_session_guid: Uuid,
+    #[serde(rename = "SelectedCharacterName")]
+    pub selected_character_name: Option<String>,
+    #[serde(rename = "Email")]
+    pub email: String,
+    #[serde(rename = "FirstName")]
+    pub first_name: String,
+    #[serde(rename = "LastName")]
+    pub last_name: String,
+    #[serde(rename = "CreateDate")]
+    pub create_date: Option<NaiveDateTime>,
+    #[serde(rename = "LastAccess")]
+    pub last_access: Option<NaiveDateTime>,
+    #[serde(rename = "Role")]
+    pub role: String,
+    // Character data (from LEFT JOIN)
+    #[sqlx(rename = "characterid")]
+    #[serde(rename = "CharacterID")]
+    pub character_id: Option<i32>,
+    #[sqlx(rename = "charname")]
+    #[serde(rename = "CharName")]
+    pub char_name: Option<String>,
+    #[serde(rename = "X")]
+    pub x: Option<f64>,
+    #[serde(rename = "Y")]
+    pub y: Option<f64>,
+    #[serde(rename = "Z")]
+    pub z: Option<f64>,
+    #[serde(rename = "RX")]
+    pub rx: Option<f64>,
+    #[serde(rename = "RY")]
+    pub ry: Option<f64>,
+    #[serde(rename = "RZ")]
+    pub rz: Option<f64>,
+    #[sqlx(rename = "mapname")]
+    #[serde(rename = "ZoneName")]
+    pub zone_name: Option<String>,
+}
+
 /// Login result
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/apps/ows/rows/src/repo.rs
+++ b/apps/ows/rows/src/repo.rs
@@ -132,6 +132,31 @@ impl<'a> UsersRepo<'a> {
         Ok(session)
     }
 
+    pub async fn get_session_with_character(
+        &self,
+        session_guid: Uuid,
+    ) -> Result<Option<crate::models::UserSessionWithCharacter>, RowsError> {
+        let session = sqlx::query_as::<_, crate::models::UserSessionWithCharacter>(
+            "SELECT us.customerguid, u.userguid, us.usersessionguid,
+                    us.selectedcharactername AS selected_character_name,
+                    u.email, u.firstname AS first_name, u.lastname AS last_name,
+                    u.createdate AS create_date, u.lastaccess AS last_access, u.role,
+                    c.characterid, c.charname, c.x, c.y, c.z, c.rx, c.ry, c.rz,
+                    c.mapname
+             FROM usersessions us
+             JOIN users u ON u.userguid = us.userguid AND u.customerguid = us.customerguid
+             LEFT JOIN characters c ON c.customerguid = us.customerguid
+                AND c.charname = us.selectedcharactername
+                AND c.userguid = us.userguid
+             WHERE us.usersessionguid = $1",
+        )
+        .bind(session_guid)
+        .fetch_optional(self.0)
+        .await?;
+
+        Ok(session)
+    }
+
     pub async fn get_all_characters(
         &self,
         customer_guid: Uuid,

--- a/apps/ows/rows/src/rest.rs
+++ b/apps/ows/rows/src/rest.rs
@@ -401,13 +401,14 @@ async fn create_char_defaults(
 struct SetSelectedCharDto {
     #[serde(rename = "userSessionGUID", alias = "userSessionGUId")]
     user_session_guid: Uuid,
+    #[serde(alias = "selectedCharacterName")]
     character_name: String,
 }
 
 async fn set_selected_char(
     State(hs): State<HandlerState>,
     Json(body): Json<SetSelectedCharDto>,
-) -> ApiResult<crate::models::UserSession> {
+) -> ApiResult<crate::models::UserSessionWithCharacter> {
     let session = hs
         .svc
         .set_selected_character_and_get_session(body.user_session_guid, &body.character_name)

--- a/apps/ows/rows/src/service/auth.rs
+++ b/apps/ows/rows/src/service/auth.rs
@@ -91,9 +91,12 @@ impl OWSService {
         &self,
         session_guid: Uuid,
         char_name: &str,
-    ) -> Result<UserSession, RowsError> {
+    ) -> Result<UserSessionWithCharacter, RowsError> {
         let repo = UsersRepo(&self.state.db);
-        repo.set_selected_character(session_guid, char_name)
+        // First update the selected character
+        let _ = repo.set_selected_character(session_guid, char_name).await?;
+        // Then fetch session with character data (including position)
+        repo.get_session_with_character(session_guid)
             .await?
             .ok_or_else(|| RowsError::NotFound("Session not found".into()))
     }


### PR DESCRIPTION
## Summary
- Fix 422 on `SetSelectedCharacterAndGetUserSession`: UE sends `selectedCharacterName` but ROWS expected `characterName` — added serde alias
- Add `UserSessionWithCharacter` struct with PascalCase field names (`UserSessionGUID`, `CharName`, `X`, `Y`, `Z`, `RX`, `RY`, `RZ`, `ZoneName`) matching UE's `GetStringField`/`GetNumberField` calls
- Add `get_session_with_character` repo query that LEFT JOINs characters table for position data (matches C# `GetUserSession` stored proc)
- `SetSelectedCharacterAndGetUserSession` now returns full session + character position data

## Fixes
- HTTP 422 `missing field characterName` on Enter World / SetSelectedCharacterAndGetUserSession
- UE would fail to read response fields due to camelCase vs PascalCase mismatch