### PR TITLE
fix(astro-kbve): manually enrich 5 OSRS runes to v3 (batch 4)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/air-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/air-rune.mdx
@@ -12,103 +12,70 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 50000
-  rune:
-    type: elemental
-    element: air
-  runecraft:
-    level: 1
-    xp: 5
-    multiple_at: 11
-    altar: Air Altar
-    altar_location: Southwest of Falador
-    essence_type: any
-  shops:
-    - shop_name: Rune shops
-      stock: Unlimited
-      price: 17
-    - shop_name: Magic tutor
-      stock: 30 free
-      price: 0
+  material:
+    type: rune
+    tier: low
   recipes:
     - skill: runecraft
       level: 1
       xp: 5
       materials:
-        - item_name: Rune essence
-          item_id: 1436
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
       product: Air rune
       product_id: 556
       product_quantity: 1
       facility: Air altar
   related_items:
-    - item_id: 554
-      item_name: Fire rune
-      slug: fire-rune
+    - item_id: 7936
+      item_name: Pure essence
+      slug: pure-essence
+      relationship: component
+      description: Members-only essence that can be crafted into any rune including air runes
+    - item_id: 1436
+      item_name: Rune essence
+      slug: rune-essence
+      relationship: component
+      description: F2P essence used to craft low-level runes such as air runes
+    - item_name: Air talisman
+      slug: air-talisman
+      relationship: component
+      description: Required to enter the Air altar for runecrafting
+    - item_name: Air tiara
+      slug: air-tiara
+      relationship: component
+      description: Head slot equivalent of the air talisman, keeps an inventory slot free
+    - item_name: Mind rune
+      slug: mind-rune
       relationship: alternative
-      description: Elemental rune
-    - item_id: 555
-      item_name: Water rune
+      description: Paired with air runes in basic combat spells like Wind Strike
+    - item_name: Water rune
       slug: water-rune
       relationship: alternative
-      description: Elemental rune
-    - item_id: 557
-      item_name: Earth rune
-      slug: earth-rune
-      relationship: alternative
-      description: Elemental rune
-    - item_id: 558
-      item_name: Mind rune
-      slug: mind-rune
-      relationship: component
-      description: Combat rune
-    - item_id: 1381
-      item_name: Staff of air
-      slug: staff-of-air
-      relationship: alternative
-      description: Unlimited air runes
+      description: Another basic elemental rune used in elemental spells
+    - item_name: Mist rune
+      slug: mist-rune
+      relationship: variant
+      description: Combination rune counting as both an air rune and a water rune
+    - item_name: Smoke rune
+      slug: smoke-rune
+      relationship: variant
+      description: Combination rune counting as both an air rune and a fire rune
+    - item_name: Dust rune
+      slug: dust-rune
+      relationship: variant
+      description: Combination rune counting as both an air rune and an earth rune
   about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 1 |
-    | XP per rune | 5 |
-    | Altar location | Southwest of Falador |
-
-    Multipliers (every 11 levels):
-    - Level 11: 2x runes
-    - Level 22: 3x runes
-    - Level 33: 4x runes
-    - Level 44: 5x runes
-    - Level 55: 6x runes
-    - Level 66: 7x runes
-    - Level 77: 8x runes
-    - Level 88: 9x runes
-    - Level 99: 10x runes
-
-    | Spell | Air Runes | Other Runes |
-    |-------|-----------|-------------|
-    | Wind Strike | 1 | 1 Mind |
-    | Wind Bolt | 2 | 1 Chaos |
-    | Wind Blast | 3 | 1 Death |
-    | Wind Wave | 5 | 1 Blood |
-    | Wind Surge | 7 | 1 Wrath |
-    | Varrock Teleport | 3 | 1 Fire, 1 Law |
-    | Falador Teleport | 3 | 1 Water, 1 Law |
+    Air runes are the most basic of the four elemental runes and are available to free-to-play players. They power every Air spell in the standard spellbook from Wind Strike up through Wind Surge, as well as numerous teleport and utility spells such as Tele-Other.
+    Players can craft air runes at Runecraft level 1 for 5 experience per essence at the Air altar located southwest of Falador, using either rune essence or pure essence. Additional runes per essence are granted every 11 Runecraft levels, reaching ten runes per essence at level 99.
   market_strategy:
     notes:
-      - Used in every combat spell
-      - Used in most teleportation spells
-      - Staff of air provides unlimited
-      - Magic training (all levels)
-      - Teleportation spells
-      - Combat magic
-      - Alchemy spells
-      - Staff of air negates need
-      - Smoke/Mist battlestaff combos
-      - Essential for early Magic
-      - Low profit margins due to volume
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Air runes are consumed in massive volume by every Magic training method, but the Staff of air gives an unlimited supply, capping demand from veteran players.
+      - Smoke and Mist battlestaves negate air rune cost in combo spells, so price spikes are rare and margins per rune stay thin.
+      - Most reliable demand comes from new accounts training Magic before they can afford an elemental staff.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/death-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/death-rune.mdx
@@ -12,15 +12,9 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 25000
-  rune:
-    type: combat
-  runecraft:
-    level: 65
-    xp: 10
-    multiple_at: 99
-    altar: Death Altar
-    altar_location: Temple of Light
-    essence_type: pure
+  material:
+    type: rune
+    tier: high
   recipes:
     - skill: runecraft
       level: 65
@@ -32,54 +26,43 @@ osrs:
       product: Death rune
       product_id: 560
       product_quantity: 1
-      facility: Death altar
+      facility: Death altar (Temple of Light)
       members_only: true
+      quest_required: Mourning's End Part II
   related_items:
     - item_id: 7936
       item_name: Pure essence
       slug: pure-essence
       relationship: component
-      description: Crafting material
-    - item_id: 565
-      item_name: Blood rune
+      description: Rune essence consumed at the Death altar to craft death runes.
+    - item_name: Death talisman
+      slug: death-talisman
+      relationship: component
+      description: Talisman that grants entry to the Death altar chamber.
+    - item_name: Death tiara
+      slug: death-tiara
+      relationship: component
+      description: Head slot alternative to the Death talisman for accessing the altar.
+    - item_name: Daeyalt essence
+      slug: daeyalt-essence
+      relationship: alternative
+      description: Alternative essence that yields higher Runecraft XP per craft.
+    - item_name: Blood rune
       slug: blood-rune
       relationship: alternative
-      description: Paired for barrages
-    - item_id: 563
-      item_name: Law rune
-      slug: law-rune
-      relationship: alternative
-      description: Tele Block combo
-    - item_id: 11907
-      item_name: Trident of the seas
-      slug: trident-of-the-seas
-      relationship: alternative
-      description: Rune consumer
+      description: Even higher-tier combat rune used for top-end Ancient and Lunar spells.
+    - item_name: Chaos rune
+      slug: chaos-rune
+      relationship: downgrade
+      description: Lower-tier combat rune used for mid-level Bolt spells.
+    - item_name: Soul rune
+      slug: soul-rune
+      relationship: upgrade
+      description: Higher-tier rune used for Surge spells and advanced teleports.
   about: |-
-    | Spell | Death Runes | Spellbook |
-    |-------|-------------|-----------|
-    | Fire Blast | 1 | Standard |
-    | Iban Blast | 1 | Standard |
-    | Magic Dart | 1 | Standard |
-    | Tele Block | 1 | Standard |
-    | Ice Barrage | 4 | Ancient |
-    | Blood Barrage | 4 | Ancient |
-    | Vengeance | 2 | Lunar |
-  market_strategy:
-    notes:
-      - 1 pure essence = 1 death rune
-      - Abyss method for speed
-      - Mourning's End Part II required
-      - All burst/barrage spells
-      - Slayer training (bursting)
-      - PvP (Tele Block, Vengeance)
-      - Trident charges
-      - Essential PvM rune
-      - Ice Barrage uses 4 per cast
-      - High consistent demand
-      - Tridents create rune sink
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Death runes are a high-tier members rune used to cast the Wave-tier elemental spells (Wind Wave, Water Wave, Earth Wave, and Fire Wave), along with Magic Dart, Iban Blast, Slayer Dart, and the Lvl-7 Enchant spell. They are crafted at level 65 Runecrafting at the Death altar inside the Temple of Light, which requires completion of the Mourning's End Part II quest to access. Players who reach 99 Runecrafting craft two death runes per essence, making them a staple Runecrafting training and profit method in the late game.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/earth-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/earth-rune.mdx
@@ -12,94 +12,63 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 50000
-  rune:
-    type: elemental
-    element: earth
-  runecraft:
-    level: 9
-    xp: 6.5
-    multiple_at: 26
-    altar: Earth Altar
-    altar_location: Northeast of Varrock
-    essence_type: any
-  shops:
-    - shop_name: Rune shops
-      stock: Unlimited
-      price: 17
+  material:
+    type: rune
+    tier: low
   recipes:
     - skill: runecraft
       level: 9
       xp: 6.5
       materials:
-        - item_name: Rune essence
-          item_id: 1436
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
       product: Earth rune
       product_id: 557
       product_quantity: 1
       facility: Earth altar
   related_items:
-    - item_id: 556
-      item_name: Air rune
+    - item_id: 7936
+      item_name: Pure essence
+      slug: pure-essence
+      relationship: component
+      description: Crafting material for earth runes
+    - item_id: 1436
+      item_name: Rune essence
+      slug: rune-essence
+      relationship: component
+      description: F2P crafting material for earth runes
+    - item_name: Earth talisman
+      slug: earth-talisman
+      relationship: component
+      description: Required to enter the Earth altar
+    - item_name: Earth tiara
+      slug: earth-tiara
+      relationship: component
+      description: Head slot alternative to the talisman
+    - item_name: Air rune
       slug: air-rune
       relationship: alternative
-      description: Elemental rune
-    - item_id: 554
-      item_name: Fire rune
-      slug: fire-rune
-      relationship: alternative
-      description: Elemental rune
-    - item_id: 555
-      item_name: Water rune
+      description: Elemental rune paired with earth spells
+    - item_name: Water rune
       slug: water-rune
       relationship: alternative
-      description: Elemental rune
-    - item_id: 564
-      item_name: Cosmic rune
-      slug: cosmic-rune
-      relationship: component
-      description: For orb charging
-    - item_id: 1385
-      item_name: Staff of earth
-      slug: staff-of-earth
-      relationship: alternative
-      description: Unlimited earth runes
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 9 |
-    | XP per rune | 6.5 |
-    | Runes per essence | 1 (8 at 99) |
-
-    Multipliers (every 26 levels):
-    - Level 26: 2x runes
-    - Level 52: 3x runes
-    - Level 78: 4x runes
-
-    | Spell | Earth Runes | Other Runes |
-    |-------|-------------|-------------|
-    | Earth Strike | 2 | 1 Air, 1 Mind |
-    | Earth Bolt | 3 | 2 Air, 1 Chaos |
-    | Earth Blast | 4 | 3 Air, 1 Death |
-    | Earth Wave | 7 | 5 Air, 1 Blood |
-    | Earth Surge | 10 | 7 Air, 1 Wrath |
-    | Bones to Bananas | 2 | 1 Nature, 2 Water |
-    | Magic Imbue | 7 | 2 Astral, 1 Fire |
-  market_strategy:
-    notes:
-      - Used in many utility spells
-      - Charge earth orb
-      - Bones to Peaches tablets
-      - Charge Earth Orb
-      - Magic Imbue spell
-      - Earth spells
-      - Bones to Peaches
-      - Staff of earth saves runes
-      - Mud/Dust battlestaff combos
-      - Lower demand than fire/water
-      - Earth orbs for battlestaves
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Elemental rune of the water element
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: variant
+      description: Combination rune of earth and water
+    - item_name: Lava rune
+      slug: lava-rune
+      relationship: variant
+      description: Combination rune of earth and fire
+    - item_name: Dust rune
+      slug: dust-rune
+      relationship: variant
+      description: Combination rune of earth and air
+  about: Earth rune is one of the four basic elemental runes and is available to free-to-play players. It powers the Earth Strike through Earth Surge spell progression along with utility spells such as Lvl-1 Enchant, Stun, and Bind. Earth runes are crafted at level 9 Runecrafting for 6.5 experience each at the Earth altar located northeast of Varrock.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fire-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fire-rune.mdx
@@ -12,96 +12,55 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 50000
-  rune:
-    type: elemental
-    element: fire
-  runecraft:
-    level: 14
-    xp: 7
-    multiple_at: 35
-    altar: Fire Altar
-    altar_location: Al Kharid
-    essence_type: any
-  shops:
-    - shop_name: Rune shops
-      stock: Unlimited
-      price: 17
-    - shop_name: TzHaar shops
-      stock: Unlimited
-      price: 6 Tokkul
+  material:
+    type: rune
+    tier: low
   recipes:
     - skill: runecraft
       level: 14
       xp: 7
       materials:
-        - item_name: Rune essence
-          item_id: 1436
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
       product: Fire rune
       product_id: 554
       product_quantity: 1
       facility: Fire altar
   related_items:
-    - item_id: 556
-      item_name: Air rune
-      slug: air-rune
-      relationship: alternative
-      description: Elemental rune
-    - item_id: 555
-      item_name: Water rune
-      slug: water-rune
-      relationship: alternative
-      description: Elemental rune
-    - item_id: 557
-      item_name: Earth rune
-      slug: earth-rune
-      relationship: alternative
-      description: Elemental rune
-    - item_id: 561
-      item_name: Nature rune
-      slug: nature-rune
+    - item_id: 7936
+      item_name: Pure essence
+      slug: pure-essence
       relationship: component
-      description: For alchemy
-    - item_id: 20714
-      item_name: Tome of fire
-      slug: tome-of-fire
+    - item_id: 1436
+      item_name: Rune essence
+      slug: rune-essence
+      relationship: component
+    - item_name: Fire talisman
+      slug: fire-talisman
+      relationship: component
+    - item_name: Fire tiara
+      slug: fire-tiara
+      relationship: component
+    - item_name: Nature rune
+      slug: nature-rune
       relationship: alternative
-      description: Unlimited fire runes
+    - item_name: Smoke rune
+      slug: smoke-rune
+      relationship: variant
+    - item_name: Steam rune
+      slug: steam-rune
+      relationship: variant
+    - item_name: Lava rune
+      slug: lava-rune
+      relationship: variant
+    - item_name: Staff of fire
+      slug: staff-of-fire
+      relationship: alternative
   about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 14 |
-    | XP per rune | 7 |
-    | Runes per essence | 1 (7 at 91) |
-
-    Multipliers (every 35 levels):
-    - Level 35: 2x runes
-    - Level 70: 3x runes
-
-    | Spell | Fire Runes | Other Runes |
-    |-------|------------|-------------|
-    | Fire Strike | 3 | 2 Air, 1 Mind |
-    | Fire Bolt | 4 | 3 Air, 1 Chaos |
-    | Fire Blast | 5 | 4 Air, 1 Death |
-    | Fire Wave | 7 | 5 Air, 1 Blood |
-    | Fire Surge | 10 | 7 Air, 1 Wrath |
-    | High Alchemy | 5 | 1 Nature |
-    | Superheat Item | 4 | 1 Nature |
-  market_strategy:
-    notes:
-      - High Level Alchemy uses 5 per cast
-      - Fire Surge most popular combat spell
-      - Smithing via Superheat
-      - High Alchemy (money making)
-      - Fire Surge (PvM meta)
-      - Superheat Item (Smithing)
-      - Charge Fire Orb
-      - Tome of Fire provides unlimited
-      - Staff of fire saves runes
-      - TzHaar shops cheap with Tokkul
-      - Price stable due to high supply
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Fire rune is a free-to-play elemental rune used to cast Fire spells from Fire Strike through Fire Surge, High Alchemy, Low Alchemy, Superheat Item, and every bolt and crossbow enchanting spell from Lvl-3 Enchant onwards. It is one of the most heavily consumed runes in Old School RuneScape due to the constant demand from alching, making it a staple of money-making and magic training alike. Players can craft fire runes at level 14 Runecrafting by binding pure or rune essence at the Fire altar located near the Duel Arena north-east of Al Kharid.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/water-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/water-rune.mdx
@@ -12,96 +12,69 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 50000
-  rune:
-    type: elemental
-    element: water
-  runecraft:
-    level: 5
-    xp: 6
-    multiple_at: 19
-    altar: Water Altar
-    altar_location: Lumbridge Swamp
-    essence_type: any
-  shops:
-    - shop_name: Rune shops
-      stock: Unlimited
-      price: 17
+  material:
+    type: rune
+    tier: low
   recipes:
     - skill: runecraft
       level: 5
       xp: 6
       materials:
-        - item_name: Rune essence
-          item_id: 1436
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
       product: Water rune
       product_id: 555
       product_quantity: 1
       facility: Water altar
   related_items:
-    - item_id: 556
-      item_name: Air rune
+    - item_id: 7936
+      item_name: Pure essence
+      slug: pure-essence
+      relationship: component
+      description: Essence used to craft water runes
+    - item_id: 1436
+      item_name: Rune essence
+      slug: rune-essence
+      relationship: component
+      description: F2P essence used to craft water runes
+    - item_name: Water talisman
+      slug: water-talisman
+      relationship: component
+      description: Grants access to the Water altar
+    - item_name: Water tiara
+      slug: water-tiara
+      relationship: component
+      description: Worn alternative to the Water talisman
+    - item_name: Air rune
       slug: air-rune
       relationship: alternative
       description: Elemental rune
-    - item_id: 554
-      item_name: Fire rune
-      slug: fire-rune
-      relationship: alternative
-      description: Elemental rune
-    - item_id: 557
-      item_name: Earth rune
+    - item_name: Earth rune
       slug: earth-rune
       relationship: alternative
       description: Elemental rune
-    - item_id: 560
-      item_name: Death rune
-      slug: death-rune
-      relationship: component
-      description: For ice spells
-    - item_id: 21006
-      item_name: Tome of water
-      slug: tome-of-water
-      relationship: alternative
-      description: Unlimited water runes
+    - item_name: Mist rune
+      slug: mist-rune
+      relationship: variant
+      description: Combination rune of water and air
+    - item_name: Steam rune
+      slug: steam-rune
+      relationship: variant
+      description: Combination rune of water and fire
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: variant
+      description: Combination rune of water and earth
   about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 5 |
-    | XP per rune | 6 |
-    | Runes per essence | 1 (10 at 95) |
-
-    Multipliers (every 19 levels):
-    - Level 19: 2x runes
-    - Level 38: 3x runes
-    - Level 57: 4x runes
-    - Level 76: 5x runes
-    - Level 95: 6x runes
-
-    | Spell | Water Runes | Other Runes |
-    |-------|-------------|-------------|
-    | Water Strike | 1 | 1 Air, 1 Mind |
-    | Water Bolt | 2 | 2 Air, 1 Chaos |
-    | Water Blast | 3 | 3 Air, 1 Death |
-    | Water Wave | 7 | 5 Air, 1 Blood |
-    | Water Surge | 10 | 7 Air, 1 Wrath |
-    | Ice spells | 2-6 | Death/Blood |
-    | Charge Water Orb | 30 | 3 Cosmic |
+    Water rune is one of the four basic elemental runes, used in F2P Water spells from Water Strike through Water Surge along with Curse, Vulnerability, Weaken, and Magic Imbue. It is crafted at level 5 Runecrafting for 6 experience per essence at the Water altar in the Lumbridge swamp. Water runes are also required for the dragonbane fire spell cast on metal dragons.
   market_strategy:
     notes:
-      - Ancient Magicks ice spells
-      - Charge water orb for battlestaves
-      - Water spell training
-      - Ice Barrage (PvP/PvM)
-      - Ice Burst (Slayer)
-      - Water orb charging
-      - Humidify spell
-      - Tome of water provides unlimited
-      - Staff of water saves runes
-      - Ice spells drive demand
-      - Mud/Mist battlestaff combos
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Bulk demand comes from Ancient Magicks Ice spells (Ice Barrage and Ice Burst), making water runes essential for slayer multi-task barraging.
+      - Used in large quantities to charge water orbs into mystic water staves and battlestaves of water.
+      - Tome of water and Staff of water both negate the rune cost, capping price growth from veteran players.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
Batch 4: complete the elemental rune set + death rune. All cross-link via combo runes (mist/smoke/dust/mud/steam/lava) for graph connectivity.

### Items enriched
- **air-rune** — material, runecraft recipe (level 1, Falador altar), 9 related items (essence + talisman + tiara + alternatives + combo variants)
- **water-rune** — material, runecraft recipe (level 5, Lumbridge swamp), 9 related items, prose about with Ice spell context
- **earth-rune** — material, runecraft recipe (level 9, Varrock altar), 9 related items
- **fire-rune** — material, runecraft recipe (level 14, Duel Arena altar), 9 related items, prose about noting alching demand
- **death-rune** — material (rune, high), runecraft recipe with Mourning's End Part II quest gate, 7 related items (talisman, tiara, alternative essence/runes)

### Schema fixes from agent output
- Removed dead non-schema fields: `rune:`, `runecraft:`, `shops:` (legacy v1 leftovers, replaced by proper schema fields)
- Compressed multi-tier recipe ladders (11 entries each!) into single base recipes — multiples are tier mechanics not separate recipes
- Removed invented fields: `recipes[*].multiples`, `recipes[*].notes`, `recipes[*].facility_location`, `recipes[*].multiples_at`
- death-rune: merged `facility_location` into `facility` name

## Test plan
- [ ] Verify astro-kbve builds without schema errors
- [ ] Spot-check rune pages cross-link correctly via combo rune variants