### PR TITLE
fix(kong): add Content-Profile to CORS allowed headers

### DIFF
--- a/apps/kube/kong/manifests/kong-config.yaml
+++ b/apps/kube/kong/manifests/kong-config.yaml
@@ -43,6 +43,7 @@ data:
                 - Accept
                 - Accept-Version
                 - Accept-Profile
+                - Content-Profile
                 - Authorization
                 - Content-Length
                 - Content-MD5

--- a/apps/kube/kong/manifests/kong-deployment.yaml
+++ b/apps/kube/kong/manifests/kong-deployment.yaml
@@ -27,6 +27,7 @@ spec:
                 app.kubernetes.io/version: '3.9'
                 version: '3.9'
             annotations:
+                config-hash: abe86a1b6665e4b135829be4ef256287
                 kuma.io/gateway: enabled
                 traffic.sidecar.istio.io/includeInboundPorts: ''
         spec:


### PR DESCRIPTION
## Summary
- Kong CORS plugin was missing `Content-Profile` in allowed headers
- The Supabase JS client sends `Content-Profile: public` on all RPC calls (e.g. `staff_permissions`)
- Browser blocked the preflight → "Request header field content-profile is not allowed"
- This caused the dashboard staff panels (Grafana, ArgoCD, ClickHouse, ROWS) to never load
- Added `config-hash` annotation to Kong deployment to trigger pod rollout on ConfigMap changes

## Test plan
- [ ] Merge to main → ArgoCD syncs Kong ConfigMap + rolls pods
- [ ] Open dashboard → staff_permissions RPC succeeds (no CORS error)
- [ ] Staff panels (Monitoring, Deployments, Logs, Game Ops) appear on dashboard home