### PR TITLE
fix(gateway): use generic HTTPS listener for all chuckrpg certs

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -20,6 +20,10 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        # Generic HTTPS listener — serves all domains.
+        # Each domain's cert is referenced here; ReferenceGrant allows
+        # cross-namespace cert access from chuckrpg, ows, etc.
+        # No hostname filter — Envoy uses SNI to select the right cert.
         - name: https
           protocol: HTTPS
           port: 443
@@ -27,16 +31,10 @@ spec:
               mode: Terminate
               certificateRefs:
                   - name: kbve-wt-tls
-          allowedRoutes:
-              namespaces:
-                  from: All
-        - name: https-game-chuckrpg
-          protocol: HTTPS
-          port: 443
-          hostname: game.chuckrpg.com
-          tls:
-              mode: Terminate
-              certificateRefs:
+                  - name: chuckrpg-tls
+                    namespace: chuckrpg
+                  - name: chuckrpg-api-tls
+                    namespace: chuckrpg
                   - name: game-chuckrpg-tls
                     namespace: chuckrpg
           allowedRoutes:


### PR DESCRIPTION
## Summary
- Remove dedicated `https-game-chuckrpg` listener from gateway
- Add `chuckrpg-tls`, `chuckrpg-api-tls`, `game-chuckrpg-tls` as cert refs on the generic HTTPS listener
- Envoy uses SNI to select the correct cert — no hostname filter needed

## Root cause
The dedicated listener with `hostname: game.chuckrpg.com` claimed the hostname at Envoy level, preventing HTTP (port 80) routing for that domain. ACME HTTP-01 challenges returned 404 because the solver's HTTPRoute on the HTTP listener couldn't match the hostname.

## Pattern going forward
All domains use the generic HTTPS listener with their cert added as a `certificateRef`. No per-domain HTTPS listeners. ACME challenges route through the hostname-less HTTP listener.

## Post-merge
```bash
kubectl delete challenge -n chuckrpg --all
kubectl delete order -n chuckrpg --all
```