### PR TITLE
chore(ows): harden ROWS deployment manifest

### DIFF
--- a/apps/kube/ows/manifest/rows-deployment.yaml
+++ b/apps/kube/ows/manifest/rows-deployment.yaml
@@ -25,17 +25,35 @@ spec:
                 app.kubernetes.io/part-of: ows
         spec:
             serviceAccountName: ows-instancelauncher
+            # TODO(security): Enable after verifying ROWS doesn't write to filesystem
+            # securityContext:
+            #     runAsNonRoot: true
+            #     runAsUser: 1000
+            #     runAsGroup: 1000
+            #     fsGroup: 1000
+            # TODO(graceful-shutdown): Increase after session drain is implemented
+            # terminationGracePeriodSeconds: 60
             containers:
                 - name: rows
                   image: ghcr.io/kbve/rows:0.1.22
                   imagePullPolicy: Always
+                  # TODO(security): Enable after verifying compatibility
+                  # securityContext:
+                  #     allowPrivilegeEscalation: false
+                  #     readOnlyRootFilesystem: true
+                  #     capabilities:
+                  #         drop: ["ALL"]
                   env:
+                      # ─── Core ───────────────────────────────
                       - name: HTTP_HOST
                         value: '0.0.0.0'
                       - name: HTTP_PORT
                         value: '4322'
+                      - name: DOCS_PORT
+                        value: '4323'
                       - name: RUST_LOG
                         value: 'info'
+                      # ─── Secrets ─────────────────────────────
                       - name: DATABASE_URL
                         valueFrom:
                             secretKeyRef:
@@ -51,10 +69,24 @@ spec:
                             secretKeyRef:
                                 name: ows-customer-guid
                                 key: customer-guid
+                      # ─── Agones ──────────────────────────────
                       - name: AGONES_NAMESPACE
                         value: 'arc-runners'
                       - name: AGONES_FLEET
                         value: 'ows-hubworld'
+                      - name: AGONES_API_TIMEOUT_SECS
+                        value: '10'
+                      - name: AGONES_CIRCUIT_BREAKER_THRESHOLD
+                        value: '5'
+                      - name: AGONES_CIRCUIT_BREAKER_RESET_SECS
+                        value: '30'
+                      # ─── Spinup Tuning ───────────────────────
+                      - name: ROWS_SPINUP_TIMEOUT_SECS
+                        value: '60'
+                      - name: ROWS_SPINUP_POLL_INTERVAL_MS
+                        value: '2000'
+                      - name: ROWS_SPINUP_INITIAL_DELAY_MS
+                        value: '3000'
                   ports:
                       - name: http
                         containerPort: 4322
@@ -103,3 +135,22 @@ spec:
           port: 4322
           targetPort: 4322
           protocol: TCP
+        - name: docs
+          port: 4323
+          targetPort: 4323
+          protocol: TCP
+---
+# PodDisruptionBudget — ensure at least 1 pod during rolling updates
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+    name: rows-pdb
+    namespace: ows
+    labels:
+        app: rows
+        app.kubernetes.io/part-of: ows
+spec:
+    minAvailable: 1
+    selector:
+        matchLabels:
+            app: rows


### PR DESCRIPTION
## Summary
- Add all configurable env vars (Agones timeouts, spinup tuning, docs port)
- Add docs port (4323) to Service for internal dashboard access
- Add PodDisruptionBudget (minAvailable: 1)
- Stub securityContext + terminationGracePeriodSeconds as TODO comments

## Changes
- Deployment: 7 new env vars, organized by category
- Service: docs port added
- PDB: new resource for rolling update safety
- TODOs: securityContext, graceful shutdown period