### PR TITLE
fix(kubevirt): increase KEDA polling to avoid GitHub API rate limit

### DIFF
--- a/apps/kube/kubevirt/download-proxy/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/download-proxy/keda-scaledobject.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
     scaleTargetRef:
         name: download-proxy
-    pollingInterval: 30
+    pollingInterval: 300
     cooldownPeriod: 300
     idleReplicaCount: 0
     minReplicaCount: 0

--- a/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
     scaleTargetRef:
         name: guacd
-    pollingInterval: 30
+    pollingInterval: 300
     cooldownPeriod: 300
     idleReplicaCount: 0
     minReplicaCount: 0
@@ -45,7 +45,7 @@ metadata:
 spec:
     scaleTargetRef:
         name: guacamole
-    pollingInterval: 30
+    pollingInterval: 300
     cooldownPeriod: 300
     idleReplicaCount: 0
     minReplicaCount: 0

--- a/apps/kube/kubevirt/keda/scaled-jobs.yaml
+++ b/apps/kube/kubevirt/keda/scaled-jobs.yaml
@@ -42,7 +42,7 @@ spec:
                       configMap:
                           name: vm-scaler-script
                           defaultMode: 0755
-    pollingInterval: 30
+    pollingInterval: 300
     minReplicaCount: 0
     maxReplicaCount: 1
     successfulJobsHistoryLimit: 3
@@ -92,7 +92,7 @@ spec:
                       configMap:
                           name: vm-scaler-script
                           defaultMode: 0755
-    pollingInterval: 30
+    pollingInterval: 300
     minReplicaCount: 0
     maxReplicaCount: 1
     successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Fixes GitHub API rate limit errors. Changed polling from 30s → 300s (5min) across all KEDA triggers. Reduces API calls from 600/hour to 60/hour.