### PR TITLE
perf(isometric): merge rock/mushroom meshes into per-chunk draw calls

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/mushrooms.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/mushrooms.rs
@@ -442,6 +442,163 @@ pub fn build_mushroom(
     (mesh_handle, max_hw, total_h)
 }
 
+/// Generate mushroom vertices in world space and push them into the provided
+/// raw buffers. Used by `compute_chunk_geometry` to merge mushrooms into a
+/// per-chunk mesh (single draw call).
+///
+/// Returns `(max_half_width, total_height)` for interaction bounding boxes.
+pub fn push_mushroom_vertices(
+    params: &MushroomParams,
+    world_x: f32,
+    world_z: f32,
+    mush_y: f32,
+    rot_y: f32,
+    positions: &mut Vec<[f32; 3]>,
+    normals: &mut Vec<[f32; 3]>,
+    colors: &mut Vec<[f32; 4]>,
+    indices: &mut Vec<u32>,
+) -> (f32, f32) {
+    let seed_base = params.tx * 31337 + params.tz * 21493;
+    let size = 0.12 + hash2d(seed_base + 100, 9100) * 0.14;
+    let bright = 0.88 + hash2d(seed_base + 200, 9200) * 0.24;
+    let hj = (hash2d(seed_base + 201, 9201) - 0.5) * 0.05;
+    let jitter = |c: &(f32, f32, f32)| -> (f32, f32, f32) {
+        (
+            ((c.0 + hj) * bright).clamp(0.0, 1.0),
+            ((c.1 + hj * 0.3) * bright).clamp(0.0, 1.0),
+            ((c.2 - hj * 0.5) * bright).clamp(0.0, 1.0),
+        )
+    };
+
+    let mut lp = Vec::with_capacity(128);
+    let mut ln = Vec::with_capacity(128);
+    let mut lc = Vec::with_capacity(128);
+    let mut li = Vec::with_capacity(256);
+
+    let (max_hw, total_h) = match params.kind {
+        MushroomKind::Porcini => {
+            let pal = &PORCINI_CAP;
+            let hl = jitter(&pal[0]);
+            let md = jitter(&pal[1]);
+            let sh = jitter(&pal[2]);
+            let st = jitter(&PORCINI_STEM);
+            let cap_rx = size * 1.3;
+            let cap_ry = size * 0.7;
+            let cap_rz = size * 1.2;
+            let stem_r = size * 0.35;
+            let stem_h = size * 0.8;
+            push_stem(
+                &mut lp,
+                &mut ln,
+                &mut lc,
+                &mut li,
+                Vec3::ZERO,
+                stem_r,
+                stem_h,
+                srgb_color(st.0, st.1, st.2),
+            );
+            push_dome_cap(
+                &mut lp,
+                &mut ln,
+                &mut lc,
+                &mut li,
+                Vec3::new(0.0, stem_h, 0.0),
+                cap_rx,
+                cap_ry,
+                cap_rz,
+                srgb_color(hl.0, hl.1, hl.2),
+                srgb_color(md.0, md.1, md.2),
+                srgb_color(sh.0, sh.1, sh.2),
+                None,
+                0.0,
+            );
+            (cap_rx.max(cap_rz), stem_h + cap_ry)
+        }
+        MushroomKind::Chanterelle => {
+            let pal = &CHANTERELLE_CAP;
+            let hl = jitter(&pal[0]);
+            let md = jitter(&pal[1]);
+            let sh = jitter(&pal[2]);
+            let bot_r = size * 0.25;
+            let top_r = size * 1.4;
+            let height = size * 1.6;
+            push_funnel(
+                &mut lp,
+                &mut ln,
+                &mut lc,
+                &mut li,
+                Vec3::ZERO,
+                bot_r,
+                top_r,
+                height,
+                srgb_color(hl.0, hl.1, hl.2),
+                srgb_color(md.0, md.1, md.2),
+                srgb_color(sh.0, sh.1, sh.2),
+            );
+            (top_r, height)
+        }
+        MushroomKind::FlyAgaric => {
+            let pal = &FLY_AGARIC_CAP;
+            let hl = jitter(&pal[0]);
+            let md = jitter(&pal[1]);
+            let sh = jitter(&pal[2]);
+            let sp = jitter(&FLY_AGARIC_SPOT);
+            let st = jitter(&FLY_AGARIC_STEM);
+            let cap_rx = size * 1.2;
+            let cap_ry = size * 0.55;
+            let cap_rz = size * 1.15;
+            let stem_r = size * 0.28;
+            let stem_h = size * 1.1;
+            push_stem(
+                &mut lp,
+                &mut ln,
+                &mut lc,
+                &mut li,
+                Vec3::ZERO,
+                stem_r,
+                stem_h,
+                srgb_color(st.0, st.1, st.2),
+            );
+            push_dome_cap(
+                &mut lp,
+                &mut ln,
+                &mut lc,
+                &mut li,
+                Vec3::new(0.0, stem_h, 0.0),
+                cap_rx,
+                cap_ry,
+                cap_rz,
+                srgb_color(hl.0, hl.1, hl.2),
+                srgb_color(md.0, md.1, md.2),
+                srgb_color(sh.0, sh.1, sh.2),
+                Some(srgb_color(sp.0, sp.1, sp.2)),
+                seed_base as f32,
+            );
+            (cap_rx.max(cap_rz), stem_h + cap_ry)
+        }
+    };
+
+    // Transform to world space: rotate by rot_y then translate.
+    let (sin_r, cos_r) = rot_y.sin_cos();
+    let base_idx = positions.len() as u32;
+    for p in &lp {
+        let rx = p[0] * cos_r - p[2] * sin_r;
+        let rz = p[0] * sin_r + p[2] * cos_r;
+        positions.push([world_x + rx, mush_y + p[1], world_z + rz]);
+    }
+    for n in &ln {
+        let rx = n[0] * cos_r - n[2] * sin_r;
+        let rz = n[0] * sin_r + n[2] * cos_r;
+        normals.push([rx, n[1], rz]);
+    }
+    colors.extend_from_slice(&lc);
+    for i in &li {
+        indices.push(base_idx + i);
+    }
+
+    (max_hw, total_h)
+}
+
 /// Determine mushroom kind from tile hash.
 pub fn mushroom_kind_from_hash(tx: i32, tz: i32) -> MushroomKind {
     let v = hash2d(tx + 25001, tz + 18001);

--- a/apps/kbve/isometric/src-tauri/src/game/rocks.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/rocks.rs
@@ -342,6 +342,160 @@ pub fn build_rock(
     (mesh_handle, max_hw, total_h)
 }
 
+/// Generate rock vertices in world space and push them into the provided raw
+/// buffers. Used by `compute_chunk_geometry` to merge rocks into a per-chunk
+/// mesh (single draw call). Applies position offset + Y-axis rotation directly
+/// to the vertex positions.
+///
+/// Returns `(max_half_width, total_height)` for interaction bounding boxes.
+pub fn push_rock_vertices(
+    params: &RockParams,
+    rot_y: f32,
+    positions: &mut Vec<[f32; 3]>,
+    normals: &mut Vec<[f32; 3]>,
+    colors: &mut Vec<[f32; 4]>,
+    indices: &mut Vec<u32>,
+) -> (f32, f32) {
+    let seed_base = params.tx * 27449 + params.tz * 19237;
+    let size = 0.25 + hash2d(seed_base + 100, 8100) * 0.35;
+
+    let (base_palette, ore_accent) = match params.kind {
+        RockKind::MossyRock => (&MOSSY_PALETTE, None),
+        RockKind::OreCopper => (&STONE_PALETTE, Some(ORE_COPPER_ACCENT)),
+        RockKind::OreIron => (&STONE_PALETTE, Some(ORE_IRON_ACCENT)),
+        RockKind::OreCrystal => (&STONE_PALETTE, Some(ORE_CRYSTAL_ACCENT)),
+        _ => (&STONE_PALETTE, None),
+    };
+
+    let bright = 0.85 + hash2d(seed_base + 200, 8200) * 0.30;
+    let hj = (hash2d(seed_base + 201, 8201) - 0.5) * 0.06;
+    let jitter = |c: &(f32, f32, f32)| -> (f32, f32, f32) {
+        (
+            ((c.0 + hj) * bright).clamp(0.0, 1.0),
+            ((c.1 + hj * 0.3) * bright).clamp(0.0, 1.0),
+            ((c.2 - hj * 0.5) * bright).clamp(0.0, 1.0),
+        )
+    };
+
+    let hl = jitter(&base_palette[0]);
+    let md = jitter(&base_palette[1]);
+    let sh = jitter(&base_palette[2]);
+    let c_top = srgb_color(hl.0, hl.1, hl.2);
+    let c_mid = srgb_color(md.0, md.1, md.2);
+    let c_shadow = srgb_color(sh.0, sh.1, sh.2);
+
+    // Generate into local buffers first, then rotate + translate into output.
+    let mut lp = Vec::with_capacity(256);
+    let mut ln = Vec::with_capacity(256);
+    let mut lc = Vec::with_capacity(256);
+    let mut li = Vec::with_capacity(512);
+
+    let jit_sx = 0.80 + hash2d(seed_base + 300, 8300) * 0.40;
+    let jit_sz = 0.80 + hash2d(seed_base + 301, 8301) * 0.40;
+
+    let main_rx = size * 1.2 * jit_sx;
+    let main_ry = size * 0.55;
+    let main_rz = size * 1.1 * jit_sz;
+    push_rock_dome(
+        &mut lp,
+        &mut ln,
+        &mut lc,
+        &mut li,
+        Vec3::ZERO,
+        main_rx,
+        main_ry,
+        main_rz,
+        c_top,
+        c_mid,
+        c_shadow,
+    );
+
+    let mut max_hw = main_rx.max(main_rz);
+    let mut total_h = main_ry;
+
+    let bump_count = 1 + (hash2d(seed_base + 400, 8400) * 2.99) as i32;
+    for bi in 0..bump_count {
+        let bi_seed = seed_base + 500 + bi * 157;
+        let angle = hash2d(bi_seed + 1, 8501) * std::f32::consts::TAU;
+        let dist = main_rx * (0.30 + hash2d(bi_seed + 2, 8502) * 0.25);
+        let bx = angle.cos() * dist;
+        let bz = angle.sin() * dist;
+        let by = main_ry * (-0.10 + hash2d(bi_seed + 3, 8503) * 0.30);
+        let b_size = 0.45 + hash2d(bi_seed + 4, 8504) * 0.30;
+        let b_rx = main_rx * b_size * jit_sx;
+        let b_rz = main_rz * b_size * jit_sz;
+        let b_ry = main_ry * b_size * 0.70;
+        let (bt, bm, bb) = if hash2d(bi_seed + 5, 8505) < 0.5 {
+            (c_top, c_mid, c_shadow)
+        } else {
+            (c_mid, c_shadow, c_shadow)
+        };
+        push_rock_dome(
+            &mut lp,
+            &mut ln,
+            &mut lc,
+            &mut li,
+            Vec3::new(bx, by, bz),
+            b_rx,
+            b_ry,
+            b_rz,
+            bt,
+            bm,
+            bb,
+        );
+        max_hw = max_hw.max(bx.abs() + b_rx.max(b_rz));
+        total_h = total_h.max(by + b_ry);
+    }
+
+    if let Some(accent) = ore_accent {
+        let a = jitter(&accent);
+        let c_ore = srgb_color(a.0, a.1, a.2);
+        let c_ore_dark = srgb_color(a.0 * 0.65, a.1 * 0.65, a.2 * 0.65);
+        let ore_angle = hash2d(seed_base + 700, 8700) * std::f32::consts::TAU;
+        let ore_dist = main_rx * 0.50;
+        let ox = ore_angle.cos() * ore_dist;
+        let oz = ore_angle.sin() * ore_dist;
+        let oy = main_ry * 0.20;
+        push_rock_dome(
+            &mut lp,
+            &mut ln,
+            &mut lc,
+            &mut li,
+            Vec3::new(ox, oy, oz),
+            main_rx * 0.30,
+            main_ry * 0.35,
+            main_rz * 0.28,
+            c_ore,
+            c_ore,
+            c_ore_dark,
+        );
+    }
+
+    // Transform local vertices to world space: rotate by rot_y then translate.
+    let (sin_r, cos_r) = rot_y.sin_cos();
+    let base_idx = positions.len() as u32;
+    for p in &lp {
+        let rx = p[0] * cos_r - p[2] * sin_r;
+        let rz = p[0] * sin_r + p[2] * cos_r;
+        positions.push([
+            params.world_x + rx,
+            params.base_y + p[1],
+            params.world_z + rz,
+        ]);
+    }
+    for n in &ln {
+        let rx = n[0] * cos_r - n[2] * sin_r;
+        let rz = n[0] * sin_r + n[2] * cos_r;
+        normals.push([rx, n[1], rz]);
+    }
+    colors.extend_from_slice(&lc);
+    for i in &li {
+        indices.push(base_idx + i);
+    }
+
+    (max_hw, total_h)
+}
+
 /// Determine what kind of rock to spawn based on tile hash.
 pub fn rock_kind_from_hash(tx: i32, tz: i32) -> RockKind {
     let v = hash2d(tx + 20001, tz + 15001);

--- a/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/tilemap.rs
@@ -1298,22 +1298,14 @@ struct RawMeshDataUV {
 }
 
 /// Vegetation spawn decision (computed off-thread, materialized on main thread).
+/// Rocks and mushrooms are merged into per-chunk meshes — only trees and
+/// flowers remain as individual entity spawns.
 #[allow(dead_code)]
 enum VegetationSpawn {
     Tree {
         tx: i32,
         tz: i32,
         column_h: f32,
-    },
-    Rock {
-        tx: i32,
-        tz: i32,
-        column_h: f32,
-        world_x: f32,
-        world_z: f32,
-        rock_y: f32,
-        rot_y: f32,
-        kind: RockKind,
     },
     Flower {
         tx: i32,
@@ -1323,15 +1315,31 @@ enum VegetationSpawn {
         world_z: f32,
         flower_y: f32,
     },
-    Mushroom {
-        tx: i32,
-        tz: i32,
-        world_x: f32,
-        world_z: f32,
-        mush_y: f32,
-        rot_y: f32,
-        kind: MushroomKind,
-    },
+}
+
+/// Interaction metadata for a rock whose mesh is merged into the chunk.
+/// Spawned as a lightweight invisible entity (no Mesh3d, no Collider).
+struct RockMeta {
+    tx: i32,
+    tz: i32,
+    world_x: f32,
+    world_z: f32,
+    rock_y: f32,
+    kind: RockKind,
+    max_hw: f32,
+    total_h: f32,
+}
+
+/// Interaction metadata for a mushroom whose mesh is merged into the chunk.
+struct MushroomMeta {
+    tx: i32,
+    tz: i32,
+    world_x: f32,
+    world_z: f32,
+    mush_y: f32,
+    kind: MushroomKind,
+    max_hw: f32,
+    total_h: f32,
 }
 
 /// Complete geometry for one chunk, computed off the main thread.
@@ -1343,9 +1351,17 @@ struct ChunkGeometry {
     cap: RawMeshData,
     grass: RawMeshDataUV,
     water: RawMeshData,
+    /// Merged rock mesh — all rocks in this chunk baked into one draw call.
+    rock_body: RawMeshData,
+    /// Merged mushroom mesh — all mushrooms baked into one draw call.
+    mushroom_body: RawMeshData,
     /// Collider sub-shapes: (position, full_extents) in chunk-local space.
     colliders: Vec<(Vec3, Vec3)>,
     vegetation: Vec<VegetationSpawn>,
+    /// Interaction metadata for merged rocks (lightweight entities, no mesh).
+    rock_metas: Vec<RockMeta>,
+    /// Interaction metadata for merged mushrooms.
+    mushroom_metas: Vec<MushroomMeta>,
 }
 
 /// Crossbeam MPSC channel for completed chunk geometries.
@@ -1406,8 +1422,12 @@ fn compute_chunk_geometry(
     };
     let mut grass = RawMeshDataUV::default();
     let mut water = RawMeshData::default();
+    let mut rock_body = RawMeshData::default();
+    let mut mushroom_body = RawMeshData::default();
     let mut colliders: Vec<(Vec3, Vec3)> = Vec::with_capacity(tile_count);
     let mut vegetation = Vec::new();
+    let mut rock_metas = Vec::new();
+    let mut mushroom_metas = Vec::new();
 
     for dx in 0..CHUNK_SIZE {
         for dz in 0..CHUNK_SIZE {
@@ -1555,7 +1575,7 @@ fn compute_chunk_geometry(
                     }
                 }
 
-                // Rocks
+                // Rocks — merge vertices into per-chunk mesh
                 if !tile_occupied {
                     let rock_noise = hash2d(tx + 19457, tz + 12391);
                     if rock_noise < 0.025 {
@@ -1573,15 +1593,31 @@ fn compute_chunk_geometry(
                             let kind = rocks::rock_kind_from_hash(tx, tz);
                             let rot_y =
                                 hash2d(tx * 8311 + 2477, tz * 7193 + 3319) * std::f32::consts::TAU;
-                            vegetation.push(VegetationSpawn::Rock {
+                            let params = rocks::RockParams {
+                                world_x,
+                                world_z,
+                                base_y: rock_y,
+                                kind,
                                 tx,
                                 tz,
-                                column_h,
+                            };
+                            let (max_hw, total_h) = rocks::push_rock_vertices(
+                                &params,
+                                rot_y,
+                                &mut rock_body.positions,
+                                &mut rock_body.normals,
+                                &mut rock_body.colors,
+                                &mut rock_body.indices,
+                            );
+                            rock_metas.push(RockMeta {
+                                tx,
+                                tz,
                                 world_x,
                                 world_z,
                                 rock_y,
-                                rot_y,
                                 kind,
+                                max_hw,
+                                total_h,
                             });
                         }
                     }
@@ -1617,7 +1653,7 @@ fn compute_chunk_geometry(
                     }
                 }
 
-                // Mushrooms
+                // Mushrooms — merge vertices into per-chunk mesh
                 if !tile_occupied {
                     let mush_noise = hash2d(tx + 23017, tz + 17293);
                     if mush_noise < 0.04 {
@@ -1634,14 +1670,27 @@ fn compute_chunk_geometry(
                             let kind = mushrooms::mushroom_kind_from_hash(tx, tz);
                             let rot_y =
                                 hash2d(tx * 9311 + 3477, tz * 8193 + 4319) * std::f32::consts::TAU;
-                            vegetation.push(VegetationSpawn::Mushroom {
+                            let params = mushrooms::MushroomParams { tx, tz, kind };
+                            let (max_hw, total_h) = mushrooms::push_mushroom_vertices(
+                                &params,
+                                world_x,
+                                world_z,
+                                mush_y,
+                                rot_y,
+                                &mut mushroom_body.positions,
+                                &mut mushroom_body.normals,
+                                &mut mushroom_body.colors,
+                                &mut mushroom_body.indices,
+                            );
+                            mushroom_metas.push(MushroomMeta {
                                 tx,
                                 tz,
                                 world_x,
                                 world_z,
                                 mush_y,
-                                rot_y,
                                 kind,
+                                max_hw,
+                                total_h,
                             });
                         }
                     }
@@ -1658,8 +1707,12 @@ fn compute_chunk_geometry(
         cap,
         grass,
         water,
+        rock_body,
+        mushroom_body,
         colliders,
         vegetation,
+        rock_metas,
+        mushroom_metas,
     }
 }
 
@@ -2041,7 +2094,121 @@ fn process_chunk_spawns_and_despawns(
             entities.push(water_entity);
         }
 
-        // ── Vegetation entities (main-thread only — needs Commands) ────
+        // ── Merged rock mesh (single draw call per chunk) ──────────────
+        if !geometry.rock_body.positions.is_empty() {
+            let rock_mesh = meshes.add(build_chunk_mesh(
+                geometry.rock_body.positions,
+                geometry.rock_body.normals,
+                geometry.rock_body.colors,
+                geometry.rock_body.indices,
+            ));
+            let rock_mesh_entity = commands
+                .spawn((
+                    Mesh3d(rock_mesh),
+                    MeshMaterial3d(tile_materials.rock_body_mat.clone()),
+                    Transform::IDENTITY,
+                    Pickable::IGNORE,
+                ))
+                .id();
+            entities.push(rock_mesh_entity);
+        }
+
+        // Lightweight interaction entities for each rock (no mesh, no collider).
+        for rm in geometry.rock_metas {
+            let mut rock_cmd = commands.spawn((
+                Transform::from_xyz(rm.world_x, rm.rock_y, rm.world_z),
+                Visibility::Hidden,
+                HoverOutline {
+                    half_extents: Vec3::new(rm.max_hw, rm.total_h / 2.0, rm.max_hw),
+                },
+                Interactable {
+                    kind: InteractableKind::Rock,
+                },
+                rm.kind,
+                TileCoord {
+                    tx: rm.tx,
+                    tz: rm.tz,
+                },
+            ));
+            if *perf_tier == super::PerfTier::High {
+                rock_cmd.insert((
+                    RigidBody::Static,
+                    Collider::cuboid(rm.max_hw * 1.6, rm.total_h, rm.max_hw * 1.6),
+                ));
+            }
+            let rock_entity = rock_cmd
+                .observe(on_pointer_over)
+                .observe(on_pointer_out)
+                .id();
+            entities.push(rock_entity);
+
+            let shadow_entity = commands
+                .spawn((
+                    Mesh3d(blob_shadow.mesh.clone()),
+                    MeshMaterial3d(blob_shadow.material.clone()),
+                    Transform::from_xyz(rm.world_x, rm.rock_y + 0.001, rm.world_z),
+                    BlobShadow {
+                        anchor: Vec3::new(rm.world_x, rm.rock_y + 0.001, rm.world_z),
+                        radius: rm.max_hw * 1.4,
+                        object_height: rm.total_h,
+                    },
+                    Pickable::IGNORE,
+                ))
+                .id();
+            entities.push(shadow_entity);
+        }
+
+        // ── Merged mushroom mesh (single draw call per chunk) ─────────
+        if !geometry.mushroom_body.positions.is_empty() {
+            let mush_mesh = meshes.add(build_chunk_mesh(
+                geometry.mushroom_body.positions,
+                geometry.mushroom_body.normals,
+                geometry.mushroom_body.colors,
+                geometry.mushroom_body.indices,
+            ));
+            let mush_mesh_entity = commands
+                .spawn((
+                    Mesh3d(mush_mesh),
+                    MeshMaterial3d(tile_materials.tree_body_mat.clone()),
+                    Transform::IDENTITY,
+                    Pickable::IGNORE,
+                ))
+                .id();
+            entities.push(mush_mesh_entity);
+        }
+
+        // Lightweight interaction entities for each mushroom.
+        for mm in geometry.mushroom_metas {
+            let mut mush_cmd = commands.spawn((
+                Transform::from_xyz(mm.world_x, mm.mush_y, mm.world_z),
+                Visibility::Hidden,
+                HoverOutline {
+                    half_extents: Vec3::new(mm.max_hw, mm.total_h / 2.0, mm.max_hw),
+                },
+                Interactable {
+                    kind: InteractableKind::Mushroom,
+                },
+                mm.kind,
+                TileCoord {
+                    tx: mm.tx,
+                    tz: mm.tz,
+                },
+            ));
+            if *perf_tier == super::PerfTier::High {
+                mush_cmd.insert((
+                    RigidBody::Static,
+                    Collider::cuboid(mm.max_hw * 1.6, mm.total_h, mm.max_hw * 1.6),
+                    Sensor,
+                ));
+            }
+            let mush_entity = mush_cmd
+                .observe(on_pointer_over)
+                .observe(on_pointer_out)
+                .id();
+            entities.push(mush_entity);
+        }
+
+        // ── Vegetation entities (trees + flowers — still individual) ──
         for veg in geometry.vegetation {
             match veg {
                 VegetationSpawn::Tree { tx, tz, column_h } => {
@@ -2057,62 +2224,6 @@ fn process_chunk_spawns_and_despawns(
                     );
                     commands.entity(tree_entity).insert(TileCoord { tx, tz });
                     entities.push(tree_entity);
-                    entities.push(shadow_entity);
-                }
-                VegetationSpawn::Rock {
-                    tx,
-                    tz,
-                    column_h: _,
-                    world_x,
-                    world_z,
-                    rock_y,
-                    rot_y,
-                    kind,
-                } => {
-                    let params = rocks::RockParams {
-                        world_x,
-                        world_z,
-                        base_y: rock_y,
-                        kind,
-                        tx,
-                        tz,
-                    };
-                    let (rock_mesh, max_hw, total_h) = rocks::build_rock(&params, &mut meshes);
-                    let rock_entity = commands
-                        .spawn((
-                            Mesh3d(rock_mesh),
-                            MeshMaterial3d(tile_materials.rock_body_mat.clone()),
-                            Transform::from_xyz(world_x, rock_y, world_z)
-                                .with_rotation(Quat::from_rotation_y(rot_y)),
-                            RigidBody::Static,
-                            Collider::cuboid(max_hw * 1.6, total_h, max_hw * 1.6),
-                            HoverOutline {
-                                half_extents: Vec3::new(max_hw, total_h / 2.0, max_hw),
-                            },
-                            Interactable {
-                                kind: InteractableKind::Rock,
-                            },
-                            kind,
-                            TileCoord { tx, tz },
-                        ))
-                        .observe(on_pointer_over)
-                        .observe(on_pointer_out)
-                        .id();
-                    entities.push(rock_entity);
-
-                    let shadow_entity = commands
-                        .spawn((
-                            Mesh3d(blob_shadow.mesh.clone()),
-                            MeshMaterial3d(blob_shadow.material.clone()),
-                            Transform::from_xyz(world_x, rock_y + 0.001, world_z),
-                            BlobShadow {
-                                anchor: Vec3::new(world_x, rock_y + 0.001, world_z),
-                                radius: max_hw * 1.4,
-                                object_height: total_h,
-                            },
-                            Pickable::IGNORE,
-                        ))
-                        .id();
                     entities.push(shadow_entity);
                 }
                 VegetationSpawn::Flower {
@@ -2163,45 +2274,6 @@ fn process_chunk_spawns_and_despawns(
                         .observe(on_pointer_out)
                         .id();
                     entities.push(flower_entity);
-                }
-                VegetationSpawn::Mushroom {
-                    tx,
-                    tz,
-                    world_x,
-                    world_z,
-                    mush_y,
-                    rot_y,
-                    kind,
-                } => {
-                    let params = mushrooms::MushroomParams { tx, tz, kind };
-                    let (mush_mesh, max_hw, total_h) =
-                        mushrooms::build_mushroom(&params, &mut meshes);
-                    let mut mush_cmd = commands.spawn((
-                        Mesh3d(mush_mesh),
-                        MeshMaterial3d(tile_materials.tree_body_mat.clone()),
-                        Transform::from_xyz(world_x, mush_y, world_z)
-                            .with_rotation(Quat::from_rotation_y(rot_y)),
-                        HoverOutline {
-                            half_extents: Vec3::new(max_hw, total_h / 2.0, max_hw),
-                        },
-                        Interactable {
-                            kind: InteractableKind::Mushroom,
-                        },
-                        kind,
-                        TileCoord { tx, tz },
-                    ));
-                    if *perf_tier == super::PerfTier::High {
-                        mush_cmd.insert((
-                            RigidBody::Static,
-                            Collider::cuboid(max_hw * 1.6, total_h, max_hw * 1.6),
-                            Sensor,
-                        ));
-                    }
-                    let mush_entity = mush_cmd
-                        .observe(on_pointer_over)
-                        .observe(on_pointer_out)
-                        .id();
-                    entities.push(mush_entity);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Merges all rock and mushroom meshes into 2 per-chunk draw calls (was ~16 individual entities per chunk)
- Vertex generation moved off main thread into `compute_chunk_geometry` workers
- Lightweight invisible entities still spawned for interaction/collection (TileCoord + Interactable + HoverOutline)
- Rock blob shadows preserved

**Draw call reduction**: ~400 draw calls → ~50 across 25 loaded chunks (rocks + mushrooms only)

**Main-thread savings**: Procedural mesh generation (dome geometry, bump maps, ore veins) now runs on worker threads instead of blocking chunk finalization

## Test plan

- [ ] Verify rocks and mushrooms render identically (visual regression check)
- [ ] Test rock mining and mushroom foraging — collection flow should work unchanged
- [ ] Verify collected tiles are excluded on chunk reload (walk away and return)
- [ ] Check desktop hover detection still works on rocks/mushrooms (avian3d raycasts on High tier)
- [ ] Check WASM hover detection still works (HoverMap tile-based on Medium/Low tier)
- [ ] Compare frame times before/after with `FrameTimeDiagnosticsPlugin`