### PR TITLE
feat(ci): add ue5_server pipeline to dispatch manifest

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -240,7 +240,7 @@
 		{
 			"key": "rows",
 			"app_name": "rows",
-			"version": "0.1.16",
+			"version": "0.1.17",
 			"version_toml": "apps/ows/rows/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rows.mdx",
 			"version_target": "apps/ows/rows/Cargo.toml",
@@ -377,12 +377,29 @@
 			"version_toml": "packages/unreal/UEDevOps/version.toml"
 		}
 	],
+	"ue5_server": [
+		{
+			"key": "unreal_chuck",
+			"app_name": "unreal-chuck",
+			"shell_path": "apps/chuckrpg/unreal-chuck",
+			"version": "0.0.1",
+			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml"
+		},
+		{
+			"key": "unreal_rareicon",
+			"app_name": "unreal-rareicon",
+			"shell_path": "apps/rareicon/unreal-rareicon",
+			"version": "0.0.1",
+			"version_toml": "apps/rareicon/unreal-rareicon/version.toml"
+		}
+	],
 	"summary": {
 		"docker": 18,
 		"npm": 4,
 		"crates": 6,
 		"python": 2,
 		"unreal": 6,
-		"total": 36
+		"ue5_server": 2,
+		"total": 38
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck.mdx
@@ -1,0 +1,44 @@
+---
+title: Unreal Chuck
+description: |
+    Chuck RPG UE5 Linux dedicated server build — uses stock Epic Docker image for CI.
+sidebar:
+    label: Unreal Chuck
+    order: 96
+tags:
+    - ue5
+    - server
+    - gaming
+key: unreal_chuck
+pipeline: ue5_server
+app_name: unreal-chuck
+shell_path: apps/chuckrpg/unreal-chuck
+version: "0.0.1"
+source_path: apps/chuckrpg/unreal-chuck
+version_toml: apps/chuckrpg/unreal-chuck/version.toml
+runner: arc-runner-ue
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+Chuck RPG dedicated server build managed via the `ci-ue5-rows.yml` workflow.
+
+Uses the cached `ghcr.io/epicgames/unreal-engine:dev-5.7.4` Docker image on the `arc-runner-ue` Kubernetes runner.
+
+### Shell Project
+
+The build configuration lives in the monorepo at `apps/chuckrpg/unreal-chuck/`:
+
+- `build.toml` — game repo, .uproject path, server target, UE image tag
+- `version.toml` — current build version
+
+### Dispatch
+
+Trigger via GitHub Actions:
+
+1. Go to **CI - Unreal Engine** workflow
+2. Select task: `dedicated-server`
+3. Set `shell_path`: `apps/chuckrpg/unreal-chuck`

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-rareicon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-rareicon.mdx
@@ -1,0 +1,44 @@
+---
+title: Unreal RareIcon
+description: |
+    RareIcon UE5 Linux dedicated server build — uses stock Epic Docker image for CI.
+sidebar:
+    label: Unreal RareIcon
+    order: 97
+tags:
+    - ue5
+    - server
+    - gaming
+key: unreal_rareicon
+pipeline: ue5_server
+app_name: unreal-rareicon
+shell_path: apps/rareicon/unreal-rareicon
+version: "0.0.1"
+source_path: apps/rareicon/unreal-rareicon
+version_toml: apps/rareicon/unreal-rareicon/version.toml
+runner: arc-runner-ue
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+RareIcon dedicated server build managed via the `ci-ue5-rows.yml` workflow.
+
+Uses the cached `ghcr.io/epicgames/unreal-engine:dev-5.7.4` Docker image on the `arc-runner-ue` Kubernetes runner.
+
+### Shell Project
+
+The build configuration lives in the monorepo at `apps/rareicon/unreal-rareicon/`:
+
+- `build.toml` — game repo, .uproject path, server target, UE image tag
+- `version.toml` — current build version
+
+### Dispatch
+
+Trigger via GitHub Actions:
+
+1. Go to **CI - Unreal Engine** workflow
+2. Select task: `dedicated-server`
+3. Set `shell_path`: `apps/rareicon/unreal-rareicon`

--- a/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
@@ -71,6 +71,7 @@ export const ICiProjectSchema = AstroProjectExtensions.extend({
 	target: CiProjectSchema.shape.target,
 	nx_project: CiProjectSchema.shape.nx_project,
 	test_framework: TestFrameworkSchema.optional(),
+	shell_path: CiProjectSchema.shape.shell_path,
 });
 
 export type ICiProject = z.infer<typeof ICiProjectSchema>;

--- a/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
@@ -61,12 +61,21 @@ interface UnrealEntry {
 	version_toml?: string;
 }
 
+interface Ue5ServerEntry {
+	key: string;
+	app_name: string;
+	shell_path: string;
+	version?: string;
+	version_toml?: string;
+}
+
 type ManifestEntry =
 	| DockerEntry
 	| NpmEntry
 	| CratesEntry
 	| PythonEntry
-	| UnrealEntry;
+	| UnrealEntry
+	| Ue5ServerEntry;
 
 interface DispatchManifest {
 	docker: DockerEntry[];
@@ -74,6 +83,7 @@ interface DispatchManifest {
 	crates: CratesEntry[];
 	python: PythonEntry[];
 	unreal: UnrealEntry[];
+	ue5_server: Ue5ServerEntry[];
 	index: Record<string, number>;
 	summary: Record<string, number>;
 }
@@ -140,6 +150,16 @@ function toManifestEntry(
 			if (vt) ue.version_toml = vt;
 			return ue;
 		}
+		case 'ue5_server': {
+			if (!d.app_name || !d.shell_path) return null;
+			return {
+				key: d.key!,
+				app_name: d.app_name,
+				shell_path: d.shell_path,
+				...(ver && { version: ver }),
+				...(vt && { version_toml: vt }),
+			};
+		}
 		default:
 			return null;
 	}
@@ -174,6 +194,7 @@ export const GET = async () => {
 		crates: [],
 		python: [],
 		unreal: [],
+		ue5_server: [],
 		index: {},
 		summary: {},
 	};
@@ -191,7 +212,7 @@ export const GET = async () => {
 
 		const pipeline = d.pipeline as keyof Pick<
 			DispatchManifest,
-			'docker' | 'npm' | 'crates' | 'python' | 'unreal'
+			'docker' | 'npm' | 'crates' | 'python' | 'unreal' | 'ue5_server'
 		>;
 		const arr = manifest[pipeline] as ManifestEntry[];
 		const idx = arr.length;

--- a/packages/data/codegen/generated/ci_registry-schema.ts
+++ b/packages/data/codegen/generated/ci_registry-schema.ts
@@ -14,6 +14,7 @@ export const DispatchPipelines = [
 	'crates',
 	'python',
 	'unreal',
+	'ue5_server',
 ] as const;
 
 export type DispatchPipelineValue = (typeof DispatchPipelines)[number];
@@ -86,6 +87,7 @@ export const CiProjectSchema = z.object({
 	target: z.string().max(64).optional(),
 	nx_project: z.string().max(64).optional(),
 	test_framework: TestFrameworkSchema.optional(),
+	shell_path: z.string().max(256).optional(),
 });
 
 export type CiProject = z.infer<typeof CiProjectSchema>;

--- a/packages/data/proto/kbve/ci_registry.proto
+++ b/packages/data/proto/kbve/ci_registry.proto
@@ -19,6 +19,7 @@ enum DispatchPipeline {
   DISPATCH_PIPELINE_CRATES = 3;
   DISPATCH_PIPELINE_PYTHON = 4;
   DISPATCH_PIPELINE_UNREAL = 5;
+  DISPATCH_PIPELINE_UE5_SERVER = 6;
 }
 
 // Language / framework that determines which CI toolchain is needed for tests.
@@ -87,6 +88,9 @@ message CiProject {
 
   // --- Test framework (E2E matrix fan-out) ---
   TestFramework test_framework = 31;       // Which CI toolchain to use for tests
+
+  // --- UE5 server build config (ue5_server pipeline) ---
+  optional string shell_path = 32;         // Monorepo shell project path (e.g. "apps/chuckrpg/unreal-chuck")
 }
 
 // The full registry — a flat list of all tracked items.

--- a/packages/npm/devops/src/lib/ci/ci_registry-schema.ts
+++ b/packages/npm/devops/src/lib/ci/ci_registry-schema.ts
@@ -14,6 +14,7 @@ export const DispatchPipelines = [
 	'crates',
 	'python',
 	'unreal',
+	'ue5_server',
 ] as const;
 
 export type DispatchPipelineValue = (typeof DispatchPipelines)[number];
@@ -86,6 +87,7 @@ export const CiProjectSchema = z.object({
 	target: z.string().max(64).optional(),
 	nx_project: z.string().max(64).optional(),
 	test_framework: TestFrameworkSchema.optional(),
+	shell_path: z.string().max(256).optional(),
 });
 
 export type CiProject = z.infer<typeof CiProjectSchema>;

--- a/packages/npm/devops/src/lib/ci/index.ts
+++ b/packages/npm/devops/src/lib/ci/index.ts
@@ -30,4 +30,5 @@ export {
 	type CratesEntry,
 	type PythonEntry,
 	type UnrealEntry,
+	type Ue5ServerEntry,
 } from './manifest.js';

--- a/packages/npm/devops/src/lib/ci/manifest.ts
+++ b/packages/npm/devops/src/lib/ci/manifest.ts
@@ -42,12 +42,19 @@ export interface UnrealEntry {
 	itch_game_id?: string;
 }
 
+export interface Ue5ServerEntry {
+	key: string;
+	app_name: string;
+	shell_path: string;
+}
+
 export interface DispatchManifest {
 	docker: DockerEntry[];
 	npm: NpmEntry[];
 	crates: CratesEntry[];
 	python: PythonEntry[];
 	unreal: UnrealEntry[];
+	ue5_server: Ue5ServerEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -95,17 +102,32 @@ function toUnreal(p: CiProject): UnrealEntry {
 	return entry;
 }
 
+function toUe5Server(p: CiProject): Ue5ServerEntry {
+	if (!p.app_name)
+		throw new Error(`UE5 server project "${p.key}" missing app_name`);
+	if (!p.shell_path)
+		throw new Error(`UE5 server project "${p.key}" missing shell_path`);
+	return { key: p.key, app_name: p.app_name, shell_path: p.shell_path };
+}
+
 const mappers: Record<
 	string,
 	(
 		p: CiProject,
-	) => DockerEntry | NpmEntry | CratesEntry | PythonEntry | UnrealEntry
+	) =>
+		| DockerEntry
+		| NpmEntry
+		| CratesEntry
+		| PythonEntry
+		| UnrealEntry
+		| Ue5ServerEntry
 > = {
 	docker: toDocker,
 	npm: toNpm,
 	crates: toCrates,
 	python: toPython,
 	unreal: toUnreal,
+	ue5_server: toUe5Server,
 };
 
 /**
@@ -119,6 +141,7 @@ export function buildDispatchManifest(): DispatchManifest {
 		crates: [],
 		python: [],
 		unreal: [],
+		ue5_server: [],
 	};
 
 	for (const project of CI_PROJECTS) {

--- a/packages/npm/devops/src/lib/ci/registry.ts
+++ b/packages/npm/devops/src/lib/ci/registry.ts
@@ -454,6 +454,38 @@ export const CI_PROJECTS: CiProject[] = ProjectArraySchema.parse([
 		tags: ['python'],
 	},
 
+	// ── UE5 Server Builds ─────────────────────────────────────
+	{
+		key: 'unreal_chuck',
+		name: 'Chuck Dedicated Server',
+		pipeline: 'ue5_server',
+		app_name: 'unreal-chuck',
+		shell_path: 'apps/chuckrpg/unreal-chuck',
+		description:
+			'Chuck RPG UE5 Linux dedicated server (stock UE 5.7 Docker)',
+		source_path: 'apps/chuckrpg/unreal-chuck',
+		runner: 'arc-runner-ue',
+		author: 'h0lybyte',
+		license: 'KBVE',
+		status: 'active',
+		tags: ['ue5', 'server', 'gaming'],
+	},
+	{
+		key: 'unreal_rareicon',
+		name: 'RareIcon Dedicated Server',
+		pipeline: 'ue5_server',
+		app_name: 'unreal-rareicon',
+		shell_path: 'apps/rareicon/unreal-rareicon',
+		description:
+			'RareIcon UE5 Linux dedicated server (stock UE 5.7 Docker)',
+		source_path: 'apps/rareicon/unreal-rareicon',
+		runner: 'arc-runner-ue',
+		author: 'h0lybyte',
+		license: 'KBVE',
+		status: 'active',
+		tags: ['ue5', 'server', 'gaming'],
+	},
+
 	// ── Unreal Plugins ─────────────────────────────────────────
 	{
 		key: 'ue_kbvexxhash',


### PR DESCRIPTION
## Summary
- Add `ue5_server` as a new dispatch pipeline type across the full proto → zod → MDX → API → manifest chain
- Two shell projects registered: `unreal_chuck` (Chuck dedicated server) and `unreal_rareicon` (RareIcon dedicated server)
- Each shell project's MDX page controls the version — bumping `version` in frontmatter will flow through to the dispatch manifest on next build+sync
- Manifest now tracks 38 items (was 36)

## Files touched
- Proto schema, codegen Zod, devops Zod copy, Astro schema, registry.ts, manifest.ts, barrel export, API endpoint, 2 MDX pages, ci-dispatch-manifest.json

## Test plan
- [ ] Verify `astro-kbve:build` succeeds
- [ ] Verify `astro-kbve:sync:ci-manifest` produces 38 items with ue5_server entries
- [ ] Verify devops package builds cleanly