### PR TITLE
feat(dashboard): integrate Guacamole RDP client

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
@@ -3,6 +3,7 @@ import ReactVMAuth from './ReactVMAuth';
 import ReactVMHeader from './ReactVMHeader';
 import ReactVMCards from './ReactVMCards';
 import ReactVMVncViewer from './ReactVMVncViewer';
+import ReactVMGuacViewer from './ReactVMGuacViewer';
 ---
 
 <section
@@ -25,6 +26,11 @@ import ReactVMVncViewer from './ReactVMVncViewer';
 				<!-- Island: VNC viewer (shown when a VM VNC is opened) -->
 				<div id="vm-vnc">
 					<ReactVMVncViewer client:only="react" />
+				</div>
+
+				<!-- Island: Guacamole RDP viewer (shown when RDP is opened) -->
+				<div id="vm-guac">
+					<ReactVMGuacViewer client:only="react" />
 				</div>
 			</div>
 		</ReactVMAuth>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMCards.tsx
@@ -400,6 +400,14 @@ function VMCard({ info }: { info: VMInfo }) {
 							disabled={false}
 							onClick={() => vmService.openVNC(name)}
 						/>
+						<ActionButton
+							icon={<Monitor size={13} />}
+							label="RDP"
+							color="#3b82f6"
+							loading={false}
+							disabled={false}
+							onClick={() => vmService.openGuac(name)}
+						/>
 					</>
 				)}
 				{isTransitioning && (

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMGuacViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMGuacViewer.tsx
@@ -1,0 +1,314 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { vmService } from './vmService';
+import { X, Maximize2, Minimize2, Keyboard } from 'lucide-react';
+
+// Guacamole client — dynamically imported to avoid SSR issues.
+let Guacamole: any = null;
+async function loadGuacamole() {
+	if (!Guacamole) {
+		const mod = await import('guacamole-common-js');
+		Guacamole = mod.default ?? mod;
+	}
+	return Guacamole;
+}
+
+export default function ReactVMGuacViewer() {
+	const guacTarget = useStore(vmService.$guacTarget);
+	const clientRef = useRef<any>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const displayRef = useRef<HTMLDivElement>(null);
+	const [fullscreen, setFullscreen] = useState(false);
+	const [connected, setConnected] = useState(false);
+	const [status, setStatus] = useState('Connecting...');
+	const [keyboardVisible, setKeyboardVisible] = useState(false);
+
+	const cleanup = useCallback(() => {
+		if (clientRef.current) {
+			clientRef.current.disconnect();
+			clientRef.current = null;
+		}
+		setConnected(false);
+		setStatus('Disconnected');
+	}, []);
+
+	useEffect(() => {
+		if (!guacTarget) {
+			cleanup();
+			return;
+		}
+
+		const target = displayRef.current;
+		if (!target) return;
+
+		target.innerHTML = '';
+		setStatus('Connecting...');
+
+		(async () => {
+			try {
+				const GuacLib = await loadGuacamole();
+
+				// Build WebSocket tunnel URL to our Guacamole proxy
+				const proto =
+					window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+				const tunnelUrl = `${proto}//${window.location.host}/dashboard/guac/proxy/guacamole/websocket-tunnel`;
+
+				const tunnel = new GuacLib.WebSocketTunnel(tunnelUrl);
+				const client = new GuacLib.Client(tunnel);
+
+				// Attach display to DOM
+				const display = client.getDisplay();
+				target.appendChild(display.getElement());
+
+				// Scale display to fit container
+				const resizeObserver = new ResizeObserver(() => {
+					if (!target || !display) return;
+					const width = target.clientWidth;
+					const height = target.clientHeight;
+					if (width > 0 && height > 0) {
+						const scale = Math.min(
+							width / display.getWidth(),
+							height / display.getHeight(),
+						);
+						display.scale(scale);
+					}
+				});
+				resizeObserver.observe(target);
+
+				client.onstatechange = (state: number) => {
+					switch (state) {
+						case 0: // IDLE
+							setStatus('Idle');
+							setConnected(false);
+							break;
+						case 1: // CONNECTING
+							setStatus('Connecting...');
+							break;
+						case 2: // WAITING
+							setStatus('Waiting for server...');
+							break;
+						case 3: // CONNECTED
+							setStatus(`Connected to ${guacTarget}`);
+							setConnected(true);
+							break;
+						case 4: // DISCONNECTING
+							setStatus('Disconnecting...');
+							break;
+						case 5: // DISCONNECTED
+							setStatus('Disconnected');
+							setConnected(false);
+							break;
+					}
+				};
+
+				client.onerror = (error: { message?: string }) => {
+					setStatus(
+						`Error: ${error?.message ?? 'Connection failed'}`,
+					);
+					setConnected(false);
+				};
+
+				// Connect with the connection parameters
+				// The token and connection ID are passed as query params
+				// Guacamole authenticates via its own session system
+				client.connect(
+					`token=${encodeURIComponent(guacTarget)}&GUAC_WIDTH=${window.screen.width}&GUAC_HEIGHT=${window.screen.height}&GUAC_DPI=96`,
+				);
+
+				clientRef.current = client;
+
+				return () => {
+					resizeObserver.disconnect();
+				};
+			} catch (err) {
+				setStatus(
+					`Failed to connect: ${err instanceof Error ? err.message : 'Unknown error'}`,
+				);
+			}
+		})();
+
+		return cleanup;
+	}, [guacTarget, cleanup]);
+
+	// Ctrl+Alt+Del sender for Windows RDP sessions
+	const sendCtrlAltDel = useCallback(() => {
+		const client = clientRef.current;
+		if (!client) return;
+		// Press keys
+		client.sendKeyEvent(1, 0xffe3); // Ctrl
+		client.sendKeyEvent(1, 0xffe9); // Alt
+		client.sendKeyEvent(1, 0xffff); // Delete
+		// Release keys
+		client.sendKeyEvent(0, 0xffff);
+		client.sendKeyEvent(0, 0xffe9);
+		client.sendKeyEvent(0, 0xffe3);
+	}, []);
+
+	const toggleKeyboard = useCallback(() => {
+		setKeyboardVisible(!keyboardVisible);
+		// Guacamole has its own keyboard handling via the display element
+	}, [keyboardVisible]);
+
+	if (!guacTarget) return null;
+
+	return (
+		<div
+			ref={containerRef}
+			className="not-content"
+			style={{
+				position: fullscreen ? 'fixed' : 'relative',
+				top: fullscreen ? 0 : undefined,
+				left: fullscreen ? 0 : undefined,
+				right: fullscreen ? 0 : undefined,
+				bottom: fullscreen ? 0 : undefined,
+				zIndex: fullscreen ? 9999 : 1,
+				marginTop: fullscreen ? 0 : '1.5rem',
+				borderRadius: fullscreen ? 0 : 12,
+				border: '1px solid var(--sl-color-gray-5, #30363d)',
+				background: '#0a0a0a',
+				overflow: 'hidden',
+				display: 'flex',
+				flexDirection: 'column',
+			}}>
+			{/* Toolbar */}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					padding: '0.5rem 1rem',
+					background: 'var(--sl-color-gray-6, #161b22)',
+					borderBottom: '1px solid var(--sl-color-gray-5, #30363d)',
+				}}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 8,
+					}}>
+					<span
+						style={{
+							width: 8,
+							height: 8,
+							borderRadius: '50%',
+							background: connected ? '#22c55e' : '#ef4444',
+							boxShadow: connected ? '0 0 6px #22c55e' : 'none',
+						}}
+					/>
+					<span
+						style={{
+							fontSize: '0.75rem',
+							padding: '2px 8px',
+							borderRadius: 4,
+							background: 'rgba(59, 130, 246, 0.15)',
+							color: '#60a5fa',
+							fontWeight: 500,
+						}}>
+						RDP
+					</span>
+					<span
+						style={{
+							fontSize: '0.8rem',
+							color: 'var(--sl-color-text, #e6edf3)',
+							fontWeight: 500,
+						}}>
+						{status}
+					</span>
+				</div>
+				<div style={{ display: 'flex', gap: 4 }}>
+					{connected && (
+						<>
+							<ToolbarButton
+								title="Send Ctrl+Alt+Del"
+								onClick={sendCtrlAltDel}>
+								<span
+									style={{
+										fontSize: '0.6rem',
+										fontWeight: 700,
+									}}>
+									CAD
+								</span>
+							</ToolbarButton>
+							<ToolbarButton
+								title="Toggle keyboard"
+								onClick={toggleKeyboard}>
+								<Keyboard size={14} />
+							</ToolbarButton>
+						</>
+					)}
+					<ToolbarButton
+						title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+						onClick={() => setFullscreen(!fullscreen)}>
+						{fullscreen ? (
+							<Minimize2 size={14} />
+						) : (
+							<Maximize2 size={14} />
+						)}
+					</ToolbarButton>
+					<ToolbarButton
+						title="Close RDP"
+						onClick={() => vmService.closeGuac()}
+						color="#ef4444">
+						<X size={14} />
+					</ToolbarButton>
+				</div>
+			</div>
+
+			{/* Guacamole renders into this container */}
+			<div
+				ref={displayRef}
+				style={{
+					flex: 1,
+					minHeight: fullscreen ? undefined : 480,
+					background: '#0a0a0a',
+					cursor: connected ? 'default' : 'not-allowed',
+					overflow: 'hidden',
+				}}
+			/>
+
+			{/* Status bar */}
+			<div
+				style={{
+					padding: '0.4rem 1rem',
+					borderTop: '1px solid var(--sl-color-gray-5, #30363d)',
+					fontSize: '0.65rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					textAlign: 'center',
+				}}>
+				{connected
+					? 'Click inside to capture keyboard · Ctrl+Alt+Del via toolbar · RDP via Guacamole'
+					: 'Waiting for RDP connection...'}
+			</div>
+		</div>
+	);
+}
+
+function ToolbarButton({
+	title,
+	onClick,
+	color,
+	children,
+}: {
+	title: string;
+	onClick: () => void;
+	color?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			title={title}
+			onClick={onClick}
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				padding: 4,
+				borderRadius: 4,
+				border: 'none',
+				background: 'transparent',
+				color: color ?? 'var(--sl-color-gray-3, #8b949e)',
+				cursor: 'pointer',
+			}}>
+			{children}
+		</button>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
@@ -351,6 +351,7 @@ class VMService {
 	public readonly $lastUpdated = atom<Date | null>(null);
 	public readonly $actionInProgress = atom<string | null>(null);
 	public readonly $vncTarget = atom<string | null>(null);
+	public readonly $guacTarget = atom<string | null>(null);
 
 	public readonly $vmInfos = computed(
 		[this.$vms, this.$vmis],
@@ -526,6 +527,16 @@ class VMService {
 
 	public closeVNC(): void {
 		this.$vncTarget.set(null);
+	}
+
+	// --- Guacamole RDP ---
+
+	public openGuac(name: string): void {
+		this.$guacTarget.set(name);
+	}
+
+	public closeGuac(): void {
+		this.$guacTarget.set(null);
 	}
 
 	public getVNCWebSocketURL(name: string): string {

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -141,6 +141,13 @@ async fn main() -> anyhow::Result<()> {
         info!("KASM proxy not configured (using default cluster URL)");
     }
 
+    // Initialize Guacamole proxy (optional - for /dashboard/guac)
+    if transport::proxy::init_guacamole_proxy() {
+        info!("Guacamole proxy initialized - /dashboard/guac/proxy enabled");
+    } else {
+        info!("Guacamole proxy not configured (using default cluster URL)");
+    }
+
     // Initialize ChuckRPG/ROWS Swagger proxy (optional - for /dashboard/chuckrpg)
     if transport::proxy::init_chuckrpg_proxy() {
         info!("ChuckRPG proxy initialized - /dashboard/chuckrpg/proxy enabled");

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -250,6 +250,14 @@ fn router(state: AppState) -> Router {
             axum::routing::put(super::proxy::kasm_scale_handler),
         )
         .route(
+            "/dashboard/guac/proxy/{*path}",
+            any(super::proxy::guacamole_proxy_handler),
+        )
+        .route(
+            "/dashboard/guac/proxy",
+            any(super::proxy::guacamole_proxy_handler),
+        )
+        .route(
             "/dashboard/edge/proxy/{*path}",
             any(super::proxy::edge_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -941,6 +941,48 @@ pub async fn kasm_scale_handler(Path(name): Path<String>, req: Request<Body>) ->
 }
 
 // ---------------------------------------------------------------------------
+// Guacamole proxy singleton (reverse proxy to Apache Guacamole web app)
+// ---------------------------------------------------------------------------
+// guacamole-common-js connects via HTTP tunnel or WebSocket to:
+//   {base}/guacamole/tunnel (HTTP polling)
+//   {base}/guacamole/websocket-tunnel (WebSocket)
+// We proxy /dashboard/guac/proxy/* → guacamole.angelscript.svc.cluster.local:8080
+
+static GUACAMOLE: OnceLock<ServiceProxy> = OnceLock::new();
+
+pub fn init_guacamole_proxy() -> bool {
+    let upstream = std::env::var("GUACAMOLE_UPSTREAM_URL")
+        .unwrap_or_else(|_| "http://guacamole.angelscript.svc.cluster.local:8080".into());
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(60))
+        .build()
+        .expect("failed to build reqwest client for guacamole proxy");
+
+    GUACAMOLE
+        .set(ServiceProxy {
+            name: "Guacamole",
+            client,
+            upstream: upstream.trim_end_matches('/').to_string(),
+            upstream_token: None, // Guacamole uses its own session auth
+        })
+        .is_ok()
+}
+
+pub async fn guacamole_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
+    match GUACAMOLE.get() {
+        Some(proxy) => proxy.handle(path, req).await,
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Guacamole proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Edge Functions proxy singleton (Supabase → internal Kong)
 // ---------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
 		"framer-motion": "^12.34.3",
 		"grid-engine": "^2.45.5",
 		"gsap": "^3.13.0",
+		"guacamole-common-js": "^1.5.0",
 		"happy-dom": "^20.8.4",
 		"html-react-parser": "^5.1.18",
 		"input-otp": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
             gsap:
                 specifier: ^3.13.0
                 version: 3.13.0
+            guacamole-common-js:
+                specifier: ^1.5.0
+                version: 1.5.0
             happy-dom:
                 specifier: ^20.8.4
                 version: 20.8.4
@@ -15270,6 +15273,12 @@ packages:
         resolution:
             {
                 integrity: sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==,
+            }
+
+    guacamole-common-js@1.5.0:
+        resolution:
+            {
+                integrity: sha512-zxztif3GGhKbg1RgOqwmqot8kXgv2HmHFg1EvWwd4q7UfEKvBcYZ0f+7G8HzvU+FUxF0Psqm9Kl5vCbgfrRgJg==,
             }
 
     gunzip-maybe@1.4.2:
@@ -38240,6 +38249,8 @@ snapshots:
 
     gsap@3.13.0: {}
 
+    guacamole-common-js@1.5.0: {}
+
     gunzip-maybe@1.4.2:
         dependencies:
             browserify-zlib: 0.1.4
@@ -45929,7 +45940,7 @@ snapshots:
             fast-json-stable-stringify: 2.1.0
             fs-extra: 9.1.0
             glob: 7.2.3
-            lodash: 4.17.23
+            lodash: 4.17.21
             pretty-bytes: 5.6.0
             rollup: 2.80.0
             source-map: 0.8.0-beta.0


### PR DESCRIPTION
## Summary
- Add `guacamole-common-js` (v1.5.0) for browser-based RDP via Apache Guacamole
- Add Guacamole reverse proxy to backend (`/dashboard/guac/proxy/*`) routing to `guacamole.angelscript.svc.cluster.local:8080`
- Create `ReactVMGuacViewer` component — WebSocket tunnel client with:
  - Auto-scaling display
  - Toolbar: Ctrl+Alt+Del, virtual keyboard, fullscreen, close
  - Connection state tracking (Idle/Connecting/Connected/Disconnected)
  - RDP badge in toolbar to distinguish from VNC sessions
- Add RDP button to all VM cards alongside existing VNC button
- Wire `$guacTarget` nanostore + `openGuac`/`closeGuac` into vmService
- Mount `ReactVMGuacViewer` island in `AstroVMDashboard.astro`

## Architecture
```
Browser → ReactVMGuacViewer
       → guacamole-common-js WebSocketTunnel
       → /dashboard/guac/proxy/guacamole/websocket-tunnel
       → axum proxy → guacamole:8080 (Tomcat)
       → guacd:4822 (protocol proxy)
       → windows-builder-rdp:3389 (VM RDP)
```

## Test plan
- [ ] Backend builds clean (`cargo build -p axum-kbve`)
- [ ] Guacamole proxy routes resolve when guacamole deployment is scaled up
- [ ] RDP button appears on VM cards
- [ ] Clicking RDP opens the Guacamole viewer panel
- [ ] Guacamole connects to Windows VM RDP session
- [ ] Ctrl+Alt+Del sends correctly through tunnel
- [ ] Fullscreen toggle works
- [ ] Close button disconnects and hides viewer