### PR TITLE
fix(cert-manager): use Cilium gateway solver for chuckrpg ACME

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -69,17 +69,21 @@ spec:
                               annotations:
                                   cert-manager.io/http01-ingress-path-type: 'Prefix'
 
-            # --- Solver 6: CHUCKRPG.COM domains ---
+            # --- Solver 6: CHUCKRPG.COM domains (Cilium Gateway API) ---
+            # Uses gatewayHTTPRoute solver — cert-manager creates an HTTPRoute
+            # that attaches to the HTTP listener on the Cilium-managed gateway.
+            # sectionName: http ensures the route binds to port 80 (not HTTPS).
             - selector:
                   dnsZones:
                       - chuckrpg.com
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      serviceType: ClusterIP
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            sectionName: http
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -15,8 +15,7 @@ resources:
     - cnpg/application.yaml
     - cnpg/plugins-application.yaml
     # MetalLB removed — Cilium LB IPAM handles IP allocation + L2 announcements
-    # ingress-nginx — kept for cert-manager HTTP-01 solver (domains not on Cloudflare DNS)
-    - ingress/application.yaml
+    # ingress-nginx removed — Cilium Gateway API handles ingress + ACME HTTP-01 challenges
     - cert-manager/application.yaml
     - sealed-secrets/application.yaml
     - keda/application.yaml


### PR DESCRIPTION
## Summary
- Switch chuckrpg.com ACME solver from nginx to `gatewayHTTPRoute` with `sectionName: http`
- The original solver lacked `sectionName`, so cert-manager's HTTPRoute could attach to HTTPS instead of HTTP — ACME challenges must come over port 80
- Reverts nginx re-addition from kustomization (PR #9404)

## Root cause
cert-manager creates an HTTPRoute for the ACME challenge. Without `sectionName: http`, the route could attach to any listener including HTTPS (443). ACME HTTP-01 verification hits port 80, so if Envoy routes the challenge to HTTPS, it returns 404.

## Post-merge
```bash
kubectl delete challenge -n chuckrpg --all
kubectl delete order -n chuckrpg --all
kubectl delete application ingress-nginx -n argocd
```