### PR TITLE
fix(devops): replace axios with native fetch after dependency removal

### DIFF
--- a/packages/npm/devops/src/lib/api.spec.ts
+++ b/packages/npm/devops/src/lib/api.spec.ts
@@ -1,72 +1,69 @@
 import { _prompt, _headers, _post, _message, _groq } from './api';
 import { _isULID } from './sanitization';
-import axios from 'axios';
 
-vi.mock('axios');
-const mockedAxios = vi.mocked(axios, true);
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
 
 describe('API Functions', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fetchMock.mockReset();
+	});
 
-  test('_isULID should validate ULIDs correctly', () => {
-    expect(_isULID('01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(true);
-    expect(_isULID('invalidULID')).toBe(false);
-  });
+	test('_isULID should validate ULIDs correctly', () => {
+		expect(_isULID('01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(true);
+		expect(_isULID('invalidULID')).toBe(false);
+	});
 
-  test('_prompt should fetch prompt successfully', async () => {
-    const ulid = '01J05G1PCD6ZXPNHEFBDYHYS77';
-    mockedAxios.get.mockResolvedValueOnce({
-      data: {
-        key: {
-          [ulid]: { task: 'test-task', system: 'test-system' },
-        },
-      },
-    });
-    const result = await _prompt(ulid);
-    expect(result).toHaveProperty('task');
-  });
+	test('_prompt should fetch prompt successfully', async () => {
+		const ulid = '01J05G1PCD6ZXPNHEFBDYHYS77';
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				key: {
+					[ulid]: { task: 'test-task', system: 'test-system' },
+				},
+			}),
+		});
+		const result = await _prompt(ulid);
+		expect(result).toHaveProperty('task');
+	});
 
-  test('_headers should construct headers correctly', () => {
-    const kbve_api = 'test_api_key';
-    const headers = _headers(kbve_api);
-    expect(headers).toEqual({
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${kbve_api}`
-    });
+	test('_headers should construct headers correctly', () => {
+		const kbve_api = 'test_api_key';
+		const headers = _headers(kbve_api);
+		expect(headers).toEqual({
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${kbve_api}`,
+		});
 
-    const headersWithoutApiKey = _headers();
-    expect(headersWithoutApiKey).toEqual({
-      'Content-Type': 'application/json'
-    });
-  });
+		const headersWithoutApiKey = _headers();
+		expect(headersWithoutApiKey).toEqual({
+			'Content-Type': 'application/json',
+		});
+	});
 
-  test('_post should make a POST request and return data', async () => {
-    mockedAxios.post.mockResolvedValueOnce({
-      data: { id: 101, title: 'foo', body: 'bar', userId: 1 },
-    });
-    const url = 'https://jsonplaceholder.typicode.com/posts';
-    const payload = { title: 'foo', body: 'bar', userId: 1 };
-    const result = await _post(url, payload, { 'Content-Type': 'application/json' });
-    expect(result).toHaveProperty('id');
-  });
+	test('_post should make a POST request and return data', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				id: 101,
+				title: 'foo',
+				body: 'bar',
+				userId: 1,
+			}),
+		});
+		const url = 'https://jsonplaceholder.typicode.com/posts';
+		const payload = { title: 'foo', body: 'bar', userId: 1 };
+		const result = await _post(url, payload, {
+			'Content-Type': 'application/json',
+		});
+		expect(result).toHaveProperty('id');
+	});
 
-  test('_message should sanitize message correctly', async () => {
-    const message = '# Hello, World!';
-    const sanitizedMessage = await _message(message, 1);
-    expect(sanitizedMessage).toEqual(JSON.stringify('Hello, World!'));
-  });
-
-  // test('_groq should process request and return API response', async () => {
-  //   const system = '01J05G1PCD6ZXPNHEFBDYHYS77';
-  //   const message = '# What other roles can you perform on my behalf?';
-  //   const kbve_api = '';
-  //   const model = 'mixtral-8x7b-32768';
-  //   const sanitizationLevel = 1;
-
-  //   const result = await _groq(system, message, kbve_api, model, sanitizationLevel);
-  //   console.log('API Response:', result);
-  //   expect(result).toBeDefined();
-  // }, { timeout: 10000 });
+	test('_message should sanitize message correctly', async () => {
+		const message = '# Hello, World!';
+		const sanitizedMessage = await _message(message, 1);
+		expect(sanitizedMessage).toEqual(JSON.stringify('Hello, World!'));
+	});
 });

--- a/packages/npm/devops/src/lib/api.ts
+++ b/packages/npm/devops/src/lib/api.ts
@@ -1,81 +1,80 @@
-import axios from 'axios';
 import {
-  _isULID,
-  markdownToJsonSafeString,
-  markdownToJsonSafeStringThenStrip,
-  _md2json,
-  __md2json,
+	_isULID,
+	markdownToJsonSafeString,
+	markdownToJsonSafeStringThenStrip,
+	_md2json,
+	__md2json,
 } from './sanitization';
 
 // Prompt Engine Interface
 
 interface FunctionParameter {
-  type: string;
-  properties: {
-    [key: string]: {
-      type: string;
-      description: string;
-    };
-  };
-  required: string[];
+	type: string;
+	properties: {
+		[key: string]: {
+			type: string;
+			description: string;
+		};
+	};
+	required: string[];
 }
 
 interface ToolFunction {
-  name: string;
-  description: string;
-  parameters: FunctionParameter;
+	name: string;
+	description: string;
+	parameters: FunctionParameter;
 }
 
 interface Tool {
-  type: string;
-  function: ToolFunction;
+	type: string;
+	function: ToolFunction;
 }
 
 interface PathwayAction {
-  condition: string;
-  action: string;
+	condition: string;
+	action: string;
 }
 
 interface Pathways {
-  [key: string]: {
-    prompt: string;
-    next: PathwayAction[];
-  };
+	[key: string]: {
+		prompt: string;
+		next: PathwayAction[];
+	};
 }
 
 interface PromptItem {
-  name: string;
-  description: string;
-  items: string[];
-  task: string;
-  tools: Tool[];
-  output: string;
-  pathways: Pathways;
-  ulid: string;
+	name: string;
+	description: string;
+	items: string[];
+	task: string;
+	tools: Tool[];
+	output: string;
+	pathways: Pathways;
+	ulid: string;
 }
 
 interface PromptEngine {
-  key: {
-    [key: string]: PromptItem;
-  };
+	key: {
+		[key: string]: PromptItem;
+	};
 }
 
 export interface GroqResponse {
-  choices?: {
-    message?: {
-      content?: string;
-    };
-  }[];
-  [key: string]: unknown;
+	choices?: {
+		message?: {
+			content?: string;
+		};
+	}[];
+	[key: string]: unknown;
 }
 
 const sanitizationFunctions: {
-  [key: number]: (text: string) => Promise<string>;
+	[key: number]: (text: string) => Promise<string>;
 } = {
-  1: markdownToJsonSafeString,
-  2: markdownToJsonSafeStringThenStrip,
-  3: _md2json,
-  4: __md2json,
+	1: markdownToJsonSafeString,
+	2: markdownToJsonSafeStringThenStrip,
+	3: _md2json,
+	4: __md2json,
 };
 
 /**
@@ -84,25 +83,27 @@ const sanitizationFunctions: {
  * @returns The prompt object.
  */
 export async function _prompt(ulid: string): Promise<PromptItem> {
-  if (!_isULID(ulid)) {
-    throw new Error(`Invalid ULID: ${ulid}`);
-  }
+	if (!_isULID(ulid)) {
+		throw new Error(`Invalid ULID: ${ulid}`);
+	}
 
-  try {
-    const response = await axios.get<PromptEngine>('https://kbve.com/api/prompt/engine.json');
-    const data = response.data.key;
+	try {
+		const res = await fetch('https://kbve.com/api/prompt/engine.json');
+		if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+		const response = (await res.json()) as PromptEngine;
+		const data = response.key;
 
-    const prompt = data[ulid];
+		const prompt = data[ulid];
 
-    if (!prompt) {
-      throw new Error(`Prompt with ULID ${ulid} not found`);
-    }
+		if (!prompt) {
+			throw new Error(`Prompt with ULID ${ulid} not found`);
+		}
 
-    return prompt;
-  } catch (error) {
-    console.error(`Error fetching prompt for ULID ${ulid}:`, error);
-    throw error;
-  }
+		return prompt;
+	} catch (error) {
+		console.error(`Error fetching prompt for ULID ${ulid}:`, error);
+		throw error;
+	}
 }
 
 /**
@@ -111,15 +112,15 @@ export async function _prompt(ulid: string): Promise<PromptItem> {
  * @returns The headers object.
  */
 export function _headers(kbve_api?: string): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+	};
 
-  if (kbve_api) {
-    headers['Authorization'] = `Bearer ${kbve_api}`;
-  }
+	if (kbve_api) {
+		headers['Authorization'] = `Bearer ${kbve_api}`;
+	}
 
-  return headers;
+	return headers;
 }
 
 /**
@@ -131,24 +132,26 @@ export function _headers(kbve_api?: string): Record<string, string> {
  * @throws Error if the response status is not successful.
  */
 export async function _post<T>(
-  url: string,
-  payload: object,
-  headers: Record<string, string>,
+	url: string,
+	payload: object,
+	headers: Record<string, string>,
 ): Promise<T> {
-  try {
-    const response = await axios.post<T>(url, payload, {
-      headers: headers,
-    });
+	try {
+		const response = await fetch(url, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(payload),
+		});
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`);
+		}
 
-    return response.data;
-  } catch (error) {
-    console.error(`Error making POST request to ${url}:`, error);
-    throw error;
-  }
+		return (await response.json()) as T;
+	} catch (error) {
+		console.error(`Error making POST request to ${url}:`, error);
+		throw error;
+	}
 }
 
 /**
@@ -158,13 +161,13 @@ export async function _post<T>(
  * @returns The sanitized message.
  */
 export async function _message(
-  message: string,
-  level: number,
+	message: string,
+	level: number,
 ): Promise<string> {
-  if (sanitizationFunctions[level]) {
-    return await sanitizationFunctions[level](message);
-  }
-  return message;
+	if (sanitizationFunctions[level]) {
+		return await sanitizationFunctions[level](message);
+	}
+	return message;
 }
 
 /**
@@ -177,36 +180,36 @@ export async function _message(
  * @returns The response data from the API.
  */
 export async function _groq(
-  system: string,
-  message: string,
-  kbve_api: string,
-  model: string,
-  sanitizationLevel: number,
+	system: string,
+	message: string,
+	kbve_api: string,
+	model: string,
+	sanitizationLevel: number,
 ): Promise<GroqResponse> {
-  try {
-    const headers = _headers(kbve_api);
+	try {
+		const headers = _headers(kbve_api);
 
-    if (_isULID(system)) {
-      const prompt = await _prompt(system);
-      system = prompt.task;
-    }
+		if (_isULID(system)) {
+			const prompt = await _prompt(system);
+			system = prompt.task;
+		}
 
-    message = await _message(message, sanitizationLevel);
+		message = await _message(message, sanitizationLevel);
 
-    const payload = {
-      system,
-      message,
-      model,
-    };
+		const payload = {
+			system,
+			message,
+			model,
+		};
 
-    const apiResponse = await _post<GroqResponse>(
-      'https://rust.kbve.com/api/v1/call_groq',
-      payload,
-      headers,
-    );
-    return apiResponse;
-  } catch (error) {
-    console.error('Error processing groq request:', error);
-    throw error;
-  }
+		const apiResponse = await _post<GroqResponse>(
+			'https://rust.kbve.com/api/v1/call_groq',
+			payload,
+			headers,
+		);
+		return apiResponse;
+	} catch (error) {
+		console.error('Error processing groq request:', error);
+		throw error;
+	}
 }

--- a/packages/npm/devops/src/lib/client/yt.spec.ts
+++ b/packages/npm/devops/src/lib/client/yt.spec.ts
@@ -1,91 +1,93 @@
 import { fetchYoutubeTitle, extractYoutubeLink, extractYoutubeId } from './yt';
-import axios from 'axios';
 
-vi.mock('axios');
-const mockedAxios = vi.mocked(axios, true);
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
 
 describe('fetchYoutubeTitle', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fetchMock.mockReset();
+	});
 
-  it('should return the title of the YouTube video', async () => {
-    mockedAxios.get.mockResolvedValueOnce({
-      data: `<html><head>
+	it('should return the title of the YouTube video', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			text: async () => `<html><head>
         <meta property="og:video:url" content="https://www.youtube.com/embed/dQw4w9WgXcQ">
         <meta name="title" content="Rick Astley - Never Gonna Give You Up (Official Music Video)">
       </head><body></body></html>`,
-    });
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
-    const title = await fetchYoutubeTitle(url);
-    expect(title).toBe(
-      'Rick Astley - Never Gonna Give You Up (Official Music Video)',
-    );
-  });
+		});
+		const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+		const title = await fetchYoutubeTitle(url);
+		expect(title).toBe(
+			'Rick Astley - Never Gonna Give You Up (Official Music Video)',
+		);
+	});
 
-  it('should return null for an invalid YouTube URL', async () => {
-    const url = 'https://www.invalidurl.com';
-    const title = await fetchYoutubeTitle(url);
-    expect(title).toBeNull();
-  });
+	it('should return null for an invalid YouTube URL', async () => {
+		const url = 'https://www.invalidurl.com';
+		const title = await fetchYoutubeTitle(url);
+		expect(title).toBeNull();
+	});
 
-  it('should return null if the title is not found', async () => {
-    mockedAxios.get.mockResolvedValueOnce({
-      data: `<html><head></head><body></body></html>`,
-    });
-    const url = 'https://www.youtube.com/watch?v=invalidVideoId';
-    const title = await fetchYoutubeTitle(url);
-    expect(title).toBeNull();
-  });
+	it('should return null if the title is not found', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			text: async () => `<html><head></head><body></body></html>`,
+		});
+		const url = 'https://www.youtube.com/watch?v=invalidVideoId';
+		const title = await fetchYoutubeTitle(url);
+		expect(title).toBeNull();
+	});
 });
 
 describe('extractYoutubeLink', () => {
-  it('should return the first YouTube link found in the message', () => {
-    const message =
-      'Check out this video: https://www.youtube.com/watch?v=dQw4w9WgXcQ and this one too!';
-    const link = extractYoutubeLink(message);
-    expect(link).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
-  });
+	it('should return the first YouTube link found in the message', () => {
+		const message =
+			'Check out this video: https://www.youtube.com/watch?v=dQw4w9WgXcQ and this one too!';
+		const link = extractYoutubeLink(message);
+		expect(link).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+	});
 
-  it('should return null if no YouTube link is found in the message', () => {
-    const message = 'This is a message with no YouTube link.';
-    const link = extractYoutubeLink(message);
-    expect(link).toBeNull();
-  });
+	it('should return null if no YouTube link is found in the message', () => {
+		const message = 'This is a message with no YouTube link.';
+		const link = extractYoutubeLink(message);
+		expect(link).toBeNull();
+	});
 
-  it('should return the first YouTube link found in the message even with multiple links', () => {
-    const message =
-      'Here are two videos: https://www.youtube.com/watch?v=dQw4w9WgXcQ and https://youtu.be/3JZ_D3ELwOQ';
-    const link = extractYoutubeLink(message);
-    expect(link).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
-  });
+	it('should return the first YouTube link found in the message even with multiple links', () => {
+		const message =
+			'Here are two videos: https://www.youtube.com/watch?v=dQw4w9WgXcQ and https://youtu.be/3JZ_D3ELwOQ';
+		const link = extractYoutubeLink(message);
+		expect(link).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+	});
 });
 
 describe('extractYoutubeId', () => {
-  it('should return the YouTube video ID from the message', () => {
-    const message =
-      'Check out this video: https://www.youtube.com/watch?v=dQw4w9WgXcQ';
-    const videoId = extractYoutubeId(message);
-    expect(videoId).toBe('dQw4w9WgXcQ');
-  });
+	it('should return the YouTube video ID from the message', () => {
+		const message =
+			'Check out this video: https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+		const videoId = extractYoutubeId(message);
+		expect(videoId).toBe('dQw4w9WgXcQ');
+	});
 
-  it('should return null if no YouTube link is found in the message', () => {
-    const message = 'This is a message with no YouTube link.';
-    const videoId = extractYoutubeId(message);
-    expect(videoId).toBeNull();
-  });
+	it('should return null if no YouTube link is found in the message', () => {
+		const message = 'This is a message with no YouTube link.';
+		const videoId = extractYoutubeId(message);
+		expect(videoId).toBeNull();
+	});
 
-  it('should return the YouTube video ID even with multiple links in the message', () => {
-    const message =
-      'Here are two videos: https://www.youtube.com/watch?v=dQw4w9WgXcQ and https://youtu.be/3JZ_D3ELwOQ';
-    const videoId = extractYoutubeId(message);
-    expect(videoId).toBe('dQw4w9WgXcQ');
-  });
+	it('should return the YouTube video ID even with multiple links in the message', () => {
+		const message =
+			'Here are two videos: https://www.youtube.com/watch?v=dQw4w9WgXcQ and https://youtu.be/3JZ_D3ELwOQ';
+		const videoId = extractYoutubeId(message);
+		expect(videoId).toBe('dQw4w9WgXcQ');
+	});
 
-  it('should return null if the link does not contain a valid video ID', () => {
-    const message =
-      'Check out this video: https://www.youtube.com/watch?v=invalidVideoId';
-    const videoId = extractYoutubeId(message);
-    expect(videoId).toBeNull();
-  });
+	it('should return null if the link does not contain a valid video ID', () => {
+		const message =
+			'Check out this video: https://www.youtube.com/watch?v=invalidVideoId';
+		const videoId = extractYoutubeId(message);
+		expect(videoId).toBeNull();
+	});
 });

--- a/packages/npm/devops/src/lib/client/yt.ts
+++ b/packages/npm/devops/src/lib/client/yt.ts
@@ -1,12 +1,10 @@
-import axios from 'axios';
 import { JSDOM } from 'jsdom';
 
 /**
  * Regular expression to validate YouTube URLs.
  * Note: No /g flag on the module-level regex to avoid lastIndex state bugs.
  */
-const YOUTUBE_URL_REGEX =
-  /https?:\/\/(www\.)?(youtube\.com|youtu\.be)\/[^\s]+/;
+const YOUTUBE_URL_REGEX = /https?:\/\/(www\.)?(youtube\.com|youtu\.be)\/[^\s]+/;
 
 /**
  * Fetches the title of a YouTube video without using the YouTube API.
@@ -14,39 +12,44 @@ const YOUTUBE_URL_REGEX =
  * @returns The title of the YouTube video.
  */
 export async function fetchYoutubeTitle(url: string): Promise<string | null> {
-  // Validate the YouTube URL
-  if (!YOUTUBE_URL_REGEX.test(url)) {
-    console.error('Invalid YouTube URL');
-    return null;
-  }
+	// Validate the YouTube URL
+	if (!YOUTUBE_URL_REGEX.test(url)) {
+		console.error('Invalid YouTube URL');
+		return null;
+	}
 
-  try {
-    const response = await axios.get(url);
-    const dom = new JSDOM(response.data);
+	try {
+		const response = await fetch(url);
+		if (!response.ok)
+			throw new Error(`HTTP error! status: ${response.status}`);
+		const html = await response.text();
+		const dom = new JSDOM(html);
 
-    const videoElement = dom.window.document.querySelector(
-      'meta[property="og:video:url"]',
-    );
+		const videoElement = dom.window.document.querySelector(
+			'meta[property="og:video:url"]',
+		);
 
-    // Check if the meta tag for the video is present
-    if (!videoElement) {
-      console.error('No valid video found on the page');
-      return null;
-    }
+		// Check if the meta tag for the video is present
+		if (!videoElement) {
+			console.error('No valid video found on the page');
+			return null;
+		}
 
-    const titleElement =
-      dom.window.document.querySelector('meta[name="title"]') ||
-      dom.window.document.querySelector('meta[property="og:title"]') ||
-      dom.window.document.querySelector('title');
+		const titleElement =
+			dom.window.document.querySelector('meta[name="title"]') ||
+			dom.window.document.querySelector('meta[property="og:title"]') ||
+			dom.window.document.querySelector('title');
 
-    if (titleElement) {
-      return titleElement.getAttribute('content') || titleElement.textContent;
-    }
-    return null;
-  } catch (error) {
-    console.error('Error fetching YouTube title:', error);
-    return null;
-  }
+		if (titleElement) {
+			return (
+				titleElement.getAttribute('content') || titleElement.textContent
+			);
+		}
+		return null;
+	} catch (error) {
+		console.error('Error fetching YouTube title:', error);
+		return null;
+	}
 }
 
 /**
@@ -55,11 +58,11 @@ export async function fetchYoutubeTitle(url: string): Promise<string | null> {
  * @returns The first YouTube link found in the message, or null if no link is found.
  */
 export function extractYoutubeLink(message: string): string | null {
-  // Use /g flag inline so lastIndex resets each call
-  const urlMatches = message.match(
-    /https?:\/\/(www\.)?(youtube\.com|youtu\.be)\/[^\s]+/g,
-  );
-  return urlMatches ? urlMatches[0] : null;
+	// Use /g flag inline so lastIndex resets each call
+	const urlMatches = message.match(
+		/https?:\/\/(www\.)?(youtube\.com|youtu\.be)\/[^\s]+/g,
+	);
+	return urlMatches ? urlMatches[0] : null;
 }
 
 /**
@@ -68,11 +71,11 @@ export function extractYoutubeLink(message: string): string | null {
  * @returns The YouTube video ID found in the message, or null if no valid ID is found.
  */
 export function extractYoutubeId(message: string): string | null {
-  const url = extractYoutubeLink(message);
-  if (!url) {
-    return null;
-  }
+	const url = extractYoutubeLink(message);
+	if (!url) {
+		return null;
+	}
 
-  const videoIdMatch = url.match(/(?:v=|\/)([0-9A-Za-z_-]{11})(?:[?&]|$)/);
-  return videoIdMatch ? videoIdMatch[1] : null;
+	const videoIdMatch = url.match(/(?:v=|\/)([0-9A-Za-z_-]{11})(?:[?&]|$)/);
+	return videoIdMatch ? videoIdMatch[1] : null;
 }


### PR DESCRIPTION
## Summary
Axios was removed from devops package.json but still imported in source and test files, causing the \`@nx/dependency-checks\` lint rule to fail.

Replace all axios usage with native \`fetch\`:
- \`api.ts\`: \`axios.get\` → \`fetch\`, \`axios.post\` → \`fetch\` with POST method
- \`yt.ts\`: \`axios.get\` → \`fetch\` + \`.text()\`
- \`api.spec.ts\`: \`vi.mock('axios')\` → \`vi.stubGlobal('fetch', fetchMock)\`
- \`yt.spec.ts\`: same mock pattern update

## Test plan
- [x] \`nx lint devops\` — 0 errors, 30 warnings
- [x] \`nx test devops\` — 204 tests pass (11 files)

Fixes #9410