### PR TITLE
fix(guacamole): add GUACAMOLE_HOME env var for user-mapping auth

### DIFF
--- a/apps/kube/kubevirt/guacamole/deployment.yaml
+++ b/apps/kube/kubevirt/guacamole/deployment.yaml
@@ -102,8 +102,10 @@ spec:
                         value: guacd.angelscript.svc.cluster.local
                       - name: GUACD_PORT
                         value: '4822'
-                      # user-mapping.xml provides auth + connection config.
-                      # For production, switch to PostgreSQL backend.
+                      # GUACAMOLE_HOME tells Guacamole where to find
+                      # user-mapping.xml and other config files.
+                      - name: GUACAMOLE_HOME
+                        value: /etc/guacamole
                   ports:
                       - containerPort: 8080
                         name: http


### PR DESCRIPTION
## Summary
- Guacamole container crashed with `FATAL: No authentication configured` despite `user-mapping.xml` being mounted
- The Guacamole Docker image requires `GUACAMOLE_HOME` env var to discover config files
- Added `GUACAMOLE_HOME=/etc/guacamole` env var to the deployment
- Also manually created the `kubevirt-guacamole` ArgoCD Application (was blocked by `kube-root` SSA validation error on `agones-ows`)

## Status
- guacd: Running 1/1
- guacamole: Running 1/1 (after fix)
- WebSocket proxy DNS resolution: working

## Test plan
- [ ] Guacamole web UI accessible (guac proxy responds)
- [ ] Dashboard Guac WebSocket tunnel connects
- [ ] RDP connection to Windows VM works through guacamole