### PR TITLE
fix(ci): add e2e_name to discordsh-bot CI manifest

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.104",
+			"version": "1.0.105",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -77,12 +77,14 @@
 			"source_path": "apps/discordsh/discordsh-bot",
 			"runner": "ubuntu-latest",
 			"image": "kbve/discordsh-bot",
-			"deployment_yaml": "apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml"
+			"e2e_name": "discordsh-bot-e2e",
+			"deployment_yaml": "apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml",
+			"has_test": true
 		},
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.26",
+			"version": "0.1.27",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -96,7 +98,7 @@
 		{
 			"key": "firecracker_ctl",
 			"app_name": "firecracker-ctl",
-			"version": "0.1.26",
+			"version": "0.1.27",
 			"version_toml": "apps/vm/firecracker-ctl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx",
 			"version_target": "apps/vm/firecracker-ctl/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -18,7 +18,8 @@ version_target: apps/discordsh/discordsh-bot/Cargo.toml
 runner: ubuntu-latest
 image: kbve/discordsh-bot
 deployment_yaml: apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
-has_test: false
+e2e_name: discordsh-bot-e2e
+has_test: true
 ---
 
 ## Overview


### PR DESCRIPTION
Fixes #9865.

The `discordsh_bot` entry in `ci-dispatch-manifest.json` was missing `e2e_name`, causing `pnpm nx e2e` to run with an empty project name — resolving to `@kbve/source` (no e2e target).

The bot has a dedicated e2e project (`discordsh-bot-e2e`) that spins up the Docker container and runs vitest health checks against it.

- MDX: replace `has_test: false` (from #9870) with `e2e_name: discordsh-bot-e2e` + `has_test: true`
- Manifest JSON: add `e2e_name` + `has_test` fields

## Test plan
- [ ] CI dispatches discordsh-bot Docker build → test job runs `pnpm nx e2e discordsh-bot-e2e --configuration=ci`