### PR TITLE
fix(discordsh-bot): use markdown links for source in embeds

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/branding.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/branding.rs
@@ -12,13 +12,13 @@ pub const PROJECT_URL: &str = "https://kbve.com/project/discordsh-bot/";
 /// Source repository tree URL.
 pub const SOURCE_URL: &str = "https://github.com/KBVE/kbve/tree/main/apps/discordsh/discordsh-bot";
 
-/// Build the standard footer text: `discordsh-bot v0.1.2`
+/// Build the standard footer text: `discordsh-bot v0.1.3`
 pub fn footer_text() -> String {
     format!("{BOT_NAME} v{BOT_VERSION}")
 }
 
-/// Build a source-linked footer for a specific module: `discordsh-bot v0.1.2 • source`
-/// The `module` is a relative path within the bot source (e.g. `src/discord/commands/health.rs`).
-pub fn footer_with_source(module: &str) -> String {
-    format!("{BOT_NAME} v{BOT_VERSION} • {SOURCE_URL}/{module}")
+/// Build a Discord markdown link to the source file for a specific module.
+/// Returns `[source](https://github.com/...)` — usable in embed descriptions/fields.
+pub fn source_link(module: &str) -> String {
+    format!("[source]({SOURCE_URL}/{module})")
 }

--- a/apps/discordsh/discordsh-bot/src/discord/commands/health.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/health.rs
@@ -49,9 +49,12 @@ pub async fn health(ctx: Context<'_>) -> Result<(), Error> {
         .field("Threads", snap.thread_count.to_string(), true)
         .field("PID", snap.pid.to_string(), true)
         .field("Uptime", &snap.uptime_formatted, true)
-        .footer(serenity::CreateEmbedFooter::new(
-            branding::footer_with_source("src/discord/commands/health.rs"),
-        ))
+        .field(
+            "",
+            branding::source_link("src/discord/commands/health.rs"),
+            false,
+        )
+        .footer(serenity::CreateEmbedFooter::new(branding::footer_text()))
         .timestamp(serenity::Timestamp::now());
 
     let reply = poise::CreateReply::default().embed(embed);

--- a/apps/discordsh/discordsh-bot/src/discord/embeds/status_embed.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/embeds/status_embed.rs
@@ -93,9 +93,12 @@ pub fn build_status_embed(snap: &StatusSnapshot) -> serenity::CreateEmbed {
     }
 
     embed
-        .footer(serenity::CreateEmbedFooter::new(
-            branding::footer_with_source("src/discord/embeds/status_embed.rs"),
-        ))
+        .field(
+            "",
+            branding::source_link("src/discord/embeds/status_embed.rs"),
+            false,
+        )
+        .footer(serenity::CreateEmbedFooter::new(branding::footer_text()))
         .timestamp(serenity::Timestamp::now())
 }
 


### PR DESCRIPTION
## Summary
- Discord embed footers don't support markdown — URLs were rendering as raw text
- Move source links from footer to embed fields using `[source](url)` markdown
- Footer now shows clean `discordsh-bot v0.1.3` only
- Replace `footer_with_source()` with `source_link()` in branding module

## Test plan
- [x] `cargo check -p discordsh-bot` passes
- [ ] After deploy, `/health` and `/status` show clickable source links