### PR TITLE
feat(dashboard): add KEDA race guard for VM stop/restart actions

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMCards.tsx
@@ -20,6 +20,9 @@ import {
 	Monitor,
 	Apple,
 	Network,
+	Bot,
+	Clock,
+	ShieldAlert,
 } from 'lucide-react';
 
 function OSIcon({ osType }: { osType: VMInfo['osType'] }) {
@@ -261,6 +264,80 @@ function VMCard({ info }: { info: VMInfo }) {
 						{vmi.status.guestOSInfo.prettyName}
 					</div>
 				)}
+
+				{/* KEDA runner banner */}
+				{info.isKedaManaged && isRunning && (
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'flex-start',
+							gap: 8,
+							padding: '0.5rem 0.75rem',
+							borderRadius: 8,
+							fontSize: '0.7rem',
+							lineHeight: 1.4,
+							marginBottom: 10,
+							...(info.mayHaveActiveJob
+								? {
+										background: 'rgba(245, 158, 11, 0.1)',
+										border: '1px solid rgba(245, 158, 11, 0.3)',
+										color: '#f59e0b',
+									}
+								: {
+										background: 'rgba(6, 182, 212, 0.08)',
+										border: '1px solid rgba(6, 182, 212, 0.2)',
+										color: '#06b6d4',
+									}),
+						}}>
+						{info.mayHaveActiveJob ? (
+							<ShieldAlert
+								size={14}
+								style={{ flexShrink: 0, marginTop: 1 }}
+							/>
+						) : (
+							<Bot
+								size={14}
+								style={{ flexShrink: 0, marginTop: 1 }}
+							/>
+						)}
+						<div>
+							<div style={{ fontWeight: 600 }}>
+								{info.mayHaveActiveJob
+									? 'Possible active CI job'
+									: 'KEDA auto-managed'}
+							</div>
+							<div style={{ opacity: 0.85 }}>
+								{info.runnerLabel && (
+									<span>
+										Runner:{' '}
+										<code style={{ fontSize: '0.65rem' }}>
+											{info.runnerLabel}
+										</code>{' '}
+										·{' '}
+									</span>
+								)}
+								{info.uptimeMinutes !== undefined && (
+									<span>
+										<Clock
+											size={10}
+											style={{
+												display: 'inline',
+												verticalAlign: 'middle',
+											}}
+										/>{' '}
+										Up {info.uptimeMinutes}m
+									</span>
+								)}
+								{info.mayHaveActiveJob && (
+									<span>
+										{' '}
+										· Stopping may kill an in-progress build
+									</span>
+								)}
+							</div>
+						</div>
+					</div>
+				)}
 			</div>
 
 			{/* Actions */}
@@ -289,7 +366,15 @@ function VMCard({ info }: { info: VMInfo }) {
 							color="#ef4444"
 							loading={currentAction === 'stop'}
 							disabled={!!currentAction}
-							onClick={() => vmService.stopVM(name)}
+							onClick={() => {
+								if (info.mayHaveActiveJob) {
+									const ok = window.confirm(
+										`⚠️ ${name} may be running a GitHub Actions build job (uptime: ${info.uptimeMinutes}m, runner: ${info.runnerLabel ?? 'unknown'}).\n\nStopping this VM will kill any in-progress CI jobs.\n\nAre you sure?`,
+									);
+									if (!ok) return;
+								}
+								vmService.stopVM(name);
+							}}
 						/>
 						<ActionButton
 							icon={<RotateCw size={13} />}
@@ -297,7 +382,15 @@ function VMCard({ info }: { info: VMInfo }) {
 							color="#f59e0b"
 							loading={currentAction === 'restart'}
 							disabled={!!currentAction}
-							onClick={() => vmService.restartVM(name)}
+							onClick={() => {
+								if (info.mayHaveActiveJob) {
+									const ok = window.confirm(
+										`⚠️ ${name} may be running a GitHub Actions build job.\n\nRestarting will kill any in-progress CI jobs.\n\nAre you sure?`,
+									);
+									if (!ok) return;
+								}
+								vmService.restartVM(name);
+							}}
 						/>
 						<ActionButton
 							icon={<Monitor size={13} />}

--- a/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
@@ -122,6 +122,14 @@ export interface VMInfo {
 	vmi?: VirtualMachineInstance;
 	phase: VMPhase;
 	osType: 'windows' | 'macos' | 'linux' | 'unknown';
+	/** Minutes since VMI started — undefined if not running */
+	uptimeMinutes?: number;
+	/** Runner label from VM labels (e.g. "UE5-Win") — signals KEDA-managed */
+	runnerLabel?: string;
+	/** True if the VM is KEDA-managed (has a runner label) */
+	isKedaManaged: boolean;
+	/** True if uptime is under the idle timeout — a job may be active */
+	mayHaveActiveJob: boolean;
 }
 
 interface CachedData {
@@ -348,11 +356,42 @@ class VMService {
 				const vmi = vmis.find(
 					(i) => i.metadata.name === vm.metadata.name,
 				);
+				const phase = getPhase(vm, vmi);
+
+				// Runner label detection — VMs managed by KEDA have a runner label
+				const labels = vm.metadata.labels ?? {};
+				const runnerLabel =
+					labels['runner'] ??
+					labels['github-actions-runner'] ??
+					labels['actions-runner'] ??
+					undefined;
+				const isKedaManaged = !!runnerLabel;
+
+				// Uptime calculation from VMI creation timestamp
+				let uptimeMinutes: number | undefined;
+				if (vmi?.metadata.creationTimestamp && phase === 'Running') {
+					const created = new Date(
+						vmi.metadata.creationTimestamp,
+					).getTime();
+					uptimeMinutes = Math.floor((Date.now() - created) / 60000);
+				}
+
+				// A KEDA-managed VM running for < 30 min likely has an active job
+				const mayHaveActiveJob =
+					isKedaManaged &&
+					phase === 'Running' &&
+					uptimeMinutes !== undefined &&
+					uptimeMinutes < 30;
+
 				return {
 					vm,
 					vmi,
-					phase: getPhase(vm, vmi),
+					phase,
 					osType: detectOS(vm),
+					uptimeMinutes,
+					runnerLabel,
+					isKedaManaged,
+					mayHaveActiveJob,
 				};
 			}),
 	);


### PR DESCRIPTION
## Summary
Prevents staff from accidentally stopping a KubeVirt VM while a GitHub Actions CI job may be running on it.

## Problem
Race condition: User A opens VNC to a running VM → User B commits code → GitHub Actions queues a `UE5-Win` job → KEDA VM is already running so the job starts immediately → User A finishes VNC and clicks Stop → **Build killed mid-run**.

## Solution

### Detection (`vmService.ts`)
- `VMInfo` now computes `uptimeMinutes` from VMI creation timestamp
- Detects KEDA-managed VMs via `runner` / `github-actions-runner` / `actions-runner` labels
- `mayHaveActiveJob = isKedaManaged && phase === 'Running' && uptimeMinutes < 30` — matches the idle shutdown CronJob threshold

### Visual Warning (`ReactVMCards.tsx`)
- **Amber banner** when `mayHaveActiveJob`: "Possible active CI job — Stopping may kill an in-progress build"
- **Cyan banner** when KEDA-managed but idle (uptime > 30m): "KEDA auto-managed"
- Shows runner label (e.g. `UE5-Win`), uptime in minutes

### Stop Guard
- **Stop/Restart** buttons trigger a `window.confirm()` dialog when `mayHaveActiveJob` is true
- Dialog warns: "This VM may be running a GitHub Actions build job. Stopping will kill in-progress CI jobs."
- Start and VNC buttons remain unguarded (safe operations)

## Scenarios

| Scenario | Behavior |
|----------|----------|
| VM running < 30m, KEDA label | Amber banner + confirm on stop |
| VM running > 30m, KEDA label | Cyan banner, no confirm (idle timeout will handle it) |
| VM running, no KEDA label | No banner, no confirm (manually managed) |
| VM stopped | Start button only, no guard needed |

## Test plan
- [ ] Verify KEDA-managed VMs show runner banner when running
- [ ] Verify amber warning appears for VMs with uptime < 30m
- [ ] Verify stop button shows confirm dialog when `mayHaveActiveJob`
- [ ] Verify clicking Cancel on confirm does NOT stop the VM
- [ ] Verify non-KEDA VMs have no banner or confirm guard