### PR TITLE
fix(kubevirt): smart VM idle shutdown with session + CI checks

### DIFF
--- a/apps/kube/kubevirt/keda/idle-shutdown-cronjob.yaml
+++ b/apps/kube/kubevirt/keda/idle-shutdown-cronjob.yaml
@@ -1,4 +1,11 @@
-# CronJob to stop idle VMs — runs every 15 minutes.
+# DEPRECATED — replaced by KEDA ScaledJobs in scaled-jobs.yaml
+# The vm-stop-windows-builder and vm-stop-macos-builder ScaledJobs
+# now handle idle shutdown with smart checks (GitHub + session detection).
+#
+# This CronJob is kept as a fallback — set suspend: true to disable.
+# Remove entirely once KEDA shutdown ScaledJobs are verified working.
+#
+# Original CronJob to stop idle VMs — runs every 15 minutes.
 #
 # Checks THREE conditions before stopping a VM:
 #   1. VM has been running for > IDLE_THRESHOLD_MINUTES (30 min)

--- a/apps/kube/kubevirt/keda/scaled-jobs.yaml
+++ b/apps/kube/kubevirt/keda/scaled-jobs.yaml
@@ -1,6 +1,8 @@
 # KEDA ScaledJobs for KubeVirt VM lifecycle.
-# Watches GitHub Actions for queued jobs targeting specific runner labels.
-# When jobs are queued → starts the VM. After idle → stops the VM.
+#
+# Full lifecycle managed by KEDA (no CronJobs):
+#   Scale UP:   github-runner trigger → start VM when jobs are queued
+#   Scale DOWN: cron trigger (every 15min) → stop VM if idle + no sessions
 #
 # The GitHub PAT needs workflow + admin:org scope for the KEDA GitHub runner scaler.
 # Uses the same github-arc-token secret as the ARC runners.
@@ -104,3 +106,122 @@ spec:
               targetWorkflowQueueLength: '1'
           authenticationRef:
               name: github-runner-auth
+---
+# ──────────────────────────────────────────────────────────────
+# SCALE DOWN — KEDA cron-triggered idle shutdown
+# Runs every 15 minutes, checks: age > 30min + no GitHub jobs + no sessions
+# ──────────────────────────────────────────────────────────────
+
+# Windows VM shutdown
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+    name: vm-stop-windows-builder
+    namespace: angelscript
+spec:
+    jobTargetRef:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 1
+        ttlSecondsAfterFinished: 300
+        template:
+            spec:
+                serviceAccountName: vm-scaler
+                restartPolicy: OnFailure
+                containers:
+                    - name: idle-checker
+                      image: registry.k8s.io/kubectl:v1.33.2
+                      command: ['/bin/sh', '/scripts/idle-shutdown.sh']
+                      env:
+                          - name: VM_NAME
+                            value: windows-builder
+                          - name: RUNNER_LABEL
+                            value: UE5-Win
+                          - name: NAMESPACE
+                            value: angelscript
+                          - name: IDLE_THRESHOLD_MINUTES
+                            value: '30'
+                          - name: GITHUB_ORG
+                            value: KBVE
+                          - name: GITHUB_TOKEN
+                            valueFrom:
+                                secretKeyRef:
+                                    name: github-arc-token
+                                    key: github_token
+                      volumeMounts:
+                          - name: script
+                            mountPath: /scripts
+                volumes:
+                    - name: script
+                      configMap:
+                          name: vm-idle-shutdown-script
+                          defaultMode: 0755
+    pollingInterval: 900
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    triggers:
+        - type: cron
+          metadata:
+              timezone: UTC
+              start: '0 */1 * * *'
+              end: '15 */1 * * *'
+              desiredReplicas: '1'
+---
+# macOS VM shutdown
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+    name: vm-stop-macos-builder
+    namespace: angelscript
+spec:
+    jobTargetRef:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 1
+        ttlSecondsAfterFinished: 300
+        template:
+            spec:
+                serviceAccountName: vm-scaler
+                restartPolicy: OnFailure
+                containers:
+                    - name: idle-checker
+                      image: registry.k8s.io/kubectl:v1.33.2
+                      command: ['/bin/sh', '/scripts/idle-shutdown.sh']
+                      env:
+                          - name: VM_NAME
+                            value: macos-builder
+                          - name: RUNNER_LABEL
+                            value: UE5-Mac
+                          - name: NAMESPACE
+                            value: angelscript
+                          - name: IDLE_THRESHOLD_MINUTES
+                            value: '30'
+                          - name: GITHUB_ORG
+                            value: KBVE
+                          - name: GITHUB_TOKEN
+                            valueFrom:
+                                secretKeyRef:
+                                    name: github-arc-token
+                                    key: github_token
+                      volumeMounts:
+                          - name: script
+                            mountPath: /scripts
+                volumes:
+                    - name: script
+                      configMap:
+                          name: vm-idle-shutdown-script
+                          defaultMode: 0755
+    pollingInterval: 900
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    triggers:
+        - type: cron
+          metadata:
+              timezone: UTC
+              start: '0 */1 * * *'
+              end: '15 */1 * * *'
+              desiredReplicas: '1'

--- a/apps/kube/kubevirt/keda/vm-idle-shutdown-script.yaml
+++ b/apps/kube/kubevirt/keda/vm-idle-shutdown-script.yaml
@@ -1,0 +1,108 @@
+# ConfigMap with the smart idle shutdown script used by KEDA ScaledJobs.
+#
+# Checks THREE conditions before stopping a VM:
+#   1. Age > IDLE_THRESHOLD_MINUTES (VM has been running long enough)
+#   2. No GitHub Actions jobs queued/in-progress for RUNNER_LABEL
+#   3. No active VNC (5900) or RDP (3389) connections
+#
+# All three must be true → stop VM. Any one fails → keep running.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: vm-idle-shutdown-script
+    namespace: angelscript
+data:
+    idle-shutdown.sh: |
+        #!/bin/sh
+        set -e
+        VM_NAME="${VM_NAME:?VM_NAME required}"
+        RUNNER_LABEL="${RUNNER_LABEL:?RUNNER_LABEL required}"
+        NAMESPACE="${NAMESPACE:-angelscript}"
+        IDLE_THRESHOLD_MINUTES="${IDLE_THRESHOLD_MINUTES:-30}"
+        GITHUB_ORG="${GITHUB_ORG:-KBVE}"
+
+        echo "=== Idle shutdown check: ${VM_NAME} (label: ${RUNNER_LABEL}) ==="
+
+        # ── Check 1: Is the VM running? ──
+        STATUS=$(kubectl get vm "${VM_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown")
+        if [ "${STATUS}" != "Running" ]; then
+            echo "SKIP: VM not running (${STATUS})"
+            exit 0
+        fi
+
+        # ── Check 2: Has it been running long enough? ──
+        CREATED=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || echo "")
+        if [ -z "${CREATED}" ]; then
+            echo "SKIP: no VMI found"
+            exit 0
+        fi
+
+        CREATED_EPOCH=$(date -d "${CREATED}" +%s 2>/dev/null || echo "0")
+        NOW_EPOCH=$(date +%s)
+        AGE_MINUTES=$(( (NOW_EPOCH - CREATED_EPOCH) / 60 ))
+        echo "Age: ${AGE_MINUTES} minutes (threshold: ${IDLE_THRESHOLD_MINUTES})"
+
+        if [ "${AGE_MINUTES}" -le "${IDLE_THRESHOLD_MINUTES}" ]; then
+            echo "KEEP: under idle threshold"
+            exit 0
+        fi
+
+        # ── Check 3: Any queued/in-progress GitHub Actions jobs? ──
+        if [ -n "${GITHUB_TOKEN}" ]; then
+            # Check for busy runners
+            BUSY_RUNNERS=$(curl -sf \
+                -H "Authorization: token ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/orgs/${GITHUB_ORG}/actions/runners?per_page=100" 2>/dev/null \
+                | grep -c '"busy": true' 2>/dev/null || echo "0")
+
+            # Check for queued runs mentioning our runner label
+            QUEUED_RUNS=$(curl -sf \
+                -H "Authorization: token ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/repos/${GITHUB_ORG}/kbve/actions/runs?status=queued&per_page=10" 2>/dev/null \
+                | grep -ci "${RUNNER_LABEL}" 2>/dev/null || echo "0")
+
+            # Check for in-progress runs
+            ACTIVE_RUNS=$(curl -sf \
+                -H "Authorization: token ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/repos/${GITHUB_ORG}/kbve/actions/runs?status=in_progress&per_page=10" 2>/dev/null \
+                | grep -ci "${RUNNER_LABEL}" 2>/dev/null || echo "0")
+
+            echo "GitHub: busy=${BUSY_RUNNERS}, queued=${QUEUED_RUNS}, active=${ACTIVE_RUNS}"
+
+            if [ "${QUEUED_RUNS}" -gt 0 ] || [ "${ACTIVE_RUNS}" -gt 0 ]; then
+                echo "KEEP: GitHub Actions activity detected"
+                exit 0
+            fi
+        else
+            echo "WARN: no GITHUB_TOKEN — skipping GitHub check"
+        fi
+
+        # ── Check 4: Any active VNC/RDP connections? ──
+        POD_NAME=$(kubectl get pods -n "${NAMESPACE}" -l "vm.kubevirt.io/name=${VM_NAME}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if [ -n "${POD_NAME}" ]; then
+            VNC_CONNS=$(kubectl exec "${POD_NAME}" -n "${NAMESPACE}" -c compute -- \
+                sh -c "ss -tn state established 2>/dev/null | grep -c ':5900' || echo 0" 2>/dev/null || echo "0")
+            RDP_CONNS=$(kubectl exec "${POD_NAME}" -n "${NAMESPACE}" -c compute -- \
+                sh -c "ss -tn state established 2>/dev/null | grep -c ':3389' || echo 0" 2>/dev/null || echo "0")
+
+            echo "Sessions: VNC=${VNC_CONNS}, RDP=${RDP_CONNS}"
+
+            if [ "${VNC_CONNS}" -gt 0 ] || [ "${RDP_CONNS}" -gt 0 ]; then
+                echo "KEEP: active VNC/RDP session"
+                exit 0
+            fi
+        fi
+
+        # ── All checks passed — stop the VM ──
+        echo "STOP: idle ${AGE_MINUTES}m, no jobs, no sessions"
+        kubectl proxy --port=8001 &
+        PROXY_PID=$!
+        sleep 2
+        curl -s -X PUT \
+            "http://localhost:8001/apis/subresources.kubevirt.io/v1/namespaces/${NAMESPACE}/virtualmachines/${VM_NAME}/stop" \
+            -H "Content-Type: application/json" -d '{}'
+        kill "${PROXY_PID}" 2>/dev/null || true
+        echo "${VM_NAME}: stop requested."


### PR DESCRIPTION
## Summary
Rewrite VM idle shutdown CronJob to check three conditions before stopping:

1. **Age check**: VM running > 30 minutes
2. **GitHub Actions check**: no queued/in-progress jobs for the VM's runner label
3. **Session check**: no active VNC (5900) or RDP (3389) connections

All three must pass → VM stops. Any one fails → VM stays running.

Fixes the issue where VMs ran idle for days because the old CronJob only checked age.