### PR TITLE
fix(chisel-ubuntu-axum): fix sccache + add versioned builder tags

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,7 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.4"
+version: "24.04.5"
 version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -50,9 +50,10 @@ RUN rustup target add x86_64-unknown-linux-gnu && \
 
 # sccache wraps rustc to cache compilation artifacts across builds.
 # Consumers mount --mount=type=cache,target=/usr/local/sccache for persistence.
+# NOTE: sccache is incompatible with incremental compilation — do NOT set
+# CARGO_INCREMENTAL=1 when RUSTC_WRAPPER=sccache.
 ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
 ENV SCCACHE_DIR=/usr/local/sccache
-ENV CARGO_INCREMENTAL=1
 
 # ── Node.js + pnpm (for Astro frontend builds) ──────────────────────
 ARG NODE_VERSION=24

--- a/packages/docker/chisel-ubuntu-axum/project.json
+++ b/packages/docker/chisel-ubuntu-axum/project.json
@@ -9,13 +9,20 @@
 			"options": {
 				"commands": [
 					"npx nx run chisel-ubuntu-axum:containerx-runtime",
-					"npx nx run chisel-ubuntu-axum:containerx-builder"
+					"npx nx run chisel-ubuntu-axum:containerx-builder",
+					"VERSION=$(grep -m1 'version' packages/docker/chisel-ubuntu-axum/version.toml | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder ghcr.io/kbve/chisel-ubuntu-axum:${VERSION}-builder && echo \"Tagged builder as ${VERSION}-builder\""
 				],
 				"parallel": false
 			},
 			"configurations": {
 				"local": {},
-				"production": {}
+				"production": {
+					"commands": [
+						"npx nx run chisel-ubuntu-axum:containerx-runtime:production",
+						"npx nx run chisel-ubuntu-axum:containerx-builder:production",
+						"VERSION=$(grep -m1 'version' packages/docker/chisel-ubuntu-axum/version.toml | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder ghcr.io/kbve/chisel-ubuntu-axum:${VERSION}-builder && docker push ghcr.io/kbve/chisel-ubuntu-axum:${VERSION}-builder && echo \"Published builder as ${VERSION}-builder\""
+					]
+				}
 			}
 		},
 		"containerx-runtime": {


### PR DESCRIPTION
## Summary
- Remove `CARGO_INCREMENTAL=1` from builder image — sccache prohibits incremental compilation, causing `cargo chef cook` to fail with exit code 101
- Add versioned builder tags (e.g. `24.04.5-builder`) — reads version from `version.toml`, tags and pushes alongside the rolling `24.04-builder` tag
- Bump to 24.04.5

## Test plan
- [ ] Chisel builder image builds successfully
- [ ] `cargo chef cook` works with sccache (no incremental conflict)
- [ ] Production publish creates both `24.04-builder` and `24.04.5-builder` tags