### PR TITLE
feat(creatures): ULID-based creature instance IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.98"
+version = "1.0.99"
 dependencies = [
  "anyhow",
  "askama",
@@ -2201,6 +2201,7 @@ dependencies = [
  "lightyear",
  "lightyear_aeronet",
  "serde",
+ "ulid",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -1905,11 +1905,13 @@ fn broadcast_creature_sync(
         &bevy_kbve_net::creatures::types::SpriteData,
         &bevy_kbve_net::creatures::types::CreaturePoolIndex,
         &bevy_kbve_net::creatures::types::SpriteCreatureMarker,
+        &bevy_kbve_net::creatures::types::CreatureId,
     )>,
     ambient_q: Query<(
         &bevy_kbve_net::creatures::types::Creature,
         &bevy_kbve_net::creatures::types::CreaturePoolIndex,
         &bevy_kbve_net::creatures::ambient_types::AmbientCreatureMarker,
+        &bevy_kbve_net::creatures::types::CreatureId,
     )>,
     types: Res<bevy_kbve_net::creatures::types::SpriteCreatureTypes>,
     player_positions: Res<bevy_kbve_net::creatures::types::PlayerPositions>,
@@ -1930,7 +1932,7 @@ fn broadcast_creature_sync(
     // --- Sprite creatures ---
     for ctype in &types.types {
         let mut snapshots = Vec::new();
-        for (cr, sd, pool_idx, marker) in &creature_q {
+        for (cr, sd, pool_idx, marker, cid) in &creature_q {
             if marker.type_key != ctype.npc_ref {
                 continue;
             }
@@ -1951,6 +1953,7 @@ fn broadcast_creature_sync(
                 bevy_kbve_net::creatures::types::SpriteHopState::Landing { .. } => 4,
             };
             snapshots.push(CreatureSnapshot {
+                creature_id: cid.as_u128(),
                 index: pool_idx.0 as u32,
                 x: cr.anchor.x,
                 y: cr.anchor.y,
@@ -1976,7 +1979,7 @@ fn broadcast_creature_sync(
     // Group by npc_ref
     let mut ambient_groups: std::collections::HashMap<&str, Vec<CreatureSnapshot>> =
         std::collections::HashMap::new();
-    for (cr, pool_idx, marker) in &ambient_q {
+    for (cr, pool_idx, marker, cid) in &ambient_q {
         if cr.state != bevy_kbve_net::creatures::types::CreatureState::Active {
             continue;
         }
@@ -1992,6 +1995,7 @@ fn broadcast_creature_sync(
             .entry(marker.type_key)
             .or_default()
             .push(CreatureSnapshot {
+                creature_id: cid.as_u128(),
                 index: pool_idx.0 as u32,
                 x: cr.anchor.x,
                 y: cr.anchor.y,

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
@@ -101,8 +101,10 @@ const SYNC_FORCE_SNAP: f32 = 15.0;
 /// - **Large drift (>15u)**: force-snap (creature recycled on server).
 /// - **Small drift (<0.5u)**: ignore — close enough.
 pub fn receive_creature_sync(
+    mut commands: Commands,
     mut receiver_q: Query<&mut MessageReceiver<CreaturePositionSync>, With<Connected>>,
     mut creature_q: Query<(
+        Entity,
         &mut SpriteCreatureMarker,
         &CreaturePoolIndex,
         &mut Creature,
@@ -112,12 +114,21 @@ pub fn receive_creature_sync(
     for mut receiver in &mut receiver_q {
         for sync in receiver.receive() {
             for snapshot in &sync.snapshots {
-                for (mut marker, pool_idx, mut cr, mut sd) in &mut creature_q {
+                for (entity, mut marker, pool_idx, mut cr, mut sd) in &mut creature_q {
                     if marker.type_key != sync.npc_ref.as_str() {
                         continue;
                     }
                     if pool_idx.0 as u32 != snapshot.index {
                         continue;
+                    }
+
+                    // Store server-assigned ULID on this entity
+                    if snapshot.creature_id != 0 {
+                        commands.entity(entity).insert(
+                            bevy_kbve_net::creatures::types::CreatureId::from_u128(
+                                snapshot.creature_id,
+                            ),
+                        );
                     }
 
                     let server_pos = Vec3::new(snapshot.x, snapshot.y, snapshot.z);

--- a/packages/rust/bevy/bevy_kbve_net/Cargo.toml
+++ b/packages/rust/bevy/bevy_kbve_net/Cargo.toml
@@ -37,6 +37,7 @@ lightyear_aeronet = { version = "0.26", optional = true }
 bevy_tasker = { version = "0.1", path = "../bevy_tasker", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 dashmap = { version = "6", optional = true }
+ulid = { version = "1", features = ["serde"] }
 bytes = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/simulate.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/simulate.rs
@@ -50,13 +50,16 @@ pub fn simulate_sprite_creatures(
         &CreaturePoolIndex,
         &mut SpriteCreatureMarker,
         Option<&mut CreatureBrain>,
+        Option<&mut CreatureId>,
     )>,
 ) {
     let dt = time.delta_secs();
     let cseed = game_time.creature_seed;
     let center = sim_center.0;
 
-    for (mut tf, mut cr, mut sd, _pool_idx, mut marker, mut brain) in &mut creature_q {
+    for (mut tf, mut cr, mut sd, _pool_idx, mut marker, mut brain, mut creature_id) in
+        &mut creature_q
+    {
         // Look up type descriptor
         let Some(ctype) = types.types.iter().find(|ct| ct.npc_ref == marker.type_key) else {
             continue;
@@ -109,6 +112,10 @@ pub fn simulate_sprite_creatures(
                 ctype.idle_min + hash_f32(ps + 500) * (ctype.idle_max - ctype.idle_min);
             sd.hop_state = SpriteHopState::Idle { timer: idle_timer };
             cr.state = CreatureState::Active;
+            // Assign new ULID — this is a recycled creature instance
+            if let Some(ref mut cid) = creature_id {
+                **cid = CreatureId::new();
+            }
             tf.translation.y = -100.0;
             continue;
         }

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/spawn.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/spawn.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 
 use super::brain::CreatureBrain;
 use super::common::hash_f32;
-use super::types::*;
+use super::types::{self, *};
 
 /// Headless spawn system — creates creature entities with simulation components.
 /// Runs on both server and client (client adds visuals separately).
@@ -63,6 +63,7 @@ pub fn spawn_creatures_headless(
             };
 
             let mut entity = commands.spawn((
+                types::CreatureId::new(),
                 Transform::from_xyz(0.0, -100.0, 0.0),
                 Creature {
                     npc_ref: creature_type.npc_ref,

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/spawn_ambient.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/spawn_ambient.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 
 use super::ambient_types::*;
 use super::common::hash_f32;
-use super::types::{Creature, CreaturePoolIndex, CreatureState, CreatureVitals};
+use super::types::{Creature, CreatureId, CreaturePoolIndex, CreatureState, CreatureVitals};
 
 /// NPC ref slug for fireflies.
 const FIREFLY_REF: &str = "meadow-firefly";
@@ -33,6 +33,7 @@ pub fn spawn_fireflies_headless(
 
     for i in 0..count {
         commands.spawn((
+            CreatureId::new(),
             Transform::from_xyz(0.0, -100.0, 0.0),
             Creature {
                 npc_ref: FIREFLY_REF,
@@ -81,6 +82,7 @@ pub fn spawn_butterflies_headless(
         let phase = hash_f32(seed * 11 + 1);
 
         commands.spawn((
+            CreatureId::new(),
             Transform::from_xyz(0.0, -100.0, 0.0),
             Creature {
                 npc_ref: BUTTERFLY_REF,

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/types.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/types.rs
@@ -2,6 +2,40 @@
 //! client and server.
 
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+// ---------------------------------------------------------------------------
+// Creature instance identity
+// ---------------------------------------------------------------------------
+
+/// Globally unique creature instance identifier assigned by the server.
+/// Embeds creation timestamp in the ULID's upper 48 bits, so you can tell
+/// when a creature was spawned from its ID alone.
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CreatureId(pub Ulid);
+
+impl CreatureId {
+    /// Generate a new ULID (server-side only).
+    pub fn new() -> Self {
+        Self(Ulid::new())
+    }
+
+    /// Reconstruct from wire u128.
+    pub fn from_u128(v: u128) -> Self {
+        Self(Ulid::from(v))
+    }
+
+    /// Serialize to u128 for wire protocol.
+    pub fn as_u128(&self) -> u128 {
+        self.0.into()
+    }
+
+    /// Millisecond timestamp embedded in the ULID.
+    pub fn timestamp_ms(&self) -> u64 {
+        self.0.timestamp_ms()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Per-entity components

--- a/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
@@ -236,7 +236,9 @@ pub struct CreatureSyncChannel;
 /// Single creature's server-authoritative state snapshot.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CreatureSnapshot {
-    /// Pool index within this creature type.
+    /// Server-assigned ULID for this creature instance (0 = not yet assigned).
+    pub creature_id: u128,
+    /// Pool index within this creature type (kept for backward compat, Phase 1).
     pub index: u32,
     /// World-space anchor position.
     pub x: f32,


### PR DESCRIPTION
## Summary
Every creature instance now gets a unique `CreatureId(Ulid)` assigned by the server at spawn. ULIDs encode creation timestamp, so you can tell when a creature was spawned from its ID.

**Phase 1 (this PR):**
- `CreatureId` component added to `bevy_kbve_net::creatures::types`
- Server assigns `Ulid::new()` at spawn (sprite + ambient creatures)
- New ULID on creature recycle (different instance = different ID)
- `creature_id: u128` added to `CreatureSnapshot` wire format
- Client stores received ULID on matched entities

**Phase 2 (follow-up):**
- Switch client sync matching to ULID-first (currently still uses pool_index)
- `CreatureIdIndex` HashMap for O(1) lookup
- Migrate remaining protocol messages to use creature_id

## Test plan
- [ ] `cargo check -p bevy_kbve_net` passes
- [ ] `cargo check -p axum-kbve` passes
- [ ] `cargo check -p isometric-game` passes
- [ ] Server starts without errors, creatures spawn with ULIDs
- [ ] Client receives creature_id in sync messages