### PR TITLE
feat(isometric): wire wraith to sprite instancing pipeline

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -15,7 +15,7 @@ pub use creature::{
     RenderKind, TimeSchedule,
 };
 pub use frog::FrogSpriteResources;
-pub use wraith::WraithMaterials;
+pub use wraith::WraithSpriteResources;
 
 /// Build creature meshes once at Startup to avoid allocating during spawn.
 fn setup_creature_meshes(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
@@ -67,7 +67,7 @@ impl Plugin for CreaturesPlugin {
         app.init_resource::<CreaturePool>();
         app.init_resource::<common::GameTime>();
         app.init_resource::<FrogSpriteResources>();
-        app.init_resource::<WraithMaterials>();
+        app.init_resource::<WraithSpriteResources>();
         app.init_resource::<firefly::FireflyState>();
         app.add_systems(Startup, setup_creature_meshes);
 

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/wraith/mod.rs
@@ -16,13 +16,17 @@
 //! https://darkpixel-kronovi.itch.io/undead-executioner
 
 use bevy::asset::RenderAssetUsages;
-use bevy::mesh::{Indices, PrimitiveTopology};
+use bevy::mesh::{Indices, MeshTag, PrimitiveTopology};
 use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
 
-use super::common::{CreaturePool, GameTime, hash_f32, scene_center};
+use super::common::{CreaturePool, GameTime, day_factor, hash_f32, scene_center};
 use super::creature::{
     Creature, CreaturePoolIndex, CreatureRegistry, CreatureState, RenderKind, SpriteData,
     SpriteHopState,
+};
+use super::sprite_material::{
+    SpriteInstanceData, SpriteSheetMaterial, SpriteTypeResources, flush_sprite_buffer,
 };
 use crate::game::camera::IsometricCamera;
 use crate::game::terrain::TerrainMap;
@@ -96,9 +100,18 @@ const ANIM_SUMMON: Anim = Anim {
 // WraithMaterials — exposed for day/night tinting in weather.rs
 // ---------------------------------------------------------------------------
 
-#[derive(Resource, Default)]
-pub struct WraithMaterials {
-    pub handles: Vec<Handle<StandardMaterial>>,
+#[derive(Resource)]
+pub struct WraithSpriteResources(pub SpriteTypeResources);
+
+impl Default for WraithSpriteResources {
+    fn default() -> Self {
+        Self(SpriteTypeResources {
+            material: Handle::default(),
+            storage_buffer: Handle::default(),
+            mesh: Handle::default(),
+            instances: Vec::new(),
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -124,12 +137,7 @@ fn build_wraith_quad() -> Mesh {
     .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, vec![[0.0, 0.0, 1.0]; 4])
     .with_inserted_attribute(
         Mesh::ATTRIBUTE_UV_0,
-        vec![
-            [0.0, 0.0],
-            [FRAME_W, 0.0],
-            [FRAME_W, FRAME_H],
-            [0.0, FRAME_H],
-        ],
+        vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
     )
     .with_inserted_indices(Indices::U32(vec![0, 2, 1, 0, 3, 2]))
 }
@@ -155,10 +163,11 @@ fn frame_uvs(anim: &Anim, frame: u32, flip: bool) -> [[f32; 2]; 4] {
 pub(super) fn spawn_wraiths(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut sprite_materials: ResMut<Assets<SpriteSheetMaterial>>,
+    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
     asset_server: Res<AssetServer>,
     mut pool: ResMut<CreaturePool>,
-    mut wraith_mats: ResMut<WraithMaterials>,
+    mut wraith_res: ResMut<WraithSpriteResources>,
     registry: Res<CreatureRegistry>,
 ) {
     if pool.wraiths_spawned {
@@ -180,19 +189,34 @@ pub(super) fn spawn_wraiths(
         asset_server.load("textures/creatures/wraith/wraith_executioner.png");
     let wraith_mesh = meshes.add(build_wraith_quad());
 
+    // Pre-fill instance data
+    let instances: Vec<SpriteInstanceData> = (0..count)
+        .map(|_| SpriteInstanceData {
+            sheet_cols: SHEET_COLS as f32,
+            sheet_rows: SHEET_ROWS as f32,
+            alpha_cutoff: 0.1, // wraiths use blend, low cutoff
+            ..Default::default()
+        })
+        .collect();
+
+    let initial_data: Vec<[f32; 4]> = instances.iter().flat_map(|inst| inst.to_floats()).collect();
+    let storage_handle = buffers.add(ShaderStorageBuffer::from(initial_data));
+
+    let material_handle = sprite_materials.add(SpriteSheetMaterial {
+        instance_data: storage_handle.clone(),
+        texture,
+    });
+
+    wraith_res.0 = SpriteTypeResources {
+        material: material_handle.clone(),
+        storage_buffer: storage_handle,
+        mesh: wraith_mesh.clone(),
+        instances,
+    };
+
     for i in 0..count {
         let seed = (i as u32).wrapping_add(7700);
         let phase = hash_f32(seed * 11 + 1);
-
-        let mat = materials.add(StandardMaterial {
-            base_color_texture: Some(texture.clone()),
-            alpha_mode: AlphaMode::Blend,
-            cull_mode: None,
-            double_sided: true,
-            unlit: true,
-            ..default()
-        });
-        wraith_mats.handles.push(mat.clone());
 
         let idle_timer = IDLE_MIN + hash_f32(seed * 53 + 11) * (IDLE_MAX - IDLE_MIN);
         let frame_duration = FRAME_DURATION_BASE * (0.8 + hash_f32(seed * 79 + 17) * 0.4);
@@ -200,7 +224,8 @@ pub(super) fn spawn_wraiths(
 
         commands.spawn((
             Mesh3d(wraith_mesh.clone()),
-            MeshMaterial3d(mat.clone()),
+            MeshMaterial3d(material_handle.clone()),
+            MeshTag(i as u32),
             Transform::from_xyz(0.0, -100.0, 0.0),
             Visibility::Hidden,
             Creature {
@@ -211,7 +236,7 @@ pub(super) fn spawn_wraiths(
                 assigned_slot: None,
                 anchor: Vec3::new(0.0, -100.0, 0.0),
                 phase,
-                mat_handle: mat,
+                mat_handle: Handle::default(),
             },
             SpriteData {
                 frame_timer: hash_f32(seed * 83 + 13) * frame_duration,
@@ -229,7 +254,7 @@ pub(super) fn spawn_wraiths(
         ));
     }
 
-    info!("[wraith] spawned {count} entities");
+    info!("[wraith] spawned {count} entities (instanced)");
 }
 
 /// Wraith-specific component: marker + deterministic patrol counter.
@@ -255,14 +280,15 @@ pub(super) fn animate_wraiths(
     game_time: Res<GameTime>,
     mut terrain: ResMut<TerrainMap>,
     camera_q: Query<&Transform, With<IsometricCamera>>,
-    mut meshes: ResMut<Assets<Mesh>>,
+    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+    mut wraith_res: ResMut<WraithSpriteResources>,
     mut wraith_q: Query<
         (
             &mut Transform,
             &mut Creature,
             &mut SpriteData,
             &mut Visibility,
-            &Mesh3d,
+            &CreaturePoolIndex,
             &mut WraithMarker,
         ),
         Without<IsometricCamera>,
@@ -278,7 +304,7 @@ pub(super) fn animate_wraiths(
     let cam_pos = cam_tf.translation;
     let center = scene_center(cam_pos);
 
-    for (mut tf, mut cr, mut sd, mut vis, mesh_handle, mut wm) in &mut wraith_q {
+    for (mut tf, mut cr, mut sd, mut vis, pool_idx, mut wm) in &mut wraith_q {
         // Relocate if too far or below world
         let dist = Vec2::new(cr.anchor.x - center.x, cr.anchor.z - center.z).length();
         if dist > RECYCLE_DIST || cr.anchor.y < -50.0 {
@@ -470,15 +496,18 @@ pub(super) fn animate_wraiths(
         }
         sd.hop_state = state;
 
-        // Update UVs for current frame
-        let anim = Anim {
-            row: sd.anim_row,
-            start_col: 0,
-            frame_count: sd.anim_frames,
-        };
-        let uvs = frame_uvs(&anim, sd.current_frame, sd.facing_left);
-        if let Some(mesh) = meshes.get_mut(mesh_handle.0.id()) {
-            mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![uvs[0], uvs[1], uvs[2], uvs[3]]);
+        // Update per-instance sprite data in storage buffer
+        let idx = pool_idx.0 as usize;
+        if idx < wraith_res.0.instances.len() {
+            let col = (sd.current_frame % SHEET_COLS) as f32;
+            let row = sd.anim_row as f32;
+            wraith_res.0.instances[idx].frame_col = col;
+            wraith_res.0.instances[idx].frame_row = row;
+            wraith_res.0.instances[idx].flip = if sd.facing_left { 1.0 } else { 0.0 };
+            // Wraiths: ghostly during day, full opacity at night
+            let night = 1.0 - day_factor(game_time.hour);
+            let alpha = 0.3 + night * 0.7;
+            wraith_res.0.instances[idx].tint = [0.7, 0.6, 0.9, alpha];
         }
 
         // Billboard: face camera
@@ -499,4 +528,7 @@ pub(super) fn animate_wraiths(
 
         *vis = Visibility::Visible;
     }
+
+    // Flush all instance data to GPU
+    flush_sprite_buffer(&wraith_res.0, &mut buffers);
 }

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -6,7 +6,7 @@ use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 
 use super::camera::IsometricCamera;
-use super::creatures::{GameTime, WraithMaterials};
+use super::creatures::GameTime;
 use super::net::ServerTime;
 use super::tilemap::TileMaterials;
 use super::trees::TreeWindSway;
@@ -462,36 +462,8 @@ fn tint_trees_for_daynight(
 // weather system needed — the animate system applies df (day factor)
 // to each frog's tint every frame.
 
-/// Tint unlit wraith materials based on time of day (same curve as frogs).
-/// Wraiths are always visible: fully opaque at night, semi-transparent (ghostly) during day.
-fn tint_wraiths_for_daynight(
-    day: Res<DayCycle>,
-    wraith_mats: Option<Res<WraithMaterials>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-) {
-    let Some(wraith_mats) = wraith_mats else {
-        return;
-    };
-    let params = sun_params(day.hour);
-    let h = params.sun_height;
-
-    let r = 0.18 + h * 0.92;
-    let g = 0.20 + h * 0.90;
-    let b = 0.28 + h * 0.75;
-
-    // Ghostly transparency during daytime: fully opaque at night, semi-transparent at day
-    let alpha = if h < 0.01 {
-        1.0
-    } else {
-        0.35 + (1.0 - h) * 0.15
-    };
-
-    for handle in &wraith_mats.handles {
-        if let Some(mat) = materials.get_mut(handle) {
-            mat.base_color = Color::srgba(r, g, b, alpha);
-        }
-    }
-}
+// Wraith day/night tinting is now handled in animate_wraiths via the
+// per-instance storage buffer (SpriteInstanceData.tint).
 
 /// Copy the current DayCycle hour and server creature seed into the shared GameTime resource.
 /// Creature modules read GameTime instead of DayCycle directly.
@@ -708,7 +680,7 @@ impl Plugin for WeatherPlugin {
                 update_sun_position,
                 tint_trees_for_daynight.run_if(resource_changed::<DayCycle>),
                 // Frog tinting now in animate_frogs via storage buffer
-                tint_wraiths_for_daynight.run_if(resource_changed::<DayCycle>),
+                // Wraith tinting now in animate_wraiths via storage buffer
                 update_blob_shadows.run_if(any_with_component::<BlobShadow>),
                 animate_veg_wind.run_if(any_with_component::<WindSway>),
                 animate_tree_wind.run_if(any_with_component::<TreeWindSway>),


### PR DESCRIPTION
## Summary
- Wraiths now use `SpriteSheetMaterial` + `ShaderStorageBuffer` + `MeshTag` (same as frogs)
- One shared mesh + material for ALL wraiths → auto-instanced into one draw call
- Day/night ghostly transparency via storage buffer tint alpha
- Removed `tint_wraiths_for_daynight` weather system (tinting now in animate)
- Both frogs and wraiths now on the instancing pipeline

## Render layer note
Sprite double-pixelation (pixel-art sprites going through the low-res pixel pipeline) is a known issue — needs a separate render layer pass. Will address in follow-up PR.

## Test plan
- [ ] Native: wraiths visible with correct atlas animation
- [ ] Wraiths ghostly/transparent during day, opaque at night
- [ ] WASM: wraiths render through WebGPU pipeline