### PR TITLE
fix(forgejo): config-revision annotation to force rollout

### DIFF
--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -40,6 +40,12 @@ spec:
                       accessModes:
                           - ReadWriteOnce
 
+                  deployment:
+                      annotations:
+                          # Bump this value to force a pod rollout when config/secrets change.
+                          # ArgoCD detects the annotation change → new ReplicaSet → pod restart.
+                          kbve.com/config-revision: '2026-03-31-forgejo-role'
+
                   gitea:
                       admin:
                           existingSecret: forgejo-admin


### PR DESCRIPTION
## Summary
Final piece for #8416

Adds `kbve.com/config-revision` annotation to the Forgejo deployment pod template. When ArgoCD syncs this, the annotation change triggers a new ReplicaSet → pod restart → Forgejo regenerates `app.ini` with:

- `USER: forgejo` (scoped role, not superuser)
- `PASSWD:` from `forgejo-db-credentials` ExternalSecret

### Why this is needed
The Forgejo Helm chart doesn't auto-restart pods on config changes. The `USER: forgejo` Helm value was merged days ago but the pod is still running with `USER: postgres` because it never restarted.

### Future use
Bump `kbve.com/config-revision` any time you change Forgejo config and need a restart. No need for manual `kubectl rollout restart`.

## Test plan
- [ ] ArgoCD syncs → new pod created
- [ ] `app.ini` shows `USER = forgejo`
- [ ] Forgejo logs: `ORM engine initialization successful`
- [ ] Forgejo web UI accessible at forgejo.kbve.com