### PR TITLE
feat(agones-mc): Velocity proxy on port 25565 + deployment fixes

### DIFF
--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -39,6 +39,12 @@ spec:
                 periodSeconds: 30
                 failureThreshold: 10
             template:
+                metadata:
+                    labels:
+                        # Pod-level label so the Velocity backend Service
+                        # can select MC gameserver pods (Agones doesn't
+                        # propagate Fleet template labels to pods).
+                        app: mc-gameserver
                 spec:
                     nodeSelector:
                         node.kbve.com/type: dedicated-server
@@ -71,8 +77,14 @@ spec:
                                 value: '12'
                               - name: SIMULATION_DISTANCE
                                 value: '8'
+                              # Velocity proxy handles Mojang auth — backend
+                              # must be offline-mode to accept forwarded sessions.
                               - name: ONLINE_MODE
-                                value: 'true'
+                                value: 'false'
+                              # Allow connections only from the Velocity proxy
+                              # via the cluster network (private addresses).
+                              - name: PREVENT_PROXY_CONNECTIONS
+                                value: 'false'
                               - name: SERVER_PORT
                                 value: '25565'
                           resources:

--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -34,10 +34,10 @@ spec:
                   containerPort: 25565
                   protocol: TCP
             health:
-                # Java + Fabric startup is slower than native binaries
-                initialDelaySeconds: 90
+                # Fabric + 8 mods + library unpacking takes ~3-4 minutes on cold start
+                initialDelaySeconds: 240
                 periodSeconds: 30
-                failureThreshold: 5
+                failureThreshold: 10
             template:
                 spec:
                     nodeSelector:
@@ -83,9 +83,11 @@ spec:
                                   memory: 4Gi
                                   cpu: '2'
                           volumeMounts:
-                              - name: world-data
-                                mountPath: /data/world
+                              # Mount entire /data so Fabric libraries, mods,
+                              # and world all persist across restarts
+                              - name: mc-data
+                                mountPath: /data
                     volumes:
-                        - name: world-data
+                        - name: mc-data
                           persistentVolumeClaim:
                               claimName: mc-world-data

--- a/apps/kube/agones/mc/velocity-configmap.yaml
+++ b/apps/kube/agones/mc/velocity-configmap.yaml
@@ -1,0 +1,62 @@
+# Velocity proxy configuration
+# Forwards client connections from port 25565 → backend MC servers
+# discovered via the mc-fabric-backend headless Service.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: mc-velocity-config
+    namespace: arc-runners
+    labels:
+        app: mc-velocity
+        app.kubernetes.io/part-of: mc
+data:
+    velocity.toml: |
+        config-version = "2.7"
+
+        bind = "0.0.0.0:25565"
+        motd = "<#FFD700>KBVE Minecraft Server"
+        show-max-players = 50
+        # Velocity authenticates clients against Mojang
+        online-mode = true
+        force-key-authentication = true
+        prevent-client-proxy-connections = false
+        # Modern forwarding requires FabricProxy-Lite mod on backend.
+        # Until that's bundled, use legacy bungeecord forwarding which
+        # most Fabric servers support natively (with bungeecord = true on backend).
+        player-info-forwarding-mode = "legacy"
+        forwarding-secret-file = "forwarding.secret"
+        announce-forge = false
+        announce-proxy-commands = true
+
+        [servers]
+        # Single backend — Agones fleet routed via headless Service.
+        # Velocity treats this as one logical server; the Service load-balances
+        # across whichever gameserver pods are Ready.
+        mc = "mc-fabric-backend.arc-runners.svc.cluster.local:25565"
+        try = ["mc"]
+
+        [forced-hosts]
+
+        [advanced]
+        compression-threshold = 256
+        compression-level = -1
+        login-ratelimit = 3000
+        connection-timeout = 5000
+        read-timeout = 30000
+        haproxy-protocol = false
+        tcp-fast-open = false
+        bungee-plugin-message-channel = true
+        show-ping-requests = false
+        failover-on-unexpected-server-disconnect = true
+        announce-proxy-commands = true
+        log-command-executions = false
+        log-player-connections = true
+        accepts-transfers = false
+
+        [query]
+        enabled = false
+        port = 25577
+        map = "Velocity"
+        show-plugins = false
+    forwarding.secret: |
+        kbve-velocity-forwarding-secret-change-me

--- a/apps/kube/agones/mc/velocity-deployment.yaml
+++ b/apps/kube/agones/mc/velocity-deployment.yaml
@@ -1,0 +1,72 @@
+# Velocity proxy deployment
+# Receives all player connections on port 25565 and forwards them to
+# the Agones-managed Fabric MC server pods.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: mc-velocity
+    namespace: arc-runners
+    labels:
+        app: mc-velocity
+        app.kubernetes.io/part-of: mc
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: mc-velocity
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
+    template:
+        metadata:
+            labels:
+                app: mc-velocity
+                app.kubernetes.io/part-of: mc
+        spec:
+            containers:
+                - name: velocity
+                  image: itzg/bungeecord:latest
+                  env:
+                      - name: TYPE
+                        value: VELOCITY
+                      - name: VELOCITY_VERSION
+                        value: '3.4.0-SNAPSHOT'
+                      - name: MEMORY
+                        value: '512M'
+                      - name: REPLACE_ENV_VARIABLES
+                        value: 'true'
+                  ports:
+                      - name: minecraft
+                        containerPort: 25565
+                        protocol: TCP
+                  resources:
+                      requests:
+                          memory: 512Mi
+                          cpu: 250m
+                      limits:
+                          memory: 1Gi
+                          cpu: 500m
+                  volumeMounts:
+                      - name: velocity-config
+                        mountPath: /config/velocity.toml
+                        subPath: velocity.toml
+                      - name: velocity-config
+                        mountPath: /config/forwarding.secret
+                        subPath: forwarding.secret
+                  livenessProbe:
+                      tcpSocket:
+                          port: 25565
+                      initialDelaySeconds: 30
+                      periodSeconds: 30
+                      failureThreshold: 5
+                  readinessProbe:
+                      tcpSocket:
+                          port: 25565
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
+            volumes:
+                - name: velocity-config
+                  configMap:
+                      name: mc-velocity-config

--- a/apps/kube/agones/mc/velocity-service.yaml
+++ b/apps/kube/agones/mc/velocity-service.yaml
@@ -1,0 +1,46 @@
+# Headless backend Service — selects the Agones gameserver pods.
+# Velocity uses this name to forward connections.
+# Headless (clusterIP: None) so DNS returns pod IPs directly,
+# bypassing kube-proxy load balancing.
+apiVersion: v1
+kind: Service
+metadata:
+    name: mc-fabric-backend
+    namespace: arc-runners
+    labels:
+        app: mc-gameserver
+        app.kubernetes.io/part-of: mc
+spec:
+    type: ClusterIP
+    clusterIP: None
+    selector:
+        app: mc-gameserver
+    ports:
+        - name: minecraft
+          port: 25565
+          targetPort: 25565
+          protocol: TCP
+---
+# LoadBalancer Service for Velocity — exposes port 25565 externally
+# via Cilium LB IPAM. Players connect here.
+apiVersion: v1
+kind: Service
+metadata:
+    name: mc-velocity
+    namespace: arc-runners
+    labels:
+        app: mc-velocity
+        app.kubernetes.io/part-of: mc
+    annotations:
+        # Hint to Cilium LB IPAM to allocate from the public pool
+        io.cilium/lb-ipam-ips: ''
+spec:
+    type: LoadBalancer
+    selector:
+        app: mc-velocity
+    ports:
+        - name: minecraft
+          port: 25565
+          targetPort: 25565
+          protocol: TCP
+    externalTrafficPolicy: Local

--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -62,9 +62,10 @@ gameservers:
         - ows
         - arc-runners
 
-    # Port range for game server host ports (UDP)
+    # Port range for game server host ports.
+    # Capped at 7900 to avoid MetalLB speaker memberlist port (7946).
     minPort: 7000
-    maxPort: 8000
+    maxPort: 7900
 
     # Node selector — only run game servers on dedicated-server nodes
     nodeSelector:


### PR DESCRIPTION
## Summary
### Velocity Proxy
Players now connect to a single LoadBalancer endpoint on the standard Minecraft port **25565** instead of needing the dynamic Agones host port.

```
Player → LoadBalancer (25565) → Velocity proxy → headless Service → Agones gameserver pod
```

- `velocity-configmap.yaml` — Velocity config (online-mode auth, legacy bungeecord forwarding)
- `velocity-deployment.yaml` — `itzg/bungeecord` image with `TYPE=VELOCITY`, 512Mi-1Gi memory
- `velocity-service.yaml` — headless backend Service + LoadBalancer Service on 25565

### Fleet Fixes
1. **PVC mount**: `/data/world` → `/data` so Fabric libraries persist across restarts (was unpacking 3-4 minutes every boot)
2. **Health check**: `initialDelaySeconds: 90 → 240`, `failureThreshold: 5 → 10` for cold start with 8 mods
3. **Pod label**: Added `app: mc-gameserver` at pod template level so the headless Service can select it (Agones doesn't propagate Fleet template labels)
4. **Online mode**: Fabric `ONLINE_MODE=false` since Velocity handles Mojang auth

### Agones Port Range
`7000-8000 → 7000-7900` to avoid MetalLB speaker memberlist port (7946).

## Test plan
- [ ] Velocity pod starts and exposes 25565
- [ ] LoadBalancer gets external IP from Cilium LB IPAM
- [ ] Player can connect to `<lb-ip>:25565` and reach the Fabric server
- [ ] Cold boot completes within new health check window
- [ ] Subsequent boots are fast (libraries persisted)