### PR TITLE
fix(ci): add nightly toolchain with wasm target to crate test workflow

### DIFF
--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -25,11 +25,16 @@ jobs:
                   sudo apt-get install -y --no-install-recommends \
                     pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
 
-            - name: Rust ToolChain
+            - name: Rust ToolChain (stable)
               uses: dtolnay/rust-toolchain@stable
               with:
                   toolchain: '1.94'
                   components: clippy
+
+            - name: Rust ToolChain (nightly + wasm)
+              uses: dtolnay/rust-toolchain@nightly
+              with:
+                  targets: wasm32-unknown-unknown
 
             - name: Setup Node v24
               uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Add `dtolnay/rust-toolchain@nightly` with `wasm32-unknown-unknown` target to `rust-test-crate.yml`
- The `bevy_mapdb` e2e target chains `test` → `check-wasm` → `check-desktop`
- `check-wasm` runs `cargo +nightly check --target wasm32-unknown-unknown`
- Workflow only installed stable 1.94 — nightly auto-installed without wasm target → `can't find crate for std`

Closes #9377

## Test plan
- [ ] Re-run CI Publish for bevy_mapdb after merge
- [ ] Verify check-wasm step passes with nightly + wasm target