### PR TITLE
fix(guacamole): fix KEDA cron trigger permanently scaling to zero

### DIFF
--- a/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
@@ -1,11 +1,8 @@
 # KEDA ScaledObjects for Guacamole stack.
 #
-# Previously used github-runner triggers (removed to save API quota).
-# Guacamole now scales based on whether the VM is running — CI workflows
-# that start VMs should also scale up guacd + guacamole via kubectl.
+# Guacamole scales to 1 replica when the Windows VM is likely in use
+# (weekdays 06:00–22:00 UTC) and back to 0 outside that window.
 # Manual override: kubectl scale deploy guacd guacamole -n angelscript --replicas=1
-#
-# Kept as ScaledObjects with no active triggers so KEDA manages scale-to-zero.
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -27,9 +24,9 @@ spec:
         - type: cron
           metadata:
               timezone: UTC
-              start: '0 6 * * 1-5'
-              end: '0 7 * * 1-5'
-              desiredReplicas: '0'
+              start: 0 6 * * 1-5
+              end: 0 22 * * 1-5
+              desiredReplicas: '1'
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -51,6 +48,6 @@ spec:
         - type: cron
           metadata:
               timezone: UTC
-              start: '0 6 * * 1-5'
-              end: '0 7 * * 1-5'
-              desiredReplicas: '0'
+              start: 0 6 * * 1-5
+              end: 0 22 * * 1-5
+              desiredReplicas: '1'


### PR DESCRIPTION
## Summary
Fix KEDA ScaledObject cron triggers for guacd and guacamole deployments.

## Root cause
The cron triggers were configured with `desiredReplicas: '0'` during a 1-hour window (06:00-07:00 UTC weekdays), and `idleReplicaCount: 0`. Outside that 1-hour window, **no trigger was active**, so KEDA fell back to `idleReplicaCount: 0` — permanently zero replicas. There was never a trigger to scale UP.

Additionally, the `kubevirt-guacamole` ArgoCD app exists in `kustomization.yaml` but is `OutOfSync` in the root app — once the root syncs, the app will be created.

## Fix
- `desiredReplicas: '1'` during business hours (Mon-Fri 06:00-22:00 UTC)
- `idleReplicaCount: 0` scales to zero outside that window (nights + weekends)
- Same pattern applied to both `guacd-scaler` and `guacamole-scaler`

## Test plan
- [ ] After merge + root app sync: Guacamole ArgoCD app is created
- [ ] KEDA scales guacd + guacamole to 1 during business hours
- [ ] RDP WebSocket connection succeeds from dashboard
- [ ] Scales to 0 after 22:00 UTC on weekdays and all day on weekends