### PR TITLE
chore(rows): clean all warnings + fix deprecated TimeoutLayer

### DIFF
--- a/apps/ows/rows/src/agones/mod.rs
+++ b/apps/ows/rows/src/agones/mod.rs
@@ -16,4 +16,3 @@ pub use allocate::AllocationResult;
 pub use client::AgonesClient;
 pub use error::AgonesError;
 pub use pipeline::AllocationPipeline;
-pub use sdk::GameServerInfo;

--- a/apps/ows/rows/src/agones/sdk.rs
+++ b/apps/ows/rows/src/agones/sdk.rs
@@ -17,7 +17,7 @@ use super::client::AgonesClient;
 use super::error::AgonesError;
 use serde_json::json;
 use std::time::Duration;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Labels used by ROWS on GameServer resources.
 pub mod labels {

--- a/apps/ows/rows/src/agones/watcher.rs
+++ b/apps/ows/rows/src/agones/watcher.rs
@@ -3,21 +3,16 @@
 //! Watches for Shutdown/Delete events and auto-cleans stale DB entries
 //! (worldservers + mapinstances) so clients never connect to dead ports.
 
-use crate::db::DbPool;
 use crate::repo::InstanceRepo;
 use crate::state::AppState;
-use dashmap::DashMap;
 use futures_lite::StreamExt;
 use kube::{
     Api, Client,
-    api::{ApiResource, DynamicObject, ListParams},
+    api::{ApiResource, DynamicObject},
     runtime::watcher::{self, Event},
 };
-use serde_json::Value;
 use std::sync::Arc;
-use std::time::Instant;
 use tracing::{error, info, warn};
-use uuid::Uuid;
 
 /// Max backoff between watcher restart attempts.
 const MAX_BACKOFF_SECS: u64 = 60;

--- a/apps/ows/rows/src/main.rs
+++ b/apps/ows/rows/src/main.rs
@@ -1,6 +1,7 @@
-// Allow structural warnings for WIP code — OWS parity requires many-arg functions
-// and some methods are implemented but not yet wired to routes.
+// OWS parity requires many-arg functions in repo/service layers.
 #![allow(clippy::too_many_arguments)]
+// SDK proxy, pipeline accessors, and repo methods are wired incrementally.
+// Dead code warnings suppressed until Iris/FastNoise/dashboard features are complete.
 #![allow(dead_code)]
 
 mod agones;
@@ -151,7 +152,10 @@ async fn main() -> anyhow::Result<()> {
         .merge(ws_router)
         .merge(grpc_router.into_axum_router())
         .layer(axum::middleware::from_fn(trace::request_trace))
-        .layer(TimeoutLayer::new(std::time::Duration::from_secs(90))) // 90s global request timeout
+        .layer(TimeoutLayer::with_status_code(
+            http::StatusCode::GATEWAY_TIMEOUT,
+            std::time::Duration::from_secs(90),
+        )) // 90s global request timeout → 504
         .layer(RequestBodyLimitLayer::new(10 * 1024 * 1024)) // 10MB max body
         .layer(CorsLayer::permissive());
 

--- a/apps/ows/rows/src/rest/system.rs
+++ b/apps/ows/rows/src/rest/system.rs
@@ -2,10 +2,8 @@
 //! All endpoints require X-CustomerGUID header (existing auth pattern).
 
 use crate::middleware::require_customer_guid;
-use crate::state::AppState;
 use axum::{Json, Router, extract::State, http::HeaderMap, middleware, routing::get};
 use serde::Serialize;
-use std::sync::Arc;
 use std::time::Instant;
 use utoipa::ToSchema;
 


### PR DESCRIPTION
## Summary
- Clean 10 unused imports via cargo fix
- Fix deprecated `TimeoutLayer::new` → `TimeoutLayer::with_status_code` (returns proper 504)
- Zero warnings from ROWS crate code