### PR TITLE
chore(axum-kbve): use pre-built chisel base image for runtime

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -1,21 +1,15 @@
 # ============================================================================
 # axum-kbve — Multi-stage Docker build
 #
-# Runtime uses the shared chisel base image:
-#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.2
-#   (chiseled Ubuntu 24.04 + jemalloc + libpq + CA certs)
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder  (Rust + Node + pnpm + cargo-chef)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.2          (chiseled Ubuntu + jemalloc + libpq)
 # ============================================================================
 
 # ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-slim AS astro-builder
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-
-# Prevent Playwright from downloading browser binaries during pnpm install —
-# they are never used in the Docker build and waste ~600MB + cause timeouts.
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS astro-builder
 
 WORKDIR /app
 
@@ -79,25 +73,8 @@ RUN find . -type f \( \
 # BuildKit layer cache handles incremental rebuilds across runs.
 # ============================================================================
 
-# [STAGE C] - Rust Base Image
-FROM --platform=linux/amd64 rust:1.94-slim AS rust-base
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        protobuf-compiler \
-        libprotobuf-dev \
-        mold && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# [STAGE D] - Cargo Chef Planner
-FROM rust-base AS planner
+# [STAGE C] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS planner
 
 COPY apps/kbve/axum-kbve/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
@@ -118,8 +95,8 @@ RUN mkdir -p apps/kbve/axum-kbve/src && echo "fn main() {}" > apps/kbve/axum-kbv
 
 RUN cargo chef prepare --recipe-path recipe.json
 
-# [STAGE E] - Cargo Chef Cook (Cache External Dependencies)
-FROM rust-base AS builder-deps
+# [STAGE D] - Cargo Chef Cook (Cache External Dependencies)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS builder-deps
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
@@ -130,8 +107,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef cook --release --recipe-path recipe.json -p axum-kbve
 
-# [STAGE E2] - Foundation Layer (Compile kbve + jedi from real source)
-FROM rust-base AS foundation
+# [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.2-builder AS foundation
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
@@ -158,8 +135,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # [STAGE F] - Build Application
 # ============================================================================
 FROM foundation AS builder
-
-ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
 # Astro build output (precompressed) -> placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/kbve/axum-kbve/templates/dist


### PR DESCRIPTION
## Summary
- Replace inline chisel build (Stage G — downloads Go, builds chisel, runs chisel cut) and jemalloc stage (Stage H) with pre-built `ghcr.io/kbve/chisel-ubuntu-axum:24.04.2`
- Matches the pattern already used by `axum-discordsh`
- Eliminates 2 build stages and ~40 lines of Dockerfile
- The chisel base image already provides jemalloc, libpq, CA certs, and the appuser

## Test plan
- [ ] Docker build completes successfully
- [ ] Runtime image starts and serves traffic