### PR TITLE
fix(isometric): pooled native toast system and remove duplicate loot toasts

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/toast.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/toast.rs
@@ -1,98 +1,299 @@
-//! Simple in-game toast notification system.
+//! Pooled in-game toast notification system with severity styling.
 //!
-//! Toasts are temporary text messages that appear at the bottom of the screen
-//! and fade out after a few seconds. Works on both native and WASM.
+//! Pre-allocates `MAX_VISIBLE` toast slots at startup. Toasts are shown by
+//! making pooled nodes visible and hidden on expiry — no per-toast
+//! spawn/despawn overhead.
 //!
 //! # Usage
 //!
 //! ```ignore
-//! commands.trigger(Toast::new("Found 1x Wood"));
+//! commands.trigger(Toast::loot("+ 3x Wood"));
 //! commands.trigger(Toast::info("Connected to server"));
 //! commands.trigger(Toast::warn("WebTransport failed — using WebSocket"));
+//! commands.trigger(Toast::error("Disconnected from server"));
 //! ```
 
 use bevy::prelude::*;
 use std::collections::VecDeque;
 
-/// Maximum number of visible toasts at once.
+use super::ui_color;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of visible toasts at once (also the pool size).
 const MAX_VISIBLE: usize = 5;
 
-/// How long a toast stays fully visible (seconds).
-const DISPLAY_DURATION: f32 = 3.0;
+/// Toast panel width.
+const TOAST_WIDTH: f32 = 280.0;
+/// Toast panel height.
+const TOAST_HEIGHT: f32 = 36.0;
+/// Width of the colored severity stripe on the left.
+const STRIPE_WIDTH: f32 = 4.0;
+/// Gap between stacked toasts.
+const TOAST_GAP: f32 = 6.0;
 
-/// How long the fade-out takes (seconds).
-const FADE_DURATION: f32 = 1.0;
+// ---------------------------------------------------------------------------
+// Toast severity
+// ---------------------------------------------------------------------------
+
+/// Severity level determines accent color and display duration.
+#[derive(Clone, Copy, Debug, Default)]
+pub enum ToastSeverity {
+    #[default]
+    Info,
+    Success,
+    Warning,
+    Error,
+    Loot,
+}
+
+impl ToastSeverity {
+    /// Accent color for the left border stripe.
+    pub fn accent_color(self) -> Color {
+        match self {
+            Self::Info => ui_color::TOAST_INFO,
+            Self::Success => ui_color::TOAST_SUCCESS,
+            Self::Warning => ui_color::TOAST_WARNING,
+            Self::Error => ui_color::TOAST_ERROR,
+            Self::Loot => ui_color::TOAST_LOOT,
+        }
+    }
+
+    /// How long the toast stays fully visible (seconds).
+    pub fn display_duration(self) -> f32 {
+        match self {
+            Self::Info => 3.0,
+            Self::Success => 3.0,
+            Self::Warning => 5.0,
+            Self::Error => 6.0,
+            Self::Loot => 4.0,
+        }
+    }
+
+    /// Fade-out duration (seconds).
+    pub fn fade_duration(self) -> f32 {
+        1.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Toast event
+// ---------------------------------------------------------------------------
 
 /// Event to trigger a toast notification.
 #[derive(Event, Clone, Debug)]
 pub struct Toast {
     pub message: String,
-    pub color: Color,
+    pub severity: ToastSeverity,
 }
 
 impl Toast {
     pub fn new(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            color: Color::srgb(0.9, 0.88, 0.75),
+            severity: ToastSeverity::Info,
         }
     }
 
     pub fn info(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            color: Color::srgb(0.6, 0.85, 0.6),
+            severity: ToastSeverity::Info,
+        }
+    }
+
+    pub fn success(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            severity: ToastSeverity::Success,
         }
     }
 
     pub fn warn(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            color: Color::srgb(0.95, 0.75, 0.3),
+            severity: ToastSeverity::Warning,
         }
     }
 
     pub fn error(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            color: Color::srgb(0.95, 0.4, 0.35),
+            severity: ToastSeverity::Error,
+        }
+    }
+
+    pub fn loot(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            severity: ToastSeverity::Loot,
         }
     }
 }
 
-/// Internal state for an active toast.
-struct ActiveToast {
-    entity: Entity,
-    timer: f32,
-}
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
 
-/// Resource tracking active toasts.
-#[derive(Resource, Default)]
-struct ToastQueue {
-    active: VecDeque<ActiveToast>,
-}
-
-/// Marker for the toast container node.
+/// Marker for the toast container node (top-right anchor).
 #[derive(Component)]
 struct ToastContainer;
 
-/// Marker for individual toast text entities.
+/// Marker for a pooled toast slot (the outer panel node).
 #[derive(Component)]
-struct ToastEntry;
+struct ToastSlot {
+    /// Pool index (0..MAX_VISIBLE).
+    index: usize,
+}
+
+/// The colored left stripe inside a toast slot.
+#[derive(Component)]
+struct ToastStripe {
+    index: usize,
+}
+
+/// The text node inside a toast slot.
+#[derive(Component)]
+struct ToastText {
+    index: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Resources
+// ---------------------------------------------------------------------------
+
+/// Tracks active toast state per pool slot.
+#[derive(Default)]
+struct SlotState {
+    active: bool,
+    timer: f32,
+    display_duration: f32,
+    fade_duration: f32,
+}
+
+/// Resource managing the toast pool.
+#[derive(Resource)]
+struct ToastPool {
+    slots: Vec<SlotState>,
+    /// FIFO queue of pending toasts when all slots are occupied.
+    pending: VecDeque<Toast>,
+}
+
+impl Default for ToastPool {
+    fn default() -> Self {
+        Self {
+            slots: (0..MAX_VISIBLE).map(|_| SlotState::default()).collect(),
+            pending: VecDeque::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
 
 pub struct ToastPlugin;
 
 impl Plugin for ToastPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ToastQueue>();
-        app.add_systems(Startup, spawn_toast_container);
+        app.init_resource::<ToastPool>();
+        app.add_systems(Startup, spawn_toast_pool);
         app.add_observer(on_toast_event);
         app.add_observer(on_loot_event);
-        app.add_systems(Update, update_toasts);
+        app.add_systems(Update, update_toast_pool);
     }
 }
 
-/// Show a toast when the player receives loot.
+// ---------------------------------------------------------------------------
+// Spawn pre-allocated pool
+// ---------------------------------------------------------------------------
+
+fn spawn_toast_pool(mut commands: Commands) {
+    // Container: top-right, column flowing downward
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(12.0),
+                right: Val::Px(12.0),
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(TOAST_GAP),
+                align_items: AlignItems::FlexEnd,
+                ..default()
+            },
+            GlobalZIndex(90),
+            ToastContainer,
+        ))
+        .with_children(|container| {
+            for i in 0..MAX_VISIBLE {
+                // Outer panel (hidden by default)
+                container
+                    .spawn((
+                        Node {
+                            width: Val::Px(TOAST_WIDTH),
+                            height: Val::Px(TOAST_HEIGHT),
+                            flex_direction: FlexDirection::Row,
+                            align_items: AlignItems::Center,
+                            overflow: Overflow::clip(),
+                            border_radius: BorderRadius::all(Val::Px(4.0)),
+                            ..default()
+                        },
+                        BackgroundColor(ui_color::TOAST_BG),
+                        Visibility::Hidden,
+                        ToastSlot { index: i },
+                    ))
+                    .with_children(|panel| {
+                        // Left accent stripe
+                        panel.spawn((
+                            Node {
+                                width: Val::Px(STRIPE_WIDTH),
+                                height: Val::Percent(100.0),
+                                ..default()
+                            },
+                            BackgroundColor(ui_color::TOAST_INFO),
+                            ToastStripe { index: i },
+                        ));
+
+                        // Text
+                        panel.spawn((
+                            Text::new(""),
+                            TextFont {
+                                font_size: 13.0,
+                                ..default()
+                            },
+                            TextColor(ui_color::TEXT_PRIMARY),
+                            Node {
+                                margin: UiRect::horizontal(Val::Px(10.0)),
+                                ..default()
+                            },
+                            ToastText { index: i },
+                        ));
+                    });
+            }
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Observers
+// ---------------------------------------------------------------------------
+
+fn on_toast_event(trigger: On<Toast>, mut pool: ResMut<ToastPool>) {
+    let toast = trigger.event().clone();
+
+    // Find a free slot
+    if let Some(slot_idx) = pool.slots.iter().position(|s| !s.active) {
+        activate_slot(&mut pool.slots[slot_idx], &toast);
+        // We can't update the UI nodes here (no query access in observer),
+        // so we store the toast data in pending with a marker
+        pool.pending.push_back(toast);
+    } else {
+        // All slots full — queue it
+        pool.pending.push_back(toast);
+    }
+}
+
 fn on_loot_event(
     trigger: On<super::inventory::LootEvent<super::inventory::ItemKind>>,
     mut commands: Commands,
@@ -101,87 +302,101 @@ fn on_loot_event(
     let loot = trigger.event();
     let name = loot.kind.display_name();
     let qty = loot.quantity;
-    commands.trigger(Toast::new(format!("+ {qty}x {name}")));
+    commands.trigger(Toast::loot(format!("+ {qty}x {name}")));
 }
 
-fn spawn_toast_container(mut commands: Commands) {
-    commands
-        .spawn(Node {
-            position_type: PositionType::Absolute,
-            bottom: Val::Px(16.0),
-            left: Val::Px(16.0),
-            flex_direction: FlexDirection::ColumnReverse,
-            row_gap: Val::Px(4.0),
-            ..default()
-        })
-        .insert(ToastContainer);
+fn activate_slot(slot: &mut SlotState, toast: &Toast) {
+    slot.active = true;
+    slot.timer = 0.0;
+    slot.display_duration = toast.severity.display_duration();
+    slot.fade_duration = toast.severity.fade_duration();
 }
 
-fn on_toast_event(
-    trigger: On<Toast>,
-    mut commands: Commands,
-    mut queue: ResMut<ToastQueue>,
-    container_q: Query<Entity, With<ToastContainer>>,
-) {
-    let Ok(container) = container_q.single() else {
-        return;
-    };
+// ---------------------------------------------------------------------------
+// Update system: applies pending toasts to UI nodes, ticks timers, fades
+// ---------------------------------------------------------------------------
 
-    let toast = trigger.event();
-
-    // Spawn toast text as child of container
-    let entry = commands
-        .spawn(Text::new(&toast.message))
-        .insert(TextFont {
-            font_size: 14.0,
-            ..default()
-        })
-        .insert(TextColor(toast.color))
-        .insert(ToastEntry)
-        .id();
-
-    commands.entity(container).add_child(entry);
-
-    queue.active.push_back(ActiveToast {
-        entity: entry,
-        timer: 0.0,
-    });
-
-    // Remove oldest if over limit
-    while queue.active.len() > MAX_VISIBLE {
-        if let Some(old) = queue.active.pop_front() {
-            commands.entity(old.entity).try_despawn();
-        }
-    }
-}
-
-fn update_toasts(
+fn update_toast_pool(
     time: Res<Time>,
-    mut commands: Commands,
-    mut queue: ResMut<ToastQueue>,
-    mut text_colors: Query<&mut TextColor, With<ToastEntry>>,
+    mut pool: ResMut<ToastPool>,
+    mut slot_q: Query<(&ToastSlot, &mut Visibility, &mut BackgroundColor)>,
+    mut stripe_q: Query<(&ToastStripe, &mut BackgroundColor), Without<ToastSlot>>,
+    mut text_q: Query<(&ToastText, &mut Text, &mut TextColor)>,
 ) {
     let dt = time.delta_secs();
-    let total_duration = DISPLAY_DURATION + FADE_DURATION;
 
-    queue.active.retain_mut(|toast| {
-        toast.timer += dt;
+    // Apply pending toasts to free slots and update their UI
+    while let Some(toast) = pool.pending.front().cloned() {
+        if let Some(slot_idx) = pool.slots.iter().position(|s| !s.active) {
+            pool.pending.pop_front();
+            activate_slot(&mut pool.slots[slot_idx], &toast);
 
-        if toast.timer >= total_duration {
-            commands.entity(toast.entity).try_despawn();
-            return false;
+            // Update UI nodes for this slot
+            for (slot, mut vis, _) in &mut slot_q {
+                if slot.index == slot_idx {
+                    *vis = Visibility::Visible;
+                }
+            }
+            for (stripe, mut bg) in &mut stripe_q {
+                if stripe.index == slot_idx {
+                    *bg = toast.severity.accent_color().into();
+                }
+            }
+            for (text, mut txt, mut color) in &mut text_q {
+                if text.index == slot_idx {
+                    **txt = toast.message.clone();
+                    color.0 = ui_color::TEXT_PRIMARY;
+                }
+            }
+        } else {
+            break; // No free slots — wait
+        }
+    }
+
+    // Tick active slots, fade out, and recycle
+    for i in 0..MAX_VISIBLE {
+        let slot = &mut pool.slots[i];
+        if !slot.active {
+            continue;
         }
 
-        // Fade out during the last FADE_DURATION seconds
-        if toast.timer > DISPLAY_DURATION {
-            let fade_progress = (toast.timer - DISPLAY_DURATION) / FADE_DURATION;
+        slot.timer += dt;
+        let total = slot.display_duration + slot.fade_duration;
+
+        if slot.timer >= total {
+            // Expired — hide and recycle
+            slot.active = false;
+            for (s, mut vis, _) in &mut slot_q {
+                if s.index == i {
+                    *vis = Visibility::Hidden;
+                }
+            }
+            continue;
+        }
+
+        // Fade out during the last fade_duration seconds
+        if slot.timer > slot.display_duration {
+            let fade_progress = (slot.timer - slot.display_duration) / slot.fade_duration;
             let alpha = 1.0 - fade_progress;
-            if let Ok(mut color) = text_colors.get_mut(toast.entity) {
-                let c = color.0.to_srgba();
-                color.0 = Color::srgba(c.red, c.green, c.blue, alpha);
+
+            for (s, _, mut bg) in &mut slot_q {
+                if s.index == i {
+                    let c = ui_color::TOAST_BG.to_srgba();
+                    *bg = Color::srgba(c.red, c.green, c.blue, c.alpha * alpha).into();
+                }
+            }
+            for (text, _, mut color) in &mut text_q {
+                if text.index == i {
+                    let c = ui_color::TEXT_PRIMARY.to_srgba();
+                    color.0 = Color::srgba(c.red, c.green, c.blue, alpha);
+                }
+            }
+            for (stripe, mut bg) in &mut stripe_q {
+                if stripe.index == i {
+                    let c = bg.0.to_srgba();
+                    *bg = Color::srgba(c.red, c.green, c.blue, alpha).into();
+                }
             }
         }
-
-        true
-    });
+    }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/ui_color.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/ui_color.rs
@@ -82,6 +82,28 @@ pub const BADGE_OFFLINE: Color = Color::srgba(0.5, 0.5, 0.55, 0.8);
 pub const BADGE_LOADING: Color = Color::srgba(0.95, 0.75, 0.2, 0.9);
 
 // ---------------------------------------------------------------------------
+// Toast severity accents (left border stripe)
+// ---------------------------------------------------------------------------
+
+/// Info toast accent.
+pub const TOAST_INFO: Color = Color::srgba(0.3, 0.7, 1.0, 1.0);
+
+/// Success toast accent.
+pub const TOAST_SUCCESS: Color = Color::srgba(0.3, 0.85, 0.45, 1.0);
+
+/// Warning toast accent.
+pub const TOAST_WARNING: Color = Color::srgba(0.95, 0.75, 0.2, 1.0);
+
+/// Error toast accent.
+pub const TOAST_ERROR: Color = Color::srgba(0.95, 0.3, 0.3, 1.0);
+
+/// Loot toast accent (golden).
+pub const TOAST_LOOT: Color = Color::srgba(0.85, 0.72, 0.25, 1.0);
+
+/// Toast panel background.
+pub const TOAST_BG: Color = Color::srgba(0.06, 0.07, 0.10, 0.92);
+
+// ---------------------------------------------------------------------------
 // Misc
 // ---------------------------------------------------------------------------
 

--- a/apps/kbve/isometric/src/hooks/useInventory.tsx
+++ b/apps/kbve/isometric/src/hooks/useInventory.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { get_inventory_json } from '../../wasm-pkg/isometric_game.js';
-import { gameEvents } from '../ui/events/event-bus';
 
 interface ItemStack {
 	kind: string;
@@ -12,61 +11,15 @@ interface InventoryData {
 	max_slots: number;
 }
 
-const ITEM_NAMES: Record<string, string> = {
-	log: 'Log',
-	stone: 'Stone',
-	mossy_stone: 'Mossy Stone',
-	copper_ore: 'Copper Ore',
-	iron_ore: 'Iron Ore',
-	crystal_ore: 'Crystal Ore',
-	tulip: 'Tulip',
-	daisy: 'Daisy',
-	lavender: 'Lavender',
-	bellflower: 'Bellflower',
-	wildflower: 'Wildflower',
-	sunflower: 'Sunflower',
-	rose: 'Rose',
-	cornflower: 'Cornflower',
-	allium: 'Allium',
-	blue_orchid: 'Blue Orchid',
-	porcini: 'Porcini',
-	chanterelle: 'Chanterelle',
-	fly_agaric: 'Fly Agaric',
-};
-
 export function useInventory() {
 	const [inventory, setInventory] = useState<InventoryData | null>(null);
-	const prevItemsRef = useRef<Map<string, number>>(new Map());
 
 	useEffect(() => {
 		const interval = setInterval(() => {
 			try {
 				const json = get_inventory_json();
 				if (!json) return;
-
-				const data = JSON.parse(json) as InventoryData;
-				setInventory(data);
-
-				// Check for new items to show loot toast
-				const current = new Map<string, number>();
-				for (const item of data.items) {
-					current.set(item.kind, item.quantity);
-				}
-
-				const prev = prevItemsRef.current;
-				for (const [kind, qty] of current) {
-					const prevQty = prev.get(kind) ?? 0;
-					if (qty > prevQty) {
-						const gained = qty - prevQty;
-						const name = ITEM_NAMES[kind] ?? kind;
-						gameEvents.emit('toast:show', {
-							message: `+${gained} ${name}`,
-							severity: 'loot',
-						});
-					}
-				}
-
-				prevItemsRef.current = current;
+				setInventory(JSON.parse(json) as InventoryData);
 			} catch {
 				// WASM not ready
 			}


### PR DESCRIPTION
## Summary
- **Phase 0:** Removed duplicate loot toast from React `useInventory.tsx` — Bevy `toast.rs` already fires via `LootEvent` observer, so JS was doubling every loot notification
- **Phase 1:** Rewrote native Bevy toast system with:
  - `ToastSeverity` enum (Info/Success/Warning/Error/Loot) with per-severity accent colors and display durations
  - Pre-allocated pool of 5 toast slots (zero spawn/despawn overhead)
  - Panel styling: dark bg, 4px colored left stripe, rounded corners
  - Top-right positioning (matches React toast layout)
  - Pending queue when all slots are occupied
  - Coordinated fade-out on panel + text + stripe
  - New `ui_color.rs` constants: `TOAST_INFO`, `TOAST_SUCCESS`, `TOAST_WARNING`, `TOAST_ERROR`, `TOAST_LOOT`, `TOAST_BG`

## Test plan
- [ ] Verify loot toasts appear only once (not duplicated)
- [ ] Verify toast appears in top-right with colored left stripe
- [ ] Verify different severity types show correct accent colors
- [ ] Verify toasts fade out after their duration
- [ ] Verify max 5 visible toasts, excess queued
- [ ] Verify no spawn/despawn entity churn in the ECS