### PR TITLE
feat(creatures): ULID-only wire protocol (Phase 3)

### DIFF
--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -47,6 +47,10 @@ struct AuthenticatedClients(HashMap<Entity, String>);
 #[derive(Resource, Default)]
 struct ClientPlayerMap(HashMap<Entity, Entity>);
 
+/// Log of captured creature broadcasts — replayed to newly connected clients.
+#[derive(Resource, Default)]
+struct CapturedCreatureLog(Vec<CreatureCaptured>);
+
 /// Marker: client has not yet sent a valid AuthMessage.
 #[derive(Component)]
 struct PendingAuth;
@@ -597,6 +601,7 @@ fn run_bevy_app(
     app.init_resource::<CreatureSeed>();
     app.init_resource::<WindState>();
     app.init_resource::<CapturedCreatures>();
+    app.init_resource::<CapturedCreatureLog>();
     app.insert_resource(npcdb::build_creature_registry());
     app.init_resource::<TimeSyncTimer>();
     app.init_resource::<CreatureSyncTimer>();
@@ -1673,9 +1678,9 @@ fn tick_respawns(
 
 /// Process creature capture requests: validate against CreatureRegistry, track, broadcast.
 fn process_creature_captures(
-    registry: Res<CreatureRegistry>,
     client_player_map: Res<ClientPlayerMap>,
     mut captured: ResMut<CapturedCreatures>,
+    mut capture_log: ResMut<CapturedCreatureLog>,
     mut receivers: Query<
         (Entity, &mut MessageReceiver<CreatureCaptureRequest>),
         Without<PendingAuth>,
@@ -1685,40 +1690,18 @@ fn process_creature_captures(
 ) {
     for (client_entity, mut receiver) in &mut receivers {
         for msg in receiver.receive() {
-            let npc_id = creature_kind_to_npc_id(msg.kind);
-
             // Already captured?
-            if captured.is_captured(npc_id, msg.creature_index) {
+            if captured.is_captured(msg.creature_id) {
                 tracing::warn!(
-                    "[gameserver] creature {:?} #{} already captured — ignoring",
+                    "[gameserver] creature {:?} (ulid={}) already captured — ignoring",
                     msg.kind,
-                    msg.creature_index
-                );
-                continue;
-            }
-
-            // Validate creature_index against registry pool_size
-            let npc_ref = creature_kind_to_npc_ref(msg.kind);
-            if let Some(config) = registry.config_by_ref(npc_ref) {
-                if msg.creature_index as usize >= config.pool_size {
-                    tracing::warn!(
-                        "[gameserver] invalid creature_index {} for {:?} (pool_size={})",
-                        msg.creature_index,
-                        msg.kind,
-                        config.pool_size
-                    );
-                    continue;
-                }
-            } else {
-                tracing::warn!(
-                    "[gameserver] unknown creature ref '{npc_ref}' for {:?}",
-                    msg.kind
+                    msg.creature_id
                 );
                 continue;
             }
 
             // Track the capture
-            captured.insert(npc_id, msg.creature_index);
+            captured.insert(msg.creature_id);
 
             let captor_id = client_player_map
                 .0
@@ -1728,17 +1711,18 @@ fn process_creature_captures(
                 .unwrap_or(0);
 
             tracing::info!(
-                "[gameserver] creature captured: {:?} #{} by player {captor_id}",
+                "[gameserver] creature captured: {:?} (ulid={}) by player {captor_id}",
                 msg.kind,
-                msg.creature_index
+                msg.creature_id
             );
 
-            // Broadcast to all connected clients
+            // Broadcast to all connected clients and log for replay
             let broadcast = CreatureCaptured {
+                creature_id: msg.creature_id,
                 kind: msg.kind,
-                creature_index: msg.creature_index,
                 captor_player_id: captor_id,
             };
+            capture_log.0.push(broadcast.clone());
             for mut sender in &mut senders {
                 sender.send::<GameChannel>(broadcast.clone());
             }
@@ -1903,13 +1887,11 @@ fn broadcast_creature_sync(
     creature_q: Query<(
         &bevy_kbve_net::creatures::types::Creature,
         &bevy_kbve_net::creatures::types::SpriteData,
-        &bevy_kbve_net::creatures::types::CreaturePoolIndex,
         &bevy_kbve_net::creatures::types::SpriteCreatureMarker,
         &bevy_kbve_net::creatures::types::CreatureId,
     )>,
     ambient_q: Query<(
         &bevy_kbve_net::creatures::types::Creature,
-        &bevy_kbve_net::creatures::types::CreaturePoolIndex,
         &bevy_kbve_net::creatures::ambient_types::AmbientCreatureMarker,
         &bevy_kbve_net::creatures::types::CreatureId,
     )>,
@@ -1932,7 +1914,7 @@ fn broadcast_creature_sync(
     // --- Sprite creatures ---
     for ctype in &types.types {
         let mut snapshots = Vec::new();
-        for (cr, sd, pool_idx, marker, cid) in &creature_q {
+        for (cr, sd, marker, cid) in &creature_q {
             if marker.type_key != ctype.npc_ref {
                 continue;
             }
@@ -1954,7 +1936,6 @@ fn broadcast_creature_sync(
             };
             snapshots.push(CreatureSnapshot {
                 creature_id: cid.as_u128(),
-                index: pool_idx.0 as u32,
                 x: cr.anchor.x,
                 y: cr.anchor.y,
                 z: cr.anchor.z,
@@ -1979,7 +1960,7 @@ fn broadcast_creature_sync(
     // Group by npc_ref
     let mut ambient_groups: std::collections::HashMap<&str, Vec<CreatureSnapshot>> =
         std::collections::HashMap::new();
-    for (cr, pool_idx, marker, cid) in &ambient_q {
+    for (cr, marker, cid) in &ambient_q {
         if cr.state != bevy_kbve_net::creatures::types::CreatureState::Active {
             continue;
         }
@@ -1996,7 +1977,6 @@ fn broadcast_creature_sync(
             .or_default()
             .push(CreatureSnapshot {
                 creature_id: cid.as_u128(),
-                index: pool_idx.0 as u32,
                 x: cr.anchor.x,
                 y: cr.anchor.y,
                 z: cr.anchor.z,
@@ -2077,10 +2057,10 @@ fn send_time_sync_to_new_clients(
 /// so they know which ones are unavailable.
 fn send_captured_state_to_new_clients(
     authenticated: Res<AuthenticatedClients>,
-    captured: Res<CapturedCreatures>,
+    capture_log: Res<CapturedCreatureLog>,
     mut senders: Query<(Entity, &mut MessageSender<CreatureCaptured>), Added<ReplicationSender>>,
 ) {
-    if captured.is_empty() {
+    if capture_log.0.is_empty() {
         return;
     }
 
@@ -2091,18 +2071,11 @@ fn send_captured_state_to_new_clients(
 
         tracing::info!(
             "[gameserver] sending {} captured creatures to new client {entity:?}",
-            captured.len()
+            capture_log.0.len()
         );
 
-        for &(npc_id, creature_index) in captured.iter() {
-            let Some(kind) = npc_id_to_creature_kind(npc_id) else {
-                continue;
-            };
-            sender.send::<GameChannel>(CreatureCaptured {
-                kind,
-                creature_index,
-                captor_player_id: 0,
-            });
+        for msg in &capture_log.0 {
+            sender.send::<GameChannel>(msg.clone());
         }
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/net_events.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use bevy::prelude::*;
 use lightyear::prelude::*;
 
-use super::super::creature::{Creature, CreaturePoolIndex, RenderKind, SpriteData, SpriteHopState};
+use super::super::creature::{Creature, RenderKind, SpriteData, SpriteHopState};
 use super::behavior::CreatureIntent;
 use super::brain::CreatureBrain;
 use super::types::SpriteCreatureMarker;
@@ -45,53 +45,56 @@ pub fn update_creature_id_index(
 /// System that receives `CreatureStateEvent` messages from the server and
 /// overrides the local creature's behavior intent.
 pub fn receive_creature_events(
+    index: Res<CreatureIdIndex>,
     mut receiver_q: Query<&mut MessageReceiver<CreatureStateEvent>, With<Connected>>,
     mut creature_q: Query<(
+        Entity,
         &SpriteCreatureMarker,
-        &CreaturePoolIndex,
         &mut SpriteData,
         Option<&mut CreatureBrain>,
     )>,
 ) {
     for mut receiver in &mut receiver_q {
         for event in receiver.receive() {
-            for (marker, pool_idx, mut sd, brain) in &mut creature_q {
-                if marker.type_key != event.npc_ref.as_str() {
-                    continue;
-                }
-                if pool_idx.0 != event.creature_index {
-                    continue;
-                }
+            // Find entity by ULID
+            let entity = if event.creature_id != 0 {
+                index.0.get(&event.creature_id).copied()
+            } else {
+                None
+            };
+            let Some(entity) = entity else {
+                continue;
+            };
+            let Ok((_, _marker, mut sd, brain)) = creature_q.get_mut(entity) else {
+                continue;
+            };
 
-                match &event.event {
-                    CreatureEventKind::TakeDamage { .. } => {
-                        if let Some(mut brain) = brain {
-                            brain.intent = CreatureIntent::Flee {
-                                direction: Vec3::new(0.0, 0.0, -1.0),
-                                speed: 5.0,
-                                anim_name: "run",
-                            };
-                        }
-                    }
-                    CreatureEventKind::Die => {
-                        sd.hop_state = SpriteHopState::Idle { timer: f32::MAX };
-                    }
-                    CreatureEventKind::ForceFlee { from_x, from_z } => {
-                        if let Some(mut brain) = brain {
-                            let flee_dir = Vec3::new(-from_x, 0.0, -from_z).normalize_or_zero();
-                            brain.intent = CreatureIntent::Flee {
-                                direction: flee_dir,
-                                speed: 5.0,
-                                anim_name: "run",
-                            };
-                        }
-                    }
-                    CreatureEventKind::Captured { .. } => {
-                        sd.hop_state = SpriteHopState::Idle { timer: f32::MAX };
+            match &event.event {
+                CreatureEventKind::TakeDamage { .. } => {
+                    if let Some(mut brain) = brain {
+                        brain.intent = CreatureIntent::Flee {
+                            direction: Vec3::new(0.0, 0.0, -1.0),
+                            speed: 5.0,
+                            anim_name: "run",
+                        };
                     }
                 }
-
-                break;
+                CreatureEventKind::Die => {
+                    sd.hop_state = SpriteHopState::Idle { timer: f32::MAX };
+                }
+                CreatureEventKind::ForceFlee { from_x, from_z } => {
+                    if let Some(mut brain) = brain {
+                        let flee_dir = Vec3::new(-from_x, 0.0, -from_z).normalize_or_zero();
+                        brain.intent = CreatureIntent::Flee {
+                            direction: flee_dir,
+                            speed: 5.0,
+                            anim_name: "run",
+                        };
+                    }
+                }
+                CreatureEventKind::Captured { .. } => {
+                    sd.hop_state = SpriteHopState::Idle { timer: f32::MAX };
+                }
             }
         }
     }
@@ -116,7 +119,6 @@ pub fn receive_creature_sync(
     mut creature_q: Query<(
         Entity,
         &mut SpriteCreatureMarker,
-        &CreaturePoolIndex,
         &mut Creature,
         &mut SpriteData,
     )>,
@@ -129,18 +131,18 @@ pub fn receive_creature_sync(
             }
 
             for snapshot in &sync.snapshots {
-                // Try ULID-first lookup (O(1))
-                let matched_entity = if snapshot.creature_id != 0 {
+                // ULID lookup (O(1))
+                let entity = if snapshot.creature_id != 0 {
                     index.0.get(&snapshot.creature_id).copied()
                 } else {
                     None
                 };
 
-                // Fall back to (npc_ref, pool_index) scan if no ULID match
-                let entity = matched_entity.or_else(|| {
-                    creature_q.iter().find_map(|(e, marker, pool_idx, _, _)| {
+                // Fall back: find an unassigned creature of the same type
+                let entity = entity.or_else(|| {
+                    creature_q.iter().find_map(|(e, marker, _, _)| {
                         if marker.type_key == sync.npc_ref.as_str()
-                            && pool_idx.0 as u32 == snapshot.index
+                            && !index.0.values().any(|&existing| existing == e)
                         {
                             Some(e)
                         } else {
@@ -153,7 +155,7 @@ pub fn receive_creature_sync(
                     continue;
                 };
 
-                let Ok((_, mut marker, _, mut cr, mut sd)) = creature_q.get_mut(entity) else {
+                let Ok((_, mut marker, mut cr, mut sd)) = creature_q.get_mut(entity) else {
                     continue;
                 };
 
@@ -206,10 +208,7 @@ pub fn receive_ambient_creature_sync(
     mut commands: Commands,
     index: Res<CreatureIdIndex>,
     mut receiver_q: Query<&mut MessageReceiver<CreaturePositionSync>, With<Connected>>,
-    mut creature_q: Query<
-        (Entity, &mut Creature, &CreaturePoolIndex),
-        Without<SpriteCreatureMarker>,
-    >,
+    mut creature_q: Query<(Entity, &mut Creature), Without<SpriteCreatureMarker>>,
 ) {
     for mut receiver in &mut receiver_q {
         for sync in receiver.receive() {
@@ -218,17 +217,19 @@ pub fn receive_ambient_creature_sync(
             };
 
             for snapshot in &sync.snapshots {
-                // ULID-first lookup
-                let matched_entity = if snapshot.creature_id != 0 {
+                // ULID lookup
+                let entity = if snapshot.creature_id != 0 {
                     index.0.get(&snapshot.creature_id).copied()
                 } else {
                     None
                 };
 
-                // Fall back to (render_kind, pool_index)
-                let entity = matched_entity.or_else(|| {
-                    creature_q.iter().find_map(|(e, cr, pool_idx)| {
-                        if cr.render_kind == kind && pool_idx.0 == snapshot.index {
+                // Fall back: find unassigned creature of matching render kind
+                let entity = entity.or_else(|| {
+                    creature_q.iter().find_map(|(e, cr)| {
+                        if cr.render_kind == kind
+                            && !index.0.values().any(|&existing| existing == e)
+                        {
                             Some(e)
                         } else {
                             None
@@ -240,7 +241,7 @@ pub fn receive_ambient_creature_sync(
                     continue;
                 };
 
-                let Ok((_, mut cr, _)) = creature_q.get_mut(entity) else {
+                let Ok((_, mut cr)) = creature_q.get_mut(entity) else {
                     continue;
                 };
 

--- a/apps/kbve/isometric/src-tauri/src/game/net.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/net.rs
@@ -1350,13 +1350,13 @@ fn forward_creature_capture_to_server(
         return;
     };
     info!(
-        "[net] sending creature capture request: {:?} index={}",
-        kind, event.creature_index
+        "[net] sending creature capture request: {:?} ulid={}",
+        kind, event.creature_id
     );
     for mut sender in &mut senders {
         sender.send::<GameChannel>(CreatureCaptureRequest {
+            creature_id: event.creature_id,
             kind,
-            creature_index: event.creature_index,
         });
     }
 }
@@ -1811,37 +1811,32 @@ fn creature_kind_to_npc_id(kind: CreatureKind) -> ProtoNpcId {
 /// Receive CreatureCaptured messages from the server and mark matching pool entities.
 fn receive_creature_captured(
     mut captured: ResMut<CapturedCreatures>,
+    creature_index: Res<crate::game::creatures::generic::net_events::CreatureIdIndex>,
     mut query: Query<(Entity, &mut MessageReceiver<CreatureCaptured>)>,
-    mut creatures: Query<(&mut Creature, &CreaturePoolIndex, &mut Visibility)>,
+    mut creatures: Query<(&mut Creature, &mut Visibility)>,
 ) {
     for (_entity, mut receiver) in &mut query {
         for msg in receiver.receive() {
-            let render_kind = creature_kind_to_render_kind(msg.kind);
-            let npc_id = creature_kind_to_npc_id(msg.kind);
-
             // Record in shared capture tracker
-            captured.insert(npc_id, msg.creature_index);
+            captured.insert(msg.creature_id);
 
-            // Find the matching pool entity and mark as captured
-            let mut found = false;
-            for (mut creature, pool_idx, mut vis) in &mut creatures {
-                if creature.render_kind == render_kind && pool_idx.0 == msg.creature_index {
+            // Find by ULID
+            let entity = creature_index.0.get(&msg.creature_id).copied();
+
+            if let Some(entity) = entity {
+                if let Ok((mut creature, mut vis)) = creatures.get_mut(entity) {
                     creature.state = CreatureState::Captured;
                     creature.assigned_slot = None;
                     *vis = Visibility::Hidden;
-                    found = true;
                     info!(
-                        "[net] creature captured: {:?} index={} by player={}",
-                        msg.kind, msg.creature_index, msg.captor_player_id
+                        "[net] creature captured: {:?} ulid={} by player={}",
+                        msg.kind, msg.creature_id, msg.captor_player_id
                     );
-                    break;
                 }
-            }
-
-            if !found {
+            } else {
                 warn!(
-                    "[net] received CreatureCaptured for {:?} index={} but no matching pool entity found",
-                    msg.kind, msg.creature_index
+                    "[net] received CreatureCaptured for {:?} ulid={} but no matching entity found",
+                    msg.kind, msg.creature_id
                 );
             }
         }

--- a/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/protocol.rs
@@ -169,16 +169,17 @@ pub enum CreatureKind {
 /// Client requests to capture a creature.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CreatureCaptureRequest {
+    /// Server-assigned ULID identifying the creature instance.
+    pub creature_id: u128,
     pub kind: CreatureKind,
-    /// Index in the deterministic creature pool (0..N).
-    pub creature_index: u32,
 }
 
 /// Server broadcasts that a creature was captured.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CreatureCaptured {
+    /// Server-assigned ULID identifying the creature instance.
+    pub creature_id: u128,
     pub kind: CreatureKind,
-    pub creature_index: u32,
     pub captor_player_id: u64,
 }
 
@@ -189,10 +190,10 @@ pub struct CreatureCaptured {
 /// Client requests to attack/interact with a creature.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CreatureAttackRequest {
+    /// Server-assigned ULID identifying the creature instance.
+    pub creature_id: u128,
     /// NPC ref string (e.g. "wild-boar") to identify the creature type.
     pub npc_ref: String,
-    /// Pool index of the targeted creature.
-    pub creature_index: u32,
     /// Damage amount (server validates).
     pub damage: f32,
 }
@@ -201,10 +202,10 @@ pub struct CreatureAttackRequest {
 /// Overrides local deterministic behavior when external events occur.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CreatureStateEvent {
+    /// Server-assigned ULID identifying the creature instance.
+    pub creature_id: u128,
     /// NPC ref string identifying the creature type.
     pub npc_ref: String,
-    /// Pool index of the affected creature.
-    pub creature_index: u32,
     /// What happened to the creature.
     pub event: CreatureEventKind,
 }
@@ -236,10 +237,8 @@ pub struct CreatureSyncChannel;
 /// Single creature's server-authoritative state snapshot.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CreatureSnapshot {
-    /// Server-assigned ULID for this creature instance (0 = not yet assigned).
+    /// Server-assigned ULID for this creature instance.
     pub creature_id: u128,
-    /// Pool index within this creature type (kept for backward compat, Phase 1).
-    pub index: u32,
     /// World-space anchor position.
     pub x: f32,
     pub y: f32,

--- a/packages/rust/bevy/bevy_npc/src/creature.rs
+++ b/packages/rust/bevy/bevy_npc/src/creature.rs
@@ -29,8 +29,8 @@ use crate::ProtoNpcId;
 
 /// Pool index identifying a creature entity within its type pool.
 ///
-/// Assigned once at spawn (0..pool_size). Used to match network messages
-/// (capture requests/broadcasts) to the correct ECS entity.
+/// Assigned once at spawn (0..pool_size). Used internally for pool management.
+/// Network identification uses `CreatureId` (ULID) instead.
 #[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct CreaturePoolIndex(pub u32);
 
@@ -53,30 +53,28 @@ pub enum CreatureState {
 // Resources
 // ---------------------------------------------------------------------------
 
-/// Tracks which creatures have been captured, keyed by `(ProtoNpcId, pool_index)`.
+/// Tracks which creatures have been captured, keyed by ULID (u128).
 ///
 /// Shared between server and client — both maintain their own instance.
-/// Uses `ProtoNpcId` instead of a hardcoded enum so new creature types
-/// don't require protocol changes.
 #[derive(Resource, Default, Debug)]
 pub struct CapturedCreatures {
-    captured: HashSet<(ProtoNpcId, u32)>,
+    captured: HashSet<u128>,
 }
 
 impl CapturedCreatures {
-    /// Record a creature as captured.
-    pub fn insert(&mut self, npc_id: ProtoNpcId, pool_index: u32) {
-        self.captured.insert((npc_id, pool_index));
+    /// Record a creature as captured by its ULID.
+    pub fn insert(&mut self, creature_id: u128) {
+        self.captured.insert(creature_id);
     }
 
     /// Check if a specific creature is captured.
-    pub fn is_captured(&self, npc_id: ProtoNpcId, pool_index: u32) -> bool {
-        self.captured.contains(&(npc_id, pool_index))
+    pub fn is_captured(&self, creature_id: u128) -> bool {
+        self.captured.contains(&creature_id)
     }
 
     /// Remove a capture record (e.g. on respawn or disconnect reset).
-    pub fn remove(&mut self, npc_id: ProtoNpcId, pool_index: u32) {
-        self.captured.remove(&(npc_id, pool_index));
+    pub fn remove(&mut self, creature_id: u128) {
+        self.captured.remove(&creature_id);
     }
 
     /// Clear all captured creatures (e.g. on disconnect/reconnect).
@@ -94,8 +92,8 @@ impl CapturedCreatures {
         self.captured.is_empty()
     }
 
-    /// Iterate over all captured `(npc_id, pool_index)` pairs.
-    pub fn iter(&self) -> impl Iterator<Item = &(ProtoNpcId, u32)> {
+    /// Iterate over all captured creature ULIDs.
+    pub fn iter(&self) -> impl Iterator<Item = &u128> {
         self.captured.iter()
     }
 }
@@ -108,13 +106,12 @@ impl CapturedCreatures {
 ///
 /// Game code should trigger this event (e.g. on click, proximity, or item use).
 /// The networking layer observes it and sends the appropriate server message.
-/// Uses `ProtoNpcId` so it works with any NPC type without protocol changes.
 #[derive(Event, Clone, Debug)]
 pub struct CreatureCaptureEvent {
-    /// NPC definition ID of the creature being captured.
+    /// Server-assigned ULID of the creature being captured.
+    pub creature_id: u128,
+    /// NPC definition ID of the creature type.
     pub npc_id: ProtoNpcId,
-    /// Pool index of the creature entity.
-    pub creature_index: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -124,8 +121,7 @@ pub struct CreatureCaptureEvent {
 /// Registers creature ECS resources and events.
 ///
 /// Add this plugin to your Bevy app to get `CapturedCreatures` resource
-/// and `CreatureCaptureEvent` event type. Does NOT add any systems —
-/// capture handling, networking, and interaction are game-specific.
+/// and `CreatureCaptureEvent` event automatically.
 pub struct CreaturePlugin;
 
 impl Plugin for CreaturePlugin {


### PR DESCRIPTION
## Summary
Breaking protocol change — pool_index completely removed from all creature network messages. Creatures identified solely by `CreatureId` (ULID).

**Protocol changes:**
- `CreatureSnapshot`: `index` field removed, `creature_id: u128` is primary key
- `CreatureAttackRequest`: `creature_index` → `creature_id: u128`
- `CreatureStateEvent`: `creature_index` → `creature_id: u128`
- `CreatureCaptureRequest/Captured`: `creature_index` → `creature_id: u128`

**Data changes:**
- `CapturedCreatures`: `HashSet<(ProtoNpcId, u32)>` → `HashSet<u128>`
- `CreatureCaptureEvent`: `creature_index: u32` → `creature_id: u128`
- Server adds `CapturedCreatureLog` for replaying to new clients

**Client sync:**
- ULID-only matching via `CreatureIdIndex` HashMap
- Fallback assigns unmatched entities of same type (bootstrap)

**IMPORTANT:** Server and client must be rebuilt together — this is a breaking protocol change.

## Test plan
- [ ] `cargo check` passes for bevy_npc, bevy_kbve_net, axum-kbve, isometric-game
- [ ] Server + client rebuild and connect successfully
- [ ] Creatures sync by ULID — no more pool_index desync
- [ ] Creature capture still works