### PR TITLE
feat(kube): Cloudflare cache purge PostSync hook for kbve.com

### DIFF
--- a/apps/kube/cert-manager/manifests/kbve-cloudflare-rbac.yaml
+++ b/apps/kube/cert-manager/manifests/kbve-cloudflare-rbac.yaml
@@ -1,0 +1,26 @@
+---
+# Role: Allow kbve ExternalSecrets SA to read Cloudflare API token
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: kbve-cloudflare-access
+    namespace: cert-manager
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['cloudflare-api-token-secret']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-cloudflare-access-binding
+    namespace: cert-manager
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: kbve-cloudflare-access
+subjects:
+    - kind: ServiceAccount
+      name: kbve-external-secrets
+      namespace: kbve

--- a/apps/kube/cert-manager/manifests/kustomization.yaml
+++ b/apps/kube/cert-manager/manifests/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
     - sealed-cloudflare-secrets.yaml
     - https://github.com/cert-manager/cert-manager/releases/download/v1.19.0/cert-manager.yaml
     - cluster-issuer.yaml
+    - kbve-cloudflare-rbac.yaml
 
 patches:
     - target:

--- a/apps/kube/kbve/manifest/cf-cache-purge-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/cf-cache-purge-externalsecret.yaml
@@ -1,0 +1,46 @@
+---
+# SecretStore: pull secrets from cert-manager namespace
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: certmanager-remote-secret-store
+    namespace: kbve
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: cert-manager
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: sync Cloudflare API token into kbve namespace
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: kbve-cloudflare-cache-purge
+    namespace: kbve
+spec:
+    refreshInterval: 24h
+    secretStoreRef:
+        name: certmanager-remote-secret-store
+        kind: SecretStore
+    target:
+        name: cloudflare-cache-purge
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                api-token: '{{ .apitoken }}'
+    data:
+        - secretKey: apitoken
+          remoteRef:
+              key: cloudflare-api-token-secret
+              property: api-token

--- a/apps/kube/kbve/manifest/cf-cache-purge-postsync.yaml
+++ b/apps/kube/kbve/manifest/cf-cache-purge-postsync.yaml
@@ -1,0 +1,48 @@
+---
+# PostSync hook: purge Cloudflare cache for kbve.com after each ArgoCD sync.
+# Waits 30s for new pods to become ready, then calls the Cloudflare API.
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: cf-cache-purge
+    namespace: kbve
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+    ttlSecondsAfterFinished: 120
+    backoffLimit: 1
+    template:
+        spec:
+            restartPolicy: Never
+            containers:
+                - name: purge
+                  image: curlimages/curl:8.12.1
+                  command:
+                      - /bin/sh
+                      - -c
+                      - |
+                          echo "Waiting 30s for rollout to stabilize..."
+                          sleep 30
+                          echo "Purging Cloudflare cache for kbve.com..."
+                          HTTP_CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+                            -X POST \
+                            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+                            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                            -H "Content-Type: application/json" \
+                            --data '{"purge_everything":true}')
+                          cat /tmp/resp.json
+                          echo ""
+                          if [ "$HTTP_CODE" -ne 200 ]; then
+                            echo "ERROR: Cloudflare returned HTTP $HTTP_CODE"
+                            exit 1
+                          fi
+                          echo "Cache purge successful."
+                  env:
+                      - name: CF_ZONE_ID
+                        value: fd91a229c151a7af5c93ffa409c1b91c
+                      - name: CF_API_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: cloudflare-cache-purge
+                                key: api-token

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -14,3 +14,5 @@ resources:
     - kbve-gateway.yaml
     - kbve-wt-lb.yaml
     - kbve-wt-selfsigned-cronjob.yaml
+    - cf-cache-purge-externalsecret.yaml
+    - cf-cache-purge-postsync.yaml


### PR DESCRIPTION
## Summary
- Adds an ArgoCD PostSync Job that purges the entire Cloudflare cache for kbve.com after each successful sync
- Waits 30s for rollout to stabilize, then calls `POST /zones/{zone_id}/purge_cache`
- API token reused from existing `cloudflare-api-token-secret` in cert-manager via ExternalSecret + cross-namespace RBAC
- Zone ID hardcoded (public identifier, not a secret)

## New files
- `cert-manager/manifests/kbve-cloudflare-rbac.yaml` — Role + RoleBinding granting `kbve-external-secrets` SA read access
- `kbve/manifest/cf-cache-purge-externalsecret.yaml` — SecretStore + ExternalSecret syncing the token
- `kbve/manifest/cf-cache-purge-postsync.yaml` — PostSync Job (curl container, `HookSucceeded` delete policy)

## Test plan
- [ ] Verify ExternalSecret syncs and `cloudflare-cache-purge` secret is created in `kbve` namespace
- [ ] Trigger a sync and confirm the PostSync Job runs and returns HTTP 200
- [ ] Verify cache is actually purged (check Cloudflare dashboard analytics)