### PR TITLE
fix(ci): free disk space before Docker builds

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -44,6 +44,17 @@ jobs:
             packages: write
 
         steps:
+            - name: Free disk space
+              uses: jlumbroso/free-disk-space@main
+              with:
+                  tool-cache: false
+                  android: true
+                  dotnet: true
+                  haskell: true
+                  large-packages: false
+                  swap-storage: false
+                  docker-images: true
+
             - name: Checkout the monorepo
               uses: actions/checkout@v6
               continue-on-error: true

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -51,6 +51,17 @@ jobs:
             packages: write
 
         steps:
+            - name: Free disk space
+              uses: jlumbroso/free-disk-space@main
+              with:
+                  tool-cache: false
+                  android: true
+                  dotnet: true
+                  haskell: true
+                  large-packages: false
+                  swap-storage: false
+                  docker-images: true
+
             - name: Checkout Repository
               uses: actions/checkout@v6
               continue-on-error: true


### PR DESCRIPTION
## Summary
- Add `jlumbroso/free-disk-space` action to `docker-test-app.yml` and `utils-publish-docker-image.yml`
- Removes Android SDK, .NET, Haskell toolchains, and pre-pulled Docker images (~10-15GB freed)
- Fixes `No space left on device` errors during Docker builds on `ubuntu-latest`

## Test plan
- [ ] CI Docker builds pass without disk space errors
- [ ] Build times not significantly impacted (cleanup takes ~30s)