### PR TITLE
fix(angelscript): set server replicas to 0 until engine image is published

### DIFF
--- a/apps/kube/angelscript/manifest/deployment.yaml
+++ b/apps/kube/angelscript/manifest/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
     labels:
         app: angelscript
 spec:
-    replicas: 1
+    # replicas: 0 until a real engine build is published to GHCR
+    # (image ghcr.io/kbve/angelscript-server:0.0.0 does not exist)
+    replicas: 0
     strategy:
         type: Recreate
     selector:


### PR DESCRIPTION
## Summary
- Set `angelscript-server` deployment replicas to 0 — the image `ghcr.io/kbve/angelscript-server:0.0.0` doesn't exist yet (placeholder version, engine not built)
- This causes permanent `ImagePullBackOff` → ArgoCD `Degraded` status
- Deployment stays in git for when a real build is published — just bump replicas back to 1

Cluster-side cleanup also done:
- Deleted stuck `angelscript-server` pod
- Deleted stuck `vm-idle-shutdown` pods/jobs

## Test plan
- [ ] ArgoCD angelscript app shows Synced + Healthy after merge to main