### PR TITLE
fix(docs): add bevy redirect

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -183,6 +183,14 @@ fn router(state: AppState) -> Router {
             "/application/kubectl",
             get(|| async { Redirect::permanent("/application/kubernetes/") }),
         )
+        .route(
+            "/application/bevy",
+            get(|| async { Redirect::permanent("/application/rust/#bevy") }),
+        )
+        .route(
+            "/application/bevy/",
+            get(|| async { Redirect::permanent("/application/rust/#bevy") }),
+        )
         .with_state(state.clone());
 
     let main_app = static_router.merge(public_router).layer(middleware);


### PR DESCRIPTION
## Summary\n- confirm the rust docs already expose a Bevy section so anchors resolve\n- add /application/bevy( / ) redirects in axum-kbve to target /application/rust/#bevy\n\n## Testing\n- not run (docs-only change)