### PR TITLE
fix(docker): ensure make available for tikv-jemalloc-sys compilation

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -121,6 +121,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 COPY --from=astro-precompressor /static /app/apps/cryptothrone/axum-cryptothrone/templates/dist
 
 COPY packages/data/proto packages/data/proto

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -128,6 +128,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 # Astro build output (precompressed) -> placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/discordsh/axum-discordsh/templates/dist
 

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -82,6 +82,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 # Foundation crate source (cargo needs source to verify fingerprints)
 COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -120,6 +120,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 COPY --from=astro-precompressor /static /app/apps/herbmail/axum-herbmail/templates/dist
 
 COPY packages/data/proto packages/data/proto

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -120,6 +120,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 COPY --from=astro-precompressor /static /app/apps/irc/irc-gateway/templates/dist
 
 COPY packages/data/proto packages/data/proto

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -141,6 +141,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 # Astro build output (precompressed) -> placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/kbve/axum-kbve/templates/dist
 

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -126,6 +126,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 # Astro build output (precompressed) -> placed into templates/dist
 COPY --from=astro-precompressor /static /app/apps/memes/axum-memes/templates/dist
 

--- a/apps/ows/rows/Dockerfile
+++ b/apps/ows/rows/Dockerfile
@@ -48,6 +48,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ── Stage 3: Build — compile only our source ────────────────
 FROM cook AS builder
 
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
+RUN dpkg -s make >/dev/null 2>&1 || \
+    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+
 COPY packages/rust/jedi/ packages/rust/jedi/
 COPY packages/rust/kbve/ packages/rust/kbve/
 COPY apps/ows/rows/src/ apps/ows/rows/src/


### PR DESCRIPTION
## Summary
- The `chisel-ubuntu-axum:24.04-builder` image on GHCR is missing `make` despite being updated in #9579, causing `tikv-jemalloc-sys` build.rs to panic with `ENOENT` when compiling jemalloc from source
- Adds a defensive `dpkg -s make` check + conditional `apt-get install make` in the builder stage of all 8 Dockerfiles that use `--features jemalloc`
- The guard is a no-op once the base builder image is republished with `make` included

## Affected Dockerfiles
- `apps/discordsh/axum-discordsh/Dockerfile`
- `apps/discordsh/discordsh-bot/Dockerfile`
- `apps/kbve/axum-kbve/Dockerfile`
- `apps/memes/axum-memes/Dockerfile`
- `apps/irc/irc-gateway/Dockerfile`
- `apps/herbmail/axum-herbmail/Dockerfile`
- `apps/cryptothrone/axum-cryptothrone/Dockerfile`
- `apps/ows/rows/Dockerfile`

Closes #9596

## Test plan
- [ ] CI Docker test for discordsh passes (jemalloc compiles successfully)
- [ ] Other Docker builds with jemalloc feature are unaffected