### PR TITLE
fix(kube): re-add ingress-nginx for cert-manager ACME solver

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -15,7 +15,8 @@ resources:
     - cnpg/application.yaml
     - cnpg/plugins-application.yaml
     # MetalLB removed — Cilium LB IPAM handles IP allocation + L2 announcements
-    # ingress-nginx removed — Cilium Gateway API handles ingress
+    # ingress-nginx — kept for cert-manager HTTP-01 solver (domains not on Cloudflare DNS)
+    - ingress/application.yaml
     - cert-manager/application.yaml
     - sealed-secrets/application.yaml
     - keda/application.yaml
@@ -46,7 +47,6 @@ resources:
     - clickhouse-operator/application.yaml
     - clickhouse/application.yaml
 
-    - mc/application.yaml
     - cityvote/application.yaml
     - herbmail/application.yaml
     - memes/application.yaml


### PR DESCRIPTION
## Summary
- Re-add `ingress/application.yaml` to kube-root kustomization
- nginx is needed solely for cert-manager HTTP-01 ACME challenges on non-Cloudflare domains (chuckrpg.com)
- Cilium Gateway API still handles all production routing
- Also removes stale `mc/application.yaml` reference

## Root cause
`game-chuckrpg-tls` cert has been pending 7+ days because the HTTP-01 challenge returns 404 — nginx controller pods were in CrashLoopBackOff (missing service). ArgoCD managing nginx via Helm will create the service and fix the controller.