### PR TITLE
fix(ci): handle project duplicate + fudster DISPLAY on headless CI

### DIFF
--- a/.github/actions/gql-project-migration/action.yml
+++ b/.github/actions/gql-project-migration/action.yml
@@ -1,122 +1,143 @@
 name: 'GQL - Project Card Migration'
 description: 'An action to manage and migrate a project card.'
 branding:
-  color: 'green'
-  icon: 'box'
+    color: 'green'
+    icon: 'box'
 inputs:
-  token:
-    description: 'Your Github Organization Token'
-    #required:
-  org:
-    description: 'Your Github Organization Name'
-    default: 'KBVE'
-  repo:
-    description: 'Your Github Repo'
-    default: 'kbve'
-  project:
-    description: 'Your Organization Project Number'
-    default: '5'
-  key:
-    description: 'Your Project Field Key'
-  value:
-    description: 'Your Project Field Value'
-  idref:
-    description: 'Your Repo Issue/PR ID'
+    token:
+        description: 'Your Github Organization Token'
+        #required:
+    org:
+        description: 'Your Github Organization Name'
+        default: 'KBVE'
+    repo:
+        description: 'Your Github Repo'
+        default: 'kbve'
+    project:
+        description: 'Your Organization Project Number'
+        default: '5'
+    key:
+        description: 'Your Project Field Key'
+    value:
+        description: 'Your Project Field Value'
+    idref:
+        description: 'Your Repo Issue/PR ID'
 
 runs:
-  using: 'composite'
-  steps:
-    - name: GQL Query Organization
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      run: |
-            gh api graphql -f query='
-              query($org: String!, $number: Int!) {
-                organization(login: $org){
-                  projectV2(number: $number) {
-                    id
-                    fields(first:20) {
-                      nodes {
-                        ... on ProjectV2Field {
-                          id
-                          name
-                        }
-                        ... on ProjectV2SingleSelectField {
-                          id
-                          name
-                          options {
+    using: 'composite'
+    steps:
+        - name: GQL Query Organization
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.token }}
+          run: |
+              gh api graphql -f query='
+                query($org: String!, $number: Int!) {
+                  organization(login: $org){
+                    projectV2(number: $number) {
+                      id
+                      fields(first:20) {
+                        nodes {
+                          ... on ProjectV2Field {
                             id
                             name
+                          }
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options {
+                              id
+                              name
+                            }
                           }
                         }
                       }
                     }
                   }
-                }
-              }' -f org=${{ inputs.org }} -F number=${{ inputs.project }} > project_data.json
+                }' -f org=${{ inputs.org }} -F number=${{ inputs.project }} > project_data.json
 
-              echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
-              echo 'DATE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Date") | .id' project_data.json) >> $GITHUB_ENV
-              echo 'KEY_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "'${{ inputs.key }}'") | .id' project_data.json) >> $GITHUB_ENV
-              echo 'VALUE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "'${{ inputs.key }}'") | .options[] | select(.name=="'${{ inputs.value }}'") |.id' project_data.json) >> $GITHUB_ENV
+                echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+                echo 'DATE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Date") | .id' project_data.json) >> $GITHUB_ENV
+                echo 'KEY_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "'${{ inputs.key }}'") | .id' project_data.json) >> $GITHUB_ENV
+                echo 'VALUE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "'${{ inputs.key }}'") | .options[] | select(.name=="'${{ inputs.value }}'") |.id' project_data.json) >> $GITHUB_ENV
 
-    - name: Log Date
-      shell: bash
-      run: echo "DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
-            
-    - name: Get Edge Id
-      shell: bash
-      env:
-          GITHUB_TOKEN: ${{ inputs.token }}
-      run: |
-          item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $content:ID!) {
-              addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
-                item {
-                  id
-                }
-              }
-            }' -f project=$PROJECT_ID -f content=${{ inputs.idref }} --jq '.data.addProjectV2ItemById.item.id')"
+        - name: Log Date
+          shell: bash
+          run: echo "DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
 
-            echo 'ITEM_ID='$item_id >> $GITHUB_ENV
-            
-    - name: Set Key Field Value
-      shell: bash
-      env:
-          GITHUB_TOKEN: ${{ inputs.token }}
-      run: |
-          gh api graphql -f query='
-            mutation (
-              $project: ID!
-              $item: ID!
-              $status_field: ID!
-              $status_value: String!
-              $date_field: ID!
-              $date_value: Date!
-            ) {
-              set_status: updateProjectV2ItemFieldValue(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $status_field
-                value: {
-                  singleSelectOptionId: $status_value
+        - name: Get Edge Id
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.token }}
+          run: |
+              item_id="$( gh api graphql -f query='
+                mutation($project:ID!, $content:ID!) {
+                  addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
+                    item {
+                      id
+                    }
                   }
-              }) {
-                projectV2Item {
-                  id
+                }' -f project=$PROJECT_ID -f content=${{ inputs.idref }} --jq '.data.addProjectV2ItemById.item.id' 2>&1)" || true
+
+                # If the item already exists, look it up instead
+                if echo "$item_id" | grep -qi "already exists"; then
+                  echo "Item already in project — looking up existing item ID"
+                  item_id="$( gh api graphql -f query='
+                    query($project:ID!, $content:ID!) {
+                      node(id: $project) {
+                        ... on ProjectV2 {
+                          items(first: 100) {
+                            nodes {
+                              id
+                              content {
+                                ... on Issue { id }
+                                ... on PullRequest { id }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }' -f project=$PROJECT_ID -f content=${{ inputs.idref }} --jq '.data.node.items.nodes[] | select(.content.id == "${{ inputs.idref }}") | .id' 2>/dev/null)" || true
+                fi
+
+                echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+        - name: Set Key Field Value
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.token }}
+          run: |
+              gh api graphql -f query='
+                mutation (
+                  $project: ID!
+                  $item: ID!
+                  $status_field: ID!
+                  $status_value: String!
+                  $date_field: ID!
+                  $date_value: Date!
+                ) {
+                  set_status: updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $status_field
+                    value: {
+                      singleSelectOptionId: $status_value
+                      }
+                  }) {
+                    projectV2Item {
+                      id
+                      }
                   }
-              }
-              set_date_posted: updateProjectV2ItemFieldValue(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $date_field
-                value: {
-                  date: $date_value
-                }
-              }) {
-                projectV2Item {
-                  id
-                }
-              }
-            }' -f project=${{ env.PROJECT_ID}} -f item=${{ env.ITEM_ID}} -f status_field=${{ env.KEY_FIELD_ID}} -f status_value=${{ env.VALUE_FIELD_ID }} -f date_field=${{ env.DATE_FIELD_ID }} -f date_value=${{ env.DATE }} --silent
+                  set_date_posted: updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $date_field
+                    value: {
+                      date: $date_value
+                    }
+                  }) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }' -f project=${{ env.PROJECT_ID}} -f item=${{ env.ITEM_ID}} -f status_field=${{ env.KEY_FIELD_ID}} -f status_value=${{ env.VALUE_FIELD_ID }} -f date_field=${{ env.DATE_FIELD_ID }} -f date_value=${{ env.DATE }} --silent

--- a/packages/python/fudster/fudster/apps/__init__.py
+++ b/packages/python/fudster/fudster/apps/__init__.py
@@ -6,7 +6,8 @@ from .runelite import RuneLiteClient  # noqa: F401, E402
 
 try:
     from .screen_client import ScreenClient  # noqa: F401, E402
-except ImportError:
+except (ImportError, KeyError):
+    # KeyError: 'DISPLAY' raised by pyautogui/mouseinfo on headless CI
     _logger.debug("ScreenClient unavailable — install fudster[automation]")
 
 try:

--- a/packages/python/fudster/fudster/apps/screen_client.py
+++ b/packages/python/fudster/fudster/apps/screen_client.py
@@ -13,7 +13,8 @@ try:
     import cv2
     import numpy as np
     from humancursor import SystemCursor
-except ImportError:
+except (ImportError, KeyError):
+    # KeyError: 'DISPLAY' raised by mouseinfo on headless CI runners
     pyautogui = None
     cv2 = None
     np = None


### PR DESCRIPTION
## Summary
- **#9335**: `gql-project-migration` action now handles "Content already exists in this project" gracefully — falls back to looking up the existing item ID instead of failing the workflow
- **#9338**: `fudster` catches `KeyError` alongside `ImportError` when `pyautogui`/`mouseinfo` tries to access the `DISPLAY` env var on headless CI runners (no X11 server)

## Test plan
- [ ] Label automation workflow runs without error on duplicate project items
- [ ] `pydesk:test` passes on CI (headless runner without DISPLAY)

Closes #9335
Closes #9338