### PR TITLE
feat(axum-discordsh): wire all 32 proto items into loot tables and treasure chests

### DIFF
--- a/apps/discordsh/axum-discordsh/src/discord/game/content.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/content.rs
@@ -258,6 +258,10 @@ fn loot_tables() -> &'static [LootTable] {
                     item_id: "vitality_potion",
                     weight: 1,
                 },
+                LootEntry {
+                    item_id: "whetstone",
+                    weight: 1,
+                },
             ],
             drop_chance: 0.3,
         },
@@ -279,6 +283,14 @@ fn loot_tables() -> &'static [LootTable] {
                 LootEntry {
                     item_id: "iron_skin_potion",
                     weight: 1,
+                },
+                LootEntry {
+                    item_id: "trap_kit",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "whetstone",
+                    weight: 2,
                 },
             ],
             drop_chance: 0.4,
@@ -304,6 +316,14 @@ fn loot_tables() -> &'static [LootTable] {
                 },
                 LootEntry {
                     item_id: "phoenix_feather",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "antidote",
+                    weight: 2,
+                },
+                LootEntry {
+                    item_id: "smoke_bomb",
                     weight: 1,
                 },
             ],
@@ -340,8 +360,67 @@ fn loot_tables() -> &'static [LootTable] {
                     item_id: "phoenix_feather",
                     weight: 1,
                 },
+                LootEntry {
+                    item_id: "elixir",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "antidote",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "smoke_bomb",
+                    weight: 1,
+                },
             ],
             drop_chance: 1.0,
+        },
+        // Treasure room loot — rolled when opening chests
+        LootTable {
+            id: "treasure",
+            entries: &[
+                LootEntry {
+                    item_id: "potion",
+                    weight: 4,
+                },
+                LootEntry {
+                    item_id: "vitality_potion",
+                    weight: 3,
+                },
+                LootEntry {
+                    item_id: "bomb",
+                    weight: 2,
+                },
+                LootEntry {
+                    item_id: "ward",
+                    weight: 2,
+                },
+                LootEntry {
+                    item_id: "iron_skin_potion",
+                    weight: 2,
+                },
+                LootEntry {
+                    item_id: "rage_draught",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "campfire_kit",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "smoke_bomb",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "trap_kit",
+                    weight: 1,
+                },
+                LootEntry {
+                    item_id: "antidote",
+                    weight: 1,
+                },
+            ],
+            drop_chance: 0.75,
         },
     ];
     TABLES
@@ -466,6 +545,45 @@ fn gear_loot_tables() -> &'static [GearLootTable] {
                 },
             ],
             drop_chance: 0.50,
+        },
+        // Treasure chests — mix of tiers, lower drop chance than combat
+        GearLootTable {
+            id: "treasure",
+            entries: &[
+                GearLootEntry {
+                    gear_id: "rusty_sword",
+                    weight: 4,
+                },
+                GearLootEntry {
+                    gear_id: "leather_vest",
+                    weight: 4,
+                },
+                GearLootEntry {
+                    gear_id: "iron_mace",
+                    weight: 3,
+                },
+                GearLootEntry {
+                    gear_id: "chain_mail",
+                    weight: 3,
+                },
+                GearLootEntry {
+                    gear_id: "shadow_dagger",
+                    weight: 2,
+                },
+                GearLootEntry {
+                    gear_id: "shadow_cloak",
+                    weight: 2,
+                },
+                GearLootEntry {
+                    gear_id: "flame_axe",
+                    weight: 1,
+                },
+                GearLootEntry {
+                    gear_id: "spiked_plate",
+                    weight: 1,
+                },
+            ],
+            drop_chance: 0.25,
         },
     ];
     TABLES

--- a/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
+++ b/apps/discordsh/axum-discordsh/src/discord/game/logic.rs
@@ -2606,6 +2606,32 @@ fn apply_treasure_choice(
         _ => return Err("Invalid treasure choice.".to_owned()),
     }
 
+    // Roll for bonus item loot from the treasure table
+    if let Some(item_id) = super::content::roll_loot("treasure") {
+        let alive_ids = session.alive_player_ids();
+        if let Some(&uid) = alive_ids.first() {
+            let player = session.player_mut(uid);
+            add_item_to_inventory(&mut player.inventory, item_id);
+            let emoji = super::content::find_item(item_id)
+                .map(|d| d.emoji.as_ref())
+                .unwrap_or("📦");
+            logs.push(format!("You also found {emoji} **{}**!", item_id));
+        }
+    }
+
+    // Roll for bonus gear loot from the treasure table
+    if let Some(gear_id) = super::content::roll_gear_loot("treasure") {
+        let alive_ids = session.alive_player_ids();
+        if let Some(&uid) = alive_ids.first() {
+            let player = session.player_mut(uid);
+            add_item_to_inventory(&mut player.inventory, gear_id);
+            let emoji = super::content::find_gear(gear_id)
+                .map(|d| d.emoji.as_ref())
+                .unwrap_or("⚔️");
+            logs.push(format!("You found {emoji} **{}** in the chest!", gear_id));
+        }
+    }
+
     if session.all_players_dead() {
         session.phase = GamePhase::GameOver(GameOverReason::Defeated);
         logs.push("The trap proved fatal...".to_owned());


### PR DESCRIPTION
## Summary
- Add 5 missing consumables to mob drop tables: `whetstone` (slime/skeleton), `trap_kit` (skeleton), `antidote` + `smoke_bomb` (wraith/boss), `elixir` (boss-only)
- Add `treasure` consumable loot table (75% drop chance) and `treasure` gear loot table (25% drop chance)
- Treasure room chests now roll bonus item and gear drops alongside gold
- All 32 discordsh-tagged proto items (22 consumables + 15 gear) are now reachable in gameplay

## Test plan
- [ ] `cargo check -p axum-discordsh` passes
- [ ] Deploy and open treasure chests — verify items/gear appear in loot logs
- [ ] Kill wraiths/bosses — verify new drops (antidote, smoke_bomb, elixir) appear
- [ ] Kill slimes/skeletons — verify whetstone and trap_kit appear

Closes #9264 (Phase 1)