### PR TITLE
feat(creatures): server-authoritative position sync

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -18,9 +18,9 @@ use lightyear::prelude::*;
 use bevy_kbve_net::npcdb::{self, CreatureRegistry, ProtoNpcId, creature::CapturedCreatures};
 use bevy_kbve_net::{
     AuthAck, AuthMessage, AuthResponse, CollectRequest, CreatureCaptureRequest, CreatureCaptured,
-    CreatureKind, DamageEvent, GameChannel, ObjectRemoved, ObjectRespawned, PlayerName,
-    PositionUpdate, ProtocolPlugin, SetUsernameRequest, SetUsernameResponse, TileKey, TimeChannel,
-    TimeSyncMessage,
+    CreatureKind, CreaturePositionSync, CreatureSnapshot, CreatureSyncChannel, DamageEvent,
+    GameChannel, ObjectRemoved, ObjectRespawned, PlayerName, PositionUpdate, ProtocolPlugin,
+    SetUsernameRequest, SetUsernameResponse, TileKey, TimeChannel, TimeSyncMessage,
 };
 
 /// Server tick rate: 20 Hz (matching client).
@@ -149,6 +149,16 @@ struct TimeSyncTimer(Timer);
 impl Default for TimeSyncTimer {
     fn default() -> Self {
         Self(Timer::from_seconds(5.0, TimerMode::Repeating))
+    }
+}
+
+/// Timer for periodic creature position sync broadcasts (every 2 seconds).
+#[derive(Resource)]
+struct CreatureSyncTimer(Timer);
+
+impl Default for CreatureSyncTimer {
+    fn default() -> Self {
+        Self(Timer::from_seconds(2.0, TimerMode::Repeating))
     }
 }
 
@@ -589,6 +599,7 @@ fn run_bevy_app(
     app.init_resource::<CapturedCreatures>();
     app.insert_resource(npcdb::build_creature_registry());
     app.init_resource::<TimeSyncTimer>();
+    app.init_resource::<CreatureSyncTimer>();
 
     // --- Server-authoritative creature simulation ---
     app.insert_resource(bevy_kbve_net::creatures::definitions::build_sprite_creature_types());
@@ -721,6 +732,9 @@ fn run_bevy_app(
             bevy_kbve_net::creatures::physics_lod::update_physics_lod,
         ),
     );
+
+    // Broadcast creature positions to clients periodically
+    app.add_systems(Update, broadcast_creature_sync);
 
     // Timeout clients that never authenticate
     app.add_systems(Update, timeout_pending_auth);
@@ -1857,6 +1871,86 @@ fn update_server_player_positions(
 ) {
     positions.0.clear();
     positions.0.extend(player_q.iter().map(|t| t.translation));
+}
+
+/// Maximum distance from any player to include a creature in the sync broadcast.
+const CREATURE_SYNC_RADIUS: f32 = 80.0;
+
+/// Periodically broadcast server creature positions to all clients.
+/// Only sends creatures within `CREATURE_SYNC_RADIUS` of at least one player.
+fn broadcast_creature_sync(
+    time: Res<Time>,
+    mut timer: ResMut<CreatureSyncTimer>,
+    creature_q: Query<(
+        &bevy_kbve_net::creatures::types::Creature,
+        &bevy_kbve_net::creatures::types::SpriteData,
+        &bevy_kbve_net::creatures::types::CreaturePoolIndex,
+        &bevy_kbve_net::creatures::types::SpriteCreatureMarker,
+    )>,
+    types: Res<bevy_kbve_net::creatures::types::SpriteCreatureTypes>,
+    player_positions: Res<bevy_kbve_net::creatures::types::PlayerPositions>,
+    mut senders: Query<&mut MessageSender<CreaturePositionSync>, With<Connected>>,
+) {
+    timer.0.tick(time.delta());
+    if !timer.0.just_finished() {
+        return;
+    }
+
+    // No players connected — nothing to sync
+    if player_positions.0.is_empty() {
+        return;
+    }
+
+    let sync_radius_sq = CREATURE_SYNC_RADIUS * CREATURE_SYNC_RADIUS;
+
+    // Build one sync message per creature type
+    for ctype in &types.types {
+        let mut snapshots = Vec::new();
+        for (cr, sd, pool_idx, marker) in &creature_q {
+            if marker.type_key != ctype.npc_ref {
+                continue;
+            }
+            // Only include creatures near at least one player
+            let near_player = player_positions.0.iter().any(|p| {
+                let dx = cr.anchor.x - p.x;
+                let dz = cr.anchor.z - p.z;
+                dx * dx + dz * dz <= sync_radius_sq
+            });
+            if !near_player {
+                continue;
+            }
+
+            let hop_state = match sd.hop_state {
+                bevy_kbve_net::creatures::types::SpriteHopState::Idle { .. } => 0,
+                bevy_kbve_net::creatures::types::SpriteHopState::Emote { .. } => 1,
+                bevy_kbve_net::creatures::types::SpriteHopState::JumpWindup { .. } => 2,
+                bevy_kbve_net::creatures::types::SpriteHopState::Airborne { .. } => 3,
+                bevy_kbve_net::creatures::types::SpriteHopState::Landing { .. } => 4,
+            };
+            snapshots.push(CreatureSnapshot {
+                index: pool_idx.0 as u32,
+                x: cr.anchor.x,
+                y: cr.anchor.y,
+                z: cr.anchor.z,
+                hop_state,
+                patrol_step: marker.patrol_step,
+                facing_left: sd.facing_left,
+            });
+        }
+
+        if snapshots.is_empty() {
+            continue;
+        }
+
+        let msg = CreaturePositionSync {
+            npc_ref: ctype.npc_ref.to_string(),
+            snapshots,
+        };
+
+        for mut sender in &mut senders {
+            sender.send::<CreatureSyncChannel>(msg.clone());
+        }
+    }
 }
 
 /// Every 5 seconds, broadcast the canonical game time to all connected clients.

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
@@ -6,11 +6,11 @@
 use bevy::prelude::*;
 use lightyear::prelude::*;
 
-use super::super::creature::{CreaturePoolIndex, SpriteData, SpriteHopState};
+use super::super::creature::{Creature, CreaturePoolIndex, SpriteData, SpriteHopState};
 use super::behavior::CreatureIntent;
 use super::brain::CreatureBrain;
 use super::types::SpriteCreatureMarker;
-use bevy_kbve_net::{CreatureEventKind, CreatureStateEvent, GameChannel};
+use bevy_kbve_net::{CreatureEventKind, CreaturePositionSync, CreatureStateEvent};
 
 /// System that receives `CreatureStateEvent` messages from the server and
 /// overrides the local creature's behavior intent.
@@ -81,6 +81,53 @@ pub fn receive_creature_events(
                 }
 
                 break; // Found the creature, no need to keep searching
+            }
+        }
+    }
+}
+
+/// How quickly the client lerps toward the server anchor (per second).
+/// 0.0 = never correct, 1.0 = snap instantly.
+const SYNC_LERP_RATE: f32 = 0.3;
+
+/// System that receives periodic `CreaturePositionSync` messages from the server
+/// and smoothly corrects local creature positions to match. Only corrects creatures
+/// that are idle — airborne/moving creatures finish their current action first.
+pub fn receive_creature_sync(
+    mut receiver_q: Query<&mut MessageReceiver<CreaturePositionSync>, With<Connected>>,
+    mut creature_q: Query<(
+        &SpriteCreatureMarker,
+        &CreaturePoolIndex,
+        &mut Creature,
+        &mut SpriteData,
+    )>,
+) {
+    for mut receiver in &mut receiver_q {
+        for sync in receiver.receive() {
+            for snapshot in &sync.snapshots {
+                for (marker, pool_idx, mut cr, mut sd) in &mut creature_q {
+                    if marker.type_key != sync.npc_ref.as_str() {
+                        continue;
+                    }
+                    if pool_idx.0 as u32 != snapshot.index {
+                        continue;
+                    }
+
+                    let server_pos = Vec3::new(snapshot.x, snapshot.y, snapshot.z);
+                    let dist = cr.anchor.distance(server_pos);
+
+                    // Hard snap if very far off (>5 units), smooth lerp otherwise
+                    if dist > 5.0 {
+                        cr.anchor = server_pos;
+                    } else if dist > 0.1 {
+                        cr.anchor = cr.anchor.lerp(server_pos, SYNC_LERP_RATE);
+                    }
+
+                    // Sync facing direction
+                    sd.facing_left = snapshot.facing_left;
+
+                    break; // Found the creature
+                }
             }
         }
     }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -107,6 +107,7 @@ impl Plugin for CreaturesPlugin {
                 generic::physics_lod::update_physics_lod
                     .run_if(any_with_component::<generic::PhysicsLod>),
                 generic::net_events::receive_creature_events,
+                generic::net_events::receive_creature_sync,
             ),
         );
     }

--- a/packages/rust/bevy/bevy_kbve_net/src/lib.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/lib.rs
@@ -20,10 +20,11 @@ pub mod worldgen;
 pub use inputs::PlayerInput;
 pub use protocol::{
     AuthAck, AuthMessage, AuthResponse, CollectRequest, CreatureAttackRequest,
-    CreatureCaptureRequest, CreatureCaptured, CreatureEventKind, CreatureKind, CreatureStateEvent,
-    DamageEvent, DamageSource, GameChannel, ObjectRemoved, ObjectRespawned, PlayerColor, PlayerId,
-    PlayerName, PlayerVitals, PositionUpdate, ProtocolPlugin, SetUsernameRequest,
-    SetUsernameResponse, TimeChannel, TimeSyncMessage,
+    CreatureCaptureRequest, CreatureCaptured, CreatureEventKind, CreatureKind,
+    CreaturePositionSync, CreatureSnapshot, CreatureStateEvent, CreatureSyncChannel, DamageEvent,
+    DamageSource, GameChannel, ObjectRemoved, ObjectRespawned, PlayerColor, PlayerId, PlayerName,
+    PlayerVitals, PositionUpdate, ProtocolPlugin, SetUsernameRequest, SetUsernameResponse,
+    TimeChannel, TimeSyncMessage,
 };
 pub use worldgen::{TileKey, WorldObjectKind, hash2d, object_at_tile};
 

--- a/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
@@ -225,6 +225,41 @@ pub enum CreatureEventKind {
 /// Unreliable sequenced channel for time sync (avoids clogging ordered-reliable GameChannel).
 pub struct TimeChannel;
 
+/// Unreliable unordered channel for creature position sync.
+/// Separate from TimeChannel so large batches don't block time sync.
+pub struct CreatureSyncChannel;
+
+// ---------------------------------------------------------------------------
+// Creature position sync
+// ---------------------------------------------------------------------------
+
+/// Single creature's server-authoritative state snapshot.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CreatureSnapshot {
+    /// Pool index within this creature type.
+    pub index: u32,
+    /// World-space anchor position.
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    /// Current hop state discriminant (0=Idle, 1=Emote, 2=JumpWindup, 3=Airborne, 4=Landing).
+    pub hop_state: u8,
+    /// Patrol step counter (for deterministic re-sync).
+    pub patrol_step: u32,
+    /// Facing left flag.
+    pub facing_left: bool,
+}
+
+/// Server periodically broadcasts creature position snapshots.
+/// Sent per creature type to keep packets manageable.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CreaturePositionSync {
+    /// NPC ref key (e.g. "wild-boar").
+    pub npc_ref: String,
+    /// Snapshots for all creatures of this type.
+    pub snapshots: Vec<CreatureSnapshot>,
+}
+
 // ---------------------------------------------------------------------------
 // Channels
 // ---------------------------------------------------------------------------
@@ -257,6 +292,12 @@ impl Plugin for ProtocolPlugin {
         .add_direction(NetworkDirection::Bidirectional);
 
         app.add_channel::<TimeChannel>(ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliable,
+            ..default()
+        })
+        .add_direction(NetworkDirection::ServerToClient);
+
+        app.add_channel::<CreatureSyncChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,
             ..default()
         })
@@ -303,6 +344,10 @@ impl Plugin for ProtocolPlugin {
             .add_direction(NetworkDirection::ClientToServer);
         // CreatureStateEvent: server → all clients (determinism corrections)
         app.register_message::<CreatureStateEvent>()
+            .add_direction(NetworkDirection::ServerToClient);
+
+        // CreaturePositionSync: server → all clients (periodic position corrections)
+        app.register_message::<CreaturePositionSync>()
             .add_direction(NetworkDirection::ServerToClient);
 
         // --- Replicated components (custom game components) ---


### PR DESCRIPTION
## Summary
- Adds `CreaturePositionSync` message + `CreatureSyncChannel` (unreliable) to lightyear protocol
- Server broadcasts creature anchor positions every 2s, filtered to creatures within 80u of any player
- Client applies smooth lerp corrections (hard snap if >5u drift, 30% lerp for smaller drift)

## Test plan
- [ ] Connect two clients, verify stags/boars/wolves appear at same positions
- [ ] Walk away from creatures and back — verify they re-sync on return
- [ ] Check no visible jitter from corrections during normal gameplay