### PR TITLE
fix(ci): wire version_target for crates — same pattern as Docker apps

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -277,42 +277,48 @@
 			"package_name": "erust",
 			"version": "0.1.7",
 			"version_toml": "packages/rust/erust/version.toml",
-			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/erust-crate.mdx"
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/erust-crate.mdx",
+			"version_target": "packages/rust/erust/Cargo.toml"
 		},
 		{
 			"key": "holy_crate",
 			"package_name": "holy",
 			"version": "0.2.0",
 			"version_toml": "packages/rust/holy/version.toml",
-			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/holy-crate.mdx"
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/holy-crate.mdx",
+			"version_target": "packages/rust/holy/Cargo.toml"
 		},
 		{
 			"key": "jedi_crate",
 			"package_name": "jedi",
 			"version": "0.2.2",
 			"version_toml": "packages/rust/jedi/version.toml",
-			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/jedi-crate.mdx"
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/jedi-crate.mdx",
+			"version_target": "packages/rust/jedi/Cargo.toml"
 		},
 		{
 			"key": "kbve_crate",
 			"package_name": "kbve",
 			"version": "0.1.26",
 			"version_toml": "packages/rust/kbve/version.toml",
-			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-crate.mdx"
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-crate.mdx",
+			"version_target": "packages/rust/kbve/Cargo.toml"
 		},
 		{
 			"key": "q_crate",
 			"package_name": "q",
 			"version": "0.1.1",
 			"version_toml": "packages/rust/q/version.toml",
-			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/q-crate.mdx"
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/q-crate.mdx",
+			"version_target": "packages/rust/q/Cargo.toml"
 		},
 		{
 			"key": "soul_crate",
 			"package_name": "soul",
 			"version": "0.1.1",
 			"version_toml": "packages/rust/soul/version.toml",
-			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/soul-crate.mdx"
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/soul-crate.mdx",
+			"version_target": "packages/rust/soul/Cargo.toml"
 		}
 	],
 	"python": [

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -237,19 +237,26 @@ jobs:
                     pkg=$(echo "$entry" | jq -r '.package_name')
                     VER=$(echo "$entry" | jq -r '.version // empty')
                     SRC=$(echo "$entry" | jq -r '.version_source // empty')
+                    TGT=$(echo "$entry" | jq -r '.version_target // empty')
                     VTOML=$(echo "$entry" | jq -r '.version_toml // empty')
                     altered=$(is_altered "$key")
 
-                    # Resolve paths: use manifest overrides or fall back to convention
+                    # Resolve paths: version_source (MDX) for dispatch check,
+                    # version_target (Cargo.toml) for patching before publish
                     cargo_src="${SRC:-packages/rust/${pkg}/Cargo.toml}"
                     cargo_vtoml="${VTOML:-packages/rust/${pkg}/version.toml}"
 
-                    # Build extra dispatch fields for non-standard paths
+                    # Build dispatch fields — same pattern as Docker apps
                     EXTRA_FIELDS=""
                     if [ -n "$SRC" ]; then
-                      EXTRA_FIELDS="--field version_source=${SRC} --field version_toml_path_override=${VTOML}"
+                      EXTRA_FIELDS="--field version_source=${SRC}"
                     fi
-                    # Pass manifest version so ci-publish can sync Cargo.toml
+                    if [ -n "$TGT" ]; then
+                      EXTRA_FIELDS="$EXTRA_FIELDS --field version_target=${TGT}"
+                    fi
+                    if [ -n "$VTOML" ]; then
+                      EXTRA_FIELDS="$EXTRA_FIELDS --field version_toml_path_override=${VTOML}"
+                    fi
                     if [ -n "$VER" ] && [ "$VER" != "0.0.0" ]; then
                       EXTRA_FIELDS="$EXTRA_FIELDS --field manifest_version=${VER}"
                     fi

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -53,6 +53,11 @@ on:
                 required: false
                 type: string
                 default: ''
+            version_target:
+                description: 'Path to Cargo.toml/package.json to patch with version before publish. E.g. packages/rust/jedi/Cargo.toml'
+                required: false
+                type: string
+                default: ''
             manifest_version:
                 description: 'Version from the MDX manifest (source of truth). When provided, Cargo.toml/package.json are patched to match before publish.'
                 required: false
@@ -236,8 +241,8 @@ jobs:
 
     # ===========================================================================
     # Rust Crates — test then publish (only runs when package_type == 'crates')
-    # When manifest_version is provided, rust-publish-crate patches Cargo.toml
-    # inline before publishing — no separate sync job or git push needed.
+    # Uses the same version_source/version_target pattern as Docker apps:
+    # version_source (MDX) is read, version_target (Cargo.toml) is patched.
     # ===========================================================================
     test_crates:
         name: Test Crate — ${{ inputs.package_name }}
@@ -262,8 +267,8 @@ jobs:
         uses: KBVE/kbve/.github/workflows/rust-publish-crate.yml@main
         with:
             package: ${{ inputs.package_name }}
-            version: ${{ inputs.manifest_version }}
             version_source: ${{ inputs.version_source }}
+            version_target: ${{ inputs.version_target }}
         secrets:
             CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
 
@@ -360,6 +365,7 @@ jobs:
             package_name: ${{ inputs.package_name }}
             version: ${{ needs.version_gate.outputs.local_version }}
             version_toml_path: ${{ inputs.version_toml_path_override != '' && inputs.version_toml_path_override || format('packages/rust/{0}/version.toml', inputs.package_name) }}
+            version_target_path: ${{ inputs.version_target }}
 
     update_version_python:
         name: Update version.toml (python)

--- a/.github/workflows/rust-publish-crate.yml
+++ b/.github/workflows/rust-publish-crate.yml
@@ -6,13 +6,13 @@ on:
             package:
                 required: true
                 type: string
-            version:
-                description: 'Target version from MDX manifest. When provided, Cargo.toml is patched to this version before publish.'
+            version_source:
+                description: 'Path to MDX/JSON with version field (source of truth)'
                 required: false
                 type: string
                 default: ''
-            version_source:
-                description: 'Path to Cargo.toml (overrides default convention)'
+            version_target:
+                description: 'Path to Cargo.toml to patch with the version before publish'
                 required: false
                 type: string
                 default: ''
@@ -34,27 +34,38 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: Patch Cargo.toml with manifest version
-              if: inputs.version != ''
+            - name: Sync version from source to Cargo.toml
+              if: ${{ inputs.version_source != '' && inputs.version_target != '' }}
               run: |
-                  NAME="${{ inputs.package }}"
-                  VERSION="${{ inputs.version }}"
                   SRC="${{ inputs.version_source }}"
-                  CARGO="${SRC:-packages/rust/${NAME}/Cargo.toml}"
+                  TGT="${{ inputs.version_target }}"
 
-                  if [ ! -f "$CARGO" ]; then
-                    echo "::error::Cargo.toml not found: $CARGO"
+                  # Read version from source (MDX or JSON)
+                  case "$SRC" in
+                    *.mdx) VER=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$SRC" | head -1) ;;
+                    *.json) VER=$(jq -r '.version // ""' "$SRC" 2>/dev/null) ;;
+                    *) VER=$(grep -m1 '^version' "$SRC" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null) ;;
+                  esac
+
+                  if [ -z "$VER" ]; then
+                    echo "::warning::Could not read version from $SRC — skipping patch"
+                    exit 0
+                  fi
+
+                  if [ ! -f "$TGT" ]; then
+                    echo "::error::Target file not found: $TGT"
                     exit 1
                   fi
 
-                  CURRENT=$(grep -m1 '^version' "$CARGO" | sed 's/version = "\(.*\)"/\1/')
-                  echo "Cargo.toml version: $CURRENT → $VERSION"
+                  CURRENT=$(grep -m1 '^version' "$TGT" | sed 's/version = "\(.*\)"/\1/')
+                  echo "Source ($SRC): $VER"
+                  echo "Target ($TGT): $CURRENT"
 
-                  if [ "$CURRENT" != "$VERSION" ]; then
-                    sed -i "s/^version = \"$CURRENT\"/version = \"$VERSION\"/" "$CARGO"
-                    echo "Patched $CARGO"
+                  if [ "$CURRENT" != "$VER" ]; then
+                    sed -i "s/^version = \"$CURRENT\"/version = \"$VER\"/" "$TGT"
+                    echo "Patched $TGT: $CURRENT → $VER"
                   else
-                    echo "Already at $VERSION — no patch needed"
+                    echo "Already at $VER — no patch needed"
                   fi
 
             - name: Rust ToolChain

--- a/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
@@ -42,6 +42,7 @@ interface CratesEntry {
 	version?: string;
 	version_toml?: string;
 	version_source?: string;
+	version_target?: string;
 }
 
 interface PythonEntry {
@@ -128,15 +129,19 @@ function toManifestEntry(
 				: null;
 		case 'crates': {
 			if (!d.package_name) return null;
-			// Default version_source to the MDX file (source of truth for version).
-			// Explicit version_source in frontmatter overrides (e.g. bevy crates).
+			// version_source: where to READ version (MDX by default, Cargo.toml for bevy)
+			// version_target: where to WRITE version (Cargo.toml — same as Docker apps)
 			const vs = d.version_source || mdxPath;
+			const vtgt =
+				d.version_target ||
+				`packages/rust/${d.package_name}/Cargo.toml`;
 			return {
 				key: d.key!,
 				package_name: d.package_name,
 				...(ver && { version: ver }),
 				...(vt && { version_toml: vt }),
 				...(vs && { version_source: vs }),
+				version_target: vtgt,
 			};
 		}
 		case 'python':


### PR DESCRIPTION
Fixes #9367

## Problem
Crate publish pipeline was missing `version_target` — the field Docker apps use to tell the pipeline which file to patch with the version. Without it, the publish workflow was patching the MDX instead of Cargo.toml.

## Fix
Wire crates into the same `version_source` / `version_target` pattern Docker apps already use:

| Field | Purpose | Example |
|-------|---------|---------|
| `version_source` | Where to READ version from (MDX) | `apps/.../project/jedi-crate.mdx` |
| `version_target` | Where to WRITE version to (Cargo.toml) | `packages/rust/jedi/Cargo.toml` |
| `version_toml` | Published version tracker | `packages/rust/jedi/version.toml` |

## Changes
- `rust-publish-crate.yml` — reads MDX, patches Cargo.toml, publishes
- `ci-publish.yml` — passes `version_target` to publish + post-publish
- `ci-main.yml` — passes `version_target` from manifest to dispatch
- `ci-dispatch-manifest.json` — added `version_target` for 6 crates
- `ci-registry.json.ts` — generator now emits `version_target` for crates

## Full publish flow
1. Bump MDX `version: "0.2.2"` → ci-main reads MDX > version.toml → dispatches
2. `rust-publish-crate` reads MDX (0.2.2), patches Cargo.toml, `cargo publish`
3. Post-publish updates both `version.toml` + `Cargo.toml` on dev via PR

## Test plan
- [ ] Re-dispatch jedi publish after merge
- [ ] Verify Cargo.toml gets patched to 0.2.2 before publish
- [ ] Verify jedi@0.2.2 appears on crates.io
- [ ] Verify post-publish PR updates both version.toml and Cargo.toml