### PR TITLE
docs(bevy_tasker): add README for crates.io listing

### DIFF
--- a/packages/rust/bevy/bevy_tasker/Cargo.toml
+++ b/packages/rust/bevy/bevy_tasker/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_tasker"
 keywords = ["bevy", "async", "wasm", "tasks", "gamedev"]
 categories = ["game-development", "asynchronous"]
+readme = "README.md"
 
 [dependencies]
 async-task = { version = "4.7", default-features = false }

--- a/packages/rust/bevy/bevy_tasker/README.md
+++ b/packages/rust/bevy/bevy_tasker/README.md
@@ -1,0 +1,34 @@
+# bevy_tasker
+
+Cross-platform async task spawning for Bevy games.
+
+- **WASM**: tasks run via the browser microtask queue (`queueMicrotask`). With atomics enabled, `spawn()` dispatches `Send` futures to web workers via a shared work queue, while `spawn_local()` pins `!Send` futures to the creating thread.
+- **Desktop**: tasks run on a thread pool backed by crossbeam channels.
+
+## Usage
+
+```rust
+use bevy_tasker::{spawn, spawn_local};
+
+// Send future — runs on web workers (WASM+atomics) or thread pool (desktop)
+let task = spawn(async {
+    42
+});
+
+// !Send future — stays on the current thread
+let task = spawn_local(async {
+    "local result"
+});
+```
+
+## Features
+
+| Platform          | `spawn()`               | `spawn_local()`                        |
+| ----------------- | ----------------------- | -------------------------------------- |
+| Desktop           | Thread pool (crossbeam) | Calling thread                         |
+| WASM (no atomics) | Microtask queue         | Microtask queue                        |
+| WASM (atomics)    | Web worker pool         | Current thread via `Atomics.waitAsync` |
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Add README.md for `bevy_tasker` so the crates.io page displays documentation
- Add `readme = "README.md"` to Cargo.toml

## Test plan
- [ ] Next crates.io publish picks up the README