### PR TITLE
chore(chisel-ubuntu-axum): add version.toml + bump to trigger first publish

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,8 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.1"
+version: "24.04.2"
+version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest
 image: kbve/chisel-ubuntu-axum

--- a/packages/docker/chisel-ubuntu-axum/version.toml
+++ b/packages/docker/chisel-ubuntu-axum/version.toml
@@ -1,0 +1,2 @@
+[package]
+version = "24.04.1"


### PR DESCRIPTION
## Summary

Add `version.toml` for CI version tracking and bump MDX to `24.04.2` to trigger the first Docker publish.

- `version.toml` at `24.04.1` (current published state: none)
- MDX at `24.04.2` (target version)
- CI version gate sees mismatch → triggers `chisel-ubuntu-axum` Docker build + push to GHCR

Version scheme: `24.04.X` where `24.04` = Ubuntu base, `X` = our patch number.