### PR TITLE
feat(isometric): add native run target to project.json

### DIFF
--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -48,6 +48,19 @@
 				"cwd": "apps/kbve/isometric"
 			}
 		},
+		"run": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "cargo run -p isometric-game",
+				"cwd": "{workspaceRoot}"
+			},
+			"configurations": {
+				"production": {
+					"command": "GAME_SERVER_URL=wss://kbve.com/ws cargo run -p isometric-game",
+					"cwd": "{workspaceRoot}"
+				}
+			}
+		},
 		"build:tauri": {
 			"executor": "nx:run-commands",
 			"options": {


### PR DESCRIPTION
## Summary
Add `isometric:run` Nx target for native Bevy desktop builds.

```sh
./kbve.sh -nx isometric:run              # local server
./kbve.sh -nx isometric:run:production   # wss://kbve.com/ws
```

## Test plan
- [ ] `nx run isometric:run` launches the native window with local server defaults
- [ ] `nx run isometric:run:production` launches and fetches token from kbve.com