### PR TITLE
fix(kbve-kubectl): add to root Cargo workspace members (#9809)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
 	'packages/rust/bevy/bevy_tasker',
 	'packages/rust/bevy/bevy_db',
 	'apps/vm/firecracker-ctl',
+	'apps/vm/kubectl',
 	'apps/mc/behavior_statetree',
 ]
 


### PR DESCRIPTION
## Summary
Add `apps/vm/kubectl` to root `Cargo.toml` workspace members. Without this, `cargo clippy -p kbve-kubectl` fails with "package ID specification did not match any packages" because cargo doesn't know the crate exists.

## Root cause
The previous PR renamed the Nx project but the root workspace was never updated to include the new crate. `firecracker-ctl` was already there — `kubectl` was missing.

## Test plan
- [ ] `pnpm nx run kbve-kubectl:lint` passes
- [ ] `pnpm nx affected --target=lint --base=origin/main --head=origin/dev` includes kbve-kubectl without error

Ref #9809