### PR TITLE
docs(bevy): add READMEs for all bevy crates

### DIFF
--- a/packages/rust/bevy/bevy_battle/Cargo.toml
+++ b/packages/rust/bevy/bevy_battle/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_battle"
 keywords = ["bevy", "combat", "battle", "gamedev", "ecs"]
 categories = ["game-development", "game-engines"]
+readme = "README.md"
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [

--- a/packages/rust/bevy/bevy_battle/README.md
+++ b/packages/rust/bevy/bevy_battle/README.md
@@ -1,0 +1,26 @@
+# bevy_battle
+
+Generic Bevy turn-based battle plugin with damage, effects, class procs, and enemy AI.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_battle::BevyBattlePlugin;
+
+fn main() {
+    App::new()
+        .add_plugins(BevyBattlePlugin)
+        .run();
+}
+```
+
+## Key Types
+
+- `BevyBattlePlugin` — main plugin entry point
+- `CombatModifiers` — resource for global combat tuning
+- `BattleRng` — seeded RNG resource for deterministic battles
+
+## License
+
+MIT

--- a/packages/rust/bevy/bevy_cam/Cargo.toml
+++ b/packages/rust/bevy/bevy_cam/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Bevy isometric camera plugin with pixel snapping, multiplicative zoom, and two-stage render-to-texture pipeline for crisp pixel-art rendering."
 homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_cam"
+readme = "README.md"
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [

--- a/packages/rust/bevy/bevy_cam/README.md
+++ b/packages/rust/bevy/bevy_cam/README.md
@@ -1,0 +1,27 @@
+# bevy_cam
+
+Bevy isometric camera plugin with pixel snapping, multiplicative zoom, and two-stage render-to-texture pipeline for crisp pixel-art rendering.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_cam::{IsometricCameraPlugin, CameraConfig, CameraFollowTarget};
+
+fn main() {
+    App::new()
+        .add_plugins(IsometricCameraPlugin::new(CameraConfig::default()))
+        .run();
+}
+```
+
+## Key Types
+
+- `IsometricCameraPlugin` — main plugin, accepts `CameraConfig`
+- `CameraConfig` — offset, viewport height, pixel density, zoom factor
+- `CameraFollowTarget` — marker component for the entity the camera tracks
+- `DisplayCamera` — marker for post-processing hooks
+
+## License
+
+MIT

--- a/packages/rust/bevy/bevy_inventory/Cargo.toml
+++ b/packages/rust/bevy/bevy_inventory/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_inventory"
 keywords = ["bevy", "inventory", "gamedev", "ecs", "plugin"]
 categories = ["game-development", "game-engines"]
+readme = "README.md"
 
 [features]
 default = ["snapshot"]

--- a/packages/rust/bevy/bevy_inventory/README.md
+++ b/packages/rust/bevy/bevy_inventory/README.md
@@ -1,0 +1,35 @@
+# bevy_inventory
+
+Generic Bevy inventory plugin with item stacking, slot limits, and loot events. WASM-compatible.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_inventory::{InventoryPlugin, Inventory, ItemStack, LootEvent};
+
+fn main() {
+    App::new()
+        .add_plugins(InventoryPlugin::new(20)) // 20 slots
+        .run();
+}
+```
+
+## Key Types
+
+- `InventoryPlugin::new(max_slots)` — main plugin entry point
+- `Inventory` — ECS component holding item slots
+- `ItemKind` — trait for defining item types (`display_name()`, `max_stack()`)
+- `ItemStack` — a stack of items in a slot
+- `LootEvent` / `InventoryFullEvent` — events for game logic
+- `SplitStackAction` / `MergeStackAction` / `MoveSlotAction` — inventory manipulation
+
+## Features
+
+| Feature              | Description                               |
+| -------------------- | ----------------------------------------- |
+| `snapshot` (default) | JSON inventory snapshots via `serde_json` |
+
+## License
+
+MIT

--- a/packages/rust/bevy/bevy_items/Cargo.toml
+++ b/packages/rust/bevy/bevy_items/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_items"
 keywords = ["bevy", "items", "gamedev", "protobuf", "plugin"]
 categories = ["game-development", "game-engines"]
+readme = "README.md"
 
 [features]
 default = []

--- a/packages/rust/bevy/bevy_kbve_net/Cargo.toml
+++ b/packages/rust/bevy/bevy_kbve_net/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_kbve_net"
 keywords = ["bevy", "lightyear", "multiplayer", "networking", "gamedev"]
 categories = ["game-development", "game-engines", "network-programming"]
+readme = "README.md"
 
 [features]
 default = []

--- a/packages/rust/bevy/bevy_kbve_net/README.md
+++ b/packages/rust/bevy/bevy_kbve_net/README.md
@@ -1,0 +1,36 @@
+# bevy_kbve_net
+
+Shared lightyear protocol for KBVE multiplayer — replicated components, inputs, channels.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_kbve_net::ProtocolPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins(ProtocolPlugin)
+        .run();
+}
+```
+
+## Key Types
+
+- `ProtocolPlugin` — registers all replicated components and channels
+- `PlayerInput` / `PlayerColor` / `PlayerId` / `PlayerName` — player state
+- `PositionUpdate` / `PlayerVitals` — replicated transforms and health
+- `AuthMessage` / `AuthAck` / `AuthResponse` — authentication handshake
+- `GameChannel` / `TimeSyncMessage` — networking channels
+
+## Features
+
+| Feature     | Description                                                       |
+| ----------- | ----------------------------------------------------------------- |
+| `client`    | Lightyear client with WebSocket, WebTransport, and UDP transports |
+| `npcdb`     | NPC creature support via `bevy_npc`                               |
+| `creatures` | Full creature system with pooling and async tasks                 |
+
+## License
+
+MIT

--- a/packages/rust/bevy/bevy_mapdb/Cargo.toml
+++ b/packages/rust/bevy/bevy_mapdb/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_mapdb"
 keywords = ["bevy", "map", "gamedev", "protobuf", "plugin"]
 categories = ["game-development", "game-engines"]
+readme = "README.md"
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [

--- a/packages/rust/bevy/bevy_mapdb/README.md
+++ b/packages/rust/bevy/bevy_mapdb/README.md
@@ -1,0 +1,26 @@
+# bevy_mapdb
+
+Proto-driven map definitions for Bevy games — compiles `mapdb.proto` into typed Rust structs with a searchable registry.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_mapdb::{BevyMapDbPlugin, MapDb};
+
+fn load_maps(mut commands: Commands) {
+    let json = include_str!("path/to/mapdb.json");
+    let db = MapDb::from_json(json).expect("Failed to parse map JSON");
+    commands.insert_resource(db);
+}
+```
+
+## Key Types
+
+- `BevyMapDbPlugin` — main plugin entry point
+- `MapDb` — searchable resource (`from_json()`, `from_bytes()`, `from_proto()`)
+- `ProtoMapId` — typed map identifier
+
+## License
+
+MIT

--- a/packages/rust/bevy/bevy_player/Cargo.toml
+++ b/packages/rust/bevy/bevy_player/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Bevy kinematic character controller with Avian3D physics — gravity, jump, collision-aware movement, and fall damage."
 homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_player"
+readme = "README.md"
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [

--- a/packages/rust/bevy/bevy_player/README.md
+++ b/packages/rust/bevy/bevy_player/README.md
@@ -1,0 +1,29 @@
+# bevy_player
+
+Bevy kinematic character controller with Avian3D physics — gravity, jump, collision-aware movement, and fall damage.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_player::{PlayerPlugin, PlayerConfig};
+
+fn main() {
+    App::new()
+        .add_plugins(PlayerPlugin::new(PlayerConfig::default()))
+        .run();
+}
+```
+
+## Key Types
+
+- `PlayerPlugin::new(PlayerConfig)` — main plugin entry point
+- `PlayerConfig` — speed, gravity, jump velocity tuning
+- `Player` / `PlayerPhysics` — ECS components
+- `DirectionMap` — input-to-direction mapping
+- `FallDamageEvent` — emitted on hard landings
+- `spawn_player_entity()` — helper to spawn a fully configured player
+
+## License
+
+MIT

--- a/packages/rust/bevy/bevy_quests/Cargo.toml
+++ b/packages/rust/bevy/bevy_quests/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_quests"
 keywords = ["bevy", "quests", "gamedev", "protobuf", "plugin"]
 categories = ["game-development", "game-engines"]
+readme = "README.md"
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [

--- a/packages/rust/bevy/bevy_skills/Cargo.toml
+++ b/packages/rust/bevy/bevy_skills/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_skills"
 keywords = ["bevy", "skills", "gamedev", "rpg", "plugin"]
 categories = ["game-development", "game-engines"]
+readme = "README.md"
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [

--- a/packages/rust/bevy/bevy_skills/README.md
+++ b/packages/rust/bevy/bevy_skills/README.md
@@ -1,0 +1,29 @@
+# bevy_skills
+
+Skill progression system for Bevy games — tracks XP, levels, and gates interactions by skill requirements.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_skills::{BevySkillsPlugin, SkillProfile, SkillId, GrantXpMsg};
+
+fn main() {
+    App::new()
+        .add_plugins(BevySkillsPlugin)
+        .run();
+}
+```
+
+## Key Types
+
+- `BevySkillsPlugin` — main plugin entry point
+- `SkillProfile` — ECS component tracking a player's skills
+- `SkillRegistry` — resource defining available skills
+- `SkillId` / `SkillDef` / `SkillEntry` — skill definitions
+- `XpCurve` — level-up thresholds
+- `GrantXpMsg` / `LevelUpMsg` / `SkillCheckMsg` — message events
+
+## License
+
+MIT

--- a/packages/rust/bevy/bevy_statemachine/Cargo.toml
+++ b/packages/rust/bevy/bevy_statemachine/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Thread-safe state snapshot bridge for Bevy — exposes ECS resources to external consumers (Tauri IPC, WASM JS, lightyear networking) with JSON and bincode support."
 homepage = "https://kbve.com/"
 repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_statemachine"
+readme = "README.md"
 
 [features]
 default = ["serde"]

--- a/packages/rust/bevy/bevy_statemachine/README.md
+++ b/packages/rust/bevy/bevy_statemachine/README.md
@@ -1,0 +1,34 @@
+# bevy_statemachine
+
+Thread-safe state snapshot bridge for Bevy — exposes ECS resources to external consumers (Tauri IPC, WASM JS, lightyear networking) with JSON and bincode support.
+
+## Usage
+
+```rust
+use bevy::prelude::*;
+use bevy_statemachine::{StateSnapshotPlugin, get_snapshot, get_snapshot_json};
+
+fn main() {
+    App::new()
+        .add_plugins(StateSnapshotPlugin::<MyState>::new())
+        .run();
+}
+```
+
+## Key Types
+
+- `StateSnapshotPlugin::<T>::new()` — main plugin, generic over your state type
+- `get_snapshot::<T>()` — retrieve the latest snapshot
+- `get_snapshot_json::<T>()` — retrieve as JSON string
+- `snapshot_version::<T>()` — monotonic version counter
+
+## Features
+
+| Feature           | Description                         |
+| ----------------- | ----------------------------------- |
+| `serde` (default) | JSON serialization via `serde_json` |
+| `bincode`         | Binary serialization via `bincode`  |
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Add README.md for 8 bevy crates: bevy_battle, bevy_cam, bevy_inventory, bevy_kbve_net, bevy_mapdb, bevy_player, bevy_skills, bevy_statemachine
- Add `readme = "README.md"` Cargo.toml field to all 10 bevy crates (including bevy_items and bevy_quests which already had READMEs)

## Test plan
- [ ] Next crates.io publish cycle picks up READMEs for all crates