### PR TITLE
feat(angelscript): add ExternalSecrets for github-arc-token

### DIFF
--- a/apps/kube/angelscript/manifest/external-secrets.yaml
+++ b/apps/kube/angelscript/manifest/external-secrets.yaml
@@ -1,0 +1,93 @@
+# ExternalSecrets setup for angelscript namespace.
+# Syncs github-arc-token from arc-systems namespace so KEDA
+# can authenticate with GitHub to watch the job queue.
+#
+# Chain: arc-systems/github-arc-token → SecretStore → ExternalSecret → angelscript/github-arc-token
+---
+# ServiceAccount for ExternalSecrets to use when reading from arc-systems
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: angelscript-external-secrets
+    namespace: angelscript
+    labels:
+        app: angelscript
+        component: external-secrets
+---
+# Role in arc-systems allowing read on the github-arc-token secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: angelscript-read-github-token
+    namespace: arc-systems
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['github-arc-token']
+      verbs: ['get']
+---
+# Bind the angelscript SA to the role in arc-systems
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: angelscript-read-github-token
+    namespace: arc-systems
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: angelscript-read-github-token
+subjects:
+    - kind: ServiceAccount
+      name: angelscript-external-secrets
+      namespace: angelscript
+---
+# SecretStore in angelscript pointing to arc-systems
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: arc-systems-secret-store
+    namespace: angelscript
+    labels:
+        app: angelscript
+        component: external-secrets
+spec:
+    provider:
+        kubernetes:
+            auth:
+                serviceAccount:
+                    name: angelscript-external-secrets
+            remoteNamespace: arc-systems
+            server:
+                caProvider:
+                    key: ca.crt
+                    name: kube-root-ca.crt
+                    namespace: kube-system
+                    type: ConfigMap
+---
+# ExternalSecret that creates angelscript/github-arc-token
+# from arc-systems/github-arc-token
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: github-arc-token
+    namespace: angelscript
+    labels:
+        app: angelscript
+        component: external-secrets
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        kind: SecretStore
+        name: arc-systems-secret-store
+    target:
+        name: github-arc-token
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                github_token: '{{ .token }}'
+    data:
+        - secretKey: token
+          remoteRef:
+              key: github-arc-token
+              property: github_token


### PR DESCRIPTION
## Summary
Fixes KEDA ScaledJob failure (`no personalAccessToken or appKey given`) by syncing `github-arc-token` from `arc-systems` → `angelscript` via ExternalSecrets.

Once deployed, KEDA can watch the GitHub Actions job queue and auto-start/stop the Windows VM.

## What was broken
- `github-arc-token` secret missing in `angelscript` namespace
- KEDA couldn't authenticate → VM scaling disabled for 9+ days
- Windows VM running idle with no jobs (8 cores, 16Gi wasted)