### PR TITLE
fix(gameserver): resolve Bevy ECS schedule cycle in lightyear system sets

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -571,17 +571,21 @@ fn run_bevy_app(
     // Shared protocol (components, inputs, channels)
     app.add_plugins(ProtocolPlugin);
 
-    // WORKAROUND: Force deferred command flush between IoSystems::Poll and
-    // LinkReceiveSystems::BufferToLink in PreUpdate. When a WebSocket client
-    // connects through a proxy (Cloudflare/Cilium), the on_connection observer
-    // inserts AeronetLinkOf via deferred commands. Without this sync point,
-    // the receive system runs before those commands flush, causing "packets
-    // not consumed" warnings and a stalled Netcode handshake.
+    // WORKAROUND: Force deferred command flush between BufferToLink and
+    // ApplyConditioner in PreUpdate. When a WebSocket client connects through
+    // a proxy (Cloudflare/Cilium), the on_connection observer inserts
+    // AeronetLinkOf via deferred commands. Without this sync point, the
+    // receive system runs before those commands flush, causing "packets not
+    // consumed" warnings and a stalled Netcode handshake.
+    //
+    // NOTE: Both BufferToLink and ApplyConditioner are .in_set(Receive) and
+    // chained. We must order within the sub-sets, NOT against the parent
+    // Receive set, to avoid a circular in_set + before/after conflict.
     app.add_systems(
         PreUpdate,
         bevy::ecs::schedule::ApplyDeferred
-            .after(lightyear::link::LinkSystems::Receive)
-            .before(lightyear::link::LinkReceiveSystems::BufferToLink),
+            .after(lightyear::link::LinkReceiveSystems::BufferToLink)
+            .before(lightyear::link::LinkReceiveSystems::ApplyConditioner),
     );
 
     // lightyear–avian3d bridge


### PR DESCRIPTION
## Summary
Fix game server thread panic that causes Docker e2e tests to fail.

The `ApplyDeferred` workaround was ordered `.after(LinkSystems::Receive)` and `.before(LinkReceiveSystems::BufferToLink)`. But lightyear 0.26.4's `LinkPlugin` configures `BufferToLink` and `ApplyConditioner` as `.in_set(Receive).chain()` — meaning both are **inside** the `Receive` set. Ordering after the parent set while before a member of that set creates an unsolvable cycle:

```
Error when initializing schedule PreUpdate: system set `Receive` and system set 
`ApplyConditioner` have both `in_set` and `before`-`after` relationships
```

Reorder to `.after(BufferToLink).before(ApplyConditioner)` — stays within the sub-set chain, preserves the deferred command flush point, avoids the parent-set conflict.

Closes #9423

## Test plan
- [ ] `cargo check -p axum-kbve` passes
- [ ] Docker e2e: game server thread no longer panics
- [ ] axum-kbve-e2e tests pass (health, static, API)