### PR TITLE
fix(kbve,axum-discordsh): map CSS generic font families so SVG text renders in containers

### DIFF
--- a/apps/discordsh/axum-discordsh/src/state.rs
+++ b/apps/discordsh/axum-discordsh/src/state.rs
@@ -127,6 +127,10 @@ impl AppState {
             );
         }
 
+        // Map CSS generic families (sans-serif, monospace, etc.) to Alagard
+        // so SVG templates render text even in containers without system fonts.
+        fontdb.set_generic_families("Alagard");
+
         tracing::info!(fonts = fontdb.len(), "Font database initialized");
 
         let http_client = reqwest::Client::builder()

--- a/packages/rust/kbve/src/entity/images/renderer.rs
+++ b/packages/rust/kbve/src/entity/images/renderer.rs
@@ -53,6 +53,24 @@ impl FontDb {
         }
     }
 
+    /// Map CSS generic font families (`sans-serif`, `serif`, `monospace`,
+    /// `cursive`, `fantasy`) to a concrete font family name loaded in this
+    /// database.
+    ///
+    /// Call this **after** loading all font files so that resvg/usvg can
+    /// resolve `font-family="sans-serif"` in SVG templates to an actual
+    /// typeface. Without this mapping, text using generic families renders
+    /// as blank when system fonts are unavailable (e.g. in containers).
+    pub fn set_generic_families(&mut self, family: &str) {
+        if let Some(db) = Arc::get_mut(&mut self.inner) {
+            db.set_sans_serif_family(family);
+            db.set_serif_family(family);
+            db.set_monospace_family(family);
+            db.set_cursive_family(family);
+            db.set_fantasy_family(family);
+        }
+    }
+
     /// Return the number of loaded font faces.
     pub fn len(&self) -> usize {
         self.inner.len()


### PR DESCRIPTION
## Summary
- SVG templates use `font-family="sans-serif"` and `"monospace"` but resvg could not resolve these generic CSS families in containerized environments where no system fonts are installed
- Add `FontDb::set_generic_families()` method that maps all five CSS generic families (sans-serif, serif, monospace, cursive, fantasy) to a concrete loaded font
- Call it in `AppState::new()` after loading Alagard so GitHub card text renders correctly

## Root cause
`usvg` resolves generic font families via `fontdb`'s family mappings. Without system fonts (Docker/k8s), those mappings are empty — text silently renders as blank pixels even though the Alagard font is loaded.

## Test plan
- [ ] `cargo check -p kbve --features image-gen` passes
- [ ] `cargo check -p axum-discordsh` passes
- [ ] Deploy to staging, run `/github issues` — card should show text instead of blank