### PR TITLE
docs(bevy_npc): add README for crates.io listing

### DIFF
--- a/packages/rust/bevy/bevy_npc/Cargo.toml
+++ b/packages/rust/bevy/bevy_npc/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_npc"
 keywords = ["bevy", "npc", "gamedev", "protobuf", "plugin"]
 categories = ["game-development", "game-engines"]
+readme = "README.md"
 
 [features]
 default = []

--- a/packages/rust/bevy/bevy_npc/README.md
+++ b/packages/rust/bevy/bevy_npc/README.md
@@ -1,0 +1,37 @@
+# bevy_npc
+
+Proto-driven NPC definitions for Bevy games.
+
+Compiles `npcdb.proto` into typed Rust structs via `prost` and wraps them in a searchable `NpcDb` Bevy resource. Game-agnostic — any game can load the same proto NPC registry and query it by slug, ULID, type flags, rarity, or creature family.
+
+## Usage
+
+### Loading from JSON
+
+```rust
+use bevy::prelude::*;
+use bevy_npc::{BevyNpcPlugin, NpcDb};
+
+fn load_npcs(mut commands: Commands) {
+    let json = include_str!("path/to/npcdb.json");
+    let db = NpcDb::from_json(json).expect("Failed to parse NPC JSON");
+    commands.insert_resource(db);
+}
+```
+
+### Loading from proto binary
+
+```rust
+let bytes = include_bytes!("path/to/npcs.binpb");
+let db = NpcDb::from_bytes(bytes).expect("Failed to decode NPC registry");
+```
+
+## Features
+
+| Feature    | Description                                                                                                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `creature` | Game-agnostic ECS components for creature pooling, capture, and interaction. Enables `CreaturePoolIndex`, `CreatureState`, `CapturedCreatures`, `CreatureCaptureEvent`, and `CreaturePlugin`. |
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Add README.md for `bevy_npc` so the crates.io page displays documentation
- Add `readme = "README.md"` to Cargo.toml

## Test plan
- [ ] Next crates.io publish picks up the README