### PR TITLE
feat(isometric): sprite sheet instancing foundation (storage buffer + MeshTag)

### DIFF
--- a/apps/kbve/isometric/src-tauri/assets/shaders/sprite_sheet.wgsl
+++ b/apps/kbve/isometric/src-tauri/assets/shaders/sprite_sheet.wgsl
@@ -1,0 +1,84 @@
+//! Sprite sheet shader using automatic instancing + storage buffer.
+//!
+//! Combines Bevy 0.18's automatic_instancing and storage_buffer examples:
+//! - Atlas texture via Material bind group (#{MATERIAL_BIND_GROUP})
+//! - Per-instance sprite data via storage buffer, indexed by MeshTag
+//! - One draw call per creature type (all frogs, all wraiths, etc.)
+//!
+//! SpriteData layout per instance:
+//!   [0] = vec4(frame_col, frame_row, sheet_cols, sheet_rows)
+//!   [1] = vec4(flip, alpha_cutoff, 0, 0)
+//!   [2] = vec4(tint_r, tint_g, tint_b, tint_a)
+
+#import bevy_pbr::{
+    mesh_functions,
+    view_transformations::position_world_to_clip
+}
+
+// Per-instance sprite data: 3 vec4s per sprite, packed into flat array
+// Index = MeshTag * 3
+@group(#{MATERIAL_BIND_GROUP}) @binding(0) var<storage, read> sprite_data: array<vec4<f32>>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(1) var sprite_texture: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(2) var sprite_sampler: sampler;
+
+struct Vertex {
+    @builtin(instance_index) instance_index: u32,
+    @location(0) position: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) tint: vec4<f32>,
+    @location(2) alpha_cutoff: f32,
+};
+
+@vertex
+fn vertex(vertex: Vertex) -> VertexOutput {
+    var out: VertexOutput;
+
+    let tag = mesh_functions::get_tag(vertex.instance_index);
+    var world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
+    let world_position = mesh_functions::mesh_position_local_to_world(
+        world_from_local,
+        vec4(vertex.position, 1.0),
+    );
+    out.clip_position = position_world_to_clip(world_position.xyz);
+
+    // Read per-instance data from storage buffer
+    let base = tag * 3u;
+    let frame_data = sprite_data[base];      // frame_col, frame_row, sheet_cols, sheet_rows
+    let extra_data = sprite_data[base + 1u]; // flip, alpha_cutoff, 0, 0
+    let tint_data = sprite_data[base + 2u];  // tint RGBA
+
+    // Compute atlas UVs
+    let frame_w = 1.0 / frame_data.z;
+    let frame_h = 1.0 / frame_data.w;
+
+    var u = vertex.uv.x;
+    if (extra_data.x > 0.5) {
+        u = 1.0 - u;
+    }
+
+    out.uv = vec2(
+        frame_data.x * frame_w + u * frame_w,
+        frame_data.y * frame_h + vertex.uv.y * frame_h,
+    );
+    out.tint = tint_data;
+    out.alpha_cutoff = extra_data.y;
+
+    return out;
+}
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    let tex = textureSample(sprite_texture, sprite_sampler, in.uv);
+    let color = tex * in.tint;
+
+    if (color.a < in.alpha_cutoff) {
+        discard;
+    }
+
+    return color;
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -3,6 +3,7 @@ pub mod common;
 pub mod creature;
 mod firefly;
 mod frog;
+pub mod sprite_material;
 mod wraith;
 
 use bevy::prelude::*;
@@ -56,6 +57,9 @@ pub struct CreaturesPlugin;
 
 impl Plugin for CreaturesPlugin {
     fn build(&self, app: &mut App) {
+        // Sprite sheet material plugin (automatic instancing + storage buffer)
+        app.add_plugins(MaterialPlugin::<sprite_material::SpriteSheetMaterial>::default());
+
         // --- Unified NpcDb-driven registry ---
         app.add_systems(Startup, setup_creature_registry);
 

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/sprite_material.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/sprite_material.rs
@@ -1,0 +1,120 @@
+//! Sprite sheet material using automatic instancing + storage buffer.
+//!
+//! Follows Bevy 0.18's automatic_instancing + storage_buffer examples:
+//! - All creatures of the same type share ONE material handle + ONE mesh handle
+//! - Per-instance data (frame, flip, tint) stored in a ShaderStorageBuffer
+//! - MeshTag on each entity indexes into the storage buffer
+//! - Bevy auto-instances all entities with the same mesh+material into one draw call
+//!
+//! Adding a new creature type = new material with its atlas texture + storage buffer.
+
+use bevy::mesh::MeshTag;
+use bevy::prelude::*;
+use bevy::render::render_resource::AsBindGroup;
+use bevy::render::storage::ShaderStorageBuffer;
+use bevy::shader::ShaderRef;
+
+const SHADER_PATH: &str = "shaders/sprite_sheet.wgsl";
+
+/// Per-instance sprite data: 3 vec4s packed into the storage buffer.
+/// Index = MeshTag * 3.
+///
+/// [0] = (frame_col, frame_row, sheet_cols, sheet_rows)
+/// [1] = (flip, alpha_cutoff, 0, 0)
+/// [2] = (tint_r, tint_g, tint_b, tint_a)
+#[derive(Clone, Copy, Debug)]
+pub struct SpriteInstanceData {
+    pub frame_col: f32,
+    pub frame_row: f32,
+    pub sheet_cols: f32,
+    pub sheet_rows: f32,
+    pub flip: f32,
+    pub alpha_cutoff: f32,
+    pub tint: [f32; 4],
+}
+
+impl Default for SpriteInstanceData {
+    fn default() -> Self {
+        Self {
+            frame_col: 0.0,
+            frame_row: 0.0,
+            sheet_cols: 1.0,
+            sheet_rows: 1.0,
+            flip: 0.0,
+            alpha_cutoff: 0.5,
+            tint: [1.0, 1.0, 1.0, 1.0],
+        }
+    }
+}
+
+impl SpriteInstanceData {
+    /// Pack into 3 vec4s (12 floats) for the storage buffer.
+    pub fn to_floats(&self) -> [[f32; 4]; 3] {
+        [
+            [
+                self.frame_col,
+                self.frame_row,
+                self.sheet_cols,
+                self.sheet_rows,
+            ],
+            [self.flip, self.alpha_cutoff, 0.0, 0.0],
+            self.tint,
+        ]
+    }
+}
+
+/// Custom material for sprite-sheet creatures.
+/// Uses storage buffer for per-instance data (indexed by MeshTag).
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct SpriteSheetMaterial {
+    #[storage(0, read_only)]
+    pub instance_data: Handle<ShaderStorageBuffer>,
+    #[texture(1)]
+    #[sampler(2)]
+    pub texture: Handle<Image>,
+}
+
+impl Material for SpriteSheetMaterial {
+    fn vertex_shader() -> ShaderRef {
+        SHADER_PATH.into()
+    }
+
+    fn fragment_shader() -> ShaderRef {
+        SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode {
+        AlphaMode::Mask(0.5)
+    }
+}
+
+/// Resource holding the shared material + storage buffer for a creature type.
+/// Each creature type (frog, wraith, etc.) gets one of these.
+#[derive(Resource)]
+pub struct SpriteTypeResources {
+    pub material: Handle<SpriteSheetMaterial>,
+    pub storage_buffer: Handle<ShaderStorageBuffer>,
+    pub mesh: Handle<Mesh>,
+    /// Current instance data — updated each frame, then flushed to the storage buffer.
+    pub instances: Vec<SpriteInstanceData>,
+}
+
+/// Component on each sprite creature entity linking it to its slot in the
+/// storage buffer. The MeshTag value matches this index.
+#[derive(Component)]
+pub struct SpriteSlot {
+    pub index: u32,
+}
+
+/// Flush updated instance data to the GPU storage buffer.
+/// Call this once per frame after animation systems update `instances`.
+pub fn flush_sprite_buffer(res: &SpriteTypeResources, buffers: &mut Assets<ShaderStorageBuffer>) {
+    if let Some(buffer) = buffers.get_mut(&res.storage_buffer) {
+        let data: Vec<[f32; 4]> = res
+            .instances
+            .iter()
+            .flat_map(|inst| inst.to_floats())
+            .collect();
+        buffer.set_data(data);
+    }
+}


### PR DESCRIPTION
## Summary
- New `SpriteSheetMaterial` using Bevy 0.18's `automatic_instancing` + `storage_buffer` example patterns
- `#[storage(0, read_only)]` for per-instance data indexed by `MeshTag`
- `#{MATERIAL_BIND_GROUP}` in WGSL — no hardcoded bind group numbers
- `mesh_functions::get_tag()` + `get_world_from_local()` + `position_world_to_clip()` — exactly matching official examples
- `SpriteTypeResources` + `SpriteInstanceData` + `flush_sprite_buffer()` for per-creature-type batching
- `MaterialPlugin::<SpriteSheetMaterial>` registered in `CreaturesPlugin`

## Architecture
- One draw call per creature type (all frogs share mesh+material, all wraiths share mesh+material)
- Per-instance frame/flip/tint data stored in `ShaderStorageBuffer`, indexed by `MeshTag`
- Foundation only — frog/wraith systems not yet converted to use this

## References
- https://bevy.org/examples-webgpu/shaders/automatic-instancing/
- https://bevy.org/examples-webgpu/shaders/storage-buffer/

## Test plan
- [ ] Foundation compiles on native and WASM
- [ ] Next PR: wire frog + wraith spawn/animate to use SpriteSheetMaterial