### PR TITLE
feat(astro-kbve): add global tooltip on OSRS item link hover

### DIFF
--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
@@ -1,6 +1,7 @@
 ---
 import OSRSPriceWidget from './OSRSPriceWidget.tsx';
 import OSRSCharts from './OSRSCharts.tsx';
+import OSRSLinkTooltip from './OSRSLinkTooltip.tsx';
 import OSRSEquipmentStats from './OSRSEquipmentStats.astro';
 import OSRSDropSources from './OSRSDropSources.astro';
 import OSRSRecipes from './OSRSRecipes.astro';
@@ -311,6 +312,9 @@ const showTradingTips = hasTradingTips(item);
 				)
 			}
 		</div>
+
+		<!-- Global tooltip for OSRS item link hovers -->
+		<OSRSLinkTooltip client:idle />
 	</div>
 </section>
 

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSLinkTooltip.tsx
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSLinkTooltip.tsx
@@ -1,0 +1,187 @@
+/**
+ * OSRSLinkTooltip — Global tooltip for OSRS item links
+ *
+ * Attaches to all <a> tags with data-osrs-tooltip attribute inside the
+ * OSRS panel. Shows item preview (name, icon, stats) on hover.
+ * Uses @kbve/droid global tooltip state for coordination.
+ */
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { openTooltip, closeTooltip } from '@kbve/droid';
+
+interface TooltipData {
+	name: string;
+	icon: string;
+	slug: string;
+	members?: boolean;
+	highalch?: number | null;
+	value?: number;
+	relationship?: string;
+}
+
+const RELATIONSHIP_LABELS: Record<string, { label: string; color: string }> = {
+	upgrade: { label: 'Upgrade', color: '#22c55e' },
+	downgrade: { label: 'Downgrade', color: '#ef4444' },
+	product: { label: 'Product', color: '#3b82f6' },
+	component: { label: 'Component', color: '#f97316' },
+	variant: { label: 'Variant', color: '#a855f7' },
+	'set-piece': { label: 'Set Piece', color: '#eab308' },
+	alternative: { label: 'Alternative', color: '#64748b' },
+};
+
+const TOOLTIP_ID = 'osrs-item-preview';
+
+export default function OSRSLinkTooltip() {
+	const tooltipRef = useRef<HTMLDivElement>(null);
+	const [data, setData] = useState<TooltipData | null>(null);
+	const [visible, setVisible] = useState(false);
+	const [pos, setPos] = useState({ x: 0, y: 0 });
+	const hideTimeout = useRef<number>(0);
+
+	const show = useCallback((el: HTMLElement, e: MouseEvent) => {
+		window.clearTimeout(hideTimeout.current);
+
+		const name = el.dataset.osrsName || el.textContent || '';
+		const icon = el.dataset.osrsIcon || '';
+		const slug = el.dataset.osrsSlug || '';
+		const members = el.dataset.osrsMembers === 'true';
+		const highalch = el.dataset.osrsHighalch
+			? parseInt(el.dataset.osrsHighalch, 10)
+			: null;
+		const value = el.dataset.osrsValue
+			? parseInt(el.dataset.osrsValue, 10)
+			: undefined;
+		const relationship = el.dataset.osrsRelationship || undefined;
+
+		setData({ name, icon, slug, members, highalch, value, relationship });
+		setPos({ x: e.clientX, y: e.clientY });
+		setVisible(true);
+		openTooltip(TOOLTIP_ID);
+	}, []);
+
+	const hide = useCallback(() => {
+		hideTimeout.current = window.setTimeout(() => {
+			setVisible(false);
+			setData(null);
+			closeTooltip(TOOLTIP_ID);
+		}, 100);
+	}, []);
+
+	const move = useCallback((e: MouseEvent) => {
+		setPos({ x: e.clientX, y: e.clientY });
+	}, []);
+
+	useEffect(() => {
+		const panel = document.querySelector('.osrs-panel');
+		if (!panel) return;
+
+		const handleEnter = (e: Event) => {
+			const target = (e.target as HTMLElement).closest?.(
+				'[data-osrs-tooltip]',
+			) as HTMLElement | null;
+			if (target) show(target, e as MouseEvent);
+		};
+
+		const handleLeave = (e: Event) => {
+			const target = (e.target as HTMLElement).closest?.(
+				'[data-osrs-tooltip]',
+			);
+			if (target) hide();
+		};
+
+		const handleMove = (e: Event) => {
+			if (visible) move(e as MouseEvent);
+		};
+
+		panel.addEventListener('mouseenter', handleEnter, true);
+		panel.addEventListener('mouseleave', handleLeave, true);
+		panel.addEventListener('mousemove', handleMove, true);
+
+		return () => {
+			panel.removeEventListener('mouseenter', handleEnter, true);
+			panel.removeEventListener('mouseleave', handleLeave, true);
+			panel.removeEventListener('mousemove', handleMove, true);
+			window.clearTimeout(hideTimeout.current);
+		};
+	}, [show, hide, move, visible]);
+
+	if (!visible || !data) return null;
+
+	const relInfo = data.relationship
+		? RELATIONSHIP_LABELS[data.relationship]
+		: null;
+	const iconUrl = data.icon
+		? `https://oldschool.runescape.wiki/images/${data.icon.replace(/ /g, '_')}`
+		: null;
+
+	return (
+		<div
+			ref={tooltipRef}
+			role="tooltip"
+			style={{
+				position: 'fixed',
+				left: `${pos.x + 12}px`,
+				top: `${pos.y - 8}px`,
+				zIndex: 9999,
+				pointerEvents: 'none',
+				background: 'var(--sl-color-bg-nav, #111)',
+				border: '1px solid var(--sl-color-gray-4, #333)',
+				borderRadius: '0.5rem',
+				padding: '0.5rem 0.75rem',
+				boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+				maxWidth: '220px',
+				fontSize: '0.75rem',
+				color: 'var(--sl-color-white, #fff)',
+				display: 'flex',
+				alignItems: 'center',
+				gap: '0.5rem',
+			}}>
+			{iconUrl && (
+				<img
+					src={iconUrl}
+					alt=""
+					width={32}
+					height={32}
+					style={{
+						imageRendering: 'pixelated',
+						flexShrink: 0,
+					}}
+				/>
+			)}
+			<div>
+				<div
+					style={{
+						fontWeight: 600,
+						fontSize: '0.8125rem',
+						lineHeight: 1.2,
+					}}>
+					{data.name}
+				</div>
+				{relInfo && (
+					<span
+						style={{
+							fontSize: '0.5625rem',
+							fontWeight: 500,
+							padding: '0.0625rem 0.25rem',
+							borderRadius: '0.125rem',
+							background: `${relInfo.color}33`,
+							color: relInfo.color,
+							display: 'inline-block',
+							marginTop: '0.125rem',
+						}}>
+						{relInfo.label}
+					</span>
+				)}
+				{data.highalch != null && (
+					<div
+						style={{
+							fontSize: '0.625rem',
+							color: 'var(--sl-color-gray-3, #999)',
+							marginTop: '0.125rem',
+						}}>
+						HA: {data.highalch.toLocaleString()} gp
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSRecipes.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSRecipes.astro
@@ -83,7 +83,11 @@ function getSkillColor(skill: string | null | undefined): string {
 								{recipe.product_id ? (
 									<a
 										href={`/osrs/${recipe.product.toLowerCase().replace(/[^a-z0-9]+/g, '-')}/`}
-										class="osrs-recipe__link">
+										class="osrs-recipe__link"
+										data-osrs-tooltip
+										data-osrs-name={recipe.product}
+										data-osrs-icon={`${recipe.product}.png`}
+										data-osrs-relationship="product">
 										{recipe.product}
 									</a>
 								) : (
@@ -107,7 +111,11 @@ function getSkillColor(skill: string | null | undefined): string {
 										{mat.item_id ? (
 											<a
 												href={`/osrs/${mat.item_name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}/`}
-												class="osrs-recipe__link">
+												class="osrs-recipe__link"
+												data-osrs-tooltip
+												data-osrs-name={mat.item_name}
+												data-osrs-icon={`${mat.item_name}.png`}
+												data-osrs-relationship="component">
 												{mat.item_name}
 											</a>
 										) : (

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSRelatedItems.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSRelatedItems.astro
@@ -71,7 +71,16 @@ function getItemUrl(item: OSRSRelatedItem): string {
 					item.relationship ?? 'alternative',
 				);
 				return (
-					<a href={getItemUrl(item)} class="osrs-related__item">
+					<a
+						href={getItemUrl(item)}
+						class="osrs-related__item"
+						data-osrs-tooltip
+						data-osrs-name={item.item_name}
+						data-osrs-slug={item.slug}
+						data-osrs-icon={
+							item.item_name ? `${item.item_name}.png` : ''
+						}
+						data-osrs-relationship={item.relationship}>
 						<div class="osrs-related__item-main">
 							<span class="osrs-related__item-name">
 								{item.item_name}


### PR DESCRIPTION
## Summary
- Add `OSRSLinkTooltip` React component that shows item previews on hover
  - Intercepts hover on any `data-osrs-tooltip` element inside the OSRS panel
  - Shows: item icon (from Wiki), name, relationship badge (color-coded), high alch value
  - Follows cursor, 100ms debounce on hide, uses `@kbve/droid` `openTooltip`/`closeTooltip` for global state
  - Loaded with `client:idle` — zero JS cost until page is interactive
- Add `data-osrs-tooltip` attributes to:
  - `OSRSRelatedItems` links (name, slug, icon, relationship)
  - `OSRSRecipes` product links (product relationship)
  - `OSRSRecipes` material links (component relationship)

## Test plan
- [ ] Hover over related item links on yew-logs — tooltip shows item name + icon + relationship badge
- [ ] Hover over recipe product links — tooltip shows "Product" badge
- [ ] Hover over recipe material links — tooltip shows "Component" badge
- [ ] Verify tooltip follows cursor and hides on mouse leave
- [ ] Verify no tooltip appears on non-OSRS links