### PR TITLE
fix(irc-e2e): update health smoke test for JSON response

### DIFF
--- a/apps/irc/irc-e2e/e2e/smoke.spec.ts
+++ b/apps/irc/irc-e2e/e2e/smoke.spec.ts
@@ -1,10 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Smoke: Health Endpoint', () => {
-	test('GET /health returns OK', async ({ request }) => {
+	test('GET /health returns JSON with status and version', async ({
+		request,
+	}) => {
 		const response = await request.get('/health');
 		expect(response.status()).toBe(200);
-		expect(await response.text()).toBe('OK');
+		const body = await response.json();
+		expect(body.status).toBe('ok');
+		expect(body.version).toBeTruthy();
+		expect(typeof body.uptime_seconds).toBe('number');
 	});
 });
 


### PR DESCRIPTION
## Summary
Fixes #9468

The `/health` endpoint was changed from `"OK"` to JSON in #9464. The e2e smoke test still expected the old plain text response.

### Change
```diff
- expect(await response.text()).toBe('OK');
+ const body = await response.json();
+ expect(body.status).toBe('ok');
+ expect(body.version).toBeTruthy();
+ expect(typeof body.uptime_seconds).toBe('number');
```

## Test plan
- [ ] CI Docker build for irc-gateway passes e2e smoke tests