### PR TITLE
fix(kubevirt): attach macOS BaseSystem as disk so OpenCore can find it

### DIFF
--- a/apps/kube/angelscript/manifest/vm-macos-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-macos-builder.yaml
@@ -110,9 +110,11 @@ spec:
                           disk:
                               bus: sata
                           bootOrder: 2
-                        # macOS install image — uploaded via virtctl, managed by CDI DataVolume
-                        - name: iso
-                          cdrom:
+                        # macOS install image — must be attached as a disk, not cdrom.
+                        # BaseSystem.img is a raw HFS+/APFS image (not ISO9660), so
+                        # OpenCore's macOS scanner only finds it on a regular disk bus.
+                        - name: installer
+                          disk:
                               bus: sata
                           bootOrder: 3
                         # Shared storage — ISOs, Xcode .xip, installers staging
@@ -162,7 +164,7 @@ spec:
                 - name: rootdisk
                   persistentVolumeClaim:
                       claimName: macos-builder-rootdisk
-                - name: iso
+                - name: installer
                   dataVolume:
                       name: macos-tahoe-builder-iso
                 - name: shared-storage


### PR DESCRIPTION
## Summary
- OpenCore boot picker was only showing **EFI / Reset NVRAM / Toggle SIP** with no macOS install entry
- Cause: the BaseSystem was attached as a SATA **CD-ROM**, but `BaseSystem.img` is a raw HFS+/APFS image (not ISO9660), so OpenCore's macOS scanner skips it on CD-ROM buses
- Switched the volume from `cdrom:` to `disk:` and renamed it from `iso` to `installer` to reflect the actual format
- Matches OSX-KVM upstream which uses `-device ide-hd`, not `ide-cd`

## Test plan
- [ ] ArgoCD sync `angelscript` app
- [ ] `virtctl restart macos-builder -n angelscript`
- [ ] `virtctl vnc macos-builder -n angelscript` — confirm OpenCore picker now shows a **macOS Base System** entry
- [ ] Boot installer, partition `rootdisk`, install macOS

Ref #9929