### PR TITLE
feat(kubevirt): KEDA auto-scaling for download-proxy

### DIFF
--- a/apps/kube/kubevirt/download-proxy/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/download-proxy/keda-scaledobject.yaml
@@ -1,0 +1,51 @@
+# KEDA ScaledObject for download-proxy.
+#
+# Lifecycle:
+#   1. GitHub Actions job queued with label 'UE5-Win' or 'UE5-Download'
+#   2. KEDA detects the queued job → scales download-proxy from 0 → 1
+#   3. CI stages downloads via aria2c RPC → files land on shared PVC
+#   4. Job completes → no more queued jobs → cooldown (5 min) → scale to 0
+#
+# The proxy shares the same trigger as the Windows VM (UE5-Win),
+# so both scale up together. Additional 'UE5-Download' label allows
+# triggering the proxy independently for pre-staging downloads.
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+    name: download-proxy-scaler
+    namespace: angelscript
+    labels:
+        app: download-proxy
+        component: kubevirt-tooling
+spec:
+    scaleTargetRef:
+        name: download-proxy
+    pollingInterval: 30
+    cooldownPeriod: 300
+    idleReplicaCount: 0
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    triggers:
+        # Scale up when UE5 Windows build jobs are queued
+        - type: github-runner
+          metadata:
+              owner: KBVE
+              runnerScope: org
+              labels: UE5-Win
+              targetWorkflowQueueLength: '1'
+          authenticationRef:
+              name: github-runner-auth
+        # Also scale up for explicit download-staging jobs
+        - type: github-runner
+          metadata:
+              owner: KBVE
+              runnerScope: org
+              labels: UE5-Download
+              targetWorkflowQueueLength: '1'
+          authenticationRef:
+              name: github-runner-auth
+    # TODO(metrics-trigger): Add aria2c active downloads metric trigger:
+    #   When aria2c has active downloads → keep proxy alive regardless of GitHub queue.
+    #   Requires exposing aria2c stats as Prometheus metrics or using KEDA external scaler.
+    #   For now, the 5-minute cooldown handles most cases.


### PR DESCRIPTION
## Summary
KEDA ScaledObject that auto-scales the download-proxy deployment based on GitHub Actions job queue.

**Flow:**
1. CI job queued with `UE5-Win` or `UE5-Download` label
2. KEDA detects → scales download-proxy 0 → 1
3. CI stages downloads via aria2c
4. Job completes → 5 min cooldown → scales back to 0

No manual `kubectl scale` needed. Proxy lifecycle is fully automated.

## Triggers
- `UE5-Win` — scales alongside Windows VM builds
- `UE5-Download` — independent download pre-staging

Refs #9328