### PR TITLE
fix(dashboard): resolve staff RPC before setting authenticated state

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
@@ -678,11 +678,11 @@ class HomeService {
 			}
 
 			this.$accessToken.set(session.access_token as string);
-			this.$authState.set('authenticated');
 
-			// Check staff permissions directly via Supabase RPC.
-			// Don't rely on profile-controller setting $auth.flags —
-			// it runs on the main site shell, not on dashboard pages.
+			// Check staff permissions BEFORE setting authenticated.
+			// The status banner's useEffect fires fetchAll() on
+			// authState change — if isStaff isn't resolved yet,
+			// staff panels get permanently marked 'unavailable'.
 			try {
 				const perms = await supa.rpc('staff_permissions');
 				const hasStaff = typeof perms === 'number' && perms > 0;
@@ -694,11 +694,15 @@ class HomeService {
 				// Non-critical — staff panels just won't show
 			}
 
+			this.$authState.set('authenticated');
+
 			// Also subscribe in case profile-controller sets it later
 			const syncStaff = () => {
 				const { flags } = $auth.get();
 				if (hasAuthFlag(flags, AuthFlags.STAFF)) {
-					this.$isStaff.set(true);
+					if (!this.$isStaff.get()) {
+						this.$isStaff.set(true);
+					}
 				}
 			};
 			$auth.subscribe(syncStaff);


### PR DESCRIPTION
## Summary
- **Root cause**: `initAuth()` set `$authState='authenticated'` before the `staff_permissions` RPC resolved
- The status banner's `useEffect` fires `fetchAll()` on `authState` change, so `isStaff` was always `false` during the first `fetchAll()` call
- This caused Grafana, ArgoCD, ClickHouse, and ROWS panels to be permanently marked `unavailable`
- **Fix**: Await the staff RPC before setting `$authState`, so `isStaff` is resolved when `fetchAll()` first runs

## Test plan
- [ ] Log in as staff user → all panels (Grafana, ArgoCD, ClickHouse, ROWS, Edge, Security, Kanban, Report, Graph) should appear
- [ ] Log in as non-staff user → only Edge, Security, Kanban, Report, Graph panels appear
- [ ] Click Refresh → staff panels reload with live data