### PR TITLE
feat(discordsh): wire up skill XP grants and /skills command

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod gh;
 pub(crate) mod github_board;
 mod health;
 mod ping;
+mod skills;
 mod status;
 
 use crate::discord::bot::{Data, Error};
@@ -19,5 +20,6 @@ pub fn all() -> Vec<poise::Command<Data, Error>> {
         dungeon::dungeon(),
         github_board::github(),
         gh::gh(),
+        skills::skills(),
     ]
 }

--- a/apps/discordsh/discordsh-bot/src/discord/commands/skills.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/skills.rs
@@ -1,0 +1,90 @@
+use poise::serenity_prelude as serenity;
+
+use crate::discord::bot::{Context, Error};
+use crate::discord::game::skills;
+
+/// View your dungeon skill levels (combat, exploration, foraging).
+#[poise::command(slash_command)]
+pub async fn skills(ctx: Context<'_>) -> Result<(), Error> {
+    let user = ctx.author().id;
+    let app = &ctx.data().app;
+
+    // Try active session first, then fall back to persisted profile.
+    let profile = match active_session_skills(user, app) {
+        Some(p) => Some(p),
+        None => persisted_skills_async(user, app).await,
+    };
+
+    let Some(profile) = profile else {
+        ctx.say("No skill data found. Start a `/dungeon` session to begin training!")
+            .await?;
+        return Ok(());
+    };
+
+    let curve = skills::dungeon_xp_curve();
+    let mut lines = Vec::new();
+
+    for (ref_name, label, emoji) in [
+        (skills::COMBAT_REF, "Combat", "\u{2694}\u{FE0F}"),
+        (skills::EXPLORATION_REF, "Exploration", "\u{1F5FA}\u{FE0F}"),
+        (skills::FORAGING_REF, "Foraging", "\u{1F33F}"),
+    ] {
+        let id = bevy_skills::SkillId::from_ref(ref_name);
+        let level = profile.level(id);
+        let total = profile.total_xp(id);
+        let to_next = curve.xp_to_next_level(total);
+        let progress = curve.progress(total);
+        let bar = progress_bar(progress, 10);
+
+        lines.push(format!(
+            "{emoji} **{label}** — Lv. {level}  |  {bar}  {total} XP ({to_next} to next)"
+        ));
+    }
+
+    let total_level = profile.total_level();
+    lines.push(String::new());
+    lines.push(format!("**Total Level:** {total_level}"));
+
+    let embed = serenity::CreateEmbed::new()
+        .title(format!("{}'s Skills", ctx.author().name))
+        .description(lines.join("\n"))
+        .color(0x2ECC71);
+
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+/// Build a text progress bar (e.g. "████░░░░░░").
+fn progress_bar(fraction: f32, width: usize) -> String {
+    let filled = (fraction * width as f32).round() as usize;
+    let empty = width.saturating_sub(filled);
+    format!(
+        "`{}{}`",
+        "\u{2588}".repeat(filled),
+        "\u{2591}".repeat(empty)
+    )
+}
+
+/// Try to read SkillProfile from an active dungeon session.
+fn active_session_skills(
+    user: serenity::UserId,
+    app: &crate::state::AppState,
+) -> Option<bevy_skills::SkillProfile> {
+    let sid = app.sessions.find_by_user(user)?;
+    let session_arc = app.sessions.get(&sid)?;
+    let session = session_arc.blocking_lock();
+    let player = session.players.get(&user)?;
+    Some(player.skills.clone())
+}
+
+/// Try to load SkillProfile from the persisted DungeonProfile.
+async fn persisted_skills_async(
+    user: serenity::UserId,
+    app: &crate::state::AppState,
+) -> Option<bevy_skills::SkillProfile> {
+    let profile = app.profiles.load(user.get()).await?;
+    if profile.skills.is_null() || profile.skills == serde_json::json!({}) {
+        return None;
+    }
+    serde_json::from_value(profile.skills).ok()
+}

--- a/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
@@ -6,6 +6,7 @@ use tracing::debug;
 use super::battle_bridge;
 use super::content;
 use super::proto_bridge;
+use super::skills;
 use super::types::*;
 
 /// Result of applying a game action, including optional ECS combat snapshot.
@@ -984,6 +985,11 @@ fn handle_enemy_deaths(session: &mut SessionState, actor: serenity::UserId) -> V
         // Increment lifetime kills for the actor
         session.player_mut(actor).lifetime_kills += 1;
 
+        // Grant combat skill XP to all alive players
+        for &uid in &alive_ids {
+            skills::grant_combat_xp(&mut session.player_mut(uid).skills, *enemy_level);
+        }
+
         // Advance kill quest objectives — derive ref slug from display name
         let enemy_ref = enemy_name.to_lowercase().replace(' ', "-");
         advance_kill_objectives(session, &enemy_ref, &mut logs);
@@ -997,6 +1003,7 @@ fn handle_enemy_deaths(session: &mut SessionState, actor: serenity::UserId) -> V
         let recipient_name = session.player(loot_recipient).name.clone();
 
         // Roll item loot drop
+        let mut items_looted: u32 = 0;
         if i < dead_loot_tables.len() {
             let loot_id = dead_loot_tables[i];
             let mut item_was_rare = false;
@@ -1014,6 +1021,7 @@ fn handle_enemy_deaths(session: &mut SessionState, actor: serenity::UserId) -> V
                             item_id,
                         ) {
                             logs.push(format!("Dropped: {}!", def.name));
+                            items_looted += 1;
                         } else {
                             logs.push(format!("Inventory full! Dropped: {}", def.name));
                         }
@@ -1050,6 +1058,7 @@ fn handle_enemy_deaths(session: &mut SessionState, actor: serenity::UserId) -> V
                                 logs.push(format!("Dropped gear: {}!", gear.name));
                             }
                         }
+                        items_looted += 1;
                     } else if let Some(gear) = content::find_gear(gear_id) {
                         logs.push(format!("Inventory full! Lost gear: {}", gear.name));
                     }
@@ -1058,6 +1067,11 @@ fn handle_enemy_deaths(session: &mut SessionState, actor: serenity::UserId) -> V
                     }
                 }
             }
+        }
+
+        // Grant foraging XP for items actually picked up
+        if items_looted > 0 {
+            skills::grant_foraging_xp(&mut session.player_mut(loot_recipient).skills, items_looted);
         }
 
         if xp_per_player > 0 {
@@ -1916,8 +1930,11 @@ fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
 
     // Increment lifetime_rooms_cleared for all alive players
     let alive_ids = session.alive_player_ids();
+    let depth = pos.depth();
     for &uid in &alive_ids {
-        session.player_mut(uid).lifetime_rooms_cleared += 1;
+        let player = session.player_mut(uid);
+        player.lifetime_rooms_cleared += 1;
+        skills::grant_exploration_xp(&mut player.skills, depth);
     }
 
     // Advance explore quest objectives
@@ -2593,6 +2610,7 @@ fn apply_treasure_choice(
         if let Some(&uid) = alive_ids.first() {
             let player = session.player_mut(uid);
             add_item_to_inventory(&mut player.inventory, item_id);
+            skills::grant_foraging_xp(&mut player.skills, 1);
             let emoji = super::content::find_item(item_id)
                 .map(|d| d.emoji.as_ref())
                 .unwrap_or("📦");
@@ -2606,6 +2624,7 @@ fn apply_treasure_choice(
         if let Some(&uid) = alive_ids.first() {
             let player = session.player_mut(uid);
             add_item_to_inventory(&mut player.inventory, gear_id);
+            skills::grant_foraging_xp(&mut player.skills, 1);
             let emoji = super::content::find_gear(gear_id)
                 .map(|d| d.emoji.as_ref())
                 .unwrap_or("⚔️");

--- a/apps/discordsh/discordsh-bot/src/discord/game/skills.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/skills.rs
@@ -44,21 +44,27 @@ pub fn dungeon_xp_curve() -> XpCurve {
 
 /// Grant combat XP based on enemy level (scaled: 10 + 5*level).
 pub fn grant_combat_xp(profile: &mut SkillProfile, enemy_level: u8) {
+    let id = combat_id();
     let xp = 10 + 5 * enemy_level as u64;
-    profile.grant_xp_direct(combat_id(), xp);
+    let total = profile.grant_xp_direct(id, xp);
+    profile.set_level_direct(id, dungeon_xp_curve().level_for_xp(total));
 }
 
 /// Grant exploration XP for clearing a room (flat 15 XP + depth bonus).
 pub fn grant_exploration_xp(profile: &mut SkillProfile, depth: u32) {
+    let id = exploration_id();
     let xp = 15 + depth as u64 * 2;
-    profile.grant_xp_direct(exploration_id(), xp);
+    let total = profile.grant_xp_direct(id, xp);
+    profile.set_level_direct(id, dungeon_xp_curve().level_for_xp(total));
 }
 
 /// Grant foraging XP for looting (flat 8 XP per item picked up).
 pub fn grant_foraging_xp(profile: &mut SkillProfile, item_count: u32) {
+    let id = foraging_id();
     let xp = 8 * item_count as u64;
     if xp > 0 {
-        profile.grant_xp_direct(foraging_id(), xp);
+        let total = profile.grant_xp_direct(id, xp);
+        profile.set_level_direct(id, dungeon_xp_curve().level_for_xp(total));
     }
 }
 


### PR DESCRIPTION
## Summary
- **Wire up XP grants** in `logic.rs` at three key game events:
  - **Combat:** all alive players get XP on enemy kill (10 + 5*enemy_level)
  - **Exploration:** all alive players get XP on room arrival (15 + depth*2)
  - **Foraging:** loot recipient gets XP per item picked up (8 per item)
- **Add `/skills` slash command** — displays combat/exploration/foraging levels with progress bars, total XP, and XP-to-next. Reads from active session or falls back to persisted DungeonProfile
- **Auto-recompute levels** inline after each XP grant (no separate recompute pass needed)

Builds on #9794 which added the bevy_skills integration and shared type unification.

## Test plan
- [x] `cargo check -p discordsh-bot` passes
- [x] `cargo test -p discordsh-bot` — all 701 tests pass
- [x] `cargo test -p bevy_skills` — all tests pass
- [ ] Verify CI passes
- [ ] Manual test: run dungeon session, kill enemies, check `/skills` shows XP accumulation