### PR TITLE
fix(isometric): support both trusted and self-signed WebTransport certs

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -281,12 +281,12 @@ fn load_webtransport_identity() -> Option<lightyear::webtransport::prelude::Iden
             match identity {
                 Ok(id) => {
                     WT_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
+                    // PEM cert from file = CA-signed (Let's Encrypt) = trusted by browsers.
+                    // Clients must NOT use serverCertificateHashes for trusted certs.
+                    WT_CERT_TRUSTED.store(true, std::sync::atomic::Ordering::Relaxed);
 
-                    // Compute cert digest — Chrome's WebTransport QUIC stack
-                    // does NOT trust local CAs (mkcert), so clients need the
-                    // SHA-256 hash for serverCertificateHashes pinning.
-                    // For production (Let's Encrypt), the digest is harmless
-                    // since the browser will trust the CA natively.
+                    // Compute cert digest for diagnostics and self-signed fallback.
+                    // For trusted certs the client should ignore this digest.
                     let cert_chain = id.certificate_chain();
                     let certs = cert_chain.as_slice();
                     if let Some(cert) = certs.first() {
@@ -617,6 +617,11 @@ static CERT_DIGEST: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 /// Whether WebTransport is enabled (set once at startup).
 static WT_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+/// Whether the loaded cert is CA-signed (trusted) vs self-signed.
+/// Trusted certs (Let's Encrypt) must NOT use serverCertificateHashes — the browser
+/// validates them via the CA chain. Self-signed certs MUST use hash pinning.
+static WT_CERT_TRUSTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 /// Read the cert digest from the global store (for the token endpoint).
 pub fn get_cert_digest() -> &'static str {
     CERT_DIGEST.get().map(|s| s.as_str()).unwrap_or("")
@@ -625,6 +630,14 @@ pub fn get_cert_digest() -> &'static str {
 /// Check whether WebTransport is enabled.
 pub fn is_wt_enabled() -> bool {
     WT_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Check whether the WT cert is CA-signed (trusted by browsers natively).
+/// When true, clients must NOT use serverCertificateHashes and should
+/// connect via hostname so the browser validates the cert against the CA chain.
+/// When false, clients MUST use the cert_digest for hash pinning.
+pub fn is_wt_cert_trusted() -> bool {
+    WT_CERT_TRUSTED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Spawn a single server entity with WebSocket + optional WebTransport.

--- a/apps/kbve/axum-kbve/src/gameserver/token.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/token.rs
@@ -40,6 +40,9 @@ pub struct TokenResponse {
     pub server_wt_url: String,
     /// SHA-256 certificate digest (hex, 64 chars). Empty if using a trusted cert.
     pub cert_digest: String,
+    /// Certificate type: "trusted" (CA-signed, no hash pinning) or "self-signed"
+    /// (must use serverCertificateHashes with cert_digest). Empty if WT disabled.
+    pub cert_type: String,
 }
 
 /// `POST /api/v1/auth/game-token`
@@ -174,17 +177,44 @@ pub async fn game_token_handler(
 
     // Build transport URLs — WS and WT take different routes:
     //   WS:  wss://{request_host}/ws — path-based, gateway routes /ws → port 5000
-    //   WT:  https://{final_host}:5001 — QUIC/UDP must hit origin directly
+    //   WT:  https://{wt_host}:5001 — QUIC/UDP must hit origin directly
     let server_url = format!("wss://{request_host}/ws");
-    let cert_digest = super::get_cert_digest().to_owned();
+    let cert_trusted = super::is_wt_cert_trusted();
+    let cert_type = if !super::is_wt_enabled() {
+        String::new()
+    } else if cert_trusted {
+        "trusted".to_string()
+    } else {
+        "self-signed".to_string()
+    };
+
+    // For trusted (CA-signed) certs, the WT URL must use the hostname so the
+    // browser validates the cert against the CA chain (e.g. wt.kbve.com:5001).
+    // For self-signed certs, use the resolved IP since hash pinning doesn't
+    // care about hostname and avoids DNS resolution in the QUIC stack.
+    let cert_digest = if cert_trusted {
+        String::new()
+    } else {
+        super::get_cert_digest().to_owned()
+    };
+
+    // Determine the host for the WT URL
+    let wt_host = if cert_trusted {
+        // Use GAME_SERVER_HOST env var directly (hostname, not resolved IP)
+        std::env::var("GAME_SERVER_HOST").unwrap_or_else(|_| final_host.clone())
+    } else {
+        // Self-signed: use resolved IP
+        final_host.clone()
+    };
+
     let server_wt_url = if super::is_wt_enabled() {
-        format!("https://{final_host}:{wt_port}")
+        format!("https://{wt_host}:{wt_port}")
     } else {
         String::new()
     };
 
     tracing::info!(
-        "[game-token] issuing token: ws_url={server_url} wt_url={} digest_len={} host={request_host} final_host={final_host} transport={} addrs={server_addrs:?}",
+        "[game-token] issuing token: ws_url={server_url} wt_url={} cert_type={cert_type} digest_len={} host={request_host} final_host={final_host} transport={} addrs={server_addrs:?}",
         if server_wt_url.is_empty() {
             "<empty>"
         } else {
@@ -199,6 +229,7 @@ pub async fn game_token_handler(
         server_url,
         server_wt_url,
         cert_digest,
+        cert_type,
     }))
 }
 

--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -174,6 +174,8 @@ struct TokenFetchResult {
     server_wt_url: String,
     /// SHA-256 cert digest for self-signed WebTransport certs.
     cert_digest: String,
+    /// "trusted" or "self-signed" — controls whether hash pinning is used.
+    cert_type: String,
 }
 
 /// Resource tracking whether a WASM token fetch is in flight.
@@ -539,6 +541,7 @@ fn poll_ws_fallback(
         ws_url,
         wt_url: String::new(),
         cert_digest: String::new(),
+        cert_type: String::new(),
     };
     connect_to_server(&mut commands, &transport, &token_bytes);
 }
@@ -770,6 +773,7 @@ fn poll_go_online_request(
             ws_url: resolved_ws.clone(),
             wt_url,
             cert_digest,
+            cert_type: "self-signed".to_string(),
         };
 
         // Arm WS fallback if trying WebTransport on desktop
@@ -817,6 +821,7 @@ fn poll_go_online_request(
                             server_url: ws,
                             server_wt_url: result.server_wt_url,
                             cert_digest: result.cert_digest,
+                            cert_type: result.cert_type,
                         });
                     }
                 }
@@ -879,6 +884,7 @@ fn poll_token_fetch_result(
         ws_url,
         wt_url,
         cert_digest: result.cert_digest.clone(),
+        cert_type: result.cert_type.clone(),
     };
 
     // Arm WS fallback if we're about to try WebTransport
@@ -937,6 +943,7 @@ struct GameTokenResult {
     server_url: String,
     server_wt_url: String,
     cert_digest: String,
+    cert_type: String,
 }
 
 /// Fetch a ConnectToken from the auth API (WASM only).
@@ -1001,6 +1008,7 @@ async fn fetch_game_token(
         .unwrap_or("")
         .to_owned();
     let cert_digest = token_resp["cert_digest"].as_str().unwrap_or("").to_owned();
+    let cert_type = token_resp["cert_type"].as_str().unwrap_or("").to_owned();
 
     let token_bytes = bevy_kbve_net::net_config::base64_to_token_bytes(token_b64)?;
     Ok(GameTokenResult {
@@ -1008,6 +1016,7 @@ async fn fetch_game_token(
         server_url,
         server_wt_url,
         cert_digest,
+        cert_type,
     })
 }
 
@@ -1441,7 +1450,12 @@ struct TransportConfig {
     /// WebTransport URL (empty = not available).
     wt_url: String,
     /// Certificate digest for self-signed WebTransport certs (hex, 64 chars).
+    /// Empty when cert_type is "trusted" (CA-signed, browser validates via CA chain).
     cert_digest: String,
+    /// "trusted" = CA-signed cert (no hash pinning, connect via hostname),
+    /// "self-signed" = must use serverCertificateHashes with cert_digest.
+    /// Empty = WebTransport not available.
+    cert_type: String,
 }
 
 /// Initiate a Netcode connection to the game server.
@@ -1485,10 +1499,16 @@ fn connect_to_server(commands: &mut Commands, transport: &TransportConfig, token
     if !transport.wt_url.is_empty() {
         use lightyear::webtransport::prelude::client::*;
 
+        let is_trusted = transport.cert_type == "trusted";
         info!(
-            "[net] connect_to_server — using WebTransport: {} (digest={}...)",
+            "[net] connect_to_server — using WebTransport: {} (cert_type={}, digest={}...)",
             transport.wt_url,
-            &transport.cert_digest[..16.min(transport.cert_digest.len())]
+            transport.cert_type,
+            if transport.cert_digest.len() >= 16 {
+                &transport.cert_digest[..16]
+            } else {
+                &transport.cert_digest
+            }
         );
 
         // Parse the server address from the URL (https://host:port)
@@ -1496,22 +1516,47 @@ fn connect_to_server(commands: &mut Commands, transport: &TransportConfig, token
             .wt_url
             .trim_start_matches("https://")
             .trim_start_matches("http://");
-        let server_addr: std::net::SocketAddr = addr_str
-            .parse()
-            .unwrap_or_else(|_| "127.0.0.1:5001".parse().unwrap());
+
+        // For trusted certs, addr_str is "wt.kbve.com:5001" — resolve to IP for SocketAddr.
+        // For self-signed, addr_str is already "IP:port".
+        let server_addr: std::net::SocketAddr = if addr_str.parse::<std::net::SocketAddr>().is_ok()
+        {
+            addr_str.parse().unwrap()
+        } else {
+            // Hostname — resolve via DNS
+            use std::net::ToSocketAddrs;
+            addr_str
+                .to_socket_addrs()
+                .ok()
+                .and_then(|mut addrs| addrs.find(|a| a.is_ipv4()))
+                .unwrap_or_else(|| "127.0.0.1:5001".parse().unwrap())
+        };
+
+        // Belt and suspenders:
+        // - Trusted (CA-signed): empty digest → browser validates via CA chain
+        // - Self-signed: pass digest → browser uses serverCertificateHashes
+        let digest = if is_trusted {
+            info!("[net] trusted cert — no hash pinning, browser will validate via CA chain");
+            String::new()
+        } else {
+            info!("[net] self-signed cert — using hash pinning with cert_digest");
+            transport.cert_digest.clone()
+        };
 
         let client_entity = commands
             .spawn((
                 netcode,
                 PeerAddr(server_addr),
                 WebTransportClientIo {
-                    certificate_digest: transport.cert_digest.clone(),
+                    certificate_digest: digest,
                 },
                 ReplicationReceiver::default(),
             ))
             .id();
 
-        info!("[net] NetcodeClient+WebTransport entity spawned: {client_entity:?}");
+        info!(
+            "[net] NetcodeClient+WebTransport entity spawned: {client_entity:?} addr={server_addr}"
+        );
         commands.trigger(Connect {
             entity: client_entity,
         });


### PR DESCRIPTION
## Summary
- Server returns `cert_type` field: `trusted` (CA-signed) or `self-signed`
- Trusted path: hostname URL + no hash pinning → browser validates via CA chain
- Self-signed path: IP URL + SHA-256 digest → `serverCertificateHashes` pinning
- Belt and suspenders: both paths work, server auto-detects based on cert source

## Root cause
Chrome's WebTransport rejects `serverCertificateHashes` for CA-signed certs.
The QUIC handshake silently failed → `QUIC_NETWORK_IDLE_TIMEOUT`.