### PR TITLE
fix(edge-e2e): add globalSetup to wait for container readiness before tests

### DIFF
--- a/apps/kbve/edge-e2e/e2e/globalSetup.ts
+++ b/apps/kbve/edge-e2e/e2e/globalSetup.ts
@@ -1,0 +1,5 @@
+import { waitForReady } from './helpers/http';
+
+export async function setup() {
+	await waitForReady();
+}

--- a/apps/kbve/edge-e2e/vitest.config.ts
+++ b/apps/kbve/edge-e2e/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	test: {
 		include: ['e2e/**/*.spec.ts'],
+		globalSetup: ['e2e/globalSetup.ts'],
 		testTimeout: 30_000,
 		hookTimeout: 60_000,
 	},


### PR DESCRIPTION
## Summary
- Edge e2e tests were failing with `SocketError: other side closed` (13 test files, all tests failing)
- Root cause: `docker run -d` returns immediately, vitest starts before the edge runtime's HTTP server is initialized — the runtime accepts TCP connections before HTTP is ready
- Added `globalSetup.ts` that calls the existing `waitForReady()` helper (polls HTTP with 500ms retry, 30s timeout) before any test file loads
- The per-test `beforeAll` waits remain as defense-in-depth

## Test plan
- [ ] Re-run CI Docker / edge workflow — all 13 test files should pass
- [ ] Verify `waitForReady()` logs show the polling before tests begin

Closes #9871