### PR TITLE
chore(isometric): auto-commit WASM build in deploy target

### DIFF
--- a/apps/kbve/isometric/project.json
+++ b/apps/kbve/isometric/project.json
@@ -57,7 +57,9 @@
 				"commands": [
 					"rm -rf ../astro-kbve/public/isometric",
 					"mkdir -p ../astro-kbve/public",
-					"cp -r dist ../astro-kbve/public/isometric"
+					"cp -r dist ../astro-kbve/public/isometric",
+					"git add ../astro-kbve/public/isometric",
+					"git commit -m 'chore|build: isometric client.'"
 				],
 				"cwd": "apps/kbve/isometric"
 			}


### PR DESCRIPTION
## Summary
- Deploy target (`npx nx run isometric:deploy`) now auto-commits the built WASM assets after copying to astro-kbve/public
- One command handles the full pipeline: build WASM → vite build → copy → git commit

## Test plan
- [ ] Run `npx nx run isometric:deploy` — verify it builds, copies, and commits in one step