### PR TITLE
fix(kasm): increase gluetun resources and probe timeouts to stop CrashLoop

### DIFF
--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -92,22 +92,22 @@ spec:
                           port: 9999
                       initialDelaySeconds: 30
                       periodSeconds: 30
-                      timeoutSeconds: 5
+                      timeoutSeconds: 10
                       failureThreshold: 5
                   readinessProbe:
                       httpGet:
                           path: /
                           port: 9999
-                      initialDelaySeconds: 10
-                      periodSeconds: 10
-                      timeoutSeconds: 5
+                      initialDelaySeconds: 15
+                      periodSeconds: 15
+                      timeoutSeconds: 10
                   resources:
                       requests:
-                          memory: '64Mi'
-                          cpu: '50m'
+                          memory: '128Mi'
+                          cpu: '100m'
                       limits:
-                          memory: '256Mi'
-                          cpu: '200m'
+                          memory: '384Mi'
+                          cpu: '500m'
 
                 # ── KASM Discord workspace ──
                 # Uses Gluetun's network namespace — all traffic exits via VPN.


### PR DESCRIPTION
## Summary
Fix Gluetun VPN sidecar CrashLoopBackOff in the KASM workspace deployment.

## Root cause
The 200m CPU limit was too low for Gluetun's health check HTTP server. Under the CPU cap, the server couldn't respond to readiness/liveness probes within the 5s timeout. The liveness probe killed the container every ~3 minutes despite WireGuard being connected and functioning.

Both pods have been CrashLooping for 2 days (541+ restarts).

## Fix
| Resource | Before | After |
|----------|--------|-------|
| CPU limit | 200m | 500m |
| CPU request | 50m | 100m |
| Memory limit | 256Mi | 384Mi |
| Memory request | 64Mi | 128Mi |
| Probe timeout | 5s | 10s |
| Readiness period | 10s | 15s |

## Test plan
- [ ] ArgoCD syncs updated deployment
- [ ] Old CrashLooping pods are replaced
- [ ] Gluetun passes health checks consistently
- [ ] Dashboard shows KASM workspace as "Running"
- [ ] VPN connection stable (check public IP via Gluetun control API)