### PR TITLE
fix(bevy_kbve_net): enable getrandom js feature for WASM target

### DIFF
--- a/packages/rust/bevy/bevy_kbve_net/Cargo.toml
+++ b/packages/rust/bevy/bevy_kbve_net/Cargo.toml
@@ -28,7 +28,9 @@ lightyear_aeronet = { version = "0.26", optional = true }
 bytes = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["WebSocket", "BinaryType", "MessageEvent", "CloseEvent", "Event"] }
 js-sys = "0.3"


### PR DESCRIPTION
## Summary
- Add `getrandom = { version = "0.2", features = ["js"] }` to WASM target dependencies
- Fixes `check-wasm` CI failure caused by `getrandom` requiring explicit `js` feature on `wasm32-unknown-unknown`

Closes #9582

## Test plan
- [ ] CI `check-wasm` target passes for `bevy_kbve_net`