### PR TITLE
refactor(creatures): ambient creature shared-sim migration

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/creatures/butterfly/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/butterfly/mod.rs
@@ -1,19 +1,17 @@
-//! Butterfly ambient creatures using unified Creature + BillboardData components.
+//! Butterfly system: spawn + sim (adapted from bevy_kbve_net) + render.
 //!
-//! Butterflies are daytime creatures that enter from the edges of the visible
-//! area, flutter around a wander anchor, and exit when they drift too far.
-//! Currently camera-relative; chunk-based deterministic seeding is pending.
+//! Simulation logic (flight state machine) uses shared types from
+//! `bevy_kbve_net::creatures::ambient_types` adapted to client resource types.
+//! Render-only code (billboard facing, wing flap, material alpha) stays client-side.
 
 use bevy::asset::RenderAssetUsages;
 use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 
-use super::common::{
-    CreatureMeshes, CreaturePool, GameTime, day_factor, flutter_offset, hash_f32, scene_center,
-};
+use super::common::{CreaturePool, GameTime, day_factor, flutter_offset, hash_f32, scene_center};
 use super::creature::{
-    BillboardData, BillboardFlightState, Creature, CreaturePoolIndex, CreatureRegistry,
-    CreatureState, EmissiveData, RenderKind,
+    AmbientCreatureMarker, AmbientRenderData, ButterflyFlightState, ButterflySimState, Creature,
+    CreaturePoolIndex, CreatureRegistry, CreatureState, RenderKind,
 };
 use crate::game::camera::IsometricCamera;
 use crate::game::terrain::TerrainMap;
@@ -25,7 +23,6 @@ const NPC_REF: &str = "woodland-butterfly";
 const MIN_FLY_HEIGHT: f32 = 0.8;
 /// Maximum additional height above MIN_FLY_HEIGHT.
 const MAX_FLY_HEIGHT_EXTRA: f32 = 1.5;
-
 /// XZ distance from scene center that triggers exit flight.
 const EXIT_TRIGGER: f32 = 18.0;
 /// Radius at which entering butterflies spawn (edge of visible area).
@@ -139,12 +136,12 @@ fn apply_flap_and_billboard(
 }
 
 // ---------------------------------------------------------------------------
-// Systems
+// Spawn
 // ---------------------------------------------------------------------------
 
 pub(super) fn spawn_butterflies(
     mut commands: Commands,
-    creature_meshes: Res<CreatureMeshes>,
+    creature_meshes: Res<super::common::CreatureMeshes>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut pool: ResMut<CreaturePool>,
     registry: Res<CreatureRegistry>,
@@ -160,17 +157,10 @@ pub(super) fn spawn_butterflies(
         .id_for_ref(NPC_REF)
         .unwrap_or(bevy_kbve_net::npcdb::ProtoNpcId(0));
     let count = config.pool_size;
-
     let wing_mesh = creature_meshes.butterfly_wings.clone();
 
     for i in 0..count {
         let seed = (i as u32).wrapping_add(500);
-        let phase = hash_f32(seed * 11 + 1);
-        let wander_speed = 0.3 + hash_f32(seed * 17 + 3) * 0.4;
-        let wander_radius = 0.8 + hash_f32(seed * 29 + 5) * 1.2;
-        let flap_speed = 6.0 + hash_f32(seed * 37 + 7) * 4.0;
-        let size_scale = 0.7 + hash_f32(seed * 41 + 9) * 0.6;
-        let idle_cooldown = hash_f32(seed * 53 + 11) * 3.0;
 
         let mat = materials.add(StandardMaterial {
             base_color: butterfly_color(i),
@@ -193,16 +183,14 @@ pub(super) fn spawn_butterflies(
                 slot_seed: seed,
                 assigned_slot: None,
                 anchor: Vec3::ZERO,
-                phase,
-                mat_handle: mat_clone,
+                phase: hash_f32(seed * 11 + 1),
+                mat_handle: mat_clone.clone(),
             },
-            BillboardData {
-                flap_speed,
-                size_scale,
-                wander_speed,
-                wander_radius,
-                flight_state: BillboardFlightState::Idle,
-                idle_cooldown,
+            AmbientCreatureMarker { type_key: NPC_REF },
+            ButterflySimState::from_seed(seed),
+            AmbientRenderData {
+                mat_handle: mat_clone,
+                light_entity: None,
             },
             CreaturePoolIndex(i as u32),
         ));
@@ -211,21 +199,21 @@ pub(super) fn spawn_butterflies(
     info!("[butterfly] spawned {count} entities");
 }
 
-pub(super) fn animate_butterflies(
+// ---------------------------------------------------------------------------
+// Simulation (adapted from bevy_kbve_net::creatures::simulate_butterfly)
+// ---------------------------------------------------------------------------
+
+/// Advance butterfly flight state machine. Writes Transform::translation.
+/// NO billboard facing, material alpha, or wing flap scale.
+#[allow(clippy::type_complexity)]
+pub(super) fn simulate_butterflies(
     time: Res<Time>,
     game_time: Res<GameTime>,
-    wind: Res<WindState>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    mut terrain: ResMut<TerrainMap>,
     camera_q: Query<&Transform, With<IsometricCamera>>,
+    mut terrain: ResMut<TerrainMap>,
     mut bfly_q: Query<
-        (
-            &mut Transform,
-            &mut Creature,
-            &mut BillboardData,
-            &mut Visibility,
-        ),
-        (Without<IsometricCamera>, Without<EmissiveData>),
+        (&mut Transform, &mut Creature, &mut ButterflySimState),
+        (With<AmbientCreatureMarker>, Without<IsometricCamera>),
     >,
 ) {
     let Ok(cam_tf) = camera_q.single() else {
@@ -234,35 +222,32 @@ pub(super) fn animate_butterflies(
     let dt = time.delta_secs();
     let t = time.elapsed_secs();
     let df = day_factor(game_time.hour);
+    let center = scene_center(cam_tf.translation);
 
+    // Nighttime: force all to idle
     if df < 0.01 {
-        for (mut tf, _cr, mut bd, mut vis) in &mut bfly_q {
-            if bd.flight_state != BillboardFlightState::Idle {
-                bd.flight_state = BillboardFlightState::Idle;
-                bd.idle_cooldown = 1.0 + hash_f32((bd.flap_speed * 10000.0) as u32) * 2.0;
+        for (mut tf, _, mut bs) in &mut bfly_q {
+            if bs.flight_state != ButterflyFlightState::Idle {
+                bs.flight_state = ButterflyFlightState::Idle;
+                bs.idle_cooldown = 1.0 + hash_f32((bs.flap_speed * 10000.0) as u32) * 2.0;
             }
-            *vis = Visibility::Hidden;
             tf.translation.y = -100.0;
         }
         return;
     }
 
-    let cam_pos = cam_tf.translation;
-    let center = scene_center(cam_pos);
-    let (wd_x, wd_z) = wind.direction;
-    let wind_drift = wind.speed_mph * 0.005;
-    let wind_off = Vec3::new(wd_x * wind_drift * t, 0.0, wd_z * wind_drift * t);
+    for (mut tf, mut cr, mut bs) in &mut bfly_q {
+        if cr.render_kind != RenderKind::Billboard {
+            continue;
+        }
 
-    for (mut tf, mut cr, mut bd, mut vis) in &mut bfly_q {
-        let mut state = bd.flight_state;
+        let mut state = bs.flight_state;
 
         match state {
-            BillboardFlightState::Idle => {
-                *vis = Visibility::Hidden;
+            ButterflyFlightState::Idle => {
                 tf.translation.y = -100.0;
-
-                bd.idle_cooldown -= dt;
-                if bd.idle_cooldown <= 0.0 {
+                bs.idle_cooldown -= dt;
+                if bs.idle_cooldown <= 0.0 {
                     let seed = (cr.phase * 10000.0) as u32 + (t * 7.1) as u32;
                     let theta = hash_f32(seed) * std::f32::consts::TAU;
                     let ry = hash_f32(seed + 200);
@@ -286,7 +271,7 @@ pub(super) fn animate_butterflies(
                         target_z,
                     );
 
-                    state = BillboardFlightState::Entering {
+                    state = ButterflyFlightState::Entering {
                         origin,
                         target,
                         progress: 0.0,
@@ -295,7 +280,7 @@ pub(super) fn animate_butterflies(
                 }
             }
 
-            BillboardFlightState::Entering {
+            ButterflyFlightState::Entering {
                 origin,
                 target,
                 ref mut progress,
@@ -303,59 +288,26 @@ pub(super) fn animate_butterflies(
                 let path_len = origin.distance(target).max(0.1);
                 *progress += dt * ENTER_SPEED / path_len;
                 let p = progress.clamp(0.0, 1.0);
-
                 let ease = p * p * (3.0 - 2.0 * p);
                 let base_pos = origin.lerp(target, ease);
-                let flut = flutter_offset(t, cr.phase, bd.wander_speed, bd.wander_radius, 0.3);
-                let mut pos = base_pos + flut + wind_off;
+                let flut = flutter_offset(t, cr.phase, bs.wander_speed, bs.wander_radius, 0.3);
+                let mut pos = base_pos + flut;
                 let ground = terrain.height_at_world(pos.x, pos.z);
                 pos.y = pos.y.max(ground + MIN_FLY_HEIGHT);
-
-                *vis = Visibility::Visible;
-                apply_flap_and_billboard(
-                    &mut tf,
-                    pos,
-                    cam_pos,
-                    t,
-                    bd.flap_speed,
-                    cr.phase,
-                    bd.size_scale,
-                );
-
-                if let Some(mat) = materials.get_mut(&cr.mat_handle) {
-                    let mut c = mat.base_color.to_srgba();
-                    c.alpha = df * 0.9 * p;
-                    mat.base_color = c.into();
-                }
+                tf.translation = pos;
 
                 if *progress >= 1.0 {
                     cr.anchor = target;
-                    state = BillboardFlightState::Active;
+                    state = ButterflyFlightState::Active;
                 }
             }
 
-            BillboardFlightState::Active => {
-                let flut = flutter_offset(t, cr.phase, bd.wander_speed, bd.wander_radius, 1.0);
-                let mut pos = cr.anchor + flut + wind_off;
+            ButterflyFlightState::Active => {
+                let flut = flutter_offset(t, cr.phase, bs.wander_speed, bs.wander_radius, 1.0);
+                let mut pos = cr.anchor + flut;
                 let ground = terrain.height_at_world(pos.x, pos.z);
                 pos.y = pos.y.max(ground + MIN_FLY_HEIGHT);
-
-                *vis = Visibility::Visible;
-                apply_flap_and_billboard(
-                    &mut tf,
-                    pos,
-                    cam_pos,
-                    t,
-                    bd.flap_speed,
-                    cr.phase,
-                    bd.size_scale,
-                );
-
-                if let Some(mat) = materials.get_mut(&cr.mat_handle) {
-                    let mut c = mat.base_color.to_srgba();
-                    c.alpha = df * 0.9;
-                    mat.base_color = c.into();
-                }
+                tf.translation = pos;
 
                 let dist_xz = Vec2::new(cr.anchor.x - center.x, cr.anchor.z - center.z).length();
                 if dist_xz > EXIT_TRIGGER {
@@ -368,7 +320,7 @@ pub(super) fn animate_butterflies(
                     } else {
                         away
                     };
-                    state = BillboardFlightState::Exiting {
+                    state = ButterflyFlightState::Exiting {
                         start: tf.translation,
                         direction: dir,
                         progress: 0.0,
@@ -376,48 +328,143 @@ pub(super) fn animate_butterflies(
                 }
             }
 
-            BillboardFlightState::Exiting {
+            ButterflyFlightState::Exiting {
                 start,
                 direction,
                 ref mut progress,
             } => {
                 *progress += dt * EXIT_SPEED / EXIT_DISTANCE;
                 let p = progress.clamp(0.0, 1.0);
-
                 let base_pos = start + direction * (p * EXIT_DISTANCE);
-                let flut = flutter_offset(t, cr.phase, bd.wander_speed, bd.wander_radius, 1.0 - p);
-                let mut pos = base_pos + flut + wind_off;
+                let flut = flutter_offset(t, cr.phase, bs.wander_speed, bs.wander_radius, 1.0 - p);
+                let mut pos = base_pos + flut;
                 let ground = terrain.height_at_world(pos.x, pos.z);
                 pos.y = pos.y.max(ground + MIN_FLY_HEIGHT);
+                tf.translation = pos;
 
+                if *progress >= 1.0 {
+                    let seed = (cr.phase * 10000.0) as u32 + (t * 3.3) as u32;
+                    bs.idle_cooldown = 1.0 + hash_f32(seed) * 2.0;
+                    tf.translation.y = -100.0;
+                    cr.state = CreatureState::Pooled;
+                    state = ButterflyFlightState::Idle;
+                }
+            }
+        }
+
+        bs.flight_state = state;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Render (client-only)
+// ---------------------------------------------------------------------------
+
+/// Per-frame render: billboard facing, wing flap, material alpha, wind, visibility.
+/// Reads sim state set by simulate_butterflies.
+#[allow(clippy::type_complexity)]
+pub(super) fn render_butterflies(
+    time: Res<Time>,
+    game_time: Res<GameTime>,
+    wind: Res<WindState>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    camera_q: Query<&Transform, With<IsometricCamera>>,
+    mut bfly_q: Query<
+        (
+            &mut Transform,
+            &Creature,
+            &ButterflySimState,
+            &AmbientRenderData,
+            &mut Visibility,
+        ),
+        (With<AmbientCreatureMarker>, Without<IsometricCamera>),
+    >,
+) {
+    let Ok(cam_tf) = camera_q.single() else {
+        return;
+    };
+    let t = time.elapsed_secs();
+    let df = day_factor(game_time.hour);
+    let cam_pos = cam_tf.translation;
+
+    // Nighttime: hide all
+    if df < 0.01 {
+        for (_, _, _, _, mut vis) in &mut bfly_q {
+            *vis = Visibility::Hidden;
+        }
+        return;
+    }
+
+    let (wd_x, wd_z) = wind.direction;
+    let wind_drift = wind.speed_mph * 0.005;
+    let wind_off = Vec3::new(wd_x * wind_drift * t, 0.0, wd_z * wind_drift * t);
+
+    for (mut tf, cr, bs, rd, mut vis) in &mut bfly_q {
+        if cr.render_kind != RenderKind::Billboard {
+            continue;
+        }
+
+        match bs.flight_state {
+            ButterflyFlightState::Idle => {
+                *vis = Visibility::Hidden;
+            }
+
+            ButterflyFlightState::Entering { progress, .. } => {
+                let pos = tf.translation + wind_off;
                 *vis = Visibility::Visible;
                 apply_flap_and_billboard(
                     &mut tf,
                     pos,
                     cam_pos,
                     t,
-                    bd.flap_speed,
+                    bs.flap_speed,
                     cr.phase,
-                    bd.size_scale,
+                    bs.size_scale,
                 );
-
-                if let Some(mat) = materials.get_mut(&cr.mat_handle) {
+                if let Some(mat) = materials.get_mut(&rd.mat_handle) {
                     let mut c = mat.base_color.to_srgba();
-                    c.alpha = df * 0.9 * (1.0 - p);
+                    c.alpha = df * 0.9 * progress;
                     mat.base_color = c.into();
                 }
+            }
 
-                if *progress >= 1.0 {
-                    let seed = (cr.phase * 10000.0) as u32 + (t * 3.3) as u32;
-                    bd.idle_cooldown = 1.0 + hash_f32(seed) * 2.0;
-                    tf.translation.y = -100.0;
-                    *vis = Visibility::Hidden;
-                    cr.state = CreatureState::Pooled;
-                    state = BillboardFlightState::Idle;
+            ButterflyFlightState::Active => {
+                let pos = tf.translation + wind_off;
+                *vis = Visibility::Visible;
+                apply_flap_and_billboard(
+                    &mut tf,
+                    pos,
+                    cam_pos,
+                    t,
+                    bs.flap_speed,
+                    cr.phase,
+                    bs.size_scale,
+                );
+                if let Some(mat) = materials.get_mut(&rd.mat_handle) {
+                    let mut c = mat.base_color.to_srgba();
+                    c.alpha = df * 0.9;
+                    mat.base_color = c.into();
+                }
+            }
+
+            ButterflyFlightState::Exiting { progress, .. } => {
+                let pos = tf.translation + wind_off;
+                *vis = Visibility::Visible;
+                apply_flap_and_billboard(
+                    &mut tf,
+                    pos,
+                    cam_pos,
+                    t,
+                    bs.flap_speed,
+                    cr.phase,
+                    bs.size_scale,
+                );
+                if let Some(mat) = materials.get_mut(&rd.mat_handle) {
+                    let mut c = mat.base_color.to_srgba();
+                    c.alpha = df * 0.9 * (1.0 - progress);
+                    mat.base_color = c.into();
                 }
             }
         }
-
-        bd.flight_state = state;
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/creature.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/creature.rs
@@ -17,6 +17,12 @@ pub use bevy_kbve_net::npcdb::creature::{
     CapturedCreatures, CreatureCaptureEvent, CreaturePoolIndex, CreatureState,
 };
 
+// Re-export shared ambient simulation types from bevy_kbve_net.
+pub use bevy_kbve_net::creatures::ambient_types::{
+    AmbientCreatureMarker, ButterflyFlightState, ButterflySimState, FireflySimState,
+    FireflySlotState,
+};
+
 // ---------------------------------------------------------------------------
 // Core component — shared by ALL creature types (client-side ECS)
 // ---------------------------------------------------------------------------
@@ -24,7 +30,7 @@ pub use bevy_kbve_net::npcdb::creature::{
 /// Unified creature component for NpcDb-driven ambient creatures.
 ///
 /// Contains shared pool/slot data. Render-specific state lives in companion
-/// components ([`EmissiveData`], [`BillboardData`], [`SpriteData`]).
+/// components ([`AmbientRenderData`], [`FireflySimState`], [`ButterflySimState`], [`SpriteData`]).
 #[derive(Component)]
 pub struct Creature {
     /// NPC definition ID from NpcDb.
@@ -49,43 +55,14 @@ pub struct Creature {
 // Render-specific companion components
 // ---------------------------------------------------------------------------
 
-/// Emissive render data (firefly-style: glow sphere + point light).
+/// Render-only data for ambient creatures (fireflies, butterflies).
+/// Holds GPU resource handles that the shared simulation components don't carry.
 #[derive(Component)]
-pub struct EmissiveData {
-    pub light_entity: Entity,
-    pub glow_phase: f32,
-    pub glow_period: f32,
-    pub orbit_radius: f32,
-    pub orbit_speed: f32,
-}
-
-/// Billboard render data (butterfly-style: mesh billboard + wing flap).
-#[derive(Component)]
-pub struct BillboardData {
-    pub flap_speed: f32,
-    pub size_scale: f32,
-    pub wander_speed: f32,
-    pub wander_radius: f32,
-    pub flight_state: BillboardFlightState,
-    pub idle_cooldown: f32,
-}
-
-/// Billboard creature flight state machine.
-#[derive(Clone, Copy, PartialEq, Default)]
-pub enum BillboardFlightState {
-    #[default]
-    Idle,
-    Entering {
-        origin: Vec3,
-        target: Vec3,
-        progress: f32,
-    },
-    Active,
-    Exiting {
-        start: Vec3,
-        direction: Vec3,
-        progress: f32,
-    },
+pub struct AmbientRenderData {
+    /// Material handle for per-entity visual updates (emissive glow, alpha blend).
+    pub mat_handle: Handle<StandardMaterial>,
+    /// PointLight entity for fireflies (None for butterflies).
+    pub light_entity: Option<Entity>,
 }
 
 /// Sprite render data (frog-style: sprite sheet UV animation + hop arcs).
@@ -139,12 +116,4 @@ pub fn apply_slot_base(creature: &mut Creature, seed: u32, anchor: Vec3, slot: (
     creature.phase = hash_f32(seed.wrapping_mul(7).wrapping_add(1));
     creature.assigned_slot = Some(slot);
     creature.state = CreatureState::Active;
-}
-
-/// Apply slot-derived params to emissive render data.
-pub fn apply_slot_emissive(data: &mut EmissiveData, seed: u32) {
-    data.glow_period = 2.0 + hash_f32(seed.wrapping_mul(13).wrapping_add(3)) * 3.0;
-    data.orbit_radius = 0.4 + hash_f32(seed.wrapping_mul(19).wrapping_add(5)) * 0.8;
-    data.orbit_speed = 0.6 + hash_f32(seed.wrapping_mul(23).wrapping_add(7)) * 0.8;
-    data.glow_phase = hash_f32(seed.wrapping_mul(7).wrapping_add(1));
 }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/firefly/mod.rs
@@ -1,22 +1,21 @@
-//! Server-seeded firefly system using the unified Creature + EmissiveData components.
+//! Firefly system: spawn + sim (adapted from bevy_kbve_net) + render.
 //!
-//! Firefly world positions are deterministically derived from `GameTime::creature_seed`,
-//! divided into spatial chunks. All clients with the same seed see identical firefly
-//! placements, enabling collection/capture mechanics.
-//!
-//! Config (pool size, chunk size, spawn chance) is read from [`CreatureRegistry`]
-//! rather than hardcoded, so tuning can happen at the NpcDb level.
+//! Simulation logic (slot assignment, orbital motion, glow phase) uses shared
+//! types from `bevy_kbve_net::creatures::ambient_types` adapted to client
+//! resource types. Render-only code (materials, PointLight, Visibility) stays
+//! client-side.
 
-use super::creature::ProtoNpcId;
 use bevy::prelude::*;
-use std::collections::HashSet;
 
 use super::common::{CreatureMeshes, CreaturePool, GameTime, night_factor, scene_center};
 use super::creature::{
-    self, Creature, CreaturePoolIndex, CreatureRegistry, CreatureState, EmissiveData, RenderKind,
+    self, AmbientCreatureMarker, AmbientRenderData, Creature, CreaturePoolIndex, CreatureRegistry,
+    CreatureState, FireflySimState, FireflySlotState, ProtoNpcId,
 };
 use crate::game::camera::IsometricCamera;
 use crate::game::weather::WindState;
+
+use std::collections::HashSet;
 
 /// NPC ref slug for fireflies in the CreatureRegistry.
 const NPC_REF: &str = "meadow-firefly";
@@ -25,22 +24,10 @@ const NPC_REF: &str = "meadow-firefly";
 const VIEW_RADIUS: i32 = 3;
 
 // ---------------------------------------------------------------------------
-// Resources
+// Spawn
 // ---------------------------------------------------------------------------
 
-/// Tracks active slot assignments and the last-seen creature_seed.
-#[derive(Resource, Default)]
-pub(super) struct FireflyState {
-    active_slots: HashSet<(i32, i32, u16)>,
-    last_seed: u64,
-}
-
-// ---------------------------------------------------------------------------
-// Systems
-// ---------------------------------------------------------------------------
-
-/// One-time spawn of the entity pool. All entities start hidden and unassigned.
-/// Pool size is read from the CreatureRegistry.
+/// One-time spawn of the firefly entity pool. All entities start hidden.
 pub(super) fn spawn_fireflies(
     mut commands: Commands,
     creature_meshes: Res<CreatureMeshes>,
@@ -56,7 +43,6 @@ pub(super) fn spawn_fireflies(
     };
     let npc_id = registry.npc_db.id_for_ref(NPC_REF).unwrap_or(ProtoNpcId(0));
     let pool_size = config.pool_size;
-
     let fly_mesh = creature_meshes.firefly_sphere.clone();
 
     for i in 0..pool_size {
@@ -91,20 +77,19 @@ pub(super) fn spawn_fireflies(
             Visibility::Hidden,
             Creature {
                 npc_id,
-                render_kind: RenderKind::Emissive,
+                render_kind: creature::RenderKind::Emissive,
                 state: CreatureState::Pooled,
                 slot_seed: 0,
                 assigned_slot: None,
                 anchor: Vec3::new(0.0, -100.0, 0.0),
                 phase: 0.0,
-                mat_handle: mat_clone,
+                mat_handle: mat_clone.clone(),
             },
-            EmissiveData {
-                light_entity,
-                glow_phase: 0.0,
-                glow_period: 3.0,
-                orbit_radius: 0.5,
-                orbit_speed: 0.7,
+            AmbientCreatureMarker { type_key: NPC_REF },
+            FireflySimState::from_seed(0),
+            AmbientRenderData {
+                mat_handle: mat_clone,
+                light_entity: Some(light_entity),
             },
             CreaturePoolIndex(i as u32),
         ));
@@ -113,15 +98,22 @@ pub(super) fn spawn_fireflies(
     info!("[firefly] spawned {pool_size} pooled entities");
 }
 
-/// Per-frame slot assignment: determines which chunk slots are visible near the
-/// camera and assigns/unassigns pool entities to match.
+// ---------------------------------------------------------------------------
+// Simulation (adapted from bevy_kbve_net::creatures::simulate_firefly)
+// ---------------------------------------------------------------------------
+
+/// Per-frame slot assignment: determines which chunk slots are visible near
+/// the camera and assigns/unassigns pool entities.
+#[allow(clippy::type_complexity)]
 pub(super) fn assign_firefly_slots(
     game_time: Res<GameTime>,
     camera_q: Query<&Transform, With<IsometricCamera>>,
     registry: Res<CreatureRegistry>,
-    mut state: ResMut<FireflyState>,
-    mut fly_q: Query<(Entity, &mut Creature, &mut EmissiveData, &mut Visibility)>,
-    mut light_vis_q: Query<&mut Visibility, (Without<Creature>, Without<IsometricCamera>)>,
+    mut slot_state: ResMut<FireflySlotState>,
+    mut fly_q: Query<
+        (Entity, &mut Creature, &mut FireflySimState, &mut Visibility),
+        With<AmbientCreatureMarker>,
+    >,
 ) {
     let Ok(cam_tf) = camera_q.single() else {
         return;
@@ -137,13 +129,13 @@ pub(super) fn assign_firefly_slots(
     let spawn_chance = config.spawn_chance;
     let pool_size = config.pool_size;
 
-    // Seed change → full reset (all entities return to pool)
-    if seed != state.last_seed {
-        state.last_seed = seed;
-        state.active_slots.clear();
-        for (_, mut cr, ed, mut vis) in &mut fly_q {
-            if let Ok(mut lvis) = light_vis_q.get_mut(ed.light_entity) {
-                *lvis = Visibility::Hidden;
+    // Seed change -> full reset
+    if seed != slot_state.last_seed {
+        slot_state.last_seed = seed;
+        slot_state.active_slots.clear();
+        for (_, mut cr, _, mut vis) in &mut fly_q {
+            if cr.render_kind != creature::RenderKind::Emissive {
+                continue;
             }
             cr.assigned_slot = None;
             cr.state = CreatureState::Pooled;
@@ -154,7 +146,7 @@ pub(super) fn assign_firefly_slots(
     let cam_cx = (center.x / chunk_size).floor() as i32;
     let cam_cz = (center.z / chunk_size).floor() as i32;
 
-    // Enumerate visible slots, sorted by distance to camera center
+    // Enumerate visible slots sorted by distance
     let capacity = ((VIEW_RADIUS * 2 + 1) * (VIEW_RADIUS * 2 + 1)) as usize * per_chunk;
     let mut candidates: Vec<((i32, i32, u16), u32, Vec3)> = Vec::with_capacity(capacity);
     for dx in -VIEW_RADIUS..=VIEW_RADIUS {
@@ -181,25 +173,23 @@ pub(super) fn assign_firefly_slots(
     let target_set: HashSet<(i32, i32, u16)> =
         candidates.iter().take(pool_size).map(|c| c.0).collect();
 
-    // Snapshot entity states (releases borrow so we can get_mut later)
-    let snapshot: Vec<(Entity, Option<(i32, i32, u16)>, Entity)> = fly_q
+    // Snapshot entity IDs + slots to release borrow for get_mut
+    let snapshot: Vec<(Entity, Option<(i32, i32, u16)>)> = fly_q
         .iter()
-        .map(|(e, cr, ed, _)| (e, cr.assigned_slot, ed.light_entity))
+        .filter(|(_, cr, _, _)| cr.render_kind == creature::RenderKind::Emissive)
+        .map(|(e, cr, _, _)| (e, cr.assigned_slot))
         .collect();
 
-    // Unassign entities whose slots left the view; collect free entity IDs
+    // Unassign entities whose slots left the view; collect free entities
     let mut free_entities: Vec<Entity> = Vec::new();
-    for &(entity, assigned, light_entity) in &snapshot {
+    for &(entity, assigned) in &snapshot {
         if let Some(slot) = assigned {
             if !target_set.contains(&slot) {
-                state.active_slots.remove(&slot);
+                slot_state.active_slots.remove(&slot);
                 if let Ok((_, mut cr, _, mut vis)) = fly_q.get_mut(entity) {
                     cr.assigned_slot = None;
                     cr.state = CreatureState::Pooled;
                     *vis = Visibility::Hidden;
-                }
-                if let Ok(mut lvis) = light_vis_q.get_mut(light_entity) {
-                    *lvis = Visibility::Hidden;
                 }
                 free_entities.push(entity);
             }
@@ -211,7 +201,7 @@ pub(super) fn assign_firefly_slots(
     // Assign free entities to unoccupied target slots (closest first)
     let mut free_idx = 0;
     for &(slot, ss, anchor) in candidates.iter().take(pool_size) {
-        if state.active_slots.contains(&slot) {
+        if slot_state.active_slots.contains(&slot) {
             continue;
         }
         if free_idx >= free_entities.len() {
@@ -219,18 +209,69 @@ pub(super) fn assign_firefly_slots(
         }
         let entity = free_entities[free_idx];
         free_idx += 1;
-        if let Ok((_, mut cr, mut ed, mut vis)) = fly_q.get_mut(entity) {
+        if let Ok((_, mut cr, mut fs, _)) = fly_q.get_mut(entity) {
             creature::apply_slot_base(&mut cr, ss, anchor, slot);
-            creature::apply_slot_emissive(&mut ed, ss);
-            state.active_slots.insert(slot);
-            // Visibility set by animate based on night_factor
-            *vis = Visibility::Hidden;
+            *fs = FireflySimState::from_seed(ss);
+            slot_state.active_slots.insert(slot);
         }
     }
 }
 
-/// Per-frame animation: orbital motion, glow pulse, wind drift, night-factor visibility.
-pub(super) fn animate_fireflies(
+/// Advance firefly simulation: orbital motion + glow phase.
+/// Writes Transform::translation only. NO render code.
+pub(super) fn simulate_fireflies(
+    time: Res<Time>,
+    game_time: Res<GameTime>,
+    mut fly_q: Query<
+        (&mut Transform, &Creature, &mut FireflySimState),
+        With<AmbientCreatureMarker>,
+    >,
+) {
+    let dt = time.delta_secs();
+    let t = time.elapsed_secs();
+    let nf = night_factor(game_time.hour);
+
+    for (mut tf, cr, mut fs) in &mut fly_q {
+        if cr.render_kind != creature::RenderKind::Emissive {
+            continue;
+        }
+        if cr.state != CreatureState::Active {
+            continue;
+        }
+
+        // Daytime: hide by pushing below ground
+        if nf < 0.01 {
+            tf.translation.y = -100.0;
+            continue;
+        }
+
+        // Advance glow phase
+        fs.glow_phase += dt / fs.glow_period;
+        if fs.glow_phase >= 1.0 {
+            fs.glow_phase -= 1.0;
+        }
+
+        // Orbital motion around anchor
+        let p = cr.phase;
+        let spd = fs.orbit_speed;
+        let r = fs.orbit_radius;
+        let ox = (t * spd * 0.7 + p * std::f32::consts::TAU).sin() * r
+            + (t * spd * 1.3 + p * std::f32::consts::PI).sin() * r * 0.4;
+        let oy = (t * spd * 0.5 + p * 4.71).sin() * 0.3 + (t * spd * 1.1 + p * 2.09).cos() * 0.15;
+        let oz = (t * spd * 0.9 + p * 5.24).cos() * r + (t * spd * 1.7 + p * 1.57).cos() * r * 0.3;
+
+        tf.translation = cr.anchor + Vec3::new(ox, oy, oz);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Render (client-only)
+// ---------------------------------------------------------------------------
+
+/// Per-frame render: material emissive, PointLight, Visibility, wind offset.
+/// Reads sim state set by simulate_fireflies.
+#[allow(clippy::type_complexity)]
+pub(super) fn render_fireflies(
     time: Res<Time>,
     game_time: Res<GameTime>,
     wind: Res<WindState>,
@@ -238,29 +279,31 @@ pub(super) fn animate_fireflies(
     mut fly_q: Query<
         (
             &mut Transform,
-            &mut Creature,
-            &mut EmissiveData,
+            &Creature,
+            &FireflySimState,
+            &AmbientRenderData,
             &mut Visibility,
         ),
-        Without<IsometricCamera>,
+        With<AmbientCreatureMarker>,
     >,
     mut light_q: Query<
         (&mut PointLight, &mut Transform, &mut Visibility),
         (Without<IsometricCamera>, Without<Creature>),
     >,
 ) {
-    let dt = time.delta_secs();
     let t = time.elapsed_secs();
     let nf = night_factor(game_time.hour);
 
     // Daytime: hide all active fireflies
     if nf < 0.01 {
-        for (_, cr, ed, mut vis) in &mut fly_q {
+        for (_, cr, _, rd, mut vis) in &mut fly_q {
             if cr.state == CreatureState::Active {
                 *vis = Visibility::Hidden;
-                if let Ok((mut pl, _, mut lvis)) = light_q.get_mut(ed.light_entity) {
-                    pl.intensity = 0.0;
-                    *lvis = Visibility::Hidden;
+                if let Some(le) = rd.light_entity {
+                    if let Ok((mut pl, _, mut lvis)) = light_q.get_mut(le) {
+                        pl.intensity = 0.0;
+                        *lvis = Visibility::Hidden;
+                    }
                 }
             }
         }
@@ -270,38 +313,27 @@ pub(super) fn animate_fireflies(
     let (wd_x, wd_z) = wind.direction;
     let wind_drift = wind.speed_mph * 0.003;
 
-    for (mut tf, cr, mut ed, mut vis) in &mut fly_q {
-        // Skip pooled/captured entities
+    for (mut tf, cr, fs, rd, mut vis) in &mut fly_q {
+        if cr.render_kind != creature::RenderKind::Emissive {
+            continue;
+        }
         if cr.state != CreatureState::Active {
             continue;
         }
 
         *vis = Visibility::Visible;
 
-        // Advance glow phase
-        ed.glow_phase += dt / ed.glow_period;
-        if ed.glow_phase >= 1.0 {
-            ed.glow_phase -= 1.0;
-        }
-
-        // Orbital motion around anchor
-        let p = cr.phase;
-        let spd = ed.orbit_speed;
-        let r = ed.orbit_radius;
-        let ox = (t * spd * 0.7 + p * 6.28).sin() * r + (t * spd * 1.3 + p * 3.14).sin() * r * 0.4;
-        let oy = (t * spd * 0.5 + p * 4.71).sin() * 0.3 + (t * spd * 1.1 + p * 2.09).cos() * 0.15;
-        let oz = (t * spd * 0.9 + p * 5.24).cos() * r + (t * spd * 1.7 + p * 1.57).cos() * r * 0.3;
-
+        // Apply wind offset on top of sim position (cosmetic only)
         let wind_off = Vec3::new(
             wd_x * wind_drift * (t % 60.0),
             0.0,
             wd_z * wind_drift * (t % 60.0),
         );
-        let pos = cr.anchor + Vec3::new(ox, oy, oz) + wind_off;
+        let pos = tf.translation + wind_off;
         tf.translation = pos;
 
-        // Double-pulse glow pattern with a faint base glow between pulses
-        let pulse_t = ed.glow_phase;
+        // Double-pulse glow pattern
+        let pulse_t = fs.glow_phase;
         let pulse = if pulse_t < 0.15 {
             (pulse_t / 0.15 * std::f32::consts::PI).sin()
         } else if pulse_t < 0.25 {
@@ -312,24 +344,25 @@ pub(super) fn animate_fireflies(
             0.0
         };
 
-        // Faint base glow (0.18) so fireflies never fully go dark — they always emit light
         let glow = 0.18 + pulse * 0.82;
         let intensity = glow * nf;
 
-        if let Some(mat) = materials.get_mut(&cr.mat_handle) {
+        if let Some(mat) = materials.get_mut(&rd.mat_handle) {
             let emit = intensity * 35.0;
             mat.emissive = LinearRgba::new(0.3 * emit, 0.85 * emit, 0.15 * emit, 1.0);
             mat.base_color = Color::srgba(0.5, 0.9, 0.3, intensity * 0.95 + 0.2 * nf);
         }
 
-        if let Ok((mut pl, mut ltf, mut lvis)) = light_q.get_mut(ed.light_entity) {
-            pl.intensity = intensity * 8000.0;
-            ltf.translation = pos;
-            *lvis = if intensity > 0.01 {
-                Visibility::Visible
-            } else {
-                Visibility::Hidden
-            };
+        if let Some(le) = rd.light_entity {
+            if let Ok((mut pl, mut ltf, mut lvis)) = light_q.get_mut(le) {
+                pl.intensity = intensity * 8000.0;
+                ltf.translation = pos;
+                *lvis = if intensity > 0.01 {
+                    Visibility::Visible
+                } else {
+                    Visibility::Hidden
+                };
+            }
         }
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -10,7 +10,8 @@ use bevy::prelude::*;
 pub use common::GameTime;
 use common::{CreatureMeshes, CreaturePool};
 pub use creature::{
-    Creature, CreatureConfig, CreaturePoolIndex, CreatureRegistry, CreatureState, EmissiveData,
+    AmbientCreatureMarker, AmbientRenderData, ButterflySimState, Creature, CreatureConfig,
+    CreaturePoolIndex, CreatureRegistry, CreatureState, FireflySimState, FireflySlotState,
     RenderKind, TimeSchedule,
 };
 
@@ -63,7 +64,7 @@ impl Plugin for CreaturesPlugin {
         // --- Shared resources ---
         app.init_resource::<CreaturePool>();
         app.init_resource::<common::GameTime>();
-        app.init_resource::<firefly::FireflyState>();
+        app.init_resource::<FireflySlotState>();
 
         // --- Generic sprite creature system ---
         app.insert_resource(generic::definitions::build_sprite_creature_types());
@@ -78,19 +79,26 @@ impl Plugin for CreaturesPlugin {
         app.add_systems(
             Update,
             (
-                // Fireflies (Creature + EmissiveData)
+                // Fireflies (Creature + FireflySimState + AmbientRenderData)
                 firefly::spawn_fireflies.run_if(|pool: Res<CreaturePool>| !pool.fireflies_spawned),
                 firefly::assign_firefly_slots
                     .after(firefly::spawn_fireflies)
-                    .run_if(any_with_component::<creature::EmissiveData>),
-                firefly::animate_fireflies
+                    .run_if(any_with_component::<FireflySimState>),
+                firefly::simulate_fireflies
                     .after(firefly::assign_firefly_slots)
-                    .run_if(any_with_component::<creature::EmissiveData>),
-                // Butterflies (Creature + BillboardData)
+                    .run_if(any_with_component::<FireflySimState>),
+                firefly::render_fireflies
+                    .after(firefly::simulate_fireflies)
+                    .run_if(any_with_component::<FireflySimState>),
+                // Butterflies (Creature + ButterflySimState + AmbientRenderData)
                 butterfly::spawn_butterflies
                     .run_if(|pool: Res<CreaturePool>| !pool.butterflies_spawned),
-                butterfly::animate_butterflies
-                    .run_if(any_with_component::<creature::BillboardData>),
+                butterfly::simulate_butterflies
+                    .after(butterfly::spawn_butterflies)
+                    .run_if(any_with_component::<ButterflySimState>),
+                butterfly::render_butterflies
+                    .after(butterfly::simulate_butterflies)
+                    .run_if(any_with_component::<ButterflySimState>),
                 // --- Generic sprite creatures (all sprite types) ---
                 generic::spawn::spawn_sprite_creatures,
                 generic::brain::dispatch_behavior_trees

--- a/packages/rust/bevy/bevy_kbve_net/src/client.rs
+++ b/packages/rust/bevy/bevy_kbve_net/src/client.rs
@@ -334,6 +334,7 @@ pub fn wasm_wt_hostname_link(
         .remove::<lightyear::webtransport::prelude::client::WebTransportClientIo>();
 }
 
+#[allow(clippy::type_complexity)]
 pub fn check_handshake_timeout(
     mut commands: Commands,
     time: Res<Time>,


### PR DESCRIPTION
## Summary
- Split firefly and butterfly client modules into **spawn + sim + render** layers
- Sim logic now uses shared types from `bevy_kbve_net` (`FireflySimState`, `ButterflySimState`, `AmbientCreatureMarker`, `FireflySlotState`) — identical to server-side simulation
- New `AmbientRenderData` component holds render-only data (`mat_handle`, `light_entity`), replacing the old `EmissiveData`/`BillboardData` components
- Removed `EmissiveData`, `BillboardData`, `BillboardFlightState` from client `creature.rs`
- Both client and server now run identical sim code, enabling capture validation

## Test plan
- [x] `cargo check -p isometric-game` compiles
- [x] `cargo check -p axum-kbve` unaffected
- [ ] Visual: fireflies appear at night with glow pulse + orbital motion
- [ ] Visual: butterflies appear during day with flight state machine + billboard facing
- [ ] Two clients see same creature positions (deterministic sim)