### PR TITLE
fix(astro-kbve): manually enrich 5 OSRS items to v3 (batch 3)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platebody.mdx
@@ -14,72 +14,92 @@ osrs:
   limit: 15
   equipment:
     slot: body
-    type: barrows
-    set: Dharok
-    tradeable: true
-    degradeable: true
     weight: 9.9
-    requirements:
-      defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -30
-      attack_ranged: -10
-      defence_stab: 122
-      defence_slash: 120
-      defence_crush: 107
-      defence_magic: -6
-      defence_ranged: 132
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -10
+    defence_bonus:
+      stab: 122
+      slash: 120
+      crush: 107
+      magic: -6
+      ranged: 132
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  set_effect:
-    name: Wretched Strength
+    requirements:
+      defence: 70
+  charges:
+    max_charges: 100
+    combat_hours: 15
+    repairable: true
+    repair_npc: Bob
+    degrade_to_id: 4886
+    degrade_to_name: Dharok's platebody 0
+  set_bonus:
+    set_name: Dharok the Wretched's equipment
     pieces_required: 4
-    description: Damage increases as HP decreases. Up to +98.9% damage at 1 HP with 99 max HP
+    description: "Increases melee damage as the player's hitpoints decrease, with maximum boost at 1 HP."
+    pieces:
+      - 4716
+      - 4720
+      - 4722
+      - 4718
   related_items:
     - item_id: 4716
       item_name: Dharok's helm
-      slug: dharoks-helm
+      slug: dharok-s-helm
       relationship: set-piece
       description: Head slot set piece
     - item_id: 4722
       item_name: Dharok's platelegs
-      slug: dharoks-platelegs
+      slug: dharok-s-platelegs
       relationship: set-piece
       description: Legs slot set piece
     - item_id: 4718
       item_name: Dharok's greataxe
-      slug: dharoks-greataxe
+      slug: dharok-s-greataxe
       relationship: set-piece
-      description: Weapon set piece
+      description: Two-handed weapon set piece
+    - item_id: 4939
+      item_name: Dharok's armour set
+      slug: dharok-s-armour-set
+      relationship: variant
+      description: Grand Exchange set containing all four Dharok pieces
+    - item_id: 4856
+      item_name: Ahrim's robetop
+      slug: ahrim-s-robetop
+      relationship: alternative
+      description: Magic-focused Barrows brother body slot armour
+    - item_id: 4732
+      item_name: Karil's leathertop
+      slug: karil-s-leathertop
+      relationship: alternative
+      description: Ranged-focused Barrows brother body slot armour
+    - item_id: 4728
+      item_name: Verac's brassard
+      slug: verac-s-brassard
+      relationship: alternative
+      description: Melee/prayer hybrid Barrows brother body slot armour
+    - item_id: 4749
+      item_name: Torag's platebody
+      slug: torag-s-platebody
+      relationship: alternative
+      description: Defensive melee Barrows brother body slot armour
+    - item_id: 4753
+      item_name: Guthan's platebody
+      slug: guthan-s-platebody
+      relationship: alternative
+      description: Healing melee Barrows brother body slot armour
   about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +122 |
-    | Slash defence | +120 |
-    | Crush defence | +107 |
-    | Magic defence | -6 |
-    | Ranged defence | +132 |
-    | Magic attack | -30 |
-    | Ranged attack | -10 |
-
-    Wretched Strength:
-    When wearing full Dharok's (helm, platebody, platelegs, greataxe):
-    - Damage increases as HP decreases
-    - Up to +98.9% damage at 1 HP with 99 max HP
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
-  market_strategy:
-    notes:
-      - Essential piece for Dharok's set effect
-      - Highest defence bonus body in Barrows
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Dharok's platebody is the body slot piece of Dharok the Wretched's equipment, obtained as a reward from the Barrows minigame and requiring 70 Defence to wear. It contributes to the Wretched Strength set effect which, when all four Dharok pieces are equipped, increases melee damage dealt as the player's hitpoints drop, reaching up to 98.9% bonus damage at 1 HP with 99 maximum hitpoints. The platebody degrades over 15 hours of combat and can be repaired by Bob in Lumbridge or at a player-owned house armour stand.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bones.mdx
@@ -22,69 +22,71 @@ osrs:
     xp_ectofuntus: 288
   drop_table:
     sources:
-      - source: Green dragon
-        source_id: 260
-        combat_level: 79
-        quantity: "1"
-        rarity: always
-        members_only: true
       - source: Blue dragon
-        source_id: 265
         combat_level: 111
         quantity: "1"
         rarity: always
+        drop_rate: "1/1"
+        members_only: true
+      - source: Red dragon
+        combat_level: 152
+        quantity: "1"
+        rarity: always
+        drop_rate: "1/1"
+        members_only: true
+      - source: Black dragon
+        combat_level: 227
+        quantity: "1"
+        rarity: always
+        drop_rate: "1/1"
+        members_only: true
+      - source: Bronze dragon
+        combat_level: 131
+        quantity: "1"
+        rarity: always
+        drop_rate: "1/1"
+        members_only: true
+      - source: Iron dragon
+        combat_level: 189
+        quantity: "1"
+        rarity: always
+        drop_rate: "1/1"
+        members_only: true
+      - source: Steel dragon
+        combat_level: 246
+        quantity: "1"
+        rarity: always
+        drop_rate: "1/1"
         members_only: true
       - source: King Black Dragon
-        source_id: 239
         combat_level: 276
         quantity: "1"
         rarity: always
-        members_only: true
-      - source: Vorkath
-        source_id: 8061
-        combat_level: 732
-        quantity: "2"
-        rarity: always
+        drop_rate: "1/1"
         members_only: true
   related_items:
-    - item_id: 22124
-      item_name: Superior dragon bones
-      slug: superior-dragon-bones
-      relationship: alternative
-      description: Higher XP (150 base)
-    - item_id: 6729
-      item_name: Dagannoth bones
-      slug: dagannoth-bones
-      relationship: alternative
-      description: Alternative (125 base XP)
-    - item_id: 6812
-      item_name: Wyvern bones
+    - item_name: Big bones
+      slug: big-bones
+      relationship: downgrade
+    - item_name: Babydragon bones
+      slug: babydragon-bones
+      relationship: downgrade
+    - item_name: Wyvern bones
       slug: wyvern-bones
       relationship: alternative
-      description: Same XP (72 base)
-    - item_id: 532
-      item_name: Big bones
-      slug: big-bones
+    - item_name: Frost dragon bones
+      slug: frost-dragon-bones
+      relationship: upgrade
+    - item_name: Superior dragon bones
+      slug: superior-dragon-bones
+      relationship: upgrade
+    - item_name: Lava dragon bones
+      slug: lava-dragon-bones
       relationship: alternative
-      description: Budget option (15 base XP)
-    - item_id: 1753
-      item_name: Green dragonhide
-      slug: green-dragonhide
-      relationship: alternative
-      description: Co-drop from green dragons
-  market_strategy:
-    notes:
-      - Players pay for bones to be used on their altar
-      - "Track:"
-      - Compare to alternative training methods
-      - New player influx
-      - Green dragon bots (major supply)
-      - Green dragons (most common)
-      - Blue dragons
-      - Various dragon bosses (KBD, Vorkath, etc.)
-      - Zulrah, Cerberus, Alchemical Hydra
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: |
+    Dragon bones are a high-tier Prayer training material dropped by nearly every adult dragon in the game, from Blue and Red dragons to Bronze, Iron, Steel, Black, and the King Black Dragon. Offering them at a gilded altar with two burners yields 252 Prayer experience per bone, making them the best mainstream training option outside of the Chaos Temple altar and premium bones like Superior or Frost dragon bones. They remain one of the most popular and accessible prayer training methods in Old School RuneScape thanks to their steady drop supply and strong XP-per-bone ratio.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-pickaxe.mdx
@@ -14,104 +14,104 @@ osrs:
   limit: 40
   equipment:
     slot: weapon
-    type: pickaxe
-    attack_style: melee
+    weapon_type: pickaxe
     attack_speed: 5
+    weight: 2.4
+    attack_bonus:
+      stab: 38
+      slash: -2
+      crush: 32
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
     requirements:
       attack: 60
       mining: 61
-    stats:
-      attack_stab: 26
-      attack_slash: 16
-      attack_crush: 22
-      strength: 30
   special_attack:
-    name: Rock Knocker
+    name: Rejuvenate
     energy: 100
-    effect: +3 Mining boost for 3 minutes
+    description: "Boosts the player's Mining level by 3 for 30 seconds. Can be activated while in inventory or wielded."
+  gathering:
+    skill: mining
+    level: 61
+    tool: Dragon pickaxe
   drop_table:
     sources:
       - source: Kalphite Queen
-        source_id: 963
         combat_level: 333
         quantity: "1"
-        rarity: 1/400
+        rarity: rare
+        drop_rate: "1/400"
         members_only: true
       - source: Chaos Elemental
-        source_id: 2054
         combat_level: 305
         quantity: "1"
-        rarity: 1/256
+        rarity: rare
+        drop_rate: "1/256"
         members_only: true
+        wilderness: true
       - source: Callisto
-        source_id: 6503
         combat_level: 470
         quantity: "1"
-        rarity: 1/256
+        rarity: rare
+        drop_rate: "1/256"
         members_only: true
+        wilderness: true
       - source: Vet'ion
-        source_id: 6611
         combat_level: 464
         quantity: "1"
-        rarity: 1/256
+        rarity: rare
+        drop_rate: "1/256"
         members_only: true
+        wilderness: true
       - source: Venenatis
-        source_id: 6504
         combat_level: 464
         quantity: "1"
-        rarity: 1/256
+        rarity: rare
+        drop_rate: "1/256"
         members_only: true
+        wilderness: true
       - source: King Black Dragon
-        source_id: 239
         combat_level: 276
         quantity: "1"
-        rarity: 1/1,000
+        rarity: very-rare
+        drop_rate: "1/1500"
         members_only: true
   related_items:
-    - item_id: 13243
-      item_name: Infernal pickaxe
-      slug: infernal-pickaxe
-      relationship: upgrade
-      description: 1/3 ore → Smithing XP
-    - item_id: 23680
-      item_name: Crystal pickaxe
+    - item_name: Rune pickaxe
+      slug: rune-pickaxe
+      relationship: downgrade
+      description: Previous tier pickaxe, no special attack.
+    - item_name: Crystal pickaxe
       slug: crystal-pickaxe
       relationship: upgrade
-      description: +4 invisible Mining levels
-    - item_id: 20014
-      item_name: 3rd age pickaxe
+      description: Equivalent power, faster XP/hour when used with crystal armour set.
+    - item_name: Infernal pickaxe
+      slug: infernal-pickaxe
+      relationship: upgrade
+      description: Burns 1/3 of mined ores for bonus Smithing experience.
+    - item_name: 3rd age pickaxe
       slug: 3rd-age-pickaxe
-      relationship: alternative
-      description: Cosmetic/flex
-    - item_id: 13245
-      item_name: Smouldering stone
-      slug: smouldering-stone
-      relationship: component
-      description: Infernal upgrade
+      relationship: variant
+      description: Cosmetic rare with identical stats.
+    - item_name: Dragon pickaxe (or)
+      slug: dragon-pickaxe-or
+      relationship: variant
+      description: Ornament kit recolour of the dragon pickaxe.
   about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Attack | 60 (to wield) |
-    | Mining | 61 (to use) |
-
-    Rock Knocker (100% energy):
-    - +3 Mining boost for 3 minutes
-    - Decays 1 level per 60 seconds
-    - Allows mining at 58 Mining with boost
-
-    | Upgrade | Requirements | Effect |
-    |---------|--------------|--------|
-    | Infernal pickaxe | 85 Smithing + Smouldering stone | 1/3 ore → Smithing XP |
-    | Crystal pickaxe | 76 Crafting/Smithing + 120 shards + seed | +4 invisible Mining levels |
-    | 3rd age pickaxe | 65 Mining | Cosmetic/flex |
-  market_strategy:
-    notes:
-      - Best pickaxe before upgrades
-      - Required for infernal/crystal
-      - Wilderness bosses = risky but common source
-      - KQ is safest source
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The dragon pickaxe is the best non-upgraded pickaxe in Old School RuneScape, tied with the 3rd age pickaxe and second only to the crystal pickaxe in mining speed. It requires 61 Mining to mine with and 60 Attack to wield, though its Rejuvenate special attack can temporarily boost Mining by 3 levels, allowing players with 58 base Mining to begin using it. The pickaxe is obtained as a rare drop from Wilderness bosses (Callisto, Venenatis, Vet'ion, Chaos Elemental, King Black Dragon), the Kalphite Queen, and as a reward from the Motherlode Mine.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nature-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nature-rune.mdx
@@ -12,15 +12,9 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 18000
-  rune:
-    type: utility
-  runecraft:
-    level: 44
-    xp: 9
-    multiple_at: 91
-    altar: Nature Altar
-    altar_location: Karamja (north)
-    essence_type: pure
+  material:
+    type: rune
+    tier: high
   recipes:
     - skill: runecraft
       level: 44
@@ -33,49 +27,38 @@ osrs:
       product_id: 561
       product_quantity: 1
       facility: Nature altar
-      members_only: true
   related_items:
-    - item_id: 554
-      item_name: Fire rune
-      slug: fire-rune
+    - item_id: 7936
+      item_name: Pure essence
+      slug: pure-essence
       relationship: component
-      description: Required for High Alchemy
-    - item_id: 855
-      item_name: Yew longbow
-      slug: yew-longbow
+      description: Required essence for crafting nature runes
+    - item_name: Rune essence
+      slug: rune-essence
+      relationship: component
+      description: Cannot be used for nature runes — pure essence only
+    - item_name: Nature talisman
+      slug: nature-talisman
+      relationship: component
+      description: Grants access to the Nature Altar
+    - item_name: Nature tiara
+      slug: nature-tiara
+      relationship: component
+      description: Head-slot alternative to carrying the talisman
+    - item_name: Daeyalt essence
+      slug: daeyalt-essence
       relationship: alternative
-      description: Common alch target
-    - item_id: 859
-      item_name: Magic longbow
-      slug: magic-longbow
-      relationship: alternative
-      description: High value alch target
-    - item_id: 1387
-      item_name: Staff of fire
-      slug: staff-of-fire
-      relationship: alternative
-      description: Infinite fire runes
-  about: |-
-    Nature runes are primarily used for Alchemy spells:
-
-    | Spell | Magic Level | Runes Required |
-    |-------|-------------|----------------|
-    | Low Alchemy | 21 | 1 Nature rune |
-    | High Alchemy | 55 | 1 Nature rune, 5 Fire runes |
-  market_strategy:
-    profit_formulas:
-      - High Alch value - Item cost - Nature rune = Profit
-    notes:
-      - Yew longbow - Alchs for 768 GP
-      - Magic longbow - Alchs for 1,536 GP
-      - Rune items - Various high alch values
-      - "Grand Exchange (buy limit: 18,000)"
-      - Runecrafting (44 RC, 91 for double)
-      - Nature Chest (Ardougne)
-      - Monster drops
-      - Shops (180 GP each)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Higher-XP alternative essence (13.5 XP per craft)
+  about: >-
+    Nature runes are the most valuable common rune in Old School RuneScape, used
+    primarily to cast High Alchemy, Low Alchemy, and Superheat Item — making
+    them a staple demand among Magic trainers and profit alchers. They are
+    crafted via Runecrafting at level 44 at the Nature Altar south-east of Tai
+    Bwo Wannai in Karamja, granting 9 XP per pure essence, with double runes
+    unlocked at level 91. Constant demand from the High Alchemy economy keeps
+    the Grand Exchange price high relative to elemental runes.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte.mdx
@@ -14,104 +14,62 @@ osrs:
   limit: 11000
   material:
     type: gem
-    tier: zenyte
+    tier: elite
   recipes:
     - skill: crafting
       level: 89
-      xp: 150
-      materials:
-        - item_name: Zenyte
-          item_id: 19493
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Zenyte ring
-      product_id: 19538
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
-    - skill: crafting
-      level: 92
-      xp: 165
-      materials:
-        - item_name: Zenyte
-          item_id: 19493
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Zenyte necklace
-      product_id: 19535
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
-    - skill: crafting
-      level: 98
       xp: 200
+      tools:
+        - Chisel
       materials:
-        - item_name: Zenyte
-          item_id: 19493
+        - item_name: Uncut zenyte
+          item_id: 19496
           quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Zenyte amulet (u)
-      product_id: 19501
+      product: Zenyte
+      product_id: 19493
       product_quantity: 1
-      facility: Furnace
-      members_only: true
-    - skill: crafting
-      level: 95
-      xp: 180
-      materials:
-        - item_name: Zenyte
-          item_id: 19493
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Zenyte bracelet
-      product_id: 19532
-      product_quantity: 1
-      facility: Furnace
       members_only: true
   related_items:
-    - item_id: 19529
+    - item_id: 19496
+      item_name: Uncut zenyte
+      slug: uncut-zenyte
+      relationship: component
+      description: Intermediate uncut form
+    - item_id: 19497
       item_name: Zenyte shard
       slug: zenyte-shard
       relationship: component
-      description: Drop from gorillas
+      description: Drop from Demonic gorillas
     - item_id: 6573
       item_name: Onyx
       slug: onyx
       relationship: component
-      description: Base gem
-    - item_id: 19553
-      item_name: Amulet of torture
+      description: Base gem combined with shard
+    - item_name: Amulet of torture
       slug: amulet-of-torture
       relationship: product
-      description: Melee BiS
-    - item_id: 19547
-      item_name: Necklace of anguish
+      description: Best-in-slot melee neck
+    - item_name: Necklace of anguish
       slug: necklace-of-anguish
       relationship: product
-      description: Ranged BiS
+      description: Best-in-slot ranged neck
+    - item_name: Ring of suffering
+      slug: ring-of-suffering
+      relationship: product
+      description: Recoil ring with defensive bonuses
+    - item_name: Tormented bracelet
+      slug: tormented-bracelet
+      relationship: product
+      description: Magic damage bracelet
   about: |-
-    | Item | Effect |
-    |------|--------|
-    | Ring of suffering | +20 all defence, prayer bonus |
-    | Necklace of anguish | +15 Ranged str, +5 Ranged |
-    | Amulet of torture | +15 melee str, +10 Attack |
-    | Tormented bracelet | +5 Magic damage |
+    Zenyte is the highest-tier gem in Old School RuneScape, sitting above onyx in the progression ladder and unlocking the most powerful jewelry in the game. It is produced by combining a cut onyx with a zenyte shard, which drops exclusively from Demonic gorillas deep within the Crash Site Cavern after Monkey Madness II. Players use zenyte to craft best-in-slot jewelry including the Amulet of torture, Necklace of anguish, Ring of suffering, and Tormented bracelet.
   market_strategy:
     notes:
-      - Requires onyx + zenyte shard
-      - Wall of Flames to create
-      - High Crafting requirements
-      - 93 Magic to enchant
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Demonic gorillas are the only source of zenyte shards, so supply is bottlenecked by Monkey Madness II completion and gorilla farming.
+      - The cut zenyte to jewelry chain holds a stable margin because the Amulet of torture and Necklace of anguish remain BiS for years.
+      - Watch shard prices closely — they directly drive the floor on every zenyte product.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
Third batch of manually-reviewed v3 enrichment.

### Items enriched
- **nature-rune** — added `material`, runecraft recipe, related items (essence + talisman + tiara), prose about
- **dharok-s-platebody** — restructured equipment from flat stats to nested bonuses, added `charges` (15hr combat, repairable by Bob), `set_bonus` (Wretched Strength), 9 related items including all set pieces
- **dragon-pickaxe** — restructured equipment, added `special_attack` (Rejuvenate +3 Mining), `gathering` (mining tool), 5 related items, fixed drop_table sources to use proper rarity enum + drop_rate fields
- **zenyte** — added `material` (gem, elite), corrected crafting recipe to level 89 cutting uncut zenyte, 7 related items (BiS jewelry chain)
- **dragon-bones** — added `material`, `prayer` XP values, `drop_table` with 7 dragon sources, 6 related items

### Schema fixes from agent output
- `relationship: set-item` → `variant` (not in enum)
- `recipes[*].notes` → removed (not in schema)
- `drop_table.sources[*].rarity: 1/256` → `rarity: rare` + `drop_rate: "1/256"`
- `recipes[*].materials[*]` use `item_name`/`item_id`/`quantity`
- equipment uses `melee_strength` not `strength`
- nature-rune: removed incorrect `members_only` flag (F2P item)

## Test plan
- [ ] Verify astro-kbve builds without schema errors
- [ ] Spot-check the 5 enriched pages render correctly