### PR TITLE
fix(discordsh-bot-e2e): add ci configuration for Docker-based e2e tests

### DIFF
--- a/apps/discordsh/discordsh-bot-e2e/project.json
+++ b/apps/discordsh/discordsh-bot-e2e/project.json
@@ -7,12 +7,21 @@
 	"targets": {
 		"e2e": {
 			"executor": "@nx/playwright:playwright",
+			"cache": false,
+			"defaultConfiguration": "local",
 			"options": {
 				"config": "apps/discordsh/discordsh-bot-e2e/playwright.config.ts"
+			},
+			"configurations": {
+				"local": {},
+				"ci": {
+					"config": "apps/discordsh/discordsh-bot-e2e/playwright.docker.config.ts"
+				}
 			}
 		},
 		"e2e:docker": {
 			"executor": "@nx/playwright:playwright",
+			"cache": false,
 			"options": {
 				"config": "apps/discordsh/discordsh-bot-e2e/playwright.docker.config.ts"
 			}


### PR DESCRIPTION
## Summary
The e2e `--configuration=ci` flag from `docker-test-app.yml` was falling back to the dev config (which runs `cargo run` — 2+ minute compile timeout on CI runners). Add a `ci` configuration to the `e2e` target that points to the Docker playwright config instead.

## Root cause
`docker-test-app.yml` runs `nx e2e discordsh-bot-e2e --configuration=ci`, but the project.json only had default options with no `ci` configuration. Nx ignored the unknown config and used the dev playwright config which starts a `cargo run` webServer.

## Fix
Add `configurations.ci` that uses `playwright.docker.config.ts` (runs the pre-built Docker image instead of compiling from source).

Ref #9286