### PR TITLE
feat(kubevirt): add Guacamole RDP gateway for Windows VM

### DIFF
--- a/apps/kube/kubevirt/guacamole-application.yaml
+++ b/apps/kube/kubevirt/guacamole-application.yaml
@@ -1,0 +1,34 @@
+# Guacamole — browser-based RDP gateway for KubeVirt Windows VMs.
+# No selfHeal — KEDA manages replicas.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: kubevirt-guacamole
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '3'
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: main
+        path: apps/kube/kubevirt/guacamole
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: angelscript
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: false
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m
+    revisionHistoryLimit: 3

--- a/apps/kube/kubevirt/guacamole/deployment.yaml
+++ b/apps/kube/kubevirt/guacamole/deployment.yaml
@@ -1,0 +1,168 @@
+# Apache Guacamole — browser-based RDP gateway for KubeVirt Windows VMs.
+#
+# Architecture:
+#   Browser → Ingress (TLS) → guacamole (web) → guacd (proxy) → ClusterIP → VM RDP (3389)
+#
+# RDP is NEVER exposed publicly. Guacamole is the single audited entry point.
+# KEDA manages replicas: 0 when idle, 1 when VM is running.
+#
+# Components:
+#   - guacd: protocol proxy daemon (translates web → RDP/VNC/SSH)
+#   - guacamole: web frontend (Tomcat + auth + connection management)
+#   - PostgreSQL: stores connections, users, history (uses existing Supabase cluster)
+#
+# Setup (one-time after deploy):
+#   1. Access Guacamole at https://guac.kbve.com/guacamole/
+#   2. Default login: guacadmin / guacadmin (CHANGE IMMEDIATELY)
+#   3. Add RDP connection:
+#      - Protocol: RDP
+#      - Hostname: windows-builder-rdp.angelscript.svc.cluster.local
+#      - Port: 3389
+#      - Username: <Windows admin user>
+#      - Password: <from sealed secret>
+#   4. Test connection from browser
+---
+# guacd — protocol proxy daemon
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: guacd
+    namespace: angelscript
+    labels:
+        app: guacd
+        component: guacamole
+spec:
+    replicas: 0
+    selector:
+        matchLabels:
+            app: guacd
+    template:
+        metadata:
+            labels:
+                app: guacd
+                component: guacamole
+        spec:
+            containers:
+                - name: guacd
+                  image: guacamole/guacd:1.5.5
+                  ports:
+                      - containerPort: 4822
+                        name: guacd
+                        protocol: TCP
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 256Mi
+                      limits:
+                          cpu: '2'
+                          memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: guacd
+    namespace: angelscript
+    labels:
+        app: guacd
+        component: guacamole
+spec:
+    selector:
+        app: guacd
+    ports:
+        - port: 4822
+          targetPort: 4822
+          name: guacd
+          protocol: TCP
+---
+# guacamole — web frontend
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: guacamole
+    namespace: angelscript
+    labels:
+        app: guacamole
+        component: guacamole
+spec:
+    replicas: 0
+    selector:
+        matchLabels:
+            app: guacamole
+    template:
+        metadata:
+            labels:
+                app: guacamole
+                component: guacamole
+        spec:
+            containers:
+                - name: guacamole
+                  image: guacamole/guacamole:1.5.5
+                  env:
+                      - name: GUACD_HOSTNAME
+                        value: guacd.angelscript.svc.cluster.local
+                      - name: GUACD_PORT
+                        value: '4822'
+                      # TODO(db): Switch to PostgreSQL for production
+                      # For initial testing, use user-mapping.xml (initdb not needed)
+                      # Production: set POSTGRESQL_HOSTNAME, POSTGRESQL_DATABASE, etc.
+                      # and run the initdb.sh script to create the schema
+                  ports:
+                      - containerPort: 8080
+                        name: http
+                        protocol: TCP
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 256Mi
+                      limits:
+                          cpu: '1'
+                          memory: 512Mi
+                  # TODO(user-mapping): Mount a ConfigMap with user-mapping.xml for initial testing:
+                  #   <user-mapping>
+                  #     <authorize username="admin" password="<hash>" encoding="sha256">
+                  #       <connection name="Windows Builder">
+                  #         <protocol>rdp</protocol>
+                  #         <param name="hostname">windows-builder-rdp.angelscript.svc.cluster.local</param>
+                  #         <param name="port">3389</param>
+                  #         <param name="username">Administrator</param>
+                  #         <param name="security">nla</param>
+                  #         <param name="ignore-cert">true</param>
+                  #       </connection>
+                  #     </authorize>
+                  #   </user-mapping>
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: guacamole
+    namespace: angelscript
+    labels:
+        app: guacamole
+        component: guacamole
+spec:
+    selector:
+        app: guacamole
+    ports:
+        - port: 8080
+          targetPort: 8080
+          name: http
+          protocol: TCP
+---
+# RDP Service — targets the Windows VM's virt-launcher pod
+apiVersion: v1
+kind: Service
+metadata:
+    name: windows-builder-rdp
+    namespace: angelscript
+    labels:
+        app: angelscript
+        component: windows-builder
+spec:
+    type: ClusterIP
+    selector:
+        vm.kubevirt.io/name: windows-builder
+    ports:
+        - name: rdp
+          port: 3389
+          targetPort: 3389
+          protocol: TCP

--- a/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
@@ -1,0 +1,61 @@
+# KEDA ScaledObjects for Guacamole stack.
+#
+# Lifecycle:
+#   VM starts (via KEDA ScaledJob or manual) → guacd + guacamole scale to 1
+#   VM stops → 5min cooldown → guacd + guacamole scale to 0
+#
+# Uses the same github-runner trigger as the VM — when UE5-Win jobs
+# are queued, both the VM and Guacamole scale up together.
+# Also supports manual override: kubectl scale deploy guacd guacamole -n angelscript --replicas=1
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+    name: guacd-scaler
+    namespace: angelscript
+    labels:
+        app: guacd
+        component: guacamole
+spec:
+    scaleTargetRef:
+        name: guacd
+    pollingInterval: 30
+    cooldownPeriod: 300
+    idleReplicaCount: 0
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    triggers:
+        - type: github-runner
+          metadata:
+              owner: KBVE
+              runnerScope: org
+              labels: UE5-Win
+              targetWorkflowQueueLength: '1'
+          authenticationRef:
+              name: github-runner-auth
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+    name: guacamole-scaler
+    namespace: angelscript
+    labels:
+        app: guacamole
+        component: guacamole
+spec:
+    scaleTargetRef:
+        name: guacamole
+    pollingInterval: 30
+    cooldownPeriod: 300
+    idleReplicaCount: 0
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    triggers:
+        - type: github-runner
+          metadata:
+              owner: KBVE
+              runnerScope: org
+              labels: UE5-Win
+              targetWorkflowQueueLength: '1'
+          authenticationRef:
+              name: github-runner-auth


### PR DESCRIPTION
## Summary
Browser-based RDP access to KubeVirt Windows VMs via Apache Guacamole.

**Flow:** Browser → Guacamole (HTTPS) → guacd → ClusterIP → Windows VM RDP (3389)

**KEDA automated:**
- Job queued (UE5-Win) → guacd + guacamole scale 0→1
- Job done + 5min cooldown → scale back to 0

**Security:** RDP never exposed publicly. Guacamole is the single audited entry point.

## Components
- `guacd` deployment + service (protocol proxy)
- `guacamole` deployment + service (web frontend)
- `windows-builder-rdp` ClusterIP service (targets VM)
- KEDA ScaledObjects for both deployments
- ArgoCD application

Refs #9328