### PR TITLE
feat(mc): call for help system + player-relative skeleton spawning

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiSkeletonManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiSkeletonManager.java
@@ -21,28 +21,29 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Manages AI Skeleton NPCs in the starter zone.
+ * Manages AI Skeleton NPCs that spawn near players.
  *
- * <p>Skeletons spawn when a player enters the zone and despawn
- * when no players remain. Each skeleton is tracked by entity ID
- * with a monotonic epoch for stale-intent detection.
+ * <p>Skeletons spawn near players and despawn when players leave.
+ * Each skeleton is tracked by entity ID with a monotonic epoch
+ * for stale-intent detection. Skeletons can call for reinforcements
+ * when wounded.
  */
 public class AiSkeletonManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
     private static final Gson GSON = new Gson();
 
-    // Starter zone: spawn point ± ZONE_RADIUS blocks
-    private static final int ZONE_RADIUS = 50;
-    private static final int MAX_SKELETONS = 3;
+    private static final int SPAWN_RADIUS = 20;
+    private static final int DESPAWN_RANGE = 64;
+    private static final int MAX_SKELETONS = 6;
     private static final int SPAWN_CHECK_INTERVAL = 100; // ticks (~5s)
     private static final double OBSERVATION_RANGE = 32.0;
+    private static final int CALL_COOLDOWN_TICKS = 200; // 10s cooldown per skeleton
 
     /** Tracked skeletons keyed by entity ID. */
     private final ConcurrentHashMap<Integer, TrackedSkeleton> skeletons = new ConcurrentHashMap<>();
 
     private int tickCounter = 0;
-    private BlockPos spawnOrigin = null;
 
     // -----------------------------------------------------------------------
     // Tracked skeleton state
@@ -51,14 +52,24 @@ public class AiSkeletonManager {
     private static class TrackedSkeleton {
         final int entityId;
         long epoch;
+        long lastCallTick;
 
         TrackedSkeleton(int entityId) {
             this.entityId = entityId;
             this.epoch = 0;
+            this.lastCallTick = 0;
         }
 
         long nextEpoch() {
             return ++epoch;
+        }
+
+        boolean canCall(long currentTick) {
+            return (currentTick - lastCallTick) > CALL_COOLDOWN_TICKS;
+        }
+
+        void markCalled(long currentTick) {
+            lastCallTick = currentTick;
         }
     }
 
@@ -66,25 +77,9 @@ public class AiSkeletonManager {
     // Tick entry point
     // -----------------------------------------------------------------------
 
-    /**
-     * Called every server tick. Handles spawn/despawn logic on intervals
-     * and returns observations for all active skeletons.
-     */
     public void tick(MinecraftServer server) {
         ServerWorld overworld = server.getOverworld();
         if (overworld == null) return;
-
-        // Lazily capture spawn origin
-        if (spawnOrigin == null) {
-            // Use first player's position as zone center, or world origin
-            if (!overworld.getPlayers().isEmpty()) {
-                var player = overworld.getPlayers().get(0);
-                spawnOrigin = player.getBlockPos();
-            } else {
-                spawnOrigin = BlockPos.ORIGIN;
-            }
-            LOGGER.info("[AI Skeleton] Starter zone centered at {} ±{}", spawnOrigin, ZONE_RADIUS);
-        }
 
         tickCounter++;
         if (tickCounter % SPAWN_CHECK_INTERVAL == 0) {
@@ -128,7 +123,7 @@ public class AiSkeletonManager {
             obs.addProperty("health", skeleton.getHealth());
             obs.addProperty("tick", currentTick);
 
-            // Nearby players as entities (skeletons treat players as hostile)
+            // Nearby players as entities
             JsonArray nearbyEntities = new JsonArray();
             Box searchBox = skeleton.getBoundingBox().expand(OBSERVATION_RANGE);
             for (ServerPlayerEntity player : overworld.getPlayers()) {
@@ -156,26 +151,47 @@ public class AiSkeletonManager {
         }
     }
 
-    /**
-     * Check if an entity ID belongs to a managed AI skeleton.
-     */
     public boolean isManaged(int entityId) {
         return skeletons.containsKey(entityId);
     }
 
-    /**
-     * Get the current epoch for an entity (for stale intent detection).
-     */
     public long getEpoch(int entityId) {
         var tracked = skeletons.get(entityId);
         return tracked != null ? tracked.epoch : -1;
     }
 
-    /**
-     * Get all tracked entity IDs.
-     */
     public Set<Integer> getTrackedIds() {
         return Collections.unmodifiableSet(skeletons.keySet());
+    }
+
+    // -----------------------------------------------------------------------
+    // Call for help — spawn reinforcements near the caller
+    // -----------------------------------------------------------------------
+
+    /**
+     * Spawn reinforcement skeletons near the calling skeleton.
+     * Returns true if reinforcements were spawned.
+     */
+    public boolean spawnReinforcements(ServerWorld world, int callerEntityId, int count, long currentTick) {
+        var tracked = skeletons.get(callerEntityId);
+        if (tracked == null || !tracked.canCall(currentTick)) return false;
+
+        var caller = world.getEntityById(callerEntityId);
+        if (caller == null || !caller.isAlive()) return false;
+
+        tracked.markCalled(currentTick);
+        int spawned = 0;
+
+        for (int i = 0; i < count && skeletons.size() < MAX_SKELETONS; i++) {
+            if (spawnSkeletonNear(world, caller.getX(), caller.getY(), caller.getZ(), 8)) {
+                spawned++;
+            }
+        }
+
+        if (spawned > 0) {
+            LOGGER.info("[AI Skeleton] {} reinforcements answered the call (id={})", spawned, callerEntityId);
+        }
+        return spawned > 0;
     }
 
     // -----------------------------------------------------------------------
@@ -183,53 +199,55 @@ public class AiSkeletonManager {
     // -----------------------------------------------------------------------
 
     private void manageSpawns(ServerWorld world) {
-        Box zone = new Box(
-                spawnOrigin.getX() - ZONE_RADIUS,
-                spawnOrigin.getY() - 10,
-                spawnOrigin.getZ() - ZONE_RADIUS,
-                spawnOrigin.getX() + ZONE_RADIUS,
-                spawnOrigin.getY() + 50,
-                spawnOrigin.getZ() + ZONE_RADIUS
-        );
+        // Despawn skeletons too far from any player
+        skeletons.entrySet().removeIf(entry -> {
+            var entity = world.getEntityById(entry.getKey());
+            if (entity == null) return true;
 
-        boolean playersInZone = false;
-        for (ServerPlayerEntity player : world.getPlayers()) {
-            if (zone.contains(player.getX(), player.getY(), player.getZ())) {
-                playersInZone = true;
-                break;
+            boolean nearPlayer = false;
+            for (ServerPlayerEntity player : world.getPlayers()) {
+                if (entity.squaredDistanceTo(player) < DESPAWN_RANGE * DESPAWN_RANGE) {
+                    nearPlayer = true;
+                    break;
+                }
             }
-        }
+            if (!nearPlayer) {
+                entity.discard();
+                LOGGER.debug("[AI Skeleton] Despawned skeleton too far from players (id={})", entry.getKey());
+                return true;
+            }
+            return false;
+        });
 
-        if (playersInZone && skeletons.size() < MAX_SKELETONS) {
-            spawnSkeleton(world);
-        } else if (!playersInZone && !skeletons.isEmpty()) {
-            despawnAll(world);
+        // Spawn skeletons near players if under limit
+        if (skeletons.size() >= MAX_SKELETONS) return;
+
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            if (skeletons.size() >= MAX_SKELETONS) break;
+            spawnSkeletonNear(world, player.getX(), player.getY(), player.getZ(), SPAWN_RADIUS);
         }
     }
 
-    private void spawnSkeleton(ServerWorld world) {
-        // Random offset from spawn within zone
-        Random rand = world.getRandom().nextBetween(0, Integer.MAX_VALUE) > 0
-                ? new Random() : new Random();
-        double offsetX = (rand.nextDouble() - 0.5) * ZONE_RADIUS;
-        double offsetZ = (rand.nextDouble() - 0.5) * ZONE_RADIUS;
+    private boolean spawnSkeletonNear(ServerWorld world, double centerX, double centerY, double centerZ, int radius) {
+        Random rand = new Random();
+        double offsetX = (rand.nextDouble() - 0.5) * 2 * radius;
+        double offsetZ = (rand.nextDouble() - 0.5) * 2 * radius;
 
-        double x = spawnOrigin.getX() + offsetX;
-        double z = spawnOrigin.getZ() + offsetZ;
-        // Find surface Y
+        double x = centerX + offsetX;
+        double z = centerZ + offsetZ;
+
         BlockPos surface = world.getTopPosition(
                 net.minecraft.world.Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
                 BlockPos.ofFloored(x, 0, z)
         );
 
         SkeletonEntity skeleton = EntityType.SKELETON.create(world, net.minecraft.entity.SpawnReason.COMMAND);
-        if (skeleton == null) return;
+        if (skeleton == null) return false;
 
-        skeleton.refreshPositionAndAngles(surface.getX() + 0.5, surface.getY(), surface.getZ() + 0.5, 0, 0);
+        skeleton.refreshPositionAndAngles(surface.getX() + 0.5, surface.getY(), surface.getZ() + 0.5, rand.nextFloat() * 360, 0);
         skeleton.setCustomName(Text.of("AI Skeleton"));
         skeleton.setCustomNameVisible(true);
         skeleton.setPersistent();
-        // Equip with stone sword instead of bow for melee combat
         skeleton.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Items.STONE_SWORD));
         skeleton.setEquipmentDropChance(EquipmentSlot.MAINHAND, 0.0f);
 
@@ -238,16 +256,6 @@ public class AiSkeletonManager {
 
         LOGGER.info("[AI Skeleton] Spawned at [{}, {}, {}] (id={})",
                 surface.getX(), surface.getY(), surface.getZ(), skeleton.getId());
-    }
-
-    private void despawnAll(ServerWorld world) {
-        for (var entry : skeletons.entrySet()) {
-            var entity = world.getEntityById(entry.getKey());
-            if (entity != null) {
-                entity.discard();
-            }
-        }
-        skeletons.clear();
-        LOGGER.info("[AI Skeleton] All skeletons despawned — no players in zone");
+        return true;
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -106,7 +106,6 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             double ty = target.get(1).getAsDouble();
             double tz = target.get(2).getAsDouble();
 
-            // Use the mob's navigation to pathfind
             mob.getNavigation().startMovingTo(tx, ty, tz, 1.0);
 
         } else if (cmd.has("Attack")) {
@@ -115,22 +114,31 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             Entity target = world.getEntityById((int) targetId);
             if (target != null && target.isAlive()) {
                 mob.tryAttack(world, target);
-                // Face the target
                 mob.lookAtEntity(target, 30.0f, 30.0f);
             }
 
         } else if (cmd.has("Idle")) {
-            // Do nothing — skeleton stands still
             mob.getNavigation().stop();
 
         } else if (cmd.has("Speak")) {
             JsonObject speak = cmd.getAsJsonObject("Speak");
             String message = speak.get("message").getAsString();
-            // Set custom name briefly to simulate speech
-            mob.setCustomName(net.minecraft.text.Text.of("AI Skeleton: " + message));
+            // Broadcast to nearby players as action bar text
+            for (var player : world.getPlayers()) {
+                if (mob.squaredDistanceTo(player) < 32 * 32) {
+                    player.sendMessage(
+                            net.minecraft.text.Text.of("§c<AI Skeleton> " + message),
+                            false
+                    );
+                }
+            }
+
+        } else if (cmd.has("CallForHelp")) {
+            JsonObject call = cmd.getAsJsonObject("CallForHelp");
+            int count = call.get("count").getAsInt();
+            skeletonManager.spawnReinforcements(world, mob.getId(), count, world.getTime());
 
         } else if (cmd.has("SetGoal")) {
-            // Goal management — future expansion
             LOGGER.debug("[AI Skeleton] SetGoal not yet implemented");
         }
     }

--- a/apps/mc/behavior_statetree/src/planner.rs
+++ b/apps/mc/behavior_statetree/src/planner.rs
@@ -4,7 +4,7 @@
 //! NpcObservation and returns an immutable NpcIntent. All world
 //! mutation happens back on the Fabric server tick thread.
 
-use crate::tree::builtin::{AttackNearest, Flee, IsHealthLow, Wander};
+use crate::tree::builtin::{AttackNearest, CallAllies, Flee, IsHealthLow, Wander};
 use crate::tree::node::{BehaviorNode, Selector, Sequence};
 use crate::types::{NpcIntent, NpcObservation};
 
@@ -13,9 +13,12 @@ use crate::types::{NpcIntent, NpcObservation};
 /// The tree structure:
 /// ```text
 /// Selector
-///   ├── Sequence [flee if low health]
+///   ├── Sequence [flee if critically low health]
 ///   │     ├── IsHealthLow(5.0)
 ///   │     └── Flee(16.0)
+///   ├── Sequence [call for help if wounded]
+///   │     ├── IsHealthLow(12.0)
+///   │     └── CallAllies(12.0, 2)
 ///   ├── AttackNearest(4.0)
 ///   └── Wander(8.0)
 /// ```
@@ -34,7 +37,7 @@ pub async fn plan_npc(observation: NpcObservation) -> NpcIntent {
 fn build_default_tree() -> Selector {
     Selector {
         children: vec![
-            // Priority 1: flee if health is low
+            // Priority 1: flee if health is critically low
             Box::new(Sequence {
                 children: vec![
                     Box::new(IsHealthLow { threshold: 5.0 }),
@@ -43,9 +46,19 @@ fn build_default_tree() -> Selector {
                     }),
                 ],
             }),
-            // Priority 2: attack nearest hostile in range
+            // Priority 2: call for help if wounded (< 12 HP but > 5)
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsHealthLow { threshold: 12.0 }),
+                    Box::new(CallAllies {
+                        health_threshold: 12.0,
+                        reinforcement_count: 2,
+                    }),
+                ],
+            }),
+            // Priority 3: attack nearest hostile in range
             Box::new(AttackNearest { range: 4.0 }),
-            // Priority 3: wander
+            // Priority 4: wander
             Box::new(Wander { radius: 8.0 }),
         ],
     }

--- a/apps/mc/behavior_statetree/src/tree/builtin.rs
+++ b/apps/mc/behavior_statetree/src/tree/builtin.rs
@@ -104,6 +104,35 @@ impl BehaviorNode for IsHealthLow {
     }
 }
 
+/// Call for reinforcements when health is in danger range.
+/// Emits a Speak + CallForHelp command to summon allies.
+pub struct CallAllies {
+    pub health_threshold: f32,
+    pub reinforcement_count: u32,
+}
+
+impl BehaviorNode for CallAllies {
+    fn evaluate(&self, observation: &NpcObservation) -> (NodeStatus, Vec<NpcCommand>) {
+        // Only call if hostiles are nearby and health is below threshold
+        let has_hostiles = observation.nearby_entities.iter().any(|e| e.is_hostile);
+        if !has_hostiles || observation.health >= self.health_threshold {
+            return (NodeStatus::Failure, vec![]);
+        }
+
+        (
+            NodeStatus::Success,
+            vec![
+                NpcCommand::Speak {
+                    message: "Skeleton roars and calls for his allies!".to_string(),
+                },
+                NpcCommand::CallForHelp {
+                    count: self.reinforcement_count,
+                },
+            ],
+        )
+    }
+}
+
 /// Idle for a number of ticks.
 pub struct Idle {
     pub ticks: u32,

--- a/apps/mc/behavior_statetree/src/types.rs
+++ b/apps/mc/behavior_statetree/src/types.rs
@@ -56,6 +56,7 @@ pub enum NpcCommand {
     Idle { ticks: u32 },
     Speak { message: String },
     SetGoal { goal: GoalId },
+    CallForHelp { count: u32 },
 }
 
 /// Result of async AI planning. Only applied if epoch matches current NPC epoch.


### PR DESCRIPTION
## Summary
### Call for Help
When an AI Skeleton takes damage and drops below 12 HP, the Rust behavior tree triggers:
1. `Speak` → broadcasts **"§c<AI Skeleton> Skeleton roars and calls for his allies!"** to nearby players in chat
2. `CallForHelp { count: 2 }` → spawns 2 reinforcement skeletons near the caller

Reinforcements have a 10s cooldown per skeleton to prevent spam. Max 6 total skeletons.

### Spawn Rework
- **Before**: Fixed origin point, skeletons could be far from players
- **After**: Skeletons spawn within 20 blocks of each player dynamically. Despawn when 64+ blocks from any player.

### Behavior Tree
```
Selector
  ├── Flee (HP < 5)
  ├── Call for Help (HP < 12, hostiles nearby)
  ├── Attack nearest (range 4)
  └── Wander (radius 8)
```

## Test plan
- [x] Docker build passes
- [ ] Skeletons spawn near player on join
- [ ] Skeletons call for help when wounded
- [ ] Chat message appears for nearby players
- [ ] Reinforcements spawn near the caller
- [ ] Max skeleton cap (6) is respected