### PR TITLE
fix(kube): add explicit CORS origins for chat.kbve.com

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -45,7 +45,7 @@ spec:
                       - name: GOTRUE_SITE_URL
                         value: 'https://kbve.com'
                       - name: GOTRUE_URI_ALLOW_LIST
-                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,https://chuckrpg.com/**,https://*.chuckrpg.com/**,https://api.chuckrpg.com/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**'
+                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://chat.kbve.com/**,https://supabase.kbve.com/**,https://forgejo.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,https://chuckrpg.com/**,https://*.chuckrpg.com/**,https://api.chuckrpg.com/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**'
                       - name: GOTRUE_DISABLE_SIGNUP
                         value: 'false'
 

--- a/apps/kube/kong/manifests/ingress.yaml
+++ b/apps/kube/kong/manifests/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
         nginx.ingress.kubernetes.io/large-client-header-buffers: '64 160k'
         nginx.ingress.kubernetes.io/client-body-buffer-size: '160k'
         nginx.ingress.kubernetes.io/enable-cors: 'true'
-        nginx.ingress.kubernetes.io/cors-allow-origin: 'https://discord.sh,https://*.discord.sh,https://kbve.com,https://*.kbve.com,https://meme.sh,https://*.meme.sh,https://herbmail.com,https://*.herbmail.com,https://chuckrpg.com,https://*.chuckrpg.com,https://cryptothrone.com,https://*.cryptothrone.com,http://localhost:4321,http://localhost:3000'
+        nginx.ingress.kubernetes.io/cors-allow-origin: 'https://discord.sh,https://*.discord.sh,https://kbve.com,https://*.kbve.com,https://chat.kbve.com,https://supabase.kbve.com,https://forgejo.kbve.com,https://meme.sh,https://*.meme.sh,https://herbmail.com,https://*.herbmail.com,https://chuckrpg.com,https://*.chuckrpg.com,https://cryptothrone.com,https://*.cryptothrone.com,http://localhost:4321,http://localhost:3000,http://localhost:3333'
         nginx.ingress.kubernetes.io/cors-allow-methods: 'GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD'
         nginx.ingress.kubernetes.io/cors-allow-headers: 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,apikey,x-client-info,x-supabase-api-version,Accept,Accept-Profile,Accept-Version'
         nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'


### PR DESCRIPTION
## Summary
- Added explicit `chat.kbve.com`, `supabase.kbve.com`, `forgejo.kbve.com` to nginx ingress `cors-allow-origin` annotation — wildcard `*.kbve.com` fails to reflect exact origin when `credentials: true`
- Added same subdomains to GoTrue `GOTRUE_URI_ALLOW_LIST` for OAuth redirect allowlisting
- Added `localhost:3333` to ingress CORS for local dev parity with Kong config

## Test plan
- [ ] Deploy to kilobase namespace and verify `chat.kbve.com` can fetch `supabase.kbve.com/auth/v1/user` without CORS error
- [ ] Verify OAuth login flow from chat.kbve.com still redirects correctly
- [ ] Confirm other subdomains (kbve.com, discord.sh) are unaffected