### PR TITLE
feat(edge): staff permission gate for argo + shared staff utilities

### DIFF
--- a/apps/kbve/edge-e2e/e2e/argo.spec.ts
+++ b/apps/kbve/edge-e2e/e2e/argo.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { createJwt } from './helpers/jwt';
+
+describe('Argo — Smoke Tests', () => {
+	let serviceToken: string;
+
+	beforeAll(async () => {
+		await waitForReady();
+		serviceToken = createJwt({ role: 'service_role' });
+	});
+
+	const headers = () => ({
+		'Content-Type': 'application/json',
+		Authorization: `Bearer ${serviceToken}`,
+	});
+
+	// -- CORS --
+
+	it('should return 200 for OPTIONS preflight without JWT', async () => {
+		const res = await fetch(`${BASE_URL}/argo`, { method: 'OPTIONS' });
+		expect(res.status).toBe(200);
+		expect(res.headers.get('access-control-allow-origin')).toBe('*');
+	});
+
+	// -- Method --
+
+	it('should return 405 for GET requests', async () => {
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${serviceToken}` },
+		});
+		expect(res.status).toBe(405);
+		const body = await res.json();
+		expect(body.error).toContain('Only POST method is allowed');
+	});
+
+	// -- Auth --
+
+	it('should return 401 when no auth header is provided', async () => {
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ command: 'health' }),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it('should return 403 for anon role (staff gate)', async () => {
+		const anonToken = createJwt({ role: 'anon' });
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${anonToken}`,
+			},
+			body: JSON.stringify({ command: 'health' }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('should return 403 for authenticated role (staff gate)', async () => {
+		const authToken = createJwt({ role: 'authenticated' });
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${authToken}`,
+			},
+			body: JSON.stringify({ command: 'health' }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	// -- Service role reaches argo (503 = no ArgoCD upstream configured in e2e) --
+
+	it('should allow service_role past staff gate and reach argo', async () => {
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({ command: 'health' }),
+		});
+		// 503 means argo booted but ARGOCD_UPSTREAM_URL is not set — auth passed
+		expect(res.status).toBe(503);
+		const body = await res.json();
+		expect(body.error).toContain('Service unavailable');
+	});
+
+	it('should return 503 for applications command (no upstream)', async () => {
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({ command: 'applications' }),
+		});
+		expect(res.status).toBe(503);
+	});
+
+	it('should return 503 for app-status command (no upstream)', async () => {
+		const res = await fetch(`${BASE_URL}/argo`, {
+			method: 'POST',
+			headers: headers(),
+			body: JSON.stringify({ command: 'app-status', name: 'test-app' }),
+		});
+		expect(res.status).toBe(503);
+	});
+});

--- a/apps/kbve/edge/functions/_shared/supabase.ts
+++ b/apps/kbve/edge/functions/_shared/supabase.ts
@@ -71,3 +71,54 @@ export function requireServiceRole(claims: JwtClaims): Response | null {
   }
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// Staff permission helpers
+//
+// Mirrors the bitwise permission system in staff.members.permissions.
+// Uses the public.staff_permissions() RPC to resolve the caller's bitmask.
+// ---------------------------------------------------------------------------
+
+export const staffPerm = {
+  STAFF: 0x0000_0001,
+  MODERATOR: 0x0000_0002,
+  ADMIN: 0x0000_0004,
+  DASHBOARD_VIEW: 0x0000_0100,
+  DASHBOARD_MANAGE: 0x0000_0200,
+  SUPERADMIN: 0x4000_0000,
+} as const;
+
+/**
+ * Call public.staff_permissions() RPC as the given user.
+ * Returns the integer permission bitmask (0 = not staff).
+ */
+export async function checkStaffPermissions(
+  token: string,
+): Promise<number> {
+  const client = createUserClient(token);
+  const { data, error } = await client.rpc("staff_permissions");
+  if (error) {
+    console.error("staff_permissions RPC error:", error.message);
+    return 0;
+  }
+  return typeof data === "number" ? data : 0;
+}
+
+/**
+ * Guard: allow service_role OR any user with staff permissions > 0.
+ * Returns a 403 Response if denied, null if allowed.
+ */
+export async function requireStaffOrServiceRole(
+  token: string,
+  claims: JwtClaims,
+): Promise<Response | null> {
+  if (claims.role === "service_role") return null;
+
+  const permissions = await checkStaffPermissions(token);
+  if (permissions > 0) return null;
+
+  return jsonResponse(
+    { error: "Access denied: staff or service_role required" },
+    403,
+  );
+}

--- a/apps/kbve/edge/functions/argo/index.ts
+++ b/apps/kbve/edge/functions/argo/index.ts
@@ -5,13 +5,13 @@ import {
   extractToken,
   jsonResponse,
   parseJwt,
-  requireServiceRole,
+  requireStaffOrServiceRole,
 } from "../_shared/supabase.ts";
 
 // ---------------------------------------------------------------------------
 // Argo Edge Function — Proxy to ArgoCD API with diagnostics
 //
-// Auth: service_role only
+// Auth: service_role OR staff (permissions > 0)
 //
 // POST /argo  { command, ...params }
 //   applications  — list all ArgoCD applications
@@ -134,7 +134,7 @@ serve(async (req) => {
     const token = extractToken(req);
     const claims = await parseJwt(token);
 
-    const denied = requireServiceRole(claims);
+    const denied = await requireStaffOrServiceRole(token, claims);
     if (denied) return denied;
 
     const sizeErr = enforceBodySizeLimit(req);

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -6,7 +6,10 @@ console.log("main function started");
 
 const JWT_SECRET = Deno.env.get("JWT_SECRET");
 const VERIFY_JWT = Deno.env.get("VERIFY_JWT") === "true";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const PUBLIC_ROUTES = new Set(["health"]);
+const STAFF_ROUTES = new Set(["argo"]);
 
 function getAuthToken(req: Request) {
   const authHeader = req.headers.get("authorization");
@@ -67,6 +70,53 @@ serve(async (req: Request) => {
       status: 400,
       headers: { "Content-Type": "application/json" },
     });
+  }
+
+  // Staff-only routes: block non-staff, non-service_role before worker boot.
+  if (STAFF_ROUTES.has(service_name) && req.method !== "OPTIONS") {
+    try {
+      const token = getAuthToken(req);
+      // Decode payload (already signature-verified above) to read role.
+      const payloadB64 = token.split(".")[1];
+      const payload = JSON.parse(atob(payloadB64));
+
+      if (payload.role !== "service_role") {
+        // Check staff via public.staff_permissions() RPC as the user.
+        const rpcRes = await fetch(
+          `${SUPABASE_URL}/rest/v1/rpc/staff_permissions`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              apikey: SUPABASE_ANON_KEY,
+              Authorization: `Bearer ${token}`,
+            },
+            body: "{}",
+          },
+        );
+        const permissions = rpcRes.ok ? await rpcRes.json() : 0;
+        if (typeof permissions !== "number" || permissions <= 0) {
+          return new Response(
+            JSON.stringify({
+              msg: "Access denied: staff or service_role required",
+            }),
+            {
+              status: 403,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+      }
+    } catch (e) {
+      console.error("Staff gate error:", e);
+      return new Response(
+        JSON.stringify({ msg: "Access denied" }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
   }
 
   const servicePath = `/home/deno/functions/${service_name}`;


### PR DESCRIPTION
## Summary
- Add `STAFF_ROUTES` gate to main router — blocks non-staff, non-service_role users with 403 before worker boot via `public.staff_permissions()` RPC
- Add shared `checkStaffPermissions()` and `requireStaffOrServiceRole()` helpers to `_shared/supabase.ts` (reusable by any function needing staff auth)
- Add `staffPerm` bit constants mirroring the Rust `staff_perm` module
- Update argo auth from `requireServiceRole` → `requireStaffOrServiceRole` (service_role OR staff)
- Add 8 argo e2e smoke tests (CORS, method, auth gates, 503 no-upstream)

## Test plan
- [x] Built edge container locally, ran full e2e suite: 13 files, 116 tests passing
- [x] Verified anon/authenticated roles get 403 on `/argo`
- [x] Verified service_role passes staff gate and reaches argo (503 = no upstream)