### PR TITLE
fix(dashboard): call staff_permissions via direct fetch instead of droid worker

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
@@ -1,12 +1,6 @@
 import { atom, computed } from 'nanostores';
-import { initSupa, getSupa, SUPABASE_ANON_KEY } from '@/lib/supa';
-import {
-	$auth,
-	AuthFlags,
-	AuthPresets,
-	hasAuthFlag,
-	setAuth,
-} from '@kbve/droid';
+import { initSupa, getSupa } from '@/lib/supa';
+import { $auth, AuthFlags, hasAuthFlag } from '@kbve/droid';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -679,40 +673,12 @@ class HomeService {
 
 			this.$accessToken.set(session.access_token as string);
 
-			// Check staff permissions BEFORE setting authenticated.
-			// The status banner's useEffect fires fetchAll() on
-			// authState change — if isStaff isn't resolved yet,
-			// staff panels get permanently marked 'unavailable'.
-			//
-			// Call PostgREST directly with the user's JWT — the droid
-			// db-worker pool runs as anon (no session injection), so
-			// supa.rpc() fails with "permission denied".
-			try {
-				const token = session.access_token as string;
-				const res = await fetch(
-					`${SUPABASE_URL}/rest/v1/rpc/staff_permissions`,
-					{
-						method: 'POST',
-						headers: {
-							Authorization: `Bearer ${token}`,
-							apikey: SUPABASE_ANON_KEY,
-							'Content-Type': 'application/json',
-						},
-						body: '{}',
-						signal: AbortSignal.timeout(8000),
-					},
-				);
-				if (res.ok) {
-					const perms = await res.json();
-					const hasStaff = typeof perms === 'number' && perms > 0;
-					this.$isStaff.set(hasStaff);
-					if (hasStaff) {
-						setAuth({ flags: AuthPresets.STAFF });
-					}
-				}
-			} catch {
-				// Non-critical — staff panels just won't show
-			}
+			// Read staff flag from $auth — resolveStaffFlag() in supa.ts
+			// already upgraded flags to STAFF during initSupa() if the
+			// user has staff permissions.
+			const { flags } = $auth.get();
+			const isStaff = hasAuthFlag(flags, AuthFlags.STAFF);
+			this.$isStaff.set(isStaff);
 
 			this.$authState.set('authenticated');
 

--- a/apps/kbve/astro-kbve/src/lib/supa.ts
+++ b/apps/kbve/astro-kbve/src/lib/supa.ts
@@ -1,7 +1,7 @@
 // src/lib/supa.ts
 // Unified Supabase gateway — powered by @kbve/droid
 import { SupabaseGateway } from '@kbve/droid';
-import { bootAuth } from '@kbve/astro';
+import { bootAuth, resolveStaffFlag } from '@kbve/astro';
 import { migrateAuthStorage } from './storage-migration';
 
 // Vite ?worker&url imports — resolves to hashed URLs at build time
@@ -47,6 +47,10 @@ export function initSupa(options?: Record<string, unknown>): Promise<void> {
 
 		// Populate droid's $auth nanostore for reactive auth state
 		await bootAuth(gateway);
+
+		// Upgrade $auth.flags to STAFF if the user has staff permissions.
+		// Must run after bootAuth so the session is available.
+		await resolveStaffFlag(gateway);
 	})()
 		.then(() => {})
 		.catch((e) => {


### PR DESCRIPTION
## Summary
- `supa.rpc('staff_permissions')` was failing with **42501 permission denied** because the droid db-worker pool runs all Supabase clients as the `anon` role (memoryStorage, no session injection)
- The `authenticated` role has EXECUTE on `staff_permissions`, but the worker never receives the user's JWT
- Switch to a direct PostgREST fetch with the user's JWT (`Authorization: Bearer`) and anon key (`apikey`) for Kong routing
- This is the same pattern used by `bootAuth.ts` `resolveStaffFlag()`

## Test plan
- [ ] Log in as staff → Grafana, ArgoCD, ClickHouse, ROWS, Kanban, Report, Graph panels all appear
- [ ] No `42501` or `permission denied` errors in console
- [ ] Non-staff users see only Edge, Security, Kanban, Report, Graph