### PR TITLE
fix(agones): resolve ArgoCD out-of-sync drift

### DIFF
--- a/apps/kube/agones/application.yaml
+++ b/apps/kube/agones/application.yaml
@@ -19,6 +19,25 @@ spec:
     destination:
         server: https://kubernetes.default.svc
         namespace: agones-system
+    ignoreDifferences:
+        # Agones Helm generates TLS certs and webhook configs at install time.
+        # These are not in git and should not cause drift.
+        - group: ''
+          kind: Secret
+          jsonPointers:
+              - /data
+        - group: admissionregistration.k8s.io
+          kind: MutatingWebhookConfiguration
+          jsonPointers:
+              - /webhooks
+        - group: admissionregistration.k8s.io
+          kind: ValidatingWebhookConfiguration
+          jsonPointers:
+              - /webhooks
+        - group: apiregistration.k8s.io
+          kind: APIService
+          jsonPointers:
+              - /spec/caBundle
     syncPolicy:
         automated:
             selfHeal: true

--- a/apps/kube/agones/ows/application.yaml
+++ b/apps/kube/agones/ows/application.yaml
@@ -14,9 +14,16 @@ spec:
     destination:
         server: https://kubernetes.default.svc
         namespace: arc-runners
+    ignoreDifferences:
+        # FleetAutoscaler manages replica count — ArgoCD should not fight it.
+        - group: agones.dev
+          kind: Fleet
+          jsonPointers:
+              - /spec/replicas
     syncPolicy:
         automated:
             prune: true
         syncOptions:
             - CreateNamespace=false
             - ServerSideApply=true
+            - RespectIgnoreDifferences=true

--- a/apps/kube/agones/ows/fleet.yaml
+++ b/apps/kube/agones/ows/fleet.yaml
@@ -34,7 +34,6 @@ spec:
                   containerPort: 7777
                   protocol: UDP
             health:
-                disabled: false
                 initialDelaySeconds: 30
                 periodSeconds: 15
                 failureThreshold: 5


### PR DESCRIPTION
## Summary
- **agones app**: Added `ignoreDifferences` for Helm-generated secrets (TLS certs), webhook configs, and APIService caBundle
- **agones-ows app**: Added `ignoreDifferences` for `spec.replicas` on Fleet (managed by FleetAutoscaler), added `RespectIgnoreDifferences` sync option
- **fleet.yaml**: Removed `health.disabled: false` (K8s default, stripped from live object, causing drift)

## Root cause
- Agones Helm chart generates TLS certs and webhook configs at install time — these exist live but not in git
- FleetAutoscaler sets replica count dynamically — ArgoCD sees `0` in git vs `5` live
- `health.disabled: false` is the K8s default, so the API server strips it, creating a diff