### PR TITLE
fix(dashboard): escape HTML-like tags in coverage report MDX

### DIFF
--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -469,7 +469,7 @@ jobs:
                       printf '%s\n' '  <TabItem label="Coverage">'
                       printf '\n'
                       printf '%s\n' '```'
-                      cat /tmp/coverage-report.txt
+                      sed 's/<\([/a-zA-Z]\)/\&lt;\1/g' /tmp/coverage-report.txt
                       printf '%s\n' '```'
                       printf '\n'
                       printf '%s\n' '  </TabItem>'

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/report.mdx
@@ -192,7 +192,7 @@ Error creating or updating pull request: Error: Unable to determine the referenc
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -204,7 +204,7 @@ Error creating issue comment: Error: API Error
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -231,7 +231,7 @@ Error sanitizing input: Error: Invalid port number. Port must be a number betwee
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -244,7 +244,7 @@ Error sanitizing input: Error: Port 443 is restricted and cannot be used.
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -257,7 +257,7 @@ Error sanitizing input: Error: Invalid container name. Container name must be al
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -270,7 +270,7 @@ Error sanitizing input: Error: Invalid container image name. Image name must be 
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -284,7 +284,7 @@ Error running Docker container: Error: Docker not found
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -299,7 +299,7 @@ Error sanitizing container name: Error: Invalid container name. Container name m
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -316,7 +316,7 @@ Error stopping Docker container: Error: Container not running
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -332,7 +332,7 @@ Error removing Docker container: Error: Remove failed
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:157:11
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:753:26
     at file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1636:20
-    at new Promise (<anonymous>)
+    at new Promise (&lt;anonymous>)
     at runWithTimeout (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1602:10)
     at runTest (file:///home/runner/_work/kbve/kbve/node_modules/@vitest/runner/dist/index.js:1309:12)
     at processTicksAndRejections (node:internal/process/task_queues:104:5)
@@ -398,15 +398,15 @@ All files          |   78.21 |    77.22 |   79.43 |   78.16 |
  ✓ src/lib/phaser/monsters/bird.spec.ts (9 tests) 22ms
  ✓ src/lib/phaser/player-controller.spec.ts (6 tests) 26ms
 stderr | src/lib/r3f/Stage.spec.tsx > Stage > should render a Canvas wrapper
-<ambientLight /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
-The tag <ambientLight> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.
-The tag <mesh> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.
+&lt;ambientLight /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
+The tag &lt;ambientLight> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.
+The tag &lt;mesh> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.
 
 stderr | src/lib/r3f/Stage.spec.tsx > Stage > should pass className to Canvas
-<ambientLight /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
+&lt;ambientLight /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
 
 stderr | src/lib/r3f/Stage.spec.tsx > Stage > should render children inside Canvas
-<ambientLight /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
+&lt;ambientLight /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
 
  ✓ src/lib/phaser/use-phaser.spec.tsx (3 tests) 57ms
  ✓ src/lib/r3f/use-game-loop.spec.tsx (3 tests) 26ms
@@ -458,10 +458,10 @@ All files          |    63.5 |    50.79 |   75.47 |   66.92 |
  ✓ src/lib/state/toasts.spec.ts (9 tests) 20ms
  ✓ src/lib/state/ui.spec.ts (16 tests) 21ms
 stdout | src/lib/droid.spec.ts > droid > should initialize and attach to window.kbve
-[DROID]: droid<T>
+[DROID]: droid&lt;T>
 
 stdout | src/lib/droid.spec.ts > droid > should initialize and attach to window.kbve
-[DROID]: Main<T>
+[DROID]: Main&lt;T>
 [DROID] Initializing workers...
 
 stdout | src/lib/droid.spec.ts > droid > should initialize and attach to window.kbve
@@ -477,7 +477,7 @@ stdout | src/lib/droid.spec.ts > droid > should initialize and attach to window.
 [KBVE] Global API ready
 
 stdout | src/lib/droid.spec.ts > droid > should initialize and attach to window.kbve
-[DROID]: droid<T> => await WorkerRefs + URLs
+[DROID]: droid&lt;T> => await WorkerRefs + URLs
 
  ✓ src/lib/droid.spec.ts (1 test) 259ms
 


### PR DESCRIPTION
## Summary
- Coverage output from vitest contains JSX-like tags (`<ambientLight />`, `<mesh>`) from React Three Fiber test stderr
- MDX v3 parses these as JSX even inside code fences when nested in `<TabItem>` components, breaking the Astro build
- Escapes HTML tag patterns (`<word`) in the `ci-dashboard.yml` sed pipeline so future daily syncs are safe
- Fixes the existing `report.mdx` content that was already broken

## Test plan
- [ ] Verify `astro-kbve:build` passes in CI
- [ ] Confirm next daily dashboard sync produces valid MDX