### PR TITLE
chore(mc): bump version to 1.0.1 to trigger initial docker build

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -12,7 +12,7 @@ tags:
 key: mc
 pipeline: docker
 app_name: mc
-version: "1.0.0"
+version: "1.0.1"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary
Both `mc.mdx` and `version.toml` were at `1.0.0`, so `check_version()` saw them as equal and skipped the docker dispatch. The image was never published.

Bumping MDX to `1.0.1` so `is_newer("1.0.1", "1.0.0")` returns true and CI dispatches `ci-docker.yml` for `mc`.

## Test plan
- [ ] After merge to main, ci-main dispatches mc docker build
- [ ] `ghcr.io/kbve/mc:1.0.1` is built and pushed
- [ ] Post-publish syncs `version.toml` to `1.0.1`