### PR TITLE
fix(dashboard): remove mc from edge function health check list

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
@@ -279,7 +279,6 @@ async function fetchEdgeSummary(): Promise<EdgeSummary | null> {
 	const functions = [
 		'health',
 		'meme',
-		'mc',
 		'discordsh',
 		'user-vault',
 		'guild-vault',


### PR DESCRIPTION
## Summary
- The mc edge function was removed but `homeService.ts` still included it in the health check list
- Caused a 500 error on every dashboard load

## Test plan
- [ ] No more 500 error for `/functions/v1/mc`
- [ ] Edge Functions status shows 6/6 operational