### PR TITLE
fix(rows): add curl to Dockerfile for utoipa-swagger-ui build

### DIFF
--- a/apps/ows/rows/Dockerfile
+++ b/apps/ows/rows/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.94-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y \
-    pkg-config libssl-dev protobuf-compiler \
+    pkg-config libssl-dev protobuf-compiler curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src


### PR DESCRIPTION
## Summary
Add `curl` to the Docker build stage — `utoipa-swagger-ui` downloads Swagger UI assets at compile time via curl, which isn't in `rust:1.94-slim-bookworm`.

## Fixes
- #9121 — CI Docker / rows build failure