### PR TITLE
perf(chisel-ubuntu-axum): add sccache + incremental compilation

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,7 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.3"
+version: "24.04.4"
 version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -105,6 +105,7 @@ COPY --from=planner /app/packages packages
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo chef cook --release --recipe-path recipe.json -p axum-kbve
 
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
@@ -129,6 +130,7 @@ COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p kbve -p jedi -p bevy_kbve_net -p bevy_npc
 
 # ============================================================================
@@ -155,6 +157,7 @@ RUN cp -a /app/apps/kbve/axum-kbve/templates/dist/askama/. /app/apps/kbve/axum-k
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p axum-kbve && \
     strip target/release/axum-kbve
 

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -22,7 +22,7 @@
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║  BUILDER TARGET                                                    ║
-# ║  Rust 1.94 + cargo-chef + mold + brotli/gzip + Node 24 + pnpm    ║
+# ║  Rust 1.94 + cargo-chef + sccache + mold + brotli/gzip + Node 24 ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 FROM --platform=linux/amd64 rust:1.94-slim AS builder
@@ -46,7 +46,13 @@ RUN apt-get update && \
 
 # ── Rust tooling ─────────────────────────────────────────────────────
 RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
+    cargo install cargo-chef sccache --locked
+
+# sccache wraps rustc to cache compilation artifacts across builds.
+# Consumers mount --mount=type=cache,target=/usr/local/sccache for persistence.
+ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
+ENV SCCACHE_DIR=/usr/local/sccache
+ENV CARGO_INCREMENTAL=1
 
 # ── Node.js + pnpm (for Astro frontend builds) ──────────────────────
 ARG NODE_VERSION=24


### PR DESCRIPTION
## Summary
- Install `sccache` in shared builder image — caches compiled artifacts across builds (cargo-chef only caches dependency fetch, not compilation)
- Set `RUSTC_WRAPPER=sccache` + `CARGO_INCREMENTAL=1` in builder ENV
- Wire up `--mount=type=cache,target=/usr/local/sccache` on all 3 cargo build/cook steps in axum-kbve Dockerfile
- Bump chisel version to 24.04.4

## Test plan
- [ ] Builder image builds with sccache installed
- [ ] First axum-kbve Docker build completes (cold sccache)
- [ ] Second build is significantly faster (warm sccache)