### PR TITLE
fix(isometric,axum-kbve): resolve QUIC idle timeout for WebTransport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9438,8 +9438,6 @@ dependencies = [
 [[package]]
 name = "lightyear_webtransport"
 version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c100a3f88ced77327f04ab3e583ecca627e53d93031c5aaf7c2260d6c9faf25"
 dependencies = [
  "aeronet_io",
  "aeronet_webtransport",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ panic = 'unwind'
 opt-level = 3
 lto = 'fat'
 codegen-units = 1
+
+[patch.crates-io]
+lightyear_webtransport = { path = "packages/rust/lightyear_webtransport_patch" }

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -239,10 +239,38 @@ pub fn init_gameserver() {
         profile_bridge_task(req_rx, resp_tx).await;
     });
 
+    // Belt: verify UDP port is bindable before handing off to Bevy/lightyear.
+    // A silent bind failure inside wtransport is the #1 cause of
+    // ERR_QUIC_PROTOCOL_ERROR / QUIC_NETWORK_IDLE_TIMEOUT on the client.
+    if wt_identity.is_some() {
+        match std::net::UdpSocket::bind(wt_addr) {
+            Ok(sock) => {
+                drop(sock); // release immediately so lightyear can bind
+                tracing::info!(
+                    "[gameserver] UDP pre-check OK — port {} is available for WebTransport",
+                    wt_addr.port()
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    "[gameserver] UDP pre-check FAILED on {wt_addr}: {e} — \
+                     WebTransport will NOT work! Clients will see QUIC_NETWORK_IDLE_TIMEOUT. \
+                     Check firewall / another process on port {}.",
+                    wt_addr.port()
+                );
+            }
+        }
+    }
+
     std::thread::spawn(move || {
         tracing::info!("game server starting on ws://{ws_addr}");
         if wt_identity.is_some() {
-            tracing::info!("WebTransport enabled on https://{wt_addr}");
+            tracing::info!(
+                "WebTransport enabled on https://{wt_addr} \
+                 (keep_alive={}s, idle_timeout={}s)",
+                std::env::var("GAME_WT_KEEP_ALIVE_SECS").unwrap_or_else(|_| "4".into()),
+                std::env::var("GAME_WT_IDLE_TIMEOUT_SECS").unwrap_or_else(|_| "30".into()),
+            );
         }
         run_bevy_app(ws_addr, wt_addr, jwt_secret, wt_identity, req_tx, resp_rx);
     });
@@ -753,10 +781,27 @@ fn start_server(
     ));
 
     if let Some(identity) = wt_identity {
+        // Configurable QUIC timeouts — read from env or use generous defaults.
+        // keep_alive must be < idle_timeout so the server pings before the
+        // connection is considered dead. 30s idle + 4s keep-alive gives plenty
+        // of headroom for transient network stalls and slow QUIC handshakes.
+        let keep_alive_secs: u64 = std::env::var("GAME_WT_KEEP_ALIVE_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(4);
+        let idle_timeout_secs: u64 = std::env::var("GAME_WT_IDLE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
+
+        tracing::info!(
+            "[gameserver] WT QUIC config: keep_alive={keep_alive_secs}s, idle_timeout={idle_timeout_secs}s"
+        );
+
         entity_cmds.insert(
-            lightyear::webtransport::prelude::server::WebTransportServerIo {
-                certificate: identity,
-            },
+            lightyear::webtransport::prelude::server::WebTransportServerIo::new(identity)
+                .with_keep_alive(Some(Duration::from_secs(keep_alive_secs)))
+                .with_max_idle_timeout(Some(Duration::from_secs(idle_timeout_secs))),
         );
     }
 

--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -1547,9 +1547,9 @@ fn connect_to_server(commands: &mut Commands, transport: &TransportConfig, token
             .spawn((
                 netcode,
                 PeerAddr(server_addr),
-                WebTransportClientIo {
-                    certificate_digest: digest,
-                },
+                WebTransportClientIo::new(digest)
+                    .with_keep_alive(Some(Duration::from_secs(4)))
+                    .with_max_idle_timeout(Some(Duration::from_secs(30))),
                 ReplicationReceiver::default(),
             ))
             .id();

--- a/packages/rust/lightyear_webtransport_patch/Cargo.toml
+++ b/packages/rust/lightyear_webtransport_patch/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+edition = "2024"
+rust-version = "1.88"
+name = "lightyear_webtransport"
+version = "0.26.4"
+description = "IO primitives for the lightyear networking library — KBVE patch with configurable QUIC timeouts"
+license = "MIT OR Apache-2.0"
+
+[package.metadata.docs.rs]
+all-features = true
+rustflags = ["--cfg=web_sys_unstable_apis"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "wasm32-unknown-unknown",
+]
+
+[features]
+client = ["aeronet_webtransport/client"]
+dangerous-configuration = ["aeronet_webtransport/dangerous-configuration"]
+default = ["self-signed"]
+self-signed = ["aeronet_webtransport/self-signed"]
+server = [
+    "aeronet_webtransport/server",
+    "bevy_reflect/std",
+]
+
+[lib]
+name = "lightyear_webtransport"
+path = "src/lib.rs"
+
+[dependencies]
+aeronet_io = "0.19"
+aeronet_webtransport = "0.19"
+bevy_app = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.18", default-features = false }
+bevy_reflect = { version = "0.18", optional = true, default-features = false }
+lightyear_aeronet = { version = "0.26.4", default-features = false }
+lightyear_link = { version = "0.26.4", default-features = false }
+thiserror = "2.0.3"
+tracing = "0.1.40"
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+len_without_is_empty = "allow"
+missing_transmute_annotations = "allow"
+module_inception = "allow"
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+too_many_arguments = "allow"
+type_complexity = "allow"
+
+[lints.rust]
+dead_code = "allow"
+unused_variables = "allow"

--- a/packages/rust/lightyear_webtransport_patch/src/client.rs
+++ b/packages/rust/lightyear_webtransport_patch/src/client.rs
@@ -1,0 +1,211 @@
+use crate::WebTransportError;
+use aeronet_io::connection::PeerAddr;
+use aeronet_webtransport::client::{ClientConfig, WebTransportClient};
+use alloc::{format, string::String, vec::Vec};
+use bevy_app::{App, Plugin};
+use bevy_ecs::prelude::*;
+use lightyear_aeronet::{AeronetLinkOf, AeronetPlugin};
+use lightyear_link::{Link, LinkStart, Linked, Linking};
+#[cfg(all(not(target_family = "wasm"), feature = "dangerous-configuration"))]
+use tracing::warn;
+
+/// Default QUIC keep-alive interval for native clients (seconds).
+#[cfg(not(target_family = "wasm"))]
+const DEFAULT_KEEP_ALIVE_SECS: u64 = 4;
+
+/// Default QUIC max idle timeout for native clients (seconds).
+#[cfg(not(target_family = "wasm"))]
+const DEFAULT_MAX_IDLE_TIMEOUT_SECS: u64 = 30;
+
+pub struct WebTransportClientPlugin;
+
+impl Plugin for WebTransportClientPlugin {
+    fn build(&self, app: &mut App) {
+        if !app.is_plugin_added::<AeronetPlugin>() {
+            app.add_plugins(AeronetPlugin);
+        }
+        app.add_plugins(aeronet_webtransport::client::WebTransportClientPlugin);
+        app.add_observer(Self::link);
+    }
+}
+
+/// WebTransport session implementation which acts as a dedicated client,
+/// connecting to a target endpoint.
+///
+/// The [`PeerAddr`] component will be used to find the server_addr.
+///
+/// Use [`WebTransportClient::connect`] to start a connection.
+#[derive(Debug, Component)]
+#[require(Link)]
+pub struct WebTransportClientIo {
+    pub certificate_digest: String,
+    /// QUIC keep-alive interval (native only, ignored on WASM).
+    /// Default: 4 seconds.
+    pub keep_alive_interval: Option<core::time::Duration>,
+    /// QUIC max idle timeout (native only, ignored on WASM).
+    /// Default: 30 seconds.
+    pub max_idle_timeout: Option<core::time::Duration>,
+}
+
+impl WebTransportClientIo {
+    /// Create with a cert digest and default QUIC timeouts.
+    pub fn new(certificate_digest: String) -> Self {
+        Self {
+            certificate_digest,
+            keep_alive_interval: Some(core::time::Duration::from_secs(4)),
+            max_idle_timeout: Some(core::time::Duration::from_secs(30)),
+        }
+    }
+
+    /// Override QUIC keep-alive interval (native only).
+    pub fn with_keep_alive(mut self, interval: Option<core::time::Duration>) -> Self {
+        self.keep_alive_interval = interval;
+        self
+    }
+
+    /// Override QUIC max idle timeout (native only).
+    pub fn with_max_idle_timeout(mut self, timeout: Option<core::time::Duration>) -> Self {
+        self.max_idle_timeout = timeout;
+        self
+    }
+}
+
+impl WebTransportClientPlugin {
+    fn link(
+        trigger: On<LinkStart>,
+        query: Query<
+            (Entity, &WebTransportClientIo, Option<&PeerAddr>),
+            (Without<Linking>, Without<Linked>),
+        >,
+        mut commands: Commands,
+    ) -> Result {
+        if let Ok((entity, client, peer_addr)) = query.get(trigger.entity) {
+            let server_addr = peer_addr.ok_or(WebTransportError::PeerAddrMissing)?.0;
+            let digest = client.certificate_digest.clone();
+            let keep_alive = client.keep_alive_interval;
+            let idle_timeout = client.max_idle_timeout;
+            commands.queue(move |world: &mut World| -> Result {
+                let config = Self::client_config(digest, keep_alive, idle_timeout)?;
+                let server_url = format!("https://{server_addr}");
+                let target = {
+                    #[cfg(target_family = "wasm")]
+                    {
+                        server_url
+                    }
+
+                    #[cfg(not(target_family = "wasm"))]
+                    {
+                        use aeronet_webtransport::wtransport::endpoint::IntoConnectOptions;
+                        server_url.into_options()
+                    }
+                };
+                let entity_mut =
+                    world.spawn((AeronetLinkOf(entity), Name::from("WebTransportClient")));
+                WebTransportClient::connect(config, target).apply(entity_mut);
+                Ok(())
+            });
+        }
+        Ok(())
+    }
+
+    // `cert_hash` is expected to be the hexadecimal representation of the SHA256 Digest, without colons
+    #[cfg(target_family = "wasm")]
+    fn client_config(
+        cert_hash: String,
+        _keep_alive: Option<core::time::Duration>,
+        _idle_timeout: Option<core::time::Duration>,
+    ) -> Result<ClientConfig> {
+        use aeronet_webtransport::xwt_web::{CertificateHash, HashAlgorithm};
+        use tracing::info;
+
+        info!("Connecting to server with certificate hash: {cert_hash}");
+        let server_certificate_hashes = if cert_hash.is_empty() {
+            Vec::new()
+        } else {
+            let hash = from_hex(&cert_hash)?;
+            vec![CertificateHash {
+                algorithm: HashAlgorithm::Sha256,
+                value: Vec::from(hash),
+            }]
+        };
+
+        Ok(ClientConfig {
+            server_certificate_hashes,
+            ..Default::default()
+        })
+    }
+
+    // `cert_digest` is expected to be the hexadecimal representation of the SHA256 Digest, without colons
+    #[cfg(not(target_family = "wasm"))]
+    fn client_config(
+        cert_digest: String,
+        keep_alive: Option<core::time::Duration>,
+        idle_timeout: Option<core::time::Duration>,
+    ) -> Result<ClientConfig> {
+        use aeronet_webtransport::wtransport::{config::IpBindConfig, tls::Sha256Digest};
+
+        let keep_alive =
+            keep_alive.unwrap_or(core::time::Duration::from_secs(DEFAULT_KEEP_ALIVE_SECS));
+        let idle_timeout = idle_timeout.unwrap_or(core::time::Duration::from_secs(
+            DEFAULT_MAX_IDLE_TIMEOUT_SECS,
+        ));
+
+        // TODO: for some reason on linux the default can bind to ipv6 which is not supported.
+        //  Let the user specify the config
+        let config = ClientConfig::builder().with_bind_config(IpBindConfig::InAddrAnyV4);
+        let config = if cert_digest.is_empty() {
+            #[cfg(feature = "dangerous-configuration")]
+            {
+                warn!("Connecting with no certificate validation");
+                config.with_no_cert_validation()
+            }
+            #[cfg(not(feature = "dangerous-configuration"))]
+            {
+                config.with_server_certificate_hashes([])
+            }
+        } else {
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(&from_hex(&cert_digest)?);
+            let digest = Sha256Digest::new(hash);
+            config.with_server_certificate_hashes([digest])
+        };
+
+        Ok(config
+            .keep_alive_interval(Some(keep_alive))
+            .max_idle_timeout(Some(idle_timeout))
+            .expect("should be a valid idle timeout")
+            .build())
+    }
+}
+
+// Adapted from https://github.com/briansmith/ring/blob/befdc87ac7cbca615ab5d68724f4355434d3a620/src/test.rs#L364-L393
+fn from_hex(hex_str: &str) -> core::result::Result<Vec<u8>, String> {
+    if !hex_str.len().is_multiple_of(2) {
+        return Err(format!(
+            "Hex string does not have an even number of digits. Length: {}. String: .{}.",
+            hex_str.len(),
+            hex_str
+        ));
+    }
+
+    let mut result = Vec::with_capacity(hex_str.len() / 2);
+    for digits in hex_str.as_bytes().chunks(2) {
+        let hi = from_hex_digit(digits[0])?;
+        let lo = from_hex_digit(digits[1])?;
+        result.push((hi * 0x10) | lo);
+    }
+    Ok(result)
+}
+
+fn from_hex_digit(d: u8) -> core::result::Result<u8, String> {
+    use core::ops::RangeInclusive;
+    const DECIMAL: (u8, RangeInclusive<u8>) = (0, b'0'..=b'9');
+    const HEX_LOWER: (u8, RangeInclusive<u8>) = (10, b'a'..=b'f');
+    const HEX_UPPER: (u8, RangeInclusive<u8>) = (10, b'A'..=b'F');
+    for (offset, range) in &[DECIMAL, HEX_LOWER, HEX_UPPER] {
+        if range.contains(&d) {
+            return Ok(d - range.start() + offset);
+        }
+    }
+    Err(format!("Invalid hex digit '{}'", d as char))
+}

--- a/packages/rust/lightyear_webtransport_patch/src/lib.rs
+++ b/packages/rust/lightyear_webtransport_patch/src/lib.rs
@@ -1,0 +1,37 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+extern crate alloc;
+
+#[cfg(feature = "client")]
+pub mod client;
+#[cfg(all(feature = "server", not(target_family = "wasm")))]
+pub mod server;
+
+use alloc::string::String;
+
+#[derive(thiserror::Error, Debug)]
+pub enum WebTransportError {
+    #[error("the certificate hash `{0}` is invalid")]
+    Certificate(String),
+    #[error("PeerAddr is required to start the WebTransportClientIo link")]
+    PeerAddrMissing,
+    #[error("LocalAddr is required to start the WebTransportServerIo")]
+    LocalAddrMissing,
+}
+
+pub mod prelude {
+    pub use crate::WebTransportError;
+
+    #[cfg(not(target_family = "wasm"))]
+    pub use aeronet_webtransport::wtransport::Identity;
+
+    #[cfg(feature = "client")]
+    pub mod client {
+        pub use crate::client::WebTransportClientIo;
+    }
+
+    #[cfg(all(feature = "server", not(target_family = "wasm")))]
+    pub mod server {
+        pub use crate::server::WebTransportServerIo;
+    }
+}

--- a/packages/rust/lightyear_webtransport_patch/src/server.rs
+++ b/packages/rust/lightyear_webtransport_patch/src/server.rs
@@ -1,0 +1,150 @@
+use crate::WebTransportError;
+use aeronet_io::Session;
+use aeronet_io::connection::{LocalAddr, PeerAddr};
+use aeronet_webtransport::server::{
+    ServerConfig, SessionRequest, SessionResponse, WebTransportServer, WebTransportServerClient,
+};
+use aeronet_webtransport::wtransport::Identity;
+use bevy_app::{App, Plugin};
+use bevy_ecs::prelude::*;
+use core::time::Duration;
+use lightyear_aeronet::server::ServerAeronetPlugin;
+use lightyear_aeronet::{AeronetLinkOf, AeronetPlugin};
+use lightyear_link::prelude::LinkOf;
+use lightyear_link::server::Server;
+use lightyear_link::{Link, LinkStart, Linked, Linking};
+use tracing::info;
+
+/// Default QUIC keep-alive interval (seconds).
+const DEFAULT_KEEP_ALIVE_SECS: u64 = 4;
+
+/// Default QUIC max idle timeout (seconds).
+const DEFAULT_MAX_IDLE_TIMEOUT_SECS: u64 = 30;
+
+/// Allows using [`WebTransportServer`].
+pub struct WebTransportServerPlugin;
+
+impl Plugin for WebTransportServerPlugin {
+    fn build(&self, app: &mut App) {
+        if !app.is_plugin_added::<AeronetPlugin>() {
+            app.add_plugins(AeronetPlugin);
+        }
+        if !app.is_plugin_added::<ServerAeronetPlugin>() {
+            app.add_plugins(ServerAeronetPlugin);
+        }
+        app.add_plugins(aeronet_webtransport::server::WebTransportServerPlugin);
+
+        app.add_observer(Self::link);
+        app.add_observer(Self::on_session_request);
+        app.add_observer(Self::on_connection);
+    }
+}
+
+/// WebTransport server implementation which listens for client connections,
+/// and coordinates messaging between multiple clients.
+///
+/// Use [`WebTransportServer::open`] to start opening a server.
+///
+/// The [`LocalAddr`] component must be inserted to specify the server_addr.
+///
+/// When a client attempts to connect, the server will trigger a
+/// [`SessionRequest`]. Your app **must** observe this, and use
+/// [`SessionRequest::respond`] to set how the server should respond to this
+/// connection attempt.
+#[derive(Debug, Component)]
+#[require(Server)]
+pub struct WebTransportServerIo {
+    pub certificate: Identity,
+    /// QUIC keep-alive interval. `None` disables keep-alive pings.
+    /// Default: 4 seconds.
+    pub keep_alive_interval: Option<Duration>,
+    /// QUIC max idle timeout. `None` means no timeout.
+    /// Default: 30 seconds.
+    pub max_idle_timeout: Option<Duration>,
+}
+
+impl WebTransportServerIo {
+    /// Create a new server IO with the given certificate and default QUIC timeouts.
+    pub fn new(certificate: Identity) -> Self {
+        Self {
+            certificate,
+            keep_alive_interval: Some(Duration::from_secs(DEFAULT_KEEP_ALIVE_SECS)),
+            max_idle_timeout: Some(Duration::from_secs(DEFAULT_MAX_IDLE_TIMEOUT_SECS)),
+        }
+    }
+
+    /// Override QUIC keep-alive interval.
+    pub fn with_keep_alive(mut self, interval: Option<Duration>) -> Self {
+        self.keep_alive_interval = interval;
+        self
+    }
+
+    /// Override QUIC max idle timeout.
+    pub fn with_max_idle_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.max_idle_timeout = timeout;
+        self
+    }
+}
+
+impl WebTransportServerPlugin {
+    fn link(
+        trigger: On<LinkStart>,
+        query: Query<
+            (Entity, &WebTransportServerIo, Option<&LocalAddr>),
+            (Without<Linking>, Without<Linked>),
+        >,
+        mut commands: Commands,
+    ) -> Result {
+        if let Ok((entity, io, local_addr)) = query.get(trigger.entity) {
+            let server_addr = local_addr.ok_or(WebTransportError::LocalAddrMissing)?.0;
+            let certificate = io.certificate.clone_identity();
+            let keep_alive = io.keep_alive_interval;
+            let idle_timeout = io.max_idle_timeout;
+            commands.queue(move |world: &mut World| {
+                let config = ServerConfig::builder()
+                    .with_bind_address(server_addr)
+                    .with_identity(certificate)
+                    .keep_alive_interval(keep_alive)
+                    .max_idle_timeout(idle_timeout)
+                    .expect("should be a valid idle timeout")
+                    .build();
+                info!(
+                    "Server WebTransport starting at {} (keep_alive={:?}, idle_timeout={:?})",
+                    server_addr, keep_alive, idle_timeout
+                );
+                let child = world.spawn((AeronetLinkOf(entity), Name::from("WebTransportServer")));
+                WebTransportServer::open(config).apply(child);
+            });
+        }
+        Ok(())
+    }
+
+    fn on_session_request(mut request: On<SessionRequest>) {
+        request.respond(SessionResponse::Accepted);
+    }
+
+    fn on_connection(
+        trigger: On<Add, Session>,
+        query: Query<&AeronetLinkOf>,
+        child_query: Query<(&ChildOf, &PeerAddr), With<WebTransportServerClient>>,
+        mut commands: Commands,
+    ) {
+        if let Ok((child_of, peer_addr)) = child_query.get(trigger.entity)
+            && let Ok(server_link) = query.get(child_of.parent())
+        {
+            let link_entity = commands
+                .spawn((
+                    LinkOf {
+                        server: server_link.0,
+                    },
+                    Link::new(None),
+                    PeerAddr(peer_addr.0),
+                ))
+                .id();
+            commands.entity(trigger.entity).insert((
+                AeronetLinkOf(link_entity),
+                Name::from("WebTransportClientOf"),
+            ));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Patch `lightyear_webtransport` locally to expose configurable `keep_alive_interval` and `max_idle_timeout` on both server and client (was hardcoded to 1s/5s, now defaults to 4s/30s)
- Server: env-configurable via `GAME_WT_KEEP_ALIVE_SECS` / `GAME_WT_IDLE_TIMEOUT_SECS`, plus UDP pre-flight bind check at startup to catch silent port conflicts
- Client (native): matching 4s/30s QUIC config; WASM relies on server keep-alive pings + existing WS fallback

## Test plan
- [ ] Deploy server, verify `[gameserver] UDP pre-check OK` and `WT QUIC config: keep_alive=4s, idle_timeout=30s` in logs
- [ ] Connect WASM client via WebTransport — confirm no `QUIC_NETWORK_IDLE_TIMEOUT` within 30s
- [ ] Block UDP port 5001, verify `UDP pre-check FAILED` log and WS fallback kicks in
- [ ] Verify native (desktop) client connects via WT with 30s idle tolerance