### PR TITLE
feat(chuckrpg): add auth system, profile page, and complete color theme

### DIFF
--- a/apps/chuckrpg/astro-chuckrpg/astro.config.mjs
+++ b/apps/chuckrpg/astro-chuckrpg/astro.config.mjs
@@ -58,6 +58,10 @@ export default defineConfig({
 					label: 'Game',
 					autogenerate: { directory: 'game' },
 				},
+				{
+					label: 'Account',
+					autogenerate: { directory: 'auth' },
+				},
 			],
 		}),
 		react(),

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/AstroCallback.astro
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/AstroCallback.astro
@@ -1,0 +1,45 @@
+---
+import ReactAuthCallback from './ReactAuthCallback';
+---
+
+<ReactAuthCallback client:only="react" />
+
+<style is:global>
+	.ck-auth-status {
+		text-align: center;
+		padding: 3rem 1rem;
+		min-height: 250px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.ck-spinner {
+		width: 50px;
+		height: 50px;
+		margin: 0 auto 20px;
+		border: 4px solid var(--sl-color-accent-low);
+		border-top-color: var(--ck-firelight);
+		border-radius: 50%;
+		animation: ck-spin 1s linear infinite;
+	}
+
+	@keyframes ck-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.ck-status-message {
+		font-family: var(--sl-font);
+		font-size: 1.125rem;
+		color: var(--ck-parchment);
+		margin-bottom: 0.5rem;
+	}
+
+	.ck-status-sub {
+		font-size: 0.875rem;
+		color: var(--sl-color-gray-3);
+	}
+</style>

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/AstroLogin.astro
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/AstroLogin.astro
@@ -1,0 +1,95 @@
+---
+import ReactAuthLogin from './ReactAuthLogin';
+---
+
+<ReactAuthLogin client:only="react" />
+
+<style is:global>
+	.ck-auth-container {
+		max-width: 500px;
+		margin: 2rem auto;
+		padding: 2rem 1rem;
+	}
+
+	.ck-auth-content {
+		text-align: center;
+	}
+
+	.ck-auth-content h2 {
+		font-family: var(--sl-font);
+		color: var(--ck-parchment);
+		margin-bottom: 1rem;
+	}
+
+	.ck-auth-desc {
+		color: var(--sl-color-gray-2);
+		margin-bottom: 2rem;
+		line-height: 1.6;
+	}
+
+	.ck-auth-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		margin-bottom: 2rem;
+	}
+
+	.ck-auth-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 0.875rem 1.5rem;
+		border: 1px solid var(--sl-color-hairline-light);
+		border-radius: 4px;
+		font-family: 'Lora', serif;
+		font-size: 1rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.ck-auth-btn:hover:not(:disabled) {
+		transform: translateY(-2px);
+		box-shadow: 0 4px 16px rgba(212, 164, 76, 0.15);
+	}
+
+	.ck-auth-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.ck-auth-btn--github {
+		background: #24292e;
+		color: white;
+	}
+
+	.ck-auth-btn--github:hover:not(:disabled) {
+		background: #2f363d;
+		border-color: var(--ck-firelight-dim);
+	}
+
+	.ck-auth-btn--discord {
+		background: #5865f2;
+		color: white;
+	}
+
+	.ck-auth-btn--discord:hover:not(:disabled) {
+		background: #4752c4;
+		border-color: var(--ck-firelight-dim);
+	}
+
+	.ck-auth-icon {
+		width: 20px;
+		height: 20px;
+	}
+
+	.ck-auth-info {
+		color: var(--sl-color-gray-3);
+		font-size: 0.875rem;
+	}
+
+	.ck-auth-info p {
+		margin: 0;
+	}
+</style>

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/AstroLogout.astro
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/AstroLogout.astro
@@ -1,0 +1,5 @@
+---
+import ReactAuthLogout from './ReactAuthLogout';
+---
+
+<ReactAuthLogout client:only="react" />

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthCallback.tsx
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthCallback.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { authBridge } from '@/lib/auth';
+
+export default function ReactAuthCallback() {
+	const [message, setMessage] = useState('Completing sign-in...');
+	const [subMessage, setSubMessage] = useState('Please wait');
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		const handleCallback = async () => {
+			try {
+				const session = await authBridge.handleCallback();
+
+				if (session) {
+					await new Promise((resolve) => setTimeout(resolve, 500));
+					window.location.href = '/';
+				} else {
+					setIsLoading(false);
+					setMessage('Authentication failed');
+					setSubMessage('Redirecting...');
+					setTimeout(() => {
+						window.location.href = '/';
+					}, 2000);
+				}
+			} catch (error) {
+				console.error('Auth callback error:', error);
+				setIsLoading(false);
+				setMessage('Authentication failed');
+				setSubMessage('Redirecting...');
+				setTimeout(() => {
+					window.location.href = '/';
+				}, 2000);
+			}
+		};
+
+		handleCallback();
+	}, []);
+
+	return (
+		<div className="ck-auth-status">
+			{isLoading && <div className="ck-spinner"></div>}
+			<div className="ck-status-message">{message}</div>
+			<div className="ck-status-sub">{subMessage}</div>
+		</div>
+	);
+}

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthLogin.tsx
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthLogin.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { authBridge } from '@/lib/auth';
+
+export default function ReactAuthLogin() {
+	const [isLoading, setIsLoading] = useState<string | null>(null);
+
+	const handleLogin = async (provider: 'github' | 'discord') => {
+		try {
+			setIsLoading(provider);
+			await authBridge.signInWithOAuth(provider);
+		} catch (error) {
+			console.error(`${provider} sign-in error:`, error);
+			setIsLoading(null);
+		}
+	};
+
+	return (
+		<div className="ck-auth-container">
+			<div className="ck-auth-content">
+				<h2>Enter the Realm</h2>
+				<p className="ck-auth-desc">
+					Sign in to save your progress, forge alliances, and compete
+					on the leaderboards.
+				</p>
+
+				<div className="ck-auth-buttons">
+					<button
+						onClick={() => handleLogin('github')}
+						disabled={isLoading !== null}
+						className="ck-auth-btn ck-auth-btn--github">
+						<svg
+							className="ck-auth-icon"
+							viewBox="0 0 16 16"
+							fill="currentColor">
+							<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+						</svg>
+						{isLoading === 'github'
+							? 'Opening portal...'
+							: 'Sign in with GitHub'}
+					</button>
+
+					<button
+						onClick={() => handleLogin('discord')}
+						disabled={isLoading !== null}
+						className="ck-auth-btn ck-auth-btn--discord">
+						<svg
+							className="ck-auth-icon"
+							viewBox="0 0 16 16"
+							fill="currentColor">
+							<path d="M13.545 2.907a13.227 13.227 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.19 12.19 0 0 0-3.658 0 8.258 8.258 0 0 0-.412-.833.051.051 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.041.041 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032c.001.014.01.028.021.037a13.276 13.276 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019c.308-.42.582-.863.818-1.329a.05.05 0 0 0-.01-.059.051.051 0 0 0-.018-.011 8.875 8.875 0 0 1-1.248-.595.05.05 0 0 1-.02-.066.051.051 0 0 1 .015-.019c.084-.063.168-.129.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.052.052 0 0 1 .053.007c.08.066.164.132.248.195a.051.051 0 0 1-.004.085 8.254 8.254 0 0 1-1.249.594.05.05 0 0 0-.03.03.052.052 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.235 13.235 0 0 0 4.001-2.02.049.049 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.034.034 0 0 0-.02-.019Zm-8.198 7.307c-.789 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612Zm5.316 0c-.788 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612Z" />
+						</svg>
+						{isLoading === 'discord'
+							? 'Opening portal...'
+							: 'Sign in with Discord'}
+					</button>
+				</div>
+
+				<div className="ck-auth-info">
+					<p>
+						By signing in, you agree to our Terms of Service and
+						Privacy Policy.
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthLogout.tsx
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthLogout.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { authBridge } from '@/lib/auth';
+
+export default function ReactAuthLogout() {
+	const [message, setMessage] = useState('Signing out...');
+	const [subMessage, setSubMessage] = useState('Please wait');
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		const handleLogout = async () => {
+			try {
+				try {
+					await authBridge.signOut();
+				} catch (err) {
+					console.log('[Logout] signOut skipped:', err);
+				}
+
+				try {
+					await authBridge.destroy();
+				} catch (err) {
+					console.warn('[Logout] destroy error:', err);
+				}
+
+				Object.keys(localStorage).forEach((key) => {
+					if (key.includes('supabase') || key.includes('sb-')) {
+						localStorage.removeItem(key);
+					}
+				});
+
+				setIsLoading(false);
+				setMessage('Signed out successfully');
+				setSubMessage('Returning to the realm...');
+
+				setTimeout(() => {
+					window.location.href = '/?_=' + Date.now();
+				}, 500);
+			} catch (error) {
+				console.error('[Logout] error:', error);
+				setIsLoading(false);
+				setMessage('Sign-out error occurred');
+				setSubMessage('Returning to the realm...');
+
+				setTimeout(() => {
+					window.location.href = '/?_=' + Date.now();
+				}, 1000);
+			}
+		};
+
+		handleLogout();
+	}, []);
+
+	return (
+		<div className="ck-auth-status">
+			{isLoading && <div className="ck-spinner"></div>}
+			<div className="ck-status-message">{message}</div>
+			<div className="ck-status-sub">{subMessage}</div>
+		</div>
+	);
+}

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/index.ts
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export { authBridge } from '@/lib/auth';

--- a/apps/chuckrpg/astro-chuckrpg/src/components/user/AstroProfile.astro
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/user/AstroProfile.astro
@@ -1,0 +1,71 @@
+---
+import ReactProfile from './ReactProfile';
+---
+
+<ReactProfile client:only="react" />
+
+<style is:global>
+	.ck-profile-guest {
+		text-align: center;
+		padding: 3rem 1rem;
+		color: var(--sl-color-gray-2);
+	}
+
+	.ck-profile-guest p {
+		margin-bottom: 1.5rem;
+		font-size: 1.1rem;
+	}
+
+	.ck-profile {
+		max-width: 600px;
+		margin: 2rem auto;
+		padding: 2rem;
+		border: 1px solid var(--sl-color-hairline-light);
+		border-radius: 4px;
+		background: var(--sl-color-gray-6);
+	}
+
+	.ck-profile__header {
+		display: flex;
+		align-items: center;
+		gap: 1.5rem;
+		margin-bottom: 2rem;
+	}
+
+	.ck-profile__avatar {
+		width: 80px;
+		height: 80px;
+		border-radius: 50%;
+		border: 2px solid var(--ck-firelight-dim);
+	}
+
+	.ck-profile__info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.ck-profile__name {
+		font-family: var(--sl-font);
+		color: var(--ck-parchment);
+		font-size: 1.5rem;
+		margin: 0;
+	}
+
+	.ck-profile__provider {
+		font-size: 0.8rem;
+		color: var(--ck-firelight);
+		text-transform: capitalize;
+		letter-spacing: 0.1em;
+	}
+
+	.ck-profile__email {
+		font-size: 0.875rem;
+		color: var(--sl-color-gray-3);
+	}
+
+	.ck-profile__actions {
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--sl-color-hairline);
+	}
+</style>

--- a/apps/chuckrpg/astro-chuckrpg/src/components/user/ReactProfile.tsx
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/user/ReactProfile.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { authBridge } from '@/lib/auth';
+import type { Session } from '@supabase/supabase-js';
+
+export default function ReactProfile() {
+	const [session, setSession] = useState<Session | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		authBridge
+			.getSession()
+			.then((s) => setSession(s))
+			.catch(() => setSession(null))
+			.finally(() => setLoading(false));
+	}, []);
+
+	if (loading) {
+		return (
+			<div className="ck-auth-status">
+				<div className="ck-spinner"></div>
+				<div className="ck-status-message">Loading profile...</div>
+			</div>
+		);
+	}
+
+	if (!session?.user) {
+		return (
+			<div className="ck-profile-guest">
+				<p>You are not signed in.</p>
+				<a href="/auth/login/" className="ck-btn ck-btn--primary">
+					<span className="ck-btn__fill"></span>
+					<span className="ck-btn__text">Sign In</span>
+				</a>
+			</div>
+		);
+	}
+
+	const user = session.user;
+	const name =
+		user.user_metadata?.full_name ||
+		user.user_metadata?.name ||
+		user.email?.split('@')[0] ||
+		'Adventurer';
+	const avatar = user.user_metadata?.avatar_url;
+	const provider = user.app_metadata?.provider || 'unknown';
+
+	return (
+		<div className="ck-profile">
+			<div className="ck-profile__header">
+				{avatar && (
+					<img
+						src={avatar}
+						alt={name}
+						className="ck-profile__avatar"
+					/>
+				)}
+				<div className="ck-profile__info">
+					<h2 className="ck-profile__name">{name}</h2>
+					<span className="ck-profile__provider">via {provider}</span>
+					{user.email && (
+						<span className="ck-profile__email">{user.email}</span>
+					)}
+				</div>
+			</div>
+
+			<div className="ck-profile__actions">
+				<a href="/auth/logout/" className="ck-btn ck-btn--ghost">
+					Sign Out
+				</a>
+			</div>
+		</div>
+	);
+}

--- a/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/callback.mdx
+++ b/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/callback.mdx
@@ -1,0 +1,10 @@
+---
+title: Callback
+description: Authentication callback
+sidebar:
+  hidden: true
+---
+
+import AstroCallback from '../../../components/auth/AstroCallback.astro';
+
+<AstroCallback />

--- a/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/login.mdx
+++ b/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/login.mdx
@@ -1,0 +1,28 @@
+---
+title: Sign In
+description: Sign in to your ChuckRPG account
+sidebar:
+  label: Sign In
+  order: 1
+---
+
+import AstroLogin from '../../../components/auth/AstroLogin.astro';
+
+<AstroLogin />
+
+## Why Sign In?
+
+### Save Your Progress
+Your game progress, settings, and preferences sync across all your devices.
+
+### Community
+Connect with the ChuckRPG community through Discord and GitHub.
+
+### Cross-Device
+Start on your desktop and continue on your laptop or mobile.
+
+## Supported Providers
+
+**GitHub** and **Discord** are currently supported for authentication.
+
+We only request basic profile information (username, email, avatar) from OAuth providers.

--- a/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/logout.mdx
+++ b/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/logout.mdx
@@ -1,0 +1,10 @@
+---
+title: Sign Out
+description: Sign out from your ChuckRPG account
+sidebar:
+  hidden: true
+---
+
+import AstroLogout from '../../../components/auth/AstroLogout.astro';
+
+<AstroLogout />

--- a/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/profile.mdx
+++ b/apps/chuckrpg/astro-chuckrpg/src/content/docs/auth/profile.mdx
@@ -1,0 +1,11 @@
+---
+title: Profile
+description: Your ChuckRPG adventurer profile
+sidebar:
+  label: Profile
+  order: 2
+---
+
+import AstroProfile from '../../../components/user/AstroProfile.astro';
+
+<AstroProfile />

--- a/apps/chuckrpg/astro-chuckrpg/src/lib/auth.ts
+++ b/apps/chuckrpg/astro-chuckrpg/src/lib/auth.ts
@@ -1,0 +1,10 @@
+// src/lib/auth.ts
+// Singleton AuthBridge for ChuckRPG — uses @kbve/astro's AuthBridge
+// which handles OAuth flows via IndexedDB-backed Supabase client.
+import { AuthBridge } from '@kbve/astro';
+
+export const SUPABASE_URL = 'https://supabase.kbve.com';
+export const SUPABASE_ANON_KEY =
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzU1NDAzMjAwLCJleHAiOjE5MTMxNjk2MDB9.oietJI22ZytbghFywvdYMSJp7rcsBdBYbcciJxeGWrg';
+
+export const authBridge = new AuthBridge(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/apps/chuckrpg/astro-chuckrpg/src/styles/global.css
+++ b/apps/chuckrpg/astro-chuckrpg/src/styles/global.css
@@ -29,10 +29,29 @@
 	--sl-color-accent: #d4a44c;
 	--sl-color-accent-high: #e8c06a;
 
+	/* Semantic colors — medieval palette */
+	--sl-color-blue-low: #2a2218;
+	--sl-color-blue: var(--ck-firelight-dim);
+	--sl-color-blue-high: var(--ck-firelight-bright);
+	--sl-color-green-low: #1a2a1e;
+	--sl-color-green: #4a7a5a;
+	--sl-color-green-high: #7aaa8a;
+	--sl-color-orange-low: #2e1e0e;
+	--sl-color-orange: #c8854a;
+	--sl-color-orange-high: #e8a86a;
+	--sl-color-red-low: #2e1414;
+	--sl-color-red: var(--ck-blood);
+	--sl-color-red-high: #c44040;
+	--sl-color-purple-low: #221a2a;
+	--sl-color-purple: #7a5a8a;
+	--sl-color-purple-high: #aa8aba;
+
 	--sl-color-bg: var(--ck-stone);
 	--sl-color-bg-nav: rgba(26, 26, 31, 0.92);
 	--sl-color-bg-sidebar: #151518;
 	--sl-color-bg-inline-code: #1f1e1c;
+	--sl-color-text-invert: var(--ck-stone);
+	--sl-color-bg-accent: var(--ck-firelight);
 
 	--sl-color-hairline-light: #2e2a26;
 	--sl-color-hairline: #242120;


### PR DESCRIPTION
## Summary
- Add OAuth login system using `@kbve/astro` AuthBridge (GitHub + Discord)
- Add auth pages: `/auth/login/`, `/auth/callback/`, `/auth/logout/`
- Add profile page at `/auth/profile/` showing user info from Supabase session
- Complete Starlight semantic color overrides (blue, green, orange, red, purple) mapped to medieval palette
- Add `--sl-color-text-invert` and `--sl-color-bg-accent` overrides
- Add Account sidebar section

## Architecture
Uses `@kbve/astro`'s `AuthBridge` class directly — no SharedWorker or SupabaseGateway complexity. Session is stored in IndexedDB via the library's built-in `IDBStorage`. Same Supabase instance as kbve.com (goauth already configured for chuckrpg.com).

## Test plan
- [x] `npx nx run astro-chuckrpg:build` passes (8 pages)
- [ ] Visual check: login page renders with ChuckRPG theme
- [ ] OAuth flow: GitHub/Discord sign-in redirects and callback works
- [ ] Profile page shows user info when authenticated
- [ ] Callout boxes render with medieval colors (not default Starlight blue)