### PR TITLE
chore(bevy_mapdb): bump version.toml to 0.1.0 for crates.io publish

### DIFF
--- a/packages/rust/bevy/bevy_mapdb/version.toml
+++ b/packages/rust/bevy/bevy_mapdb/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.0"
+version = "0.1.0"
 publish = true


### PR DESCRIPTION
## Summary
- Bumps `version.toml` from `0.0.0` to `0.1.0` so the CI version gate allows the publish step to proceed
- Cargo.toml already had `0.1.0`; only `version.toml` was out of sync
- `cargo publish --dry-run` passes locally
- `cargo +nightly check --target wasm32-unknown-unknown` passes locally

## Note on CI failure
The [previous CI run](https://github.com/KBVE/kbve/actions/runs/23782510372) failed at `check-wasm` with `can't find crate for std` on `wasm32-unknown-unknown`. This is a transient nightly toolchain issue in CI (the wasm target std wasn't available for that nightly build), not a code problem. A re-run or pinning a known-good nightly date would fix it.

## Test plan
- [ ] Re-trigger CI publish for bevy_mapdb after merge
- [ ] Verify crate appears on crates.io at 0.1.0