### PR TITLE
fix(creatures): hop to server position instead of teleporting

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
@@ -107,13 +107,12 @@ pub fn receive_creature_sync(
         &CreaturePoolIndex,
         &mut Creature,
         &mut SpriteData,
-        Option<&mut CreatureBrain>,
     )>,
 ) {
     for mut receiver in &mut receiver_q {
         for sync in receiver.receive() {
             for snapshot in &sync.snapshots {
-                for (mut marker, pool_idx, mut cr, mut sd, brain) in &mut creature_q {
+                for (mut marker, pool_idx, mut cr, mut sd) in &mut creature_q {
                     if marker.type_key != sync.npc_ref.as_str() {
                         continue;
                     }
@@ -142,20 +141,12 @@ pub fn receive_creature_sync(
                         break;
                     }
 
-                    // Only correct idle creatures — inject a MoveTo so the
-                    // creature hops to the server position using its normal
-                    // animation instead of teleporting.
+                    // Only correct idle creatures — set JumpWindup so
+                    // simulate_sprite_creatures picks the correct move anim
+                    // and speed from the creature type's behavior definition.
+                    // Frogs will hop, stags/wolves will run, etc.
                     if let SpriteHopState::Idle { .. } = sd.hop_state {
-                        if let Some(mut brain) = brain {
-                            brain.intent = CreatureIntent::MoveTo {
-                                target: server_pos,
-                                speed: 3.0,
-                                anim_name: "run",
-                            };
-                        } else {
-                            // No brain — use JumpWindup which simulate picks up
-                            sd.hop_state = SpriteHopState::JumpWindup { target: server_pos };
-                        }
+                        sd.hop_state = SpriteHopState::JumpWindup { target: server_pos };
                     }
 
                     break; // Found the creature


### PR DESCRIPTION
## Summary
- Instead of lerping/snapping anchors (which causes visible teleporting), inject a `MoveTo` intent when an idle creature is drifted from the server position
- Creature naturally hops to the correct position using its run animation
- Drift <0.5u ignored (close enough), >15u force-snaps (creature recycled)
- `patrol_step` always synced for deterministic alignment

## Test plan
- [ ] Frogs hop smoothly to corrected positions — no teleporting
- [ ] Stags/wolves/boars also animate toward server positions
- [ ] Creatures mid-hop are unaffected until they land
- [ ] Recycled creatures (far away) still snap correctly