### PR TITLE
fix(firecracker-ctl): add ca-certificates to Docker download stage

### DIFF
--- a/apps/vm/firecracker-ctl/Dockerfile
+++ b/apps/vm/firecracker-ctl/Dockerfile
@@ -69,7 +69,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM --platform=linux/amd64 ubuntu:24.04 AS firecracker-dl
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 ARG FC_VERSION=1.10.1


### PR DESCRIPTION
## Summary
- Add `ca-certificates` to the `firecracker-dl` Docker stage

## Root cause
The `curl` command downloading the Firecracker binary from GitHub fails with `exit code 77` (`error setting certificate file: /etc/ssl/certs/ca-certificates.crt`) because Ubuntu 24.04 minimal does not include CA certificates. Adding `ca-certificates` to the `apt-get install` line resolves the HTTPS download.

Fixes #9543

## Test plan
- [ ] CI Docker build passes for firecracker-ctl