### PR TITLE
feat(dashboard): add Firecracker microVM panel to VM dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
@@ -5,6 +5,7 @@ import ReactVMCards from './ReactVMCards';
 import ReactVMVncViewer from './ReactVMVncViewer';
 import ReactVMGuacViewer from './ReactVMGuacViewer';
 import ReactKasmCards from './ReactKasmCards';
+import ReactFirecrackerCards from './ReactFirecrackerCards';
 ---
 
 <section
@@ -37,6 +38,11 @@ import ReactKasmCards from './ReactKasmCards';
 				<!-- Island: KASM workspaces (start/stop/connect) -->
 				<div id="kasm-cards">
 					<ReactKasmCards client:only="react" />
+				</div>
+
+				<!-- Island: Firecracker microVMs (status/destroy) -->
+				<div id="firecracker-cards">
+					<ReactFirecrackerCards client:only="react" />
 				</div>
 			</div>
 		</ReactVMAuth>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactFirecrackerCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactFirecrackerCards.tsx
@@ -1,0 +1,299 @@
+import { useEffect } from 'react';
+import { useStore } from '@nanostores/react';
+import { firecrackerService, type FirecrackerInfo } from './firecrackerService';
+import { vmService } from './vmService';
+import { Flame, Trash2, Cpu, HardDrive, Loader2, Activity } from 'lucide-react';
+
+function phaseColor(phase: string): string {
+	switch (phase) {
+		case 'Running':
+			return '#22c55e';
+		case 'Creating':
+			return '#f59e0b';
+		case 'Completed':
+			return '#3b82f6';
+		case 'Failed':
+			return '#ef4444';
+		case 'Timeout':
+			return '#f97316';
+		case 'Destroyed':
+			return '#6b7280';
+		default:
+			return '#6b7280';
+	}
+}
+
+function FirecrackerCard({ info }: { info: FirecrackerInfo }) {
+	const actionInProgress = useStore(firecrackerService.$actionInProgress);
+	const lastAction = useStore(firecrackerService.$lastAction);
+	const token = useStore(vmService.$accessToken);
+	const { vm, phase } = info;
+
+	const isActing = actionInProgress?.includes(vm.vm_id) ?? false;
+	const cardAction = lastAction?.vm_id === vm.vm_id ? lastAction : null;
+	const canDestroy = phase === 'Running' || phase === 'Creating';
+	const color = phaseColor(phase);
+	const shortId = vm.vm_id.slice(0, 15);
+
+	return (
+		<div
+			style={{
+				background: 'rgba(255,255,255,0.03)',
+				border: '1px solid rgba(255,255,255,0.08)',
+				borderRadius: '12px',
+				padding: '1.25rem',
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '0.75rem',
+			}}>
+			{/* Header */}
+			<div
+				style={{
+					display: 'flex',
+					justifyContent: 'space-between',
+					alignItems: 'center',
+				}}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.5rem',
+					}}>
+					<Flame size={18} style={{ color: '#f97316' }} />
+					<span
+						style={{
+							fontWeight: 600,
+							fontSize: '0.95rem',
+							fontFamily: 'monospace',
+						}}>
+						{shortId}
+					</span>
+				</div>
+				<span
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+						fontSize: '0.8rem',
+						color,
+						fontWeight: 500,
+					}}>
+					<span
+						style={{
+							width: 8,
+							height: 8,
+							borderRadius: '50%',
+							background: color,
+							display: 'inline-block',
+						}}
+					/>
+					{phase}
+				</span>
+			</div>
+
+			{/* Details */}
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns: '1fr 1fr',
+					gap: '0.4rem',
+					fontSize: '0.8rem',
+					color: 'rgba(255,255,255,0.6)',
+				}}>
+				<span
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.25rem',
+					}}>
+					<HardDrive size={12} /> {vm.rootfs}
+				</span>
+				<span
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.25rem',
+					}}>
+					<Cpu size={12} /> {vm.vcpu_count} vCPU / {vm.mem_size_mib}{' '}
+					MiB
+				</span>
+			</div>
+
+			{/* Actions */}
+			<div
+				style={{
+					display: 'flex',
+					gap: '0.5rem',
+					marginTop: '0.25rem',
+				}}>
+				{canDestroy && (
+					<button
+						onClick={() =>
+							token &&
+							firecrackerService.destroyVM(token, vm.vm_id)
+						}
+						disabled={isActing}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '0.3rem',
+							padding: '0.35rem 0.75rem',
+							background: '#ef444422',
+							border: '1px solid #ef444444',
+							borderRadius: '6px',
+							color: '#ef4444',
+							fontSize: '0.8rem',
+							cursor: isActing ? 'wait' : 'pointer',
+						}}>
+						{isActing ? (
+							<Loader2 size={14} className="animate-spin" />
+						) : (
+							<Trash2 size={14} />
+						)}
+						Destroy
+					</button>
+				)}
+			</div>
+
+			{/* Action feedback */}
+			{cardAction && (
+				<div
+					style={{
+						padding: '0.4rem 0.75rem',
+						borderRadius: '6px',
+						fontSize: '0.8rem',
+						background: cardAction.ok
+							? 'rgba(34, 197, 94, 0.1)'
+							: 'rgba(239, 68, 68, 0.1)',
+						border: `1px solid ${cardAction.ok ? 'rgba(34, 197, 94, 0.25)' : 'rgba(239, 68, 68, 0.25)'}`,
+						color: cardAction.ok ? '#22c55e' : '#ef4444',
+					}}>
+					{cardAction.message}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default function ReactFirecrackerCards() {
+	const vms = useStore(firecrackerService.$vms);
+	const health = useStore(firecrackerService.$health);
+	const loading = useStore(firecrackerService.$loading);
+	const error = useStore(firecrackerService.$error);
+	const token = useStore(vmService.$accessToken);
+
+	useEffect(() => {
+		if (token) {
+			firecrackerService.fetchData(token);
+			firecrackerService.startAutoRefresh(token);
+		}
+	}, [token]);
+
+	if (!token) return null;
+	if (loading && vms.length === 0 && !health) return null;
+
+	const serviceStatus =
+		health?.status === 'ok' ? 'Online' : error ? 'Unreachable' : 'Unknown';
+	const statusColor =
+		serviceStatus === 'Online'
+			? '#22c55e'
+			: serviceStatus === 'Unreachable'
+				? '#ef4444'
+				: '#6b7280';
+
+	return (
+		<div style={{ marginTop: '2rem' }}>
+			<h3
+				style={{
+					fontSize: '1.1rem',
+					fontWeight: 600,
+					marginBottom: '1rem',
+					color: 'var(--sl-color-text, #e6edf3)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Flame size={20} style={{ color: '#f97316' }} />
+				Firecracker MicroVMs
+				<span
+					style={{
+						fontSize: '0.8rem',
+						fontWeight: 400,
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+					}}>
+					<span
+						style={{
+							width: 8,
+							height: 8,
+							borderRadius: '50%',
+							background: statusColor,
+							display: 'inline-block',
+						}}
+					/>
+					<span style={{ color: statusColor }}>{serviceStatus}</span>
+					{health?.version && (
+						<span style={{ color: 'rgba(255,255,255,0.4)' }}>
+							v{health.version}
+						</span>
+					)}
+					{vms.length > 0 && (
+						<span style={{ color: 'rgba(255,255,255,0.5)' }}>
+							({vms.filter((v) => v.phase === 'Running').length}/
+							{vms.length} running)
+						</span>
+					)}
+				</span>
+			</h3>
+
+			{error && (
+				<div
+					style={{
+						padding: '0.75rem',
+						background: '#ef444422',
+						border: '1px solid #ef444444',
+						borderRadius: '8px',
+						color: '#ef4444',
+						fontSize: '0.85rem',
+						marginBottom: '1rem',
+					}}>
+					{error}
+				</div>
+			)}
+
+			{vms.length === 0 ? (
+				<div
+					style={{
+						padding: '1rem',
+						background: 'rgba(255,255,255,0.03)',
+						borderRadius: '8px',
+						color: 'rgba(255,255,255,0.4)',
+						textAlign: 'center',
+						fontSize: '0.9rem',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						gap: '0.5rem',
+					}}>
+					<Activity size={16} />
+					{serviceStatus === 'Online'
+						? 'No active microVMs'
+						: 'Firecracker service not available'}
+				</div>
+			) : (
+				<div
+					style={{
+						display: 'grid',
+						gridTemplateColumns:
+							'repeat(auto-fill, minmax(340px, 1fr))',
+						gap: '1rem',
+					}}>
+					{vms.map((info) => (
+						<FirecrackerCard key={info.vm.vm_id} info={info} />
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/firecrackerService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/firecrackerService.ts
@@ -1,0 +1,206 @@
+import { atom, computed } from 'nanostores';
+import { vmService } from './vmService';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FirecrackerVM {
+	vm_id: string;
+	status:
+		| 'creating'
+		| 'running'
+		| 'completed'
+		| 'failed'
+		| 'timeout'
+		| 'destroyed';
+	rootfs: string;
+	vcpu_count: number;
+	mem_size_mib: number;
+	created_at: string;
+}
+
+export interface FirecrackerHealth {
+	status: string;
+	service: string;
+	version: string;
+	timestamp: string;
+}
+
+export type FirecrackerPhase =
+	| 'Running'
+	| 'Completed'
+	| 'Failed'
+	| 'Creating'
+	| 'Timeout'
+	| 'Destroyed';
+
+export interface FirecrackerInfo {
+	vm: FirecrackerVM;
+	phase: FirecrackerPhase;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FC_PROXY_BASE = '/dashboard/firecracker/proxy';
+const REFRESH_INTERVAL_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function fcFetch<T>(
+	token: string,
+	path: string,
+	method = 'GET',
+	body?: unknown,
+): Promise<T> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${token}`,
+	};
+	const opts: RequestInit = {
+		method,
+		headers,
+		signal: AbortSignal.timeout(15000),
+	};
+	if (body !== undefined) {
+		headers['Content-Type'] = 'application/json';
+		opts.body = JSON.stringify(body);
+	}
+
+	const resp = await fetch(`${FC_PROXY_BASE}${path}`, opts);
+	if (!resp.ok) {
+		const text = await resp.text().catch(() => '');
+		throw new Error(
+			`Firecracker API error ${resp.status}: ${text.slice(0, 200)}`,
+		);
+	}
+
+	const text = await resp.text();
+	if (!text || text.trim().length === 0) return {} as T;
+	try {
+		return JSON.parse(text) as T;
+	} catch {
+		return {} as T;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase mapping
+// ---------------------------------------------------------------------------
+
+function vmPhase(status: FirecrackerVM['status']): FirecrackerPhase {
+	switch (status) {
+		case 'running':
+			return 'Running';
+		case 'creating':
+			return 'Creating';
+		case 'completed':
+			return 'Completed';
+		case 'failed':
+			return 'Failed';
+		case 'timeout':
+			return 'Timeout';
+		case 'destroyed':
+			return 'Destroyed';
+		default:
+			return 'Failed';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+class FirecrackerService {
+	public readonly $vms = atom<FirecrackerInfo[]>([]);
+	public readonly $health = atom<FirecrackerHealth | null>(null);
+	public readonly $loading = atom<boolean>(true);
+	public readonly $error = atom<string | null>(null);
+	public readonly $actionInProgress = atom<string | null>(null);
+	public readonly $lastAction = atom<{
+		vm_id: string;
+		ok: boolean;
+		message: string;
+	} | null>(null);
+
+	public readonly $runningCount = computed(
+		[this.$vms],
+		(vms) => vms.filter((v) => v.phase === 'Running').length,
+	);
+
+	public readonly $totalCount = computed([this.$vms], (vms) => vms.length);
+
+	private _refreshInterval: ReturnType<typeof setInterval> | undefined;
+
+	public async fetchData(token: string): Promise<void> {
+		try {
+			this.$error.set(null);
+
+			// Fetch health and VM list in parallel
+			const [healthData, vmData] = await Promise.allSettled([
+				fcFetch<FirecrackerHealth>(token, '/health'),
+				fcFetch<{ vms: FirecrackerVM[]; count: number }>(token, '/vm'),
+			]);
+
+			if (healthData.status === 'fulfilled') {
+				this.$health.set(healthData.value);
+			}
+
+			if (vmData.status === 'fulfilled') {
+				const vms = (vmData.value.vms ?? []).map((vm) => ({
+					vm: vm,
+					phase: vmPhase(vm.status),
+				}));
+				this.$vms.set(vms);
+			} else if (vmData.status === 'rejected') {
+				// Service unreachable — show health status only
+				this.$vms.set([]);
+				if (healthData.status === 'rejected') {
+					this.$error.set('Firecracker service unreachable');
+				}
+			}
+		} catch (e) {
+			this.$error.set(e instanceof Error ? e.message : 'Unknown error');
+		} finally {
+			this.$loading.set(false);
+		}
+	}
+
+	public startAutoRefresh(token: string): void {
+		if (this._refreshInterval) clearInterval(this._refreshInterval);
+		this._refreshInterval = setInterval(
+			() => this.fetchData(token),
+			REFRESH_INTERVAL_MS,
+		);
+	}
+
+	public async destroyVM(token: string, vmId: string): Promise<void> {
+		this.$actionInProgress.set(`destroy:${vmId}`);
+		this.$lastAction.set({
+			vm_id: vmId,
+			ok: true,
+			message: 'Destroying...',
+		});
+		try {
+			await fcFetch(token, `/vm/${vmId}`, 'DELETE');
+			this.$lastAction.set({
+				vm_id: vmId,
+				ok: true,
+				message: `VM ${vmId.slice(0, 12)} destroyed`,
+			});
+			// Refresh immediately
+			await this.fetchData(token);
+		} catch (e) {
+			const msg =
+				e instanceof Error ? e.message : `Failed to destroy ${vmId}`;
+			this.$lastAction.set({ vm_id: vmId, ok: false, message: msg });
+		} finally {
+			this.$actionInProgress.set(null);
+		}
+	}
+}
+
+export const firecrackerService = new FirecrackerService();

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -141,6 +141,13 @@ async fn main() -> anyhow::Result<()> {
         info!("KASM proxy not configured (using default cluster URL)");
     }
 
+    // Initialize Firecracker proxy (optional - for /dashboard/firecracker)
+    if transport::proxy::init_firecracker_proxy() {
+        info!("Firecracker proxy initialized - /dashboard/firecracker/proxy enabled");
+    } else {
+        info!("Firecracker proxy not configured (using default cluster URL)");
+    }
+
     // Initialize Guacamole proxy (optional - for /dashboard/guac)
     if transport::proxy::init_guacamole_proxy() {
         info!("Guacamole proxy initialized - /dashboard/guac/proxy enabled");

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -242,6 +242,14 @@ fn router(state: AppState) -> Router {
             axum::routing::get(super::proxy::kubevirt_vnc_handler),
         )
         .route(
+            "/dashboard/firecracker/proxy/{*path}",
+            any(super::proxy::firecracker_proxy_handler),
+        )
+        .route(
+            "/dashboard/firecracker/proxy",
+            any(super::proxy::firecracker_proxy_handler),
+        )
+        .route(
             "/dashboard/kasm/proxy/{*path}",
             any(super::proxy::kasm_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -987,6 +987,49 @@ pub async fn kasm_scale_handler(Path(name): Path<String>, req: Request<Body>) ->
 }
 
 // ---------------------------------------------------------------------------
+// Firecracker proxy singleton (reverse proxy to firecracker-ctl REST API)
+// ---------------------------------------------------------------------------
+
+static FIRECRACKER: OnceLock<ServiceProxy> = OnceLock::new();
+
+pub fn init_firecracker_proxy() -> bool {
+    let upstream = std::env::var("FIRECRACKER_CTL_URL")
+        .unwrap_or_else(|_| "http://firecracker-ctl.firecracker.svc.cluster.local:9001".into());
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("failed to build reqwest client for firecracker proxy");
+
+    FIRECRACKER
+        .set(ServiceProxy {
+            name: "Firecracker",
+            client,
+            upstream: upstream.trim_end_matches('/').to_string(),
+            upstream_token: None,
+        })
+        .is_ok()
+}
+
+pub async fn firecracker_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    if let Err(resp) = require_dashboard_view(&headers, "Firecracker").await {
+        return resp;
+    }
+
+    match FIRECRACKER.get() {
+        Some(proxy) => proxy.handle(path, req).await,
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Firecracker proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Guacamole proxy singleton (reverse proxy to Apache Guacamole web app)
 // ---------------------------------------------------------------------------
 // guacamole-common-js connects via HTTP tunnel or WebSocket to:


### PR DESCRIPTION
## Summary
Add Firecracker microVM status panel to the `/dashboard/vm/` page, alongside KubeVirt and KASM panels.

### Frontend
- `firecrackerService.ts` — nanostores service polling firecracker-ctl health + VM list
- `ReactFirecrackerCards.tsx` — status cards showing service health, VM phase (Running/Creating/Completed/Failed/Timeout), rootfs, vCPU/memory, destroy action
- Wired into `AstroVMDashboard.astro` as a new island

### Backend
- Firecracker reverse proxy in `proxy.rs` — `ServiceProxy` singleton pointing to `firecracker-ctl.firecracker.svc.cluster.local:9001`
- Routes: `/dashboard/firecracker/proxy/*` with dashboard auth gate
- Init in `main.rs`, env var `FIRECRACKER_CTL_URL` for override

## Test plan
- [ ] Dashboard renders Firecracker panel (shows "Unreachable" until firecracker-ctl pod is running)
- [ ] When firecracker-ctl is live, health status shows "Online" with version
- [ ] VM cards display with correct phase colors
- [ ] Destroy action sends DELETE to firecracker-ctl
- [ ] Auth gate requires staff permission