### PR TITLE
feat(firecracker): Phase 4 — firecracker-ctl binary, Dockerfile, rootfs images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "unicode-ident",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1372,7 +1372,7 @@ dependencies = [
  "fs-err",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.37",
@@ -1814,7 +1814,7 @@ dependencies = [
  "concurrent-queue",
  "derive_more 2.1.1",
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "nonmax",
  "serde",
@@ -2455,7 +2455,7 @@ dependencies = [
  "erased-serde",
  "foldhash 0.2.0",
  "glam 0.30.10",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "inventory",
  "petgraph",
  "serde",
@@ -2474,7 +2474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
 dependencies = [
  "bevy_macro_utils",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2516,7 +2516,7 @@ dependencies = [
  "fixedbitset",
  "glam 0.30.10",
  "image",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "js-sys",
  "naga 27.0.3",
  "nonmax",
@@ -3058,16 +3058,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -3595,9 +3595,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickhouse"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d975a05171c6f8a453f60ec6287c0018c90911d5a8a46d9b6abe386ea359fab3"
+checksum = "0bfb36e41b644dcd5be4ef54a3b7d2abc9bb07eda777ab3f90d1b0dbb97c940a"
 dependencies = [
  "bnum",
  "bstr",
@@ -3608,7 +3608,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "lz4_flex",
  "polonius-the-crab",
@@ -3632,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "clickhouse-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358fbfd439fb0bed02a3e2ecc5131f6a9d039ba5639aed650cf0e845f6ebfc16"
+checksum = "30a5efddc880ce9e2573bd867413d9056fa2bea0206af88dec21e72178b9dc74"
 dependencies = [
  "bytes",
  "thiserror 2.0.18",
@@ -3660,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cms"
@@ -3879,7 +3879,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -4262,9 +4262,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -5489,6 +5489,23 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "firecracker-ctl"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "dashmap 6.1.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
 
 [[package]]
 name = "fixed"
@@ -6784,7 +6801,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -6803,7 +6820,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -7210,9 +7227,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -7243,9 +7260,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -7258,7 +7275,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -7274,7 +7290,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
@@ -7305,7 +7321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "rustls 0.23.37",
@@ -7323,7 +7339,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -7342,7 +7358,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -7389,12 +7405,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -7402,9 +7419,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -7415,9 +7432,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -7429,15 +7446,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -7449,15 +7466,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -7553,9 +7570,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -7610,9 +7627,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8062b737e5389949f477d4760a2ebbff0c366f97798f2419b8d8f366363d3342"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -7803,7 +7820,7 @@ dependencies = [
  "fred",
  "futures-util",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "once_cell",
  "papaya",
@@ -8144,7 +8161,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-http-proxy",
  "hyper-rustls 0.27.7",
  "hyper-timeout",
@@ -8234,7 +8251,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser 0.29.6",
  "html5ever 0.29.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "selectors 0.24.0",
 ]
 
@@ -8346,9 +8363,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -8829,7 +8846,7 @@ dependencies = [
  "bevy_utils",
  "bytes",
  "dashmap 6.1.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "lightyear_connection",
  "lightyear_core",
  "lightyear_link",
@@ -8924,7 +8941,7 @@ dependencies = [
  "crossbeam-channel",
  "enum_dispatch",
  "governor",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "lightyear_connection",
  "lightyear_core",
  "lightyear_link",
@@ -9058,9 +9075,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -9318,7 +9335,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "metrics",
  "ordered-float 5.3.0",
  "quanta",
@@ -9455,7 +9472,7 @@ dependencies = [
  "half 2.7.1",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "libm",
  "log",
  "num-traits",
@@ -9482,7 +9499,7 @@ dependencies = [
  "half 2.7.1",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "libm",
  "log",
  "num-traits",
@@ -9500,7 +9517,7 @@ checksum = "310c347db1b30e69581f3b84dc9a5c311ed583f67851b39b77953cb7a066c97f"
 dependencies = [
  "codespan-reporting 0.12.0",
  "data-encoding",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "naga 27.0.3",
  "regex",
  "rustc-hash 1.1.0",
@@ -10763,7 +10780,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde",
  "serde_derive",
 ]
@@ -11117,12 +11134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11203,7 +11214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -11365,9 +11376,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -11464,7 +11475,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -12246,7 +12257,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -12288,7 +12299,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -12395,9 +12406,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
  "bitflags 2.11.0",
  "once_cell",
@@ -12422,7 +12433,7 @@ dependencies = [
  "futures-lite",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "jedi",
  "jsonwebtoken",
@@ -13229,7 +13240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde_core",
@@ -13281,9 +13292,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -13310,7 +13321,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -13337,7 +13348,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -13877,7 +13888,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "memchr",
  "once_cell",
@@ -14919,9 +14930,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -15148,9 +15159,9 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -15159,17 +15170,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -15192,9 +15203,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -15205,7 +15216,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -15216,7 +15227,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -15229,7 +15240,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.15",
@@ -15237,30 +15248,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.13.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -15276,7 +15287,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -15365,7 +15376,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -15562,7 +15573,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -15739,9 +15750,9 @@ dependencies = [
 
 [[package]]
 name = "typewit"
-version = "1.14.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+checksum = "06fee3a8df48c50c55ad646a4e03b00a370da6fe1850ebf467a8d0165dfcafae"
 
 [[package]]
 name = "ucd-trie"
@@ -16065,7 +16076,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -16369,7 +16380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -16408,15 +16419,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs 1.2.1",
@@ -16428,9 +16439,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
  "rustix 1.1.4",
@@ -16451,9 +16462,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3298683470fbdc6ca40151dfc48c8f2fd4c41a26e13042f801f85002384091"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
  "rustix 1.1.4",
  "wayland-client",
@@ -16462,9 +16473,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.11"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -16487,9 +16498,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-misc"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429b99200febaf95d4f4e46deff6fe4382bcff3280ee16a41cf887b3c3364984"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -16500,9 +16511,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d392fc283a87774afc9beefcd6f931582bb97fe0e6ced0b306a62cb1d026527c"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -16513,9 +16524,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -16526,9 +16537,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml 0.39.2",
@@ -16537,9 +16548,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -16835,7 +16846,7 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "naga 27.0.3",
  "once_cell",
@@ -16868,7 +16879,7 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "naga 29.0.1",
  "once_cell",
@@ -17849,9 +17860,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -17904,7 +17915,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -17935,7 +17946,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -17954,7 +17965,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -17966,9 +17977,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
@@ -18237,9 +18248,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -18248,9 +18259,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18383,18 +18394,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18424,9 +18435,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -18435,9 +18446,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -18446,9 +18457,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18464,7 +18475,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
 	'packages/rust/bevy/bevy_battle',
 	'packages/rust/bevy/bevy_skills',
 	'packages/rust/bevy/bevy_tasker',
+	'apps/kube/firecracker/firecracker-ctl',
 ]
 
 [profile.dev]

--- a/apps/kube/firecracker/DESIGN.md
+++ b/apps/kube/firecracker/DESIGN.md
@@ -195,16 +195,21 @@ Start with Option A (MMDS) — sufficient for request/response workloads. Gradua
 - [x] Documentation: edge.mdx expanded with Firecracker design
 - [x] Documentation: kubernetes.mdx Firecracker reference section
 
-### Phase 3: Integration (current)
+### Phase 3: Integration (complete)
 
 - [x] Wire edge function → Firecracker via OWS module (`ows/firecracker.ts`)
 - [x] E2E tests (`edge-e2e/e2e/firecracker.spec.ts`)
 - [x] ClickHouse schema (`firecracker.vm_events` + `vm_stats_1m` materialized view)
 - [x] KEDA ScaledObject (cron + CPU-based autoscaling, scale-to-zero)
 
-### Phase 4: Production
+### Phase 4: Production (current)
 
-- [ ] TAP networking (if needed)
-- [ ] Additional rootfs images
+- [x] `firecracker-ctl` Rust Axum binary (`apps/kube/firecracker/firecracker-ctl/`)
+- [x] Dockerfile with Firecracker v1.10.1 binary + jailer
+- [x] Nx project.json with build/test/lint/container targets
+- [x] Registered in workspace Cargo.toml
+- [x] Rootfs Dockerfiles: alpine-minimal, alpine-node, alpine-python
+- [ ] TAP networking (deferred — MMDS sufficient for now)
 - [ ] Warm pool (pre-booted VMs for <50ms dispatch)
 - [ ] Multi-node scheduling
+- [ ] Linux kernel (vmlinux) build/download pipeline

--- a/apps/kube/firecracker/firecracker-ctl/Cargo.toml
+++ b/apps/kube/firecracker/firecracker-ctl/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "firecracker-ctl"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "REST API service for managing Firecracker microVMs"
+
+[dependencies]
+axum = { version = "0.8.8", features = ["macros"] }
+tokio = { version = "1.0", features = ["full", "rt-multi-thread", "process"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tower = { version = "0.5.3", features = ["util", "timeout"] }
+tower-http = { version = "0.6.8", features = ["trace", "cors"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1", features = ["v4"] }
+tokio-stream = "0.1"
+dashmap = "6"
+
+[features]
+default = []

--- a/apps/kube/firecracker/firecracker-ctl/Cargo.workspace.toml
+++ b/apps/kube/firecracker/firecracker-ctl/Cargo.workspace.toml
@@ -1,0 +1,12 @@
+[workspace]
+resolver = "2"
+members = [
+    "apps/kube/firecracker/firecracker-ctl",
+]
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/apps/kube/firecracker/firecracker-ctl/Dockerfile
+++ b/apps/kube/firecracker/firecracker-ctl/Dockerfile
@@ -1,0 +1,112 @@
+# ============================================================================
+# firecracker-ctl — Multi-stage Docker build
+#
+# Builds the REST API service that manages Firecracker microVM lifecycle.
+# Runtime includes the Firecracker binary + minimal Linux kernel + rootfs images.
+# ============================================================================
+
+# ============================================================================
+# [STAGE A] - Rust Build Base
+# ============================================================================
+FROM --platform=linux/amd64 rust:1.85-slim AS rust-base
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-chef --locked
+
+WORKDIR /app
+
+# ============================================================================
+# [STAGE B] - Cargo Chef Planner
+# ============================================================================
+FROM rust-base AS planner
+
+COPY apps/kube/firecracker/firecracker-ctl/Cargo.workspace.toml Cargo.toml
+COPY apps/kube/firecracker/firecracker-ctl/Cargo.toml apps/kube/firecracker/firecracker-ctl/Cargo.toml
+
+RUN mkdir -p apps/kube/firecracker/firecracker-ctl/src && \
+    echo "fn main() {}" > apps/kube/firecracker/firecracker-ctl/src/main.rs
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ============================================================================
+# [STAGE C] - Cargo Chef Cook (Cache Dependencies)
+# ============================================================================
+FROM rust-base AS builder-deps
+
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml ./
+COPY --from=planner /app/apps apps
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo chef cook --release --recipe-path recipe.json -p firecracker-ctl
+
+# ============================================================================
+# [STAGE D] - Build Application
+# ============================================================================
+FROM rust-base AS builder
+
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+COPY --from=planner /app/Cargo.toml ./
+
+COPY apps/kube/firecracker/firecracker-ctl apps/kube/firecracker/firecracker-ctl
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p firecracker-ctl && \
+    strip target/release/firecracker-ctl
+
+# ============================================================================
+# [STAGE E] - Download Firecracker Binary
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS firecracker-dl
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG FC_VERSION=1.10.1
+RUN curl -fSL "https://github.com/firecracker-microvm/firecracker/releases/download/v${FC_VERSION}/firecracker-v${FC_VERSION}-x86_64.tgz" \
+    -o /tmp/fc.tgz && \
+    tar -xzf /tmp/fc.tgz -C /tmp && \
+    mv "/tmp/release-v${FC_VERSION}-x86_64/firecracker-v${FC_VERSION}-x86_64" /usr/local/bin/firecracker && \
+    mv "/tmp/release-v${FC_VERSION}-x86_64/jailer-v${FC_VERSION}-x86_64" /usr/local/bin/jailer && \
+    chmod +x /usr/local/bin/firecracker /usr/local/bin/jailer && \
+    rm -rf /tmp/fc.tgz /tmp/release-*
+
+# ============================================================================
+# [STAGE Z] - Runtime
+# ============================================================================
+FROM --platform=linux/amd64 ubuntu:24.04 AS runtime
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        iproute2 \
+        iptables && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 10001 appgroup && \
+    useradd -u 10001 -g appgroup -s /bin/false appuser && \
+    mkdir -p /var/lib/firecracker/rootfs /var/lib/firecracker/scratch && \
+    chown -R 10001:10001 /var/lib/firecracker
+
+COPY --from=builder /app/target/release/firecracker-ctl /usr/local/bin/firecracker-ctl
+COPY --from=firecracker-dl /usr/local/bin/firecracker /usr/local/bin/firecracker
+COPY --from=firecracker-dl /usr/local/bin/jailer /usr/local/bin/jailer
+
+ENV FC_PORT=9001
+ENV FC_ROOTFS_DIR=/var/lib/firecracker/rootfs
+ENV RUST_LOG=firecracker_ctl=info,tower_http=info
+
+EXPOSE 9001
+
+# Note: runs as root because Firecracker needs /dev/kvm access.
+# The jailer handles per-VM sandboxing (cgroup + seccomp + chroot).
+ENTRYPOINT ["firecracker-ctl"]

--- a/apps/kube/firecracker/firecracker-ctl/project.json
+++ b/apps/kube/firecracker/firecracker-ctl/project.json
@@ -1,0 +1,90 @@
+{
+	"name": "firecracker-ctl",
+	"$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/kube/firecracker/firecracker-ctl/src",
+	"targets": {
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/firecracker-ctl"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/firecracker-ctl"
+			}
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/firecracker-ctl"
+			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx firecracker-ctl:containerx",
+						"VERSION=$(grep '^version' apps/kube/firecracker/firecracker-ctl/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/firecracker-ctl:latest kbve/firecracker-ctl:$VERSION && echo \"Tagged kbve/firecracker-ctl:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx firecracker-ctl:containerx --configuration=production",
+						"VERSION=$(grep '^version' apps/kube/firecracker/firecracker-ctl/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/firecracker-ctl:latest kbve/firecracker-ctl:$VERSION && docker tag kbve/firecracker-ctl:latest ghcr.io/kbve/firecracker-ctl:latest && docker tag kbve/firecracker-ctl:latest ghcr.io/kbve/firecracker-ctl:$VERSION && echo \"Tagged ghcr.io/kbve/firecracker-ctl:$VERSION\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/kube/firecracker/firecracker-ctl/Dockerfile",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/firecracker-ctl:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"metadata": {
+						"images": [
+							"ghcr.io/kbve/firecracker-ctl",
+							"kbve/firecracker-ctl"
+						],
+						"tags": ["latest"]
+					},
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/firecracker-ctl:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/firecracker-ctl:buildcache,mode=max"
+					]
+				}
+			}
+		}
+	},
+	"tags": ["scope:kube", "firecracker", "infrastructure"]
+}

--- a/apps/kube/firecracker/firecracker-ctl/src/main.rs
+++ b/apps/kube/firecracker/firecracker-ctl/src/main.rs
@@ -1,0 +1,467 @@
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post},
+};
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use std::{net::SocketAddr, sync::Arc, time::Instant};
+use tokio::process::Command;
+use tower_http::trace::TraceLayer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateVmRequest {
+    pub rootfs: String,
+    #[serde(default = "default_vcpu")]
+    pub vcpu_count: u8,
+    #[serde(default = "default_mem")]
+    pub mem_size_mib: u16,
+    #[serde(default = "default_timeout")]
+    pub timeout_ms: u64,
+    pub entrypoint: String,
+    #[serde(default)]
+    pub env: serde_json::Map<String, serde_json::Value>,
+    #[serde(default = "default_boot_args")]
+    pub boot_args: String,
+}
+
+fn default_vcpu() -> u8 {
+    1
+}
+fn default_mem() -> u16 {
+    128
+}
+fn default_timeout() -> u64 {
+    30000
+}
+fn default_boot_args() -> String {
+    "console=ttyS0 reboot=k panic=1".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum VmStatus {
+    Creating,
+    Running,
+    Completed,
+    Failed,
+    Timeout,
+    Destroyed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VmInfo {
+    pub vm_id: String,
+    pub status: VmStatus,
+    pub rootfs: String,
+    pub vcpu_count: u8,
+    pub mem_size_mib: u16,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VmResult {
+    pub vm_id: String,
+    pub status: VmStatus,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug)]
+struct VmRecord {
+    info: VmInfo,
+    result: Option<VmResult>,
+    _created: Instant,
+}
+
+// ---------------------------------------------------------------------------
+// App State
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct AppState {
+    vms: Arc<DashMap<String, VmRecord>>,
+    rootfs_dir: String,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn health() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "status": "ok",
+        "service": "firecracker-ctl",
+        "version": env!("CARGO_PKG_VERSION"),
+        "timestamp": chrono_now(),
+    }))
+}
+
+async fn create_vm(
+    State(state): State<AppState>,
+    Json(req): Json<CreateVmRequest>,
+) -> impl IntoResponse {
+    // Validate rootfs exists
+    let rootfs_path = format!("{}/{}.ext4", state.rootfs_dir, req.rootfs);
+    if !tokio::fs::try_exists(&rootfs_path).await.unwrap_or(false) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("rootfs '{}' not found at {}", req.rootfs, rootfs_path),
+                "available": list_rootfs(&state.rootfs_dir).await,
+            })),
+        );
+    }
+
+    let vm_id = format!("fc-{}", Uuid::new_v4().as_simple());
+    let now = chrono_now();
+
+    let info = VmInfo {
+        vm_id: vm_id.clone(),
+        status: VmStatus::Creating,
+        rootfs: req.rootfs.clone(),
+        vcpu_count: req.vcpu_count,
+        mem_size_mib: req.mem_size_mib,
+        created_at: now,
+    };
+
+    state.vms.insert(
+        vm_id.clone(),
+        VmRecord {
+            info: info.clone(),
+            result: None,
+            _created: Instant::now(),
+        },
+    );
+
+    // Spawn VM lifecycle in background
+    let vms = state.vms.clone();
+    let rootfs_dir = state.rootfs_dir.clone();
+    tokio::spawn(async move {
+        run_vm_lifecycle(vms, vm_id, req, rootfs_dir).await;
+    });
+
+    (StatusCode::CREATED, Json(serde_json::json!(info)))
+}
+
+async fn get_vm_status(
+    State(state): State<AppState>,
+    Path(vm_id): Path<String>,
+) -> impl IntoResponse {
+    match state.vms.get(&vm_id) {
+        Some(record) => (StatusCode::OK, Json(serde_json::json!(record.info))),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "VM not found"})),
+        ),
+    }
+}
+
+async fn get_vm_result(
+    State(state): State<AppState>,
+    Path(vm_id): Path<String>,
+) -> impl IntoResponse {
+    match state.vms.get(&vm_id) {
+        Some(record) => match &record.result {
+            Some(result) => (StatusCode::OK, Json(serde_json::json!(result))),
+            None => (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({
+                    "vm_id": vm_id,
+                    "status": record.info.status,
+                    "message": "VM has not completed yet",
+                })),
+            ),
+        },
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "VM not found"})),
+        ),
+    }
+}
+
+async fn destroy_vm(State(state): State<AppState>, Path(vm_id): Path<String>) -> impl IntoResponse {
+    match state.vms.get_mut(&vm_id) {
+        Some(mut record) => {
+            record.info.status = VmStatus::Destroyed;
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"vm_id": vm_id, "status": "destroyed"})),
+            )
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "VM not found"})),
+        ),
+    }
+}
+
+async fn list_vms(State(state): State<AppState>) -> impl IntoResponse {
+    let vms: Vec<VmInfo> = state
+        .vms
+        .iter()
+        .map(|entry| entry.value().info.clone())
+        .collect();
+    Json(serde_json::json!({ "vms": vms, "count": vms.len() }))
+}
+
+// ---------------------------------------------------------------------------
+// VM Lifecycle
+// ---------------------------------------------------------------------------
+
+async fn run_vm_lifecycle(
+    vms: Arc<DashMap<String, VmRecord>>,
+    vm_id: String,
+    req: CreateVmRequest,
+    rootfs_dir: String,
+) {
+    let start = Instant::now();
+
+    // Update status to running
+    if let Some(mut record) = vms.get_mut(&vm_id) {
+        record.info.status = VmStatus::Running;
+    }
+
+    let rootfs_path = format!("{}/{}.ext4", rootfs_dir, req.rootfs);
+
+    // Build firecracker config and launch via the Firecracker binary.
+    // The Firecracker binary communicates over a Unix socket; we create
+    // a per-VM socket in the scratch directory.
+    let socket_path = format!("/var/lib/firecracker/scratch/{}.sock", vm_id);
+    let config = serde_json::json!({
+        "boot-source": {
+            "kernel_image_path": format!("{}/vmlinux", rootfs_dir),
+            "boot_args": req.boot_args,
+        },
+        "drives": [{
+            "drive_id": "rootfs",
+            "path_on_host": rootfs_path,
+            "is_root_device": true,
+            "is_read_only": true,
+        }],
+        "machine-config": {
+            "vcpu_count": req.vcpu_count,
+            "mem_size_mib": req.mem_size_mib,
+        },
+    });
+
+    let config_path = format!("/var/lib/firecracker/scratch/{}.json", vm_id);
+
+    // Write config
+    if let Err(e) = tokio::fs::write(&config_path, config.to_string()).await {
+        tracing::error!("Failed to write VM config: {}", e);
+        set_vm_failed(
+            &vms,
+            &vm_id,
+            start,
+            -1,
+            "".into(),
+            format!("Config write failed: {}", e),
+        );
+        return;
+    }
+
+    // Launch firecracker process
+    let timeout = tokio::time::Duration::from_millis(req.timeout_ms);
+    let child = Command::new("firecracker")
+        .args(["--api-sock", &socket_path, "--config-file", &config_path])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn();
+
+    let mut child = match child {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to spawn firecracker: {}", e);
+            set_vm_failed(
+                &vms,
+                &vm_id,
+                start,
+                -1,
+                "".into(),
+                format!("Spawn failed: {}", e),
+            );
+            cleanup_files(&config_path, &socket_path).await;
+            return;
+        }
+    };
+
+    // Wait with timeout. Use wait() + take stdout/stderr separately to
+    // allow killing the child on timeout (wait_with_output takes ownership).
+    let child_stdout = child.stdout.take();
+    let child_stderr = child.stderr.take();
+    let result = tokio::time::timeout(timeout, child.wait()).await;
+
+    match result {
+        Ok(Ok(exit_status)) => {
+            let exit_code = exit_status.code().unwrap_or(-1);
+            let stdout = if let Some(mut out) = child_stdout {
+                let mut buf = Vec::new();
+                let _ = tokio::io::AsyncReadExt::read_to_end(&mut out, &mut buf).await;
+                String::from_utf8_lossy(&buf).to_string()
+            } else {
+                String::new()
+            };
+            let stderr = if let Some(mut err) = child_stderr {
+                let mut buf = Vec::new();
+                let _ = tokio::io::AsyncReadExt::read_to_end(&mut err, &mut buf).await;
+                String::from_utf8_lossy(&buf).to_string()
+            } else {
+                String::new()
+            };
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let status = if exit_code == 0 {
+                VmStatus::Completed
+            } else {
+                VmStatus::Failed
+            };
+
+            if let Some(mut record) = vms.get_mut(&vm_id) {
+                record.info.status = status.clone();
+                record.result = Some(VmResult {
+                    vm_id: vm_id.clone(),
+                    status,
+                    exit_code,
+                    stdout,
+                    stderr,
+                    duration_ms,
+                });
+            }
+        }
+        Ok(Err(e)) => {
+            tracing::error!("VM {} process error: {}", vm_id, e);
+            set_vm_failed(
+                &vms,
+                &vm_id,
+                start,
+                -1,
+                "".into(),
+                format!("Process error: {}", e),
+            );
+        }
+        Err(_) => {
+            tracing::warn!("VM {} timed out after {}ms", vm_id, req.timeout_ms);
+            let _ = child.kill().await;
+            if let Some(mut record) = vms.get_mut(&vm_id) {
+                record.info.status = VmStatus::Timeout;
+                record.result = Some(VmResult {
+                    vm_id: vm_id.clone(),
+                    status: VmStatus::Timeout,
+                    exit_code: -1,
+                    stdout: String::new(),
+                    stderr: format!("VM timed out after {}ms", req.timeout_ms),
+                    duration_ms: start.elapsed().as_millis() as u64,
+                });
+            }
+        }
+    }
+
+    cleanup_files(&config_path, &socket_path).await;
+}
+
+fn set_vm_failed(
+    vms: &DashMap<String, VmRecord>,
+    vm_id: &str,
+    start: Instant,
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+) {
+    if let Some(mut record) = vms.get_mut(vm_id) {
+        record.info.status = VmStatus::Failed;
+        record.result = Some(VmResult {
+            vm_id: vm_id.to_string(),
+            status: VmStatus::Failed,
+            exit_code,
+            stdout,
+            stderr,
+            duration_ms: start.elapsed().as_millis() as u64,
+        });
+    }
+}
+
+async fn cleanup_files(config_path: &str, socket_path: &str) {
+    let _ = tokio::fs::remove_file(config_path).await;
+    let _ = tokio::fs::remove_file(socket_path).await;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn chrono_now() -> String {
+    // Simple ISO 8601 without pulling in chrono crate
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+    // Return epoch seconds as string — proper formatting can come later
+    format!("{}Z", secs)
+}
+
+async fn list_rootfs(dir: &str) -> Vec<String> {
+    let mut rootfs = Vec::new();
+    if let Ok(mut entries) = tokio::fs::read_dir(dir).await {
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.ends_with(".ext4") {
+                rootfs.push(name.trim_end_matches(".ext4").to_string());
+            }
+        }
+    }
+    rootfs
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "firecracker_ctl=debug,tower_http=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let port: u16 = std::env::var("FC_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(9001);
+
+    let rootfs_dir = std::env::var("FC_ROOTFS_DIR")
+        .unwrap_or_else(|_| "/var/lib/firecracker/rootfs".to_string());
+
+    let state = AppState {
+        vms: Arc::new(DashMap::new()),
+        rootfs_dir,
+    };
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/vm/create", post(create_vm))
+        .route("/vm", get(list_vms))
+        .route("/vm/{vm_id}", get(get_vm_status))
+        .route("/vm/{vm_id}/result", get(get_vm_result))
+        .route("/vm/{vm_id}", delete(destroy_vm))
+        .layer(TraceLayer::new_for_http())
+        .with_state(state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!("firecracker-ctl listening on {}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/apps/kube/firecracker/rootfs/Dockerfile.alpine-minimal
+++ b/apps/kube/firecracker/rootfs/Dockerfile.alpine-minimal
@@ -1,0 +1,36 @@
+# ============================================================================
+# Firecracker rootfs builder — alpine-minimal
+#
+# Produces a minimal ext4 filesystem image (~8 MB) for Firecracker microVMs.
+# Contains Alpine Linux with busybox — no package manager, no extras.
+#
+# Usage:
+#   docker build -f Dockerfile.alpine-minimal -t fc-rootfs-alpine-minimal .
+#   docker run --rm fc-rootfs-alpine-minimal cat /rootfs.ext4 > alpine-minimal.ext4
+# ============================================================================
+
+FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
+
+RUN apk add --no-cache e2fsprogs
+
+# Build a minimal root filesystem
+RUN mkdir -p /rootfs && \
+    # Install minimal Alpine into /rootfs
+    apk add --root /rootfs --initdb --no-cache \
+        alpine-baselayout \
+        busybox \
+        musl \
+        ca-certificates-bundle && \
+    # Create required directories
+    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log} && \
+    # Create init script that runs the entrypoint from MMDS or /entrypoint
+    printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nif [ -x /entrypoint ]; then\n  exec /entrypoint\nelse\n  exec /bin/sh\nfi\n' > /rootfs/init && \
+    chmod +x /rootfs/init && \
+    # Create ext4 image (32MB sparse, will compress to ~8MB)
+    dd if=/dev/zero of=/rootfs.ext4 bs=1M count=0 seek=32 && \
+    mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \
+    # Shrink to minimum size
+    resize2fs -M /rootfs.ext4
+
+FROM scratch
+COPY --from=rootfs-builder /rootfs.ext4 /rootfs.ext4

--- a/apps/kube/firecracker/rootfs/Dockerfile.alpine-node
+++ b/apps/kube/firecracker/rootfs/Dockerfile.alpine-node
@@ -1,0 +1,30 @@
+# ============================================================================
+# Firecracker rootfs builder — alpine-node
+#
+# Alpine Linux + Node.js 22 LTS (~40 MB ext4 image) for Firecracker microVMs.
+#
+# Usage:
+#   docker build -f Dockerfile.alpine-node -t fc-rootfs-alpine-node .
+#   docker run --rm fc-rootfs-alpine-node cat /rootfs.ext4 > alpine-node.ext4
+# ============================================================================
+
+FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
+
+RUN apk add --no-cache e2fsprogs
+
+RUN mkdir -p /rootfs && \
+    apk add --root /rootfs --initdb --no-cache \
+        alpine-baselayout \
+        busybox \
+        musl \
+        ca-certificates-bundle \
+        nodejs && \
+    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log} && \
+    printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nif [ -x /entrypoint ]; then\n  exec /entrypoint\nelse\n  exec /bin/sh\nfi\n' > /rootfs/init && \
+    chmod +x /rootfs/init && \
+    dd if=/dev/zero of=/rootfs.ext4 bs=1M count=0 seek=128 && \
+    mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \
+    resize2fs -M /rootfs.ext4
+
+FROM scratch
+COPY --from=rootfs-builder /rootfs.ext4 /rootfs.ext4

--- a/apps/kube/firecracker/rootfs/Dockerfile.alpine-python
+++ b/apps/kube/firecracker/rootfs/Dockerfile.alpine-python
@@ -1,0 +1,30 @@
+# ============================================================================
+# Firecracker rootfs builder — alpine-python
+#
+# Alpine Linux + Python 3.12 (~45 MB ext4 image) for Firecracker microVMs.
+#
+# Usage:
+#   docker build -f Dockerfile.alpine-python -t fc-rootfs-alpine-python .
+#   docker run --rm fc-rootfs-alpine-python cat /rootfs.ext4 > alpine-python.ext4
+# ============================================================================
+
+FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
+
+RUN apk add --no-cache e2fsprogs
+
+RUN mkdir -p /rootfs && \
+    apk add --root /rootfs --initdb --no-cache \
+        alpine-baselayout \
+        busybox \
+        musl \
+        ca-certificates-bundle \
+        python3 && \
+    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log} && \
+    printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nif [ -x /entrypoint ]; then\n  exec /entrypoint\nelse\n  exec /bin/sh\nfi\n' > /rootfs/init && \
+    chmod +x /rootfs/init && \
+    dd if=/dev/zero of=/rootfs.ext4 bs=1M count=0 seek=128 && \
+    mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \
+    resize2fs -M /rootfs.ext4
+
+FROM scratch
+COPY --from=rootfs-builder /rootfs.ext4 /rootfs.ext4


### PR DESCRIPTION
## Summary
- Add `firecracker-ctl` Rust Axum service with full VM lifecycle REST API (health, create, list, status, result, destroy)
- Multi-stage Dockerfile: cargo-chef cached build + Firecracker v1.10.1 binary + jailer download
- Nx project.json with build/test/lint/container/containerx targets matching repo conventions
- Registered in workspace `Cargo.toml`
- Rootfs Dockerfiles for building ext4 images: `alpine-minimal` (~8MB), `alpine-node` (~40MB), `alpine-python` (~45MB)
- Updated DESIGN.md phase tracking — Phases 1-3 complete, Phase 4 in progress

## Architecture
The `firecracker-ctl` binary manages VM lifecycle via DashMap in-memory state. On `POST /vm/create`, it validates the rootfs exists, writes a per-VM Firecracker config JSON, spawns the `firecracker` process with a per-VM Unix socket, and monitors it with timeout enforcement. Results (stdout/stderr/exit_code/duration) are stored and retrievable via `GET /vm/{id}/result`.

## Remaining Phase 4 items
- TAP networking (deferred — MMDS sufficient for initial workloads)
- Warm VM pool (pre-boot for <50ms dispatch)
- Linux kernel (vmlinux) download pipeline
- Multi-node scheduling

## Test plan
- [x] `cargo check -p firecracker-ctl` passes
- [x] rustfmt clean
- [ ] Docker build on Linux CI runner with BuildKit
- [ ] Rootfs Dockerfile builds produce valid ext4 images
- [ ] Existing CI unaffected (new crate is isolated)