### PR TITLE
feat(rows): Agones direct allocation + polling wait + character create NOT NULL fix

### DIFF
--- a/apps/ows/rows/src/repo.rs
+++ b/apps/ows/rows/src/repo.rs
@@ -579,7 +579,9 @@ impl<'a> CharsRepo<'a> {
     }
 
     /// Default stat columns for character INSERT — all NOT NULL in the DB.
+    /// All NOT NULL columns that need defaults when creating a character.
     const CHAR_DEFAULTS: &'static str = "
+        x, y, z, rx, ry, rz,
         perception, acrobatics, climb, stealth, spirit, magic,
         teamnumber, thirst, hunger, gold, score, characterlevel,
         gender, xp, hitdie, wounds, size, weight,
@@ -597,9 +599,11 @@ impl<'a> CharsRepo<'a> {
         initiative, naturalarmor, physicalarmor, bonusarmor, forcearmor, magicarmor,
         resistance, reloadspeed, range, speed,
         silver, copper, freecurrency, premiumcurrency, fame, alignment,
-        isadmin, ismoderator";
+        defaultpawnclasspath, isinternalnetworktestuser, classid,
+        lastactivity, isadmin, ismoderator";
 
     const CHAR_ZEROS: &'static str = "
+        0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 1,
         0, 0, 0, 0, 1, 0,
@@ -617,7 +621,8 @@ impl<'a> CharsRepo<'a> {
         0, 0, 0, 0, 0, 0,
         0, 0, 0, 0,
         0, 0, 0, 0, 0, 0,
-        false, false";
+        '', false, 0,
+        NOW(), false, false";
 
     pub async fn create_character(
         &self,

--- a/apps/ows/rows/src/service/instances.rs
+++ b/apps/ows/rows/src/service/instances.rs
@@ -5,6 +5,11 @@ use crate::mq::SpinUpMessage;
 use crate::repo::{CharsRepo, InstanceRepo};
 use uuid::Uuid;
 
+/// Max time to wait for a server to become ready after Agones allocation
+const SPINUP_TIMEOUT_SECS: u64 = 30;
+/// How often to poll the DB for instance status during spinup
+const SPINUP_POLL_INTERVAL_MS: u64 = 2000;
+
 impl OWSService {
     pub async fn get_server_to_connect_to(
         &self,
@@ -35,37 +40,125 @@ impl OWSService {
             .join_map_by_char_name(customer_guid, char_name, &resolved_zone)
             .await?;
 
-        if result.need_to_startup_map {
-            // Spin-up lock: prevent duplicate Agones allocations for the same zone.
-            // If another request is already spinning up this zone, skip the publish.
-            let lock_key = format!("{customer_guid}:{resolved_zone}");
-            if self.state.zone_spinup_locks.contains_key(&lock_key) {
-                tracing::info!(
-                    zone = zone_name,
-                    "Zone spin-up already in progress, skipping duplicate"
-                );
-            } else {
-                self.state.zone_spinup_locks.insert(lock_key.clone(), true);
+        // If there's a ready instance, return it immediately
+        if !result.need_to_startup_map
+            && result.map_instance_id > 0
+            && result.map_instance_status == 2
+        {
+            return Ok(result);
+        }
 
-                if let Some(ref mq) = self.state.mq {
-                    let msg = SpinUpMessage {
-                        customer_guid: customer_guid.to_string(),
-                        world_server_id: result.world_server_id,
-                        zone_instance_id: result.map_instance_id,
-                        map_name: result.map_name_to_start.clone(),
-                        port: result.port,
-                    };
-                    if let Err(e) = mq.publish_spin_up(result.world_server_id, &msg).await {
-                        tracing::error!(error = %e, "Failed to publish spin-up message");
+        // No ready instance — need to spin up a server
+        let lock_key = format!("{customer_guid}:{resolved_zone}");
+        if !self.state.zone_spinup_locks.contains_key(&lock_key) {
+            self.state.zone_spinup_locks.insert(lock_key.clone(), true);
+
+            // Try Agones direct allocation first (fastest path)
+            if let Some(ref agones) = self.state.agones {
+                tracing::info!(zone = %resolved_zone, "Allocating GameServer via Agones");
+
+                match agones.allocate(&resolved_zone, 0).await {
+                    Ok(alloc) => {
+                        tracing::info!(
+                            gs = %alloc.game_server_name,
+                            addr = %alloc.address,
+                            port = alloc.port,
+                            "GameServer allocated — creating mapinstance"
+                        );
+
+                        // Ensure world server exists for this allocation
+                        let world_server_id = repo
+                            .register_launcher(
+                                customer_guid,
+                                &alloc.game_server_name,
+                                &alloc.address,
+                                10,
+                                &alloc.address,
+                                alloc.port,
+                            )
+                            .await
+                            .unwrap_or(0);
+
+                        if world_server_id > 0 {
+                            if let Err(e) = repo
+                                .spin_up_server_instance(
+                                    customer_guid,
+                                    world_server_id,
+                                    0,
+                                    &resolved_zone,
+                                    alloc.port,
+                                )
+                                .await
+                            {
+                                tracing::error!(error = %e, "Failed to create mapinstance after allocation");
+                            }
+                        }
+
+                        // Track the GameServer name for cleanup/deallocation
+                        if let Ok(fresh) = repo
+                            .join_map_by_char_name(customer_guid, char_name, &resolved_zone)
+                            .await
+                        {
+                            if fresh.map_instance_id > 0 {
+                                self.state
+                                    .zone_servers
+                                    .insert(fresh.map_instance_id, alloc.game_server_name);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, zone = %resolved_zone, "Agones allocation failed");
                         self.state.zone_spinup_locks.remove(&lock_key);
                     }
                 }
-                // Lock is released by the MQ consumer after successful allocation,
-                // or by the background health job after timeout.
+            } else if let Some(ref mq) = self.state.mq {
+                // Fallback: publish to RabbitMQ for async allocation
+                tracing::info!(zone = %resolved_zone, "Agones unavailable, publishing spin-up via MQ");
+                let msg = SpinUpMessage {
+                    customer_guid: customer_guid.to_string(),
+                    world_server_id: result.world_server_id,
+                    zone_instance_id: result.map_instance_id,
+                    map_name: result.map_name_to_start.clone(),
+                    port: result.port,
+                };
+                if let Err(e) = mq.publish_spin_up(result.world_server_id, &msg).await {
+                    tracing::error!(error = %e, "Failed to publish spin-up message");
+                    self.state.zone_spinup_locks.remove(&lock_key);
+                }
+            } else {
+                self.state.zone_spinup_locks.remove(&lock_key);
+                tracing::error!("No Agones or MQ available for server allocation");
             }
         }
 
-        Ok(result)
+        // Poll DB until the instance is ready or timeout
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(SPINUP_TIMEOUT_SECS);
+
+        while start.elapsed() < timeout {
+            tokio::time::sleep(std::time::Duration::from_millis(SPINUP_POLL_INTERVAL_MS)).await;
+
+            let poll_result = repo
+                .join_map_by_char_name(customer_guid, char_name, &resolved_zone)
+                .await?;
+
+            if poll_result.map_instance_id > 0 && !poll_result.server_ip.is_empty() {
+                tracing::info!(
+                    ip = %poll_result.server_ip,
+                    port = poll_result.port,
+                    "Server ready for zone {resolved_zone}"
+                );
+                self.state.zone_spinup_locks.remove(&lock_key);
+                return Ok(poll_result);
+            }
+        }
+
+        // Timeout — return whatever we have
+        self.state.zone_spinup_locks.remove(&lock_key);
+        let final_result = repo
+            .join_map_by_char_name(customer_guid, char_name, &resolved_zone)
+            .await?;
+        Ok(final_result)
     }
 
     pub async fn get_zone_instances(


### PR DESCRIPTION
## Summary
### Server allocation
- `GetServerToConnectTo` now allocates GameServers via Agones directly
- Falls back to RabbitMQ if Agones unavailable
- Polls DB for ready instance (30s timeout) instead of returning empty
- Spin-up lock prevents duplicate allocations

### Character creation
- Fixed all remaining NOT NULL constraint violations
- Added defaults for: x/y/z/rx/ry/rz, classid, defaultpawnclasspath,
  lastactivity, isinternalnetworktestuser