### PR TITLE
fix(mc): resolve JVM GC conflict — disable Aikar flags, use ZGC

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -18,7 +18,8 @@ version_toml: apps/mc/version.toml
 runner: ubuntu-latest
 image: kbve/mc
 deployment_yaml: apps/kube/agones/mc/fleet.yaml
-has_test: false
+has_test: true
+e2e_name: mc
 ---
 
 ## Overview

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -49,8 +49,10 @@ ENV SPAWN_PROTECTION=0
 ENV ONLINE_MODE=true
 ENV SERVER_PORT=25565
 
-ENV USE_AIKAR_FLAGS=true
-ENV JVM_XX_OPTS="-XX:+UseZGC -XX:+ZGenerational"
+# ZGC with generational mode — lower pause times than G1GC for MC servers.
+# Aikar flags disabled to avoid GC conflict (Aikar sets G1GC).
+ENV USE_AIKAR_FLAGS=false
+ENV JVM_XX_OPTS="-XX:+UseZGC -XX:+ZGenerational -XX:+AlwaysPreTouch -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled"
 
 # ── Modrinth mods (downloaded + sha1 verified in single layer) ────────
 # Modrinth only provides sha1/sha512; Docker ADD --checksum requires sha256.

--- a/apps/mc/project.json
+++ b/apps/mc/project.json
@@ -48,8 +48,8 @@
 			"options": {
 				"commands": [
 					"docker rm -f mc-e2e 2>/dev/null || true",
-					"docker run -d --name mc-e2e -p 25575:25575 -p 25565:25565 -e EULA=TRUE -e RCON_PASSWORD=test -e ENABLE_RCON=true kbve/mc:latest",
-					"echo 'Waiting for MC server RCON...' && for i in $(seq 1 300); do if docker logs mc-e2e 2>&1 | grep -q 'RCON running'; then echo 'RCON ready after '\"$i\"'s'; break; fi; if [ $i -eq 300 ]; then echo 'Server did not start in 300s'; docker logs mc-e2e 2>&1 | tail -50; docker rm -f mc-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
+					"docker run -d --name mc-e2e -p 25575:25575 -p 25565:25565 -e EULA=TRUE -e RCON_PASSWORD=test -e ENABLE_RCON=true -e ONLINE_MODE=false kbve/mc:latest",
+					"echo 'Waiting for MC server RCON...' && for i in $(seq 1 300); do if docker logs mc-e2e 2>&1 | grep -q 'RCON running'; then echo 'RCON ready after '\"$i\"'s'; break; fi; if docker logs mc-e2e 2>&1 | grep -q 'Multiple garbage collectors'; then echo 'JVM GC conflict detected'; docker logs mc-e2e 2>&1 | tail -20; docker rm -f mc-e2e 2>/dev/null || true; exit 1; fi; if [ $i -eq 300 ]; then echo 'Server did not start in 300s'; docker logs mc-e2e 2>&1 | tail -50; docker rm -f mc-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
 					"RCON_PASSWORD=test npx vitest run; EC=$?; echo '--- container logs ---'; docker logs mc-e2e 2>&1 | tail -50; docker rm -f mc-e2e 2>/dev/null || true; exit $EC"
 				],
 				"parallel": false,


### PR DESCRIPTION
## Summary
MC server crashes immediately with `Multiple garbage collectors selected`:
- `USE_AIKAR_FLAGS=true` sets G1GC via Aikar's JVM flags
- `JVM_XX_OPTS` adds ZGC on top
- JVM refuses to start with two GCs

Fix: Disable Aikar flags, keep ZGC with generational mode + tuning flags (AlwaysPreTouch, DisableExplicitGC, ParallelRefProcEnabled). ZGC has lower pause times than G1GC for MC servers.

## Test plan
- [ ] JVM starts without GC conflict
- [ ] Fabric server loads all mods
- [ ] Server accepts player connections on 1.21.11