### PR TITLE
fix(clickhouse): use Distributed table for cross-shard log queries

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCHLogStream.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCHLogStream.tsx
@@ -284,7 +284,7 @@ export default function ReactCHLogStream() {
 					<span>
 						Showing {logs.rows.length} of {logs.count} results
 					</span>
-					<span>Source: observability.logs_raw</span>
+					<span>Source: observability.logs_distributed</span>
 				</div>
 			)}
 		</>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactClickHouseDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactClickHouseDashboard.tsx
@@ -1451,7 +1451,7 @@ export default function ReactClickHouseDashboard() {
 						<span>
 							Showing {logs.rows.length} of {logs.count} results
 						</span>
-						<span>Source: observability.logs_raw</span>
+						<span>Source: observability.logs_distributed</span>
 					</div>
 				)}
 			</div>

--- a/apps/kbve/edge/functions/logs/index.ts
+++ b/apps/kbve/edge/functions/logs/index.ts
@@ -10,7 +10,7 @@ import {
 import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
 
 // ---------------------------------------------------------------------------
-// Logs Edge Function — Query observability.logs_raw in ClickHouse
+// Logs Edge Function — Query observability.logs_distributed in ClickHouse
 //
 // Auth: service_role only (admin/staff access)
 //
@@ -82,7 +82,7 @@ async function handleQuery(params: QueryParams) {
     query: `
       SELECT timestamp, pod_namespace, service, level,
              message, pod_name, metadata
-      FROM logs_raw
+      FROM logs_distributed
       ${where}
       ORDER BY timestamp DESC
       LIMIT {lim:UInt32}
@@ -101,7 +101,7 @@ async function handleStats(params: { minutes?: number }) {
   const resultSet = await ch.query({
     query: `
       SELECT pod_namespace, service, level, count() as cnt
-      FROM logs_raw
+      FROM logs_distributed
       WHERE timestamp > now() - INTERVAL {minutes:UInt32} MINUTE
       GROUP BY pod_namespace, service, level
       ORDER BY cnt DESC

--- a/packages/data/ch/schemas/observability.sql
+++ b/packages/data/ch/schemas/observability.sql
@@ -1,6 +1,9 @@
--- observability.logs_raw — single raw log table for Vector → ClickHouse direct pipeline
+-- observability.logs_raw — replicated local table for Vector → ClickHouse direct pipeline
 -- All services (kong, auth, rest, realtime, storage, functions, db, analytics, meta, studio)
 -- land in one table, partitioned by day, 45-day TTL.
+--
+-- Cluster topology: 2 shards × 2 replicas.
+-- Vector writes to logs_raw (local); queries go through logs_distributed.
 
 CREATE DATABASE IF NOT EXISTS observability ON CLUSTER 'cluster';
 
@@ -15,7 +18,13 @@ CREATE TABLE IF NOT EXISTS observability.logs_raw ON CLUSTER 'cluster'
     pod_namespace   LowCardinality(String) DEFAULT '',
     ingested_at     DateTime64(3, 'UTC') DEFAULT now64(3)
 )
-ENGINE = MergeTree
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/observability/logs_raw', '{replica}')
 ORDER BY (service, timestamp)
 PARTITION BY toYYYYMMDD(timestamp)
 TTL toDateTime(timestamp) + INTERVAL 45 DAY;
+
+-- Distributed table — fans out reads/writes across all shards.
+-- Queries should use this table; Vector writes to logs_raw (local) directly.
+CREATE TABLE IF NOT EXISTS observability.logs_distributed ON CLUSTER 'cluster'
+AS observability.logs_raw
+ENGINE = Distributed('cluster', 'observability', 'logs_raw', rand());


### PR DESCRIPTION
## Summary
- Dashboard showed 0 logs because `logs_raw` used `MergeTree` on a 2-shard cluster — queries only hit the local shard
- Changed `logs_raw` engine to `ReplicatedMergeTree` for intra-shard replication
- Added `logs_distributed` table (`Distributed` engine) to fan out queries across all shards
- Updated edge function and UI labels to query `logs_distributed`

## Deployment
After merge, the existing `logs_raw` table must be dropped and recreated (engine change requires DDL):
1. `DROP TABLE IF EXISTS observability.logs_raw ON CLUSTER 'cluster'`
2. Run the updated `observability.sql` schema
3. Vector resumes writing automatically; dashboard reads via `logs_distributed`

## Test plan
- [ ] Verify `logs_raw` creates with `ReplicatedMergeTree` engine on cluster
- [ ] Verify `logs_distributed` fans out `SELECT` across both shards
- [ ] Confirm dashboard shows non-zero log counts after Vector resumes ingestion