### PR TITLE
feat(firecracker): microVM runtime design and k8s manifests

### DIFF
--- a/apps/kbve/edge/functions/_shared/firecracker.ts
+++ b/apps/kbve/edge/functions/_shared/firecracker.ts
@@ -1,0 +1,128 @@
+/**
+ * Firecracker microVM client for edge functions.
+ *
+ * Usage:
+ *   import { createVM, getResult, destroyVM } from "../_shared/firecracker.ts";
+ *
+ *   const vm = await createVM({
+ *     rootfs: "alpine-minimal",
+ *     vcpu_count: 1,
+ *     mem_size_mib: 128,
+ *     timeout_ms: 30000,
+ *     entrypoint: "/usr/local/bin/worker",
+ *     env: { TASK: "compute", INPUT: payload },
+ *   });
+ *
+ *   const result = await getResult(vm.vm_id);
+ */
+
+const FIRECRACKER_URL =
+  Deno.env.get("FIRECRACKER_URL") ?? "http://firecracker-ctl:9001";
+
+export interface CreateVMRequest {
+  rootfs: string;
+  vcpu_count?: number;
+  mem_size_mib?: number;
+  timeout_ms?: number;
+  entrypoint: string;
+  env?: Record<string, string>;
+  boot_args?: string;
+}
+
+export interface VMInfo {
+  vm_id: string;
+  status: "creating" | "running" | "completed" | "failed" | "timeout";
+  created_at: string;
+}
+
+export interface VMResult {
+  vm_id: string;
+  status: "completed" | "failed" | "timeout";
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+  duration_ms: number;
+}
+
+export async function createVM(req: CreateVMRequest): Promise<VMInfo> {
+  const res = await fetch(`${FIRECRACKER_URL}/vm/create`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      rootfs: req.rootfs,
+      vcpu_count: req.vcpu_count ?? 1,
+      mem_size_mib: req.mem_size_mib ?? 128,
+      timeout_ms: req.timeout_ms ?? 30000,
+      entrypoint: req.entrypoint,
+      env: req.env ?? {},
+      boot_args: req.boot_args ?? "console=ttyS0 reboot=k panic=1",
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`firecracker-ctl create failed (${res.status}): ${body}`);
+  }
+
+  return await res.json();
+}
+
+export async function getResult(vmId: string): Promise<VMResult> {
+  const res = await fetch(`${FIRECRACKER_URL}/vm/${vmId}/result`);
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`firecracker-ctl result failed (${res.status}): ${body}`);
+  }
+
+  return await res.json();
+}
+
+export async function getStatus(vmId: string): Promise<VMInfo> {
+  const res = await fetch(`${FIRECRACKER_URL}/vm/${vmId}`);
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`firecracker-ctl status failed (${res.status}): ${body}`);
+  }
+
+  return await res.json();
+}
+
+export async function destroyVM(vmId: string): Promise<void> {
+  const res = await fetch(`${FIRECRACKER_URL}/vm/${vmId}`, {
+    method: "DELETE",
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`firecracker-ctl delete failed (${res.status}): ${body}`);
+  }
+}
+
+/**
+ * Create a VM, poll until completion, and return the result.
+ * Convenience wrapper for simple request/response workloads.
+ */
+export async function runVM(
+  req: CreateVMRequest,
+  pollIntervalMs = 500,
+): Promise<VMResult> {
+  const vm = await createVM(req);
+  const deadline = Date.now() + (req.timeout_ms ?? 30000) + 5000;
+
+  while (Date.now() < deadline) {
+    const info = await getStatus(vm.vm_id);
+    if (
+      info.status === "completed" ||
+      info.status === "failed" ||
+      info.status === "timeout"
+    ) {
+      return await getResult(vm.vm_id);
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+
+  await destroyVM(vm.vm_id);
+  throw new Error(`VM ${vm.vm_id} timed out waiting for result`);
+}

--- a/apps/kube/firecracker/DESIGN.md
+++ b/apps/kube/firecracker/DESIGN.md
@@ -1,0 +1,206 @@
+# Firecracker MicroVM Runtime — Design Document
+
+## Overview
+
+Extend the KBVE edge platform with Firecracker microVM support, enabling edge
+functions to dispatch workloads into hardware-isolated virtual machines with
+sub-second boot times (~125 ms) and minimal overhead (~5 MB per VMM process).
+
+## Problem
+
+The current Supabase edge-runtime provides Deno V8 worker isolation (150 MB
+memory, 60 s timeout). This is sufficient for TypeScript functions but cannot
+run arbitrary binaries, long-running processes, or untrusted code that requires
+full OS-level isolation.
+
+## Architecture
+
+```
+                    ┌──────────────────────────────────┐
+                    │        Edge Runtime Pod           │
+                    │   (supabase/edge-runtime:v1.73)   │
+                    │                                    │
+                    │  Deno workers (Tier 1 — isolates)  │
+                    │    health, meme, vault, argo ...   │
+                    └────────────┬─────────────────────┘
+                                 │ HTTP/gRPC (internal)
+                                 ▼
+                    ┌──────────────────────────────────┐
+                    │     Firecracker Service Pod       │
+                    │   (kbve/firecracker-ctl:latest)   │
+                    │                                    │
+                    │  REST API → Firecracker VMM        │
+                    │  /dev/kvm mounted via device plugin │
+                    │                                    │
+                    │  Tier 2 — microVM workloads        │
+                    │  ┌─────┐ ┌─────┐ ┌─────┐         │
+                    │  │ VM1 │ │ VM2 │ │ VM3 │         │
+                    │  └─────┘ └─────┘ └─────┘         │
+                    └──────────────────────────────────┘
+```
+
+### Two-tier isolation model
+
+| Tier | Isolation   | Boot   | Use Case                           |
+| ---- | ----------- | ------ | ---------------------------------- |
+| 1    | V8 isolates | ~10ms  | TypeScript edge functions          |
+| 2    | Firecracker | ~125ms | Arbitrary binaries, untrusted code |
+
+### Communication flow
+
+1. Edge function receives HTTP request
+2. For VM-eligible workloads, the function POSTs to the Firecracker service
+3. Firecracker service creates/reuses a microVM
+4. microVM executes the workload and returns result
+5. Edge function forwards response to caller
+
+## Infrastructure Requirements
+
+### Node requirements
+
+- Linux kernel with KVM support (Intel VT-x / AMD-V)
+- `/dev/kvm` exposed via Kubernetes device plugin
+    - Option A: `kubevirt/device-plugin-kvm` (already in cluster for KubeVirt)
+    - Option B: `smarter-project/smarter-device-manager`
+- Bare metal nodes preferred (nested virt adds latency)
+
+### Kubernetes resources
+
+- **Namespace:** `kilobase` (co-located with edge-runtime)
+- **Device plugin:** KVM device request in pod spec
+- **Node affinity:** Schedule on nodes with `kvm=true` label
+- **RBAC:** Minimal — only needs KVM device access, no cluster-admin
+
+### Firecracker service pod spec (draft)
+
+```yaml
+containers:
+    - name: firecracker-ctl
+      image: ghcr.io/kbve/firecracker-ctl:latest
+      resources:
+          requests:
+              cpu: 250m
+              memory: 512Mi
+              devices.kubevirt.io/kvm: '1'
+          limits:
+              cpu: '2'
+              memory: 2Gi
+              devices.kubevirt.io/kvm: '1'
+      securityContext:
+          capabilities:
+              add: ['NET_ADMIN'] # for TAP device networking
+      volumeMounts:
+          - name: rootfs-cache
+            mountPath: /var/lib/firecracker/rootfs
+```
+
+## Integration Paths (evaluated)
+
+### Path 1: Kata Containers (rejected)
+
+- Transparent CRI integration — every pod gets VM isolation
+- Too coarse-grained; we want selective VM dispatch, not all-pods-in-VMs
+- Adds latency to pods that don't need VM isolation
+
+### Path 2: Custom Firecracker service (selected)
+
+- Dedicated service with REST API
+- Edge functions call it explicitly for VM workloads
+- Fine-grained control over rootfs images, networking, lifecycle
+- Clean separation of concerns
+
+### Path 3: Fork Supabase edge-runtime (rejected)
+
+- Maximum integration but high maintenance burden
+- Couples VM lifecycle to Deno process — failure domains overlap
+- Upstream updates become painful to rebase
+
+## API Design (draft)
+
+### POST /vm/create
+
+```json
+{
+	"rootfs": "alpine-minimal",
+	"vcpu_count": 1,
+	"mem_size_mib": 128,
+	"boot_args": "console=ttyS0 reboot=k panic=1",
+	"timeout_ms": 30000,
+	"env": { "TASK": "compute", "INPUT": "..." },
+	"entrypoint": "/usr/local/bin/worker"
+}
+```
+
+### Response
+
+```json
+{
+	"vm_id": "fc-a1b2c3",
+	"status": "running",
+	"created_at": "2026-04-02T12:00:00Z"
+}
+```
+
+### GET /vm/{vm_id}/result
+
+Returns the stdout/stderr and exit code once the VM completes.
+
+### DELETE /vm/{vm_id}
+
+Force-terminates a running VM.
+
+## Rootfs Images
+
+Pre-built minimal root filesystems stored as OCI artifacts in GHCR:
+
+| Image            | Size    | Contents                             |
+| ---------------- | ------- | ------------------------------------ |
+| `alpine-minimal` | ~8 MB   | Alpine + busybox, no package manager |
+| `alpine-python`  | ~45 MB  | Alpine + Python 3.12 minimal         |
+| `alpine-node`    | ~40 MB  | Alpine + Node.js 22 LTS              |
+| `ubuntu-rust`    | ~120 MB | Ubuntu minimal + Rust toolchain      |
+
+## Networking
+
+- **Option A (simple):** No networking — stdin/stdout pipe via MMDS (Firecracker metadata service)
+- **Option B (advanced):** TAP device with CNI bridge — microVM gets a routable IP
+
+Start with Option A (MMDS) — sufficient for request/response workloads. Graduate to TAP networking when persistent connections or service-to-service calls are needed.
+
+## Security
+
+- Firecracker's jailer enforces cgroup + seccomp + chroot per VM
+- No root inside microVMs — drop all capabilities
+- Read-only rootfs with tmpfs overlay for scratch space
+- Network policy: only allow traffic from edge-runtime pods
+- VM timeout enforced both client-side (edge function) and server-side (firecracker-ctl)
+
+## Phased Rollout
+
+### Phase 1: Foundation (current)
+
+- [ ] Design document (this file)
+- [ ] Firecracker binary packaging (Dockerfile)
+- [ ] Kubernetes manifests (deployment, service, RBAC)
+- [ ] Health check endpoint
+
+### Phase 2: Core API
+
+- [ ] VM lifecycle API (create, status, result, delete)
+- [ ] MMDS-based stdin/stdout communication
+- [ ] Alpine-minimal rootfs build pipeline
+- [ ] Edge function client library (`_shared/firecracker.ts`)
+
+### Phase 3: Integration
+
+- [ ] Wire edge function → Firecracker for a test workload
+- [ ] E2E tests
+- [ ] Monitoring (VM count, boot latency, memory usage → ClickHouse)
+- [ ] KEDA autoscaling based on VM queue depth
+
+### Phase 4: Production
+
+- [ ] TAP networking (if needed)
+- [ ] Additional rootfs images
+- [ ] Warm pool (pre-booted VMs for <50ms dispatch)
+- [ ] Multi-node scheduling

--- a/apps/kube/firecracker/application.yaml
+++ b/apps/kube/firecracker/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: firecracker-ctl
+    namespace: argocd
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: HEAD
+        path: apps/kube/firecracker/manifests
+        kustomize: {}
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: kilobase
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: false
+        syncOptions:
+            - CreateNamespace=false
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true

--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: firecracker-ctl
+    namespace: kilobase
+    labels:
+        app: firecracker-ctl
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: firecracker-ctl
+    template:
+        metadata:
+            labels:
+                app: firecracker-ctl
+        spec:
+            nodeSelector:
+                kvm: 'true'
+            containers:
+                - name: firecracker-ctl
+                  image: ghcr.io/kbve/firecracker-ctl:0.1.0
+                  command: ['firecracker-ctl', 'serve', '--port', '9001']
+                  ports:
+                      - containerPort: 9001
+                        name: api
+                        protocol: TCP
+                  resources:
+                      requests:
+                          cpu: 250m
+                          memory: 512Mi
+                          devices.kubevirt.io/kvm: '1'
+                      limits:
+                          cpu: '2'
+                          memory: 2Gi
+                          devices.kubevirt.io/kvm: '1'
+                  securityContext:
+                      capabilities:
+                          add: ['NET_ADMIN']
+                  volumeMounts:
+                      - name: rootfs-cache
+                        mountPath: /var/lib/firecracker/rootfs
+                        readOnly: true
+                      - name: vm-scratch
+                        mountPath: /var/lib/firecracker/scratch
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: api
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                  readinessProbe:
+                      httpGet:
+                          path: /health
+                          port: api
+                      initialDelaySeconds: 3
+                      periodSeconds: 5
+            volumes:
+                - name: rootfs-cache
+                  persistentVolumeClaim:
+                      claimName: firecracker-rootfs
+                - name: vm-scratch
+                  emptyDir:
+                      sizeLimit: 4Gi

--- a/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: firecracker-ctl-ingress
+    namespace: kilobase
+spec:
+    podSelector:
+        matchLabels:
+            app: firecracker-ctl
+    policyTypes:
+        - Ingress
+    ingress:
+        - from:
+              - podSelector:
+                    matchLabels:
+                        app: edge-functions
+          ports:
+              - protocol: TCP
+                port: 9001

--- a/apps/kube/firecracker/manifests/firecracker-pvc.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: firecracker-rootfs
+    namespace: kilobase
+    labels:
+        app: firecracker-ctl
+spec:
+    accessModes:
+        - ReadWriteOnce
+    storageClassName: longhorn
+    resources:
+        requests:
+            storage: 2Gi

--- a/apps/kube/firecracker/manifests/firecracker-service.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: firecracker-ctl
+    namespace: kilobase
+    labels:
+        app: firecracker-ctl
+spec:
+    type: ClusterIP
+    selector:
+        app: firecracker-ctl
+    ports:
+        - port: 9001
+          targetPort: api
+          protocol: TCP
+          name: api


### PR DESCRIPTION
## Summary
- Add Firecracker microVM integration as a composable Tier 2 isolation layer alongside the existing Deno edge-runtime (Tier 1)
- Design document with two-tier architecture, API spec, phased rollout plan
- Kubernetes manifests: Deployment (with `/dev/kvm` device plugin), Service, PVC (Longhorn), NetworkPolicy
- ArgoCD application (selfHeal disabled for early-phase manual control)
- Shared TypeScript client library (`_shared/firecracker.ts`) for edge functions to dispatch VM workloads

## Test plan
- [ ] Review design document for architecture alignment
- [ ] Validate K8s manifests against cluster node labels (`kvm=true`)
- [ ] Verify NetworkPolicy restricts ingress to edge-functions pods only
- [ ] TypeScript client compiles within Deno edge-runtime sandbox