### PR TITLE
perf(isometric): campfire polish + mobile shader/light/brain optimizations

### DIFF
--- a/apps/kbve/isometric/src-tauri/assets/shaders/fire.wgsl
+++ b/apps/kbve/isometric/src-tauri/assets/shaders/fire.wgsl
@@ -4,7 +4,7 @@ struct FireUniforms {
     time: f32,
     intensity: f32,
     pixel_size: f32,
-    _pad: f32,
+    quality: f32,  // 0.0 = low (mobile), 0.5 = medium, 1.0 = high
     color_core: vec4<f32>,
     color_mid: vec4<f32>,
     color_outer: vec4<f32>,
@@ -29,6 +29,11 @@ fn value_noise(p: vec2<f32>) -> f32 {
     let c = hash21(i + vec2(0.0, 1.0));
     let d = hash21(i + vec2(1.0, 1.0));
     return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+fn fbm2(p: vec2<f32>) -> f32 {
+    return value_noise(p) * 0.65
+         + value_noise(p * 2.13) * 0.35;
 }
 
 fn fbm3(p: vec2<f32>) -> f32 {
@@ -79,25 +84,35 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let sway = sway_base + sway_mid + sway_tip;
     let wobble_x = cx - sway;
 
-    // ── Noise layers ────────────────────────────────────────────────
+    // ── Noise layers — fewer on low quality ────────────────────────
+    let q = fire.quality;
+
     let scroll1 = vec2(sin(t * 0.7) * 0.3, -t * 2.5);
-    let n1 = fbm4(vec2(uv.x * 4.0, cy * 3.5) + scroll1);
-
     let scroll2 = vec2(cos(t * 0.5) * 0.2, -t * 1.8 + 3.0);
-    let n2 = fbm3(vec2(uv.x * 2.5 + 7.0, cy * 2.8) + scroll2);
 
-    let scroll3 = vec2(sin(t * 1.3) * 0.5, -t * 4.5 + 11.0);
-    let n3 = fbm3(vec2(uv.x * 6.0, cy * 5.0) + scroll3);
-
-    let scroll4 = vec2(t * 0.15, -t * 0.8 + 20.0);
-    let n4 = fbm3(vec2(uv.x * 1.5 + 15.0, cy * 2.0) + scroll4);
+    // Low quality: 2 layers with fbm2 (4 noise calls total)
+    // High quality: 4 layers with fbm3/fbm4 (38 noise calls total)
+    var n1: f32; var n2: f32; var n3: f32; var n4: f32;
+    if q > 0.3 {
+        n1 = fbm4(vec2(uv.x * 4.0, cy * 3.5) + scroll1);
+        n2 = fbm3(vec2(uv.x * 2.5 + 7.0, cy * 2.8) + scroll2);
+        let scroll3 = vec2(sin(t * 1.3) * 0.5, -t * 4.5 + 11.0);
+        n3 = fbm3(vec2(uv.x * 6.0, cy * 5.0) + scroll3);
+        let scroll4 = vec2(t * 0.15, -t * 0.8 + 20.0);
+        n4 = fbm3(vec2(uv.x * 1.5 + 15.0, cy * 2.0) + scroll4);
+    } else {
+        n1 = fbm2(vec2(uv.x * 4.0, cy * 3.5) + scroll1);
+        n2 = fbm2(vec2(uv.x * 2.5 + 7.0, cy * 2.8) + scroll2);
+        n3 = 0.5;
+        n4 = 0.5;
+    }
 
     // ── Ember bed (bottom 25%) ──────────────────────────────────────
     // Wide glowing disc at the base — the coals the flame sits on.
     // Uses a flat radial distance (ignores Y stretching) so the
     // ember bed reads as a wide circle on the ground.
     let ember_breath = 1.0 + sin(t * 0.8) * 0.06 + sin(t * 2.3 + 1.5) * 0.04;
-    let ember_radius = 0.75 * ember_breath;
+    let ember_radius = 0.60 * ember_breath;
     // Flat XZ disc: Y contribution is very small so it spreads wide
     let ember_dist = length(vec2(wobble_x * 0.85, max(0.0, cy - 0.03) * 2.5));
     let ember_mask = smoothstep(ember_radius, ember_radius * 0.15, ember_dist);
@@ -111,8 +126,8 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // Wide mushroom base that narrows into a dancing tip.
     // The base is WIDER than mid-height to look like fire spreading
     // from a broad coal bed.
-    let base_width = 0.58 * breath_profile;
-    let flame_h = 0.85;
+    let base_width = 0.48 * breath_profile;
+    let flame_h = 0.75;
 
     // Width profile: very wide at bottom, belly bulge at ~25%, narrow tip.
     // The smoothstep pair creates a fat mushroom silhouette.
@@ -135,7 +150,7 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let noise_top    = n1 * 0.12 + n3 * 0.32 + n4 * 0.08;
     let noise = mix(noise_bottom, noise_top, cy);
 
-    let edge = (1.0 - ellipse_dist) * 0.9 + noise * 0.55;
+    let edge = (1.0 - ellipse_dist) * 0.9 + noise * 0.40;
 
     // NO bottom_merge cutoff — let the flame reach all the way to cy=0.
     // The ember bed and flame overlap naturally at the base.
@@ -145,26 +160,29 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
 
     var flame_density = edge * height_mask * fire.intensity;
 
-    // ── Wispy tendrils ──────────────────────────────────────────────
-    // Extended range and wider reach for more organic tips
-    let wisp_noise = fbm3(vec2(uv.x * 8.0, cy * 6.0) + vec2(t * 0.9, -t * 3.5));
-    let wisp_mask = smoothstep(0.30, 0.65, cy) * (1.0 - smoothstep(0.80, 0.95, cy));
-    let wisp = (wisp_noise - 0.40) * wisp_mask * 2.0;
-    flame_density = max(flame_density, wisp * step(abs(wobble_x), 0.40) * fire.intensity);
+    // ── Wispy tendrils (skip on low quality) ──────────────────────
+    if q > 0.3 {
+        let wisp_noise = fbm3(vec2(uv.x * 8.0, cy * 6.0) + vec2(t * 0.9, -t * 3.5));
+        let wisp_mask = smoothstep(0.30, 0.65, cy) * (1.0 - smoothstep(0.80, 0.95, cy));
+        let wisp = (wisp_noise - 0.40) * wisp_mask * 2.0;
+        flame_density = max(flame_density, wisp * step(abs(wobble_x), 0.40) * fire.intensity);
+    }
 
-    // ── Smoke wisps above the flame ─────────────────────────────────
-    // Fade well before quad edge so smoke never clips.
-    let smoke_scroll = vec2(sin(t * 0.4) * 0.6, -t * 1.2 + 50.0);
-    let smoke_noise = fbm4(vec2(uv.x * 3.0 + 40.0, cy * 2.5) + smoke_scroll);
+    // ── Smoke wisps (skip entirely on low quality) ──────────────
+    var smoke_density: f32 = 0.0;
+    var smoke_noise: f32 = 0.5;
+    if q > 0.3 {
+        let smoke_scroll = vec2(sin(t * 0.4) * 0.6, -t * 1.2 + 50.0);
+        smoke_noise = fbm4(vec2(uv.x * 3.0 + 40.0, cy * 2.5) + smoke_scroll);
 
-    let smoke_scroll2 = vec2(cos(t * 0.7) * 0.4, -t * 0.9 + 60.0);
-    let smoke_noise2 = fbm3(vec2(uv.x * 2.0 + 55.0, cy * 1.8) + smoke_scroll2);
+        let smoke_scroll2 = vec2(cos(t * 0.7) * 0.4, -t * 0.9 + 60.0);
+        let smoke_noise2 = fbm3(vec2(uv.x * 2.0 + 55.0, cy * 1.8) + smoke_scroll2);
 
-    // Smoke lives in the upper portion, fading well before the top
-    let smoke_height = smoothstep(0.45, 0.65, cy) * (1.0 - smoothstep(0.82, 0.94, cy));
-    let smoke_width = 0.40 + smoke_noise2 * 0.25;
-    let smoke_lateral = smoothstep(smoke_width, smoke_width * 0.25, abs(wobble_x * 0.65));
-    let smoke_density = smoke_noise * smoke_lateral * smoke_height * 0.55;
+        let smoke_height = smoothstep(0.45, 0.65, cy) * (1.0 - smoothstep(0.82, 0.94, cy));
+        let smoke_width = 0.40 + smoke_noise2 * 0.25;
+        let smoke_lateral = smoothstep(smoke_width, smoke_width * 0.25, abs(wobble_x * 0.65));
+        smoke_density = smoke_noise * smoke_lateral * smoke_height * 0.55;
+    }
 
     // ── Combine: ember bed + flame + smoke ──────────────────────────
     // Determine which layer this pixel belongs to for coloring
@@ -178,28 +196,24 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         discard;
     }
 
-    // ── 3D depth — noise-driven, not just geometric ──────────────────
-    // The hot core wanders around inside the flame, driven by noise.
-    // This breaks up the flat "stripe" look of purely geometric depth.
-
-    // Geometric base depth (center = deep)
+    // ── 3D depth ─────────────────────────────────────────────────────
     let geo_depth = 1.0 - clamp(sqrt(ellipse_dist), 0.0, 1.0);
 
-    // Noise-driven "hotspot" that moves through the flame volume
-    let hotspot_scroll = vec2(sin(t * 0.9) * 0.4, -t * 2.0 + 77.0);
-    let hotspot_noise = fbm3(vec2(uv.x * 5.0 + 90.0, cy * 4.0) + hotspot_scroll);
-
-    // Second hotspot at different frequency — creates multiple hot pockets
-    let hotspot2_scroll = vec2(cos(t * 1.4) * 0.3, -t * 3.0 + 33.0);
-    let hotspot2_noise = fbm3(vec2(uv.x * 3.5 + 120.0, cy * 3.0) + hotspot2_scroll);
-
-    // Combine: geometric depth + wandering hotspots
-    // The noise adds ~30% variation to depth, so color bands break up
-    let noise_depth = hotspot_noise * 0.35 + hotspot2_noise * 0.20;
-    let depth = clamp(geo_depth * 0.50 + noise_depth + total_flame * 0.15, 0.0, 1.0);
+    var depth: f32;
+    if q > 0.3 {
+        // High quality: noise-driven hotspots break up flat bands
+        let hotspot_scroll = vec2(sin(t * 0.9) * 0.4, -t * 2.0 + 77.0);
+        let hotspot_noise = fbm3(vec2(uv.x * 5.0 + 90.0, cy * 4.0) + hotspot_scroll);
+        let hotspot2_scroll = vec2(cos(t * 1.4) * 0.3, -t * 3.0 + 33.0);
+        let hotspot2_noise = fbm3(vec2(uv.x * 3.5 + 120.0, cy * 3.0) + hotspot2_scroll);
+        let noise_depth = hotspot_noise * 0.35 + hotspot2_noise * 0.20;
+        depth = clamp(geo_depth * 0.50 + noise_depth + total_flame * 0.15, 0.0, 1.0);
+    } else {
+        // Low quality: geometric depth only (no extra noise calls)
+        depth = clamp(geo_depth * 0.65 + total_flame * 0.20, 0.0, 1.0);
+    }
     let depth_sq = depth * depth;
 
-    // Vertical: bottom is ember-hot, top is cooler wispy surface
     let vert_depth = 1.0 - cy * 0.55;
     let volume = depth_sq * vert_depth;
 
@@ -211,9 +225,14 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let yellow  = fire.color_core.rgb;
     let hot     = vec3(1.0, 0.97, 0.85);
 
-    // Color selection: mix density, volume, AND noise so bands wobble
-    let color_noise = fbm3(vec2(uv.x * 4.5 + 200.0, cy * 3.5) + vec2(t * 0.2, -t * 1.5));
-    let color_t = clamp(total_flame * 0.35 + volume * 0.40 + color_noise * 0.25, 0.0, 1.0);
+    // Color selection
+    var color_t: f32;
+    if q > 0.3 {
+        let color_noise = fbm3(vec2(uv.x * 4.5 + 200.0, cy * 3.5) + vec2(t * 0.2, -t * 1.5));
+        color_t = clamp(total_flame * 0.35 + volume * 0.40 + color_noise * 0.25, 0.0, 1.0);
+    } else {
+        color_t = clamp(total_flame * 0.45 + volume * 0.55, 0.0, 1.0);
+    }
     let bands = 7.0;
     let banded = floor(color_t * bands) / (bands - 1.0);
 
@@ -232,9 +251,14 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         flame_color = hot;
     }
 
-    // Rim darkening — stronger + noise-modulated so rim isn't a smooth ring
-    let rim_noise = fbm3(vec2(uv.x * 7.0 + 150.0, cy * 5.0) + vec2(-t * 0.8, t * 0.3));
-    let rim = smoothstep(0.55, 0.0, geo_depth) * (0.7 + rim_noise * 0.3);
+    // Rim darkening
+    var rim: f32;
+    if q > 0.3 {
+        let rim_noise = fbm3(vec2(uv.x * 7.0 + 150.0, cy * 5.0) + vec2(-t * 0.8, t * 0.3));
+        rim = smoothstep(0.55, 0.0, geo_depth) * (0.7 + rim_noise * 0.3);
+    } else {
+        rim = smoothstep(0.55, 0.0, geo_depth);
+    }
     flame_color = mix(flame_color, deep_or * 0.6, rim * 0.40);
 
     // Core glow — wanders with the hotspot, not fixed to center

--- a/apps/kbve/isometric/src-tauri/src/game/campfire.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/campfire.rs
@@ -21,7 +21,8 @@ pub struct FireUniforms {
     pub time: f32,
     pub intensity: f32,
     pub pixel_size: f32,
-    pub _pad: f32,
+    /// Shader quality: 0.0 = low (mobile), 1.0 = high (desktop).
+    pub quality: f32,
     pub color_core: Vec4,
     pub color_mid: Vec4,
     pub color_outer: Vec4,
@@ -76,8 +77,14 @@ fn setup_campfires(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut fire_materials: ResMut<Assets<FireMaterial>>,
     mut terrain: ResMut<TerrainMap>,
+    perf_tier: Res<super::PerfTier>,
 ) {
-    let quad = meshes.add(build_fire_quad(1.8, 2.4));
+    let quality = match *perf_tier {
+        super::PerfTier::Low => 0.0,
+        super::PerfTier::Medium => 0.5,
+        super::PerfTier::High => 1.0,
+    };
+    let quad = meshes.add(build_fire_quad(1.3, 1.7));
 
     // Shared unlit material for stone ring + logs (vertex-colored)
     let pit_mat = materials.add(StandardMaterial {
@@ -95,8 +102,8 @@ fn setup_campfires(
             uniforms: FireUniforms {
                 time: 0.0,
                 intensity: 1.0,
-                pixel_size: 24.0,
-                _pad: 0.0,
+                pixel_size: if quality < 0.5 { 16.0 } else { 24.0 },
+                quality,
                 color_core: Vec4::new(1.0, 0.92, 0.55, 1.0),
                 color_mid: Vec4::new(1.0, 0.55, 0.0, 1.0),
                 color_outer: Vec4::new(0.85, 0.12, 0.0, 1.0),
@@ -134,19 +141,21 @@ fn setup_campfires(
             },
         ));
 
-        // Warm point light — big pool of light around the campfire
-        commands.spawn((
-            PointLight {
-                color: Color::srgb(1.0, 0.62, 0.18),
-                intensity: 120000.0,
-                radius: 1.0,
-                range: 40.0,
-                shadows_enabled: false,
-                ..default()
-            },
-            Transform::from_xyz(wx, ground_y + 1.4, wz),
-            CampfireLight,
-        ));
+        // Warm point light — skip on Low tier (PointLights are expensive on mobile)
+        if *perf_tier != super::PerfTier::Low {
+            commands.spawn((
+                PointLight {
+                    color: Color::srgb(1.0, 0.62, 0.18),
+                    intensity: 120000.0,
+                    radius: 1.0,
+                    range: 40.0,
+                    shadows_enabled: false,
+                    ..default()
+                },
+                Transform::from_xyz(wx, ground_y + 1.4, wz),
+                CampfireLight,
+            ));
+        }
     }
 }
 

--- a/apps/kbve/isometric/src-tauri/src/game/candle.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/candle.rs
@@ -39,7 +39,13 @@ fn setup_candles(
     mut std_materials: ResMut<Assets<StandardMaterial>>,
     mut fire_materials: ResMut<Assets<FireMaterial>>,
     mut terrain: ResMut<TerrainMap>,
+    perf_tier: Res<super::PerfTier>,
 ) {
+    let quality = match *perf_tier {
+        super::PerfTier::Low => 0.0,
+        super::PerfTier::Medium => 0.5,
+        super::PerfTier::High => 1.0,
+    };
     let flame_quad = meshes.add(build_candle_flame_quad(0.45, 0.7));
     let candle_body = meshes.add(build_candle_body(0.10, 0.45, 8));
 
@@ -68,7 +74,7 @@ fn setup_candles(
                 time: 0.0,
                 intensity: 0.9,
                 pixel_size: 16.0,
-                _pad: 0.0,
+                quality,
                 color_core: Vec4::new(1.0, 0.95, 0.70, 1.0),
                 color_mid: Vec4::new(1.0, 0.65, 0.10, 1.0),
                 color_outer: Vec4::new(0.90, 0.30, 0.02, 1.0),
@@ -84,19 +90,21 @@ fn setup_candles(
             CandleFlame,
         ));
 
-        // Small warm point light
-        commands.spawn((
-            PointLight {
-                color: Color::srgb(1.0, 0.75, 0.35),
-                intensity: 4000.0,
-                radius: 0.1,
-                range: 6.0,
-                shadows_enabled: false,
-                ..default()
-            },
-            Transform::from_xyz(wx, candle_top + 0.3, wz),
-            CandleLight,
-        ));
+        // Small warm point light — skip on Low tier
+        if *perf_tier != super::PerfTier::Low {
+            commands.spawn((
+                PointLight {
+                    color: Color::srgb(1.0, 0.75, 0.35),
+                    intensity: 4000.0,
+                    radius: 0.1,
+                    range: 6.0,
+                    shadows_enabled: false,
+                    ..default()
+                },
+                Transform::from_xyz(wx, candle_top + 0.3, wz),
+                CandleLight,
+            ));
+        }
     }
 }
 

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/brain.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/brain.rs
@@ -42,9 +42,14 @@ impl CreatureBrain {
 /// Capture world snapshots for idle creatures and dispatch behavior tree
 /// evaluation to bevy_tasker. Only evaluates when the creature is idle
 /// (no pending intent and not currently moving/emoting).
+///
+/// On mobile (PerfTier::Low), each creature only dispatches every 4th
+/// frame (staggered by slot_seed) to reduce async task pressure.
 pub fn dispatch_behavior_trees(
     game_time: Res<GameTime>,
     types: Res<SpriteCreatureTypes>,
+    time: Res<Time>,
+    perf_tier: Option<Res<crate::game::PerfTier>>,
     mut brain_q: Query<(
         &Creature,
         &SpriteData,
@@ -53,6 +58,12 @@ pub fn dispatch_behavior_trees(
         Option<&PlayerProximity>,
     )>,
 ) {
+    let is_low = perf_tier
+        .map(|t| *t == crate::game::PerfTier::Low)
+        .unwrap_or(false);
+    // Approximate frame counter from elapsed time (good enough for staggering)
+    let frame = (time.elapsed_secs() * 60.0) as u32;
+
     for (cr, sd, mut marker, mut brain, proximity) in &mut brain_q {
         // Skip if already has a pending evaluation or active intent
         if brain.pending {
@@ -67,6 +78,12 @@ pub fn dispatch_behavior_trees(
         }
         // Skip pooled/hidden creatures
         if cr.anchor.y < -50.0 {
+            continue;
+        }
+
+        // On Low tier, stagger dispatches: each creature fires every 4th
+        // frame, offset by slot_seed so they don't all fire on the same frame.
+        if is_low && (frame + cr.slot_seed) % 4 != 0 {
             continue;
         }
 


### PR DESCRIPTION
## Summary

- Shrink campfire flame to realistic proportions (quad 1.3x1.7, narrower shader body)
- Fire shader quality LOD: Low tier uses 4 noise calls/pixel (was 38) — skips wisps, smoke, volumetric depth noise, rim noise
- Skip all campfire + candle PointLights on Low tier (7 fewer lights on mobile GPU)
- Throttle creature brain dispatch on Low tier: each creature dispatches every 4th frame staggered by slot_seed (~75% fewer async tasks)

## Test plan

- [ ] Desktop: verify fire visual quality unchanged (quality=1.0)
- [ ] Mobile/WASM: check fire still looks reasonable at low quality
- [ ] Verify no PointLights spawn on Low tier (check entity count)
- [ ] Creature behavior still works on Low tier (just slightly delayed reactions)
- [ ] Compare FPS before/after on Android Chrome