### PR TITLE
feat(chat): boot droid workers + auto-connect on chat.kbve.com

### DIFF
--- a/apps/irc/astro-irc/src/components/chat/ReactChatRoom.tsx
+++ b/apps/irc/astro-irc/src/components/chat/ReactChatRoom.tsx
@@ -1,11 +1,5 @@
 /** @jsxImportSource react */
-import React, {
-	useState,
-	useEffect,
-	useCallback,
-	useRef,
-	useMemo,
-} from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useStore } from '@nanostores/react';
 import { cn } from '@kbve/astro';
 
@@ -521,21 +515,27 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 	);
 	const [token, setToken] = useState('');
 
-	// Check for existing Supabase session on mount
+	// Boot droid workers (provides window.kbve.ws) + check Supabase session
 	useEffect(() => {
 		let cancelled = false;
 		(async () => {
 			try {
+				const { bootChat } = await import('../../lib/boot');
+				await bootChat();
+				if (cancelled) return;
+
 				const { authBridge } = await import('../../lib/supa');
 				const session = await authBridge.getSession();
 				if (cancelled) return;
+
 				if (session?.access_token) {
 					setToken(session.access_token);
 					setAuthState('auth');
 				} else {
 					setAuthState('anon');
 				}
-			} catch {
+			} catch (err) {
+				console.error('[chat] Boot failed:', err);
 				if (!cancelled) setAuthState('anon');
 			}
 		})();
@@ -543,6 +543,17 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 			cancelled = true;
 		};
 	}, []);
+
+	// Auto-connect once authenticated and droid is ready
+	useEffect(() => {
+		if (
+			authState === 'auth' &&
+			token &&
+			$connectionStatus.get() === 'disconnected'
+		) {
+			connect(wsUrl, token);
+		}
+	}, [authState, token, wsUrl]);
 
 	// Graceful disconnect on unmount or page unload
 	useEffect(() => {

--- a/apps/irc/astro-irc/src/components/chat/service.ts
+++ b/apps/irc/astro-irc/src/components/chat/service.ts
@@ -326,6 +326,8 @@ function handleIncoming(raw: string): void {
 					$activeChannel.get(),
 					parsed.trailing ?? 'Welcome to IRC',
 				);
+				// Auto-join default channel after welcome
+				joinChannel($activeChannel.get());
 				break;
 			}
 

--- a/apps/irc/astro-irc/src/lib/boot.ts
+++ b/apps/irc/astro-irc/src/lib/boot.ts
@@ -1,0 +1,37 @@
+// boot.ts — Initialize droid workers + Supabase auth for chat.kbve.com
+//
+// Call once early (e.g. in a layout or top-level component).
+// After this resolves, window.kbve.ws is available for WebSocket chat.
+
+import { droid } from '@kbve/droid';
+import { workerURLs } from './workers';
+import { initSupa } from './supa';
+
+let _bootPromise: Promise<void> | null = null;
+
+/**
+ * Boot droid workers and Supabase auth in parallel.
+ * Safe to call multiple times — subsequent calls return the same promise.
+ */
+export function bootChat(): Promise<void> {
+	if (_bootPromise) return _bootPromise;
+
+	_bootPromise = (async () => {
+		// Boot droid (workers) and auth in parallel
+		const [droidResult] = await Promise.all([
+			droid({ workerURLs, initTimeout: 15_000 }),
+			initSupa(),
+		]);
+
+		if (!droidResult.initialized) {
+			throw new Error('Droid worker initialization failed');
+		}
+
+		console.log('[chat] Boot complete — droid + auth ready');
+	})().catch((e) => {
+		_bootPromise = null;
+		throw e;
+	});
+
+	return _bootPromise;
+}


### PR DESCRIPTION
## Summary

Wires up the droid WebSocket SharedWorker on chat.kbve.com so the IRC chat actually connects.

### What was missing
The chat frontend had the full UI (channels, messages, users, input) but `window.kbve.ws` was never initialized — the droid worker boot step was skipped on the chat site.

### Changes
- **boot.ts** — new module that initializes droid workers + Supabase auth in parallel
- **ReactChatRoom.tsx** — calls `bootChat()` before auth check, auto-connects WebSocket with JWT once authenticated
- **service.ts** — auto-joins `#general` after IRC 001 welcome message

### Connection flow
```
Page load → bootChat() → [droid workers + Supabase auth]
  → auth check → session found?
    → yes: auto-connect wss://chat.kbve.com/ws?token=jwt
      → IRC 001 welcome → auto-join #general → chatting
    → no: show OAuth login prompt (GitHub/Discord/Twitch)
```

### Build verified
`./kbve.sh -nx astro-irc:build` — 7 pages built, no errors

## Test plan
- [ ] Load chat.kbve.com/chat — should show login prompt if not authenticated
- [ ] Sign in via OAuth — should auto-connect and join #general
- [ ] Send a message — should appear in chat
- [ ] Open second tab — SharedWorker shares connection