### PR TITLE
feat(firecracker): expand pip cache to 14 packages

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-pip-cache-cronjob.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-pip-cache-cronjob.yaml
@@ -43,9 +43,16 @@ spec:
                                   PIPCACHE=$(mktemp -d)
                                   mkdir -p "${PIPCACHE}/pip"
 
-                                  echo "Downloading latest wheels..."
+                                  PACKAGES=$(grep -v '^\s*$' /pip-packages/packages.txt | tr '\n' ' ')
+                                  echo "Downloading latest wheels: ${PACKAGES}"
                                   pip3 download --dest "${PIPCACHE}/pip" \
-                                      kbve fudster 2>&1 || true
+                                      --only-binary=:all: \
+                                      --platform=musllinux_1_2_x86_64 \
+                                      --platform=musllinux_1_1_x86_64 \
+                                      --platform=any \
+                                      --python-version=3.12 \
+                                      ${PACKAGES} 2>&1 || \
+                                  pip3 download --dest "${PIPCACHE}/pip" ${PACKAGES} 2>&1 || true
 
                                   WHEEL_COUNT=$(ls "${PIPCACHE}/pip/"*.whl "${PIPCACHE}/pip/"*.tar.gz 2>/dev/null | wc -l)
 
@@ -59,7 +66,7 @@ spec:
 
                                   # Build new cache image to a temp file first, then atomic swap
                                   TMPIMG=$(mktemp -p "${OUTPUT}" pip-cache.XXXXXX)
-                                  dd if=/dev/zero of="${TMPIMG}" bs=1M count=0 seek=256 2>/dev/null
+                                  dd if=/dev/zero of="${TMPIMG}" bs=1M count=0 seek=384 2>/dev/null
                                   mkfs.ext4 -F -d "${PIPCACHE}" "${TMPIMG}"
 
                                   # Atomic replace — prevents partial reads by firecracker-ctl
@@ -78,7 +85,13 @@ spec:
                           volumeMounts:
                               - name: rootfs
                                 mountPath: /rootfs
+                              - name: pip-packages
+                                mountPath: /pip-packages
+                                readOnly: true
                     volumes:
                         - name: rootfs
                           persistentVolumeClaim:
                               claimName: firecracker-rootfs
+                        - name: pip-packages
+                          configMap:
+                              name: firecracker-pip-packages

--- a/apps/kube/firecracker/manifests/firecracker-pip-packages.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-pip-packages.yaml
@@ -1,0 +1,36 @@
+# Package list for the firecracker pip cache.
+# Consumed by both the rootfs init job (first build) and the weekly
+# refresh CronJob. Updating this list + bumping the init job version
+# (v6 → v7) triggers a rebuild on next ArgoCD sync.
+#
+# Selection criteria:
+#   - Useful for a Python code playground (not ML-heavy)
+#   - Must have musl-compatible wheels (alpine) or be pure Python
+#   - Stable, widely-used libraries
+#
+# Skipped (musl wheel issues or too heavy):
+#   - numpy, pandas, lxml, grpcio — build-from-source on alpine, too slow
+#   - opencv, pillow, tesseract — large binary deps
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: firecracker-pip-packages
+    namespace: firecracker
+    labels:
+        app: firecracker-ctl
+data:
+    packages.txt: |
+        kbve
+        fudster
+        requests
+        httpx
+        pydantic
+        click
+        rich
+        beautifulsoup4
+        python-dateutil
+        pyyaml
+        toml
+        orjson
+        tabulate
+        jmespath

--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v6
+    name: firecracker-rootfs-init-v7
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -100,16 +100,26 @@ spec:
                           build_rootfs "alpine-node" 128 nodejs
 
                           # --- pip package cache ---
+                          # Reads package list from ConfigMap (firecracker-pip-packages).
+                          # Rebuild triggered when init job name is bumped (v6 → v7).
                           echo "[5/5] pip-cache..."
                           if [ ! -f "${OUTPUT}/pip-cache.ext4" ]; then
                               apk add --no-cache python3 py3-pip
                               PIPCACHE=$(mktemp -d)
                               mkdir -p "${PIPCACHE}/pip"
+                              PACKAGES=$(grep -v '^\s*$' /pip-packages/packages.txt | tr '\n' ' ')
+                              echo "  Downloading: ${PACKAGES}"
                               pip3 download --dest "${PIPCACHE}/pip" \
-                                  kbve fudster 2>/dev/null || true
+                                  --only-binary=:all: \
+                                  --platform=musllinux_1_2_x86_64 \
+                                  --platform=musllinux_1_1_x86_64 \
+                                  --platform=any \
+                                  --python-version=3.12 \
+                                  ${PACKAGES} 2>&1 || \
+                              pip3 download --dest "${PIPCACHE}/pip" ${PACKAGES} 2>&1 || true
                               WHEEL_COUNT=$(ls "${PIPCACHE}/pip/"*.whl "${PIPCACHE}/pip/"*.tar.gz 2>/dev/null | wc -l)
                               if [ "$WHEEL_COUNT" -gt 0 ]; then
-                                  dd if=/dev/zero of="${OUTPUT}/pip-cache.ext4" bs=1M count=0 seek=256 2>/dev/null
+                                  dd if=/dev/zero of="${OUTPUT}/pip-cache.ext4" bs=1M count=0 seek=384 2>/dev/null
                                   mkfs.ext4 -F -d "${PIPCACHE}" "${OUTPUT}/pip-cache.ext4"
                                   echo "  pip-cache.ext4: $(du -h ${OUTPUT}/pip-cache.ext4 | cut -f1) (${WHEEL_COUNT} packages)"
                               else
@@ -135,6 +145,9 @@ spec:
                       - name: vm-init
                         mountPath: /vm-init
                         readOnly: true
+                      - name: pip-packages
+                        mountPath: /pip-packages
+                        readOnly: true
             volumes:
                 - name: rootfs
                   persistentVolumeClaim:
@@ -142,3 +155,6 @@ spec:
                 - name: vm-init
                   configMap:
                       name: firecracker-vm-init
+                - name: pip-packages
+                  configMap:
+                      name: firecracker-pip-packages


### PR DESCRIPTION
## Summary
- Centralized package list in `firecracker-pip-packages` ConfigMap (single source of truth)
- Init job bumped v6 → v7 to trigger rebuild
- CronJob uses same ConfigMap for weekly refresh
- Added: **requests, httpx, pydantic, click, rich, beautifulsoup4, python-dateutil, pyyaml, toml, orjson, tabulate, jmespath** (plus existing kbve + fudster)
- Prefers musllinux wheels, falls back to sdist
- Cache size 256MB → 384MB

## Skipped
Heavy/incompatible with alpine musl: numpy, pandas, lxml, grpcio, opencv, pillow.

## Test plan
- [ ] ArgoCD syncs ConfigMap
- [ ] Init job v7 runs, rebuilds pip-cache.ext4 with new packages
- [ ] Verify VM can `import requests, httpx, pydantic, rich` without network