### PR TITLE
fix(astro-kbve): manually enrich 5 OSRS items to v3 (batch 2)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-karambwan.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-karambwan.mdx
@@ -32,8 +32,11 @@ osrs:
       product: Cooked karambwan
       product_id: 3144
       product_quantity: 1
-      facility: Range/Fire
+      facility: Range
       members_only: true
+  material:
+    type: fish
+    tier: high
   related_items:
     - item_id: 3142
       item_name: Raw karambwan
@@ -56,30 +59,14 @@ osrs:
       relationship: alternative
       description: Alternative
   about: |-
-    | Effect | Value |
-    |--------|-------|
-    | Heals | 18 HP |
-    | Buy limit | 10,000 |
-
-    Combo Eating:
-    - Eat same tick as other food
-    - Essential for high-level PvM
-    - Used with shark/anglerfish
+    Cooked karambwan is a members-only fish that restores 18 Hitpoints and acts as a fast food, meaning it can be eaten on the same tick as another food item for an instant double heal. This combo-eating property makes it a staple at raids and other high-end PvM encounters where burst healing matters more than raw heal-per-bite. Cooking raw karambwan requires level 30 Cooking and completion of the Tai Bwo Wannai Trio quest — without the quest, players will only produce poison karambwan instead.
   market_strategy:
     notes:
-      - Tick eating meta
-      - Raids/Inferno staple
-      - High demand always
-      - Combo eating (PvM/PvP)
-      - Theatre of Blood
-      - Inferno attempts
-      - Cox/ToA raids
-      - 1-tick karambwan technique
-      - Eat with shark for 38 HP
-      - Quest required to cook
-      - Always in demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cooked karambwan anchors the tick-eating meta, letting players stack a bite on the same tick as shark, anglerfish, or brews for burst heals.
+      - Demand is driven almost entirely by PvM — Theatre of Blood, Chambers of Xeric, Tombs of Amascut, and Inferno runs all burn through stacks per attempt.
+      - The Tai Bwo Wannai Trio quest gate keeps the supply of self-cooked karambwan tight, since new accounts cannot produce them until the quest is finished.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow.mdx
@@ -12,16 +12,18 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 11000
+  about: |
+    Dragon arrows are the strongest type of arrow in Old School RuneScape, providing +60 ranged strength and requiring 60 Ranged to wield. Unlike lower-tier arrows, they are only compatible with a handful of high-end bows — the dark bow, twisted bow, venator bow, scorching bow, and 3rd age bow — making them the ammunition of choice for end-game ranged combat and raids. They are created through the Fletching skill at level 90 by combining dragon arrowtips with headless arrows, producing 15 arrows per action for 225 Fletching experience.
   ammunition:
     type: arrow
+    tier: dragon
     ranged_strength: 60
-    slot: ammo
-  fletching:
-    level: 90
-    xp: 15
-    product: Dragon arrow
-    product_id: 11212
-    quantity_per_action: 15
+    compatible_weapons:
+      - Dark bow
+      - Twisted bow
+      - Venator bow
+      - Scorching bow
+      - 3rd age bow
   equipment:
     slot: ammo
     weight: 0
@@ -60,50 +62,41 @@ osrs:
       product_quantity: 15
       members_only: true
   related_items:
-    - item_id: 53
-      item_name: Headless arrow
-      slug: headless-arrow
-      relationship: component
-      description: Arrow shaft component
     - item_id: 11237
       item_name: Dragon arrowtips
       slug: dragon-arrowtips
       relationship: component
       description: Dragon tip component
+    - item_id: 53
+      item_name: Headless arrow
+      slug: headless-arrow
+      relationship: component
+      description: Arrow shaft component
     - item_id: 892
       item_name: Rune arrow
       slug: rune-arrow
       relationship: downgrade
       description: Lower tier arrow
+    - item_id: 4160
+      item_name: Broad arrows
+      slug: broad-arrows
+      relationship: alternative
+      description: Alternative arrow option
     - item_id: 21326
       item_name: Amethyst arrow
       slug: amethyst-arrow
       relationship: alternative
       description: Alternative high-tier arrow
-    - item_id: 20997
-      item_name: Twisted bow
-      slug: twisted-bow
-      relationship: alternative
-      description: Primary user of dragon arrows
   market_strategy:
     profit_formulas:
-      - (Dragon arrow × 15) - (Headless × 15) - (Dragon arrowtips × 15) = Profit
+      - "(Dragon arrow × 15) - (Headless arrow × 15) - (Dragon arrowtips × 15) = Fletching profit"
     notes:
-      - "Calculate:"
-      - 90 Fletching required
-      - Check arrowtip vs arrow margins
-      - Dragon arrowtips from Vorkath, Zulrah
-      - High volume from boss farming
-      - Twisted bow primary ammo
-      - Dark bow spec attacks
-      - High-level ranged training
-      - Cox/ToB raids
-      - Best arrows in game
-      - Twisted bow users = huge demand
-      - Often cheaper than rune arrows
-      - Check Vorkath supply levels
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Demand is driven by Twisted bow users farming raids and high-level boss content.
+      - Dragon arrowtip supply comes mainly from Vorkath and Zulrah drops, so check their kill rates when forecasting price moves.
+      - Compare arrowtip prices to finished arrow prices regularly — fletching margins can flip when Vorkath supply spikes.
+      - Often trades at or below rune arrow prices despite being end-game ammo, due to the steep 90 Fletching requirement limiting buyers.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranarr-weed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranarr-weed.mdx
@@ -12,27 +12,61 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 11000
-  herb:
-    type: clean
-    tier: mid-high
+  material:
+    type: herb
+    tier: high
   farming:
-    level: 32
-    xp: 91
+    farming_level: 32
+    plant_xp: 27
+    harvest_xp: 30.5
+    patch_type: herb
     growth_time: 80
+    payment: "1 sack of potatoes"
+    payment_item_id: 5418
     seed_id: 5295
     seed_name: Ranarr seed
-  herblore:
-    cleaning_level: 25
-    cleaning_xp: 7.5
-    grimy_id: 207
-    grimy_name: Grimy ranarr weed
+    min_yield: 6
+    compost_type: ultracompost
+    disease_free: false
+  about: >-
+    Ranarr weed is widely regarded as the most valuable common herb in Old
+    School RuneScape, prized almost exclusively for its role as the primary
+    ingredient in prayer potions — a staple consumable across virtually every
+    PvM encounter. Players can plant ranarr seeds at 32 Farming or clean the
+    grimy version at 25 Herblore, both routes feeding into an enormous and
+    remarkably stable market. Because prayer potions are consumed constantly
+    by the entire game, ranarr weed maintains high demand and consistently
+    strong prices on the Grand Exchange.
   recipes:
+    - skill: herblore
+      level: 25
+      xp: 7.5
+      materials:
+        - item_name: Grimy ranarr weed
+          item_id: 207
+          quantity: 1
+      product: Ranarr weed
+      product_id: 257
+      members_only: true
+    - skill: herblore
+      level: 30
+      xp: 0
+      materials:
+        - item_name: Ranarr weed
+          item_id: 257
+          quantity: 1
+        - item_name: Vial of water
+          item_id: 227
+          quantity: 1
+      product: Ranarr potion (unf)
+      product_id: 97
+      members_only: true
     - skill: herblore
       level: 38
       xp: 87.5
       materials:
-        - item_name: Ranarr weed
-          item_id: 257
+        - item_name: Ranarr potion (unf)
+          item_id: 97
           quantity: 1
         - item_name: Snape grass
           item_id: 231
@@ -44,50 +78,57 @@ osrs:
     - item_id: 207
       item_name: Grimy ranarr weed
       slug: grimy-ranarr-weed
-      relationship: component
-      description: Uncleaned version
+      relationship: variant
+      description: Uncleaned version — cleaned at 25 Herblore for 7.5 XP
     - item_id: 5295
       item_name: Ranarr seed
       slug: ranarr-seed
       relationship: component
-      description: For farming
-    - item_id: 231
-      item_name: Snape grass
-      slug: snape-grass
-      relationship: component
-      description: Secondary ingredient
+      description: Planted at 32 Farming in a herb patch
+    - item_id: 97
+      item_name: Ranarr potion (unf)
+      slug: ranarr-potion-unf
+      relationship: product
+      description: Unfinished prayer potion base (ranarr + vial of water)
     - item_id: 2434
       item_name: Prayer potion(4)
       slug: prayer-potion-4
       relationship: product
-      description: Final product
-    - item_id: 227
-      item_name: Vial of water
-      slug: vial-of-water
-      relationship: component
-      description: Required for potion
+      description: Final product — restores prayer points
+    - item_id: 3051
+      item_name: Snapdragon
+      slug: snapdragon
+      relationship: alternative
+      description: Higher tier herb — used for super restore potions
+    - item_id: 209
+      item_name: Irit leaf
+      slug: irit-leaf
+      relationship: alternative
+      description: Lower tier herb — used for super attack and antipoison potions
   market_strategy:
+    title: Prayer potion processing
     steps:
       - order: 1
-        action: Buy Grimy ranarr weed or clean Ranarr weed
+        action: Buy Grimy ranarr weed and clean to Ranarr weed
+        item_slug: grimy-ranarr-weed
       - order: 2
-        action: Buy Snape grass
+        action: Combine with Vial of water to make Ranarr potion (unf)
+        item_slug: ranarr-potion-unf
       - order: 3
-        action: Make Prayer potion(4)
+        action: Add Snape grass to make Prayer potion(3)
+        item_slug: prayer-potion-3
       - order: 4
-        action: "Calculate: `Prayer potion price - Ranarr price - Snape grass price - Vial = Profit`"
+        action: Decant 3-dose potions into 4-dose for higher value
+        item_slug: prayer-potion-4
     profit_formulas:
-      - Prayer potion price - Ranarr price - Snape grass price - Vial = Profit
+      - "Prayer potion(4) - Ranarr weed - Snape grass - Vial of water = profit margin"
     notes:
-      - Buy grimy → Clean → Sell clean
-      - Small margin but high volume
-      - Ranarr seed → Grow → Harvest
-      - One of the most profitable herbs to farm
-      - Prayer potions used by every account
-      - Essential for all PvM content
-      - High volume, stable prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cleaning grimy ranarr is the easiest entry point — small margin per herb but huge volume.
+      - Farming a herb run with ultracompost is one of the most profitable activities in OSRS, returning 6+ herbs per patch.
+      - Demand is permanent and price-stable because every PvM account consumes prayer potions.
+      - Watch grimy vs clean spread for cleaning arbitrage opportunities.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-4.mdx
@@ -16,29 +16,24 @@ osrs:
     doses: 4
     herblore_level: 63
     herblore_xp: 142.5
-    effect: Restores 8-32 Prayer points and all reduced stats except Hitpoints
+    effect: Restores 8-32 Prayer points per dose and also restores all other lowered stats except Hitpoints
     effects:
-      - stat: Prayer
+      - stat: prayer
         boost_formula: 8 + floor(level / 4)
-      - stat: All stats
-        boost_type: restore
-        boost_value: 0
-        description: Restores all reduced stats except Hitpoints
   recipes:
     - skill: herblore
       level: 63
       xp: 142.5
       materials:
-        - item_name: Snapdragon
-          item_id: 3000
+        - item_name: Snapdragon potion (unf)
+          item_id: 3002
           quantity: 1
         - item_name: Red spiders' eggs
           item_id: 223
           quantity: 1
-        - item_name: Vial of water
-          item_id: 227
-          quantity: 1
-          consumed: true
+      product: Super restore(4)
+      product_id: 3024
+      product_quantity: 1
       ticks: 2
       members_only: true
   related_items:
@@ -67,25 +62,17 @@ osrs:
       slug: super-restore-3
       relationship: variant
       description: 3-dose version
-  about: |-
-    Super restore is preferred over prayer potions because it:
-    - Restores ALL reduced stats (not just prayer)
-    - Essential for raids where stats get drained
-    - Required for high-level PvM
+  about: Super restore(4) is a four-dose members potion that restores Prayer points along with any other lowered stats except Hitpoints, making it the go-to recovery potion for raids and high-level PvM where stat drain is common. It is preferred over prayer potions because a single drink refills both Prayer and drained combat or skill levels, saving inventory space during long encounters. Crafting one requires level 63 Herblore by combining a snapdragon potion (unf) with red spiders' eggs for 142.5 experience.
   market_strategy:
     profit_formulas:
-      - Super restore(4) - Snapdragon - Red spiders' eggs - Vial
+      - "Super restore(4) - Snapdragon - Red spiders' eggs - Vial of water = profit margin"
     notes:
-      - "Calculate:"
-      - Higher margin than prayer potions
-      - Consistent raid demand
-      - Super restore costs more but restores stats
-      - Raid tax creates premium demand
-      - Check relative margins between both
-      - Compare 4-dose vs 3-dose prices
-      - Decanting can profit in either direction
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Super restore(4) typically holds a higher margin than prayer potions due to consistent raid and PvM demand.
+      - The premium over prayer potions reflects the added utility of restoring drained combat and skill stats in a single dose.
+      - Compare 4-dose and 3-dose prices regularly, as decanting between them can produce profit in either direction.
+      - Watch relative margins against prayer potion(4) to spot arbitrage opportunities when PvM activity spikes.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-godsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-godsword.mdx
@@ -14,100 +14,71 @@ osrs:
   limit: 8
   equipment:
     slot: 2h
-    type: godsword
-    attack_style: slash
+    weapon_type: two-handed-sword
     attack_speed: 6
+    attack_range: 1
+    weight: 10
+    attack_bonus:
+      stab: 0
+      slash: 132
+      crush: 80
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 132
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 8
     requirements:
       attack: 75
-    stats:
-      attack_slash: 132
-      attack_crush: 80
-      strength: 132
-      prayer: 8
   special_attack:
     name: Ice Cleave
     energy: 50
-    effect: Doubled accuracy, +10% max hit, freezes for 19.2 seconds
-  recipes:
-    - skill: none
-      level: 0
-      xp: 0
-      materials:
-        - item_name: Godsword blade
-          item_id: 11798
-          quantity: 1
-        - item_name: Zamorak hilt
-          item_id: 11816
-          quantity: 1
-      product: Zamorak godsword
-      product_id: 11808
-      product_quantity: 1
-      facility: None
-      members_only: true
+    description: "Doubles accuracy, increases max hit by 10%, and freezes the target for 19.2 seconds (32 ticks) on a successful hit. Cannot freeze targets already frozen."
+    accuracy_modifier: 2.0
+    damage_modifier: 1.1
+    freezes: true
+    freeze_duration: 32
   related_items:
     - item_id: 11816
       item_name: Zamorak hilt
       slug: zamorak-hilt
       relationship: component
-      description: Hilt component
+      description: Hilt component dropped by K'ril Tsutsaroth; attach to a Godsword blade to create the Zamorak godsword.
     - item_id: 11798
       item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Blade component
+      description: Blade component forged from three Godsword shards; combined with the Zamorak hilt to assemble the weapon.
     - item_id: 11802
       item_name: Armadyl godsword
       slug: armadyl-godsword
       relationship: alternative
-      description: KO spec
+      description: Alternative godsword known for its high-damage KO special attack.
     - item_id: 11804
       item_name: Bandos godsword
       slug: bandos-godsword
       relationship: alternative
-      description: Defence drain
+      description: Alternative godsword that drains enemy combat stats on special attack.
     - item_id: 11806
       item_name: Saradomin godsword
       slug: saradomin-godsword
       relationship: alternative
-      description: Healing spec
-  about: |-
-    Attach Zamorak hilt to Godsword blade.
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Zamorak hilt | K'ril Tsutsaroth (1/508) | ~18M gp |
-    | Godsword blade | GWD bosses | ~526K gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Slash attack | +132 |
-    | Crush attack | +80 |
-    | Strength | +132 |
-    | Prayer | +8 |
-    | Attack speed | 6 tick (3.6s) |
-    | Requirements | 75 Attack |
-
-    Ice Cleave (50% energy):
-    - Doubled accuracy
-    - +10% max hit
-    - Freezes target for 19.2 seconds (same as Ice Barrage)
-
-    Best For:
-    - Castle Wars (freezing flag carriers)
-    - Barrows (freezing brothers)
-    - Chambers of Xeric (Muttadiles)
-    - PvP (freeze combos)
-
-    Niche Uses:
-    - Preventing boss mechanics (healing, moving)
-    - Controlling adds in multi-combat
+      description: Alternative godsword that heals the user on special attack.
+  about: "The Zamorak godsword is the cheapest of the five godsword variants, assembled by attaching a Zamorak hilt (dropped by K'ril Tsutsaroth) to a completed Godsword blade. Its Ice Cleave special attack consumes 50% energy to double accuracy, add 10% to max hit, and freeze the target for 19.2 seconds (32 ticks) on a successful hit. It is best known for freezing flag carriers in Castle Wars, locking down melee Barrows brothers, and controlling Muttadiles in the Chambers of Xeric. The sword requires 75 Attack to wield and shares the same base slash stats as the other godswords."
   market_strategy:
     notes:
       - Cheapest godsword
       - Niche but useful freeze
       - Good for specific content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
Second batch of manually-reviewed v3 enrichment with parallel agent fetching + human schema validation.

### Items enriched
- **cooked-karambwan** — cleaned about prose (was a markdown table), trimmed market notes from 11 fragments to 3 sentences, added `material: { type: fish, tier: high }`
- **super-restore-4** — removed invalid `All stats` effect entry (not in OSRSSkill enum), fixed recipe to use snapdragon potion (unf) instead of raw snapdragon, cleaned prose and market notes
- **zamorak-godsword** — restructured `equipment` from flat `stats: { attack_slash, ... }` into proper nested `attack_bonus` / `defence_bonus` / `other_bonus` shape, fixed `special_attack` with proper schema fields (`accuracy_modifier: 2.0`, `damage_modifier: 1.1`, `freezes: true`, `freeze_duration: 32`), removed invalid recipe with `skill: none`
- **dragon-arrow** — removed invented top-level `fletching:` field (not in schema), removed invalid `ammunition.slot` (slot is in equipment), added prose about, trimmed market notes from 13 fragments to 4 sentences
- **ranarr-weed** — added `material`, full `farming` block, 3 herblore recipes (clean → unfinished potion → prayer potion), expanded `related_items` to 6 items, structured `market_strategy` with ordered processing steps, removed `null` farming field values

### Common agent issues fixed in review
- `name:` → `item_name:` in related_items and recipe materials
- Flat `equipment.stats` → nested `attack_bonus`/`defence_bonus`/`other_bonus`
- `null` fields removed (use missing keys instead — schema is `.optional()` not `.nullable()`)
- Invented fields like `fletching:`, `ammunition.slot`, `equipment.type` removed
- `recipes[*].skill: none` removed (must be valid OSRSSkill enum)
- Market strategy notes trimmed from fragmented bullet lists to complete sentences

## Test plan
- [ ] Verify astro-kbve builds without schema validation errors
- [ ] Spot-check the 5 enriched items render correctly with sub-components
- [ ] Verify equipment cards show nested bonuses for zamorak-godsword