### PR TITLE
fix(isometric): wraiths visible day/night and brighter firefly glow

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
@@ -74,8 +74,8 @@ pub(super) fn spawn_fireflies(
                 PointLight {
                     color: Color::srgb(0.4, 0.85, 0.25),
                     intensity: 0.0,
-                    radius: 0.05,
-                    range: 5.0,
+                    radius: 0.08,
+                    range: 10.0,
                     shadows_enabled: false,
                     ..default()
                 },
@@ -300,9 +300,9 @@ pub(super) fn animate_fireflies(
         let pos = cr.anchor + Vec3::new(ox, oy, oz) + wind_off;
         tf.translation = pos;
 
-        // Double-pulse glow pattern
+        // Double-pulse glow pattern with a faint base glow between pulses
         let pulse_t = ed.glow_phase;
-        let glow = if pulse_t < 0.15 {
+        let pulse = if pulse_t < 0.15 {
             (pulse_t / 0.15 * std::f32::consts::PI).sin()
         } else if pulse_t < 0.25 {
             0.0
@@ -312,16 +312,18 @@ pub(super) fn animate_fireflies(
             0.0
         };
 
+        // Faint base glow (0.18) so fireflies never fully go dark — they always emit light
+        let glow = 0.18 + pulse * 0.82;
         let intensity = glow * nf;
 
         if let Some(mat) = materials.get_mut(&cr.mat_handle) {
-            let emit = intensity * 12.0;
+            let emit = intensity * 35.0;
             mat.emissive = LinearRgba::new(0.3 * emit, 0.85 * emit, 0.15 * emit, 1.0);
-            mat.base_color = Color::srgba(0.5, 0.9, 0.3, intensity * 0.9 + 0.15 * nf);
+            mat.base_color = Color::srgba(0.5, 0.9, 0.3, intensity * 0.95 + 0.2 * nf);
         }
 
         if let Ok((mut pl, mut ltf, mut lvis)) = light_q.get_mut(ed.light_entity) {
-            pl.intensity = intensity * 2800.0;
+            pl.intensity = intensity * 8000.0;
             ltf.translation = pos;
             *lvis = if intensity > 0.01 {
                 Visibility::Visible

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -19,7 +19,7 @@ pub use wraith::WraithMaterials;
 /// Build creature meshes once at Startup to avoid allocating during spawn.
 fn setup_creature_meshes(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     commands.insert_resource(CreatureMeshes {
-        firefly_sphere: meshes.add(Sphere::new(0.04).mesh().ico(1).unwrap()),
+        firefly_sphere: meshes.add(Sphere::new(0.07).mesh().ico(1).unwrap()),
         butterfly_wings: meshes.add(butterfly::build_butterfly_mesh()),
     });
 }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
@@ -19,7 +19,7 @@ use bevy::asset::RenderAssetUsages;
 use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 
-use super::common::{CreaturePool, GameTime, hash_f32, night_factor, scene_center};
+use super::common::{CreaturePool, hash_f32, scene_center};
 use super::creature::{
     Creature, CreaturePoolIndex, CreatureRegistry, CreatureState, RenderKind, SpriteData,
     SpriteHopState,
@@ -186,7 +186,7 @@ pub(super) fn spawn_wraiths(
 
         let mat = materials.add(StandardMaterial {
             base_color_texture: Some(texture.clone()),
-            alpha_mode: AlphaMode::Mask(0.5),
+            alpha_mode: AlphaMode::Blend,
             cull_mode: None,
             double_sided: true,
             unlit: true,
@@ -236,7 +236,6 @@ pub struct WraithMarker;
 
 pub(super) fn animate_wraiths(
     time: Res<Time>,
-    game_time: Res<GameTime>,
     mut terrain: ResMut<TerrainMap>,
     camera_q: Query<&Transform, With<IsometricCamera>>,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -256,17 +255,7 @@ pub(super) fn animate_wraiths(
     };
     let dt = time.delta_secs();
     let t = time.elapsed_secs();
-    let nf = night_factor(game_time.hour);
-
-    // Hide wraiths during daytime
-    if nf < 0.01 {
-        for (mut tf, mut cr, _, mut vis, _) in &mut wraith_q {
-            *vis = Visibility::Hidden;
-            tf.translation.y = -100.0;
-            cr.anchor.y = -100.0;
-        }
-        return;
-    }
+    // Wraiths are always visible — alpha modulation handled by tint_wraiths_for_daynight
 
     let cam_pos = cam_tf.translation;
     let center = scene_center(cam_pos);

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -481,6 +481,7 @@ fn tint_frogs_for_daynight(
 }
 
 /// Tint unlit wraith materials based on time of day (same curve as frogs).
+/// Wraiths are always visible: fully opaque at night, semi-transparent (ghostly) during day.
 fn tint_wraiths_for_daynight(
     day: Res<DayCycle>,
     wraith_mats: Option<Res<WraithMaterials>>,
@@ -496,9 +497,16 @@ fn tint_wraiths_for_daynight(
     let g = 0.20 + h * 0.90;
     let b = 0.28 + h * 0.75;
 
+    // Ghostly transparency during daytime: fully opaque at night, semi-transparent at day
+    let alpha = if h < 0.01 {
+        1.0
+    } else {
+        0.35 + (1.0 - h) * 0.15
+    };
+
     for handle in &wraith_mats.handles {
         if let Some(mat) = materials.get_mut(handle) {
-            mat.base_color = Color::srgb(r, g, b);
+            mat.base_color = Color::srgba(r, g, b, alpha);
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Wraiths** now render 24/7 — semi-transparent ghostly appearance during daytime (AlphaMode::Blend + alpha tint), fully opaque at night. Removed the night_factor gate that hid them during the day.
- **Fireflies** act as proper light sources with a faint persistent glow: emissive 35x (was 12x), PointLight intensity 8000 (was 2800), range 10 (was 5), sphere radius 0.07 (was 0.04), and 18% base glow floor so they never fully go dark between pulses.

## Test plan
- [ ] Verify wraiths are visible during daytime with ghostly transparency
- [ ] Verify wraiths are fully opaque at night
- [ ] Verify fireflies emit a visible faint glow that illuminates nearby terrain
- [ ] Verify firefly double-pulse pattern still works with the new base glow floor
- [ ] Confirm no regression in day/night cycle transitions