### PR TITLE
fix(mc): throttle AI tick rate, add sun protection, rate-limit calls

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiSkeletonManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiSkeletonManager.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>Skeletons spawn near players and despawn when players leave.
  * Each skeleton is tracked by entity ID with a monotonic epoch
  * for stale-intent detection. Skeletons can call for reinforcements
- * when wounded.
+ * when wounded, subject to per-skeleton and global cooldowns.
  */
 public class AiSkeletonManager {
 
@@ -35,15 +35,17 @@ public class AiSkeletonManager {
 
     private static final int SPAWN_RADIUS = 20;
     private static final int DESPAWN_RANGE = 64;
-    private static final int MAX_SKELETONS = 6;
+    private static final int MAX_SKELETONS = 3;
     private static final int SPAWN_CHECK_INTERVAL = 100; // ticks (~5s)
     private static final double OBSERVATION_RANGE = 32.0;
-    private static final int CALL_COOLDOWN_TICKS = 200; // 10s cooldown per skeleton
+    private static final int CALL_COOLDOWN_TICKS = 400; // 20s cooldown per skeleton
+    private static final int GLOBAL_CALL_COOLDOWN_TICKS = 400; // 20s global cooldown
 
     /** Tracked skeletons keyed by entity ID. */
     private final ConcurrentHashMap<Integer, TrackedSkeleton> skeletons = new ConcurrentHashMap<>();
 
     private int tickCounter = 0;
+    private long lastGlobalCallTick = 0;
 
     // -----------------------------------------------------------------------
     // Tracked skeleton state
@@ -95,6 +97,7 @@ public class AiSkeletonManager {
 
     /**
      * Build observation JSON for each tracked skeleton and submit to Tokio.
+     * Called at throttled intervals by NpcTickHandler, not every tick.
      */
     public void submitObservations(MinecraftServer server) {
         ServerWorld overworld = server.getOverworld();
@@ -123,7 +126,6 @@ public class AiSkeletonManager {
             obs.addProperty("health", skeleton.getHealth());
             obs.addProperty("tick", currentTick);
 
-            // Nearby players as entities
             JsonArray nearbyEntities = new JsonArray();
             Box searchBox = skeleton.getBoundingBox().expand(OBSERVATION_RANGE);
             for (ServerPlayerEntity player : overworld.getPlayers()) {
@@ -168,18 +170,21 @@ public class AiSkeletonManager {
     // Call for help — spawn reinforcements near the caller
     // -----------------------------------------------------------------------
 
-    /**
-     * Spawn reinforcement skeletons near the calling skeleton.
-     * Returns true if reinforcements were spawned.
-     */
     public boolean spawnReinforcements(ServerWorld world, int callerEntityId, int count, long currentTick) {
+        // Global cooldown — prevent cascade
+        if ((currentTick - lastGlobalCallTick) < GLOBAL_CALL_COOLDOWN_TICKS) return false;
+
         var tracked = skeletons.get(callerEntityId);
         if (tracked == null || !tracked.canCall(currentTick)) return false;
 
         var caller = world.getEntityById(callerEntityId);
         if (caller == null || !caller.isAlive()) return false;
 
+        // Already at max — no reinforcements
+        if (skeletons.size() >= MAX_SKELETONS) return false;
+
         tracked.markCalled(currentTick);
+        lastGlobalCallTick = currentTick;
         int spawned = 0;
 
         for (int i = 0; i < count && skeletons.size() < MAX_SKELETONS; i++) {
@@ -213,7 +218,6 @@ public class AiSkeletonManager {
             }
             if (!nearPlayer) {
                 entity.discard();
-                LOGGER.debug("[AI Skeleton] Despawned skeleton too far from players (id={})", entry.getKey());
                 return true;
             }
             return false;
@@ -248,6 +252,10 @@ public class AiSkeletonManager {
         skeleton.setCustomName(Text.of("AI Skeleton"));
         skeleton.setCustomNameVisible(true);
         skeleton.setPersistent();
+        // Iron helmet — prevents burning in sunlight
+        skeleton.equipStack(EquipmentSlot.HEAD, new ItemStack(Items.IRON_HELMET));
+        skeleton.setEquipmentDropChance(EquipmentSlot.HEAD, 0.0f);
+        // Stone sword for melee
         skeleton.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Items.STONE_SWORD));
         skeleton.setEquipmentDropChance(EquipmentSlot.MAINHAND, 0.0f);
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -9,29 +9,26 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.Vec3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Server tick handler — the sync boundary between Fabric and Tokio.
  *
- * <p>Each tick:
- * <ol>
- *   <li>Manage AI skeleton spawns/despawns via {@link AiSkeletonManager}</li>
- *   <li>Gather NPC observations and submit to Tokio runtime</li>
- *   <li>Poll completed intents and apply validated commands</li>
- * </ol>
- *
- * <p>The Fabric server tick thread is the ONLY thread that mutates entity state.
- * Tokio tasks produce immutable intents that are validated here before application.
+ * <p>Observations are throttled to every {@link #OBSERVE_INTERVAL} ticks
+ * to avoid overwhelming the Tokio runtime. Intents are polled every tick
+ * so actions feel responsive once decided.
  */
 public class NpcTickHandler implements ServerTickEvents.EndTick {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
     private static final Gson GSON = new Gson();
 
+    /** Only submit observations every N ticks (10 = 0.5s at 20 TPS). */
+    private static final int OBSERVE_INTERVAL = 10;
+
     private final AiSkeletonManager skeletonManager = new AiSkeletonManager();
+    private int tickCounter = 0;
 
     @Override
     public void onEndTick(MinecraftServer server) {
@@ -39,19 +36,21 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             return;
         }
 
-        // Phase 0: Manage skeleton lifecycle
+        tickCounter++;
+
+        // Phase 0: Manage skeleton lifecycle (every tick for cleanup)
         skeletonManager.tick(server);
 
-        // Phase 1: Gather observations and submit to Tokio
-        skeletonManager.submitObservations(server);
+        // Phase 1: Gather observations — throttled to reduce load
+        if (tickCounter % OBSERVE_INTERVAL == 0) {
+            skeletonManager.submitObservations(server);
+        }
 
-        // Phase 2: Poll completed intents from Tokio
+        // Phase 2 + 3: Poll and apply intents every tick for responsiveness
         String intentsJson = NativeRuntime.pollIntents();
         if (intentsJson == null || intentsJson.equals("[]")) {
             return;
         }
-
-        // Phase 3: Parse intents, validate epochs, apply commands
         applyIntents(server, intentsJson);
     }
 
@@ -76,10 +75,8 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             int entityId = intent.get("entity_id").getAsInt();
             long epoch = intent.get("epoch").getAsLong();
 
-            // Only apply to managed skeletons
             if (!skeletonManager.isManaged(entityId)) continue;
 
-            // Epoch check — discard stale intents
             long currentEpoch = skeletonManager.getEpoch(entityId);
             if (epoch != currentEpoch) continue;
 
@@ -98,14 +95,12 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
     }
 
     private void applyCommand(ServerWorld world, MobEntity mob, JsonObject cmd) {
-        // Commands are tagged unions — check which fields exist
         if (cmd.has("MoveTo")) {
             JsonObject moveTo = cmd.getAsJsonObject("MoveTo");
             JsonArray target = moveTo.getAsJsonArray("target");
             double tx = target.get(0).getAsDouble();
             double ty = target.get(1).getAsDouble();
             double tz = target.get(2).getAsDouble();
-
             mob.getNavigation().startMovingTo(tx, ty, tz, 1.0);
 
         } else if (cmd.has("Attack")) {
@@ -123,11 +118,10 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
         } else if (cmd.has("Speak")) {
             JsonObject speak = cmd.getAsJsonObject("Speak");
             String message = speak.get("message").getAsString();
-            // Broadcast to nearby players as action bar text
             for (var player : world.getPlayers()) {
                 if (mob.squaredDistanceTo(player) < 32 * 32) {
                     player.sendMessage(
-                            net.minecraft.text.Text.of("§c<AI Skeleton> " + message),
+                            net.minecraft.text.Text.of("\u00A7c<AI Skeleton> " + message),
                             false
                     );
                 }


### PR DESCRIPTION
## Summary
Fixes issues observed during live testing:

| Problem | Fix |
|---------|-----|
| Observations every tick (20/s) caused call-for-help spam | Throttle to every 10 ticks (0.5s) |
| Skeletons burned to death in daylight | Iron helmet on spawn |
| Reinforcement cascade — calls triggered more calls | 20s global cooldown + 20s per-skeleton cooldown |
| Too many skeletons overwhelming player | Max reduced to 3 |

Intent polling remains every tick for responsive actions.

## Test plan
- [ ] Skeletons survive daytime
- [ ] Call for help only fires once per 20s
- [ ] Max 3 skeletons at any time
- [ ] No log spam from observations