### PR TITLE
chore(discordsh-bot): bump version to 0.1.1 to trigger first Docker publish

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
Bump MDX version from 0.1.0 to 0.1.1 so the CI version gate sees LOCAL > PUBLISHED and triggers the first Docker build + GHCR publish.

Ref #9286