### PR TITLE
fix: resolve CodeQL code scanning alerts #482, #485, #488

### DIFF
--- a/apps/kbve/edge/functions/meme/index.ts
+++ b/apps/kbve/edge/functions/meme/index.ts
@@ -75,8 +75,8 @@ serve(async (req) => {
 
   try {
     // All access requires service_role — axum gateway handles user auth
-    let token = "";
-    let claims: JwtClaims = { role: "anon" };
+    let token: string;
+    let claims: JwtClaims;
 
     try {
       token = extractToken(req);

--- a/apps/memes/astro-memes/src/components/feed/ReactMemeContent.tsx
+++ b/apps/memes/astro-memes/src/components/feed/ReactMemeContent.tsx
@@ -32,7 +32,7 @@ import { PLACEHOLDER_MEMES } from '../../lib/stores/placeholders';
 const SIGNIN_MODAL = 'signin';
 
 export default function ReactMemeContent() {
-	const auth = useStore($auth);
+	useStore($auth);
 	const memes = useStore($feedMemes);
 	const hasMore = useStore($feedHasMore);
 	const feedLoading = useStore($feedLoading);

--- a/packages/data/codegen/generate-proto-registry.mjs
+++ b/packages/data/codegen/generate-proto-registry.mjs
@@ -51,7 +51,6 @@ const allProtos = findProtos(protoRoot);
 
 // Build registry
 const protos = allProtos.map((protoFile) => {
-	const name = protoFile.replace(/\.proto$/, '').replace(/\//g, '_').replace(/^[^_]+_/, '');
 	const fullPath = resolve(protoRoot, protoFile);
 	const content = readFileSync(fullPath, 'utf8');
 


### PR DESCRIPTION
## Summary
- **#482** (warning): Remove useless initial assignment to `token` and `claims` in `edge/functions/meme/index.ts` — the catch block returns early, so the initial values are never read
- **#485** (note): Drop unused `auth` variable in `ReactMemeContent.tsx` — `useStore($auth)` kept for re-render trigger, but the variable was unused (code uses `$auth.get()` directly)
- **#488** (note): Remove unused `name` variable in `generate-proto-registry.mjs` — computed but never referenced in the return object

## Test plan
- [x] All changes are dead code removal — no behavioral change
- [ ] CodeQL re-scan should close these alerts