### PR TITLE
feat(dashboard/ide): language switching, execution history, DESIGN.md overhaul

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useStore } from '@nanostores/react';
-import { ideService, PRESETS, type RunResult } from './ideService';
+import {
+	ideService,
+	PRESETS,
+	type RunResult,
+	type HistoryEntry,
+} from './ideService';
 import { vmService } from './vmService';
 import {
 	Play,
@@ -11,9 +16,22 @@ import {
 	CheckCircle2,
 } from 'lucide-react';
 import { EditorView, basicSetup } from 'codemirror';
-import { EditorState } from '@codemirror/state';
+import { EditorState, Compartment } from '@codemirror/state';
 import { python } from '@codemirror/lang-python';
+import { javascript } from '@codemirror/lang-javascript';
 import { oneDark } from '@codemirror/theme-one-dark';
+import type { Extension } from '@codemirror/state';
+
+function langExtension(language: string): Extension {
+	switch (language) {
+		case 'python':
+			return python();
+		case 'javascript':
+			return javascript();
+		default:
+			return [];
+	}
+}
 
 function PhaseIndicator({ phase }: { phase: string }) {
 	const config: Record<
@@ -138,6 +156,7 @@ export default function ReactCodeIDE() {
 	const preset = useStore(ideService.$preset);
 	const editorRef = useRef<HTMLDivElement>(null);
 	const viewRef = useRef<EditorView | null>(null);
+	const langCompartment = useRef(new Compartment());
 
 	// Initialize CodeMirror
 	useEffect(() => {
@@ -147,7 +166,7 @@ export default function ReactCodeIDE() {
 			doc: ideService.$code.get(),
 			extensions: [
 				basicSetup,
-				python(),
+				langCompartment.current.of(langExtension(preset.language)),
 				oneDark,
 				EditorView.updateListener.of((update) => {
 					if (update.docChanged) {
@@ -173,7 +192,19 @@ export default function ReactCodeIDE() {
 			view.destroy();
 			viewRef.current = null;
 		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
+
+	// Switch language when preset changes
+	useEffect(() => {
+		if (viewRef.current) {
+			viewRef.current.dispatch({
+				effects: langCompartment.current.reconfigure(
+					langExtension(preset.language),
+				),
+			});
+		}
+	}, [preset.language]);
 
 	const handleRun = useCallback(() => {
 		if (token && phase !== 'creating' && phase !== 'running') {
@@ -339,6 +370,120 @@ export default function ReactCodeIDE() {
 					}}>
 					<OutputPanel result={result} error={error} />
 				</div>
+			</div>
+
+			{/* Execution History */}
+			<HistoryPanel />
+		</div>
+	);
+}
+
+function HistoryPanel() {
+	const history = useStore(ideService.$history);
+	if (history.length === 0) return null;
+
+	return (
+		<div style={{ marginTop: '1.5rem' }}>
+			<h3
+				style={{
+					fontSize: '0.95rem',
+					fontWeight: 600,
+					marginBottom: '0.75rem',
+					color: 'var(--sl-color-text, #e6edf3)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.4rem',
+				}}>
+				<Clock size={16} />
+				History
+				<span
+					style={{
+						fontSize: '0.75rem',
+						color: 'rgba(255,255,255,0.4)',
+						fontWeight: 400,
+					}}>
+					({history.length})
+				</span>
+			</h3>
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.5rem',
+				}}>
+				{history.map((entry: HistoryEntry) => {
+					const ok =
+						entry.result?.exit_code === 0 &&
+						entry.result?.status === 'completed';
+					const presetLabel =
+						PRESETS.find((p) => p.id === entry.preset_id)?.label ??
+						entry.preset_id;
+					const time = new Date(entry.timestamp).toLocaleTimeString();
+					return (
+						<div
+							key={entry.id + entry.timestamp}
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								padding: '0.5rem 0.75rem',
+								background: 'rgba(255,255,255,0.02)',
+								border: '1px solid rgba(255,255,255,0.06)',
+								borderRadius: '8px',
+								fontSize: '0.8rem',
+								cursor: 'pointer',
+							}}
+							onClick={() => {
+								ideService.$code.set(entry.code);
+							}}
+							title="Click to load code">
+							<div
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: '0.5rem',
+								}}>
+								{ok ? (
+									<CheckCircle2
+										size={14}
+										style={{ color: '#22c55e' }}
+									/>
+								) : (
+									<AlertCircle
+										size={14}
+										style={{ color: '#ef4444' }}
+									/>
+								)}
+								<span
+									style={{
+										color: 'rgba(255,255,255,0.6)',
+										fontFamily: 'monospace',
+										maxWidth: 300,
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+										whiteSpace: 'nowrap',
+									}}>
+									{entry.code
+										.split('\n')
+										.find((l) => l.trim()) ?? '(empty)'}
+								</span>
+							</div>
+							<div
+								style={{
+									display: 'flex',
+									gap: '0.75rem',
+									color: 'rgba(255,255,255,0.35)',
+									fontSize: '0.7rem',
+								}}>
+								<span>{presetLabel}</span>
+								{entry.result && (
+									<span>{entry.result.duration_ms}ms</span>
+								)}
+								<span>{time}</span>
+							</div>
+						</div>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
@@ -15,6 +15,15 @@ export interface RunResult {
 
 export type RunPhase = 'idle' | 'creating' | 'running' | 'completed' | 'failed';
 
+export interface HistoryEntry {
+	id: string;
+	preset_id: string;
+	code: string;
+	result: RunResult | null;
+	error: string | null;
+	timestamp: number;
+}
+
 export interface RuntimePreset {
 	id: string;
 	label: string;
@@ -152,14 +161,30 @@ const DEFAULT_CODES: Record<string, string> = {
 	shell: '#!/bin/sh\necho "Hello from Firecracker!"\n',
 };
 
+const MAX_HISTORY = 20;
+
 class IDEService {
 	public readonly $phase = atom<RunPhase>('idle');
 	public readonly $result = atom<RunResult | null>(null);
 	public readonly $error = atom<string | null>(null);
 	public readonly $preset = atom<RuntimePreset>(PRESETS[0]);
 	public readonly $code = atom<string>(DEFAULT_CODES.python);
+	public readonly $history = atom<HistoryEntry[]>([]);
 
 	private _abortController: AbortController | null = null;
+
+	private _pushHistory(result: RunResult | null, error: string | null): void {
+		const entry: HistoryEntry = {
+			id: result?.vm_id ?? `err-${Date.now()}`,
+			preset_id: this.$preset.get().id,
+			code: this.$code.get(),
+			result,
+			error,
+			timestamp: Date.now(),
+		};
+		const prev = this.$history.get();
+		this.$history.set([entry, ...prev].slice(0, MAX_HISTORY));
+	}
 
 	public selectPreset(presetId: string): void {
 		const preset = PRESETS.find((p) => p.id === presetId);
@@ -228,6 +253,7 @@ class IDEService {
 						`/vm/${vmId}/result`,
 					);
 					this.$result.set(result);
+					this._pushHistory(result, null);
 					this.$phase.set(
 						result.status === 'completed' && result.exit_code === 0
 							? 'completed'
@@ -248,13 +274,15 @@ class IDEService {
 			} catch {
 				// ignore
 			}
+			const timeoutErr = `Execution timed out after ${preset.timeout_ms / 1000}s`;
 			this.$phase.set('failed');
-			this.$error.set(
-				`Execution timed out after ${preset.timeout_ms / 1000}s`,
-			);
+			this.$error.set(timeoutErr);
+			this._pushHistory(this.$result.get(), timeoutErr);
 		} catch (e) {
+			const errMsg = e instanceof Error ? e.message : 'Unknown error';
 			this.$phase.set('failed');
-			this.$error.set(e instanceof Error ? e.message : 'Unknown error');
+			this.$error.set(errMsg);
+			this._pushHistory(null, errMsg);
 		}
 	}
 

--- a/apps/kube/firecracker/DESIGN.md
+++ b/apps/kube/firecracker/DESIGN.md
@@ -3,40 +3,37 @@
 ## Overview
 
 Extend the KBVE edge platform with Firecracker microVM support, enabling edge
-functions to dispatch workloads into hardware-isolated virtual machines with
-sub-second boot times (~125 ms) and minimal overhead (~5 MB per VMM process).
-
-## Problem
-
-The current Supabase edge-runtime provides Deno V8 worker isolation (150 MB
-memory, 60 s timeout). This is sufficient for TypeScript functions but cannot
-run arbitrary binaries, long-running processes, or untrusted code that requires
-full OS-level isolation.
+functions and a browser-based IDE to dispatch workloads into hardware-isolated
+virtual machines with sub-second boot times (~125 ms) and minimal overhead
+(~5 MB per VMM process).
 
 ## Architecture
 
 ```
-                    ┌──────────────────────────────────┐
-                    │        Edge Runtime Pod           │
-                    │   (supabase/edge-runtime:v1.73)   │
-                    │                                    │
-                    │  Deno workers (Tier 1 — isolates)  │
-                    │    health, meme, vault, argo ...   │
-                    └────────────┬─────────────────────┘
-                                 │ HTTP/gRPC (internal)
-                                 ▼
-                    ┌──────────────────────────────────┐
-                    │     Firecracker Service Pod       │
-                    │   (kbve/firecracker-ctl:latest)   │
-                    │                                    │
-                    │  REST API → Firecracker VMM        │
-                    │  /dev/kvm mounted via device plugin │
-                    │                                    │
-                    │  Tier 2 — microVM workloads        │
-                    │  ┌─────┐ ┌─────┐ ┌─────┐         │
-                    │  │ VM1 │ │ VM2 │ │ VM3 │         │
-                    │  └─────┘ └─────┘ └─────┘         │
-                    └──────────────────────────────────┘
+Browser (dashboard/ide/)
+  ┌──────────────────────────┐
+  │ CodeMirror 6 Editor      │  Python / JavaScript / Shell
+  ├──────────────────────────┤
+  │ [Run]  preset selector   │  Configurable timeout/memory/vCPU
+  ├──────────────────────────┤
+  │ stdout / stderr / stats  │  Execution history (last 20 runs)
+  └──────────────────────────┘
+           │ /dashboard/firecracker/proxy/*
+           ▼
+  ┌──────────────────────────┐     ┌──────────────────────────┐
+  │ axum-kbve (kbve ns)      │     │ Edge Runtime (kilobase)  │
+  │ JWT auth + proxy         │     │ Deno workers (Tier 1)    │
+  └──────────────────────────┘     └──────────────────────────┘
+           │                                │
+           └────────────┬───────────────────┘
+                        ▼ HTTP :9001
+           ┌──────────────────────────┐
+           │ firecracker-ctl           │  Rust Axum REST API
+           │ (firecracker ns)          │  /dev/kvm via device plugin
+           │ ┌────┐ ┌────┐ ┌────┐    │
+           │ │VM1 │ │VM2 │ │VM3 │    │  alpine-python / alpine-node / alpine-minimal
+           │ └────┘ └────┘ └────┘    │
+           └──────────────────────────┘
 ```
 
 ### Two-tier isolation model
@@ -46,182 +43,93 @@ full OS-level isolation.
 | 1    | V8 isolates | ~10ms  | TypeScript edge functions          |
 | 2    | Firecracker | ~125ms | Arbitrary binaries, untrusted code |
 
-### Communication flow
+## Components
 
-1. Edge function receives HTTP request
-2. For VM-eligible workloads, the function POSTs to the Firecracker service
-3. Firecracker service creates/reuses a microVM
-4. microVM executes the workload and returns result
-5. Edge function forwards response to caller
+### firecracker-ctl (Rust Axum)
 
-## Infrastructure Requirements
+- **Source:** `apps/vm/firecracker-ctl/`
+- **Image:** `ghcr.io/kbve/firecracker-ctl`
+- **API:** `GET /health`, `POST /vm/create`, `GET /vm`, `GET /vm/{id}`, `GET /vm/{id}/result`, `DELETE /vm/{id}`
+- **Dockerfile:** chisel-ubuntu-axum builder + Firecracker v1.10.1 binary + jailer
 
-### Node requirements
+### Kubernetes (firecracker namespace)
 
-- Linux kernel with KVM support (Intel VT-x / AMD-V)
-- `/dev/kvm` exposed via Kubernetes device plugin
-    - Option A: `kubevirt/device-plugin-kvm` (already in cluster for KubeVirt)
-    - Option B: `smarter-project/smarter-device-manager`
-- Bare metal nodes preferred (nested virt adds latency)
+- **Manifests:** `apps/kube/firecracker/manifests/`
+- **Namespace:** `firecracker` (privileged PodSecurity for KVM + NET_ADMIN)
+- **Deployment:** `devices.kubevirt.io/kvm: 1`, `nodeSelector: kvm: true`
+- **NetworkPolicy:** Default-deny + ingress from kilobase/functions and kbve/app:kbve only, egress DNS-only
+- **PVC:** 2Gi Longhorn for rootfs images + vmlinux kernel
+- **Init Job:** Builds alpine-minimal/python/node ext4 images + downloads vmlinux in-cluster
+- **KEDA:** Scale-to-zero outside business hours, CPU-based scale-out
 
-### Kubernetes resources
+### Rootfs Images
 
-- **Namespace:** `kilobase` (co-located with edge-runtime)
-- **Device plugin:** KVM device request in pod spec
-- **Node affinity:** Schedule on nodes with `kvm=true` label
-- **RBAC:** Minimal — only needs KVM device access, no cluster-admin
+Built in-cluster by the init Job (`alpine:3.21` + `e2fsprogs` + `mkfs.ext4`):
 
-### Firecracker service pod spec (draft)
+| Image            | Size   | Contents          |
+| ---------------- | ------ | ----------------- |
+| `alpine-minimal` | ~8 MB  | Alpine + busybox  |
+| `alpine-python`  | ~45 MB | Alpine + Python 3 |
+| `alpine-node`    | ~40 MB | Alpine + Node.js  |
 
-```yaml
-containers:
-    - name: firecracker-ctl
-      image: ghcr.io/kbve/firecracker-ctl:latest
-      resources:
-          requests:
-              cpu: 250m
-              memory: 512Mi
-              devices.kubevirt.io/kvm: '1'
-          limits:
-              cpu: '2'
-              memory: 2Gi
-              devices.kubevirt.io/kvm: '1'
-      securityContext:
-          capabilities:
-              add: ['NET_ADMIN'] # for TAP device networking
-      volumeMounts:
-          - name: rootfs-cache
-            mountPath: /var/lib/firecracker/rootfs
-```
+### Dashboard IDE (`/dashboard/ide/`)
 
-## Integration Paths (evaluated)
+- **CodeMirror 6** editor with Python/JavaScript/Shell syntax switching
+- **Preset inventory:** 6 presets (Python Quick/Standard/Heavy, Node.js Quick/Standard, Shell)
+- **Execution history:** Last 20 runs with click-to-reload
+- **Proxy:** axum-kbve `/dashboard/firecracker/proxy/*` → firecracker-ctl
 
-### Path 1: Kata Containers (rejected)
+### Dashboard VM Panel (`/dashboard/vm/`)
 
-- Transparent CRI integration — every pod gets VM isolation
-- Too coarse-grained; we want selective VM dispatch, not all-pods-in-VMs
-- Adds latency to pods that don't need VM isolation
+- Firecracker section shows service health, version, active VM cards
+- Alongside KubeVirt and KASM panels
 
-### Path 2: Custom Firecracker service (selected)
+### Edge Function Integration
 
-- Dedicated service with REST API
-- Edge functions call it explicitly for VM workloads
-- Fine-grained control over rootfs images, networking, lifecycle
-- Clean separation of concerns
+- `_shared/firecracker.ts` client library
+- OWS function `firecracker.*` commands (status, create, list, destroy)
+- `FIRECRACKER_URL` env wired in functions deployment
 
-### Path 3: Fork Supabase edge-runtime (rejected)
+### Observability
 
-- Maximum integration but high maintenance burden
-- Couples VM lifecycle to Deno process — failure domains overlap
-- Upstream updates become painful to rebase
+- **Vector:** `firecracker` route → ClickHouse `observability.logs_raw`
+- **ClickHouse:** `firecracker.vm_events` + `vm_stats_1m` materialized view
+- **E2E tests:** `edge-e2e/e2e/firecracker.spec.ts`
 
-## API Design (draft)
+### CI/CD
 
-### POST /vm/create
-
-```json
-{
-	"rootfs": "alpine-minimal",
-	"vcpu_count": 1,
-	"mem_size_mib": 128,
-	"boot_args": "console=ttyS0 reboot=k panic=1",
-	"timeout_ms": 30000,
-	"env": { "TASK": "compute", "INPUT": "..." },
-	"entrypoint": "/usr/local/bin/worker"
-}
-```
-
-### Response
-
-```json
-{
-	"vm_id": "fc-a1b2c3",
-	"status": "running",
-	"created_at": "2026-04-02T12:00:00Z"
-}
-```
-
-### GET /vm/{vm_id}/result
-
-Returns the stdout/stderr and exit code once the VM completes.
-
-### DELETE /vm/{vm_id}
-
-Force-terminates a running VM.
-
-## Rootfs Images
-
-Pre-built minimal root filesystems stored as OCI artifacts in GHCR:
-
-| Image            | Size    | Contents                             |
-| ---------------- | ------- | ------------------------------------ |
-| `alpine-minimal` | ~8 MB   | Alpine + busybox, no package manager |
-| `alpine-python`  | ~45 MB  | Alpine + Python 3.12 minimal         |
-| `alpine-node`    | ~40 MB  | Alpine + Node.js 22 LTS              |
-| `ubuntu-rust`    | ~120 MB | Ubuntu minimal + Rust toolchain      |
-
-## Networking
-
-- **Option A (simple):** No networking — stdin/stdout pipe via MMDS (Firecracker metadata service)
-- **Option B (advanced):** TAP device with CNI bridge — microVM gets a routable IP
-
-Start with Option A (MMDS) — sufficient for request/response workloads. Graduate to TAP networking when persistent connections or service-to-service calls are needed.
+- CI dispatch manifest entry (`firecracker_ctl`)
+- Docker build: chisel-ubuntu-axum builder + sccache
+- Version gated via `version.toml`
 
 ## Security
 
-- Firecracker's jailer enforces cgroup + seccomp + chroot per VM
-- No root inside microVMs — drop all capabilities
-- Read-only rootfs with tmpfs overlay for scratch space
-- Network policy: only allow traffic from edge-runtime pods
-- VM timeout enforced both client-side (edge function) and server-side (firecracker-ctl)
+- Firecracker namespace: `privileged` PodSecurity (KVM + NET_ADMIN)
+- Default-deny NetworkPolicy: all pods start with zero network access
+- firecracker-ctl egress: DNS only (no access to databases, Supabase, secrets)
+- Ingress: only kilobase/functions + kbve/app:kbve on port 9001
+- Firecracker jailer: cgroup + seccomp + chroot per VM
+- Read-only rootfs with tmpfs overlay
+- Staff-only dashboard permission required
 
-## Phased Rollout
+## Completed Phases
 
-### Phase 1: Foundation (complete)
+- **Phase 1:** Design document, K8s manifests, ArgoCD app
+- **Phase 2:** Edge function client, env wiring, documentation (edge.mdx, kubernetes.mdx)
+- **Phase 3:** OWS integration, e2e tests, ClickHouse schema, KEDA scaling
+- **Phase 4:** firecracker-ctl binary, Dockerfile, rootfs Dockerfiles, Nx project
+- **Phase 5:** CI pipeline, ArgoCD registration, Vector routing, vmlinux init Job
+- **Phase 6:** Dedicated namespace (privileged), NetworkPolicy hardening, Talos kvm label
+- **Phase 7:** Dashboard VM panel, Firecracker cards component
+- **Phase 8:** Browser IDE (CodeMirror, preset inventory, execution history)
+- **Phase 9:** Rootfs init Job rewrite (build ext4 in-cluster), Docker build fixes
 
-- [x] Design document (this file)
-- [ ] Firecracker binary packaging (Dockerfile)
-- [x] Kubernetes manifests (deployment, service, PVC, NetworkPolicy)
-- [ ] Health check endpoint
+## Remaining Work
 
-### Phase 2: Core API & Integration (complete)
-
-- [ ] VM lifecycle API (create, status, result, delete)
-- [ ] MMDS-based stdin/stdout communication
-- [ ] Alpine-minimal rootfs build pipeline
-- [x] Edge function client library (`_shared/firecracker.ts`)
-- [x] FIRECRACKER_URL env wired in functions-deployment.yaml
-- [x] Main router env allowlist updated for `ows` function
-- [x] Documentation: edge.mdx expanded with Firecracker design
-- [x] Documentation: kubernetes.mdx Firecracker reference section
-
-### Phase 3: Integration (complete)
-
-- [x] Wire edge function → Firecracker via OWS module (`ows/firecracker.ts`)
-- [x] E2E tests (`edge-e2e/e2e/firecracker.spec.ts`)
-- [x] ClickHouse schema (`firecracker.vm_events` + `vm_stats_1m` materialized view)
-- [x] KEDA ScaledObject (cron + CPU-based autoscaling, scale-to-zero)
-
-### Phase 4: Production (complete)
-
-- [x] `firecracker-ctl` Rust Axum binary (`apps/vm/firecracker-ctl/`)
-- [x] Dockerfile with Firecracker v1.10.1 binary + jailer
-- [x] Nx project.json with build/test/lint/container targets
-- [x] Registered in workspace Cargo.toml
-- [x] Rootfs Dockerfiles: alpine-minimal, alpine-node, alpine-python
-
-### Phase 5: Deployment & CI (complete)
-
-- [x] CI dispatch manifest entry (`firecracker_ctl` in `ci-dispatch-manifest.json`)
-- [x] ArgoCD application registered in `kustomization.yaml`
-- [x] Vector log routing for `firecracker-ctl` → ClickHouse
-- [x] vmlinux kernel download script + K8s init Job (PostSync hook)
-- [x] version.toml for CI pipeline version gating
-
-### Phase 6: Deployment fixes & hardening (current)
-
-- [x] Remove redundant `nodeSelector` removal — keep `kvm: "true"` as defense-in-depth
-- [x] Talos machine config patch for `kvm=true` node label (`talos/patches/kvm-node-label.yaml`)
-- [ ] TAP networking (deferred — MMDS sufficient for now)
-- [ ] Warm pool (pre-booted VMs for <50ms dispatch)
+- [ ] TAP networking (deferred — MMDS sufficient for current workloads)
+- [ ] Warm VM pool (pre-booted VMs for <50ms dispatch)
 - [ ] Multi-node scheduling
+- [ ] Additional rootfs images (ubuntu-rust, alpine-go)
+- [ ] File upload to VMs (code injection via MMDS instead of env vars)
+- [ ] IDE: real-time streaming output (WebSocket)
+- [ ] IDE: file tree / multi-file support

--- a/package.json
+++ b/package.json
@@ -111,7 +111,9 @@
 	"dependencies": {
 		"@astropub/worker": "^0.2.0",
 		"@bufbuild/protobuf": "^2.11.0",
+		"@codemirror/lang-javascript": "^6.2.5",
 		"@codemirror/lang-python": "^6.2.1",
+		"@codemirror/legacy-modes": "^6.5.2",
 		"@codemirror/state": "^6.6.0",
 		"@codemirror/theme-one-dark": "^6.1.3",
 		"@codemirror/view": "^6.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,15 @@ importers:
             '@bufbuild/protobuf':
                 specifier: ^2.11.0
                 version: 2.11.0
+            '@codemirror/lang-javascript':
+                specifier: ^6.2.5
+                version: 6.2.5
             '@codemirror/lang-python':
                 specifier: ^6.2.1
                 version: 6.2.1
+            '@codemirror/legacy-modes':
+                specifier: ^6.5.2
+                version: 6.5.2
             '@codemirror/state':
                 specifier: ^6.6.0
                 version: 6.6.0
@@ -2233,6 +2239,12 @@ packages:
                 integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==,
             }
 
+    '@codemirror/lang-javascript@6.2.5':
+        resolution:
+            {
+                integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==,
+            }
+
     '@codemirror/lang-python@6.2.1':
         resolution:
             {
@@ -2243,6 +2255,12 @@ packages:
         resolution:
             {
                 integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==,
+            }
+
+    '@codemirror/legacy-modes@6.5.2':
+        resolution:
+            {
+                integrity: sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==,
             }
 
     '@codemirror/lint@6.9.5':
@@ -4073,6 +4091,12 @@ packages:
         resolution:
             {
                 integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==,
+            }
+
+    '@lezer/javascript@1.5.4':
+        resolution:
+            {
+                integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==,
             }
 
     '@lezer/lr@1.4.8':
@@ -28404,6 +28428,16 @@ snapshots:
             '@codemirror/view': 6.41.0
             '@lezer/common': 1.5.1
 
+    '@codemirror/lang-javascript@6.2.5':
+        dependencies:
+            '@codemirror/autocomplete': 6.20.1
+            '@codemirror/language': 6.12.3
+            '@codemirror/lint': 6.9.5
+            '@codemirror/state': 6.6.0
+            '@codemirror/view': 6.41.0
+            '@lezer/common': 1.5.1
+            '@lezer/javascript': 1.5.4
+
     '@codemirror/lang-python@6.2.1':
         dependencies:
             '@codemirror/autocomplete': 6.20.1
@@ -28420,6 +28454,10 @@ snapshots:
             '@lezer/highlight': 1.2.3
             '@lezer/lr': 1.4.8
             style-mod: 4.1.3
+
+    '@codemirror/legacy-modes@6.5.2':
+        dependencies:
+            '@codemirror/language': 6.12.3
 
     '@codemirror/lint@6.9.5':
         dependencies:
@@ -29784,6 +29822,12 @@ snapshots:
     '@lezer/highlight@1.2.3':
         dependencies:
             '@lezer/common': 1.5.1
+
+    '@lezer/javascript@1.5.4':
+        dependencies:
+            '@lezer/common': 1.5.1
+            '@lezer/highlight': 1.2.3
+            '@lezer/lr': 1.4.8
 
     '@lezer/lr@1.4.8':
         dependencies:


### PR DESCRIPTION
## Summary
IDE improvements and DESIGN.md complete rewrite.

### IDE
- **Language switching:** CodeMirror `Compartment` dynamically swaps Python/JavaScript/Shell syntax when preset changes
- **Execution history:** Last 20 runs displayed with status icon, first line preview, preset label, duration, timestamp. Click any entry to reload its code into the editor.
- **@codemirror/lang-javascript** added for Node.js preset support

### DESIGN.md
- Complete rewrite reflecting all 9 completed phases
- Updated architecture diagram showing IDE → axum proxy → firecracker-ctl flow
- Consolidated component reference with current paths and configs
- Security section matches actual NetworkPolicy (default-deny, egress DNS-only)
- Remaining work itemized: TAP networking, warm pool, streaming output, multi-file IDE

## Test plan
- [ ] Switching preset changes CodeMirror syntax highlighting
- [ ] Running code adds entry to history panel
- [ ] Clicking history entry loads code back into editor
- [ ] History caps at 20 entries