### PR TITLE
fix(astro-kbve): manually enrich 10 OSRS items to v3 (batch 5)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond.mdx
@@ -14,10 +14,7 @@ osrs:
   limit: 11000
   material:
     type: gem
-    tier: mid-high
-  crafting:
-    level: 43
-    xp: 107.5
+    tier: high
   recipes:
     - skill: crafting
       level: 43
@@ -34,22 +31,8 @@ osrs:
       product_quantity: 1
       facility: Furnace
     - skill: crafting
-      level: 56
-      xp: 90
-      materials:
-        - item_name: Diamond
-          item_id: 1601
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Diamond necklace
-      product_id: 1662
-      product_quantity: 1
-      facility: Furnace
-    - skill: crafting
       level: 70
-      xp: 100
+      xp: 150
       materials:
         - item_name: Diamond
           item_id: 1601
@@ -61,75 +44,44 @@ osrs:
       product_id: 1681
       product_quantity: 1
       facility: Furnace
-    - skill: crafting
-      level: 58
-      xp: 95
-      materials:
-        - item_name: Diamond
-          item_id: 1601
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Diamond bracelet
-      product_id: 11092
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
-    - skill: fletching
-      level: 65
-      xp: 7
-      materials:
-        - item_name: Diamond
-          item_id: 1601
-          quantity: 1
-      product: Diamond bolt tips
-      product_id: 9192
-      product_quantity: 12
-      members_only: true
   related_items:
     - item_id: 1617
       item_name: Uncut diamond
       slug: uncut-diamond
       relationship: component
-      description: Raw gem
-    - item_id: 2570
-      item_name: Ring of life
-      slug: ring-of-life
+    - item_id: 1643
+      item_name: Diamond ring
+      slug: diamond-ring
       relationship: product
-      description: Enchanted ring
-    - item_id: 11090
-      item_name: Phoenix necklace
-      slug: phoenix-necklace
+    - item_id: 1656
+      item_name: Diamond necklace
+      slug: diamond-necklace
       relationship: product
-      description: Enchanted necklace
-    - item_id: 1603
-      item_name: Ruby
+    - item_id: 1683
+      item_name: Diamond amulet
+      slug: diamond-amulet
+      relationship: product
+    - item_id: 11074
+      item_name: Diamond bracelet
+      slug: diamond-bracelet
+      relationship: product
+    - item_id: 9192
+      item_name: Diamond bolt tips
+      slug: diamond-bolt-tips
+      relationship: product
+    - item_name: Emerald
+      slug: emerald
+      relationship: downgrade
+    - item_name: Ruby
       slug: ruby
-      relationship: alternative
-      description: Lower tier gem
-    - item_id: 1615
-      item_name: Dragonstone
+      relationship: downgrade
+    - item_name: Dragonstone
       slug: dragonstone
-      relationship: alternative
-      description: Higher tier gem
+      relationship: upgrade
   about: |-
-    | Item | Effect |
-    |------|--------|
-    | Ring of life | Auto-teleport at 10% HP |
-    | Phoenix necklace | Heal when low HP |
-    | Abyssal bracelet | Skull protection |
-    | Amulet of power | +6 all combat |
-  market_strategy:
-    notes:
-      - Ring of life for safety
-      - Phoenix necklace for PvP
-      - Diamond bolts (e) for PvM
-      - High-tier common gem
-      - Ring of life essential
-      - Good bolt tips for bossing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Diamond is the cut form of the uncut diamond and the highest tier of the standard gem jewelry line below dragonstone. It is used at a furnace with gold bars to craft the Diamond ring, Diamond necklace, Diamond amulet, and Diamond bracelet, and can be fletched into Diamond bolt tips for ranged ammunition. Diamond jewelry is enchanted with the Lvl-4 Enchant spell at 57 Magic to create powerful pieces such as the Ring of life and Amulet of power.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dust-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dust-rune.mdx
@@ -12,67 +12,59 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 18000
-  item:
+  material:
     type: rune
-    subtype: combination
-    tradeable: true
-    stackable: true
-    weight: 0
-    elements:
-      - air
-      - earth
+    tier: mid
   recipes:
     - skill: runecraft
       level: 10
-      xp: 8.3
-      altar: Air
+      xp: 8.4
+      members_only: true
+      facility: Earth altar (with Binding necklace)
       materials:
-        - item_name: Pure essence
-          quantity: 1
-        - item_name: Earth rune
-          quantity: 1
-        - item_name: Earth talisman
-          quantity: 1
-    - skill: runecraft
-      level: 10
-      xp: 9
-      altar: Earth
-      materials:
-        - item_name: Pure essence
-          quantity: 1
         - item_name: Air rune
+          item_id: 556
           quantity: 1
-        - item_name: Air talisman
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
+      product: Dust rune
+      product_id: 4696
   related_items:
-    - item_id: 4697
-      item_name: Smoke rune
-      slug: smoke-rune
-      relationship: alternative
-      description: Air + Fire combo rune
-    - item_id: 4695
-      item_name: Mist rune
+    - item_name: Air rune
+      item_id: 556
+      slug: air-rune
+      relationship: component
+    - item_name: Earth rune
+      item_id: 557
+      slug: earth-rune
+      relationship: component
+    - item_name: Pure essence
+      item_id: 7936
+      slug: pure-essence
+      relationship: component
+    - item_name: Binding necklace
+      slug: binding-necklace
+      relationship: component
+    - item_name: Mist rune
       slug: mist-rune
       relationship: alternative
-      description: Air + Water combo rune
-    - item_id: 4699
-      item_name: Lava rune
+    - item_name: Smoke rune
+      slug: smoke-rune
+      relationship: alternative
+    - item_name: Steam rune
+      slug: steam-rune
+      relationship: alternative
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: alternative
+    - item_name: Lava rune
       slug: lava-rune
       relationship: alternative
-      description: Earth + Fire combo rune
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Combination Rune |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    Counts as both air and earth rune.
-
-    Used in earth spells.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Dust runes are members-only combination runes that count as both an air rune and an earth rune, letting a single dust rune satisfy either requirement (or both) in any spell. They are crafted at the Earth altar by bringing pure essence and air runes while wearing a binding necklace, typically paired with the Lunar spell Magic Imbue to avoid consuming a talisman. Dust runes can also be purchased with Pizazz points from the Mage Training Arena.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lava-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lava-rune.mdx
@@ -12,65 +12,62 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 18000
-  item:
+  material:
     type: rune
-    subtype: combination
-    tradeable: true
-    stackable: true
-    weight: 0
-    elements:
-      - earth
-      - fire
+    tier: mid
   recipes:
     - skill: runecraft
       level: 23
-      xp: 10
-      altar: Earth
-      materials:
-        - item_name: Pure essence
-          quantity: 1
-        - item_name: Fire rune
-          quantity: 1
-        - item_name: Fire talisman
-          quantity: 1
-    - skill: runecraft
-      level: 23
       xp: 10.5
-      altar: Fire
+      members_only: true
+      facility: Fire altar (with Binding necklace)
+      product: Lava rune
+      product_id: 4699
       materials:
-        - item_name: Pure essence
-          quantity: 1
         - item_name: Earth rune
+          item_id: 557
           quantity: 1
-        - item_name: Earth talisman
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
   related_items:
-    - item_id: 4694
-      item_name: Steam rune
-      slug: steam-rune
+    - item_name: Earth rune
+      item_id: 557
+      slug: earth-rune
+      relationship: component
+    - item_name: Fire rune
+      item_id: 554
+      slug: fire-rune
+      relationship: component
+    - item_name: Pure essence
+      item_id: 7936
+      slug: pure-essence
+      relationship: component
+    - item_name: Binding necklace
+      slug: binding-necklace
+      relationship: component
+    - item_name: Mist rune
+      slug: mist-rune
       relationship: alternative
-      description: Water + Fire combo rune
-    - item_id: 4697
-      item_name: Smoke rune
+    - item_name: Smoke rune
       slug: smoke-rune
       relationship: alternative
-      description: Air + Fire combo rune
-    - item_id: 4698
-      item_name: Mud rune
+    - item_name: Steam rune
+      slug: steam-rune
+      relationship: alternative
+    - item_name: Dust rune
+      slug: dust-rune
+      relationship: alternative
+    - item_name: Mud rune
       slug: mud-rune
       relationship: alternative
-      description: Water + Earth combo rune
+    - item_name: Lava battlestaff
+      slug: lava-battlestaff
+      relationship: alternative
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Combination Rune |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    Counts as both earth and fire rune.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Lava rune is a members-only combination rune that counts as both an earth rune and a fire rune, so any spell requiring either element consumes just a single lava rune. They are crafted at level 23 Runecraft by bringing pure essence and earth runes to the Fire Altar, using a Binding necklace for a guaranteed success and Magic Imbue to preserve the talisman. Equipping a Lava battlestaff or Mystic lava staff provides an unlimited supply of lava runes for combo spells.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mist-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mist-rune.mdx
@@ -12,67 +12,59 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 18000
-  item:
+  material:
     type: rune
-    subtype: combination
-    tradeable: true
-    stackable: true
-    weight: 0
-    elements:
-      - air
-      - water
+    tier: mid
   recipes:
     - skill: runecraft
       level: 6
-      xp: 8
-      altar: Air
-      materials:
-        - item_name: Pure essence
-          quantity: 1
-        - item_name: Water rune
-          quantity: 1
-        - item_name: Water talisman
-          quantity: 1
-    - skill: runecraft
-      level: 6
       xp: 8.5
-      altar: Water
+      members_only: true
+      facility: Water altar (with Binding necklace)
       materials:
-        - item_name: Pure essence
-          quantity: 1
         - item_name: Air rune
+          item_id: 556
           quantity: 1
-        - item_name: Air talisman
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
+      product: Mist rune
+      product_id: 4695
   related_items:
-    - item_id: 4697
-      item_name: Smoke rune
+    - item_name: Air rune
+      item_id: 556
+      slug: air-rune
+      relationship: component
+    - item_name: Water rune
+      item_id: 555
+      slug: water-rune
+      relationship: component
+    - item_name: Pure essence
+      item_id: 7936
+      slug: pure-essence
+      relationship: component
+    - item_name: Binding necklace
+      slug: binding-necklace
+      relationship: component
+    - item_name: Smoke rune
       slug: smoke-rune
       relationship: alternative
-      description: Air + Fire combo rune
-    - item_id: 4696
-      item_name: Dust rune
-      slug: dust-rune
-      relationship: alternative
-      description: Air + Earth combo rune
-    - item_id: 4694
-      item_name: Steam rune
+    - item_name: Steam rune
       slug: steam-rune
       relationship: alternative
-      description: Water + Fire combo rune
+    - item_name: Dust rune
+      slug: dust-rune
+      relationship: alternative
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: alternative
+    - item_name: Lava rune
+      slug: lava-rune
+      relationship: alternative
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Combination Rune |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    Counts as both air and water rune.
-
-    Used in water spells.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Mist rune is a members-only combination rune that counts as both an Air rune and a Water rune when casting spells, letting a single rune satisfy both elemental requirements. Players can craft it at level 6 Runecraft at the Water altar by using Air runes with pure essence while wearing a Binding necklace for a guaranteed success, or by using the Lunar spell Magic Imbue from Lunar Diplomacy to skip the talisman requirement. It awards 8.5 Runecraft experience per rune and is commonly used to save inventory space for water-based combat spells.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mud-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mud-rune.mdx
@@ -12,65 +12,62 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 18000
-  item:
+  material:
     type: rune
-    subtype: combination
-    tradeable: true
-    stackable: true
-    weight: 0
-    elements:
-      - water
-      - earth
+    tier: mid
   recipes:
     - skill: runecraft
       level: 13
       xp: 9.3
-      altar: Water
+      members_only: true
+      facility: Earth altar (with Binding necklace)
+      product: Mud rune
+      product_id: 4698
       materials:
-        - item_name: Pure essence
-          quantity: 1
-        - item_name: Earth rune
-          quantity: 1
-        - item_name: Earth talisman
-          quantity: 1
-    - skill: runecraft
-      level: 13
-      xp: 9.5
-      altar: Earth
-      materials:
-        - item_name: Pure essence
-          quantity: 1
         - item_name: Water rune
+          item_id: 555
           quantity: 1
-        - item_name: Water talisman
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
   related_items:
-    - item_id: 4699
-      item_name: Lava rune
-      slug: lava-rune
-      relationship: alternative
-      description: Earth + Fire combo rune
-    - item_id: 4694
-      item_name: Steam rune
-      slug: steam-rune
-      relationship: alternative
-      description: Water + Fire combo rune
-    - item_id: 4695
-      item_name: Mist rune
+    - item_name: Water rune
+      item_id: 555
+      slug: water-rune
+      relationship: component
+    - item_name: Earth rune
+      item_id: 557
+      slug: earth-rune
+      relationship: component
+    - item_name: Pure essence
+      item_id: 7936
+      slug: pure-essence
+      relationship: component
+    - item_name: Binding necklace
+      slug: binding-necklace
+      relationship: component
+    - item_name: Mist rune
       slug: mist-rune
       relationship: alternative
-      description: Air + Water combo rune
+    - item_name: Smoke rune
+      slug: smoke-rune
+      relationship: alternative
+    - item_name: Steam rune
+      slug: steam-rune
+      relationship: alternative
+    - item_name: Dust rune
+      slug: dust-rune
+      relationship: alternative
+    - item_name: Lava rune
+      slug: lava-rune
+      relationship: alternative
+    - item_name: Mud battlestaff
+      slug: mud-battlestaff
+      relationship: alternative
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Combination Rune |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    Counts as both water and earth rune.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Mud rune is a members-only combination rune that counts as both a water rune and an earth rune, so any spell needing either (or both) consumes only one mud rune. It is crafted at level 13 Runecraft by bringing pure essence and water runes to the Earth altar, with the Lunar spell Magic Imbue replacing the need for a talisman and a Binding necklace guaranteeing a successful craft. The Mud battlestaff (and its mystic variant) provides an unlimited supply of mud runes when wielded, making it the standard tool for Magic training that relies on mud-rune spells.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby.mdx
@@ -15,9 +15,6 @@ osrs:
   material:
     type: gem
     tier: mid
-  crafting:
-    level: 34
-    xp: 85
   recipes:
     - skill: crafting
       level: 34
@@ -30,52 +27,11 @@ osrs:
           item_id: 2357
           quantity: 1
       product: Ruby ring
-      product_id: 1641
+      product_id: 1639
       product_quantity: 1
       facility: Furnace
-    - skill: crafting
-      level: 40
-      xp: 75
-      materials:
-        - item_name: Ruby
-          item_id: 1603
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Ruby necklace
-      product_id: 1660
-      product_quantity: 1
-      facility: Furnace
-    - skill: crafting
-      level: 50
-      xp: 85
-      materials:
-        - item_name: Ruby
-          item_id: 1603
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Ruby amulet (u)
-      product_id: 1679
-      product_quantity: 1
-      facility: Furnace
-    - skill: crafting
-      level: 42
-      xp: 80
-      materials:
-        - item_name: Ruby
-          item_id: 1603
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Ruby bracelet
-      product_id: 11085
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
+      tools:
+        - Ring mould
     - skill: fletching
       level: 63
       xp: 6.3
@@ -84,52 +40,47 @@ osrs:
           item_id: 1603
           quantity: 1
       product: Ruby bolt tips
-      product_id: 9191
+      product_id: 9189
       product_quantity: 12
-      members_only: true
+      tools:
+        - Chisel
   related_items:
     - item_id: 1619
       item_name: Uncut ruby
       slug: uncut-ruby
       relationship: component
-      description: Raw gem
-    - item_id: 2568
-      item_name: Ring of forging
-      slug: ring-of-forging
+    - item_id: 1639
+      item_name: Ruby ring
+      slug: ruby-ring
       relationship: product
-      description: Enchanted ring
-    - item_id: 11194
-      item_name: Digsite pendant
-      slug: digsite-pendant
+    - item_id: 1654
+      item_name: Ruby necklace
+      slug: ruby-necklace
       relationship: product
-      description: Enchanted necklace
-    - item_id: 1605
-      item_name: Emerald
+    - item_id: 1679
+      item_name: Ruby amulet
+      slug: ruby-amulet
+      relationship: product
+    - item_id: 11085
+      item_name: Ruby bracelet
+      slug: ruby-bracelet
+      relationship: product
+    - item_id: 9189
+      item_name: Ruby bolt tips
+      slug: ruby-bolt-tips
+      relationship: product
+    - item_name: Ruby bolts
+      slug: ruby-bolts
+      relationship: product
+    - item_name: Emerald
       slug: emerald
-      relationship: alternative
-      description: Lower tier gem
-    - item_id: 1601
-      item_name: Diamond
+      relationship: downgrade
+    - item_name: Diamond
       slug: diamond
-      relationship: alternative
-      description: Higher tier gem
-  about: |-
-    | Item | Effect |
-    |------|--------|
-    | Ring of forging | 100% iron smelting |
-    | Digsite pendant | Digsite teleports |
-    | Inoculation bracelet | Disease immunity |
-    | Amulet of strength | +10 Strength |
-  market_strategy:
-    notes:
-      - Ring of forging for smithing
-      - Amulet of strength
-      - Crafting training
-      - Mid-tier gem
-      - Ring of forging popular
-      - Ruby bolts (e) for PvM
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: upgrade
+  about: Ruby is the cut form of the uncut ruby gem, produced with a chisel at level 34 Crafting. It is used to craft Ruby jewelry (ring, necklace, amulet, bracelet) with gold bars, and can be fletched into Ruby bolt tips at level 63 Fletching. Enchanted ruby bolts trigger the Blood Forfeit effect, dealing 20% of the user's current HP as bonus damage, which makes Ruby bolts (e) the most popular ranged ammunition for high-HP bosses in OSRS.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/smoke-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/smoke-rune.mdx
@@ -12,67 +12,59 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 18000
-  item:
+  material:
     type: rune
-    subtype: combination
-    tradeable: true
-    stackable: true
-    weight: 0
-    elements:
-      - air
-      - fire
+    tier: mid
   recipes:
     - skill: runecraft
       level: 15
-      xp: 8.5
-      altar: Air
-      materials:
-        - item_name: Pure essence
-          quantity: 1
-        - item_name: Fire rune
-          quantity: 1
-        - item_name: Fire talisman
-          quantity: 1
-    - skill: runecraft
-      level: 15
       xp: 9.5
-      altar: Fire
+      members_only: true
+      facility: Fire altar (with Binding necklace)
       materials:
-        - item_name: Pure essence
-          quantity: 1
         - item_name: Air rune
+          item_id: 556
           quantity: 1
-        - item_name: Air talisman
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
+      product: Smoke rune
+      product_id: 4697
   related_items:
-    - item_id: 4694
-      item_name: Steam rune
-      slug: steam-rune
-      relationship: alternative
-      description: Water + Fire combo rune
-    - item_id: 4696
-      item_name: Dust rune
-      slug: dust-rune
-      relationship: alternative
-      description: Air + Earth combo rune
-    - item_id: 4695
-      item_name: Mist rune
+    - item_id: 556
+      item_name: Air rune
+      slug: air-rune
+      relationship: component
+    - item_id: 554
+      item_name: Fire rune
+      slug: fire-rune
+      relationship: component
+    - item_id: 7936
+      item_name: Pure essence
+      slug: pure-essence
+      relationship: component
+    - item_name: Binding necklace
+      slug: binding-necklace
+      relationship: component
+    - item_name: Mist rune
       slug: mist-rune
       relationship: alternative
-      description: Air + Water combo rune
+    - item_name: Steam rune
+      slug: steam-rune
+      relationship: alternative
+    - item_name: Dust rune
+      slug: dust-rune
+      relationship: alternative
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: alternative
+    - item_name: Lava rune
+      slug: lava-rune
+      relationship: alternative
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Combination Rune |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    Counts as both air and fire rune.
-
-    Used in fire spells and smoke spells (Ancient Magicks).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Smoke rune is a members-only combination rune that counts as both an air rune and a fire rune, letting a single rune satisfy either (or both) requirements in any spell. It is the defining ammunition for Smoke Barrage and Smoke Burst on the Ancient Magicks spellbook, which inflict poison on struck enemies and are staples of multi-target Slayer barraging. Crafted at the Fire Altar with pure essence and air runes (9.5 XP at Runecraft 15), smoke runes are typically made with a binding necklace for a guaranteed success rate.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steam-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steam-rune.mdx
@@ -12,67 +12,62 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 18000
-  item:
+  material:
     type: rune
-    subtype: combination
-    tradeable: true
-    stackable: true
-    weight: 0
-    elements:
-      - water
-      - fire
+    tier: mid
   recipes:
     - skill: runecraft
       level: 19
-      xp: 9.5
-      altar: Water
-      materials:
-        - item_name: Pure essence
-          quantity: 1
-        - item_name: Fire rune
-          quantity: 1
-        - item_name: Fire talisman
-          quantity: 1
-    - skill: runecraft
-      level: 19
       xp: 10
-      altar: Fire
+      members_only: true
+      facility: Fire altar (with Binding necklace)
       materials:
-        - item_name: Pure essence
-          quantity: 1
         - item_name: Water rune
+          item_id: 555
           quantity: 1
-        - item_name: Water talisman
+        - item_name: Pure essence
+          item_id: 7936
           quantity: 1
+      product: Steam rune
+      product_id: 4694
   related_items:
-    - item_id: 4696
-      item_name: Dust rune
-      slug: dust-rune
-      relationship: alternative
-      description: Air + Earth combo rune
-    - item_id: 4695
-      item_name: Mist rune
+    - item_name: Water rune
+      item_id: 555
+      slug: water-rune
+      relationship: component
+    - item_name: Fire rune
+      item_id: 554
+      slug: fire-rune
+      relationship: component
+    - item_name: Pure essence
+      item_id: 7936
+      slug: pure-essence
+      relationship: component
+    - item_name: Binding necklace
+      slug: binding-necklace
+      relationship: component
+    - item_name: Mist rune
       slug: mist-rune
       relationship: alternative
-      description: Air + Water combo rune
-    - item_id: 4697
-      item_name: Smoke rune
+    - item_name: Smoke rune
       slug: smoke-rune
       relationship: alternative
-      description: Air + Fire combo rune
+    - item_name: Dust rune
+      slug: dust-rune
+      relationship: alternative
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: alternative
+    - item_name: Lava rune
+      slug: lava-rune
+      relationship: alternative
+    - item_name: Steam battlestaff
+      slug: steam-battlestaff
+      relationship: alternative
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Combination Rune |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    Counts as both water and fire rune.
-
-    One steam rune replaces one of each element.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Steam runes are combination runes that count as both a water rune and a fire rune, letting a single steam rune satisfy either (or both) elemental requirements for a spell. They are members-only and crafted at level 19 Runecraft by bringing pure essence and the complementary rune to the Fire or Water altar, typically alongside a Binding necklace for a guaranteed success and the Lunar spell Magic Imbue to preserve the talisman. When equipped, the Steam battlestaff and Mystic steam staff provide an unlimited supply of steam runes.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-diamond.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-diamond.mdx
@@ -15,21 +15,12 @@ osrs:
   material:
     type: gem
     tier: high
-  crafting:
-    cutting_level: 43
-    cutting_xp: 107.5
-    uncut: true
-  drop_table:
-    sources:
-      - source: Gem rocks
-        source_id: 0
-        quantity: "1"
-        rarity: uncommon
-        members_only: true
   recipes:
     - skill: crafting
       level: 43
       xp: 107.5
+      tools:
+        - Chisel
       materials:
         - item_name: Uncut diamond
           item_id: 1617
@@ -37,76 +28,53 @@ osrs:
       product: Diamond
       product_id: 1601
       product_quantity: 1
-    - skill: fletching
-      level: 65
-      xp: 7
-      materials:
-        - item_name: Diamond
-          item_id: 1601
-          quantity: 1
-      product: Diamond bolt tips
-      product_id: 9192
-      product_quantity: 12
-      members_only: true
   related_items:
     - item_id: 1601
       item_name: Diamond
       slug: diamond
       relationship: product
-      description: Cut version
-    - item_id: 9192
-      item_name: Diamond bolt tips
-      slug: diamond-bolt-tips
-      relationship: product
-      description: Fletching product
+    - item_id: 1621
+      item_name: Uncut emerald
+      slug: uncut-emerald
+      relationship: downgrade
     - item_id: 1619
       item_name: Uncut ruby
       slug: uncut-ruby
-      relationship: alternative
-      description: Lower tier gem
+      relationship: downgrade
     - item_id: 1631
       item_name: Uncut dragonstone
       slug: uncut-dragonstone
-      relationship: alternative
-      description: Higher tier gem
-    - item_id: 1755
-      item_name: Chisel
-      slug: chisel
-      relationship: component
-      description: Required tool
+      relationship: upgrade
+    - item_id: 6571
+      item_name: Uncut onyx
+      slug: uncut-onyx
+      relationship: upgrade
+  drop_table:
+    sources:
+      - source: Cyclops
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/128"
+      - source: Dust devil
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/128"
+      - source: Lizardman shaman
+        quantity: "1"
+        rarity: uncommon
+        drop_rate: "1/75"
+      - source: Skeleton (Wilderness)
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/128"
+      - source: Steel dragon
+        quantity: "1"
+        rarity: uncommon
+        drop_rate: "1/64"
   about: |-
-    Use a Chisel on Uncut diamond to cut it.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Crafting Level | 43 |
-    | XP gained | 107.5 |
-
-    | Product | Crafting Level | XP |
-    |---------|----------------|-----|
-    | Diamond | 43 | 107.5 |
-    | Diamond bolt tips | 65 | 7 per tip |
-
-    Diamonds craft into high-tier jewelry:
-    - Diamond ring → Ring of life
-    - Diamond necklace → Phoenix necklace
-    - Diamond amulet → Amulet of power
-  market_strategy:
-    profit_formulas:
-      - Diamond - Uncut diamond = Profit
-      - (Bolt tips × 12) - Uncut diamond = Profit
-    notes:
-      - Buy uncut → Cut → Sell cut
-      - "Calculate:"
-      - Fast XP, check margins before bulk buying
-      - 1 diamond = 12 bolt tips
-      - "Calculate:"
-      - Diamond bolts (e) are popular for PvM
-      - Gem rocks (Shilo Village)
-      - Various monsters
-      - Clue scrolls
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    An uncut diamond is the rough form of the diamond, a high-tier precious gem in Old School RuneScape. It is dropped commonly by mid-to-high level monsters with access to the rare drop table and can be obtained from mining gem rocks in Shilo Village or the Tai Bwo Wannai Cleanup activity. Players with level 43 Crafting can use a chisel on an uncut diamond to cut it into a diamond, gaining 107.5 Crafting experience. Cut diamonds are used to make the diamond ring, necklace, amulet, and bracelet jewellery chain.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-ruby.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-ruby.mdx
@@ -14,22 +14,13 @@ osrs:
   limit: 10000
   material:
     type: gem
-    tier: mid-high
-  crafting:
-    cutting_level: 34
-    cutting_xp: 85
-    uncut: true
-  drop_table:
-    sources:
-      - source: Gem rocks
-        source_id: 0
-        quantity: "1"
-        rarity: uncommon
-        members_only: true
+    tier: mid
   recipes:
     - skill: crafting
       level: 34
-      xp: 85
+      xp: 50
+      tools:
+        - Chisel
       materials:
         - item_name: Uncut ruby
           item_id: 1619
@@ -37,68 +28,55 @@ osrs:
       product: Ruby
       product_id: 1603
       product_quantity: 1
-    - skill: fletching
-      level: 63
-      xp: 6
-      materials:
-        - item_name: Ruby
-          item_id: 1603
-          quantity: 1
-      product: Ruby bolt tips
-      product_id: 9191
-      product_quantity: 12
-      members_only: true
   related_items:
-    - item_id: 1617
-      item_name: Uncut diamond
-      slug: uncut-diamond
-      relationship: alternative
-      description: Higher tier gem
-    - item_id: 1621
-      item_name: Uncut emerald
-      slug: uncut-emerald
-      relationship: alternative
-      description: Lower tier gem
     - item_id: 1603
       item_name: Ruby
       slug: ruby
       relationship: product
-      description: Cut version
-    - item_id: 9242
-      item_name: Ruby bolts (e)
-      slug: ruby-bolts-e
-      relationship: product
-      description: Popular ammunition
-    - item_id: 1755
-      item_name: Chisel
-      slug: chisel
-      relationship: component
-      description: For cutting
+    - item_id: 1621
+      item_name: Uncut emerald
+      slug: uncut-emerald
+      relationship: downgrade
+    - item_id: 1617
+      item_name: Uncut diamond
+      slug: uncut-diamond
+      relationship: upgrade
+    - item_id: 1623
+      item_name: Uncut sapphire
+      slug: uncut-sapphire
+      relationship: downgrade
+    - item_id: 1631
+      item_name: Uncut dragonstone
+      slug: uncut-dragonstone
+      relationship: upgrade
+  drop_table:
+    sources:
+      - source: Gem rocks
+        quantity: "1"
+        rarity: uncommon
+        drop_rate: "1/29"
+        members_only: true
+      - source: Lesser demon
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/128"
+      - source: Ankou
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/256"
+      - source: Dust devil
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/256"
+        members_only: true
+      - source: Hill giant
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/512"
   about: |-
-    | Item | Enchantment | Effect |
-    |------|-------------|--------|
-    | Ruby ring | Ring of forging | No iron ore fail |
-    | Ruby necklace | Digsite pendant | Teleport |
-    | Ruby amulet | Amulet of strength | +10 Strength |
-    | Ruby bolts | Ruby bolts (e) | Blood Forfeit spec |
-  market_strategy:
-    title: Gem Processing
-    profit_formulas:
-      - Cut ruby price - Uncut price = Profit
-    notes:
-      - Buy uncut → Cut → Sell for profit
-      - "Calculate:"
-      - Factor in failure rate below 34 Crafting
-      - Ruby bolt tips (e) enchanting
-      - Jewellery crafting
-      - Ring of forging
-      - Amulet of strength
-      - Ruby bolt (e) very popular
-      - Blood Fury combines with ruby
-      - Higher margins than emerald
-      - Consistent demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Uncut ruby is the raw form of the ruby, a mid-tier precious gem dropped by many monsters via the rare drop table and mined from gem rocks in Shilo Village and Tai Bwo Wannai. It can be cut with a chisel at level 34 Crafting, granting 50 experience per cut. Cut rubies are used to craft ruby jewellery such as the amulet of strength and ring of forging, and to make ruby bolt tips for enchanted ranged ammunition.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
Batch 5 — first 10-item batch. Two coherent sets that complete category clusters in the graph.

### Items enriched (10)
**Combo runes** (mist, dust, smoke, mud, steam, lava):
- material classification, recipes with Magic Imbue + Binding necklace facility
- 9-10 related items each cross-linking to other combo runes, base elemental runes, and battlestaves

**Gem chains** (uncut-diamond, diamond, uncut-ruby, ruby):
- material classification (gem high/mid)
- recipes for cutting + jewelry crafting + bolt tip fletching
- drop_table sources for uncut variants with proper rarity enum + quoted drop_rate
- related_items chains across the gem progression and jewelry products

### Schema fixes from agent output
- Removed dead non-schema `item: { type, subtype, tradeable, stackable, weight, elements }` blocks left over from v1
- Renamed `recipes[*].members` → `members_only` (correct schema field name)
- Quoted unquoted `drop_rate` fractions (`1/29` → `"1/29"`)
- Removed `source_id` from `drop_table.sources` (not in schema)

## Test plan
- [ ] Verify astro-kbve builds without schema errors
- [ ] Spot-check rune family graph clustering
- [ ] Spot-check gem progression cross-links