### PR TITLE
feat(discordsh-bot): add health server, e2e tests, and docs page (Phase 3A)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -77,9 +77,9 @@
 			"source_path": "apps/discordsh/discordsh-bot",
 			"runner": "ubuntu-latest",
 			"image": "kbve/discordsh-bot",
-			"e2e_name": "discordsh-bot",
+			"e2e_name": "discordsh-bot-e2e",
 			"deployment_yaml": "apps/kube/discordsh-bot/manifest/deployment.yaml",
-			"has_test": false
+			"has_test": true
 		},
 		{
 			"key": "edge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,6 +4970,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "askama",
+ "axum",
  "bevy_battle",
  "bevy_inventory",
  "bevy_items",

--- a/apps/discordsh/discordsh-bot-e2e/docker-teardown.ts
+++ b/apps/discordsh/discordsh-bot-e2e/docker-teardown.ts
@@ -1,0 +1,11 @@
+import { execSync } from 'child_process';
+
+export default function globalTeardown() {
+	try {
+		execSync('docker rm -f discordsh-bot-e2e-test 2>/dev/null', {
+			stdio: 'ignore',
+		});
+	} catch {
+		// Container may already be stopped
+	}
+}

--- a/apps/discordsh/discordsh-bot-e2e/e2e/smoke.spec.ts
+++ b/apps/discordsh/discordsh-bot-e2e/e2e/smoke.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('discordsh-bot health endpoints', () => {
+	test('GET /health returns 200 with JSON status', async ({ request }) => {
+		const response = await request.get('/health');
+		expect(response.status()).toBe(200);
+
+		const body = await response.json();
+		expect(body.status).toBe('ok');
+		expect(body.version).toBeDefined();
+		expect(typeof body.version).toBe('string');
+		expect(body.uptime_secs).toBeGreaterThanOrEqual(0);
+	});
+
+	test('GET /healthz returns 200 with plain text', async ({ request }) => {
+		const response = await request.get('/healthz');
+		expect(response.status()).toBe(200);
+
+		const text = await response.text();
+		expect(text).toBe('ok');
+	});
+
+	test('GET /health version matches Cargo.toml', async ({ request }) => {
+		const response = await request.get('/health');
+		const body = await response.json();
+
+		// Version should be a valid semver-like string
+		expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
+	});
+
+	test('GET /nonexistent returns 404', async ({ request }) => {
+		const response = await request.get('/nonexistent');
+		expect(response.status()).toBe(404);
+	});
+});

--- a/apps/discordsh/discordsh-bot-e2e/playwright.config.ts
+++ b/apps/discordsh/discordsh-bot-e2e/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+const port = Number(process.env['E2E_PORT']) || 4322;
+const baseURL = `http://localhost:${port}`;
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		baseURL,
+	},
+	projects: [
+		{
+			name: 'smoke',
+			use: { baseURL },
+		},
+	],
+	webServer: {
+		command: `HEALTH_PORT=${port} cargo run -p discordsh-bot`,
+		url: `${baseURL}/health`,
+		reuseExistingServer: !process.env['CI'],
+		timeout: 120_000,
+	},
+});

--- a/apps/discordsh/discordsh-bot-e2e/playwright.docker.config.ts
+++ b/apps/discordsh/discordsh-bot-e2e/playwright.docker.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const workspaceRoot = resolve(__dirname, '../../..');
+const port = Number(process.env['E2E_PORT']) || 4322;
+const baseURL = `http://localhost:${port}`;
+
+const cargoToml = readFileSync(
+	resolve(workspaceRoot, 'apps/discordsh/discordsh-bot/Cargo.toml'),
+	'utf-8',
+);
+const version = cargoToml.match(/^version\s*=\s*"(.+)"/m)?.[1] ?? '0.1.0';
+
+const killPort = `docker rm -f discordsh-bot-e2e-test 2>/dev/null; lsof -ti:${port} | xargs kill -9 2>/dev/null; sleep 1;`;
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+	workers: process.env['CI'] ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		baseURL,
+	},
+	projects: [
+		{
+			name: 'docker',
+			use: { baseURL },
+		},
+	],
+	webServer: {
+		command: `${killPort} docker run --rm --name discordsh-bot-e2e-test -e HEALTH_PORT=${port} -p ${port}:${port} kbve/discordsh-bot:${version}`,
+		url: `${baseURL}/health`,
+		reuseExistingServer: false,
+		timeout: 60_000,
+	},
+	globalTeardown: resolve(__dirname, 'docker-teardown.ts'),
+});

--- a/apps/discordsh/discordsh-bot-e2e/project.json
+++ b/apps/discordsh/discordsh-bot-e2e/project.json
@@ -1,0 +1,21 @@
+{
+	"name": "discordsh-bot-e2e",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "apps/discordsh/discordsh-bot-e2e",
+	"projectType": "application",
+	"implicitDependencies": ["discordsh-bot"],
+	"targets": {
+		"e2e": {
+			"executor": "@nx/playwright:playwright",
+			"options": {
+				"config": "apps/discordsh/discordsh-bot-e2e/playwright.config.ts"
+			}
+		},
+		"e2e:docker": {
+			"executor": "@nx/playwright:playwright",
+			"options": {
+				"config": "apps/discordsh/discordsh-bot-e2e/playwright.docker.config.ts"
+			}
+		}
+	}
+}

--- a/apps/discordsh/discordsh-bot-e2e/tsconfig.json
+++ b/apps/discordsh/discordsh-bot-e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"include": ["e2e/**/*.ts", "*.ts"]
+}

--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+axum = { version = "0.8.8", default-features = false, features = ["json"] }
 askama = "0.15.4"
 dotenvy = "0.15"
 serenity = { version = "0.12.5", default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"] }

--- a/apps/discordsh/discordsh-bot/src/health_server.rs
+++ b/apps/discordsh/discordsh-bot/src/health_server.rs
@@ -1,0 +1,50 @@
+//! Minimal HTTP health server for k8s probes and e2e smoke tests.
+//!
+//! Runs on a separate port (default 4322) alongside the Discord gateway.
+//! Provides `/health` (JSON) and `/healthz` (plain text) endpoints.
+
+use std::sync::Arc;
+
+use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
+use serde_json::json;
+
+use crate::state::AppState;
+
+const DEFAULT_PORT: u16 = 4322;
+
+/// Start the health HTTP server. Runs until the task is cancelled.
+pub async fn serve(state: Arc<AppState>) -> anyhow::Result<()> {
+    let port: u16 = std::env::var("HEALTH_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_PORT);
+
+    let app = Router::new()
+        .route("/health", get(health_json))
+        .route("/healthz", get(health_plain))
+        .with_state(state);
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!(%addr, "Health server listening");
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn health_json(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let uptime = state.start_time.elapsed().as_secs();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "ok",
+            "version": env!("CARGO_PKG_VERSION"),
+            "uptime_secs": uptime,
+        })),
+    )
+}
+
+async fn health_plain() -> impl IntoResponse {
+    (StatusCode::OK, "ok")
+}

--- a/apps/discordsh/discordsh-bot/src/main.rs
+++ b/apps/discordsh/discordsh-bot/src/main.rs
@@ -1,5 +1,6 @@
 mod discord;
 mod health;
+mod health_server;
 mod state;
 mod tracker;
 
@@ -40,6 +41,9 @@ async fn main() -> anyhow::Result<()> {
 
     let app_state = Arc::new(state::AppState::new(health_monitor, tracker));
 
+    // Minimal health HTTP server for k8s probes and e2e tests
+    let health_http = tokio::spawn(health_server::serve(Arc::clone(&app_state)));
+
     // Bot restart loop: restarts when restart_flag is set, exits otherwise
     loop {
         let app = Arc::clone(&app_state);
@@ -69,6 +73,9 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     }
+
+    // Let health server wind down
+    health_http.abort();
 
     Ok(())
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -1,0 +1,49 @@
+---
+title: DiscordSH Bot
+description: |
+    Standalone Discord gateway bot for DiscordSH — slash commands, embed dungeon game, GitHub integration.
+sidebar:
+    label: DiscordSH Bot
+    order: 421
+tags:
+    - discord
+    - bot
+key: discordsh_bot
+pipeline: docker
+app_name: discordsh-bot
+version: "0.1.0"
+source_path: apps/discordsh/discordsh-bot
+version_toml: apps/discordsh/discordsh-bot/version.toml
+version_target: apps/discordsh/discordsh-bot/Cargo.toml
+runner: ubuntu-latest
+image: kbve/discordsh-bot
+deployment_yaml: apps/kube/discordsh-bot/manifest/deployment.yaml
+---
+
+import {
+    Adsense,
+    MDXLayer,
+    Widget,
+    Heading,
+} from '@kbve/astro-ve';
+
+<MDXLayer title={frontmatter.title} description={frontmatter.description}>
+
+## Overview
+
+`discordsh-bot` is the standalone Discord gateway bot extracted from the axum-discordsh monolith. It handles all Discord interactions independently of the HTTP server.
+
+### Features
+
+- Poise/serenity Discord gateway with shard support
+- Slash commands: `/github`, `/gh`, `/dungeon`, `/ping`, `/status`, `/health`, `/admin`
+- Embed Dungeon game with bevy_battle combat, bevy_inventory item management
+- GitHub issue/PR management with SVG card rendering
+- Player persistence via Supabase
+- Minimal health HTTP server for k8s probes
+
+### Related
+
+- [DiscordSH](/project/discordsh/) — HTTP server (Astro site, REST API)
+
+</MDXLayer>

--- a/apps/kube/discordsh-bot/manifest/deployment.yaml
+++ b/apps/kube/discordsh-bot/manifest/deployment.yaml
@@ -74,19 +74,18 @@ spec:
                       limits:
                           memory: '512Mi'
                           cpu: '500m'
+                  ports:
+                      - name: health
+                        containerPort: 4322
                   livenessProbe:
-                      exec:
-                          command:
-                              - /bin/sh
-                              - -c
-                              - 'test $(( $(date +%s) - $(stat -c %Y /tmp/bot-heartbeat 2>/dev/null || echo 0) )) -lt 120'
+                      httpGet:
+                          path: /health
+                          port: 4322
                       initialDelaySeconds: 30
                       periodSeconds: 30
                   readinessProbe:
-                      exec:
-                          command:
-                              - /bin/sh
-                              - -c
-                              - 'test -f /tmp/bot-heartbeat'
+                      httpGet:
+                          path: /healthz
+                          port: 4322
                       initialDelaySeconds: 10
                       periodSeconds: 10


### PR DESCRIPTION
## Summary
- Add minimal axum health HTTP server to discordsh-bot (port 4322, `/health` JSON + `/healthz` plain text)
- Create `discordsh-bot-e2e` Playwright project with smoke tests (dev + docker configs)
- Update k8s StatefulSet to use HTTP liveness/readiness probes instead of exec-based
- Create `discordsh-bot.mdx` docs page as version_source for CI gate
- Enable `has_test: true` in CI dispatch manifest

## E2E smoke tests
- `GET /health` → 200, JSON `{status, version, uptime_secs}`
- `GET /healthz` → 200, plain text `"ok"`
- Version matches semver pattern
- Unknown routes return 404

## CI pipeline flow (after merge)
```
File change detected → ci-docker dispatched → Docker build →
e2e:docker smoke tests → publish to GHCR → k8s deploy
```

## Test plan
- [x] `cargo check -p discordsh-bot` — compiles with axum health server
- [x] 699 Rust tests pass
- [ ] Bump version in MDX to trigger first CI build
- [ ] Verify e2e smoke tests pass in Docker mode

Ref #9286