### PR TITLE
fix(axum-kbve): add ApplyDeferred sync point to fix WS packet consume

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -571,6 +571,19 @@ fn run_bevy_app(
     // Shared protocol (components, inputs, channels)
     app.add_plugins(ProtocolPlugin);
 
+    // WORKAROUND: Force deferred command flush between IoSystems::Poll and
+    // LinkReceiveSystems::BufferToLink in PreUpdate. When a WebSocket client
+    // connects through a proxy (Cloudflare/Cilium), the on_connection observer
+    // inserts AeronetLinkOf via deferred commands. Without this sync point,
+    // the receive system runs before those commands flush, causing "packets
+    // not consumed" warnings and a stalled Netcode handshake.
+    app.add_systems(
+        PreUpdate,
+        bevy::ecs::schedule::ApplyDeferred
+            .after(lightyear::link::LinkSystems::Receive)
+            .before(lightyear::link::LinkReceiveSystems::BufferToLink),
+    );
+
     // lightyear–avian3d bridge
     app.add_plugins(lightyear_avian3d::prelude::LightyearAvianPlugin::default());
 


### PR DESCRIPTION
## Summary
Root cause found for the production WebSocket stall (packets arrive but Netcode never processes them).

When a WebSocket client connects through a proxy (Cloudflare → Cilium Gateway → pod), lightyear's `on_connection` observer inserts `AeronetLinkOf` via **deferred commands**. The `lightyear_aeronet::receive` system (which drains `Session.recv` → `Link.recv`) runs before those commands flush, so it can't find the `AeronetLinkOf` → `Link` chain. Packets pile up in `Session.recv` and get cleared every tick with aeronet's "packets not consumed" warning.

**Fix:** Insert a `bevy::ecs::schedule::ApplyDeferred` sync point in `PreUpdate` between `LinkSystems::Receive` and `LinkReceiveSystems::BufferToLink` to force observer deferred commands to flush before the receive system runs.

This works locally because direct connections complete within a single tick. Proxied connections add enough latency to expose the race between observer command flush and system execution.

## Test plan
- [ ] Deploy new image, connect WASM client via `wss://kbve.com/ws`
- [ ] Verify "packets not consumed" warnings are gone from server logs
- [ ] Verify client shows `send > 0` and `recv > 0` in heartbeat logs
- [ ] Verify Netcode handshake completes (`CONNECTED` state)