### PR TITLE
fix(ci): exclude post-publish atoms from ci-atom.yml to prevent race condition

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - 'atom-*'
+            - '!atom-post-publish-*'
 
 concurrency:
     group: atom-${{ github.ref_name }}


### PR DESCRIPTION
## Problem

When `utils-post-publish.yml` pushes an `atom-post-publish-*` branch, two workflows race:

1. `utils-post-publish.yml` creates PR → auto-merge merges it → branch deleted
2. `ci-atom.yml` triggers on `atom-*` push → tries to create duplicate PR → **fails with "head field invalid"** because the branch is already gone

This caused the `atom-post-publish-chisel-ubuntu-axum-v24.04.2` run to fail.

## Fix

Add `!atom-post-publish-*` exclusion to `ci-atom.yml`'s push branch filter:

```yaml
on:
    push:
        branches:
            - 'atom-*'
            - '!atom-post-publish-*'
```

Post-publish atoms are fully handled by `utils-post-publish.yml` — they don't need lint/test/security from `ci-atom.yml`.

## CI Audit Summary

The failure tracking system is working correctly:
- `utils-ci-failure-tracker.yml` creates GitHub issues on failure (label: `bug,ci,6`)
- Comments on existing issues for repeat failures
- Auto-closes issues when the workflow passes again
- Used by: ci-docker, ci-atom, ci-ue, ci-bevy, ci-angelscript-engine, ci-ue5-ows, ci-ue5-rows

## Test plan
- [ ] Next post-publish sync should not trigger ci-atom.yml
- [ ] Regular atom branches (e.g. `atom-0326xxxx-fix-something`) still trigger ci-atom.yml