### PR TITLE
feat(isometric): time sync gate + bevy toast system

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/mod.rs
@@ -20,6 +20,7 @@ pub mod telemetry;
 pub mod terrain;
 pub mod tilemap;
 pub mod title_screen;
+pub mod toast;
 pub mod trees;
 pub mod ui_color;
 pub mod virtual_joystick;
@@ -89,5 +90,6 @@ impl PluginGroup for GamePluginGroup {
             .add(OrbHudPlugin)
             .add(ActionsPlugin)
             .add(PixelatePlugin)
+            .add(toast::ToastPlugin)
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -1136,10 +1136,10 @@ fn receive_auth_response(
                     msg.server_time
                 );
 
-                // Gate: only now transition from Connecting → Playing
+                // Don't transition to Playing yet — wait for first TimeSyncMessage
+                // so the world has correct time-of-day before the player sees it.
                 if **phase == super::phase::GamePhase::Connecting {
-                    info!("[net] handshake complete — transitioning Connecting → Playing");
-                    next_phase.set(super::phase::GamePhase::Playing);
+                    info!("[net] auth complete — waiting for first time sync before Playing");
                 }
             } else {
                 warn!("[net] AUTH FAILED from entity {entity:?} — triggering Disconnect to reset");
@@ -1762,6 +1762,8 @@ fn poll_set_username_request(
 /// Receive TimeSyncMessage from the server and update ServerTime resource.
 fn receive_time_sync(
     mut server_time: ResMut<ServerTime>,
+    mut next_phase: ResMut<NextState<super::phase::GamePhase>>,
+    phase: Res<State<super::phase::GamePhase>>,
     mut query: Query<(Entity, &mut MessageReceiver<TimeSyncMessage>)>,
 ) {
     for (_entity, mut receiver) in &mut query {
@@ -1777,6 +1779,12 @@ fn receive_time_sync(
                     msg.game_hour, msg.day_speed, msg.creature_seed
                 );
                 server_time.active = true;
+
+                // Now that we have the world time, transition to Playing
+                if **phase == super::phase::GamePhase::Connecting {
+                    info!("[net] time sync received — transitioning Connecting → Playing");
+                    next_phase.set(super::phase::GamePhase::Playing);
+                }
             }
         }
     }

--- a/apps/kbve/isometric/src-tauri/src/game/toast.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/toast.rs
@@ -1,0 +1,187 @@
+//! Simple in-game toast notification system.
+//!
+//! Toasts are temporary text messages that appear at the bottom of the screen
+//! and fade out after a few seconds. Works on both native and WASM.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! commands.trigger(Toast::new("Found 1x Wood"));
+//! commands.trigger(Toast::info("Connected to server"));
+//! commands.trigger(Toast::warn("WebTransport failed — using WebSocket"));
+//! ```
+
+use bevy::prelude::*;
+use std::collections::VecDeque;
+
+/// Maximum number of visible toasts at once.
+const MAX_VISIBLE: usize = 5;
+
+/// How long a toast stays fully visible (seconds).
+const DISPLAY_DURATION: f32 = 3.0;
+
+/// How long the fade-out takes (seconds).
+const FADE_DURATION: f32 = 1.0;
+
+/// Event to trigger a toast notification.
+#[derive(Event, Clone, Debug)]
+pub struct Toast {
+    pub message: String,
+    pub color: Color,
+}
+
+impl Toast {
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            color: Color::srgb(0.9, 0.88, 0.75),
+        }
+    }
+
+    pub fn info(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            color: Color::srgb(0.6, 0.85, 0.6),
+        }
+    }
+
+    pub fn warn(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            color: Color::srgb(0.95, 0.75, 0.3),
+        }
+    }
+
+    pub fn error(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            color: Color::srgb(0.95, 0.4, 0.35),
+        }
+    }
+}
+
+/// Internal state for an active toast.
+struct ActiveToast {
+    entity: Entity,
+    timer: f32,
+}
+
+/// Resource tracking active toasts.
+#[derive(Resource, Default)]
+struct ToastQueue {
+    active: VecDeque<ActiveToast>,
+}
+
+/// Marker for the toast container node.
+#[derive(Component)]
+struct ToastContainer;
+
+/// Marker for individual toast text entities.
+#[derive(Component)]
+struct ToastEntry;
+
+pub struct ToastPlugin;
+
+impl Plugin for ToastPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ToastQueue>();
+        app.add_systems(Startup, spawn_toast_container);
+        app.add_observer(on_toast_event);
+        app.add_observer(on_loot_event);
+        app.add_systems(Update, update_toasts);
+    }
+}
+
+/// Show a toast when the player receives loot.
+fn on_loot_event(
+    trigger: On<super::inventory::LootEvent<super::inventory::ItemKind>>,
+    mut commands: Commands,
+) {
+    use bevy_inventory::ItemKind as _;
+    let loot = trigger.event();
+    let name = loot.kind.display_name();
+    let qty = loot.quantity;
+    commands.trigger(Toast::new(format!("+ {qty}x {name}")));
+}
+
+fn spawn_toast_container(mut commands: Commands) {
+    commands
+        .spawn(Node {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(16.0),
+            left: Val::Px(16.0),
+            flex_direction: FlexDirection::ColumnReverse,
+            row_gap: Val::Px(4.0),
+            ..default()
+        })
+        .insert(ToastContainer);
+}
+
+fn on_toast_event(
+    trigger: On<Toast>,
+    mut commands: Commands,
+    mut queue: ResMut<ToastQueue>,
+    container_q: Query<Entity, With<ToastContainer>>,
+) {
+    let Ok(container) = container_q.single() else {
+        return;
+    };
+
+    let toast = trigger.event();
+
+    // Spawn toast text as child of container
+    let entry = commands
+        .spawn(Text::new(&toast.message))
+        .insert(TextFont {
+            font_size: 14.0,
+            ..default()
+        })
+        .insert(TextColor(toast.color))
+        .insert(ToastEntry)
+        .id();
+
+    commands.entity(container).add_child(entry);
+
+    queue.active.push_back(ActiveToast {
+        entity: entry,
+        timer: 0.0,
+    });
+
+    // Remove oldest if over limit
+    while queue.active.len() > MAX_VISIBLE {
+        if let Some(old) = queue.active.pop_front() {
+            commands.entity(old.entity).try_despawn();
+        }
+    }
+}
+
+fn update_toasts(
+    time: Res<Time>,
+    mut commands: Commands,
+    mut queue: ResMut<ToastQueue>,
+    mut text_colors: Query<&mut TextColor, With<ToastEntry>>,
+) {
+    let dt = time.delta_secs();
+    let total_duration = DISPLAY_DURATION + FADE_DURATION;
+
+    queue.active.retain_mut(|toast| {
+        toast.timer += dt;
+
+        if toast.timer >= total_duration {
+            commands.entity(toast.entity).try_despawn();
+            return false;
+        }
+
+        // Fade out during the last FADE_DURATION seconds
+        if toast.timer > DISPLAY_DURATION {
+            let fade_progress = (toast.timer - DISPLAY_DURATION) / FADE_DURATION;
+            let alpha = 1.0 - fade_progress;
+            if let Ok(mut color) = text_colors.get_mut(toast.entity) {
+                let c = color.0.to_srgba();
+                color.0 = Color::srgba(c.red, c.green, c.blue, alpha);
+            }
+        }
+
+        true
+    });
+}


### PR DESCRIPTION
## Summary
- Phase transition `Connecting → Playing` now waits for first `TimeSyncMessage` — world has correct time-of-day before the player sees it
- New `ToastPlugin` — bevy-native notification system (bottom-left, fades after 3s)
- `LootEvent` observer triggers toast on item pickup (e.g. "+ 1x Wood")
- Works on both native `cargo run` and WASM — no React dependency

## Test plan
- [ ] Connect to production, verify Playing phase enters after time sync log
- [ ] Chop a tree, verify toast shows "+ 1x Wood" at bottom-left
- [ ] Verify toast fades after ~3 seconds
- [ ] Test on WASM — same behavior