### PR TITLE
fix(isometric): responsive title buttons and gate input to Playing phase

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/actions.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/actions.rs
@@ -8,6 +8,7 @@ use super::inventory::{
     ITEM_LOG, ITEM_PORCINI, ITEM_STONE, ITEM_WILDFLOWER, ItemKind, LootEvent,
     item_from_flower_archetype, item_from_mushroom_kind, item_from_rock_kind,
 };
+use super::phase::GamePhase;
 use super::scene_objects::{
     CollectEvent, FlowerArchetype, HoverOutline, Interactable, InteractableKind, MushroomKind,
     RockKind,
@@ -167,7 +168,7 @@ impl Plugin for ActionsPlugin {
         app.add_systems(
             Update,
             (
-                process_action_buffer,
+                process_action_buffer.run_if(in_state(GamePhase::Playing)),
                 animate_tree_chop.run_if(any_with_component::<ChoppingTree>),
                 animate_rock_mine.run_if(any_with_component::<MiningRock>),
                 animate_forageable_collect.run_if(any_with_component::<CollectingForageable>),

--- a/apps/kbve/isometric/src-tauri/src/game/input_bridge.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/input_bridge.rs
@@ -6,6 +6,8 @@ use bevy::input::mouse::{MouseButtonInput, MouseWheel};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 
+use super::phase::GamePhase;
+
 // ---------------------------------------------------------------------------
 // Bridged cursor position (replaces window.cursor_position() since we
 // skip WinitPlugin and can't update the Window's internal cursor state)
@@ -84,9 +86,24 @@ impl Plugin for InputBridgePlugin {
         app.init_resource::<BridgedCursorPosition>();
         app.add_systems(
             PreUpdate,
-            inject_input_from_ipc.before(bevy::input::InputSystems),
+            inject_input_from_ipc
+                .before(bevy::input::InputSystems)
+                .run_if(in_state(GamePhase::Playing)),
+        );
+        // Drain stale input during non-Playing phases so nothing queues up
+        app.add_systems(
+            PreUpdate,
+            drain_input_buffer.run_if(not(in_state(GamePhase::Playing))),
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Drain stale input during non-Playing phases (Title, Connecting)
+// ---------------------------------------------------------------------------
+
+fn drain_input_buffer() {
+    let _ = INPUT_BUFFER.lock().unwrap().take();
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kbve/isometric/src-tauri/src/game/title_screen.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/title_screen.rs
@@ -50,6 +50,13 @@ struct PlayOfflineBtn;
 #[derive(Component)]
 struct SettingsBtn;
 
+/// Tracks whether a button is primary or secondary for hover/press styling.
+#[derive(Component, Clone, Copy, PartialEq, Eq)]
+enum ButtonKind {
+    Primary,
+    Secondary,
+}
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -64,6 +71,7 @@ impl Plugin for TitleScreenPlugin {
             (
                 update_transport_label,
                 update_auth_label,
+                button_visuals,
                 handle_title_buttons,
             )
                 .run_if(in_state(GamePhase::Title)),
@@ -203,6 +211,11 @@ fn spawn_button(
     marker: impl Component,
     primary: bool,
 ) {
+    let kind = if primary {
+        ButtonKind::Primary
+    } else {
+        ButtonKind::Secondary
+    };
     let bg = if primary {
         ui_color::BTN_PRIMARY
     } else {
@@ -221,6 +234,7 @@ fn spawn_button(
             },
             BackgroundColor(bg),
             Interaction::default(),
+            kind,
             marker,
         ))
         .with_child((
@@ -288,6 +302,25 @@ fn update_auth_label(
                 color.0 = ui_color::TEXT_SECONDARY;
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Button visuals (hover / press feedback)
+// ---------------------------------------------------------------------------
+
+fn button_visuals(
+    mut query: Query<(&Interaction, &ButtonKind, &mut BackgroundColor), Changed<Interaction>>,
+) {
+    for (interaction, kind, mut bg) in &mut query {
+        *bg = match (interaction, kind) {
+            (Interaction::Pressed, ButtonKind::Primary) => ui_color::BTN_PRIMARY_PRESSED.into(),
+            (Interaction::Pressed, ButtonKind::Secondary) => ui_color::BTN_SECONDARY_PRESSED.into(),
+            (Interaction::Hovered, ButtonKind::Primary) => ui_color::BTN_PRIMARY_HOVER.into(),
+            (Interaction::Hovered, ButtonKind::Secondary) => ui_color::BTN_SECONDARY_HOVER.into(),
+            (Interaction::None, ButtonKind::Primary) => ui_color::BTN_PRIMARY.into(),
+            (Interaction::None, ButtonKind::Secondary) => ui_color::BTN_SECONDARY.into(),
+        };
     }
 }
 


### PR DESCRIPTION
## Summary
- Title screen buttons now show hover/pressed visual feedback (color changes) using the existing `ui_color` palette — `BTN_PRIMARY_HOVER`, `BTN_SECONDARY_HOVER`, `BTN_PRIMARY_PRESSED`, `BTN_SECONDARY_PRESSED`
- Added `ButtonKind` component (Primary/Secondary) and `button_visuals` system to drive interaction-based color changes
- Input bridge (`inject_input_from_ipc`) gated to `GamePhase::Playing` — keyboard/mouse events no longer reach Bevy systems during Title or Connecting phases
- Stale input drained during non-Playing phases to prevent queue buildup on phase transition
- `process_action_buffer` gated to `GamePhase::Playing` — action dispatches from JS are ignored until the game is active

## Test plan
- [ ] Verify title screen buttons show hover highlight on mouse-over
- [ ] Verify title screen buttons show pressed state on click
- [ ] Verify no keyboard/mouse input reaches the game during Title screen
- [ ] Verify no actions are processed during Connecting phase
- [ ] Verify input works normally after transitioning to Playing