### PR TITLE
chore(deps): bump rand from 0.8/0.9 to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ dependencies = [
  "num_cpus",
  "prost",
  "prost-build",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rayon",
  "regex",
  "reqwest 0.12.28",
@@ -1656,7 +1656,7 @@ name = "bevy_battle"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "rand 0.9.2",
+ "rand 0.10.0",
  "serde",
 ]
 
@@ -7122,7 +7122,7 @@ version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.10.0",
  "syn 2.0.117",
  "trybuild",
 ]
@@ -7788,7 +7788,7 @@ dependencies = [
  "lightyear",
  "log",
  "pollster",
- "rand 0.9.2",
+ "rand 0.10.0",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -11526,7 +11526,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -15319,9 +15319,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.13.1",
  "toml_datetime 1.1.1+spec-1.1.0",

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -65,7 +65,7 @@ lightyear = { version = "0.26", default-features = false, features = [
     "avian3d",
 ] }
 base64 = "0.22"
-rand = "0.9"
+rand = "0.10"
 lightyear_avian3d = { version = "0.26", default-features = false, features = ["3d"] }
 bevy_kbve_net = { path = "../../../packages/rust/bevy/bevy_kbve_net", features = ["npcdb", "creatures"] }
 futures-util = "0.3"

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -67,7 +67,7 @@ lightyear = { version = "0.26", default-features = false, features = [
     "webtransport",
 ] }
 base64 = "0.22"
-rand = "0.9"
+rand = "0.10"
 bevy_tasker = { path = "../../../../packages/rust/bevy/bevy_tasker" }
 crossbeam-channel = "0.5"
 dashmap = "6"

--- a/packages/rust/bevy/bevy_battle/Cargo.toml
+++ b/packages/rust/bevy/bevy_battle/Cargo.toml
@@ -17,7 +17,7 @@ bevy = { version = "0.18", default-features = false, features = [
     "bevy_state",
 ] }
 serde = { version = "1", features = ["derive"] }
-rand = "0.9"
+rand = "0.10"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/rust/bevy/bevy_battle/src/resource.rs
+++ b/packages/rust/bevy/bevy_battle/src/resource.rs
@@ -31,7 +31,7 @@ pub struct BattleRng(pub StdRng);
 
 impl Default for BattleRng {
     fn default() -> Self {
-        Self(StdRng::from_os_rng())
+        Self(rand::make_rng())
     }
 }
 

--- a/packages/rust/bevy/bevy_battle/src/system/attack.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/attack.rs
@@ -1,7 +1,7 @@
 //! Player attack and item-use systems.
 
 use bevy::prelude::*;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::component::*;
 use crate::event::*;

--- a/packages/rust/bevy/bevy_battle/src/system/defend.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/defend.rs
@@ -1,7 +1,7 @@
 //! Defend action system.
 
 use bevy::prelude::*;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::component::*;
 use crate::event::*;

--- a/packages/rust/bevy/bevy_battle/src/system/enemy_turn.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/enemy_turn.rs
@@ -1,7 +1,7 @@
 //! Enemy AI turn system — execute intents, roll new intents.
 
 use bevy::prelude::*;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::component::*;
 use crate::event::*;
@@ -249,7 +249,7 @@ pub fn enemy_turn_system(
     }
 }
 
-fn roll_and_set_intent(ai: &mut EnemyAI, intent: &mut CurrentIntent, rng: &mut impl Rng) {
+fn roll_and_set_intent(ai: &mut EnemyAI, intent: &mut CurrentIntent, rng: &mut impl RngExt) {
     if ai.charged {
         ai.charged = false;
         let mut heavy_dmg = 12 + ai.level as i32 * 3;
@@ -263,7 +263,7 @@ fn roll_and_set_intent(ai: &mut EnemyAI, intent: &mut CurrentIntent, rng: &mut i
 }
 
 /// Generate a random intent based on enemy level tier.
-pub fn roll_new_intent(level: u8, is_enraged: bool, rng: &mut impl Rng) -> Intent {
+pub fn roll_new_intent(level: u8, is_enraged: bool, rng: &mut impl RngExt) -> Intent {
     let mut intent = if level >= 4 {
         match rng.random_range(0..10) {
             0 => Intent::Attack {

--- a/packages/rust/bevy/bevy_battle/src/system/flee.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/flee.rs
@@ -1,7 +1,7 @@
 //! Flee resolution system.
 
 use bevy::prelude::*;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::component::*;
 use crate::event::*;

--- a/packages/rust/holy/Cargo.toml
+++ b/packages/rust/holy/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"
-rand = "0.8"
+rand = "0.10"
 
 [lib]
 proc-macro = true

--- a/packages/rust/holy/src/fuzz/fuzz_macro.rs
+++ b/packages/rust/holy/src/fuzz/fuzz_macro.rs
@@ -5,287 +5,299 @@ use syn::{Data, DeriveInput, Fields, Type};
 use crate::utils::get_holy_string_value;
 
 enum FuzzStrategy {
-	Ascii(usize, usize),
-	AlphanumericStr(usize, usize),
-	Range(String, String),
+    Ascii(usize, usize),
+    AlphanumericStr(usize, usize),
+    Range(String, String),
 }
 
 enum FuzzTypeKind {
-	String,
-	Bool,
-	Integer,
-	Float,
-	Other(String),
+    String,
+    Bool,
+    Integer,
+    Float,
+    Other(String),
 }
 
 fn classify_fuzz_type(ty: &Type) -> FuzzTypeKind {
-	if let Type::Path(type_path) = ty {
-		if let Some(segment) = type_path.path.segments.last() {
-			let ident = segment.ident.to_string();
-			return match ident.as_str() {
-				"String" => FuzzTypeKind::String,
-				"bool" => FuzzTypeKind::Bool,
-				"i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "isize"
-				| "usize" => FuzzTypeKind::Integer,
-				"f32" | "f64" => FuzzTypeKind::Float,
-				other => FuzzTypeKind::Other(other.to_string()),
-			};
-		}
-	}
-	FuzzTypeKind::Other("unknown".to_string())
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            let ident = segment.ident.to_string();
+            return match ident.as_str() {
+                "String" => FuzzTypeKind::String,
+                "bool" => FuzzTypeKind::Bool,
+                "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "isize" | "usize" => {
+                    FuzzTypeKind::Integer
+                }
+                "f32" | "f64" => FuzzTypeKind::Float,
+                other => FuzzTypeKind::Other(other.to_string()),
+            };
+        }
+    }
+    FuzzTypeKind::Other("unknown".to_string())
 }
 
-fn parse_two_args(inner: &str, name: &str, span: proc_macro2::Span) -> Result<(String, String), syn::Error> {
-	let parts: Vec<&str> = inner.splitn(2, ',').collect();
-	if parts.len() != 2 {
-		return Err(syn::Error::new(
-			span,
-			format!("{} requires two arguments: {}(a, b)", name, name),
-		));
-	}
-	Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))
+fn parse_two_args(
+    inner: &str,
+    name: &str,
+    span: proc_macro2::Span,
+) -> Result<(String, String), syn::Error> {
+    let parts: Vec<&str> = inner.splitn(2, ',').collect();
+    if parts.len() != 2 {
+        return Err(syn::Error::new(
+            span,
+            format!("{} requires two arguments: {}(a, b)", name, name),
+        ));
+    }
+    Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))
 }
 
-fn parse_fuzz_strategy(
-	raw: &str,
-	span: proc_macro2::Span,
-) -> Result<FuzzStrategy, syn::Error> {
-	let trimmed = raw.trim();
+fn parse_fuzz_strategy(raw: &str, span: proc_macro2::Span) -> Result<FuzzStrategy, syn::Error> {
+    let trimmed = raw.trim();
 
-	if let Some(inner) = trimmed.strip_prefix("ascii(").and_then(|s| s.strip_suffix(')')) {
-		let (a, b) = parse_two_args(inner, "ascii", span)?;
-		let min: usize = a.parse().map_err(|_| {
-			syn::Error::new(span, format!("invalid ascii min length: '{}'", a))
-		})?;
-		let max: usize = b.parse().map_err(|_| {
-			syn::Error::new(span, format!("invalid ascii max length: '{}'", b))
-		})?;
-		return Ok(FuzzStrategy::Ascii(min, max));
-	}
+    if let Some(inner) = trimmed
+        .strip_prefix("ascii(")
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        let (a, b) = parse_two_args(inner, "ascii", span)?;
+        let min: usize = a
+            .parse()
+            .map_err(|_| syn::Error::new(span, format!("invalid ascii min length: '{}'", a)))?;
+        let max: usize = b
+            .parse()
+            .map_err(|_| syn::Error::new(span, format!("invalid ascii max length: '{}'", b)))?;
+        return Ok(FuzzStrategy::Ascii(min, max));
+    }
 
-	if let Some(inner) = trimmed
-		.strip_prefix("alphanumeric(")
-		.and_then(|s| s.strip_suffix(')'))
-	{
-		let (a, b) = parse_two_args(inner, "alphanumeric", span)?;
-		let min: usize = a.parse().map_err(|_| {
-			syn::Error::new(span, format!("invalid alphanumeric min length: '{}'", a))
-		})?;
-		let max: usize = b.parse().map_err(|_| {
-			syn::Error::new(span, format!("invalid alphanumeric max length: '{}'", b))
-		})?;
-		return Ok(FuzzStrategy::AlphanumericStr(min, max));
-	}
+    if let Some(inner) = trimmed
+        .strip_prefix("alphanumeric(")
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        let (a, b) = parse_two_args(inner, "alphanumeric", span)?;
+        let min: usize = a.parse().map_err(|_| {
+            syn::Error::new(span, format!("invalid alphanumeric min length: '{}'", a))
+        })?;
+        let max: usize = b.parse().map_err(|_| {
+            syn::Error::new(span, format!("invalid alphanumeric max length: '{}'", b))
+        })?;
+        return Ok(FuzzStrategy::AlphanumericStr(min, max));
+    }
 
-	if let Some(inner) = trimmed.strip_prefix("range(").and_then(|s| s.strip_suffix(')')) {
-		let (a, b) = parse_two_args(inner, "range", span)?;
-		return Ok(FuzzStrategy::Range(a, b));
-	}
+    if let Some(inner) = trimmed
+        .strip_prefix("range(")
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        let (a, b) = parse_two_args(inner, "range", span)?;
+        return Ok(FuzzStrategy::Range(a, b));
+    }
 
-	Err(syn::Error::new(
-		span,
-		format!("unknown fuzz strategy: '{}'", trimmed),
-	))
+    Err(syn::Error::new(
+        span,
+        format!("unknown fuzz strategy: '{}'", trimmed),
+    ))
 }
 
 fn validate_fuzz_strategy(
-	strategy: &FuzzStrategy,
-	type_kind: &FuzzTypeKind,
-	field_name: &syn::Ident,
-	span: proc_macro2::Span,
+    strategy: &FuzzStrategy,
+    type_kind: &FuzzTypeKind,
+    field_name: &syn::Ident,
+    span: proc_macro2::Span,
 ) -> Result<(), syn::Error> {
-	match strategy {
-		FuzzStrategy::Ascii(_, _) | FuzzStrategy::AlphanumericStr(_, _) => {
-			if !matches!(type_kind, FuzzTypeKind::String) {
-				return Err(syn::Error::new(
-					span,
-					format!(
-						"fuzz strategy is only valid for String fields, but field '{}' is not a String",
-						field_name
-					),
-				));
-			}
-		}
-		FuzzStrategy::Range(_, _) => {
-			if !matches!(type_kind, FuzzTypeKind::Integer | FuzzTypeKind::Float) {
-				return Err(syn::Error::new(
-					span,
-					format!(
-						"fuzz strategy 'range' is only valid for numeric fields, but field '{}' is not numeric",
-						field_name
-					),
-				));
-			}
-		}
-	}
-	Ok(())
+    match strategy {
+        FuzzStrategy::Ascii(_, _) | FuzzStrategy::AlphanumericStr(_, _) => {
+            if !matches!(type_kind, FuzzTypeKind::String) {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "fuzz strategy is only valid for String fields, but field '{}' is not a String",
+                        field_name
+                    ),
+                ));
+            }
+        }
+        FuzzStrategy::Range(_, _) => {
+            if !matches!(type_kind, FuzzTypeKind::Integer | FuzzTypeKind::Float) {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "fuzz strategy 'range' is only valid for numeric fields, but field '{}' is not numeric",
+                        field_name
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn generate_fuzz_default_expr(
-	strategy: Option<&FuzzStrategy>,
-	type_kind: &FuzzTypeKind,
-	field_name: &syn::Ident,
-	span: proc_macro2::Span,
+    strategy: Option<&FuzzStrategy>,
+    type_kind: &FuzzTypeKind,
+    field_name: &syn::Ident,
+    span: proc_macro2::Span,
 ) -> Result<proc_macro2::TokenStream, syn::Error> {
-	match (type_kind, strategy) {
-		(FuzzTypeKind::String, Some(FuzzStrategy::Ascii(min, max))) => {
-			let len = (min + max) / 2;
-			let s = "a".repeat(len);
-			Ok(quote! { String::from(#s) })
-		}
-		(FuzzTypeKind::String, Some(FuzzStrategy::AlphanumericStr(min, max))) => {
-			let len = (min + max) / 2;
-			let s = "a".repeat(len);
-			Ok(quote! { String::from(#s) })
-		}
-		(FuzzTypeKind::String, None) => Ok(quote! { String::from("aaaa") }),
-		(FuzzTypeKind::Bool, None) => Ok(quote! { false }),
-		(FuzzTypeKind::Integer, Some(FuzzStrategy::Range(min, max))) => {
-			let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
-			let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
-			Ok(quote! { (#min_lit + #max_lit) / 2 })
-		}
-		(FuzzTypeKind::Integer, None) => Ok(quote! { 0 }),
-		(FuzzTypeKind::Float, Some(FuzzStrategy::Range(min, max))) => {
-			let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
-			let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
-			Ok(quote! { (#min_lit + #max_lit) / 2.0 })
-		}
-		(FuzzTypeKind::Float, None) => Ok(quote! { 0.0 }),
-		(FuzzTypeKind::Other(type_name), _) => Err(syn::Error::new(
-			span,
-			format!(
-				"Fuzz: unsupported type '{}' for field '{}', use a supported type (String, bool, numeric) or annotate with #[holy(fuzz = \"...\")]",
-				type_name, field_name
-			),
-		)),
-		_ => Err(syn::Error::new(
-			span,
-			format!("invalid fuzz strategy for field '{}'", field_name),
-		)),
-	}
+    match (type_kind, strategy) {
+        (FuzzTypeKind::String, Some(FuzzStrategy::Ascii(min, max))) => {
+            let len = (min + max) / 2;
+            let s = "a".repeat(len);
+            Ok(quote! { String::from(#s) })
+        }
+        (FuzzTypeKind::String, Some(FuzzStrategy::AlphanumericStr(min, max))) => {
+            let len = (min + max) / 2;
+            let s = "a".repeat(len);
+            Ok(quote! { String::from(#s) })
+        }
+        (FuzzTypeKind::String, None) => Ok(quote! { String::from("aaaa") }),
+        (FuzzTypeKind::Bool, None) => Ok(quote! { false }),
+        (FuzzTypeKind::Integer, Some(FuzzStrategy::Range(min, max))) => {
+            let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
+            let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
+            Ok(quote! { (#min_lit + #max_lit) / 2 })
+        }
+        (FuzzTypeKind::Integer, None) => Ok(quote! { 0 }),
+        (FuzzTypeKind::Float, Some(FuzzStrategy::Range(min, max))) => {
+            let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
+            let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
+            Ok(quote! { (#min_lit + #max_lit) / 2.0 })
+        }
+        (FuzzTypeKind::Float, None) => Ok(quote! { 0.0 }),
+        (FuzzTypeKind::Other(type_name), _) => Err(syn::Error::new(
+            span,
+            format!(
+                "Fuzz: unsupported type '{}' for field '{}', use a supported type (String, bool, numeric) or annotate with #[holy(fuzz = \"...\")]",
+                type_name, field_name
+            ),
+        )),
+        _ => Err(syn::Error::new(
+            span,
+            format!("invalid fuzz strategy for field '{}'", field_name),
+        )),
+    }
 }
 
 fn generate_fuzz_rng_expr(
-	strategy: Option<&FuzzStrategy>,
-	type_kind: &FuzzTypeKind,
-	field_name: &syn::Ident,
-	span: proc_macro2::Span,
+    strategy: Option<&FuzzStrategy>,
+    type_kind: &FuzzTypeKind,
+    field_name: &syn::Ident,
+    span: proc_macro2::Span,
 ) -> Result<proc_macro2::TokenStream, syn::Error> {
-	match (type_kind, strategy) {
-		(FuzzTypeKind::String, Some(FuzzStrategy::Ascii(min, max))) => Ok(quote! {
-			{
-				let len = rand::Rng::gen_range(rng, #min..=#max);
-				(0..len).map(|_| rand::Rng::gen_range(rng, b' '..=b'~') as char).collect::<String>()
-			}
-		}),
-		(FuzzTypeKind::String, Some(FuzzStrategy::AlphanumericStr(min, max))) => Ok(quote! {
-			{
-				let len = rand::Rng::gen_range(rng, #min..=#max);
-				let chars: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-				(0..len).map(|_| chars[rand::Rng::gen_range(rng, 0..chars.len())] as char).collect::<String>()
-			}
-		}),
-		(FuzzTypeKind::String, None) => Ok(quote! {
-			{
-				let len = rand::Rng::gen_range(rng, 0usize..=64usize);
-				(0..len).map(|_| rand::Rng::gen_range(rng, b' '..=b'~') as char).collect::<String>()
-			}
-		}),
-		(FuzzTypeKind::Bool, None) => Ok(quote! { rand::Rng::gen_bool(rng, 0.5) }),
-		(FuzzTypeKind::Integer, Some(FuzzStrategy::Range(min, max))) => {
-			let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
-			let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
-			Ok(quote! { rand::Rng::gen_range(rng, #min_lit..=#max_lit) })
-		}
-		(FuzzTypeKind::Integer, None) => {
-			let gen_ident = syn::Ident::new_raw("gen", proc_macro2::Span::call_site());
-			Ok(quote! { rand::Rng::#gen_ident(rng) })
-		}
-		(FuzzTypeKind::Float, Some(FuzzStrategy::Range(min, max))) => {
-			let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
-			let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
-			Ok(quote! { rand::Rng::gen_range(rng, #min_lit..=#max_lit) })
-		}
-		(FuzzTypeKind::Float, None) => Ok(quote! {
-			rand::Rng::gen_range(rng, -1_000_000.0f64..1_000_000.0f64)
-		}),
-		(FuzzTypeKind::Other(type_name), _) => Err(syn::Error::new(
-			span,
-			format!(
-				"Fuzz: unsupported type '{}' for field '{}'",
-				type_name, field_name
-			),
-		)),
-		_ => Err(syn::Error::new(
-			span,
-			format!("invalid fuzz strategy for field '{}'", field_name),
-		)),
-	}
+    match (type_kind, strategy) {
+        (FuzzTypeKind::String, Some(FuzzStrategy::Ascii(min, max))) => Ok(quote! {
+            {
+                let len = rand::RngExt::random_range(rng, #min..=#max);
+                (0..len).map(|_| rand::RngExt::random_range(rng, b' '..=b'~') as char).collect::<String>()
+            }
+        }),
+        (FuzzTypeKind::String, Some(FuzzStrategy::AlphanumericStr(min, max))) => Ok(quote! {
+            {
+                let len = rand::RngExt::random_range(rng, #min..=#max);
+                let chars: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+                (0..len).map(|_| chars[rand::RngExt::random_range(rng, 0..chars.len())] as char).collect::<String>()
+            }
+        }),
+        (FuzzTypeKind::String, None) => Ok(quote! {
+            {
+                let len = rand::RngExt::random_range(rng, 0usize..=64usize);
+                (0..len).map(|_| rand::RngExt::random_range(rng, b' '..=b'~') as char).collect::<String>()
+            }
+        }),
+        (FuzzTypeKind::Bool, None) => Ok(quote! { rand::RngExt::random_bool(rng, 0.5) }),
+        (FuzzTypeKind::Integer, Some(FuzzStrategy::Range(min, max))) => {
+            let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
+            let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
+            Ok(quote! { rand::RngExt::random_range(rng, #min_lit..=#max_lit) })
+        }
+        (FuzzTypeKind::Integer, None) => {
+            let random_ident = syn::Ident::new("random", proc_macro2::Span::call_site());
+            Ok(quote! { rand::RngExt::#random_ident(rng) })
+        }
+        (FuzzTypeKind::Float, Some(FuzzStrategy::Range(min, max))) => {
+            let min_lit: proc_macro2::TokenStream = min.parse().unwrap();
+            let max_lit: proc_macro2::TokenStream = max.parse().unwrap();
+            Ok(quote! { rand::RngExt::random_range(rng, #min_lit..=#max_lit) })
+        }
+        (FuzzTypeKind::Float, None) => Ok(quote! {
+            rand::RngExt::random_range(rng, -1_000_000.0f64..1_000_000.0f64)
+        }),
+        (FuzzTypeKind::Other(type_name), _) => Err(syn::Error::new(
+            span,
+            format!(
+                "Fuzz: unsupported type '{}' for field '{}'",
+                type_name, field_name
+            ),
+        )),
+        _ => Err(syn::Error::new(
+            span,
+            format!("invalid fuzz strategy for field '{}'", field_name),
+        )),
+    }
 }
 
 pub fn impl_fuzz_macro(ast: &DeriveInput) -> Result<TokenStream, syn::Error> {
-	let struct_name = &ast.ident;
-	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let struct_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-	let fields = match &ast.data {
-		Data::Struct(data) => match &data.fields {
-			Fields::Named(named) => &named.named,
-			_ => {
-				return Err(syn::Error::new_spanned(
-					ast,
-					"Fuzz macro only supports structs with named fields",
-				));
-			}
-		},
-		_ => {
-			return Err(syn::Error::new_spanned(
-				ast,
-				"Fuzz macro only supports structs",
-			));
-		}
-	};
+    let fields = match &ast.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(named) => &named.named,
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    ast,
+                    "Fuzz macro only supports structs with named fields",
+                ));
+            }
+        },
+        _ => {
+            return Err(syn::Error::new_spanned(
+                ast,
+                "Fuzz macro only supports structs",
+            ));
+        }
+    };
 
-	let mut default_field_inits = Vec::new();
-	let mut rng_field_inits = Vec::new();
+    let mut default_field_inits = Vec::new();
+    let mut rng_field_inits = Vec::new();
 
-	for field in fields.iter() {
-		let field_name = field.ident.as_ref().unwrap();
-		let type_kind = classify_fuzz_type(&field.ty);
+    for field in fields.iter() {
+        let field_name = field.ident.as_ref().unwrap();
+        let type_kind = classify_fuzz_type(&field.ty);
 
-		let strategy = match get_holy_string_value(&field.attrs, "fuzz") {
-			Some((raw, span)) => Some(parse_fuzz_strategy(&raw, span)?),
-			None => None,
-		};
+        let strategy = match get_holy_string_value(&field.attrs, "fuzz") {
+            Some((raw, span)) => Some(parse_fuzz_strategy(&raw, span)?),
+            None => None,
+        };
 
-		if let Some(ref strat) = strategy {
-			validate_fuzz_strategy(strat, &type_kind, field_name, field_name.span())?;
-		}
+        if let Some(ref strat) = strategy {
+            validate_fuzz_strategy(strat, &type_kind, field_name, field_name.span())?;
+        }
 
-		let default_expr =
-			generate_fuzz_default_expr(strategy.as_ref(), &type_kind, field_name, field_name.span())?;
-		let rng_expr =
-			generate_fuzz_rng_expr(strategy.as_ref(), &type_kind, field_name, field_name.span())?;
+        let default_expr = generate_fuzz_default_expr(
+            strategy.as_ref(),
+            &type_kind,
+            field_name,
+            field_name.span(),
+        )?;
+        let rng_expr =
+            generate_fuzz_rng_expr(strategy.as_ref(), &type_kind, field_name, field_name.span())?;
 
-		default_field_inits.push(quote! { #field_name: #default_expr });
-		rng_field_inits.push(quote! { #field_name: #rng_expr });
-	}
+        default_field_inits.push(quote! { #field_name: #default_expr });
+        rng_field_inits.push(quote! { #field_name: #rng_expr });
+    }
 
-	let expanded = quote! {
-		impl #impl_generics #struct_name #ty_generics #where_clause {
-			pub fn fuzz_default() -> Self {
-				Self {
-					#(#default_field_inits,)*
-				}
-			}
+    let expanded = quote! {
+        impl #impl_generics #struct_name #ty_generics #where_clause {
+            pub fn fuzz_default() -> Self {
+                Self {
+                    #(#default_field_inits,)*
+                }
+            }
 
-			pub fn fuzz_with(rng: &mut impl rand::Rng) -> Self {
-				Self {
-					#(#rng_field_inits,)*
-				}
-			}
-		}
-	};
+            pub fn fuzz_with(rng: &mut impl rand::RngExt) -> Self {
+                Self {
+                    #(#rng_field_inits,)*
+                }
+            }
+        }
+    };
 
-	Ok(TokenStream::from(expanded))
+    Ok(TokenStream::from(expanded))
 }


### PR DESCRIPTION
## Summary
- Bumps `rand` to 0.10.0 across `axum-kbve`, `isometric`, `bevy_battle`, and `holy`
- Migrates breaking API changes: `Rng` → `RngExt`, `StdRng::from_os_rng()` → `rand::make_rng()`, `gen_range`/`gen_bool`/`gen` → `random_range`/`random_bool`/`random` in holy macro codegen
- All 58 bevy_battle tests + 18 holy trybuild tests pass

Resolves #9692

## Test plan
- [x] `cargo check -p bevy_battle` compiles
- [x] `cargo test -p bevy_battle` — 58 tests pass
- [x] `cargo check -p holy` compiles
- [x] `cargo test -p holy` — 18 trybuild tests pass
- [ ] CI lint + test