### PR TITLE
fix(kube): remove stale MC references from kustomization + RBAC

### DIFF
--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -5,7 +5,6 @@ namespace: kbve
 resources:
     - kbve-serviceaccount.yaml
     - kbve-externalsecret.yaml
-    - mc-rcon-externalsecret.yaml
     - forgejo-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml

--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -58,9 +58,6 @@ subjects:
       name: rentearth-external-secrets
       namespace: rentearth
     - kind: ServiceAccount
-      name: mc-external-secrets
-      namespace: mc
-    - kind: ServiceAccount
       name: n8n-external-secrets
       namespace: n8n
     - kind: ServiceAccount


### PR DESCRIPTION
## Summary
- Remove `mc-rcon-externalsecret.yaml` from `kustomization.yaml` — file was deleted in #9362 but the kustomize resource reference remained, likely causing ArgoCD sync failures
- Remove `mc-external-secrets` ServiceAccount from `kilobase/cross-namespace-rbac.yaml` — mc namespace no longer exists

## Test plan
- [ ] kbve ArgoCD app syncs cleanly
- [ ] kilobase RBAC applies without referencing dead namespace