### PR TITLE
refactor(discordsh): unify game types with bevy crates, add bevy_skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.100"
+version = "1.0.101"
 dependencies = [
  "anyhow",
  "askama",
@@ -4697,6 +4697,7 @@ dependencies = [
  "bevy_items",
  "bevy_npc",
  "bevy_quests",
+ "bevy_skills",
  "chrono",
  "dashmap 6.1.0",
  "dotenvy",

--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -35,6 +35,7 @@ bevy_inventory = { path = "../../../packages/rust/bevy/bevy_inventory", default-
 bevy_battle = { path = "../../../packages/rust/bevy/bevy_battle" }
 bevy_npc = { path = "../../../packages/rust/bevy/bevy_npc" }
 bevy_quests = { path = "../../../packages/rust/bevy/bevy_quests" }
+bevy_skills = { path = "../../../packages/rust/bevy/bevy_skills" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
@@ -21,166 +21,20 @@ use super::content;
 use super::proto_bridge as pb;
 use super::types::*;
 
-// ── Type conversion helpers ────────────────────────────────────────
+// ── Type helpers ──────────────────────────────────────────────────
+// EffectKind, EffectInstance, Intent, ClassType, Personality, and UseEffect
+// are now re-exported from bevy_battle via types.rs — no conversion needed.
 
-/// Convert session EffectKind → bevy_battle EffectKind.
-fn to_bb_effect(kind: &EffectKind) -> bevy_battle::EffectKind {
-    match kind {
-        EffectKind::Poison => bevy_battle::EffectKind::Poison,
-        EffectKind::Burning => bevy_battle::EffectKind::Burning,
-        EffectKind::Bleed => bevy_battle::EffectKind::Bleed,
-        EffectKind::Shielded => bevy_battle::EffectKind::Shielded,
-        EffectKind::Weakened => bevy_battle::EffectKind::Weakened,
-        EffectKind::Stunned => bevy_battle::EffectKind::Stunned,
-        EffectKind::Sharpened => bevy_battle::EffectKind::Sharpened,
-        EffectKind::Thorns => bevy_battle::EffectKind::Thorns,
-    }
-}
-
-/// Convert bevy_battle EffectKind → session EffectKind.
-pub(super) fn from_bb_effect(kind: &bevy_battle::EffectKind) -> EffectKind {
-    match kind {
-        bevy_battle::EffectKind::Poison => EffectKind::Poison,
-        bevy_battle::EffectKind::Burning => EffectKind::Burning,
-        bevy_battle::EffectKind::Bleed => EffectKind::Bleed,
-        bevy_battle::EffectKind::Shielded => EffectKind::Shielded,
-        bevy_battle::EffectKind::Weakened => EffectKind::Weakened,
-        bevy_battle::EffectKind::Stunned => EffectKind::Stunned,
-        bevy_battle::EffectKind::Sharpened => EffectKind::Sharpened,
-        bevy_battle::EffectKind::Thorns => EffectKind::Thorns,
-    }
-}
-
-/// Convert session EffectInstance → bevy_battle EffectInstance.
-fn to_bb_effect_instance(e: &EffectInstance) -> bevy_battle::EffectInstance {
-    bevy_battle::EffectInstance {
-        kind: to_bb_effect(&e.kind),
-        stacks: e.stacks,
-        turns_left: e.turns_left,
-    }
-}
-
-/// Convert session Intent → bevy_battle Intent.
-fn to_bb_intent(intent: &Intent) -> bevy_battle::Intent {
-    match intent {
-        Intent::Attack { dmg } => bevy_battle::Intent::Attack { dmg: *dmg },
-        Intent::HeavyAttack { dmg } => bevy_battle::Intent::HeavyAttack { dmg: *dmg },
-        Intent::Defend { armor } => bevy_battle::Intent::Defend { armor: *armor },
-        Intent::Charge => bevy_battle::Intent::Charge,
-        Intent::Flee => bevy_battle::Intent::Flee,
-        Intent::Debuff {
-            effect,
-            stacks,
-            turns,
-        } => bevy_battle::Intent::Debuff {
-            effect: to_bb_effect(effect),
-            stacks: *stacks,
-            turns: *turns,
-        },
-        Intent::AoeAttack { dmg } => bevy_battle::Intent::AoeAttack { dmg: *dmg },
-        Intent::HealSelf { amount } => bevy_battle::Intent::HealSelf { amount: *amount },
-    }
-}
-
-/// Convert bevy_battle Intent → session Intent.
-pub(super) fn from_bb_intent(intent: &bevy_battle::Intent) -> Intent {
-    match intent {
-        bevy_battle::Intent::Attack { dmg } => Intent::Attack { dmg: *dmg },
-        bevy_battle::Intent::HeavyAttack { dmg } => Intent::HeavyAttack { dmg: *dmg },
-        bevy_battle::Intent::Defend { armor } => Intent::Defend { armor: *armor },
-        bevy_battle::Intent::Charge => Intent::Charge,
-        bevy_battle::Intent::Flee => Intent::Flee,
-        bevy_battle::Intent::Debuff {
-            effect,
-            stacks,
-            turns,
-        } => Intent::Debuff {
-            effect: from_bb_effect(effect),
-            stacks: *stacks,
-            turns: *turns,
-        },
-        bevy_battle::Intent::AoeAttack { dmg } => Intent::AoeAttack { dmg: *dmg },
-        bevy_battle::Intent::HealSelf { amount } => Intent::HealSelf { amount: *amount },
-    }
-}
-
-/// Convert session ClassType → bevy_battle ClassType.
-fn to_bb_class(class: &ClassType) -> bevy_battle::ClassType {
-    match class {
-        ClassType::Warrior => bevy_battle::ClassType::Warrior,
-        ClassType::Rogue => bevy_battle::ClassType::Rogue,
-        ClassType::Cleric => bevy_battle::ClassType::Cleric,
-    }
-}
-
-/// Convert bevy_battle ClassType → session ClassType.
-pub(super) fn from_bb_class(class: &bevy_battle::ClassType) -> ClassType {
-    match class {
-        bevy_battle::ClassType::Warrior => ClassType::Warrior,
-        bevy_battle::ClassType::Rogue => ClassType::Rogue,
-        bevy_battle::ClassType::Cleric => ClassType::Cleric,
-    }
-}
-
-/// Convert session Personality → bevy_battle Personality.
-fn to_bb_personality(p: &Personality) -> bevy_battle::Personality {
-    match p {
-        Personality::Aggressive => bevy_battle::Personality::Aggressive,
-        Personality::Cunning => bevy_battle::Personality::Cunning,
-        Personality::Fearful => bevy_battle::Personality::Fearful,
-        Personality::Stoic => bevy_battle::Personality::Stoic,
-        Personality::Feral => bevy_battle::Personality::Feral,
-        Personality::Ancient => bevy_battle::Personality::Ancient,
-        Personality::Cheerful => bevy_battle::Personality::Cheerful,
-        Personality::Mysterious => bevy_battle::Personality::Mysterious,
-        Personality::Cowardly => bevy_battle::Personality::Cowardly,
-        Personality::Noble => bevy_battle::Personality::Noble,
-        Personality::Passive => bevy_battle::Personality::Passive,
-    }
-}
-
-/// Convert a session UseEffect → bevy_battle UseEffect for combat-relevant variants.
-///
-/// Returns `None` for session-level effects (GuaranteedFlee, CampfireRest,
-/// TeleportCity, ReviveAlly) that must be handled in logic.rs.
-pub fn to_bb_use_effect(effect: &UseEffect) -> Option<bevy_battle::UseEffect> {
+/// Filter combat-relevant UseEffect variants. Returns `None` for session-level
+/// effects (GuaranteedFlee, CampfireRest, TeleportCity, ReviveAlly) that must
+/// be handled in logic.rs.
+pub fn combat_use_effect(effect: &UseEffect) -> Option<&UseEffect> {
     match effect {
-        UseEffect::Heal { amount } => Some(bevy_battle::UseEffect::Heal { amount: *amount }),
-        UseEffect::DamageEnemy { amount } => {
-            Some(bevy_battle::UseEffect::DamageEnemy { amount: *amount })
-        }
-        UseEffect::ApplyEffect {
-            kind,
-            stacks,
-            turns,
-        } => Some(bevy_battle::UseEffect::ApplyEffect {
-            kind: to_bb_effect(kind),
-            stacks: *stacks,
-            turns: *turns,
-        }),
-        UseEffect::RemoveEffect { kind } => Some(bevy_battle::UseEffect::RemoveEffect {
-            kind: to_bb_effect(kind),
-        }),
-        UseEffect::FullHeal => Some(bevy_battle::UseEffect::FullHeal),
-        UseEffect::RemoveAllNegativeEffects => {
-            Some(bevy_battle::UseEffect::RemoveAllNegativeEffects)
-        }
-        UseEffect::DamageAndApply {
-            damage,
-            kind,
-            stacks,
-            turns,
-        } => Some(bevy_battle::UseEffect::DamageAndApply {
-            damage: *damage,
-            kind: to_bb_effect(kind),
-            stacks: *stacks,
-            turns: *turns,
-        }),
-        // Session-level effects — not handled by bevy_battle
         UseEffect::GuaranteedFlee
         | UseEffect::CampfireRest { .. }
         | UseEffect::TeleportCity
         | UseEffect::ReviveAlly { .. } => None,
+        _ => Some(effect),
     }
 }
 
@@ -375,8 +229,6 @@ impl CombatWorld {
             }
             // Sync inventory into ECS format
             inventories.insert(*uid, session_inventory_to_ecs(&ps.inventory));
-            let effects: Vec<bevy_battle::EffectInstance> =
-                ps.effects.iter().map(to_bb_effect_instance).collect();
 
             let entity = app
                 .world_mut()
@@ -384,7 +236,7 @@ impl CombatWorld {
                     CombatName(ps.name.clone()),
                     Health::new(ps.hp, ps.max_hp),
                     Armor { value: ps.armor },
-                    ActiveEffects(effects),
+                    ActiveEffects(ps.effects.clone()),
                     CombatStats {
                         accuracy: ps.accuracy,
                         crit_chance: ps.crit_chance,
@@ -393,7 +245,7 @@ impl CombatWorld {
                         first_attack_in_combat: ps.first_attack_in_combat,
                         heals_used_this_combat: ps.heals_used_this_combat,
                     },
-                    PlayerClass(to_bb_class(&ps.class)),
+                    PlayerClass(ps.class),
                     resolve_equipped_gear(ps),
                     Combatant,
                     PlayerTag,
@@ -407,24 +259,21 @@ impl CombatWorld {
             if es.hp <= 0 {
                 continue;
             }
-            let effects: Vec<bevy_battle::EffectInstance> =
-                es.effects.iter().map(to_bb_effect_instance).collect();
-
             let entity = app
                 .world_mut()
                 .spawn((
                     CombatName(es.name.clone()),
                     Health::new(es.hp, es.max_hp),
                     Armor { value: es.armor },
-                    ActiveEffects(effects),
+                    ActiveEffects(es.effects.clone()),
                     EnemyAI {
                         level: es.level,
                         charged: es.charged,
                         enraged: es.enraged,
                         first_strike: es.first_strike,
-                        personality: to_bb_personality(&es.personality),
+                        personality: es.personality,
                     },
-                    CurrentIntent(to_bb_intent(&es.intent)),
+                    CurrentIntent(es.intent.clone()),
                     CombatIndex(es.index),
                     Combatant,
                     EnemyTag,
@@ -588,15 +437,7 @@ impl CombatWorld {
             }
 
             if let Some(effects) = world.get::<ActiveEffects>(*entity) {
-                player.effects = effects
-                    .0
-                    .iter()
-                    .map(|e| EffectInstance {
-                        kind: from_bb_effect(&e.kind),
-                        stacks: e.stacks,
-                        turns_left: e.turns_left,
-                    })
-                    .collect();
+                player.effects = effects.0.clone();
             }
 
             // Sync inventory back from bridge
@@ -624,15 +465,7 @@ impl CombatWorld {
             }
 
             if let Some(effects) = world.get::<ActiveEffects>(*entity) {
-                enemy.effects = effects
-                    .0
-                    .iter()
-                    .map(|e| EffectInstance {
-                        kind: from_bb_effect(&e.kind),
-                        stacks: e.stacks,
-                        turns_left: e.turns_left,
-                    })
-                    .collect();
+                enemy.effects = effects.0.clone();
             }
 
             if let Some(ai) = world.get::<EnemyAI>(*entity) {
@@ -641,7 +474,7 @@ impl CombatWorld {
             }
 
             if let Some(intent) = world.get::<CurrentIntent>(*entity) {
-                enemy.intent = from_bb_intent(&intent.0);
+                enemy.intent = intent.0.clone();
             }
         }
     }
@@ -1039,6 +872,7 @@ mod tests {
                 lifetime_gold_earned: 0,
                 lifetime_rooms_cleared: 0,
                 lifetime_bosses_defeated: 0,
+                skills: bevy_skills::SkillProfile::default(),
                 saved_snapshot: None,
             },
         );
@@ -1157,45 +991,15 @@ mod tests {
     }
 
     #[test]
-    fn type_conversion_roundtrip() {
-        let effects = vec![
-            EffectKind::Poison,
-            EffectKind::Burning,
-            EffectKind::Bleed,
-            EffectKind::Shielded,
-            EffectKind::Weakened,
-            EffectKind::Stunned,
-            EffectKind::Sharpened,
-            EffectKind::Thorns,
-        ];
-        for e in &effects {
-            let bb = to_bb_effect(e);
-            let back = from_bb_effect(&bb);
-            assert_eq!(*e, back, "Roundtrip failed for {:?}", e);
-        }
-    }
+    fn shared_types_are_bevy_battle() {
+        // After migration, session types ARE bevy_battle types — no conversion layer.
+        let effect = EffectKind::Poison;
+        let bb_effect: bevy_battle::EffectKind = effect;
+        assert_eq!(bb_effect, EffectKind::Poison);
 
-    #[test]
-    fn intent_conversion_roundtrip() {
-        let intents = vec![
-            Intent::Attack { dmg: 10 },
-            Intent::HeavyAttack { dmg: 20 },
-            Intent::Defend { armor: 5 },
-            Intent::Charge,
-            Intent::Flee,
-            Intent::AoeAttack { dmg: 8 },
-            Intent::HealSelf { amount: 15 },
-            Intent::Debuff {
-                effect: EffectKind::Poison,
-                stacks: 2,
-                turns: 3,
-            },
-        ];
-        for i in &intents {
-            let bb = to_bb_intent(i);
-            let back = from_bb_intent(&bb);
-            assert_eq!(*i, back, "Roundtrip failed for {:?}", i);
-        }
+        let intent = Intent::Attack { dmg: 10 };
+        let bb_intent: bevy_battle::Intent = intent.clone();
+        assert_eq!(bb_intent, Intent::Attack { dmg: 10 });
     }
 
     #[test]

--- a/apps/discordsh/discordsh-bot/src/discord/game/card.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/card.rs
@@ -2,7 +2,6 @@ use askama::Template;
 use bevy_battle::snapshot::CombatSnapshot;
 use kbve::{FontDb, render_svg_to_png};
 
-use super::battle_bridge::{from_bb_class, from_bb_effect, from_bb_intent};
 use super::types::*;
 
 // ── Pre-computed display values ─────────────────────────────────────
@@ -554,7 +553,7 @@ impl GameCardTemplate {
                 let xp_to_next = session_player.map(|p| p.xp_to_next).unwrap_or(100);
                 let class_label = session_player
                     .map(|p| p.class.label().to_string())
-                    .unwrap_or_else(|| from_bb_class(&sp.class).label().to_string());
+                    .unwrap_or_else(|| sp.class.label().to_string());
 
                 // Build weapon/armor display strings from session
                 let weapon_display = session_player
@@ -568,12 +567,11 @@ impl GameCardTemplate {
                     .map(|g| format!("\u{1F6E1} {}", g.name))
                     .unwrap_or_default();
 
-                // Convert snapshot effects to session EffectInstances for badge building
                 let effects: Vec<EffectInstance> = sp
                     .effects
                     .iter()
                     .map(|e| EffectInstance {
-                        kind: from_bb_effect(&e.kind),
+                        kind: e.kind,
                         stacks: e.stacks,
                         turns_left: e.turns_left,
                     })
@@ -668,8 +666,7 @@ impl GameCardTemplate {
                     let y_intent = y_def + 20;
                     let y_effects = y_intent + 30;
 
-                    let session_intent = from_bb_intent(&se.intent);
-                    let (icon, text) = intent_to_icon_and_text(&session_intent);
+                    let (icon, text) = intent_to_icon_and_text(&se.intent);
                     let display_name = if se.enraged {
                         format!("{} \u{1F525}", se.name)
                     } else {
@@ -680,7 +677,7 @@ impl GameCardTemplate {
                         .effects
                         .iter()
                         .map(|e| EffectInstance {
-                            kind: from_bb_effect(&e.kind),
+                            kind: e.kind,
                             stacks: e.stacks,
                             turns_left: e.turns_left,
                         })

--- a/apps/discordsh/discordsh-bot/src/discord/game/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/mod.rs
@@ -8,6 +8,7 @@ pub mod proto_bridge;
 pub mod render;
 pub mod router;
 pub mod session;
+pub mod skills;
 pub mod types;
 
 pub use persistence::ProfileStore;

--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -44,6 +44,9 @@ pub struct DungeonProfile {
     pub armor_gear: Option<String>,
     pub inventory: serde_json::Value,
     pub completed_quests: Vec<String>,
+    /// Serialized `SkillProfile` (JSONB). Empty/null for legacy profiles.
+    #[serde(default)]
+    pub skills: serde_json::Value,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }
@@ -280,6 +283,14 @@ pub fn apply_profile_to_player(
         }
     }
 
+    // Restore skill profile from JSONB (empty object = fresh profile)
+    if !profile.skills.is_null() && profile.skills != serde_json::json!({}) {
+        if let Ok(sp) = serde_json::from_value::<bevy_skills::SkillProfile>(profile.skills.clone())
+        {
+            player.skills = sp;
+        }
+    }
+
     // Restore completed quests
     for ref_slug in &profile.completed_quests {
         if !journal.is_completed(ref_slug) {
@@ -384,6 +395,7 @@ pub fn extract_save_payload(
         armor_gear: player.armor_gear.clone(),
         inventory: final_inventory,
         completed_quests: journal.completed.clone(),
+        skills: serde_json::to_value(&player.skills).unwrap_or_default(),
         created_at: None,
         updated_at: None,
     };
@@ -534,6 +546,7 @@ mod tests {
             armor_gear: None,
             inventory: serde_json::json!([]),
             completed_quests: Vec::new(),
+            skills: serde_json::json!({}),
             created_at: None,
             updated_at: None,
         };
@@ -587,6 +600,7 @@ mod tests {
             armor_gear: None,
             inventory: serde_json::json!([]),
             completed_quests: Vec::new(),
+            skills: serde_json::json!({}),
             created_at: None,
             updated_at: None,
         };

--- a/apps/discordsh/discordsh-bot/src/discord/game/skills.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/skills.rs
@@ -1,0 +1,108 @@
+//! Skill definitions and XP grant helpers for the Embed Dungeon.
+//!
+//! Uses `bevy_skills::SkillProfile` as a standalone data structure (no ECS).
+//! The profile is stored on `PlayerState` and persisted via `DungeonProfile`.
+
+use bevy_skills::{SkillId, SkillProfile, XpCurve};
+
+// ── Skill IDs ──────────────────────────────────────────────────────
+
+pub const COMBAT_REF: &str = "combat";
+pub const EXPLORATION_REF: &str = "exploration";
+pub const FORAGING_REF: &str = "foraging";
+
+/// Stable skill ID for combat (killing enemies, boss fights).
+pub fn combat_id() -> SkillId {
+    SkillId::from_ref(COMBAT_REF)
+}
+
+/// Stable skill ID for exploration (rooms cleared, maps traversed).
+pub fn exploration_id() -> SkillId {
+    SkillId::from_ref(EXPLORATION_REF)
+}
+
+/// Stable skill ID for foraging (gathering, looting, treasure rooms).
+pub fn foraging_id() -> SkillId {
+    SkillId::from_ref(FORAGING_REF)
+}
+
+// ── XP curve ────────────────────────────────────────────────────────
+
+/// The XP curve shared by all dungeon skills.
+///
+/// Level 1 = 75 XP, quadratic scaling:
+///   `xp_for_level(n) = 50*n + 25*n*n`
+pub fn dungeon_xp_curve() -> XpCurve {
+    XpCurve {
+        base: 50,
+        scaling: 25,
+        max_level: 99,
+    }
+}
+
+// ── XP grant helpers ────────────────────────────────────────────────
+
+/// Grant combat XP based on enemy level (scaled: 10 + 5*level).
+pub fn grant_combat_xp(profile: &mut SkillProfile, enemy_level: u8) {
+    let xp = 10 + 5 * enemy_level as u64;
+    profile.grant_xp_direct(combat_id(), xp);
+}
+
+/// Grant exploration XP for clearing a room (flat 15 XP + depth bonus).
+pub fn grant_exploration_xp(profile: &mut SkillProfile, depth: u32) {
+    let xp = 15 + depth as u64 * 2;
+    profile.grant_xp_direct(exploration_id(), xp);
+}
+
+/// Grant foraging XP for looting (flat 8 XP per item picked up).
+pub fn grant_foraging_xp(profile: &mut SkillProfile, item_count: u32) {
+    let xp = 8 * item_count as u64;
+    if xp > 0 {
+        profile.grant_xp_direct(foraging_id(), xp);
+    }
+}
+
+/// Recompute levels for all skills using the dungeon XP curve.
+///
+/// Call this after granting XP to update cached levels.
+pub fn recompute_levels(profile: &mut SkillProfile) {
+    let curve = dungeon_xp_curve();
+    // Collect ids + xp first to release the immutable borrow.
+    let entries: Vec<(SkillId, u64)> = profile.iter().map(|(id, e)| (id, e.total_xp)).collect();
+    for (id, total) in entries {
+        let level = curve.level_for_xp(total);
+        profile.set_level_direct(id, level);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combat_xp_scales_with_level() {
+        let mut profile = SkillProfile::default();
+        grant_combat_xp(&mut profile, 1);
+        assert_eq!(profile.total_xp(combat_id()), 15); // 10 + 5*1
+        grant_combat_xp(&mut profile, 10);
+        assert_eq!(profile.total_xp(combat_id()), 75); // 15 + 10 + 5*10
+    }
+
+    #[test]
+    fn exploration_xp_includes_depth() {
+        let mut profile = SkillProfile::default();
+        grant_exploration_xp(&mut profile, 5);
+        assert_eq!(profile.total_xp(exploration_id()), 25); // 15 + 5*2
+    }
+
+    #[test]
+    fn level_computation() {
+        let mut profile = SkillProfile::default();
+        // Grant enough XP for level 1 (75 on default curve)
+        for _ in 0..5 {
+            grant_combat_xp(&mut profile, 10); // 5 * 60 = 300 total
+        }
+        recompute_levels(&mut profile);
+        assert!(profile.level(combat_id()) >= 1);
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/discord/game/types.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/types.rs
@@ -6,6 +6,9 @@ use std::time::Instant;
 use poise::serenity_prelude as serenity;
 use serde::ser::SerializeMap;
 
+// ── Re-exports from bevy_battle (canonical game types) ────────────
+pub use bevy_battle::{ClassType, EffectInstance, EffectKind, Intent, Personality, UseEffect};
+
 // ── Map types ──────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -220,53 +223,10 @@ pub enum RoomType {
 }
 
 // ── Effects ─────────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-pub enum EffectKind {
-    Poison,
-    Burning,
-    Bleed,
-    Shielded,
-    Weakened,
-    Stunned,
-    Sharpened,
-    Thorns,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct EffectInstance {
-    pub kind: EffectKind,
-    pub stacks: u8,
-    pub turns_left: u8,
-}
+// EffectKind and EffectInstance are re-exported from bevy_battle above.
 
 // ── Enemy intent (telegraph) ────────────────────────────────────────
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-pub enum Intent {
-    Attack {
-        dmg: i32,
-    },
-    HeavyAttack {
-        dmg: i32,
-    },
-    Defend {
-        armor: i32,
-    },
-    Charge,
-    Flee,
-    Debuff {
-        effect: EffectKind,
-        stacks: u8,
-        turns: u8,
-    },
-    AoeAttack {
-        dmg: i32,
-    },
-    HealSelf {
-        amount: i32,
-    },
-}
+// Intent is re-exported from bevy_battle above.
 
 // ── Items ───────────────────────────────────────────────────────────
 
@@ -274,46 +234,10 @@ pub const MAX_INVENTORY_SLOTS: usize = 16;
 
 pub type ItemId = String;
 
-#[derive(Debug, Clone, serde::Serialize)]
-pub enum UseEffect {
-    Heal {
-        amount: i32,
-    },
-    DamageEnemy {
-        amount: i32,
-    },
-    ApplyEffect {
-        kind: EffectKind,
-        stacks: u8,
-        turns: u8,
-    },
-    RemoveEffect {
-        kind: EffectKind,
-    },
-    GuaranteedFlee,
-    FullHeal,
-    RemoveAllNegativeEffects,
-    /// Rest all alive party members: heal % of max HP, clear negative effects.
-    CampfireRest {
-        heal_percent: u8,
-    },
-    /// Teleport the entire party back to the origin city tile.
-    TeleportCity,
-    /// Deal damage to an enemy and apply a status effect.
-    DamageAndApply {
-        damage: i32,
-        kind: EffectKind,
-        stacks: u8,
-        turns: u8,
-    },
-    /// Revive a dead party member at a percentage of their max HP.
-    ReviveAlly {
-        heal_percent: u8,
-    },
-}
+// UseEffect is re-exported from bevy_battle above.
 
 // ── Item rarity ────────────────────────────────────────────────────
-
+// TODO: migrate ItemRarity to a shared crate (bevy_items) in a follow-up.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 pub enum ItemRarity {
     Common,
@@ -467,16 +391,16 @@ pub struct GearDef {
 }
 
 // ── Player class ────────────────────────────────────────────────────
+// ClassType is re-exported from bevy_battle above.
+// Presentation helpers via extension trait (emoji/label are Discord-specific).
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-pub enum ClassType {
-    Warrior,
-    Rogue,
-    Cleric,
+pub trait ClassTypeExt {
+    fn emoji(&self) -> &'static str;
+    fn label(&self) -> &'static str;
 }
 
-impl ClassType {
-    pub fn emoji(&self) -> &'static str {
+impl ClassTypeExt for ClassType {
+    fn emoji(&self) -> &'static str {
         match self {
             ClassType::Warrior => "\u{2694}",
             ClassType::Rogue => "\u{1F5E1}",
@@ -484,7 +408,7 @@ impl ClassType {
         }
     }
 
-    pub fn label(&self) -> &'static str {
+    fn label(&self) -> &'static str {
         match self {
             ClassType::Warrior => "Warrior",
             ClassType::Rogue => "Rogue",
@@ -523,6 +447,8 @@ pub struct PlayerState {
     pub lifetime_gold_earned: u32,
     pub lifetime_rooms_cleared: u32,
     pub lifetime_bosses_defeated: u32,
+    /// Skill progression (combat, exploration, foraging, etc.).
+    pub skills: bevy_skills::SkillProfile,
     /// Snapshot of the loaded profile at session start (for death penalty diff).
     #[serde(skip)]
     pub saved_snapshot: Option<super::persistence::DungeonProfile>,
@@ -557,6 +483,7 @@ impl Default for PlayerState {
             lifetime_gold_earned: 0,
             lifetime_rooms_cleared: 0,
             lifetime_bosses_defeated: 0,
+            skills: bevy_skills::SkillProfile::default(),
             saved_snapshot: None,
         }
     }
@@ -604,32 +531,7 @@ impl PlayerState {
 
 // ── Enemy personality ───────────────────────────────────────────────
 
-/// Personality archetype that drives flavor text selection for enemy actions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-pub enum Personality {
-    /// Relentless, rage-fueled — loves to taunt and charge.
-    Aggressive,
-    /// Calculating, deceptive — comments on strategy, mocks mistakes.
-    Cunning,
-    /// Cowardly, desperate — panics at low HP, hesitates before attacking.
-    Fearful,
-    /// Silent, disciplined — minimal dialogue, matter-of-fact.
-    Stoic,
-    /// Bestial, instinct-driven — growls, hisses, no real speech.
-    Feral,
-    /// Ancient, weary — speaks in riddles, references the past.
-    Ancient,
-    /// Cheerful, upbeat — jokes mid-combat, stays positive.
-    Cheerful,
-    /// Mysterious, enigmatic — cryptic remarks, veiled threats.
-    Mysterious,
-    /// Cowardly, skittish — flees early, begs for mercy.
-    Cowardly,
-    /// Noble, honorable — fights with dignity, respects foes.
-    Noble,
-    /// Passive, docile — ambient creatures, rarely aggressive.
-    Passive,
-}
+// Personality is re-exported from bevy_battle above.
 
 // ── Enemy state ─────────────────────────────────────────────────────
 

--- a/packages/rust/bevy/bevy_skills/src/profile.rs
+++ b/packages/rust/bevy/bevy_skills/src/profile.rs
@@ -59,6 +59,21 @@ impl SkillProfile {
         }
     }
 
+    /// Grant XP directly without going through the ECS message pipeline.
+    ///
+    /// Useful for headless or non-ECS consumers (e.g. Discord bot sessions).
+    /// The caller is responsible for recomputing levels afterward.
+    pub fn grant_xp_direct(&mut self, id: SkillId, amount: u64) -> u64 {
+        self.grant_xp(id, amount)
+    }
+
+    /// Set the cached level directly without going through the ECS system.
+    ///
+    /// Useful for headless consumers that compute levels externally.
+    pub fn set_level_direct(&mut self, id: SkillId, level: u32) {
+        self.set_level(id, level);
+    }
+
     /// Iterate over all trained skills.
     pub fn iter(&self) -> impl Iterator<Item = (SkillId, &SkillEntry)> {
         self.skills.iter().map(|(&id, entry)| (id, entry))


### PR DESCRIPTION
## Summary
- **Eliminate 6 duplicate enum definitions** (EffectKind, EffectInstance, Intent, ClassType, Personality, UseEffect) in discordsh-bot — now re-exported from `bevy_battle` directly
- **Remove ~250 lines of bidirectional type conversion** boilerplate in `battle_bridge.rs` (all `to_bb_*`/`from_bb_*` functions deleted)
- **Integrate `bevy_skills`** crate: SkillProfile on PlayerState with combat/exploration/foraging XP grants, persisted as JSONB in DungeonProfile
- **Add public API** to `bevy_skills::SkillProfile` (`grant_xp_direct`, `set_level_direct`) for non-ECS consumers

Net: **-157 lines** (191 added, 348 removed)

## Test plan
- [x] `cargo check -p discordsh-bot` passes
- [x] `cargo check -p bevy_skills` passes
- [x] `cargo test -p discordsh-bot` — all 701 tests pass
- [x] `cargo test -p bevy_skills` — all 3 tests pass
- [ ] Verify CI passes