### PR TITLE
feat(bevy_db): cross-platform async key-value persistence crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_db"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy_tasker",
+ "bincode 1.3.3",
+ "crossbeam-channel",
+ "dirs",
+ "js-sys",
+ "redb",
+ "rexie",
+ "serde",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "bevy_derive"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7507,6 +7524,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "idb"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6554f394e990a1af530a528a7fdcad6e01b29cb1b990f89df3ffd62cf15f7828"
+dependencies = [
+ "indexmap 2.13.1",
+ "js-sys",
+ "num-traits",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12113,6 +12145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d463f2884048e7153449a55166f91028d5b0ea53c79377099ce4e8cf0cf9bb"
 
 [[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redis-protocol"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12363,6 +12404,17 @@ dependencies = [
  "tiny-skia 0.12.0",
  "usvg",
  "zune-jpeg",
+]
+
+[[package]]
+name = "rexie"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887466cfa8a12c08ee4b174998135cea8ff0fd84858627cd793e56535a045bc9"
+dependencies = [
+ "idb",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
 	'packages/rust/bevy/bevy_battle',
 	'packages/rust/bevy/bevy_skills',
 	'packages/rust/bevy/bevy_tasker',
+	'packages/rust/bevy/bevy_db',
 	'apps/vm/firecracker-ctl',
 ]
 

--- a/packages/rust/bevy/bevy_db/Cargo.toml
+++ b/packages/rust/bevy/bevy_db/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "bevy_db"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.94"
+license = "MIT"
+description = "Cross-platform async key-value persistence for Bevy — redb on desktop, IndexedDB on WASM"
+homepage = "https://kbve.com/"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_db"
+keywords = ["bevy", "persistence", "wasm", "database", "gamedev"]
+categories = ["game-development", "database"]
+
+[dependencies]
+bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
+bevy_tasker = { version = "0.1", path = "../bevy_tasker" }
+crossbeam-channel = "0.5"
+serde = { version = "1", features = ["derive"] }
+bincode = "1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+redb = "2"
+dirs = "6"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rexie = "0.6"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"

--- a/packages/rust/bevy/bevy_db/src/backend/mod.rs
+++ b/packages/rust/bevy/bevy_db/src/backend/mod.rs
@@ -1,0 +1,13 @@
+//! Platform-specific database backends.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use native::NativeStore as BackendStore;
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) use wasm::WasmStore as BackendStore;

--- a/packages/rust/bevy/bevy_db/src/backend/native.rs
+++ b/packages/rust/bevy/bevy_db/src/backend/native.rs
@@ -1,0 +1,164 @@
+//! Native backend — redb (pure Rust B+tree embedded database).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use redb::{Database, TableDefinition};
+
+use crate::error::DbError;
+use crate::store::DbStore;
+
+/// Composite key format: `"table\0key"`. Using null byte as separator
+/// since it won't appear in valid UTF-8 table/key names.
+fn composite_key(table: &str, key: &str) -> String {
+    format!("{table}\0{key}")
+}
+
+/// Extract the key portion from a composite key.
+fn extract_key(composite: &str, table: &str) -> Option<String> {
+    let prefix = format!("{table}\0");
+    composite.strip_prefix(&prefix).map(|s| s.to_owned())
+}
+
+/// Single redb table definition for all data.
+const DATA_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("data");
+
+/// Native database store backed by redb.
+pub(crate) struct NativeStore {
+    db: Arc<Database>,
+}
+
+impl NativeStore {
+    /// Open or create the database at the given path.
+    pub fn open(path: PathBuf) -> Result<Self, DbError> {
+        let db = Database::create(path).map_err(|e| DbError::Backend(format!("redb open: {e}")))?;
+        Ok(Self { db: Arc::new(db) })
+    }
+}
+
+impl DbStore for NativeStore {
+    async fn get(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, DbError> {
+        let ck = composite_key(table, key);
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+
+        let tbl = match read_txn.open_table(DATA_TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(DbError::Backend(e.to_string())),
+        };
+
+        match tbl.get(ck.as_str()) {
+            Ok(Some(val)) => Ok(Some(val.value().to_vec())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(DbError::Backend(e.to_string())),
+        }
+    }
+
+    async fn put(&self, table: &str, key: &str, value: Vec<u8>) -> Result<(), DbError> {
+        let ck = composite_key(table, key);
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        {
+            let mut tbl = write_txn
+                .open_table(DATA_TABLE)
+                .map_err(|e| DbError::Backend(e.to_string()))?;
+            tbl.insert(ck.as_str(), value.as_slice())
+                .map_err(|e| DbError::Backend(e.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn delete(&self, table: &str, key: &str) -> Result<(), DbError> {
+        let ck = composite_key(table, key);
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        {
+            let mut tbl = match write_txn.open_table(DATA_TABLE) {
+                Ok(t) => t,
+                Err(redb::TableError::TableDoesNotExist(_)) => return Ok(()),
+                Err(e) => return Err(DbError::Backend(e.to_string())),
+            };
+            tbl.remove(ck.as_str())
+                .map_err(|e| DbError::Backend(e.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn list_keys(&self, table: &str, prefix: &str) -> Result<Vec<String>, DbError> {
+        let scan_prefix = format!("{table}\0{prefix}");
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+
+        let tbl = match read_txn.open_table(DATA_TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+            Err(e) => return Err(DbError::Backend(e.to_string())),
+        };
+
+        let mut keys = Vec::new();
+        let range = tbl
+            .range(scan_prefix.as_str()..)
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+
+        for entry in range {
+            let (k, _) = entry.map_err(|e| DbError::Backend(e.to_string()))?;
+            let composite = k.value().to_string();
+            if !composite.starts_with(&scan_prefix) {
+                break; // Past the prefix range
+            }
+            if let Some(key) = extract_key(&composite, table) {
+                keys.push(key);
+            }
+        }
+
+        Ok(keys)
+    }
+
+    async fn write_batch(
+        &self,
+        ops: Vec<(String, String, Option<Vec<u8>>)>,
+    ) -> Result<(), DbError> {
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        {
+            let mut tbl = write_txn
+                .open_table(DATA_TABLE)
+                .map_err(|e| DbError::Backend(e.to_string()))?;
+
+            for (table, key, value) in &ops {
+                let ck = composite_key(table, key);
+                match value {
+                    Some(bytes) => {
+                        tbl.insert(ck.as_str(), bytes.as_slice())
+                            .map_err(|e| DbError::Backend(e.to_string()))?;
+                    }
+                    None => {
+                        tbl.remove(ck.as_str())
+                            .map_err(|e| DbError::Backend(e.to_string()))?;
+                    }
+                }
+            }
+        }
+        write_txn
+            .commit()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/packages/rust/bevy/bevy_db/src/backend/wasm.rs
+++ b/packages/rust/bevy/bevy_db/src/backend/wasm.rs
@@ -1,0 +1,184 @@
+//! WASM backend — rexie (IndexedDB wrapper).
+//!
+//! Uses a single object store with composite keys (`"table\0key"`) to avoid
+//! needing to know all table names at IndexedDB open time.
+
+use std::sync::Arc;
+
+use rexie::{ObjectStore, Rexie, TransactionMode};
+use wasm_bindgen::JsValue;
+
+use crate::error::DbError;
+use crate::store::DbStore;
+
+const STORE_NAME: &str = "kv";
+const DB_VERSION: u32 = 1;
+
+/// Composite key format matching the native backend.
+fn composite_key(table: &str, key: &str) -> String {
+    format!("{table}\0{key}")
+}
+
+fn extract_key(composite: &str, table: &str) -> Option<String> {
+    let prefix = format!("{table}\0");
+    composite.strip_prefix(&prefix).map(|s| s.to_owned())
+}
+
+fn js_err(e: rexie::Error) -> DbError {
+    DbError::Backend(format!("IndexedDB: {e}"))
+}
+
+/// WASM database store backed by IndexedDB via rexie.
+pub(crate) struct WasmStore {
+    db_name: String,
+    /// Lazily initialized. First operation triggers the IndexedDB open.
+    db: tokio::sync::OnceCell<Rexie>,
+}
+
+// Safety: WASM is single-threaded. Rexie handles are !Send but we never
+// actually cross threads. This unsafe impl allows Arc<WasmStore> in the
+// Db resource which requires Send + Sync.
+unsafe impl Send for WasmStore {}
+unsafe impl Sync for WasmStore {}
+
+impl WasmStore {
+    pub fn new(db_name: String) -> Self {
+        Self {
+            db_name,
+            db: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    async fn get_db(&self) -> Result<&Rexie, DbError> {
+        self.db
+            .get_or_try_init(|| async {
+                Rexie::builder(&self.db_name)
+                    .version(DB_VERSION)
+                    .add_object_store(ObjectStore::new(STORE_NAME))
+                    .build()
+                    .await
+                    .map_err(js_err)
+            })
+            .await
+    }
+}
+
+impl DbStore for WasmStore {
+    async fn get(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, DbError> {
+        let db = self.get_db().await?;
+        let ck = composite_key(table, key);
+
+        let tx = db
+            .transaction(&[STORE_NAME], TransactionMode::ReadOnly)
+            .map_err(js_err)?;
+        let store = tx.store(STORE_NAME).map_err(js_err)?;
+
+        let result = store.get(&JsValue::from_str(&ck)).await.map_err(js_err)?;
+
+        tx.done().await.map_err(js_err)?;
+
+        match result {
+            Some(val) => {
+                let array = js_sys::Uint8Array::new(&val);
+                Ok(Some(array.to_vec()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn put(&self, table: &str, key: &str, value: Vec<u8>) -> Result<(), DbError> {
+        let db = self.get_db().await?;
+        let ck = composite_key(table, key);
+
+        let tx = db
+            .transaction(&[STORE_NAME], TransactionMode::ReadWrite)
+            .map_err(js_err)?;
+        let store = tx.store(STORE_NAME).map_err(js_err)?;
+
+        let js_key = JsValue::from_str(&ck);
+        let js_val = js_sys::Uint8Array::from(value.as_slice()).into();
+
+        store.put(&js_val, Some(&js_key)).await.map_err(js_err)?;
+
+        tx.done().await.map_err(js_err)?;
+        Ok(())
+    }
+
+    async fn delete(&self, table: &str, key: &str) -> Result<(), DbError> {
+        let db = self.get_db().await?;
+        let ck = composite_key(table, key);
+
+        let tx = db
+            .transaction(&[STORE_NAME], TransactionMode::ReadWrite)
+            .map_err(js_err)?;
+        let store = tx.store(STORE_NAME).map_err(js_err)?;
+
+        store
+            .delete(&JsValue::from_str(&ck))
+            .await
+            .map_err(js_err)?;
+
+        tx.done().await.map_err(js_err)?;
+        Ok(())
+    }
+
+    async fn list_keys(&self, table: &str, prefix: &str) -> Result<Vec<String>, DbError> {
+        let db = self.get_db().await?;
+        let scan_prefix = format!("{table}\0{prefix}");
+
+        let tx = db
+            .transaction(&[STORE_NAME], TransactionMode::ReadOnly)
+            .map_err(js_err)?;
+        let store = tx.store(STORE_NAME).map_err(js_err)?;
+
+        // Get all keys and filter by prefix (IndexedDB doesn't support prefix scans natively)
+        let all_keys = store
+            .get_all(None, None, None, None)
+            .await
+            .map_err(js_err)?;
+
+        let mut keys = Vec::new();
+        for (js_key, _) in &all_keys {
+            if let Some(s) = js_key.as_string() {
+                if s.starts_with(&scan_prefix) {
+                    if let Some(k) = extract_key(&s, table) {
+                        keys.push(k);
+                    }
+                }
+            }
+        }
+
+        tx.done().await.map_err(js_err)?;
+        Ok(keys)
+    }
+
+    async fn write_batch(
+        &self,
+        ops: Vec<(String, String, Option<Vec<u8>>)>,
+    ) -> Result<(), DbError> {
+        let db = self.get_db().await?;
+
+        let tx = db
+            .transaction(&[STORE_NAME], TransactionMode::ReadWrite)
+            .map_err(js_err)?;
+        let store = tx.store(STORE_NAME).map_err(js_err)?;
+
+        for (table, key, value) in &ops {
+            let ck = composite_key(table, key);
+            let js_key = JsValue::from_str(&ck);
+
+            match value {
+                Some(bytes) => {
+                    let js_val = js_sys::Uint8Array::from(bytes.as_slice()).into();
+                    store.put(&js_val, Some(&js_key)).await.map_err(js_err)?;
+                }
+                None => {
+                    store.delete(&js_key).await.map_err(js_err)?;
+                }
+            }
+        }
+
+        tx.done().await.map_err(js_err)?;
+        Ok(())
+    }
+}

--- a/packages/rust/bevy/bevy_db/src/batch.rs
+++ b/packages/rust/bevy/bevy_db/src/batch.rs
@@ -1,0 +1,60 @@
+//! `WriteBatch` — builder for atomic multi-key writes.
+
+use std::sync::Arc;
+
+use crossbeam_channel::bounded;
+use serde::Serialize;
+
+use crate::backend::BackendStore;
+use crate::error::DbError;
+use crate::handle::DbRequest;
+use crate::store::DbStore;
+
+/// Accumulates put/delete operations and executes them atomically.
+pub struct WriteBatch {
+    store: Arc<BackendStore>,
+    ops: Vec<(String, String, Option<Vec<u8>>)>,
+}
+
+impl WriteBatch {
+    pub(crate) fn new(store: Arc<BackendStore>) -> Self {
+        Self {
+            store,
+            ops: Vec::new(),
+        }
+    }
+
+    /// Queue a put operation.
+    pub fn put<T: Serialize>(
+        &mut self,
+        table: &str,
+        key: &str,
+        value: &T,
+    ) -> Result<&mut Self, DbError> {
+        let bytes = bincode::serialize(value).map_err(|e| DbError::Serialization(e.to_string()))?;
+        self.ops
+            .push((table.to_owned(), key.to_owned(), Some(bytes)));
+        Ok(self)
+    }
+
+    /// Queue a delete operation.
+    pub fn delete(&mut self, table: &str, key: &str) -> &mut Self {
+        self.ops.push((table.to_owned(), key.to_owned(), None));
+        self
+    }
+
+    /// Execute all queued operations atomically. Returns a `DbRequest<()>` handle.
+    pub fn execute(self) -> DbRequest<()> {
+        let (tx, rx) = bounded(1);
+        let store = self.store;
+        let ops = self.ops;
+
+        bevy_tasker::spawn(async move {
+            let result = store.write_batch(ops).await;
+            let _ = tx.send(result);
+        })
+        .detach();
+
+        DbRequest { rx }
+    }
+}

--- a/packages/rust/bevy/bevy_db/src/error.rs
+++ b/packages/rust/bevy/bevy_db/src/error.rs
@@ -1,0 +1,27 @@
+//! Error types for bevy_db operations.
+
+/// Errors returned by database operations.
+#[derive(Debug, Clone)]
+pub enum DbError {
+    /// Key not found in the store.
+    NotFound,
+    /// Serialization or deserialization failed.
+    Serialization(String),
+    /// Backend-specific error (redb I/O, IndexedDB DOM exception, etc.).
+    Backend(String),
+    /// The result channel was closed before a response arrived.
+    ChannelClosed,
+}
+
+impl std::fmt::Display for DbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "key not found"),
+            Self::Serialization(msg) => write!(f, "serialization error: {msg}"),
+            Self::Backend(msg) => write!(f, "backend error: {msg}"),
+            Self::ChannelClosed => write!(f, "result channel closed"),
+        }
+    }
+}
+
+impl std::error::Error for DbError {}

--- a/packages/rust/bevy/bevy_db/src/handle.rs
+++ b/packages/rust/bevy/bevy_db/src/handle.rs
@@ -1,0 +1,148 @@
+//! `Db` resource and `DbRequest<T>` — the public API for database operations.
+//!
+//! Systems use `Db` to dispatch async reads/writes via `bevy_tasker`. Each call
+//! returns a `DbRequest<T>` that is polled with `try_recv()` on subsequent frames.
+
+use std::sync::Arc;
+
+use bevy::prelude::*;
+use crossbeam_channel::{Receiver, TryRecvError, bounded};
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::backend::BackendStore;
+use crate::error::DbError;
+use crate::store::DbStore;
+
+// ---------------------------------------------------------------------------
+// DbRequest — non-blocking result handle
+// ---------------------------------------------------------------------------
+
+/// Handle to a pending database operation. Poll with `try_recv()`.
+pub struct DbRequest<T> {
+    pub(crate) rx: Receiver<Result<T, DbError>>,
+}
+
+impl<T> DbRequest<T> {
+    /// Non-blocking poll. Returns `None` if the result isn't ready yet.
+    pub fn try_recv(&self) -> Option<Result<T, DbError>> {
+        match self.rx.try_recv() {
+            Ok(result) => Some(result),
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => Some(Err(DbError::ChannelClosed)),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Db — Bevy Resource
+// ---------------------------------------------------------------------------
+
+/// Async key-value database resource. Clone is cheap (Arc).
+///
+/// All operations dispatch to `bevy_tasker` and return a `DbRequest<T>` handle.
+/// The game thread never blocks on I/O.
+#[derive(Resource, Clone)]
+pub struct Db {
+    pub(crate) inner: Arc<BackendStore>,
+}
+
+impl Db {
+    pub(crate) fn new(store: BackendStore) -> Self {
+        Self {
+            inner: Arc::new(store),
+        }
+    }
+
+    /// Get a typed value from a table.
+    pub fn get<T: DeserializeOwned + Send + 'static>(
+        &self,
+        table: &str,
+        key: &str,
+    ) -> DbRequest<Option<T>> {
+        let (tx, rx) = bounded(1);
+        let store = Arc::clone(&self.inner);
+        let table = table.to_owned();
+        let key = key.to_owned();
+
+        bevy_tasker::spawn(async move {
+            let result = store.get(&table, &key).await;
+            let typed = result.and_then(|opt| {
+                opt.map(|bytes| {
+                    bincode::deserialize(&bytes).map_err(|e| DbError::Serialization(e.to_string()))
+                })
+                .transpose()
+            });
+            let _ = tx.send(typed);
+        })
+        .detach();
+
+        DbRequest { rx }
+    }
+
+    /// Put a typed value into a table.
+    pub fn put<T: Serialize + Send + Sync + 'static>(
+        &self,
+        table: &str,
+        key: &str,
+        value: &T,
+    ) -> DbRequest<()> {
+        let bytes = match bincode::serialize(value) {
+            Ok(b) => b,
+            Err(e) => {
+                let (tx, rx) = bounded(1);
+                let _ = tx.send(Err(DbError::Serialization(e.to_string())));
+                return DbRequest { rx };
+            }
+        };
+
+        let (tx, rx) = bounded(1);
+        let store = Arc::clone(&self.inner);
+        let table = table.to_owned();
+        let key = key.to_owned();
+
+        bevy_tasker::spawn(async move {
+            let result = store.put(&table, &key, bytes).await;
+            let _ = tx.send(result);
+        })
+        .detach();
+
+        DbRequest { rx }
+    }
+
+    /// Delete a key from a table.
+    pub fn delete(&self, table: &str, key: &str) -> DbRequest<()> {
+        let (tx, rx) = bounded(1);
+        let store = Arc::clone(&self.inner);
+        let table = table.to_owned();
+        let key = key.to_owned();
+
+        bevy_tasker::spawn(async move {
+            let result = store.delete(&table, &key).await;
+            let _ = tx.send(result);
+        })
+        .detach();
+
+        DbRequest { rx }
+    }
+
+    /// List all keys in a table matching a prefix.
+    pub fn list_keys(&self, table: &str, prefix: &str) -> DbRequest<Vec<String>> {
+        let (tx, rx) = bounded(1);
+        let store = Arc::clone(&self.inner);
+        let table = table.to_owned();
+        let prefix = prefix.to_owned();
+
+        bevy_tasker::spawn(async move {
+            let result = store.list_keys(&table, &prefix).await;
+            let _ = tx.send(result);
+        })
+        .detach();
+
+        DbRequest { rx }
+    }
+
+    /// Start building a batch write.
+    pub fn batch(&self) -> crate::batch::WriteBatch {
+        crate::batch::WriteBatch::new(Arc::clone(&self.inner))
+    }
+}

--- a/packages/rust/bevy/bevy_db/src/lib.rs
+++ b/packages/rust/bevy/bevy_db/src/lib.rs
@@ -1,0 +1,72 @@
+//! `bevy_db` — Cross-platform async key-value persistence for Bevy.
+//!
+//! Uses `redb` (pure Rust B+tree) on native and `rexie` (IndexedDB) on WASM.
+//! All I/O is dispatched off the game thread via `bevy_tasker`.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! app.add_plugins(BevyDbPlugin::default());
+//!
+//! fn save_system(db: Res<Db>) {
+//!     let _req = db.put("players", "hero", &player_state);
+//! }
+//!
+//! fn load_system(db: Res<Db>, mut pending: Local<Option<DbRequest<Option<PlayerState>>>>) {
+//!     if pending.is_none() {
+//!         *pending = Some(db.get("players", "hero"));
+//!     }
+//!     if let Some(ref req) = *pending {
+//!         if let Some(result) = req.try_recv() {
+//!             // Use result
+//!             *pending = None;
+//!         }
+//!     }
+//! }
+//! ```
+
+pub mod backend;
+pub mod batch;
+pub mod error;
+pub mod handle;
+pub(crate) mod store;
+
+pub use error::DbError;
+pub use handle::{Db, DbRequest};
+
+use bevy::prelude::*;
+
+/// Plugin that initializes the database backend and inserts the `Db` resource.
+pub struct BevyDbPlugin {
+    /// Database name. On native this becomes the filename; on WASM the IndexedDB name.
+    pub db_name: String,
+}
+
+impl Default for BevyDbPlugin {
+    fn default() -> Self {
+        Self {
+            db_name: "kbve_db".into(),
+        }
+    }
+}
+
+impl Plugin for BevyDbPlugin {
+    fn build(&self, app: &mut App) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let path = dirs::data_local_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join(&self.db_name)
+                .with_extension("redb");
+
+            let store = backend::BackendStore::open(path).expect("failed to open bevy_db database");
+            app.insert_resource(Db::new(store));
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let store = backend::BackendStore::new(self.db_name.clone());
+            app.insert_resource(Db::new(store));
+        }
+    }
+}

--- a/packages/rust/bevy/bevy_db/src/store.rs
+++ b/packages/rust/bevy/bevy_db/src/store.rs
@@ -1,0 +1,43 @@
+//! Internal backend trait — implemented by native (redb) and WASM (rexie) backends.
+
+use crate::error::DbError;
+
+/// Async key-value store contract. Each backend implements this.
+/// Keys and tables are strings; values are opaque bytes (bincode-serialized by the handle layer).
+pub(crate) trait DbStore: Send + Sync + 'static {
+    /// Get a value by table + key. Returns None if not found.
+    fn get(
+        &self,
+        table: &str,
+        key: &str,
+    ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, DbError>> + Send;
+
+    /// Put a value at table + key. Overwrites if exists.
+    fn put(
+        &self,
+        table: &str,
+        key: &str,
+        value: Vec<u8>,
+    ) -> impl std::future::Future<Output = Result<(), DbError>> + Send;
+
+    /// Delete a key from a table. No-op if not found.
+    fn delete(
+        &self,
+        table: &str,
+        key: &str,
+    ) -> impl std::future::Future<Output = Result<(), DbError>> + Send;
+
+    /// List all keys in a table matching a prefix.
+    fn list_keys(
+        &self,
+        table: &str,
+        prefix: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>, DbError>> + Send;
+
+    /// Atomically write a batch of operations.
+    /// Each tuple: (table, key, Some(value)) for put or (table, key, None) for delete.
+    fn write_batch(
+        &self,
+        ops: Vec<(String, String, Option<Vec<u8>>)>,
+    ) -> impl std::future::Future<Output = Result<(), DbError>> + Send;
+}


### PR DESCRIPTION
## Summary
- New `bevy_db` crate at `packages/rust/bevy/bevy_db/`
- Async key-value persistence that works on native desktop (redb) and WASM browser (IndexedDB via rexie)
- All I/O dispatched off the game thread via `bevy_tasker` + `crossbeam-channel`
- `Db` resource with typed `get<T>`/`put<T>`/`delete`/`list_keys`/`batch` operations
- `DbRequest<T>` polling handle — same pattern as the creature patrol system
- `WriteBatch` for atomic multi-key transactions
- `BevyDbPlugin` auto-selects backend at compile time

## Architecture
```
Db resource (Bevy ECS)
  └─ bevy_tasker::spawn(async { store.op().await })
       ├─ Native: redb (pure Rust B+tree, single-file, ACID)
       └─ WASM: rexie (IndexedDB, lazy-init, composite keys)
```

## Test plan
- [x] `cargo check -p bevy_db` — native compiles clean
- [ ] WASM compilation (rexie backend)
- [ ] Integration with isometric-game