### PR TITLE
feat(rows): GetZoneAssignment endpoint for Iris integration

### DIFF
--- a/apps/ows/rows/src/models.rs
+++ b/apps/ows/rows/src/models.rs
@@ -391,3 +391,13 @@ pub struct ZoneInstanceInfo {
     pub map_name: String,
     pub zone_name: String,
 }
+
+/// Zone assignment for Iris integration.
+/// Returned by GetZoneAssignment — tells the server which map to load.
+#[derive(sqlx::FromRow)]
+pub struct ZoneAssignment {
+    pub zone_instance_id: i32,
+    pub map_name: String,
+    pub zone_name: String,
+    pub port: i32,
+}

--- a/apps/ows/rows/src/repo/instances.rs
+++ b/apps/ows/rows/src/repo/instances.rs
@@ -608,4 +608,32 @@ impl<'a> InstanceRepo<'a> {
 
         Ok(info)
     }
+
+    /// Get zone assignment for a world server (Iris integration).
+    /// Returns the first active mapinstance assigned to this world server.
+    pub async fn get_zone_assignment(
+        &self,
+        customer_guid: Uuid,
+        world_server_id: i32,
+    ) -> Result<Option<ZoneAssignment>, RowsError> {
+        let assignment: Option<ZoneAssignment> = sqlx::query_as(
+            "SELECT mi.mapinstanceid AS zone_instance_id,
+                    m.mapname AS map_name,
+                    m.zonename AS zone_name,
+                    mi.port
+             FROM mapinstances mi
+             JOIN maps m ON m.mapid = mi.mapid AND m.customerguid = mi.customerguid
+             WHERE mi.customerguid = $1
+               AND mi.worldserverid = $2
+               AND mi.status > 0
+             ORDER BY mi.mapinstanceid DESC
+             LIMIT 1",
+        )
+        .bind(customer_guid)
+        .bind(world_server_id)
+        .fetch_optional(self.0)
+        .await?;
+
+        Ok(assignment)
+    }
 }

--- a/apps/ows/rows/src/rest/instances.rs
+++ b/apps/ows/rows/src/rest/instances.rs
@@ -56,6 +56,7 @@ pub(super) fn instance_mgmt_routes(hs: HandlerState) -> Router {
             "/api/Instance/GetCurrentWorldTime",
             post(get_current_world_time),
         )
+        .route("/api/Instance/GetZoneAssignment", post(get_zone_assignment))
         .layer(middleware::from_fn(require_customer_guid))
         .with_state(hs)
 }
@@ -419,4 +420,53 @@ async fn get_server_instance_from_port(
         .get_server_instance_from_port(customer_guid, body.port)
         .await?;
     Ok(Json(info))
+}
+
+// ─── Zone Assignment (Iris Integration) ─────────────────────
+
+/// GET /api/Instance/GetZoneAssignment
+/// Called by the dedicated server to check if it has been assigned a zone.
+/// Returns the zone/map info if an allocation exists for this world server,
+/// or empty if no assignment yet (server should keep polling).
+///
+/// Flow:
+///   Server starts on Entry → registers with ROWS → polls this endpoint every 5s
+///   ROWS allocates → creates mapinstance → this returns the zone info
+///   Server receives → ServerTravel to the map → stops polling
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ZoneAssignmentDto {
+    world_server_id: i32,
+}
+
+async fn get_zone_assignment(
+    State(hs): State<HandlerState>,
+    headers: HeaderMap,
+    Json(body): Json<ZoneAssignmentDto>,
+) -> Json<serde_json::Value> {
+    let customer_guid = extract_customer_guid(&headers);
+    let repo = crate::repo::InstanceRepo(&hs.app.db);
+
+    // Look for an active mapinstance assigned to this world server
+    match repo
+        .get_zone_assignment(customer_guid, body.world_server_id)
+        .await
+    {
+        Ok(Some(assignment)) => Json(serde_json::json!({
+            "assigned": true,
+            "zoneInstanceId": assignment.zone_instance_id,
+            "mapName": assignment.map_name,
+            "zoneName": assignment.zone_name,
+            "port": assignment.port,
+            "worldServerId": body.world_server_id
+        })),
+        Ok(None) => Json(serde_json::json!({
+            "assigned": false,
+            "message": "No zone assignment yet. Keep polling."
+        })),
+        Err(e) => Json(serde_json::json!({
+            "assigned": false,
+            "error": e.to_string()
+        })),
+    }
 }


### PR DESCRIPTION
## Summary
- New `POST /api/Instance/GetZoneAssignment` endpoint
- Dedicated servers poll this to discover which map to ServerTravel to
- Returns zone/map info when a mapinstance is allocated, or `assigned: false` if still waiting
- New `ZoneAssignment` model + `get_zone_assignment()` repo method

## Iris Flow
```
Server starts on Entry → Agones Ready → RegisterWithROWS
  └─ Polls GetZoneAssignment every 5s
ROWS allocates server → creates mapinstance
  └─ GetZoneAssignment returns {mapName, zoneName, zoneInstanceId}
Server receives → ServerTravel("/Game/ThirdPerson/Lvl_ThirdPerson")
```

## Test plan
- [ ] Verify endpoint returns `assigned: false` for unassigned servers
- [ ] Verify endpoint returns zone info after allocation