### PR TITLE
chore: enable jemalloc in all Rust service Dockerfiles

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -154,7 +154,7 @@ COPY apps/cryptothrone/axum-cryptothrone/templates/askama /app/apps/cryptothrone
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p axum-cryptothrone && \
+    cargo build --release -p axum-cryptothrone --features jemalloc && \
     strip target/release/axum-cryptothrone
 
 # ============================================================================

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -163,7 +163,7 @@ COPY apps/discordsh/axum-discordsh apps/discordsh/axum-discordsh
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p axum-discordsh && \
+    cargo build --release -p axum-discordsh --features jemalloc && \
     strip target/release/axum-discordsh
 
 # ============================================================================

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -144,7 +144,7 @@ COPY apps/herbmail/axum-herbmail/templates/askama /app/apps/herbmail/axum-herbma
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p axum-herbmail && \
+    cargo build --release -p axum-herbmail --features jemalloc && \
     strip target/release/axum-herbmail
 
 # ============================================================================

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -141,7 +141,7 @@ COPY packages/data/proto packages/data/proto
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p irc-gateway && \
+    cargo build --release -p irc-gateway --features jemalloc && \
     strip target/release/irc-gateway
 
 # ============================================================================

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -161,7 +161,7 @@ RUN cp -a /app/apps/kbve/axum-kbve/templates/dist/askama/. /app/apps/kbve/axum-k
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo build --release -p axum-kbve && \
+    cargo build --release -p axum-kbve --features jemalloc && \
     strip target/release/axum-kbve
 
 # ============================================================================

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -144,7 +144,7 @@ COPY apps/memes/axum-memes/templates/askama /app/apps/memes/axum-memes/templates
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p axum-memes && \
+    cargo build --release -p axum-memes --features jemalloc && \
     strip target/release/axum-memes
 
 # ============================================================================

--- a/apps/ows/rows/Dockerfile
+++ b/apps/ows/rows/Dockerfile
@@ -52,7 +52,7 @@ COPY packages/rust/kbve/ packages/rust/kbve/
 COPY apps/ows/rows/src/ apps/ows/rows/src/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     touch apps/ows/rows/src/main.rs && \
-    cargo build --release -p rows && \
+    cargo build --release -p rows --features jemalloc && \
     cp target/release/rows /usr/local/bin/rows
 
 # ── Stage 4: Runtime ────────────────────────────────────────


### PR DESCRIPTION
## Summary
Enable `--features jemalloc` in all 7 remaining Rust service Dockerfiles:
- `axum-discordsh`
- `axum-kbve`
- `axum-memes`
- `irc-gateway`
- `axum-herbmail`
- `axum-cryptothrone`
- `rows`

All already had `tikv-jemallocator` as an optional dep and the chisel runtime image ships `libjemalloc.so`, but the binaries weren't compiled to use it — falling back to the system allocator.

## Test plan
- [ ] CI validates Dockerfiles on PR
- [ ] Next rebuild of each service picks up jemalloc automatically