### PR TITLE
docs(isometric): update README and add project page

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/isometric.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/isometric.mdx
@@ -1,0 +1,110 @@
+---
+title: Isometric
+description: |
+    KBVE Isometric — multiplayer browser game built with Bevy, lightyear, and avian3d. Runs as WASM (WebGPU) and Tauri desktop.
+sidebar:
+    label: Isometric
+    order: 10
+tags:
+    - game
+    - bevy
+    - rust
+    - wasm
+key: isometric
+source_path: apps/kbve/isometric
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+import {
+    Aside,
+    Steps,
+    Card,
+    CardGrid,
+} from '@astrojs/starlight/components';
+
+## Overview
+
+The **Isometric** game is KBVE's flagship multiplayer browser experience — an isometric 3D world built entirely in Rust with Bevy 0.18, networked via lightyear, and rendered through WebGPU in the browser.
+
+<CardGrid>
+    <Card title="Bevy 0.18" icon="rocket">
+        Full ECS game engine compiled to WASM with WebGPU rendering
+    </Card>
+    <Card title="Multiplayer" icon="star">
+        lightyear networking with WebSocket and WebTransport (QUIC)
+    </Card>
+    <Card title="Physics" icon="puzzle">
+        avian3d rigid-body physics with isometric collision
+    </Card>
+    <Card title="Cross-platform" icon="laptop">
+        WASM web app + Tauri 2 native desktop
+    </Card>
+</CardGrid>
+
+## Architecture
+
+The game runs as a **client** that connects to an **authoritative server** hosted inside `axum-kbve`. The server runs a headless Bevy app with lightyear server plugins and avian3d physics.
+
+### Transport Layer
+
+| Transport      | Protocol | Path                        | Use Case                  |
+| -------------- | -------- | --------------------------- | ------------------------- |
+| WebSocket      | TCP/TLS  | `wss://kbve.com/ws`        | Primary (all browsers)    |
+| WebTransport   | QUIC/UDP | `https://wt.kbve.com:5001` | Low-latency (Chrome/Edge) |
+
+WebTransport is preferred when available. Safari and older browsers fall back to WebSocket automatically.
+
+### Shared Crates
+
+| Crate            | Purpose                                              |
+| ---------------- | ---------------------------------------------------- |
+| `bevy_inventory` | Slot-based inventory with auto-stacking              |
+| `bevy_items`     | Proto-driven item database from Astro itemdb         |
+| `bevy_cam`       | Isometric camera controller                          |
+| `bevy_kbve_net`  | Protocol types shared between client and server      |
+| `bevy_tasker`    | Async task bridge for WASM/native                    |
+
+## Features
+
+- Procedural isometric terrain with tile-based collision
+- Day/night cycle with dynamic lighting and fireflies
+- Resource gathering (trees, rocks, ores, flowers, mushrooms)
+- 16-slot inventory backed by 117+ proto-driven item definitions
+- Creature system (frogs, fireflies) with behavioral AI
+- Server-authoritative physics and entity replication
+- JWT authentication with Supabase
+- Pixel-art post-processing shader
+
+## Running Locally
+
+<Steps>
+1. **Full local stack** (game + server):
+   ```sh
+   nx run isometric:quick
+   ```
+
+2. **WASM dev only** (no server):
+   ```sh
+   nx run isometric:dev
+   ```
+
+3. **Desktop build** (Tauri):
+   ```sh
+   nx run isometric:build:tauri
+   ```
+
+4. **Connect desktop to production**:
+   ```sh
+   GAME_SERVER_URL=wss://kbve.com/ws cargo run -p isometric-game
+   ```
+</Steps>
+
+## Item Database
+
+Items are defined as MDX files in the [itemdb collection](/itemdb/) and baked into the game binary at compile time. To regenerate after adding items:
+
+```sh
+node apps/kbve/isometric/scripts/sync-itemdb.mjs
+```

--- a/apps/kbve/isometric/README.md
+++ b/apps/kbve/isometric/README.md
@@ -13,9 +13,14 @@ apps/kbve/isometric/
 │   │   ├── lib.rs             # WASM entry point (wasm_main)
 │   │   ├── main.rs            # Tauri desktop entry point
 │   │   ├── commands.rs        # WASM-exported functions (JS bridge)
+│   │   ├── data/
+│   │   │   └── itemdb.json    # Baked item database (generated)
 │   │   └── game/              # All game logic (see modules below)
 │   │       └── mod.rs         # GamePluginGroup — registers all plugins
 │   └── Cargo.toml
+├── scripts/
+│   └── sync-itemdb.mjs        # Extracts itemdb from Astro MDX → JSON
+├── certificates/              # WebTransport TLS certs (local dev)
 ├── src/                       # Frontend (React + TypeScript)
 ├── public/                    # Static assets
 ├── package.json               # Node scripts (build:wasm, dev, build)
@@ -28,42 +33,60 @@ apps/kbve/isometric/
 
 All game logic lives in `src-tauri/src/game/`. The `GamePluginGroup` in `mod.rs` registers these plugins (order matters for dependencies):
 
-| Module             | Plugin                      | Purpose                                                                        |
-| ------------------ | --------------------------- | ------------------------------------------------------------------------------ |
-| `net`              | `NetPlugin`                 | Lightyear client setup, server connection, player replication, username labels |
-| `state`            | `GameStatePlugin`           | App state machine (Loading, InGame, etc.)                                      |
-| `terrain`          | `TerrainPlugin`             | Ground mesh generation                                                         |
-| `camera`           | `IsometricCameraPlugin`     | Isometric camera rig and controls                                              |
-| `tilemap`          | `TilemapPlugin`             | Tile-based map rendering                                                       |
-| `player`           | `PlayerPlugin`              | Local player spawning, movement, jump physics, input handling                  |
-| `object_registry`  | `ObjectRegistryPlugin`      | Shared object type registry                                                    |
-| `scene_objects`    | `SceneObjectsPlugin`        | Placeable world objects                                                        |
-| `trees`            | `TreesPlugin`               | Tree generation and rendering                                                  |
-| `water`            | `WaterPlugin`               | Water tiles and effects                                                        |
-| `inventory`        | `InventoryPlugin<ItemKind>` | 16-slot inventory system                                                       |
-| `weather`          | `WeatherPlugin`             | Weather effects                                                                |
-| `creatures`        | `CreaturesPlugin`           | NPC/mob spawning and AI (has submodules)                                       |
-| `virtual_joystick` | `VirtualJoystickPlugin`     | Touch/mobile joystick input                                                    |
-| `orb_hud`          | `OrbHudPlugin`              | Health/mana orb HUD                                                            |
-| `actions`          | `ActionsPlugin`             | Player action system                                                           |
-| `pixelate`         | `PixelatePlugin`            | Pixel-art post-processing shader                                               |
+| Module             | Plugin                                          | Purpose                                                    |
+| ------------------ | ----------------------------------------------- | ---------------------------------------------------------- |
+| `phase`            | `PhasePlugin`                                   | Game phase state machine (Title, Connecting, InGame)       |
+| `title_screen`     | `TitleScreenPlugin`                             | Title screen UI and Play Online button                     |
+| `net`              | `NetPlugin`                                     | Lightyear client, WS/WT transport, auth flow, replication  |
+| `state`            | `GameStatePlugin`                               | Player state tracking                                      |
+| `terrain`          | `TerrainPlugin`                                 | Ground mesh generation                                     |
+| `camera`           | `IsometricCameraPlugin`                         | Isometric camera rig and controls                          |
+| `tilemap`          | `TilemapPlugin`                                 | Tile-based map rendering and collision                     |
+| `player`           | `PlayerPlugin`                                  | Local player spawning, movement, jump physics, input       |
+| `object_registry`  | `ObjectRegistryPlugin`                          | Shared object type registry                                |
+| `scene_objects`    | `SceneObjectsPlugin`                            | World objects (rocks, flowers, mushrooms, trees)           |
+| `trees`            | `TreesPlugin`                                   | Tree generation and rendering                              |
+| `water`            | `WaterPlugin`                                   | Water tiles and effects                                    |
+| `inventory`        | `BevyItemsPlugin` + `InventoryPlugin<ItemKind>` | Proto-driven item database + 16-slot inventory             |
+| `weather`          | `WeatherPlugin`                                 | Weather effects, day/night cycle                           |
+| `creatures`        | `CreaturesPlugin`                               | Creature spawning and AI (frogs, fireflies)                |
+| `virtual_joystick` | `VirtualJoystickPlugin`                         | Touch/mobile joystick input                                |
+| `orb_hud`          | `OrbHudPlugin`                                  | Health/mana orb HUD                                        |
+| `actions`          | `ActionsPlugin`                                 | Player action dispatch (chop, mine, forage) with animation |
+| `pixelate`         | `PixelatePlugin`                                | Pixel-art post-processing shader                           |
 
-Additional modules without plugins: `grass`, `mushrooms`, `rocks`, `input_bridge`.
+Additional modules without plugins: `grass`, `mushrooms`, `rocks`, `input_bridge`, `hover_bvh`, `ui_color`, `telemetry`, `client_profile`.
+
+## Local Crate Dependencies
+
+| Crate            | Path                                | Purpose                                               |
+| ---------------- | ----------------------------------- | ----------------------------------------------------- |
+| `bevy_inventory` | `packages/rust/bevy/bevy_inventory` | Slot-based inventory system                           |
+| `bevy_items`     | `packages/rust/bevy/bevy_items`     | Proto-driven item database (with `inventory` feature) |
+| `bevy_cam`       | `packages/rust/bevy/bevy_cam`       | Camera utilities                                      |
+| `bevy_kbve_net`  | `packages/rust/bevy/bevy_kbve_net`  | Shared protocol types (with `npcdb` feature)          |
+| `bevy_tasker`    | `packages/rust/bevy/bevy_tasker`    | Async task bridge                                     |
 
 ## Networking Architecture
 
 - **Protocol crate**: `packages/rust/bevy/bevy_kbve_net` — shared types between client and server
 - **Server**: `apps/kbve/axum-kbve/src/gameserver/` — Bevy headless + lightyear server, runs inside axum via `std::thread::spawn`
-- **Replication**: lightyear handles component replication (`PlayerPosition`, `PlayerId`, `PlayerName`, etc.) with prediction and interpolation
+- **Transports**: WebSocket (`wss://`) primary, WebTransport (QUIC/UDP) when available
 - **Auth flow**: JWT token → `AuthMessage` → server validates → spawns replicated player entity
-- **Profile bridge**: Async channel (`std::sync::mpsc`) bridges Bevy (sync) and tokio (async) for database lookups (username, profiles)
+- **Profile bridge**: Async channel (`std::sync::mpsc`) bridges Bevy (sync) and tokio (async) for database lookups
 - **Player IDs**: FNV-1a hash of user identity string for stable IDs across sessions
 
-## Local Crate Dependencies
+## Item Database
 
-- `bevy_inventory` — `packages/rust/bevy/bevy_inventory`
-- `bevy_cam` — `packages/rust/bevy/bevy_cam`
-- `bevy_kbve_net` — `packages/rust/bevy/bevy_kbve_net` (protocol, shared types)
+Items are defined as MDX files in `apps/kbve/astro-kbve/src/content/docs/itemdb/` and baked into the binary at compile time via `include_str!()`.
+
+To regenerate after adding or changing items:
+
+```sh
+node apps/kbve/isometric/scripts/sync-itemdb.mjs
+```
+
+This reads MDX frontmatter and writes `src-tauri/src/data/itemdb.json`.
 
 ## Build & Run
 
@@ -76,6 +99,20 @@ All commands use Nx from the monorepo root (`./kbve.sh -nx` or `pnpm nx`):
 | `nx run isometric:build`       | Release WASM build + tsc + vite production build                   |
 | `nx run isometric:deploy`      | Build then copy `dist/` → `apps/kbve/astro-kbve/public/isometric/` |
 | `nx run isometric:build:tauri` | Tauri desktop build                                                |
+
+### Environment Variables
+
+| Variable           | Default                   | Purpose                                 |
+| ------------------ | ------------------------- | --------------------------------------- |
+| `GAME_SERVER_URL`  | `wss://127.0.0.1:5000`    | Override WebSocket server URL           |
+| `GAME_PRIVATE_KEY` | all zeros (dev)           | Hex-encoded 32-byte Netcode private key |
+| `GAME_WT_DIGEST`   | `certificates/digest.txt` | Path to WebTransport cert digest file   |
+
+### Connecting to production server (desktop)
+
+```sh
+GAME_SERVER_URL=wss://kbve.com/ws cargo run -p isometric-game
+```
 
 ### Manual WASM build
 
@@ -91,3 +128,4 @@ wasm-pack build --target web --out-dir ../wasm-pkg --out-name isometric_game
 - **Physics**: avian3d 0.5 with f32 precision
 - **Cargo package name**: `isometric-game` (hyphen, not underscore)
 - **Crate lib name**: `isometric_game` (underscore, for wasm-pack)
+- **Item system**: `ProtoItemKind` from `bevy_items` — backed by baked `itemdb.json`


### PR DESCRIPTION
## Summary
- Update README with current state: bevy_items integration, sync-itemdb script, env vars for server connection, all 5 local crate deps, full module table
- Add project MDX page at `/project/isometric/` for site discoverability

## Test plan
- [ ] README accurately reflects current mod.rs plugin list and Cargo.toml deps
- [ ] Project page renders correctly on astro-kbve build