### PR TITLE
feat(edge|firecracker): Phase 2 env wiring, docs, NetworkPolicy fix

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/kubernetes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/kubernetes.mdx
@@ -681,6 +681,100 @@ virtctl start windows-builder -n angelscript && \
 
 ---
 
+## Firecracker MicroVMs
+
+Firecracker is an open-source VMM (Virtual Machine Monitor) built by AWS for serverless workloads. It creates lightweight microVMs with ~5 MB overhead and ~125 ms boot times, using KVM for hardware-level isolation.
+
+### KBVE Integration
+
+The KBVE edge platform uses Firecracker as a composable Tier 2 isolation layer alongside the Deno edge-runtime (Tier 1). Edge functions dispatch VM workloads to the `firecracker-ctl` service via an internal REST API on port 9001.
+
+**Manifests:** `apps/kube/firecracker/manifests/`
+
+### Requirements
+
+- Linux kernel with KVM support (Intel VT-x / AMD-V)
+- `/dev/kvm` exposed via `kubevirt/device-plugin-kvm` (already deployed for KubeVirt)
+- Nodes labeled `kvm=true`
+- Bare metal preferred (nested virt adds latency)
+
+### Deployment
+
+```shell
+# Verify KVM device plugin is running
+kubectl get pods -n kubevirt -l app=kvm-device-plugin
+
+# Check firecracker-ctl deployment
+kubectl get deploy firecracker-ctl -n kilobase
+
+# Check firecracker-ctl service
+kubectl get svc firecracker-ctl -n kilobase
+
+# View firecracker-ctl logs
+kubectl logs -n kilobase -l app=firecracker-ctl -f
+```
+
+### Pod Spec Overview
+
+```yaml
+nodeSelector:
+    kvm: 'true'
+containers:
+    - name: firecracker-ctl
+      image: ghcr.io/kbve/firecracker-ctl:0.1.0
+      resources:
+          requests:
+              devices.kubevirt.io/kvm: '1'
+              cpu: 250m
+              memory: 512Mi
+          limits:
+              devices.kubevirt.io/kvm: '1'
+              cpu: '2'
+              memory: 2Gi
+      securityContext:
+          capabilities:
+              add: ['NET_ADMIN']
+```
+
+### Network Policy
+
+Only edge-runtime pods (`app: functions`) can reach `firecracker-ctl` on port 9001. All other ingress is denied.
+
+### API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/vm/create` | Create and start a microVM |
+| `GET` | `/vm/{vm_id}` | Get VM status |
+| `GET` | `/vm/{vm_id}/result` | Get stdout/stderr/exit_code |
+| `DELETE` | `/vm/{vm_id}` | Force-terminate a VM |
+| `GET` | `/health` | Health check |
+
+### Rootfs Images
+
+| Image | Size | Contents |
+|-------|------|----------|
+| `alpine-minimal` | ~8 MB | Alpine + busybox |
+| `alpine-python` | ~45 MB | Alpine + Python 3.12 |
+| `alpine-node` | ~40 MB | Alpine + Node.js 22 LTS |
+| `ubuntu-rust` | ~120 MB | Ubuntu minimal + Rust toolchain |
+
+### Troubleshooting
+
+```shell
+# Check if /dev/kvm is available on a node
+kubectl debug node/<node-name> -it --image=busybox -- ls -la /dev/kvm
+
+# Verify device plugin allocations
+kubectl describe node <node-name> | grep -A5 "devices.kubevirt.io/kvm"
+
+# Test firecracker-ctl health from within cluster
+kubectl run -n kilobase --rm -it --restart=Never test-fc \
+  --image=curlimages/curl -- curl -s http://firecracker-ctl:9001/health
+```
+
+---
+
 ## Sealed Secrets
 
 ### Encoding

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -27,4 +27,120 @@ status: active
 
 ## Overview
 
-Supabase edge functions service.
+Supabase edge functions service built on `supabase/edge-runtime:v1.73.2`. Each function runs as an isolated Deno V8 worker with 150 MB memory and a 60-second timeout. The main router (`functions/main/index.ts`) handles JWT verification, per-function env allowlisting, and worker dispatch.
+
+### Function Registry
+
+| Function | Description |
+|----------|-------------|
+| `health` | Core health check (public, no JWT) |
+| `meme` | Meme feed and reactions |
+| `discordsh` | Discord server integration |
+| `user-vault` | User API token management |
+| `guild-vault` | Guild token management |
+| `vault-reader` | System secret access (service_role only) |
+| `argo` | ArgoCD API proxy with diagnostics |
+| `logs` | ClickHouse observability logs |
+| `ows` | OWS admin operations |
+
+### Shared Modules
+
+All functions share utilities under `functions/_shared/`:
+
+- **`cors.ts`** — CORS headers with origin allowlist
+- **`supabase.ts`** — JWT parsing, Supabase client factories, role guards
+- **`validators.ts`** — Input validation, body size limits, SSRF protection
+- **`formats.ts`** — Regex patterns for UUIDs, ULIDs, Discord snowflakes, etc.
+- **`firecracker.ts`** — Firecracker microVM client (Tier 2 dispatch)
+
+---
+
+## Firecracker MicroVM Integration
+
+### Two-Tier Isolation
+
+The edge platform uses a two-tier isolation model. Tier 1 (Deno workers) handles standard TypeScript functions. Tier 2 (Firecracker microVMs) handles workloads that need full OS-level isolation — arbitrary binaries, untrusted code, or long-running processes.
+
+| Tier | Isolation | Boot Time | Use Case |
+|------|-----------|-----------|----------|
+| 1 | V8 isolates (Deno workers) | ~10ms | TypeScript edge functions |
+| 2 | Firecracker microVMs | ~125ms | Arbitrary binaries, untrusted code |
+
+### Architecture
+
+Edge functions in Tier 1 act as the control plane. When a request needs VM-level isolation, the function dispatches to the Firecracker service via an internal REST API. The two tiers are fully independent — a VM crash never affects edge function availability.
+
+```
+Edge Runtime Pod (Tier 1)         Firecracker Service Pod (Tier 2)
+┌─────────────────────┐           ┌──────────────────────────┐
+│ Deno V8 Workers     │  HTTP →   │ REST API → Firecracker   │
+│ health, meme, vault │  :9001    │ /dev/kvm via device plugin│
+│ argo, logs, ows ... │           │ ┌────┐ ┌────┐ ┌────┐    │
+└─────────────────────┘           │ │VM1 │ │VM2 │ │VM3 │    │
+                                  │ └────┘ └────┘ └────┘    │
+                                  └──────────────────────────┘
+```
+
+### Client Library
+
+Edge functions use the shared `firecracker.ts` client to dispatch VM workloads:
+
+```typescript
+import { runVM } from "../_shared/firecracker.ts";
+
+const result = await runVM({
+  rootfs: "alpine-minimal",
+  vcpu_count: 1,
+  mem_size_mib: 128,
+  timeout_ms: 30000,
+  entrypoint: "/usr/local/bin/worker",
+  env: { TASK: "compute", INPUT: payload },
+});
+// result.stdout, result.stderr, result.exit_code, result.duration_ms
+```
+
+### API Endpoints (firecracker-ctl)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/vm/create` | Create and start a microVM |
+| `GET` | `/vm/{vm_id}` | Get VM status |
+| `GET` | `/vm/{vm_id}/result` | Get stdout/stderr/exit_code after completion |
+| `DELETE` | `/vm/{vm_id}` | Force-terminate a running VM |
+| `GET` | `/health` | Service health check |
+
+### Rootfs Images
+
+Pre-built minimal root filesystems stored as OCI artifacts in GHCR:
+
+| Image | Size | Contents |
+|-------|------|----------|
+| `alpine-minimal` | ~8 MB | Alpine + busybox |
+| `alpine-python` | ~45 MB | Alpine + Python 3.12 |
+| `alpine-node` | ~40 MB | Alpine + Node.js 22 LTS |
+| `ubuntu-rust` | ~120 MB | Ubuntu minimal + Rust toolchain |
+
+### Security
+
+- Firecracker jailer enforces cgroup + seccomp + chroot per VM
+- No root inside microVMs — all capabilities dropped
+- Read-only rootfs with tmpfs overlay for scratch
+- Kubernetes NetworkPolicy restricts ingress to edge-runtime pods only
+- VM timeout enforced both client-side (edge function) and server-side (firecracker-ctl)
+
+### Kubernetes Resources
+
+All manifests live in `apps/kube/firecracker/manifests/`:
+
+- **Deployment** — `firecracker-ctl` with `/dev/kvm` device plugin, `kvm=true` node selector
+- **Service** — ClusterIP on port 9001
+- **PVC** — 2Gi Longhorn volume for rootfs image cache
+- **NetworkPolicy** — Ingress only from `app: functions` pods
+- **ArgoCD Application** — `selfHeal: false` during early phases
+
+### Phased Rollout
+
+- **Phase 1** (merged) — Design document, K8s manifests, edge client library
+- **Phase 2** (current) — Environment wiring, documentation, deployment integration
+- **Phase 3** — E2E tests, ClickHouse monitoring, KEDA autoscaling
+- **Phase 4** — TAP networking, warm VM pool, multi-node scheduling

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -93,7 +93,7 @@ serve(async (req: Request) => {
     "user-vault": [],
     "vault-reader": [],
     meme: [],
-    ows: [],
+    ows: ["FIRECRACKER_URL"],
     logs: ["CLICKHOUSE_URL", "CLICKHOUSE_USER", "CLICKHOUSE_PASSWORD"],
     health: [],
   };

--- a/apps/kube/firecracker/DESIGN.md
+++ b/apps/kube/firecracker/DESIGN.md
@@ -177,19 +177,23 @@ Start with Option A (MMDS) — sufficient for request/response workloads. Gradua
 
 ## Phased Rollout
 
-### Phase 1: Foundation (current)
+### Phase 1: Foundation (complete)
 
-- [ ] Design document (this file)
+- [x] Design document (this file)
 - [ ] Firecracker binary packaging (Dockerfile)
-- [ ] Kubernetes manifests (deployment, service, RBAC)
+- [x] Kubernetes manifests (deployment, service, PVC, NetworkPolicy)
 - [ ] Health check endpoint
 
-### Phase 2: Core API
+### Phase 2: Core API & Integration (current)
 
 - [ ] VM lifecycle API (create, status, result, delete)
 - [ ] MMDS-based stdin/stdout communication
 - [ ] Alpine-minimal rootfs build pipeline
-- [ ] Edge function client library (`_shared/firecracker.ts`)
+- [x] Edge function client library (`_shared/firecracker.ts`)
+- [x] FIRECRACKER_URL env wired in functions-deployment.yaml
+- [x] Main router env allowlist updated for `ows` function
+- [x] Documentation: edge.mdx expanded with Firecracker design
+- [x] Documentation: kubernetes.mdx Firecracker reference section
 
 ### Phase 3: Integration
 

--- a/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
@@ -13,7 +13,7 @@ spec:
         - from:
               - podSelector:
                     matchLabels:
-                        app: edge-functions
+                        app: functions
           ports:
               - protocol: TCP
                 port: 9001

--- a/apps/kube/functions/manifests/functions-deployment.yaml
+++ b/apps/kube/functions/manifests/functions-deployment.yaml
@@ -59,6 +59,8 @@ spec:
                                 key: secret-key
                       - name: VERIFY_JWT
                         value: 'true'
+                      - name: FIRECRACKER_URL
+                        value: 'http://firecracker-ctl:9001'
                       - name: CLICKHOUSE_ENDPOINT
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## Summary
- Wire `FIRECRACKER_URL` env var into the edge-runtime functions deployment (pointing to `http://firecracker-ctl:9001`)
- Allowlist `FIRECRACKER_URL` for the `ows` edge function in the main router's per-function env map
- Expand `edge.mdx` with full Firecracker architecture, two-tier isolation model, client library usage, API reference, rootfs images, security model, and phased rollout tracker
- Add Firecracker MicroVM section to `kubernetes.mdx` with deployment commands, pod spec overview, API table, rootfs images, and troubleshooting commands
- Fix NetworkPolicy pod selector from `app: edge-functions` to `app: functions` (matches actual functions deployment label)
- Update DESIGN.md phase tracking to reflect completed items

## Test plan
- [ ] Verify edge.mdx renders correctly in Astro dev server
- [ ] Verify kubernetes.mdx Firecracker section renders correctly
- [ ] Confirm functions-deployment.yaml has FIRECRACKER_URL env var
- [ ] Confirm NetworkPolicy selector matches `app: functions` label
- [ ] Validate main router index.ts env allowlist includes FIRECRACKER_URL for ows