### PR TITLE
feat(firecracker-ctl): inject user code into microVM via block device

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v3
+    name: firecracker-rootfs-init-v4
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -75,8 +75,9 @@ spec:
                               mkdir -p "${ROOTFS}/dev" "${ROOTFS}/proc" "${ROOTFS}/sys" \
                                        "${ROOTFS}/tmp" "${ROOTFS}/run" "${ROOTFS}/var/log"
 
-                              # Init script — mounts filesystems and runs entrypoint or shell
-                              printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nif [ -x /entrypoint ]; then\n    exec /entrypoint\nelse\n    exec /bin/sh\nfi\n' > "${ROOTFS}/init"
+                              # Init script — mounts filesystems, reads code from /dev/vdb,
+                              # parses entrypoint from kernel cmdline, and executes.
+                              printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nmkdir -p /tmp\nENTRYPOINT="/bin/sh"\nfor param in $(cat /proc/cmdline); do\n  case "$param" in\n    fc_entrypoint=*) ENTRYPOINT="${param#fc_entrypoint=}" ;;\n  esac\ndone\nif [ -b /dev/vdb ]; then\n  dd if=/dev/vdb bs=4096 2>/dev/null | tr -d \"\\\\0\" > /tmp/code\n  exec $ENTRYPOINT /tmp/code\nelse\n  exec /bin/sh\nfi\n' > "${ROOTFS}/init"
                               chmod +x "${ROOTFS}/init"
 
                               # Create sparse ext4 image and populate from rootfs directory

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -233,29 +233,68 @@ async fn run_vm_lifecycle(
     }
 
     let rootfs_path = format!("{}/{}.ext4", rootfs_dir, req.rootfs);
+    let scratch_dir = "/var/lib/firecracker/scratch";
+
+    // Write user code to a raw block file that the VM reads from /dev/vdb.
+    // Padded to 512-byte boundary so Firecracker accepts it as a drive.
+    let code_path = format!("{}/{}.code", scratch_dir, vm_id);
+    let code = req
+        .env
+        .get("CODE")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    {
+        let mut buf = code.as_bytes().to_vec();
+        let pad = (512 - (buf.len() % 512)) % 512;
+        buf.resize(buf.len() + pad, 0);
+        if let Err(e) = tokio::fs::write(&code_path, &buf).await {
+            tracing::error!("Failed to write code file: {}", e);
+            set_vm_failed(
+                &vms,
+                &vm_id,
+                start,
+                -1,
+                "".into(),
+                format!("Code write failed: {}", e),
+            );
+            return;
+        }
+    }
+
+    // Append entrypoint to boot_args so the init script knows what to exec
+    let boot_args = format!("{} fc_entrypoint={}", req.boot_args, req.entrypoint);
 
     // Build firecracker config and launch via the Firecracker binary.
     // The Firecracker binary communicates over a Unix socket; we create
     // a per-VM socket in the scratch directory.
-    let socket_path = format!("/var/lib/firecracker/scratch/{}.sock", vm_id);
+    let socket_path = format!("{}/{}.sock", scratch_dir, vm_id);
     let config = serde_json::json!({
         "boot-source": {
             "kernel_image_path": format!("{}/vmlinux", rootfs_dir),
-            "boot_args": req.boot_args,
+            "boot_args": boot_args,
         },
-        "drives": [{
-            "drive_id": "rootfs",
-            "path_on_host": rootfs_path,
-            "is_root_device": true,
-            "is_read_only": true,
-        }],
+        "drives": [
+            {
+                "drive_id": "rootfs",
+                "path_on_host": rootfs_path,
+                "is_root_device": true,
+                "is_read_only": true,
+            },
+            {
+                "drive_id": "code",
+                "path_on_host": code_path.clone(),
+                "is_root_device": false,
+                "is_read_only": true,
+            },
+        ],
         "machine-config": {
             "vcpu_count": req.vcpu_count,
             "mem_size_mib": req.mem_size_mib,
         },
     });
 
-    let config_path = format!("/var/lib/firecracker/scratch/{}.json", vm_id);
+    let config_path = format!("{}/{}.json", scratch_dir, vm_id);
 
     // Write config
     if let Err(e) = tokio::fs::write(&config_path, config.to_string()).await {
@@ -291,7 +330,7 @@ async fn run_vm_lifecycle(
                 "".into(),
                 format!("Spawn failed: {}", e),
             );
-            cleanup_files(&config_path, &socket_path).await;
+            cleanup_files(&config_path, &socket_path, &code_path).await;
             return;
         }
     };
@@ -366,7 +405,7 @@ async fn run_vm_lifecycle(
         }
     }
 
-    cleanup_files(&config_path, &socket_path).await;
+    cleanup_files(&config_path, &socket_path, &code_path).await;
 }
 
 fn set_vm_failed(
@@ -390,9 +429,10 @@ fn set_vm_failed(
     }
 }
 
-async fn cleanup_files(config_path: &str, socket_path: &str) {
+async fn cleanup_files(config_path: &str, socket_path: &str, code_path: &str) {
     let _ = tokio::fs::remove_file(config_path).await;
     let _ = tokio::fs::remove_file(socket_path).await;
+    let _ = tokio::fs::remove_file(code_path).await;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix VM timeout: user code was never injected into the microVM — the VM would boot, init would exec `/bin/sh`, and it would hang until timeout
- Write user code (from `env.CODE`) to a raw block file padded to 512-byte boundary, attach as second Firecracker drive (`/dev/vdb`)
- Pass entrypoint via `boot_args` (`fc_entrypoint=/usr/bin/python3`), parsed by init from `/proc/cmdline`
- Updated rootfs init script: reads code from `/dev/vdb`, strips null padding, writes to `/tmp/code`, execs with entrypoint
- Bumped rootfs init job to v4 so ArgoCD rebuilds images with new init script
- Rootfs images already rebuilt in-cluster and verified

## Test plan
- [x] Rust compiles cleanly (`npx nx run firecracker-ctl:build`)
- [x] Rootfs images rebuilt with new init script (all 3 completed)
- [ ] After CI builds new Docker image: verify code execution via IDE