### PR TITLE
fix(rows): return worldServerId from RegisterLauncher + deploy script fixes

### DIFF
--- a/apps/ows/rows/src/rest.rs
+++ b/apps/ows/rows/src/rest.rs
@@ -586,7 +586,7 @@ async fn register_launcher(
     State(hs): State<HandlerState>,
     headers: HeaderMap,
     Json(body): Json<RegisterLauncherWrapper>,
-) -> Json<SuccessResponse> {
+) -> Json<serde_json::Value> {
     let customer_guid = extract_customer_guid(&headers);
     let r = &body.request;
     let repo = crate::repo::InstanceRepo(&hs.app.db);
@@ -603,9 +603,16 @@ async fn register_launcher(
     {
         Ok(id) => {
             tracing::info!(world_server_id = id, "Launcher registered");
-            Json(SuccessResponse::ok())
+            Json(serde_json::json!({
+                "success": true,
+                "errorMessage": "",
+                "worldServerId": id
+            }))
         }
-        Err(e) => Json(SuccessResponse::err(e.to_string())),
+        Err(e) => Json(serde_json::json!({
+            "success": false,
+            "errorMessage": e.to_string()
+        })),
     }
 }
 


### PR DESCRIPTION
## Summary
- `RegisterLauncher` endpoint now returns `{"success": true, "worldServerId": <id>}` instead of just `SuccessResponse` — the UE dedicated server needs the world server ID to track itself
- Deploy script: `-IgnoreCookErrors` for broken PhotoMode BPs, cook log dump on failure

## Chuck project changes (separate repo)
- `ChuckGameMode::RegisterWithROWS()` — calls `RegisterLauncher` on startup to register as a world server
- Agones SDK integration — `Connect()` + `HealthPing()` for GameServer readiness
- `ExportDataTableToJSONString` → `GetTableAsJSON()` fix for dedicated server builds (editor-only API)