### PR TITLE
chore(deps): remove @nx/dotnet and dotnet CI infrastructure

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -214,59 +214,19 @@ jobs:
             version_target: ${{ needs.config.outputs.version_target }}
 
     # ---------------------------------------------------------------------------
-    # Compile Check — runs `dotnet restore + test` via Nx for dotnet projects.
-    # Catches compilation errors before the Docker publish stage.
-    # Only runs when a .sln file exists in source_path (i.e. dotnet projects).
-    # ---------------------------------------------------------------------------
-    compile_check:
-        name: Compile Check
-        needs: [config]
-        if: |
-            always() &&
-            needs.config.result == 'success' &&
-            needs.config.outputs.source_path != '' &&
-            !cancelled()
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v6
-            - name: Check for .sln file
-              id: detect
-              run: |
-                  SLN=$(find "${{ needs.config.outputs.source_path }}" -maxdepth 1 -name '*.sln' -print -quit 2>/dev/null)
-                  if [ -n "$SLN" ]; then
-                    echo "is_dotnet=true" >> "$GITHUB_OUTPUT"
-                    echo "sln_path=$SLN" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "is_dotnet=false" >> "$GITHUB_OUTPUT"
-                  fi
-            - name: Setup .NET SDK
-              if: steps.detect.outputs.is_dotnet == 'true'
-              uses: actions/setup-dotnet@v5
-              with:
-                  dotnet-version: '8.0.x'
-            - name: Dotnet restore and build
-              if: steps.detect.outputs.is_dotnet == 'true'
-              run: |
-                  dotnet restore "${{ steps.detect.outputs.sln_path }}"
-                  dotnet build "${{ steps.detect.outputs.sln_path }}" --no-restore -c Release
-
-    # ---------------------------------------------------------------------------
     # Publish — promotes the ci-{sha} tag built in test to the release tag.
     # Falls back to a full rebuild only if the ci-{sha} image is not in GHCR.
     # For apps without a test step (kilobase) this is the primary build path.
     # ---------------------------------------------------------------------------
     publish:
         name: Publish Docker
-        needs: [config, test, compile_check, version_gate]
+        needs: [config, test, version_gate]
         if: |
             always() &&
             !cancelled() &&
             needs.config.result == 'success' &&
             needs.version_gate.outputs.should_publish == 'true' &&
-            (needs.test.result == 'success' || needs.test.result == 'skipped') &&
-            (needs.compile_check.result == 'success' || needs.compile_check.result == 'skipped')
+            (needs.test.result == 'success' || needs.test.result == 'skipped')
         permissions:
             contents: read
             packages: write

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -84,13 +84,6 @@ jobs:
               with:
                   node-version: 24
 
-            - name: Setup .NET SDK
-              uses: actions/setup-dotnet@v5
-              with:
-                  dotnet-version: |
-                      8.0.x
-                      10.0.x
-
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v5
               with:

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -104,9 +104,6 @@ jobs:
                   mkdir -p ~/.pgrx
                   printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
 
-            - name: Restore .NET dependencies
-              run: dotnet restore apps/ows/OWS.sln || true
-
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud
 

--- a/kbve.sh
+++ b/kbve.sh
@@ -53,7 +53,6 @@ install_brew_toolchain() {
     brew_install pnpm pnpm
     brew_install python3 python@3.12
     brew_install poetry poetry
-    brew_install dotnet dotnet
     brew_install protoc protobuf
     brew_install tmux tmux
 
@@ -64,7 +63,6 @@ install_brew_toolchain() {
     echo "pnpm:     $(pnpm --version 2>/dev/null || echo 'not found')"
     echo "Python:   $(python3 --version 2>/dev/null || echo 'not found')"
     echo "Poetry:   $(poetry --version 2>/dev/null || echo 'not found')"
-    echo ".NET:     $(dotnet --version 2>/dev/null || echo 'not found')"
     echo "Protobuf: $(protoc --version 2>/dev/null || echo 'not found')"
 }
 
@@ -79,12 +77,6 @@ install_node_pnpm() {
     brew_check
     brew_install node node
     brew_install pnpm pnpm
-}
-
-# Function to install and prepare DotNet
-install_dotnet() {
-    brew_check
-    brew_install dotnet dotnet
 }
 
 # Function to install and prepare Python + Poetry
@@ -851,9 +843,6 @@ case "$1" in
     -installnode)
         install_node_pnpm
         ;;
-    -installnet)
-        install_dotnet
-        ;;
     -installpy)
         install_python_and_poetry
         ;;
@@ -1058,7 +1047,6 @@ case "$1" in
         echo "  -install           Run pnpm install for monorepo"
         echo "  -installrust       Install Rust via Homebrew"
         echo "  -installnode       Install Node.js + pnpm via Homebrew"
-        echo "  -installnet        Install .NET via Homebrew"
         echo "  -installpy         Install Python + Poetry via Homebrew"
         echo ""
         echo "Development:"

--- a/nx.json
+++ b/nx.json
@@ -113,10 +113,6 @@
 			"options": {
 				"testTargetName": "test"
 			}
-		},
-		{
-			"plugin": "@nx/dotnet",
-			"include": ["apps/ows/**"]
 		}
 	],
 	"defaultProject": "kbve.com",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"@nanostores/react": "^1.0.0",
 		"@nx-tools/nx-container": "^7.2.1",
 		"@nx/devkit": "22.6.1",
-		"@nx/dotnet": "22.6.1",
 		"@nx/esbuild": "22.6.1",
 		"@nx/eslint": "22.6.1",
 		"@nx/eslint-plugin": "22.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,9 +292,6 @@ importers:
             '@nx/devkit':
                 specifier: 22.6.1
                 version: 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))
-            '@nx/dotnet':
-                specifier: 22.6.1
-                version: 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))
             '@nx/esbuild':
                 specifier: 22.6.1
                 version: 22.6.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18))(esbuild@0.25.0)(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
@@ -5157,12 +5154,6 @@ packages:
         resolution:
             {
                 integrity: sha512-FEPgS466SVtttAGgwYXhi+SUBVZnhTms0GVAmwbXAw3oAjB3HcZAF1OVy8RtHlk0TGckcJb7TL/PiImwIiwRFA==,
-            }
-
-    '@nx/dotnet@22.6.1':
-        resolution:
-            {
-                integrity: sha512-vdbEdqPNzMiWPbedUXPvQJ3YtyZcTequlDBWHf8Xg1uY/wpslJ+PLOwUtTfZO2aWwbmBXHvYspUqKGvylYSv5w==,
             }
 
     '@nx/esbuild@22.6.1':
@@ -30562,14 +30553,6 @@ snapshots:
         dependencies:
             '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))
             enquirer: 2.3.6
-            tslib: 2.8.1
-        transitivePeerDependencies:
-            - nx
-
-    '@nx/dotnet@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))':
-        dependencies:
-            '@nx/devkit': 22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))
-            ignore: 7.0.5
             tslib: 2.8.1
         transitivePeerDependencies:
             - nx


### PR DESCRIPTION
## Summary
- Removed `@nx/dotnet` from package.json + nx.json plugin config
- Removed dotnet compile check job from ci-docker.yml
- Removed .NET SDK setup from docker-test-app.yml  
- Removed dotnet restore from utils-ci-lint-test.yml
- Removed dotnet install/flags from kbve.sh
- Updated pnpm-lock.yaml

## Kept (intentionally)
- `.csproj` case branches in version-sync workflows (dead paths, harmless)
- `ci-ue-win-setup.yml` dotnet install (needed for Unreal Engine builds, not OWS)

Refs #9334