### PR TITLE
fix(kube): KASM scaling + VNC/Guac WebSocket gateway timeout

### DIFF
--- a/apps/kube/kasm/application.yaml
+++ b/apps/kube/kasm/application.yaml
@@ -12,9 +12,18 @@ spec:
     destination:
         server: https://kubernetes.default.svc
         namespace: kasm
+    # Allow the dashboard to scale deployments without ArgoCD reverting
+    # replicas back to the Git-defined value (0). selfHeal still manages
+    # all other fields — only spec.replicas is ignored.
+    ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+              - /spec/replicas
     syncPolicy:
         automated:
             prune: true
             selfHeal: true
         syncOptions:
             - CreateNamespace=true
+            - RespectIgnoreDifferences=true

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -61,6 +61,21 @@ spec:
           backendRefs:
               - name: kbve-service
                 port: 5000
+        # Dashboard WebSocket paths — VNC (noVNC), Guacamole (RDP),
+        # KASM proxy. These are long-lived WebSocket connections that
+        # need the same generous timeout as the game /ws path.
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /dashboard/vm/vnc
+              - path:
+                    type: PathPrefix
+                    value: /dashboard/guac/proxy/guacamole/websocket-tunnel
+          timeouts:
+              backendRequest: 3600s
+          backendRefs:
+              - name: kbve-service
+                port: 4321
         - matches:
               - path:
                     type: PathPrefix


### PR DESCRIPTION
## Summary
- **KASM scaling**: ArgoCD `selfHeal: true` was reverting `replicas` back to 0 immediately after the dashboard scaled to 1. Add `ignoreDifferences` for `spec.replicas` on Deployments + `RespectIgnoreDifferences=true` sync option.
- **VNC/Guac WebSocket**: The catch-all `/` HTTPRoute rule had no `backendRequest` timeout, so Cilium used its default (~15s). WebSocket upgrade requests for VNC and Guacamole were timing out. Add dedicated rules with `3600s` timeout.

## Test plan
- [ ] Click Start on KASM workspace → pod actually starts and stays running
- [ ] VNC WebSocket connects to windows-builder when VM is running
- [ ] Guacamole WebSocket tunnel connects when Guacamole is deployed