### PR TITLE
feat(isometric): GPU-driven sprite sheet shader for frog and wraith

### DIFF
--- a/apps/kbve/isometric/src-tauri/assets/shaders/sprite_sheet.wgsl
+++ b/apps/kbve/isometric/src-tauri/assets/shaders/sprite_sheet.wgsl
@@ -1,0 +1,67 @@
+//! Uniform-driven sprite sheet shader.
+//!
+//! Computes atlas UVs in the vertex shader from frame/sheet uniforms,
+//! eliminating per-frame mesh UV buffer uploads. Supports horizontal
+//! flip and RGBA tint for day/night coloring.
+
+#import bevy_pbr::mesh_functions::mesh_position_local_to_clip
+#import bevy_pbr::forward_io::Vertex
+
+struct SpriteUniforms {
+    tint: vec4<f32>,
+    frame_col: f32,
+    frame_row: f32,
+    sheet_cols: f32,
+    sheet_rows: f32,
+    flip: f32,
+    alpha_cutoff: f32,
+    _pad0: f32,
+    _pad1: f32,
+}
+
+@group(2) @binding(0) var<uniform> sprite: SpriteUniforms;
+@group(2) @binding(1) var sprite_texture: texture_2d<f32>;
+@group(2) @binding(2) var sprite_sampler: sampler;
+
+struct SpriteVertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vertex(in: Vertex) -> SpriteVertexOutput {
+    var out: SpriteVertexOutput;
+
+    out.position = mesh_position_local_to_clip(
+        in.instance_index,
+        vec4(in.position, 1.0),
+    );
+
+    // in.uv is [0,1] normalized across the quad.
+    // Map to the correct atlas frame using uniforms.
+    let frame_w = 1.0 / sprite.sheet_cols;
+    let frame_h = 1.0 / sprite.sheet_rows;
+
+    var u = in.uv.x;
+    if (sprite.flip > 0.5) {
+        u = 1.0 - u;
+    }
+
+    let atlas_u = sprite.frame_col * frame_w + u * frame_w;
+    let atlas_v = sprite.frame_row * frame_h + in.uv.y * frame_h;
+
+    out.uv = vec2(atlas_u, atlas_v);
+    return out;
+}
+
+@fragment
+fn fragment(in: SpriteVertexOutput) -> @location(0) vec4<f32> {
+    let tex = textureSample(sprite_texture, sprite_sampler, in.uv);
+    let color = tex * sprite.tint;
+
+    if (color.a < sprite.alpha_cutoff) {
+        discard;
+    }
+
+    return color;
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/frog/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/frog/mod.rs
@@ -13,6 +13,7 @@ use super::creature::{
     Creature, CreaturePoolIndex, CreatureRegistry, CreatureState, RenderKind, SpriteData,
     SpriteHopState,
 };
+use super::sprite_material::{SpriteMatHandle, SpriteSheetMaterial, SpriteUniforms};
 use super::wraith::WraithMarker;
 use crate::game::camera::IsometricCamera;
 use crate::game::terrain::TerrainMap;
@@ -26,8 +27,6 @@ const NPC_REF: &str = "green-toad";
 /// Sprite sheet layout: 9 columns x 5 rows of 48x48 frames in a 432x240 texture.
 const SHEET_COLS: u32 = 9;
 const SHEET_ROWS: u32 = 5;
-const FRAME_W: f32 = 1.0 / SHEET_COLS as f32;
-const FRAME_H: f32 = 1.0 / SHEET_ROWS as f32;
 
 /// World-space size of the frog billboard quad.
 const FROG_SIZE: f32 = 0.9;
@@ -78,7 +77,7 @@ const JUMP_AIRBORNE_FRAME: u32 = 4;
 /// Holds all frog material handles so the weather system can tint them.
 #[derive(Resource, Default)]
 pub struct FrogMaterials {
-    pub handles: Vec<Handle<StandardMaterial>>,
+    pub handles: Vec<Handle<SpriteSheetMaterial>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -104,28 +103,9 @@ fn build_frog_quad() -> Mesh {
     .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, vec![[0.0, 0.0, 1.0]; 4])
     .with_inserted_attribute(
         Mesh::ATTRIBUTE_UV_0,
-        vec![
-            [0.0, 0.0],
-            [FRAME_W, 0.0],
-            [FRAME_W, FRAME_H],
-            [0.0, FRAME_H],
-        ],
+        vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
     )
     .with_inserted_indices(Indices::U32(vec![0, 2, 1, 0, 3, 2]))
-}
-
-fn frame_uvs(anim: &Anim, frame: u32, flip: bool) -> [[f32; 2]; 4] {
-    let col = anim.start_col + (frame % anim.frame_count);
-    let row = anim.row;
-    let u0 = col as f32 * FRAME_W;
-    let u1 = u0 + FRAME_W;
-    let v0 = row as f32 * FRAME_H;
-    let v1 = v0 + FRAME_H;
-    if flip {
-        [[u1, v0], [u0, v0], [u0, v1], [u1, v1]]
-    } else {
-        [[u0, v0], [u1, v0], [u1, v1], [u0, v1]]
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +115,8 @@ fn frame_uvs(anim: &Anim, frame: u32, flip: bool) -> [[f32; 2]; 4] {
 pub(super) fn spawn_frogs(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut materials: ResMut<Assets<SpriteSheetMaterial>>,
+    mut std_materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,
     mut pool: ResMut<CreaturePool>,
     mut frog_mats: ResMut<FrogMaterials>,
@@ -158,24 +139,35 @@ pub(super) fn spawn_frogs(
 
     let texture: Handle<Image> = asset_server.load("textures/frog_green_mob.png");
     let frog_mesh = meshes.add(build_frog_quad());
+    // Dummy StandardMaterial handle for Creature.mat_handle (unused for frogs now)
+    let dummy_std = std_materials.add(StandardMaterial::default());
 
     for i in 0..count {
         let seed = (i as u32).wrapping_add(900);
         let phase = hash_f32(seed * 11 + 1);
+        let start_frame = (hash_f32(seed * 41 + 7) * ANIM_IDLE.frame_count as f32) as u32;
 
-        let mat = materials.add(StandardMaterial {
-            base_color_texture: Some(texture.clone()),
-            alpha_mode: AlphaMode::Mask(0.5),
-            cull_mode: None,
-            double_sided: true,
-            unlit: true,
-            ..default()
+        let mat = materials.add(SpriteSheetMaterial {
+            uniforms: SpriteUniforms {
+                tint: Vec4::ONE,
+                frame_col: (start_frame % ANIM_IDLE.frame_count) as f32,
+                frame_row: ANIM_IDLE.row as f32,
+                sheet_cols: SHEET_COLS as f32,
+                sheet_rows: SHEET_ROWS as f32,
+                flip: if hash_f32(seed * 67 + 3) > 0.5 {
+                    1.0
+                } else {
+                    0.0
+                },
+                alpha_cutoff: 0.5,
+                ..default()
+            },
+            texture: texture.clone(),
         });
         frog_mats.handles.push(mat.clone());
 
         let idle_timer = IDLE_MIN + hash_f32(seed * 53 + 11) * (IDLE_MAX - IDLE_MIN);
         let frame_duration = FRAME_DURATION_BASE * (0.8 + hash_f32(seed * 79 + 17) * 0.4);
-        let start_frame = (hash_f32(seed * 41 + 7) * ANIM_IDLE.frame_count as f32) as u32;
 
         commands.spawn((
             Mesh3d(frog_mesh.clone()),
@@ -190,8 +182,9 @@ pub(super) fn spawn_frogs(
                 assigned_slot: None,
                 anchor: Vec3::new(0.0, -100.0, 0.0),
                 phase,
-                mat_handle: mat,
+                mat_handle: dummy_std.clone(),
             },
+            SpriteMatHandle(mat),
             SpriteData {
                 frame_timer: hash_f32(seed * 83 + 13) * frame_duration,
                 frame_duration,
@@ -205,7 +198,7 @@ pub(super) fn spawn_frogs(
         ));
     }
 
-    info!("[frog] spawned {count} entities");
+    info!("[frog] spawned {count} entities (GPU-driven sprite sheet)");
 }
 
 pub(super) fn animate_frogs(
@@ -213,14 +206,14 @@ pub(super) fn animate_frogs(
     game_time: Res<GameTime>,
     mut terrain: ResMut<TerrainMap>,
     camera_q: Query<&Transform, With<IsometricCamera>>,
-    mut meshes: ResMut<Assets<Mesh>>,
+    mut sprite_mats: ResMut<Assets<SpriteSheetMaterial>>,
     mut frog_q: Query<
         (
             &mut Transform,
             &mut Creature,
             &mut SpriteData,
             &mut Visibility,
-            &Mesh3d,
+            &SpriteMatHandle,
         ),
         (Without<IsometricCamera>, Without<WraithMarker>),
     >,
@@ -244,7 +237,7 @@ pub(super) fn animate_frogs(
     let cam_pos = cam_tf.translation;
     let center = scene_center(cam_pos);
 
-    for (mut tf, mut cr, mut sd, mut vis, mesh_handle) in &mut frog_q {
+    for (mut tf, mut cr, mut sd, mut vis, smat) in &mut frog_q {
         let frog_id = (cr.phase * 100000.0) as u32;
 
         // Relocate frog if too far from scene center or below world
@@ -412,15 +405,12 @@ pub(super) fn animate_frogs(
         }
         sd.hop_state = state;
 
-        // Update UVs on the mesh to show current frame
-        let anim = Anim {
-            row: sd.anim_row,
-            start_col: 0,
-            frame_count: sd.anim_frames,
-        };
-        let uvs = frame_uvs(&anim, sd.current_frame, sd.facing_left);
-        if let Some(mesh) = meshes.get_mut(mesh_handle.0.id()) {
-            mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![uvs[0], uvs[1], uvs[2], uvs[3]]);
+        // Update sprite sheet uniforms (GPU-driven, no mesh upload)
+        if let Some(mat) = sprite_mats.get_mut(&smat.0) {
+            let col = sd.current_frame % sd.anim_frames;
+            mat.uniforms.frame_col = col as f32;
+            mat.uniforms.frame_row = sd.anim_row as f32;
+            mat.uniforms.flip = if sd.facing_left { 1.0 } else { 0.0 };
         }
 
         // Billboard: face camera

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -3,6 +3,7 @@ pub mod common;
 pub mod creature;
 mod firefly;
 mod frog;
+pub mod sprite_material;
 mod wraith;
 
 use bevy::prelude::*;
@@ -56,6 +57,9 @@ pub struct CreaturesPlugin;
 
 impl Plugin for CreaturesPlugin {
     fn build(&self, app: &mut App) {
+        // GPU-driven sprite sheet material (shared by frog + wraith)
+        app.add_plugins(MaterialPlugin::<sprite_material::SpriteSheetMaterial>::default());
+
         // --- Unified NpcDb-driven registry ---
         app.add_systems(Startup, setup_creature_registry);
 

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/sprite_material.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/sprite_material.rs
@@ -1,0 +1,84 @@
+//! GPU-driven sprite sheet material.
+//!
+//! Replaces per-frame `insert_attribute(UV_0)` mesh uploads with a uniform
+//! buffer that the vertex shader reads to compute atlas UVs on the GPU.
+//! Used by both frog and wraith sprite creatures.
+
+use bevy::prelude::*;
+use bevy::render::render_resource::{AsBindGroup, ShaderType};
+use bevy::shader::ShaderRef;
+
+/// Uniform block matching the WGSL `SpriteUniforms` struct.
+#[derive(ShaderType, Clone, Copy, Debug)]
+pub struct SpriteUniforms {
+    /// RGBA tint applied to the texture sample (used for day/night).
+    pub tint: Vec4,
+    /// Current frame column in the atlas (0-based).
+    pub frame_col: f32,
+    /// Current frame row in the atlas (0-based).
+    pub frame_row: f32,
+    /// Total columns in the sprite sheet.
+    pub sheet_cols: f32,
+    /// Total rows in the sprite sheet.
+    pub sheet_rows: f32,
+    /// >0.5 to flip horizontally.
+    pub flip: f32,
+    /// Alpha discard threshold (0.5 for mask, 0.01 for blend).
+    pub alpha_cutoff: f32,
+    pub _pad0: f32,
+    pub _pad1: f32,
+}
+
+impl Default for SpriteUniforms {
+    fn default() -> Self {
+        Self {
+            tint: Vec4::ONE,
+            frame_col: 0.0,
+            frame_row: 0.0,
+            sheet_cols: 1.0,
+            sheet_rows: 1.0,
+            flip: 0.0,
+            alpha_cutoff: 0.5,
+            _pad0: 0.0,
+            _pad1: 0.0,
+        }
+    }
+}
+
+/// Custom material for sprite-sheet creatures.
+///
+/// Bind layout:
+/// - binding(0): `SpriteUniforms` uniform buffer
+/// - binding(1): sprite atlas texture
+/// - binding(2): sampler
+#[derive(Asset, TypePath, AsBindGroup, Clone)]
+pub struct SpriteSheetMaterial {
+    #[uniform(0)]
+    pub uniforms: SpriteUniforms,
+    #[texture(1)]
+    #[sampler(2)]
+    pub texture: Handle<Image>,
+}
+
+/// Component that stores the SpriteSheetMaterial handle on sprite creatures.
+/// Used instead of `Creature.mat_handle` (which is typed StandardMaterial).
+#[derive(Component)]
+pub struct SpriteMatHandle(pub Handle<SpriteSheetMaterial>);
+
+impl Material for SpriteSheetMaterial {
+    fn vertex_shader() -> ShaderRef {
+        "shaders/sprite_sheet.wgsl".into()
+    }
+
+    fn fragment_shader() -> ShaderRef {
+        "shaders/sprite_sheet.wgsl".into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode {
+        if self.uniforms.alpha_cutoff > 0.4 {
+            AlphaMode::Mask(self.uniforms.alpha_cutoff)
+        } else {
+            AlphaMode::Blend
+        }
+    }
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
@@ -24,6 +24,7 @@ use super::creature::{
     Creature, CreaturePoolIndex, CreatureRegistry, CreatureState, RenderKind, SpriteData,
     SpriteHopState,
 };
+use super::sprite_material::{SpriteMatHandle, SpriteSheetMaterial, SpriteUniforms};
 use crate::game::camera::IsometricCamera;
 use crate::game::terrain::TerrainMap;
 
@@ -35,8 +36,6 @@ const NPC_REF: &str = "wraith-executioner";
 
 const SHEET_COLS: u32 = 20;
 const SHEET_ROWS: u32 = 6;
-const FRAME_W: f32 = 1.0 / SHEET_COLS as f32;
-const FRAME_H: f32 = 1.0 / SHEET_ROWS as f32;
 
 /// World-space size of the wraith billboard quad (larger than frog).
 const WRAITH_SIZE: f32 = 3.52;
@@ -98,7 +97,7 @@ const ANIM_SUMMON: Anim = Anim {
 
 #[derive(Resource, Default)]
 pub struct WraithMaterials {
-    pub handles: Vec<Handle<StandardMaterial>>,
+    pub handles: Vec<Handle<SpriteSheetMaterial>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -124,28 +123,9 @@ fn build_wraith_quad() -> Mesh {
     .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, vec![[0.0, 0.0, 1.0]; 4])
     .with_inserted_attribute(
         Mesh::ATTRIBUTE_UV_0,
-        vec![
-            [0.0, 0.0],
-            [FRAME_W, 0.0],
-            [FRAME_W, FRAME_H],
-            [0.0, FRAME_H],
-        ],
+        vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
     )
     .with_inserted_indices(Indices::U32(vec![0, 2, 1, 0, 3, 2]))
-}
-
-fn frame_uvs(anim: &Anim, frame: u32, flip: bool) -> [[f32; 2]; 4] {
-    let col = anim.start_col + (frame % anim.frame_count);
-    let row = anim.row;
-    let u0 = col as f32 * FRAME_W;
-    let u1 = u0 + FRAME_W;
-    let v0 = row as f32 * FRAME_H;
-    let v1 = v0 + FRAME_H;
-    if flip {
-        [[u1, v0], [u0, v0], [u0, v1], [u1, v1]]
-    } else {
-        [[u0, v0], [u1, v0], [u1, v1], [u0, v1]]
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -155,7 +135,8 @@ fn frame_uvs(anim: &Anim, frame: u32, flip: bool) -> [[f32; 2]; 4] {
 pub(super) fn spawn_wraiths(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut materials: ResMut<Assets<SpriteSheetMaterial>>,
+    mut std_materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,
     mut pool: ResMut<CreaturePool>,
     mut wraith_mats: ResMut<WraithMaterials>,
@@ -179,24 +160,34 @@ pub(super) fn spawn_wraiths(
     let texture: Handle<Image> =
         asset_server.load("textures/creatures/wraith/wraith_executioner.png");
     let wraith_mesh = meshes.add(build_wraith_quad());
+    let dummy_std = std_materials.add(StandardMaterial::default());
 
     for i in 0..count {
         let seed = (i as u32).wrapping_add(7700);
         let phase = hash_f32(seed * 11 + 1);
+        let start_frame = (hash_f32(seed * 41 + 7) * ANIM_IDLE.frame_count as f32) as u32;
 
-        let mat = materials.add(StandardMaterial {
-            base_color_texture: Some(texture.clone()),
-            alpha_mode: AlphaMode::Blend,
-            cull_mode: None,
-            double_sided: true,
-            unlit: true,
-            ..default()
+        let mat = materials.add(SpriteSheetMaterial {
+            uniforms: SpriteUniforms {
+                tint: Vec4::ONE,
+                frame_col: (start_frame % ANIM_IDLE.frame_count) as f32,
+                frame_row: ANIM_IDLE.row as f32,
+                sheet_cols: SHEET_COLS as f32,
+                sheet_rows: SHEET_ROWS as f32,
+                flip: if hash_f32(seed * 67 + 3) > 0.5 {
+                    1.0
+                } else {
+                    0.0
+                },
+                alpha_cutoff: 0.01, // Blend mode for wraiths
+                ..default()
+            },
+            texture: texture.clone(),
         });
         wraith_mats.handles.push(mat.clone());
 
         let idle_timer = IDLE_MIN + hash_f32(seed * 53 + 11) * (IDLE_MAX - IDLE_MIN);
         let frame_duration = FRAME_DURATION_BASE * (0.8 + hash_f32(seed * 79 + 17) * 0.4);
-        let start_frame = (hash_f32(seed * 41 + 7) * ANIM_IDLE.frame_count as f32) as u32;
 
         commands.spawn((
             Mesh3d(wraith_mesh.clone()),
@@ -211,8 +202,9 @@ pub(super) fn spawn_wraiths(
                 assigned_slot: None,
                 anchor: Vec3::new(0.0, -100.0, 0.0),
                 phase,
-                mat_handle: mat,
+                mat_handle: dummy_std.clone(),
             },
+            SpriteMatHandle(mat),
             SpriteData {
                 frame_timer: hash_f32(seed * 83 + 13) * frame_duration,
                 frame_duration,
@@ -229,7 +221,7 @@ pub(super) fn spawn_wraiths(
         ));
     }
 
-    info!("[wraith] spawned {count} entities");
+    info!("[wraith] spawned {count} entities (GPU-driven sprite sheet)");
 }
 
 /// Wraith-specific component: marker + deterministic patrol counter.
@@ -255,14 +247,14 @@ pub(super) fn animate_wraiths(
     game_time: Res<GameTime>,
     mut terrain: ResMut<TerrainMap>,
     camera_q: Query<&Transform, With<IsometricCamera>>,
-    mut meshes: ResMut<Assets<Mesh>>,
+    mut sprite_mats: ResMut<Assets<SpriteSheetMaterial>>,
     mut wraith_q: Query<
         (
             &mut Transform,
             &mut Creature,
             &mut SpriteData,
             &mut Visibility,
-            &Mesh3d,
+            &SpriteMatHandle,
             &mut WraithMarker,
         ),
         Without<IsometricCamera>,
@@ -278,7 +270,7 @@ pub(super) fn animate_wraiths(
     let cam_pos = cam_tf.translation;
     let center = scene_center(cam_pos);
 
-    for (mut tf, mut cr, mut sd, mut vis, mesh_handle, mut wm) in &mut wraith_q {
+    for (mut tf, mut cr, mut sd, mut vis, smat, mut wm) in &mut wraith_q {
         // Relocate if too far or below world
         let dist = Vec2::new(cr.anchor.x - center.x, cr.anchor.z - center.z).length();
         if dist > RECYCLE_DIST || cr.anchor.y < -50.0 {
@@ -470,15 +462,12 @@ pub(super) fn animate_wraiths(
         }
         sd.hop_state = state;
 
-        // Update UVs for current frame
-        let anim = Anim {
-            row: sd.anim_row,
-            start_col: 0,
-            frame_count: sd.anim_frames,
-        };
-        let uvs = frame_uvs(&anim, sd.current_frame, sd.facing_left);
-        if let Some(mesh) = meshes.get_mut(mesh_handle.0.id()) {
-            mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![uvs[0], uvs[1], uvs[2], uvs[3]]);
+        // Update sprite sheet uniforms (GPU-driven, no mesh upload)
+        if let Some(mat) = sprite_mats.get_mut(&smat.0) {
+            let col = sd.current_frame % sd.anim_frames;
+            mat.uniforms.frame_col = col as f32;
+            mat.uniforms.frame_row = sd.anim_row as f32;
+            mat.uniforms.flip = if sd.facing_left { 1.0 } else { 0.0 };
         }
 
         // Billboard: face camera

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -6,6 +6,7 @@ use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 
 use super::camera::IsometricCamera;
+use super::creatures::sprite_material::SpriteSheetMaterial;
 use super::creatures::{FrogMaterials, GameTime, WraithMaterials};
 use super::net::ServerTime;
 use super::tilemap::TileMaterials;
@@ -457,11 +458,11 @@ fn tint_trees_for_daynight(
     }
 }
 
-/// Tint unlit frog materials based on time of day (same curve as trees).
+/// Tint frog sprite sheet materials based on time of day (same curve as trees).
 fn tint_frogs_for_daynight(
     day: Res<DayCycle>,
     frog_mats: Option<Res<FrogMaterials>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut materials: ResMut<Assets<SpriteSheetMaterial>>,
 ) {
     let Some(frog_mats) = frog_mats else {
         return;
@@ -475,17 +476,17 @@ fn tint_frogs_for_daynight(
 
     for handle in &frog_mats.handles {
         if let Some(mat) = materials.get_mut(handle) {
-            mat.base_color = Color::srgb(r, g, b);
+            mat.uniforms.tint = Vec4::new(r, g, b, 1.0);
         }
     }
 }
 
-/// Tint unlit wraith materials based on time of day (same curve as frogs).
+/// Tint wraith sprite sheet materials based on time of day.
 /// Wraiths are always visible: fully opaque at night, semi-transparent (ghostly) during day.
 fn tint_wraiths_for_daynight(
     day: Res<DayCycle>,
     wraith_mats: Option<Res<WraithMaterials>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut materials: ResMut<Assets<SpriteSheetMaterial>>,
 ) {
     let Some(wraith_mats) = wraith_mats else {
         return;
@@ -506,7 +507,7 @@ fn tint_wraiths_for_daynight(
 
     for handle in &wraith_mats.handles {
         if let Some(mat) = materials.get_mut(handle) {
-            mat.base_color = Color::srgba(r, g, b, alpha);
+            mat.uniforms.tint = Vec4::new(r, g, b, alpha);
         }
     }
 }


### PR DESCRIPTION
## Summary
- New `SpriteSheetMaterial` + `sprite_sheet.wgsl` vertex/fragment shader that computes atlas UVs from uniforms on the GPU
- Eliminates all per-frame `insert_attribute(UV_0)` mesh buffer uploads for frogs (8) and wraiths (6) — **14 GPU mesh uploads/frame → 0**
- UV computation moved to vertex shader: `frame_col`, `frame_row`, `sheet_cols`, `sheet_rows`, `flip` uniforms drive atlas frame selection
- `tint` uniform replaces `base_color` modulation for day/night tinting (wraith ghostly alpha included)
- Mesh UVs normalized to [0,1] — shader maps to correct atlas frame
- `SpriteMatHandle` component stores the custom material handle alongside the existing `Creature` struct

## Test plan
- [ ] Verify frog sprite animations play correctly (idle, jump, land)
- [ ] Verify wraith sprite animations play correctly (idle, glide, attack, skill, summon)
- [ ] Verify horizontal sprite flipping works for both frogs and wraiths
- [ ] Verify day/night tinting works for both creature types
- [ ] Verify wraith ghostly transparency during daytime
- [ ] Confirm no visual regression vs previous `insert_attribute` approach