### PR TITLE
chore(ci): regenerate manifest with chisel version_toml for Docker publish

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -17,7 +17,8 @@
 		{
 			"key": "chisel_ubuntu_axum",
 			"app_name": "chisel-ubuntu-axum",
-			"version": "24.04.1",
+			"version": "24.04.2",
+			"version_toml": "packages/docker/chisel-ubuntu-axum/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx",
 			"source_path": "packages/docker/chisel-ubuntu-axum",
 			"runner": "ubuntu-latest",
@@ -27,7 +28,7 @@
 		{
 			"key": "chuckrpg",
 			"app_name": "axum-chuckrpg",
-			"version": "0.1.4",
+			"version": "0.1.5",
 			"version_toml": "apps/chuckrpg/axum-chuckrpg/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx",
 			"version_target": "apps/chuckrpg/axum-chuckrpg/Cargo.toml",
@@ -239,7 +240,7 @@
 		{
 			"key": "rows",
 			"app_name": "rows",
-			"version": "0.1.11",
+			"version": "0.1.16",
 			"version_toml": "apps/ows/rows/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rows.mdx",
 			"version_target": "apps/ows/rows/Cargo.toml",


### PR DESCRIPTION
## Problem

The chisel-ubuntu-axum Docker image was never published because the CI dispatch manifest was missing the `version_toml` field. Without it, the version gate can't compare MDX version against the toml and the publish step is skipped.

## Fix

Rebuilt `astro-kbve` and ran `sync:ci-manifest` to regenerate the dispatch manifest. The chisel entry now includes:

```json
{
  "version": "24.04.2",
  "version_toml": "packages/docker/chisel-ubuntu-axum/version.toml"
}
```

CI will see `24.04.2` (MDX) vs `24.04.1` (toml) → mismatch → triggers Docker publish.

## Test plan
- [ ] CI dispatches `chisel-ubuntu-axum` Docker build after merge
- [ ] `ghcr.io/kbve/chisel-ubuntu-axum:24.04.2` appears in GHCR