### PR TITLE
fix(kbve): enable ROWS proxy + OSRS timeouts + CI timeout bump

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -36,7 +36,7 @@ jobs:
     test:
         name: Test ${{ inputs.project }} Docker App
         runs-on: ${{ inputs.runner }}
-        timeout-minutes: 120
+        timeout-minutes: 180
         env:
             NX_NO_CLOUD: true
         permissions:

--- a/apps/kbve/axum-kbve/src/db/osrs.rs
+++ b/apps/kbve/axum-kbve/src/db/osrs.rs
@@ -313,7 +313,11 @@ impl OSRSCacheActor {
 
 /// Fetch item mapping from OSRS Wiki API
 async fn fetch_item_mapping() -> Result<Vec<OSRSItem>, reqwest::Error> {
-    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(15))
+        .build()?;
 
     let items: Vec<OSRSItem> = client
         .get("https://prices.runescape.wiki/api/v1/osrs/mapping")
@@ -327,7 +331,11 @@ async fn fetch_item_mapping() -> Result<Vec<OSRSItem>, reqwest::Error> {
 
 /// Fetch latest prices from OSRS Wiki API
 async fn fetch_latest_prices() -> Result<HashMap<String, OSRSPrice>, reqwest::Error> {
-    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(15))
+        .build()?;
 
     #[derive(Deserialize)]
     struct PriceResponse {

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -129,6 +129,8 @@ spec:
                         value: '/etc/ssl/webtransport-selfsigned/tls.crt'
                       - name: GAME_WT_SELFSIGNED_KEY
                         value: '/etc/ssl/webtransport-selfsigned/tls.key'
+                      - name: CHUCKRPG_UPSTREAM_URL
+                        value: 'http://rows.ows.svc.cluster.local:4322'
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd


### PR DESCRIPTION
## Summary
- Add `CHUCKRPG_UPSTREAM_URL=http://rows.ows.svc.cluster.local:4322` to kbve deployment — enables axum-kbve to proxy requests to ROWS across the ows namespace
- Add `connect_timeout(5s)` and `timeout(15s)` to OSRS wiki reqwest clients in `db/osrs.rs` — previously had no timeout and could hang indefinitely in CI
- Bump `docker-test-app.yml` job timeout from 120 to 180 minutes — cold-runner Docker builds for axum-kbve (Rust + Bevy + Axum multi-stage) regularly exceed 120min

## Test plan
- [ ] Verify axum-kbve logs "ChuckRPG proxy initialized" on startup
- [ ] Verify `/dashboard/chuckrpg/proxy/health` returns ROWS health response
- [ ] CI Docker e2e job completes without timeout

Closes #9256