### PR TITLE
feat(dashboard): KASM workspace viewer page

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKasmDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKasmDashboard.astro
@@ -1,0 +1,41 @@
+---
+import ReactVMAuth from './ReactVMAuth';
+import ReactKasmViewer from './ReactKasmViewer';
+---
+
+<section
+	id="kasm-dashboard-wrapper"
+	class="kasm-dashboard-wrapper"
+	aria-label="KASM Workspace Viewer">
+	<div id="kasm-content" class="kasm-content">
+		<ReactVMAuth client:only="react">
+			<div class="not-content kasm-dashboard">
+				<ReactKasmViewer client:only="react" />
+			</div>
+		</ReactVMAuth>
+	</div>
+</section>
+
+<style>
+	.kasm-dashboard-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100vw;
+		margin-left: calc(-50vw + 50%);
+	}
+
+	.kasm-content {
+		max-width: 100%;
+		margin: 0 auto;
+		padding: 1rem;
+	}
+
+	.kasm-dashboard {
+		display: flex;
+		flex-direction: column;
+		color: var(--sl-color-text, #e6edf3);
+		min-height: 80vh;
+		gap: 0.5rem;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
@@ -184,9 +184,7 @@ function KasmCard({ info }: { info: KasmInfo }) {
 				)}
 				{canConnect && (
 					<a
-						href={`https://${window.location.host}/dashboard/vm/kasm/${workspace.name}`}
-						target="_blank"
-						rel="noopener noreferrer"
+						href={`/dashboard/vm/kasm/?workspace=${encodeURIComponent(workspace.name)}`}
 						style={{
 							display: 'inline-flex',
 							alignItems: 'center',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmViewer.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import { vmService } from './vmService';
+import { kasmService, KasmState } from './kasmService';
+
+/** Extract workspace name from URL query parameter.
+ *  e.g. /dashboard/vm/kasm/?workspace=kasm-vpn → "kasm-vpn"
+ */
+function getWorkspaceName(): string | null {
+	const params = new URLSearchParams(window.location.search);
+	return params.get('workspace');
+}
+
+export default function ReactKasmViewer() {
+	const token = useStore(vmService.$accessToken);
+	const workspaces = useStore(kasmService.$workspaces);
+	const loading = useStore(kasmService.$loading);
+	const [workspaceName] = useState(() => getWorkspaceName());
+
+	// Fetch KASM workspaces on mount
+	useEffect(() => {
+		if (token) {
+			kasmService.fetchData(token);
+		}
+	}, [token]);
+
+	const workspace = useMemo(
+		() => workspaces.find((w) => w.workspace.name === workspaceName),
+		[workspaces, workspaceName],
+	);
+
+	const canConnect = workspace
+		? (workspace.state & KasmState.CAN_CONNECT) !== 0
+		: false;
+
+	// Build the proxy URL for the iframe
+	const proxyUrl = useMemo(() => {
+		if (!workspaceName || !token) return null;
+		return `/dashboard/kasm/proxy/?access_token=${encodeURIComponent(token)}`;
+	}, [workspaceName, token]);
+
+	// --- No workspace name in URL ---
+	if (!workspaceName) {
+		return (
+			<div style={containerStyle}>
+				<div style={headerStyle}>
+					<a href="/dashboard/vm/" style={backLinkStyle}>
+						&larr; Back to VM Dashboard
+					</a>
+					<h2 style={titleStyle}>KASM Workspace</h2>
+				</div>
+				<div style={messageStyle}>
+					<p>No workspace specified in URL.</p>
+					<p style={{ fontSize: '0.85rem', opacity: 0.7 }}>
+						Navigate to a workspace from the{' '}
+						<a href="/dashboard/vm/" style={{ color: '#8b5cf6' }}>
+							VM Dashboard
+						</a>
+						.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	// --- Loading ---
+	if (loading) {
+		return (
+			<div style={containerStyle}>
+				<div style={headerStyle}>
+					<a href="/dashboard/vm/" style={backLinkStyle}>
+						&larr; Back to VM Dashboard
+					</a>
+					<h2 style={titleStyle}>{workspaceName}</h2>
+				</div>
+				<div style={messageStyle}>
+					<p>Loading workspace...</p>
+				</div>
+			</div>
+		);
+	}
+
+	// --- Workspace not found or not connectable ---
+	if (!workspace || !canConnect || !proxyUrl) {
+		return (
+			<div style={containerStyle}>
+				<div style={headerStyle}>
+					<a href="/dashboard/vm/" style={backLinkStyle}>
+						&larr; Back to VM Dashboard
+					</a>
+					<h2 style={titleStyle}>{workspaceName}</h2>
+				</div>
+				<div style={messageStyle}>
+					{!workspace ? (
+						<p>
+							Workspace <strong>{workspaceName}</strong> not
+							found.
+						</p>
+					) : (
+						<p>
+							Workspace <strong>{workspaceName}</strong> is not
+							running. Start it from the{' '}
+							<a
+								href="/dashboard/vm/"
+								style={{ color: '#8b5cf6' }}>
+								VM Dashboard
+							</a>
+							.
+						</p>
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	// --- Connected: show iframe ---
+	return (
+		<div style={containerStyle}>
+			<div style={headerStyle}>
+				<a href="/dashboard/vm/" style={backLinkStyle}>
+					&larr; Back
+				</a>
+				<h2 style={titleStyle}>
+					{workspaceName}
+					<span style={statusBadgeStyle}>
+						{workspace.workspace.image}
+					</span>
+				</h2>
+			</div>
+			<div style={iframeWrapperStyle}>
+				<iframe
+					src={proxyUrl}
+					title={`KASM Workspace: ${workspaceName}`}
+					style={iframeStyle}
+					allow="clipboard-read; clipboard-write; autoplay; fullscreen"
+					sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals"
+				/>
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const containerStyle: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	height: 'calc(100vh - 4rem)',
+	gap: '0.5rem',
+};
+
+const headerStyle: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: '1rem',
+	padding: '0.5rem 0',
+	flexShrink: 0,
+};
+
+const backLinkStyle: React.CSSProperties = {
+	color: '#8b5cf6',
+	textDecoration: 'none',
+	fontSize: '0.85rem',
+	whiteSpace: 'nowrap',
+};
+
+const titleStyle: React.CSSProperties = {
+	margin: 0,
+	fontSize: '1.1rem',
+	fontWeight: 600,
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.75rem',
+};
+
+const statusBadgeStyle: React.CSSProperties = {
+	fontSize: '0.7rem',
+	fontWeight: 400,
+	background: '#8b5cf622',
+	border: '1px solid #8b5cf644',
+	borderRadius: '4px',
+	padding: '0.15rem 0.5rem',
+	color: '#8b5cf6',
+};
+
+const messageStyle: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'center',
+	justifyContent: 'center',
+	flex: 1,
+	opacity: 0.8,
+	textAlign: 'center',
+};
+
+const iframeWrapperStyle: React.CSSProperties = {
+	flex: 1,
+	borderRadius: '8px',
+	overflow: 'hidden',
+	border: '1px solid #30363d',
+	background: '#0d1117',
+};
+
+const iframeStyle: React.CSSProperties = {
+	width: '100%',
+	height: '100%',
+	border: 'none',
+	display: 'block',
+};

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/kasm/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/kasm/index.mdx
@@ -1,0 +1,22 @@
+---
+title: KASM Workspace
+description: KASM Workspace Viewer
+template: splash
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: KASM Viewer
+    order: 6
+    hidden: true
+unsplash: 1558494949-ef010cbdcc31
+img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - kasm
+    - vm
+---
+
+import AstroKasmDashboard from '@/components/dashboard/AstroKasmDashboard.astro';
+
+<AstroKasmDashboard />


### PR DESCRIPTION
## Summary
- Add KASM workspace viewer page at `/dashboard/vm/kasm/?workspace={name}`
- Embeds KasmVNC web interface via iframe through the existing `/dashboard/kasm/proxy/` backend
- Stays within the dashboard layout with auth gate, back navigation, and workspace status display
- Fix: "Open" button in KASM cards now links to the viewer page instead of a non-existent route that 404'd

## New files
- `AstroKasmDashboard.astro` — Astro wrapper with auth gate
- `ReactKasmViewer.tsx` — React component: reads workspace from query param, checks status, renders iframe
- `dashboard/vm/kasm/index.mdx` — Content page (hidden from sidebar)

## Test plan
- [ ] Navigate to VM Dashboard → KASM card → click "Open" → viewer loads
- [ ] Viewer shows workspace name, image badge, and embedded KasmVNC
- [ ] Back button returns to VM Dashboard
- [ ] Non-running workspace shows "not running" message with link to start