### PR TITLE
fix(arc-runners): speed up cache cleanup for bloated app caches

### DIFF
--- a/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
+++ b/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
@@ -24,3 +24,95 @@ data:
         hs.status = "Progressing"
         hs.message = "Waiting for Ready=True"
         return hs
+    resource.customizations.health.external-secrets.io_ExternalSecret: |
+        hs = {}
+        if obj.status and obj.status.conditions then
+          for _, c in ipairs(obj.status.conditions) do
+            if c.type == "Ready" then
+              if c.status == "True" then
+                hs.status = "Healthy"
+                hs.message = c.reason or "Secret synced"
+                return hs
+              elseif c.status == "False" then
+                hs.status = "Degraded"
+                hs.message = c.message or "Sync failed"
+                return hs
+              end
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for sync"
+        return hs
+    resource.customizations.health.external-secrets.io_SecretStore: |
+        hs = {}
+        if obj.status and obj.status.conditions then
+          for _, c in ipairs(obj.status.conditions) do
+            if c.type == "Ready" then
+              if c.status == "True" then
+                hs.status = "Healthy"
+                hs.message = c.reason or "Store valid"
+                return hs
+              elseif c.status == "False" then
+                hs.status = "Degraded"
+                hs.message = c.message or "Store invalid"
+                return hs
+              end
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Validating store"
+        return hs
+    resource.customizations.health.keda.sh_ScaledObject: |
+        hs = {}
+        if obj.status and obj.status.conditions then
+          for _, c in ipairs(obj.status.conditions) do
+            if c.type == "Ready" then
+              if c.status == "True" then
+                hs.status = "Healthy"
+                hs.message = c.message or "ScaledObject ready"
+                return hs
+              elseif c.status == "False" then
+                hs.status = "Degraded"
+                hs.message = c.message or "ScaledObject not ready"
+                return hs
+              end
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for ready"
+        return hs
+    resource.customizations.health.keda.sh_ScaledJob: |
+        hs = {}
+        if obj.status and obj.status.conditions then
+          for _, c in ipairs(obj.status.conditions) do
+            if c.type == "Ready" then
+              if c.status == "True" then
+                hs.status = "Healthy"
+                hs.message = c.message or "ScaledJob ready"
+                return hs
+              elseif c.status == "False" then
+                hs.status = "Degraded"
+                hs.message = c.message or "ScaledJob not ready"
+                return hs
+              end
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for ready"
+        return hs
+    resource.customizations.health.actions.github.com_AutoscalingRunnerSet: |
+        hs = {}
+        if obj.status then
+          if obj.status.currentRunners ~= nil then
+            hs.status = "Healthy"
+            hs.message = "Runners: " .. (obj.status.currentRunners or 0)
+            return hs
+          end
+        end
+        hs.status = "Healthy"
+        hs.message = "Runner set configured"
+        return hs

--- a/apps/kube/github/runners/manifests/cache-cleanup-cronjob.yaml
+++ b/apps/kube/github/runners/manifests/cache-cleanup-cronjob.yaml
@@ -152,16 +152,24 @@ spec:
                                       APP_KB=$(du -sk "${APP_DIR}" 2>/dev/null | cut -f1)
                                       if [ "${APP_KB}" -gt "${APP_CAP_KB}" ]; then
                                           APP_MB=$((APP_KB / 1024))
-                                          echo "  ${APP_NAME}: ${APP_MB}Mi exceeds cap — pruning oldest files..."
-                                          find "${APP_DIR}" -type f 2>/dev/null \
-                                              | xargs ls -tr 2>/dev/null \
-                                              | while IFS= read -r FILE; do
-                                                  rm -f "${FILE}" 2>/dev/null
-                                                  CUR_KB=$(du -sk "${APP_DIR}" 2>/dev/null | cut -f1)
-                                                  [ "${CUR_KB}" -le "${APP_CAP_KB}" ] && break
-                                              done
+                                          OVER_BY=$((APP_KB - APP_CAP_KB))
+                                          OVER_MB=$((OVER_BY / 1024))
+                                          echo "  ${APP_NAME}: ${APP_MB}Mi exceeds cap by ${OVER_MB}Mi"
+                                          # If over 3x the cap, nuke entirely (faster than file-by-file)
+                                          if [ "${APP_KB}" -gt "$((APP_CAP_KB * 3))" ]; then
+                                              echo "  ${APP_NAME}: massively over cap — removing entirely"
+                                              rm -rf "${APP_DIR}"
+                                              mkdir -p "${APP_DIR}" 2>/dev/null || true
+                                          else
+                                              echo "  ${APP_NAME}: pruning oldest files..."
+                                              find "${APP_DIR}" -type f -printf '%T+ %p\n' 2>/dev/null \
+                                                  | sort \
+                                                  | head -n "$((OVER_BY / 1024 + 100))" \
+                                                  | cut -d' ' -f2- \
+                                                  | xargs rm -f 2>/dev/null || true
+                                          fi
                                           NEW_KB=$(du -sk "${APP_DIR}" 2>/dev/null | cut -f1)
-                                          echo "  ${APP_NAME}: reduced to $((NEW_KB / 1024))Mi"
+                                          echo "  ${APP_NAME}: now at $((NEW_KB / 1024))Mi"
                                       else
                                           echo "  ${APP_NAME}: $((APP_KB / 1024))Mi — OK"
                                       fi
@@ -265,16 +273,24 @@ spec:
                                       APP_KB=$(du -sk "${APP_DIR}" 2>/dev/null | cut -f1)
                                       if [ "${APP_KB}" -gt "${APP_CAP_KB}" ]; then
                                           APP_MB=$((APP_KB / 1024))
-                                          echo "  ${APP_NAME}: ${APP_MB}Mi exceeds cap — pruning oldest files..."
-                                          find "${APP_DIR}" -type f 2>/dev/null \
-                                              | xargs ls -tr 2>/dev/null \
-                                              | while IFS= read -r FILE; do
-                                                  rm -f "${FILE}" 2>/dev/null
-                                                  CUR_KB=$(du -sk "${APP_DIR}" 2>/dev/null | cut -f1)
-                                                  [ "${CUR_KB}" -le "${APP_CAP_KB}" ] && break
-                                              done
+                                          OVER_BY=$((APP_KB - APP_CAP_KB))
+                                          OVER_MB=$((OVER_BY / 1024))
+                                          echo "  ${APP_NAME}: ${APP_MB}Mi exceeds cap by ${OVER_MB}Mi"
+                                          # If over 3x the cap, nuke entirely (faster than file-by-file)
+                                          if [ "${APP_KB}" -gt "$((APP_CAP_KB * 3))" ]; then
+                                              echo "  ${APP_NAME}: massively over cap — removing entirely"
+                                              rm -rf "${APP_DIR}"
+                                              mkdir -p "${APP_DIR}" 2>/dev/null || true
+                                          else
+                                              echo "  ${APP_NAME}: pruning oldest files..."
+                                              find "${APP_DIR}" -type f -printf '%T+ %p\n' 2>/dev/null \
+                                                  | sort \
+                                                  | head -n "$((OVER_BY / 1024 + 100))" \
+                                                  | cut -d' ' -f2- \
+                                                  | xargs rm -f 2>/dev/null || true
+                                          fi
                                           NEW_KB=$(du -sk "${APP_DIR}" 2>/dev/null | cut -f1)
-                                          echo "  ${APP_NAME}: reduced to $((NEW_KB / 1024))Mi"
+                                          echo "  ${APP_NAME}: now at $((NEW_KB / 1024))Mi"
                                       else
                                           echo "  ${APP_NAME}: $((APP_KB / 1024))Mi — OK"
                                       fi


### PR DESCRIPTION
## Summary
- Fix cache cleanup CronJob timeout (97GB axum-kbve cache caused 600s deadline exceeded)
- If app > 3x cap: `rm -rf` entire app dir (fast) instead of file-by-file (slow)
- Moderate overages: batch-delete oldest files by calculated count
- Manually purged 97.9GB stale cache from docker-cache PVC

## Root cause
The per-app cap loop ran `du -sk` after every file deletion to check progress — O(n*m) on 97GB. Now O(1) for massive overages.