### PR TITLE
feat(discordsh-bot): add deployment pipeline — Dockerfile, CI, k8s manifests (Phase 2)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -68,6 +68,20 @@
 			"has_test": true
 		},
 		{
+			"key": "discordsh_bot",
+			"app_name": "discordsh-bot",
+			"version": "0.1.0",
+			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
+			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
+			"source_path": "apps/discordsh/discordsh-bot",
+			"runner": "ubuntu-latest",
+			"image": "kbve/discordsh-bot",
+			"e2e_name": "discordsh-bot",
+			"deployment_yaml": "apps/kube/discordsh-bot/manifest/deployment.yaml",
+			"has_test": false
+		},
+		{
 			"key": "edge",
 			"app_name": "edge",
 			"version": "0.1.21",

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -106,6 +106,9 @@ on:
             discordsh:
                 description: 'Discordsh app changed'
                 value: ${{ jobs.alter.outputs.discordsh }}
+            discordsh_bot:
+                description: 'Discordsh Bot changed'
+                value: ${{ jobs.alter.outputs.discordsh_bot }}
             proxy:
                 description: 'Proxy changed'
                 value: ${{ jobs.alter.outputs.proxy }}
@@ -204,6 +207,7 @@ jobs:
             irc_gateway: ${{ steps.delta.outputs.irc_gateway_any_changed }}
             droid: ${{ steps.delta.outputs.droid_any_changed }}
             discordsh: ${{ steps.delta.outputs.discordsh_any_changed}}
+            discordsh_bot: ${{ steps.delta.outputs.discordsh_bot_any_changed }}
             proxy: ${{ steps.delta.outputs.proxy_any_changed }}
             saber: ${{ steps.delta.outputs.saber_any_changed }}
             cryptothrone: ${{ steps.delta.outputs.cryptothrone_any_changed }}
@@ -293,6 +297,8 @@ jobs:
                           - 'apps/irc/**'
                       discordsh:
                           - 'apps/discordsh/**'
+                      discordsh_bot:
+                          - 'apps/discordsh/discordsh-bot/**'
                       proxy:
                           - 'apps/proxy/**'
                       saber:

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -1,0 +1,43 @@
+# ── Stage A: Dependency planner (cargo-chef) ────────────────────────
+FROM rust:1.94 AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+# ── Stage B: Prepare dependency recipe ──────────────────────────────
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ── Stage C: Build dependencies (cached layer) ─────────────────────
+FROM chef AS builder
+
+# System libraries needed for compilation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p discordsh-bot
+
+# ── Stage D: Build application ─────────────────────────────────────
+COPY . .
+RUN cargo build --release -p discordsh-bot --features jemalloc && \
+    strip target/release/discordsh-bot
+
+# ── Stage Z: Runtime ───────────────────────────────────────────────
+FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04.2 AS runtime
+
+WORKDIR /app
+
+# Copy the binary
+COPY --from=builder /app/target/release/discordsh-bot /app/discordsh-bot
+
+# Copy fonts for SVG rendering
+COPY apps/discordsh/discordsh-bot/alagard.ttf /app/alagard.ttf
+COPY apps/discordsh/discordsh-bot/NotoSansSymbols-Regular.ttf /app/NotoSansSymbols-Regular.ttf
+
+ENV RUST_LOG=discordsh_bot=debug,kbve=debug \
+    FONT_PATH=/app/alagard.ttf \
+    SYMBOL_FONT_PATH=/app/NotoSansSymbols-Regular.ttf
+
+ENTRYPOINT ["/app/discordsh-bot"]

--- a/apps/discordsh/discordsh-bot/version.toml
+++ b/apps/discordsh/discordsh-bot/version.toml
@@ -1,0 +1,2 @@
+version = "0.1.0"
+publish = false

--- a/apps/kube/discordsh-bot/application.yaml
+++ b/apps/kube/discordsh-bot/application.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: discordsh-bot
+    namespace: argocd
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: HEAD
+        path: apps/kube/discordsh-bot/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: discordsh-bot
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - PrunePropagationPolicy=foreground
+            - PruneLast=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m

--- a/apps/kube/discordsh-bot/manifest/configmap.yaml
+++ b/apps/kube/discordsh-bot/manifest/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: discordsh-bot-config
+    namespace: discordsh-bot
+data:
+    PUBLIC_SUPABASE_URL: 'https://api.kbve.com'
+    RUST_LOG: 'discordsh_bot=debug,kbve=debug'

--- a/apps/kube/discordsh-bot/manifest/deployment.yaml
+++ b/apps/kube/discordsh-bot/manifest/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: discordsh-bot-headless
+    namespace: discordsh-bot
+    labels:
+        app: discordsh-bot
+spec:
+    clusterIP: None
+    selector:
+        app: discordsh-bot
+    ports:
+        - name: health
+          port: 4322
+          targetPort: 4322
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    name: discordsh-bot
+    namespace: discordsh-bot
+    labels:
+        app: discordsh-bot
+spec:
+    serviceName: discordsh-bot-headless
+    replicas: 1
+    selector:
+        matchLabels:
+            app: discordsh-bot
+    template:
+        metadata:
+            labels:
+                app: discordsh-bot
+        spec:
+            containers:
+                - name: discordsh-bot
+                  image: ghcr.io/kbve/discordsh-bot:0.1.0
+                  imagePullPolicy: Always
+                  env:
+                      - name: RUST_LOG
+                        value: 'discordsh_bot=debug,kbve=debug'
+                      - name: FONT_PATH
+                        value: '/app/alagard.ttf'
+                      - name: SYMBOL_FONT_PATH
+                        value: '/app/NotoSansSymbols-Regular.ttf'
+                      - name: SHARD_COUNT
+                        value: '1'
+                      - name: DISCORD_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: discordsh-bot-secrets
+                                key: DISCORD_TOKEN
+                      - name: SUPABASE_URL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: discordsh-bot-config
+                                key: PUBLIC_SUPABASE_URL
+                      - name: SUPABASE_SERVICE_ROLE_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: discordsh-bot-supabase
+                                key: service-role-key
+                      - name: REDIS_URL
+                        value: 'redis://:$(REDIS_PASSWORD)@redis-master.redis.svc.cluster.local:6379'
+                      - name: REDIS_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: discordsh-bot-redis
+                                key: redis-password
+                  resources:
+                      requests:
+                          memory: '256Mi'
+                          cpu: '100m'
+                      limits:
+                          memory: '512Mi'
+                          cpu: '500m'
+                  livenessProbe:
+                      exec:
+                          command:
+                              - /bin/sh
+                              - -c
+                              - 'test $(( $(date +%s) - $(stat -c %Y /tmp/bot-heartbeat 2>/dev/null || echo 0) )) -lt 120'
+                      initialDelaySeconds: 30
+                      periodSeconds: 30
+                  readinessProbe:
+                      exec:
+                          command:
+                              - /bin/sh
+                              - -c
+                              - 'test -f /tmp/bot-heartbeat'
+                      initialDelaySeconds: 10
+                      periodSeconds: 10

--- a/apps/kube/discordsh-bot/manifest/externalsecret.yaml
+++ b/apps/kube/discordsh-bot/manifest/externalsecret.yaml
@@ -1,0 +1,71 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: discordsh-bot-redis-store
+    namespace: discordsh-bot
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: redis
+            server:
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+            auth:
+                serviceAccount:
+                    name: discordsh-bot-external-secrets
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: discordsh-bot-supabase-store
+    namespace: discordsh-bot
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            server:
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+            auth:
+                serviceAccount:
+                    name: discordsh-bot-external-secrets
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: discordsh-bot-redis
+    namespace: discordsh-bot
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: discordsh-bot-redis-store
+        kind: SecretStore
+    target:
+        name: discordsh-bot-redis
+    data:
+        - secretKey: redis-password
+          remoteRef:
+              key: redis
+              property: redis-password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: discordsh-bot-supabase
+    namespace: discordsh-bot
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: discordsh-bot-supabase-store
+        kind: SecretStore
+    target:
+        name: discordsh-bot-supabase
+    data:
+        - secretKey: service-role-key
+          remoteRef:
+              key: supabase-service-role
+              property: service-role-key

--- a/apps/kube/discordsh-bot/manifest/namespace.yaml
+++ b/apps/kube/discordsh-bot/manifest/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: discordsh-bot
+    labels:
+        app.kubernetes.io/name: discordsh-bot
+        app.kubernetes.io/part-of: discordsh

--- a/apps/kube/discordsh-bot/manifest/rbac.yaml
+++ b/apps/kube/discordsh-bot/manifest/rbac.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: discordsh-bot-sa
+    namespace: discordsh-bot
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: discordsh-bot-external-secrets
+    namespace: discordsh-bot
+---
+# Allow reading Redis secrets from the redis namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: discordsh-bot-redis-reader
+    namespace: redis
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['redis']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: discordsh-bot-redis-binding
+    namespace: redis
+subjects:
+    - kind: ServiceAccount
+      name: discordsh-bot-external-secrets
+      namespace: discordsh-bot
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: discordsh-bot-redis-reader
+---
+# Allow reading Supabase secrets from the kilobase namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: discordsh-bot-supabase-reader
+    namespace: kilobase
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-cluster-app', 'supabase-service-role']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: discordsh-bot-supabase-binding
+    namespace: kilobase
+subjects:
+    - kind: ServiceAccount
+      name: discordsh-bot-external-secrets
+      namespace: discordsh-bot
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: discordsh-bot-supabase-reader
+---
+# NetworkPolicy: allow bot to reach Redis
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: discordsh-bot-egress-redis
+    namespace: discordsh-bot
+spec:
+    podSelector:
+        matchLabels:
+            app: discordsh-bot
+    policyTypes:
+        - Egress
+    egress:
+        - to:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: redis
+                podSelector:
+                    matchLabels:
+                        app.kubernetes.io/name: redis
+          ports:
+              - protocol: TCP
+                port: 6379


### PR DESCRIPTION
## Summary
- **Dockerfile**: Multi-stage Rust build (cargo-chef cached deps → release binary → chisel-ubuntu-axum runtime). No Node.js/Astro stages — bot-only.
- **CI pipeline**: Added `discordsh_bot` entry to `ci-dispatch-manifest.json` and file alteration detection in `utils-file-alterations.yml`
- **K8s manifests**: Namespace, StatefulSet (1 replica), ConfigMap, RBAC (Redis + Supabase cross-namespace access), ExternalSecrets, ArgoCD application

## Deployment notes
- Bot uses exec-based health probes (heartbeat file) — no HTTP server
- Image: `ghcr.io/kbve/discordsh-bot:0.1.0`
- Secrets: Discord token (manual sealed secret), Redis password + Supabase service key (ExternalSecrets)
- `version.toml` starts at `0.1.0` with `publish = false` — first deploy requires bumping version in docs MDX

## What's NOT in this PR
- The docs MDX page (`discordsh-bot.mdx`) — needed before first deploy to set version_source
- The Discord bot token sealed secret — must be created manually in the cluster
- The heartbeat file touch in bot code — will add in a follow-up if exec probes are the approach

## Test plan
- [x] `cargo check -p discordsh-bot` passes
- [ ] Apply ArgoCD application to cluster
- [ ] Create `discordsh-bot-secrets` sealed secret with `DISCORD_TOKEN`
- [ ] Bump version in MDX + version.toml to trigger CI build
- [ ] Verify pod starts and bot connects to Discord gateway

Ref #9286