### PR TITLE
perf(rows): session TTL, pool sizing, K8s + request timeouts (#9182)

### DIFF
--- a/apps/ows/rows/Cargo.toml
+++ b/apps/ows/rows/Cargo.toml
@@ -21,7 +21,7 @@ prost-types = "0.13"
 
 # Tower (shared middleware layer for axum + tonic multiplexing)
 tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit", "steer"] }
-tower-http = { version = "0.6.8", features = ["compression-full", "limit", "trace", "cors", "set-header"] }
+tower-http = { version = "0.6.8", features = ["compression-full", "limit", "trace", "cors", "set-header", "timeout"] }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1", "http2"] }
 http = "1"

--- a/apps/ows/rows/src/agones/allocate.rs
+++ b/apps/ows/rows/src/agones/allocate.rs
@@ -108,7 +108,10 @@ impl AgonesClient {
             .body(serde_json::to_vec(&allocation)?)
             .map_err(|e| anyhow::anyhow!("Failed to build request: {e}"))?;
 
-        let resp: serde_json::Value = self.client.request(req).await?;
+        let resp: serde_json::Value =
+            tokio::time::timeout(std::time::Duration::from_secs(10), self.client.request(req))
+                .await
+                .map_err(|_| anyhow::anyhow!("K8s allocation request timed out (10s)"))??;
 
         let status = resp
             .get("status")

--- a/apps/ows/rows/src/agones/deallocate.rs
+++ b/apps/ows/rows/src/agones/deallocate.rs
@@ -65,7 +65,10 @@ impl AgonesClient {
             .body(Vec::new())
             .map_err(|e| anyhow::anyhow!("Failed to build request: {e}"))?;
 
-        let _: serde_json::Value = self.client.request(req).await?;
+        let _: serde_json::Value =
+            tokio::time::timeout(std::time::Duration::from_secs(10), self.client.request(req))
+                .await
+                .map_err(|_| anyhow::anyhow!("K8s deallocation request timed out (10s)"))??;
         Ok(())
     }
 }

--- a/apps/ows/rows/src/agones/fleet.rs
+++ b/apps/ows/rows/src/agones/fleet.rs
@@ -41,7 +41,10 @@ impl AgonesClient {
             .body(Vec::new())
             .map_err(|e| anyhow::anyhow!("Failed to build fleet status request: {e}"))?;
 
-        let resp: serde_json::Value = self.client.request(req).await?;
+        let resp: serde_json::Value =
+            tokio::time::timeout(std::time::Duration::from_secs(10), self.client.request(req))
+                .await
+                .map_err(|_| anyhow::anyhow!("K8s fleet status request timed out (10s)"))??;
 
         let items = resp
             .get("items")

--- a/apps/ows/rows/src/db.rs
+++ b/apps/ows/rows/src/db.rs
@@ -25,9 +25,14 @@ pub async fn connect(database_url: &str) -> anyhow::Result<DbPool> {
     let opts = opts.options([("search_path", "ows,extensions,public")]);
     info!("Database search_path set to: ows,extensions,public");
 
+    let max_conns: u32 = std::env::var("DB_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+
     let pool = PgPoolOptions::new()
-        .max_connections(20)
-        .min_connections(2)
+        .max_connections(max_conns)
+        .min_connections(5)
         .acquire_timeout(Duration::from_secs(5))
         .idle_timeout(Duration::from_secs(300))
         .connect_with(opts)

--- a/apps/ows/rows/src/jobs.rs
+++ b/apps/ows/rows/src/jobs.rs
@@ -8,7 +8,8 @@ use tracing::{error, info, warn};
 pub fn spawn_all(svc: Arc<OWSService>) {
     tokio::spawn(zone_health_monitor(svc.clone()));
     tokio::spawn(stale_zone_cleanup(svc.clone()));
-    tokio::spawn(spinup_lock_expiry(svc));
+    tokio::spawn(spinup_lock_expiry(svc.clone()));
+    tokio::spawn(session_cache_sweep(svc));
 }
 
 /// Periodic zone health monitor — logs metrics every 30s.
@@ -118,6 +119,43 @@ async fn spinup_lock_expiry(svc: Arc<OWSService>) {
 
         if expired > 0 {
             warn!(expired, "Expired stale spin-up locks");
+        }
+    }
+}
+
+/// Sweep expired sessions from the in-memory cache every 5 minutes.
+/// Sessions older than 24 hours are evicted. Prevents unbounded memory growth
+/// from abandoned sessions that never call PlayerLogout.
+async fn session_cache_sweep(svc: Arc<OWSService>) {
+    let mut interval = tokio::time::interval(Duration::from_secs(300));
+    interval.tick().await;
+
+    loop {
+        interval.tick().await;
+
+        let max_age = Duration::from_secs(24 * 60 * 60); // 24 hours
+        let before = svc.state().sessions.len();
+
+        let stale_keys: Vec<uuid::Uuid> = svc
+            .state()
+            .sessions
+            .iter()
+            .filter(|entry| entry.value().created_at.elapsed() > max_age)
+            .map(|entry| *entry.key())
+            .collect();
+
+        for key in &stale_keys {
+            svc.state().sessions.remove(key);
+        }
+
+        let evicted = stale_keys.len();
+        if evicted > 0 {
+            info!(
+                evicted,
+                before,
+                after = svc.state().sessions.len(),
+                "Session cache sweep"
+            );
         }
     }
 }

--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -24,6 +24,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::timeout::TimeoutLayer;
 use tracing::info;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -126,6 +127,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(ws_router)
         .merge(grpc_router.into_axum_router())
         .layer(axum::middleware::from_fn(trace::request_trace))
+        .layer(TimeoutLayer::new(std::time::Duration::from_secs(90))) // 90s global request timeout
         .layer(RequestBodyLimitLayer::new(10 * 1024 * 1024)) // 10MB max body
         .layer(CorsLayer::permissive());
 

--- a/apps/ows/rows/src/service/auth.rs
+++ b/apps/ows/rows/src/service/auth.rs
@@ -19,6 +19,7 @@ impl OWSService {
                             CachedSession {
                                 customer_guid: self.state.config.customer_guid,
                                 user_guid,
+                                created_at: std::time::Instant::now(),
                             },
                         );
                     }
@@ -81,6 +82,7 @@ impl OWSService {
         let cached = CachedSession {
             customer_guid: session.customer_guid,
             user_guid,
+            created_at: std::time::Instant::now(),
         };
 
         self.state.sessions.insert(session_guid, cached.clone());

--- a/apps/ows/rows/src/service/mod.rs
+++ b/apps/ows/rows/src/service/mod.rs
@@ -22,10 +22,12 @@ pub struct OWSService {
 }
 
 /// Cached session data stored in DashMap — avoids DB hit on hot path.
+/// Includes `created_at` for TTL-based eviction (24h default).
 #[derive(Clone)]
 pub struct CachedSession {
     pub customer_guid: uuid::Uuid,
     pub user_guid: uuid::Uuid,
+    pub created_at: std::time::Instant,
 }
 
 impl OWSService {


### PR DESCRIPTION
Addresses #9182 items 2-6:
- Session cache: TTL-based eviction (24h, sweep every 5m)
- DB pool: 20 → 50 (configurable via `DB_MAX_CONNECTIONS`)
- K8s API: 10s timeout per request (allocate, deallocate, fleet)
- Global: 90s request timeout via `TimeoutLayer`

Closes #9182 items 2-6.