### PR TITLE
fix(firecracker): write entrypoint to code block device instead of kernel cmdline

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -77,7 +77,7 @@ spec:
 
                               # Init script — mounts filesystems, reads code from /dev/vdb,
                               # parses entrypoint from kernel cmdline, and executes.
-                              printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nmkdir -p /tmp\nENTRYPOINT="/bin/sh"\nfor param in $(cat /proc/cmdline); do\n  case "$param" in\n    fc_entrypoint=*) ENTRYPOINT="${param#fc_entrypoint=}" ;;\n  esac\ndone\nif [ -b /dev/vdb ]; then\n  dd if=/dev/vdb bs=4096 2>/dev/null | tr -d \"\\\\0\" > /tmp/code\n  exec $ENTRYPOINT /tmp/code\nelse\n  exec /bin/sh\nfi\n' > "${ROOTFS}/init"
+                              printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nmkdir -p /tmp\nif [ -b /dev/vdb ]; then\n  dd if=/dev/vdb bs=4096 2>/dev/null | tr -d \"\\\\0\" > /tmp/code\n  chmod +x /tmp/code\n  exec sh /tmp/code\nfi\nexec /bin/sh\n' > "${ROOTFS}/init"
                               chmod +x "${ROOTFS}/init"
 
                               # Create sparse ext4 image and populate from rootfs directory

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -237,12 +237,15 @@ async fn run_vm_lifecycle(
 
     // Write user code to a raw block file that the VM reads from /dev/vdb.
     // Padded to 512-byte boundary so Firecracker accepts it as a drive.
+    // If CODE env var is set (IDE mode), use that; otherwise fall back
+    // to the entrypoint string (dashboard presets).
     let code_path = format!("{}/{}.code", scratch_dir, vm_id);
     let code = req
         .env
         .get("CODE")
         .and_then(|v| v.as_str())
-        .unwrap_or("")
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&req.entrypoint)
         .to_string();
     {
         let mut buf = code.as_bytes().to_vec();


### PR DESCRIPTION
## Summary
Two bugs caused every dashboard preset script to timeout at 15s:

1. **Kernel cmdline splitting** — entrypoint passed as `fc_entrypoint=uname -a && cat /proc/cpuinfo` in boot_args, but the kernel cmdline is space-delimited. The init script's `for param in $(cat /proc/cmdline)` only captured `fc_entrypoint=uname` — the rest were lost.

2. **No shell evaluation** — init did `exec $ENTRYPOINT /tmp/code` which treated the string as a program name + args, not shell syntax. Operators like `&&` and `|` were never interpreted.

**Fix:**
- `main.rs`: Always write entrypoint to the `/dev/vdb` code block device (fall back from `CODE` env var)
- Init script: Simply `exec sh /tmp/code` — no kernel cmdline parsing needed
- Works for both dashboard presets (entrypoint string) and IDE mode (CODE env var)

## Test plan
- [ ] Run "System Info" preset → completes in <2s with uname/cpuinfo/free output
- [ ] Run "Python Hello" preset → prints Python version
- [ ] Run IDE mode with CODE env var → executes multi-line script
- [ ] Timeout still works for long-running scripts