### PR TITLE
fix(angelscript): add K8s API URL to ExternalSecrets SecretStore

### DIFF
--- a/apps/kube/angelscript/manifest/external-secrets.yaml
+++ b/apps/kube/angelscript/manifest/external-secrets.yaml
@@ -58,6 +58,7 @@ spec:
                     name: angelscript-external-secrets
             remoteNamespace: arc-systems
             server:
+                url: 'https://kubernetes.default.svc'
                 caProvider:
                     key: ca.crt
                     name: kube-root-ca.crt


### PR DESCRIPTION
Missing `url` field in SecretStore caused localhost connection. Fixes KEDA auth → unblocks VM auto-scaling.