### PR TITLE
feat(unreal): add KBVEROWS plugin — UE5 ROWS backend integration

### DIFF
--- a/packages/unreal/KBVEROWS/KBVEROWS.uplugin
+++ b/packages/unreal/KBVEROWS/KBVEROWS.uplugin
@@ -1,0 +1,21 @@
+{
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "1.0",
+	"FriendlyName": "KBVE ROWS",
+	"Description": "Rust Open World Server — unified backend integration plugin for UE5. Provides auth, instance management, character persistence, and global data subsystems via ROWS REST API.",
+	"Category": "Game",
+	"CreatedBy": "KBVE",
+	"CreatedByURL": "https://kbve.com",
+	"DocsURL": "https://kbve.com/project/rows/",
+	"EnabledByDefault": true,
+	"CanContainContent": false,
+	"IsBetaVersion": true,
+	"Modules": [
+		{
+			"Name": "ROWS",
+			"Type": "Runtime",
+			"LoadingPhase": "Default"
+		}
+	]
+}

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/KBVEROWS.Build.cs
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/KBVEROWS.Build.cs
@@ -1,0 +1,22 @@
+using UnrealBuildTool;
+
+public class ROWS : ModuleRules
+{
+	public ROWS(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"HTTP",
+			"Json",
+			"JsonUtilities",
+			"Slate",
+			"SlateCore",
+			"UMG"
+		});
+	}
+}

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSAuthSubsystem.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSAuthSubsystem.cpp
@@ -1,0 +1,183 @@
+#include "ROWSAuthSubsystem.h"
+#include "ROWSSubsystem.h"
+#include "JsonObjectConverter.h"
+#include "Serialization/JsonSerializer.h"
+
+void UROWSAuthSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	Collection.InitializeDependency<UROWSSubsystem>();
+	Core = GetGameInstance()->GetSubsystem<UROWSSubsystem>();
+}
+
+// ---------------------------------------------------------------------------
+// Auth API
+// ---------------------------------------------------------------------------
+
+void UROWSAuthSubsystem::LoginAndCreateSession(const FString& Email, const FString& Password)
+{
+	FROWSLoginRequest Req;
+	Req.Email = Email.TrimStartAndEnd();
+	Req.Password = Password;
+
+	FString Body;
+	FJsonObjectConverter::UStructToJsonObjectString(Req, Body);
+
+	Core->PostRequest(Core->GetAPIPath(), TEXT("api/Users/LoginAndCreateSession"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSAuthSubsystem::OnLoginResponse));
+}
+
+void UROWSAuthSubsystem::ExternalLoginAndCreateSession(const FString& ExternalLoginToken)
+{
+	FROWSExternalLoginRequest Req;
+	Req.ExternalLoginToken = ExternalLoginToken;
+
+	FString Body;
+	FJsonObjectConverter::UStructToJsonObjectString(Req, Body);
+
+	Core->PostRequest(Core->GetAPIPath(), TEXT("api/Users/ExternalLoginAndCreateSession"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSAuthSubsystem::OnExternalLoginResponse));
+}
+
+void UROWSAuthSubsystem::Register(const FString& Email, const FString& Password, const FString& FirstName, const FString& LastName)
+{
+	FROWSRegisterRequest Req;
+	Req.Email = Email.TrimStartAndEnd();
+	Req.Password = Password;
+	Req.FirstName = FirstName.TrimStartAndEnd();
+	Req.LastName = LastName.TrimStartAndEnd();
+
+	FString Body;
+	FJsonObjectConverter::UStructToJsonObjectString(Req, Body);
+
+	Core->PostRequest(Core->GetAPIPath(), TEXT("api/Users/RegisterUser"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSAuthSubsystem::OnRegisterResponse));
+}
+
+void UROWSAuthSubsystem::Logout(const FString& UserSessionGUID)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("UserSessionGUID"), UserSessionGUID);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetAPIPath(), TEXT("api/Users/Logout"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSAuthSubsystem::OnLogoutResponse));
+}
+
+// ---------------------------------------------------------------------------
+// Response Handlers
+// ---------------------------------------------------------------------------
+
+void UROWSAuthSubsystem::OnLoginResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("Login"), ErrorMsg, Json))
+	{
+		OnLoginError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	FROWSLoginResponse LoginResp;
+	if (!Core->JsonObjectToStruct(Json, LoginResp))
+	{
+		OnLoginError.Broadcast(TEXT("Failed to deserialize login response"));
+		return;
+	}
+
+	if (!LoginResp.ErrorMessage.IsEmpty())
+	{
+		OnLoginError.Broadcast(LoginResp.ErrorMessage);
+		return;
+	}
+
+	if (!LoginResp.Authenticated || LoginResp.UserSessionGUID.IsEmpty())
+	{
+		OnLoginError.Broadcast(TEXT("Unknown Login Error"));
+		return;
+	}
+
+	Core->SetUserSessionGUID(LoginResp.UserSessionGUID);
+	UE_LOG(LogROWS, Log, TEXT("Login successful — Session: %s"), *LoginResp.UserSessionGUID);
+	OnLoginSuccess.Broadcast(LoginResp.UserSessionGUID);
+}
+
+void UROWSAuthSubsystem::OnExternalLoginResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("ExternalLogin"), ErrorMsg, Json))
+	{
+		OnLoginError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	FROWSLoginResponse LoginResp;
+	if (!Core->JsonObjectToStruct(Json, LoginResp))
+	{
+		OnLoginError.Broadcast(TEXT("Failed to deserialize external login response"));
+		return;
+	}
+
+	if (!LoginResp.Authenticated || LoginResp.UserSessionGUID.IsEmpty())
+	{
+		FString Err = LoginResp.ErrorMessage.IsEmpty() ? TEXT("External login failed") : LoginResp.ErrorMessage;
+		OnLoginError.Broadcast(Err);
+		return;
+	}
+
+	Core->SetUserSessionGUID(LoginResp.UserSessionGUID);
+	UE_LOG(LogROWS, Log, TEXT("External login successful — Session: %s"), *LoginResp.UserSessionGUID);
+	OnLoginSuccess.Broadcast(LoginResp.UserSessionGUID);
+}
+
+void UROWSAuthSubsystem::OnRegisterResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("Register"), ErrorMsg, Json))
+	{
+		OnRegisterError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	FROWSRegisterResponse RegResp;
+	if (!Core->JsonObjectToStruct(Json, RegResp))
+	{
+		OnRegisterError.Broadcast(TEXT("Failed to deserialize register response"));
+		return;
+	}
+
+	if (!RegResp.Success || !RegResp.ErrorMessage.IsEmpty())
+	{
+		FString Err = RegResp.ErrorMessage.IsEmpty() ? TEXT("Registration failed") : RegResp.ErrorMessage;
+		OnRegisterError.Broadcast(Err);
+		return;
+	}
+
+	Core->SetUserSessionGUID(RegResp.UserSessionGUID);
+	UE_LOG(LogROWS, Log, TEXT("Registration successful — Session: %s"), *RegResp.UserSessionGUID);
+	OnRegisterSuccess.Broadcast(RegResp.UserSessionGUID);
+}
+
+void UROWSAuthSubsystem::OnLogoutResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("Logout"), ErrorMsg, Json))
+	{
+		OnLogoutError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	Core->ClearSession();
+	UE_LOG(LogROWS, Log, TEXT("Logout successful"));
+	OnLogoutSuccess.Broadcast();
+}

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSCharacterSubsystem.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSCharacterSubsystem.cpp
@@ -1,0 +1,228 @@
+#include "ROWSCharacterSubsystem.h"
+#include "ROWSSubsystem.h"
+#include "JsonObjectConverter.h"
+#include "Serialization/JsonSerializer.h"
+
+void UROWSCharacterSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	Collection.InitializeDependency<UROWSSubsystem>();
+	Core = GetGameInstance()->GetSubsystem<UROWSSubsystem>();
+}
+
+// ---------------------------------------------------------------------------
+// Character API
+// ---------------------------------------------------------------------------
+
+void UROWSCharacterSubsystem::GetAllCharacters(const FString& UserSessionGUID)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("UserSessionGUID"), UserSessionGUID);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Users/GetAllCharacters"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnGetAllCharactersResponse));
+}
+
+void UROWSCharacterSubsystem::CreateCharacter(const FString& UserSessionGUID, const FString& CharacterName, const FString& ClassName)
+{
+	FROWSCreateCharacterRequest Req;
+	Req.UserSessionGUID = UserSessionGUID;
+	Req.CharacterName = CharacterName.TrimStartAndEnd();
+	Req.ClassName = ClassName;
+
+	FString Body;
+	FJsonObjectConverter::UStructToJsonObjectString(Req, Body);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Users/CreateCharacter"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnCreateCharacterResponse));
+}
+
+void UROWSCharacterSubsystem::CreateCharacterUsingDefaults(const FString& UserSessionGUID, const FString& CharacterName, const FString& ClassName)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("UserSessionGUID"), UserSessionGUID);
+	Json->SetStringField(TEXT("CharacterName"), CharacterName.TrimStartAndEnd());
+	Json->SetStringField(TEXT("DefaultSetName"), ClassName);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Users/CreateCharacterUsingDefaultCharacterValues"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnCreateCharacterDefaultsResponse));
+}
+
+void UROWSCharacterSubsystem::RemoveCharacter(const FString& UserSessionGUID, const FString& CharacterName)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("UserSessionGUID"), UserSessionGUID);
+	Json->SetStringField(TEXT("CharacterName"), CharacterName);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Users/RemoveCharacter"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnRemoveCharacterResponse));
+}
+
+void UROWSCharacterSubsystem::AddOrUpdateCustomCharacterData(const FString& CharacterName, const FString& FieldName, const FString& FieldValue)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("CharacterName"), CharacterName);
+	Json->SetStringField(TEXT("CustomFieldName"), FieldName);
+	Json->SetStringField(TEXT("FieldValue"), FieldValue);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Users/AddOrUpdateCustomCharacterData"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnAddOrUpdateCustomDataResponse));
+}
+
+void UROWSCharacterSubsystem::GetCustomCharacterData(const FString& CharacterName)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("CharacterName"), CharacterName);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Users/GetCustomCharacterData"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnGetCustomDataResponse));
+}
+
+// ---------------------------------------------------------------------------
+// Response Handlers
+// ---------------------------------------------------------------------------
+
+void UROWSCharacterSubsystem::OnGetAllCharactersResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("GetAllCharacters"), ErrorMsg, Json))
+	{
+		OnGetCharactersError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	TArray<FROWSUserCharacter> Characters;
+	const TArray<TSharedPtr<FJsonValue>>* CharArray;
+	if (Json->TryGetArrayField(TEXT("Characters"), CharArray))
+	{
+		for (const TSharedPtr<FJsonValue>& Val : *CharArray)
+		{
+			const TSharedPtr<FJsonObject>* CharObj;
+			if (Val->TryGetObject(CharObj))
+			{
+				FROWSUserCharacter Char;
+				if (FJsonObjectConverter::JsonObjectToUStruct((*CharObj).ToSharedRef(), &Char))
+				{
+					Characters.Add(Char);
+				}
+			}
+		}
+	}
+
+	UE_LOG(LogROWS, Log, TEXT("GetAllCharacters: %d character(s)"), Characters.Num());
+	OnGetCharactersSuccess.Broadcast(Characters);
+}
+
+void UROWSCharacterSubsystem::OnCreateCharacterResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("CreateCharacter"), ErrorMsg, Json))
+	{
+		OnCreateCharacterError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	FROWSCreateCharacterResponse Resp;
+	if (!Core->JsonObjectToStruct(Json, Resp))
+	{
+		OnCreateCharacterError.Broadcast(TEXT("Failed to deserialize create character response"));
+		return;
+	}
+
+	if (!Resp.Success || !Resp.ErrorMessage.IsEmpty())
+	{
+		FString Err = Resp.ErrorMessage.IsEmpty() ? TEXT("Character creation failed") : Resp.ErrorMessage;
+		OnCreateCharacterError.Broadcast(Err);
+		return;
+	}
+
+	UE_LOG(LogROWS, Log, TEXT("Character created: %s"), *Resp.CharacterName);
+	OnCreateCharacterSuccess.Broadcast(Resp);
+}
+
+void UROWSCharacterSubsystem::OnCreateCharacterDefaultsResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("CreateCharacterDefaults"), ErrorMsg, Json))
+	{
+		OnCreateCharacterError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	// Default character creation returns success/error, no full character data
+	FROWSCreateCharacterResponse Resp;
+	Resp.Success = true;
+	UE_LOG(LogROWS, Log, TEXT("Character created (defaults)"));
+	OnCreateCharacterSuccess.Broadcast(Resp);
+}
+
+void UROWSCharacterSubsystem::OnRemoveCharacterResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("RemoveCharacter"), ErrorMsg, Json))
+	{
+		OnRemoveCharacterError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	UE_LOG(LogROWS, Log, TEXT("Character removed"));
+	OnRemoveCharacterSuccess.Broadcast();
+}
+
+void UROWSCharacterSubsystem::OnAddOrUpdateCustomDataResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	if (!bWasSuccessful || !Response.IsValid())
+	{
+		OnCustomDataError.Broadcast(TEXT("AddOrUpdateCustomData: HTTP request failed"));
+		return;
+	}
+
+	UE_LOG(LogROWS, Verbose, TEXT("Custom data saved"));
+}
+
+void UROWSCharacterSubsystem::OnGetCustomDataResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("GetCustomData"), ErrorMsg, Json))
+	{
+		OnCustomDataError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	// Return raw JSON string so consumers can parse their own schema
+	FString JsonString;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&JsonString);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	OnCustomDataReceived.Broadcast(JsonString);
+}

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSInstanceSubsystem.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSInstanceSubsystem.cpp
@@ -1,0 +1,151 @@
+#include "ROWSInstanceSubsystem.h"
+#include "ROWSSubsystem.h"
+#include "JsonObjectConverter.h"
+#include "Serialization/JsonSerializer.h"
+
+void UROWSInstanceSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	Collection.InitializeDependency<UROWSSubsystem>();
+	Core = GetGameInstance()->GetSubsystem<UROWSSubsystem>();
+}
+
+// ---------------------------------------------------------------------------
+// Instance API
+// ---------------------------------------------------------------------------
+
+void UROWSInstanceSubsystem::RegisterLauncher(const FString& ServerIP, int32 Port, int32 MaxInstances)
+{
+	FString LauncherGUID = FPlatformMisc::GetEnvironmentVariable(TEXT("HOSTNAME"));
+	if (LauncherGUID.IsEmpty())
+	{
+		LauncherGUID = FGuid::NewGuid().ToString();
+	}
+
+	FString Body = FString::Printf(
+		TEXT("{\"request\":{\"launcherGUID\":\"%s\",\"serverIP\":\"%s\",\"maxNumberOfInstances\":%d,\"internalServerIP\":\"%s\",\"startingInstancePort\":%d}}"),
+		*LauncherGUID, *ServerIP, MaxInstances, *ServerIP, Port);
+
+	UE_LOG(LogROWS, Log, TEXT("RegisterLauncher — GUID: %s, IP: %s, Port: %d"), *LauncherGUID, *ServerIP, Port);
+
+	Core->PostRequest(Core->GetInstanceManagementPath(), TEXT("api/Instance/RegisterLauncher"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSInstanceSubsystem::OnRegisterLauncherResponse));
+}
+
+void UROWSInstanceSubsystem::GetZoneInstance(int32 ZoneInstanceID)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetNumberField(TEXT("ZoneInstanceID"), ZoneInstanceID);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetInstanceManagementPath(), TEXT("api/Instance/GetZoneInstance"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSInstanceSubsystem::OnGetZoneInstanceResponse));
+}
+
+void UROWSInstanceSubsystem::UpdateNumberOfPlayers(int32 ZoneInstanceID, int32 NumberOfPlayers)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetNumberField(TEXT("ZoneInstanceID"), ZoneInstanceID);
+	Json->SetNumberField(TEXT("NumberOfReportedPlayers"), NumberOfPlayers);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetInstanceManagementPath(), TEXT("api/Instance/UpdateNumberOfPlayers"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSInstanceSubsystem::OnUpdateNumberOfPlayersResponse));
+}
+
+void UROWSInstanceSubsystem::GetServerToConnectTo(const FString& CharacterName, const FString& ZoneName)
+{
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("CharacterName"), CharacterName);
+	Json->SetStringField(TEXT("ZoneName"), ZoneName);
+	Json->SetNumberField(TEXT("PlayerGroupType"), 0);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetAPIPath(), TEXT("api/Users/GetServerToConnectTo"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSInstanceSubsystem::OnGetServerToConnectToResponse));
+}
+
+// ---------------------------------------------------------------------------
+// Response Handlers
+// ---------------------------------------------------------------------------
+
+void UROWSInstanceSubsystem::OnRegisterLauncherResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	if (bWasSuccessful && Response.IsValid())
+	{
+		UE_LOG(LogROWS, Log, TEXT("RegisterLauncher response: %s"), *Response->GetContentAsString());
+		OnRegisterLauncherSuccess.Broadcast(Response->GetContentAsString());
+	}
+	else
+	{
+		FString Err = TEXT("RegisterLauncher: HTTP request failed");
+		UE_LOG(LogROWS, Error, TEXT("%s"), *Err);
+		OnRegisterLauncherError.Broadcast(Err);
+	}
+}
+
+void UROWSInstanceSubsystem::OnGetZoneInstanceResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("GetZoneInstance"), ErrorMsg, Json))
+	{
+		OnGetZoneInstanceError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	FROWSZoneInstance Zone;
+	if (!Core->JsonObjectToStruct(Json, Zone))
+	{
+		OnGetZoneInstanceError.Broadcast(TEXT("Failed to deserialize zone instance"));
+		return;
+	}
+
+	UE_LOG(LogROWS, Log, TEXT("GetZoneInstance: %s (%s:%d)"), *Zone.ZoneName, *Zone.ServerIP, Zone.Port);
+	OnGetZoneInstanceSuccess.Broadcast(Zone);
+}
+
+void UROWSInstanceSubsystem::OnUpdateNumberOfPlayersResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("UpdateNumberOfPlayers"), ErrorMsg, Json))
+	{
+		OnUpdateServerStatusError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	FROWSServerStatus Status;
+	Status.Success = true;
+	OnUpdateServerStatusSuccess.Broadcast(Status);
+}
+
+void UROWSInstanceSubsystem::OnGetServerToConnectToResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	FString ErrorMsg;
+	TSharedPtr<FJsonObject> Json;
+
+	if (!Core->ParseJsonResponse(Request, Response, bWasSuccessful, TEXT("GetServerToConnectTo"), ErrorMsg, Json))
+	{
+		OnGetZoneInstanceError.Broadcast(ErrorMsg);
+		return;
+	}
+
+	FROWSZoneInstance Zone;
+	Zone.ServerIP = Json->GetStringField(TEXT("serverip"));
+	Zone.Port = Json->GetIntegerField(TEXT("port"));
+
+	UE_LOG(LogROWS, Log, TEXT("GetServerToConnectTo: %s:%d"), *Zone.ServerIP, Zone.Port);
+	OnGetZoneInstanceSuccess.Broadcast(Zone);
+}

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSLoadingWidget.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSLoadingWidget.cpp
@@ -1,0 +1,60 @@
+#include "ROWSLoadingWidget.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+#include "Components/Overlay.h"
+#include "Components/OverlaySlot.h"
+#include "Blueprint/WidgetTree.h"
+
+TSharedRef<SWidget> UROWSLoadingWidget::RebuildWidget()
+{
+	if (WidgetTree && !bWidgetsCreated)
+	{
+		bWidgetsCreated = true;
+
+		UOverlay* Root = WidgetTree->ConstructWidget<UOverlay>(UOverlay::StaticClass(), TEXT("LoadingRoot"));
+
+		UVerticalBox* VBox = WidgetTree->ConstructWidget<UVerticalBox>(UVerticalBox::StaticClass(), TEXT("LoadingVBox"));
+		UOverlaySlot* VBoxSlot = Root->AddChildToOverlay(VBox);
+		VBoxSlot->SetHorizontalAlignment(HAlign_Center);
+		VBoxSlot->SetVerticalAlignment(VAlign_Center);
+
+		StatusText = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass(), TEXT("LoadingStatus"));
+		StatusText->SetText(FText::FromString(TEXT("Loading")));
+		StatusText->SetJustification(ETextJustify::Center);
+		FSlateFontInfo Font = StatusText->GetFont();
+		Font.Size = 24;
+		StatusText->SetFont(Font);
+		VBox->AddChildToVerticalBox(StatusText)->SetHorizontalAlignment(HAlign_Center);
+
+		DotsText = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass(), TEXT("LoadingDots"));
+		DotsText->SetText(FText::FromString(TEXT(".")));
+		DotsText->SetJustification(ETextJustify::Center);
+		DotsText->SetFont(Font);
+		VBox->AddChildToVerticalBox(DotsText)->SetHorizontalAlignment(HAlign_Center);
+
+		WidgetTree->RootWidget = Root;
+	}
+	return Super::RebuildWidget();
+}
+
+void UROWSLoadingWidget::NativeConstruct() { Super::NativeConstruct(); }
+
+void UROWSLoadingWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+{
+	Super::NativeTick(MyGeometry, InDeltaTime);
+	DotTimer += InDeltaTime;
+	if (DotTimer >= 0.4f)
+	{
+		DotTimer = 0.f;
+		DotCount = (DotCount + 1) % 4;
+		FString Dots;
+		for (int32 i = 0; i <= DotCount; i++) Dots += TEXT(".");
+		if (DotsText) DotsText->SetText(FText::FromString(Dots));
+	}
+}
+
+void UROWSLoadingWidget::SetStatus(const FString& Message)
+{
+	if (StatusText) StatusText->SetText(FText::FromString(Message));
+}

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSLoginController.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSLoginController.cpp
@@ -1,0 +1,188 @@
+#include "ROWSLoginController.h"
+#include "ROWSSubsystem.h"
+#include "ROWSAuthSubsystem.h"
+#include "ROWSCharacterSubsystem.h"
+#include "ROWSLoginWidget.h"
+#include "ROWSLoadingWidget.h"
+#include "Kismet/GameplayStatics.h"
+
+AROWSLoginController::AROWSLoginController()
+{
+}
+
+void AROWSLoginController::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (!IsLocalController()) return;
+
+	Core = GetGameInstance()->GetSubsystem<UROWSSubsystem>();
+	Auth = GetGameInstance()->GetSubsystem<UROWSAuthSubsystem>();
+	Characters = GetGameInstance()->GetSubsystem<UROWSCharacterSubsystem>();
+
+	if (Auth)
+	{
+		Auth->OnLoginSuccess.AddDynamic(this, &AROWSLoginController::HandleLoginSuccess);
+		Auth->OnLoginError.AddDynamic(this, &AROWSLoginController::HandleLoginError);
+		Auth->OnLogoutSuccess.AddDynamic(this, &AROWSLoginController::HandleLogoutSuccess);
+		Auth->OnLogoutError.AddDynamic(this, &AROWSLoginController::HandleLogoutError);
+	}
+
+	if (Characters)
+	{
+		Characters->OnGetCharactersSuccess.AddDynamic(this, &AROWSLoginController::HandleGetCharactersSuccess);
+		Characters->OnGetCharactersError.AddDynamic(this, &AROWSLoginController::HandleGetCharactersError);
+	}
+
+	ShowLoginScreen();
+	OnLoginFlowStarted();
+}
+
+void AROWSLoginController::HideAllWidgets()
+{
+	if (LoginWidget) { LoginWidget->RemoveFromParent(); }
+	if (LoadingWidget) { LoadingWidget->RemoveFromParent(); }
+}
+
+void AROWSLoginController::ShowLoginScreen()
+{
+	HideAllWidgets();
+
+	if (!LoginWidget)
+	{
+		if (LoginWidgetClass)
+		{
+			LoginWidget = CreateWidget<UROWSLoginWidget>(this, LoginWidgetClass);
+		}
+		else
+		{
+			LoginWidget = CreateWidget<UROWSLoginWidget>(this, UROWSLoginWidget::StaticClass());
+		}
+	}
+
+	if (LoginWidget)
+	{
+		LoginWidget->AddToViewport();
+		FInputModeUIOnly InputMode;
+		InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+		SetInputMode(InputMode);
+		SetShowMouseCursor(true);
+	}
+}
+
+void AROWSLoginController::ShowCharacterSelect()
+{
+	if (Characters && !UserSessionGUID.IsEmpty())
+	{
+		Characters->GetAllCharacters(UserSessionGUID);
+	}
+}
+
+void AROWSLoginController::ShowLoadingScreen(const FString& StatusMessage)
+{
+	HideAllWidgets();
+
+	if (!LoadingWidget)
+	{
+		if (LoadingWidgetClass)
+		{
+			LoadingWidget = CreateWidget<UROWSLoadingWidget>(this, LoadingWidgetClass);
+		}
+		else
+		{
+			LoadingWidget = CreateWidget<UROWSLoadingWidget>(this, UROWSLoadingWidget::StaticClass());
+		}
+	}
+
+	if (LoadingWidget)
+	{
+		LoadingWidget->SetStatus(StatusMessage);
+		LoadingWidget->AddToViewport();
+	}
+}
+
+void AROWSLoginController::OnLoginSuccess(const FString& InUserSessionGUID)
+{
+	UE_LOG(LogROWS, Log, TEXT("AROWSLoginController::OnLoginSuccess — GUID=%s"), *InUserSessionGUID);
+	UserSessionGUID = InUserSessionGUID;
+	ShowCharacterSelect();
+}
+
+void AROWSLoginController::OnPlayClicked(const FString& CharacterName)
+{
+	SelectedCharacterName = CharacterName;
+	UE_LOG(LogROWS, Log, TEXT("AROWSLoginController::OnPlayClicked — Character=%s"), *SelectedCharacterName);
+
+	ShowLoadingScreen(TEXT("Connecting to server..."));
+
+	FInputModeUIOnly InputMode;
+	InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+	SetInputMode(InputMode);
+	SetShowMouseCursor(true);
+
+	FCoreUObjectDelegates::PreLoadMap.AddWeakLambda(this, [this](const FString& MapName)
+	{
+		FInputModeGameOnly GameInput;
+		SetInputMode(GameInput);
+		SetShowMouseCursor(false);
+	});
+
+	OnTravelStarted();
+
+	// TODO: When ROWS supports zone routing, use GetServerToConnectTo + ClientTravel here.
+	UGameplayStatics::OpenLevel(this, GameMapName, true);
+}
+
+void AROWSLoginController::OnLogout()
+{
+	if (Auth && !UserSessionGUID.IsEmpty())
+	{
+		Auth->Logout(UserSessionGUID);
+	}
+	else
+	{
+		UserSessionGUID.Empty();
+		SelectedCharacterName.Empty();
+		ShowLoginScreen();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delegate Handlers
+// ---------------------------------------------------------------------------
+
+void AROWSLoginController::HandleLoginSuccess(const FString& InUserSessionGUID)
+{
+	OnLoginSuccess(InUserSessionGUID);
+}
+
+void AROWSLoginController::HandleLoginError(const FString& ErrorMessage)
+{
+	UE_LOG(LogROWS, Error, TEXT("Login failed: %s"), *ErrorMessage);
+}
+
+void AROWSLoginController::HandleGetCharactersSuccess(const TArray<FROWSUserCharacter>& InCharacters)
+{
+	UE_LOG(LogROWS, Log, TEXT("Got %d character(s)"), InCharacters.Num());
+	OnCharacterSelectReady(InCharacters.Num());
+}
+
+void AROWSLoginController::HandleGetCharactersError(const FString& ErrorMessage)
+{
+	UE_LOG(LogROWS, Error, TEXT("GetAllCharacters failed: %s"), *ErrorMessage);
+}
+
+void AROWSLoginController::HandleLogoutSuccess()
+{
+	UserSessionGUID.Empty();
+	SelectedCharacterName.Empty();
+	ShowLoginScreen();
+}
+
+void AROWSLoginController::HandleLogoutError(const FString& ErrorMessage)
+{
+	UE_LOG(LogROWS, Error, TEXT("Logout failed: %s — returning to login"), *ErrorMessage);
+	UserSessionGUID.Empty();
+	SelectedCharacterName.Empty();
+	ShowLoginScreen();
+}

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSLoginWidget.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSLoginWidget.cpp
@@ -1,0 +1,265 @@
+#include "ROWSLoginWidget.h"
+#include "ROWSAuthSubsystem.h"
+#include "ROWSSubsystem.h"
+#include "Components/EditableTextBox.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+#include "Components/Overlay.h"
+#include "Components/OverlaySlot.h"
+#include "Components/WidgetSwitcher.h"
+#include "Components/SizeBox.h"
+#include "Components/Spacer.h"
+#include "Blueprint/WidgetTree.h"
+
+// ---------------------------------------------------------------------------
+// RebuildWidget — widget tree built here, NOT NativeConstruct
+// ---------------------------------------------------------------------------
+
+TSharedRef<SWidget> UROWSLoginWidget::RebuildWidget()
+{
+	if (WidgetTree && !bWidgetsCreated)
+	{
+		bWidgetsCreated = true;
+
+		RootOverlay = WidgetTree->ConstructWidget<UOverlay>(UOverlay::StaticClass(), TEXT("RootOverlay"));
+
+		USizeBox* SizeBox = WidgetTree->ConstructWidget<USizeBox>(USizeBox::StaticClass(), TEXT("FormSizeBox"));
+		SizeBox->SetMaxDesiredWidth(400.f);
+		UOverlaySlot* SizeBoxSlot = RootOverlay->AddChildToOverlay(SizeBox);
+		SizeBoxSlot->SetHorizontalAlignment(HAlign_Center);
+		SizeBoxSlot->SetVerticalAlignment(VAlign_Center);
+
+		FormContainer = WidgetTree->ConstructWidget<UVerticalBox>(UVerticalBox::StaticClass(), TEXT("FormContainer"));
+		SizeBox->AddChild(FormContainer);
+
+		TitleText = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass(), TEXT("TitleText"));
+		TitleText->SetText(FText::FromString(TEXT("ROWS Login")));
+		FSlateFontInfo TitleFont = TitleText->GetFont();
+		TitleFont.Size = 28;
+		TitleText->SetFont(TitleFont);
+		TitleText->SetJustification(ETextJustify::Center);
+		UVerticalBoxSlot* TitleSlot = FormContainer->AddChildToVerticalBox(TitleText);
+		TitleSlot->SetHorizontalAlignment(HAlign_Fill);
+		TitleSlot->SetPadding(FMargin(0.f, 0.f, 0.f, 20.f));
+
+		PanelSwitcher = WidgetTree->ConstructWidget<UWidgetSwitcher>(UWidgetSwitcher::StaticClass(), TEXT("PanelSwitcher"));
+		UVerticalBoxSlot* SwitcherSlot = FormContainer->AddChildToVerticalBox(PanelSwitcher);
+		SwitcherSlot->SetHorizontalAlignment(HAlign_Fill);
+
+		LoginPanel = BuildLoginPanel();
+		PanelSwitcher->AddChild(LoginPanel);
+		RegisterPanel = BuildRegisterPanel();
+		PanelSwitcher->AddChild(RegisterPanel);
+		PanelSwitcher->SetActiveWidgetIndex(0);
+
+		USpacer* StatusSpacer = WidgetTree->ConstructWidget<USpacer>(USpacer::StaticClass(), TEXT("StatusSpacer"));
+		StatusSpacer->SetSize(FVector2D(0.f, 16.f));
+		FormContainer->AddChildToVerticalBox(StatusSpacer);
+
+		StatusText = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass(), TEXT("StatusText"));
+		StatusText->SetText(FText::GetEmpty());
+		StatusText->SetJustification(ETextJustify::Center);
+		StatusText->SetAutoWrapText(true);
+		UVerticalBoxSlot* StatusSlot = FormContainer->AddChildToVerticalBox(StatusText);
+		StatusSlot->SetHorizontalAlignment(HAlign_Fill);
+
+		WidgetTree->RootWidget = RootOverlay;
+	}
+
+	return Super::RebuildWidget();
+}
+
+// ---------------------------------------------------------------------------
+// NativeConstruct — delegate binding only
+// ---------------------------------------------------------------------------
+
+void UROWSLoginWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	AuthSubsystem = GetGameInstance()->GetSubsystem<UROWSAuthSubsystem>();
+
+	if (LoginButton) LoginButton->OnClicked.AddDynamic(this, &UROWSLoginWidget::OnLoginButtonClicked);
+	if (SwitchToRegisterButton) SwitchToRegisterButton->OnClicked.AddDynamic(this, &UROWSLoginWidget::OnSwitchToRegisterClicked);
+	if (RegisterButton) RegisterButton->OnClicked.AddDynamic(this, &UROWSLoginWidget::OnRegisterButtonClicked);
+	if (SwitchToLoginButton) SwitchToLoginButton->OnClicked.AddDynamic(this, &UROWSLoginWidget::OnSwitchToLoginClicked);
+
+	if (AuthSubsystem)
+	{
+		AuthSubsystem->OnLoginSuccess.AddDynamic(this, &UROWSLoginWidget::HandleLoginSuccess);
+		AuthSubsystem->OnLoginError.AddDynamic(this, &UROWSLoginWidget::HandleLoginError);
+		AuthSubsystem->OnRegisterSuccess.AddDynamic(this, &UROWSLoginWidget::HandleRegisterSuccess);
+		AuthSubsystem->OnRegisterError.AddDynamic(this, &UROWSLoginWidget::HandleRegisterError);
+		AuthSubsystem->OnLogoutSuccess.AddDynamic(this, &UROWSLoginWidget::HandleLogoutSuccess);
+		AuthSubsystem->OnLogoutError.AddDynamic(this, &UROWSLoginWidget::HandleLogoutError);
+	}
+}
+
+void UROWSLoginWidget::NativeDestruct()
+{
+	if (AuthSubsystem)
+	{
+		AuthSubsystem->OnLoginSuccess.RemoveDynamic(this, &UROWSLoginWidget::HandleLoginSuccess);
+		AuthSubsystem->OnLoginError.RemoveDynamic(this, &UROWSLoginWidget::HandleLoginError);
+		AuthSubsystem->OnRegisterSuccess.RemoveDynamic(this, &UROWSLoginWidget::HandleRegisterSuccess);
+		AuthSubsystem->OnRegisterError.RemoveDynamic(this, &UROWSLoginWidget::HandleRegisterError);
+		AuthSubsystem->OnLogoutSuccess.RemoveDynamic(this, &UROWSLoginWidget::HandleLogoutSuccess);
+		AuthSubsystem->OnLogoutError.RemoveDynamic(this, &UROWSLoginWidget::HandleLogoutError);
+	}
+	Super::NativeDestruct();
+}
+
+// ---------------------------------------------------------------------------
+// Panel Builders
+// ---------------------------------------------------------------------------
+
+UVerticalBox* UROWSLoginWidget::BuildLoginPanel()
+{
+	UVerticalBox* Panel = WidgetTree->ConstructWidget<UVerticalBox>(UVerticalBox::StaticClass(), TEXT("LoginPanel"));
+
+	LoginEmailField = CreateTextField(TEXT("Email"));
+	Panel->AddChildToVerticalBox(LoginEmailField)->SetPadding(FMargin(0.f, 0.f, 0.f, 8.f));
+
+	LoginPasswordField = CreateTextField(TEXT("Password"), true);
+	Panel->AddChildToVerticalBox(LoginPasswordField)->SetPadding(FMargin(0.f, 0.f, 0.f, 16.f));
+
+	LoginButton = CreateButton(TEXT("Login"), LoginButtonText);
+	Panel->AddChildToVerticalBox(LoginButton)->SetPadding(FMargin(0.f, 0.f, 0.f, 8.f));
+
+	SwitchToRegisterButton = CreateButton(TEXT("Create Account"), SwitchToRegisterText);
+	FButtonStyle LinkStyle;
+	LinkStyle.Normal.TintColor = FSlateColor(FLinearColor::Transparent);
+	LinkStyle.Hovered.TintColor = FSlateColor(FLinearColor(1.f, 1.f, 1.f, 0.1f));
+	LinkStyle.Pressed.TintColor = FSlateColor(FLinearColor(1.f, 1.f, 1.f, 0.2f));
+	SwitchToRegisterButton->SetStyle(LinkStyle);
+	Panel->AddChildToVerticalBox(SwitchToRegisterButton);
+
+	return Panel;
+}
+
+UVerticalBox* UROWSLoginWidget::BuildRegisterPanel()
+{
+	UVerticalBox* Panel = WidgetTree->ConstructWidget<UVerticalBox>(UVerticalBox::StaticClass(), TEXT("RegisterPanel"));
+
+	RegisterFirstNameField = CreateTextField(TEXT("First Name"));
+	Panel->AddChildToVerticalBox(RegisterFirstNameField)->SetPadding(FMargin(0.f, 0.f, 0.f, 8.f));
+
+	RegisterLastNameField = CreateTextField(TEXT("Last Name"));
+	Panel->AddChildToVerticalBox(RegisterLastNameField)->SetPadding(FMargin(0.f, 0.f, 0.f, 8.f));
+
+	RegisterEmailField = CreateTextField(TEXT("Email"));
+	Panel->AddChildToVerticalBox(RegisterEmailField)->SetPadding(FMargin(0.f, 0.f, 0.f, 8.f));
+
+	RegisterPasswordField = CreateTextField(TEXT("Password"), true);
+	Panel->AddChildToVerticalBox(RegisterPasswordField)->SetPadding(FMargin(0.f, 0.f, 0.f, 16.f));
+
+	RegisterButton = CreateButton(TEXT("Register"), RegisterButtonText);
+	Panel->AddChildToVerticalBox(RegisterButton)->SetPadding(FMargin(0.f, 0.f, 0.f, 8.f));
+
+	SwitchToLoginButton = CreateButton(TEXT("Back to Login"), SwitchToLoginText);
+	FButtonStyle LinkStyle;
+	LinkStyle.Normal.TintColor = FSlateColor(FLinearColor::Transparent);
+	LinkStyle.Hovered.TintColor = FSlateColor(FLinearColor(1.f, 1.f, 1.f, 0.1f));
+	LinkStyle.Pressed.TintColor = FSlateColor(FLinearColor(1.f, 1.f, 1.f, 0.2f));
+	SwitchToLoginButton->SetStyle(LinkStyle);
+	Panel->AddChildToVerticalBox(SwitchToLoginButton);
+
+	return Panel;
+}
+
+UEditableTextBox* UROWSLoginWidget::CreateTextField(const FString& HintText, bool bIsPassword)
+{
+	FName WidgetName = *FString::Printf(TEXT("Field_%s"), *HintText.Replace(TEXT(" "), TEXT("")));
+	UEditableTextBox* Field = WidgetTree->ConstructWidget<UEditableTextBox>(UEditableTextBox::StaticClass(), WidgetName);
+	Field->SetHintText(FText::FromString(HintText));
+	Field->SetIsPassword(bIsPassword);
+	Field->SetMinDesiredWidth(300.f);
+	FSlateFontInfo Font = Field->WidgetStyle.TextStyle.Font;
+	Font.Size = 14;
+	Field->WidgetStyle.SetFont(Font);
+	Field->WidgetStyle.SetPadding(FMargin(8.f, 8.f));
+	return Field;
+}
+
+UButton* UROWSLoginWidget::CreateButton(const FString& Label, TObjectPtr<UTextBlock>& OutTextBlock)
+{
+	FName BtnName = *FString::Printf(TEXT("Btn_%s"), *Label.Replace(TEXT(" "), TEXT("")));
+	UButton* Btn = WidgetTree->ConstructWidget<UButton>(UButton::StaticClass(), BtnName);
+
+	FName TextName = *FString::Printf(TEXT("BtnText_%s"), *Label.Replace(TEXT(" "), TEXT("")));
+	OutTextBlock = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass(), TextName);
+	OutTextBlock->SetText(FText::FromString(Label));
+	OutTextBlock->SetJustification(ETextJustify::Center);
+	FSlateFontInfo BtnFont = OutTextBlock->GetFont();
+	BtnFont.Size = 16;
+	OutTextBlock->SetFont(BtnFont);
+	Btn->AddChild(OutTextBlock);
+	return Btn;
+}
+
+void UROWSLoginWidget::SetStatusMessage(const FString& Message, FLinearColor Color)
+{
+	if (StatusText)
+	{
+		StatusText->SetText(FText::FromString(Message));
+		StatusText->SetColorAndOpacity(FSlateColor(Color));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Panel Switching
+// ---------------------------------------------------------------------------
+
+void UROWSLoginWidget::ShowLoginPanel()  { if (PanelSwitcher) { PanelSwitcher->SetActiveWidgetIndex(0); SetStatusMessage(TEXT("")); } }
+void UROWSLoginWidget::ShowRegisterPanel() { if (PanelSwitcher) { PanelSwitcher->SetActiveWidgetIndex(1); SetStatusMessage(TEXT("")); } }
+
+// ---------------------------------------------------------------------------
+// Button Handlers
+// ---------------------------------------------------------------------------
+
+void UROWSLoginWidget::OnLoginButtonClicked()
+{
+	if (!LoginEmailField || !LoginPasswordField) return;
+	FString Email = LoginEmailField->GetText().ToString();
+	FString Password = LoginPasswordField->GetText().ToString();
+	if (Email.IsEmpty() || Password.IsEmpty()) { SetStatusMessage(TEXT("Please enter email and password."), FLinearColor(1.f, 0.6f, 0.f)); return; }
+	SetStatusMessage(TEXT("Logging in..."), FLinearColor::White);
+	LoginAndCreateSession(Email, Password);
+}
+
+void UROWSLoginWidget::OnRegisterButtonClicked()
+{
+	if (!RegisterEmailField || !RegisterPasswordField) return;
+	FString Email = RegisterEmailField->GetText().ToString();
+	FString Password = RegisterPasswordField->GetText().ToString();
+	FString First = RegisterFirstNameField ? RegisterFirstNameField->GetText().ToString() : TEXT("");
+	FString Last = RegisterLastNameField ? RegisterLastNameField->GetText().ToString() : TEXT("");
+	if (Email.IsEmpty() || Password.IsEmpty()) { SetStatusMessage(TEXT("Email and password are required."), FLinearColor(1.f, 0.6f, 0.f)); return; }
+	SetStatusMessage(TEXT("Registering..."), FLinearColor::White);
+	Register(Email, Password, First, Last);
+}
+
+void UROWSLoginWidget::OnSwitchToRegisterClicked() { ShowRegisterPanel(); }
+void UROWSLoginWidget::OnSwitchToLoginClicked() { ShowLoginPanel(); }
+
+// ---------------------------------------------------------------------------
+// Auth Actions
+// ---------------------------------------------------------------------------
+
+void UROWSLoginWidget::LoginAndCreateSession(const FString& Email, const FString& Password) { if (AuthSubsystem) AuthSubsystem->LoginAndCreateSession(Email, Password); }
+void UROWSLoginWidget::ExternalLoginAndCreateSession(const FString& Token) { if (AuthSubsystem) AuthSubsystem->ExternalLoginAndCreateSession(Token); }
+void UROWSLoginWidget::Register(const FString& Email, const FString& Password, const FString& First, const FString& Last) { if (AuthSubsystem) AuthSubsystem->Register(Email, Password, First, Last); }
+void UROWSLoginWidget::Logout() { if (AuthSubsystem) { UROWSSubsystem* Core = GetGameInstance()->GetSubsystem<UROWSSubsystem>(); if (Core) AuthSubsystem->Logout(Core->GetUserSessionGUID()); } }
+
+// ---------------------------------------------------------------------------
+// Delegate Handlers -> Status + Blueprint Events
+// ---------------------------------------------------------------------------
+
+void UROWSLoginWidget::HandleLoginSuccess(const FString& GUID) { SetStatusMessage(TEXT("Login successful!"), FLinearColor::Green); NotifyLoginSuccess(GUID); }
+void UROWSLoginWidget::HandleLoginError(const FString& Err) { SetStatusMessage(Err, FLinearColor::Red); NotifyLoginError(Err); }
+void UROWSLoginWidget::HandleRegisterSuccess(const FString& GUID) { SetStatusMessage(TEXT("Registration successful!"), FLinearColor::Green); NotifyRegisterSuccess(GUID); }
+void UROWSLoginWidget::HandleRegisterError(const FString& Err) { SetStatusMessage(Err, FLinearColor::Red); NotifyRegisterError(Err); }
+void UROWSLoginWidget::HandleLogoutSuccess() { SetStatusMessage(TEXT("Logged out."), FLinearColor::White); NotifyLogoutSuccess(); }
+void UROWSLoginWidget::HandleLogoutError(const FString& Err) { SetStatusMessage(Err, FLinearColor::Red); NotifyLogoutError(Err); }

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSModule.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSModule.cpp
@@ -1,0 +1,15 @@
+#include "ROWSModule.h"
+
+#define LOCTEXT_NAMESPACE "FROWSModule"
+
+void FROWSModule::StartupModule()
+{
+}
+
+void FROWSModule::ShutdownModule()
+{
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FROWSModule, ROWS)

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSSubsystem.cpp
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Private/ROWSSubsystem.cpp
@@ -1,0 +1,119 @@
+#include "ROWSSubsystem.h"
+#include "HttpModule.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "JsonObjectConverter.h"
+#include "Misc/ConfigCacheIni.h"
+
+DEFINE_LOG_CATEGORY(LogROWS);
+
+void UROWSSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	const TCHAR* Section = TEXT("/Script/EngineSettings.GeneralProjectSettings");
+
+	// Read config from DefaultGame.ini — same keys as OWS for compatibility
+	GConfig->GetString(Section, TEXT("OWSAPICustomerKey"), CustomerKey, GGameIni);
+	GConfig->GetString(Section, TEXT("OWS2APIPath"), APIPath, GGameIni);
+	GConfig->GetString(Section, TEXT("OWS2InstanceManagementAPIPath"), InstanceManagementPath, GGameIni);
+	GConfig->GetString(Section, TEXT("OWS2CharacterPersistenceAPIPath"), CharacterPersistencePath, GGameIni);
+	GConfig->GetString(Section, TEXT("OWS2GlobalDataAPIPath"), GlobalDataPath, GGameIni);
+	GConfig->GetString(Section, TEXT("OWSEncryptionKey"), EncryptionKey, GGameIni);
+
+	// Environment variable overrides (Kubernetes / container deployments)
+	auto OverrideFromEnv = [](const TCHAR* EnvVar, FString& Target)
+	{
+		FString Value = FPlatformMisc::GetEnvironmentVariable(EnvVar);
+		if (!Value.IsEmpty()) { Target = Value; }
+	};
+
+	OverrideFromEnv(TEXT("OWS_API_CUSTOMER_KEY"), CustomerKey);
+	OverrideFromEnv(TEXT("OWS_API_PATH"), APIPath);
+	OverrideFromEnv(TEXT("OWS_INSTANCE_MANAGEMENT_PATH"), InstanceManagementPath);
+	OverrideFromEnv(TEXT("OWS_CHARACTER_PERSISTENCE_PATH"), CharacterPersistencePath);
+	OverrideFromEnv(TEXT("OWS_GLOBAL_DATA_PATH"), GlobalDataPath);
+
+	// Ensure trailing slashes
+	auto EnsureTrailingSlash = [](FString& Path)
+	{
+		if (!Path.IsEmpty() && !Path.EndsWith(TEXT("/"))) { Path += TEXT("/"); }
+	};
+
+	EnsureTrailingSlash(APIPath);
+	EnsureTrailingSlash(InstanceManagementPath);
+	EnsureTrailingSlash(CharacterPersistencePath);
+	EnsureTrailingSlash(GlobalDataPath);
+
+	UE_LOG(LogROWS, Log, TEXT("ROWS initialized — API: %s | Instance: %s | Character: %s | GlobalData: %s"),
+		*APIPath, *InstanceManagementPath, *CharacterPersistencePath, *GlobalDataPath);
+}
+
+void UROWSSubsystem::Deinitialize()
+{
+	Super::Deinitialize();
+}
+
+// ---------------------------------------------------------------------------
+// HTTP
+// ---------------------------------------------------------------------------
+
+void UROWSSubsystem::PostRequest(
+	const FString& BasePath,
+	const FString& Endpoint,
+	const FString& PostContent,
+	const FHttpRequestCompleteDelegate& Callback)
+{
+	FHttpModule& Http = FHttpModule::Get();
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = Http.CreateRequest();
+
+	Request->OnProcessRequestComplete() = Callback;
+	Request->SetURL(BasePath + Endpoint);
+	Request->SetVerb(TEXT("POST"));
+	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	Request->SetHeader(TEXT("X-CustomerGUID"), CustomerKey);
+	Request->SetContentAsString(PostContent);
+
+	UE_LOG(LogROWS, Verbose, TEXT("POST %s%s"), *BasePath, *Endpoint);
+
+	Request->ProcessRequest();
+}
+
+bool UROWSSubsystem::ParseJsonResponse(
+	FHttpRequestPtr Request,
+	FHttpResponsePtr Response,
+	bool bWasSuccessful,
+	const FString& CallerName,
+	FString& OutErrorMsg,
+	TSharedPtr<FJsonObject>& OutJsonObject)
+{
+	OutErrorMsg.Empty();
+
+	if (!bWasSuccessful || !Response.IsValid())
+	{
+		OutErrorMsg = FString::Printf(TEXT("%s: HTTP request failed"), *CallerName);
+		UE_LOG(LogROWS, Error, TEXT("%s"), *OutErrorMsg);
+		return false;
+	}
+
+	if (!EHttpResponseCodes::IsOk(Response->GetResponseCode()))
+	{
+		OutErrorMsg = FString::Printf(TEXT("%s: HTTP %d — %s"),
+			*CallerName, Response->GetResponseCode(), *Response->GetContentAsString());
+		UE_LOG(LogROWS, Error, TEXT("%s"), *OutErrorMsg);
+		return false;
+	}
+
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Response->GetContentAsString());
+	if (!FJsonSerializer::Deserialize(Reader, OutJsonObject) || !OutJsonObject.IsValid())
+	{
+		OutErrorMsg = FString::Printf(TEXT("%s: Failed to parse JSON"), *CallerName);
+		UE_LOG(LogROWS, Error, TEXT("%s"), *OutErrorMsg);
+		return false;
+	}
+
+	return true;
+}
+
+// JsonObjectToStruct template is defined inline in ROWSSubsystem.h

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSAuthSubsystem.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSAuthSubsystem.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "ROWSTypes.h"
+#include "ROWSAuthSubsystem.generated.h"
+
+class UROWSSubsystem;
+
+/**
+ * UROWSAuthSubsystem
+ *
+ * Handles authentication: login, external login, register, logout.
+ * Mirrors OWSLoginWidget + OWSAPISubsystem auth endpoints.
+ * Delegates all HTTP to UROWSSubsystem (shared config/plumbing).
+ *
+ * This is the Supabase swap point — replace this subsystem's
+ * endpoint calls without touching Instance or Character subsystems.
+ */
+UCLASS()
+class ROWS_API UROWSAuthSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+	// --- Auth API ---
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Auth")
+	void LoginAndCreateSession(const FString& Email, const FString& Password);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Auth")
+	void ExternalLoginAndCreateSession(const FString& ExternalLoginToken);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Auth")
+	void Register(const FString& Email, const FString& Password, const FString& FirstName, const FString& LastName);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Auth")
+	void Logout(const FString& UserSessionGUID);
+
+	// --- Delegates ---
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Auth")
+	FOnROWSLoginSuccess OnLoginSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Auth")
+	FOnROWSLoginError OnLoginError;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Auth")
+	FOnROWSRegisterSuccess OnRegisterSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Auth")
+	FOnROWSRegisterError OnRegisterError;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Auth")
+	FOnROWSLogoutSuccess OnLogoutSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Auth")
+	FOnROWSLogoutError OnLogoutError;
+
+protected:
+	UPROPERTY()
+	TObjectPtr<UROWSSubsystem> Core;
+
+	void OnLoginResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnExternalLoginResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnRegisterResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnLogoutResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSCharacterSubsystem.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSCharacterSubsystem.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "ROWSTypes.h"
+#include "ROWSCharacterSubsystem.generated.h"
+
+class UROWSSubsystem;
+
+/**
+ * UROWSCharacterSubsystem
+ *
+ * Handles character CRUD: GetAllCharacters, CreateCharacter, RemoveCharacter,
+ * custom character data, and SetSelectedCharacterAndConnectToLastZone.
+ *
+ * Mirrors OWSPlayerControllerComponent's character API surface.
+ */
+UCLASS()
+class ROWS_API UROWSCharacterSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+	// --- Character API ---
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void GetAllCharacters(const FString& UserSessionGUID);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void CreateCharacter(const FString& UserSessionGUID, const FString& CharacterName, const FString& ClassName);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void CreateCharacterUsingDefaults(const FString& UserSessionGUID, const FString& CharacterName, const FString& ClassName);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void RemoveCharacter(const FString& UserSessionGUID, const FString& CharacterName);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void AddOrUpdateCustomCharacterData(const FString& CharacterName, const FString& FieldName, const FString& FieldValue);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void GetCustomCharacterData(const FString& CharacterName);
+
+	// --- Delegates ---
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSGetCharactersSuccess OnGetCharactersSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSGetCharactersError OnGetCharactersError;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSCreateCharacterSuccess OnCreateCharacterSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSCreateCharacterError OnCreateCharacterError;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSRemoveCharacterSuccess OnRemoveCharacterSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSRemoveCharacterError OnRemoveCharacterError;
+
+	// Custom data callback — fires with raw JSON object
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSCustomDataReceived, const FString&, JsonData);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSCustomDataError, const FString&, ErrorMessage);
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSCustomDataReceived OnCustomDataReceived;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
+	FOnROWSCustomDataError OnCustomDataError;
+
+protected:
+	UPROPERTY()
+	TObjectPtr<UROWSSubsystem> Core;
+
+	void OnGetAllCharactersResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnCreateCharacterResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnCreateCharacterDefaultsResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnRemoveCharacterResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnAddOrUpdateCustomDataResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnGetCustomDataResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSInstanceSubsystem.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSInstanceSubsystem.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "ROWSTypes.h"
+#include "ROWSInstanceSubsystem.generated.h"
+
+class UROWSSubsystem;
+
+/**
+ * UROWSInstanceSubsystem
+ *
+ * Handles server instance lifecycle: RegisterLauncher, zone lookup,
+ * server status updates, player count reporting.
+ *
+ * Replaces the inline HTTP code in RIGameMode::RegisterWithROWS().
+ * Mirrors OWSGameMode's instance management API calls.
+ */
+UCLASS()
+class ROWS_API UROWSInstanceSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+	// --- Instance API ---
+
+	/** Register this server with ROWS backend. Called from GameMode::StartPlay. */
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Instance")
+	void RegisterLauncher(const FString& ServerIP, int32 Port, int32 MaxInstances = 10);
+
+	/** Get zone instance info by zone instance ID (used for zone travel routing). */
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Instance")
+	void GetZoneInstance(int32 ZoneInstanceID);
+
+	/** Update server status and player count (periodic heartbeat). */
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Instance")
+	void UpdateNumberOfPlayers(int32 ZoneInstanceID, int32 NumberOfPlayers);
+
+	/** Get server to connect to for a character (zone travel). */
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Instance")
+	void GetServerToConnectTo(const FString& CharacterName, const FString& ZoneName);
+
+	// --- Delegates ---
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Instance")
+	FOnROWSRegisterLauncherSuccess OnRegisterLauncherSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Instance")
+	FOnROWSRegisterLauncherError OnRegisterLauncherError;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Instance")
+	FOnROWSGetZoneInstanceSuccess OnGetZoneInstanceSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Instance")
+	FOnROWSGetZoneInstanceError OnGetZoneInstanceError;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Instance")
+	FOnROWSUpdateServerStatusSuccess OnUpdateServerStatusSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "ROWS|Instance")
+	FOnROWSUpdateServerStatusError OnUpdateServerStatusError;
+
+protected:
+	UPROPERTY()
+	TObjectPtr<UROWSSubsystem> Core;
+
+	void OnRegisterLauncherResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnGetZoneInstanceResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnUpdateNumberOfPlayersResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnGetServerToConnectToResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSLoadingWidget.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSLoadingWidget.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "ROWSLoadingWidget.generated.h"
+
+class UTextBlock;
+
+UCLASS()
+class ROWS_API UROWSLoadingWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	virtual TSharedRef<SWidget> RebuildWidget() override;
+	virtual void NativeConstruct() override;
+	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Loading")
+	void SetStatus(const FString& Message);
+
+protected:
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|Loading") TObjectPtr<UTextBlock> StatusText;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|Loading") TObjectPtr<UTextBlock> DotsText;
+
+private:
+	bool bWidgetsCreated = false;
+	float DotTimer = 0.f;
+	int32 DotCount = 0;
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSLoginController.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSLoginController.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "ROWSTypes.h"
+#include "ROWSLoginController.generated.h"
+
+class UROWSSubsystem;
+class UROWSAuthSubsystem;
+class UROWSCharacterSubsystem;
+class UROWSLoginWidget;
+class UROWSLoadingWidget;
+
+/**
+ * AROWSLoginController
+ *
+ * Orchestrates: Login Screen -> Character Select -> Loading -> Travel to Game Map
+ * Mirrors ChuckLoginController — create-once widgets, HideAllWidgets, delegates to ROWS subsystems.
+ */
+UCLASS()
+class ROWS_API AROWSLoginController : public APlayerController
+{
+	GENERATED_BODY()
+
+public:
+	AROWSLoginController();
+	virtual void BeginPlay() override;
+
+	// Widget classes (set in Blueprint Class Defaults)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "ROWS|Widgets")
+	TSubclassOf<UROWSLoginWidget> LoginWidgetClass;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "ROWS|Widgets")
+	TSubclassOf<UROWSLoadingWidget> LoadingWidgetClass;
+
+	// Active widget instances
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS")
+	TObjectPtr<UROWSLoginWidget> LoginWidget;
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS")
+	TObjectPtr<UROWSLoadingWidget> LoadingWidget;
+
+	// Session
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS")
+	FString UserSessionGUID;
+
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS")
+	FString SelectedCharacterName;
+
+	// Screen management
+	UFUNCTION(BlueprintCallable, Category = "ROWS")
+	void ShowLoginScreen();
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS")
+	void ShowCharacterSelect();
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS")
+	void ShowLoadingScreen(const FString& StatusMessage);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS")
+	void OnLoginSuccess(const FString& InUserSessionGUID);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS")
+	void OnPlayClicked(const FString& CharacterName);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS")
+	void OnLogout();
+
+	// Map to travel to after login
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "ROWS|Config")
+	FName GameMapName = FName(TEXT("Lvl_TopDown"));
+
+	// Blueprint events
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS")
+	void OnLoginFlowStarted();
+
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS")
+	void OnCharacterSelectReady(int32 CharacterCount);
+
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS")
+	void OnTravelStarted();
+
+protected:
+	UPROPERTY()
+	TObjectPtr<UROWSSubsystem> Core;
+
+	UPROPERTY()
+	TObjectPtr<UROWSAuthSubsystem> Auth;
+
+	UPROPERTY()
+	TObjectPtr<UROWSCharacterSubsystem> Characters;
+
+private:
+	void HideAllWidgets();
+
+	UFUNCTION()
+	void HandleLoginSuccess(const FString& InUserSessionGUID);
+	UFUNCTION()
+	void HandleLoginError(const FString& ErrorMessage);
+	UFUNCTION()
+	void HandleGetCharactersSuccess(const TArray<FROWSUserCharacter>& InCharacters);
+	UFUNCTION()
+	void HandleGetCharactersError(const FString& ErrorMessage);
+	UFUNCTION()
+	void HandleLogoutSuccess();
+	UFUNCTION()
+	void HandleLogoutError(const FString& ErrorMessage);
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSLoginWidget.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSLoginWidget.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Components/EditableTextBox.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/Overlay.h"
+#include "Components/WidgetSwitcher.h"
+#include "ROWSTypes.h"
+#include "ROWSLoginWidget.generated.h"
+
+class UROWSAuthSubsystem;
+
+/**
+ * UROWSLoginWidget
+ *
+ * Full C++ login widget — email/password fields, login/register buttons,
+ * panel switcher, status text. All built in RebuildWidget().
+ * Every element is BlueprintReadOnly for restyling in child BPs.
+ */
+UCLASS()
+class ROWS_API UROWSLoginWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	virtual TSharedRef<SWidget> RebuildWidget() override;
+	virtual void NativeConstruct() override;
+	virtual void NativeDestruct() override;
+
+	// Auth actions
+	UFUNCTION(BlueprintCallable, Category = "ROWS") void LoginAndCreateSession(const FString& Email, const FString& Password);
+	UFUNCTION(BlueprintCallable, Category = "ROWS") void ExternalLoginAndCreateSession(const FString& ExternalLoginToken);
+	UFUNCTION(BlueprintCallable, Category = "ROWS") void Register(const FString& Email, const FString& Password, const FString& FirstName, const FString& LastName);
+	UFUNCTION(BlueprintCallable, Category = "ROWS") void Logout();
+
+	// Panel switching
+	UFUNCTION(BlueprintCallable, Category = "ROWS|UI") void ShowLoginPanel();
+	UFUNCTION(BlueprintCallable, Category = "ROWS|UI") void ShowRegisterPanel();
+
+	// Blueprint events
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS") void NotifyLoginSuccess(const FString& UserSessionGUID);
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS") void NotifyLoginError(const FString& ErrorMessage);
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS") void NotifyRegisterSuccess(const FString& UserSessionGUID);
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS") void NotifyRegisterError(const FString& ErrorMessage);
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS") void NotifyLogoutSuccess();
+	UFUNCTION(BlueprintImplementableEvent, Category = "ROWS") void NotifyLogoutError(const FString& ErrorMessage);
+
+	// UI elements (accessible from Blueprint)
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UOverlay> RootOverlay;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UVerticalBox> FormContainer;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UWidgetSwitcher> PanelSwitcher;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UTextBlock> TitleText;
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UVerticalBox> LoginPanel;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UEditableTextBox> LoginEmailField;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UEditableTextBox> LoginPasswordField;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UButton> LoginButton;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UTextBlock> LoginButtonText;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UButton> SwitchToRegisterButton;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UTextBlock> SwitchToRegisterText;
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UVerticalBox> RegisterPanel;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UEditableTextBox> RegisterEmailField;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UEditableTextBox> RegisterPasswordField;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UEditableTextBox> RegisterFirstNameField;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UEditableTextBox> RegisterLastNameField;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UButton> RegisterButton;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UTextBlock> RegisterButtonText;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UButton> SwitchToLoginButton;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UTextBlock> SwitchToLoginText;
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS|UI") TObjectPtr<UTextBlock> StatusText;
+
+protected:
+	UPROPERTY() TObjectPtr<UROWSAuthSubsystem> AuthSubsystem;
+
+	UVerticalBox* BuildLoginPanel();
+	UVerticalBox* BuildRegisterPanel();
+	UEditableTextBox* CreateTextField(const FString& HintText, bool bIsPassword = false);
+	UButton* CreateButton(const FString& Label, TObjectPtr<UTextBlock>& OutTextBlock);
+	void SetStatusMessage(const FString& Message, FLinearColor Color = FLinearColor::White);
+
+	bool bWidgetsCreated = false;
+
+private:
+	UFUNCTION() void OnLoginButtonClicked();
+	UFUNCTION() void OnRegisterButtonClicked();
+	UFUNCTION() void OnSwitchToRegisterClicked();
+	UFUNCTION() void OnSwitchToLoginClicked();
+
+	UFUNCTION() void HandleLoginSuccess(const FString& UserSessionGUID);
+	UFUNCTION() void HandleLoginError(const FString& ErrorMessage);
+	UFUNCTION() void HandleRegisterSuccess(const FString& UserSessionGUID);
+	UFUNCTION() void HandleRegisterError(const FString& ErrorMessage);
+	UFUNCTION() void HandleLogoutSuccess();
+	UFUNCTION() void HandleLogoutError(const FString& ErrorMessage);
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSModule.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSModule.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Modules/ModuleManager.h"
+
+class FROWSModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSSubsystem.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSSubsystem.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "ROWSTypes.h"
+#include "JsonObjectConverter.h"
+#include "ROWSSubsystem.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogROWS, Log, All);
+
+/**
+ * UROWSSubsystem
+ *
+ * Core GameInstance subsystem — owns all ROWS backend configuration, HTTP
+ * plumbing, and session state. Domain subsystems (Auth, Instance, Character)
+ * delegate HTTP calls here rather than managing their own connections.
+ *
+ * Reads config from DefaultGame.ini (OWS* keys) with env var overrides
+ * for Kubernetes deployments. This is the single source of truth for
+ * backend connectivity — mirrors what was spread across OWSLoginWidget,
+ * OWSAPISubsystem, OWSGameInstance, and RIGameMode.
+ */
+UCLASS()
+class ROWS_API UROWSSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	// --- Session State ---
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Session")
+	FString GetUserSessionGUID() const { return UserSessionGUID; }
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Session")
+	void SetUserSessionGUID(const FString& InGUID) { UserSessionGUID = InGUID; }
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Session")
+	void ClearSession() { UserSessionGUID.Empty(); }
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Session")
+	bool IsLoggedIn() const { return !UserSessionGUID.IsEmpty(); }
+
+	// --- Config Accessors ---
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Config")
+	FString GetAPIPath() const { return APIPath; }
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Config")
+	FString GetInstanceManagementPath() const { return InstanceManagementPath; }
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Config")
+	FString GetCharacterPersistencePath() const { return CharacterPersistencePath; }
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Config")
+	FString GetGlobalDataPath() const { return GlobalDataPath; }
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Config")
+	FString GetCustomerKey() const { return CustomerKey; }
+
+	// --- HTTP Helpers (used by domain subsystems) ---
+
+	void PostRequest(
+		const FString& BasePath,
+		const FString& Endpoint,
+		const FString& PostContent,
+		const FHttpRequestCompleteDelegate& Callback
+	);
+
+	bool ParseJsonResponse(
+		FHttpRequestPtr Request,
+		FHttpResponsePtr Response,
+		bool bWasSuccessful,
+		const FString& CallerName,
+		FString& OutErrorMsg,
+		TSharedPtr<FJsonObject>& OutJsonObject
+	);
+
+	template<typename T>
+	bool JsonObjectToStruct(const TSharedPtr<FJsonObject>& JsonObject, T& OutStruct)
+	{
+		return FJsonObjectConverter::JsonObjectToUStruct(JsonObject.ToSharedRef(), &OutStruct);
+	}
+
+protected:
+	// Config — loaded once at init
+	FString CustomerKey;
+	FString APIPath;
+	FString InstanceManagementPath;
+	FString CharacterPersistencePath;
+	FString GlobalDataPath;
+	FString EncryptionKey;
+
+	// Session
+	FString UserSessionGUID;
+};

--- a/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSTypes.h
+++ b/packages/unreal/KBVEROWS/Source/KBVEROWS/Public/ROWSTypes.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ROWSTypes.generated.h"
+
+// ---------------------------------------------------------------------------
+// Auth Provider — expandable for Supabase, OAuth, etc.
+// ---------------------------------------------------------------------------
+
+UENUM(BlueprintType)
+enum class EROWSAuthProvider : uint8
+{
+	ROWS		UMETA(DisplayName = "ROWS"),
+	Supabase	UMETA(DisplayName = "Supabase"),
+	Custom		UMETA(DisplayName = "Custom")
+};
+
+// ---------------------------------------------------------------------------
+// Auth Structs (mirrors OWS api/Users/*)
+// ---------------------------------------------------------------------------
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSLoginRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString Email;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString Password;
+};
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSRegisterRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString Email;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString Password;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString FirstName;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString LastName;
+};
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSExternalLoginRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString ExternalLoginToken;
+};
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSLoginResponse
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") bool Authenticated = false;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ErrorMessage;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString UserSessionGUID;
+};
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSRegisterResponse
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") bool Success = false;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ErrorMessage;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString UserSessionGUID;
+};
+
+// ---------------------------------------------------------------------------
+// Character Structs (mirrors OWS FUserCharacter, FCreateCharacter)
+// ---------------------------------------------------------------------------
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSUserCharacter
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString CharacterName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ClassName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 Level = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 Gender = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ZoneName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 Gold = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 Silver = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 Copper = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 FreeCurrency = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 PremiumCurrency = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 Score = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 XP = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 TeamNumber = 0;
+};
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSCreateCharacterRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString UserSessionGUID;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString CharacterName;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString ClassName;
+};
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSCreateCharacterResponse
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") bool Success = false;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ErrorMessage;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString CharacterName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ClassName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 CharacterLevel = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString StartingMapName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") float X = 0.f;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") float Y = 0.f;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") float Z = 0.f;
+};
+
+// ---------------------------------------------------------------------------
+// Instance/Zone Structs (mirrors OWS instance management)
+// ---------------------------------------------------------------------------
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSZoneInstance
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 MapInstanceID = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString MapName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ZoneName;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 WorldServerID = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString ServerIP;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 Port = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 SoftPlayerCap = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 HardPlayerCap = 0;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") FString Status;
+	UPROPERTY(BlueprintReadOnly, Category = "ROWS") int32 NumberOfReportedPlayers = 0;
+};
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSServerStatus
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") bool Success = false;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString ErrorMessage;
+};
+
+// ---------------------------------------------------------------------------
+// Global Data (mirrors OWS GlobalData API)
+// ---------------------------------------------------------------------------
+
+USTRUCT(BlueprintType)
+struct ROWS_API FROWSGlobalDataItem
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString GlobalDataKey;
+	UPROPERTY(BlueprintReadWrite, Category = "ROWS") FString GlobalDataValue;
+};
+
+// ---------------------------------------------------------------------------
+// Delegates — Auth
+// ---------------------------------------------------------------------------
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSLoginSuccess, const FString&, UserSessionGUID);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSLoginError, const FString&, ErrorMessage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSRegisterSuccess, const FString&, UserSessionGUID);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSRegisterError, const FString&, ErrorMessage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnROWSLogoutSuccess);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSLogoutError, const FString&, ErrorMessage);
+
+// ---------------------------------------------------------------------------
+// Delegates — Characters
+// ---------------------------------------------------------------------------
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSGetCharactersSuccess, const TArray<FROWSUserCharacter>&, Characters);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSGetCharactersError, const FString&, ErrorMessage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSCreateCharacterSuccess, const FROWSCreateCharacterResponse&, Response);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSCreateCharacterError, const FString&, ErrorMessage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnROWSRemoveCharacterSuccess);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSRemoveCharacterError, const FString&, ErrorMessage);
+
+// ---------------------------------------------------------------------------
+// Delegates — Instances
+// ---------------------------------------------------------------------------
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSRegisterLauncherSuccess, const FString&, ResponseBody);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSRegisterLauncherError, const FString&, ErrorMessage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSGetZoneInstanceSuccess, const FROWSZoneInstance&, ZoneInstance);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSGetZoneInstanceError, const FString&, ErrorMessage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSUpdateServerStatusSuccess, const FROWSServerStatus&, Status);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSUpdateServerStatusError, const FString&, ErrorMessage);
+
+// ---------------------------------------------------------------------------
+// Delegates — Global Data
+// ---------------------------------------------------------------------------
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSGetGlobalDataSuccess, const FROWSGlobalDataItem&, Item);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSGetGlobalDataError, const FString&, ErrorMessage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnROWSSetGlobalDataSuccess);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnROWSSetGlobalDataError, const FString&, ErrorMessage);


### PR DESCRIPTION
## Summary
Reusable UE5 plugin for ROWS backend communication at `packages/unreal/KBVEROWS/`.

**Subsystems (GameInstance-scoped):**
- `ROWSSubsystem` — core config, HTTP plumbing, session state
- `ROWSAuthSubsystem` — login/register/logout (Supabase swap point)
- `ROWSCharacterSubsystem` — character CRUD, custom data
- `ROWSInstanceSubsystem` — server registration, zone lookup, heartbeat

**UI:**
- `ROWSLoginController` — login → character select → loading → travel
- `ROWSLoginWidget` + `ROWSLoadingWidget` — Blueprint-extendable base widgets

**Usage:**
1. Copy `KBVEROWS/` into your project's `Plugins/` directory
2. Enable in `.uproject`
3. Configure `DefaultGame.ini` with OWS API paths
4. Create Blueprint subclass of `ROWSLoginController`

All 2038 lines Blueprint-exposed via `UPROPERTY`/`UFUNCTION` with delegates.