### PR TITLE
fix(chisel): add make to builder image for jemalloc builds

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/chisel.mdx
@@ -14,7 +14,7 @@ tags:
 key: chisel_ubuntu_axum
 pipeline: docker
 app_name: chisel-ubuntu-axum
-version: "24.04.6"
+version: "24.04.7"
 version_toml: packages/docker/chisel-ubuntu-axum/version.toml
 source_path: packages/docker/chisel-ubuntu-axum
 runner: ubuntu-latest

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
         libssl-dev \
         libpq-dev \
         libjemalloc-dev \
+        make \
         protobuf-compiler \
         libprotobuf-dev \
         mold \


### PR DESCRIPTION
## Summary
- Add `make` to chisel builder `apt-get install` — required by `tikv-jemalloc-sys` build script
- Bump version `24.04.6` → `24.04.7` to trigger rebuild

All 7 Rust services are currently failing because the builder image lacks `make`.

Closes #9558

## Test plan
- [ ] Chisel builder image publishes successfully
- [ ] Downstream service Docker builds pass with `--features jemalloc`