### PR TITLE
fix(rows): resolve GETLASTZONENAME + default stat values for character create

### DIFF
--- a/apps/ows/rows/src/repo.rs
+++ b/apps/ows/rows/src/repo.rs
@@ -578,6 +578,47 @@ impl<'a> CharsRepo<'a> {
         Ok(data)
     }
 
+    /// Default stat columns for character INSERT — all NOT NULL in the DB.
+    const CHAR_DEFAULTS: &'static str = "
+        perception, acrobatics, climb, stealth, spirit, magic,
+        teamnumber, thirst, hunger, gold, score, characterlevel,
+        gender, xp, hitdie, wounds, size, weight,
+        maxhealth, health, healthregenrate,
+        maxmana, mana, manaregenrate,
+        maxenergy, energy, energyregenrate,
+        maxfatigue, fatigue, fatigueregenrate,
+        maxstamina, stamina, staminaregenrate,
+        maxendurance, endurance, enduranceregenrate,
+        strength, dexterity, constitution, intellect, wisdom, charisma, agility,
+        fortitude, reflex, willpower,
+        baseattack, baseattackbonus, attackpower, attackspeed,
+        critchance, critmultiplier, haste, spellpower, spellpenetration,
+        defense, dodge, parry, avoidance, versatility, multishot,
+        initiative, naturalarmor, physicalarmor, bonusarmor, forcearmor, magicarmor,
+        resistance, reloadspeed, range, speed,
+        silver, copper, freecurrency, premiumcurrency, fame, alignment,
+        isadmin, ismoderator";
+
+    const CHAR_ZEROS: &'static str = "
+        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 1,
+        0, 0, 0, 0, 1, 0,
+        100, 100, 0,
+        100, 100, 0,
+        100, 100, 0,
+        100, 100, 0,
+        100, 100, 0,
+        100, 100, 0,
+        0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+        false, false";
+
     pub async fn create_character(
         &self,
         customer_guid: Uuid,
@@ -585,17 +626,20 @@ impl<'a> CharsRepo<'a> {
         char_name: &str,
         _class_name: &str,
     ) -> Result<(), RowsError> {
-        sqlx::query(
-            "INSERT INTO characters (customerguid, userguid, charname, email, createdate)
-             SELECT $1, $2, $3, u.email, NOW()
+        let sql = format!(
+            "INSERT INTO characters (customerguid, userguid, charname, email, createdate, {})
+             SELECT $1, $2, $3, u.email, NOW(), {}
              FROM users u
              WHERE u.customerguid = $1 AND u.userguid = $2",
-        )
-        .bind(customer_guid)
-        .bind(user_guid)
-        .bind(char_name)
-        .execute(self.0)
-        .await?;
+            Self::CHAR_DEFAULTS,
+            Self::CHAR_ZEROS
+        );
+        sqlx::query(&sql)
+            .bind(customer_guid)
+            .bind(user_guid)
+            .bind(char_name)
+            .execute(self.0)
+            .await?;
         Ok(())
     }
 
@@ -608,23 +652,25 @@ impl<'a> CharsRepo<'a> {
         char_name: &str,
         default_set_name: &str,
     ) -> Result<(), RowsError> {
-        // Insert character using defaults from DefaultCharacterValues table
-        sqlx::query(
+        let sql = format!(
             "INSERT INTO characters (customerguid, userguid, charname, email, createdate,
-                mapname, x, y, z, rx, ry, rz)
+                mapname, x, y, z, rx, ry, rz, {})
              SELECT $1, $2, $3, u.email, NOW(),
-                    dcv.startingmapname, dcv.x, dcv.y, dcv.z, dcv.rx, dcv.ry, dcv.rz
+                    dcv.startingmapname, dcv.x, dcv.y, dcv.z, dcv.rx, dcv.ry, dcv.rz, {}
              FROM defaultcharactervalues dcv
              JOIN users u ON u.customerguid = $1 AND u.userguid = $2
              WHERE dcv.customerguid = $1
                AND dcv.defaultsetname = $4",
-        )
-        .bind(customer_guid)
-        .bind(user_guid)
-        .bind(char_name)
-        .bind(default_set_name)
-        .execute(self.0)
-        .await?;
+            Self::CHAR_DEFAULTS,
+            Self::CHAR_ZEROS
+        );
+        sqlx::query(&sql)
+            .bind(customer_guid)
+            .bind(user_guid)
+            .bind(char_name)
+            .bind(default_set_name)
+            .execute(self.0)
+            .await?;
         Ok(())
     }
 

--- a/apps/ows/rows/src/service/instances.rs
+++ b/apps/ows/rows/src/service/instances.rs
@@ -2,7 +2,7 @@ use super::OWSService;
 use crate::error::RowsError;
 use crate::models::*;
 use crate::mq::SpinUpMessage;
-use crate::repo::InstanceRepo;
+use crate::repo::{CharsRepo, InstanceRepo};
 use uuid::Uuid;
 
 impl OWSService {
@@ -12,15 +12,33 @@ impl OWSService {
         char_name: &str,
         zone_name: &str,
     ) -> Result<JoinMapResult, RowsError> {
+        // Resolve GETLASTZONENAME: look up the character's last zone from the DB
+        let resolved_zone = if zone_name.is_empty() || zone_name == "GETLASTZONENAME" {
+            let chars_repo = CharsRepo(&self.state.db);
+            let character = chars_repo
+                .get_by_name(customer_guid, char_name)
+                .await?
+                .ok_or_else(|| RowsError::NotFound(format!("Character not found: {char_name}")))?;
+            character.map_name.unwrap_or_default()
+        } else {
+            zone_name.to_string()
+        };
+
+        if resolved_zone.is_empty() {
+            return Err(RowsError::BadRequest(
+                "ZoneName is empty. Make sure the character is assigned to a Zone!".into(),
+            ));
+        }
+
         let repo = InstanceRepo(&self.state.db);
         let result = repo
-            .join_map_by_char_name(customer_guid, char_name, zone_name)
+            .join_map_by_char_name(customer_guid, char_name, &resolved_zone)
             .await?;
 
         if result.need_to_startup_map {
             // Spin-up lock: prevent duplicate Agones allocations for the same zone.
             // If another request is already spinning up this zone, skip the publish.
-            let lock_key = format!("{customer_guid}:{zone_name}");
+            let lock_key = format!("{customer_guid}:{resolved_zone}");
             if self.state.zone_spinup_locks.contains_key(&lock_key) {
                 tracing::info!(
                     zone = zone_name,


### PR DESCRIPTION
## Summary

### GETLASTZONENAME resolution
When UE sends `GetServerToConnectTo` with `ZoneName = "GETLASTZONENAME"`, ROWS now looks up the character's `mapname` from the DB instead of passing the literal string to the query. This matches upstream C# OWS behavior and is required for travel after login.

### Character create defaults
Both `create_character` and `create_character_with_defaults` now set default 0 values for all 80+ NOT NULL stat columns (perception, acrobatics, gold, maxhealth, etc.). Previously only a handful of columns were set, causing NOT NULL constraint violations.

## Fixes
- Empty `serverip` / `port` on Enter World (GETLASTZONENAME not resolved)
- `null value in column "perception" violates not-null constraint` on character creation