### PR TITLE
chore(discordsh-bot): bump version to 0.1.2

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.1"
+version: "0.1.2"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
## Summary
- Bump MDX version `0.1.1` → `0.1.2` to trigger the initial Docker image build

The `discordsh-bot` image was never published to GHCR — the version gate saw `version_source == version_toml` (both `0.1.1`) and skipped the build. This bump makes the version gate detect an unpublished version and dispatch `ci-docker.yml`.

## Expected pipeline flow
1. Merge to `dev` → merge to `main`
2. `ci-main.yml` detects `discordsh_bot` version `0.1.2` > `version.toml` `0.1.1` → dispatches `ci-docker.yml`
3. `ci-docker.yml` → version sync (Cargo.toml `0.1.1` → `0.1.2`) → e2e → build → push `ghcr.io/kbve/discordsh-bot:0.1.2`
4. `post_publish` → updates `version.toml` + k8s deployment YAML → ArgoCD syncs → pod comes up healthy