### PR TITLE
fix(firecracker-ctl): bump Rust to 1.86 for cargo-chef compatibility

### DIFF
--- a/apps/vm/firecracker-ctl/Dockerfile
+++ b/apps/vm/firecracker-ctl/Dockerfile
@@ -8,7 +8,7 @@
 # ============================================================================
 # [STAGE A] - Rust Build Base
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.85-slim AS rust-base
+FROM --platform=linux/amd64 rust:1.86-slim AS rust-base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
Bump Docker build base from `rust:1.85-slim` to `rust:1.86-slim`.

## Root cause
`cargo-chef v0.1.77` depends on `cargo_metadata@0.23.1` and `guppy@0.17.25`, both requiring `rustc 1.86.0`. The previous `rust:1.85-slim` image ships rustc 1.85, causing `cargo install cargo-chef --locked` to fail with exit code 101.

Fixes #9550

## Test plan
- [ ] CI Docker build passes for firecracker-ctl