### PR TITLE
feat(discordsh-bot): PR status, commit heatmap, and health history charts

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
@@ -534,6 +534,19 @@ async fn pulls(
                         reply = reply.embed(detail_embed);
                     }
                 }
+                // Chart buttons
+                let chart_row = poise::serenity_prelude::CreateActionRow::Buttons(vec![
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|pr_status"
+                    ))
+                    .label("PR Status")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F4CA}".to_owned(),
+                    )),
+                ]);
+                reply = reply.components(vec![chart_row]);
+
                 ctx.send(reply).await.map_err(|e| e.to_string())?;
                 Ok(())
             }
@@ -735,6 +748,19 @@ async fn commits(
                         reply = reply.embed(detail_embed);
                     }
                 }
+                // Chart buttons
+                let chart_row = poise::serenity_prelude::CreateActionRow::Buttons(vec![
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|commit_freq"
+                    ))
+                    .label("Heatmap")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F525}".to_owned(),
+                    )),
+                ]);
+                reply = reply.components(vec![chart_row]);
+
                 ctx.send(reply).await.map_err(|e| e.to_string())?;
                 Ok(())
             }

--- a/apps/discordsh/discordsh-bot/src/discord/commands/health.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/health.rs
@@ -58,7 +58,17 @@ pub async fn health(ctx: Context<'_>) -> Result<(), Error> {
         .footer(serenity::CreateEmbedFooter::new(branding::footer_text()))
         .timestamp(serenity::Timestamp::now());
 
-    let reply = poise::CreateReply::default().embed(embed);
+    // Health history chart button
+    let chart_row = serenity::CreateActionRow::Buttons(vec![
+        serenity::CreateButton::new("chart|health|history")
+            .label("History")
+            .style(serenity::ButtonStyle::Secondary)
+            .emoji(serenity::ReactionType::Unicode("\u{1F4C8}".to_owned())),
+    ]);
+
+    let reply = poise::CreateReply::default()
+        .embed(embed)
+        .components(vec![chart_row]);
     ctx.send(reply).await?;
     Ok(())
 }

--- a/apps/discordsh/discordsh-bot/src/discord/components/chart_buttons.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/chart_buttons.rs
@@ -1,5 +1,5 @@
 //! Chart button interaction handler — renders on-demand SVG charts
-//! when users click chart buttons on `/github` embeds.
+//! when users click chart buttons on `/github` and `/health` embeds.
 
 use poise::serenity_prelude as serenity;
 use std::sync::Arc;
@@ -12,8 +12,8 @@ use crate::state::AppState;
 
 /// Handle a component interaction whose `custom_id` starts with `"chart|"`.
 ///
-/// Custom ID format: `chart|<owner/repo>|<chart_type>`
-/// Chart types: `languages`, `activity`, `labels`
+/// Custom ID format: `chart|<owner/repo>|<chart_type>` or `chart|health|history`
+/// Chart types: `languages`, `activity`, `labels`, `pr_status`, `commit_freq`, `history`
 pub async fn handle_chart_component(
     ctx: &serenity::Context,
     component: &serenity::ComponentInteraction,
@@ -25,7 +25,7 @@ pub async fn handle_chart_component(
         return;
     }
 
-    let repo = parts[1].to_owned();
+    let target = parts[1].to_owned();
     let chart_type = parts[2].to_owned();
 
     // Defer with ephemeral — chart is shown only to the requester
@@ -42,7 +42,13 @@ pub async fn handle_chart_component(
         return;
     }
 
-    let result = render_chart(ctx, component, app, &repo, &chart_type).await;
+    // Health chart is special — no GitHub API needed
+    if target == "health" && chart_type == "history" {
+        handle_health_chart(ctx, component, app).await;
+        return;
+    }
+
+    let result = render_github_chart(ctx, component, app, &target, &chart_type).await;
 
     match result {
         Ok((png_bytes, filename, title, full_name)) => {
@@ -76,7 +82,80 @@ pub async fn handle_chart_component(
     }
 }
 
-async fn render_chart(
+async fn handle_health_chart(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    app: &Arc<AppState>,
+) {
+    let history = app.health_monitor.history().await;
+
+    if history.len() < 2 {
+        let _ = component
+            .edit_response(
+                &ctx.http,
+                serenity::EditInteractionResponse::new()
+                    .content("Not enough health data yet — try again in a few minutes."),
+            )
+            .await;
+        return;
+    }
+
+    let uptime = app
+        .health_monitor
+        .snapshot()
+        .await
+        .map(|s| s.uptime_formatted.clone())
+        .unwrap_or_else(|| "unknown".to_owned());
+
+    let fontdb = app.fontdb.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        github_cards::render_health_chart_blocking(&history, &uptime, &fontdb)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(png_bytes)) => {
+            let attachment = serenity::CreateAttachment::bytes(png_bytes, "health.png");
+            let embed = serenity::CreateEmbed::new()
+                .title("System Health History")
+                .image("attachment://health.png")
+                .color(0x57F287)
+                .author(branding::embed_author())
+                .footer(branding::embed_footer(None));
+
+            let _ = component
+                .edit_response(
+                    &ctx.http,
+                    serenity::EditInteractionResponse::new()
+                        .embed(embed)
+                        .new_attachment(attachment),
+                )
+                .await;
+        }
+        Ok(Err(e)) => {
+            warn!(error = %e, "Health chart render error");
+            let _ = component
+                .edit_response(
+                    &ctx.http,
+                    serenity::EditInteractionResponse::new()
+                        .content(format!("Chart render failed: {e}")),
+                )
+                .await;
+        }
+        Err(e) => {
+            warn!(error = %e, "Health chart task panicked");
+            let _ = component
+                .edit_response(
+                    &ctx.http,
+                    serenity::EditInteractionResponse::new().content("Chart render failed"),
+                )
+                .await;
+        }
+    }
+}
+
+async fn render_github_chart(
     _ctx: &serenity::Context,
     component: &serenity::ComponentInteraction,
     app: &Arc<AppState>,
@@ -165,6 +244,46 @@ async fn render_chart(
                 png,
                 "labels.png".to_owned(),
                 "Label Distribution".to_owned(),
+                full_name,
+            ))
+        }
+        "pr_status" => {
+            let pulls = gh
+                .list_pulls(&owner, &repo_name, Some("open"), Some(25))
+                .await
+                .map_err(|e| format!("Failed to fetch PRs: {e}"))?;
+
+            let full_clone = full_name.clone();
+            let png = tokio::task::spawn_blocking(move || {
+                github_cards::render_pr_status_chart_blocking(&pulls, &full_clone, &fontdb)
+            })
+            .await
+            .map_err(|e| format!("Task panicked: {e}"))??;
+
+            Ok((
+                png,
+                "pr_status.png".to_owned(),
+                "PR Status".to_owned(),
+                full_name,
+            ))
+        }
+        "commit_freq" => {
+            let commits = gh
+                .list_commits(&owner, &repo_name, None, Some(100))
+                .await
+                .map_err(|e| format!("Failed to fetch commits: {e}"))?;
+
+            let full_clone = full_name.clone();
+            let png = tokio::task::spawn_blocking(move || {
+                github_cards::render_commit_frequency_chart_blocking(&commits, &full_clone, &fontdb)
+            })
+            .await
+            .map_err(|e| format!("Task panicked: {e}"))??;
+
+            Ok((
+                png,
+                "commit_freq.png".to_owned(),
+                "Commit Frequency".to_owned(),
                 full_name,
             ))
         }

--- a/apps/discordsh/discordsh-bot/src/discord/game/github_cards.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/github_cards.rs
@@ -4,6 +4,7 @@
 //! Askama SVG template → resvg PNG rendering via `spawn_blocking`.
 
 use askama::Template;
+use chrono::Datelike;
 use jedi::entity::github::{GitHubCommit, GitHubIssue, GitHubPull, GitHubRepo};
 use std::collections::HashMap;
 
@@ -1038,6 +1039,421 @@ pub fn render_activity_chart_blocking(
         .render()
         .map_err(|e| format!("Activity chart SVG: {e}"))?;
     kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Activity chart PNG: {e}"))
+}
+
+// ── PR Status Chart ────────────────────────────────────────────────
+
+pub struct PrStatusRow {
+    pub number: u64,
+    pub title: String,
+    pub status_color: String,
+    pub age_bar: f64,
+    pub age_color: String,
+    pub age_text: String,
+    pub age_label_x: f64,
+    pub y: u32,
+}
+
+#[derive(Template)]
+#[template(path = "github/pr_status_chart.svg")]
+pub struct PrStatusChartTemplate {
+    pub repo_name: String,
+    pub total_prs: usize,
+    pub draft_count: usize,
+    pub ready_count: usize,
+    pub ready_width: f64,
+    pub draft_width: f64,
+    pub prs: Vec<PrStatusRow>,
+    pub height: u32,
+    pub footer_y: u32,
+    pub brand_y: u32,
+}
+
+pub fn build_pr_status_chart(pulls: &[GitHubPull], repo_name: &str) -> PrStatusChartTemplate {
+    let now = chrono::Utc::now();
+    let draft_count = pulls.iter().filter(|p| p.draft).count();
+    let ready_count = pulls.len() - draft_count;
+    let bar_total = 744.0;
+
+    let (ready_width, draft_width) = if !pulls.is_empty() {
+        let rw = (ready_count as f64 / pulls.len() as f64) * bar_total;
+        (rw, bar_total - rw)
+    } else {
+        (0.0, 0.0)
+    };
+
+    let max_age_days = pulls
+        .iter()
+        .filter_map(|p| {
+            chrono::DateTime::parse_from_rfc3339(&p.created_at)
+                .ok()
+                .map(|dt| (now - dt.with_timezone(&chrono::Utc)).num_days().max(0) as f64)
+        })
+        .fold(1.0_f64, f64::max);
+
+    let prs: Vec<PrStatusRow> = pulls
+        .iter()
+        .take(12)
+        .enumerate()
+        .map(|(i, pr)| {
+            let age_days = chrono::DateTime::parse_from_rfc3339(&pr.created_at)
+                .ok()
+                .map(|dt| (now - dt.with_timezone(&chrono::Utc)).num_days().max(0))
+                .unwrap_or(0);
+
+            let age_frac = age_days as f64 / max_age_days;
+            let age_bar = (age_frac * 240.0).max(4.0);
+            let age_color = if age_days > 14 {
+                "#da3633".to_owned()
+            } else if age_days > 7 {
+                "#e3b341".to_owned()
+            } else {
+                "#238636".to_owned()
+            };
+
+            PrStatusRow {
+                number: pr.number,
+                title: truncate(&pr.title, 50),
+                status_color: if pr.draft {
+                    "#8b949e".to_owned()
+                } else {
+                    "#238636".to_owned()
+                },
+                age_bar,
+                age_color,
+                age_text: format!("{}d", age_days),
+                age_label_x: 500.0 + age_bar + 8.0,
+                y: 125 + (i as u32 * 28),
+            }
+        })
+        .collect();
+
+    let row_count = prs.len() as u32;
+    let height = 125 + row_count * 28 + 30;
+
+    PrStatusChartTemplate {
+        repo_name: repo_name.to_owned(),
+        total_prs: pulls.len(),
+        draft_count,
+        ready_count,
+        ready_width,
+        draft_width,
+        prs,
+        height,
+        footer_y: height - 8,
+        brand_y: height - 14,
+    }
+}
+
+pub fn render_pr_status_chart_blocking(
+    pulls: &[GitHubPull],
+    repo_name: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_pr_status_chart(pulls, repo_name);
+    let svg = template
+        .render()
+        .map_err(|e| format!("PR status chart SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("PR status chart PNG: {e}"))
+}
+
+// ── Commit Frequency Chart ─────────────────────────────────────────
+
+pub struct HeatmapCell {
+    pub x: f64,
+    pub y: f64,
+    pub color: String,
+}
+
+pub struct WeekLabel {
+    pub x: f64,
+    pub text: String,
+}
+
+pub struct TopAuthor {
+    pub name: String,
+    pub count: usize,
+    pub x: u32,
+}
+
+pub struct LegendSwatch {
+    pub x: u32,
+    pub color: String,
+}
+
+#[derive(Template)]
+#[template(path = "github/commit_frequency_chart.svg")]
+pub struct CommitFrequencyChartTemplate {
+    pub repo_name: String,
+    pub total_commits: usize,
+    pub day_count: usize,
+    pub avg_per_day: String,
+    pub cells: Vec<HeatmapCell>,
+    pub week_labels: Vec<WeekLabel>,
+    pub legend_swatches: Vec<LegendSwatch>,
+    pub legend_more_x: u32,
+    pub top_authors: Vec<TopAuthor>,
+}
+
+pub fn build_commit_frequency_chart(
+    commits: &[GitHubCommit],
+    repo_name: &str,
+) -> CommitFrequencyChartTemplate {
+    let now = chrono::Utc::now();
+    let weeks = 8usize;
+    let day_count = weeks * 7;
+
+    // Count commits per day slot (row=weekday, col=week)
+    let mut grid = vec![vec![0u32; weeks]; 7];
+    let mut author_counts: HashMap<String, usize> = HashMap::new();
+
+    for c in commits {
+        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&c.commit.author.date) {
+            let days_ago = (now - dt.with_timezone(&chrono::Utc)).num_days();
+            if days_ago >= 0 && (days_ago as usize) < day_count {
+                let weekday = dt.weekday().num_days_from_monday() as usize; // 0=Mon
+                let week_idx = weeks - 1 - (days_ago as usize / 7);
+                if week_idx < weeks {
+                    grid[weekday][week_idx] += 1;
+                }
+            }
+            *author_counts
+                .entry(c.commit.author.name.clone())
+                .or_default() += 1;
+        }
+    }
+
+    let max_count = grid
+        .iter()
+        .flat_map(|r| r.iter())
+        .copied()
+        .max()
+        .unwrap_or(1)
+        .max(1);
+    let cell_size = 18.0;
+    let gap = 2.0;
+
+    // Heatmap cells
+    let cells: Vec<HeatmapCell> = (0..7)
+        .flat_map(|row| {
+            let grid_ref = &grid;
+            (0..weeks).map(move |col| {
+                let count = grid_ref[row][col];
+                let intensity = count as f64 / max_count as f64;
+                let color = heatmap_color(intensity);
+                HeatmapCell {
+                    x: col as f64 * (cell_size + gap),
+                    y: row as f64 * (cell_size + gap),
+                    color,
+                }
+            })
+        })
+        .collect();
+
+    // Week labels
+    let week_labels: Vec<WeekLabel> = (0..weeks)
+        .filter(|w| w % 2 == 0)
+        .map(|w| {
+            let date = now - chrono::Duration::days(((weeks - 1 - w) * 7) as i64);
+            WeekLabel {
+                x: w as f64 * (cell_size + gap) + cell_size / 2.0,
+                text: date.format("%m/%d").to_string(),
+            }
+        })
+        .collect();
+
+    // Legend
+    let legend_swatches: Vec<LegendSwatch> = (0..5)
+        .map(|i| LegendSwatch {
+            x: 36 + i * 20,
+            color: heatmap_color(i as f64 / 4.0),
+        })
+        .collect();
+
+    // Top authors
+    let mut sorted_authors: Vec<_> = author_counts.into_iter().collect();
+    sorted_authors.sort_by(|a, b| b.1.cmp(&a.1));
+    let top_authors: Vec<TopAuthor> = sorted_authors
+        .iter()
+        .take(4)
+        .enumerate()
+        .map(|(i, (name, count))| TopAuthor {
+            name: truncate(name, 15),
+            count: *count,
+            x: i as u32 * 180,
+        })
+        .collect();
+
+    let avg = if day_count > 0 {
+        format!("{:.1}", commits.len() as f64 / day_count as f64)
+    } else {
+        "0".to_owned()
+    };
+
+    CommitFrequencyChartTemplate {
+        repo_name: repo_name.to_owned(),
+        total_commits: commits.len(),
+        day_count,
+        avg_per_day: avg,
+        cells,
+        week_labels,
+        legend_swatches,
+        legend_more_x: 36 + 5 * 20 + 4,
+        top_authors,
+    }
+}
+
+fn heatmap_color(intensity: f64) -> String {
+    match intensity {
+        x if x <= 0.0 => "#161b22".to_owned(),
+        x if x <= 0.25 => "#0e4429".to_owned(),
+        x if x <= 0.5 => "#006d32".to_owned(),
+        x if x <= 0.75 => "#26a641".to_owned(),
+        _ => "#39d353".to_owned(),
+    }
+}
+
+pub fn render_commit_frequency_chart_blocking(
+    commits: &[GitHubCommit],
+    repo_name: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_commit_frequency_chart(commits, repo_name);
+    let svg = template
+        .render()
+        .map_err(|e| format!("Commit frequency SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Commit frequency PNG: {e}"))
+}
+
+// ── Health History Chart ───────────────────────────────────────────
+
+pub struct HealthGridLine {
+    pub y: f64,
+    pub label_y: f64,
+    pub value: u32,
+}
+
+pub struct HealthTimeLabel {
+    pub x: f64,
+    pub text: String,
+}
+
+#[derive(Template)]
+#[template(path = "github/health_chart.svg")]
+pub struct HealthChartTemplate {
+    pub sample_count: usize,
+    pub uptime: String,
+    pub memory_path: String,
+    pub cpu_path: String,
+    pub grid_lines: Vec<HealthGridLine>,
+    pub time_labels: Vec<HealthTimeLabel>,
+    pub current_memory: String,
+    pub current_cpu: String,
+    pub current_threads: usize,
+    pub current_pid: u32,
+}
+
+pub fn build_health_chart(
+    history: &[crate::health::HealthSnapshot],
+    uptime: &str,
+) -> HealthChartTemplate {
+    let chart_width = 680.0;
+    let chart_height = 180.0;
+    let sample_count = history.len();
+
+    // Build polyline paths
+    let step = if sample_count > 1 {
+        chart_width / (sample_count - 1) as f64
+    } else {
+        chart_width
+    };
+
+    let memory_path: String = history
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let x = i as f64 * step;
+            let y = chart_height - (s.memory_percent / 100.0) * chart_height;
+            format!("{:.1},{:.1}", x, y)
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let cpu_path: String = history
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let x = i as f64 * step;
+            let y = chart_height - (s.cpu_percent / 100.0) * chart_height;
+            format!("{:.1},{:.1}", x, y)
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    // Grid lines at 0%, 25%, 50%, 75%, 100%
+    let grid_lines: Vec<HealthGridLine> = (0..=4)
+        .map(|i| {
+            let pct = (4 - i) * 25;
+            let y = (i as f64 / 4.0) * chart_height;
+            HealthGridLine {
+                y,
+                label_y: y + 4.0,
+                value: pct,
+            }
+        })
+        .collect();
+
+    // Time labels
+    let time_labels: Vec<HealthTimeLabel> = if sample_count > 4 {
+        let step_label = sample_count / 4;
+        (0..=4)
+            .map(|i| {
+                let idx = (i * step_label).min(sample_count - 1);
+                let mins_ago = (sample_count - 1 - idx) as u32;
+                HealthTimeLabel {
+                    x: idx as f64 * step,
+                    text: if mins_ago == 0 {
+                        "now".to_owned()
+                    } else {
+                        format!("-{}m", mins_ago)
+                    },
+                }
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let last = history.last();
+
+    HealthChartTemplate {
+        sample_count,
+        uptime: uptime.to_owned(),
+        memory_path,
+        cpu_path,
+        grid_lines,
+        time_labels,
+        current_memory: last
+            .map(|s| format!("{:.1}", s.memory_percent))
+            .unwrap_or_default(),
+        current_cpu: last
+            .map(|s| format!("{:.1}", s.cpu_percent))
+            .unwrap_or_default(),
+        current_threads: last.map(|s| s.thread_count).unwrap_or(0),
+        current_pid: last.map(|s| s.pid).unwrap_or(0),
+    }
+}
+
+pub fn render_health_chart_blocking(
+    history: &[crate::health::HealthSnapshot],
+    uptime: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_health_chart(history, uptime);
+    let svg = template
+        .render()
+        .map_err(|e| format!("Health chart SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Health chart PNG: {e}"))
 }
 
 #[cfg(test)]

--- a/apps/discordsh/discordsh-bot/src/health/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/health/mod.rs
@@ -92,9 +92,13 @@ impl HealthSnapshot {
 ///
 /// Owns a persistent `sysinfo::System` for accurate CPU delta measurement
 /// and exposes the latest `HealthSnapshot` via an `Arc<RwLock<>>`.
+/// Maximum number of historical snapshots to retain (60 = ~1 hour at 60s intervals).
+const HISTORY_CAPACITY: usize = 60;
+
 pub struct HealthMonitor {
     sys: RwLock<System>,
     snapshot: RwLock<Option<HealthSnapshot>>,
+    history: RwLock<std::collections::VecDeque<HealthSnapshot>>,
     start_time: Instant,
     pid: sysinfo::Pid,
 }
@@ -110,6 +114,7 @@ impl HealthMonitor {
         Self {
             sys: RwLock::new(sys),
             snapshot: RwLock::new(None),
+            history: RwLock::new(std::collections::VecDeque::with_capacity(HISTORY_CAPACITY)),
             start_time: Instant::now(),
             pid,
         }
@@ -129,6 +134,11 @@ impl HealthMonitor {
         self.snapshot.read().await.clone()
     }
 
+    /// Read the rolling history of snapshots (oldest first).
+    pub async fn history(&self) -> Vec<HealthSnapshot> {
+        self.history.read().await.iter().cloned().collect()
+    }
+
     /// Force an immediate metric refresh (used by the Refresh button).
     pub async fn force_refresh(&self) {
         let snap = self.collect_inner().await;
@@ -141,7 +151,8 @@ impl HealthMonitor {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         let snap = self.collect_inner().await;
-        *self.snapshot.write().await = Some(snap);
+        *self.snapshot.write().await = Some(snap.clone());
+        self.push_history(snap).await;
         info!("Initial health snapshot collected");
 
         let mut interval = tokio::time::interval(Duration::from_secs(60));
@@ -150,8 +161,18 @@ impl HealthMonitor {
         loop {
             interval.tick().await;
             let snap = self.collect_inner().await;
-            *self.snapshot.write().await = Some(snap);
+            *self.snapshot.write().await = Some(snap.clone());
+            self.push_history(snap).await;
         }
+    }
+
+    /// Push a snapshot into the rolling history, evicting the oldest if at capacity.
+    async fn push_history(&self, snap: HealthSnapshot) {
+        let mut history = self.history.write().await;
+        if history.len() >= HISTORY_CAPACITY {
+            history.pop_front();
+        }
+        history.push_back(snap);
     }
 
     /// Refresh the persistent System and extract a snapshot.

--- a/apps/discordsh/discordsh-bot/templates/github/commit_frequency_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/commit_frequency_chart.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="340" viewBox="0 0 800 340">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="340" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="340" fill="#2EA043" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">Commit Frequency -- {{ repo_name }}</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">{{ total_commits }} commits over {{ day_count }} days | avg {{ avg_per_day }} / day</text>
+
+  <!-- Heatmap grid (7 rows x N cols) -->
+  <g transform="translate(80, 80)">
+    <!-- Day labels -->
+    <text x="-12" y="16" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">Mon</text>
+    <text x="-12" y="36" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">Tue</text>
+    <text x="-12" y="56" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">Wed</text>
+    <text x="-12" y="76" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">Thu</text>
+    <text x="-12" y="96" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">Fri</text>
+    <text x="-12" y="116" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">Sat</text>
+    <text x="-12" y="136" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">Sun</text>
+
+    <!-- Heatmap cells -->
+    {% for cell in cells %}
+    <rect x="{{ cell.x }}" y="{{ cell.y }}" width="16" height="16" fill="{{ cell.color }}" rx="3"/>
+    {% endfor %}
+
+    <!-- Week labels -->
+    {% for wl in week_labels %}
+    <text x="{{ wl.x }}" y="-6" font-family="sans-serif" font-size="9" fill="#484f58" text-anchor="middle">{{ wl.text }}</text>
+    {% endfor %}
+  </g>
+
+  <!-- Color legend -->
+  <g transform="translate(80, 240)">
+    <text x="0" y="12" font-family="sans-serif" font-size="11" fill="#484f58">Less</text>
+    {% for swatch in legend_swatches %}
+    <rect x="{{ swatch.x }}" y="0" width="16" height="16" fill="{{ swatch.color }}" rx="3"/>
+    {% endfor %}
+    <text x="{{ legend_more_x }}" y="12" font-family="sans-serif" font-size="11" fill="#484f58">More</text>
+  </g>
+
+  <!-- Top authors -->
+  <g transform="translate(28, 275)">
+    <text x="0" y="0" font-family="sans-serif" font-size="12" font-weight="600" fill="#8b949e">Top contributors</text>
+    {% for author in top_authors %}
+    <text x="{{ author.x }}" y="20" font-family="sans-serif" font-size="12" fill="#e6edf3">{{ author.name }} ({{ author.count }})</text>
+    {% endfor %}
+  </g>
+
+  <!-- Footer -->
+  <rect x="0" y="332" width="800" height="8" fill="#2EA043" opacity="0.3"/>
+  <text x="760" y="326" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>

--- a/apps/discordsh/discordsh-bot/templates/github/health_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/health_chart.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="320" viewBox="0 0 800 320">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="320" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="320" fill="#57F287" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">System Health History</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">Last {{ sample_count }} readings | {{ uptime }}</text>
+
+  <!-- Legend -->
+  <g transform="translate(540, 28)">
+    <line x1="0" y1="8" x2="20" y2="8" stroke="#57F287" stroke-width="2"/>
+    <text x="24" y="12" font-family="sans-serif" font-size="11" fill="#8b949e">Memory %</text>
+    <line x1="110" y1="8" x2="130" y2="8" stroke="#5865F2" stroke-width="2"/>
+    <text x="134" y="12" font-family="sans-serif" font-size="11" fill="#8b949e">CPU %</text>
+  </g>
+
+  <!-- Chart area -->
+  <g transform="translate(60, 75)">
+    <!-- Grid lines -->
+    {% for grid in grid_lines %}
+    <line x1="0" y1="{{ grid.y }}" x2="680" y2="{{ grid.y }}" stroke="#21262d" stroke-width="1"/>
+    <text x="-8" y="{{ grid.label_y }}" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="end">{{ grid.value }}%</text>
+    {% endfor %}
+
+    <!-- Memory line (green) -->
+    {% if memory_path.len() > 0 %}
+    <polyline points="{{ memory_path }}" fill="none" stroke="#57F287" stroke-width="2" stroke-linejoin="round"/>
+    {% endif %}
+
+    <!-- CPU line (blue/blurple) -->
+    {% if cpu_path.len() > 0 %}
+    <polyline points="{{ cpu_path }}" fill="none" stroke="#5865F2" stroke-width="2" stroke-linejoin="round" stroke-dasharray="4,2"/>
+    {% endif %}
+
+    <!-- Time labels -->
+    {% for tl in time_labels %}
+    <text x="{{ tl.x }}" y="200" font-family="sans-serif" font-size="10" fill="#484f58" text-anchor="middle">{{ tl.text }}</text>
+    {% endfor %}
+  </g>
+
+  <!-- Current values -->
+  <g transform="translate(28, 290)">
+    <text x="0" y="0" font-family="sans-serif" font-size="13" fill="#57F287">Memory: {{ current_memory }}%</text>
+    <text x="180" y="0" font-family="sans-serif" font-size="13" fill="#5865F2">CPU: {{ current_cpu }}%</text>
+    <text x="320" y="0" font-family="sans-serif" font-size="13" fill="#8b949e">Threads: {{ current_threads }}</text>
+    <text x="460" y="0" font-family="sans-serif" font-size="13" fill="#8b949e">PID: {{ current_pid }}</text>
+  </g>
+
+  <!-- Footer -->
+  <rect x="0" y="312" width="800" height="8" fill="#57F287" opacity="0.3"/>
+  <text x="760" y="306" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>

--- a/apps/discordsh/discordsh-bot/templates/github/pr_status_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/pr_status_chart.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="{{ height }}" viewBox="0 0 800 {{ height }}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="{{ height }}" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="{{ height }}" fill="#8957E5" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">PR Status -- {{ repo_name }}</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">{{ total_prs }} open | {{ draft_count }} draft, {{ ready_count }} ready for review</text>
+
+  <!-- Summary bar -->
+  <g transform="translate(28, 72)">
+    {% if ready_width > 0.0 %}
+    <rect x="0" y="0" width="{{ ready_width }}" height="14" fill="#238636" rx="7"/>
+    {% endif %}
+    {% if draft_width > 0.0 %}
+    <rect x="{{ ready_width }}" y="0" width="{{ draft_width }}" height="14" fill="#8b949e" rx="0"/>
+    {% endif %}
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(28, 100)">
+    <rect x="0" y="0" width="10" height="10" fill="#238636" rx="2"/>
+    <text x="14" y="10" font-family="sans-serif" font-size="11" fill="#8b949e">Ready ({{ ready_count }})</text>
+    <rect x="120" y="0" width="10" height="10" fill="#8b949e" rx="2"/>
+    <text x="134" y="10" font-family="sans-serif" font-size="11" fill="#8b949e">Draft ({{ draft_count }})</text>
+  </g>
+
+  <!-- PR rows -->
+  {% for pr in prs %}
+  <g transform="translate(28, {{ pr.y }})">
+    <!-- Status dot -->
+    <circle cx="8" cy="10" r="6" fill="{{ pr.status_color }}"/>
+    <!-- PR number + title -->
+    <text x="22" y="14" font-family="sans-serif" font-size="13" font-weight="600" fill="#e6edf3">#{{ pr.number }} {{ pr.title }}</text>
+    <!-- Age bar -->
+    <rect x="500" y="2" width="{{ pr.age_bar }}" height="16" fill="{{ pr.age_color }}" rx="3" opacity="0.7"/>
+    <!-- Age label -->
+    <text x="{{ pr.age_label_x }}" y="14" font-family="sans-serif" font-size="11" fill="#8b949e">{{ pr.age_text }}</text>
+  </g>
+  {% endfor %}
+
+  <!-- Footer -->
+  <rect x="0" y="{{ footer_y }}" width="800" height="8" fill="#8957E5" opacity="0.3"/>
+  <text x="760" y="{{ brand_y }}" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>


### PR DESCRIPTION
## Summary
Expand the interactive chart suite with three new chart types:

| Command | Button | Chart |
|---------|--------|-------|
| `/github pulls` | PR Status | Draft vs ready breakdown + age-colored bars |
| `/github commits` | Heatmap | 8-week GitHub-style commit frequency grid |
| `/health` | History | Memory % and CPU % line chart (rolling 1hr) |

**Total chart buttons: 6** (languages, activity, labels, pr_status, commit_freq, health history)

### New infrastructure
- `HealthMonitor` now retains a rolling `VecDeque<HealthSnapshot>` (60 samples, ~1 hour at 60s intervals) for the health history chart
- Three new Askama SVG templates in `templates/github/`
- `chart_buttons.rs` extended with `pr_status`, `commit_freq`, and `health|history` handlers

## Test plan
- [x] `cargo check -p discordsh-bot` passes (27 pre-existing warnings)
- [ ] After deploy, `/github pulls` shows "PR Status" button
- [ ] After deploy, `/github commits` shows "Heatmap" button
- [ ] After deploy, `/health` shows "History" button
- [ ] Health history chart populates after bot runs for a few minutes