### PR TITLE
feat(dashboard/ide): code examples dropdown and copy-to-clipboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react';
 import {
 	ideService,
 	PRESETS,
+	EXAMPLES,
 	type RunResult,
 	type HistoryEntry,
 } from './ideService';
@@ -14,6 +15,7 @@ import {
 	Clock,
 	AlertCircle,
 	Trash2,
+	Copy,
 	CheckCircle2,
 } from 'lucide-react';
 import { EditorView, basicSetup } from 'codemirror';
@@ -88,6 +90,34 @@ function PhaseIndicator({
 	);
 }
 
+function CopyButton({ text }: { text: string }) {
+	const [copied, setCopied] = useState(false);
+	return (
+		<button
+			onClick={() => {
+				navigator.clipboard.writeText(text);
+				setCopied(true);
+				setTimeout(() => setCopied(false), 2000);
+			}}
+			title="Copy to clipboard"
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: '0.25rem',
+				padding: '0.2rem 0.5rem',
+				background: 'rgba(255,255,255,0.05)',
+				border: '1px solid rgba(255,255,255,0.1)',
+				borderRadius: '4px',
+				color: copied ? '#22c55e' : 'rgba(255,255,255,0.4)',
+				fontSize: '0.7rem',
+				cursor: 'pointer',
+			}}>
+			<Copy size={12} />
+			{copied ? 'Copied' : 'Copy'}
+		</button>
+	);
+}
+
 function OutputPanel({
 	result,
 	error,
@@ -122,6 +152,10 @@ function OutputPanel({
 		);
 	}
 
+	const fullOutput = [result.stdout, result.stderr]
+		.filter(Boolean)
+		.join('\n');
+
 	return (
 		<div
 			style={{
@@ -129,7 +163,16 @@ function OutputPanel({
 				fontFamily: 'monospace',
 				fontSize: '0.85rem',
 				whiteSpace: 'pre-wrap',
+				position: 'relative',
 			}}>
+			<div
+				style={{
+					position: 'absolute',
+					top: '0.5rem',
+					right: '0.5rem',
+				}}>
+				<CopyButton text={fullOutput} />
+			</div>
 			{result.stdout && (
 				<div
 					style={{
@@ -324,6 +367,53 @@ export default function ReactCodeIDE() {
 							</option>
 						))}
 					</select>
+					{(() => {
+						const langExamples = EXAMPLES.filter(
+							(ex) => ex.language === preset.language,
+						);
+						if (langExamples.length === 0) return null;
+						return (
+							<select
+								value=""
+								onChange={(e) => {
+									const ex = EXAMPLES.find(
+										(x) => x.id === e.target.value,
+									);
+									if (ex) {
+										ideService.$code.set(ex.code);
+										if (viewRef.current) {
+											viewRef.current.dispatch({
+												changes: {
+													from: 0,
+													to: viewRef.current.state
+														.doc.length,
+													insert: ex.code,
+												},
+											});
+										}
+									}
+								}}
+								disabled={isRunning}
+								style={{
+									fontSize: '0.75rem',
+									color: 'rgba(255,255,255,0.8)',
+									background: 'rgba(255,255,255,0.05)',
+									border: '1px solid rgba(255,255,255,0.1)',
+									padding: '0.25rem 0.5rem',
+									borderRadius: '6px',
+									cursor: 'pointer',
+								}}>
+								<option value="" disabled>
+									📖 Examples…
+								</option>
+								{langExamples.map((ex) => (
+									<option key={ex.id} value={ex.id}>
+										{ex.label}
+									</option>
+								))}
+							</select>
+						);
+					})()}
 				</div>
 				<PhaseIndicator phase={phase} elapsed={elapsed} />
 			</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
@@ -161,6 +161,126 @@ const DEFAULT_CODES: Record<string, string> = {
 	shell: '#!/bin/sh\necho "Hello from Firecracker!"\n',
 };
 
+export interface CodeExample {
+	id: string;
+	label: string;
+	language: string;
+	code: string;
+}
+
+export const EXAMPLES: CodeExample[] = [
+	{
+		id: 'py-fibonacci',
+		label: 'Fibonacci',
+		language: 'python',
+		code: `# Generate Fibonacci sequence
+def fibonacci(n):
+    a, b = 0, 1
+    result = []
+    for _ in range(n):
+        result.append(a)
+        a, b = b, a + b
+    return result
+
+print(f"First 20 Fibonacci numbers:")
+print(fibonacci(20))
+`,
+	},
+	{
+		id: 'py-sysinfo',
+		label: 'System Info',
+		language: 'python',
+		code: `# Inspect the Firecracker microVM environment
+import os, platform, sys
+
+print(f"Python:   {sys.version}")
+print(f"Platform: {platform.platform()}")
+print(f"Machine:  {platform.machine()}")
+print(f"CPU:      {os.cpu_count()} cores")
+print(f"PID:      {os.getpid()}")
+print(f"CWD:      {os.getcwd()}")
+print(f"User:     {os.getenv('USER', 'unknown')}")
+
+# Memory info from /proc
+try:
+    with open("/proc/meminfo") as f:
+        for line in f:
+            if line.startswith(("MemTotal", "MemFree", "MemAvailable")):
+                print(line.strip())
+except FileNotFoundError:
+    print("(no /proc/meminfo)")
+`,
+	},
+	{
+		id: 'py-primes',
+		label: 'Prime Sieve',
+		language: 'python',
+		code: `# Sieve of Eratosthenes — benchmark the VM
+import time
+
+def sieve(limit):
+    is_prime = [True] * (limit + 1)
+    is_prime[0] = is_prime[1] = False
+    for i in range(2, int(limit**0.5) + 1):
+        if is_prime[i]:
+            for j in range(i*i, limit + 1, i):
+                is_prime[j] = False
+    return [i for i in range(limit + 1) if is_prime[i]]
+
+start = time.time()
+primes = sieve(1_000_000)
+elapsed = time.time() - start
+
+print(f"Found {len(primes):,} primes up to 1,000,000")
+print(f"Elapsed: {elapsed:.3f}s")
+print(f"Last 10: {primes[-10:]}")
+`,
+	},
+	{
+		id: 'js-fetch-sim',
+		label: 'JSON Parser',
+		language: 'javascript',
+		code: `// Parse and transform JSON data
+const data = {
+  users: [
+    { name: "Alice", age: 30, role: "admin" },
+    { name: "Bob", age: 25, role: "user" },
+    { name: "Charlie", age: 35, role: "admin" },
+  ]
+};
+
+const admins = data.users
+  .filter(u => u.role === "admin")
+  .map(u => \`\${u.name} (age \${u.age})\`);
+
+console.log("Admins:", admins.join(", "));
+console.log("Average age:", data.users.reduce((s, u) => s + u.age, 0) / data.users.length);
+console.log("Node version:", process.version);
+`,
+	},
+	{
+		id: 'sh-disk',
+		label: 'VM Inspection',
+		language: 'shell',
+		code: `#!/bin/sh
+echo "=== Firecracker MicroVM ==="
+echo "Hostname: $(hostname)"
+echo "Kernel:   $(uname -r)"
+echo "Arch:     $(uname -m)"
+echo "Uptime:   $(cat /proc/uptime | cut -d' ' -f1)s"
+echo ""
+echo "=== Memory ==="
+free -h 2>/dev/null || cat /proc/meminfo | head -3
+echo ""
+echo "=== Mounts ==="
+mount | head -5
+echo ""
+echo "=== Processes ==="
+ps aux 2>/dev/null || echo "PID 1: $(cat /proc/1/cmdline | tr '\\0' ' ')"
+`,
+	},
+];
+
 const MAX_HISTORY = 20;
 
 class IDEService {


### PR DESCRIPTION
## Summary
- Add 5 pre-built code examples (Fibonacci, System Info, Prime Sieve, JSON Parser, VM Inspection) to `ideService.ts`
- Add examples dropdown selector in IDE header, filtered by current language preset
- Add copy-to-clipboard button on output panel for easy result sharing

## Test plan
- [ ] Select Python preset → examples dropdown shows 3 Python examples
- [ ] Select Node.js preset → examples dropdown shows 1 JS example
- [ ] Select Shell preset → examples dropdown shows 1 Shell example
- [ ] Click an example → code loads into editor
- [ ] Run code → click Copy button on output → verify clipboard content