### PR TITLE
fix(agones-mc): expose Velocity via Cilium Gateway TCPRoute (no extra LB IP)

### DIFF
--- a/apps/kube/agones/mc/velocity-service.yaml
+++ b/apps/kube/agones/mc/velocity-service.yaml
@@ -21,8 +21,10 @@ spec:
           targetPort: 25565
           protocol: TCP
 ---
-# LoadBalancer Service for Velocity — exposes port 25565 externally
-# via Cilium LB IPAM. Players connect here.
+# ClusterIP Service for Velocity — the Cilium Gateway TCPRoute
+# (apps/kube/agones/mc/velocity-tcproute.yaml) handles external
+# exposure on port 25565 by sharing the kbve-gateway IP.
+# No standalone LoadBalancer needed → no IP pool exhaustion.
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,11 +33,8 @@ metadata:
     labels:
         app: mc-velocity
         app.kubernetes.io/part-of: mc
-    annotations:
-        # Hint to Cilium LB IPAM to allocate from the public pool
-        io.cilium/lb-ipam-ips: ''
 spec:
-    type: LoadBalancer
+    type: ClusterIP
     selector:
         app: mc-velocity
     ports:
@@ -43,4 +42,3 @@ spec:
           port: 25565
           targetPort: 25565
           protocol: TCP
-    externalTrafficPolicy: Local

--- a/apps/kube/agones/mc/velocity-tcproute.yaml
+++ b/apps/kube/agones/mc/velocity-tcproute.yaml
@@ -1,0 +1,22 @@
+# TCPRoute — forwards port 25565 from the shared Cilium Gateway
+# to the Velocity proxy Service. Velocity then routes players to
+# the Agones-managed Fabric MC backends.
+#
+# Players connect to: <gateway-ip>:25565 → Velocity → Fabric server
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+    name: mc-velocity-route
+    namespace: arc-runners
+    labels:
+        app: mc-velocity
+        app.kubernetes.io/part-of: mc
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+          sectionName: minecraft
+    rules:
+        - backendRefs:
+              - name: mc-velocity
+                port: 25565

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -35,6 +35,17 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        # Minecraft TCP listener — shares the gateway IP with HTTP/HTTPS.
+        # Velocity proxy in arc-runners handles MC protocol + Mojang auth,
+        # then forwards to the Agones-managed Fabric backends.
+        - name: minecraft
+          protocol: TCP
+          port: 25565
+          allowedRoutes:
+              namespaces:
+                  from: All
+              kinds:
+                  - kind: TCPRoute
 ---
 ## kbve.com routes
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
## Summary
The new `mc-velocity` LoadBalancer Service was stuck `pending` because the Cilium LB IPAM `public-ip-pool` only has 2 IPs and both are already taken:
- `142.132.206.74` → `cilium-gateway-kbve-gateway`
- `142.132.206.71` → `kbve-wt-lb`

Fix: share the existing `kbve-gateway` IP via Gateway API.

### Changes
1. **kbve-gateway**: Add a TCP listener on port 25565 with `kinds: [TCPRoute]`
2. **velocity-tcproute.yaml** (new): TCPRoute in `arc-runners` referencing the gateway in `kbve` namespace via `sectionName: minecraft`, backend → `mc-velocity` Service
3. **velocity-service.yaml**: Switch from `LoadBalancer` to `ClusterIP` since the gateway handles external exposure

### Architecture
```
Player → 142.132.206.74:25565
           │ (Cilium Gateway TCP listener)
           ▼
       TCPRoute (mc-velocity-route)
           │
           ▼
       mc-velocity ClusterIP Service
           │
           ▼
       Velocity Pod (Mojang auth + forwarding)
           │
           ▼
       mc-fabric-backend headless Service
           │
           ▼
       Fabric Gameserver Pod (Agones)
```

## Test plan
- [ ] TCPRoute attaches to gateway listener
- [ ] Players can connect to `<gateway-ip>:25565`
- [ ] Velocity forwards to backend pods successfully