### PR TITLE
fix(agones): revert map arg — crashes server

### DIFF
--- a/apps/kube/agones/ows/fleet.yaml
+++ b/apps/kube/agones/ows/fleet.yaml
@@ -78,7 +78,6 @@ spec:
                                   # h0lybyte 03/25/2026 - Finding Agones
                                   # Force ChuckGameMode to ensure Agones SDK + ROWS registration runs
                                   exec "${SERVER_BIN}" \
-                                    /Game/ThirdPerson/Lvl_ThirdPerson \
                                     -server \
                                     -log \
                                     -nosteam \


### PR DESCRIPTION
Reverts the /Game/ThirdPerson/Lvl_ThirdPerson positional arg. Servers need to start on Entry and ServerTravel to the game map.