### PR TITLE
fix(rows): RegisterLauncher field casing aliases

### DIFF
--- a/apps/ows/rows/src/rest.rs
+++ b/apps/ows/rows/src/rest.rs
@@ -576,9 +576,13 @@ struct RegisterLauncherWrapper {
 struct RegisterLauncherPayload {
     #[serde(alias = "launcherGUID", alias = "LauncherGUID")]
     launcher_guid: String,
+    #[serde(alias = "serverIP")]
     server_ip: String,
+    #[serde(alias = "maxNumberOfInstances")]
     max_number_of_instances: i32,
+    #[serde(alias = "internalServerIP")]
     internal_server_ip: String,
+    #[serde(alias = "startingInstancePort")]
     starting_instance_port: i32,
 }
 


### PR DESCRIPTION
## Summary
UE dedicated server sends `serverIP`, `internalServerIP` but ROWS `camelCase` expects `serverIp`, `internalServerIp`. Added aliases to accept both.

Fixes 422 on `RegisterLauncher` from GameServer pods.