### PR TITLE
chore(kbve-kubectl): bump versions for first publish (#9809)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -13,7 +13,7 @@ tags:
 key: kubectl
 pipeline: docker
 app_name: kbve-kubectl
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/vm/kubectl
 version_toml: apps/vm/kubectl/version.toml
 version_target: apps/vm/kubectl/Cargo.toml

--- a/apps/vm/kubectl/version.toml
+++ b/apps/vm/kubectl/version.toml
@@ -1,1 +1,1 @@
-version = "0.0.0"
+version = "0.1.0"


### PR DESCRIPTION
## Summary
- `version.toml`: `0.0.0` → `0.1.0` (matches Cargo.toml)
- MDX `version`: `0.1.0` → `0.1.1` (drives first ci-docker dispatch)

## Why
The ci-main dispatcher's \`is_newer()\` function returns \`false\` if either local or published version is \`0.0.0\` (the "not ready" guard). Without bootstrapping, kubectl would never get dispatched. After this merges to main, ci-main will see MDX 0.1.1 > version.toml 0.1.0 and fire ci-docker for kbve-kubectl.

The post-publish sync job will then bump version.toml + Cargo.toml to 0.1.1 to match.

Ref #9809