### PR TITLE
fix(astro-kbve): remove stale import breaking Vite build

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -20,15 +20,6 @@ image: kbve/discordsh-bot
 deployment_yaml: apps/kube/discordsh-bot/manifest/deployment.yaml
 ---
 
-import {
-    Adsense,
-    MDXLayer,
-    Widget,
-    Heading,
-} from '@kbve/astro-ve';
-
-<MDXLayer title={frontmatter.title} description={frontmatter.description}>
-
 ## Overview
 
 `discordsh-bot` is the standalone Discord gateway bot extracted from the axum-discordsh monolith. It handles all Discord interactions independently of the HTTP server.
@@ -45,5 +36,3 @@ import {
 ### Related
 
 - [DiscordSH](/project/discordsh/) — HTTP server (Astro site, REST API)
-
-</MDXLayer>


### PR DESCRIPTION
## Summary
Fixes #9348

- Remove `@kbve/astro-ve` import from `discordsh-bot.mdx` — the package doesn't exist
- Remove `<MDXLayer>` wrapper — Starlight handles layout natively

The file was created from an older template that used custom components. All other project MDX files in this directory use plain markdown.

## Test plan
- [ ] `npx nx run astro-kbve:build` succeeds without Vite resolve error