### PR TITLE
fix(firecracker-ctl): add CARGO_INCREMENTAL=0 to planner stage

### DIFF
--- a/apps/vm/firecracker-ctl/Dockerfile
+++ b/apps/vm/firecracker-ctl/Dockerfile
@@ -10,6 +10,7 @@
 # [STAGE A] - Cargo Chef Planner
 # ============================================================================
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
+ENV CARGO_INCREMENTAL=0
 
 COPY apps/vm/firecracker-ctl/Cargo.workspace.toml Cargo.toml
 COPY apps/vm/firecracker-ctl/Cargo.toml apps/vm/firecracker-ctl/Cargo.toml
@@ -17,8 +18,7 @@ COPY apps/vm/firecracker-ctl/Cargo.toml apps/vm/firecracker-ctl/Cargo.toml
 RUN mkdir -p apps/vm/firecracker-ctl/src && \
     echo "fn main() {}" > apps/vm/firecracker-ctl/src/main.rs
 
-RUN --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo chef prepare --recipe-path recipe.json
+RUN cargo chef prepare --recipe-path recipe.json
 
 # ============================================================================
 # [STAGE B] - Cargo Chef Cook (Cache Dependencies)


### PR DESCRIPTION
## Summary
Add `ENV CARGO_INCREMENTAL=0` to the planner stage and remove the unnecessary sccache mount from `cargo chef prepare`.

## Root cause
The chisel builder image has `RUSTC_WRAPPER=sccache` baked in. sccache refuses to run when `CARGO_INCREMENTAL` is set (error: `sccache: incremental compilation is prohibited`). The planner stage was missing `ENV CARGO_INCREMENTAL=0` and had a sccache cache mount that activated sccache during `cargo chef prepare`. Other Axum Dockerfiles (discordsh, memes, etc.) don't mount sccache on the planner — `cargo chef prepare` only reads metadata, no compilation needed.

Fixes #9578

## Test plan
- [ ] CI Docker build passes for firecracker-ctl