### PR TITLE
feat(kubevirt): add aria2c download proxy for reliable VM downloads

### DIFF
--- a/apps/kube/kubevirt/download-proxy/deployment.yaml
+++ b/apps/kube/kubevirt/download-proxy/deployment.yaml
@@ -1,0 +1,141 @@
+# Download proxy for KubeVirt VMs — aria2c with retry + resume.
+#
+# Solves: Cilium VXLAN masquerade NAT drops long-lived TCP connections,
+# causing large downloads (UE5 ~40GB, VS Build Tools ~5GB) to fail.
+#
+# Architecture:
+#   This pod runs on the SAME node as the VM (via node affinity).
+#   The VM accesses it via ClusterIP service at download-proxy.angelscript.svc:6800
+#   aria2c handles retries, resume, and multi-connection downloads.
+#
+# Usage from inside the VM:
+#   1. Add a download:
+#      curl -d '{"jsonrpc":"2.0","id":"1","method":"aria2.addUri","params":[["https://example.com/file.zip"],{"dir":"/downloads"}]}' \
+#        http://download-proxy.angelscript.svc:6800/jsonrpc
+#   2. Check status:
+#      curl -d '{"jsonrpc":"2.0","id":"1","method":"aria2.tellActive","params":[]}' \
+#        http://download-proxy.angelscript.svc:6800/jsonrpc
+#   3. Download the file from the shared PVC:
+#      curl http://download-proxy.angelscript.svc:8080/file.zip -o C:\file.zip
+#
+# The proxy pod has stable internet (runs as a normal pod, not through masquerade).
+# Downloaded files land on the shared PVC which is also mounted in the VM.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: download-proxy
+    namespace: angelscript
+    labels:
+        app: download-proxy
+        component: kubevirt-tooling
+spec:
+    replicas: 0
+    selector:
+        matchLabels:
+            app: download-proxy
+    template:
+        metadata:
+            labels:
+                app: download-proxy
+                component: kubevirt-tooling
+        spec:
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                fsGroup: 1000
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                # aria2c — download engine with retry, resume, multi-connection
+                - name: aria2
+                  image: p3terx/aria2-pro:latest
+                  env:
+                      - name: PUID
+                        value: '1000'
+                      - name: PGID
+                        value: '1000'
+                      # RPC secret — set to empty for internal-only access
+                      - name: RPC_SECRET
+                        value: ''
+                      # Max concurrent downloads
+                      - name: CUSTOM_TRACKER_URL
+                        value: ''
+                  ports:
+                      - containerPort: 6800
+                        name: rpc
+                        protocol: TCP
+                  volumeMounts:
+                      - name: downloads
+                        mountPath: /downloads
+                      - name: aria2-config
+                        mountPath: /config
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 128Mi
+                      limits:
+                          cpu: '2'
+                          memory: 1Gi
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+                # HTTP file server — serves completed downloads to the VM
+                - name: file-server
+                  image: python:3.12-alpine
+                  command:
+                      [
+                          'python3',
+                          '-m',
+                          'http.server',
+                          '8080',
+                          '--directory',
+                          '/downloads',
+                      ]
+                  ports:
+                      - containerPort: 8080
+                        name: http
+                  volumeMounts:
+                      - name: downloads
+                        mountPath: /downloads
+                  resources:
+                      requests:
+                          cpu: 50m
+                          memory: 64Mi
+                      limits:
+                          cpu: 500m
+                          memory: 256Mi
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+            volumes:
+                - name: downloads
+                  persistentVolumeClaim:
+                      claimName: builder-shared-storage
+                - name: aria2-config
+                  emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: download-proxy
+    namespace: angelscript
+    labels:
+        app: download-proxy
+        component: kubevirt-tooling
+spec:
+    selector:
+        app: download-proxy
+    ports:
+        - port: 6800
+          targetPort: 6800
+          name: rpc
+          protocol: TCP
+        - port: 8080
+          targetPort: 8080
+          name: http
+          protocol: TCP

--- a/apps/kube/kubevirt/download-proxy/download.sh
+++ b/apps/kube/kubevirt/download-proxy/download.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Queue a download via the aria2c RPC API on the download-proxy pod.
+# Usage:
+#   ./download.sh <url> [filename]
+#   ./download.sh https://aka.ms/vs/17/release/vs_buildtools.exe
+#   ./download.sh https://example.com/file.zip custom-name.zip
+#
+# The file lands on the shared PVC at /downloads/<filename>
+# The VM can access it at http://download-proxy.angelscript.svc:8080/<filename>
+
+PROXY_RPC="http://download-proxy.angelscript.svc:6800/jsonrpc"
+NAMESPACE="${NAMESPACE:-angelscript}"
+URL="${1:?Usage: ./download.sh <url> [filename]}"
+FILENAME="${2:-$(basename "$URL")}"
+
+echo "Queuing download: ${URL}"
+echo "  Filename: ${FILENAME}"
+echo "  Proxy: ${PROXY_RPC}"
+
+# Scale up the proxy if it's at 0
+REPLICAS=$(kubectl get deploy download-proxy -n "${NAMESPACE}" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
+if [ "${REPLICAS}" = "0" ]; then
+    echo "Scaling up download-proxy..."
+    kubectl scale deploy download-proxy -n "${NAMESPACE}" --replicas=1
+    kubectl wait --for=condition=Ready pod -l app=download-proxy -n "${NAMESPACE}" --timeout=60s
+fi
+
+# Queue the download via aria2c JSON-RPC
+kubectl exec deploy/download-proxy -n "${NAMESPACE}" -c aria2 -- \
+    curl -sf -d "{
+        \"jsonrpc\": \"2.0\",
+        \"id\": \"dl-${FILENAME}\",
+        \"method\": \"aria2.addUri\",
+        \"params\": [[\"${URL}\"], {
+            \"dir\": \"/downloads\",
+            \"out\": \"${FILENAME}\",
+            \"max-connection-per-server\": \"16\",
+            \"split\": \"16\",
+            \"min-split-size\": \"10M\",
+            \"max-tries\": \"10\",
+            \"retry-wait\": \"5\",
+            \"continue\": \"true\",
+            \"auto-file-renaming\": \"false\",
+            \"allow-overwrite\": \"true\"
+        }]
+    }" http://localhost:6800/jsonrpc
+
+echo ""
+echo "Download queued. Monitor with:"
+echo "  kubectl exec deploy/download-proxy -n ${NAMESPACE} -c aria2 -- curl -sf -d '{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"aria2.tellActive\",\"params\":[]}' http://localhost:6800/jsonrpc | python3 -m json.tool"
+echo ""
+echo "VM access URL: http://download-proxy.angelscript.svc:8080/${FILENAME}"


### PR DESCRIPTION
## Summary
Fixes #9328 — adds a download proxy pod that handles large file downloads reliably for KubeVirt Windows VMs.

**Problem:** Cilium VXLAN masquerade NAT drops long-lived TCP connections, causing UE5 (~40GB) and VS Build Tools (~5GB) downloads to fail inside VMs.

**Solution:** Dedicated download-proxy pod with:
- `aria2c`: 16-connection parallel downloads with auto-retry + resume
- Python HTTP server: serves completed files to VM at port 8080
- Shared PVC: files persist across pod/VM restarts
- Helper script: `download.sh` queues downloads via aria2c JSON-RPC

**Usage:**
```bash
# Scale up proxy
kubectl scale deploy download-proxy -n angelscript --replicas=1

# Queue a download
./apps/kube/kubevirt/download-proxy/download.sh https://aka.ms/vs/17/release/vs_buildtools.exe

# From inside VM:
curl http://download-proxy.angelscript.svc:8080/vs_buildtools.exe -o C:\vs_buildtools.exe
```

Default replicas: 0 (scale up when needed, down when done).