### PR TITLE
fix(droid): disable autoRefreshToken in db-worker pool to prevent DataCloneError

### DIFF
--- a/packages/npm/droid/src/lib/workers/supabase-db-worker.ts
+++ b/packages/npm/droid/src/lib/workers/supabase-db-worker.ts
@@ -109,8 +109,12 @@ self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
 						...authOverrides,
 						storage: memoryStorage,
 						storageKey: 'sb-auth-token',
-						autoRefreshToken: true,
-						persistSession: true,
+						// DB pool workers are stateless (memoryStorage) — token
+						// refresh is handled by the SharedWorker which owns the
+						// IDB-backed session. Disabling here avoids SDK-internal
+						// callbacks that produce non-cloneable objects.
+						autoRefreshToken: false,
+						persistSession: false,
 						detectSessionInUrl: false,
 					},
 				});


### PR DESCRIPTION
## Summary
- The supabase-db-worker pool (3 dedicated workers) had `autoRefreshToken: true` with ephemeral `memoryStorage` — the SDK's internal refresh callbacks produced non-cloneable objects that caused `DataCloneError` when comlink's `import-wrapper-prod` tried to `postMessage`
- Set `autoRefreshToken: false` and `persistSession: false` — these workers are stateless, token refresh is owned by the SharedWorker which has the IDB-backed session
- Previous fixes (#9541, #9635) caught the explicit `postMessage` calls but missed the SDK-internal callbacks that fire asynchronously during token refresh

## Test plan
- [ ] `npx nx run droid:test` — 72/72 pass
- [ ] `npx nx run irc-e2e:e2e` — 30/30 pass (including DataCloneError detection)
- [ ] Deploy and verify no more `DataCloneError` in chat.kbve.com console