### PR TITLE
feat(discordsh): cross-platform profile schema for MUD convergence

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -47,6 +47,9 @@ pub struct DungeonProfile {
     /// Serialized `SkillProfile` (JSONB). Empty/null for legacy profiles.
     #[serde(default)]
     pub skills: serde_json::Value,
+    /// Faction reputation standing (JSONB). Empty/null for legacy profiles.
+    #[serde(default)]
+    pub faction_standing: serde_json::Value,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }
@@ -185,6 +188,8 @@ impl ProfileStore {
                 "p_armor_gear": profile.armor_gear,
                 "p_inventory": profile.inventory,
                 "p_completed_quests": profile.completed_quests,
+                "p_skills": profile.skills,
+                "p_faction_standing": profile.faction_standing,
                 "p_run_outcome": run.outcome,
                 "p_run_rooms_cleared": run.rooms_cleared,
                 "p_run_kills": run.kills,
@@ -288,6 +293,15 @@ pub fn apply_profile_to_player(
         if let Ok(sp) = serde_json::from_value::<bevy_skills::SkillProfile>(profile.skills.clone())
         {
             player.skills = sp;
+        }
+    }
+
+    // Restore faction standing from JSONB
+    if !profile.faction_standing.is_null() && profile.faction_standing != serde_json::json!({}) {
+        if let Ok(factions) = serde_json::from_value::<std::collections::HashMap<String, i32>>(
+            profile.faction_standing.clone(),
+        ) {
+            player.faction_standing = factions;
         }
     }
 
@@ -396,6 +410,7 @@ pub fn extract_save_payload(
         inventory: final_inventory,
         completed_quests: journal.completed.clone(),
         skills: serde_json::to_value(&player.skills).unwrap_or_default(),
+        faction_standing: serde_json::to_value(&player.faction_standing).unwrap_or_default(),
         created_at: None,
         updated_at: None,
     };
@@ -547,6 +562,7 @@ mod tests {
             inventory: serde_json::json!([]),
             completed_quests: Vec::new(),
             skills: serde_json::json!({}),
+            faction_standing: serde_json::json!({}),
             created_at: None,
             updated_at: None,
         };
@@ -601,6 +617,7 @@ mod tests {
             inventory: serde_json::json!([]),
             completed_quests: Vec::new(),
             skills: serde_json::json!({}),
+            faction_standing: serde_json::json!({}),
             created_at: None,
             updated_at: None,
         };

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -18,6 +18,7 @@ version_target: apps/discordsh/discordsh-bot/Cargo.toml
 runner: ubuntu-latest
 image: kbve/discordsh-bot
 deployment_yaml: apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+has_test: false
 ---
 
 ## Overview

--- a/packages/data/sql/dbmate/migrations/20260409210000_discordsh_cross_platform_profiles.sql
+++ b/packages/data/sql/dbmate/migrations/20260409210000_discordsh_cross_platform_profiles.sql
@@ -1,0 +1,418 @@
+-- migrate:up
+-- ============================================================
+-- CROSS-PLATFORM PROFILE EXTENSION
+--
+-- Adds columns to discordsh.dungeon_profiles for:
+--   1. skills       — JSONB SkillProfile (already used by bot, now persisted in DB)
+--   2. faction_standing — JSONB {faction_id: rep_points} map
+--   3. auth_user_id — optional FK to auth.users for isometric game account linking
+--
+-- Also updates the service_load_profile and service_upsert_profile RPCs
+-- to include the new columns.
+--
+-- Design: isometric players without a linked Discord account play as guests
+-- (no persistence). Linking a Supabase auth account to a Discord profile
+-- enables cross-platform persistence.
+-- ============================================================
+
+BEGIN;
+
+-- ===========================================
+-- ADD NEW COLUMNS
+-- ===========================================
+
+ALTER TABLE discordsh.dungeon_profiles
+    ADD COLUMN IF NOT EXISTS skills          JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS faction_standing JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS auth_user_id    UUID UNIQUE;
+
+COMMENT ON COLUMN discordsh.dungeon_profiles.skills IS
+    'Serialized bevy_skills::SkillProfile — shared across Discord and isometric game';
+COMMENT ON COLUMN discordsh.dungeon_profiles.faction_standing IS
+    'Faction reputation: {"crystal-order": 25, "shadow-court": -10, "deep-wardens": 50}';
+COMMENT ON COLUMN discordsh.dungeon_profiles.auth_user_id IS
+    'Optional link to auth.users(id) — enables isometric game to load this profile via JWT';
+
+-- Index for isometric game profile lookup by auth user
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_auth_user
+    ON discordsh.dungeon_profiles (auth_user_id)
+    WHERE auth_user_id IS NOT NULL;
+
+-- ===========================================
+-- UPDATE: service_load_profile — add new columns to output
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_load_profile(
+    p_discord_id BIGINT
+)
+RETURNS TABLE(
+    discord_id BIGINT,
+    discord_name TEXT,
+    class_id SMALLINT,
+    level SMALLINT,
+    xp INT,
+    xp_to_next INT,
+    gold INT,
+    lifetime_kills INT,
+    lifetime_gold_earned INT,
+    lifetime_rooms_cleared INT,
+    lifetime_bosses_defeated INT,
+    lifetime_deaths INT,
+    lifetime_victories INT,
+    lifetime_escapes INT,
+    weapon TEXT,
+    armor_gear TEXT,
+    inventory JSONB,
+    completed_quests TEXT[],
+    skills JSONB,
+    faction_standing JSONB,
+    auth_user_id UUID,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        p.discord_id,
+        p.discord_name,
+        p.class_id,
+        p.level,
+        p.xp,
+        p.xp_to_next,
+        p.gold,
+        p.lifetime_kills,
+        p.lifetime_gold_earned,
+        p.lifetime_rooms_cleared,
+        p.lifetime_bosses_defeated,
+        p.lifetime_deaths,
+        p.lifetime_victories,
+        p.lifetime_escapes,
+        p.weapon,
+        p.armor_gear,
+        p.inventory,
+        p.completed_quests,
+        p.skills,
+        p.faction_standing,
+        p.auth_user_id,
+        p.created_at,
+        p.updated_at
+    FROM discordsh.dungeon_profiles p
+    WHERE p.discord_id = p_discord_id;
+END;
+$$;
+
+-- ===========================================
+-- NEW: service_load_profile_by_auth — for isometric game
+--
+-- Loads a profile by Supabase auth.users UUID instead of Discord snowflake.
+-- Returns empty if no linked profile exists (guest mode).
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_load_profile_by_auth(
+    p_auth_user_id UUID
+)
+RETURNS TABLE(
+    discord_id BIGINT,
+    discord_name TEXT,
+    class_id SMALLINT,
+    level SMALLINT,
+    xp INT,
+    xp_to_next INT,
+    gold INT,
+    lifetime_kills INT,
+    lifetime_gold_earned INT,
+    lifetime_rooms_cleared INT,
+    lifetime_bosses_defeated INT,
+    lifetime_deaths INT,
+    lifetime_victories INT,
+    lifetime_escapes INT,
+    weapon TEXT,
+    armor_gear TEXT,
+    inventory JSONB,
+    completed_quests TEXT[],
+    skills JSONB,
+    faction_standing JSONB,
+    auth_user_id UUID,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        p.discord_id,
+        p.discord_name,
+        p.class_id,
+        p.level,
+        p.xp,
+        p.xp_to_next,
+        p.gold,
+        p.lifetime_kills,
+        p.lifetime_gold_earned,
+        p.lifetime_rooms_cleared,
+        p.lifetime_bosses_defeated,
+        p.lifetime_deaths,
+        p.lifetime_victories,
+        p.lifetime_escapes,
+        p.weapon,
+        p.armor_gear,
+        p.inventory,
+        p.completed_quests,
+        p.skills,
+        p.faction_standing,
+        p.auth_user_id,
+        p.created_at,
+        p.updated_at
+    FROM discordsh.dungeon_profiles p
+    WHERE p.auth_user_id = p_auth_user_id;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_load_profile_by_auth IS
+    'Load a dungeon profile by Supabase auth UUID. Returns empty if no linked profile (guest mode).';
+
+REVOKE ALL ON FUNCTION discordsh.service_load_profile_by_auth(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_load_profile_by_auth(UUID) TO service_role;
+ALTER FUNCTION discordsh.service_load_profile_by_auth(UUID) OWNER TO service_role;
+
+-- ===========================================
+-- UPDATE: service_upsert_profile — add new columns
+-- ===========================================
+
+DROP FUNCTION IF EXISTS discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+);
+
+CREATE OR REPLACE FUNCTION discordsh.service_upsert_profile(
+    -- Profile fields
+    p_discord_id            BIGINT,
+    p_discord_name          TEXT,
+    p_class_id              SMALLINT,
+    p_level                 SMALLINT,
+    p_xp                    INT,
+    p_xp_to_next            INT,
+    p_gold                  INT,
+    p_lifetime_kills        INT,
+    p_lifetime_gold_earned  INT,
+    p_lifetime_rooms_cleared INT,
+    p_lifetime_bosses_defeated INT,
+    p_lifetime_deaths       INT,
+    p_lifetime_victories    INT,
+    p_lifetime_escapes      INT,
+    p_weapon                TEXT DEFAULT NULL,
+    p_armor_gear            TEXT DEFAULT NULL,
+    p_inventory             JSONB DEFAULT '[]'::JSONB,
+    p_completed_quests      TEXT[] DEFAULT '{}',
+    p_skills                JSONB DEFAULT '{}'::JSONB,
+    p_faction_standing      JSONB DEFAULT '{}'::JSONB,
+    -- Run fields
+    p_run_outcome           SMALLINT DEFAULT NULL,
+    p_run_rooms_cleared     INT DEFAULT 0,
+    p_run_kills             INT DEFAULT 0,
+    p_run_gold_earned       INT DEFAULT 0,
+    p_run_gold_lost         INT DEFAULT 0,
+    p_run_bosses_defeated   INT DEFAULT 0,
+    p_run_xp_earned         INT DEFAULT 0,
+    p_run_level_at_end      SMALLINT DEFAULT 1,
+    p_run_duration_secs     INT DEFAULT NULL
+)
+RETURNS TABLE(success BOOLEAN, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    -- Advisory lock: serialize saves per player using discord_id directly
+    PERFORM pg_advisory_xact_lock(p_discord_id);
+
+    -- Upsert profile
+    INSERT INTO discordsh.dungeon_profiles (
+        discord_id, discord_name, class_id, level, xp, xp_to_next, gold,
+        lifetime_kills, lifetime_gold_earned, lifetime_rooms_cleared,
+        lifetime_bosses_defeated, lifetime_deaths, lifetime_victories,
+        lifetime_escapes, weapon, armor_gear, inventory, completed_quests,
+        skills, faction_standing
+    )
+    VALUES (
+        p_discord_id, p_discord_name, p_class_id, p_level, p_xp, p_xp_to_next, p_gold,
+        p_lifetime_kills, p_lifetime_gold_earned, p_lifetime_rooms_cleared,
+        p_lifetime_bosses_defeated, p_lifetime_deaths, p_lifetime_victories,
+        p_lifetime_escapes, p_weapon, p_armor_gear, p_inventory, p_completed_quests,
+        p_skills, p_faction_standing
+    )
+    ON CONFLICT (discord_id) DO UPDATE SET
+        discord_name            = EXCLUDED.discord_name,
+        class_id                = EXCLUDED.class_id,
+        level                   = EXCLUDED.level,
+        xp                      = EXCLUDED.xp,
+        xp_to_next              = EXCLUDED.xp_to_next,
+        gold                    = EXCLUDED.gold,
+        lifetime_kills          = EXCLUDED.lifetime_kills,
+        lifetime_gold_earned    = EXCLUDED.lifetime_gold_earned,
+        lifetime_rooms_cleared  = EXCLUDED.lifetime_rooms_cleared,
+        lifetime_bosses_defeated = EXCLUDED.lifetime_bosses_defeated,
+        lifetime_deaths         = EXCLUDED.lifetime_deaths,
+        lifetime_victories      = EXCLUDED.lifetime_victories,
+        lifetime_escapes        = EXCLUDED.lifetime_escapes,
+        weapon                  = EXCLUDED.weapon,
+        armor_gear              = EXCLUDED.armor_gear,
+        inventory               = EXCLUDED.inventory,
+        completed_quests        = EXCLUDED.completed_quests,
+        skills                  = EXCLUDED.skills,
+        faction_standing        = EXCLUDED.faction_standing;
+
+    -- Insert run log (if outcome provided)
+    IF p_run_outcome IS NOT NULL THEN
+        INSERT INTO discordsh.dungeon_runs (
+            discord_id, outcome, rooms_cleared, kills,
+            gold_earned, gold_lost, bosses_defeated,
+            xp_earned, level_at_end, duration_secs
+        )
+        VALUES (
+            p_discord_id, p_run_outcome, p_run_rooms_cleared, p_run_kills,
+            p_run_gold_earned, p_run_gold_lost, p_run_bosses_defeated,
+            p_run_xp_earned, p_run_level_at_end, p_run_duration_secs
+        );
+    END IF;
+
+    RETURN QUERY SELECT true, 'Profile saved.'::TEXT;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN QUERY SELECT false, SQLERRM::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_upsert_profile IS
+    'Atomic upsert of dungeon profile (with skills + faction) + run log. Advisory-locked per discord_id. Bot-only.';
+
+REVOKE ALL ON FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[], JSONB, JSONB,
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[], JSONB, JSONB,
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) TO service_role;
+ALTER FUNCTION discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[], JSONB, JSONB,
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+) OWNER TO service_role;
+
+-- ===========================================
+-- NEW: service_link_auth — link a Supabase auth account to a Discord profile
+--
+-- Called by an edge function when a user links their accounts.
+-- Requires both discord_id and auth_user_id to be valid.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_link_auth(
+    p_discord_id    BIGINT,
+    p_auth_user_id  UUID
+)
+RETURNS TABLE(success BOOLEAN, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    UPDATE discordsh.dungeon_profiles
+    SET auth_user_id = p_auth_user_id
+    WHERE discord_id = p_discord_id;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT false, 'Discord profile not found.'::TEXT;
+        RETURN;
+    END IF;
+
+    RETURN QUERY SELECT true, 'Account linked.'::TEXT;
+
+EXCEPTION
+    WHEN unique_violation THEN
+        RETURN QUERY SELECT false, 'Auth account already linked to another profile.'::TEXT;
+    WHEN OTHERS THEN
+        RETURN QUERY SELECT false, SQLERRM::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_link_auth IS
+    'Link a Supabase auth.users UUID to a Discord dungeon profile. Enables cross-platform persistence.';
+
+REVOKE ALL ON FUNCTION discordsh.service_link_auth(BIGINT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_link_auth(BIGINT, UUID) TO service_role;
+ALTER FUNCTION discordsh.service_link_auth(BIGINT, UUID) OWNER TO service_role;
+
+-- ===========================================
+-- VERIFICATION
+-- ===========================================
+
+DO $$
+BEGIN
+    PERFORM set_config('search_path', '', true);
+
+    -- Verify new columns exist
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'skills'
+    ) THEN
+        RAISE EXCEPTION 'skills column not found on discordsh.dungeon_profiles';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'faction_standing'
+    ) THEN
+        RAISE EXCEPTION 'faction_standing column not found on discordsh.dungeon_profiles';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'auth_user_id'
+    ) THEN
+        RAISE EXCEPTION 'auth_user_id column not found on discordsh.dungeon_profiles';
+    END IF;
+
+    -- Verify new function exists
+    PERFORM 'discordsh.service_load_profile_by_auth(uuid)'::regprocedure;
+    PERFORM 'discordsh.service_link_auth(bigint, uuid)'::regprocedure;
+
+    RAISE NOTICE 'cross_platform_profiles migration verified successfully.';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;
+
+-- migrate:down
+
+BEGIN;
+
+-- Drop new functions
+DROP FUNCTION IF EXISTS discordsh.service_link_auth(BIGINT, UUID);
+DROP FUNCTION IF EXISTS discordsh.service_load_profile_by_auth(UUID);
+
+-- Drop index
+DROP INDEX IF EXISTS discordsh.idx_discordsh_dungeon_profiles_auth_user;
+
+-- Remove columns
+ALTER TABLE discordsh.dungeon_profiles
+    DROP COLUMN IF EXISTS auth_user_id,
+    DROP COLUMN IF EXISTS faction_standing,
+    DROP COLUMN IF EXISTS skills;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Extends `discordsh.dungeon_profiles` for cross-platform persistence (#9850 task 3). No new tables — the existing schema gains 3 columns and 2 new RPC functions.

### New columns
| Column | Type | Purpose |
|--------|------|---------|
| `skills` | JSONB | `bevy_skills::SkillProfile` (already serialized by bot, now DB-persisted) |
| `faction_standing` | JSONB | `{"crystal-order": 25, "shadow-court": -10}` |
| `auth_user_id` | UUID (unique, nullable) | Links Discord profile to Supabase `auth.users` for isometric game |

### New RPCs
- `service_load_profile_by_auth(UUID)` — isometric game loads profile by JWT. Empty result = guest mode.
- `service_link_auth(discord_id, auth_user_id)` — links accounts. Returns error if auth already linked elsewhere.

### Updated RPCs
- `service_load_profile` — returns skills, faction_standing, auth_user_id
- `service_upsert_profile` — accepts p_skills, p_faction_standing

### Guest mode
Isometric players without a linked account get no persistence. Their game state lives only in local `bevy_db` (redb/IndexedDB). Linking via `service_link_auth` enables cross-platform sync.

### Discord bot changes
- `DungeonProfile.faction_standing` field added
- `save_async` sends skills + faction_standing to upsert RPC
- `apply_profile_to_player` restores faction_standing from JSONB

Addresses task 3 of #9850. Migration includes `migrate:down` for rollback.

## Deploy steps
```bash
kubectl port-forward -n kilobase svc/supabase-cluster-rw 54322:5432
dbmate --no-dump-schema --migrations-dir packages/data/sql/dbmate/migrations up
```

## Test plan
- [x] All 701 bot tests pass
- [x] Migration has verification block
- [x] `migrate:down` drops columns and new functions
- [ ] Apply migration to staging
- [ ] Verify `service_load_profile` returns new columns
- [ ] Verify `service_load_profile_by_auth` returns empty for unlinked users