### PR TITLE
refactor(firecracker): dedicated namespace with privileged PodSecurity

### DIFF
--- a/apps/kube/firecracker/application.yaml
+++ b/apps/kube/firecracker/application.yaml
@@ -14,12 +14,12 @@ spec:
         kustomize: {}
     destination:
         server: https://kubernetes.default.svc
-        namespace: kilobase
+        namespace: firecracker
     syncPolicy:
         automated:
             prune: true
             selfHeal: false
         syncOptions:
-            - CreateNamespace=false
+            - CreateNamespace=true
             - ServerSideApply=true
             - RespectIgnoreDifferences=true

--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
     name: firecracker-ctl
-    namespace: kilobase
+    namespace: firecracker
     labels:
         app: firecracker-ctl
 spec:
@@ -33,6 +33,9 @@ spec:
                           cpu: '2'
                           memory: 2Gi
                           devices.kubevirt.io/kvm: '1'
+                  securityContext:
+                      capabilities:
+                          add: ['NET_ADMIN']
                   volumeMounts:
                       - name: rootfs-cache
                         mountPath: /var/lib/firecracker/rootfs

--- a/apps/kube/firecracker/manifests/firecracker-keda.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-keda.yaml
@@ -2,7 +2,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
     name: firecracker-ctl-scaler
-    namespace: kilobase
+    namespace: firecracker
 spec:
     scaleTargetRef:
         name: firecracker-ctl

--- a/apps/kube/firecracker/manifests/firecracker-namespace.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: firecracker
+    labels:
+        app: firecracker
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/audit: privileged
+        pod-security.kubernetes.io/warn: privileged

--- a/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
     name: firecracker-ctl-ingress
-    namespace: kilobase
+    namespace: firecracker
 spec:
     podSelector:
         matchLabels:
@@ -11,7 +11,10 @@ spec:
         - Ingress
     ingress:
         - from:
-              - podSelector:
+              - namespaceSelector:
+                    matchLabels:
+                        app: kilobase
+                podSelector:
                     matchLabels:
                         app: functions
           ports:

--- a/apps/kube/firecracker/manifests/firecracker-pvc.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
     name: firecracker-rootfs
-    namespace: kilobase
+    namespace: firecracker
     labels:
         app: firecracker-ctl
 spec:

--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
     name: firecracker-rootfs-init
-    namespace: kilobase
+    namespace: firecracker
     labels:
         app: firecracker-ctl
     annotations:

--- a/apps/kube/firecracker/manifests/firecracker-service.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
     name: firecracker-ctl
-    namespace: kilobase
+    namespace: firecracker
     labels:
         app: firecracker-ctl
 spec:

--- a/apps/kube/functions/manifests/functions-deployment.yaml
+++ b/apps/kube/functions/manifests/functions-deployment.yaml
@@ -60,7 +60,7 @@ spec:
                       - name: VERIFY_JWT
                         value: 'true'
                       - name: FIRECRACKER_URL
-                        value: 'http://firecracker-ctl:9001'
+                        value: 'http://firecracker-ctl.firecracker.svc.cluster.local:9001'
                       - name: CLICKHOUSE_ENDPOINT
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## Summary
Move firecracker-ctl from `kilobase` namespace to a dedicated `firecracker` namespace with `privileged` PodSecurity enforcement.

## Changes
- New `firecracker` namespace with `pod-security.kubernetes.io/enforce: privileged`
- All manifests migrated from `kilobase` → `firecracker` namespace
- ArgoCD app destination updated with `CreateNamespace=true`
- `NET_ADMIN` capability restored (allowed in privileged namespace, needed for future TAP networking)
- NetworkPolicy updated for cross-namespace ingress from `kilobase` namespace (`app: functions` pods)
- `FIRECRACKER_URL` in functions deployment updated to FQDN: `http://firecracker-ctl.firecracker.svc.cluster.local:9001`

## Why
`kilobase` enforces PodSecurity `baseline` which blocks `NET_ADMIN` and `devices.kubevirt.io/kvm`. Firecracker needs privileged access for KVM and will need NET_ADMIN for TAP networking. Dedicated namespace provides proper isolation and security boundary.

## Test plan
- [ ] ArgoCD creates `firecracker` namespace and syncs all resources
- [ ] Pod creation no longer blocked by PodSecurity
- [ ] Edge functions can reach firecracker-ctl via FQDN
- [ ] NetworkPolicy allows ingress only from kilobase/functions pods