### PR TITLE
chore(chuckrpg): use chisel-ubuntu-axum base images

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -6,7 +6,7 @@
 # ============================================================================
 # [STAGE A] - Build Astro Static Site (uses builder's Node.js + pnpm)
 # ============================================================================
-FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS astro-builder
+FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
@@ -59,7 +59,7 @@ RUN find . -type f \( \
 # ============================================================================
 # [STAGE C] - Cargo Chef Planner
 # ============================================================================
-FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS planner
+FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
 WORKDIR /app
 
@@ -85,7 +85,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ============================================================================
 # [STAGE D] - Cargo Chef Cook (Cache External Dependencies)
 # ============================================================================
-FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS builder-deps
+FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
 
 WORKDIR /app
 
@@ -101,7 +101,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
 # ============================================================================
-FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS foundation
+FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
 
 WORKDIR /app
 
@@ -152,7 +152,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 # [STAGE Z] - Runtime Image (pre-built chisel + jemalloc + libpq)
 # ============================================================================
-FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04.2 AS runtime
+FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04 AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Replace inline toolchain/chisel/jemalloc stages with pre-built `ghcr.io/kbve/chisel-ubuntu-axum:24.04.2` images
- **Builder** (`24.04.2-builder`): Rust 1.94, cargo-chef, protobuf, libssl, libpq-dev, jemalloc-dev, Node.js 24 + pnpm — eliminates 3 stages (rust-base, chisel-builder, jemalloc)
- **Runtime** (`24.04.2`): Chiseled Ubuntu + jemalloc + libpq + CA certs — ready-to-use scratch-based image
- Dockerfile goes from 225 lines / 10 stages to 147 lines / 8 stages

## Stages eliminated
| Old stage | What it did | Now provided by |
|-----------|-------------|-----------------|
| Stage C (rust-base) | apt install Rust deps + cargo-chef | `24.04.2-builder` |
| Stage G (chisel-builder) | Download Go, build chisel, cut rootfs | `24.04.2` runtime |
| Stage H (jemalloc) | apt install libjemalloc-dev | `24.04.2` runtime |
| Stage A (node:24-slim) | Separate Node.js image for Astro | `24.04.2-builder` includes Node+pnpm |

## Test plan
- [ ] CI Docker build + e2e test passes for axum-chuckrpg
- [ ] Runtime image still serves static files and health endpoint