### PR TITLE
feat(edge): add IRC edge function for REST-based Ergo access

### DIFF
--- a/apps/kbve/edge/functions/_shared/cors.ts
+++ b/apps/kbve/edge/functions/_shared/cors.ts
@@ -8,6 +8,7 @@ const ALLOWED_ORIGINS = new Set([
   "https://www.chuckrpg.com",
   "https://herbmail.com",
   "https://www.herbmail.com",
+  "https://chat.kbve.com",
   "http://localhost:3000",
   "http://localhost:4321",
   "http://localhost:1420",

--- a/apps/kbve/edge/functions/irc/_shared.ts
+++ b/apps/kbve/edge/functions/irc/_shared.ts
@@ -1,0 +1,169 @@
+import {
+  extractToken,
+  jsonResponse,
+  parseJwt,
+  requireServiceRole,
+  createServiceClient,
+  type JwtClaims,
+} from "../_shared/supabase.ts";
+
+export { extractToken, jsonResponse, parseJwt, createServiceClient };
+
+// ---------------------------------------------------------------------------
+// IRC Edge Function — Shared Types & Helpers
+// ---------------------------------------------------------------------------
+
+export interface IrcRequest {
+  token: string;
+  claims: JwtClaims;
+  body: Record<string, unknown>;
+  action: string;
+}
+
+/** Require service_role OR staff permissions via Supabase RPC. */
+export async function requireStaffOrAdmin(
+  claims: JwtClaims,
+  token: string,
+): Promise<Response | null> {
+  // service_role passes immediately
+  if (claims.role === "service_role") return null;
+
+  // Authenticated users: check staff_permissions RPC
+  if (!claims.sub) {
+    return jsonResponse({ error: "Access denied" }, 403);
+  }
+
+  try {
+    const sb = createServiceClient();
+    const { data, error } = await sb.rpc("staff_permissions", {
+      target_user_id: claims.sub,
+    });
+    if (error) throw error;
+    // staff_permissions returns an integer bitmask; non-zero = staff
+    if (typeof data === "number" && data > 0) return null;
+  } catch (err) {
+    console.error("staff check failed:", err);
+  }
+
+  return jsonResponse({ error: "Access denied: staff or service_role required" }, 403);
+}
+
+// ---------------------------------------------------------------------------
+// IRC protocol constants
+// ---------------------------------------------------------------------------
+
+const ERGO_HOST = Deno.env.get("ERGO_IRC_HOST") ??
+  "ergo-irc-service.irc.svc.cluster.local";
+const ERGO_PORT = parseInt(Deno.env.get("ERGO_IRC_PORT") ?? "6667", 10);
+
+const IRC_NICK = "edge-bot";
+const IRC_USER = "edge-bot 0 * :KBVE Edge Function";
+
+/** Max time to wait for IRC responses (ms). */
+const IRC_TIMEOUT_MS = 10_000;
+
+/**
+ * Open a raw TCP connection to Ergo, register as the edge bot,
+ * execute a callback, then disconnect.
+ *
+ * The callback receives helpers to send raw IRC lines and read
+ * accumulated responses.
+ */
+export async function withIrcConnection<T>(
+  fn: (irc: IrcConn) => Promise<T>,
+): Promise<T> {
+  const conn = await Deno.connect({ hostname: ERGO_HOST, port: ERGO_PORT });
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const buf = new Uint8Array(4096);
+  const lines: string[] = [];
+  let partial = "";
+
+  const irc: IrcConn = {
+    async send(line: string) {
+      await conn.write(encoder.encode(line + "\r\n"));
+    },
+    async read(timeoutMs = IRC_TIMEOUT_MS): Promise<string[]> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        // Use Deno.conn with a short read timeout
+        conn.setReadDeadline?.(new Date(Math.min(Date.now() + 500, deadline)));
+        try {
+          const n = await conn.read(buf);
+          if (n === null) break;
+          partial += decoder.decode(buf.subarray(0, n));
+          const parts = partial.split("\r\n");
+          partial = parts.pop()!;
+          lines.push(...parts);
+        } catch {
+          // read timeout or closed — check if we have enough data
+          break;
+        }
+      }
+      const result = [...lines];
+      lines.length = 0;
+      return result;
+    },
+    async readUntil(
+      predicate: (line: string) => boolean,
+      timeoutMs = IRC_TIMEOUT_MS,
+    ): Promise<string[]> {
+      const deadline = Date.now() + timeoutMs;
+      const collected: string[] = [];
+      while (Date.now() < deadline) {
+        conn.setReadDeadline?.(new Date(Math.min(Date.now() + 500, deadline)));
+        try {
+          const n = await conn.read(buf);
+          if (n === null) break;
+          partial += decoder.decode(buf.subarray(0, n));
+          const parts = partial.split("\r\n");
+          partial = parts.pop()!;
+          for (const line of parts) {
+            // Respond to PING immediately to stay alive
+            if (line.startsWith("PING")) {
+              await conn.write(
+                encoder.encode(line.replace("PING", "PONG") + "\r\n"),
+              );
+              continue;
+            }
+            collected.push(line);
+            if (predicate(line)) return collected;
+          }
+        } catch {
+          break;
+        }
+      }
+      return collected;
+    },
+  };
+
+  try {
+    // Register with Ergo
+    await irc.send(`NICK ${IRC_NICK}`);
+    await irc.send(`USER ${IRC_USER}`);
+
+    // Wait for welcome (001) or error
+    await irc.readUntil(
+      (line) => line.includes(" 001 ") || line.includes(" 433 "),
+    );
+
+    return await fn(irc);
+  } finally {
+    try {
+      await irc.send("QUIT :edge function done");
+    } catch { /* best-effort */ }
+    try {
+      conn.close();
+    } catch { /* best-effort */ }
+  }
+}
+
+export interface IrcConn {
+  send(line: string): Promise<void>;
+  read(timeoutMs?: number): Promise<string[]>;
+  readUntil(
+    predicate: (line: string) => boolean,
+    timeoutMs?: number,
+  ): Promise<string[]>;
+}

--- a/apps/kbve/edge/functions/irc/channel.ts
+++ b/apps/kbve/edge/functions/irc/channel.ts
@@ -1,0 +1,144 @@
+import { jsonResponse, withIrcConnection } from "./_shared.ts";
+import type { IrcRequest } from "./_shared.ts";
+
+// ---------------------------------------------------------------------------
+// IRC Channel — List, Topic, Names
+//
+// Actions: list, topic, names
+// ---------------------------------------------------------------------------
+
+export const CHANNEL_ACTIONS = ["list", "topic", "names"];
+
+export async function handleChannel(req: IrcRequest): Promise<Response> {
+  switch (req.action) {
+    case "list": {
+      try {
+        const channels = await withIrcConnection(async (irc) => {
+          await irc.send("LIST");
+          const lines = await irc.readUntil((l) => l.includes(" 323 "));
+          // 322 = RPL_LIST: <channel> <visible> :<topic>
+          return lines
+            .filter((l) => l.includes(" 322 "))
+            .map((l) => {
+              const match = l.match(/ 322 \S+ (\S+) (\d+) :?(.*)/);
+              if (!match) return null;
+              return {
+                channel: match[1],
+                users: parseInt(match[2], 10),
+                topic: match[3] || "",
+              };
+            })
+            .filter(Boolean);
+        });
+        return jsonResponse({ channels });
+      } catch (err) {
+        console.error("irc channel.list error:", err);
+        return jsonResponse(
+          { error: "Failed to list channels — Ergo unreachable" },
+          503,
+        );
+      }
+    }
+
+    case "topic": {
+      const { channel } = req.body;
+      if (!channel || typeof channel !== "string") {
+        return jsonResponse(
+          { error: "channel is required (e.g. '#general')" },
+          400,
+        );
+      }
+      const safeChan = sanitizeChannel(channel);
+      if (!safeChan) {
+        return jsonResponse({ error: "Invalid channel name" }, 400);
+      }
+
+      try {
+        const topic = await withIrcConnection(async (irc) => {
+          await irc.send(`TOPIC ${safeChan}`);
+          const lines = await irc.readUntil(
+            (l) =>
+              l.includes(" 332 ") ||
+              l.includes(" 331 ") ||
+              l.includes(" 403 "),
+          );
+          const topicLine = lines.find((l) => l.includes(" 332 "));
+          if (topicLine) {
+            const parts = topicLine.split(" :");
+            return parts.length > 1 ? parts[parts.length - 1] : "";
+          }
+          return null;
+        });
+        return jsonResponse({ channel: safeChan, topic: topic ?? "(no topic set)" });
+      } catch (err) {
+        console.error("irc channel.topic error:", err);
+        return jsonResponse(
+          { error: "Failed to get topic — Ergo unreachable" },
+          503,
+        );
+      }
+    }
+
+    case "names": {
+      const { channel } = req.body;
+      if (!channel || typeof channel !== "string") {
+        return jsonResponse(
+          { error: "channel is required (e.g. '#general')" },
+          400,
+        );
+      }
+      const safeChan = sanitizeChannel(channel);
+      if (!safeChan) {
+        return jsonResponse({ error: "Invalid channel name" }, 400);
+      }
+
+      try {
+        const names = await withIrcConnection(async (irc) => {
+          await irc.send(`NAMES ${safeChan}`);
+          const lines = await irc.readUntil(
+            (l) => l.includes(" 366 ") || l.includes(" 403 "),
+          );
+          // 353 = RPL_NAMREPLY: = <channel> :<names...>
+          return lines
+            .filter((l) => l.includes(" 353 "))
+            .flatMap((l) => {
+              const parts = l.split(" :");
+              const nameStr = parts.length > 1 ? parts[parts.length - 1] : "";
+              return nameStr
+                .split(" ")
+                .map((n) => n.replace(/^[@+%~&!]/, ""))
+                .filter(Boolean);
+            });
+        });
+        return jsonResponse({ channel: safeChan, names });
+      } catch (err) {
+        console.error("irc channel.names error:", err);
+        return jsonResponse(
+          { error: "Failed to get names — Ergo unreachable" },
+          503,
+        );
+      }
+    }
+
+    default:
+      return jsonResponse(
+        {
+          error: `Unknown channel action: ${req.action}. Available: ${CHANNEL_ACTIONS.join(", ")}`,
+        },
+        400,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Sanitize a channel name — must start with # and contain no spaces/control chars. */
+function sanitizeChannel(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("#")) return null;
+  if (trimmed.length > 50) return null;
+  if (/[\s\x00-\x1f\x07,]/.test(trimmed)) return null;
+  return trimmed;
+}

--- a/apps/kbve/edge/functions/irc/index.ts
+++ b/apps/kbve/edge/functions/irc/index.ts
@@ -1,0 +1,123 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import {
+  requireJsonContentType,
+  enforceBodySizeLimit,
+} from "../_shared/validators.ts";
+import {
+  extractToken,
+  jsonResponse,
+  parseJwt,
+  requireStaffOrAdmin,
+  type IrcRequest,
+} from "./_shared.ts";
+import { CHANNEL_ACTIONS, handleChannel } from "./channel.ts";
+import { MESSAGE_ACTIONS, handleMessage } from "./message.ts";
+import { SERVER_ACTIONS, handleServer } from "./server.ts";
+
+// ---------------------------------------------------------------------------
+// IRC Edge Function — Admin Router
+//
+// Provides a REST interface to the internal Ergo IRC server.
+// All actions require service_role JWT or staff permissions.
+//
+// Command format: "module.action"
+//   server:   status, motd
+//   channel:  list, topic, names
+//   message:  send, history
+// ---------------------------------------------------------------------------
+
+const MODULES: Record<
+  string,
+  {
+    handler: (req: IrcRequest) => Promise<Response>;
+    actions: string[];
+  }
+> = {
+  server: { handler: handleServer, actions: SERVER_ACTIONS },
+  channel: { handler: handleChannel, actions: CHANNEL_ACTIONS },
+  message: { handler: handleMessage, actions: MESSAGE_ACTIONS },
+};
+
+function buildHelpText(): string {
+  const commands: string[] = [];
+  for (const [mod, { actions }] of Object.entries(MODULES)) {
+    for (const action of actions) {
+      commands.push(`${mod}.${action}`);
+    }
+  }
+  return commands.join(", ");
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+  }
+
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+
+  try {
+    const token = extractToken(req);
+    const claims = await parseJwt(token);
+
+    // Gate: service_role or staff only
+    const accessErr = await requireStaffOrAdmin(claims, token);
+    if (accessErr) return accessErr;
+
+    const sizeErr = enforceBodySizeLimit(req);
+    if (sizeErr) return sizeErr;
+
+    const body = await req.json();
+    const { command } = body;
+
+    if (!command || typeof command !== "string") {
+      return jsonResponse(
+        {
+          error: `command is required (format: "module.action"). Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const dotIndex = command.indexOf(".");
+    if (dotIndex === -1) {
+      return jsonResponse(
+        {
+          error: `Invalid command format. Use "module.action". Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const moduleName = command.slice(0, dotIndex);
+    const action = command.slice(dotIndex + 1);
+
+    const mod = MODULES[moduleName];
+    if (!mod) {
+      return jsonResponse(
+        {
+          error: `Unknown module: ${moduleName}. Available: ${Object.keys(MODULES).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    return mod.handler({ token, claims, body, action });
+  } catch (err) {
+    console.error("irc error:", err);
+    const rawMessage = err instanceof Error
+      ? err.message
+      : "Internal server error";
+    const isAuthError =
+      rawMessage.includes("authorization") || rawMessage.includes("JWT");
+    if (isAuthError) {
+      return jsonResponse({ error: rawMessage }, 401);
+    }
+    return jsonResponse({ error: "Internal server error" }, 500);
+  }
+});

--- a/apps/kbve/edge/functions/irc/message.ts
+++ b/apps/kbve/edge/functions/irc/message.ts
@@ -1,0 +1,151 @@
+import { jsonResponse, withIrcConnection } from "./_shared.ts";
+import type { IrcRequest } from "./_shared.ts";
+
+// ---------------------------------------------------------------------------
+// IRC Message — Send & History
+//
+// Actions: send, history
+// ---------------------------------------------------------------------------
+
+export const MESSAGE_ACTIONS = ["send", "history"];
+
+export async function handleMessage(req: IrcRequest): Promise<Response> {
+  switch (req.action) {
+    case "send": {
+      const { channel, text } = req.body;
+      if (!channel || typeof channel !== "string") {
+        return jsonResponse(
+          { error: "channel is required (e.g. '#general')" },
+          400,
+        );
+      }
+      if (!text || typeof text !== "string") {
+        return jsonResponse({ error: "text is required" }, 400);
+      }
+
+      const safeChan = sanitizeChannel(channel);
+      if (!safeChan) {
+        return jsonResponse({ error: "Invalid channel name" }, 400);
+      }
+      const safeText = sanitizeMessage(text);
+      if (!safeText) {
+        return jsonResponse(
+          { error: "Message is empty or exceeds 480 characters" },
+          400,
+        );
+      }
+
+      try {
+        await withIrcConnection(async (irc) => {
+          await irc.send(`JOIN ${safeChan}`);
+          // Wait for JOIN acknowledgment or channel info
+          await irc.readUntil(
+            (l) =>
+              l.includes(" 366 ") ||
+              l.includes(" JOIN ") ||
+              l.includes(" 473 ") ||
+              l.includes(" 475 "),
+            5000,
+          );
+          await irc.send(`PRIVMSG ${safeChan} :${safeText}`);
+          // Small delay to ensure the message is sent before QUIT
+          await irc.read(500);
+        });
+        return jsonResponse({ ok: true, channel: safeChan });
+      } catch (err) {
+        console.error("irc message.send error:", err);
+        return jsonResponse(
+          { error: "Failed to send message — Ergo unreachable" },
+          503,
+        );
+      }
+    }
+
+    case "history": {
+      const { channel, limit } = req.body;
+      if (!channel || typeof channel !== "string") {
+        return jsonResponse(
+          { error: "channel is required (e.g. '#general')" },
+          400,
+        );
+      }
+      const safeChan = sanitizeChannel(channel);
+      if (!safeChan) {
+        return jsonResponse({ error: "Invalid channel name" }, 400);
+      }
+      const count = Math.min(Math.max(parseInt(String(limit ?? 50), 10) || 50, 1), 100);
+
+      try {
+        const messages = await withIrcConnection(async (irc) => {
+          await irc.send(`JOIN ${safeChan}`);
+          await irc.readUntil(
+            (l) => l.includes(" 366 ") || l.includes(" JOIN "),
+            5000,
+          );
+
+          // CHATHISTORY is an IRCv3 extension supported by Ergo
+          await irc.send(
+            `CHATHISTORY LATEST ${safeChan} * ${count}`,
+          );
+
+          const lines = await irc.readUntil(
+            (l) =>
+              l.includes("BATCH") && l.includes("-") && !l.includes("+"),
+            8000,
+          );
+
+          // Parse PRIVMSG lines from the batch
+          return lines
+            .filter((l) => l.includes("PRIVMSG"))
+            .map((l) => {
+              const match = l.match(/:(\S+)!\S* PRIVMSG (\S+) :(.*)/);
+              if (!match) return null;
+              // Extract server-time tag if present
+              const timeMatch = l.match(/time=(\S+)/);
+              return {
+                nick: match[1],
+                channel: match[2],
+                text: match[3],
+                time: timeMatch ? timeMatch[1] : null,
+              };
+            })
+            .filter(Boolean);
+        });
+        return jsonResponse({ channel: safeChan, messages });
+      } catch (err) {
+        console.error("irc message.history error:", err);
+        return jsonResponse(
+          { error: "Failed to get history — Ergo unreachable" },
+          503,
+        );
+      }
+    }
+
+    default:
+      return jsonResponse(
+        {
+          error: `Unknown message action: ${req.action}. Available: ${MESSAGE_ACTIONS.join(", ")}`,
+        },
+        400,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sanitizeChannel(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("#")) return null;
+  if (trimmed.length > 50) return null;
+  if (/[\s\x00-\x1f\x07,]/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/** Sanitize a message — strip control chars, enforce max length. */
+function sanitizeMessage(input: string): string | null {
+  const cleaned = input.replace(/[\x00-\x1f\x07]/g, "").trim();
+  if (!cleaned || cleaned.length > 480) return null;
+  return cleaned;
+}

--- a/apps/kbve/edge/functions/irc/server.ts
+++ b/apps/kbve/edge/functions/irc/server.ts
@@ -1,0 +1,71 @@
+import { jsonResponse, withIrcConnection } from "./_shared.ts";
+import type { IrcRequest } from "./_shared.ts";
+
+// ---------------------------------------------------------------------------
+// IRC Server — Status & MOTD
+//
+// Actions: status, motd
+// ---------------------------------------------------------------------------
+
+export const SERVER_ACTIONS = ["status", "motd"];
+
+export async function handleServer(req: IrcRequest): Promise<Response> {
+  switch (req.action) {
+    case "status": {
+      try {
+        const info = await withIrcConnection(async (irc) => {
+          await irc.send("LUSERS");
+          const lines = await irc.readUntil(
+            (l) => l.includes(" 266 ") || l.includes(" 252 "),
+          );
+          return lines
+            .filter((l) => / (25[0-9]|26[0-6]) /.test(l))
+            .map((l) => {
+              // Extract the human-readable part after the nick
+              const parts = l.split(" :");
+              return parts.length > 1 ? parts[parts.length - 1] : l;
+            });
+        });
+        return jsonResponse({ status: "connected", info });
+      } catch (err) {
+        console.error("irc server.status error:", err);
+        return jsonResponse(
+          { status: "unreachable", error: "Ergo IRC server is not reachable" },
+          503,
+        );
+      }
+    }
+
+    case "motd": {
+      try {
+        const motd = await withIrcConnection(async (irc) => {
+          await irc.send("MOTD");
+          const lines = await irc.readUntil(
+            (l) => l.includes(" 376 ") || l.includes(" 422 "),
+          );
+          return lines
+            .filter((l) => l.includes(" 372 "))
+            .map((l) => {
+              const parts = l.split(" :");
+              return parts.length > 1 ? parts[parts.length - 1] : l;
+            });
+        });
+        return jsonResponse({ motd });
+      } catch (err) {
+        console.error("irc server.motd error:", err);
+        return jsonResponse(
+          { error: "Failed to retrieve MOTD — Ergo unreachable" },
+          503,
+        );
+      }
+    }
+
+    default:
+      return jsonResponse(
+        {
+          error: `Unknown server action: ${req.action}. Available: ${SERVER_ACTIONS.join(", ")}`,
+        },
+        400,
+      );
+  }
+}

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -94,6 +94,7 @@ serve(async (req: Request) => {
     "vault-reader": [],
     meme: [],
     ows: ["FIRECRACKER_URL"],
+    irc: ["ERGO_IRC_HOST", "ERGO_IRC_PORT"],
     logs: ["CLICKHOUSE_URL", "CLICKHOUSE_USER", "CLICKHOUSE_PASSWORD"],
     health: [],
   };

--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -45,3 +45,8 @@ publish = true
 name = "ows"
 label = "OWS"
 description = "OWS admin operations (unstuck, maintenance, status)"
+
+[[functions]]
+name = "irc"
+label = "IRC"
+description = "IRC admin operations (channels, messages, server status)"


### PR DESCRIPTION
## Summary
- New `irc` edge function providing REST interface to internal Ergo IRC server
- Staff/service_role gated — requires valid JWT with admin or staff permissions
- Connects to `ergo-irc-service.irc.svc.cluster.local:6667` via raw TCP
- Commands: `server.status`, `server.motd`, `channel.list`, `channel.topic`, `channel.names`, `message.send`, `message.history`
- Added `chat.kbve.com` to edge CORS allowlist
- Registered `irc` in `version.toml` function registry and `main/index.ts` env allowlist

## Test plan
- [ ] Deploy edge function and verify `POST /irc` with `{"command": "server.status"}` returns Ergo stats
- [ ] Verify `channel.list` returns available channels
- [ ] Verify `message.send` delivers to `#general`
- [ ] Verify `message.history` returns CHATHISTORY results
- [ ] Confirm non-staff/non-service_role tokens are rejected with 403