### PR TITLE
fix(axum-discordsh): remove unused bevy crates from Docker build

### DIFF
--- a/apps/discordsh/axum-discordsh/Cargo.workspace.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.workspace.toml
@@ -4,9 +4,6 @@ members = [
     "apps/discordsh/axum-discordsh",
     "packages/rust/jedi",
     "packages/rust/kbve",
-    "packages/rust/bevy/bevy_inventory",
-    "packages/rust/bevy/bevy_items",
-    "packages/rust/bevy/bevy_battle",
 ]
 
 [profile.release]

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -102,22 +102,12 @@ COPY Cargo.lock ./
 COPY apps/discordsh/axum-discordsh/Cargo.toml apps/discordsh/axum-discordsh/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
-COPY packages/rust/bevy/bevy_inventory/Cargo.toml packages/rust/bevy/bevy_inventory/Cargo.toml
-COPY packages/rust/bevy/bevy_items/Cargo.toml packages/rust/bevy/bevy_items/Cargo.toml
-COPY packages/rust/bevy/bevy_battle/Cargo.toml packages/rust/bevy/bevy_battle/Cargo.toml
-COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
-COPY packages/rust/bevy/bevy_quests/Cargo.toml packages/rust/bevy/bevy_quests/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
 RUN mkdir -p apps/discordsh/axum-discordsh/src && echo "fn main() {}" > apps/discordsh/axum-discordsh/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
-    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_inventory/src && echo "" > packages/rust/bevy/bevy_inventory/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_items/src && echo "" > packages/rust/bevy/bevy_items/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_battle/src && echo "" > packages/rust/bevy/bevy_battle/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_quests/src && echo "" > packages/rust/bevy/bevy_quests/src/lib.rs
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -150,15 +140,10 @@ COPY packages/data/proto packages/data/proto
 
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
-COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
-COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
-COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
-COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
-COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc -p bevy_quests
+    cargo build --release -p kbve -p jedi
 
 # ============================================================================
 # [STAGE F] - Build Application
@@ -172,11 +157,6 @@ COPY --from=astro-precompressor /static /app/apps/discordsh/axum-discordsh/templ
 COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
-COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
-COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
-COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
-COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
-COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 
 # Application source (most frequently changing — placed last for cache)
 COPY apps/discordsh/axum-discordsh apps/discordsh/axum-discordsh


### PR DESCRIPTION
## Summary
- Remove `bevy_inventory`, `bevy_items`, `bevy_battle`, `bevy_npc`, and `bevy_quests` from Dockerfile and `Cargo.workspace.toml`
- None are dependencies of `axum-discordsh` (chain: `axum-discordsh` → `kbve` → `jedi`)
- These pulled in `bevy 0.18` causing compilation failures (exit code 101) in the foundation stage
- Also reduces Docker build time by eliminating ~5 unnecessary crate compilations

## Test plan
- [x] `cargo build --release -p kbve -p jedi` — passes
- [x] `cargo build --release -p axum-discordsh` — passes
- [ ] CI Docker build validates on PR