### PR TITLE
feat(isometric): generic ECS-driven sprite creature system

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/creatures/common.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/common.rs
@@ -124,3 +124,50 @@ pub fn flutter_offset(t: f32, phase: f32, speed: f32, radius: f32, amp: f32) -> 
 pub fn scene_center(cam_pos: Vec3) -> Vec3 {
     Vec3::new(cam_pos.x - 15.0, 0.0, cam_pos.z - 15.0)
 }
+
+// ---------------------------------------------------------------------------
+// Shared mesh builder for sprite billboard quads
+// ---------------------------------------------------------------------------
+
+/// Build a single-sided billboard quad, bottom-aligned (y=0..y=size).
+/// UVs span full [0,1] — the shader maps to the correct atlas cell.
+pub fn build_billboard_quad(size: f32) -> Mesh {
+    use bevy::asset::RenderAssetUsages;
+    use bevy::mesh::{Indices, PrimitiveTopology};
+
+    let h = size;
+    let w = size;
+    Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    )
+    .with_inserted_attribute(
+        Mesh::ATTRIBUTE_POSITION,
+        vec![
+            [-w * 0.5, h, 0.0],
+            [w * 0.5, h, 0.0],
+            [w * 0.5, 0.0, 0.0],
+            [-w * 0.5, 0.0, 0.0],
+        ],
+    )
+    .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, vec![[0.0, 0.0, 1.0]; 4])
+    .with_inserted_attribute(
+        Mesh::ATTRIBUTE_UV_0,
+        vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+    )
+    .with_inserted_indices(Indices::U32(vec![0, 2, 1, 0, 3, 2]))
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic patrol seed (shared by all patrol-based creatures)
+// ---------------------------------------------------------------------------
+
+/// Deterministic seed for creature decisions. Combines slot_seed, patrol_step,
+/// and creature_seed so all clients produce identical behavior.
+#[inline]
+pub fn patrol_seed(slot_seed: u32, step: u32, creature_seed: u64) -> u32 {
+    slot_seed
+        .wrapping_mul(2654435761)
+        .wrapping_add(step.wrapping_mul(7919))
+        .wrapping_add(creature_seed as u32)
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/animate.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/animate.rs
@@ -1,0 +1,430 @@
+//! Generic animate system for all sprite-sheet creatures.
+
+use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
+
+use super::super::common::{GameTime, day_factor, hash_f32, patrol_seed, scene_center};
+use super::super::creature::{
+    Creature, CreaturePoolIndex, CreatureState, SpriteData, SpriteHopState,
+};
+use super::super::sprite_material::SpriteAnimData;
+use super::types::*;
+use crate::game::camera::IsometricCamera;
+use crate::game::terrain::TerrainMap;
+use crate::game::weather::BlobShadow;
+
+/// Single animate system for all generic sprite creatures.
+pub fn animate_sprite_creatures(
+    time: Res<Time>,
+    game_time: Res<GameTime>,
+    mut terrain: ResMut<TerrainMap>,
+    camera_q: Query<&Transform, With<IsometricCamera>>,
+    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+    mut atlas_pool: ResMut<SpriteAtlasPool>,
+    types: Res<SpriteCreatureTypes>,
+    mut creature_q: Query<
+        (
+            &mut Transform,
+            &mut Creature,
+            &mut SpriteData,
+            &mut Visibility,
+            &CreaturePoolIndex,
+            &mut SpriteCreatureMarker,
+            Option<&CreatureShadowLink>,
+        ),
+        Without<IsometricCamera>,
+    >,
+    mut shadow_q: Query<(&mut BlobShadow, &mut Visibility), Without<Creature>>,
+) {
+    let Ok(cam_tf) = camera_q.single() else {
+        return;
+    };
+    let dt = time.delta_secs();
+    let t = time.elapsed_secs();
+    let cseed = game_time.creature_seed;
+    let cam_pos = cam_tf.translation;
+    let center = scene_center(cam_pos);
+
+    for (mut tf, mut cr, mut sd, mut vis, pool_idx, mut marker, shadow) in &mut creature_q {
+        // Look up type descriptor
+        let Some(ctype) = types.types.iter().find(|ct| ct.npc_ref == marker.type_key) else {
+            continue;
+        };
+
+        // --- Visibility schedule ---
+        match ctype.visibility {
+            VisibilitySchedule::Day => {
+                if day_factor(game_time.hour) < 0.01 {
+                    *vis = Visibility::Hidden;
+                    tf.translation.y = -100.0;
+                    cr.anchor.y = -100.0;
+                    hide_shadow(shadow, &mut shadow_q);
+                    continue;
+                }
+            }
+            VisibilitySchedule::Night => {
+                if day_factor(game_time.hour) > 0.99 {
+                    *vis = Visibility::Hidden;
+                    tf.translation.y = -100.0;
+                    cr.anchor.y = -100.0;
+                    hide_shadow(shadow, &mut shadow_q);
+                    continue;
+                }
+            }
+            VisibilitySchedule::Always => {}
+        }
+
+        // --- Recycle if too far ---
+        let dist = Vec2::new(cr.anchor.x - center.x, cr.anchor.z - center.z).length();
+        if dist > ctype.recycle_dist || cr.anchor.y < -50.0 {
+            marker.patrol_step = marker.patrol_step.wrapping_add(1);
+            let ps = patrol_seed(cr.slot_seed, marker.patrol_step, cseed);
+            let angle = hash_f32(ps) * std::f32::consts::TAU;
+            let ring = ctype.spawn_ring_inner
+                + hash_f32(ps + 100) * (ctype.spawn_ring_outer - ctype.spawn_ring_inner);
+            let spawn_x = center.x + angle.cos() * ring;
+            let spawn_z = center.z + angle.sin() * ring;
+            let ground = terrain.height_at_world(spawn_x, spawn_z);
+            cr.anchor = Vec3::new(spawn_x, ground, spawn_z);
+
+            // Reset direction
+            match &ctype.direction_model {
+                DirectionModel::Flip => {
+                    sd.facing_left = hash_f32(ps + 300) > 0.5;
+                }
+                DirectionModel::FourWay { .. } => {
+                    marker.direction = (hash_f32(ps + 300) * 4.0) as u32 % 4;
+                }
+            }
+
+            set_anim(&mut sd, &mut marker, &ctype.anims.idle);
+            let idle_timer =
+                ctype.idle_min + hash_f32(ps + 500) * (ctype.idle_max - ctype.idle_min);
+            sd.hop_state = SpriteHopState::Idle { timer: idle_timer };
+            cr.state = CreatureState::Active;
+            *vis = Visibility::Hidden;
+            tf.translation.y = -100.0;
+            hide_shadow(shadow, &mut shadow_q);
+            continue;
+        }
+
+        // --- Frame advance ---
+        sd.frame_timer += dt;
+        if sd.frame_timer >= sd.frame_duration {
+            sd.frame_timer -= sd.frame_duration;
+            sd.current_frame += 1;
+            if sd.current_frame >= sd.anim_frames {
+                sd.current_frame = 0;
+            }
+        }
+
+        // --- Terrain snap ---
+        let ground = terrain.height_at_world(cr.anchor.x, cr.anchor.z);
+        cr.anchor.y = ground;
+
+        // --- State machine ---
+        let mut state = sd.hop_state;
+        match state {
+            SpriteHopState::Idle { ref mut timer } => {
+                set_anim(&mut sd, &mut marker, &ctype.anims.idle);
+                tf.translation = cr.anchor;
+                *timer -= dt;
+
+                if *timer <= 0.0 {
+                    marker.patrol_step = marker.patrol_step.wrapping_add(1);
+                    let ps = patrol_seed(cr.slot_seed, marker.patrol_step, cseed);
+                    let roll = hash_f32(ps);
+
+                    // Find matching behavior
+                    let action = ctype
+                        .behavior
+                        .choices
+                        .iter()
+                        .find(|c| roll < c.threshold)
+                        .map(|c| &c.action);
+
+                    if let Some(action) = action {
+                        match action {
+                            BehaviorAction::Move {
+                                anim_name,
+                                min_dist,
+                                max_dist,
+                                speed,
+                            } => {
+                                let angle = hash_f32(ps + 100) * std::f32::consts::TAU;
+                                let run_dist =
+                                    min_dist + hash_f32(ps + 200) * (max_dist - min_dist);
+                                let target_x = cr.anchor.x + angle.cos() * run_dist;
+                                let target_z = cr.anchor.z + angle.sin() * run_dist;
+                                let target_ground = terrain.height_at_world(target_x, target_z);
+                                let target = Vec3::new(target_x, target_ground, target_z);
+                                let dx = target.x - cr.anchor.x;
+                                let dz = target.z - cr.anchor.z;
+
+                                // Update direction
+                                match &ctype.direction_model {
+                                    DirectionModel::Flip => {
+                                        sd.facing_left = (dx - dz) < 0.0;
+                                    }
+                                    DirectionModel::FourWay { quadrant_to_row } => {
+                                        let q = iso_quadrant(dx, dz) as usize;
+                                        marker.direction = quadrant_to_row[q];
+                                    }
+                                }
+
+                                let anim_def = ctype.anims.find(anim_name);
+                                set_anim(&mut sd, &mut marker, &anim_def);
+                                marker.active_move_speed = *speed;
+                                state = SpriteHopState::Airborne {
+                                    start: cr.anchor,
+                                    target,
+                                    progress: 0.0,
+                                };
+                            }
+                            BehaviorAction::Emote { anim_name, repeat } => {
+                                let anim_def = ctype.anims.find(anim_name);
+                                set_anim(&mut sd, &mut marker, &anim_def);
+                                state = SpriteHopState::Emote {
+                                    remaining_frames: anim_def.frame_count * repeat,
+                                };
+                            }
+                            BehaviorAction::ExtendedIdle { repeat } => {
+                                set_anim(&mut sd, &mut marker, &ctype.anims.idle);
+                                state = SpriteHopState::Emote {
+                                    remaining_frames: ctype.anims.idle.frame_count * repeat,
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+
+            SpriteHopState::Emote {
+                ref mut remaining_frames,
+            } => {
+                tf.translation = cr.anchor;
+                if sd.frame_timer < 0.001 && sd.current_frame == 0 && *remaining_frames > 0 {
+                    *remaining_frames = remaining_frames.saturating_sub(sd.anim_frames);
+                }
+                if sd.current_frame == sd.anim_frames - 1 && *remaining_frames == 0 {
+                    marker.patrol_step = marker.patrol_step.wrapping_add(1);
+                    let ps = patrol_seed(cr.slot_seed, marker.patrol_step, cseed);
+                    set_anim(&mut sd, &mut marker, &ctype.anims.idle);
+                    state = SpriteHopState::Idle {
+                        timer: ctype.idle_min + hash_f32(ps) * (ctype.idle_max - ctype.idle_min),
+                    };
+                }
+            }
+
+            SpriteHopState::Airborne {
+                start,
+                target,
+                ref mut progress,
+            } => {
+                let speed = marker.active_move_speed.max(1.0);
+                let duration = start.distance(target) / speed;
+                *progress += dt / duration.max(0.1);
+                let p = progress.clamp(0.0, 1.0);
+
+                match &ctype.movement {
+                    MovementProfile::HopArc {
+                        base_height,
+                        height_per_dist,
+                        ..
+                    } => {
+                        let pos = start.lerp(target, p);
+                        let arc = 4.0
+                            * (base_height + start.distance(target) * height_per_dist)
+                            * p
+                            * (1.0 - p);
+                        tf.translation = Vec3::new(pos.x, pos.y + arc, pos.z);
+                    }
+                    MovementProfile::LinearRun => {
+                        tf.translation = start.lerp(target, p);
+                    }
+                    MovementProfile::Glide {
+                        hover_base,
+                        hover_amplitude,
+                        hover_frequency,
+                        ..
+                    } => {
+                        let pos = start.lerp(target, p);
+                        let hover = (t * hover_frequency + cr.phase * 6.28).sin() * hover_amplitude;
+                        tf.translation = Vec3::new(pos.x, pos.y + hover_base + hover, pos.z);
+                    }
+                }
+
+                // Update direction during movement
+                let dx = target.x - start.x;
+                let dz = target.z - start.z;
+                match &ctype.direction_model {
+                    DirectionModel::Flip => {
+                        sd.facing_left = (dx - dz) < 0.0;
+                    }
+                    DirectionModel::FourWay { quadrant_to_row } => {
+                        let q = iso_quadrant(dx, dz) as usize;
+                        marker.direction = quadrant_to_row[q];
+                        sd.anim_row = marker.anim_base_row + marker.direction;
+                    }
+                }
+
+                if *progress >= 1.0 {
+                    cr.anchor = target;
+                    set_anim(&mut sd, &mut marker, &ctype.anims.idle);
+                    state = SpriteHopState::Landing { timer: 0.2 };
+                }
+            }
+
+            SpriteHopState::JumpWindup { target } => {
+                // For HopArc: wait for airborne frame, then transition
+                // For others: skip straight to Airborne
+                let dx = target.x - cr.anchor.x;
+                let dz = target.z - cr.anchor.z;
+                match &ctype.direction_model {
+                    DirectionModel::Flip => {
+                        sd.facing_left = (dx - dz) < 0.0;
+                    }
+                    DirectionModel::FourWay { quadrant_to_row } => {
+                        let q = iso_quadrant(dx, dz) as usize;
+                        marker.direction = quadrant_to_row[q];
+                    }
+                }
+                // Find the move anim (first Move action's anim)
+                if let Some(move_action) = ctype.behavior.choices.iter().find_map(|c| {
+                    if let BehaviorAction::Move {
+                        anim_name, speed, ..
+                    } = &c.action
+                    {
+                        Some((*anim_name, *speed))
+                    } else {
+                        None
+                    }
+                }) {
+                    let anim_def = ctype.anims.find(move_action.0);
+                    set_anim(&mut sd, &mut marker, &anim_def);
+                    marker.active_move_speed = move_action.1;
+                }
+                state = SpriteHopState::Airborne {
+                    start: cr.anchor,
+                    target,
+                    progress: 0.0,
+                };
+            }
+
+            SpriteHopState::Landing { ref mut timer } => {
+                tf.translation = cr.anchor;
+                set_anim(&mut sd, &mut marker, &ctype.anims.idle);
+                *timer -= dt;
+                if *timer <= 0.0 {
+                    marker.patrol_step = marker.patrol_step.wrapping_add(1);
+                    let ps = patrol_seed(cr.slot_seed, marker.patrol_step, cseed);
+                    state = SpriteHopState::Idle {
+                        timer: ctype.idle_min + hash_f32(ps) * (ctype.idle_max - ctype.idle_min),
+                    };
+                }
+            }
+        }
+        sd.hop_state = state;
+
+        // --- SSBO update ---
+        let entry = atlas_pool
+            .entries
+            .iter_mut()
+            .find(|e| e.type_key == marker.type_key);
+        if let Some(entry) = entry {
+            let idx = pool_idx.0 as usize;
+            if idx < entry.anim_data.len() {
+                let col = sd.current_frame % ctype.sheet_cols;
+                let row = sd.anim_row;
+                let flip = match &ctype.direction_model {
+                    DirectionModel::Flip => {
+                        if sd.facing_left {
+                            1
+                        } else {
+                            0
+                        }
+                    }
+                    DirectionModel::FourWay { .. } => 0,
+                };
+                entry.anim_data[idx] = SpriteAnimData {
+                    frame: col + row * ctype.sheet_cols,
+                    flip,
+                    _pad1: 0,
+                    _pad2: 0,
+                };
+            }
+        }
+
+        // --- Billboard ---
+        tf.look_to(cam_tf.forward().as_vec3(), Vec3::Y);
+
+        // --- Glide hover for idle/landing (wraith-style) ---
+        if let MovementProfile::Glide {
+            hover_base,
+            hover_amplitude,
+            hover_frequency,
+            ..
+        } = &ctype.movement
+        {
+            if matches!(
+                sd.hop_state,
+                SpriteHopState::Idle { .. } | SpriteHopState::Landing { .. }
+            ) {
+                let hover = (t * hover_frequency + cr.phase * 6.28).sin() * hover_amplitude;
+                tf.translation.y = cr.anchor.y + hover_base + hover;
+            }
+        }
+
+        // --- Shadow sync ---
+        if let Some(CreatureShadowLink(se)) = shadow {
+            if let Ok((mut bs, mut sv)) = shadow_q.get_mut(*se) {
+                bs.anchor = Vec3::new(cr.anchor.x, cr.anchor.y + 0.01, cr.anchor.z);
+                *sv = Visibility::Visible;
+            }
+        }
+
+        *vis = Visibility::Visible;
+    }
+
+    // --- Flush all SSBO buffers ---
+    for entry in &atlas_pool.entries {
+        if let Some(buffer) = buffers.get_mut(&entry.anim_buffer) {
+            buffer.set_data(entry.anim_data.as_slice());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Set the active animation on a sprite creature, resetting frame on anim change.
+fn set_anim(sd: &mut SpriteData, marker: &mut SpriteCreatureMarker, anim: &AnimDef) {
+    if marker.anim_base_row != anim.base_row {
+        marker.anim_base_row = anim.base_row;
+        marker.anim_frame_count = anim.frame_count;
+        sd.anim_row = anim.base_row + marker.direction;
+        sd.anim_frames = anim.frame_count;
+        sd.current_frame = 0;
+        sd.frame_timer = 0.0;
+    } else {
+        sd.anim_row = anim.base_row + marker.direction;
+        sd.anim_frames = anim.frame_count;
+        if sd.current_frame >= sd.anim_frames {
+            sd.current_frame = 0;
+        }
+    }
+}
+
+/// Hide a creature's blob shadow.
+fn hide_shadow(
+    shadow: Option<&CreatureShadowLink>,
+    shadow_q: &mut Query<(&mut BlobShadow, &mut Visibility), Without<Creature>>,
+) {
+    if let Some(CreatureShadowLink(se)) = shadow {
+        if let Ok((mut bs, mut sv)) = shadow_q.get_mut(*se) {
+            bs.anchor.y = -100.0;
+            *sv = Visibility::Hidden;
+        }
+    }
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/definitions.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/definitions.rs
@@ -1,0 +1,75 @@
+//! Creature type descriptors — the data that drives the generic system.
+
+use super::types::*;
+
+/// Build all sprite creature type descriptors.
+pub fn build_sprite_creature_types() -> SpriteCreatureTypes {
+    SpriteCreatureTypes {
+        types: vec![boar()],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boar: 4-directional, 2 anims (idle + run), always visible, linear run
+// ---------------------------------------------------------------------------
+
+fn boar() -> SpriteCreatureType {
+    SpriteCreatureType {
+        npc_ref: "wild-boar",
+        texture_path: "textures/creatures/boar/boar-sprite.png",
+        sheet_cols: 7,
+        sheet_rows: 8,
+        sprite_size: 1.4,
+        shadow_radius_factor: 0.4,
+        shadow_height_factor: 0.5,
+        frame_duration_base: 0.12,
+        idle_min: 3.0,
+        idle_max: 10.0,
+        recycle_dist: 32.0,
+        spawn_ring_inner: 18.0,
+        spawn_ring_outer: 26.0,
+        seed_offset: 4400,
+        direction_model: DirectionModel::FourWay {
+            // NE=0, NW=1, SE=2, SW=3 (stag/boar row order)
+            // quadrant index: (diff>=0)<<1 | (sum>=0)
+            //   diff>=0, sum<0  → q=2 → NE → row 0
+            //   diff<0,  sum<0  → q=0 → NW → row 1
+            //   diff>=0, sum>=0 → q=3 → SE → row 2
+            //   diff<0,  sum>=0 → q=1 → SW → row 3
+            quadrant_to_row: [1, 3, 0, 2],
+        },
+        movement: MovementProfile::LinearRun,
+        visibility: VisibilitySchedule::Always,
+        tint: TintProfile::Standard,
+        anims: AnimSet {
+            idle: AnimDef {
+                base_row: 0,
+                frame_count: 7,
+            },
+            actions: vec![AnimAction {
+                name: "run",
+                def: AnimDef {
+                    base_row: 4,
+                    frame_count: 4,
+                },
+            }],
+        },
+        behavior: BehaviorProfile {
+            choices: vec![
+                BehaviorChoice {
+                    threshold: 0.40,
+                    action: BehaviorAction::Move {
+                        anim_name: "run",
+                        min_dist: 2.0,
+                        max_dist: 5.0,
+                        speed: 3.5,
+                    },
+                },
+                BehaviorChoice {
+                    threshold: 1.0,
+                    action: BehaviorAction::ExtendedIdle { repeat: 2 },
+                },
+            ],
+        },
+    }
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/mod.rs
@@ -1,0 +1,12 @@
+//! Generic data-driven sprite creature system.
+//!
+//! Replaces per-creature modules (frog, wolf, etc.) with a single set of
+//! spawn/animate/tint systems driven by `SpriteCreatureType` descriptors.
+
+pub mod animate;
+pub mod definitions;
+pub mod spawn;
+pub mod tint;
+pub mod types;
+
+pub use types::{CreatureShadowLink, SpriteAtlasPool, SpriteCreatureMarker, SpriteCreatureTypes};

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/spawn.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/spawn.rs
@@ -1,0 +1,171 @@
+//! Generic spawn system for all sprite-sheet creatures.
+
+use bevy::camera::visibility::NoFrustumCulling;
+use bevy::light::NotShadowCaster;
+use bevy::mesh::MeshTag;
+use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
+
+use super::super::common::{CreaturePool, build_billboard_quad, hash_f32};
+use super::super::creature::{
+    Creature, CreaturePoolIndex, CreatureRegistry, CreatureState, RenderKind, SpriteData,
+    SpriteHopState,
+};
+use super::super::sprite_material::{SpriteAnimData, SpriteAtlasMaterial};
+use super::types::*;
+use crate::game::weather::BlobShadowAssets;
+
+/// Single spawn system that spawns all generic sprite creature types.
+pub fn spawn_sprite_creatures(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut atlas_materials: ResMut<Assets<SpriteAtlasMaterial>>,
+    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+    asset_server: Res<AssetServer>,
+    pool: Res<CreaturePool>,
+    registry: Res<CreatureRegistry>,
+    types: Res<SpriteCreatureTypes>,
+    mut atlas_pool: ResMut<SpriteAtlasPool>,
+    blob_shadow: Option<Res<BlobShadowAssets>>,
+) {
+    for creature_type in &types.types {
+        // Skip if already spawned
+        if atlas_pool
+            .entries
+            .iter()
+            .any(|e| e.type_key == creature_type.npc_ref && e.spawned)
+        {
+            continue;
+        }
+
+        // Look up pool size from registry
+        let Some(config) = registry.config_by_ref(creature_type.npc_ref) else {
+            warn!(
+                "[generic] no registry config for '{}' — skipping",
+                creature_type.npc_ref
+            );
+            continue;
+        };
+        let npc_id = registry
+            .npc_db
+            .id_for_ref(creature_type.npc_ref)
+            .unwrap_or(bevy_kbve_net::npcdb::ProtoNpcId(0));
+        let count = config.pool_size;
+
+        // Build shared resources
+        let texture: Handle<Image> = asset_server.load(creature_type.texture_path);
+        let quad_mesh = meshes.add(build_billboard_quad(creature_type.sprite_size));
+
+        let anim_data: Vec<SpriteAnimData> =
+            (0..count).map(|_| SpriteAnimData::default()).collect();
+        let anim_buffer = buffers.add(ShaderStorageBuffer::from(anim_data.clone()));
+
+        let material = atlas_materials.add(SpriteAtlasMaterial {
+            atlas: texture,
+            anim_data: anim_buffer.clone(),
+            atlas_grid: UVec2::new(creature_type.sheet_cols, creature_type.sheet_rows),
+            tint: LinearRgba::WHITE,
+        });
+
+        // Store in atlas pool
+        let entry_idx = atlas_pool.entries.len();
+        atlas_pool.entries.push(SpriteAtlasEntry {
+            type_key: creature_type.npc_ref,
+            material: material.clone(),
+            anim_buffer: anim_buffer.clone(),
+            anim_data,
+            spawned: true,
+        });
+
+        let idle_anim = &creature_type.anims.idle;
+        let seed_offset = creature_type.seed_offset;
+
+        for i in 0..count {
+            let seed = (i as u32).wrapping_add(seed_offset);
+            let phase = hash_f32(seed * 11 + 1);
+            let direction = match &creature_type.direction_model {
+                DirectionModel::Flip => 0,
+                DirectionModel::FourWay { .. } => (hash_f32(seed * 37 + 5) * 4.0) as u32 % 4,
+            };
+            let idle_timer = creature_type.idle_min
+                + hash_f32(seed * 53 + 11) * (creature_type.idle_max - creature_type.idle_min);
+            let frame_duration =
+                creature_type.frame_duration_base * (0.8 + hash_f32(seed * 79 + 17) * 0.4);
+
+            let initial_row = match &creature_type.direction_model {
+                DirectionModel::Flip => idle_anim.base_row,
+                DirectionModel::FourWay { quadrant_to_row } => idle_anim.base_row + direction,
+            };
+
+            // Spawn blob shadow
+            let shadow_entity = if let Some(ref bs) = blob_shadow {
+                Some(
+                    commands
+                        .spawn((
+                            Mesh3d(bs.mesh.clone()),
+                            MeshMaterial3d(bs.material.clone()),
+                            Transform::from_xyz(0.0, -100.0, 0.0),
+                            Visibility::Hidden,
+                            crate::game::weather::BlobShadow {
+                                anchor: Vec3::new(0.0, -100.0, 0.0),
+                                radius: creature_type.sprite_size
+                                    * creature_type.shadow_radius_factor,
+                                object_height: creature_type.sprite_size
+                                    * creature_type.shadow_height_factor,
+                            },
+                        ))
+                        .id(),
+                )
+            } else {
+                None
+            };
+
+            let mut entity = commands.spawn((
+                Mesh3d(quad_mesh.clone()),
+                MeshMaterial3d(material.clone()),
+                MeshTag(i as u32),
+                Transform::from_xyz(0.0, -100.0, 0.0),
+                Visibility::Hidden,
+                NoFrustumCulling,
+                NotShadowCaster,
+                Creature {
+                    npc_id,
+                    render_kind: RenderKind::Sprite,
+                    state: CreatureState::Pooled,
+                    slot_seed: seed,
+                    assigned_slot: None,
+                    anchor: Vec3::new(0.0, -100.0, 0.0),
+                    phase,
+                    mat_handle: Handle::default(),
+                },
+                SpriteData {
+                    frame_timer: hash_f32(seed * 83 + 13) * frame_duration,
+                    frame_duration,
+                    current_frame: 0,
+                    anim_row: initial_row,
+                    anim_frames: idle_anim.frame_count,
+                    facing_left: hash_f32(seed * 67 + 3) > 0.5,
+                    hop_state: SpriteHopState::Idle { timer: idle_timer },
+                },
+                CreaturePoolIndex(i as u32),
+                SpriteCreatureMarker {
+                    type_key: creature_type.npc_ref,
+                    patrol_step: (hash_f32(seed * 97 + 31) * 1000.0) as u32,
+                    direction,
+                    anim_base_row: idle_anim.base_row,
+                    anim_frame_count: idle_anim.frame_count,
+                    active_move_speed: 0.0,
+                },
+            ));
+
+            if let Some(se) = shadow_entity {
+                entity.insert(CreatureShadowLink(se));
+            }
+        }
+
+        info!(
+            "[generic] spawned {} '{}' entities (atlas instanced)",
+            count, creature_type.npc_ref
+        );
+    }
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/tint.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/tint.rs
@@ -1,0 +1,47 @@
+//! Unified day/night tinting for all generic sprite creatures.
+
+use bevy::prelude::*;
+
+use super::super::sprite_material::SpriteAtlasMaterial;
+use super::types::{SpriteAtlasPool, SpriteCreatureTypes, TintProfile};
+use crate::game::weather::{DayCycle, sun_params};
+
+/// Single system that tints all sprite creature materials based on time of day.
+/// Replaces per-creature `tint_xyz_for_daynight` functions.
+pub fn tint_sprite_creatures(
+    day: Res<DayCycle>,
+    atlas_pool: Res<SpriteAtlasPool>,
+    types: Res<SpriteCreatureTypes>,
+    mut atlas_materials: ResMut<Assets<SpriteAtlasMaterial>>,
+) {
+    let params = sun_params(day.hour);
+    let h = params.sun_height;
+
+    let r = 0.18 + h * 0.92;
+    let g = 0.20 + h * 0.90;
+    let b = 0.28 + h * 0.75;
+
+    for entry in &atlas_pool.entries {
+        let tint_profile = types
+            .types
+            .iter()
+            .find(|t| t.npc_ref == entry.type_key)
+            .map(|t| t.tint)
+            .unwrap_or(TintProfile::Standard);
+
+        let alpha = match tint_profile {
+            TintProfile::Standard => 1.0,
+            TintProfile::Ghost => {
+                if h < 0.01 {
+                    1.0
+                } else {
+                    0.35 + (1.0 - h) * 0.15
+                }
+            }
+        };
+
+        if let Some(mat) = atlas_materials.get_mut(&entry.material) {
+            mat.tint = LinearRgba::new(r, g, b, alpha);
+        }
+    }
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/types.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/types.rs
@@ -1,0 +1,234 @@
+//! Generic sprite creature types — data-driven definitions that replace
+//! per-creature hardcoded modules.
+
+use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
+
+use super::super::sprite_material::{SpriteAnimData, SpriteAtlasMaterial};
+
+// ---------------------------------------------------------------------------
+// Per-entity components
+// ---------------------------------------------------------------------------
+
+/// Generic marker for all sprite-sheet creatures processed by the unified
+/// spawn/animate systems. Replaces per-creature markers (WolfMarker, etc.).
+#[derive(Component)]
+pub struct SpriteCreatureMarker {
+    /// Key into `SpriteCreatureTypes` resource.
+    pub type_key: &'static str,
+    /// Deterministic patrol counter — incremented on every decision.
+    pub patrol_step: u32,
+    /// Current 4-way direction index (ignored for `DirectionModel::Flip`).
+    pub direction: u32,
+    /// Base row of the currently active animation block.
+    pub anim_base_row: u32,
+    /// Frame count of the currently active animation.
+    pub anim_frame_count: u32,
+    /// Movement speed for the current action (set at transition time).
+    pub active_move_speed: f32,
+}
+
+/// Links a sprite creature entity to its blob shadow entity.
+#[derive(Component)]
+pub struct CreatureShadowLink(pub Entity);
+
+// ---------------------------------------------------------------------------
+// Direction handling
+// ---------------------------------------------------------------------------
+
+/// How a sprite creature resolves its facing direction.
+#[derive(Clone, Debug)]
+pub enum DirectionModel {
+    /// 2-way: sprite faces left or right via UV mirror (frog, wraith).
+    Flip,
+    /// 4-directional atlas rows. Each animation block has 4 sub-rows.
+    /// `quadrant_to_row[q]` maps an isometric quadrant index to a row offset.
+    ///
+    /// Quadrant index is derived from movement delta `(dx, dz)`:
+    ///   `q = (diff_positive as u32) << 1 | sum_positive as u32`
+    ///   where `diff = dx - dz`, `sum = dx + dz`.
+    FourWay { quadrant_to_row: [u32; 4] },
+}
+
+/// Compute 4-way isometric direction from movement delta.
+/// Returns a quadrant index: `(diff>=0) << 1 | (sum>=0)`.
+#[inline]
+pub fn iso_quadrant(dx: f32, dz: f32) -> u32 {
+    let diff = dx - dz;
+    let sum = dx + dz;
+    ((diff >= 0.0) as u32) << 1 | (sum >= 0.0) as u32
+}
+
+// ---------------------------------------------------------------------------
+// Movement
+// ---------------------------------------------------------------------------
+
+/// How a creature moves during `SpriteHopState::Airborne`.
+#[derive(Clone, Debug)]
+pub enum MovementProfile {
+    /// Frog-style hop with parabolic arc.
+    HopArc {
+        base_height: f32,
+        height_per_dist: f32,
+        max_jump_height_diff: f32,
+        jump_airborne_frame: u32,
+    },
+    /// Linear ground run at the speed specified per-action.
+    LinearRun,
+    /// Wraith-style glide with sine hover bob.
+    Glide {
+        speed: f32,
+        hover_base: f32,
+        hover_amplitude: f32,
+        hover_frequency: f32,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Animation
+// ---------------------------------------------------------------------------
+
+/// A single animation definition: base row + frame count.
+#[derive(Clone, Copy, Debug)]
+pub struct AnimDef {
+    pub base_row: u32,
+    pub frame_count: u32,
+}
+
+/// A named animation action (e.g. "run", "bite", "attack").
+#[derive(Clone, Debug)]
+pub struct AnimAction {
+    pub name: &'static str,
+    pub def: AnimDef,
+}
+
+/// Complete animation set for a creature type.
+#[derive(Clone, Debug)]
+pub struct AnimSet {
+    /// The default idle animation.
+    pub idle: AnimDef,
+    /// Additional named animations referenced by `BehaviorAction`.
+    pub actions: Vec<AnimAction>,
+}
+
+impl AnimSet {
+    /// Look up an action by name, falling back to idle if not found.
+    pub fn find(&self, name: &str) -> AnimDef {
+        self.actions
+            .iter()
+            .find(|a| a.name == name)
+            .map(|a| a.def)
+            .unwrap_or(self.idle)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Behavior
+// ---------------------------------------------------------------------------
+
+/// What a creature does when its idle timer expires.
+#[derive(Clone, Debug)]
+pub enum BehaviorAction {
+    /// Move to a random nearby position.
+    Move {
+        anim_name: &'static str,
+        min_dist: f32,
+        max_dist: f32,
+        speed: f32,
+    },
+    /// Play an emote animation in place.
+    Emote {
+        anim_name: &'static str,
+        repeat: u32,
+    },
+    /// Extended idle (same as Emote with idle anim).
+    ExtendedIdle { repeat: u32 },
+}
+
+/// A weighted behavior choice.
+#[derive(Clone, Debug)]
+pub struct BehaviorChoice {
+    /// Cumulative probability threshold (0.0–1.0).
+    pub threshold: f32,
+    pub action: BehaviorAction,
+}
+
+/// Behavior profile: weighted list of choices on idle timeout.
+#[derive(Clone, Debug)]
+pub struct BehaviorProfile {
+    pub choices: Vec<BehaviorChoice>,
+}
+
+// ---------------------------------------------------------------------------
+// Tinting
+// ---------------------------------------------------------------------------
+
+/// How weather tinting is applied to this creature type.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TintProfile {
+    /// Standard day/night RGB tint, alpha = 1.0.
+    Standard,
+    /// Ghost tint: same RGB, alpha fades during daytime (wraith).
+    Ghost,
+}
+
+// ---------------------------------------------------------------------------
+// Visibility schedule (reuses TimeSchedule from bevy_kbve_net)
+// ---------------------------------------------------------------------------
+
+pub use bevy_kbve_net::npcdb::TimeSchedule as VisibilitySchedule;
+
+// ---------------------------------------------------------------------------
+// Complete type descriptor
+// ---------------------------------------------------------------------------
+
+/// Static descriptor for one sprite creature type. Lives in the
+/// `SpriteCreatureTypes` resource, keyed by NPC ref string.
+#[derive(Clone, Debug)]
+pub struct SpriteCreatureType {
+    pub npc_ref: &'static str,
+    pub texture_path: &'static str,
+    pub sheet_cols: u32,
+    pub sheet_rows: u32,
+    pub sprite_size: f32,
+    pub shadow_radius_factor: f32,
+    pub shadow_height_factor: f32,
+    pub frame_duration_base: f32,
+    pub idle_min: f32,
+    pub idle_max: f32,
+    pub recycle_dist: f32,
+    pub spawn_ring_inner: f32,
+    pub spawn_ring_outer: f32,
+    pub seed_offset: u32,
+    pub direction_model: DirectionModel,
+    pub movement: MovementProfile,
+    pub visibility: VisibilitySchedule,
+    pub tint: TintProfile,
+    pub anims: AnimSet,
+    pub behavior: BehaviorProfile,
+}
+
+// ---------------------------------------------------------------------------
+// Resources
+// ---------------------------------------------------------------------------
+
+/// All registered sprite creature type descriptors.
+#[derive(Resource, Default)]
+pub struct SpriteCreatureTypes {
+    pub types: Vec<SpriteCreatureType>,
+}
+
+/// Per-creature-type GPU resources (material + SSBO). One entry per type.
+#[derive(Resource, Default)]
+pub struct SpriteAtlasPool {
+    pub entries: Vec<SpriteAtlasEntry>,
+}
+
+/// GPU resources for a single creature type.
+pub struct SpriteAtlasEntry {
+    pub type_key: &'static str,
+    pub material: Handle<SpriteAtlasMaterial>,
+    pub anim_buffer: Handle<ShaderStorageBuffer>,
+    pub anim_data: Vec<SpriteAnimData>,
+    pub spawned: bool,
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -4,6 +4,7 @@ pub mod common;
 pub mod creature;
 mod firefly;
 mod frog;
+pub mod generic;
 pub mod sprite_material;
 mod stag;
 mod wolf;
@@ -77,6 +78,11 @@ impl Plugin for CreaturesPlugin {
         app.init_resource::<StagAtlasResources>();
         app.init_resource::<BoarAtlasResources>();
         app.init_resource::<firefly::FireflyState>();
+
+        // --- Generic sprite creature system ---
+        app.insert_resource(generic::definitions::build_sprite_creature_types());
+        app.init_resource::<generic::SpriteAtlasPool>();
+
         app.add_systems(Startup, setup_creature_meshes);
 
         // --- Per-type systems ---
@@ -108,9 +114,11 @@ impl Plugin for CreaturesPlugin {
                 // Stags (SpriteAtlasMaterial + SSBO, 4-directional, daytime)
                 stag::spawn_stags.run_if(|pool: Res<CreaturePool>| !pool.stags_spawned),
                 stag::animate_stags.run_if(any_with_component::<stag::StagMarker>),
-                // Boars (SpriteAtlasMaterial + SSBO, 4-directional)
-                boar::spawn_boars.run_if(|pool: Res<CreaturePool>| !pool.boars_spawned),
-                boar::animate_boars.run_if(any_with_component::<boar::BoarMarker>),
+                // --- Generic sprite creatures (boar migrated) ---
+                generic::spawn::spawn_sprite_creatures,
+                generic::animate::animate_sprite_creatures
+                    .after(generic::spawn::spawn_sprite_creatures)
+                    .run_if(any_with_component::<generic::SpriteCreatureMarker>),
             ),
         );
     }

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -43,7 +43,7 @@ impl Default for DayCycle {
 }
 
 /// Sun arc parameters derived from game hour.
-struct SunParams {
+pub(crate) struct SunParams {
     /// Direction the light points (normalized, toward ground).
     direction: Vec3,
     /// Direct light illuminance (lux).
@@ -55,12 +55,12 @@ struct SunParams {
     /// Ambient color.
     ambient_color: Color,
     /// 0.0 at night, 1.0 at zenith — used to tint unlit materials.
-    sun_height: f32,
+    pub(crate) sun_height: f32,
 }
 
 /// Compute sun parameters for a given game hour.
 /// Sun rises ~6:00, peaks ~12:00, sets ~18:00. Night 20:00–4:00.
-fn sun_params(hour: f32) -> SunParams {
+pub(crate) fn sun_params(hour: f32) -> SunParams {
     // Sun elevation: 0 at horizon, π/2 at zenith
     // Maps 6:00=sunrise, 12:00=zenith, 18:00=sunset
     // Outside 5:00–19:00 the sun is below horizon
@@ -793,6 +793,8 @@ impl Plugin for WeatherPlugin {
                 tint_wolves_for_daynight.run_if(resource_changed::<DayCycle>),
                 tint_stags_for_daynight.run_if(resource_changed::<DayCycle>),
                 tint_boars_for_daynight.run_if(resource_changed::<DayCycle>),
+                super::creatures::generic::tint::tint_sprite_creatures
+                    .run_if(resource_changed::<DayCycle>),
                 update_blob_shadows.run_if(any_with_component::<BlobShadow>),
                 animate_veg_wind.run_if(any_with_component::<WindSway>),
                 animate_tree_wind.run_if(any_with_component::<TreeWindSway>),


### PR DESCRIPTION
## Summary
- Build data-driven creature system alongside existing per-creature modules
- `SpriteCreatureType` descriptors define atlas layout, animations, movement profiles, behavior weights, and direction models
- Single `spawn_sprite_creatures` + `animate_sprite_creatures` + `tint_sprite_creatures` systems replace per-creature hardcoded modules
- Migrate boar as first creature to validate the generic system
- Legacy modules (frog, wolf, stag, wraith) remain active — future phases migrate them one at a time

## New files
- `creatures/generic/types.rs` — all type definitions
- `creatures/generic/definitions.rs` — boar descriptor as data
- `creatures/generic/spawn.rs` — single spawn system
- `creatures/generic/animate.rs` — parameterized state machine
- `creatures/generic/tint.rs` — unified day/night tinting

## Test plan
- [ ] Run isometric game — boar should spawn, animate, move, and tint identically to before
- [ ] Verify other creatures (frog, wolf, stag, wraith) still work via legacy systems
- [ ] Check day/night tinting cycle for boar
- [ ] Verify blob shadows appear under boar