### PR TITLE
feat(dashboard): integrate ROWS into home dashboard + status banner

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactHomeServiceCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactHomeServiceCards.tsx
@@ -21,6 +21,7 @@ import {
 	Kanban,
 	FileText,
 	Network,
+	Gamepad2,
 } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -376,6 +377,7 @@ export default function ReactHomeServiceCards() {
 	const kanban = useStore(homeService.$kanban);
 	const report = useStore(homeService.$report);
 	const graph = useStore(homeService.$graph);
+	const rows = useStore(homeService.$rows);
 
 	const grafanaStatus = useStore(homeService.$grafanaStatus);
 	const argoStatus = useStore(homeService.$argoStatus);
@@ -385,6 +387,7 @@ export default function ReactHomeServiceCards() {
 	const kanbanStatus = useStore(homeService.$kanbanStatus);
 	const reportStatus = useStore(homeService.$reportStatus);
 	const graphStatus = useStore(homeService.$graphStatus);
+	const rowsStatus = useStore(homeService.$rowsStatus);
 
 	return (
 		<div
@@ -472,6 +475,39 @@ export default function ReactHomeServiceCards() {
 								color="#ef4444"
 							/>
 						)}
+					</>
+				) : (
+					<UnavailableMessage />
+				)}
+			</ServiceCard>
+
+			{/* ROWS — Game Server Operations */}
+			<ServiceCard
+				title="Game Ops (ROWS)"
+				description="ChuckRPG game server backend"
+				href="/dashboard/rows/"
+				icon={<Gamepad2 size={18} />}
+				accentColor="#f97316"
+				status={rowsStatus}>
+				{rowsStatus === 'loading' ? (
+					<LoadingPlaceholder />
+				) : rows ? (
+					<>
+						<MetricValue
+							label="Sessions"
+							value={rows.active_sessions}
+							color="#f97316"
+						/>
+						<MetricValue
+							label="Instances"
+							value={rows.active_instances}
+							color="#06b6d4"
+						/>
+						<MetricValue
+							label="Version"
+							value={`v${rows.version}`}
+							color="var(--sl-color-gray-3, #8b949e)"
+						/>
 					</>
 				) : (
 					<UnavailableMessage />

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactHomeStatusBanner.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactHomeStatusBanner.tsx
@@ -26,6 +26,7 @@ export default function ReactHomeStatusBanner() {
 	const edgeStatus = useStore(homeService.$edgeStatus);
 	const clickhouseStatus = useStore(homeService.$clickhouseStatus);
 	const securityStatus = useStore(homeService.$securityStatus);
+	const rowsStatus = useStore(homeService.$rowsStatus);
 	const allOk = useStore(homeService.$allOk);
 	const anyError = useStore(homeService.$anyError);
 	const anyLoading = useStore(homeService.$anyLoading);
@@ -57,6 +58,7 @@ export default function ReactHomeStatusBanner() {
 	const services = [
 		{ name: 'Monitoring', status: grafanaStatus },
 		{ name: 'Deployments', status: argoStatus },
+		{ name: 'Game Ops', status: rowsStatus },
 		{ name: 'Edge', status: edgeStatus },
 		{ name: 'Logs', status: clickhouseStatus },
 		{ name: 'Security', status: securityStatus },

--- a/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
@@ -71,6 +71,15 @@ export interface GraphSummary {
 	e2e: number;
 }
 
+export interface RowsSummary {
+	status: string;
+	version: string;
+	uptime_seconds: number;
+	active_sessions: number;
+	active_instances: number;
+	checks: Record<string, { ok: boolean; latency_ms?: number }>;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -474,6 +483,26 @@ async function fetchReportSummary(): Promise<ReportSummary | null> {
 	}
 }
 
+const ROWS_PROXY_BASE = '/dashboard/chuckrpg/proxy';
+
+async function fetchRowsSummary(token: string): Promise<RowsSummary | null> {
+	const cached = getCache<RowsSummary>('cache:dashboard:rows-summary');
+	if (cached) return cached;
+
+	try {
+		const resp = await fetch(`${ROWS_PROXY_BASE}/api/System/Health`, {
+			headers: { Authorization: `Bearer ${token}` },
+			signal: AbortSignal.timeout(8000),
+		});
+		if (!resp.ok) return null;
+		const data: RowsSummary = await resp.json();
+		setCache('cache:dashboard:rows-summary', data);
+		return data;
+	} catch {
+		return null;
+	}
+}
+
 async function fetchGraphSummary(): Promise<GraphSummary | null> {
 	const cached = getCache<GraphSummary>('cache:dashboard:graph-summary');
 	if (cached) return cached;
@@ -554,6 +583,7 @@ class HomeService {
 	public readonly $kanban = atom<KanbanSummary | null>(null);
 	public readonly $report = atom<ReportSummary | null>(null);
 	public readonly $graph = atom<GraphSummary | null>(null);
+	public readonly $rows = atom<RowsSummary | null>(null);
 
 	// Loading
 	public readonly $loading = atom<boolean>(true);
@@ -568,6 +598,7 @@ class HomeService {
 	public readonly $kanbanStatus = atom<ServiceStatus>('loading');
 	public readonly $reportStatus = atom<ServiceStatus>('loading');
 	public readonly $graphStatus = atom<ServiceStatus>('loading');
+	public readonly $rowsStatus = atom<ServiceStatus>('loading');
 
 	// Computed
 	public readonly $allOk = computed(
@@ -577,9 +608,15 @@ class HomeService {
 			this.$edgeStatus,
 			this.$clickhouseStatus,
 			this.$securityStatus,
+			this.$rowsStatus,
 		],
-		(g, a, e, c, s) =>
-			g === 'ok' && a === 'ok' && e === 'ok' && c === 'ok' && s === 'ok',
+		(g, a, e, c, s, r) =>
+			g === 'ok' &&
+			a === 'ok' &&
+			e === 'ok' &&
+			c === 'ok' &&
+			s === 'ok' &&
+			r === 'ok',
 	);
 
 	public readonly $anyError = computed(
@@ -588,9 +625,14 @@ class HomeService {
 			this.$argoStatus,
 			this.$edgeStatus,
 			this.$clickhouseStatus,
+			this.$rowsStatus,
 		],
-		(g, a, e, c) =>
-			g === 'error' || a === 'error' || e === 'error' || c === 'error',
+		(g, a, e, c, r) =>
+			g === 'error' ||
+			a === 'error' ||
+			e === 'error' ||
+			c === 'error' ||
+			r === 'error',
 	);
 
 	public readonly $anyLoading = computed(
@@ -600,13 +642,15 @@ class HomeService {
 			this.$edgeStatus,
 			this.$clickhouseStatus,
 			this.$securityStatus,
+			this.$rowsStatus,
 		],
-		(g, a, e, c, s) =>
+		(g, a, e, c, s, r) =>
 			g === 'loading' ||
 			a === 'loading' ||
 			e === 'loading' ||
 			c === 'loading' ||
-			s === 'loading',
+			s === 'loading' ||
+			r === 'loading',
 	);
 
 	// --- Auth ---
@@ -642,6 +686,7 @@ class HomeService {
 		this.$kanbanStatus.set('loading');
 		this.$reportStatus.set('loading');
 		this.$graphStatus.set('loading');
+		this.$rowsStatus.set('loading');
 
 		const token = this.$accessToken.get();
 
@@ -689,6 +734,16 @@ class HomeService {
 				},
 			);
 
+			const rowsPromise = fetchRowsSummary(token).then((r) => {
+				this.$rows.set(r);
+				if (r) {
+					const allOk = Object.values(r.checks).every((c) => c.ok);
+					this.$rowsStatus.set(allOk ? 'ok' : 'unavailable');
+				} else {
+					this.$rowsStatus.set('unavailable');
+				}
+			});
+
 			await Promise.all([
 				grafanaPromise,
 				argoPromise,
@@ -698,6 +753,7 @@ class HomeService {
 				kanbanPromise,
 				reportPromise,
 				graphPromise,
+				rowsPromise,
 			]);
 		} else {
 			await Promise.all([

--- a/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
@@ -125,14 +125,31 @@ async function fetchRows<T>(path: string): Promise<T | null> {
 		const headers = await getAuthHeaders();
 		if (!headers.Authorization) return null;
 
-		const resp = await fetch(`${PROXY_BASE}${path}`, { headers });
+		const resp = await fetch(`${PROXY_BASE}${path}`, {
+			headers,
+			signal: AbortSignal.timeout(8000),
+		});
 		if (!resp.ok) {
-			console.warn(`[rows] ${path} returned ${resp.status}`);
+			if (resp.status === 502) {
+				console.warn(
+					`[rows] ${path} — ROWS unreachable (502 Bad Gateway)`,
+				);
+			} else if (resp.status === 503) {
+				console.warn(`[rows] ${path} — proxy not configured (503)`);
+			} else if (resp.status === 401 || resp.status === 403) {
+				console.warn(`[rows] ${path} — auth rejected (${resp.status})`);
+			} else {
+				console.warn(`[rows] ${path} returned ${resp.status}`);
+			}
 			return null;
 		}
 		return (await resp.json()) as T;
 	} catch (e) {
-		console.error(`[rows] fetch ${path} failed:`, e);
+		if (e instanceof DOMException && e.name === 'TimeoutError') {
+			console.warn(`[rows] ${path} timed out after 8s`);
+		} else {
+			console.error(`[rows] fetch ${path} failed:`, e);
+		}
 		return null;
 	}
 }


### PR DESCRIPTION
## Summary
- ROWS "Game Ops" service card on dashboard home (sessions, instances, version)
- ROWS health dot in status banner (green/red alongside other services)
- ROWS included in all-ok/any-error/any-loading computed stores
- 8s timeout + descriptive error logging in rowsService.ts

4 files changed. No ROWS-side changes — this is purely astro-kbve/dashboard integration.

Ref #9182