### PR TITLE
fix(isometric): double wraith billboard size for visibility

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
@@ -39,7 +39,7 @@ const FRAME_W: f32 = 1.0 / SHEET_COLS as f32;
 const FRAME_H: f32 = 1.0 / SHEET_ROWS as f32;
 
 /// World-space size of the wraith billboard quad (larger than frog).
-const WRAITH_SIZE: f32 = 1.6;
+const WRAITH_SIZE: f32 = 3.2;
 
 const FRAME_DURATION_BASE: f32 = 0.12;
 


### PR DESCRIPTION
## Summary
- Doubled `WRAITH_SIZE` from 1.6 → 3.2 so wraiths are visible on screen

## Test plan
- [ ] Verify wraiths are noticeably larger and easy to spot during both day and night
- [ ] Confirm billboard scaling and UV mapping still look correct at the new size