### PR TITLE
fix(firecracker): add missing caps for jailer chown

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -56,10 +56,13 @@ spec:
                           drop:
                               - ALL
                           add:
+                              - CHOWN
+                              - DAC_OVERRIDE
+                              - FOWNER
+                              - MKNOD
                               - NET_ADMIN
                               - SYS_ADMIN
                               - SYS_CHROOT
-                              - MKNOD
                   volumeMounts:
                       - name: rootfs-cache
                         mountPath: /var/lib/firecracker/rootfs


### PR DESCRIPTION
## Summary
- Jailer fails at `chown /: Operation not permitted` after pivot_root succeeds
- `drop: ALL` removed `CHOWN`, `DAC_OVERRIDE`, `FOWNER` which the jailer needs to set ownership of jail files to uid 10001
- Adds the 3 missing caps (total now 7: CHOWN, DAC_OVERRIDE, FOWNER, MKNOD, NET_ADMIN, SYS_ADMIN, SYS_CHROOT)

## Test plan
- [ ] ArgoCD syncs, pods restart
- [ ] Create VM, verify no chown EPERM, exit code 0