### PR TITLE
feat(firecracker): output markers + tabbed view for user code output

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
@@ -118,6 +118,19 @@ function CopyButton({ text }: { text: string }) {
 	);
 }
 
+const FC_OUTPUT_START = '---FC_OUTPUT_START---';
+const FC_OUTPUT_END = '---FC_OUTPUT_END---';
+
+function parseUserOutput(stdout: string): string | null {
+	const startIdx = stdout.indexOf(FC_OUTPUT_START);
+	const endIdx = stdout.indexOf(FC_OUTPUT_END);
+	if (startIdx === -1) return null;
+	const start = startIdx + FC_OUTPUT_START.length;
+	const end = endIdx === -1 ? stdout.length : endIdx;
+	const output = stdout.slice(start, end).replace(/^\n/, '');
+	return output || null;
+}
+
 function OutputPanel({
 	result,
 	error,
@@ -125,6 +138,8 @@ function OutputPanel({
 	result: RunResult | null;
 	error: string | null;
 }) {
+	const [tab, setTab] = useState<'output' | 'log'>('output');
+
 	if (error) {
 		return (
 			<div
@@ -152,14 +167,26 @@ function OutputPanel({
 		);
 	}
 
-	const fullOutput = [result.stdout, result.stderr]
-		.filter(Boolean)
-		.join('\n');
+	const userOutput = result.stdout ? parseUserOutput(result.stdout) : null;
+	const hasMarkers = userOutput !== null;
+	const displayText =
+		tab === 'output' && hasMarkers
+			? userOutput
+			: [result.stdout, result.stderr].filter(Boolean).join('\n');
+
+	const tabStyle = (active: boolean) => ({
+		padding: '0.25rem 0.75rem',
+		fontSize: '0.75rem',
+		border: 'none',
+		borderBottom: active ? '2px solid #58a6ff' : '2px solid transparent',
+		background: 'none',
+		color: active ? '#e6edf3' : 'rgba(255,255,255,0.4)',
+		cursor: 'pointer' as const,
+	});
 
 	return (
 		<div
 			style={{
-				padding: '1rem',
 				fontFamily: 'monospace',
 				fontSize: '0.85rem',
 				whiteSpace: 'pre-wrap',
@@ -167,37 +194,70 @@ function OutputPanel({
 			}}>
 			<div
 				style={{
-					position: 'absolute',
-					top: '0.5rem',
-					right: '0.5rem',
+					display: 'flex',
+					gap: '0.25rem',
+					borderBottom: '1px solid rgba(255,255,255,0.08)',
+					padding: '0 1rem',
 				}}>
-				<CopyButton text={fullOutput} />
+				<button
+					style={tabStyle(tab === 'output')}
+					onClick={() => setTab('output')}>
+					Output
+				</button>
+				<button
+					style={tabStyle(tab === 'log')}
+					onClick={() => setTab('log')}>
+					Full Log
+				</button>
+				<div style={{ flex: 1 }} />
+				<div style={{ padding: '0.25rem 0' }}>
+					<CopyButton text={displayText ?? ''} />
+				</div>
 			</div>
-			{result.stdout && (
+			<div style={{ padding: '1rem' }}>
+				{tab === 'output' && hasMarkers && userOutput && (
+					<div style={{ color: '#e6edf3' }}>{userOutput}</div>
+				)}
+				{tab === 'output' && !hasMarkers && result.stdout && (
+					<div style={{ color: '#e6edf3' }}>{result.stdout}</div>
+				)}
+				{tab === 'log' && (
+					<>
+						{result.stdout && (
+							<div
+								style={{
+									color: '#e6edf3',
+									marginBottom: result.stderr ? '0.75rem' : 0,
+								}}>
+								{result.stdout}
+							</div>
+						)}
+						{result.stderr && (
+							<div style={{ color: '#f97316' }}>
+								{result.stderr}
+							</div>
+						)}
+					</>
+				)}
+				{tab === 'output' && !hasMarkers && !result.stdout && (
+					<div style={{ color: 'rgba(255,255,255,0.3)' }}>
+						No output captured.
+					</div>
+				)}
 				<div
 					style={{
-						color: '#e6edf3',
-						marginBottom: result.stderr ? '0.75rem' : 0,
+						marginTop: '0.75rem',
+						paddingTop: '0.5rem',
+						borderTop: '1px solid rgba(255,255,255,0.08)',
+						fontSize: '0.75rem',
+						color: 'rgba(255,255,255,0.4)',
+						display: 'flex',
+						gap: '1rem',
 					}}>
-					{result.stdout}
+					<span>Exit: {result.exit_code}</span>
+					<span>Duration: {result.duration_ms}ms</span>
+					<span>VM: {result.vm_id.slice(0, 15)}</span>
 				</div>
-			)}
-			{result.stderr && (
-				<div style={{ color: '#f97316' }}>{result.stderr}</div>
-			)}
-			<div
-				style={{
-					marginTop: '0.75rem',
-					paddingTop: '0.5rem',
-					borderTop: '1px solid rgba(255,255,255,0.08)',
-					fontSize: '0.75rem',
-					color: 'rgba(255,255,255,0.4)',
-					display: 'flex',
-					gap: '1rem',
-				}}>
-				<span>Exit: {result.exit_code}</span>
-				<span>Duration: {result.duration_ms}ms</span>
-				<span>VM: {result.vm_id.slice(0, 15)}</span>
 			</div>
 		</div>
 	);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactFirecrackerCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactFirecrackerCards.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	firecrackerService,
@@ -45,8 +45,26 @@ function phaseColor(phase: string): string {
 // VM Result Viewer — shows stdout/stderr after completion
 // ---------------------------------------------------------------------------
 
+const FC_OUTPUT_START = '---FC_OUTPUT_START---';
+const FC_OUTPUT_END = '---FC_OUTPUT_END---';
+
+function parseUserOutput(stdout: string): string | null {
+	const startIdx = stdout.indexOf(FC_OUTPUT_START);
+	const endIdx = stdout.indexOf(FC_OUTPUT_END);
+	if (startIdx === -1) return null;
+	const start = startIdx + FC_OUTPUT_START.length;
+	const end = endIdx === -1 ? stdout.length : endIdx;
+	const output = stdout.slice(start, end).replace(/^\n/, '');
+	return output || null;
+}
+
 function ResultViewer({ result }: { result: VmResult }) {
+	const [showFullLog, setShowFullLog] = useState(false);
 	const exitColor = result.exit_code === 0 ? '#22c55e' : '#ef4444';
+	const userOutput = result.stdout ? parseUserOutput(result.stdout) : null;
+	const hasMarkers = userOutput !== null;
+	const displayStdout =
+		showFullLog || !hasMarkers ? result.stdout : userOutput;
 
 	return (
 		<div
@@ -81,10 +99,26 @@ function ResultViewer({ result }: { result: VmResult }) {
 						{result.duration_ms}ms
 					</span>
 				)}
+				{hasMarkers && (
+					<button
+						onClick={() => setShowFullLog(!showFullLog)}
+						style={{
+							marginLeft: 'auto',
+							padding: '0.15rem 0.5rem',
+							fontSize: '0.65rem',
+							border: '1px solid rgba(255,255,255,0.15)',
+							borderRadius: '4px',
+							background: 'none',
+							color: 'rgba(255,255,255,0.5)',
+							cursor: 'pointer',
+						}}>
+						{showFullLog ? 'Output' : 'Full Log'}
+					</button>
+				)}
 			</div>
 
 			{/* stdout */}
-			{result.stdout && (
+			{displayStdout && (
 				<div style={{ padding: '0.5rem 0.75rem' }}>
 					<div
 						style={{
@@ -94,7 +128,7 @@ function ResultViewer({ result }: { result: VmResult }) {
 							color: 'rgba(255,255,255,0.35)',
 							marginBottom: '0.25rem',
 						}}>
-						stdout
+						{showFullLog || !hasMarkers ? 'stdout' : 'output'}
 					</div>
 					<pre
 						style={{
@@ -109,7 +143,7 @@ function ResultViewer({ result }: { result: VmResult }) {
 							whiteSpace: 'pre-wrap',
 							wordBreak: 'break-all',
 						}}>
-						{result.stdout}
+						{displayStdout}
 					</pre>
 				</div>
 			)}

--- a/apps/kube/firecracker/manifests/firecracker-vm-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-vm-init.yaml
@@ -39,6 +39,10 @@ data:
         if [ -b /dev/vdb ]; then
           dd if=/dev/vdb of=/tmp/code.raw bs=4096 2>/dev/null
           tr -d '\0' < /tmp/code.raw > /tmp/code
-          exec "$ENTRYPOINT" /tmp/code
+          echo "---FC_OUTPUT_START---"
+          "$ENTRYPOINT" /tmp/code
+          EC=$?
+          echo "---FC_OUTPUT_END---"
+          exit $EC
         fi
         exec /bin/sh


### PR DESCRIPTION
## Summary
- VM init script wraps user code with `---FC_OUTPUT_START---` / `---FC_OUTPUT_END---` markers
- IDE dashboard: "Output" tab (default) shows only user code output, "Full Log" tab shows raw stdout
- VM cards: toggle button for Output / Full Log view
- Backwards compatible — no markers = shows raw stdout as before

## Test plan
- [ ] Deploy updated init job (v6 rootfs rebuild or manual ConfigMap update)
- [ ] Run Python/Node.js code, verify Output tab shows only print output
- [ ] Click Full Log tab, verify boot messages visible
- [ ] VM cards show same toggle behavior