### PR TITLE
fix(droid): resolve DataCloneError in SharedWorker and add worker-error event

### DIFF
--- a/packages/npm/droid/src/lib/gateway/SupabaseGateway.ts
+++ b/packages/npm/droid/src/lib/gateway/SupabaseGateway.ts
@@ -17,6 +17,8 @@ import {
 import { SharedWorkerStrategy } from './strategies/SharedWorkerStrategy';
 import { WebWorkerStrategy } from './strategies/WebWorkerStrategy';
 import { DirectStrategy } from './strategies/DirectStrategy';
+import { getWorkerCommunication } from './WorkerCommunication';
+import { DroidEvents } from '../workers/events';
 
 // Vite ?worker&url imports — bundles workers as JS and returns their URL
 import defaultSharedWorkerUrl from '../workers/supabase-shared-worker?worker&url';
@@ -71,6 +73,22 @@ export class SupabaseGateway implements ISupabaseStrategy {
 			case 'direct':
 				this.strategy = new DirectStrategy();
 				break;
+		}
+
+		// Forward worker-error events from BroadcastChannel to DroidEvents
+		if (typeof window !== 'undefined') {
+			const comm = getWorkerCommunication();
+			comm.on('worker-error', (payload) => {
+				DroidEvents.emit(
+					'worker-error',
+					payload as {
+						timestamp: number;
+						worker: 'shared' | 'db' | 'ws';
+						operation: string;
+						message: string;
+					},
+				);
+			});
 		}
 	}
 

--- a/packages/npm/droid/src/lib/gateway/WorkerCommunication.ts
+++ b/packages/npm/droid/src/lib/gateway/WorkerCommunication.ts
@@ -58,7 +58,7 @@ export class WorkerCommunication {
 		if (type === 'realtime' && key) {
 			this.emit(`realtime:${key}`, event.payload);
 		} else {
-			this.emit(type, event);
+			this.emit(type, event.data ?? event);
 		}
 	}
 

--- a/packages/npm/droid/src/lib/gateway/types.ts
+++ b/packages/npm/droid/src/lib/gateway/types.ts
@@ -1,91 +1,118 @@
 // Shared types for all gateway strategies
 
 export interface SupabaseConfig {
-  url: string;
-  anonKey: string;
-  options?: Record<string, unknown>;
+	url: string;
+	anonKey: string;
+	options?: Record<string, unknown>;
 }
 
 export interface Session {
-  access_token: string;
-  refresh_token: string;
-  user: Record<string, unknown>;
-  expires_at?: number;
+	access_token: string;
+	refresh_token: string;
+	user: Record<string, unknown>;
+	expires_at?: number;
 }
 
 export interface SessionResponse {
-  session: Session | null;
-  user?: Record<string, unknown>;
+	session: Session | null;
+	user?: Record<string, unknown>;
 }
 
 export interface WebSocketStatus {
-  status: 'connected' | 'disconnected' | 'connecting' | 'error';
-  readyState: number | null;
-  error?: string;
+	status: 'connected' | 'disconnected' | 'connecting' | 'error';
+	readyState: number | null;
+	error?: string;
 }
 
 // Unified API that all strategies must implement
 export interface ISupabaseStrategy {
-  // Lifecycle
-  init(url: string, anonKey: string, options?: Record<string, unknown>): Promise<SessionResponse>;
+	// Lifecycle
+	init(
+		url: string,
+		anonKey: string,
+		options?: Record<string, unknown>,
+	): Promise<SessionResponse>;
 
-  // Event handling
-  on(event: string, callback: (payload: unknown) => void): () => void;
+	// Event handling
+	on(event: string, callback: (payload: unknown) => void): () => void;
 
-  // Auth
-  getSession(): Promise<SessionResponse>;
-  signInWithPassword(email: string, password: string): Promise<SessionResponse>;
-  signOut(): Promise<void>;
+	// Auth
+	getSession(): Promise<SessionResponse>;
+	signInWithPassword(
+		email: string,
+		password: string,
+	): Promise<SessionResponse>;
+	signOut(): Promise<void>;
 
-  // Database
-  select(table: string, opts?: SelectOptions): Promise<unknown[]>;
-  insert(table: string, data: Record<string, unknown> | Record<string, unknown>[]): Promise<unknown[]>;
-  update(table: string, data: Record<string, unknown>, match: Record<string, unknown>): Promise<unknown[]>;
-  upsert(table: string, data: Record<string, unknown> | Record<string, unknown>[]): Promise<unknown[]>;
-  delete(table: string, match: Record<string, unknown>): Promise<unknown[]>;
-  rpc(fn: string, args?: Record<string, unknown>): Promise<unknown>;
+	// Database
+	select(table: string, opts?: SelectOptions): Promise<unknown[]>;
+	insert(
+		table: string,
+		data: Record<string, unknown> | Record<string, unknown>[],
+	): Promise<unknown[]>;
+	update(
+		table: string,
+		data: Record<string, unknown>,
+		match: Record<string, unknown>,
+	): Promise<unknown[]>;
+	upsert(
+		table: string,
+		data: Record<string, unknown> | Record<string, unknown>[],
+	): Promise<unknown[]>;
+	delete(table: string, match: Record<string, unknown>): Promise<unknown[]>;
+	rpc(fn: string, args?: Record<string, unknown>): Promise<unknown>;
 
-  // Realtime
-  subscribePostgres(key: string, params: Record<string, unknown>, callback: (payload: unknown) => void): () => void;
+	// Realtime
+	subscribePostgres(
+		key: string,
+		params: Record<string, unknown>,
+		callback: (payload: unknown) => void,
+	): () => void;
 
-  // WebSocket
-  connectWebSocket(wsUrl?: string): Promise<WebSocketStatus>;
-  disconnectWebSocket(): Promise<void>;
-  sendWebSocketMessage(data: unknown): Promise<void>;
-  getWebSocketStatus(): Promise<WebSocketStatus>;
-  onWebSocketMessage(callback: (message: unknown) => void): () => void;
-  onWebSocketStatus(callback: (status: WebSocketStatus) => void): () => void;
+	// WebSocket
+	connectWebSocket(wsUrl?: string): Promise<WebSocketStatus>;
+	disconnectWebSocket(): Promise<void>;
+	sendWebSocketMessage(data: unknown): Promise<void>;
+	getWebSocketStatus(): Promise<WebSocketStatus>;
+	onWebSocketMessage(callback: (message: unknown) => void): () => void;
+	onWebSocketStatus(callback: (status: WebSocketStatus) => void): () => void;
 
-  // Cleanup
-  terminate(): void;
+	// Cleanup
+	terminate(): void;
 }
 
 export interface SelectOptions {
-  columns?: string;
-  match?: Record<string, unknown>;
-  limit?: number;
+	columns?: string;
+	match?: Record<string, unknown>;
+	limit?: number;
 }
 
 // Worker communication messages
 export interface WorkerMessage {
-  id: string;
-  type: string;
-  payload?: unknown;
+	id: string;
+	type: string;
+	payload?: unknown;
 }
 
 export interface WorkerResponse {
-  id: string;
-  ok: boolean;
-  data?: unknown;
-  error?: string;
+	id: string;
+	ok: boolean;
+	data?: unknown;
+	error?: string;
 }
 
 // BroadcastChannel event types
 export interface BroadcastEvent {
-  type: 'auth' | 'ws.message' | 'ws.status' | 'realtime' | 'ready';
-  data?: unknown;
-  key?: string;
-  payload?: unknown;
+	type:
+		| 'auth'
+		| 'ws.message'
+		| 'ws.status'
+		| 'realtime'
+		| 'ready'
+		| 'worker-error';
+	data?: unknown;
+	key?: string;
+	payload?: unknown;
 }
 
 // Strategy types
@@ -93,20 +120,20 @@ export type StrategyType = 'shared-worker' | 'web-worker' | 'direct';
 
 // Browser capabilities
 export interface BrowserCapabilities {
-  hasSharedWorker: boolean;
-  hasWorker: boolean;
-  hasBroadcastChannel: boolean;
-  isAndroid: boolean;
-  isSafari: boolean;
+	hasSharedWorker: boolean;
+	hasWorker: boolean;
+	hasBroadcastChannel: boolean;
+	isAndroid: boolean;
+	isSafari: boolean;
 }
 
 // Gateway configuration
 export interface GatewayConfig {
-  workerUrls?: {
-    sharedWorker?: string | URL;
-    dbWorker?: string | URL;
-    webSocketWorker?: string | URL;
-  };
-  forceStrategy?: StrategyType;
-  poolSize?: number;
+	workerUrls?: {
+		sharedWorker?: string | URL;
+		dbWorker?: string | URL;
+		webSocketWorker?: string | URL;
+	};
+	forceStrategy?: StrategyType;
+	poolSize?: number;
 }

--- a/packages/npm/droid/src/lib/types/event-types.ts
+++ b/packages/npm/droid/src/lib/types/event-types.ts
@@ -54,6 +54,13 @@ export const AuthErrorSchema = z.object({
 	message: z.string(),
 });
 
+export const WorkerErrorSchema = z.object({
+	timestamp: z.number(),
+	worker: z.enum(['shared', 'db', 'ws']),
+	operation: z.string(),
+	message: z.string(),
+});
+
 export const DroidEventSchemas = {
 	'droid-first-connect': DroidFirstConnectSchema,
 	'droid-ready': DroidReadySchema,
@@ -70,6 +77,7 @@ export const DroidEventSchemas = {
 	'modal-closed': ModalPayloadSchema.pick({ id: true }),
 	'auth-ready': AuthReadySchema,
 	'auth-error': AuthErrorSchema,
+	'worker-error': WorkerErrorSchema,
 };
 
 export type DroidEventMap = {

--- a/packages/npm/droid/src/lib/workers/supabase-shared-worker.ts
+++ b/packages/npm/droid/src/lib/workers/supabase-shared-worker.ts
@@ -97,13 +97,29 @@ type Res =
 
 const ports = new Set<MessagePort>();
 
+/** Emit a worker-error event via BroadcastChannel so the main thread can surface it. */
+function broadcastError(operation: string, err: unknown) {
+	const message = err instanceof Error ? err.message : String(err);
+	console.error(`[SharedWorker] ${operation}:`, message);
+	comm.broadcast({
+		type: 'worker-error',
+		data: {
+			timestamp: Date.now(),
+			worker: 'shared',
+			operation,
+			message,
+		},
+	});
+}
+
 /** Post to all connected ports, removing dead ones on failure */
 function safeBroadcast(msg: unknown) {
 	for (const p of ports) {
 		try {
 			p.postMessage(msg);
-		} catch {
+		} catch (err) {
 			ports.delete(p);
+			broadcastError('postMessage', err);
 		}
 	}
 }
@@ -234,14 +250,12 @@ async function connectWebSocket(wsUrl?: string) {
 			safeBroadcast({ type: 'ws.message', data: message });
 			comm.broadcast({ type: 'ws.message', data: message });
 		} catch (error) {
-			console.error(
-				'[SharedWorker] Failed to parse WebSocket message:',
-				error,
-			);
+			broadcastError('ws.onmessage', error);
 		}
 	};
 
 	ws.onerror = () => {
+		broadcastError('ws.connect', 'WebSocket connection error');
 		safeBroadcast({
 			type: 'ws.status',
 			status: 'error',
@@ -364,15 +378,29 @@ async function ensureClient(
 	});
 
 	client.auth.onAuthStateChange(async (_event, session) => {
-		safeBroadcast({ type: 'auth', session });
-		comm.broadcast({ type: 'auth', data: { session } });
+		// Supabase session objects may contain non-cloneable references
+		// (internal SDK callbacks, circular refs). JSON round-trip strips
+		// them so postMessage / BroadcastChannel.postMessage won't throw
+		// DataCloneError.
+		const safe = session ? JSON.parse(JSON.stringify(session)) : null;
+		safeBroadcast({ type: 'auth', session: safe });
+		comm.broadcast({ type: 'auth', data: { session: safe } });
 	});
 
 	return client;
 }
 
+/** JSON round-trip to strip non-cloneable refs (functions, circular) before postMessage. */
+function cloneSafe<T>(obj: T): T {
+	try {
+		return JSON.parse(JSON.stringify(obj));
+	} catch {
+		return obj;
+	}
+}
+
 function reply(port: MessagePort, msg: Res) {
-	port.postMessage(msg);
+	port.postMessage(cloneSafe(msg));
 }
 
 (self as unknown as SharedWorkerGlobalScope).onconnect = (
@@ -559,6 +587,7 @@ function reply(port: MessagePort, msg: Res) {
 				}
 			}
 		} catch (err: unknown) {
+			broadcastError(m.type, err);
 			reply(port, {
 				id: m.id,
 				ok: false,


### PR DESCRIPTION
## Summary
- Fix `DataCloneError: The object can not be cloned` when SharedWorker broadcasts auth state changes or replies to main thread — Supabase session objects contain non-cloneable SDK internals, now stripped via JSON round-trip
- Add `worker-error` event to DroidEvents bus so app code can observe worker failures (`DroidEvents.on('worker-error', ...)`) instead of errors silently swallowing in the worker context
- Wire `broadcastError()` into SharedWorker's WebSocket error/message handlers, `safeBroadcast` catch, and the main request handler catch block
- `SupabaseGateway` constructor forwards `worker-error` from BroadcastChannel → DroidEvents on the main thread

## Test plan
- [ ] Login on chat.kbve.com — no more `DataCloneError` in console
- [ ] Auth state changes propagate correctly across tabs via SharedWorker
- [ ] Worker errors (e.g. WS connection failure) appear as `worker-error` events on DroidEvents
- [ ] Verify chuckrpg.com / discord.sh auth flows are unaffected (they use DirectStrategy, not SharedWorker)