### PR TITLE
fix(forgejo): RBAC missing forgejo-db-credentials access

### DIFF
--- a/apps/kube/forgejo/manifest/rbac.yaml
+++ b/apps/kube/forgejo/manifest/rbac.yaml
@@ -1,4 +1,4 @@
-# Role: Allow forgejo ExternalSecrets SA to read supabase-postgres secret
+# Role: Allow forgejo ExternalSecrets SA to read DB secrets in kilobase
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -7,7 +7,7 @@ metadata:
 rules:
     - apiGroups: ['']
       resources: ['secrets']
-      resourceNames: ['supabase-postgres']
+      resourceNames: ['supabase-postgres', 'forgejo-db-credentials']
       verbs: ['get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
Fixes the ExternalSecret `SecretSyncedError` blocking #8416 rollout.

The `forgejo-supabase-access` Role in `kilobase` namespace only allowed reading `supabase-postgres`. The new `forgejo-db-credentials` sealed secret (from #9365) was inaccessible, causing:

```
could not get secret data from provider
```

### Fix
Add `forgejo-db-credentials` to `resourceNames` in the RBAC role.

### Current production state
- Migration applied, `forgejo` role exists with correct password
- Sealed secret synced to `kilobase` namespace
- ExternalSecret failing (this fix)
- Forgejo still running as `USER: postgres` (pod hasn't restarted)

### After this merges to main + ArgoCD syncs
1. RBAC allows ExternalSecret to read `forgejo-db-credentials`
2. ExternalSecret resolves → `forgejo-db` secret created in `forgejo` namespace
3. Forgejo pod restarts with `USER: forgejo` + new password
4. Issue #8416 fully resolved

## Test plan
- [ ] ArgoCD syncs RBAC change
- [ ] ExternalSecret status becomes `SecretSynced`
- [ ] Forgejo logs: `ORM engine initialization successful`