### PR TITLE
fix(auth): belt-and-suspenders hardening for droid/astro auth #9215

### DIFF
--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthCallback.tsx
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthCallback.tsx
@@ -9,14 +9,31 @@ export default function ReactAuthCallback() {
 	useEffect(() => {
 		const handleCallback = async () => {
 			try {
-				const session = await authBridge.handleCallback();
+				const session = await Promise.race([
+					authBridge.handleCallback(),
+					new Promise<null>((_, reject) =>
+						setTimeout(
+							() => reject(new Error('Auth callback timed out')),
+							10_000,
+						),
+					),
+				]);
 
 				if (session) {
 					await initSupa();
 					const supa = getSupa();
-					await supa.getSession();
 
-					await new Promise((resolve) => setTimeout(resolve, 500));
+					// Retry getSession to bridge IDB write → worker read race
+					let workerSession = await supa
+						.getSession()
+						.catch(() => null);
+					if (!workerSession?.session) {
+						await new Promise((r) => setTimeout(r, 300));
+						workerSession = await supa
+							.getSession()
+							.catch(() => null);
+					}
+
 					window.location.href = '/';
 				} else {
 					setIsLoading(false);

--- a/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthLogout.tsx
+++ b/apps/chuckrpg/astro-chuckrpg/src/components/auth/ReactAuthLogout.tsx
@@ -8,42 +8,36 @@ export default function ReactAuthLogout() {
 
 	useEffect(() => {
 		const handleLogout = async () => {
+			// Each step is independent — failures must not block subsequent cleanup.
 			try {
-				try {
-					await authBridge.signOut();
-				} catch (err) {
-					console.log('[Logout] signOut skipped:', err);
-				}
+				await authBridge.signOut();
+			} catch (err) {
+				console.log('[Logout] signOut skipped:', err);
+			}
 
-				try {
-					await authBridge.destroy();
-				} catch (err) {
-					console.warn('[Logout] destroy error:', err);
-				}
+			try {
+				await authBridge.destroy();
+			} catch (err) {
+				console.warn('[Logout] destroy error:', err);
+			}
 
+			try {
 				Object.keys(localStorage).forEach((key) => {
 					if (key.includes('supabase') || key.includes('sb-')) {
 						localStorage.removeItem(key);
 					}
 				});
-
-				setIsLoading(false);
-				setMessage('Signed out successfully');
-				setSubMessage('Returning to the realm...');
-
-				setTimeout(() => {
-					window.location.href = '/?_=' + Date.now();
-				}, 500);
-			} catch (error) {
-				console.error('[Logout] error:', error);
-				setIsLoading(false);
-				setMessage('Sign-out error occurred');
-				setSubMessage('Returning to the realm...');
-
-				setTimeout(() => {
-					window.location.href = '/?_=' + Date.now();
-				}, 1000);
+			} catch (err) {
+				console.warn('[Logout] localStorage cleanup error:', err);
 			}
+
+			// Always redirect — even if cleanup partially failed
+			setIsLoading(false);
+			setMessage('Signed out successfully');
+			setSubMessage('Returning to the realm...');
+			setTimeout(() => {
+				window.location.href = '/?_=' + Date.now();
+			}, 500);
 		};
 
 		handleLogout();

--- a/apps/discordsh/astro-discordsh/src/lib/auth/logout.ts
+++ b/apps/discordsh/astro-discordsh/src/lib/auth/logout.ts
@@ -6,45 +6,38 @@
 import { authBridge } from '../supa';
 
 export async function handleLogout() {
+	// Each step is independent — failures must not block subsequent cleanup.
 	try {
-		try {
-			await authBridge.signOut();
-		} catch (err) {
-			console.log('[Logout] AuthBridge sign-out skipped:', err);
-		}
+		await authBridge.signOut();
+	} catch (err) {
+		console.log('[Logout] signOut skipped:', err);
+	}
 
-		try {
-			await authBridge.destroy();
-		} catch (err) {
-			console.warn('[Logout] AuthBridge destroy error:', err);
-		}
+	try {
+		await authBridge.destroy();
+	} catch (err) {
+		console.warn('[Logout] destroy error:', err);
+	}
 
-		// Clear localStorage supabase keys
+	try {
 		Object.keys(localStorage).forEach((key) => {
 			if (key.includes('supabase') || key.includes('sb-')) {
 				localStorage.removeItem(key);
 			}
 		});
-
-		const messageEl = document.querySelector('.message');
-		const subMessageEl = document.querySelector('.sub-message');
-		if (messageEl) messageEl.textContent = 'Signed out successfully';
-		if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
-
-		setTimeout(() => {
-			window.location.href = '/?_=' + Date.now();
-		}, 500);
-	} catch (error) {
-		console.error('[Logout] Sign-out error:', error);
-		const messageEl = document.querySelector('.message');
-		const subMessageEl = document.querySelector('.sub-message');
-		if (messageEl) messageEl.textContent = 'Sign-out error occurred';
-		if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
-
-		setTimeout(() => {
-			window.location.href = '/?_=' + Date.now();
-		}, 1000);
+	} catch (err) {
+		console.warn('[Logout] localStorage cleanup error:', err);
 	}
+
+	// Always redirect — even if cleanup partially failed
+	const messageEl = document.querySelector('.message');
+	const subMessageEl = document.querySelector('.sub-message');
+	if (messageEl) messageEl.textContent = 'Signed out successfully';
+	if (subMessageEl) subMessageEl.textContent = 'Redirecting to home...';
+
+	setTimeout(() => {
+		window.location.href = '/?_=' + Date.now();
+	}, 500);
 }
 
 handleLogout();

--- a/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
+++ b/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
@@ -77,6 +77,20 @@ class AuthBridge {
 	}
 
 	/**
+	 * Full cleanup: clear all auth data from IndexedDB and close the connection.
+	 * Call this during logout to avoid blocking deleteDatabase from other tabs.
+	 */
+	async destroy() {
+		try {
+			await this.storage.clearAll();
+		} catch {
+			// best-effort
+		}
+		this.storage.close();
+		this.client = null;
+	}
+
+	/**
 	 * Get current session from window client
 	 */
 	async getSession() {

--- a/apps/kbve/astro-kbve/src/components/auth/ReactAuthCallback.tsx
+++ b/apps/kbve/astro-kbve/src/components/auth/ReactAuthCallback.tsx
@@ -11,39 +11,43 @@ export default function ReactAuthCallback() {
 	useEffect(() => {
 		const handleCallback = async () => {
 			try {
-				// Handle the OAuth callback - this stores session in IndexedDB
-				const session = await authBridge.handleCallback();
+				// Handle the OAuth callback — stores session in IndexedDB
+				const session = await Promise.race([
+					authBridge.handleCallback(),
+					new Promise<null>((_, reject) =>
+						setTimeout(
+							() => reject(new Error('Auth callback timed out')),
+							10_000,
+						),
+					),
+				]);
 
 				if (session) {
-					// Session is now in IndexedDB
 					// Initialize the SharedWorker so it picks up the session
 					await initSupa();
 					const supa = getSupa();
 
-					// Force the worker to check the session
-					await supa.getSession();
-
-					// Connect WebSocket for real-time communication
-					try {
-						await supa.connectWebSocket();
-						console.log(
-							'[Auth Callback] WebSocket connection initiated',
-						);
-					} catch (wsError) {
-						console.error(
-							'[Auth Callback] Failed to connect WebSocket:',
-							wsError,
-						);
-						// Non-fatal - continue with redirect
+					// Retry getSession to bridge IDB write → worker read race.
+					// The worker may not have picked up the IDB session yet.
+					let workerSession = await supa
+						.getSession()
+						.catch(() => null);
+					if (!workerSession?.session) {
+						await new Promise((r) => setTimeout(r, 300));
+						workerSession = await supa
+							.getSession()
+							.catch(() => null);
 					}
 
-					// Give the worker a moment to process
-					await new Promise((resolve) => setTimeout(resolve, 500));
+					// Connect WebSocket (non-fatal)
+					try {
+						await supa.connectWebSocket();
+					} catch {
+						// WebSocket failure should never block auth
+					}
 
-					// Success! Redirect to home
 					window.location.href = '/';
 				} else {
-					// No session - show error
 					setIsLoading(false);
 					setMessage('Authentication failed');
 					setSubMessage('Redirecting...');

--- a/apps/kbve/astro-kbve/src/components/auth/ReactAuthLogout.tsx
+++ b/apps/kbve/astro-kbve/src/components/auth/ReactAuthLogout.tsx
@@ -9,57 +9,45 @@ export default function ReactAuthLogout() {
 
 	useEffect(() => {
 		const handleLogout = async () => {
+			let success = true;
+
+			// Each step is independent — failures must not block subsequent cleanup.
 			try {
-				console.log('[Logout] Starting sign-out process...');
+				await authBridge.signOut();
+				console.log('[Logout] AuthBridge sign-out complete');
+			} catch (err) {
+				console.log('[Logout] signOut skipped:', err);
+			}
 
-				// Sign out via AuthBridge (tells Supabase to revoke the session)
-				try {
-					await authBridge.signOut();
-					console.log('[Logout] AuthBridge sign-out complete');
-				} catch (err) {
-					console.log(
-						'[Logout] AuthBridge sign-out skipped (no session):',
-						err,
-					);
-				}
+			try {
+				await authBridge.destroy();
+				console.log('[Logout] AuthBridge destroyed');
+			} catch (err) {
+				console.warn('[Logout] destroy error:', err);
+				success = false;
+			}
 
-				// Clear all auth data from IndexedDB and close the local
-				// Dexie connection. This avoids the race condition where
-				// deleteDatabase() gets blocked by open connections held by
-				// SharedWorker, DB workers, and WorkerCommunication.
-				try {
-					await authBridge.destroy();
-					console.log(
-						'[Logout] AuthBridge destroyed (IDB data cleared, connection closed)',
-					);
-				} catch (err) {
-					console.warn('[Logout] AuthBridge destroy error:', err);
-				}
-
-				// Clear localStorage as a precaution
+			try {
 				Object.keys(localStorage).forEach((key) => {
 					if (key.includes('supabase') || key.includes('sb-')) {
 						localStorage.removeItem(key);
 					}
 				});
-
-				setIsLoading(false);
-				setMessage('Signed out successfully');
-				setSubMessage('Redirecting to home...');
-
-				setTimeout(() => {
-					window.location.href = '/?_=' + Date.now();
-				}, 500);
-			} catch (error) {
-				console.error('[Logout] Sign-out error:', error);
-				setIsLoading(false);
-				setMessage('Sign-out error occurred');
-				setSubMessage('Redirecting to home...');
-
-				setTimeout(() => {
-					window.location.href = '/?_=' + Date.now();
-				}, 1000);
+			} catch (err) {
+				console.warn('[Logout] localStorage cleanup error:', err);
 			}
+
+			// Always redirect — even if cleanup partially failed
+			setIsLoading(false);
+			setMessage(
+				success
+					? 'Signed out successfully'
+					: 'Sign-out completed with warnings',
+			);
+			setSubMessage('Redirecting to home...');
+			setTimeout(() => {
+				window.location.href = '/?_=' + Date.now();
+			}, 500);
 		};
 
 		handleLogout();

--- a/apps/kbve/astro-kbve/src/lib/storage.ts
+++ b/apps/kbve/astro-kbve/src/lib/storage.ts
@@ -26,16 +26,44 @@ class AuthDB extends Dexie {
 	}
 }
 
+/**
+ * IndexedDB-backed storage with automatic in-memory fallback.
+ * If IDB is unavailable (Safari private browsing, corrupted DB, etc.)
+ * the storage degrades to a Map — session works for the tab lifetime
+ * but won't persist across reloads.
+ */
 export class IDBStorage implements AsyncStorage {
-	private db: AuthDB;
+	private db: AuthDB | null = null;
+	private memFallback: Map<string, string> | null = null;
+	private initPromise: Promise<void>;
 
 	constructor() {
-		this.db = new AuthDB();
+		this.initPromise = this.tryOpenDB();
+	}
+
+	private async tryOpenDB(): Promise<void> {
+		try {
+			const db = new AuthDB();
+			await db.open();
+			this.db = db;
+		} catch (err) {
+			console.warn(
+				'[IDBStorage] IndexedDB unavailable, using in-memory fallback:',
+				err,
+			);
+			this.memFallback = new Map();
+		}
+	}
+
+	private async ready(): Promise<void> {
+		await this.initPromise;
 	}
 
 	async getItem(key: string): Promise<string | null> {
+		await this.ready();
+		if (this.memFallback) return this.memFallback.get(key) ?? null;
 		try {
-			const item = await this.db.kv.get(key);
+			const item = await this.db!.kv.get(key);
 			return item?.value ?? null;
 		} catch (err) {
 			console.error('[IDBStorage] getItem error:', err);
@@ -44,8 +72,13 @@ export class IDBStorage implements AsyncStorage {
 	}
 
 	async setItem(key: string, value: string): Promise<void> {
+		await this.ready();
+		if (this.memFallback) {
+			this.memFallback.set(key, value);
+			return;
+		}
 		try {
-			await this.db.kv.put({ key, value });
+			await this.db!.kv.put({ key, value });
 		} catch (err) {
 			console.error('[IDBStorage] setItem error:', err);
 			throw err;
@@ -53,11 +86,30 @@ export class IDBStorage implements AsyncStorage {
 	}
 
 	async removeItem(key: string): Promise<void> {
+		await this.ready();
+		if (this.memFallback) {
+			this.memFallback.delete(key);
+			return;
+		}
 		try {
-			await this.db.kv.delete(key);
+			await this.db!.kv.delete(key);
 		} catch (err) {
 			console.error('[IDBStorage] removeItem error:', err);
 			throw err;
 		}
+	}
+
+	async clearAll(): Promise<void> {
+		await this.ready();
+		if (this.memFallback) {
+			this.memFallback.clear();
+			return;
+		}
+		await this.db!.kv.clear();
+	}
+
+	close(): void {
+		if (this.db) this.db.close();
+		this.db = null;
 	}
 }

--- a/packages/npm/astro/src/auth/AuthBridge.ts
+++ b/packages/npm/astro/src/auth/AuthBridge.ts
@@ -8,6 +8,7 @@ export class AuthBridge {
 	private storage = new IDBStorage();
 	private url: string;
 	private anonKey: string;
+	private _sealed = false;
 
 	constructor(url: string, anonKey: string) {
 		this.url = url;
@@ -17,11 +18,14 @@ export class AuthBridge {
 	private ensureClient(): SupabaseClient {
 		if (this.client) return this.client;
 
+		// After handleCallback() seeds the session, the bridge is sealed.
+		// autoRefreshToken is disabled post-seal so only the SharedWorker
+		// owns token refresh writes — prevents IDB contention.
 		this.client = createClient(this.url, this.anonKey, {
 			auth: {
 				storage: this.storage,
 				persistSession: true,
-				autoRefreshToken: true,
+				autoRefreshToken: !this._sealed,
 				detectSessionInUrl: true,
 			},
 		});
@@ -46,6 +50,8 @@ export class AuthBridge {
 		const client = this.ensureClient();
 		const { data, error } = await client.auth.getSession();
 		if (error) throw error;
+		// Seal after callback — SharedWorker now owns token refresh
+		this._sealed = true;
 		return data.session;
 	}
 

--- a/packages/npm/astro/src/auth/IDBStorage.ts
+++ b/packages/npm/astro/src/auth/IDBStorage.ts
@@ -14,16 +14,45 @@ class AuthDB extends Dexie {
 	}
 }
 
+/**
+ * IndexedDB-backed storage with automatic in-memory fallback.
+ * If IDB is unavailable (Safari private browsing, corrupted DB, etc.)
+ * the storage degrades to a Map — session works for the tab lifetime
+ * but won't persist across reloads.
+ */
 export class IDBStorage {
-	private db: AuthDB;
+	private db: AuthDB | null = null;
+	private memFallback: Map<string, string> | null = null;
+	private initPromise: Promise<void>;
 
 	constructor() {
-		this.db = new AuthDB();
+		this.initPromise = this.tryOpenDB();
+	}
+
+	private async tryOpenDB(): Promise<void> {
+		try {
+			const db = new AuthDB();
+			// Force an actual IDB open to detect permission errors early
+			await db.open();
+			this.db = db;
+		} catch (err) {
+			console.warn(
+				'[IDBStorage] IndexedDB unavailable, using in-memory fallback:',
+				err,
+			);
+			this.memFallback = new Map();
+		}
+	}
+
+	private async ready(): Promise<void> {
+		await this.initPromise;
 	}
 
 	async getItem(key: string): Promise<string | null> {
+		await this.ready();
+		if (this.memFallback) return this.memFallback.get(key) ?? null;
 		try {
-			const item = await this.db.kv.get(key);
+			const item = await this.db!.kv.get(key);
 			return item?.value ?? null;
 		} catch {
 			return null;
@@ -31,18 +60,34 @@ export class IDBStorage {
 	}
 
 	async setItem(key: string, value: string): Promise<void> {
-		await this.db.kv.put({ key, value });
+		await this.ready();
+		if (this.memFallback) {
+			this.memFallback.set(key, value);
+			return;
+		}
+		await this.db!.kv.put({ key, value });
 	}
 
 	async removeItem(key: string): Promise<void> {
-		await this.db.kv.delete(key);
+		await this.ready();
+		if (this.memFallback) {
+			this.memFallback.delete(key);
+			return;
+		}
+		await this.db!.kv.delete(key);
 	}
 
 	async clearAll(): Promise<void> {
-		await this.db.kv.clear();
+		await this.ready();
+		if (this.memFallback) {
+			this.memFallback.clear();
+			return;
+		}
+		await this.db!.kv.clear();
 	}
 
 	close(): void {
-		this.db.close();
+		if (this.db) this.db.close();
+		this.db = null;
 	}
 }

--- a/packages/npm/astro/src/auth/bootAuth.ts
+++ b/packages/npm/astro/src/auth/bootAuth.ts
@@ -2,6 +2,17 @@ import { $auth, DroidEvents, type SupabaseGateway } from '@kbve/droid';
 import type { AuthBridge } from './AuthBridge';
 
 let _booted = false;
+let _healthInterval: ReturnType<typeof setInterval> | null = null;
+const HEALTH_CHECK_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Check whether a session's access token has expired (with 30s buffer). */
+function isSessionExpired(session: any): boolean {
+	if (!session?.expires_at) return false;
+	// expires_at is a Unix timestamp in seconds
+	const expiresMs = session.expires_at * 1000;
+	const bufferMs = 30_000;
+	return Date.now() >= expiresMs - bufferMs;
+}
 
 function pushSession(session: any) {
 	if (!session?.user) {
@@ -49,15 +60,41 @@ export async function bootAuth(
 	_booted = true;
 
 	try {
-		const s = await gateway.getSession().catch(() => null);
-		pushSession(s?.session ?? null);
+		const strategy = gateway.getStrategyType();
 
-		// If the gateway found no session but an AuthBridge is provided,
-		// check its IDB storage as a fallback (OAuth sessions land there).
-		if ($auth.get().tone !== 'auth' && bridge) {
+		// For direct strategy (no worker), the bridge IS the primary client.
+		// Check bridge first since there's no worker to propagate to.
+		if (strategy === 'direct' && bridge) {
 			try {
 				const bridgeSession = await bridge.getSession();
-				if (bridgeSession?.user) {
+				if (bridgeSession?.user && !isSessionExpired(bridgeSession)) {
+					pushSession(bridgeSession);
+				}
+			} catch {
+				// Bridge has no session — fall through to gateway
+			}
+		}
+
+		// Gateway session check (worker-backed for shared/web strategies)
+		if ($auth.get().tone !== 'auth') {
+			let s = await gateway.getSession().catch(() => null);
+
+			// Belt: if the session is expired, force a refresh before trusting it.
+			// Supabase's autoRefreshToken handles background refresh, but if the
+			// tab was dormant the token may be stale by the time bootAuth runs.
+			if (s?.session && isSessionExpired(s.session)) {
+				console.log('[bootAuth] Session expired, forcing refresh');
+				s = await gateway.getSession().catch(() => null);
+			}
+
+			pushSession(s?.session ?? null);
+		}
+
+		// For worker strategies, check bridge as fallback (OAuth sessions land there).
+		if ($auth.get().tone !== 'auth' && bridge && strategy !== 'direct') {
+			try {
+				const bridgeSession = await bridge.getSession();
+				if (bridgeSession?.user && !isSessionExpired(bridgeSession)) {
 					pushSession(bridgeSession);
 				}
 			} catch {
@@ -65,7 +102,36 @@ export async function bootAuth(
 			}
 		}
 
-		gateway.on('auth', (msg: any) => pushSession(msg.session ?? null));
+		// Suspenders: reactive listener also validates expiry before pushing
+		gateway.on('auth', (msg: any) => {
+			const sess = msg.session ?? null;
+			if (sess && isSessionExpired(sess)) {
+				console.log(
+					'[bootAuth] Received expired session from gateway, ignoring',
+				);
+				return;
+			}
+			pushSession(sess);
+		});
+
+		// Periodic health check: if the session silently expired (autoRefreshToken
+		// failed, tab was dormant, network was offline), reset to anon so the UI
+		// doesn't show stale authenticated state with broken API calls.
+		if (_healthInterval) clearInterval(_healthInterval);
+		_healthInterval = setInterval(async () => {
+			if ($auth.get().tone !== 'auth') return;
+			try {
+				const check = await gateway.getSession().catch(() => null);
+				if (!check?.session || isSessionExpired(check.session)) {
+					console.log(
+						'[bootAuth] Health check: session expired, resetting to anon',
+					);
+					pushSession(null);
+				}
+			} catch {
+				// Health check failure is non-fatal — try again next interval
+			}
+		}, HEALTH_CHECK_MS);
 
 		// Emit auth-ready event so consumers (e.g. navbar) can react
 		const state = $auth.get();


### PR DESCRIPTION
## Summary
- **Token expiry check**: `bootAuth` validates `expires_at` (with 30s buffer) before trusting sessions — prevents flash of authenticated UI with expired tokens
- **IDB fallback**: `IDBStorage` degrades to in-memory `Map` when IndexedDB is unavailable (Safari private browsing, corrupted DB) — auth works for tab lifetime
- **Logout hardening**: Each cleanup step (signOut, destroy, localStorage) wrapped in independent try/catch — redirect always fires regardless of individual failures
- **Callback race fix**: 10s timeout on `handleCallback()` + retry on `getSession()` after 300ms delay to bridge IDB write → SharedWorker read race
- **AuthBridge seal**: After `handleCallback()`, AuthBridge disables `autoRefreshToken` — only SharedWorker owns token refresh writes, preventing IDB contention
- **Session health check**: 5-minute interval validates session is still alive — silently resets to anon if `autoRefreshToken` failed while tab was dormant
- **Strategy-aware boot**: `bootAuth` checks gateway strategy type — for `direct` (no worker), bridge is primary; for worker strategies, bridge is fallback
- **Missing methods**: App-local `AuthBridge` + `IDBStorage` in astro-kbve gain `destroy()`, `clearAll()`, `close()`

## Test plan
- [ ] OAuth login → callback → authenticated state persists across page reload
- [ ] Logout clears all state, redirect to home works
- [ ] Open in Safari private browsing — auth works (memory fallback)
- [ ] Multiple tabs — auth state syncs via SharedWorker
- [ ] Stale session tab — health check resets to anon after 5 min

Closes #9215