### PR TITLE
feat(dashboard): firecracker script presets and VM result viewer

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactFirecrackerCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactFirecrackerCards.tsx
@@ -1,8 +1,26 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useStore } from '@nanostores/react';
-import { firecrackerService, type FirecrackerInfo } from './firecrackerService';
+import {
+	firecrackerService,
+	SCRIPT_PRESETS,
+	type FirecrackerInfo,
+	type VmResult,
+} from './firecrackerService';
 import { vmService } from './vmService';
-import { Flame, Trash2, Cpu, HardDrive, Loader2, Activity } from 'lucide-react';
+import {
+	Flame,
+	Trash2,
+	Cpu,
+	HardDrive,
+	Loader2,
+	Activity,
+	Play,
+	Terminal,
+	FileText,
+	Clock,
+	ChevronDown,
+	ChevronUp,
+} from 'lucide-react';
 
 function phaseColor(phase: string): string {
 	switch (phase) {
@@ -23,17 +41,147 @@ function phaseColor(phase: string): string {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// VM Result Viewer — shows stdout/stderr after completion
+// ---------------------------------------------------------------------------
+
+function ResultViewer({ result }: { result: VmResult }) {
+	const exitColor = result.exit_code === 0 ? '#22c55e' : '#ef4444';
+
+	return (
+		<div
+			style={{
+				marginTop: '0.5rem',
+				borderRadius: '8px',
+				overflow: 'hidden',
+				border: '1px solid rgba(255,255,255,0.08)',
+			}}>
+			{/* Result header */}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.75rem',
+					padding: '0.5rem 0.75rem',
+					background: 'rgba(255,255,255,0.03)',
+					fontSize: '0.75rem',
+					color: 'rgba(255,255,255,0.5)',
+				}}>
+				<span style={{ color: exitColor, fontWeight: 600 }}>
+					exit: {result.exit_code ?? '?'}
+				</span>
+				{result.duration_ms != null && (
+					<span
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '0.2rem',
+						}}>
+						<Clock size={10} />
+						{result.duration_ms}ms
+					</span>
+				)}
+			</div>
+
+			{/* stdout */}
+			{result.stdout && (
+				<div style={{ padding: '0.5rem 0.75rem' }}>
+					<div
+						style={{
+							fontSize: '0.65rem',
+							textTransform: 'uppercase',
+							letterSpacing: '0.05em',
+							color: 'rgba(255,255,255,0.35)',
+							marginBottom: '0.25rem',
+						}}>
+						stdout
+					</div>
+					<pre
+						style={{
+							margin: 0,
+							padding: '0.5rem',
+							background: 'rgba(0,0,0,0.3)',
+							borderRadius: '4px',
+							fontSize: '0.75rem',
+							color: 'rgba(255,255,255,0.8)',
+							overflow: 'auto',
+							maxHeight: '200px',
+							whiteSpace: 'pre-wrap',
+							wordBreak: 'break-all',
+						}}>
+						{result.stdout}
+					</pre>
+				</div>
+			)}
+
+			{/* stderr */}
+			{result.stderr && (
+				<div style={{ padding: '0 0.75rem 0.5rem' }}>
+					<div
+						style={{
+							fontSize: '0.65rem',
+							textTransform: 'uppercase',
+							letterSpacing: '0.05em',
+							color: '#ef4444',
+							marginBottom: '0.25rem',
+						}}>
+						stderr
+					</div>
+					<pre
+						style={{
+							margin: 0,
+							padding: '0.5rem',
+							background: 'rgba(239,68,68,0.05)',
+							borderRadius: '4px',
+							fontSize: '0.75rem',
+							color: '#fca5a5',
+							overflow: 'auto',
+							maxHeight: '120px',
+							whiteSpace: 'pre-wrap',
+							wordBreak: 'break-all',
+						}}>
+						{result.stderr}
+					</pre>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// FirecrackerCard — individual VM card with result toggle
+// ---------------------------------------------------------------------------
+
 function FirecrackerCard({ info }: { info: FirecrackerInfo }) {
 	const actionInProgress = useStore(firecrackerService.$actionInProgress);
 	const lastAction = useStore(firecrackerService.$lastAction);
+	const results = useStore(firecrackerService.$results);
 	const token = useStore(vmService.$accessToken);
 	const { vm, phase } = info;
+
+	const resultRef = useRef<HTMLDivElement>(null);
+	const chevRef = useRef<{ open: boolean }>({ open: false });
 
 	const isActing = actionInProgress?.includes(vm.vm_id) ?? false;
 	const cardAction = lastAction?.vm_id === vm.vm_id ? lastAction : null;
 	const canDestroy = phase === 'Running' || phase === 'Creating';
+	const hasResult =
+		phase === 'Completed' || phase === 'Failed' || phase === 'Timeout';
+	const result = results[vm.vm_id];
 	const color = phaseColor(phase);
 	const shortId = vm.vm_id.slice(0, 15);
+
+	const toggleResult = () => {
+		if (!token) return;
+		if (!result) {
+			firecrackerService.fetchResult(token, vm.vm_id);
+		}
+		const el = resultRef.current;
+		if (!el) return;
+		const opening = el.style.display === 'none';
+		el.style.display = opening ? '' : 'none';
+		chevRef.current.open = opening;
+	};
 
 	return (
 		<div
@@ -146,12 +294,59 @@ function FirecrackerCard({ info }: { info: FirecrackerInfo }) {
 							cursor: isActing ? 'wait' : 'pointer',
 						}}>
 						{isActing ? (
-							<Loader2 size={14} className="animate-spin" />
+							<Loader2
+								size={14}
+								style={{ animation: 'spin 1s linear infinite' }}
+							/>
 						) : (
 							<Trash2 size={14} />
 						)}
 						Destroy
 					</button>
+				)}
+				{hasResult && (
+					<button
+						onClick={toggleResult}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '0.3rem',
+							padding: '0.35rem 0.75rem',
+							background: '#3b82f622',
+							border: '1px solid #3b82f644',
+							borderRadius: '6px',
+							color: '#3b82f6',
+							fontSize: '0.8rem',
+							cursor: 'pointer',
+						}}>
+						<FileText size={14} />
+						Result
+					</button>
+				)}
+			</div>
+
+			{/* Result panel (hidden by default, toggled via ref) */}
+			<div ref={resultRef} style={{ display: 'none' }}>
+				{result ? (
+					<ResultViewer result={result} />
+				) : (
+					<div
+						style={{
+							padding: '0.75rem',
+							textAlign: 'center',
+							color: 'rgba(255,255,255,0.4)',
+							fontSize: '0.8rem',
+						}}>
+						<Loader2
+							size={14}
+							style={{
+								animation: 'spin 1s linear infinite',
+								display: 'inline-block',
+								marginRight: '0.4rem',
+							}}
+						/>
+						Loading result...
+					</div>
 				)}
 			</div>
 
@@ -174,6 +369,197 @@ function FirecrackerCard({ info }: { info: FirecrackerInfo }) {
 		</div>
 	);
 }
+
+// ---------------------------------------------------------------------------
+// Script Presets Panel
+// ---------------------------------------------------------------------------
+
+function ScriptPresetsPanel({ token }: { token: string }) {
+	const creating = useStore(firecrackerService.$creating);
+	const lastAction = useStore(firecrackerService.$lastAction);
+	const panelRef = useRef<HTMLDivElement>(null);
+	const chevronRef = useRef<SVGSVGElement>(null);
+
+	const toggle = () => {
+		const el = panelRef.current;
+		const chev = chevronRef.current;
+		if (!el) return;
+		const opening = el.style.display === 'none';
+		el.style.display = opening ? '' : 'none';
+		if (chev) {
+			chev.style.transform = opening ? 'rotate(180deg)' : 'rotate(0deg)';
+		}
+	};
+
+	const newAction = lastAction?.vm_id === 'new' ? lastAction : null;
+
+	return (
+		<div
+			style={{
+				marginBottom: '1rem',
+				border: '1px solid rgba(255,255,255,0.08)',
+				borderRadius: '12px',
+				overflow: 'hidden',
+			}}>
+			{/* Toggle header */}
+			<button
+				onClick={toggle}
+				style={{
+					width: '100%',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+					padding: '0.75rem 1rem',
+					background: 'rgba(249, 115, 22, 0.06)',
+					border: 'none',
+					borderBottom: '1px solid rgba(255,255,255,0.06)',
+					color: 'var(--sl-color-text, #e6edf3)',
+					cursor: 'pointer',
+					fontSize: '0.9rem',
+					fontWeight: 600,
+					textAlign: 'left',
+				}}>
+				<Terminal size={16} style={{ color: '#f97316' }} />
+				Run Script
+				<ChevronDown
+					ref={chevronRef}
+					size={14}
+					style={{
+						marginLeft: 'auto',
+						color: 'rgba(255,255,255,0.4)',
+						transition: 'transform 0.15s ease',
+					}}
+				/>
+			</button>
+
+			{/* Preset grid (hidden by default) */}
+			<div ref={panelRef} style={{ display: 'none', padding: '1rem' }}>
+				<div
+					style={{
+						display: 'grid',
+						gridTemplateColumns:
+							'repeat(auto-fill, minmax(240px, 1fr))',
+						gap: '0.75rem',
+					}}>
+					{SCRIPT_PRESETS.map((preset) => (
+						<button
+							key={preset.name}
+							disabled={creating}
+							onClick={() =>
+								firecrackerService.createVM(token, {
+									rootfs: preset.rootfs,
+									entrypoint: preset.entrypoint,
+									vcpu_count: preset.vcpu_count,
+									mem_size_mib: preset.mem_size_mib,
+									timeout_ms: preset.timeout_ms,
+								})
+							}
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '0.3rem',
+								padding: '0.75rem',
+								background: 'rgba(255,255,255,0.03)',
+								border: '1px solid rgba(255,255,255,0.08)',
+								borderRadius: '8px',
+								color: 'var(--sl-color-text, #e6edf3)',
+								cursor: creating ? 'wait' : 'pointer',
+								textAlign: 'left',
+								transition: 'border-color 0.15s',
+							}}
+							onMouseEnter={(e) =>
+								(e.currentTarget.style.borderColor =
+									'rgba(249, 115, 22, 0.4)')
+							}
+							onMouseLeave={(e) =>
+								(e.currentTarget.style.borderColor =
+									'rgba(255,255,255,0.08)')
+							}>
+							<div
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: '0.4rem',
+									fontSize: '0.85rem',
+									fontWeight: 600,
+								}}>
+								<Play size={14} style={{ color: '#f97316' }} />
+								{preset.name}
+							</div>
+							<div
+								style={{
+									fontSize: '0.75rem',
+									color: 'rgba(255,255,255,0.45)',
+								}}>
+								{preset.description}
+							</div>
+							<div
+								style={{
+									display: 'flex',
+									gap: '0.5rem',
+									fontSize: '0.7rem',
+									color: 'rgba(255,255,255,0.3)',
+									marginTop: '0.15rem',
+								}}>
+								<span>{preset.rootfs}</span>
+								<span>
+									{preset.vcpu_count} vCPU /{' '}
+									{preset.mem_size_mib} MiB
+								</span>
+								<span>{preset.timeout_ms / 1000}s timeout</span>
+							</div>
+						</button>
+					))}
+				</div>
+
+				{/* Creating indicator */}
+				{creating && (
+					<div
+						style={{
+							marginTop: '0.75rem',
+							padding: '0.5rem 0.75rem',
+							borderRadius: '6px',
+							background: 'rgba(249, 115, 22, 0.1)',
+							border: '1px solid rgba(249, 115, 22, 0.25)',
+							color: '#f97316',
+							fontSize: '0.8rem',
+							display: 'flex',
+							alignItems: 'center',
+							gap: '0.4rem',
+						}}>
+						<Loader2
+							size={14}
+							style={{ animation: 'spin 1s linear infinite' }}
+						/>
+						Creating microVM...
+					</div>
+				)}
+
+				{/* Create feedback */}
+				{newAction && !creating && (
+					<div
+						style={{
+							marginTop: '0.75rem',
+							padding: '0.5rem 0.75rem',
+							borderRadius: '6px',
+							background: newAction.ok
+								? 'rgba(34, 197, 94, 0.1)'
+								: 'rgba(239, 68, 68, 0.1)',
+							border: `1px solid ${newAction.ok ? 'rgba(34, 197, 94, 0.25)' : 'rgba(239, 68, 68, 0.25)'}`,
+							color: newAction.ok ? '#22c55e' : '#ef4444',
+							fontSize: '0.8rem',
+						}}>
+						{newAction.message}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
 
 export default function ReactFirecrackerCards() {
 	const vms = useStore(firecrackerService.$vms);
@@ -261,6 +647,9 @@ export default function ReactFirecrackerCards() {
 					{error}
 				</div>
 			)}
+
+			{/* Script presets (only when service is online) */}
+			{serviceStatus === 'Online' && <ScriptPresetsPanel token={token} />}
 
 			{vms.length === 0 ? (
 				<div

--- a/apps/kbve/astro-kbve/src/components/dashboard/firecrackerService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/firecrackerService.ts
@@ -40,6 +40,86 @@ export interface FirecrackerInfo {
 	phase: FirecrackerPhase;
 }
 
+export interface CreateVmRequest {
+	rootfs: string;
+	entrypoint: string;
+	vcpu_count?: number;
+	mem_size_mib?: number;
+	timeout_ms?: number;
+	env?: Record<string, string>;
+}
+
+export interface VmResult {
+	vm_id: string;
+	status: string;
+	exit_code: number | null;
+	stdout: string;
+	stderr: string;
+	duration_ms: number | null;
+}
+
+export interface ScriptPreset {
+	name: string;
+	description: string;
+	rootfs: string;
+	entrypoint: string;
+	vcpu_count: number;
+	mem_size_mib: number;
+	timeout_ms: number;
+}
+
+export const SCRIPT_PRESETS: ScriptPreset[] = [
+	{
+		name: 'System Info',
+		description: 'Print kernel, CPU, and memory info',
+		rootfs: 'alpine-minimal',
+		entrypoint: 'uname -a && cat /proc/cpuinfo | head -20 && free -m',
+		vcpu_count: 1,
+		mem_size_mib: 128,
+		timeout_ms: 15000,
+	},
+	{
+		name: 'Disk Benchmark',
+		description: 'Write/read 64MB to measure I/O speed',
+		rootfs: 'alpine-minimal',
+		entrypoint:
+			'dd if=/dev/zero of=/tmp/bench bs=1M count=64 2>&1 && dd if=/tmp/bench of=/dev/null bs=1M 2>&1 && rm /tmp/bench',
+		vcpu_count: 1,
+		mem_size_mib: 128,
+		timeout_ms: 30000,
+	},
+	{
+		name: 'Network Test',
+		description: 'Check DNS resolution and HTTP connectivity',
+		rootfs: 'alpine-minimal',
+		entrypoint:
+			'nslookup kbve.com 2>&1 || echo "DNS failed"; wget -qO- --timeout=5 http://ifconfig.me 2>&1 || echo "HTTP failed"',
+		vcpu_count: 1,
+		mem_size_mib: 128,
+		timeout_ms: 20000,
+	},
+	{
+		name: 'Python Hello',
+		description: 'Run a basic Python script',
+		rootfs: 'alpine-python',
+		entrypoint:
+			"python3 -c \"import sys,platform; print(f'Python {sys.version}'); print(f'Platform: {platform.platform()}')\"",
+		vcpu_count: 1,
+		mem_size_mib: 256,
+		timeout_ms: 15000,
+	},
+	{
+		name: 'Node.js Hello',
+		description: 'Run a basic Node.js script',
+		rootfs: 'alpine-node',
+		entrypoint:
+			"node -e \"console.log('Node', process.version); console.log('Arch:', process.arch); console.log('Memory:', Math.round(require('os').totalmem()/1024/1024), 'MiB')\"",
+		vcpu_count: 1,
+		mem_size_mib: 256,
+		timeout_ms: 15000,
+	},
+];
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -175,6 +255,41 @@ class FirecrackerService {
 			() => this.fetchData(token),
 			REFRESH_INTERVAL_MS,
 		);
+	}
+
+	public readonly $results = atom<Record<string, VmResult>>({});
+	public readonly $creating = atom<boolean>(false);
+
+	public async createVM(token: string, req: CreateVmRequest): Promise<void> {
+		this.$creating.set(true);
+		try {
+			const res = await fcFetch<{ vm_id: string }>(
+				token,
+				'/vm/create',
+				'POST',
+				req,
+			);
+			this.$lastAction.set({
+				vm_id: res.vm_id ?? 'new',
+				ok: true,
+				message: `VM created: ${(res.vm_id ?? '').slice(0, 12)}`,
+			});
+			await this.fetchData(token);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : 'Failed to create VM';
+			this.$lastAction.set({ vm_id: 'new', ok: false, message: msg });
+		} finally {
+			this.$creating.set(false);
+		}
+	}
+
+	public async fetchResult(token: string, vmId: string): Promise<void> {
+		try {
+			const result = await fcFetch<VmResult>(token, `/vm/${vmId}/result`);
+			this.$results.set({ ...this.$results.get(), [vmId]: result });
+		} catch {
+			// Result not yet available — ignore
+		}
 	}
 
 	public async destroyVM(token: string, vmId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds a **Run Script** panel with 5 preset scripts (system info, disk benchmark, network test, Python hello, Node.js hello) that create Firecracker microVMs with one click
- Adds **Result** button on completed/failed/timeout VM cards to view stdout, stderr, exit code, and duration
- New service methods: `createVM()`, `fetchResult()` with types for `CreateVmRequest`, `VmResult`, and `ScriptPreset`
- All toggle panels use `useRef` for direct DOM manipulation (no re-renders)

## Test plan
- [ ] Verify preset buttons render when firecracker service is online
- [ ] Click a preset → VM card appears in grid with Creating/Running status
- [ ] After VM completes, click Result → stdout/stderr displayed
- [ ] Destroy button works on running VMs
- [ ] Panel toggles smoothly without re-rendering child components