### PR TITLE
feat(dashboard): add interactive VNC viewer for KubeVirt VMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tower",
  "tower-http",
  "tracing",
@@ -15094,6 +15095,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
 						{ label: 'Edge', link: '/dashboard/edge/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'Forgejo', link: '/dashboard/forgejo/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'Grafana', link: '/dashboard/grafana/', attrs: { 'data-auth-visibility': 'staff' } },
+						{ label: 'Virtual Machines', link: '/dashboard/vm/', attrs: { 'data-auth-visibility': 'staff' } },
 					],
 				},
 				{

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -1,94 +1,103 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import { vmService } from './vmService';
-import { X, Maximize2, Minimize2 } from 'lucide-react';
-import { useState } from 'react';
+import { X, Maximize2, Minimize2, Keyboard } from 'lucide-react';
+
+// noVNC RFB client — handles the full VNC/RFB protocol over WebSocket
+// including framebuffer rendering, keyboard, and mouse forwarding.
+// @ts-expect-error — noVNC ships without TypeScript declarations
+import RFB from '@novnc/novnc/core/rfb';
 
 export default function ReactVMVncViewer() {
 	const vncTarget = useStore(vmService.$vncTarget);
-	const accessToken = useStore(vmService.$accessToken);
-	const canvasRef = useRef<HTMLCanvasElement>(null);
-	const wsRef = useRef<WebSocket | null>(null);
+	const rfbRef = useRef<InstanceType<typeof RFB> | null>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const viewerRef = useRef<HTMLDivElement>(null);
 	const [fullscreen, setFullscreen] = useState(false);
 	const [connected, setConnected] = useState(false);
 	const [status, setStatus] = useState('Connecting...');
-	const containerRef = useRef<HTMLDivElement>(null);
+	const [keyboardVisible, setKeyboardVisible] = useState(false);
 
 	const cleanup = useCallback(() => {
-		if (wsRef.current) {
-			wsRef.current.close();
-			wsRef.current = null;
+		if (rfbRef.current) {
+			rfbRef.current.disconnect();
+			rfbRef.current = null;
 		}
 		setConnected(false);
 		setStatus('Disconnected');
 	}, []);
 
 	useEffect(() => {
-		if (!vncTarget || !accessToken) {
+		if (!vncTarget) {
 			cleanup();
 			return;
 		}
 
+		const target = viewerRef.current;
+		if (!target) return;
+
+		// Clear previous content
+		target.innerHTML = '';
+
 		const wsUrl = vmService.getVNCWebSocketURL(vncTarget);
 		setStatus('Connecting...');
 
-		const ws = new WebSocket(wsUrl, ['base64.binary.k8s.io']);
-		wsRef.current = ws;
+		try {
+			const rfb = new RFB(target, wsUrl, {
+				wsProtocols: ['binary.k8s.io', 'base64.binary.k8s.io'],
+			});
 
-		ws.binaryType = 'arraybuffer';
+			rfb.scaleViewport = true;
+			rfb.resizeSession = false;
+			rfb.clipViewport = false;
+			rfb.showDotCursor = true;
+			rfb.qualityLevel = 6;
+			rfb.compressionLevel = 2;
 
-		ws.onopen = () => {
-			setConnected(true);
-			setStatus(`Connected to ${vncTarget}`);
-		};
+			rfb.addEventListener('connect', () => {
+				setConnected(true);
+				setStatus(`Connected to ${vncTarget}`);
+			});
 
-		ws.onclose = () => {
-			setConnected(false);
-			setStatus('Connection closed');
-		};
-
-		ws.onerror = () => {
-			setConnected(false);
-			setStatus('Connection error — VNC may not be available');
-		};
-
-		ws.onmessage = (event) => {
-			// Raw VNC/RFB frames — for a full implementation you would use
-			// a noVNC library here. This minimal viewer renders a placeholder
-			// with connection status. To get full interactive VNC, integrate
-			// @novnc/novnc or a similar library.
-			const canvas = canvasRef.current;
-			if (!canvas) return;
-			const ctx = canvas.getContext('2d');
-			if (!ctx) return;
-
-			// Draw a simple "connected" indicator
-			ctx.fillStyle = '#0a0a0a';
-			ctx.fillRect(0, 0, canvas.width, canvas.height);
-			ctx.fillStyle = '#22c55e';
-			ctx.font = '14px monospace';
-			ctx.fillText(`VNC stream active — ${vncTarget}`, 20, 30);
-			ctx.fillStyle = '#8b949e';
-			ctx.font = '11px monospace';
-			ctx.fillText('Receiving framebuffer data...', 20, 50);
-			ctx.fillText(
-				'Full noVNC integration renders interactive desktop here.',
-				20,
-				70,
+			rfb.addEventListener(
+				'disconnect',
+				(e: { detail: { clean: boolean } }) => {
+					setConnected(false);
+					setStatus(
+						e.detail.clean
+							? 'Disconnected cleanly'
+							: 'Connection lost — VM may have stopped',
+					);
+					rfbRef.current = null;
+				},
 			);
-		};
+
+			rfb.addEventListener('securityfailure', () => {
+				setStatus('Security handshake failed');
+			});
+
+			rfbRef.current = rfb;
+		} catch (err) {
+			setStatus(
+				`Failed to connect: ${err instanceof Error ? err.message : 'Unknown error'}`,
+			);
+		}
 
 		return cleanup;
-	}, [vncTarget, accessToken, cleanup]);
+	}, [vncTarget, cleanup]);
 
-	// Handle keyboard events
-	const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-		if (e.key === 'Escape') {
-			vmService.closeVNC();
-		}
-		// In a full noVNC implementation, key events would be forwarded
-		// to the VM via the WebSocket connection
+	// Ctrl+Alt+Del sender
+	const sendCtrlAltDel = useCallback(() => {
+		rfbRef.current?.sendCtrlAltDel();
 	}, []);
+
+	// Toggle virtual keyboard (mobile/tablet)
+	const toggleKeyboard = useCallback(() => {
+		if (rfbRef.current) {
+			rfbRef.current.focusOnClick = !keyboardVisible;
+			setKeyboardVisible(!keyboardVisible);
+		}
+	}, [keyboardVisible]);
 
 	if (!vncTarget) return null;
 
@@ -96,8 +105,6 @@ export default function ReactVMVncViewer() {
 		<div
 			ref={containerRef}
 			className="not-content"
-			onKeyDown={handleKeyDown}
-			tabIndex={0}
 			style={{
 				position: fullscreen ? 'fixed' : 'relative',
 				top: fullscreen ? 0 : undefined,
@@ -143,66 +150,56 @@ export default function ReactVMVncViewer() {
 					</span>
 				</div>
 				<div style={{ display: 'flex', gap: 4 }}>
-					<button
-						onClick={() => setFullscreen(!fullscreen)}
-						style={{
-							display: 'flex',
-							alignItems: 'center',
-							padding: 4,
-							borderRadius: 4,
-							border: 'none',
-							background: 'transparent',
-							color: 'var(--sl-color-gray-3, #8b949e)',
-							cursor: 'pointer',
-						}}>
+					{connected && (
+						<>
+							<ToolbarButton
+								title="Send Ctrl+Alt+Del"
+								onClick={sendCtrlAltDel}>
+								<span
+									style={{
+										fontSize: '0.6rem',
+										fontWeight: 700,
+									}}>
+									CAD
+								</span>
+							</ToolbarButton>
+							<ToolbarButton
+								title="Toggle keyboard"
+								onClick={toggleKeyboard}>
+								<Keyboard size={14} />
+							</ToolbarButton>
+						</>
+					)}
+					<ToolbarButton
+						title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+						onClick={() => setFullscreen(!fullscreen)}>
 						{fullscreen ? (
 							<Minimize2 size={14} />
 						) : (
 							<Maximize2 size={14} />
 						)}
-					</button>
-					<button
+					</ToolbarButton>
+					<ToolbarButton
+						title="Close VNC"
 						onClick={() => vmService.closeVNC()}
-						style={{
-							display: 'flex',
-							alignItems: 'center',
-							padding: 4,
-							borderRadius: 4,
-							border: 'none',
-							background: 'transparent',
-							color: '#ef4444',
-							cursor: 'pointer',
-						}}>
+						color="#ef4444">
 						<X size={14} />
-					</button>
+					</ToolbarButton>
 				</div>
 			</div>
 
-			{/* Canvas */}
+			{/* noVNC renders into this container */}
 			<div
+				ref={viewerRef}
 				style={{
 					flex: 1,
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
 					minHeight: fullscreen ? undefined : 480,
-					padding: '1rem',
-				}}>
-				<canvas
-					ref={canvasRef}
-					width={1024}
-					height={768}
-					style={{
-						maxWidth: '100%',
-						maxHeight: '100%',
-						borderRadius: 4,
-						background: '#0a0a0a',
-						cursor: connected ? 'default' : 'not-allowed',
-					}}
-				/>
-			</div>
+					background: '#0a0a0a',
+					cursor: connected ? 'default' : 'not-allowed',
+				}}
+			/>
 
-			{/* Hint */}
+			{/* Status bar */}
 			<div
 				style={{
 					padding: '0.4rem 1rem',
@@ -211,9 +208,40 @@ export default function ReactVMVncViewer() {
 					color: 'var(--sl-color-gray-3, #8b949e)',
 					textAlign: 'center',
 				}}>
-				Press Escape to close · Full noVNC integration renders
-				interactive desktop with keyboard and mouse forwarding
+				{connected
+					? 'Click inside to capture keyboard · Ctrl+Alt+Del via toolbar'
+					: 'Waiting for VNC connection...'}
 			</div>
 		</div>
+	);
+}
+
+function ToolbarButton({
+	title,
+	onClick,
+	color,
+	children,
+}: {
+	title: string;
+	onClick: () => void;
+	color?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			title={title}
+			onClick={onClick}
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				padding: 4,
+				borderRadius: 4,
+				border: 'none',
+				background: 'transparent',
+				color: color ?? 'var(--sl-color-gray-3, #8b949e)',
+				cursor: 'pointer',
+			}}>
+			{children}
+		</button>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
@@ -488,9 +488,9 @@ class VMService {
 	}
 
 	public getVNCWebSocketURL(name: string): string {
-		// Build WebSocket URL for noVNC
+		// Dedicated VNC WebSocket bridge — axum handles auth + upstream relay
 		const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-		return `${proto}//${window.location.host}${PROXY_BASE}/apis/subresources.kubevirt.io/v1/namespaces/${VM_NAMESPACE}/virtualmachineinstances/${name}/vnc`;
+		return `${proto}//${window.location.host}/dashboard/vm/vnc/${name}`;
 	}
 
 	private _startAutoRefresh(): void {

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -69,6 +69,7 @@ rand = "0.9"
 lightyear_avian3d = { version = "0.26", default-features = false, features = ["3d"] }
 bevy_kbve_net = { path = "../../../packages/rust/bevy/bevy_kbve_net", features = ["npcdb"] }
 futures-util = "0.3"
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi" }

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -230,6 +230,10 @@ fn router(state: AppState) -> Router {
             any(super::proxy::kubevirt_proxy_handler),
         )
         .route(
+            "/dashboard/vm/vnc/{name}",
+            axum::routing::get(super::proxy::kubevirt_vnc_handler),
+        )
+        .route(
             "/dashboard/edge/proxy/{*path}",
             any(super::proxy::edge_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -582,6 +582,154 @@ pub async fn kubevirt_proxy_handler(path: Option<Path<String>>, req: Request<Bod
 }
 
 // ---------------------------------------------------------------------------
+// KubeVirt VNC WebSocket bridge
+// ---------------------------------------------------------------------------
+// Upgrades the browser connection to WebSocket and opens an upstream WebSocket
+// to the KubeVirt VNC subresource, then relays frames bidirectionally.
+// This enables interactive noVNC sessions from the dashboard.
+
+pub async fn kubevirt_vnc_handler(
+    Path(vm_name): Path<String>,
+    ws: axum::extract::ws::WebSocketUpgrade,
+    req: Request<Body>,
+) -> Response {
+    let headers = req.headers().clone();
+
+    // Auth gate — staff only
+    if let Err(resp) = require_dashboard_view(&headers, "KubeVirt-VNC").await {
+        return resp;
+    }
+
+    let kubevirt = match KUBEVIRT.get() {
+        Some(k) => k,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({"error": "KubeVirt proxy not configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    // Sanitize VM name — alphanumeric + hyphens only
+    if !vm_name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-')
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({"error": "Invalid VM name"})),
+        )
+            .into_response();
+    }
+
+    let upstream_url = format!(
+        "{}/apis/subresources.kubevirt.io/v1/namespaces/{}/virtualmachineinstances/{}/vnc",
+        kubevirt.upstream, VM_NAMESPACE, vm_name
+    );
+    let upstream_token = kubevirt.upstream_token.clone();
+
+    // Accept the WebSocket upgrade and spawn the bridge
+    ws.protocols(["binary.k8s.io", "base64.binary.k8s.io"])
+        .on_upgrade(move |browser_ws| async move {
+            if let Err(e) = vnc_bridge(browser_ws, &upstream_url, upstream_token.as_deref()).await {
+                warn!("VNC bridge error for {vm_name}: {e}");
+            }
+        })
+}
+
+/// Bidirectional WebSocket bridge between the browser and KubeVirt VNC.
+async fn vnc_bridge(
+    browser_ws: axum::extract::ws::WebSocket,
+    upstream_url: &str,
+    token: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use axum::extract::ws::Message as AxumMsg;
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::{Message as TungMsg, client::IntoClientRequest};
+
+    // Build upstream request with auth + subprotocol
+    let ws_url = upstream_url
+        .replace("https://", "wss://")
+        .replace("http://", "ws://");
+    let mut request = ws_url.into_client_request()?;
+    if let Some(t) = token {
+        request
+            .headers_mut()
+            .insert("Authorization", format!("Bearer {t}").parse()?);
+    }
+    request
+        .headers_mut()
+        .insert("Sec-WebSocket-Protocol", "base64.binary.k8s.io".parse()?);
+
+    // Connect to K8s API VNC subresource
+    let (upstream_ws, _resp) =
+        tokio_tungstenite::connect_async_tls_with_config(request, None, false, None).await?;
+
+    // Split both sides into sender/receiver
+    let (mut browser_tx, mut browser_rx) = browser_ws.split();
+    let (mut upstream_tx, mut upstream_rx) = upstream_ws.split();
+
+    // Browser → K8s
+    let browser_to_upstream = async {
+        while let Some(msg) = browser_rx.next().await {
+            match msg {
+                Ok(AxumMsg::Binary(data)) => {
+                    if upstream_tx
+                        .send(TungMsg::Binary(data.into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Ok(AxumMsg::Text(text)) => {
+                    let s: String = text.to_string();
+                    if upstream_tx.send(TungMsg::Text(s.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Ok(AxumMsg::Close(_)) | Err(_) => break,
+                _ => {}
+            }
+        }
+        let _ = upstream_tx.close().await;
+    };
+
+    // K8s → Browser
+    let upstream_to_browser = async {
+        while let Some(msg) = upstream_rx.next().await {
+            match msg {
+                Ok(TungMsg::Binary(data)) => {
+                    if browser_tx.send(AxumMsg::Binary(data.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Ok(TungMsg::Text(text)) => {
+                    let s: String = text.to_string();
+                    if browser_tx.send(AxumMsg::Text(s.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Ok(TungMsg::Close(_)) | Err(_) => break,
+                _ => {}
+            }
+        }
+        let _ = browser_tx.close().await;
+    };
+
+    // Run both directions concurrently — when either ends, the other stops
+    tokio::select! {
+        _ = browser_to_upstream => {},
+        _ = upstream_to_browser => {},
+    }
+
+    Ok(())
+}
+
+const VM_NAMESPACE: &str = "angelscript";
+
+// ---------------------------------------------------------------------------
 // Edge Functions proxy singleton (Supabase → internal Kong)
 // ---------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 		"@gsap/react": "^2.1.2",
 		"@hcaptcha/react-hcaptcha": "^2.0.2",
 		"@hookform/resolvers": "^5.2.2",
+		"@novnc/novnc": "^1.6.0",
 		"@peculiar/webcrypto": "^1.5.0",
 		"@phaserjs/rapier-connector": "^1.0.2",
 		"@react-three/drei": "^10.7.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
             '@hookform/resolvers':
                 specifier: ^5.2.2
                 version: 5.2.2(react-hook-form@7.55.0(react@19.2.4))
+            '@novnc/novnc':
+                specifier: ^1.6.0
+                version: 1.6.0
             '@peculiar/webcrypto':
                 specifier: ^1.5.0
                 version: 1.5.0
@@ -5091,6 +5094,12 @@ packages:
                 integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
             }
         engines: { node: '>= 8' }
+
+    '@novnc/novnc@1.6.0':
+        resolution:
+            {
+                integrity: sha512-CJrmdSe9Yt2ZbLsJpVFoVkEu0KICEvnr3njW25Nz0jodaiFJtg8AYLGZogRYy0/N5HUWkGUsCmegKXYBSqwygw==,
+            }
 
     '@nx-tools/ci-context@7.2.1':
         resolution:
@@ -30478,6 +30487,8 @@ snapshots:
         dependencies:
             '@nodelib/fs.scandir': 2.1.5
             fastq: 1.17.1
+
+    '@novnc/novnc@1.6.0': {}
 
     '@nx-tools/ci-context@7.2.1(@nx/devkit@22.6.1(nx@22.6.1(@swc-node/register@1.11.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18))))(tslib@2.8.1)':
         dependencies:


### PR DESCRIPTION
## Summary
Adds a full interactive VNC remote desktop viewer to the dashboard, enabling staff to control KubeVirt Windows/macOS builder VMs directly from kbve.com/dashboard/vm/.

## Architecture

```
Browser (noVNC RFB client)
  │ wss://kbve.com/dashboard/vm/vnc/{name}
  ▼
Axum WebSocket bridge (JWT + DASHBOARD_VIEW auth)
  │ wss://kubernetes-api:6443/.../vnc
  ▼
KubeVirt API → virt-handler → QEMU VNC
```

## Backend Changes (axum-kbve)
- New `GET /dashboard/vm/vnc/{name}` WebSocket endpoint
- JWT + `DASHBOARD_VIEW` staff permission gate (same as other dashboard proxies)
- Bidirectional WebSocket relay via `tokio::select!` — browser frames → K8s, K8s frames → browser
- VM name sanitization (alphanumeric + hyphens only)
- Added `tokio-tungstenite` with rustls for upstream K8s WebSocket client

## Frontend Changes (astro-kbve)
- `ReactVMVncViewer.tsx` rewritten with `@novnc/novnc` RFB client (replaces placeholder canvas)
- Full interactive desktop: keyboard, mouse, clipboard forwarding
- Toolbar: Ctrl+Alt+Del button, virtual keyboard toggle, fullscreen mode
- Scale-to-fit viewport with quality/compression tuning
- `vmService.ts` VNC URL updated to use dedicated `/vnc/` route

## Navigation
- VM dashboard added to sidebar under Dashboard → Virtual Machines (staff-only)

## Test plan
- [ ] Verify `cargo check -p axum-kbve` passes
- [ ] Visit /dashboard/vm/ as staff user — VM cards should render
- [ ] Click VNC on a running VM — noVNC viewer should connect and render desktop
- [ ] Test Ctrl+Alt+Del button, fullscreen toggle, close button
- [ ] Verify non-staff users get 403 on VNC WebSocket
- [ ] Verify invalid VM names get 400