### PR TITLE
fix(firecracker): add SETUID, SETGID, KILL caps for jailer exec

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -59,8 +59,11 @@ spec:
                               - CHOWN
                               - DAC_OVERRIDE
                               - FOWNER
+                              - KILL
                               - MKNOD
                               - NET_ADMIN
+                              - SETGID
+                              - SETUID
                               - SYS_ADMIN
                               - SYS_CHROOT
                   volumeMounts:


### PR DESCRIPTION
## Summary
- Jailer fails at `exec into Firecracker: Operation not permitted` after chown succeeds
- The jailer drops privileges to uid/gid 10001 before exec — needs SETUID + SETGID
- KILL needed for firecracker-ctl to manage child VM processes
- Total caps now 10 (drop ALL + add back minimum required)

## Test plan
- [ ] ArgoCD syncs, pods restart
- [ ] Create VM, verify exit code 0