### PR TITLE
feat(discordsh-bot): interactive chart buttons for GitHub embeds

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/bot.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/bot.rs
@@ -86,6 +86,9 @@ async fn event_handler(
                 components::github_components::handle_github_component(ctx, component, &data.app)
                     .await;
                 Ok(())
+            } else if custom_id.starts_with("chart|") {
+                components::chart_buttons::handle_chart_component(ctx, component, &data.app).await;
+                Ok(())
             } else {
                 Ok(())
             };

--- a/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
@@ -406,6 +406,25 @@ async fn issues(
                     }
                 }
 
+                // Chart buttons
+                let chart_row = poise::serenity_prelude::CreateActionRow::Buttons(vec![
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|activity"
+                    ))
+                    .label("Activity")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F4C8}".to_owned(),
+                    )),
+                    poise::serenity_prelude::CreateButton::new(format!("chart|{full_name}|labels"))
+                        .label("Labels")
+                        .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                        .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                            "\u{1F3F7}".to_owned(),
+                        )),
+                ]);
+                reply = reply.components(vec![chart_row]);
+
                 ctx.send(reply).await.map_err(|e| e.to_string())?;
                 Ok(())
             }
@@ -558,6 +577,7 @@ async fn repo(
 
         match gh.get_repo(&owner, &repo_name).await {
             Ok(info) => {
+                let full_name = info.full_name.clone();
                 let fontdb = ctx.data().app.fontdb.clone();
                 let info_clone = info.clone();
 
@@ -601,6 +621,19 @@ async fn repo(
                         reply = reply.embed(detail_embed);
                     }
                 }
+
+                // Chart buttons
+                let chart_row = poise::serenity_prelude::CreateActionRow::Buttons(vec![
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|languages"
+                    ))
+                    .label("Languages")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F4CA}".to_owned(),
+                    )),
+                ]);
+                reply = reply.components(vec![chart_row]);
 
                 ctx.send(reply).await.map_err(|e| e.to_string())?;
                 Ok(())

--- a/apps/discordsh/discordsh-bot/src/discord/components/chart_buttons.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/chart_buttons.rs
@@ -1,0 +1,173 @@
+//! Chart button interaction handler — renders on-demand SVG charts
+//! when users click chart buttons on `/github` embeds.
+
+use poise::serenity_prelude as serenity;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+use crate::discord::branding;
+use crate::discord::game::github_cards;
+use crate::discord::github::resolve_github_token;
+use crate::state::AppState;
+
+/// Handle a component interaction whose `custom_id` starts with `"chart|"`.
+///
+/// Custom ID format: `chart|<owner/repo>|<chart_type>`
+/// Chart types: `languages`, `activity`, `labels`
+pub async fn handle_chart_component(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    app: &Arc<AppState>,
+) {
+    let parts: Vec<&str> = component.data.custom_id.split('|').collect();
+    if parts.len() != 3 {
+        warn!(custom_id = %component.data.custom_id, "Invalid chart custom_id");
+        return;
+    }
+
+    let repo = parts[1].to_owned();
+    let chart_type = parts[2].to_owned();
+
+    // Defer with ephemeral — chart is shown only to the requester
+    if let Err(e) = component
+        .create_response(
+            &ctx.http,
+            serenity::CreateInteractionResponse::Defer(
+                serenity::CreateInteractionResponseMessage::new().ephemeral(true),
+            ),
+        )
+        .await
+    {
+        warn!(error = %e, "Failed to defer chart interaction");
+        return;
+    }
+
+    let result = render_chart(ctx, component, app, &repo, &chart_type).await;
+
+    match result {
+        Ok((png_bytes, filename, title, full_name)) => {
+            let attachment = serenity::CreateAttachment::bytes(png_bytes, filename.clone());
+            let embed = serenity::CreateEmbed::new()
+                .title(format!("{title} -- {full_name}"))
+                .image(format!("attachment://{filename}"))
+                .color(branding::GH_DARK)
+                .author(branding::embed_author())
+                .footer(branding::embed_footer(Some(&full_name)));
+
+            let _ = component
+                .edit_response(
+                    &ctx.http,
+                    serenity::EditInteractionResponse::new()
+                        .embed(embed)
+                        .new_attachment(attachment),
+                )
+                .await;
+        }
+        Err(msg) => {
+            warn!(error = %msg, "Chart render failed");
+            let _ = component
+                .edit_response(
+                    &ctx.http,
+                    serenity::EditInteractionResponse::new()
+                        .content(format!("Failed to render chart: {msg}")),
+                )
+                .await;
+        }
+    }
+}
+
+async fn render_chart(
+    _ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    app: &Arc<AppState>,
+    repo: &str,
+    chart_type: &str,
+) -> Result<(Vec<u8>, String, String, String), String> {
+    let (owner, repo_name) = repo
+        .split_once('/')
+        .ok_or_else(|| "Invalid repository format.".to_string())?;
+
+    let guild_id = component.guild_id.map(|g| g.get());
+    let token = resolve_github_token(guild_id)
+        .await
+        .ok_or_else(|| "No GitHub token configured for this server.".to_string())?;
+
+    let gh =
+        jedi::entity::github::GitHubClient::new(&token).with_policy(app.github_repo_policy.clone());
+
+    let fontdb = app.fontdb.clone();
+    let owner = owner.to_owned();
+    let repo_name = repo_name.to_owned();
+    let full_name = format!("{}/{}", owner, repo_name);
+
+    info!(
+        user = %component.user.name,
+        repo = full_name,
+        chart = chart_type,
+        "Chart requested"
+    );
+
+    match chart_type {
+        "languages" => {
+            let langs = gh
+                .get_languages(&owner, &repo_name)
+                .await
+                .map_err(|e| format!("Failed to fetch languages: {e}"))?;
+
+            let full_clone = full_name.clone();
+            let png = tokio::task::spawn_blocking(move || {
+                github_cards::render_languages_chart_blocking(&langs, &full_clone, &fontdb)
+            })
+            .await
+            .map_err(|e| format!("Task panicked: {e}"))??;
+
+            Ok((
+                png,
+                "languages.png".to_owned(),
+                "Languages".to_owned(),
+                full_name,
+            ))
+        }
+        "activity" => {
+            let issues = gh
+                .list_issues(&owner, &repo_name, None, Some(100))
+                .await
+                .map_err(|e| format!("Failed to fetch issues: {e}"))?;
+
+            let full_clone = full_name.clone();
+            let png = tokio::task::spawn_blocking(move || {
+                github_cards::render_activity_chart_blocking(&issues, &full_clone, &fontdb)
+            })
+            .await
+            .map_err(|e| format!("Task panicked: {e}"))??;
+
+            Ok((
+                png,
+                "activity.png".to_owned(),
+                "Issue Activity".to_owned(),
+                full_name,
+            ))
+        }
+        "labels" => {
+            let issues = gh
+                .list_issues(&owner, &repo_name, Some("open"), Some(100))
+                .await
+                .map_err(|e| format!("Failed to fetch issues: {e}"))?;
+
+            let full_clone = full_name.clone();
+            let png = tokio::task::spawn_blocking(move || {
+                github_cards::render_label_chart_blocking(&issues, &full_clone, &fontdb)
+            })
+            .await
+            .map_err(|e| format!("Task panicked: {e}"))??;
+
+            Ok((
+                png,
+                "labels.png".to_owned(),
+                "Label Distribution".to_owned(),
+                full_name,
+            ))
+        }
+        other => Err(format!("Unknown chart type: {other}")),
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/discord/components/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod chart_buttons;
 pub mod github_components;
 mod status_buttons;
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/github_cards.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/github_cards.rs
@@ -5,6 +5,7 @@
 
 use askama::Template;
 use jedi::entity::github::{GitHubCommit, GitHubIssue, GitHubPull, GitHubRepo};
+use std::collections::HashMap;
 
 use crate::discord::embeds::notice_board_embed::NoticeItem;
 use crate::discord::embeds::task_board_embed::TaskItem;
@@ -655,6 +656,388 @@ fn priority_color_from_labels(labels: &[jedi::entity::github::GitHubLabel]) -> S
         }
     }
     "#30363d".to_owned()
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Chart Cards — on-demand visualizations triggered by button clicks
+// ═══════════════════════════════════════════════════════════════════
+
+// ── Languages Chart ────────────────────────────────────────────────
+
+/// GitHub language colors (top languages only; fallback to gray).
+fn language_color(name: &str) -> &'static str {
+    match name.to_lowercase().as_str() {
+        "rust" => "#dea584",
+        "typescript" => "#3178c6",
+        "javascript" => "#f1e05a",
+        "python" => "#3572a5",
+        "go" => "#00add8",
+        "java" => "#b07219",
+        "c++" | "cpp" => "#f34b7d",
+        "c" => "#555555",
+        "c#" | "csharp" => "#178600",
+        "ruby" => "#701516",
+        "swift" => "#f05138",
+        "kotlin" => "#a97bff",
+        "dart" => "#00b4ab",
+        "shell" | "bash" => "#89e051",
+        "html" => "#e34c26",
+        "css" | "scss" => "#563d7c",
+        "lua" => "#000080",
+        "astro" => "#ff5a03",
+        "svelte" => "#ff3e00",
+        "mdx" => "#fcb32c",
+        "nix" => "#7e7eff",
+        "dockerfile" => "#384d54",
+        "protobuf" | "proto" => "#ccc",
+        "makefile" => "#427819",
+        _ => "#8b949e",
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    if bytes >= 1_000_000 {
+        format!("{:.1}MB", bytes as f64 / 1_000_000.0)
+    } else if bytes >= 1_000 {
+        format!("{:.1}KB", bytes as f64 / 1_000.0)
+    } else {
+        format!("{}B", bytes)
+    }
+}
+
+pub struct LanguageBarSegment {
+    pub x: f64,
+    pub width: f64,
+    pub color: String,
+}
+
+pub struct LanguageRow {
+    pub name: String,
+    pub percent: String,
+    pub color: String,
+    pub bar_width: f64,
+    pub bytes_display: String,
+    pub label_x: f64,
+    pub y: u32,
+}
+
+#[derive(Template)]
+#[template(path = "github/languages_chart.svg")]
+pub struct LanguagesChartTemplate {
+    pub repo_name: String,
+    pub total_bytes_display: String,
+    pub languages: Vec<LanguageRow>,
+    pub bar_segments: Vec<LanguageBarSegment>,
+    pub height: u32,
+    pub footer_y: u32,
+    pub brand_y: u32,
+}
+
+pub fn build_languages_chart(
+    lang_map: &HashMap<String, u64>,
+    repo_name: &str,
+) -> LanguagesChartTemplate {
+    let total: u64 = lang_map.values().sum();
+    let mut sorted: Vec<_> = lang_map.iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(a.1));
+    let sorted = &sorted[..sorted.len().min(12)]; // top 12
+
+    let max_bar = 480.0;
+
+    // Stacked bar segments
+    let mut bar_segments = Vec::new();
+    let mut seg_x = 0.0;
+    let bar_total_width = 744.0;
+    for (name, bytes) in sorted {
+        let bytes = **bytes;
+        let frac = if total > 0 {
+            bytes as f64 / total as f64
+        } else {
+            0.0
+        };
+        let w = (frac * bar_total_width).max(1.0);
+        bar_segments.push(LanguageBarSegment {
+            x: seg_x,
+            width: w,
+            color: language_color(name).to_owned(),
+        });
+        seg_x += w;
+    }
+
+    // Individual rows
+    let languages: Vec<LanguageRow> = sorted
+        .iter()
+        .enumerate()
+        .map(|(i, (name, bytes))| {
+            let bytes = **bytes;
+            let pct = if total > 0 {
+                (bytes as f64 / total as f64) * 100.0
+            } else {
+                0.0
+            };
+            let bw = (pct / 100.0) * max_bar;
+            LanguageRow {
+                name: name.to_string(),
+                percent: format!("{:.1}", pct),
+                color: language_color(name).to_owned(),
+                bar_width: bw.max(2.0),
+                bytes_display: format_bytes(bytes),
+                label_x: 260.0 + bw.max(2.0) + 8.0,
+                y: 100 + (i as u32 * 28),
+            }
+        })
+        .collect();
+
+    let row_count = languages.len() as u32;
+    let height = 100 + row_count * 28 + 30;
+
+    LanguagesChartTemplate {
+        repo_name: repo_name.to_owned(),
+        total_bytes_display: format_bytes(total),
+        languages,
+        bar_segments,
+        height,
+        footer_y: height - 8,
+        brand_y: height - 14,
+    }
+}
+
+pub fn render_languages_chart_blocking(
+    lang_map: &HashMap<String, u64>,
+    repo_name: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_languages_chart(lang_map, repo_name);
+    let svg = template
+        .render()
+        .map_err(|e| format!("Languages chart SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Languages chart PNG: {e}"))
+}
+
+// ── Label Distribution Chart ───────────────────────────────────────
+
+pub struct LabelChartRow {
+    pub name: String,
+    pub color: String,
+    pub count: u64,
+    pub bar_width: f64,
+    pub count_x: f64,
+    pub y: u32,
+}
+
+#[derive(Template)]
+#[template(path = "github/label_chart.svg")]
+pub struct LabelChartTemplate {
+    pub repo_name: String,
+    pub total_issues: usize,
+    pub label_count: usize,
+    pub labels: Vec<LabelChartRow>,
+    pub height: u32,
+    pub footer_y: u32,
+    pub brand_y: u32,
+}
+
+pub fn build_label_chart(issues: &[GitHubIssue], repo_name: &str) -> LabelChartTemplate {
+    // Count issues per label
+    let mut counts: HashMap<String, (u64, String)> = HashMap::new();
+    for issue in issues {
+        for label in &issue.labels {
+            let entry = counts.entry(label.name.clone()).or_insert((
+                0,
+                label.color.clone().unwrap_or_else(|| "8b949e".to_owned()),
+            ));
+            entry.0 += 1;
+        }
+    }
+
+    let mut sorted: Vec<_> = counts.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.0.cmp(&a.1.0));
+    let sorted = &sorted[..sorted.len().min(15)]; // top 15
+
+    let max_count = sorted.first().map(|(_, (c, _))| *c).unwrap_or(1);
+    let max_bar = 480.0;
+
+    let labels: Vec<LabelChartRow> = sorted
+        .iter()
+        .enumerate()
+        .map(|(i, (name, (count, color)))| {
+            let bw = (*count as f64 / max_count as f64) * max_bar;
+            LabelChartRow {
+                name: truncate(name, 25),
+                color: color.clone(),
+                count: *count,
+                bar_width: bw.max(4.0),
+                count_x: 220.0 + bw.max(4.0) + 8.0,
+                y: 75 + (i as u32 * 28),
+            }
+        })
+        .collect();
+
+    let row_count = labels.len() as u32;
+    let height = 75 + row_count * 28 + 30;
+
+    LabelChartTemplate {
+        repo_name: repo_name.to_owned(),
+        total_issues: issues.len(),
+        label_count: labels.len(),
+        labels,
+        height,
+        footer_y: height - 8,
+        brand_y: height - 14,
+    }
+}
+
+pub fn render_label_chart_blocking(
+    issues: &[GitHubIssue],
+    repo_name: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_label_chart(issues, repo_name);
+    let svg = template
+        .render()
+        .map_err(|e| format!("Label chart SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Label chart PNG: {e}"))
+}
+
+// ── Activity Chart ─────────────────────────────────────────────────
+
+pub struct ActivityBar {
+    pub x: f64,
+    pub width: f64,
+    pub opened_y: f64,
+    pub opened_h: f64,
+    pub closed_x: f64,
+    pub closed_y: f64,
+    pub closed_h: f64,
+}
+
+pub struct GridLine {
+    pub y: f64,
+    pub label_y: f64,
+    pub value: u32,
+}
+
+pub struct XLabel {
+    pub x: f64,
+    pub text: String,
+}
+
+#[derive(Template)]
+#[template(path = "github/activity_chart.svg")]
+pub struct ActivityChartTemplate {
+    pub repo_name: String,
+    pub day_count: usize,
+    pub total_opened: u32,
+    pub total_closed: u32,
+    pub bars: Vec<ActivityBar>,
+    pub grid_lines: Vec<GridLine>,
+    pub x_labels: Vec<XLabel>,
+}
+
+pub fn build_activity_chart(issues: &[GitHubIssue], repo_name: &str) -> ActivityChartTemplate {
+    let now = chrono::Utc::now();
+    let day_count = 14usize;
+    let chart_width = 700.0;
+    let chart_height = 180.0;
+
+    // Bucket issues by day offset
+    let mut opened_by_day = vec![0u32; day_count];
+    let mut closed_by_day = vec![0u32; day_count];
+
+    for issue in issues {
+        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&issue.created_at) {
+            let days_ago = (now - dt.with_timezone(&chrono::Utc)).num_days();
+            if days_ago >= 0 && (days_ago as usize) < day_count {
+                opened_by_day[day_count - 1 - days_ago as usize] += 1;
+            }
+        }
+        if issue.state == "closed" {
+            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&issue.updated_at) {
+                let days_ago = (now - dt.with_timezone(&chrono::Utc)).num_days();
+                if days_ago >= 0 && (days_ago as usize) < day_count {
+                    closed_by_day[day_count - 1 - days_ago as usize] += 1;
+                }
+            }
+        }
+    }
+
+    let max_val = opened_by_day
+        .iter()
+        .chain(closed_by_day.iter())
+        .copied()
+        .max()
+        .unwrap_or(1)
+        .max(1);
+
+    let bar_group_width = chart_width / day_count as f64;
+    let bar_width = (bar_group_width * 0.35).min(20.0);
+    let gap = 2.0;
+
+    let bars: Vec<ActivityBar> = (0..day_count)
+        .map(|i| {
+            let opened = opened_by_day[i];
+            let closed = closed_by_day[i];
+            let oh = (opened as f64 / max_val as f64) * chart_height;
+            let ch = (closed as f64 / max_val as f64) * chart_height;
+            let center_x = i as f64 * bar_group_width + bar_group_width / 2.0;
+            ActivityBar {
+                x: center_x - bar_width - gap / 2.0,
+                width: bar_width,
+                opened_y: chart_height - oh,
+                opened_h: oh,
+                closed_x: center_x + gap / 2.0,
+                closed_y: chart_height - ch,
+                closed_h: ch,
+            }
+        })
+        .collect();
+
+    // Grid lines (3 lines)
+    let grid_lines: Vec<GridLine> = (0..=3)
+        .map(|i| {
+            let val = (max_val as f64 * (1.0 - i as f64 / 3.0)) as u32;
+            let y = (i as f64 / 3.0) * chart_height;
+            GridLine {
+                y,
+                label_y: y + 4.0,
+                value: val,
+            }
+        })
+        .collect();
+
+    // X-axis labels (every other day)
+    let x_labels: Vec<XLabel> = (0..day_count)
+        .filter(|i| i % 2 == 0 || *i == day_count - 1)
+        .map(|i| {
+            let date = now - chrono::Duration::days((day_count - 1 - i) as i64);
+            XLabel {
+                x: i as f64 * bar_group_width + bar_group_width / 2.0,
+                text: date.format("%m/%d").to_string(),
+            }
+        })
+        .collect();
+
+    ActivityChartTemplate {
+        repo_name: repo_name.to_owned(),
+        day_count,
+        total_opened: opened_by_day.iter().sum(),
+        total_closed: closed_by_day.iter().sum(),
+        bars,
+        grid_lines,
+        x_labels,
+    }
+}
+
+pub fn render_activity_chart_blocking(
+    issues: &[GitHubIssue],
+    repo_name: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_activity_chart(issues, repo_name);
+    let svg = template
+        .render()
+        .map_err(|e| format!("Activity chart SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Activity chart PNG: {e}"))
 }
 
 #[cfg(test)]

--- a/apps/discordsh/discordsh-bot/templates/github/activity_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/activity_chart.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="320" viewBox="0 0 800 320">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="320" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="320" fill="#238636" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">Issue Activity -- {{ repo_name }}</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">Last {{ day_count }} days | {{ total_opened }} opened, {{ total_closed }} closed</text>
+
+  <!-- Legend -->
+  <g transform="translate(600, 28)">
+    <rect x="0" y="0" width="10" height="10" fill="#238636" rx="2"/>
+    <text x="14" y="10" font-family="sans-serif" font-size="11" fill="#8b949e">Opened</text>
+    <rect x="80" y="0" width="10" height="10" fill="#8957E5" rx="2"/>
+    <text x="94" y="10" font-family="sans-serif" font-size="11" fill="#8b949e">Closed</text>
+  </g>
+
+  <!-- Chart area -->
+  <g transform="translate(50, 75)">
+    <!-- Grid lines -->
+    {% for grid in grid_lines %}
+    <line x1="0" y1="{{ grid.y }}" x2="700" y2="{{ grid.y }}" stroke="#21262d" stroke-width="1"/>
+    <text x="-8" y="{{ grid.label_y }}" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">{{ grid.value }}</text>
+    {% endfor %}
+
+    <!-- Bars -->
+    {% for bar in bars %}
+    <!-- Opened (green) -->
+    {% if bar.opened_h > 0.0 %}
+    <rect x="{{ bar.x }}" y="{{ bar.opened_y }}" width="{{ bar.width }}" height="{{ bar.opened_h }}" fill="#238636" rx="2"/>
+    {% endif %}
+    <!-- Closed (purple) -->
+    {% if bar.closed_h > 0.0 %}
+    <rect x="{{ bar.closed_x }}" y="{{ bar.closed_y }}" width="{{ bar.width }}" height="{{ bar.closed_h }}" fill="#8957E5" rx="2"/>
+    {% endif %}
+    {% endfor %}
+
+    <!-- X-axis labels -->
+    {% for label in x_labels %}
+    <text x="{{ label.x }}" y="195" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="middle">{{ label.text }}</text>
+    {% endfor %}
+  </g>
+
+  <!-- Footer -->
+  <rect x="0" y="312" width="800" height="8" fill="#238636" opacity="0.3"/>
+  <text x="760" y="306" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>

--- a/apps/discordsh/discordsh-bot/templates/github/label_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/label_chart.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="{{ height }}" viewBox="0 0 800 {{ height }}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="{{ height }}" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="{{ height }}" fill="#58a6ff" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">Label Distribution -- {{ repo_name }}</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">{{ total_issues }} issues across {{ label_count }} labels</text>
+
+  <!-- Bars -->
+  {% for label in labels %}
+  <g transform="translate(28, {{ label.y }})">
+    <!-- Color dot -->
+    <circle cx="8" cy="10" r="6" fill="#{{ label.color }}"/>
+    <!-- Label name -->
+    <text x="22" y="14" font-family="sans-serif" font-size="13" font-weight="600" fill="#e6edf3">{{ label.name }}</text>
+    <!-- Bar -->
+    <rect x="220" y="2" width="{{ label.bar_width }}" height="16" fill="#{{ label.color }}" rx="3" opacity="0.8"/>
+    <!-- Count -->
+    <text x="{{ label.count_x }}" y="14" font-family="sans-serif" font-size="12" font-weight="bold" fill="#e6edf3">{{ label.count }}</text>
+  </g>
+  {% endfor %}
+
+  <!-- Footer -->
+  <rect x="0" y="{{ footer_y }}" width="800" height="8" fill="#58a6ff" opacity="0.3"/>
+  <text x="760" y="{{ brand_y }}" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>

--- a/apps/discordsh/discordsh-bot/templates/github/languages_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/languages_chart.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="{{ height }}" viewBox="0 0 800 {{ height }}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="{{ height }}" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="{{ height }}" fill="#8957E5" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">Languages -- {{ repo_name }}</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">{{ total_bytes_display }} total</text>
+
+  <!-- Stacked bar (full width) -->
+  <g transform="translate(28, 72)">
+    {% for seg in bar_segments %}
+    <rect x="{{ seg.x }}" y="0" width="{{ seg.width }}" height="14" fill="{{ seg.color }}" rx="{% if loop.first %}7{% else %}0{% endif %}"/>
+    {% endfor %}
+  </g>
+
+  <!-- Legend + individual bars -->
+  {% for lang in languages %}
+  <g transform="translate(28, {{ lang.y }})">
+    <!-- Color dot -->
+    <circle cx="8" cy="8" r="6" fill="{{ lang.color }}"/>
+    <!-- Language name -->
+    <text x="22" y="12" font-family="sans-serif" font-size="14" font-weight="600" fill="#e6edf3">{{ lang.name }}</text>
+    <!-- Percentage -->
+    <text x="200" y="12" font-family="sans-serif" font-size="13" fill="#8b949e">{{ lang.percent }}%</text>
+    <!-- Bar -->
+    <rect x="260" y="1" width="{{ lang.bar_width }}" height="14" fill="{{ lang.color }}" rx="3" opacity="0.85"/>
+    <!-- Bytes -->
+    <text x="{{ lang.label_x }}" y="12" font-family="sans-serif" font-size="11" fill="#484f58">{{ lang.bytes_display }}</text>
+  </g>
+  {% endfor %}
+
+  <!-- Footer accent -->
+  <rect x="0" y="{{ footer_y }}" width="800" height="8" fill="#8957E5" opacity="0.3"/>
+  <text x="760" y="{{ brand_y }}" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>

--- a/packages/rust/jedi/src/entity/github/client.rs
+++ b/packages/rust/jedi/src/entity/github/client.rs
@@ -185,6 +185,30 @@ impl GitHubClient {
         self.parse_response(resp).await
     }
 
+    // ── Repository Languages ──────────────────────────────────────
+
+    /// Fetch repository language breakdown (bytes per language).
+    /// Returns a map like `{"Rust": 123456, "TypeScript": 78901}`.
+    pub async fn get_languages(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<std::collections::HashMap<String, u64>, JediError> {
+        self.policy.check(owner, repo)?;
+        let url = format!("{}/repos/{}/{}/languages", self.base_url, owner, repo);
+
+        let resp = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| JediError::Internal(Cow::Owned(format!("GitHub request failed: {e}"))))?;
+
+        let resp = self.check_rate_limit(resp);
+        self.parse_response(resp).await
+    }
+
     // ── Single Issue/PR ────────────────────────────────────────────
 
     /// Fetch a single issue or pull request by number.


### PR DESCRIPTION
## Summary
Add on-demand SVG chart rendering to `/github` embeds via interactive buttons:

| Command | Button | Chart |
|---------|--------|-------|
| `/github repo` | Languages | Horizontal bar chart of repo language breakdown |
| `/github issues` | Activity | 14-day bar chart of issues opened vs closed |
| `/github issues` | Labels | Horizontal bar chart of issue count per label |

**How it works:**
1. User runs `/github repo` or `/github issues` — embed appears with chart buttons
2. User clicks a button (e.g. "Languages")
3. Bot fetches data from GitHub API, renders Askama SVG template, converts to PNG via resvg
4. Chart appears as an ephemeral reply (only visible to requester)

**New additions:**
- `jedi::GitHubClient::get_languages()` — fetches `/repos/{owner}/{repo}/languages` endpoint
- 3 SVG chart templates in `templates/github/`
- `chart_buttons.rs` component handler with `chart|{repo}|{type}` custom ID pattern
- Language color mapping for 25+ languages (matching GitHub's UI)

## Test plan
- [x] `cargo check -p jedi` passes
- [x] `cargo check -p discordsh-bot` passes
- [ ] After deploy, `/github repo` shows "Languages" button
- [ ] After deploy, `/github issues` shows "Activity" and "Labels" buttons
- [ ] Clicking buttons renders charts as ephemeral PNG embeds