### PR TITLE
fix(astro-kbve): load noVNC from CDN instead of bare npm import

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -3,14 +3,14 @@ import { useStore } from '@nanostores/react';
 import { vmService } from './vmService';
 import { X, Maximize2, Minimize2, Keyboard } from 'lucide-react';
 
-// noVNC RFB client — dynamically imported to avoid Vite pre-bundling issues
-// (noVNC 1.6.0 uses `await` in non-async function which breaks Rollup).
-// Loaded at runtime only when VNC viewer is actually opened.
+// noVNC RFB client — loaded from CDN at runtime.
+// The npm package uses top-level `await` in CJS which breaks Rollup bundling,
+// so we load the ESM build from esm.sh instead. Only fetched when VNC viewer opens.
+const NOVNC_CDN = 'https://esm.sh/@novnc/novnc@1.6.0/lib/rfb.js';
 let RFB: any = null;
 async function loadRFB() {
 	if (!RFB) {
-		// @ts-expect-error — noVNC ships without TypeScript declarations
-		const mod = await import('@novnc/novnc/lib/rfb');
+		const mod = await import(/* @vite-ignore */ NOVNC_CDN);
 		RFB = mod.default ?? mod;
 	}
 	return RFB;


### PR DESCRIPTION
## Summary
- Load noVNC RFB client from `esm.sh` CDN instead of `@novnc/novnc` npm bare import
- The npm package uses top-level `await` in CJS (`lib/util/browser.js:179`) which Rollup can't parse
- Previous workaround externalized the package, but that causes runtime failure in production:
  `"Module name '@novnc/novnc/lib/rfb' does not resolve to a valid URL"`
- CDN ESM build avoids both the Rollup parse error and the runtime resolution failure

## Test plan
- [ ] `astro build` succeeds
- [ ] Open VM dashboard, click VNC on a running VM — viewer connects
- [ ] Verify esm.sh import loads correctly in browser network tab