### PR TITLE
fix(edge): remove ghost mc function + fix e2e failures

### DIFF
--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -93,7 +93,6 @@ serve(async (req: Request) => {
     "user-vault": [],
     "vault-reader": [],
     meme: [],
-    mc: [],
     ows: [],
     logs: ["CLICKHOUSE_URL", "CLICKHOUSE_USER", "CLICKHOUSE_PASSWORD"],
     health: [],

--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -11,11 +11,6 @@ label = "Meme"
 description = "Meme feed and reactions"
 
 [[functions]]
-name = "mc"
-label = "Minecraft"
-description = "MC data operations"
-
-[[functions]]
 name = "discordsh"
 label = "Discord"
 description = "Discord server integration"


### PR DESCRIPTION
## Summary
- Remove `mc` (Minecraft) ghost entry from `version.toml` — no source directory exists
- Remove `mc` from main router env allowlist in `functions/main/index.ts`
- Delete `e2e/mc.spec.ts` — 10 tests against nonexistent function (6 failing)
- Remove `mc` from `content-type.spec.ts` endpoint list (2 failing tests)

Fixes #9432

## Root cause
mc was removed from the monorepo but references remained in:
1. `version.toml` (function registry)
2. `main/index.ts` (env allowlist)
3. `edge-e2e/e2e/mc.spec.ts` (full test suite)
4. `edge-e2e/e2e/content-type.spec.ts` (endpoint list)

This caused 8 e2e test failures: mc.spec.ts (6 failures — function returns 500 instead of expected responses) + content-type.spec.ts (2 failures — expected 415, got 500).

## Test plan
- [ ] Edge e2e tests pass (8 fewer tests, 0 failures)
- [ ] Health endpoint returns 9 functions (not 10)