### PR TITLE
fix(dashboard): KASM RBAC + noVNC fallback + Guac error

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMGuacViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMGuacViewer.tsx
@@ -10,12 +10,22 @@ let Guacamole: any = null;
 async function loadGuacamole() {
 	if (!Guacamole) {
 		try {
-			const mod = await import(/* @vite-ignore */ 'guacamole-common-js');
+			// Try vendored ESM first
+			const vendorUrl = `${window.location.origin}/vendor/guacamole/guacamole-common.js`;
+			const mod = await import(/* @vite-ignore */ vendorUrl);
 			Guacamole = mod.default ?? mod;
 		} catch {
-			throw new Error(
-				'Guacamole module not available — ensure guacamole-common-js is installed',
-			);
+			try {
+				// Fallback: npm package (dev mode)
+				const mod = await import(
+					/* @vite-ignore */ 'guacamole-common-js'
+				);
+				Guacamole = mod.default ?? mod;
+			} catch {
+				throw new Error(
+					'RDP not available — Guacamole server is not deployed. Deploy via ArgoCD (kubevirt-guacamole app).',
+				);
+			}
 		}
 	}
 	return Guacamole;

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -4,24 +4,31 @@ import { vmService } from './vmService';
 import { X, Maximize2, Minimize2, Keyboard } from 'lucide-react';
 
 // noVNC RFB client — loaded from vendored ESM source in /vendor/novnc/.
-// The npm package ships broken CJS (top-level await), so we vendor the
-// original ESM files from the noVNC GitHub repo into public/vendor/novnc/.
-// Dynamic import from /vendor/ is same-origin (no CORS/SharedArrayBuffer issues)
-// and completely outside Rollup's module graph.
+// Uses dynamic import with the full origin URL to bypass Vite's module graph.
+// The vendored files are plain ESM from the noVNC GitHub repo, served as
+// static assets from public/vendor/novnc/.
 let RFB: any = null;
 async function loadRFB() {
 	if (!RFB) {
 		try {
-			const url = new URL(
-				'/vendor/novnc/core/rfb.js',
-				window.location.origin,
-			).href;
-			const mod = await import(/* @vite-ignore */ url);
+			// Try vendored ESM first (production path)
+			const vendorUrl = `${window.location.origin}/vendor/novnc/core/rfb.js`;
+			const mod = await import(/* @vite-ignore */ vendorUrl);
 			RFB = mod.default ?? mod;
-		} catch {
-			throw new Error(
-				'noVNC module not available — ensure @novnc/novnc is installed',
-			);
+		} catch (vendorErr) {
+			try {
+				// Fallback: try npm package (works in dev mode)
+				// @ts-expect-error — noVNC ships without TypeScript declarations
+				const mod = await import(
+					/* @vite-ignore */ '@novnc/novnc/lib/rfb'
+				);
+				RFB = mod.default ?? mod;
+			} catch {
+				console.error('noVNC load failed:', vendorErr);
+				throw new Error(
+					'noVNC module not available — check browser console for details',
+				);
+			}
 		}
 	}
 	return RFB;

--- a/apps/kube/kbve/manifest/kubevirt-rbac.yaml
+++ b/apps/kube/kbve/manifest/kubevirt-rbac.yaml
@@ -21,6 +21,12 @@ rules:
           - virtualmachines/restart
           - virtualmachineinstances/vnc
       verbs: ['update', 'get']
+    # KASM workspace management — list/scale deployments in kasm namespace
+    - apiGroups: ['apps']
+      resources:
+          - deployments
+          - deployments/scale
+      verbs: ['get', 'list', 'patch', 'update']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary
1. **KASM 403** — added `apps/deployments` RBAC to kbve-app ClusterRole
2. **noVNC** — dual import: vendored ESM → npm fallback, with console error logging
3. **RDP** — clear "not deployed" error instead of infinite "Waiting for server..."