### PR TITLE
fix(chisel-ubuntu-axum): fix sccache conflict + versioned builder tag push

### DIFF
--- a/packages/docker/chisel-ubuntu-axum/project.json
+++ b/packages/docker/chisel-ubuntu-axum/project.json
@@ -20,7 +20,7 @@
 					"commands": [
 						"npx nx run chisel-ubuntu-axum:containerx-runtime:production",
 						"npx nx run chisel-ubuntu-axum:containerx-builder:production",
-						"VERSION=$(grep -m1 'version' packages/docker/chisel-ubuntu-axum/version.toml | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder ghcr.io/kbve/chisel-ubuntu-axum:${VERSION}-builder && docker push ghcr.io/kbve/chisel-ubuntu-axum:${VERSION}-builder && echo \"Published builder as ${VERSION}-builder\""
+						"VERSION=$(grep -m1 'version' packages/docker/chisel-ubuntu-axum/version.toml | sed 's/.*\"\\(.*\\)\"/\\1/') && docker buildx imagetools create --tag ghcr.io/kbve/chisel-ubuntu-axum:${VERSION}-builder ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder && echo \"Published builder as ${VERSION}-builder\""
 					]
 				}
 			}


### PR DESCRIPTION
## Summary
- Remove `CARGO_INCREMENTAL=1` from builder — sccache prohibits it, was causing `cargo chef cook` to fail
- Fix versioned builder tag: use `docker buildx imagetools create` instead of `docker tag` — buildx with `docker-container` driver pushes directly to registry without loading locally, so `docker tag` couldn't find the image

Closes #9509

## Test plan
- [ ] Chisel builder builds without sccache/incremental conflict
- [ ] Versioned builder tag (e.g. `24.04.5-builder`) published to GHCR