### PR TITLE
fix(firecracker): Phase 6 — Talos kvm label patch, deployment cleanup

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/kubernetes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/kubernetes.mdx
@@ -695,8 +695,21 @@ The KBVE edge platform uses Firecracker as a composable Tier 2 isolation layer a
 
 - Linux kernel with KVM support (Intel VT-x / AMD-V)
 - `/dev/kvm` exposed via `kubevirt/device-plugin-kvm` (already deployed for KubeVirt)
-- Nodes labeled `kvm=true`
+- Nodes labeled `kvm=true` (applied via Talos machine config patch)
 - Bare metal preferred (nested virt adds latency)
+
+### Node Setup (Talos)
+
+The `nodeSelector: kvm: "true"` requires a node label. On Talos, apply the machine config patch:
+
+```shell
+# Apply kvm=true node label via Talos machine config
+talosctl patch machineconfig --nodes <node> \
+  --patch @apps/kube/talos/patches/kvm-node-label.yaml
+
+# Verify label was applied
+kubectl get nodes --show-labels | grep kvm
+```
 
 ### Deployment
 

--- a/apps/kube/firecracker/DESIGN.md
+++ b/apps/kube/firecracker/DESIGN.md
@@ -210,14 +210,18 @@ Start with Option A (MMDS) — sufficient for request/response workloads. Gradua
 - [x] Registered in workspace Cargo.toml
 - [x] Rootfs Dockerfiles: alpine-minimal, alpine-node, alpine-python
 
-### Phase 5: Deployment & CI (current)
+### Phase 5: Deployment & CI (complete)
 
 - [x] CI dispatch manifest entry (`firecracker_ctl` in `ci-dispatch-manifest.json`)
 - [x] ArgoCD application registered in `kustomization.yaml`
 - [x] Vector log routing for `firecracker-ctl` → ClickHouse
 - [x] vmlinux kernel download script + K8s init Job (PostSync hook)
 - [x] version.toml for CI pipeline version gating
-- [ ] Node label `kvm=true` (requires manual kubectl — see deployment notes)
+
+### Phase 6: Deployment fixes & hardening (current)
+
+- [x] Remove redundant `nodeSelector` removal — keep `kvm: "true"` as defense-in-depth
+- [x] Talos machine config patch for `kvm=true` node label (`talos/patches/kvm-node-label.yaml`)
 - [ ] TAP networking (deferred — MMDS sufficient for now)
 - [ ] Warm pool (pre-booted VMs for <50ms dispatch)
 - [ ] Multi-node scheduling

--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -20,7 +20,6 @@ spec:
             containers:
                 - name: firecracker-ctl
                   image: ghcr.io/kbve/firecracker-ctl:0.1.0
-                  command: ['firecracker-ctl', 'serve', '--port', '9001']
                   ports:
                       - containerPort: 9001
                         name: api

--- a/apps/kube/talos/patches/kvm-node-label.yaml
+++ b/apps/kube/talos/patches/kvm-node-label.yaml
@@ -1,0 +1,10 @@
+## Talos machine config patch — add kvm=true node label
+## Apply: talosctl patch machineconfig --nodes <node> --patch @kvm-node-label.yaml
+##
+## Enables scheduling of Firecracker microVM workloads on this node.
+## The firecracker-ctl deployment uses nodeSelector: kvm: "true"
+## in addition to the devices.kubevirt.io/kvm resource request.
+
+machine:
+    nodeLabels:
+        kvm: 'true'


### PR DESCRIPTION
## Summary
- Add Talos machine config patch (`talos/patches/kvm-node-label.yaml`) to set `kvm=true` node label — eliminates manual `kubectl label` step
- Keep `nodeSelector: kvm: "true"` in deployment as defense-in-depth alongside `devices.kubevirt.io/kvm` resource request
- Remove redundant `command` override from deployment (entrypoint is set in the Dockerfile)
- Update kubernetes.mdx with Talos node setup instructions
- Update DESIGN.md phase tracking

## Deployment steps after merge
1. Apply Talos patch: `talosctl patch machineconfig --nodes talos-4bn-whr --patch @apps/kube/talos/patches/kvm-node-label.yaml`
2. ArgoCD auto-syncs the rest

## Test plan
- [ ] Verify Talos patch YAML is valid
- [ ] Confirm deployment still has nodeSelector + device request
- [ ] kubernetes.mdx renders correctly