### PR TITLE
fix(isometric): revert WebTransportClientIo to upstream struct literal

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -1551,9 +1551,9 @@ fn connect_to_server(commands: &mut Commands, transport: &TransportConfig, token
             .spawn((
                 netcode,
                 PeerAddr(server_addr),
-                WebTransportClientIo::new(digest)
-                    .with_keep_alive(Some(Duration::from_secs(4)))
-                    .with_max_idle_timeout(Some(Duration::from_secs(30))),
+                WebTransportClientIo {
+                    certificate_digest: digest,
+                },
                 ReplicationReceiver::default(),
             ))
             .id();


### PR DESCRIPTION
## Summary
- The `lightyear_webtransport` patch crate (which added `::new()` and `.with_keep_alive()` builder methods) was lost when subsequent PRs merged without it
- Revert to upstream `WebTransportClientIo { certificate_digest: digest }` struct literal syntax
- Fixes `cargo check -p isometric-game` build failure

## Test plan
- [ ] `cargo check -p isometric-game` passes
- [ ] `cargo run -p isometric-game` launches without errors