### PR TITLE
feat(rows): self-service fleet restart via API

### DIFF
--- a/apps/kube/ows/manifest/launcher-agones-rbac.yaml
+++ b/apps/kube/ows/manifest/launcher-agones-rbac.yaml
@@ -18,6 +18,9 @@ rules:
     - apiGroups: ['agones.dev']
       resources: ['gameservers']
       verbs: ['get', 'list', 'watch', 'delete']
+    - apiGroups: ['agones.dev']
+      resources: ['fleets', 'fleets/scale']
+      verbs: ['get', 'patch', 'update']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/apps/ows/rows/src/agones/client.rs
+++ b/apps/ows/rows/src/agones/client.rs
@@ -91,4 +91,38 @@ impl AgonesClient {
     pub fn fleet(&self) -> &str {
         &self.fleet
     }
+
+    /// Scale the fleet to a given number of replicas.
+    /// Used by RestartFleet to scale 0 → wait → scale back up.
+    pub async fn scale_fleet(&self, replicas: i32) -> Result<(), super::AgonesError> {
+        let url = format!(
+            "/apis/agones.dev/v1/namespaces/{}/fleets/{}/scale",
+            self.namespace, self.fleet
+        );
+
+        let body = serde_json::json!({
+            "apiVersion": "agones.dev/v1",
+            "kind": "Scale",
+            "metadata": {
+                "name": &self.fleet,
+                "namespace": &self.namespace
+            },
+            "spec": {
+                "replicas": replicas
+            }
+        });
+
+        let req = http::Request::put(&url)
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_vec(&body).unwrap())
+            .map_err(|e| anyhow::anyhow!("Failed to build scale request: {e}"))?;
+
+        let _resp: serde_json::Value =
+            tokio::time::timeout(Duration::from_secs(10), self.client.request(req))
+                .await
+                .map_err(|_| anyhow::anyhow!("Fleet scale request timed out"))??;
+
+        info!(fleet = %self.fleet, replicas, "Fleet scaled");
+        Ok(())
+    }
 }

--- a/apps/ows/rows/src/rest/system.rs
+++ b/apps/ows/rows/src/rest/system.rs
@@ -319,10 +319,28 @@ async fn restart_game_server(
 
 /// Restart the entire fleet — scale to 0, clean all DB entries, scale back up.
 /// Use with caution — disconnects all players.
-async fn restart_fleet(State(hs): State<HandlerState>) -> Json<serde_json::Value> {
+async fn restart_fleet(
+    State(hs): State<HandlerState>,
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
     let customer_guid = hs.app.config.customer_guid;
+    let desired_replicas = body.get("replicas").and_then(|v| v.as_i64()).unwrap_or(2) as i32;
 
-    // Clean all zone instance DB entries
+    // Step 1: Scale fleet to 0 (kills all pods including Allocated)
+    if let Some(ref agones) = hs.app.agones {
+        tracing::info!("RestartFleet: scaling to 0");
+        if let Err(e) = agones.scale_fleet(0).await {
+            return Json(serde_json::json!({
+                "success": false,
+                "error": format!("Failed to scale fleet to 0: {e}")
+            }));
+        }
+
+        // Wait for pods to terminate
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+
+    // Step 2: Clean all zone instance DB entries
     let repo = crate::repo::InstanceRepo(&hs.app.db);
     if let Err(e) = repo.delete_all_map_instances(customer_guid).await {
         return Json(serde_json::json!({
@@ -334,9 +352,20 @@ async fn restart_fleet(State(hs): State<HandlerState>) -> Json<serde_json::Value
         tracing::warn!(error = %e, "Failed to deactivate world servers");
     }
 
-    // Clear tracking maps
+    // Step 3: Clear tracking maps
     hs.app.zone_servers.clear();
     hs.app.zone_spinup_locks.clear();
+
+    // Step 4: Scale fleet back up
+    if let Some(ref agones) = hs.app.agones {
+        tracing::info!(replicas = desired_replicas, "RestartFleet: scaling back up");
+        if let Err(e) = agones.scale_fleet(desired_replicas).await {
+            return Json(serde_json::json!({
+                "success": false,
+                "error": format!("DB cleaned but failed to scale fleet back up: {e}. Manual scale needed.")
+            }));
+        }
+    }
 
     // Log the event
     hs.app.instance_log.push(InstanceEvent {
@@ -350,6 +379,6 @@ async fn restart_fleet(State(hs): State<HandlerState>) -> Json<serde_json::Value
 
     Json(serde_json::json!({
         "success": true,
-        "message": "Fleet DB cleaned. Scale fleet manually via kubectl or ArgoCD to restart pods."
+        "message": format!("Fleet restarted. Scaled 0 → {desired_replicas}. DB cleaned.")
     }))
 }


### PR DESCRIPTION
## Summary
- `POST /api/System/RestartFleet` now fully self-service: scales fleet to 0 → cleans DB → scales back up
- New `scale_fleet()` method on AgonesClient
- RBAC: added `fleets` + `fleets/scale` permissions for `ows-instancelauncher` service account
- Accepts `{"replicas": N}` body (default 2)

## Usage
```bash
curl -X POST https://api.chuckrpg.com/api/System/RestartFleet \
  -H "X-CustomerGUID: 83d88046-..." \
  -d '{"replicas": 2}'
```