### PR TITLE
feat(astro-kbve): add OSRS item linking to site graph via frontmatter

### DIFF
--- a/apps/kbve/astro-kbve/src/components/sitegraph/SiteGraph.tsx
+++ b/apps/kbve/astro-kbve/src/components/sitegraph/SiteGraph.tsx
@@ -14,6 +14,8 @@ interface SiteGraphNode {
 	title: string;
 	links: string[];
 	backlinks: string[];
+	/** OSRS relationship metadata: target slug → relationship type */
+	osrsEdges?: Record<string, string>;
 }
 
 type SiteGraphData = Record<string, SiteGraphNode>;
@@ -22,11 +24,27 @@ interface GraphNode extends SimulationNodeDatum {
 	id: string;
 	title: string;
 	isCurrent: boolean;
+	/** True if this is an OSRS item page */
+	isOsrs: boolean;
 }
+
+/** OSRS relationship type → edge color */
+const EDGE_COLORS: Record<string, string> = {
+	upgrade: '#22c55e',
+	downgrade: '#ef4444',
+	product: '#3b82f6',
+	component: '#f97316',
+	variant: '#a855f7',
+	'set-piece': '#eab308',
+	alternative: '#64748b',
+	'drop-source': '#ec4899',
+};
 
 interface GraphLink extends SimulationLinkDatum<GraphNode> {
 	source: GraphNode;
 	target: GraphNode;
+	/** OSRS relationship type if available */
+	relationship?: string;
 }
 
 interface SiteGraphProps {
@@ -82,6 +100,7 @@ function getNeighborhood(
 			id: slug,
 			title: entry.title,
 			isCurrent: slug === startSlug,
+			isOsrs: slug.startsWith('osrs/'),
 		});
 	}
 
@@ -94,6 +113,7 @@ function getNeighborhood(
 				links.push({
 					source: nodeMap.get(slug)!,
 					target: nodeMap.get(target)!,
+					relationship: entry.osrsEdges?.[target],
 				});
 			}
 		}
@@ -428,13 +448,18 @@ export default function SiteGraph({
 				<g
 					transform={`translate(${width / 2 + panX},${height / 2 + panY}) scale(${zoom}) translate(${-width / 2},${-height / 2})`}>
 					{/* Links */}
-					{links.map((link, i) => (
+					{links.map((l, i) => (
 						<line
 							key={`link-${i}`}
 							className="sg-link"
-							stroke="var(--sl-color-gray-5)"
-							strokeWidth={1 / zoom}
-							strokeOpacity={0.4}
+							stroke={
+								l.relationship
+									? EDGE_COLORS[l.relationship] ||
+										'var(--sl-color-gray-4)'
+									: 'var(--sl-color-gray-5)'
+							}
+							strokeWidth={l.relationship ? 1.5 / zoom : 1 / zoom}
+							strokeOpacity={l.relationship ? 0.6 : 0.4}
 						/>
 					))}
 
@@ -457,20 +482,24 @@ export default function SiteGraph({
 								closeTooltip(`sg-node-${node.id}`);
 							}}>
 							<circle
-								r={node.isCurrent ? 6 : 4}
+								r={node.isCurrent ? 6 : node.isOsrs ? 4.5 : 4}
 								fill={
 									node.isCurrent
 										? 'var(--sl-color-accent)'
 										: hoveredId === node.id
 											? 'var(--sl-color-accent)'
-											: 'var(--sl-color-white)'
+											: node.isOsrs
+												? '#eab308'
+												: 'var(--sl-color-white)'
 								}
 								stroke={
 									node.isCurrent
 										? 'var(--sl-color-accent-high)'
 										: hoveredId === node.id
 											? 'var(--sl-color-accent-high)'
-											: 'var(--sl-color-gray-4)'
+											: node.isOsrs
+												? '#a16207'
+												: 'var(--sl-color-gray-4)'
 								}
 								strokeWidth={node.isCurrent ? 2 : 1}
 								style={{

--- a/apps/kbve/astro-kbve/src/pages/api/sitegraph.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/sitegraph.json.ts
@@ -4,6 +4,11 @@
  * Build-time endpoint that extracts internal links from all docs content
  * and produces a JSON adjacency map with backlinks. Consumed by the
  * SiteGraph React component in the right sidebar.
+ *
+ * Link sources:
+ *   1. Markdown body links [text](url)
+ *   2. OSRS frontmatter: related_items[].slug, recipes[].product slug,
+ *      recipes[].materials[].item_id → slug lookup
  */
 import { getCollection } from 'astro:content';
 
@@ -11,6 +16,8 @@ interface SiteGraphNode {
 	title: string;
 	links: string[];
 	backlinks: string[];
+	/** OSRS relationship metadata for graph edges (x-kbve-graph-data) */
+	osrsEdges?: Record<string, string>;
 }
 
 type SiteGraph = Record<string, SiteGraphNode>;
@@ -50,12 +57,95 @@ function extractLinks(body: string | undefined, currentSlug: string): string[] {
 	return [...links];
 }
 
+/** Convert an item name to a slug (same logic as generator) */
+function nameToSlug(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+/**
+ * Extract links + relationship metadata from OSRS frontmatter.
+ * Returns { links: string[], edges: Record<slug, relationship> }
+ */
+function extractOsrsLinks(
+	osrs: any,
+	currentSlug: string,
+): { links: string[]; edges: Record<string, string> } {
+	const links = new Set<string>();
+	const edges: Record<string, string> = {};
+
+	if (!osrs) return { links: [], edges };
+
+	// related_items — strongest signal for graph connections
+	if (Array.isArray(osrs.related_items)) {
+		for (const rel of osrs.related_items) {
+			const slug =
+				rel.slug || (rel.item_name ? nameToSlug(rel.item_name) : null);
+			if (slug) {
+				const target = `osrs/${slug}`;
+				if (target !== currentSlug) {
+					links.add(target);
+					edges[target] = rel.relationship || 'related';
+				}
+			}
+		}
+	}
+
+	// recipes — link to products
+	if (Array.isArray(osrs.recipes)) {
+		for (const recipe of osrs.recipes) {
+			if (recipe.product) {
+				const slug = nameToSlug(recipe.product);
+				const target = `osrs/${slug}`;
+				if (target !== currentSlug) {
+					links.add(target);
+					edges[target] = edges[target] || 'product';
+				}
+			}
+			// materials — link to ingredients
+			if (Array.isArray(recipe.materials)) {
+				for (const mat of recipe.materials) {
+					if (mat.item_name) {
+						const slug = nameToSlug(mat.item_name);
+						const target = `osrs/${slug}`;
+						if (target !== currentSlug) {
+							links.add(target);
+							edges[target] = edges[target] || 'component';
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// drop_table — link to drop sources (if they have pages)
+	if (osrs.drop_table) {
+		const sources = Array.isArray(osrs.drop_table)
+			? osrs.drop_table
+			: osrs.drop_table.sources || [];
+		for (const src of sources) {
+			if (src.source) {
+				const slug = nameToSlug(src.source);
+				const target = `osrs/${slug}`;
+				if (target !== currentSlug) {
+					links.add(target);
+					edges[target] = edges[target] || 'drop-source';
+				}
+			}
+		}
+	}
+
+	return { links: [...links], edges };
+}
+
 export const GET = async () => {
 	const entries = await getCollection('docs');
 
 	const graph: SiteGraph = {};
 
-	// Pass 1: build nodes with outgoing links
+	// Pass 1: build nodes with outgoing links from body + OSRS frontmatter
 	for (const entry of entries) {
 		const slug = entry.id.replace(/\/index$/, '').replace(/\.mdx?$/, '');
 		const title =
@@ -66,12 +156,25 @@ export const GET = async () => {
 				?.replace(/-/g, ' ')
 				.replace(/\b\w/g, (c: string) => c.toUpperCase()) ||
 			slug;
-		const links = extractLinks(entry.body, slug);
+
+		// Body links (markdown)
+		const bodyLinks = extractLinks(entry.body, slug);
+
+		// OSRS frontmatter links
+		const osrs = (entry.data as any).osrs;
+		const { links: osrsLinks, edges: osrsEdges } = extractOsrsLinks(
+			osrs,
+			slug,
+		);
+
+		// Merge — deduplicate, OSRS edges override body-derived ones
+		const allLinks = [...new Set([...bodyLinks, ...osrsLinks])];
 
 		graph[slug] = {
 			title,
-			links,
+			links: allLinks,
 			backlinks: [],
+			...(Object.keys(osrsEdges).length > 0 ? { osrsEdges } : {}),
 		};
 	}
 
@@ -90,6 +193,9 @@ export const GET = async () => {
 	}
 
 	return new Response(JSON.stringify(graph), {
-		headers: { 'Content-Type': 'application/json' },
+		headers: {
+			'Content-Type': 'application/json',
+			'x-kbve-graph-data': 'v2',
+		},
 	});
 };


### PR DESCRIPTION
## Summary
- Update `sitegraph.json.ts` to extract links from OSRS frontmatter data in addition to markdown body links
  - `related_items[].slug` → graph edges with relationship type
  - `recipes[].product` → product links
  - `recipes[].materials[].item_name` → component links
  - `drop_table` sources → drop-source links
- Adds `osrsEdges` metadata to graph nodes for relationship-typed edge rendering
- Response includes `x-kbve-graph-data: v2` header
- Update `SiteGraph.tsx`:
  - OSRS item nodes render in gold to distinguish from regular pages
  - Relationship-typed edges are color-coded (green=upgrade, blue=product, orange=component, purple=variant, yellow=set-piece, pink=drop-source)
  - Typed edges are thicker and more opaque

## Why this matters
v2 OSRS items have no markdown body (all data in frontmatter), so the old link extraction found zero connections. Now the graph surfaces the rich relationship data from `related_items`, `recipes`, and `drop_table`.

## Test plan
- [ ] Open yew-logs page, expand right sidebar graph — should show connections to yew longbow, bow string, maple logs, magic logs
- [ ] Open abyssal-whip page — should show connections to abyssal tentacle, kraken tentacle, dagger variants
- [ ] Verify edge colors match relationship types
- [ ] Verify non-OSRS pages still render normally with white nodes