### PR TITLE
fix(axum-discordsh): add missing serial_test dev-dependency and resolve clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "serial_test",
  "socket2 0.6.3",
  "sysinfo 0.38.4",
  "thiserror 2.0.18",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -39,6 +39,7 @@ tikv-jemallocator = { version = "0.6", optional = true }
 
 [dev-dependencies]
 http-body-util = "0.1"
+serial_test = "3"
 
 [features]
 default = []

--- a/apps/discordsh/axum-discordsh/src/api/rate_limit.rs
+++ b/apps/discordsh/axum-discordsh/src/api/rate_limit.rs
@@ -49,6 +49,7 @@ impl RateLimiter {
 
     /// Prune entries older than 2x the window to prevent unbounded growth.
     /// Call periodically from a background task.
+    #[allow(dead_code)]
     pub fn prune(&self) {
         let now = Instant::now();
         let cutoff = self.window_secs * 2;

--- a/apps/discordsh/axum-discordsh/src/api/servers.rs
+++ b/apps/discordsh/axum-discordsh/src/api/servers.rs
@@ -39,6 +39,7 @@ pub struct SubmitServerRequest {
 
 /// Successful response echoed back to the frontend.
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 struct SubmitResponse {
     status: &'static str,
     message: String,
@@ -102,28 +103,32 @@ async fn submit_server(
         return err(StatusCode::BAD_REQUEST, "Invalid invite code").into_response();
     }
 
-    if let Some(ref desc) = req.description {
-        if desc.len() > 2000 || !is_safe_text(desc) {
-            return err(StatusCode::BAD_REQUEST, "Invalid description").into_response();
-        }
+    if let Some(ref desc) = req.description
+        && (desc.len() > 2000 || !is_safe_text(desc))
+    {
+        return err(StatusCode::BAD_REQUEST, "Invalid description").into_response();
     }
 
-    if let Some(ref url) = req.icon_url {
-        if !is_safe_url(url, 2048) {
-            return err(StatusCode::BAD_REQUEST, "Invalid icon URL").into_response();
-        }
+    if let Some(ref url) = req.icon_url
+        && !is_safe_url(url, 2048)
+    {
+        return err(StatusCode::BAD_REQUEST, "Invalid icon URL").into_response();
     }
 
-    if let Some(ref url) = req.banner_url {
-        if !is_safe_url(url, 2048) {
-            return err(StatusCode::BAD_REQUEST, "Invalid banner URL").into_response();
-        }
+    if let Some(ref url) = req.banner_url
+        && !is_safe_url(url, 2048)
+    {
+        return err(StatusCode::BAD_REQUEST, "Invalid banner URL").into_response();
     }
 
     if req.categories.is_empty() || req.categories.len() > MAX_CATEGORIES {
         return err(StatusCode::BAD_REQUEST, "Must have 1-3 categories").into_response();
     }
-    if req.categories.iter().any(|&c| c < 1 || c > MAX_CATEGORY_ID) {
+    if req
+        .categories
+        .iter()
+        .any(|&c| !(1..=MAX_CATEGORY_ID).contains(&c))
+    {
         return err(StatusCode::BAD_REQUEST, "Invalid category ID").into_response();
     }
 

--- a/apps/discordsh/axum-discordsh/src/api/validate.rs
+++ b/apps/discordsh/axum-discordsh/src/api/validate.rs
@@ -1,5 +1,4 @@
 /// Shared validation functions mirroring PostgreSQL `is_safe_text()` and friends.
-
 /// Check that a string contains no dangerous control characters.
 /// Mirrors `discordsh.is_safe_text()` in PostgreSQL.
 pub fn is_safe_text(s: &str) -> bool {

--- a/apps/discordsh/axum-discordsh/src/health/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/health/mod.rs
@@ -34,6 +34,7 @@ impl HealthStatus {
 
     /// Discord embed color override.
     /// Returns `None` for Healthy (caller should use the normal state color).
+    #[allow(dead_code)]
     pub fn color_override(self) -> Option<u32> {
         match self {
             Self::Healthy => None,
@@ -42,6 +43,7 @@ impl HealthStatus {
         }
     }
 
+    #[allow(dead_code)]
     pub fn emoji(self) -> &'static str {
         match self {
             Self::Healthy => "\u{1F7E2}",
@@ -70,6 +72,7 @@ pub struct HealthSnapshot {
 
 impl HealthSnapshot {
     /// Generate a Discord-friendly memory bar using emoji squares.
+    #[allow(dead_code)]
     pub fn memory_bar(&self, width: usize) -> String {
         let filled = ((self.memory_percent / 100.0) * width as f64).round() as usize;
         let filled = filled.min(width);
@@ -130,6 +133,7 @@ impl HealthMonitor {
     }
 
     /// Force an immediate metric refresh (used by the Refresh button).
+    #[allow(dead_code)]
     pub async fn force_refresh(&self) {
         let snap = self.collect_inner().await;
         *self.snapshot.write().await = Some(snap);

--- a/apps/discordsh/axum-discordsh/src/state.rs
+++ b/apps/discordsh/axum-discordsh/src/state.rs
@@ -10,6 +10,7 @@ pub struct AppState {
     pub health_monitor: Arc<HealthMonitor>,
 
     /// Process start time (for uptime calculation).
+    #[allow(dead_code)]
     pub start_time: Instant,
 
     /// Shared reqwest client for outbound calls.

--- a/apps/discordsh/axum-discordsh/src/transport/security.rs
+++ b/apps/discordsh/axum-discordsh/src/transport/security.rs
@@ -40,12 +40,13 @@ fn percent_decode(s: &str) -> String {
     let mut i = 0;
 
     while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
-                out.push(hi << 4 | lo);
-                i += 3;
-                continue;
-            }
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2]))
+        {
+            out.push(hi << 4 | lo);
+            i += 3;
+            continue;
         }
         out.push(bytes[i]);
         i += 1;
@@ -64,6 +65,7 @@ fn hex_val(b: u8) -> Option<u8> {
 }
 
 /// Validate that a session ID is exactly 8 lowercase hex characters.
+#[allow(dead_code)]
 pub fn is_valid_session_id(id: &str) -> bool {
     id.len() == 8 && id.bytes().all(|b| b.is_ascii_hexdigit())
 }


### PR DESCRIPTION
## Summary
- Add `serial_test = "3"` to `[dev-dependencies]` — fixes `error[E0432]: unresolved import` that broke `axum-discordsh:test` in CI
- Resolve all clippy warnings: collapse nested `if let` guards, use `RangeInclusive::contains`, fix empty line after doc comment
- Suppress `dead_code` warnings on methods staged for future Discord embed integration

Closes #9482

## Test plan
- [x] `cargo test -p axum-discordsh` — 31/31 pass
- [x] `cargo clippy -p axum-discordsh` — zero warnings
- [ ] CI validates on PR