### PR TITLE
fix(kbve-kubectl): rename Nx project to match Cargo package name (#9809)

### DIFF
--- a/apps/vm/kubectl-e2e/project.json
+++ b/apps/vm/kubectl-e2e/project.json
@@ -3,7 +3,7 @@
 	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"projectType": "application",
 	"sourceRoot": "apps/vm/kubectl-e2e/e2e",
-	"implicitDependencies": ["kubectl"],
+	"implicitDependencies": ["kbve-kubectl"],
 	"targets": {
 		"test": {
 			"executor": "nx:noop",

--- a/apps/vm/kubectl/project.json
+++ b/apps/vm/kubectl/project.json
@@ -1,5 +1,5 @@
 {
-	"name": "kubectl",
+	"name": "kbve-kubectl",
 	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"projectType": "application",
 	"sourceRoot": "apps/vm/kubectl/src",
@@ -39,13 +39,13 @@
 			"configurations": {
 				"local": {
 					"commands": [
-						"./kbve.sh -nx kubectl:containerx",
+						"./kbve.sh -nx kbve-kubectl:containerx",
 						"VERSION=$(grep '^version' apps/vm/kubectl/version.toml | sed 's/version = \"\\(.*\\)\"/\\1/') && docker tag kbve/kubectl:latest kbve/kubectl:$VERSION && echo \"Tagged kbve/kubectl:$VERSION\""
 					]
 				},
 				"production": {
 					"commands": [
-						"./kbve.sh -nx kubectl:containerx --configuration=production",
+						"./kbve.sh -nx kbve-kubectl:containerx --configuration=production",
 						"VERSION=$(grep '^version' apps/vm/kubectl/version.toml | sed 's/version = \"\\(.*\\)\"/\\1/') && docker tag kbve/kubectl:latest kbve/kubectl:$VERSION && docker tag kbve/kubectl:latest ghcr.io/kbve/kubectl:latest && docker tag kbve/kubectl:latest ghcr.io/kbve/kubectl:$VERSION && echo \"Tagged ghcr.io/kbve/kubectl:$VERSION\""
 					]
 				}


### PR DESCRIPTION
## Summary
- Rename Nx project from `kubectl` to `kbve-kubectl` so `@monodon/rust` executor passes `-p kbve-kubectl` to cargo (not `-p kubectl`)
- Restore `@monodon/rust:build`, `@monodon/rust:test`, `@monodon/rust:lint` executors — consistent with all other Rust projects
- Update container target refs from `kubectl:containerx` to `kbve-kubectl:containerx`
- Update kubectl-e2e `implicitDependencies` from `kubectl` to `kbve-kubectl`

## Root cause
`@monodon/rust` uses the Nx project name as the `-p` flag to cargo. Nx name was `kubectl` but Cargo package is `kbve-kubectl` → `cargo clippy -p kubectl` → "package ID specification did not match any packages"

Ref #9809