### PR TITLE
feat(ci): version-gated ROWS pipeline with BUILD_INFO

### DIFF
--- a/.github/workflows/ci-ue5-rows.yml
+++ b/.github/workflows/ci-ue5-rows.yml
@@ -120,11 +120,42 @@ jobs:
 
                   echo "::notice::Shell: ${SHELL} | v${VERSION} | ${REPO} | ${SERVER_TARGET} | UE ${UE_IMAGE_TAG} | ${SERVER_CONFIG}"
 
+    # ── Version Gate ───────────────────────────────────────
+    version_gate:
+        name: Version Gate
+        needs: [guard, config]
+        if: needs.guard.outputs.allowed == 'true'
+        runs-on: arc-runner-ue
+        timeout-minutes: 5
+        outputs:
+            should_build: ${{ steps.check.outputs.should_build }}
+        steps:
+            - name: Check if version already deployed
+              id: check
+              run: |
+                  VERSION="${{ needs.config.outputs.version }}"
+                  TARGET="${{ needs.config.outputs.server_target }}"
+                  DEST="/mnt/longhorn/ows-server/${TARGET}/${VERSION}"
+
+                  if [ -d "${DEST}/LinuxServer" ]; then
+                    FILE_COUNT=$(find "${DEST}/LinuxServer" -type f 2>/dev/null | wc -l)
+                    if [ "${FILE_COUNT}" -gt 0 ]; then
+                      echo "::notice::v${VERSION} already deployed (${FILE_COUNT} files). Skipping build."
+                      echo "should_build=false" >> "$GITHUB_OUTPUT"
+                    else
+                      echo "::notice::v${VERSION} directory exists but is empty. Will rebuild."
+                      echo "should_build=true" >> "$GITHUB_OUTPUT"
+                    fi
+                  else
+                    echo "::notice::v${VERSION} not found on PVC. Will build."
+                    echo "should_build=true" >> "$GITHUB_OUTPUT"
+                  fi
+
     # ── Build Dedicated Server ──────────────────────────────
     build:
         name: Build ${{ needs.config.outputs.server_target }} (Linux)
-        needs: [guard, config]
-        if: needs.guard.outputs.allowed == 'true'
+        needs: [guard, config, version_gate]
+        if: needs.guard.outputs.allowed == 'true' && needs.version_gate.outputs.should_build == 'true'
         runs-on: arc-runner-ue
         timeout-minutes: 480
         permissions:
@@ -238,10 +269,17 @@ jobs:
                         -NoP4
                     '
 
-            - name: Deploy server to PVC
+            - name: Write BUILD_INFO
               run: |
                   VERSION="${{ needs.config.outputs.version }}"
                   TARGET="${{ needs.config.outputs.server_target }}"
+                  CONFIG="${{ needs.config.outputs.server_config }}"
+                  REPO="${{ needs.config.outputs.project_repo }}"
+                  UE_TAG="${{ needs.config.outputs.ue_image_tag }}"
+
+                  # Get Chuck repo commit SHA
+                  CHUCK_SHA=$(cd /tmp/game-project && git rev-parse HEAD)
+
                   SERVER_DIR=$(find /tmp/ue5-build-output -name "LinuxServer" -type d | head -1)
                   if [ -z "${SERVER_DIR}" ]; then
                     echo "::error::LinuxServer output not found"
@@ -249,14 +287,63 @@ jobs:
                     exit 1
                   fi
 
+                  cat > "${SERVER_DIR}/BUILD_INFO" <<-BUILDEOF
+                  version=${VERSION}
+                  server_target=${TARGET}
+                  server_config=${CONFIG}
+                  source_repo=${REPO}
+                  source_commit=${CHUCK_SHA}
+                  ue_image=ghcr.io/epicgames/unreal-engine:${UE_TAG}
+                  build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  build_run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  actor=${{ github.actor }}
+                  BUILDEOF
+
+                  echo "::notice::BUILD_INFO written — source ${REPO}@${CHUCK_SHA:0:8}, config ${CONFIG}"
+
+            - name: Deploy server to PVC
+              run: |
+                  VERSION="${{ needs.config.outputs.version }}"
+                  TARGET="${{ needs.config.outputs.server_target }}"
+                  SERVER_DIR=$(find /tmp/ue5-build-output -name "LinuxServer" -type d | head -1)
+
                   DEST="/mnt/longhorn/ows-server/${TARGET}/${VERSION}"
+
+                  # Clean destination if partial deploy exists
+                  rm -rf "${DEST}" 2>/dev/null || true
                   mkdir -p "${DEST}"
                   cp -r "${SERVER_DIR}/." "${DEST}/"
                   chmod -R 755 "${DEST}"
-                  ln -sfn "${DEST}" "/mnt/longhorn/ows-server/${TARGET}/latest"
+
+                  # Update latest symlink
+                  ln -sfn "${VERSION}" "/mnt/longhorn/ows-server/${TARGET}/latest"
 
                   echo "::notice::${TARGET} v${VERSION} deployed to PVC ($(du -sh ${DEST} | cut -f1))"
                   ls -la "${DEST}/" | head -10
+                  cat "${DEST}/BUILD_INFO"
+
+            - name: Prune old versions
+              run: |
+                  TARGET="${{ needs.config.outputs.server_target }}"
+                  PVC_DIR="/mnt/longhorn/ows-server/${TARGET}"
+                  KEEP=3
+
+                  echo "Pruning old versions in ${PVC_DIR} (keeping latest ${KEEP})..."
+                  cd "${PVC_DIR}"
+                  DIRS=$(ls -dt [0-9]* 2>/dev/null | tail -n +$((KEEP+1)))
+                  if [ -n "${DIRS}" ]; then
+                    for DIR in ${DIRS}; do
+                      # Skip if in use by running game server (NFS lock files)
+                      if find "${DIR}" -name ".nfs*" -print -quit 2>/dev/null | grep -q .; then
+                        echo "  Skipping ${DIR} (in use by running server)"
+                      else
+                        echo "  Removing ${DIR}"
+                        rm -rf "${DIR}"
+                      fi
+                    done
+                  else
+                    echo "  Nothing to prune."
+                  fi
 
             - name: Cleanup
               if: always()
@@ -269,7 +356,7 @@ jobs:
     track_failure:
         name: Track Failures
         if: ${{ always() && contains(needs.*.result, 'failure') }}
-        needs: [build]
+        needs: [build, version_gate]
         permissions:
             issues: write
             contents: read

--- a/apps/chuckrpg/unreal-chuck/version.toml
+++ b/apps/chuckrpg/unreal-chuck/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.1"
+version = "0.3.19"


### PR DESCRIPTION
## Summary
Closes acceptance criteria from #9230

- Bump `apps/chuckrpg/unreal-chuck/version.toml` from `0.0.1` → `0.3.19`
- Add **version gate** job — checks PVC, skips build if version already deployed
- Add **BUILD_INFO** file written into each deploy with full traceability:
  - Source repo + commit SHA
  - Server config (Development/Shipping)
  - UE image tag
  - Build timestamp + Actions run link
  - Actor who triggered the build
- Clean destination before deploy (no stale partial uploads)
- Prune old versions (keep 3, skip NFS-locked active game servers)

### Pipeline flow
```
Fork Guard → Read Config → Version Gate → Build → BUILD_INFO → Deploy → Prune → Cleanup
                                ↓ (skip)
                          (version exists)
```

### BUILD_INFO example
```
version=0.3.19
server_target=ChuckServer
server_config=Development
source_repo=KBVE/chuck
source_commit=abc1234
ue_image=ghcr.io/epicgames/unreal-engine:dev-5.7.4
build_time=2026-03-29T12:00:00Z
build_run=https://github.com/KBVE/kbve/actions/runs/12345
actor=h0lybyte
```

## Test plan
- [ ] Dispatch with `dedicated-server` task, confirm version gate checks PVC
- [ ] Bump version.toml, dispatch again, confirm full build + deploy
- [ ] Verify BUILD_INFO on PVC matches expected values
- [ ] Dispatch same version again, confirm version gate skips build