### PR TITLE
fix(kong): CORS for chat.kbve.com + improved /health endpoint

### DIFF
--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -15,7 +15,7 @@ tower-http = { version = "0.6.8", features = ["compression-full", "limit", "trac
 tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-axum = { version = "0.8.5", features = ["ws", "macros"] }
+axum = { version = "0.8.5", features = ["ws", "macros", "json"] }
 axum-extra = { version = "0.12.1", features = ["cookie"] }
 socket2 = "0.6.1"
 num_cpus = "1.17.0"

--- a/apps/irc/irc-gateway/src/main.rs
+++ b/apps/irc/irc-gateway/src/main.rs
@@ -18,13 +18,13 @@ mod allocator {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
+    transport::https::init_start_time();
 
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| {
-                    format!("{}=info,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
-                }),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                format!("{}=info,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/apps/irc/irc-gateway/src/transport/https.rs
+++ b/apps/irc/irc-gateway/src/transport/https.rs
@@ -2,10 +2,10 @@ use anyhow::Result;
 use std::{net::SocketAddr, time::Duration};
 
 use axum::{
-    http::{header, HeaderName, HeaderValue},
+    Json, Router,
+    http::{HeaderName, HeaderValue, header},
     response::IntoResponse,
     routing::get,
-    Router,
 };
 use tokio::net::TcpListener;
 use tower_http::set_header::SetResponseHeaderLayer;
@@ -62,10 +62,16 @@ fn router(static_config: &crate::astro::StaticConfig) -> Router {
                 if err.is::<tower::timeout::error::Elapsed>() {
                     (axum::http::StatusCode::REQUEST_TIMEOUT, "request timed out")
                 } else if err.is::<tower::load_shed::error::Overloaded>() {
-                    (axum::http::StatusCode::SERVICE_UNAVAILABLE, "service overloaded")
+                    (
+                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                        "service overloaded",
+                    )
                 } else {
                     tracing::warn!(error = %err, "middleware error");
-                    (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+                    (
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "internal server error",
+                    )
                 }
             },
         ))
@@ -85,12 +91,24 @@ fn router(static_config: &crate::astro::StaticConfig) -> Router {
     static_router.merge(api_router).layer(middleware)
 }
 
+static START_TIME: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+
+pub fn init_start_time() {
+    START_TIME.get_or_init(std::time::Instant::now);
+}
+
 async fn health() -> impl IntoResponse {
-    "OK"
+    let uptime = START_TIME.get().map(|t| t.elapsed().as_secs()).unwrap_or(0);
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+        "uptime_seconds": uptime,
+    }))
 }
 
 fn tuned_listener(addr: SocketAddr) -> Result<TcpListener> {
-    use socket2::{Socket, Domain, Type, Protocol};
+    use socket2::{Domain, Protocol, Socket, Type};
 
     let domain = match addr {
         SocketAddr::V4(_) => Domain::IPV4,
@@ -164,7 +182,10 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(&body[..], b"OK");
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
+        assert!(json["uptime_seconds"].is_number());
     }
 
     #[tokio::test]
@@ -184,10 +205,7 @@ mod tests {
             response.headers().get("x-content-type-options").unwrap(),
             "nosniff"
         );
-        assert_eq!(
-            response.headers().get("x-frame-options").unwrap(),
-            "DENY"
-        );
+        assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
         assert_eq!(
             response.headers().get("referrer-policy").unwrap(),
             "strict-origin-when-cross-origin"

--- a/apps/kube/kong/manifests/kong-config.yaml
+++ b/apps/kube/kong/manifests/kong-config.yaml
@@ -21,12 +21,16 @@ data:
                 - https://*.meme.sh
                 - https://kbve.com
                 - https://*.kbve.com
+                - https://chat.kbve.com
+                - https://supabase.kbve.com
+                - https://forgejo.kbve.com
                 - https://chuckrpg.com
                 - https://*.chuckrpg.com
                 - https://cryptothrone.com
                 - https://*.cryptothrone.com
                 - http://localhost:4321
                 - http://localhost:3000
+                - http://localhost:3333
               methods:
                 - GET
                 - POST


### PR DESCRIPTION
## Summary

### Task 1: CORS fix
Kong's wildcard `*.kbve.com` doesn't match subdomains when `credentials: true` is set. Added explicit entries:
- `https://chat.kbve.com`
- `https://supabase.kbve.com`
- `https://forgejo.kbve.com`
- `http://localhost:3333` (local chat dev)

Confirmed via curl: `kbve.com` returns `Access-Control-Allow-Origin` but `chat.kbve.com` did not.

### Task 2: Better /health endpoint
Before: `"OK"` (plain text)
After:
```json
{
  "status": "ok",
  "version": "0.1.3",
  "uptime_seconds": 12345
}
```
- Version from `Cargo.toml` at compile time (`env!("CARGO_PKG_VERSION")`)
- Uptime via `OnceLock<Instant>` initialized at startup

### Tests
5/5 irc-gateway tests pass (including updated health check)

## Test plan
- [ ] After Kong configmap syncs: `curl -I https://supabase.kbve.com/auth/v1/user -H "Origin: https://chat.kbve.com"` returns `Access-Control-Allow-Origin: https://chat.kbve.com`
- [ ] After irc-gateway redeploy: `https://chat.kbve.com/health` returns JSON with version
- [ ] Chat OAuth flow works end-to-end