### PR TITLE
fix(kasm): disable DoT to stop gluetun healthcheck restart loop

### DIFF
--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -71,6 +71,18 @@ spec:
                         value: '6901'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
+                      # Disable DNS-over-TLS — port 853 is blocked
+                      # through the WireGuard tunnel, causing gluetun's
+                      # internal healthcheck to fail every 6s.
+                      - name: DOT
+                        value: 'off'
+                      # Use plaintext DNS through the tunnel instead
+                      - name: DNS_ADDRESS
+                        value: '1.1.1.1'
+                      # Give VPN tunnel time to stabilize before
+                      # gluetun's internal healthcheck starts checking
+                      - name: HEALTH_VPN_DURATION_INITIAL
+                        value: '30s'
                       # Health check server
                       - name: HEALTH_SERVER_ADDRESS
                         value: '0.0.0.0:9999'


### PR DESCRIPTION
## Summary
- Gluetun sidecar crash-loops (630+ restarts) because its internal healthcheck uses DNS-over-TLS (port 853) which is blocked by the WireGuard VPN provider
- Disables DoT (`DOT=off`), uses plaintext DNS (`DNS_ADDRESS=1.1.1.1`) through the tunnel
- Adds 30s grace period (`HEALTH_VPN_DURATION_INITIAL`) before gluetun starts checking VPN health

## Test plan
- [ ] Merge to dev, let ArgoCD sync the kasm namespace
- [ ] Scale kasm-vpn to 1: `kubectl scale deploy/kasm-vpn -n kasm --replicas=1`
- [ ] Verify gluetun stops restart-looping: `kubectl logs deploy/kasm-vpn -n kasm -c gluetun --tail=20`
- [ ] Confirm KASM workspace becomes 1/1 Running