### PR TITLE
fix(lint): resolve clippy warnings blocking dev→main merge

### DIFF
--- a/apps/kbve/axum-kbve/src/auth/jwt_cache.rs
+++ b/apps/kbve/axum-kbve/src/auth/jwt_cache.rs
@@ -56,6 +56,7 @@ impl TokenInfo {
     }
 
     /// Check if user is any kind of staff member (has any permission).
+    #[allow(dead_code)]
     pub fn is_staff(&self) -> bool {
         self.staff_permissions > 0
     }

--- a/apps/kbve/axum-kbve/src/gameserver/mod.rs
+++ b/apps/kbve/axum-kbve/src/gameserver/mod.rs
@@ -15,7 +15,7 @@ use bevy::prelude::*;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
 
-use bevy_kbve_net::npcdb::{self, CreatureRegistry, ProtoNpcId, creature::CapturedCreatures};
+use bevy_kbve_net::npcdb::{self, ProtoNpcId, creature::CapturedCreatures};
 use bevy_kbve_net::{
     AuthAck, AuthMessage, AuthResponse, CollectRequest, CreatureCaptureRequest, CreatureCaptured,
     CreatureKind, CreaturePositionSync, CreatureSnapshot, CreatureSyncChannel, DamageEvent,
@@ -99,7 +99,7 @@ struct CreatureSeed(u64);
 
 impl Default for CreatureSeed {
     fn default() -> Self {
-        Self(0x4B_BE_F0_2026)
+        Self(0x4BBEF02026)
     }
 }
 
@@ -120,6 +120,7 @@ impl Default for WindState {
 }
 
 /// Map a protocol `CreatureKind` to its NPC ref string.
+#[allow(dead_code)]
 fn creature_kind_to_npc_ref(kind: CreatureKind) -> &'static str {
     match kind {
         CreatureKind::Firefly => "meadow-firefly",
@@ -129,11 +130,13 @@ fn creature_kind_to_npc_ref(kind: CreatureKind) -> &'static str {
 }
 
 /// Map a protocol `CreatureKind` to a `ProtoNpcId`.
+#[allow(dead_code)]
 fn creature_kind_to_npc_id(kind: CreatureKind) -> ProtoNpcId {
     ProtoNpcId::from_ref(creature_kind_to_npc_ref(kind))
 }
 
 /// Map a `ProtoNpcId` back to a protocol `CreatureKind` (for wire messages).
+#[allow(dead_code)]
 fn npc_id_to_creature_kind(npc_id: ProtoNpcId) -> Option<CreatureKind> {
     if npc_id == ProtoNpcId::from_ref("meadow-firefly") {
         Some(CreatureKind::Firefly)
@@ -566,7 +569,7 @@ fn run_bevy_app(
 
     // Minimal headless Bevy — no window, no renderer
     app.add_plugins(MinimalPlugins);
-    app.add_plugins(bevy::transform::TransformPlugin::default());
+    app.add_plugins(bevy::transform::TransformPlugin);
 
     // avian3d physics (headless — disable transform sync plugins,
     // lightyear_avian handles that)
@@ -973,6 +976,7 @@ fn load_pem_identity(
 /// Diagnostic: log Link buffer states every tick for entities in the Server collection.
 /// If the server's Netcode receive system processes packets, link.recv will be empty
 /// after Update. If packets pile up, they're not being consumed.
+#[allow(clippy::type_complexity)]
 fn debug_link_packet_flow(
     server_q: Query<(Entity, &Server), Without<Stopped>>,
     link_q: Query<(Entity, &Link, Has<Linked>, Has<Linking>, Option<&Name>)>,
@@ -1013,6 +1017,7 @@ fn debug_link_packet_flow(
 }
 
 /// Diagnostic: log ALL Link entities to detect orphans not in Server collection.
+#[allow(clippy::type_complexity)]
 fn debug_all_links(
     all_links: Query<(
         Entity,
@@ -1188,6 +1193,7 @@ fn server_debug_link_buffers(
 
 /// Diagnostic: logs per-NetcodeServer collection() size every ~2s.
 /// This reveals whether WT/WS connections produce Link entities visible to the Netcode layer.
+#[allow(clippy::type_complexity)]
 fn server_debug_netcode_collection(
     time: Res<Time>,
     mut timer: Local<Option<Timer>>,
@@ -1305,6 +1311,7 @@ fn game_time_challenge(day: &DayCycle) -> u64 {
 /// On success, sends AuthResponse with a `server_time` challenge (game clock)
 /// and inserts PendingAck — the client must echo server_time in AuthAck to
 /// complete the 4-step handshake.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn process_auth_messages(
     mut commands: Commands,
     jwt_secret: Res<JwtSecret>,

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -28,7 +28,7 @@ use crate::db::{
 };
 
 /// Static table of simple permanent redirects handled by Axum before hitting Astro.
-const PERMANENT_REDIRECTS: &[(&'static str, &'static str)] = &[
+const PERMANENT_REDIRECTS: &[(&str, &str)] = &[
     ("/application/kube", "/application/kubernetes/"),
     ("/application/kubectl", "/application/kubernetes/"),
     ("/application/bevy", "/application/rust/#bevy"),

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -721,11 +721,7 @@ async fn vnc_bridge(
         while let Some(msg) = browser_rx.next().await {
             match msg {
                 Ok(AxumMsg::Binary(data)) => {
-                    if upstream_tx
-                        .send(TungMsg::Binary(data.into()))
-                        .await
-                        .is_err()
-                    {
+                    if upstream_tx.send(TungMsg::Binary(data)).await.is_err() {
                         break;
                     }
                 }
@@ -747,7 +743,7 @@ async fn vnc_bridge(
         while let Some(msg) = upstream_rx.next().await {
             match msg {
                 Ok(TungMsg::Binary(data)) => {
-                    if browser_tx.send(AxumMsg::Binary(data.into())).await.is_err() {
+                    if browser_tx.send(AxumMsg::Binary(data)).await.is_err() {
                         break;
                     }
                 }
@@ -1154,11 +1150,7 @@ async fn guacamole_ws_bridge(
                     }
                 }
                 Ok(AxumMsg::Binary(data)) => {
-                    if upstream_tx
-                        .send(TungMsg::Binary(data.into()))
-                        .await
-                        .is_err()
-                    {
+                    if upstream_tx.send(TungMsg::Binary(data)).await.is_err() {
                         break;
                     }
                 }
@@ -1180,7 +1172,7 @@ async fn guacamole_ws_bridge(
                     }
                 }
                 Ok(TungMsg::Binary(data)) => {
-                    if browser_tx.send(AxumMsg::Binary(data.into())).await.is_err() {
+                    if browser_tx.send(AxumMsg::Binary(data)).await.is_err() {
                         break;
                     }
                 }

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/brain.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/brain.rs
@@ -27,6 +27,12 @@ pub struct CreatureBrain {
     pending: bool,
 }
 
+impl Default for CreatureBrain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CreatureBrain {
     pub fn new() -> Self {
         Self {
@@ -44,6 +50,7 @@ impl CreatureBrain {
 /// Capture world snapshots for idle creatures and dispatch behavior tree
 /// evaluation to bevy_tasker. Only evaluates when the creature is idle
 /// (no pending intent and not currently moving/emoting).
+#[allow(clippy::type_complexity)]
 pub fn dispatch_behavior_trees(
     game_time: Res<GameTime>,
     types: Res<SpriteCreatureTypes>,

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/common.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/common.rs
@@ -55,7 +55,7 @@ const NIGHT_BAND: f32 = 1.5;
 
 /// Daytime visibility factor: 0.0 at night, 1.0 during full day.
 pub fn day_factor(hour: f32) -> f32 {
-    if hour >= DAY_START && hour <= DAY_END {
+    if (DAY_START..=DAY_END).contains(&hour) {
         let fade_in = ((hour - DAY_START) / DAY_BAND).clamp(0.0, 1.0);
         let fade_out = ((DAY_END - hour) / DAY_BAND).clamp(0.0, 1.0);
         fade_in.min(fade_out)
@@ -85,10 +85,10 @@ pub fn flutter_offset(t: f32, phase: f32, speed: f32, radius: f32, amp: f32) -> 
     let p = phase;
     let spd = speed;
     let r = radius * amp;
-    let ox = (t * spd * 0.6 + p * 6.28).sin() * r
+    let ox = (t * spd * 0.6 + p * std::f32::consts::TAU).sin() * r
         + (t * spd * 1.7 + p * 2.1).sin() * r * 0.3
         + (t * spd * 3.1 + p * 4.5).cos() * r * 0.1;
-    let oy = ((t * spd * 0.8 + p * 3.14).sin() * 0.25
+    let oy = ((t * spd * 0.8 + p * std::f32::consts::PI).sin() * 0.25
         + (t * spd * 2.3 + p * 1.57).cos() * 0.12
         + (t * spd * 4.0 + p * 5.0).sin() * 0.06)
         * amp;

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/nav_systems.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/nav_systems.rs
@@ -181,6 +181,7 @@ pub struct PendingPatrolCompute {
 }
 
 /// Tag newly-activated creatures that have an influence profile but no route.
+#[allow(clippy::type_complexity)]
 pub fn tag_creatures_needing_routes(
     mut commands: Commands,
     types: Res<SpriteCreatureTypes>,

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/simulate.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/simulate.rs
@@ -37,6 +37,7 @@ impl Default for SimulationCenter {
 /// Handles: visibility-schedule culling (sets anchor.y = -100 instead of
 /// Visibility component), recycle/respawn ring, frame advance, terrain snap,
 /// state machine (idle -> intent -> airborne -> landing), direction updates.
+#[allow(clippy::type_complexity)]
 pub fn simulate_sprite_creatures(
     time: Res<Time>,
     game_time: Res<GameTime>,

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/simulate_firefly.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/simulate_firefly.rs
@@ -81,6 +81,7 @@ pub fn assign_firefly_slots(
         candidates.iter().take(pool_size).map(|c| c.0).collect();
 
     // Snapshot entities — collect (Entity-free) to avoid borrow issues
+    #[allow(clippy::type_complexity)]
     let snapshot: Vec<(usize, Option<(i32, i32, u16)>)> = fly_q
         .iter()
         .enumerate()
@@ -94,11 +95,13 @@ pub fn assign_firefly_slots(
         if let Some(slot) = assigned {
             if !target_set.contains(&slot) {
                 slot_state.active_slots.remove(&slot);
-                if let Some((mut cr, _)) = fly_q.iter_mut().nth(idx) {
-                    if cr.npc_ref == NPC_REF {
-                        cr.assigned_slot = None;
-                        cr.state = CreatureState::Pooled;
-                    }
+                if let Some((mut cr, _)) = fly_q
+                    .iter_mut()
+                    .nth(idx)
+                    .filter(|(cr, _)| cr.npc_ref == NPC_REF)
+                {
+                    cr.assigned_slot = None;
+                    cr.state = CreatureState::Pooled;
                 }
                 free_indices.push(idx);
             }
@@ -118,16 +121,18 @@ pub fn assign_firefly_slots(
         }
         let entity_idx = free_indices[free_idx];
         free_idx += 1;
-        if let Some((mut cr, mut fs)) = fly_q.iter_mut().nth(entity_idx) {
-            if cr.npc_ref == NPC_REF {
-                cr.slot_seed = ss;
-                cr.anchor = anchor;
-                cr.phase = hash_f32(ss.wrapping_mul(7).wrapping_add(1));
-                cr.assigned_slot = Some(slot);
-                cr.state = CreatureState::Active;
-                *fs = FireflySimState::from_seed(ss);
-                slot_state.active_slots.insert(slot);
-            }
+        if let Some((mut cr, mut fs)) = fly_q
+            .iter_mut()
+            .nth(entity_idx)
+            .filter(|(cr, _)| cr.npc_ref == NPC_REF)
+        {
+            cr.slot_seed = ss;
+            cr.anchor = anchor;
+            cr.phase = hash_f32(ss.wrapping_mul(7).wrapping_add(1));
+            cr.assigned_slot = Some(slot);
+            cr.state = CreatureState::Active;
+            *fs = FireflySimState::from_seed(ss);
+            slot_state.active_slots.insert(slot);
         }
     }
 }
@@ -171,7 +176,8 @@ pub fn simulate_fireflies(
         let p = cr.phase;
         let spd = fs.orbit_speed;
         let r = fs.orbit_radius;
-        let ox = (t * spd * 0.7 + p * 6.28).sin() * r + (t * spd * 1.3 + p * 3.14).sin() * r * 0.4;
+        let ox = (t * spd * 0.7 + p * std::f32::consts::TAU).sin() * r
+            + (t * spd * 1.3 + p * std::f32::consts::PI).sin() * r * 0.4;
         let oy = (t * spd * 0.5 + p * 4.71).sin() * 0.3 + (t * spd * 1.1 + p * 2.09).cos() * 0.15;
         let oz = (t * spd * 0.9 + p * 5.24).cos() * r + (t * spd * 1.7 + p * 1.57).cos() * r * 0.3;
 

--- a/packages/rust/bevy/bevy_kbve_net/src/creatures/types.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/creatures/types.rs
@@ -15,6 +15,12 @@ use ulid::Ulid;
 #[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CreatureId(pub Ulid);
 
+impl Default for CreatureId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CreatureId {
     /// Generate a new ULID (server-side only).
     pub fn new() -> Self {

--- a/packages/rust/bevy/bevy_kbve_net/src/npcdb.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/npcdb.rs
@@ -72,7 +72,7 @@ pub struct CreatureConfig {
 ///
 /// Populated at startup with creature definitions + game-specific configs.
 /// Systems read this to know how to spawn, assign, and animate each creature type.
-#[derive(Resource)]
+#[derive(Resource, Default)]
 pub struct CreatureRegistry {
     /// The NPC database with proto-defined creature data.
     pub npc_db: NpcDb,
@@ -80,16 +80,6 @@ pub struct CreatureRegistry {
     pub configs: HashMap<ProtoNpcId, CreatureConfig>,
     /// Ordered list of creature NPC IDs for deterministic iteration.
     pub creature_ids: Vec<ProtoNpcId>,
-}
-
-impl Default for CreatureRegistry {
-    fn default() -> Self {
-        Self {
-            npc_db: NpcDb::default(),
-            configs: HashMap::new(),
-            creature_ids: Vec::new(),
-        }
-    }
 }
 
 impl CreatureRegistry {


### PR DESCRIPTION
## Summary
- Replace hardcoded `6.28`/`3.14` with `std::f32::consts::TAU`/`PI` in creature simulation
- Add `Default` impls for `CreatureId` and `CreatureBrain` (clippy `new_without_default`)
- Derive `Default` for `CreatureRegistry` instead of manual impl
- Add `#[allow(clippy::type_complexity)]` on Bevy system queries with 5+ components
- Fix redundant `&'static` lifetimes in `PERMANENT_REDIRECTS`
- Remove useless `.into()` on already-correct `Bytes` types in proxy.rs
- Suppress `dead_code` on creature kind mapping functions kept for future use

## Test plan
- [x] `cargo clippy -p axum-kbve -- -D warnings` passes locally
- [x] `npx nx run axum-kbve:lint` passes locally
- [ ] CI lint job passes on this PR