### PR TITLE
feat(kilobase): sealed secret for forgejo DB role

### DIFF
--- a/apps/kube/kilobase/manifests/sealed-forgejo-db-credentials.yaml
+++ b/apps/kube/kilobase/manifests/sealed-forgejo-db-credentials.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: forgejo-db-credentials
+    namespace: kilobase
+spec:
+    encryptedData:
+        password: AgAWHzR+WLzRDiKjVM0jy8IQiGj0NccrQGLupdKv0qJrxhGyQ1W+SX9WYM0I8yCcuyjxCTvdIpQ26Q9OEybhzA6xy3YQhRCblrWt7+b3uuCJ4X2OAgkuD+MPp/XtuiiszR89Uocu7YAi2wLx1+5oik3fedtmFJRK1NP1ukezomWDkT9SlKehtGC50as9t22DjksIxicqf6J9YByKhX5hT5sAXvPkO4hX4VlwV+LolixWovy/W3eP5b5V4naNq70EHkJZwvz19kV9Ujpr4Uhl77LphebR1kn3tACnyqamR5ZD/wv9NBV26QZbxOuNZ8VQTj/I+162p2T9ndaLnbTFlvKjXnpeAvspEdaCh5hVu9uUoqGicz/+LMyI31hgw68j2vvoF4chnvupe2RASkQlbwkEqhPnonTlKylxhb0qyEqMmDMRJpZj70ygapRs46DvXsM/caUP7BSYJF6grknFCtd89vbWNOx5GktQyygZyU/fXaUM2s3GDcR8WWkWkZoPFb7WvL/KtSFOS8LIJbhQlJcm/XQEJWpKCvq0InLxZM4dXx8CMvSqqvebvh4gTfTZSYQSvdxYxJfu897V/SKcDOXW56D66CXPSu3snp5jgESeEt+u//HmbKrupK/IOV1ZedwK00lKH0McaJQvVg7B4xPGv0NZEPiIooayYEV4Lb5zeuinuZRTG7KZmUFQT0aEz9iIhbatygHZFwXv7FCKZYPnDozoTYmbL05U3lergh49wMaQwLrxdqsX
+    template:
+        metadata:
+            name: forgejo-db-credentials
+            namespace: kilobase

--- a/apps/kube/kilobase/seal-forgejo-db-credentials.sh
+++ b/apps/kube/kilobase/seal-forgejo-db-credentials.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# seal-forgejo-db-credentials.sh — Seal the Forgejo Postgres role password
+#
+# Pipeline that:
+#   1. Prompts for (or reads from env) the forgejo DB password
+#   2. Wraps it in a Kubernetes Secret (kubectl --dry-run)
+#   3. Encrypts it via kubeseal (cluster public key)
+#   4. Writes ONLY the SealedSecret YAML to the repo
+#
+# The plaintext password exists only in memory between pipe stages.
+# It never touches disk, shell history, or git.
+#
+# The ExternalSecret in the forgejo namespace reads from this secret
+# to inject FORGEJO__DATABASE__PASSWD at runtime.
+#
+# Prerequisites:
+#   - kubectl configured with cluster access
+#   - kubeseal installed (brew install kubeseal)
+#   - sealed-secrets-controller running in kube-system
+#
+# Usage:
+#   ./seal-forgejo-db-credentials.sh
+#   # or: FORGEJO_DB_PASSWORD=<value> ./seal-forgejo-db-credentials.sh
+#   # or: generate a random password automatically:
+#   FORGEJO_DB_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=' | head -c 40) \
+#     ./seal-forgejo-db-credentials.sh
+#
+# After sealing:
+#   1. Apply the dbmate migration (creates forgejo role)
+#   2. Set the role password: ALTER ROLE forgejo WITH PASSWORD '<same-password>';
+#   3. Commit + push the sealed secret — ArgoCD syncs it
+#   4. ExternalSecret picks up the password → Forgejo restarts with scoped role
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_FILE="${SCRIPT_DIR}/manifests/sealed-forgejo-db-credentials.yaml"
+TARGET_NS="kilobase"
+
+# --- Preflight checks ---
+
+for cmd in kubectl kubeseal; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is not installed or not in PATH" >&2
+        exit 1
+    fi
+done
+
+if ! kubectl cluster-info &>/dev/null; then
+    echo "Error: Cannot connect to Kubernetes cluster" >&2
+    exit 1
+fi
+
+if ! kubectl get deployment sealed-secrets-controller -n kube-system &>/dev/null; then
+    echo "Error: sealed-secrets-controller not found in kube-system namespace" >&2
+    exit 1
+fi
+
+# --- Get password ---
+
+if [[ -z "${FORGEJO_DB_PASSWORD:-}" ]]; then
+    echo -n "Enter Forgejo DB password (or set FORGEJO_DB_PASSWORD env): "
+    read -rs FORGEJO_DB_PASSWORD
+    echo
+fi
+
+if [[ -z "${FORGEJO_DB_PASSWORD}" ]]; then
+    echo "Error: Forgejo DB password cannot be empty" >&2
+    exit 1
+fi
+
+# --- Seal the password ---
+
+echo "Sealing Forgejo DB credentials into ${TARGET_NS} namespace..."
+
+echo -n "${FORGEJO_DB_PASSWORD}" \
+| kubectl create secret generic forgejo-db-credentials \
+    --namespace="${TARGET_NS}" \
+    --from-file=password=/dev/stdin \
+    --dry-run=client \
+    -o yaml \
+| kubeseal \
+    --controller-name=sealed-secrets-controller \
+    --controller-namespace=kube-system \
+    --format=yaml \
+> "${OUTPUT_FILE}"
+
+echo ""
+echo "Sealed secret written to: ${OUTPUT_FILE}"
+echo "Plaintext password was never written to disk."
+echo ""
+echo "Next steps:"
+echo "  1. git add ${OUTPUT_FILE}"
+echo "  2. Commit and push — ArgoCD will sync the SealedSecret to ${TARGET_NS}"
+echo "  3. Run dbmate migration to create the forgejo role"
+echo "  4. Set role password: psql -c \"ALTER ROLE forgejo WITH PASSWORD '<password>';\""
+echo "  5. ExternalSecret in forgejo namespace will pick up the password"


### PR DESCRIPTION
## Summary
Continues #8416

- **seal-forgejo-db-credentials.sh** — generates SealedSecret for the `forgejo` Postgres role password in `kilobase` namespace
- **sealed-forgejo-db-credentials.yaml** — encrypted secret, safe to commit
- Follows same pattern as valkey, clickhouse, n8n seal scripts

### Credential flow
```
kilobase/sealed-forgejo-db-credentials
  → unsealed by sealed-secrets-controller
  → kilobase/forgejo-db-credentials (plain Secret)
  → ExternalSecret reads from kilobase
  → forgejo/forgejo-db (injected as FORGEJO__DATABASE__PASSWD)
  → Forgejo connects as USER: forgejo
```

### Production deploy order
1. Merge this → ArgoCD syncs sealed secret to kilobase
2. Port-forward: `kubectl port-forward -n kilobase svc/supabase-cluster-rw 54322:5432`
3. `dbmate up` (creates forgejo role)
4. `ALTER ROLE forgejo WITH PASSWORD '<password>';`
5. ArgoCD syncs forgejo deployment (USER: forgejo already in dev)

## Test plan
- [x] `kubeseal` generates valid SealedSecret
- [x] Namespace and secret name match ExternalSecret `remoteRef`
- [ ] ArgoCD syncs sealed secret after merge to main
- [ ] Forgejo restarts with scoped role after full deploy