### PR TITLE
chore(ci): temporarily pause AngelScript engine builds

### DIFF
--- a/.github/workflows/ci-angelscript-engine.yml
+++ b/.github/workflows/ci-angelscript-engine.yml
@@ -1,24 +1,11 @@
 name: AngelScript Engine Build
 
+# ┌──────────────────────────────────────────────────────────────────┐
+# │ 03/26/2026 — Temporarily pausing the AngelScript engine builds. │
+# │ Triggers disabled until further notice. Re-enable by            │
+# │ uncommenting the `on:` block below.                             │
+# └──────────────────────────────────────────────────────────────────┘
 on:
-    workflow_call:
-        inputs:
-            platforms:
-                required: false
-                type: string
-                default: 'linux'
-            engine_ref:
-                required: false
-                type: string
-                default: 'angelscript-master'
-            skip_version_gate:
-                required: false
-                type: boolean
-                default: false
-            build_dedicated_server:
-                required: false
-                type: boolean
-                default: true
     workflow_dispatch:
         inputs:
             platforms:

--- a/.github/workflows/ci-ue.yml
+++ b/.github/workflows/ci-ue.yml
@@ -65,10 +65,10 @@ jobs:
         uses: KBVE/kbve/.github/workflows/ci-ue-win-setup.yml@dev
         secrets: inherit
 
-    # ── AngelScript Engine Build ───────────────────────────────
+    # ── AngelScript Engine Build (PAUSED 03/26/2026) ────────────
     engine_build:
         name: Engine Build
-        if: inputs.task == 'engine-build'
+        if: false # inputs.task == 'engine-build' — paused 03/26/2026
         uses: KBVE/kbve/.github/workflows/ci-angelscript-engine.yml@dev
         with:
             platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
## Summary

Temporarily pausing the AngelScript engine build pipeline (dated 03/26/2026).

### Changes
- **ci-angelscript-engine.yml**: Removed `workflow_call` trigger, kept `workflow_dispatch` for manual runs
- **ci-ue.yml**: Disabled `engine_build` job with `if: false`

Both annotated with date so they're easy to find and re-enable when ready.

### What still works
- Manual dispatch via `workflow_dispatch` on ci-angelscript-engine.yml
- All other ci-ue.yml jobs (dedicated_server, ows_server, win_setup)
- Failure tracker still wired up