### PR TITLE
docs(unreal): add macOS VM build pipeline stubs + workflow

### DIFF
--- a/.github/workflows/ci-ue-mac-setup.yml
+++ b/.github/workflows/ci-ue-mac-setup.yml
@@ -1,0 +1,68 @@
+# macOS KubeVirt VM Setup — install Xcode + UE build deps
+#
+# TODO(implement): This is a stub workflow for the macOS build pipeline.
+# Mirrors ci-ue-win-setup.yml but for macOS on KubeVirt.
+#
+# Prerequisites (not yet done):
+#   1. Provision macOS VM in KubeVirt (vm-macos-builder.yaml)
+#      - Upload BaseSystem.img via virtctl
+#      - Install macOS via VNC
+#      - Install GitHub Actions runner
+#   2. Apple hardware requirement — macOS VMs must run on Apple-branded hosts
+#      (Mac Pro, Mac Mini cluster node) per Apple EULA
+#   3. KEDA ScaledJob for UE5-Mac label already exists (scaled-jobs.yaml)
+#
+# Pipeline (when implemented):
+#   Job 1 (Linux runner): Stage downloads via download-proxy
+#     - Xcode .xip (requires Apple Developer account)
+#     - Command Line Tools .dmg
+#     - UE5 source (from KBVE/UnrealEngine-Angelscript)
+#   Job 2 (macOS VM runner): Install from staged files
+#     - xip -x Xcode.xip
+#     - xcode-select --install
+#     - Build UE5 from source (GenerateProjectFiles + xcodebuild)
+#
+# Challenges:
+#   - Xcode requires Apple ID auth for download (~13GB)
+#   - macOS VMs need GPU passthrough for Metal shader compilation
+#   - KubeVirt macOS networking uses same masquerade NAT (download-proxy needed)
+#   - OSX-KVM approach needs specific CPU feature flags (already in VM manifest)
+
+name: UE Mac Setup
+on:
+    workflow_dispatch:
+        inputs:
+            xcode_version:
+                description: 'Xcode version (e.g. 16.2)'
+                required: false
+                default: '16.2'
+# TODO: Uncomment and implement when macOS VM is provisioned
+# jobs:
+#   stage-downloads:
+#     name: Stage Downloads
+#     runs-on: arc-runner-set
+#     steps:
+#       - name: Scale up download proxy
+#         run: kubectl scale deploy download-proxy -n angelscript --replicas=1
+#
+#       - name: Wait for proxy
+#         run: kubectl wait --for=condition=Ready pod -l app=download-proxy -n angelscript --timeout=60s
+#
+#       - name: Stage Xcode CLI Tools
+#         run: |
+#           # TODO: Download Command Line Tools from Apple
+#           # Requires Apple Developer session cookie or API token
+#           echo "Staging Xcode CLI tools..."
+#
+#   install:
+#     name: Install on macOS VM
+#     runs-on: UE5-Mac
+#     needs: stage-downloads
+#     steps:
+#       - name: Install from staged files
+#         run: |
+#           # TODO: Install from download-proxy
+#           # curl http://download-proxy.angelscript.svc:8080/CommandLineTools.dmg -o /tmp/CLT.dmg
+#           # hdiutil attach /tmp/CLT.dmg
+#           # installer -pkg /Volumes/Command\ Line\ Tools/CommandLineTools.pkg -target /
+#           echo "Installing build tools..."

--- a/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/unreal.mdx
@@ -577,4 +577,61 @@ winget install --id Microsoft.VisualStudio.2022.BuildTools -e --source winget
     See [issue #9328](https://github.com/KBVE/kbve/issues/9328).
 </Aside>
 
+---
+
+## macOS VM Tooling (KubeVirt)
+
+<Aside type="caution" title="Apple EULA">
+    macOS VMs must run on genuine Apple hardware (Mac Pro, Mac Mini, etc.)
+    per Apple's EULA. Only deploy on Apple-branded physical hosts.
+</Aside>
+
+### Status: Not Yet Provisioned
+
+The macOS KubeVirt VM (`macos-builder`) manifest exists but hasn't been set up yet.
+Uses the [OSX-KVM](https://github.com/kholia/OSX-KVM) approach for KVM-based macOS.
+
+### Provisioning Checklist
+
+- [ ] Apple hardware node added to cluster (Mac Mini / Mac Pro with Talos)
+- [ ] Upload macOS install image via virtctl (`BaseSystem.img`)
+- [ ] Install macOS via VNC (`virtctl vnc macos-builder -n angelscript`)
+- [ ] Install Xcode + Command Line Tools
+- [ ] Install GitHub Actions runner (label: `UE5-Mac`)
+- [ ] Configure download-proxy access for large downloads
+- [ ] Test UE5 source build (`GenerateProjectFiles.sh` + `xcodebuild`)
+
+### Required Tools (inside macOS VM)
+
+| Tool | Purpose | Size |
+|------|---------|------|
+| Xcode | Metal shader compiler, iOS/macOS SDK | ~13GB |
+| Command Line Tools | `clang`, `make`, `git` without full Xcode | ~3GB |
+| Homebrew | Package manager for cmake, ninja, etc. | ~500MB |
+| GitHub Actions Runner | Self-hosted runner for CI jobs | ~200MB |
+
+### Xcode Installation (Offline via download-proxy)
+
+```bash
+# Stage Xcode .xip on the download proxy (from a machine with Apple ID auth)
+# Then inside the macOS VM:
+curl http://download-proxy.angelscript.svc:8080/Xcode_16.2.xip -o /tmp/Xcode.xip
+xip -x /tmp/Xcode.xip -C /Applications/
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+xcodebuild -license accept
+```
+
+### CI Workflow
+
+The `ci-ue-mac-setup.yml` workflow (stub) follows the same two-job pattern as Windows:
+1. **Linux runner**: stages downloads via download-proxy (aria2c)
+2. **macOS VM runner**: installs from staged files on the shared PVC
+
+### Challenges
+
+- Xcode download requires Apple Developer account authentication
+- Metal shader compilation needs GPU passthrough (not available on non-Apple hosts)
+- Same masquerade NAT issue as Windows — use download-proxy
+- OSX-KVM requires specific CPU feature flags (`invtsc`, `vmx`, `avx2` — already configured)
+
 <Giscus />


### PR DESCRIPTION
## Summary
- Stub `ci-ue-mac-setup.yml` workflow for macOS KubeVirt build pipeline
- Add macOS VM tooling section to unreal.mdx (provisioning checklist, tools, challenges)
- Documents the two-job CI pattern: Linux stages downloads → macOS VM installs

No functional changes — planning + documentation only.