### PR TITLE
docs(rows): add edge case TODOs across all critical modules

### DIFF
--- a/apps/ows/rows/src/agones/watcher.rs
+++ b/apps/ows/rows/src/agones/watcher.rs
@@ -2,6 +2,28 @@
 //!
 //! Watches for Shutdown/Delete events and auto-cleans stale DB entries
 //! (worldservers + mapinstances) so clients never connect to dead ports.
+//!
+//! # Edge Cases
+//!
+//! TODO(orphan-detection): Detect GameServers not in tracking map:
+//!   - On every Init/InitDone cycle, compare Allocated GameServers with tracking map
+//!   - If Allocated GS has no entry in zone_servers → it's orphaned from a previous ROWS
+//!   - Options: adopt it (add to tracking), deallocate it, or log for manual review
+//!
+//! TODO(partial-cleanup): Handle DB failures during cleanup:
+//!   - If deactivate_world_server succeeds but delete_map_instance fails,
+//!     the worldserver is inactive but mapinstance remains → stale data
+//!   - Consider: retry cleanup with exponential backoff, or mark as "needs_cleanup"
+//!
+//! TODO(event-ordering): Handle out-of-order events:
+//!   - Watcher may receive Shutdown for a GS that was just re-allocated
+//!   - Check GS creation timestamp before cleaning up — if it's newer than the
+//!     event, skip cleanup (it's a different GS with the same name)
+//!
+//! TODO(multi-customer): Support multiple customers on one fleet:
+//!   - Current cleanup uses a single customer_guid from config
+//!   - If fleet serves multiple customers, need to look up customer from GS labels
+//!   - Or use ows.kbve.com/customer-guid annotation set during tag_allocated()
 
 use crate::repo::InstanceRepo;
 use crate::state::AppState;

--- a/apps/ows/rows/src/error.rs
+++ b/apps/ows/rows/src/error.rs
@@ -101,3 +101,25 @@ impl SuccessResponse {
 /// Handler return type — axum serializes Json<T> directly (single pass),
 /// errors go through RowsError::into_response (typed ApiErrorBody).
 pub type ApiResult<T> = Result<axum::Json<T>, RowsError>;
+
+// ─── Edge Case Notes ─────────────────────────────────────────
+//
+// TODO(error-context): Add request context to errors:
+//   - Include request_id, customer_guid, endpoint path in error responses
+//   - Makes debugging from client-side logs easier
+//   - Example: {"code": "NOT_FOUND", "request_id": "abc123", "path": "/api/Users/GetAllCharacters"}
+//
+// TODO(error-telemetry): Forward errors to observability stack:
+//   - 5xx errors → Vector → ClickHouse for alerting
+//   - Track error rates per endpoint for SLO monitoring
+//   - Circuit breaker state changes → alert on Agones degradation
+//
+// TODO(retry-header): Add Retry-After header on transient errors:
+//   - 503 (Agones allocation in progress) → Retry-After: 5
+//   - 429 (rate limited) → Retry-After: <seconds until reset>
+//   - Helps UE5 HTTP client implement exponential backoff
+//
+// TODO(timeout-variant): Add RowsError::Timeout for explicit timeout handling:
+//   - Distinguish between "server busy" (503) and "operation timed out" (504)
+//   - Allocation timeout → RowsError::Timeout("Allocation timed out after 60s")
+//   - DB query timeout → RowsError::Timeout("Query timed out after 30s")

--- a/apps/ows/rows/src/jobs.rs
+++ b/apps/ows/rows/src/jobs.rs
@@ -4,6 +4,33 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
+// ─── Edge Case Notes ─────────────────────────────────────────
+//
+// TODO(crash-recovery): On ROWS startup, reconcile all running jobs:
+//   - Scan Agones for Allocated GameServers with no matching DB entry
+//     (orphaned from a previous ROWS crash during allocation)
+//   - Deallocate orphaned GameServers
+//   - Partially done via reconcile_allocations() in main.rs startup,
+//     but doesn't handle the inverse (DB entry with no live GameServer)
+//
+// TODO(db-reconcile): Periodic DB → Agones reconciliation:
+//   - Every 5 minutes, compare mapinstances (status > 0) with live GameServers
+//   - If mapinstance exists but GameServer is gone → delete mapinstance
+//   - If GameServer is Allocated but no mapinstance → deallocate GameServer
+//   - This catches any state drift between DB and Agones
+//
+// TODO(health-escalation): Escalate repeated health failures:
+//   - If DB unreachable for 3+ consecutive checks → set readiness to false
+//   - K8s will stop routing traffic → gives DB time to recover
+//   - Re-enable readiness once DB comes back
+//
+// TODO(session-limit): Cap total sessions per customer:
+//   - Prevents a single customer from consuming all memory
+//   - Track session count per customer_guid, reject above limit
+//   - Default: 10000 sessions per customer
+//
+// ──────────────────────────────────────────────────────────────
+
 /// Spawn all background jobs as tokio tasks.
 pub fn spawn_all(svc: Arc<OWSService>) {
     tokio::spawn(zone_health_monitor(svc.clone()));

--- a/apps/ows/rows/src/middleware.rs
+++ b/apps/ows/rows/src/middleware.rs
@@ -39,6 +39,21 @@ pub async fn require_customer_guid(req: Request, next: Next) -> Response {
 /// Returns Uuid::nil() if not present — callers behind require_customer_guid
 /// middleware are guaranteed a valid GUID, but this avoids panics if called
 /// from unprotected routes.
+///
+/// # Edge cases
+/// - Nil UUID (all zeros) will query DB and return empty results — safe but wasteful
+/// - Malformed UUIDs are logged and fall back to nil
+///
+/// TODO(auth): Replace with Supabase JWT validation for production:
+///   1. Parse Authorization: Bearer <jwt> header
+///   2. Validate JWT signature against Supabase JWT secret
+///   3. Extract customer_guid from JWT claims
+///   4. Cache validated tokens in sessions map (avoid re-validation per request)
+///
+/// TODO(rate-limit): Add per-GUID rate limiting:
+///   - Track request count per customer_guid per minute
+///   - Return 429 Too Many Requests when exceeded
+///   - Separate limits for read (100/min) vs write (20/min) operations
 pub fn extract_customer_guid(headers: &axum::http::HeaderMap) -> Uuid {
     headers
         .get(CUSTOMER_GUID_HEADER)
@@ -51,3 +66,14 @@ pub fn extract_customer_guid(headers: &axum::http::HeaderMap) -> Uuid {
             Uuid::nil()
         })
 }
+
+// TODO(service-key): Add SERVICE_KEY middleware for system endpoints:
+//   - Reads SERVICE_KEY from env var (separate from OWS_API_KEY)
+//   - Dashboard sends Authorization: Bearer <service-key>
+//   - Validates against stored hash (not plaintext compare)
+//   - Required for /api/System/* endpoints (RestartFleet, VerifyDeployment, etc.)
+//
+// TODO(ip-allowlist): Add IP allowlist for admin endpoints:
+//   - ADMIN_ALLOWED_IPS env var (comma-separated CIDRs)
+//   - Check X-Forwarded-For / X-Real-IP against allowlist
+//   - Return 403 for non-allowed IPs on /api/System/* routes

--- a/apps/ows/rows/src/service/instances.rs
+++ b/apps/ows/rows/src/service/instances.rs
@@ -5,6 +5,32 @@ use crate::models::*;
 use crate::repo::{CharsRepo, InstanceRepo};
 use uuid::Uuid;
 
+// ─── Edge Case Notes ─────────────────────────────────────────
+//
+// TODO(concurrent-allocation): Two players requesting the same zone simultaneously
+//   can both trigger allocation. The spinup lock prevents duplicate Agones allocations
+//   but the second request still polls for 60s. Consider:
+//   - Returning the in-progress allocation immediately (skip poll, return "pending")
+//   - Using a tokio::sync::watch channel to notify waiters when allocation completes
+//
+// TODO(zone-capacity): Check zone player cap before allocation:
+//   - Query mapinstances.numberofreportedplayers for the zone
+//   - If above soft_player_cap, try to allocate a new instance instead of joining existing
+//   - If above hard_player_cap, return error "Zone is full"
+//
+// TODO(graceful-travel): Handle client disconnect during GetServerToConnectTo:
+//   - Client HTTP timeout (30s) vs server allocation time (up to 60s)
+//   - If client disconnects, the allocated server is still created
+//   - Consider: allocation should be idempotent per character — same char gets same instance
+//
+// TODO(cross-zone-travel): Support ServerTravel between zones:
+//   - Player on Zone A wants to enter Zone B
+//   - Save position on Zone A → allocate on Zone B → return Zone B IP:port
+//   - Client does ClientTravel → new server handles the rest
+//   - Requires: character position save before zone handoff (partially done in OWS)
+//
+// ──────────────────────────────────────────────────────────────
+
 impl OWSService {
     /// Get a server for a player to connect to.
     /// Resolves zone name → finds or allocates a GameServer → returns IP + port.


### PR DESCRIPTION
## Summary
Structured TODO stubs across 5 modules laying out the production hardening roadmap:

- **middleware**: Supabase JWT, rate limiting, service key, IP allowlist
- **service/instances**: concurrent allocation, zone capacity, cross-zone travel, graceful travel
- **jobs**: crash recovery, DB-Agones reconciliation, health escalation, session limits
- **watcher**: orphan detection, partial cleanup retry, event ordering, multi-customer
- **error**: request context, telemetry, retry headers, timeout variant

No logic changes — documentation-only.