### PR TITLE
feat(axum-discordsh): Admin + Board tier write commands for GitHub

### DIFF
--- a/apps/discordsh/axum-discordsh/README.md
+++ b/apps/discordsh/axum-discordsh/README.md
@@ -111,14 +111,22 @@ Auto-posts notice board and task board embeds to a Discord thread on a recurring
 
 All `/github` subcommands are gated by the permission check (`GITHUB_REQUIRED_PERMISSIONS`) and per-user rate limiter (`GITHUB_CMD_RATE_LIMIT`). Each accepts an optional `repo` argument in `owner/repo` format — defaults to `GITHUB_DEFAULT_REPO` / `GH_REPO` / `KBVE/kbve`.
 
-| Command               | Parameters                                   | Description                                                                                                      |
-| --------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `/github noticeboard` | `repo?`, `stale_days?` (default: 3)          | Fetches open issues + PRs, filters stale items, and posts a priority-sorted notice board embed (critical first). |
-| `/github taskboard`   | `repo?`, `phase?` (default: "Current Phase") | Groups open issues by department label (programming, qa, devops, etc.) and shows progress counts.                |
-| `/github issues`      | `repo?`, `limit?` (default: 10, max: 25)     | Lists open issues with labels, assignees, and links. Embed sidebar color matches the first label.                |
-| `/github pulls`       | `repo?`, `limit?` (default: 10, max: 25)     | Lists open PRs with branch, labels, assignees, and `[DRAFT]` markers.                                            |
-| `/github repo`        | `repo?`                                      | Shows repository info — description, default branch, and open issue count.                                       |
-| `/github commits`     | `repo?`, `limit?` (default: 10, max: 25)     | Shows recent commits with author, short SHA, and first line of the commit message.                               |
+| Command               | Parameters                                    | Description                                                                                                      |
+| --------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `/github noticeboard` | `repo?`, `stale_days?` (default: 3)           | Fetches open issues + PRs, filters stale items, and posts a priority-sorted notice board embed (critical first). |
+| `/github taskboard`   | `repo?`, `phase?` (default: "Current Phase")  | Groups open issues by department label (programming, qa, devops, etc.) and shows progress counts.                |
+| `/github issues`      | `repo?`, `limit?` (default: 10, max: 25)      | Lists open issues with labels, assignees, and links. Embed sidebar color matches the first label.                |
+| `/github pulls`       | `repo?`, `limit?` (default: 10, max: 25)      | Lists open PRs with branch, labels, assignees, and `[DRAFT]` markers.                                            |
+| `/github repo`        | `repo?`                                       | Shows repository info — description, default branch, and open issue count.                                       |
+| `/github commits`     | `repo?`, `limit?` (default: 10, max: 25)      | Shows recent commits with author, short SHA, and first line of the commit message.                               |
+| `/github view`        | `number`, `repo?`                             | Detailed issue/PR card with priority badge and interactive dropdowns (Board+ tier).                              |
+| `/gh`                 | `number`                                      | Top-level shortcut for `/github view` using the default repo.                                                    |
+| `/github create`      | `title`, `body?`, `labels?`, `type?`, `repo?` | Create a new issue. Labels are comma-separated. **(Admin tier)**                                                 |
+| `/github close`       | `number`, `repo?`                             | Close an issue or PR. **(Admin tier)**                                                                           |
+| `/github reopen`      | `number`, `repo?`                             | Reopen a closed issue or PR. **(Admin tier)**                                                                    |
+| `/github comment`     | `number`, `text`, `repo?`                     | Post a comment on an issue/PR. Attributed to the Discord user. **(Board tier)**                                  |
+| `/github assign`      | `number`, `username`, `repo?`                 | Assign a GitHub user to an issue. **(Board tier)**                                                               |
+| `/github unassign`    | `number`, `username`, `repo?`                 | Remove a GitHub user from an issue. **(Board tier)**                                                             |
 
 ## Development
 

--- a/apps/discordsh/axum-discordsh/src/discord/commands/github_board.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/commands/github_board.rs
@@ -2,7 +2,7 @@
 //! issues, and pull request embeds powered by the guild's GitHub PAT.
 
 use askama::Template;
-use jedi::entity::github::GitHubClient;
+use jedi::entity::github::{CreateIssueRequest, GitHubClient, UpdateIssueRequest};
 use tracing::{info, warn};
 
 use crate::discord::bot::{Context, Error};
@@ -87,7 +87,13 @@ fn parse_label_color(labels: &[jedi::entity::github::GitHubLabel]) -> Option<u32
         "pulls",
         "repo",
         "commits",
-        "view"
+        "view",
+        "create",
+        "close",
+        "reopen",
+        "comment",
+        "assign",
+        "unassign"
     )
 )]
 pub async fn github(_ctx: Context<'_>) -> Result<(), Error> {
@@ -843,5 +849,340 @@ fn truncate(s: &str, max: usize) -> String {
         s.to_string()
     } else {
         format!("{}…", &s[..max - 1])
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Write Commands (Admin / Board tier)
+// ═══════════════════════════════════════════════════════════════════
+
+// ── /github create ──────────────────────────────────────────────────
+
+/// Create a new issue.
+#[poise::command(slash_command)]
+async fn create(
+    ctx: Context<'_>,
+    #[description = "Issue title"] title: String,
+    #[description = "Issue body (optional)"] body: Option<String>,
+    #[description = "Comma-separated labels (optional)"] labels: Option<String>,
+    #[description = "Issue type: Bug, Feature, or Task (optional)"] issue_type: Option<String>,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    if !check_tier(ctx, CommandTier::Admin).await? {
+        return Ok(());
+    }
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+        let full_name = format!("{}/{}", owner, repo_name);
+
+        let label_list: Vec<String> = labels
+            .as_deref()
+            .unwrap_or("")
+            .split(',')
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let req = CreateIssueRequest {
+            title: title.clone(),
+            body,
+            labels: label_list,
+            assignees: vec![],
+            issue_type,
+        };
+
+        match gh.create_issue(&owner, &repo_name, &req).await {
+            Ok(issue) => {
+                info!(
+                    user = %ctx.author().name,
+                    repo = full_name,
+                    issue = issue.number,
+                    "Issue created via Discord"
+                );
+
+                let embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(format!(
+                        "Created #{} — {}",
+                        issue.number,
+                        truncate(&issue.title, 60)
+                    ))
+                    .url(&issue.html_url)
+                    .description(format!("Issue created in `{full_name}`"))
+                    .color(0x238636);
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => {
+                warn!(error = %e, repo = full_name, "Failed to create issue");
+                Err(format!("Failed to create issue in `{full_name}`: {e}"))
+            }
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => send_error(ctx, "The request timed out — please try again.").await,
+    }
+}
+
+// ── /github close ───────────────────────────────────────────────────
+
+/// Close an issue or pull request.
+#[poise::command(slash_command)]
+async fn close(
+    ctx: Context<'_>,
+    #[description = "Issue or PR number"] number: u64,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    if !check_tier(ctx, CommandTier::Admin).await? {
+        return Ok(());
+    }
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+        let full_name = format!("{}/{}", owner, repo_name);
+
+        let req = UpdateIssueRequest {
+            state: Some("closed".to_owned()),
+            ..Default::default()
+        };
+
+        match gh.update_issue(&owner, &repo_name, number, &req).await {
+            Ok(_) => {
+                ctx.data()
+                    .app
+                    .github_cache
+                    .invalidate_issue(&owner, &repo_name, number);
+                info!(user = %ctx.author().name, issue = number, "Issue closed via Discord");
+
+                let embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(format!("Closed #{number}"))
+                    .description(format!("Issue closed in `{full_name}`"))
+                    .color(0x8b949e);
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to close #{number}: {e}")),
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => send_error(ctx, "The request timed out — please try again.").await,
+    }
+}
+
+// ── /github reopen ──────────────────────────────────────────────────
+
+/// Reopen a closed issue or pull request.
+#[poise::command(slash_command)]
+async fn reopen(
+    ctx: Context<'_>,
+    #[description = "Issue or PR number"] number: u64,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    if !check_tier(ctx, CommandTier::Admin).await? {
+        return Ok(());
+    }
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+        let full_name = format!("{}/{}", owner, repo_name);
+
+        let req = UpdateIssueRequest {
+            state: Some("open".to_owned()),
+            ..Default::default()
+        };
+
+        match gh.update_issue(&owner, &repo_name, number, &req).await {
+            Ok(_) => {
+                ctx.data()
+                    .app
+                    .github_cache
+                    .invalidate_issue(&owner, &repo_name, number);
+                info!(user = %ctx.author().name, issue = number, "Issue reopened via Discord");
+
+                let embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(format!("Reopened #{number}"))
+                    .description(format!("Issue reopened in `{full_name}`"))
+                    .color(0x238636);
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to reopen #{number}: {e}")),
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => send_error(ctx, "The request timed out — please try again.").await,
+    }
+}
+
+// ── /github comment ─────────────────────────────────────────────────
+
+/// Post a comment on an issue or pull request.
+#[poise::command(slash_command)]
+async fn comment(
+    ctx: Context<'_>,
+    #[description = "Issue or PR number"] number: u64,
+    #[description = "Comment text"] text: String,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    if !check_tier(ctx, CommandTier::Board).await? {
+        return Ok(());
+    }
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+        let full_name = format!("{}/{}", owner, repo_name);
+
+        // Prepend Discord author attribution
+        let comment_body = format!("**{}** (via Discord):\n\n{}", ctx.author().name, text);
+
+        match gh
+            .create_comment(&owner, &repo_name, number, &comment_body)
+            .await
+        {
+            Ok(c) => {
+                info!(
+                    user = %ctx.author().name,
+                    issue = number,
+                    comment_id = c.id,
+                    "Comment posted via Discord"
+                );
+
+                let embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(format!("Commented on #{number}"))
+                    .url(&c.html_url)
+                    .description(truncate(&text, 200))
+                    .color(0x58a6ff);
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to comment on #{number}: {e}")),
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => send_error(ctx, "The request timed out — please try again.").await,
+    }
+}
+
+// ── /github assign ──────────────────────────────────────────────────
+
+/// Assign a user to an issue.
+#[poise::command(slash_command)]
+async fn assign(
+    ctx: Context<'_>,
+    #[description = "Issue or PR number"] number: u64,
+    #[description = "GitHub username to assign"] username: String,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    if !check_tier(ctx, CommandTier::Board).await? {
+        return Ok(());
+    }
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+        let full_name = format!("{}/{}", owner, repo_name);
+
+        match gh.add_assignees(&owner, &repo_name, number, &[username.as_str()]).await {
+            Ok(_) => {
+                ctx.data().app.github_cache.invalidate_issue(&owner, &repo_name, number);
+                info!(user = %ctx.author().name, issue = number, assignee = %username, "Assignee added via Discord");
+
+                let embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(format!("Assigned `{username}` to #{number}"))
+                    .description(format!("in `{full_name}`"))
+                    .color(0x58a6ff);
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to assign `{username}` to #{number}: {e}")),
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => send_error(ctx, "The request timed out — please try again.").await,
+    }
+}
+
+// ── /github unassign ────────────────────────────────────────────────
+
+/// Remove a user from an issue.
+#[poise::command(slash_command)]
+async fn unassign(
+    ctx: Context<'_>,
+    #[description = "Issue or PR number"] number: u64,
+    #[description = "GitHub username to remove"] username: String,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    if !check_tier(ctx, CommandTier::Board).await? {
+        return Ok(());
+    }
+    ctx.defer().await?;
+
+    match tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let gh = get_github_client(ctx).await?;
+        let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+        let full_name = format!("{}/{}", owner, repo_name);
+
+        match gh.remove_assignees(&owner, &repo_name, number, &[username.as_str()]).await {
+            Ok(_) => {
+                ctx.data().app.github_cache.invalidate_issue(&owner, &repo_name, number);
+                info!(user = %ctx.author().name, issue = number, assignee = %username, "Assignee removed via Discord");
+
+                let embed = poise::serenity_prelude::CreateEmbed::new()
+                    .title(format!("Unassigned `{username}` from #{number}"))
+                    .description(format!("in `{full_name}`"))
+                    .color(0x8b949e);
+
+                ctx.send(poise::CreateReply::default().embed(embed))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to unassign `{username}` from #{number}: {e}")),
+        }
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => send_error(ctx, &msg).await,
+        Err(_) => send_error(ctx, "The request timed out — please try again.").await,
     }
 }


### PR DESCRIPTION
## Summary

Complete the three-tier permission system with write commands that consume the jedi GitHub write API.

### Admin Tier (ADMINISTRATOR by default)
| Command | Description |
|---|---|
| `/github create` | Create issue with title, body, comma-separated labels, and issue type (Bug/Feature/Task) |
| `/github close` | Close an issue or PR by number |
| `/github reopen` | Reopen a closed issue or PR |

### Board Tier (MANAGE_MESSAGES by default)
| Command | Description |
|---|---|
| `/github comment` | Post a comment on an issue/PR, attributed to the Discord user who ran the command |
| `/github assign` | Assign a GitHub user to an issue |
| `/github unassign` | Remove a GitHub user from an issue |

### Design decisions
- Comments are prefixed with `**username** (via Discord):` for attribution
- Cache is invalidated after every mutation (close, reopen, assign, unassign)
- All commands follow the same timeout + error handling + audit logging pattern
- `/github create` supports the native GitHub issue type field

### Full command count: 15 subcommands
Read (4): `issues`, `pulls`, `repo`, `commits`
Board (6): `noticeboard`, `taskboard`, `view`, `comment`, `assign`, `unassign`
Admin (3): `create`, `close`, `reopen`
Shortcut (1): `/gh`

## Test plan
- [x] 742 axum-discordsh tests pass
- [ ] Manual: Admin user can `/github create` a new issue
- [ ] Manual: Admin user can `/github close 9081` and `/github reopen 9081`
- [ ] Manual: Board user can `/github comment 9081 "test"` and see attribution
- [ ] Manual: Board user can `/github assign 9081 username`
- [ ] Manual: Read-only user gets denied on all write commands