### PR TITLE
fix(astro): export resolveStaffFlag from package entry

### DIFF
--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -21,6 +21,7 @@ export {
 	AuthBridge,
 	useAuthBridge,
 	bootAuth,
+	resolveStaffFlag,
 	IDBStorage,
 	setSharedToken,
 	getSharedToken,


### PR DESCRIPTION
## Summary
- `resolveStaffFlag` was exported from `auth/index.ts` but not re-exported from the main package entry (`src/index.ts`)
- The Astro build failed with `"resolveStaffFlag" is not exported by @kbve/astro` after PR #9778 added the import in `supa.ts`
- This blocked the Docker image build → e2e tests → publish pipeline

## Test plan
- [ ] `npx nx run astro-kbve:build` completes without Rollup import errors
- [ ] CI Docker build passes