### PR TITLE
feat(astro-kbve): add 19 isometric game items to itemdb

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/allium.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/allium.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Allium'
+description: 'A round purple allium with a striking spherical bloom. Mildly aromatic.'
+ref: 'allium'
+key: 113
+id: '01KMVPV9ZJ37XD5AAAP211W0XM'
+name: 'Allium'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 4
+sell_price: 2
+emoji: '🟣'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 5
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-allium'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/bellflower.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/bellflower.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Bellflower'
+description: 'A delicate bell-shaped bloom that sways gently in the breeze. Found in shaded groves.'
+ref: 'bellflower'
+key: 108
+id: '01KMVPV9ZHMZNVQDYGK8F47P5D'
+name: 'Bellflower'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 4
+sell_price: 2
+emoji: '🔔'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 5
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-bell'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/blue-orchid.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/blue-orchid.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Blue Orchid'
+description: 'A rare and delicate blue orchid found in damp, shaded areas. Prized by collectors.'
+ref: 'blue-orchid'
+key: 114
+id: '01KMVPV9ZJCX2MW8DR54AV33JS'
+name: 'Blue Orchid'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 7
+sell_price: 3
+emoji: '🏵️'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 8
+  gather_time: 0.5
+  respawn_time: 25
+  resource_node: 'flower-blue-orchid'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/chanterelle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/chanterelle.mdx
@@ -1,0 +1,41 @@
+---
+title: 'Chanterelle'
+description: 'A golden funnel-shaped mushroom with a fruity aroma. A favorite among foragers.'
+ref: 'chanterelle'
+key: 116
+id: '01KMVPV9ZJF97SBP3WTVTPV93C'
+name: 'Chanterelle'
+type_flags: 136
+consumable: true
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 10
+sell_price: 5
+emoji: '🍄'
+weight: 0.15
+skilling:
+  skill: 'foraging'
+  xp_reward: 10
+  gather_time: 0.5
+  respawn_time: 25
+  resource_node: 'mushroom-chanterelle'
+food:
+  heals: 4
+  doses: 1
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/copper-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/copper-ore.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Copper Ore'
+description: 'Raw copper ore mined from veins in the earth. Can be smelted into copper bars.'
+ref: 'copper-ore'
+key: 102
+id: '01KMVPV9ZHV1GFHM1MPDN4FV70'
+name: 'Copper Ore'
+type_flags: 384
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 12
+sell_price: 6
+emoji: '🟤'
+weight: 4.0
+skilling:
+  skill: 'mining'
+  skill_level: 1
+  xp_reward: 18
+  gather_time: 3.0
+  respawn_time: 40
+  resource_node: 'ore-copper'
+  tool_required: 'pickaxe'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/cornflower.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/cornflower.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Cornflower'
+description: 'A striking blue cornflower found along field edges. Used in dyes and herblore.'
+ref: 'cornflower'
+key: 112
+id: '01KMVPV9ZJHTX417X4HV0DY663'
+name: 'Cornflower'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 5
+sell_price: 2
+emoji: '🔵'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 5
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-cornflower'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/crystal-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/crystal-ore.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Crystal Ore'
+description: 'A shimmering crystalline ore pulsing with faint energy. Rare and highly sought after.'
+ref: 'crystal-ore'
+key: 104
+id: '01KMVPV9ZHRQSBQJDRNEAJN368'
+name: 'Crystal Ore'
+type_flags: 384
+consumable: false
+stackable: true
+max_stack: 16
+rarity: 'rare'
+buy_price: 75
+sell_price: 35
+emoji: '💎'
+weight: 3.5
+skilling:
+  skill: 'mining'
+  skill_level: 30
+  xp_reward: 65
+  gather_time: 5.0
+  respawn_time: 90
+  resource_node: 'ore-crystal'
+  tool_required: 'pickaxe'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/daisy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/daisy.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Daisy'
+description: 'A cheerful white daisy with a golden center. Found across open fields.'
+ref: 'daisy'
+key: 106
+id: '01KMVPV9ZH852GF5HWAQJQD0G1'
+name: 'Daisy'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 4
+sell_price: 2
+emoji: '🌼'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 5
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-daisy'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/fly-agaric.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/fly-agaric.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Fly Agaric'
+description: 'An iconic red-capped mushroom with white spots. Toxic if consumed raw, but useful in alchemy.'
+ref: 'fly-agaric'
+key: 117
+id: '01KMVPV9ZJTK4QB8KGBH5XAEW4'
+name: 'Fly Agaric'
+type_flags: 160
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'uncommon'
+buy_price: 15
+sell_price: 8
+emoji: '🍄'
+weight: 0.2
+skilling:
+  skill: 'foraging'
+  xp_reward: 12
+  gather_time: 0.5
+  respawn_time: 30
+  resource_node: 'mushroom-fly-agaric'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/iron-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/iron-ore.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Iron Ore'
+description: 'Dense iron ore extracted from deep rock. Smelts into sturdy iron bars for smithing.'
+ref: 'iron-ore'
+key: 103
+id: '01KMVPV9ZHGWG5M1Q4R3YPYSG7'
+name: 'Iron Ore'
+type_flags: 384
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'uncommon'
+buy_price: 25
+sell_price: 12
+emoji: '⛏️'
+weight: 5.0
+skilling:
+  skill: 'mining'
+  skill_level: 15
+  xp_reward: 35
+  gather_time: 4.0
+  respawn_time: 60
+  resource_node: 'ore-iron'
+  tool_required: 'pickaxe'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/lavender.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/lavender.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Lavender'
+description: 'Fragrant purple lavender prized for its calming scent. Used in herblore and alchemy.'
+ref: 'lavender'
+key: 107
+id: '01KMVPV9ZH2X5XSMVAE90D21YM'
+name: 'Lavender'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 6
+sell_price: 3
+emoji: '💜'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 7
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-lavender'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/log.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/log.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Log'
+description: 'A freshly chopped log. Essential raw material for crafting and construction.'
+ref: 'log'
+key: 99
+id: '01KMVPV9ZG6TPG7BVB5Q9QV69M'
+name: 'Log'
+type_flags: 384
+consumable: false
+stackable: true
+max_stack: 64
+rarity: 'common'
+buy_price: 5
+sell_price: 2
+emoji: '🪵'
+weight: 2.5
+skilling:
+  skill: 'woodcutting'
+  xp_reward: 10
+  gather_time: 2.5
+  respawn_time: 30
+  resource_node: 'tree'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/mossy-stone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/mossy-stone.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Mossy Stone'
+description: 'A weathered stone covered in moss. Slightly more valuable than ordinary stone.'
+ref: 'mossy-stone'
+key: 101
+id: '01KMVPV9ZHNPTTYJPWD3RD00Y2'
+name: 'Mossy Stone'
+type_flags: 384
+consumable: false
+stackable: true
+max_stack: 64
+rarity: 'uncommon'
+buy_price: 8
+sell_price: 4
+emoji: '🪨'
+weight: 3.0
+skilling:
+  skill: 'mining'
+  xp_reward: 15
+  gather_time: 2.5
+  respawn_time: 35
+  resource_node: 'mossy-rock'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/porcini.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/porcini.mdx
@@ -1,0 +1,41 @@
+---
+title: 'Porcini'
+description: 'A prized edible mushroom with a rich, nutty flavor. Found near the base of trees.'
+ref: 'porcini'
+key: 115
+id: '01KMVPV9ZJB35BQJ3SNZ4W9GDA'
+name: 'Porcini'
+type_flags: 136
+consumable: true
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 8
+sell_price: 4
+emoji: '🍄'
+weight: 0.2
+skilling:
+  skill: 'foraging'
+  xp_reward: 8
+  gather_time: 0.5
+  respawn_time: 25
+  resource_node: 'mushroom-porcini'
+food:
+  heals: 3
+  doses: 1
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/rose.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/rose.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Rose'
+description: 'A classic red rose with sharp thorns. Valued for its beauty and alchemical properties.'
+ref: 'rose'
+key: 111
+id: '01KMVPV9ZHZ93N2B6DB35FDJAM'
+name: 'Rose'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 6
+sell_price: 3
+emoji: '🌹'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 6
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-rose'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/stone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/stone.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Stone'
+description: 'A rough chunk of stone broken from a boulder. Used in basic crafting and construction.'
+ref: 'stone'
+key: 100
+id: '01KMVPV9ZHPBRJZZEN7C0Q9R4Q'
+name: 'Stone'
+type_flags: 384
+consumable: false
+stackable: true
+max_stack: 64
+rarity: 'common'
+buy_price: 3
+sell_price: 1
+emoji: '🪨'
+weight: 3.0
+skilling:
+  skill: 'mining'
+  xp_reward: 8
+  gather_time: 2.0
+  respawn_time: 25
+  resource_node: 'boulder'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/sunflower.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/sunflower.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Sunflower'
+description: 'A tall, golden sunflower that always faces the light. Bright and easy to spot.'
+ref: 'sunflower'
+key: 110
+id: '01KMVPV9ZHQSEG1JXEWWJY2WKV'
+name: 'Sunflower'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 5
+sell_price: 2
+emoji: '🌻'
+weight: 0.15
+skilling:
+  skill: 'foraging'
+  xp_reward: 6
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-sunflower'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/tulip.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/tulip.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Tulip'
+description: 'A vibrant tulip with soft petals. Commonly foraged in meadows and grasslands.'
+ref: 'tulip'
+key: 105
+id: '01KMVPV9ZHDT45T6PYS5PH82F7'
+name: 'Tulip'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 4
+sell_price: 2
+emoji: '🌷'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 5
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-tulip'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />

--- a/apps/kbve/astro-kbve/src/content/docs/itemdb/wildflower.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itemdb/wildflower.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Wildflower'
+description: 'A hardy wildflower that thrives in untamed fields. The most common forageable bloom.'
+ref: 'wildflower'
+key: 109
+id: '01KMVPV9ZHCFW48C0G9S0CZA2J'
+name: 'Wildflower'
+type_flags: 128
+consumable: false
+stackable: true
+max_stack: 32
+rarity: 'common'
+buy_price: 3
+sell_price: 1
+emoji: '🌸'
+weight: 0.1
+skilling:
+  skill: 'foraging'
+  xp_reward: 4
+  gather_time: 0.5
+  respawn_time: 20
+  resource_node: 'flower-wildflower'
+tags:
+  - isometric
+---
+
+import ItemDBPanel from '@/components/itemdb/ItemDBPanel.astro';
+
+import {
+	Aside,
+	Steps,
+	Card,
+	CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+<ItemDBPanel data={frontmatter} />


### PR DESCRIPTION
## Summary
- Add 19 MDX item definitions for all isometric game forageable/mineable items
- Resources (keys 99-104): log, stone, mossy-stone, copper-ore, iron-ore, crystal-ore
- Flowers (keys 105-114): tulip, daisy, lavender, bellflower, wildflower, sunflower, rose, cornflower, allium, blue-orchid
- Mushrooms (keys 115-117): porcini, chanterelle, fly-agaric

## Test plan
- [ ] Verify `astro-kbve` builds without schema validation errors
- [ ] Check `/api/itemdb.json` includes all 19 new items with correct refs and keys
- [ ] Confirm no duplicate keys or refs with existing 99 items