### PR TITLE
fix(chuckrpg): remove game-chuckrpg-tls — Agones uses UDP not HTTPS

### DIFF
--- a/apps/kube/chuckrpg/README.md
+++ b/apps/kube/chuckrpg/README.md
@@ -1,0 +1,48 @@
+# ChuckRPG — Kubernetes Deployment
+
+## Domain Architecture
+
+| Domain              | Purpose                        | Proxy             | TLS                            |
+| ------------------- | ------------------------------ | ----------------- | ------------------------------ |
+| `chuckrpg.com`      | Astro frontend (axum-chuckrpg) | Cloudflare        | Let's Encrypt via cert-manager |
+| `api.chuckrpg.com`  | ROWS API (OWS backend)         | Cloudflare        | Let's Encrypt via cert-manager |
+| `game.chuckrpg.com` | Agones game servers (UE5 UDP)  | Direct (no proxy) | N/A — UDP only                 |
+
+## Networking
+
+### HTTP/HTTPS (Cilium Gateway API)
+
+`chuckrpg.com` and `api.chuckrpg.com` route through the shared Cilium gateway (`kbve-gateway` in the `kbve` namespace). Cloudflare terminates public TLS on the edge; the origin uses cert-manager certs for Full/Strict SSL mode.
+
+- HTTPRoutes: `chuckrpg-routes`, `chuckrpg-api-routes`
+- Certificates: `chuckrpg-tls`, `chuckrpg-api-tls` (issued by `letsencrypt-http` ClusterIssuer)
+- ACME challenges work because Cloudflare proxies HTTP traffic to the gateway
+
+### Game Server (Agones UDP)
+
+`game.chuckrpg.com` points directly to the Agones node IP. Game traffic is UDP on dynamic ports assigned by Agones — it does NOT go through the Cilium gateway or any HTTP/HTTPS listener.
+
+- No TLS certificate needed (UDP, not HTTPS)
+- No HTTPRoute (not HTTP traffic)
+- Fleet: `ows-hubworld` in `arc-runners` namespace
+- Server binary: auto-detected from `ows-server-build` PVC
+
+### WebTransport (wt.kbve.com)
+
+The isometric game client uses WebTransport (QUIC/UDP) on `wt.kbve.com:5001`. This has its own dedicated LoadBalancer (`kbve-wt-lb`) and self-signed cert rotation CronJob — separate from the Cilium gateway.
+
+## Manifests
+
+| File                   | Resources                                                        |
+| ---------------------- | ---------------------------------------------------------------- |
+| `namespace.yaml`       | `chuckrpg` namespace                                             |
+| `deployment.yaml`      | `chuckrpg-deployment` (axum-chuckrpg)                            |
+| `httproute.yaml`       | HTTPRoutes for `chuckrpg.com` and `api.chuckrpg.com`             |
+| `certificate.yaml`     | TLS certs for `chuckrpg.com` and `api.chuckrpg.com`              |
+| `reference-grant.yaml` | Allows `kbve-gateway` to reference certs in `chuckrpg` namespace |
+
+## ArgoCD
+
+- App: `chuckrpg` (source: `apps/kube/chuckrpg/manifest`)
+- Sync: automated with prune
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/chuckrpg/manifest/certificate.yaml
+++ b/apps/kube/chuckrpg/manifest/certificate.yaml
@@ -25,17 +25,3 @@ spec:
         name: letsencrypt-http
         kind: ClusterIssuer
         group: cert-manager.io
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-    name: game-chuckrpg-tls
-    namespace: chuckrpg
-spec:
-    secretName: game-chuckrpg-tls
-    dnsNames:
-        - game.chuckrpg.com
-    issuerRef:
-        name: letsencrypt-http
-        kind: ClusterIssuer
-        group: cert-manager.io

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -20,10 +20,11 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
-        # Generic HTTPS listener — serves all domains.
-        # Each domain's cert is referenced here; ReferenceGrant allows
-        # cross-namespace cert access from chuckrpg, ows, etc.
-        # No hostname filter — Envoy uses SNI to select the right cert.
+        # HTTPS listener — Cloudflare terminates public TLS on the edge.
+        # This listener handles origin TLS for Full/Strict SSL modes.
+        # chuckrpg.com and api.chuckrpg.com certs are issued by cert-manager
+        # in the chuckrpg namespace; Cloudflare proxies handle the public edge.
+        # game.chuckrpg.com uses Agones UDP (not HTTPS) — no cert needed here.
         - name: https
           protocol: HTTPS
           port: 443
@@ -31,12 +32,6 @@ spec:
               mode: Terminate
               certificateRefs:
                   - name: kbve-wt-tls
-                  - name: chuckrpg-tls
-                    namespace: chuckrpg
-                  - name: chuckrpg-api-tls
-                    namespace: chuckrpg
-                  - name: game-chuckrpg-tls
-                    namespace: chuckrpg
           allowedRoutes:
               namespaces:
                   from: All


### PR DESCRIPTION
## Summary
- Remove `game-chuckrpg-tls` Certificate CRD (game.chuckrpg.com is Agones UDP, not HTTPS)
- Revert gateway HTTPS listener to single `kbve-wt-tls` cert ref (fixes Envoy duplicate filter chain NACK)
- Add `apps/kube/chuckrpg/README.md` documenting domain architecture

## Root cause chain
1. `game-chuckrpg-tls` cert couldn't issue (ACME HTTP-01 returned 404)
2. We tried adding it to the generic HTTPS listener with other certs
3. Multiple cert refs on one listener caused Envoy NACK (duplicate TLS filter chains)
4. Gateway went Degraded, blocking all HTTPS routing updates

## Fix
game.chuckrpg.com doesn't need a TLS cert — it's UDP game server traffic via Agones. Remove the cert entirely, revert gateway to single cert ref.

## Post-merge
```bash
kubectl delete certificate game-chuckrpg-tls -n chuckrpg
kubectl delete secret game-chuckrpg-tls -n chuckrpg
kubectl delete challenge -n chuckrpg --all
```