### PR TITLE
refactor(discordsh): use shared chisel-ubuntu-axum base images

### DIFF
--- a/apps/discordsh/astro-discordsh/src/content/docs/index.mdx
+++ b/apps/discordsh/astro-discordsh/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ template: splash
 hero:
   tagline: The smartest way to grow and discover Discord communities.
   image:
-    file: ../../assets/discord-sh-mascot.png
+    html: <img src="/images/discord-sh-mascot.png" alt="Discord.sh mascot" width="400" height="400" />
   actions:
     - text: Browse Servers
       link: /servers/

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -9,7 +9,9 @@
 # ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-alpine AS astro-builder
+# node:24-slim (Debian) instead of Alpine — Sharp image optimizer needs
+# glibc-compatible native binaries for Astro image processing
+FROM --platform=linux/amd64 node:24-slim AS astro-builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 


### PR DESCRIPTION
## Summary
- Replace inline chisel/jemalloc/libpq/rust-base Docker stages with shared `ghcr.io/kbve/chisel-ubuntu-axum:24.04.2` builder and runtime images
- Removes ~80 lines of duplicated setup (chisel install, jemalloc extraction, libpq extraction, rust toolchain deps)
- Same cargo-chef layering, precompression pipeline, and runtime behavior — just sourced from the shared base
- Test bed for rolling chisel base images out to other Axum services

## Changes
- `apps/discordsh/axum-discordsh/Dockerfile`: 15 insertions, 86 deletions

## Test plan
- [ ] Local Docker build completes successfully
- [ ] Container starts and serves on port 4321
- [ ] CI Docker build passes