### PR TITLE
fix(axum-kbve): exclusive world.flush() to fix WS packet consume race

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -571,21 +571,14 @@ fn run_bevy_app(
     // Shared protocol (components, inputs, channels)
     app.add_plugins(ProtocolPlugin);
 
-    // WORKAROUND: Force deferred command flush between BufferToLink and
-    // ApplyConditioner in PreUpdate. When a WebSocket client connects through
-    // a proxy (Cloudflare/Cilium), the on_connection observer inserts
-    // AeronetLinkOf via deferred commands. Without this sync point, the
-    // receive system runs before those commands flush, causing "packets not
-    // consumed" warnings and a stalled Netcode handshake.
-    //
-    // NOTE: Both BufferToLink and ApplyConditioner are .in_set(Receive) and
-    // chained. We must order within the sub-sets, NOT against the parent
-    // Receive set, to avoid a circular in_set + before/after conflict.
+    // WORKAROUND: lightyear's WebSocketServerPlugin::on_connection observer
+    // inserts AeronetLinkOf via deferred commands. When a client connects
+    // through a proxy, the receive system can run before those commands flush,
+    // leaving Session.recv unconsumed. This exclusive system runs early in
+    // PreUpdate and forces a command flush to close the race window.
     app.add_systems(
         PreUpdate,
-        bevy::ecs::schedule::ApplyDeferred
-            .after(lightyear::link::LinkReceiveSystems::BufferToLink)
-            .before(lightyear::link::LinkReceiveSystems::ApplyConditioner),
+        flush_deferred_commands.before(lightyear::link::LinkSystems::Receive),
     );
 
     // lightyear–avian3d bridge
@@ -898,6 +891,14 @@ fn load_pem_identity(
 // ---------------------------------------------------------------------------
 // Debug observers — transport + link lifecycle tracing
 // ---------------------------------------------------------------------------
+
+/// Exclusive system: flush all pending deferred commands (including observer
+/// outputs like AeronetLinkOf inserts). This ensures the entity wiring from
+/// lightyear's on_connection observer is complete before the receive system
+/// tries to drain Session.recv into Link.recv.
+fn flush_deferred_commands(world: &mut World) {
+    world.flush();
+}
 
 /// Diagnostic: log Link buffer states every tick for entities in the Server collection.
 /// If the server's Netcode receive system processes packets, link.recv will be empty


### PR DESCRIPTION
## Summary
The previous `ApplyDeferred` fix (#9394, reworked in #9428) was placed AFTER `BufferToLink` due to schedule cycle constraints — too late to help. Packets still pile up as "not consumed."

Replace with an **exclusive system** that calls `world.flush()` ordered `.before(LinkSystems::Receive)`. Exclusive systems can be ordered against parent system sets without causing cycles.

This forces all pending deferred commands (including `AeronetLinkOf` inserts from lightyear's `on_connection` observer) to apply before the receive system tries to drain `Session.recv` → `Link.recv`.

## Why this works
- `world.flush()` applies ALL pending commands immediately
- Exclusive system ordering against a parent set (`LinkSystems::Receive`) doesn't create cycles
- The observer's deferred `AeronetLinkOf` insert is guaranteed to be visible to `lightyear_aeronet::receive`

## Test plan
- [ ] Deploy new image, connect via `wss://kbve.com/ws`
- [ ] Verify "packets not consumed" warnings are gone from server logs
- [ ] Verify client Netcode handshake completes (CONNECTED state)