### PR TITLE
feat(discordsh-bot): contributors + workflow runs charts, expand chart buttons

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/github_board.rs
@@ -188,6 +188,25 @@ async fn noticeboard(
                     }
                 }
 
+                // Chart buttons
+                let chart_row = poise::serenity_prelude::CreateActionRow::Buttons(vec![
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|activity"
+                    ))
+                    .label("Activity")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F4C8}".to_owned(),
+                    )),
+                    poise::serenity_prelude::CreateButton::new(format!("chart|{full_name}|labels"))
+                        .label("Labels")
+                        .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                        .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                            "\u{1F3F7}".to_owned(),
+                        )),
+                ]);
+                reply = reply.components(vec![chart_row]);
+
                 ctx.send(reply).await.map_err(|e| e.to_string())?;
                 Ok(())
             }
@@ -290,6 +309,26 @@ async fn taskboard(
                         reply = reply.embed(detail_embed);
                     }
                 }
+
+                // Chart buttons
+                let chart_row = poise::serenity_prelude::CreateActionRow::Buttons(vec![
+                    poise::serenity_prelude::CreateButton::new(format!("chart|{full_name}|labels"))
+                        .label("Labels")
+                        .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                        .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                            "\u{1F3F7}".to_owned(),
+                        )),
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|activity"
+                    ))
+                    .label("Activity")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F4C8}".to_owned(),
+                    )),
+                ]);
+                reply = reply.components(vec![chart_row]);
+
                 ctx.send(reply).await.map_err(|e| e.to_string())?;
                 Ok(())
             }
@@ -644,6 +683,14 @@ async fn repo(
                     .style(poise::serenity_prelude::ButtonStyle::Secondary)
                     .emoji(poise::serenity_prelude::ReactionType::Unicode(
                         "\u{1F4CA}".to_owned(),
+                    )),
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|contributors"
+                    ))
+                    .label("Contributors")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F465}".to_owned(),
                     )),
                 ]);
                 reply = reply.components(vec![chart_row]);
@@ -1657,9 +1704,25 @@ async fn workflows(
                     ))));
                 }
 
-                ctx.send(poise::CreateReply::default().embed(embed))
-                    .await
-                    .map_err(|e| e.to_string())?;
+                // Chart button for workflow runs
+                let chart_row = poise::serenity_prelude::CreateActionRow::Buttons(vec![
+                    poise::serenity_prelude::CreateButton::new(format!(
+                        "chart|{full_name}|workflow_runs"
+                    ))
+                    .label("Run History")
+                    .style(poise::serenity_prelude::ButtonStyle::Secondary)
+                    .emoji(poise::serenity_prelude::ReactionType::Unicode(
+                        "\u{1F4CA}".to_owned(),
+                    )),
+                ]);
+
+                ctx.send(
+                    poise::CreateReply::default()
+                        .embed(embed)
+                        .components(vec![chart_row]),
+                )
+                .await
+                .map_err(|e| e.to_string())?;
                 Ok(())
             }
             Err(e) => {

--- a/apps/discordsh/discordsh-bot/src/discord/components/chart_buttons.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/chart_buttons.rs
@@ -13,7 +13,8 @@ use crate::state::AppState;
 /// Handle a component interaction whose `custom_id` starts with `"chart|"`.
 ///
 /// Custom ID format: `chart|<owner/repo>|<chart_type>` or `chart|health|history`
-/// Chart types: `languages`, `activity`, `labels`, `pr_status`, `commit_freq`, `history`
+/// Chart types: `languages`, `activity`, `labels`, `pr_status`, `commit_freq`,
+/// `contributors`, `workflow_runs`, `history`
 pub async fn handle_chart_component(
     ctx: &serenity::Context,
     component: &serenity::ComponentInteraction,
@@ -284,6 +285,54 @@ async fn render_github_chart(
                 png,
                 "commit_freq.png".to_owned(),
                 "Commit Frequency".to_owned(),
+                full_name,
+            ))
+        }
+        "contributors" => {
+            let contribs = gh
+                .get_contributors(&owner, &repo_name, Some(25))
+                .await
+                .map_err(|e| format!("Failed to fetch contributors: {e}"))?;
+
+            if contribs.is_empty() {
+                return Err("No contributors found.".to_owned());
+            }
+
+            let full_clone = full_name.clone();
+            let png = tokio::task::spawn_blocking(move || {
+                github_cards::render_contributors_chart_blocking(&contribs, &full_clone, &fontdb)
+            })
+            .await
+            .map_err(|e| format!("Task panicked: {e}"))??;
+
+            Ok((
+                png,
+                "contributors.png".to_owned(),
+                "Top Contributors".to_owned(),
+                full_name,
+            ))
+        }
+        "workflow_runs" => {
+            let runs = gh
+                .list_workflow_runs(&owner, &repo_name, Some(30))
+                .await
+                .map_err(|e| format!("Failed to fetch workflow runs: {e}"))?;
+
+            if runs.is_empty() {
+                return Err("No workflow runs found.".to_owned());
+            }
+
+            let full_clone = full_name.clone();
+            let png = tokio::task::spawn_blocking(move || {
+                github_cards::render_workflow_runs_chart_blocking(&runs, &full_clone, &fontdb)
+            })
+            .await
+            .map_err(|e| format!("Task panicked: {e}"))??;
+
+            Ok((
+                png,
+                "workflow_runs.png".to_owned(),
+                "Workflow Runs".to_owned(),
                 full_name,
             ))
         }

--- a/apps/discordsh/discordsh-bot/src/discord/game/github_cards.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/github_cards.rs
@@ -5,7 +5,9 @@
 
 use askama::Template;
 use chrono::Datelike;
-use jedi::entity::github::{GitHubCommit, GitHubIssue, GitHubPull, GitHubRepo};
+use jedi::entity::github::{
+    GitHubCommit, GitHubContributor, GitHubIssue, GitHubPull, GitHubRepo, GitHubWorkflowRun,
+};
 use std::collections::HashMap;
 
 use crate::discord::embeds::notice_board_embed::NoticeItem;
@@ -1454,6 +1456,217 @@ pub fn render_health_chart_blocking(
         .render()
         .map_err(|e| format!("Health chart SVG: {e}"))?;
     kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Health chart PNG: {e}"))
+}
+
+// ── Contributors Chart ─────────────────────────────────────────────
+
+pub struct ContributorRow {
+    pub rank: usize,
+    pub login: String,
+    pub contributions: u64,
+    pub bar_width: f64,
+    pub count_x: f64,
+    pub y: u32,
+}
+
+#[derive(Template)]
+#[template(path = "github/contributors_chart.svg")]
+pub struct ContributorsChartTemplate {
+    pub repo_name: String,
+    pub total_contributors: usize,
+    pub total_commits: u64,
+    pub contributors: Vec<ContributorRow>,
+    pub height: u32,
+    pub footer_y: u32,
+    pub brand_y: u32,
+}
+
+pub fn build_contributors_chart(
+    contribs: &[GitHubContributor],
+    repo_name: &str,
+) -> ContributorsChartTemplate {
+    let top = &contribs[..contribs.len().min(15)];
+    let max_count = top.first().map(|c| c.contributions).unwrap_or(1);
+    let total_commits: u64 = top.iter().map(|c| c.contributions).sum();
+    let max_bar = 480.0;
+
+    let contributors: Vec<ContributorRow> = top
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let bw = (c.contributions as f64 / max_count as f64) * max_bar;
+            ContributorRow {
+                rank: i + 1,
+                login: truncate(&c.login, 25),
+                contributions: c.contributions,
+                bar_width: bw.max(4.0),
+                count_x: 200.0 + bw.max(4.0) + 8.0,
+                y: 75 + (i as u32 * 28),
+            }
+        })
+        .collect();
+
+    let row_count = contributors.len() as u32;
+    let height = 75 + row_count * 28 + 30;
+
+    ContributorsChartTemplate {
+        repo_name: repo_name.to_owned(),
+        total_contributors: contribs.len(),
+        total_commits,
+        contributors,
+        height,
+        footer_y: height - 8,
+        brand_y: height - 14,
+    }
+}
+
+pub fn render_contributors_chart_blocking(
+    contribs: &[GitHubContributor],
+    repo_name: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_contributors_chart(contribs, repo_name);
+    let svg = template
+        .render()
+        .map_err(|e| format!("Contributors chart SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Contributors chart PNG: {e}"))
+}
+
+// ── Workflow Runs Chart ───────────────────────────────────────────
+
+pub struct WorkflowRunRow {
+    pub name: String,
+    pub branch: String,
+    pub run_number: u64,
+    pub status_color: String,
+    pub age: String,
+    pub y: u32,
+}
+
+#[derive(Template)]
+#[template(path = "github/workflow_runs_chart.svg")]
+pub struct WorkflowRunsChartTemplate {
+    pub repo_name: String,
+    pub total_runs: usize,
+    pub success_count: usize,
+    pub failure_count: usize,
+    pub success_width: f64,
+    pub failure_width: f64,
+    pub failure_x: f64,
+    pub other_width: f64,
+    pub other_x: f64,
+    pub runs: Vec<WorkflowRunRow>,
+    pub height: u32,
+    pub footer_y: u32,
+    pub brand_y: u32,
+}
+
+fn run_age(created_at: &str) -> String {
+    let Ok(dt) = chrono::DateTime::parse_from_rfc3339(created_at) else {
+        return "?".to_owned();
+    };
+    let diff = chrono::Utc::now() - dt.with_timezone(&chrono::Utc);
+    let mins = diff.num_minutes();
+    if mins < 60 {
+        format!("{mins}m ago")
+    } else if mins < 1440 {
+        format!("{}h ago", mins / 60)
+    } else {
+        format!("{}d ago", mins / 1440)
+    }
+}
+
+fn run_status_color(conclusion: Option<&str>, status: &str) -> String {
+    match conclusion {
+        Some("success") => "#238636".to_owned(),
+        Some("failure") | Some("timed_out") => "#da3633".to_owned(),
+        Some("cancelled") => "#8b949e".to_owned(),
+        Some("skipped") => "#484f58".to_owned(),
+        _ if status == "in_progress" || status == "queued" => "#d29922".to_owned(),
+        _ => "#8b949e".to_owned(),
+    }
+}
+
+pub fn build_workflow_runs_chart(
+    runs: &[GitHubWorkflowRun],
+    repo_name: &str,
+) -> WorkflowRunsChartTemplate {
+    let display_runs = &runs[..runs.len().min(20)];
+    let total = display_runs.len();
+
+    let success_count = display_runs
+        .iter()
+        .filter(|r| r.conclusion.as_deref() == Some("success"))
+        .count();
+    let failure_count = display_runs
+        .iter()
+        .filter(|r| matches!(r.conclusion.as_deref(), Some("failure") | Some("timed_out")))
+        .count();
+    let other_count = total.saturating_sub(success_count + failure_count);
+
+    let bar_width = 744.0;
+    let success_width = if total > 0 {
+        (success_count as f64 / total as f64) * bar_width
+    } else {
+        0.0
+    };
+    let failure_width = if total > 0 {
+        (failure_count as f64 / total as f64) * bar_width
+    } else {
+        0.0
+    };
+    let other_width = if total > 0 {
+        (other_count as f64 / total as f64) * bar_width
+    } else {
+        0.0
+    };
+
+    let run_rows: Vec<WorkflowRunRow> = display_runs
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let name = r.name.as_deref().unwrap_or("unknown");
+            WorkflowRunRow {
+                name: truncate(name, 45),
+                branch: truncate(r.head_branch.as_deref().unwrap_or("?"), 18),
+                run_number: r.run_number,
+                status_color: run_status_color(r.conclusion.as_deref(), &r.status),
+                age: run_age(&r.created_at),
+                y: 120 + (i as u32 * 24),
+            }
+        })
+        .collect();
+
+    let row_count = run_rows.len() as u32;
+    let height = 120 + row_count * 24 + 30;
+
+    WorkflowRunsChartTemplate {
+        repo_name: repo_name.to_owned(),
+        total_runs: total,
+        success_count,
+        failure_count,
+        success_width,
+        failure_width,
+        failure_x: success_width,
+        other_width,
+        other_x: success_width + failure_width,
+        runs: run_rows,
+        height,
+        footer_y: height - 8,
+        brand_y: height - 14,
+    }
+}
+
+pub fn render_workflow_runs_chart_blocking(
+    runs: &[GitHubWorkflowRun],
+    repo_name: &str,
+    fontdb: &kbve::FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_workflow_runs_chart(runs, repo_name);
+    let svg = template
+        .render()
+        .map_err(|e| format!("Workflow runs chart SVG: {e}"))?;
+    kbve::render_svg_to_png(&svg, fontdb).map_err(|e| format!("Workflow runs chart PNG: {e}"))
 }
 
 #[cfg(test)]

--- a/apps/discordsh/discordsh-bot/templates/github/contributors_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/contributors_chart.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="{{ height }}" viewBox="0 0 800 {{ height }}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="{{ height }}" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="{{ height }}" fill="#58a6ff" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">Top Contributors -- {{ repo_name }}</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">{{ total_contributors }} contributors | {{ total_commits }} commits shown</text>
+
+  <!-- Contributor bars -->
+  {% for c in contributors %}
+  <g transform="translate(28, {{ c.y }})">
+    <!-- Rank -->
+    <text x="0" y="14" font-family="sans-serif" font-size="13" fill="#484f58">#{{ c.rank }}</text>
+    <!-- Username -->
+    <text x="32" y="14" font-family="sans-serif" font-size="14" font-weight="600" fill="#e6edf3">{{ c.login }}</text>
+    <!-- Bar -->
+    <rect x="200" y="2" width="{{ c.bar_width }}" height="14" fill="#58a6ff" rx="3" opacity="0.85"/>
+    <!-- Commit count -->
+    <text x="{{ c.count_x }}" y="14" font-family="sans-serif" font-size="12" fill="#8b949e">{{ c.contributions }}</text>
+  </g>
+  {% endfor %}
+
+  <!-- Footer accent -->
+  <rect x="0" y="{{ footer_y }}" width="800" height="8" fill="#58a6ff" opacity="0.3"/>
+  <text x="760" y="{{ brand_y }}" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>

--- a/apps/discordsh/discordsh-bot/templates/github/workflow_runs_chart.svg
+++ b/apps/discordsh/discordsh-bot/templates/github/workflow_runs_chart.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="{{ height }}" viewBox="0 0 800 {{ height }}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="{{ height }}" fill="url(#bg)" rx="12"/>
+  <rect x="0" y="0" width="4" height="{{ height }}" fill="#2EA043" rx="2"/>
+
+  <!-- Title -->
+  <text x="28" y="38" font-family="sans-serif" font-size="18" font-weight="bold" fill="#e6edf3">Workflow Runs -- {{ repo_name }}</text>
+  <text x="28" y="58" font-family="sans-serif" font-size="12" fill="#8b949e">{{ total_runs }} recent runs | {{ success_count }} passed | {{ failure_count }} failed</text>
+
+  <!-- Summary bar -->
+  <g transform="translate(28, 72)">
+    {% if success_width > 0.0 %}
+    <rect x="0" y="0" width="{{ success_width }}" height="14" fill="#238636" rx="7"/>
+    {% endif %}
+    {% if failure_width > 0.0 %}
+    <rect x="{{ failure_x }}" y="0" width="{{ failure_width }}" height="14" fill="#da3633"/>
+    {% endif %}
+    {% if other_width > 0.0 %}
+    <rect x="{{ other_x }}" y="0" width="{{ other_width }}" height="14" fill="#8b949e" rx="{% if failure_width == 0.0 && success_width == 0.0 %}7{% else %}0{% endif %}"/>
+    {% endif %}
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(28, 100)">
+    <circle cx="6" cy="6" r="5" fill="#238636"/>
+    <text x="16" y="10" font-family="sans-serif" font-size="11" fill="#8b949e">Success</text>
+    <circle cx="86" cy="6" r="5" fill="#da3633"/>
+    <text x="96" y="10" font-family="sans-serif" font-size="11" fill="#8b949e">Failed</text>
+    <circle cx="156" cy="6" r="5" fill="#8b949e"/>
+    <text x="166" y="10" font-family="sans-serif" font-size="11" fill="#8b949e">Other</text>
+  </g>
+
+  <!-- Run rows -->
+  {% for run in runs %}
+  <g transform="translate(28, {{ run.y }})">
+    <!-- Status dot -->
+    <circle cx="8" cy="8" r="5" fill="{{ run.status_color }}"/>
+    <!-- Run name -->
+    <text x="22" y="12" font-family="sans-serif" font-size="13" font-weight="600" fill="#e6edf3">{{ run.name }}</text>
+    <!-- Branch -->
+    <text x="420" y="12" font-family="sans-serif" font-size="11" fill="#8b949e">{{ run.branch }}</text>
+    <!-- Run # -->
+    <text x="580" y="12" font-family="sans-serif" font-size="11" fill="#484f58">#{{ run.run_number }}</text>
+    <!-- Age -->
+    <text x="640" y="12" font-family="sans-serif" font-size="11" fill="#484f58">{{ run.age }}</text>
+  </g>
+  {% endfor %}
+
+  <!-- Footer accent -->
+  <rect x="0" y="{{ footer_y }}" width="800" height="8" fill="#2EA043" opacity="0.3"/>
+  <text x="760" y="{{ brand_y }}" font-family="sans-serif" font-size="10" fill="#30363d" text-anchor="end">discord.sh</text>
+</svg>

--- a/packages/rust/jedi/src/entity/github/client.rs
+++ b/packages/rust/jedi/src/entity/github/client.rs
@@ -628,6 +628,57 @@ impl GitHubClient {
         }
     }
 
+    // ── Contributors ──────────────────────────────────────────────────
+
+    /// Fetch top contributors for a repository (sorted by commit count).
+    pub async fn get_contributors(
+        &self,
+        owner: &str,
+        repo: &str,
+        per_page: Option<u8>,
+    ) -> Result<Vec<GitHubContributor>, JediError> {
+        self.policy.check(owner, repo)?;
+        let url = format!("{}/repos/{}/{}/contributors", self.base_url, owner, repo);
+
+        let resp = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[("per_page", per_page.unwrap_or(25).to_string())])
+            .send()
+            .await
+            .map_err(|e| JediError::Internal(Cow::Owned(format!("GitHub request failed: {e}"))))?;
+
+        let resp = self.check_rate_limit(resp);
+        self.parse_response(resp).await
+    }
+
+    // ── Workflow Runs ───────────────────────────────────────────────
+
+    /// Fetch recent workflow runs for a repository.
+    pub async fn list_workflow_runs(
+        &self,
+        owner: &str,
+        repo: &str,
+        per_page: Option<u8>,
+    ) -> Result<Vec<GitHubWorkflowRun>, JediError> {
+        self.policy.check(owner, repo)?;
+        let url = format!("{}/repos/{}/{}/actions/runs", self.base_url, owner, repo);
+
+        let resp = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[("per_page", per_page.unwrap_or(30).to_string())])
+            .send()
+            .await
+            .map_err(|e| JediError::Internal(Cow::Owned(format!("GitHub request failed: {e}"))))?;
+
+        let resp = self.check_rate_limit(resp);
+        let wrapper: GitHubWorkflowRunsResponse = self.parse_response(resp).await?;
+        Ok(wrapper.workflow_runs)
+    }
+
     // ── Merge Pull Request ──────────────────────────────────────────
 
     /// Merge a pull request.

--- a/packages/rust/jedi/src/entity/github/types.rs
+++ b/packages/rust/jedi/src/entity/github/types.rs
@@ -239,6 +239,42 @@ pub struct GitHubMergeResult {
     pub message: String,
 }
 
+// ── Contributors ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubContributor {
+    pub login: String,
+    pub contributions: u64,
+    #[serde(default)]
+    pub avatar_url: String,
+    #[serde(default)]
+    pub html_url: String,
+}
+
+// ── Workflow Runs ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubWorkflowRunsResponse {
+    pub total_count: u64,
+    pub workflow_runs: Vec<GitHubWorkflowRun>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubWorkflowRun {
+    pub id: u64,
+    pub name: Option<String>,
+    pub status: String,
+    #[serde(default)]
+    pub conclusion: Option<String>,
+    pub run_number: u64,
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+    pub html_url: String,
+    #[serde(default)]
+    pub head_branch: Option<String>,
+}
+
 // ── Rate Limit ──────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Add **Contributors chart** (top 15 by commit count, blue horizontal bars) and **Workflow Runs chart** (CI/CD run history with success/fail summary bar + status rows) as new interactive chart types
- New jedi API methods: `get_contributors()`, `list_workflow_runs()` with corresponding types (`GitHubContributor`, `GitHubWorkflowRun`)
- Expand chart buttons to 4 more subcommands: `/github repo` (+Contributors), `/github workflows` (+Run History), `/github noticeboard` (+Activity, Labels), `/github taskboard` (+Labels, Activity)
- Total interactive chart buttons now on **8 of 19** GitHub subcommands (up from 4)

## Test plan
- [x] `cargo build --release -p discordsh-bot` compiles cleanly
- [x] All 699 tests pass (`cargo test -p discordsh-bot`)
- [ ] Deploy and verify Contributors button on `/github repo`
- [ ] Deploy and verify Run History button on `/github workflows`
- [ ] Deploy and verify Activity/Labels buttons on `/github noticeboard` and `/github taskboard`