### PR TITLE
feat(mc): integrate headless Bevy ECS into behavior_statetree

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -1,12 +1,16 @@
 # ── Stage 1: Build Rust native library (.so) ──────────────────────────
-FROM rust:1.85-bookworm AS rust-builder
+FROM rust:1.94-bookworm AS rust-builder
 WORKDIR /build
 
-# Standalone workspace with only the behavior_statetree crate.
+# Standalone workspace with behavior_statetree + bevy_npc dependency.
 # Uses the repo Cargo.lock for reproducible dependency resolution.
 COPY Cargo.lock .
 COPY apps/mc/behavior_statetree/ behavior_statetree/
-RUN printf '[workspace]\nresolver = "2"\nmembers = ["behavior_statetree"]\n' > Cargo.toml
+COPY packages/rust/bevy/bevy_npc/ bevy_npc/
+
+# Rewrite bevy_npc path in behavior_statetree Cargo.toml for Docker context
+RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_npc"|path = "../bevy_npc"|' behavior_statetree/Cargo.toml
+RUN printf '[workspace]\nresolver = "2"\nmembers = ["behavior_statetree", "bevy_npc"]\n' > Cargo.toml
 
 RUN cargo build -p behavior_statetree --release
 # Output: /build/target/release/libbehavior_statetree.so

--- a/apps/mc/behavior_statetree/Cargo.toml
+++ b/apps/mc/behavior_statetree/Cargo.toml
@@ -3,10 +3,10 @@ name = "behavior_statetree"
 authors = ["kbve", "h0lybyte"]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.94"
 license = "MIT"
 publish = false
-description = "Hybrid Tokio/JNI NPC AI planner for Fabric Minecraft — behavior trees computed async, applied on server tick."
+description = "Hybrid Bevy ECS / JNI NPC AI planner for Fabric Minecraft — headless ECS manages entity state, behavior trees computed via systems, applied on server tick."
 
 [lib]
 crate-type = ["cdylib"]
@@ -15,10 +15,10 @@ crate-type = ["cdylib"]
 # JNI bridge — Rust ↔ JVM interop
 jni = "0.21"
 
-# Async runtime — single Tokio runtime for all NPC planning
+# Async runtime — hosts Bevy ECS tick loop
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 
-# Bounded channels for message passing (observation → intent)
+# Bounded channels for message passing (JNI ↔ ECS)
 crossbeam-channel = "0.5"
 
 # Serialization for snapshot/intent DTOs
@@ -27,3 +27,12 @@ serde_json = "1"
 
 # Logging
 tracing = "0.1"
+
+# Headless Bevy ECS — MinimalPlugins only, no rendering
+bevy = { version = "0.18", default-features = false, features = [
+    "bevy_state",
+    "multi_threaded",
+] }
+
+# Creature components from the shared bevy_npc package
+bevy_npc = { path = "../../../packages/rust/bevy/bevy_npc", features = ["creature"] }

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -1,0 +1,110 @@
+//! ECS components for AI-managed entities.
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Marker for entities managed by the AI behavior system.
+#[derive(Component, Debug)]
+pub struct AiManaged;
+
+/// Position in Minecraft world coordinates.
+#[derive(Component, Debug, Clone, Serialize, Deserialize)]
+pub struct McPosition {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+/// Health component mirroring the Minecraft entity's health.
+#[derive(Component, Debug, Clone)]
+pub struct McHealth {
+    pub current: f32,
+    pub max: f32,
+}
+
+/// Tracks the monotonic epoch for stale-intent detection.
+#[derive(Component, Debug)]
+pub struct AiEpoch {
+    pub value: u64,
+}
+
+impl AiEpoch {
+    pub fn next(&mut self) -> u64 {
+        self.value += 1;
+        self.value
+    }
+}
+
+/// Cooldown tracker for call-for-help ability.
+#[derive(Component, Debug)]
+pub struct CallCooldown {
+    pub last_call_tick: u64,
+    pub cooldown_ticks: u64,
+}
+
+impl CallCooldown {
+    pub fn new(cooldown_ticks: u64) -> Self {
+        Self {
+            last_call_tick: 0,
+            cooldown_ticks,
+        }
+    }
+
+    pub fn can_call(&self, current_tick: u64) -> bool {
+        current_tick.saturating_sub(self.last_call_tick) > self.cooldown_ticks
+    }
+
+    pub fn mark_called(&mut self, current_tick: u64) {
+        self.last_call_tick = current_tick;
+    }
+}
+
+/// The Minecraft entity ID (mapped from Java side).
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct McEntityId(pub u64);
+
+/// Nearby entity snapshot stored as a component for AI queries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NearbyEntity {
+    pub entity_id: u64,
+    pub entity_type: String,
+    pub position: [f64; 3],
+    pub health: f32,
+    pub is_hostile: bool,
+}
+
+/// List of nearby entities visible to this AI entity.
+#[derive(Component, Debug, Clone, Default)]
+pub struct NearbyEntities {
+    pub entities: Vec<NearbyEntity>,
+}
+
+/// Current server tick — updated from Java observations.
+#[derive(Resource, Debug, Default)]
+pub struct ServerTick(pub u64);
+
+/// Global call-for-help cooldown to prevent cascade.
+#[derive(Resource, Debug)]
+pub struct GlobalCallCooldown {
+    pub last_call_tick: u64,
+    pub cooldown_ticks: u64,
+}
+
+impl Default for GlobalCallCooldown {
+    fn default() -> Self {
+        Self {
+            last_call_tick: 0,
+            cooldown_ticks: 400, // 20s
+        }
+    }
+}
+
+impl GlobalCallCooldown {
+    pub fn can_call(&self, current_tick: u64) -> bool {
+        current_tick.saturating_sub(self.last_call_tick) > self.cooldown_ticks
+    }
+
+    pub fn mark_called(&mut self, current_tick: u64) {
+        self.last_call_tick = current_tick;
+    }
+}

--- a/apps/mc/behavior_statetree/src/ecs/events.rs
+++ b/apps/mc/behavior_statetree/src/ecs/events.rs
@@ -1,0 +1,29 @@
+//! Resource-based message buffers for JNI ↔ ECS communication.
+//!
+//! Using Resources with Vec buffers instead of Bevy Events to avoid
+//! feature-gating issues with MinimalPlugins. These are drained each
+//! ECS tick by the systems.
+
+use bevy::prelude::*;
+
+use crate::types::{NpcCommand, NpcObservation};
+
+/// Inbound buffer: observations queued from JNI, drained by ingest system.
+#[derive(Resource, Default)]
+pub struct ObservationBuffer {
+    pub pending: Vec<NpcObservation>,
+}
+
+/// Outbound buffer: intents produced by plan system, drained by runtime.
+#[derive(Resource, Default)]
+pub struct IntentBuffer {
+    pub ready: Vec<IntentReady>,
+}
+
+/// A single intent ready to send back to Java.
+#[derive(Debug, Clone)]
+pub struct IntentReady {
+    pub entity_id: u64,
+    pub epoch: u64,
+    pub commands: Vec<NpcCommand>,
+}

--- a/apps/mc/behavior_statetree/src/ecs/mod.rs
+++ b/apps/mc/behavior_statetree/src/ecs/mod.rs
@@ -1,0 +1,31 @@
+//! Headless Bevy ECS module for AI entity management.
+//!
+//! Runs inside the Tokio runtime with `MinimalPlugins` — no rendering,
+//! no window, no asset loading. Pure ECS logic for NPC state management
+//! and behavior tree evaluation.
+//!
+//! Uses Resource-based message buffers instead of Events for cross-thread
+//! communication with the JNI bridge.
+
+pub mod components;
+pub mod events;
+pub mod systems;
+
+use bevy::prelude::*;
+
+use components::{GlobalCallCooldown, ServerTick};
+use events::{IntentBuffer, ObservationBuffer};
+use systems::{ingest_observations, plan_behavior};
+
+/// Plugin that registers all AI ECS components, resources, and systems.
+pub struct AiBehaviorPlugin;
+
+impl Plugin for AiBehaviorPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ServerTick>()
+            .init_resource::<GlobalCallCooldown>()
+            .init_resource::<ObservationBuffer>()
+            .init_resource::<IntentBuffer>()
+            .add_systems(Update, (ingest_observations, plan_behavior).chain());
+    }
+}

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -1,0 +1,163 @@
+//! ECS systems for AI behavior planning.
+//!
+//! These run inside the headless Bevy App on the Tokio runtime.
+//! They read ECS components, evaluate behavior trees, and produce intents.
+
+use bevy::prelude::*;
+
+use crate::tree::builtin::{AttackNearest, CallAllies, Flee, IsHealthLow, Wander};
+use crate::tree::node::{BehaviorNode, Selector, Sequence};
+use crate::types::NpcObservation;
+
+use super::components::*;
+use super::events::*;
+
+/// System: ingest observations from the buffer, upsert ECS entities.
+pub fn ingest_observations(
+    mut commands: Commands,
+    mut obs_buffer: ResMut<ObservationBuffer>,
+    mut query: Query<(
+        &McEntityId,
+        &mut McPosition,
+        &mut McHealth,
+        &mut AiEpoch,
+        &mut NearbyEntities,
+    )>,
+    mut server_tick: ResMut<ServerTick>,
+) {
+    for obs in obs_buffer.pending.drain(..) {
+        server_tick.0 = obs.tick;
+
+        // Try to find existing entity
+        let mut found = false;
+        for (mc_id, mut pos, mut health, mut epoch, mut nearby) in &mut query {
+            if mc_id.0 == obs.entity_id {
+                pos.x = obs.position[0];
+                pos.y = obs.position[1];
+                pos.z = obs.position[2];
+                health.current = obs.health;
+                epoch.next();
+                nearby.entities = obs
+                    .nearby_entities
+                    .iter()
+                    .map(|e| NearbyEntity {
+                        entity_id: e.entity_id,
+                        entity_type: e.entity_type.clone(),
+                        position: e.position,
+                        health: e.health,
+                        is_hostile: e.is_hostile,
+                    })
+                    .collect();
+                found = true;
+                break;
+            }
+        }
+
+        // Spawn new ECS entity if not found
+        if !found {
+            commands.spawn((
+                AiManaged,
+                McEntityId(obs.entity_id),
+                McPosition {
+                    x: obs.position[0],
+                    y: obs.position[1],
+                    z: obs.position[2],
+                },
+                McHealth {
+                    current: obs.health,
+                    max: 20.0,
+                },
+                AiEpoch { value: 1 },
+                CallCooldown::new(400),
+                NearbyEntities {
+                    entities: obs
+                        .nearby_entities
+                        .iter()
+                        .map(|e| NearbyEntity {
+                            entity_id: e.entity_id,
+                            entity_type: e.entity_type.clone(),
+                            position: e.position,
+                            health: e.health,
+                            is_hostile: e.is_hostile,
+                        })
+                        .collect(),
+                },
+            ));
+        }
+    }
+}
+
+/// System: evaluate behavior trees for all AI-managed entities, write intents.
+pub fn plan_behavior(
+    query: Query<
+        (
+            &McEntityId,
+            &McPosition,
+            &McHealth,
+            &AiEpoch,
+            &NearbyEntities,
+        ),
+        With<AiManaged>,
+    >,
+    server_tick: Res<ServerTick>,
+    mut intent_buffer: ResMut<IntentBuffer>,
+) {
+    let tree = build_behavior_tree();
+
+    for (mc_id, pos, health, epoch, nearby) in &query {
+        let observation = NpcObservation {
+            entity_id: mc_id.0,
+            epoch: epoch.value,
+            position: [pos.x, pos.y, pos.z],
+            health: health.current,
+            nearby_entities: nearby
+                .entities
+                .iter()
+                .map(|e| crate::types::EntitySnapshot {
+                    entity_id: e.entity_id,
+                    entity_type: e.entity_type.clone(),
+                    position: e.position,
+                    health: e.health,
+                    is_hostile: e.is_hostile,
+                })
+                .collect(),
+            nearby_blocks: vec![],
+            current_goal: None,
+            tick: server_tick.0,
+        };
+
+        let (_status, commands) = tree.evaluate(&observation);
+
+        intent_buffer.ready.push(IntentReady {
+            entity_id: mc_id.0,
+            epoch: epoch.value,
+            commands,
+        });
+    }
+}
+
+fn build_behavior_tree() -> Selector {
+    Selector {
+        children: vec![
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsHealthLow { threshold: 5.0 }),
+                    Box::new(Flee {
+                        flee_distance: 16.0,
+                    }),
+                ],
+            }),
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsHealthLow { threshold: 12.0 }),
+                    Box::new(CallAllies {
+                        health_threshold: 12.0,
+                        reinforcement_count: 2,
+                    }),
+                ],
+            }),
+            Box::new(AttackNearest { range: 4.0 }),
+            Box::new(Wander { radius: 8.0 }),
+        ],
+    }
+}

--- a/apps/mc/behavior_statetree/src/lib.rs
+++ b/apps/mc/behavior_statetree/src/lib.rs
@@ -11,6 +11,7 @@
 //! All message passing uses bounded channels with immutable snapshots.
 //! Per-NPC epochs prevent stale decisions from being applied.
 
+pub mod ecs;
 pub mod planner;
 pub mod runtime;
 pub mod tree;

--- a/apps/mc/behavior_statetree/src/runtime.rs
+++ b/apps/mc/behavior_statetree/src/runtime.rs
@@ -1,63 +1,49 @@
-//! Tokio runtime lifecycle — one runtime for all NPC planning.
+//! Runtime hosting a headless Bevy ECS App on a dedicated thread.
 //!
-//! The runtime owns bounded channels for job submission and intent collection.
-//! The JVM side submits observations via `submit_job()` and drains completed
-//! intents via `poll_intents()` on each server tick.
+//! Bevy's App is not Send, so it runs on its own OS thread (not Tokio).
+//! Crossbeam channels bridge the JNI thread and the ECS thread.
 
-use std::sync::Arc;
+use std::time::Duration;
 
+use bevy::MinimalPlugins;
+use bevy::app::App;
 use crossbeam_channel::{Receiver, Sender, bounded};
-use tokio::runtime::Runtime;
+use tracing::{debug, warn};
 
-use crate::planner::plan_npc;
+use crate::ecs::AiBehaviorPlugin;
+use crate::ecs::events::{IntentBuffer, ObservationBuffer};
 use crate::types::{NpcIntent, NpcThinkJob};
 
-/// Channel capacity — bounds memory usage and back-pressure.
 const JOB_CHANNEL_SIZE: usize = 256;
 const INTENT_CHANNEL_SIZE: usize = 256;
+const ECS_TICK_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Owns the Tokio runtime and channels for NPC AI planning.
+/// Owns the ECS thread and JNI channels.
 pub struct AiRuntime {
-    _runtime: Arc<Runtime>,
     job_tx: Sender<NpcThinkJob>,
     intent_rx: Receiver<NpcIntent>,
 }
 
 impl AiRuntime {
-    /// Start the Tokio runtime and spawn the job consumer loop.
     pub fn start() -> Self {
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .thread_name("npc-planner")
-                .enable_all()
-                .build()
-                .expect("failed to create Tokio runtime for NPC planner"),
-        );
-
         let (job_tx, job_rx) = bounded::<NpcThinkJob>(JOB_CHANNEL_SIZE);
         let (intent_tx, intent_rx) = bounded::<NpcIntent>(INTENT_CHANNEL_SIZE);
 
-        // Spawn the consumer loop inside the Tokio runtime
-        let rt = Arc::clone(&runtime);
-        rt.spawn(async move {
-            consumer_loop(job_rx, intent_tx).await;
-        });
+        // Dedicated OS thread for the Bevy App (not Send, can't use Tokio)
+        std::thread::Builder::new()
+            .name("npc-ecs".into())
+            .spawn(move || {
+                ecs_tick_loop(job_rx, intent_tx);
+            })
+            .expect("failed to spawn NPC ECS thread");
 
-        Self {
-            _runtime: runtime,
-            job_tx,
-            intent_rx,
-        }
+        Self { job_tx, intent_rx }
     }
 
-    /// Submit an NPC observation for async planning. Non-blocking.
-    /// Returns false if the channel is full (back-pressure).
     pub fn submit_job(&self, job: NpcThinkJob) -> bool {
         self.job_tx.try_send(job).is_ok()
     }
 
-    /// Drain all completed intents. Called on each server tick.
     pub fn poll_intents(&self) -> Vec<NpcIntent> {
         let mut intents = Vec::new();
         while let Ok(intent) = self.intent_rx.try_recv() {
@@ -67,19 +53,43 @@ impl AiRuntime {
     }
 }
 
-/// Consumer loop — receives jobs from the server tick thread,
-/// spawns a Tokio task per job, and sends completed intents back.
-async fn consumer_loop(job_rx: Receiver<NpcThinkJob>, intent_tx: Sender<NpcIntent>) {
-    loop {
-        let job = match job_rx.recv() {
-            Ok(job) => job,
-            Err(_) => break, // channel closed, runtime shutting down
-        };
+fn ecs_tick_loop(job_rx: Receiver<NpcThinkJob>, intent_tx: Sender<NpcIntent>) {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(AiBehaviorPlugin);
 
-        let tx = intent_tx.clone();
-        tokio::spawn(async move {
-            let intent = plan_npc(job.observation).await;
-            let _ = tx.try_send(intent);
-        });
+    debug!("Bevy ECS App initialized (headless, MinimalPlugins) on dedicated thread");
+
+    loop {
+        // Drain observations into ECS resource buffer
+        {
+            let mut obs_buffer = app.world_mut().resource_mut::<ObservationBuffer>();
+            while let Ok(job) = job_rx.try_recv() {
+                obs_buffer.pending.push(job.observation);
+            }
+        }
+
+        // Tick the Bevy App
+        app.update();
+
+        // Drain intent buffer and send through channel
+        {
+            let mut intent_buffer = app.world_mut().resource_mut::<IntentBuffer>();
+            for intent in intent_buffer.ready.drain(..) {
+                let npc_intent = NpcIntent {
+                    entity_id: intent.entity_id,
+                    epoch: intent.epoch,
+                    commands: intent.commands,
+                };
+                if intent_tx.try_send(npc_intent).is_err() {
+                    warn!(
+                        "Intent channel full — dropping intent for entity {}",
+                        intent.entity_id
+                    );
+                }
+            }
+        }
+
+        std::thread::sleep(ECS_TICK_INTERVAL);
     }
 }


### PR DESCRIPTION
## Summary
Replaces manual `ConcurrentHashMap` + counter state management in the Rust AI planner with **headless Bevy ECS** (`MinimalPlugins`). Reuses the existing `bevy_npc` package (creature feature).

### Architecture
```
Java (Fabric tick) ──JNI──► crossbeam channel
                                    │
                    ┌────────────────▼────────────────┐
                    │   Bevy App (dedicated OS thread) │
                    │   MinimalPlugins — no rendering  │
                    │                                  │
                    │   ingest_observations system     │
                    │   plan_behavior system           │
                    │                                  │
                    │   Components: AiManaged,         │
                    │     McEntityId, McPosition,      │
                    │     McHealth, AiEpoch,           │
                    │     CallCooldown, NearbyEntities │
                    └────────────────┬────────────────┘
                                    │
                    crossbeam channel ──JNI──► Java
```

### Changes
- New `ecs/` module: components, systems, resource-based event buffers, plugin
- `runtime.rs`: dedicated OS thread (Bevy App is !Send) with 100ms tick interval
- JNI interface unchanged — Java side requires zero changes
- Rust 1.85 → 1.94 (bevy_npc MSRV), Docker base updated to match
- Dockerfile copies `bevy_npc` package into build context

### Why not Tokio?
Bevy's `App` is `!Send` — can't hold it across `.await` points. Dedicated thread with `std::thread::sleep` for the tick interval.

## Test plan
- [x] `cargo check -p behavior_statetree` passes
- [x] Docker build succeeds
- [ ] Server starts with Bevy ECS log message
- [ ] AI Skeletons spawn and behave correctly via ECS-driven planning