### PR TITLE
fix(discordsh-bot): align CI manifest and MDX deployment path

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -70,7 +70,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -17,7 +17,7 @@ version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml
 runner: ubuntu-latest
 image: kbve/discordsh-bot
-deployment_yaml: apps/kube/discordsh-bot/manifest/deployment.yaml
+deployment_yaml: apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- Sync manifest version `0.1.0` → `0.1.1` to match MDX source of truth (Cargo.toml + version.toml already at 0.1.1)
- Fix MDX `deployment_yaml` path from `apps/kube/discordsh-bot/manifest/deployment.yaml` (nonexistent) to `apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml` (actual location)

Without these fixes, the `post_publish` job would fail to update the k8s deployment image tag after a successful build, keeping the pod stuck on the old/missing image.

## Test plan
- [x] `cargo check -p discordsh-bot` compiles successfully
- [x] Manifest `deployment_yaml` path matches actual k8s manifest location
- [x] Version alignment: MDX (0.1.1) = Cargo.toml (0.1.1) = version.toml (0.1.1) = manifest (0.1.1)
- [ ] CI validates on merge to `main` → `ci-docker.yml` dispatches and builds image