### PR TITLE
fix(cert-manager): switch chuckrpg.com to nginx HTTP-01 solver

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -69,16 +69,17 @@ spec:
                               annotations:
                                   cert-manager.io/http01-ingress-path-type: 'Prefix'
 
-            # --- Solver 6: CHUCKRPG.COM domains (Gateway API HTTP-01) ---
+            # --- Solver 6: CHUCKRPG.COM domains ---
             - selector:
                   dnsZones:
                       - chuckrpg.com
               http01:
-                  gatewayHTTPRoute:
-                      parentRefs:
-                          - name: kbve-gateway
-                            namespace: kbve
-                            kind: Gateway
+                  ingress:
+                      ingressClassName: nginx
+                      ingressTemplate:
+                          metadata:
+                              annotations:
+                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer


### PR DESCRIPTION
## Summary
- Switch chuckrpg.com ACME solver from `gatewayHTTPRoute` to `ingress` (nginx)
- The Gateway API solver has been stuck pending for 7 days (Cilium returns 404 for ACME challenges)
- All other domains already use the nginx ingress solver successfully

## Post-merge action
After this reaches main, delete the stale challenge to force retry:
```
kubectl delete challenge -n chuckrpg --all
kubectl delete order game-chuckrpg-tls-1-2445924413 -n chuckrpg
```