### PR TITLE
fix(discordsh-bot-e2e): build Docker image before running e2e tests

### DIFF
--- a/apps/discordsh/discordsh-bot-e2e/playwright.docker.config.ts
+++ b/apps/discordsh/discordsh-bot-e2e/playwright.docker.config.ts
@@ -13,6 +13,11 @@ const cargoToml = readFileSync(
 const version = cargoToml.match(/^version\s*=\s*"(.+)"/m)?.[1] ?? '0.1.0';
 
 const killPort = `docker rm -f discordsh-bot-e2e-test 2>/dev/null; lsof -ti:${port} | xargs kill -9 2>/dev/null; sleep 1;`;
+const imageName = `kbve/discordsh-bot:${version}`;
+const dockerfile = 'apps/discordsh/discordsh-bot/Dockerfile';
+
+// Build the image if it doesn't exist locally (first-ever build or clean CI runner)
+const ensureImage = `docker image inspect ${imageName} >/dev/null 2>&1 || docker build -f ${dockerfile} -t ${imageName} .`;
 
 export default defineConfig({
 	testDir: './e2e',
@@ -31,10 +36,10 @@ export default defineConfig({
 		},
 	],
 	webServer: {
-		command: `${killPort} docker run --rm --name discordsh-bot-e2e-test -e HEALTH_PORT=${port} -p ${port}:${port} kbve/discordsh-bot:${version}`,
+		command: `${killPort} ${ensureImage} && docker run --rm --name discordsh-bot-e2e-test -e HEALTH_PORT=${port} -p ${port}:${port} ${imageName}`,
 		url: `${baseURL}/health`,
 		reuseExistingServer: false,
-		timeout: 60_000,
+		timeout: 600_000,
 	},
 	globalTeardown: resolve(__dirname, 'docker-teardown.ts'),
 });


### PR DESCRIPTION
## Summary
The e2e docker config tried to \`docker run kbve/discordsh-bot:0.1.1\` but the image doesn't exist yet (first-ever build). Add a \`docker image inspect || docker build\` step so the image is built locally before the test container starts.

## Root cause
\`docker-test-app.yml\` runs e2e tests **before** publish. The playwright docker config assumed the image was pre-built, but for a brand-new app there's no existing image on GHCR or locally.

## Fix
- Check if image exists locally via \`docker image inspect\`
- If not, build it from the Dockerfile
- Increase webServer timeout to 600s (Rust compilation in CI takes ~5-8 min)

Fixes #9347
Ref #9286