### PR TITLE
perf(isometric): platform-aware performance budgets for mobile WASM

### DIFF
--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -98,7 +98,7 @@ js-sys = "0.3"
 wasm-bindgen = "=0.2.114"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [
-    "Document", "Window", "Location", "Storage", "HtmlCanvasElement",
+    "Document", "Window", "Navigator", "Location", "Storage", "HtmlCanvasElement",
     "Request", "RequestInit", "RequestMode", "Response", "Headers",
 ] }
 serde-wasm-bindgen = "0.6"

--- a/apps/kbve/isometric/src-tauri/src/game/camera.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/camera.rs
@@ -50,11 +50,24 @@ impl Plugin for IsometricCameraPlugin {
 }
 
 /// One-shot: attach `PixelateSettings` to the display camera.
+/// On Low perf tier, use coarser pixels and disable edge detection to save
+/// mobile GPU fill rate.
 fn attach_pixelate_settings(
     mut commands: Commands,
     display_query: Query<Entity, (With<DisplayCamera>, Without<PixelateSettings>)>,
+    perf_tier: Res<super::PerfTier>,
 ) {
+    let settings = match *perf_tier {
+        super::PerfTier::Low => PixelateSettings {
+            pixel_size: 3.0,
+            highlight_strength: 0.0,
+            shadow_strength: 0.0,
+            color_noise: 0.0,
+            ..PixelateSettings::default()
+        },
+        _ => PixelateSettings::default(),
+    };
     for entity in &display_query {
-        commands.entity(entity).insert(PixelateSettings::default());
+        commands.entity(entity).insert(settings);
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/game/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/mod.rs
@@ -32,7 +32,7 @@ pub mod water;
 pub mod weather;
 
 use bevy::app::{Plugin, PluginGroup, PluginGroupBuilder};
-use bevy::prelude::Startup;
+use bevy::prelude::*;
 
 use actions::ActionsPlugin;
 use camera::IsometricCameraPlugin;
@@ -59,6 +59,56 @@ use virtual_joystick::VirtualJoystickPlugin;
 use water::WaterPlugin;
 use weather::WeatherPlugin;
 
+// ---------------------------------------------------------------------------
+// Performance tier — detected at startup, read by throttled systems
+// ---------------------------------------------------------------------------
+
+/// Performance tier used to scale system budgets per platform.
+///
+/// `High`   — desktop native (all effects at full rate).
+/// `Medium` — desktop WASM / powerful tablets.
+/// `Low`    — mobile phones (throttled wind, fewer colliders, coarser pixelate).
+#[derive(Resource, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PerfTier {
+    High,
+    Medium,
+    Low,
+}
+
+impl Default for PerfTier {
+    fn default() -> Self {
+        detect_perf_tier()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn detect_perf_tier() -> PerfTier {
+    PerfTier::High
+}
+
+#[cfg(target_arch = "wasm32")]
+fn detect_perf_tier() -> PerfTier {
+    let ua = web_sys::window()
+        .and_then(|w| w.navigator().user_agent().ok())
+        .unwrap_or_default()
+        .to_lowercase();
+    if ua.contains("android") || ua.contains("iphone") || ua.contains("ipad") {
+        PerfTier::Low
+    } else {
+        PerfTier::Medium
+    }
+}
+
+struct PerfTierPlugin;
+
+impl Plugin for PerfTierPlugin {
+    fn build(&self, app: &mut bevy::app::App) {
+        let tier = PerfTier::default();
+        info!("[perf] detected tier: {:?}", tier);
+        app.insert_resource(tier);
+    }
+}
+
 /// Loads the baked itemdb at startup so ProtoItemKind can resolve display names.
 struct ItemDbLoaderPlugin;
 
@@ -75,6 +125,8 @@ pub struct GamePluginGroup;
 impl PluginGroup for GamePluginGroup {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
+            // Performance tier detection — must be first so other plugins can read it
+            .add(PerfTierPlugin)
             // Database must be first — persist plugin reads cached state at startup
             .add(bevy_db::BevyDbPlugin::default())
             // Phase must be early — other plugins depend on GamePhase state

--- a/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
@@ -1825,6 +1825,7 @@ fn process_chunk_spawns_and_despawns(
     player_query: Query<&Transform, With<Player>>,
     collected_tiles: Res<CollectedTiles>,
     terrain_ready: Option<Res<TerrainReady>>,
+    perf_tier: Res<super::PerfTier>,
 ) {
     let Some(tile_materials) = tile_materials else {
         return;
@@ -1924,11 +1925,13 @@ fn process_chunk_spawns_and_despawns(
     // Sort near chunks first so they get priority.
     results.sort_by_key(|g| if g.is_near { 0i32 } else { 1 });
 
-    // With pthreads, workers produce results faster — increase finalization budget.
-    #[cfg(target_arch = "wasm32")]
-    const MAX_DISTANT_FINALIZES: usize = 4;
-    #[cfg(not(target_arch = "wasm32"))]
-    const MAX_DISTANT_FINALIZES: usize = 8;
+    // Finalization budget: each chunk spawns dozens of entities + colliders.
+    // On mobile WASM, limit to 1 distant chunk per frame to avoid frame spikes.
+    let max_distant_finalizes: usize = match *perf_tier {
+        super::PerfTier::Low => 1,
+        super::PerfTier::Medium => 2,
+        super::PerfTier::High => 8,
+    };
 
     let mut far_finalized = 0usize;
     let mut had_near = false;
@@ -1943,7 +1946,7 @@ fn process_chunk_spawns_and_despawns(
 
         if !geometry.is_near {
             far_finalized += 1;
-            if far_finalized > MAX_DISTANT_FINALIZES {
+            if far_finalized > max_distant_finalizes {
                 // Re-queue for next frame via the channel.
                 let _ = chunk_channel.tx.send(geometry);
                 continue;
@@ -2132,23 +2135,30 @@ fn process_chunk_spawns_and_despawns(
                         8 => FlowerArchetype::Allium,
                         _ => FlowerArchetype::BlueOrchid,
                     };
-                    let flower_entity = commands
-                        .spawn((
-                            Mesh3d(tile_materials.flower_meshes[arch_idx].clone()),
-                            MeshMaterial3d(tile_materials.flower_mat.clone()),
-                            Transform::from_xyz(world_x, flower_y, world_z),
+                    let mut flower_cmd = commands.spawn((
+                        Mesh3d(tile_materials.flower_meshes[arch_idx].clone()),
+                        MeshMaterial3d(tile_materials.flower_mat.clone()),
+                        Transform::from_xyz(world_x, flower_y, world_z),
+                        HoverOutline {
+                            half_extents: Vec3::new(0.2, 0.25, 0.2),
+                        },
+                        Interactable {
+                            kind: InteractableKind::Flower,
+                        },
+                        archetype,
+                        TileCoord { tx, tz },
+                    ));
+                    // Only add physics colliders on High tier (desktop native).
+                    // WASM hover uses tile-based HoverMap, not avian3d raycasts,
+                    // so sensor colliders are pure overhead on the physics broadphase.
+                    if *perf_tier == super::PerfTier::High {
+                        flower_cmd.insert((
                             RigidBody::Static,
                             Collider::cuboid(0.4, 0.5, 0.4),
                             Sensor,
-                            HoverOutline {
-                                half_extents: Vec3::new(0.2, 0.25, 0.2),
-                            },
-                            Interactable {
-                                kind: InteractableKind::Flower,
-                            },
-                            archetype,
-                            TileCoord { tx, tz },
-                        ))
+                        ));
+                    }
+                    let flower_entity = flower_cmd
                         .observe(on_pointer_over)
                         .observe(on_pointer_out)
                         .id();
@@ -2166,24 +2176,28 @@ fn process_chunk_spawns_and_despawns(
                     let params = mushrooms::MushroomParams { tx, tz, kind };
                     let (mush_mesh, max_hw, total_h) =
                         mushrooms::build_mushroom(&params, &mut meshes);
-                    let mush_entity = commands
-                        .spawn((
-                            Mesh3d(mush_mesh),
-                            MeshMaterial3d(tile_materials.tree_body_mat.clone()),
-                            Transform::from_xyz(world_x, mush_y, world_z)
-                                .with_rotation(Quat::from_rotation_y(rot_y)),
+                    let mut mush_cmd = commands.spawn((
+                        Mesh3d(mush_mesh),
+                        MeshMaterial3d(tile_materials.tree_body_mat.clone()),
+                        Transform::from_xyz(world_x, mush_y, world_z)
+                            .with_rotation(Quat::from_rotation_y(rot_y)),
+                        HoverOutline {
+                            half_extents: Vec3::new(max_hw, total_h / 2.0, max_hw),
+                        },
+                        Interactable {
+                            kind: InteractableKind::Mushroom,
+                        },
+                        kind,
+                        TileCoord { tx, tz },
+                    ));
+                    if *perf_tier == super::PerfTier::High {
+                        mush_cmd.insert((
                             RigidBody::Static,
                             Collider::cuboid(max_hw * 1.6, total_h, max_hw * 1.6),
                             Sensor,
-                            HoverOutline {
-                                half_extents: Vec3::new(max_hw, total_h / 2.0, max_hw),
-                            },
-                            Interactable {
-                                kind: InteractableKind::Mushroom,
-                            },
-                            kind,
-                            TileCoord { tx, tz },
-                        ))
+                        ));
+                    }
+                    let mush_entity = mush_cmd
                         .observe(on_pointer_over)
                         .observe(on_pointer_out)
                         .id();

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -211,6 +211,20 @@ fn build_streak_mesh() -> Mesh {
 }
 
 // ---------------------------------------------------------------------------
+// Throttle timers (used on Low/Medium perf tiers)
+// ---------------------------------------------------------------------------
+
+/// Throttle timer for wind animation systems. On Low tier, wind updates at
+/// ~15 Hz instead of every frame — saves hundreds of sin/cos calls per tick.
+#[derive(Resource)]
+pub struct WindAnimThrottle(pub Timer);
+
+/// Throttle timer for blob shadow position updates. On Low tier, shadows
+/// update at ~10 Hz — shadows follow the sun angle which changes very slowly.
+#[derive(Resource)]
+pub struct ShadowUpdateThrottle(pub Timer);
+
+// ---------------------------------------------------------------------------
 // Systems
 // ---------------------------------------------------------------------------
 
@@ -324,9 +338,15 @@ fn stabilize_shadow_cascades(
 /// Shadow offset = light direction projected onto ground plane, scaled by object height.
 /// Shadow also stretches along the light direction for a natural elongated look.
 fn update_blob_shadows(
+    time: Res<Time>,
+    mut throttle: ResMut<ShadowUpdateThrottle>,
     light_query: Query<&GlobalTransform, With<DirectionalLight>>,
     mut shadow_query: Query<(&mut Transform, &BlobShadow)>,
 ) {
+    throttle.0.tick(time.delta());
+    if !throttle.0.just_finished() {
+        return;
+    }
     let Ok(light_gt) = light_query.single() else {
         return;
     };
@@ -475,8 +495,14 @@ fn sync_game_time(
 fn animate_veg_wind(
     time: Res<Time>,
     wind: Res<WindState>,
+    mut throttle: ResMut<WindAnimThrottle>,
     mut query: Query<(&mut Transform, &WindSway)>,
 ) {
+    throttle.0.tick(time.delta());
+    if !throttle.0.just_finished() {
+        return;
+    }
+
     let t = time.elapsed_secs();
     let spd = wind.speed_mph;
     if spd < 0.5 {
@@ -502,8 +528,15 @@ fn animate_veg_wind(
 fn animate_tree_wind(
     time: Res<Time>,
     wind: Res<WindState>,
+    throttle: Res<WindAnimThrottle>,
     mut query: Query<(&mut Transform, &TreeWindSway)>,
 ) {
+    // Share the same throttle cadence as vegetation wind — the timer was
+    // already ticked by animate_veg_wind which runs in the same system set.
+    if !throttle.0.just_finished() {
+        return;
+    }
+
     let t = time.elapsed_secs();
     let spd = wind.speed_mph;
     if spd < 0.5 {
@@ -663,6 +696,33 @@ impl Plugin for WeatherPlugin {
         app.init_resource::<DayCycle>();
         app.init_resource::<WindState>();
         app.init_resource::<WindStreakPool>();
+
+        // Throttle timers — interval depends on perf tier.
+        // High = every frame (essentially no throttle), Low = reduced Hz.
+        let tier = app
+            .world()
+            .get_resource::<super::PerfTier>()
+            .copied()
+            .unwrap_or(super::PerfTier::High);
+        let wind_interval = match tier {
+            super::PerfTier::Low => 1.0 / 15.0,    // 15 Hz
+            super::PerfTier::Medium => 1.0 / 30.0, // 30 Hz
+            super::PerfTier::High => 0.0,          // every frame
+        };
+        let shadow_interval = match tier {
+            super::PerfTier::Low => 1.0 / 10.0,    // 10 Hz
+            super::PerfTier::Medium => 1.0 / 20.0, // 20 Hz
+            super::PerfTier::High => 0.0,          // every frame
+        };
+        app.insert_resource(WindAnimThrottle(Timer::from_seconds(
+            wind_interval,
+            TimerMode::Repeating,
+        )));
+        app.insert_resource(ShadowUpdateThrottle(Timer::from_seconds(
+            shadow_interval,
+            TimerMode::Repeating,
+        )));
+
         app.add_systems(Startup, (setup_weather, spawn_lighting));
         app.add_systems(
             Update,
@@ -675,7 +735,9 @@ impl Plugin for WeatherPlugin {
                     .run_if(resource_changed::<DayCycle>),
                 update_blob_shadows.run_if(any_with_component::<BlobShadow>),
                 animate_veg_wind.run_if(any_with_component::<WindSway>),
-                animate_tree_wind.run_if(any_with_component::<TreeWindSway>),
+                animate_tree_wind
+                    .after(animate_veg_wind)
+                    .run_if(any_with_component::<TreeWindSway>),
                 spawn_wind_streaks.run_if(|pool: Res<WindStreakPool>| !pool.initialized),
                 animate_wind_streaks.run_if(any_with_component::<WindStreak>),
             ),


### PR DESCRIPTION
## Summary

- Adds `PerfTier` resource (High/Medium/Low) with automatic mobile detection via user agent
- Strips physics colliders from flowers and mushrooms on non-High tiers (~1000 fewer broadphase entries)
- Throttles wind animation (15 Hz) and blob shadow updates (10 Hz) on Low tier
- Reduces distant chunk finalization budget from 4 to 1 per frame on mobile
- Coarsens pixelate post-process and disables edge detection on Low tier

Desktop native behavior is unchanged (High tier = no throttling).

## Test plan

- [ ] Build WASM and verify mobile detection sets Low tier (check console for `[perf] detected tier: Low`)
- [ ] Verify desktop browser stays at Medium tier with full wind/shadow animation
- [ ] Confirm flowers and mushrooms are still visible and interactable on WASM (hover via HoverMap)
- [ ] Check chunk loading doesn't stall on mobile (1 distant finalize/frame should still keep up)
- [ ] Verify native desktop build compiles and runs without regression