### PR TITLE
fix(discordsh-bot): add bevy_skills to Docker build

### DIFF
--- a/apps/discordsh/discordsh-bot/Cargo.workspace.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.workspace.toml
@@ -9,6 +9,7 @@ members = [
     "packages/rust/bevy/bevy_battle",
     "packages/rust/bevy/bevy_npc",
     "packages/rust/bevy/bevy_quests",
+    "packages/rust/bevy/bevy_skills",
 ]
 
 [profile.release]

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -20,6 +20,7 @@ COPY packages/rust/bevy/bevy_items/Cargo.toml packages/rust/bevy/bevy_items/Carg
 COPY packages/rust/bevy/bevy_battle/Cargo.toml packages/rust/bevy/bevy_battle/Cargo.toml
 COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
 COPY packages/rust/bevy/bevy_quests/Cargo.toml packages/rust/bevy/bevy_quests/Cargo.toml
+COPY packages/rust/bevy/bevy_skills/Cargo.toml packages/rust/bevy/bevy_skills/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
@@ -30,7 +31,8 @@ RUN mkdir -p apps/discordsh/discordsh-bot/src && echo "fn main() {}" > apps/disc
     mkdir -p packages/rust/bevy/bevy_items/src && echo "" > packages/rust/bevy/bevy_items/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_battle/src && echo "" > packages/rust/bevy/bevy_battle/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_quests/src && echo "" > packages/rust/bevy/bevy_quests/src/lib.rs
+    mkdir -p packages/rust/bevy/bevy_quests/src && echo "" > packages/rust/bevy/bevy_quests/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_skills/src && echo "" > packages/rust/bevy/bevy_skills/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -71,11 +73,12 @@ COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
 COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
 COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
+COPY packages/rust/bevy/bevy_skills packages/rust/bevy/bevy_skills
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc -p bevy_quests
+    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills
 
 # ============================================================================
 # [STAGE D] - Build Application
@@ -95,6 +98,7 @@ COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
 COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
 COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
+COPY packages/rust/bevy/bevy_skills packages/rust/bevy/bevy_skills
 
 # Application source (most frequently changing — placed last for cache)
 COPY apps/discordsh/discordsh-bot apps/discordsh/discordsh-bot


### PR DESCRIPTION
## Summary
- `discordsh-bot` gained a dependency on `bevy_skills` but the Dockerfile and `Cargo.workspace.toml` were not updated
- `cargo chef prepare` fails: `failed to read /app/packages/rust/bevy/bevy_skills/Cargo.toml`
- Add `bevy_skills` to all 4 Dockerfile stages (planner COPY, planner stubs, foundation COPY+build, builder COPY) and the Docker workspace toml

Closes the build failure in https://github.com/KBVE/kbve/actions/runs/24126106769

## Test plan
- [ ] CI Docker build for discordsh-bot passes