### PR TITLE
fix(firecracker): VM code execution with ConfigMap init script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.100"
+version = "1.0.101"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
@@ -347,7 +347,7 @@ class IDEService {
 					timeout_ms: preset.timeout_ms,
 					entrypoint: preset.entrypoint,
 					env: { CODE: code },
-					boot_args: 'console=ttyS0 reboot=k panic=1',
+					boot_args: 'console=ttyS0 reboot=k panic=1 init=/init',
 				},
 			);
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.24"
+version: "0.1.25"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v4
+    name: firecracker-rootfs-init-v5
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -75,9 +75,8 @@ spec:
                               mkdir -p "${ROOTFS}/dev" "${ROOTFS}/proc" "${ROOTFS}/sys" \
                                        "${ROOTFS}/tmp" "${ROOTFS}/run" "${ROOTFS}/var/log"
 
-                              # Init script — mounts filesystems, reads code from /dev/vdb,
-                              # parses entrypoint from kernel cmdline, and executes.
-                              printf '#!/bin/sh\nmount -t proc proc /proc\nmount -t sysfs sys /sys\nmount -t devtmpfs dev /dev\nmkdir -p /tmp\nif [ -b /dev/vdb ]; then\n  dd if=/dev/vdb bs=4096 2>/dev/null | tr -d \"\\\\0\" > /tmp/code\n  chmod +x /tmp/code\n  exec sh /tmp/code\nfi\nexec /bin/sh\n' > "${ROOTFS}/init"
+                              # Copy init script from ConfigMap
+                              cp /vm-init/init "${ROOTFS}/init"
                               chmod +x "${ROOTFS}/init"
 
                               # Create sparse ext4 image and populate from rootfs directory
@@ -112,7 +111,13 @@ spec:
                   volumeMounts:
                       - name: rootfs
                         mountPath: /rootfs
+                      - name: vm-init
+                        mountPath: /vm-init
+                        readOnly: true
             volumes:
                 - name: rootfs
                   persistentVolumeClaim:
                       claimName: firecracker-rootfs
+                - name: vm-init
+                  configMap:
+                      name: firecracker-vm-init

--- a/apps/kube/firecracker/manifests/firecracker-vm-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-vm-init.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: firecracker-vm-init
+    namespace: firecracker
+    labels:
+        app: firecracker-ctl
+data:
+    init: |
+        #!/bin/sh
+        mount -t proc proc /proc
+        mount -t sysfs sys /sys
+        mount -t devtmpfs dev /dev 2>/dev/null
+        mount -t tmpfs tmpfs /tmp
+
+        ENTRYPOINT="/bin/sh"
+        for param in $(cat /proc/cmdline); do
+          case "$param" in
+            fc_entrypoint=*) ENTRYPOINT="${param#fc_entrypoint=}" ;;
+          esac
+        done
+
+        if [ -b /dev/vdb ]; then
+          dd if=/dev/vdb of=/tmp/code.raw bs=4096 2>/dev/null
+          tr -d '\0' < /tmp/code.raw > /tmp/code
+          exec $ENTRYPOINT /tmp/code
+        fi
+        exec /bin/sh

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -43,7 +43,7 @@ fn default_timeout() -> u64 {
     30000
 }
 fn default_boot_args() -> String {
-    "console=ttyS0 reboot=k panic=1".to_string()
+    "console=ttyS0 reboot=k panic=1 init=/init".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## Summary
- Fix VM timeout: kernel was running Alpine's `/sbin/init` (OpenRC) instead of our custom `/init` — added `init=/init` to `boot_args`
- Fix read-only rootfs: init script now mounts `tmpfs` on `/tmp` for writable scratch space
- Move VM init script to a **ConfigMap** (`firecracker-vm-init`) — eliminates printf/heredoc escape issues in YAML and makes the script easy to maintain
- Rootfs init job mounts the ConfigMap and copies the init script into each rootfs image
- Fix null byte stripping: use `tr -d '\0'` (busybox-compatible) instead of `sed 's/\x0//g'`
- Version bumped to 0.1.25 for new Docker build

## Test plan
- [x] Manually tested in-cluster: Python code executes and prints output correctly
- [x] Rust compiles cleanly
- [x] Rootfs images rebuilt with ConfigMap-sourced init script
- [ ] After CI builds v0.1.25: verify IDE code execution end-to-end