### PR TITLE
fix(axum-kbve-e2e): wait for container readiness before running tests

### DIFF
--- a/apps/kbve/axum-kbve-e2e/e2e/helpers/http.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/helpers/http.ts
@@ -8,7 +8,7 @@ export const BASE_URL = `http://${AXUM_HOST}:${AXUM_PORT}`;
  * TCP-only checks are insufficient — the server accepts TCP
  * connections before the HTTP handler is fully initialized.
  */
-export async function waitForReady(timeoutMs = 30_000): Promise<void> {
+export async function waitForReady(timeoutMs = 60_000): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 
 	while (Date.now() < deadline) {

--- a/apps/kbve/axum-kbve-e2e/project.json
+++ b/apps/kbve/axum-kbve-e2e/project.json
@@ -21,8 +21,9 @@
 			"options": {
 				"commands": [
 					"docker rm -f axum-kbve-e2e 2>/dev/null || true",
-					"docker run -d --name axum-kbve-e2e -p 4323:4321 -e HTTP_HOST=0.0.0.0 -e HTTP_PORT=4321 -e RUST_LOG=info kbve/kbve:latest",
-					"npx vitest run; EC=$?; docker rm -f axum-kbve-e2e 2>/dev/null || true; exit $EC"
+					"docker run -d --name axum-kbve-e2e -p 4323:4321 -e HTTP_HOST=0.0.0.0 -e HTTP_PORT=4321 -e RUST_LOG=info -e GAME_WT_DISABLE=1 kbve/kbve:latest",
+					"echo 'Waiting for axum-kbve container to become ready...' && for i in $(seq 1 120); do if docker logs axum-kbve-e2e 2>&1 | grep -q 'HTTP listening'; then echo 'Container ready after '\"$i\"'s'; break; fi; if [ $i -eq 120 ]; then echo 'Container did not become ready in 120s'; docker logs axum-kbve-e2e 2>&1 | tail -30; docker rm -f axum-kbve-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
+					"npx vitest run; EC=$?; echo '--- container logs ---'; docker logs axum-kbve-e2e 2>&1 | tail -50; docker rm -f axum-kbve-e2e 2>/dev/null || true; exit $EC"
 				],
 				"parallel": false,
 				"cwd": "apps/kbve/axum-kbve-e2e"


### PR DESCRIPTION
## Summary
- Add Docker log polling loop (up to 120s) that waits for `HTTP listening` before starting vitest
- Disable WebTransport in e2e container (`GAME_WT_DISABLE=1`) to skip UDP port binding on CI
- Dump container logs (`tail -50`) after test run for debugging on failures
- Increase vitest-side timeout from 30s to 60s as safety net

## Root cause
The e2e target ran `docker run -d` then immediately `npx vitest run`. The server needs time to initialize (OSRS cache HTTP fetch, game server thread spawn, HTTP port bind). On CI runners this took >30s, so the vitest health poll timed out with "server not ready at http://127.0.0.1:4323 after 30000ms".

Closes #9401

## Test plan
- [ ] Re-run CI Docker workflow for axum-kbve after merge
- [ ] Verify container readiness log appears before tests start
- [ ] Verify container logs are dumped in CI output on both pass and fail