### PR TITLE
fix(ci): patch Cargo.toml inline during crate publish

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -235,59 +235,14 @@ jobs:
             NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # ===========================================================================
-    # Rust Crates — sync Cargo.toml version from manifest, test, then publish.
-    # The MDX frontmatter is the version source of truth. When manifest_version
-    # is provided, Cargo.toml is patched to match before test & publish.
+    # Rust Crates — test then publish (only runs when package_type == 'crates')
+    # When manifest_version is provided, rust-publish-crate patches Cargo.toml
+    # inline before publishing — no separate sync job or git push needed.
     # ===========================================================================
-    sync_crate_version:
-        name: Sync Crate Version — ${{ inputs.package_name }}
-        needs: [queue_guard, version_gate]
-        if: inputs.package_type == 'crates' && inputs.manifest_version != '' && needs.version_gate.outputs.should_publish == 'true'
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        permissions:
-            contents: write
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Patch Cargo.toml with manifest version
-              run: |
-                  NAME="${{ inputs.package_name }}"
-                  VERSION="${{ inputs.manifest_version }}"
-                  CRATE_SRC="${{ inputs.version_source }}"
-                  CARGO="${CRATE_SRC:-packages/rust/${NAME}/Cargo.toml}"
-
-                  if [ ! -f "$CARGO" ]; then
-                    echo "::error::Cargo.toml not found: $CARGO"
-                    exit 1
-                  fi
-
-                  CURRENT=$(grep -m1 '^version' "$CARGO" | sed 's/version = "\(.*\)"/\1/')
-                  echo "Current Cargo.toml version: $CURRENT"
-                  echo "Manifest version: $VERSION"
-
-                  if [ "$CURRENT" = "$VERSION" ]; then
-                    echo "Already in sync — no patch needed."
-                    exit 0
-                  fi
-
-                  sed -i "s/^version = \"$CURRENT\"/version = \"$VERSION\"/" "$CARGO"
-                  echo "Patched $CARGO: $CURRENT → $VERSION"
-
-                  # Commit the version sync so publish uses the correct version
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add "$CARGO"
-                  git commit -m "chore($NAME): sync Cargo.toml version to $VERSION [skip ci]" || echo "No changes to commit"
-                  git push
-
     test_crates:
         name: Test Crate — ${{ inputs.package_name }}
-        needs: [queue_guard, sync_crate_version]
-        if: always() && inputs.package_type == 'crates' && (needs.sync_crate_version.result == 'success' || needs.sync_crate_version.result == 'skipped')
+        needs: [queue_guard]
+        if: inputs.package_type == 'crates'
         permissions:
             contents: read
         uses: KBVE/kbve/.github/workflows/rust-test-crate.yml@main
@@ -307,6 +262,8 @@ jobs:
         uses: KBVE/kbve/.github/workflows/rust-publish-crate.yml@main
         with:
             package: ${{ inputs.package_name }}
+            version: ${{ inputs.manifest_version }}
+            version_source: ${{ inputs.version_source }}
         secrets:
             CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
 

--- a/.github/workflows/rust-publish-crate.yml
+++ b/.github/workflows/rust-publish-crate.yml
@@ -6,6 +6,16 @@ on:
             package:
                 required: true
                 type: string
+            version:
+                description: 'Target version from MDX manifest. When provided, Cargo.toml is patched to this version before publish.'
+                required: false
+                type: string
+                default: ''
+            version_source:
+                description: 'Path to Cargo.toml (overrides default convention)'
+                required: false
+                type: string
+                default: ''
         secrets:
             CRATES_TOKEN:
                 required: true
@@ -23,6 +33,29 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
+
+            - name: Patch Cargo.toml with manifest version
+              if: inputs.version != ''
+              run: |
+                  NAME="${{ inputs.package }}"
+                  VERSION="${{ inputs.version }}"
+                  SRC="${{ inputs.version_source }}"
+                  CARGO="${SRC:-packages/rust/${NAME}/Cargo.toml}"
+
+                  if [ ! -f "$CARGO" ]; then
+                    echo "::error::Cargo.toml not found: $CARGO"
+                    exit 1
+                  fi
+
+                  CURRENT=$(grep -m1 '^version' "$CARGO" | sed 's/version = "\(.*\)"/\1/')
+                  echo "Cargo.toml version: $CURRENT → $VERSION"
+
+                  if [ "$CURRENT" != "$VERSION" ]; then
+                    sed -i "s/^version = \"$CURRENT\"/version = \"$VERSION\"/" "$CARGO"
+                    echo "Patched $CARGO"
+                  else
+                    echo "Already at $VERSION — no patch needed"
+                  fi
 
             - name: Rust ToolChain
               uses: dtolnay/rust-toolchain@stable
@@ -53,4 +86,4 @@ jobs:
             - name: Cargo Publish
               if: steps.version_check.outputs.should_publish == 'true'
               run: |
-                  cargo publish -p ${{ inputs.package }}
+                  cargo publish -p ${{ inputs.package }} --allow-dirty


### PR DESCRIPTION
Fixes #9367

## Root Cause
The `sync_crate_version` job pushed a commit patching Cargo.toml to 0.2.2, but `rust-publish-crate.yml` did a **fresh checkout** of the original SHA — it never saw the patched version. So it tried to publish 0.2.1, which already exists on crates.io:

```
Local version: 0.2.1
error: crate jedi@0.2.1 already exists on crates.io index
```

## Fix
- Removed the `sync_crate_version` job entirely (separate checkout = separate universe)
- `rust-publish-crate.yml` now accepts `version` and `version_source` inputs
- When `version` is provided, it patches Cargo.toml **inline in the same checkout** before `cargo publish --allow-dirty`
- `ci-publish.yml` passes `manifest_version` and `version_source` through to the publish workflow
- No git commit needed — the patch is ephemeral (only lives for the duration of the publish job)

## Flow After Fix
1. ci-main reads MDX version (0.2.2) > version.toml (0.2.1) → dispatches with `manifest_version=0.2.2`
2. ci-publish version_gate: manifest_version 0.2.2 > version.toml 0.2.1 → `should_publish=true`
3. rust-publish-crate: patches Cargo.toml 0.2.1 → 0.2.2 inline
4. cargo publish: publishes jedi@0.2.2 to crates.io
5. update_version_crates: writes 0.2.2 to version.toml

## Test plan
- [ ] Re-dispatch jedi publish after merge — should succeed with 0.2.2
- [ ] Verify `cargo publish --allow-dirty` works with the inline patch
- [ ] Verify version.toml gets updated to 0.2.2 after successful publish