### PR TITLE
fix(agones-mc): update fleet image to 1.0.1 and wire deployment_yaml for auto-updates

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -17,6 +17,7 @@ source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest
 image: kbve/mc
+deployment_yaml: apps/kube/agones/mc/fleet.yaml
 has_test: false
 ---
 

--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -44,7 +44,7 @@ spec:
                         node.kbve.com/type: dedicated-server
                     containers:
                         - name: mc-server
-                          image: ghcr.io/kbve/mc:1.0.0
+                          image: ghcr.io/kbve/mc:1.0.1
                           env:
                               - name: TYPE
                                 value: FABRIC


### PR DESCRIPTION
## Summary
- **Manual fix**: Fleet image `ghcr.io/kbve/mc:1.0.0` → `1.0.1` (1.0.0 was never published, 1.0.1 just built successfully)
- **Automation fix**: Added `deployment_yaml: apps/kube/agones/mc/fleet.yaml` to mc.mdx so CI post-publish automatically updates the fleet image tag on future version bumps

## Test plan
- [ ] ArgoCD syncs new fleet, pod pulls `ghcr.io/kbve/mc:1.0.1` successfully
- [ ] GameServer exits ImagePullBackOff and starts Fabric server
- [ ] Future version bumps auto-update fleet.yaml via CI post-publish