### PR TITLE
fix(chuckrpg): add missing certificates and api route to git

### DIFF
--- a/apps/kube/chuckrpg/manifest/certificate.yaml
+++ b/apps/kube/chuckrpg/manifest/certificate.yaml
@@ -1,6 +1,34 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+    name: chuckrpg-tls
+    namespace: chuckrpg
+spec:
+    secretName: chuckrpg-tls
+    dnsNames:
+        - chuckrpg.com
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+        group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: chuckrpg-api-tls
+    namespace: chuckrpg
+spec:
+    secretName: chuckrpg-api-tls
+    dnsNames:
+        - api.chuckrpg.com
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+        group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
     name: game-chuckrpg-tls
     namespace: chuckrpg
 spec:

--- a/apps/kube/chuckrpg/manifest/httproute.yaml
+++ b/apps/kube/chuckrpg/manifest/httproute.yaml
@@ -18,3 +18,23 @@ spec:
           backendRefs:
               - name: chuckrpg-service
                 port: 4322
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: chuckrpg-api-routes
+    namespace: chuckrpg
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - api.chuckrpg.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: chuckrpg-service
+                port: 4322


### PR DESCRIPTION
## Summary
- Add `chuckrpg-tls` and `chuckrpg-api-tls` Certificate CRDs to `certificate.yaml`
- Add `chuckrpg-api-routes` HTTPRoute for `api.chuckrpg.com`
- These resources existed live but not in git, causing ArgoCD OutOfSync/Degraded

## Root cause
The original chuckrpg setup created certs manually. When ArgoCD took over management, these orphaned resources caused perpetual OutOfSync because ArgoCD couldn't reconcile them.