### PR TITLE
fix(ows): add watch verb to Agones RBAC for GameServer watcher

### DIFF
--- a/apps/kube/ows/manifest/launcher-agones-rbac.yaml
+++ b/apps/kube/ows/manifest/launcher-agones-rbac.yaml
@@ -17,7 +17,7 @@ rules:
       verbs: ['create']
     - apiGroups: ['agones.dev']
       resources: ['gameservers']
-      verbs: ['get', 'list', 'delete']
+      verbs: ['get', 'list', 'watch', 'delete']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary
- Add `watch` verb to the `agones-allocator-for-ows` Role for `gameservers` resource
- Fixes 403 Forbidden on the GameServer watcher that auto-cleans DB on server shutdown

## Test plan
- [ ] After merge + ArgoCD sync, verify ROWS logs show "GameServer watcher started" without 403 errors
- [ ] Kill a GameServer pod and verify DB entries are auto-cleaned