### PR TITLE
fix(ci): add stub job to ci-ue-mac-setup.yml

### DIFF
--- a/.github/workflows/ci-ue-mac-setup.yml
+++ b/.github/workflows/ci-ue-mac-setup.yml
@@ -36,8 +36,14 @@ on:
                 description: 'Xcode version (e.g. 16.2)'
                 required: false
                 default: '16.2'
-# TODO: Uncomment and implement when macOS VM is provisioned
-# jobs:
+jobs:
+    stub:
+        name: macOS Setup (not yet implemented)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Stub
+              run: echo "macOS VM not yet provisioned — see workflow comments for implementation plan"
+# TODO: Uncomment and replace stub when macOS VM is provisioned
 #   stage-downloads:
 #     name: Stage Downloads
 #     runs-on: arc-runner-set


### PR DESCRIPTION
Workflow had no `jobs:` key — entire section was commented out. GitHub Actions requires at least one job. Added stub until macOS VM is provisioned.