### PR TITLE
feat(isometric): self-signed cert fallback + 12-day rotation CronJob

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -322,10 +322,72 @@ fn load_webtransport_identity() -> Option<lightyear::webtransport::prelude::Iden
         }
     }
 
-    // --- Dev path: self-signed cert ---
-    tracing::info!("[wt-cert] generating self-signed cert...");
-    let identity =
-        Identity::self_signed(&["localhost", "127.0.0.1", "::1"]).expect("self-signed cert");
+    // --- Fallback path: pre-generated self-signed cert from CronJob ---
+    // In production, a CronJob rotates a self-signed cert every 12 days
+    // (WebTransport spec limit for hash-pinned certs) and stores it in
+    // the kbve-wt-selfsigned Secret mounted at GAME_WT_SELFSIGNED_CERT/KEY.
+    let ss_cert_path = std::env::var("GAME_WT_SELFSIGNED_CERT").ok();
+    let ss_key_path = std::env::var("GAME_WT_SELFSIGNED_KEY").ok();
+    if let (Some(sc), Some(sk)) = (ss_cert_path, ss_key_path) {
+        if std::path::Path::new(&sc).exists() && std::path::Path::new(&sk).exists() {
+            tracing::info!("[wt-cert] loading pre-generated self-signed cert from {sc}");
+            let identity = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(Identity::load_pemfiles(&sc, &sk))
+            });
+            match identity {
+                Ok(id) => {
+                    WT_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
+                    // Self-signed = NOT trusted, must use hash pinning
+                    let cert_chain = id.certificate_chain();
+                    if let Some(cert) = cert_chain.as_slice().first() {
+                        let digest = cert.hash();
+                        let raw_bytes: &[u8] = digest.as_ref();
+                        let digest_hex: String =
+                            raw_bytes.iter().map(|b| format!("{b:02X}")).collect();
+                        tracing::info!(
+                            "[wt-cert] pre-generated self-signed cert digest: {digest_hex}"
+                        );
+                        let _ = CERT_DIGEST.set(digest_hex);
+                    }
+                    tracing::info!("[wt-cert] using pre-generated self-signed cert (hash-pinned)");
+                    return Some(id);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "[wt-cert] failed to load pre-generated self-signed cert: {e} — generating at runtime"
+                    );
+                }
+            }
+        }
+    }
+
+    // --- Last resort: generate self-signed cert at runtime ---
+    // Include production hostname + public IP in SANs so the cert works
+    // both locally and in production.
+    let mut sans = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    if let Ok(host) = std::env::var("GAME_SERVER_HOST") {
+        if !host.is_empty() && host != "localhost" {
+            tracing::info!("[wt-cert] adding GAME_SERVER_HOST '{host}' to self-signed SANs");
+            sans.push(host.clone());
+            // Also resolve and add the IP so both hostname and IP connections work
+            if let Ok(addrs) = std::net::ToSocketAddrs::to_socket_addrs(&(host.as_str(), 0)) {
+                for addr in addrs {
+                    let ip = addr.ip().to_string();
+                    if !sans.contains(&ip) {
+                        tracing::info!("[wt-cert] adding resolved IP '{ip}' to self-signed SANs");
+                        sans.push(ip);
+                    }
+                }
+            }
+        }
+    }
+    let san_refs: Vec<&str> = sans.iter().map(|s| s.as_str()).collect();
+    tracing::info!("[wt-cert] generating self-signed cert with SANs: {san_refs:?}");
+    let identity = Identity::self_signed(&san_refs).expect("self-signed cert");
     WT_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
     tracing::info!("[wt-cert] self-signed identity created OK");
 

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -125,12 +125,19 @@ spec:
                         value: '/etc/ssl/webtransport/tls.crt'
                       - name: GAME_WT_KEY
                         value: '/etc/ssl/webtransport/tls.key'
+                      - name: GAME_WT_SELFSIGNED_CERT
+                        value: '/etc/ssl/webtransport-selfsigned/tls.crt'
+                      - name: GAME_WT_SELFSIGNED_KEY
+                        value: '/etc/ssl/webtransport-selfsigned/tls.key'
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd
                         readOnly: true
                       - name: wt-tls
                         mountPath: /etc/ssl/webtransport
+                        readOnly: true
+                      - name: wt-selfsigned-tls
+                        mountPath: /etc/ssl/webtransport-selfsigned
                         readOnly: true
                   resources:
                       requests:
@@ -149,6 +156,10 @@ spec:
                 - name: wt-tls
                   secret:
                       secretName: kbve-wt-tls
+                - name: wt-selfsigned-tls
+                  secret:
+                      secretName: kbve-wt-selfsigned
+                      optional: true
 ---
 apiVersion: v1
 kind: Service

--- a/apps/kube/kbve/manifest/kbve-wt-selfsigned-cronjob.yaml
+++ b/apps/kube/kbve/manifest/kbve-wt-selfsigned-cronjob.yaml
@@ -1,0 +1,113 @@
+---
+# ServiceAccount for the cert rotation CronJob
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: kbve-wt-cert-rotator
+    namespace: kbve
+---
+# RBAC: allow the CronJob to manage the selfsigned cert Secret
+# and trigger deployment rollouts
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: kbve-wt-cert-rotator
+    namespace: kbve
+rules:
+    - apiGroups: ['']
+      resources: [secrets]
+      resourceNames: [kbve-wt-selfsigned]
+      verbs: [get, update, patch]
+    - apiGroups: ['']
+      resources: [secrets]
+      verbs: [create]
+    - apiGroups: [apps]
+      resources: [deployments]
+      resourceNames: [kbve-deployment]
+      verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-wt-cert-rotator
+    namespace: kbve
+subjects:
+    - kind: ServiceAccount
+      name: kbve-wt-cert-rotator
+      namespace: kbve
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: kbve-wt-cert-rotator
+---
+# CronJob: generate a self-signed cert every 12 days for WebTransport
+# hash pinning. The cert includes wt.kbve.com + the LB public IP as SANs.
+# After creating the Secret, it patches the deployment annotation to
+# trigger a rolling restart so the server picks up the new cert.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+    name: kbve-wt-cert-rotator
+    namespace: kbve
+    labels:
+        app: kbve
+        component: webtransport-cert-rotator
+spec:
+    # Every 12 days at 03:00 UTC (288 hours)
+    schedule: '0 3 1,13,25 * *'
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 2
+    failedJobsHistoryLimit: 3
+    jobTemplate:
+        spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 300
+            template:
+                spec:
+                    serviceAccountName: kbve-wt-cert-rotator
+                    restartPolicy: OnFailure
+                    containers:
+                        - name: certgen
+                          image: alpine/openssl:latest
+                          command:
+                              - /bin/sh
+                              - -c
+                              - |
+                                  set -e
+
+                                  # Install kubectl
+                                  apk add --no-cache curl
+                                  curl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+                                  chmod +x kubectl && mv kubectl /usr/local/bin/
+
+                                  HOSTNAME="wt.kbve.com"
+                                  PUBLIC_IP="142.132.206.71"
+                                  SECRET_NAME="kbve-wt-selfsigned"
+                                  DEPLOY_NAME="kbve-deployment"
+                                  DAYS=13
+
+                                  echo "Generating self-signed cert for ${HOSTNAME} / ${PUBLIC_IP} (${DAYS} days)"
+
+                                  # Generate ECDSA key + self-signed cert with SANs
+                                  openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+                                    -keyout /tmp/tls.key -out /tmp/tls.crt \
+                                    -days ${DAYS} -nodes \
+                                    -subj "/CN=${HOSTNAME}" \
+                                    -addext "subjectAltName=DNS:${HOSTNAME},DNS:localhost,IP:${PUBLIC_IP},IP:127.0.0.1"
+
+                                  echo "Cert generated:"
+                                  openssl x509 -in /tmp/tls.crt -noout -subject -dates -ext subjectAltName
+
+                                  # Create or update the Secret
+                                  kubectl create secret tls "${SECRET_NAME}" \
+                                    --cert=/tmp/tls.crt --key=/tmp/tls.key \
+                                    --dry-run=client -o yaml | kubectl apply -f -
+
+                                  echo "Secret ${SECRET_NAME} updated"
+
+                                  # Trigger rollout restart by patching annotation
+                                  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                                  kubectl patch deployment "${DEPLOY_NAME}" \
+                                    -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"wt-cert-rotated\":\"${TIMESTAMP}\"}}}}}"
+
+                                  echo "Deployment ${DEPLOY_NAME} rollout triggered at ${TIMESTAMP}"

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
     - kbve-deployment.yaml
     - kbve-gateway.yaml
     - kbve-wt-lb.yaml
+    - kbve-wt-selfsigned-cronjob.yaml


### PR DESCRIPTION
## Summary
Follow-up to #9110 (trusted cert fix). Adds the self-signed fallback layer.

### Server cert loading priority (belt and suspenders):
1. Trusted (CA-signed) from `GAME_WT_CERT/KEY` — no hash pinning
2. Pre-generated self-signed from `GAME_WT_SELFSIGNED_CERT/KEY` — hash pinning
3. Runtime-generated self-signed with production SANs — hash pinning
4. WebSocket fallback if all WT paths fail

### CronJob (`kbve-wt-cert-rotator`):
- Runs 1st, 13th, 25th of each month (within 14-day WT spec limit)
- Generates ECDSA self-signed cert for `wt.kbve.com` + `142.132.206.71`
- Updates `kbve-wt-selfsigned` Secret + triggers deployment rollout

### Deployment:
- Second volume mount for self-signed cert (optional Secret)
- `GAME_WT_SELFSIGNED_CERT/KEY` env vars