### PR TITLE
fix(kubectl-e2e): run docker buildx from workspace root (#9932)

### DIFF
--- a/apps/vm/kubectl-e2e/project.json
+++ b/apps/vm/kubectl-e2e/project.json
@@ -18,10 +18,9 @@
 					"docker buildx build --platform linux/amd64 -f apps/vm/kubectl/Dockerfile -t kbve/kubectl:e2e --load .",
 					"docker run -d --name kubectl-e2e --entrypoint sleep kbve/kubectl:e2e infinity",
 					"echo 'Waiting for container...' && for i in $(seq 1 30); do if docker exec kubectl-e2e /bin/sh -c 'echo ok' >/dev/null 2>&1; then echo 'Container ready after '\"$i\"'s'; break; fi; if [ $i -eq 30 ]; then echo 'Container did not become ready'; docker logs kubectl-e2e 2>&1 | tail -20; docker rm -f kubectl-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
-					"npx vitest run; EC=$?; docker rm -f kubectl-e2e 2>/dev/null || true; exit $EC"
+					"cd apps/vm/kubectl-e2e && npx vitest run; EC=$?; docker rm -f kubectl-e2e 2>/dev/null || true; exit $EC"
 				],
-				"parallel": false,
-				"cwd": "apps/vm/kubectl-e2e"
+				"parallel": false
 			},
 			"configurations": {
 				"ci": {}


### PR DESCRIPTION
## Summary
Drop the `cwd: apps/vm/kubectl-e2e` from the e2e target. The cwd was causing `docker buildx -f apps/vm/kubectl/Dockerfile` to look for the Dockerfile relative to the e2e dir, producing `lstat apps: no such file or directory`.

The vitest command now has its own `cd apps/vm/kubectl-e2e &&` prefix so it still finds its config, while docker commands run from workspace root where the relative Dockerfile path resolves correctly.

## Root cause
nx `cwd` chdirs into the project before running commands. With cwd set, `apps/vm/kubectl/Dockerfile` resolves to `apps/vm/kubectl-e2e/apps/vm/kubectl/Dockerfile` → not found.

## Test plan
- [ ] `pnpm nx e2e kubectl-e2e --configuration=ci --no-cloud --output-style=stream` succeeds locally
- [ ] CI - Docker / kbve-kubectl passes after merge

Closes #9932