### PR TITLE
refactor(discordsh-bot): rebrand embeds and enable jemalloc

### DIFF
--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -111,7 +111,7 @@ COPY apps/discordsh/discordsh-bot apps/discordsh/discordsh-bot
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p discordsh-bot && \
+    cargo build --release -p discordsh-bot --features jemalloc && \
     strip target/release/discordsh-bot
 
 # ============================================================================

--- a/apps/discordsh/discordsh-bot/src/discord/branding.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/branding.rs
@@ -1,0 +1,24 @@
+//! Shared branding constants for Discord embeds.
+
+/// Bot display name used in embed footers.
+pub const BOT_NAME: &str = "discordsh-bot";
+
+/// Bot version pulled from Cargo.toml at compile time.
+pub const BOT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Project page URL (clickable embed author link).
+pub const PROJECT_URL: &str = "https://kbve.com/project/discordsh-bot/";
+
+/// Source repository tree URL.
+pub const SOURCE_URL: &str = "https://github.com/KBVE/kbve/tree/main/apps/discordsh/discordsh-bot";
+
+/// Build the standard footer text: `discordsh-bot v0.1.2`
+pub fn footer_text() -> String {
+    format!("{BOT_NAME} v{BOT_VERSION}")
+}
+
+/// Build a source-linked footer for a specific module: `discordsh-bot v0.1.2 • source`
+/// The `module` is a relative path within the bot source (e.g. `src/discord/commands/health.rs`).
+pub fn footer_with_source(module: &str) -> String {
+    format!("{BOT_NAME} v{BOT_VERSION} • {SOURCE_URL}/{module}")
+}

--- a/apps/discordsh/discordsh-bot/src/discord/commands/health.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/health.rs
@@ -1,4 +1,5 @@
 use crate::discord::bot::{Context, Error};
+use crate::discord::branding;
 use poise::serenity_prelude as serenity;
 
 /// Reports detailed system health information.
@@ -19,6 +20,7 @@ pub async fn health(ctx: Context<'_>) -> Result<(), Error> {
 
     let embed = serenity::CreateEmbed::new()
         .title("System Health Report")
+        .url(branding::PROJECT_URL)
         .color(color)
         .field(
             "Health Status",
@@ -47,10 +49,9 @@ pub async fn health(ctx: Context<'_>) -> Result<(), Error> {
         .field("Threads", snap.thread_count.to_string(), true)
         .field("PID", snap.pid.to_string(), true)
         .field("Uptime", &snap.uptime_formatted, true)
-        .footer(serenity::CreateEmbedFooter::new(format!(
-            "axum-discordsh v{}",
-            env!("CARGO_PKG_VERSION")
-        )))
+        .footer(serenity::CreateEmbedFooter::new(
+            branding::footer_with_source("src/discord/commands/health.rs"),
+        ))
         .timestamp(serenity::Timestamp::now());
 
     let reply = poise::CreateReply::default().embed(embed);

--- a/apps/discordsh/discordsh-bot/src/discord/commands/status.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/status.rs
@@ -1,4 +1,5 @@
 use crate::discord::bot::{Context, Error};
+use crate::discord::branding;
 use crate::discord::components::build_status_action_row;
 use crate::discord::embeds::{StatusSnapshot, StatusState, build_status_embed};
 
@@ -10,7 +11,7 @@ pub async fn status(ctx: Context<'_>) -> Result<(), Error> {
 
     let snap = StatusSnapshot {
         state: StatusState::Online,
-        version: env!("CARGO_PKG_VERSION"),
+        version: branding::BOT_VERSION,
         guild_count: ctx.cache().guild_count(),
         shard_id: Some(ctx.serenity_context().shard_id.0),
         uptime: data.app.start_time.elapsed(),

--- a/apps/discordsh/discordsh-bot/src/discord/components/status_buttons.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/status_buttons.rs
@@ -2,6 +2,7 @@ use poise::serenity_prelude as serenity;
 use tracing::{error, info};
 
 use crate::discord::bot::{Data, Error};
+use crate::discord::branding;
 use crate::discord::embeds::{StatusSnapshot, StatusState, build_status_embed};
 
 // ── Custom ID constants ──────────────────────────────────────────────
@@ -40,7 +41,7 @@ async fn collect_snapshot(data: &Data, cache: &serenity::Cache) -> StatusSnapsho
     let health = data.app.health_monitor.snapshot().await;
     StatusSnapshot {
         state: StatusState::Online,
-        version: env!("CARGO_PKG_VERSION"),
+        version: branding::BOT_VERSION,
         guild_count: cache.guild_count(),
         shard_id: None,
         uptime: data.app.start_time.elapsed(),

--- a/apps/discordsh/discordsh-bot/src/discord/embeds/notice_board_embed.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/embeds/notice_board_embed.rs
@@ -4,6 +4,8 @@
 use jedi::entity::github::{GitHubClient, GitHubIssue, GitHubPull};
 use poise::serenity_prelude as serenity;
 
+use crate::discord::branding;
+
 // ── Priority ────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -132,8 +134,9 @@ pub fn build_notice_embed(item: &NoticeItem, repo_name: &str) -> serenity::Creat
     }
 
     embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
-        "Notice Board • {}",
-        repo_name
+        "Notice Board • {} • {}",
+        repo_name,
+        branding::footer_text()
     )));
 
     embed
@@ -198,14 +201,16 @@ pub fn build_notice_board_summary(items: &[NoticeItem], repo_name: &str) -> sere
 
     if items.len() > 25 {
         embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
-            "Showing 25 of {} • {}",
+            "Showing 25 of {} • {} • {}",
             items.len(),
-            repo_name
+            repo_name,
+            branding::footer_text()
         )));
     } else {
         embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
-            "Notice Board • {}",
-            repo_name
+            "Notice Board • {} • {}",
+            repo_name,
+            branding::footer_text()
         )));
     }
 

--- a/apps/discordsh/discordsh-bot/src/discord/embeds/status_embed.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/embeds/status_embed.rs
@@ -2,6 +2,7 @@ use poise::serenity_prelude as serenity;
 use std::time::Duration;
 
 use super::status_state::StatusState;
+use crate::discord::branding;
 use crate::health::HealthSnapshot;
 
 /// Data bag passed into the embed builder, decoupled from poise's Data struct.
@@ -54,6 +55,7 @@ pub fn build_status_embed(snap: &StatusSnapshot) -> serenity::CreateEmbed {
 
     let mut embed = serenity::CreateEmbed::new()
         .title("Bot Status Dashboard")
+        .url(branding::PROJECT_URL)
         .color(color)
         .thumbnail(state.thumbnail_url())
         .field(
@@ -91,10 +93,9 @@ pub fn build_status_embed(snap: &StatusSnapshot) -> serenity::CreateEmbed {
     }
 
     embed
-        .footer(serenity::CreateEmbedFooter::new(format!(
-            "axum-discordsh v{}",
-            snap.version
-        )))
+        .footer(serenity::CreateEmbedFooter::new(
+            branding::footer_with_source("src/discord/embeds/status_embed.rs"),
+        ))
         .timestamp(serenity::Timestamp::now())
 }
 

--- a/apps/discordsh/discordsh-bot/src/discord/embeds/task_board_embed.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/embeds/task_board_embed.rs
@@ -5,6 +5,8 @@ use jedi::entity::github::GitHubIssue;
 use poise::serenity_prelude as serenity;
 use std::collections::BTreeMap;
 
+use crate::discord::branding;
+
 // ── Task Status ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy)]
@@ -186,7 +188,10 @@ fn truncate_value(s: &str, max: usize) -> String {
 fn add_footer(embed: serenity::CreateEmbed, repo_url: &str) -> serenity::CreateEmbed {
     embed
         .field("Repository", repo_url, false)
-        .footer(serenity::CreateEmbedFooter::new("Task Board"))
+        .footer(serenity::CreateEmbedFooter::new(format!(
+            "Task Board • {}",
+            branding::footer_text()
+        )))
 }
 
 #[cfg(test)]

--- a/apps/discordsh/discordsh-bot/src/discord/game/render.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/render.rs
@@ -1,6 +1,7 @@
 use poise::serenity_prelude as serenity;
 
 use super::types::*;
+use crate::discord::branding;
 
 // ── Colors ──────────────────────────────────────────────────────────
 
@@ -435,8 +436,10 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
 
     // Footer — turn/session only
     embed = embed.footer(serenity::CreateEmbedFooter::new(format!(
-        "Turn {}  //  Session {}",
-        session.turn, session.short_id
+        "Turn {}  //  Session {}  //  {}",
+        session.turn,
+        session.short_id,
+        branding::footer_text()
     )));
 
     embed

--- a/apps/discordsh/discordsh-bot/src/discord/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/mod.rs
@@ -1,4 +1,5 @@
 pub mod bot;
+pub mod branding;
 pub mod commands;
 pub mod components;
 pub mod embeds;


### PR DESCRIPTION
## Summary
- Add `discord::branding` module — centralizes bot name, version, project URL, and source URL
- Replace hardcoded `axum-discordsh` with `discordsh-bot` in all embed footers
- Embed titles (`/health`, `/status`) now link to [kbve.com/project/discordsh-bot](https://kbve.com/project/discordsh-bot/)
- Each embed footer includes a source file link back to the repo
- Notice board, task board, and dungeon game footers include version tag
- Enable `--features jemalloc` in Dockerfile for reduced memory fragmentation

## Test plan
- [x] `cargo check -p discordsh-bot` passes
- [ ] CI validates on PR
- [ ] After deploy, verify `/health` and `/status` show correct branding in Discord