### PR TITLE
feat(ci): wire version_source/version_target for npm and python

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -166,25 +166,33 @@
 			"key": "devops",
 			"package_name": "devops",
 			"version": "0.0.19",
-			"version_toml": "packages/npm/devops/version.toml"
+			"version_toml": "packages/npm/devops/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/devops.mdx",
+			"version_target": "packages/npm/devops/package.json"
 		},
 		{
 			"key": "droid",
 			"package_name": "droid",
 			"version": "0.1.1",
-			"version_toml": "packages/npm/droid/version.toml"
+			"version_toml": "packages/npm/droid/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/droid.mdx",
+			"version_target": "packages/npm/droid/package.json"
 		},
 		{
 			"key": "khashvault",
 			"package_name": "khashvault",
 			"version": "1.0.12",
-			"version_toml": "packages/npm/khashvault/version.toml"
+			"version_toml": "packages/npm/khashvault/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/khashvault.mdx",
+			"version_target": "packages/npm/khashvault/package.json"
 		},
 		{
 			"key": "laser",
 			"package_name": "laser",
 			"version": "0.1.0",
-			"version_toml": "packages/npm/laser/version.toml"
+			"version_toml": "packages/npm/laser/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/laser.mdx",
+			"version_target": "packages/npm/laser/package.json"
 		}
 	],
 	"crates": [
@@ -327,14 +335,18 @@
 			"package_name": "python-fudster",
 			"pypi_name": "fudster",
 			"version": "1.0.3",
-			"version_toml": "packages/python/fudster/version.toml"
+			"version_toml": "packages/python/fudster/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/fudster.mdx",
+			"version_target": "packages/python/fudster/pyproject.toml"
 		},
 		{
 			"key": "py_lib_kbve",
 			"package_name": "python-kbve",
 			"pypi_name": "kbve",
 			"version": "1.0.13",
-			"version_toml": "packages/python/kbve/version.toml"
+			"version_toml": "packages/python/kbve/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/python-kbve.mdx",
+			"version_target": "packages/python/kbve/pyproject.toml"
 		}
 	],
 	"unreal": [

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -212,14 +212,27 @@ jobs:
                   while IFS= read -r entry; do
                     key=$(echo "$entry" | jq -r '.key')
                     pkg=$(echo "$entry" | jq -r '.package_name')
+                    SRC=$(echo "$entry" | jq -r '.version_source // empty')
+                    TGT=$(echo "$entry" | jq -r '.version_target // empty')
+                    VTOML=$(echo "$entry" | jq -r '.version_toml // empty')
+                    VER=$(echo "$entry" | jq -r '.version // empty')
                     altered=$(is_altered "$key")
+
+                    npm_src="${SRC:-packages/npm/${pkg}/package.json}"
+                    npm_vtoml="${VTOML:-packages/npm/${pkg}/version.toml}"
+
+                    EXTRA_FIELDS=""
+                    [ -n "$SRC" ] && EXTRA_FIELDS="$EXTRA_FIELDS --field version_source=${SRC}"
+                    [ -n "$TGT" ] && EXTRA_FIELDS="$EXTRA_FIELDS --field version_target=${TGT}"
+                    [ -n "$VER" ] && [ "$VER" != "0.0.0" ] && EXTRA_FIELDS="$EXTRA_FIELDS --field manifest_version=${VER}"
+
                     if [ "$altered" = "true" ]; then
-                      echo "  ✓ $pkg — files changed, dispatching"
-                      dispatch_publish npm --field package_name="$pkg"
+                      echo "  ✓ $pkg — files changed, dispatching (v$VER)"
+                      dispatch_publish npm --field package_name="$pkg" $EXTRA_FIELDS
                       DISPATCHED=$((DISPATCHED + 1))
-                    elif [ "$(check_version "packages/npm/${pkg}/package.json" "packages/npm/${pkg}/version.toml")" = "true" ]; then
-                      echo "  ✓ $pkg — unpublished version, dispatching"
-                      dispatch_publish npm --field package_name="$pkg"
+                    elif [ "$(check_version "$npm_src" "$npm_vtoml")" = "true" ]; then
+                      echo "  ✓ $pkg — unpublished version, dispatching (v$VER)"
+                      dispatch_publish npm --field package_name="$pkg" $EXTRA_FIELDS
                       DISPATCHED=$((DISPATCHED + 1))
                     else
                       echo "  · $pkg — no changes, version published, skipping"
@@ -283,14 +296,27 @@ jobs:
                     key=$(echo "$entry" | jq -r '.key')
                     pkg=$(echo "$entry" | jq -r '.package_name')
                     pypi=$(echo "$entry" | jq -r '.pypi_name')
+                    SRC=$(echo "$entry" | jq -r '.version_source // empty')
+                    TGT=$(echo "$entry" | jq -r '.version_target // empty')
+                    VTOML=$(echo "$entry" | jq -r '.version_toml // empty')
+                    VER=$(echo "$entry" | jq -r '.version // empty')
                     altered=$(is_altered "$key")
+
+                    py_src="${SRC:-packages/python/${pypi}/pyproject.toml}"
+                    py_vtoml="${VTOML:-packages/python/${pypi}/version.toml}"
+
+                    EXTRA_FIELDS="--field pypi_name=$pypi"
+                    [ -n "$SRC" ] && EXTRA_FIELDS="$EXTRA_FIELDS --field version_source=${SRC}"
+                    [ -n "$TGT" ] && EXTRA_FIELDS="$EXTRA_FIELDS --field version_target=${TGT}"
+                    [ -n "$VER" ] && [ "$VER" != "0.0.0" ] && EXTRA_FIELDS="$EXTRA_FIELDS --field manifest_version=${VER}"
+
                     if [ "$altered" = "true" ]; then
-                      echo "  ✓ $pkg — files changed, dispatching"
-                      dispatch_publish python --field package_name="$pkg" --field pypi_name="$pypi"
+                      echo "  ✓ $pkg — files changed, dispatching (v$VER)"
+                      dispatch_publish python --field package_name="$pkg" $EXTRA_FIELDS
                       DISPATCHED=$((DISPATCHED + 1))
-                    elif [ "$(check_version "packages/python/${pypi}/pyproject.toml" "packages/python/${pypi}/version.toml")" = "true" ]; then
-                      echo "  ✓ $pkg — unpublished version, dispatching"
-                      dispatch_publish python --field package_name="$pkg" --field pypi_name="$pypi"
+                    elif [ "$(check_version "$py_src" "$py_vtoml")" = "true" ]; then
+                      echo "  ✓ $pkg — unpublished version, dispatching (v$VER)"
+                      dispatch_publish python --field package_name="$pkg" $EXTRA_FIELDS
                       DISPATCHED=$((DISPATCHED + 1))
                     else
                       echo "  · $pkg — no changes, version published, skipping"

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -236,6 +236,8 @@ jobs:
         uses: KBVE/kbve/.github/workflows/utils-npm-publish.yml@main
         with:
             project: ${{ inputs.package_name }}
+            version_source: ${{ inputs.version_source }}
+            version_target: ${{ inputs.version_target }}
         secrets:
             NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -296,6 +298,8 @@ jobs:
         with:
             project: ${{ inputs.package_name }}
             pypi_name: ${{ inputs.pypi_name }}
+            version_source: ${{ inputs.version_source }}
+            version_target: ${{ inputs.version_target }}
         secrets:
             PYPI_TOKEN: ${{ secrets.PYPI_API_SCOPE_TOKEN }}
 
@@ -350,6 +354,7 @@ jobs:
             package_name: ${{ inputs.package_name }}
             version: ${{ needs.version_gate.outputs.local_version }}
             version_toml_path: packages/npm/${{ inputs.package_name }}/version.toml
+            version_target_path: ${{ inputs.version_target }}
 
     update_version_crates:
         name: Update version.toml (crates)
@@ -381,6 +386,7 @@ jobs:
             package_name: ${{ inputs.package_name }}
             version: ${{ needs.version_gate.outputs.local_version }}
             version_toml_path: packages/python/${{ inputs.pypi_name }}/version.toml
+            version_target_path: ${{ inputs.version_target }}
 
     # ---------------------------------------------------------------------------
     # Failure Tracker — opens a GitHub issue on any pipeline failure (#8186).

--- a/.github/workflows/utils-npm-publish.yml
+++ b/.github/workflows/utils-npm-publish.yml
@@ -6,6 +6,16 @@ on:
             project:
                 required: true
                 type: string
+            version_source:
+                description: 'Path to MDX/JSON with version field (source of truth)'
+                required: false
+                type: string
+                default: ''
+            version_target:
+                description: 'Path to package.json to patch with the version before publish'
+                required: false
+                type: string
+                default: ''
         secrets:
             NPM_TOKEN:
                 required: true
@@ -55,6 +65,28 @@ jobs:
 
             - name: Install pnpm dependencies
               run: pnpm install
+
+            - name: Sync version from source to package.json
+              if: ${{ inputs.version_source != '' && inputs.version_target != '' }}
+              run: |
+                  SRC="${{ inputs.version_source }}"
+                  TGT="${{ inputs.version_target }}"
+                  case "$SRC" in
+                    *.mdx) VER=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$SRC" | head -1) ;;
+                    *.json) VER=$(jq -r '.version // ""' "$SRC" 2>/dev/null) ;;
+                    *) VER="" ;;
+                  esac
+                  if [ -z "$VER" ] || [ ! -f "$TGT" ]; then
+                    echo "::warning::Skipping version sync (VER=$VER, TGT=$TGT)"
+                    exit 0
+                  fi
+                  CURRENT=$(jq -r '.version' "$TGT")
+                  echo "Source ($SRC): $VER"
+                  echo "Target ($TGT): $CURRENT"
+                  if [ "$CURRENT" != "$VER" ]; then
+                    jq --arg v "$VER" '.version = $v' "$TGT" > "$TGT.tmp" && mv "$TGT.tmp" "$TGT"
+                    echo "Patched $TGT: $CURRENT → $VER"
+                  fi
 
             - name: Check version against npm registry
               id: version_check

--- a/.github/workflows/utils-python-publish.yml
+++ b/.github/workflows/utils-python-publish.yml
@@ -9,6 +9,16 @@ on:
             pypi_name:
                 required: true
                 type: string
+            version_source:
+                description: 'Path to MDX/JSON with version field (source of truth)'
+                required: false
+                type: string
+                default: ''
+            version_target:
+                description: 'Path to pyproject.toml to patch with the version before publish'
+                required: false
+                type: string
+                default: ''
         secrets:
             PYPI_TOKEN:
                 required: true
@@ -65,6 +75,28 @@ jobs:
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
+
+            - name: Sync version from source to pyproject.toml
+              if: ${{ inputs.version_source != '' && inputs.version_target != '' }}
+              run: |
+                  SRC="${{ inputs.version_source }}"
+                  TGT="${{ inputs.version_target }}"
+                  case "$SRC" in
+                    *.mdx) VER=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$SRC" | head -1) ;;
+                    *.json) VER=$(jq -r '.version // ""' "$SRC" 2>/dev/null) ;;
+                    *) VER="" ;;
+                  esac
+                  if [ -z "$VER" ] || [ ! -f "$TGT" ]; then
+                    echo "::warning::Skipping version sync (VER=$VER, TGT=$TGT)"
+                    exit 0
+                  fi
+                  CURRENT=$(grep -m1 '^version' "$TGT" | sed 's/version = "\(.*\)"/\1/')
+                  echo "Source ($SRC): $VER"
+                  echo "Target ($TGT): $CURRENT"
+                  if [ "$CURRENT" != "$VER" ]; then
+                    sed -i "s/^version = \"$CURRENT\"/version = \"$VER\"/" "$TGT"
+                    echo "Patched $TGT: $CURRENT → $VER"
+                  fi
 
             - name: Check version against PyPI
               id: version_check

--- a/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
@@ -34,6 +34,8 @@ interface NpmEntry {
 	package_name: string;
 	version?: string;
 	version_toml?: string;
+	version_source?: string;
+	version_target?: string;
 }
 
 interface CratesEntry {
@@ -51,6 +53,8 @@ interface PythonEntry {
 	pypi_name: string;
 	version?: string;
 	version_toml?: string;
+	version_source?: string;
+	version_target?: string;
 }
 
 interface UnrealEntry {
@@ -118,15 +122,21 @@ function toManifestEntry(
 				...(d.target && { target: d.target }),
 				...(d.nx_project && { nx_project: d.nx_project }),
 			};
-		case 'npm':
-			return d.package_name
-				? {
-						key: d.key!,
-						package_name: d.package_name,
-						...(ver && { version: ver }),
-						...(vt && { version_toml: vt }),
-					}
-				: null;
+		case 'npm': {
+			if (!d.package_name) return null;
+			const npmVs = d.version_source || mdxPath;
+			const npmVtgt =
+				d.version_target ||
+				`packages/npm/${d.package_name}/package.json`;
+			return {
+				key: d.key!,
+				package_name: d.package_name,
+				...(ver && { version: ver }),
+				...(vt && { version_toml: vt }),
+				...(npmVs && { version_source: npmVs }),
+				version_target: npmVtgt,
+			};
+		}
 		case 'crates': {
 			if (!d.package_name) return null;
 			// version_source: where to READ version (MDX by default, Cargo.toml for bevy)
@@ -144,16 +154,22 @@ function toManifestEntry(
 				version_target: vtgt,
 			};
 		}
-		case 'python':
-			return d.package_name && d.pypi_name
-				? {
-						key: d.key!,
-						package_name: d.package_name,
-						pypi_name: d.pypi_name,
-						...(ver && { version: ver }),
-						...(vt && { version_toml: vt }),
-					}
-				: null;
+		case 'python': {
+			if (!d.package_name || !d.pypi_name) return null;
+			const pyVs = d.version_source || mdxPath;
+			const pyVtgt =
+				d.version_target ||
+				`packages/python/${d.pypi_name}/pyproject.toml`;
+			return {
+				key: d.key!,
+				package_name: d.package_name,
+				pypi_name: d.pypi_name,
+				...(ver && { version: ver }),
+				...(vt && { version_toml: vt }),
+				...(pyVs && { version_source: pyVs }),
+				version_target: pyVtgt,
+			};
+		}
 		case 'unreal': {
 			if (!d.plugin_name || !d.plugin_path) return null;
 			const ue: UnrealEntry = {


### PR DESCRIPTION
## Summary
Extends the version_source/version_target pattern to npm and python packages — now all four ecosystems (Docker, Crates, NPM, Python) use the same unified flow.

## How it works (all ecosystems now)
| Step | What happens |
|------|-------------|
| **1. Bump** | Edit the MDX `version:` field |
| **2. Dispatch** | ci-main reads MDX > version.toml → dispatches |
| **3. Sync** | Publish workflow reads MDX, patches target file inline |
| **4. Publish** | cargo publish / npm publish / pypi upload |
| **5. Post-publish** | Updates version.toml + target file on dev via PR |

## Manifest fields per ecosystem
| Ecosystem | version_source (read) | version_target (write) |
|-----------|----------------------|----------------------|
| Docker | `project/*.mdx` | `*/Cargo.toml` |
| Crates | `project/*.mdx` | `packages/rust/*/Cargo.toml` |
| NPM | `project/*.mdx` | `packages/npm/*/package.json` |
| Python | `project/*.mdx` | `packages/python/*/pyproject.toml` |

## Changes
- `utils-npm-publish.yml` — sync step: reads MDX → patches package.json
- `utils-python-publish.yml` — sync step: reads MDX → patches pyproject.toml
- `ci-publish.yml` — passes version_source/version_target to all publish + post-publish jobs
- `ci-main.yml` — reads version_source/version_target from manifest for npm/python dispatch
- `ci-dispatch-manifest.json` — added fields for 4 npm + 2 python packages
- `ci-registry.json.ts` — generator emits version_source + version_target for npm/python

## Test plan
- [ ] Verify npm dispatch passes version_source/version_target
- [ ] Verify python dispatch passes version_source/version_target
- [ ] Verify bumping an npm MDX version triggers publish + patches package.json
- [ ] Verify post-publish PR updates both version.toml and target file