### PR TITLE
fix(droid): resolve DataCloneError in ws-worker Comlink callback

### DIFF
--- a/packages/npm/droid/src/lib/workers/db-worker.ts
+++ b/packages/npm/droid/src/lib/workers/db-worker.ts
@@ -1,7 +1,6 @@
 import { expose } from 'comlink';
 import Dexie, { type Table } from 'dexie';
 import type { DiscordServer, DiscordTag, Profile } from '../types/discord';
-import { toReference } from './flexbuilder';
 
 interface SharedWorkerGlobalScope extends Worker {
 	onconnect: (event: MessageEvent) => void;
@@ -16,7 +15,10 @@ class AppDexie extends Dexie {
 	servers!: Table<DiscordServer>;
 	tags!: Table<DiscordTag>;
 	profiles!: Table<Profile>;
-	ws_messages!: Table<{ key: string; message: Record<string, unknown> }>;
+	ws_messages!: Table<{
+		key: string;
+		message: Uint8Array | Record<string, unknown>;
+	}>;
 	auth_tokens!: Table<{ key: string; value: string; expires_at?: number }>;
 
 	constructor() {
@@ -52,17 +54,12 @@ const storageAPI = {
 	// WebSocket
 
 	async storeWsMessage(key: string, buffer: ArrayBuffer) {
-		const decoded = toReference(buffer).toObject() as Record<
-			string,
-			unknown
-		>;
-		// FlexBuffers toObject() may return objects containing typed array
-		// views (Uint8Array) that reference the original ArrayBuffer.
-		// Dexie broadcasts changes via BroadcastChannel.postMessage() for
-		// multi-tab sync, which throws DataCloneError on such views.
-		// JSON round-trip produces a plain, cloneable object.
-		const safe = JSON.parse(JSON.stringify(decoded));
-		await db.ws_messages.put({ key, message: safe });
+		// Store raw bytes — format-agnostic so the ws-worker can carry
+		// any protocol (IRC text, FlatBuffers, Protobuf, etc.).
+		// Uint8Array is natively supported by IndexedDB and safe for
+		// Dexie's BroadcastChannel multi-tab sync (no DataCloneError).
+		// Consumers decode on read using the appropriate deserializer.
+		await db.ws_messages.put({ key, message: new Uint8Array(buffer) });
 	},
 
 	async getWsMessage(key: string) {
@@ -70,7 +67,7 @@ const storageAPI = {
 	},
 
 	async getAllWsMessages(): Promise<
-		{ key: string; message: Record<string, unknown> }[]
+		{ key: string; message: Uint8Array | Record<string, unknown> }[]
 	> {
 		const raw = await db.ws_messages.toArray();
 		return raw.sort((a, b) => {

--- a/packages/npm/droid/src/lib/workers/db-worker.ts
+++ b/packages/npm/droid/src/lib/workers/db-worker.ts
@@ -56,7 +56,13 @@ const storageAPI = {
 			string,
 			unknown
 		>;
-		await db.ws_messages.put({ key, message: decoded });
+		// FlexBuffers toObject() may return objects containing typed array
+		// views (Uint8Array) that reference the original ArrayBuffer.
+		// Dexie broadcasts changes via BroadcastChannel.postMessage() for
+		// multi-tab sync, which throws DataCloneError on such views.
+		// JSON round-trip produces a plain, cloneable object.
+		const safe = JSON.parse(JSON.stringify(decoded));
+		await db.ws_messages.put({ key, message: safe });
 	},
 
 	async getWsMessage(key: string) {

--- a/packages/npm/droid/src/lib/workers/db-worker.ts
+++ b/packages/npm/droid/src/lib/workers/db-worker.ts
@@ -38,6 +38,29 @@ class AppDexie extends Dexie {
 }
 const db = new AppDexie();
 
+// --- ws-worker → db-worker direct pipeline ---
+// Listen for WebSocket messages from the ws-worker via BroadcastChannel.
+// This keeps the main thread out of the data storage path entirely.
+if (typeof BroadcastChannel !== 'undefined') {
+	const wsChannel = new BroadcastChannel('kbve_ws_data');
+	wsChannel.onmessage = (e: MessageEvent) => {
+		const msg = e.data;
+		if (msg?.type !== 'ws.store') return;
+
+		const key = `ws:${msg.ts ?? Date.now()}`;
+		const message =
+			msg.format === 'text'
+				? new TextEncoder().encode(msg.data)
+				: msg.data instanceof Uint8Array
+					? msg.data
+					: new Uint8Array(msg.data ?? []);
+
+		db.ws_messages.put({ key, message }).catch((err) => {
+			console.error('[DB] Failed to store ws message:', err);
+		});
+	};
+}
+
 function renderHtmlForServer(server: DiscordServer): string {
 	return `
 		<div class="flex flex-col gap-2 p-2">

--- a/packages/npm/droid/src/lib/workers/main.ts
+++ b/packages/npm/droid/src/lib/workers/main.ts
@@ -1,4 +1,4 @@
-import { wrap, proxy } from 'comlink';
+import { wrap } from 'comlink';
 import type { Remote } from 'comlink';
 import { persistentMap } from '@nanostores/persistent';
 import type { LocalStorageAPI } from './db-worker';
@@ -582,22 +582,6 @@ function initSWComlink() {
 	channel.port1.start();
 }
 
-// --- Bridge ---
-export function bridgeWsToDb(
-	ws: Remote<WSInstance>,
-	db: Remote<LocalStorageAPI>,
-) {
-	const handler = proxy(async (data: string | ArrayBuffer) => {
-		if (typeof data === 'string') return;
-		dispatchAsync(() => {
-			const key = `ws:${Date.now()}`;
-			void db.storeWsMessage(key, data);
-		});
-	});
-
-	ws.onMessage(handler);
-}
-
 // --- MAIN ---
 export async function main(opts?: {
 	workerURLs?: Record<string, string>;
@@ -694,7 +678,8 @@ export async function main(opts?: {
 					});
 				}
 
-				bridgeWsToDb(ws, api);
+				// ws-worker → db-worker storage now happens directly via
+				// BroadcastChannel ('kbve_ws_data'), no main-thread bridge needed.
 
 				const data = scopeData;
 				i18n.api = api;

--- a/packages/npm/droid/src/lib/workers/ws-worker.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.ts
@@ -9,6 +9,14 @@ let ws: WebSocket | null = null;
 let onMessageCallback: ((data: string | ArrayBuffer) => void) | null = null;
 let onStatusCallback: ((status: string) => void) | null = null;
 
+// BroadcastChannel for direct ws-worker → db-worker communication.
+// The db-worker listens on this channel and writes to IndexedDB,
+// keeping the main thread out of the data pipeline entirely.
+const dbChannel =
+	typeof BroadcastChannel !== 'undefined'
+		? new BroadcastChannel('kbve_ws_data')
+		: null;
+
 // Heartbeat
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 let lastPongTime = 0;
@@ -118,10 +126,28 @@ const wsInstanceAPI = {
 					}
 				}
 
-				if (e.data instanceof ArrayBuffer) {
-					onMessageCallback?.(e.data);
-				} else {
-					onMessageCallback?.(e.data);
+				// Forward to main thread callback (UI rendering)
+				onMessageCallback?.(e.data);
+
+				// Forward to db-worker for storage (off main thread).
+				// BroadcastChannel requires structured-cloneable data,
+				// so we send text as-is and binary as a Uint8Array copy.
+				if (dbChannel) {
+					if (typeof e.data === 'string') {
+						dbChannel.postMessage({
+							type: 'ws.store',
+							format: 'text',
+							data: e.data,
+							ts: Date.now(),
+						});
+					} else if (e.data instanceof ArrayBuffer) {
+						dbChannel.postMessage({
+							type: 'ws.store',
+							format: 'binary',
+							data: new Uint8Array(e.data),
+							ts: Date.now(),
+						});
+					}
 				}
 			} catch (err) {
 				console.error('[WS] Failed to forward message', err);


### PR DESCRIPTION
## Summary
Replaced the main-thread `bridgeWsToDb` pattern with direct worker-to-worker communication via BroadcastChannel.

**Before** (main thread in the data path):
```
ws-worker → Comlink → main thread → Comlink → db-worker → IndexedDB
```

**After** (main thread only handles UI events):
```
ws-worker → BroadcastChannel → db-worker → IndexedDB
```

### Changes
- **ws-worker**: broadcasts classified messages (`text`/`binary` + timestamp) to `kbve_ws_data` BroadcastChannel — main thread callback still fires for UI rendering
- **db-worker**: listens on `kbve_ws_data` channel, stores raw bytes as `Uint8Array` (format-agnostic — IRC text, FlatBuffers, Protobuf all stored the same way, consumers decode on read)
- **main.ts**: removed `bridgeWsToDb` function and unused `proxy` import — main thread no longer participates in the storage pipeline
- **DataCloneError fix**: removed FlexBuffers `toReference` decode from db-worker write path — was producing objects with typed array views that Dexie's BroadcastChannel sync couldn't clone

## Test plan
- [ ] Open IRC Gateway (chat.kbve.com) — verify no DataCloneError
- [ ] Send/receive messages — verify WebSocket messages display correctly
- [ ] Open multiple tabs — verify Dexie multi-tab sync works without errors
- [ ] Verify droid + astro-irc build clean