### PR TITLE
chore(deps-dev): bump cssnano from 7.0.6 to 7.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"autoprefixer": "^10.4.24",
 		"babel-plugin-macros": "^3.1.0",
 		"babel-plugin-styled-components": "2.1.4",
-		"cssnano": "^7.0.6",
+		"cssnano": "^7.1.4",
 		"esbuild": "0.25.0",
 		"eslint": "8.57.0",
 		"eslint-config-prettier": "10.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,8 +465,8 @@ importers:
                 specifier: 2.1.4
                 version: 2.1.4(@babel/core@7.26.10)(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
             cssnano:
-                specifier: ^7.0.6
-                version: 7.0.6(postcss@8.5.3)
+                specifier: ^7.1.4
+                version: 7.1.4(postcss@8.5.3)
             esbuild:
                 specifier: 0.25.0
                 version: 0.25.0
@@ -2291,6 +2291,12 @@ packages:
         resolution:
             {
                 integrity: sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==,
+            }
+
+    '@colordx/core@5.0.3':
+        resolution:
+            {
+                integrity: sha512-xBQ0MYRTNNxW3mS2sJtlQTT7C3Sasqgh1/PsHva7fyDb5uqYY+gv9V0utDdX8X80mqzbGz3u/IDJdn2d/uW09g==,
             }
 
     '@cspotcode/source-map-support@0.8.1':
@@ -11928,12 +11934,6 @@ packages:
             }
         engines: { node: '>=12.5.0' }
 
-    colord@2.9.3:
-        resolution:
-            {
-                integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==,
-            }
-
     colorette@1.4.0:
         resolution:
             {
@@ -12514,23 +12514,14 @@ packages:
         engines: { node: '>=4' }
         hasBin: true
 
-    cssnano-preset-default@7.0.6:
+    cssnano-preset-default@7.0.12:
         resolution:
             {
-                integrity: sha512-ZzrgYupYxEvdGGuqL+JKOY70s7+saoNlHSCK/OGn1vB2pQK8KSET8jvenzItcY+kA7NoWvfbb/YhlzuzNKjOhQ==,
+                integrity: sha512-B3Eoouzw/sl2zANI0AL9KbacummJTCww+fkHaDBMZad/xuVx8bUduPLly6hKVQAlrmvYkS1jB1CVQEKm3gn0AA==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
-
-    cssnano-utils@5.0.0:
-        resolution:
-            {
-                integrity: sha512-Uij0Xdxc24L6SirFr25MlwC2rCFX6scyUmuKpzI+JQ7cyqDEwD42fJ0xfB3yLfOnRDU5LKGgjQ9FA6LYh76GWQ==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     cssnano-utils@5.0.1:
         resolution:
@@ -12541,14 +12532,14 @@ packages:
         peerDependencies:
             postcss: ^8.4.32
 
-    cssnano@7.0.6:
+    cssnano@7.1.4:
         resolution:
             {
-                integrity: sha512-54woqx8SCbp8HwvNZYn68ZFAepuouZW4lTwiMVnBErM3VkO7/Sd4oTOt3Zz3bPx3kxQ36aISppyXj2Md4lg8bw==,
+                integrity: sha512-T9PNS7y+5Nc9Qmu9mRONqfxG1RVY7Vuvky0XN6MZ+9hqplesTEwnj9r0ROtVuSwUVfaDhVlavuzWIVLUgm4hkQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     csso@5.0.5:
         resolution:
@@ -17950,10 +17941,10 @@ packages:
             }
         engines: { node: '>= 12.0.0' }
 
-    lilconfig@3.1.2:
+    lilconfig@3.1.3:
         resolution:
             {
-                integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==,
+                integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
             }
         engines: { node: '>=14' }
 
@@ -20608,59 +20599,59 @@ packages:
         peerDependencies:
             postcss: ^8.4.38
 
-    postcss-colormin@7.0.2:
+    postcss-colormin@7.0.7:
         resolution:
             {
-                integrity: sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==,
+                integrity: sha512-sBQ628lSj3VQpDquQel8Pen5mmjFPsO4pH9lDLaHB1AVkMRHtkl0pRB5DCWznc9upWsxint/kV+AveSj7W1tew==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-convert-values@7.0.4:
+    postcss-convert-values@7.0.9:
         resolution:
             {
-                integrity: sha512-e2LSXPqEHVW6aoGbjV9RsSSNDO3A0rZLCBxN24zvxF25WknMPpX8Dm9UxxThyEbaytzggRuZxaGXqaOhxQ514Q==,
+                integrity: sha512-l6uATQATZaCa0bckHV+r6dLXfWtUBKXxO3jK+AtxxJJtgMPD+VhhPCCx51I4/5w8U5uHV67g3w7PXj+V3wlMlg==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-discard-comments@7.0.3:
+    postcss-discard-comments@7.0.6:
         resolution:
             {
-                integrity: sha512-q6fjd4WU4afNhWOA2WltHgCbkRhZPgQe7cXF74fuVB/ge4QbM9HEaOIzGSiMvM+g/cOsNAUGdf2JDzqA2F8iLA==,
+                integrity: sha512-Sq+Fzj1Eg5/CPf1ERb0wS1Im5cvE2gDXCE+si4HCn1sf+jpQZxDI4DXEp8t77B/ImzDceWE2ebJQFXdqZ6GRJw==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-discard-duplicates@7.0.1:
+    postcss-discard-duplicates@7.0.2:
         resolution:
             {
-                integrity: sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==,
+                integrity: sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-discard-empty@7.0.0:
+    postcss-discard-empty@7.0.1:
         resolution:
             {
-                integrity: sha512-e+QzoReTZ8IAwhnSdp/++7gBZ/F+nBq9y6PomfwORfP7q9nBpK5AMP64kOt0bA+lShBFbBDcgpJ3X4etHg4lzA==,
+                integrity: sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-discard-overridden@7.0.0:
+    postcss-discard-overridden@7.0.1:
         resolution:
             {
-                integrity: sha512-GmNAzx88u3k2+sBTZrJSDauR0ccpE24omTQCVmaTTZFz1du6AasspjaUPMJ2ud4RslZpoFKyf+6MSPETLojc6w==,
+                integrity: sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     postcss-import@14.1.0:
         resolution:
@@ -20681,14 +20672,14 @@ packages:
             postcss: ^7.0.0 || ^8.0.1
             webpack: ^5.0.0
 
-    postcss-merge-longhand@7.0.4:
+    postcss-merge-longhand@7.0.5:
         resolution:
             {
-                integrity: sha512-zer1KoZA54Q8RVHKOY5vMke0cCdNxMP3KBfDerjH/BYHh4nCIh+1Yy0t1pAEQF18ac/4z3OFclO+ZVH8azjR4A==,
+                integrity: sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     postcss-merge-rules@7.0.8:
         resolution:
@@ -20699,41 +20690,41 @@ packages:
         peerDependencies:
             postcss: ^8.4.32
 
-    postcss-minify-font-values@7.0.0:
+    postcss-minify-font-values@7.0.1:
         resolution:
             {
-                integrity: sha512-2ckkZtgT0zG8SMc5aoNwtm5234eUx1GGFJKf2b1bSp8UflqaeFzR50lid4PfqVI9NtGqJ2J4Y7fwvnP/u1cQog==,
+                integrity: sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-minify-gradients@7.0.0:
+    postcss-minify-gradients@7.0.2:
         resolution:
             {
-                integrity: sha512-pdUIIdj/C93ryCHew0UgBnL2DtUS3hfFa5XtERrs4x+hmpMYGhbzo6l/Ir5de41O0GaKVpK1ZbDNXSY6GkXvtg==,
+                integrity: sha512-fVY3AB8Um7SJR5usHqTY2Ngf9qh8IRN+FFzrBP0ONJy6yYXsP7xyjK2BvSAIrpgs1cST+H91V0TXi3diHLYJtw==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-minify-params@7.0.2:
+    postcss-minify-params@7.0.6:
         resolution:
             {
-                integrity: sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==,
+                integrity: sha512-YOn02gC68JijlaXVuKvFSCvQOhTpblkcfDre2hb/Aaa58r2BIaK4AtE/cyZf2wV7YKAG+UlP9DT+By0ry1E4VQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-minify-selectors@7.0.4:
+    postcss-minify-selectors@7.0.6:
         resolution:
             {
-                integrity: sha512-JG55VADcNb4xFCf75hXkzc1rNeURhlo7ugf6JjiiKRfMsKlDzN9CXHZDyiG6x/zGchpjQS+UAgb1d4nqXqOpmA==,
+                integrity: sha512-lIbC0jy3AAwDxEgciZlBullDiMBeBCT+fz5G8RcA9MWqh/hfUkpOI3vNDUNEZHgokaoiv0juB9Y8fGcON7rU/A==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     postcss-modules-extract-imports@3.1.0:
         resolution:
@@ -20788,113 +20779,113 @@ packages:
         peerDependencies:
             postcss: ^8.2.14
 
-    postcss-normalize-charset@7.0.0:
+    postcss-normalize-charset@7.0.1:
         resolution:
             {
-                integrity: sha512-ABisNUXMeZeDNzCQxPxBCkXexvBrUHV+p7/BXOY+ulxkcjUZO0cp8ekGBwvIh2LbCwnWbyMPNJVtBSdyhM2zYQ==,
+                integrity: sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-display-values@7.0.0:
+    postcss-normalize-display-values@7.0.1:
         resolution:
             {
-                integrity: sha512-lnFZzNPeDf5uGMPYgGOw7v0BfB45+irSRz9gHQStdkkhiM0gTfvWkWB5BMxpn0OqgOQuZG/mRlZyJxp0EImr2Q==,
+                integrity: sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-positions@7.0.0:
+    postcss-normalize-positions@7.0.1:
         resolution:
             {
-                integrity: sha512-I0yt8wX529UKIGs2y/9Ybs2CelSvItfmvg/DBIjTnoUSrPxSV7Z0yZ8ShSVtKNaV/wAY+m7bgtyVQLhB00A1NQ==,
+                integrity: sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-repeat-style@7.0.0:
+    postcss-normalize-repeat-style@7.0.1:
         resolution:
             {
-                integrity: sha512-o3uSGYH+2q30ieM3ppu9GTjSXIzOrRdCUn8UOMGNw7Af61bmurHTWI87hRybrP6xDHvOe5WlAj3XzN6vEO8jLw==,
+                integrity: sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-string@7.0.0:
+    postcss-normalize-string@7.0.1:
         resolution:
             {
-                integrity: sha512-w/qzL212DFVOpMy3UGyxrND+Kb0fvCiBBujiaONIihq7VvtC7bswjWgKQU/w4VcRyDD8gpfqUiBQ4DUOwEJ6Qg==,
+                integrity: sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-timing-functions@7.0.0:
+    postcss-normalize-timing-functions@7.0.1:
         resolution:
             {
-                integrity: sha512-tNgw3YV0LYoRwg43N3lTe3AEWZ66W7Dh7lVEpJbHoKOuHc1sLrzMLMFjP8SNULHaykzsonUEDbKedv8C+7ej6g==,
+                integrity: sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-unicode@7.0.2:
+    postcss-normalize-unicode@7.0.6:
         resolution:
             {
-                integrity: sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==,
+                integrity: sha512-z6bwTV84YW6ZvvNoaNLuzRW4/uWxDKYI1iIDrzk6D2YTL7hICApy+Q1LP6vBEsljX8FM7YSuV9qI79XESd4ddQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-url@7.0.0:
+    postcss-normalize-url@7.0.1:
         resolution:
             {
-                integrity: sha512-+d7+PpE+jyPX1hDQZYG+NaFD+Nd2ris6r8fPTBAjE8z/U41n/bib3vze8x7rKs5H1uEw5ppe9IojewouHk0klQ==,
+                integrity: sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-normalize-whitespace@7.0.0:
+    postcss-normalize-whitespace@7.0.1:
         resolution:
             {
-                integrity: sha512-37/toN4wwZErqohedXYqWgvcHUGlT8O/m2jVkAfAe9Bd4MzRqlBmXrJRePH0e9Wgnz2X7KymTgTOaaFizQe3AQ==,
+                integrity: sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-ordered-values@7.0.1:
+    postcss-ordered-values@7.0.2:
         resolution:
             {
-                integrity: sha512-irWScWRL6nRzYmBOXReIKch75RRhNS86UPUAxXdmW/l0FcAsg0lvAXQCby/1lymxn/o0gVa6Rv/0f03eJOwHxw==,
+                integrity: sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-reduce-initial@7.0.2:
+    postcss-reduce-initial@7.0.6:
         resolution:
             {
-                integrity: sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==,
+                integrity: sha512-G6ZyK68AmrPdMB6wyeA37ejnnRG2S8xinJrZJnOv+IaRKf6koPAVbQsiC7MfkmXaGmF1UO+QCijb27wfpxuRNg==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-reduce-transforms@7.0.0:
+    postcss-reduce-transforms@7.0.1:
         resolution:
             {
-                integrity: sha512-pnt1HKKZ07/idH8cpATX/ujMbtOGhUfE+m8gbqwJE05aTaNw8gbo34a2e3if0xc0dlu75sUOiqvwCGY3fzOHew==,
+                integrity: sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     postcss-selector-parser@6.0.10:
         resolution:
@@ -20910,13 +20901,6 @@ packages:
             }
         engines: { node: '>=4' }
 
-    postcss-selector-parser@7.1.0:
-        resolution:
-            {
-                integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==,
-            }
-        engines: { node: '>=4' }
-
     postcss-selector-parser@7.1.1:
         resolution:
             {
@@ -20924,23 +20908,23 @@ packages:
             }
         engines: { node: '>=4' }
 
-    postcss-svgo@7.0.1:
+    postcss-svgo@7.1.1:
         resolution:
             {
-                integrity: sha512-0WBUlSL4lhD9rA5k1e5D8EN5wCEyZD6HJk0jIvRxl+FDVOMlJ7DePHYWGGVc5QRqrJ3/06FTXM0bxjmJpmTPSA==,
+                integrity: sha512-zU9H9oEDrUFKa0JB7w+IYL7Qs9ey1mZyjhbf0KLxwJDdDRtoPvCmaEfknzqfHj44QS9VD6c5sJnBAVYTLRg/Sg==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >= 18 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
-    postcss-unique-selectors@7.0.3:
+    postcss-unique-selectors@7.0.5:
         resolution:
             {
-                integrity: sha512-J+58u5Ic5T1QjP/LDV9g3Cx4CNOgB5vz+kM6+OxHHhFACdcDeKhBXjQmB7fnIZM12YSTvsL0Opwco83DmacW2g==,
+                integrity: sha512-3QoYmEt4qg/rUWDn6Tc8+ZVPmbp4G1hXDtCNWDx0st8SjtCbRcxRXDDM1QrEiXGG3A45zscSJFb4QH90LViyxg==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     postcss-value-parser@4.2.0:
         resolution:
@@ -23619,14 +23603,14 @@ packages:
             react-dom:
                 optional: true
 
-    stylehacks@7.0.4:
+    stylehacks@7.0.8:
         resolution:
             {
-                integrity: sha512-i4zfNrGMt9SB4xRK9L83rlsFCgdGANfeDAYacO1pkqcE7cRHPdWHwnKZVz7WY17Veq/FvyYsRAU++Ga+qDFIww==,
+                integrity: sha512-I3f053GBLIiS5Fg6OMFhq/c+yW+5Hc2+1fgq7gElDMMSqwlRb3tBf2ef6ucLStYRpId4q//bQO1FjcyNyy4yDQ==,
             }
         engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
         peerDependencies:
-            postcss: ^8.4.31
+            postcss: ^8.4.32
 
     stylis@4.3.6:
         resolution:
@@ -28488,6 +28472,8 @@ snapshots:
             crelt: 1.0.6
             style-mod: 4.1.3
             w3c-keyname: 2.2.8
+
+    '@colordx/core@5.0.3': {}
 
     '@cspotcode/source-map-support@0.8.1':
         dependencies:
@@ -36044,8 +36030,6 @@ snapshots:
             color-string: 1.9.1
         optional: true
 
-    colord@2.9.3: {}
-
     colorette@1.4.0: {}
 
     colorette@2.0.20: {}
@@ -36315,7 +36299,7 @@ snapshots:
     css-minimizer-webpack-plugin@8.0.0(esbuild@0.25.0)(lightningcss@1.30.2)(webpack@5.105.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(esbuild@0.25.0)):
         dependencies:
             '@jridgewell/trace-mapping': 0.3.31
-            cssnano: 7.0.6(postcss@8.5.6)
+            cssnano: 7.1.4(postcss@8.5.6)
             jest-worker: 30.2.0
             postcss: 8.5.6
             schema-utils: 4.3.3
@@ -36360,81 +36344,73 @@ snapshots:
 
     cssesc@3.0.0: {}
 
-    cssnano-preset-default@7.0.6(postcss@8.5.3):
+    cssnano-preset-default@7.0.12(postcss@8.5.3):
         dependencies:
             browserslist: 4.28.1
             css-declaration-sorter: 7.2.0(postcss@8.5.3)
-            cssnano-utils: 5.0.0(postcss@8.5.3)
+            cssnano-utils: 5.0.1(postcss@8.5.3)
             postcss: 8.5.3
             postcss-calc: 10.1.1(postcss@8.5.3)
-            postcss-colormin: 7.0.2(postcss@8.5.3)
-            postcss-convert-values: 7.0.4(postcss@8.5.3)
-            postcss-discard-comments: 7.0.3(postcss@8.5.3)
-            postcss-discard-duplicates: 7.0.1(postcss@8.5.3)
-            postcss-discard-empty: 7.0.0(postcss@8.5.3)
-            postcss-discard-overridden: 7.0.0(postcss@8.5.3)
-            postcss-merge-longhand: 7.0.4(postcss@8.5.3)
+            postcss-colormin: 7.0.7(postcss@8.5.3)
+            postcss-convert-values: 7.0.9(postcss@8.5.3)
+            postcss-discard-comments: 7.0.6(postcss@8.5.3)
+            postcss-discard-duplicates: 7.0.2(postcss@8.5.3)
+            postcss-discard-empty: 7.0.1(postcss@8.5.3)
+            postcss-discard-overridden: 7.0.1(postcss@8.5.3)
+            postcss-merge-longhand: 7.0.5(postcss@8.5.3)
             postcss-merge-rules: 7.0.8(postcss@8.5.3)
-            postcss-minify-font-values: 7.0.0(postcss@8.5.3)
-            postcss-minify-gradients: 7.0.0(postcss@8.5.3)
-            postcss-minify-params: 7.0.2(postcss@8.5.3)
-            postcss-minify-selectors: 7.0.4(postcss@8.5.3)
-            postcss-normalize-charset: 7.0.0(postcss@8.5.3)
-            postcss-normalize-display-values: 7.0.0(postcss@8.5.3)
-            postcss-normalize-positions: 7.0.0(postcss@8.5.3)
-            postcss-normalize-repeat-style: 7.0.0(postcss@8.5.3)
-            postcss-normalize-string: 7.0.0(postcss@8.5.3)
-            postcss-normalize-timing-functions: 7.0.0(postcss@8.5.3)
-            postcss-normalize-unicode: 7.0.2(postcss@8.5.3)
-            postcss-normalize-url: 7.0.0(postcss@8.5.3)
-            postcss-normalize-whitespace: 7.0.0(postcss@8.5.3)
-            postcss-ordered-values: 7.0.1(postcss@8.5.3)
-            postcss-reduce-initial: 7.0.2(postcss@8.5.3)
-            postcss-reduce-transforms: 7.0.0(postcss@8.5.3)
-            postcss-svgo: 7.0.1(postcss@8.5.3)
-            postcss-unique-selectors: 7.0.3(postcss@8.5.3)
+            postcss-minify-font-values: 7.0.1(postcss@8.5.3)
+            postcss-minify-gradients: 7.0.2(postcss@8.5.3)
+            postcss-minify-params: 7.0.6(postcss@8.5.3)
+            postcss-minify-selectors: 7.0.6(postcss@8.5.3)
+            postcss-normalize-charset: 7.0.1(postcss@8.5.3)
+            postcss-normalize-display-values: 7.0.1(postcss@8.5.3)
+            postcss-normalize-positions: 7.0.1(postcss@8.5.3)
+            postcss-normalize-repeat-style: 7.0.1(postcss@8.5.3)
+            postcss-normalize-string: 7.0.1(postcss@8.5.3)
+            postcss-normalize-timing-functions: 7.0.1(postcss@8.5.3)
+            postcss-normalize-unicode: 7.0.6(postcss@8.5.3)
+            postcss-normalize-url: 7.0.1(postcss@8.5.3)
+            postcss-normalize-whitespace: 7.0.1(postcss@8.5.3)
+            postcss-ordered-values: 7.0.2(postcss@8.5.3)
+            postcss-reduce-initial: 7.0.6(postcss@8.5.3)
+            postcss-reduce-transforms: 7.0.1(postcss@8.5.3)
+            postcss-svgo: 7.1.1(postcss@8.5.3)
+            postcss-unique-selectors: 7.0.5(postcss@8.5.3)
 
-    cssnano-preset-default@7.0.6(postcss@8.5.6):
+    cssnano-preset-default@7.0.12(postcss@8.5.6):
         dependencies:
             browserslist: 4.28.1
             css-declaration-sorter: 7.2.0(postcss@8.5.6)
-            cssnano-utils: 5.0.0(postcss@8.5.6)
+            cssnano-utils: 5.0.1(postcss@8.5.6)
             postcss: 8.5.6
             postcss-calc: 10.1.1(postcss@8.5.6)
-            postcss-colormin: 7.0.2(postcss@8.5.6)
-            postcss-convert-values: 7.0.4(postcss@8.5.6)
-            postcss-discard-comments: 7.0.3(postcss@8.5.6)
-            postcss-discard-duplicates: 7.0.1(postcss@8.5.6)
-            postcss-discard-empty: 7.0.0(postcss@8.5.6)
-            postcss-discard-overridden: 7.0.0(postcss@8.5.6)
-            postcss-merge-longhand: 7.0.4(postcss@8.5.6)
+            postcss-colormin: 7.0.7(postcss@8.5.6)
+            postcss-convert-values: 7.0.9(postcss@8.5.6)
+            postcss-discard-comments: 7.0.6(postcss@8.5.6)
+            postcss-discard-duplicates: 7.0.2(postcss@8.5.6)
+            postcss-discard-empty: 7.0.1(postcss@8.5.6)
+            postcss-discard-overridden: 7.0.1(postcss@8.5.6)
+            postcss-merge-longhand: 7.0.5(postcss@8.5.6)
             postcss-merge-rules: 7.0.8(postcss@8.5.6)
-            postcss-minify-font-values: 7.0.0(postcss@8.5.6)
-            postcss-minify-gradients: 7.0.0(postcss@8.5.6)
-            postcss-minify-params: 7.0.2(postcss@8.5.6)
-            postcss-minify-selectors: 7.0.4(postcss@8.5.6)
-            postcss-normalize-charset: 7.0.0(postcss@8.5.6)
-            postcss-normalize-display-values: 7.0.0(postcss@8.5.6)
-            postcss-normalize-positions: 7.0.0(postcss@8.5.6)
-            postcss-normalize-repeat-style: 7.0.0(postcss@8.5.6)
-            postcss-normalize-string: 7.0.0(postcss@8.5.6)
-            postcss-normalize-timing-functions: 7.0.0(postcss@8.5.6)
-            postcss-normalize-unicode: 7.0.2(postcss@8.5.6)
-            postcss-normalize-url: 7.0.0(postcss@8.5.6)
-            postcss-normalize-whitespace: 7.0.0(postcss@8.5.6)
-            postcss-ordered-values: 7.0.1(postcss@8.5.6)
-            postcss-reduce-initial: 7.0.2(postcss@8.5.6)
-            postcss-reduce-transforms: 7.0.0(postcss@8.5.6)
-            postcss-svgo: 7.0.1(postcss@8.5.6)
-            postcss-unique-selectors: 7.0.3(postcss@8.5.6)
-
-    cssnano-utils@5.0.0(postcss@8.5.3):
-        dependencies:
-            postcss: 8.5.3
-
-    cssnano-utils@5.0.0(postcss@8.5.6):
-        dependencies:
-            postcss: 8.5.6
+            postcss-minify-font-values: 7.0.1(postcss@8.5.6)
+            postcss-minify-gradients: 7.0.2(postcss@8.5.6)
+            postcss-minify-params: 7.0.6(postcss@8.5.6)
+            postcss-minify-selectors: 7.0.6(postcss@8.5.6)
+            postcss-normalize-charset: 7.0.1(postcss@8.5.6)
+            postcss-normalize-display-values: 7.0.1(postcss@8.5.6)
+            postcss-normalize-positions: 7.0.1(postcss@8.5.6)
+            postcss-normalize-repeat-style: 7.0.1(postcss@8.5.6)
+            postcss-normalize-string: 7.0.1(postcss@8.5.6)
+            postcss-normalize-timing-functions: 7.0.1(postcss@8.5.6)
+            postcss-normalize-unicode: 7.0.6(postcss@8.5.6)
+            postcss-normalize-url: 7.0.1(postcss@8.5.6)
+            postcss-normalize-whitespace: 7.0.1(postcss@8.5.6)
+            postcss-ordered-values: 7.0.2(postcss@8.5.6)
+            postcss-reduce-initial: 7.0.6(postcss@8.5.6)
+            postcss-reduce-transforms: 7.0.1(postcss@8.5.6)
+            postcss-svgo: 7.1.1(postcss@8.5.6)
+            postcss-unique-selectors: 7.0.5(postcss@8.5.6)
 
     cssnano-utils@5.0.1(postcss@8.5.3):
         dependencies:
@@ -36444,16 +36420,16 @@ snapshots:
         dependencies:
             postcss: 8.5.6
 
-    cssnano@7.0.6(postcss@8.5.3):
+    cssnano@7.1.4(postcss@8.5.3):
         dependencies:
-            cssnano-preset-default: 7.0.6(postcss@8.5.3)
-            lilconfig: 3.1.2
+            cssnano-preset-default: 7.0.12(postcss@8.5.3)
+            lilconfig: 3.1.3
             postcss: 8.5.3
 
-    cssnano@7.0.6(postcss@8.5.6):
+    cssnano@7.1.4(postcss@8.5.6):
         dependencies:
-            cssnano-preset-default: 7.0.6(postcss@8.5.6)
-            lilconfig: 3.1.2
+            cssnano-preset-default: 7.0.12(postcss@8.5.6)
+            lilconfig: 3.1.3
             postcss: 8.5.6
 
     csso@5.0.5:
@@ -40308,7 +40284,7 @@ snapshots:
             lightningcss-win32-x64-msvc: 1.31.1
         optional: true
 
-    lilconfig@3.1.2: {}
+    lilconfig@3.1.3: {}
 
     lines-and-columns@1.2.4: {}
 
@@ -42354,74 +42330,74 @@ snapshots:
     postcss-calc@10.1.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
-            postcss-selector-parser: 7.1.0
+            postcss-selector-parser: 7.1.1
             postcss-value-parser: 4.2.0
 
     postcss-calc@10.1.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
-            postcss-selector-parser: 7.1.0
+            postcss-selector-parser: 7.1.1
             postcss-value-parser: 4.2.0
 
-    postcss-colormin@7.0.2(postcss@8.5.3):
+    postcss-colormin@7.0.7(postcss@8.5.3):
         dependencies:
+            '@colordx/core': 5.0.3
             browserslist: 4.28.1
             caniuse-api: 3.0.0
-            colord: 2.9.3
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-colormin@7.0.2(postcss@8.5.6):
+    postcss-colormin@7.0.7(postcss@8.5.6):
         dependencies:
+            '@colordx/core': 5.0.3
             browserslist: 4.28.1
             caniuse-api: 3.0.0
-            colord: 2.9.3
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-convert-values@7.0.4(postcss@8.5.3):
+    postcss-convert-values@7.0.9(postcss@8.5.3):
         dependencies:
             browserslist: 4.28.1
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-convert-values@7.0.4(postcss@8.5.6):
+    postcss-convert-values@7.0.9(postcss@8.5.6):
         dependencies:
             browserslist: 4.28.1
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-discard-comments@7.0.3(postcss@8.5.3):
+    postcss-discard-comments@7.0.6(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
-    postcss-discard-comments@7.0.3(postcss@8.5.6):
+    postcss-discard-comments@7.0.6(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
-    postcss-discard-duplicates@7.0.1(postcss@8.5.3):
+    postcss-discard-duplicates@7.0.2(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
 
-    postcss-discard-duplicates@7.0.1(postcss@8.5.6):
-        dependencies:
-            postcss: 8.5.6
-
-    postcss-discard-empty@7.0.0(postcss@8.5.3):
-        dependencies:
-            postcss: 8.5.3
-
-    postcss-discard-empty@7.0.0(postcss@8.5.6):
+    postcss-discard-duplicates@7.0.2(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
 
-    postcss-discard-overridden@7.0.0(postcss@8.5.3):
+    postcss-discard-empty@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
 
-    postcss-discard-overridden@7.0.0(postcss@8.5.6):
+    postcss-discard-empty@7.0.1(postcss@8.5.6):
+        dependencies:
+            postcss: 8.5.6
+
+    postcss-discard-overridden@7.0.1(postcss@8.5.3):
+        dependencies:
+            postcss: 8.5.3
+
+    postcss-discard-overridden@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
 
@@ -42440,17 +42416,17 @@ snapshots:
             semver: 7.7.4
             webpack: 5.105.1(@swc/core@1.15.21(@swc/helpers@0.5.18))(esbuild@0.25.0)
 
-    postcss-merge-longhand@7.0.4(postcss@8.5.3):
+    postcss-merge-longhand@7.0.5(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
-            stylehacks: 7.0.4(postcss@8.5.3)
+            stylehacks: 7.0.8(postcss@8.5.3)
 
-    postcss-merge-longhand@7.0.4(postcss@8.5.6):
+    postcss-merge-longhand@7.0.5(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
-            stylehacks: 7.0.4(postcss@8.5.6)
+            stylehacks: 7.0.8(postcss@8.5.6)
 
     postcss-merge-rules@7.0.8(postcss@8.5.3):
         dependencies:
@@ -42468,55 +42444,55 @@ snapshots:
             postcss: 8.5.6
             postcss-selector-parser: 7.1.1
 
-    postcss-minify-font-values@7.0.0(postcss@8.5.3):
+    postcss-minify-font-values@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-minify-font-values@7.0.0(postcss@8.5.6):
+    postcss-minify-font-values@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-minify-gradients@7.0.0(postcss@8.5.3):
+    postcss-minify-gradients@7.0.2(postcss@8.5.3):
         dependencies:
-            colord: 2.9.3
-            cssnano-utils: 5.0.0(postcss@8.5.3)
+            '@colordx/core': 5.0.3
+            cssnano-utils: 5.0.1(postcss@8.5.3)
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-minify-gradients@7.0.0(postcss@8.5.6):
+    postcss-minify-gradients@7.0.2(postcss@8.5.6):
         dependencies:
-            colord: 2.9.3
-            cssnano-utils: 5.0.0(postcss@8.5.6)
+            '@colordx/core': 5.0.3
+            cssnano-utils: 5.0.1(postcss@8.5.6)
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-minify-params@7.0.2(postcss@8.5.3):
+    postcss-minify-params@7.0.6(postcss@8.5.3):
         dependencies:
             browserslist: 4.28.1
-            cssnano-utils: 5.0.0(postcss@8.5.3)
+            cssnano-utils: 5.0.1(postcss@8.5.3)
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-minify-params@7.0.2(postcss@8.5.6):
+    postcss-minify-params@7.0.6(postcss@8.5.6):
         dependencies:
             browserslist: 4.28.1
-            cssnano-utils: 5.0.0(postcss@8.5.6)
+            cssnano-utils: 5.0.1(postcss@8.5.6)
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-minify-selectors@7.0.4(postcss@8.5.3):
+    postcss-minify-selectors@7.0.6(postcss@8.5.3):
         dependencies:
             cssesc: 3.0.0
             postcss: 8.5.3
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
-    postcss-minify-selectors@7.0.4(postcss@8.5.6):
+    postcss-minify-selectors@7.0.6(postcss@8.5.6):
         dependencies:
             cssesc: 3.0.0
             postcss: 8.5.6
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
     postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
         dependencies:
@@ -42556,126 +42532,126 @@ snapshots:
             postcss: 8.5.6
             postcss-selector-parser: 6.1.2
 
-    postcss-normalize-charset@7.0.0(postcss@8.5.3):
+    postcss-normalize-charset@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
 
-    postcss-normalize-charset@7.0.0(postcss@8.5.6):
+    postcss-normalize-charset@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
 
-    postcss-normalize-display-values@7.0.0(postcss@8.5.3):
-        dependencies:
-            postcss: 8.5.3
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-display-values@7.0.0(postcss@8.5.6):
-        dependencies:
-            postcss: 8.5.6
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-positions@7.0.0(postcss@8.5.3):
+    postcss-normalize-display-values@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-positions@7.0.0(postcss@8.5.6):
+    postcss-normalize-display-values@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-repeat-style@7.0.0(postcss@8.5.3):
+    postcss-normalize-positions@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-repeat-style@7.0.0(postcss@8.5.6):
+    postcss-normalize-positions@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-string@7.0.0(postcss@8.5.3):
+    postcss-normalize-repeat-style@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-string@7.0.0(postcss@8.5.6):
+    postcss-normalize-repeat-style@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-timing-functions@7.0.0(postcss@8.5.3):
+    postcss-normalize-string@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-timing-functions@7.0.0(postcss@8.5.6):
+    postcss-normalize-string@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-unicode@7.0.2(postcss@8.5.3):
+    postcss-normalize-timing-functions@7.0.1(postcss@8.5.3):
+        dependencies:
+            postcss: 8.5.3
+            postcss-value-parser: 4.2.0
+
+    postcss-normalize-timing-functions@7.0.1(postcss@8.5.6):
+        dependencies:
+            postcss: 8.5.6
+            postcss-value-parser: 4.2.0
+
+    postcss-normalize-unicode@7.0.6(postcss@8.5.3):
         dependencies:
             browserslist: 4.28.1
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-unicode@7.0.2(postcss@8.5.6):
+    postcss-normalize-unicode@7.0.6(postcss@8.5.6):
         dependencies:
             browserslist: 4.28.1
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-url@7.0.0(postcss@8.5.3):
+    postcss-normalize-url@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-url@7.0.0(postcss@8.5.6):
+    postcss-normalize-url@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-whitespace@7.0.0(postcss@8.5.3):
+    postcss-normalize-whitespace@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-normalize-whitespace@7.0.0(postcss@8.5.6):
+    postcss-normalize-whitespace@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-ordered-values@7.0.1(postcss@8.5.3):
+    postcss-ordered-values@7.0.2(postcss@8.5.3):
         dependencies:
-            cssnano-utils: 5.0.0(postcss@8.5.3)
+            cssnano-utils: 5.0.1(postcss@8.5.3)
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-ordered-values@7.0.1(postcss@8.5.6):
+    postcss-ordered-values@7.0.2(postcss@8.5.6):
         dependencies:
-            cssnano-utils: 5.0.0(postcss@8.5.6)
+            cssnano-utils: 5.0.1(postcss@8.5.6)
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
 
-    postcss-reduce-initial@7.0.2(postcss@8.5.3):
-        dependencies:
-            browserslist: 4.28.1
-            caniuse-api: 3.0.0
-            postcss: 8.5.3
-
-    postcss-reduce-initial@7.0.2(postcss@8.5.6):
+    postcss-reduce-initial@7.0.6(postcss@8.5.3):
         dependencies:
             browserslist: 4.28.1
             caniuse-api: 3.0.0
+            postcss: 8.5.3
+
+    postcss-reduce-initial@7.0.6(postcss@8.5.6):
+        dependencies:
+            browserslist: 4.28.1
+            caniuse-api: 3.0.0
             postcss: 8.5.6
 
-    postcss-reduce-transforms@7.0.0(postcss@8.5.3):
+    postcss-reduce-transforms@7.0.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
 
-    postcss-reduce-transforms@7.0.0(postcss@8.5.6):
+    postcss-reduce-transforms@7.0.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
@@ -42690,37 +42666,32 @@ snapshots:
             cssesc: 3.0.0
             util-deprecate: 1.0.2
 
-    postcss-selector-parser@7.1.0:
-        dependencies:
-            cssesc: 3.0.0
-            util-deprecate: 1.0.2
-
     postcss-selector-parser@7.1.1:
         dependencies:
             cssesc: 3.0.0
             util-deprecate: 1.0.2
 
-    postcss-svgo@7.0.1(postcss@8.5.3):
+    postcss-svgo@7.1.1(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
             postcss-value-parser: 4.2.0
-            svgo: 3.3.2
+            svgo: 4.0.1
 
-    postcss-svgo@7.0.1(postcss@8.5.6):
+    postcss-svgo@7.1.1(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
             postcss-value-parser: 4.2.0
-            svgo: 3.3.2
+            svgo: 4.0.1
 
-    postcss-unique-selectors@7.0.3(postcss@8.5.3):
+    postcss-unique-selectors@7.0.5(postcss@8.5.3):
         dependencies:
             postcss: 8.5.3
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
-    postcss-unique-selectors@7.0.3(postcss@8.5.6):
+    postcss-unique-selectors@7.0.5(postcss@8.5.6):
         dependencies:
             postcss: 8.5.6
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
     postcss-value-parser@4.2.0: {}
 
@@ -44642,17 +44613,17 @@ snapshots:
         optionalDependencies:
             react-dom: 19.2.4(react@19.2.4)
 
-    stylehacks@7.0.4(postcss@8.5.3):
+    stylehacks@7.0.8(postcss@8.5.3):
         dependencies:
             browserslist: 4.28.1
             postcss: 8.5.3
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
-    stylehacks@7.0.4(postcss@8.5.6):
+    stylehacks@7.0.8(postcss@8.5.6):
         dependencies:
             browserslist: 4.28.1
             postcss: 8.5.6
-            postcss-selector-parser: 6.1.2
+            postcss-selector-parser: 7.1.1
 
     stylis@4.3.6: {}
 


### PR DESCRIPTION
## Summary
- Bumps `cssnano` from 7.0.6 to 7.1.4 (devDependency)
- Bug fixes: color conversion rounding, CSS comment recognition, `linear()` percent stripping
- Perf: selector merging WeakMap cache, startup preset loading optimization
- No breaking changes

Resolves #9694

## Test plan
- [x] `pnpm install` succeeds with updated lockfile
- [ ] CI lint + test