### PR TITLE
refactor: migrate all Rust Dockerfiles to shared chisel builder base

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -1,34 +1,31 @@
 # ============================================================================
+# axum-cryptothrone — Multi-stage Docker build
+#
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + Node + pnpm + cargo-chef)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu + jemalloc + libpq)
+# ============================================================================
+
+# ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-slim AS astro-builder
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-
-# Prevent Playwright from downloading browser binaries during pnpm install —
-# they are never used in the Docker build and waste ~600MB + cause timeouts.
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
-# Copy root dependency and config files (layer-cached separately from source)
 COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
 
-# Install all dependencies (hoisted mode - all go to root node_modules)
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
+    pnpm install --frozen-lockfile
 
-# Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
 
-# Copy generated schemas (content collections may import these)
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 
-# Copy astro-cryptothrone source
 COPY apps/cryptothrone/astro-cryptothrone/ apps/cryptothrone/astro-cryptothrone/
 
-# Build astro site
 WORKDIR /app/apps/cryptothrone/astro-cryptothrone
 RUN rm -rf .astro && npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
@@ -60,29 +57,11 @@ RUN find . -type f \( \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# Rust build stages — cargo-chef separates dependency compilation from source.
-# BuildKit layer cache handles incremental rebuilds across runs.
+# Rust build stages
 # ============================================================================
 
-# [STAGE C] - Rust Base Image
-FROM --platform=linux/amd64 rust:1.94-slim AS rust-base
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        protobuf-compiler \
-        libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# [STAGE D] - Cargo Chef Planner
-FROM rust-base AS planner
+# [STAGE C] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
 COPY apps/cryptothrone/axum-cryptothrone/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
@@ -99,8 +78,9 @@ RUN mkdir -p apps/cryptothrone/axum-cryptothrone/src && echo "fn main() {}" > ap
 
 RUN cargo chef prepare --recipe-path recipe.json
 
-# [STAGE E] - Cargo Chef Cook (Cache External Dependencies)
-FROM rust-base AS builder-deps
+# [STAGE D] - Cargo Chef Cook (Cache External Dependencies)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
@@ -109,10 +89,12 @@ COPY --from=planner /app/packages packages
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo chef cook --release --recipe-path recipe.json -p axum-cryptothrone
 
-# [STAGE E2] - Foundation Layer (Compile kbve + jedi from real source)
-FROM rust-base AS foundation
+# [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
@@ -131,6 +113,7 @@ COPY packages/rust/kbve packages/rust/kbve
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p kbve -p jedi
 
 # ============================================================================
@@ -138,88 +121,36 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
-# Astro build output (precompressed) → placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/cryptothrone/axum-cryptothrone/templates/dist
 
-# Foundation crate source (cargo needs source to verify fingerprints)
 COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
 
-# Application source (most frequently changing — placed last for cache)
 COPY apps/cryptothrone/axum-cryptothrone apps/cryptothrone/axum-cryptothrone
 
-# Copy Askama templates
 COPY apps/cryptothrone/axum-cryptothrone/templates/askama /app/apps/cryptothrone/axum-cryptothrone/templates/askama
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p axum-cryptothrone --features jemalloc && \
     strip target/release/axum-cryptothrone
 
 # ============================================================================
-# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
+# [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
-
-RUN apt-get update && apt-get install -y wget ca-certificates
-
-WORKDIR /tmp
-
-RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
-    tar -xvf go1.23.4.linux-amd64.tar.gz && \
-    mv go /usr/local
-
-RUN GOBIN=/usr/local/bin/ /usr/local/go/bin/go install github.com/canonical/chisel/cmd/chisel@latest
-
-WORKDIR /rootfs
-RUN chisel cut --release ubuntu-24.04 --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libgcc-s1_libs \
-        libc6_libs \
-        libstdc++6_libs \
-        openssl_config && \
-    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
-    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
-    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
-
-# ============================================================================
-# [STAGE H] - Jemalloc
-# ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libjemalloc-dev && \
-    apt-get autoremove -y && \
-    apt-get purge -y --auto-remove && \
-    rm -rf /var/lib/apt/lists/*
-
-# ============================================================================
-# [STAGE Z] - Runtime Image (Scratch + Chisel + Jemalloc)
-# ============================================================================
-FROM --platform=linux/amd64 scratch AS runtime
-
-COPY --from=chisel-builder /rootfs /
-
-COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-
-WORKDIR /app
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/axum-cryptothrone /app/axum-cryptothrone
 
 COPY --from=builder --chown=10001:10001 /app/apps/cryptothrone/axum-cryptothrone/templates/dist /app/templates/dist
 COPY --from=builder --chown=10001:10001 /app/apps/cryptothrone/axum-cryptothrone/templates/askama /app/templates/askama
 
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=4321
 ENV RUST_LOG=info
 
 EXPOSE 4321
-
-USER 10001:10001
 
 ENTRYPOINT ["/app/axum-cryptothrone"]

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -1,23 +1,15 @@
 # ============================================================================
 # axum-discordsh — Multi-stage Docker build
 #
-# Runtime uses the shared chisel base image:
-#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.2
-#   (chiseled Ubuntu 24.04 + jemalloc + libpq + CA certs)
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + Node + pnpm + cargo-chef)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu + jemalloc + libpq)
 # ============================================================================
 
 # ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-# node:24-slim (Debian) instead of Alpine — Sharp image optimizer needs
-# glibc-compatible native binaries for Astro image processing
-FROM --platform=linux/amd64 node:24-slim AS astro-builder
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-
-# Prevent Playwright from downloading browser binaries during pnpm install —
-# they are never used in the Docker build and waste ~600MB + cause timeouts.
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
@@ -25,7 +17,8 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
 
 # Install all dependencies (hoisted mode - all go to root node_modules)
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
+    pnpm install --frozen-lockfile
 
 # Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
@@ -74,27 +67,8 @@ RUN find . -type f \( \
 # BuildKit layer cache handles incremental rebuilds across runs.
 # ============================================================================
 
-# [STAGE C] - Rust Base Image
-FROM --platform=linux/amd64 rust:1.94-slim AS rust-base
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        libpq-dev \
-        libjemalloc-dev \
-        protobuf-compiler \
-        libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# [STAGE D] - Cargo Chef Planner
-FROM rust-base AS planner
+# [STAGE C] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
 COPY apps/discordsh/axum-discordsh/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
@@ -111,8 +85,9 @@ RUN mkdir -p apps/discordsh/axum-discordsh/src && echo "fn main() {}" > apps/dis
 
 RUN cargo chef prepare --recipe-path recipe.json
 
-# [STAGE E] - Cargo Chef Cook (Cache External Dependencies)
-FROM rust-base AS builder-deps
+# [STAGE D] - Cargo Chef Cook (Cache External Dependencies)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
@@ -121,10 +96,12 @@ COPY --from=planner /app/packages packages
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo chef cook --release --recipe-path recipe.json -p axum-discordsh
 
-# [STAGE E2] - Foundation Layer (Compile kbve + jedi from real source)
-FROM rust-base AS foundation
+# [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
@@ -143,6 +120,7 @@ COPY packages/rust/kbve packages/rust/kbve
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p kbve -p jedi
 
 # ============================================================================
@@ -163,13 +141,14 @@ COPY apps/discordsh/axum-discordsh apps/discordsh/axum-discordsh
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p axum-discordsh --features jemalloc && \
     strip target/release/axum-discordsh
 
 # ============================================================================
 # [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
-FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.2 AS runtime
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/axum-discordsh /app/axum-discordsh
 

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -1,31 +1,13 @@
 # ============================================================================
 # discordsh-bot — Multi-stage Docker build
 #
-# Follows the same cargo-chef + foundation layer pattern as axum-discordsh.
-# No Astro/Node stages — bot-only binary.
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + cargo-chef + sccache)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu + jemalloc + libpq)
 # ============================================================================
 
-# [STAGE A] - Rust Base Image
-FROM --platform=linux/amd64 rust:1.94-slim AS rust-base
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        libpq-dev \
-        libjemalloc-dev \
-        protobuf-compiler \
-        libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# [STAGE B] - Cargo Chef Planner
-FROM rust-base AS planner
+# [STAGE A] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
 COPY apps/discordsh/discordsh-bot/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
@@ -52,8 +34,9 @@ RUN mkdir -p apps/discordsh/discordsh-bot/src && echo "fn main() {}" > apps/disc
 
 RUN cargo chef prepare --recipe-path recipe.json
 
-# [STAGE C] - Cargo Chef Cook (Cache External Dependencies)
-FROM rust-base AS builder-deps
+# [STAGE B] - Cargo Chef Cook (Cache External Dependencies)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
@@ -62,10 +45,12 @@ COPY --from=planner /app/packages packages
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo chef cook --release --recipe-path recipe.json -p discordsh-bot
 
-# [STAGE D] - Foundation Layer (Compile workspace crates from real source)
-FROM rust-base AS foundation
+# [STAGE C] - Foundation Layer (Compile workspace crates from real source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
@@ -89,10 +74,11 @@ COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc -p bevy_quests
 
 # ============================================================================
-# [STAGE E] - Build Application
+# [STAGE D] - Build Application
 # ============================================================================
 FROM foundation AS builder
 
@@ -111,13 +97,14 @@ COPY apps/discordsh/discordsh-bot apps/discordsh/discordsh-bot
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p discordsh-bot --features jemalloc && \
     strip target/release/discordsh-bot
 
 # ============================================================================
 # [STAGE Z] - Runtime Image
 # ============================================================================
-FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.2 AS runtime
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/discordsh-bot /app/discordsh-bot
 

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -1,33 +1,30 @@
 # ============================================================================
+# axum-herbmail — Multi-stage Docker build
+#
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + Node + pnpm + cargo-chef)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu + jemalloc + libpq)
+# ============================================================================
+
+# ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-alpine AS astro-builder
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-
-# Prevent Playwright from downloading browser binaries during pnpm install —
-# they are never used in the Docker build and waste ~600MB + cause timeouts.
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
-# Copy root dependency and config files (layer-cached separately from source)
 COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
 
-# Install all dependencies (hoisted mode - all go to root node_modules)
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
+    pnpm install --frozen-lockfile
 
-# Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 
-# Copy generated schemas (content collections may import these)
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 
-# Copy astro-herbmail source
 COPY apps/herbmail/astro-herbmail/ apps/herbmail/astro-herbmail/
 
-# Build astro site
 WORKDIR /app/apps/herbmail/astro-herbmail
 RUN rm -rf .astro && npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
@@ -59,157 +56,100 @@ RUN find . -type f \( \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# [STAGE C] - Rust Base Image
+# Rust build stages
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-slim AS rust-base
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        protobuf-compiler \
-        libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
+# [STAGE C] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# ============================================================================
-# [STAGE D] - Cargo Chef Planner
-# ============================================================================
-FROM rust-base AS planner
-
-# Minimal workspace with only herbmail's actual dependencies
 COPY apps/herbmail/axum-herbmail/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 
-# Copy only the 3 crates we need
 COPY apps/herbmail/axum-herbmail/Cargo.toml apps/herbmail/axum-herbmail/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 
-# Create stubs for cargo chef
+COPY packages/data/proto packages/data/proto
+
 RUN mkdir -p apps/herbmail/axum-herbmail/src && echo "fn main() {}" > apps/herbmail/axum-herbmail/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
 
-# Copy proto files (needed for jedi build.rs)
-COPY packages/data/proto packages/data/proto
-
 RUN cargo chef prepare --recipe-path recipe.json
 
-# ============================================================================
-# [STAGE E] - Cargo Chef Builder (Cache Dependencies)
-# ============================================================================
-FROM rust-base AS builder-deps
+# [STAGE D] - Cargo Chef Cook (Cache External Dependencies)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
 COPY --from=planner /app/packages packages
 
-# Copy proto files
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo chef cook --release --recipe-path recipe.json -p axum-herbmail
+
+# [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+ENV CARGO_INCREMENTAL=0
+
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+COPY --from=planner /app/Cargo.toml ./
+COPY Cargo.lock ./
+
+COPY apps/herbmail/axum-herbmail/Cargo.toml apps/herbmail/axum-herbmail/Cargo.toml
+RUN mkdir -p apps/herbmail/axum-herbmail/src && \
+    echo "fn main() {}" > apps/herbmail/axum-herbmail/src/main.rs
+
 COPY packages/data/proto packages/data/proto
+
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo chef cook --release --recipe-path recipe.json -p axum-herbmail
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo build --release -p kbve -p jedi
 
 # ============================================================================
 # [STAGE F] - Build Application
 # ============================================================================
-FROM rust-base AS builder
+FROM foundation AS builder
 
-# Copy cached dependencies
-COPY --from=builder-deps /app/target target
-COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
-
-# Copy Astro build output (precompressed)
 COPY --from=astro-precompressor /static /app/apps/herbmail/axum-herbmail/templates/dist
 
-# Use the same minimal workspace
-COPY --from=planner /app/Cargo.toml ./
-COPY Cargo.lock ./
-
-# Copy only the 3 crates (full source)
+COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
-COPY apps/herbmail/axum-herbmail apps/herbmail/axum-herbmail
-COPY packages/data/proto packages/data/proto
 
-# Copy Askama templates
+COPY apps/herbmail/axum-herbmail apps/herbmail/axum-herbmail
+
 COPY apps/herbmail/axum-herbmail/templates/askama /app/apps/herbmail/axum-herbmail/templates/askama
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p axum-herbmail --features jemalloc && \
     strip target/release/axum-herbmail
 
 # ============================================================================
-# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
+# [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
-
-RUN apt-get update && apt-get install -y wget ca-certificates
-
-WORKDIR /tmp
-
-RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
-    tar -xvf go1.23.4.linux-amd64.tar.gz && \
-    mv go /usr/local
-
-RUN GOBIN=/usr/local/bin/ /usr/local/go/bin/go install github.com/canonical/chisel/cmd/chisel@latest
-
-WORKDIR /rootfs
-RUN chisel cut --release ubuntu-24.04 --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libgcc-s1_libs \
-        libc6_libs \
-        libstdc++6_libs \
-        openssl_config && \
-    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
-    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
-    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
-
-# ============================================================================
-# [STAGE H] - Jemalloc
-# ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libjemalloc-dev && \
-    apt-get autoremove -y && \
-    apt-get purge -y --auto-remove && \
-    rm -rf /var/lib/apt/lists/*
-
-# ============================================================================
-# [STAGE Z] - Runtime Image (Scratch + Chisel + Jemalloc)
-# ============================================================================
-FROM --platform=linux/amd64 scratch AS runtime
-
-COPY --from=chisel-builder /rootfs /
-
-COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-
-WORKDIR /app
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/axum-herbmail /app/axum-herbmail
 
 COPY --from=builder --chown=10001:10001 /app/apps/herbmail/axum-herbmail/templates/dist /app/templates/dist
 COPY --from=builder --chown=10001:10001 /app/apps/herbmail/axum-herbmail/templates/askama /app/templates/askama
 
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=4321
 ENV RUST_LOG=info
 
 EXPOSE 4321
-
-USER 10001:10001
 
 ENTRYPOINT ["/app/axum-herbmail"]

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -1,33 +1,30 @@
 # ============================================================================
+# irc-gateway — Multi-stage Docker build
+#
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + Node + pnpm + cargo-chef)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu + jemalloc + libpq)
+# ============================================================================
+
+# ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-alpine AS astro-builder
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-
-# Prevent Playwright from downloading browser binaries during pnpm install —
-# they are never used in the Docker build and waste ~600MB + cause timeouts.
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
-# Copy root dependency and config files (layer-cached separately from source)
 COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
 
-# Install all dependencies (hoisted mode - all go to root node_modules)
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
+    pnpm install --frozen-lockfile
 
-# Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 
-# Copy generated schemas (content collections may import these)
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 
-# Copy astro-irc source
 COPY apps/irc/astro-irc/ apps/irc/astro-irc/
 
-# Build astro site
 WORKDIR /app/apps/irc/astro-irc
 RUN rm -rf .astro && npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
@@ -52,161 +49,107 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) -exec sh -c ' \
+    \) ! -path "*/askama/*" -exec sh -c ' \
         gzip -9 -k "$1" && \
         brotli --best --keep "$1" \
     ' _ {} \; && \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# [STAGE C] - Rust Base Image
+# Rust build stages
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-slim AS rust-base
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        protobuf-compiler \
-        libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
+# [STAGE C] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# ============================================================================
-# [STAGE D] - Cargo Chef Planner
-# ============================================================================
-FROM rust-base AS planner
-
-# Minimal workspace with only irc-gateway's actual dependencies
 COPY apps/irc/irc-gateway/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 
-# Copy only the 3 crates we need
 COPY apps/irc/irc-gateway/Cargo.toml apps/irc/irc-gateway/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 
-# Create stubs for cargo chef
+COPY packages/data/proto packages/data/proto
+
 RUN mkdir -p apps/irc/irc-gateway/src && echo "fn main() {}" > apps/irc/irc-gateway/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
 
-# Copy proto files (needed for jedi build.rs)
-COPY packages/data/proto packages/data/proto
-
 RUN cargo chef prepare --recipe-path recipe.json
 
-# ============================================================================
-# [STAGE E] - Cargo Chef Builder (Cache Dependencies)
-# ============================================================================
-FROM rust-base AS builder-deps
+# [STAGE D] - Cargo Chef Cook (Cache External Dependencies)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
 COPY --from=planner /app/packages packages
 
-# Copy proto files
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo chef cook --release --recipe-path recipe.json -p irc-gateway
+
+# [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+ENV CARGO_INCREMENTAL=0
+
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+COPY --from=planner /app/Cargo.toml ./
+COPY Cargo.lock ./
+
+COPY apps/irc/irc-gateway/Cargo.toml apps/irc/irc-gateway/Cargo.toml
+RUN mkdir -p apps/irc/irc-gateway/src && \
+    echo "fn main() {}" > apps/irc/irc-gateway/src/main.rs
+
 COPY packages/data/proto packages/data/proto
+
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo chef cook --release --recipe-path recipe.json -p irc-gateway
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo build --release -p kbve -p jedi
 
 # ============================================================================
 # [STAGE F] - Build Application
 # ============================================================================
-FROM rust-base AS builder
+FROM foundation AS builder
 
-# Copy cached dependencies
-COPY --from=builder-deps /app/target target
-COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
-
-# Copy Astro build output (precompressed)
 COPY --from=astro-precompressor /static /app/apps/irc/irc-gateway/templates/dist
 
-# Use the same minimal workspace
-COPY --from=planner /app/Cargo.toml ./
-COPY Cargo.lock ./
-
-# Copy only the 3 crates (full source)
+COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
+
 COPY apps/irc/irc-gateway apps/irc/irc-gateway
-COPY packages/data/proto packages/data/proto
+
+COPY apps/irc/irc-gateway/templates/askama /app/apps/irc/irc-gateway/templates/askama
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p irc-gateway --features jemalloc && \
     strip target/release/irc-gateway
 
 # ============================================================================
-# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
+# [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
-
-RUN apt-get update && apt-get install -y wget ca-certificates
-
-WORKDIR /tmp
-
-RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
-    tar -xvf go1.23.4.linux-amd64.tar.gz && \
-    mv go /usr/local
-
-RUN GOBIN=/usr/local/bin/ /usr/local/go/bin/go install github.com/canonical/chisel/cmd/chisel@latest
-
-WORKDIR /rootfs
-RUN chisel cut --release ubuntu-24.04 --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libgcc-s1_libs \
-        libc6_libs \
-        libstdc++6_libs \
-        openssl_config && \
-    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
-    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
-    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
-
-# ============================================================================
-# [STAGE H] - Jemalloc
-# ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libjemalloc-dev && \
-    apt-get autoremove -y && \
-    apt-get purge -y --auto-remove && \
-    rm -rf /var/lib/apt/lists/*
-
-# ============================================================================
-# [STAGE Z] - Runtime Image (Scratch + Chisel + Jemalloc)
-# ============================================================================
-FROM --platform=linux/amd64 scratch AS runtime
-
-COPY --from=chisel-builder /rootfs /
-
-COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-
-WORKDIR /app
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/irc-gateway /app/irc-gateway
 
 COPY --from=builder --chown=10001:10001 /app/apps/irc/irc-gateway/templates/dist /app/templates/dist
+COPY --from=builder --chown=10001:10001 /app/apps/irc/irc-gateway/templates/askama /app/templates/askama
 
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=4321
 ENV RUST_LOG=info
 
 EXPOSE 4321
-EXPOSE 6667
-
-USER 10001:10001
 
 ENTRYPOINT ["/app/irc-gateway"]

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -1,13 +1,15 @@
 # ============================================================================
+# axum-memes — Multi-stage Docker build
+#
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + Node + pnpm + cargo-chef)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu + jemalloc + libpq)
+# ============================================================================
+
+# ============================================================================
 # [STAGE A] - Build Astro Static Site
 # ============================================================================
-FROM --platform=linux/amd64 node:24-alpine AS astro-builder
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-
-# Prevent Playwright from downloading browser binaries during pnpm install —
-# they are never used in the Docker build and waste ~600MB + cause timeouts.
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS astro-builder
 
 WORKDIR /app
 
@@ -15,7 +17,8 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc tsconfig.base.json ./
 
 # Install all dependencies (hoisted mode - all go to root node_modules)
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
+    pnpm install --frozen-lockfile
 
 # Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
@@ -59,157 +62,104 @@ RUN find . -type f \( \
     echo "Precompression complete (brotli-11 + gzip-9)"
 
 # ============================================================================
-# [STAGE C] - Rust Base Image
+# Rust build stages
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.94-slim AS rust-base
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        pkg-config \
-        libssl-dev \
-        protobuf-compiler \
-        libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
+# [STAGE C] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
-RUN rustup target add x86_64-unknown-linux-gnu && \
-    cargo install cargo-chef --locked
-
-WORKDIR /app
-
-# ============================================================================
-# [STAGE D] - Cargo Chef Planner
-# ============================================================================
-FROM rust-base AS planner
-
-# Minimal workspace with only memes's actual dependencies
 COPY apps/memes/axum-memes/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 
-# Copy only the 3 crates we need
 COPY apps/memes/axum-memes/Cargo.toml apps/memes/axum-memes/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 
-# Create stubs for cargo chef
+COPY packages/data/proto packages/data/proto
+
 RUN mkdir -p apps/memes/axum-memes/src && echo "fn main() {}" > apps/memes/axum-memes/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
 
-# Copy proto files (needed for jedi build.rs)
-COPY packages/data/proto packages/data/proto
-
 RUN cargo chef prepare --recipe-path recipe.json
 
-# ============================================================================
-# [STAGE E] - Cargo Chef Builder (Cache Dependencies)
-# ============================================================================
-FROM rust-base AS builder-deps
+# [STAGE D] - Cargo Chef Cook (Cache External Dependencies)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
 COPY --from=planner /app/apps apps
 COPY --from=planner /app/packages packages
 
-# Copy proto files
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo chef cook --release --recipe-path recipe.json -p axum-memes
+
+# [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+ENV CARGO_INCREMENTAL=0
+
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+COPY --from=planner /app/Cargo.toml ./
+COPY Cargo.lock ./
+
+COPY apps/memes/axum-memes/Cargo.toml apps/memes/axum-memes/Cargo.toml
+RUN mkdir -p apps/memes/axum-memes/src && \
+    echo "fn main() {}" > apps/memes/axum-memes/src/main.rs
+
 COPY packages/data/proto packages/data/proto
+
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo chef cook --release --recipe-path recipe.json -p axum-memes
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo build --release -p kbve -p jedi
 
 # ============================================================================
 # [STAGE F] - Build Application
 # ============================================================================
-FROM rust-base AS builder
+FROM foundation AS builder
 
-# Copy cached dependencies
-COPY --from=builder-deps /app/target target
-COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
-
-# Copy Astro build output (precompressed)
+# Astro build output (precompressed) -> placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/memes/axum-memes/templates/dist
 
-# Use the same minimal workspace
-COPY --from=planner /app/Cargo.toml ./
-COPY Cargo.lock ./
-
-# Copy only the 3 crates (full source)
+# Foundation crate source (cargo needs source to verify fingerprints)
+COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
+
+# Application source (most frequently changing — placed last for cache)
 COPY apps/memes/axum-memes apps/memes/axum-memes
-COPY packages/data/proto packages/data/proto
 
 # Copy Askama templates
 COPY apps/memes/axum-memes/templates/askama /app/apps/memes/axum-memes/templates/askama
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p axum-memes --features jemalloc && \
     strip target/release/axum-memes
 
 # ============================================================================
-# [STAGE G] - Chisel Ubuntu Base (Minimal Runtime)
+# [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-builder
-
-RUN apt-get update && apt-get install -y wget ca-certificates
-
-WORKDIR /tmp
-
-RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
-    tar -xvf go1.23.4.linux-amd64.tar.gz && \
-    mv go /usr/local
-
-RUN GOBIN=/usr/local/bin/ /usr/local/go/bin/go install github.com/canonical/chisel/cmd/chisel@latest
-
-WORKDIR /rootfs
-RUN chisel cut --release ubuntu-24.04 --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libgcc-s1_libs \
-        libc6_libs \
-        libstdc++6_libs \
-        openssl_config && \
-    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
-    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
-    mkdir -p /rootfs/app && chown 10001:10001 /rootfs/app
-
-# ============================================================================
-# [STAGE H] - Jemalloc
-# ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS jemalloc
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libjemalloc-dev && \
-    apt-get autoremove -y && \
-    apt-get purge -y --auto-remove && \
-    rm -rf /var/lib/apt/lists/*
-
-# ============================================================================
-# [STAGE Z] - Runtime Image (Scratch + Chisel + Jemalloc)
-# ============================================================================
-FROM --platform=linux/amd64 scratch AS runtime
-
-COPY --from=chisel-builder /rootfs /
-
-COPY --from=jemalloc /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-
-WORKDIR /app
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/axum-memes /app/axum-memes
 
 COPY --from=builder --chown=10001:10001 /app/apps/memes/axum-memes/templates/dist /app/templates/dist
 COPY --from=builder --chown=10001:10001 /app/apps/memes/axum-memes/templates/askama /app/templates/askama
 
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=4321
 ENV RUST_LOG=info
 
 EXPOSE 4321
-
-USER 10001:10001
 
 ENTRYPOINT ["/app/axum-memes"]

--- a/apps/ows/rows/Dockerfile
+++ b/apps/ows/rows/Dockerfile
@@ -1,8 +1,14 @@
 # syntax=docker/dockerfile:1
+# ============================================================================
+# rows — Multi-stage Docker build
+#
+# Uses shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + cargo-chef + sccache)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu + jemalloc + libpq)
+# ============================================================================
+
 # ── Stage 1: Plan — generate dependency recipe ──────────────
-FROM rust:1.94-slim-bookworm AS planner
-RUN cargo install cargo-chef
-WORKDIR /src
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
 # Create workspace
 RUN printf '[workspace]\nmembers = ["apps/ows/rows", "packages/rust/jedi", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
@@ -20,14 +26,8 @@ COPY packages/rust/kbve/src/ packages/rust/kbve/src/
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Stage 2: Cook — build deps only (cached layer) ─────────
-FROM rust:1.94-slim-bookworm AS cook
-
-RUN apt-get update && apt-get install -y \
-    pkg-config libssl-dev protobuf-compiler curl \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN cargo install cargo-chef
-WORKDIR /src
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS cook
+ENV CARGO_INCREMENTAL=0
 
 # Create workspace
 RUN printf '[workspace]\nmembers = ["apps/ows/rows", "packages/rust/jedi", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
@@ -42,6 +42,7 @@ COPY apps/ows/rows/build.rs apps/ows/rows/build.rs
 # Cook deps from recipe — this layer is cached until Cargo.toml/Cargo.lock change
 COPY --from=planner /src/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo chef cook --release --recipe-path recipe.json -p rows
 
 # ── Stage 3: Build — compile only our source ────────────────
@@ -51,22 +52,15 @@ COPY packages/rust/jedi/ packages/rust/jedi/
 COPY packages/rust/kbve/ packages/rust/kbve/
 COPY apps/ows/rows/src/ apps/ows/rows/src/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     touch apps/ows/rows/src/main.rs && \
     cargo build --release -p rows --features jemalloc && \
-    cp target/release/rows /usr/local/bin/rows
+    strip target/release/rows
 
 # ── Stage 4: Runtime ────────────────────────────────────────
-FROM debian:bookworm-slim
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
-RUN apt-get update && apt-get install -y \
-    ca-certificates libssl3 \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN groupadd -r rows && useradd -r -g rows rows
-
-COPY --from=builder /usr/local/bin/rows /usr/local/bin/rows
-
-USER rows
+COPY --from=builder --chown=10001:10001 /app/target/release/rows /app/rows
 
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=4322
@@ -76,6 +70,6 @@ EXPOSE 4322
 EXPOSE 4323
 
 HEALTHCHECK --interval=15s --timeout=3s --start-period=5s \
-    CMD ["/usr/local/bin/rows", "--health-check"] || exit 1
+    CMD ["/app/rows", "--health-check"] || exit 1
 
-ENTRYPOINT ["/usr/local/bin/rows"]
+ENTRYPOINT ["/app/rows"]


### PR DESCRIPTION
## Summary
- Migrate 7 Rust service Dockerfiles from `rust:1.94-slim` to `ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder`
- Fixes #9558 — `discordsh-bot` build failing because `tikv-jemalloc-sys` needs `make` (already in chisel builder)
- Removes ~300 lines of duplicated `apt-get install`, `rustup target add`, `cargo install cargo-chef`
- Eliminates inline chisel/jemalloc runtime stages from memes, herbmail, irc-gateway, cryptothrone
- Adds sccache cache mounts + `CARGO_INCREMENTAL=0` for faster builds
- Upgrades runtime images to `24.04.3`

| Service | Before | After |
|---------|--------|-------|
| discordsh-bot | `rust:1.94-slim` | `chisel:24.04-builder` |
| axum-discordsh | `rust:1.94-slim` + `node:24-slim` | `chisel:24.04-builder` |
| axum-memes | `rust:1.94-slim` + `node:24-alpine` + inline chisel | `chisel:24.04-builder` |
| irc-gateway | `rust:1.94-slim` + `node:24-alpine` + inline chisel | `chisel:24.04-builder` |
| axum-herbmail | `rust:1.94-slim` + `node:24-alpine` + inline chisel | `chisel:24.04-builder` |
| axum-cryptothrone | `rust:1.94-slim` + `node:24-slim` + inline chisel | `chisel:24.04-builder` |
| rows | `rust:1.94-slim-bookworm` + `debian:bookworm-slim` | `chisel:24.04-builder` |

## Test plan
- [ ] CI validates on PR
- [ ] `discordsh-bot` Docker build succeeds with jemalloc
- [ ] Next rebuild of each service uses shared base image

Closes #9558