### PR TITLE
chore(kubevirt): add ArgoCD application for download-proxy

### DIFF
--- a/apps/kube/kubevirt/download-proxy-application.yaml
+++ b/apps/kube/kubevirt/download-proxy-application.yaml
@@ -1,0 +1,35 @@
+# Download proxy for reliable VM downloads via aria2c.
+# No selfHeal — KEDA manages replicas (0 idle, 1 when jobs are queued).
+# Manual override: kubectl scale deploy download-proxy -n angelscript --replicas=1
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: kubevirt-download-proxy
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '3'
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: main
+        path: apps/kube/kubevirt/download-proxy
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: angelscript
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: false
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m
+    revisionHistoryLimit: 3


### PR DESCRIPTION
Deploys the download-proxy manifests via ArgoCD. selfHeal disabled so KEDA can manage replicas.