### PR TITLE
fix(kong): bump RESTART_TRIGGER to reload CORS config with chat.kbve.com

### DIFF
--- a/apps/kube/kong/manifests/kong-deployment.yaml
+++ b/apps/kube/kong/manifests/kong-deployment.yaml
@@ -192,7 +192,7 @@ spec:
                       - name: KONG_CLUSTER_LISTEN
                         value: 'off'
                       - name: RESTART_TRIGGER
-                        value: 'cors-chuckrpg-cryptothrone-2026-03-28'
+                        value: 'cors-chat-supabase-forgejo-2026-04-02'
                       - name: KONG_STREAM_LISTEN
                         value: 'off'
                       - name: KONG_PREFIX


### PR DESCRIPTION
## Summary
- Kong runs in DB-less mode and only reads `kong.yml` at pod startup
- PR #9464 added explicit `chat.kbve.com`, `supabase.kbve.com`, `forgejo.kbve.com` to the Kong CORS ConfigMap but the `RESTART_TRIGGER` env var was never bumped
- The pods continued serving stale config — confirmed via `curl` that `chat.kbve.com` origin gets no `Access-Control-Allow-Origin` header while `discord.sh` and `kbve.com` (pre-existing entries) work fine
- Bumping `RESTART_TRIGGER` causes ArgoCD to detect a deployment spec change → rolling restart → pods load updated ConfigMap

## Test plan
- [ ] After merge to `main`, verify ArgoCD triggers a rolling restart of `kong-kong` in `kilobase` namespace
- [ ] `curl -sI -H "Origin: https://chat.kbve.com" https://supabase.kbve.com/auth/v1/user` returns `access-control-allow-origin: https://chat.kbve.com`
- [ ] Verify chat.kbve.com auth flow completes without CORS errors
- [ ] Confirm existing domains (kbve.com, discord.sh, chuckrpg.com) remain unaffected