### PR TITLE
fix(kube): switch bitnami/kubectl to registry.k8s.io + remove mc from PostgREST

### DIFF
--- a/apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
+++ b/apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
@@ -91,7 +91,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: healthcheck
-                          image: bitnami/kubectl:1.31.5
+                          image: registry.k8s.io/kubectl:1.32
                           securityContext:
                               allowPrivilegeEscalation: false
                               readOnlyRootFilesystem: true

--- a/apps/kube/kilobase/manifests/backup-restore-test.yaml
+++ b/apps/kube/kilobase/manifests/backup-restore-test.yaml
@@ -223,7 +223,7 @@ spec:
                     restartPolicy: Never
                     containers:
                         - name: restore-test
-                          image: bitnami/kubectl:1.31
+                          image: registry.k8s.io/kubectl:1.32
                           resources:
                               limits:
                                   cpu: 200m

--- a/apps/kube/kilobase/manifests/backup-watchdog.yaml
+++ b/apps/kube/kilobase/manifests/backup-watchdog.yaml
@@ -98,7 +98,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: watchdog
-                          image: bitnami/kubectl:1.31.5
+                          image: registry.k8s.io/kubectl:1.32
                           securityContext:
                               allowPrivilegeEscalation: false
                               readOnlyRootFilesystem: true

--- a/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
+++ b/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
@@ -92,7 +92,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: gc
-                          image: bitnami/kubectl:1.31.5
+                          image: registry.k8s.io/kubectl:1.32
                           securityContext:
                               allowPrivilegeEscalation: false
                               readOnlyRootFilesystem: true

--- a/apps/kube/postgrest/manifests/postgrest-deployment.yaml
+++ b/apps/kube/postgrest/manifests/postgrest-deployment.yaml
@@ -35,7 +35,7 @@ spec:
 
                       # PostgREST configuration
                       - name: PGRST_DB_SCHEMAS
-                        value: 'public,storage,graphql_public,tracker,profile,rentearth,mc,meme,discordsh'
+                        value: 'public,storage,graphql_public,tracker,profile,rentearth,meme,discordsh'
                       - name: PGRST_DB_ANON_ROLE
                         value: 'anon'
                       - name: PGRST_DB_USE_LEGACY_GUCS


### PR DESCRIPTION
## Summary
- Switch all `bitnami/kubectl:1.31` images to `registry.k8s.io/kubectl:1.32` across 4 CronJobs — fixes `ImagePullBackOff` caused by Docker Hub rate limits or missing Bitnami tags
  - `kilobase/backup-restore-test` (weekly fire drill)
  - `kilobase/backup-watchdog` (daily health check)
  - `namespace/pod-gc-cronjob` (stale pod cleanup)
  - `crossplane/s3-healthcheck-cronjob`
- Remove `mc` from PostgREST `PGRST_DB_SCHEMAS` — mc schema no longer active

## Test plan
- [ ] backup-restore-test CronJob pulls image successfully on next Sunday run
- [ ] backup-watchdog pulls successfully on next daily run
- [ ] pod-gc and s3-healthcheck CronJobs pull successfully
- [ ] PostgREST restarts cleanly without mc schema