### PR TITLE
fix(vector): resolve VRL compile error causing CrashLoopBackOff

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -5,7 +5,7 @@ metadata:
     name: vector-config
     namespace: vector
     annotations:
-        kbve.sh/last-updated: '2026-04-04T09:00:00Z'
+        kbve.sh/last-updated: '2026-04-06T17:00:00Z'
 data:
     vector.yml: |
         api:
@@ -203,7 +203,7 @@ data:
               if (string(.metadata.parsed.error_severity) ?? "") == "info" {
                   .metadata.parsed.error_severity = "log"
               }
-              .metadata.parsed.error_severity = upcase(string(.metadata.parsed.error_severity) ?? "LOG") ?? "LOG"
+              .metadata.parsed.error_severity = upcase(string(.metadata.parsed.error_severity) ?? "LOG")
 
           analytics_logs:
             type: remap

--- a/apps/kube/vector/manifests/vector-daemonset.yaml
+++ b/apps/kube/vector/manifests/vector-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
                 app: supabase-vector
                 component: vector
             annotations:
-                kbve.sh/config-updated: '2026-04-04T09:00:00Z'
+                kbve.sh/config-updated: '2026-04-06T17:00:00Z'
         spec:
             serviceAccountName: vector
             containers:


### PR DESCRIPTION
## Summary
- Vector has been in CrashLoopBackOff for 2 days (569 restarts) due to a VRL compilation error in the `db_logs` transform
- Vector 0.54 treats redundant `??` on infallible `upcase()` as a fatal error — removed the trailing `?? "LOG"`
- Updated `kbve.sh/last-updated` and `kbve.sh/config-updated` annotations to trigger pod rollout

## Test plan
- [ ] Vector pod exits CrashLoopBackOff and reaches Running state
- [ ] Logs begin flowing into ClickHouse `observability.logs_distributed`
- [ ] Dashboard at kbve.com/dashboard/clickhouse shows non-zero counts