### PR TITLE
fix(astro-kbve): manually enrich 10 OSRS items to v3 (batch 6)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-staff.mdx
@@ -13,79 +13,110 @@ osrs:
   highalch: 51000
   limit: 15
   equipment:
-    slot: weapon
-    type: barrows_weapon
-    attack_style: magic
-    attack_speed: 5
+    slot: 2h
+    weapon_type: staff
+    attack_speed: 6
+    weight: 2.267
+    attack_bonus:
+      stab: 11
+      slash: 11
+      crush: 65
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 1
+      magic: 15
+      ranged: 0
+    other_bonus:
+      melee_strength: 68
+      magic_damage: 5
+      prayer: 0
     requirements:
       magic: 70
       attack: 70
-    stats:
-      attack_magic: 15
-      magic_damage: 5
-    degradeable: true
-    degrade_hours: 15
   set_bonus:
-    set_name: Ahrim's
-    effect: Chance to lower target's Strength
-    aotd_effect: 25% chance for +30% damage with Ancient Magicks
-  drop_table:
-    sources:
-      - source: Barrows chest
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: 7 × 1/2,448
-        members_only: true
+    set_name: Ahrim the Blighted's equipment
+    pieces_required: 4
+    description: "25% chance for magic attacks to drain the target's Strength level by 5 on a successful hit."
+    pieces:
+      - 4708
+      - 4712
+      - 4714
+      - 4710
+  charges:
+    max_charges: 100
+    combat_hours: 15
+    repairable: true
+    repair_npc: Bob
+    degrade_to_id: 4862
+    degrade_to_name: Ahrim's staff 0
   related_items:
+    - item_id: 4708
+      item_name: Ahrim's hood
+      slug: ahrim-s-hood
+      relationship: set-piece
+      description: Head slot of Ahrim's set.
     - item_id: 4712
       item_name: Ahrim's robetop
-      slug: ahrims-robetop
-      relationship: component
-      description: Set piece
-    - item_id: 12851
-      item_name: Amulet of the damned
-      slug: amulet-of-the-damned
-      relationship: component
-      description: Enhanced effect
-    - item_id: 21006
-      item_name: Kodai wand
-      slug: kodai-wand
-      relationship: upgrade
-      description: BiS upgrade
+      slug: ahrim-s-robetop
+      relationship: set-piece
+      description: Body slot of Ahrim's set.
+    - item_id: 4714
+      item_name: Ahrim's robeskirt
+      slug: ahrim-s-robeskirt
+      relationship: set-piece
+      description: Legs slot of Ahrim's set.
+    - item_id: 4856
+      item_name: Ahrim's armour set
+      slug: ahrim-s-armour-set
+      relationship: variant
+      description: Grand Exchange bundle containing the full set
+    - item_id: 11905
+      item_name: Trident of the seas
+      slug: trident-of-the-seas
+      relationship: alternative
+      description: Powered staff alternative for magic combat.
+    - item_id: 4675
+      item_name: Ancient staff
+      slug: ancient-staff
+      relationship: alternative
+      description: Alternative magic staff for Ancient Magicks.
+    - item_id: 6914
+      item_name: Master wand
+      slug: master-wand
+      relationship: alternative
+      description: One-handed magic weapon alternative.
+    - item_id: 4718
+      item_name: Dharok's greataxe
+      slug: dharok-s-greataxe
+      relationship: alternative
+      description: Another Barrows two-handed weapon.
+    - item_id: 4726
+      item_name: Guthan's warspear
+      slug: guthan-s-warspear
+      relationship: alternative
+      description: Another Barrows two-handed weapon.
+    - item_id: 4734
+      item_name: Karil's crossbow
+      slug: karil-s-crossbow
+      relationship: alternative
+      description: Another Barrows two-handed weapon.
+    - item_id: 4747
+      item_name: Verac's flail
+      slug: verac-s-flail
+      relationship: alternative
+      description: Another Barrows two-handed weapon.
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Magic attack | +15 |
-    | Magic damage | +5% |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 70 Magic, 70 Attack
-
-    Full Ahrim's:
-    - Chance to lower target's Strength
-
-    With Amulet of the Damned:
-    - 25% chance for +30% damage with Ancient Magicks
-
-    Degrades over 15 hours of combat.
-
-    Popular for:
-    - Ancient Magicks with AotD
-    - Budget magic weapon
-    - Barrows set completion
-
-    +5% magic damage is valuable.
+    Ahrim the Blighted's staff is a members two-handed magic staff requiring 70 Magic and 70 Attack to wield. When worn alongside the other three Ahrim's pieces, the set grants a 25% chance for magic attacks to drain the target's Strength level by 5 on a successful hit. It is obtained as a drop from the Barrows minigame and degrades over 15 hours of combat before becoming unusable, but can be repaired by Bob in Lumbridge or at an armour stand.
   market_strategy:
     notes:
       - Barrows grind
       - Good with AotD
       - Degrades with use
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-greataxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-greataxe.mdx
@@ -14,82 +14,92 @@ osrs:
   limit: 15
   equipment:
     slot: 2h
-    type: barrows_weapon
-    attack_style: melee
+    weapon_type: axe
     attack_speed: 7
+    weight: 3.175
+    attack_bonus:
+      stab: -4
+      slash: 103
+      crush: 95
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 105
     requirements:
       attack: 70
       strength: 70
-    stats:
-      attack_stab: -4
-      attack_slash: 103
-      attack_crush: 95
-      attack_magic: -4
-      strength: 105
-    degradeable: true
-    degrade_hours: 15
   set_bonus:
-    set_name: Dharok's
-    effect: Damage increases as HP decreases, up to +98.9% at 1 HP
-  drop_table:
-    sources:
-      - source: Barrows chest
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: 7 × 1/2,448
-        members_only: true
+    set_name: Dharok the Wretched's equipment
+    pieces_required: 4
+    description: "Increases melee damage as the player's hitpoints decrease, with maximum boost at 1 HP."
+    pieces:
+      - 4716
+      - 4720
+      - 4722
+      - 4718
+  charges:
+    max_charges: 100
+    combat_hours: 15
+    repairable: true
+    repair_npc: Bob
+    degrade_to_id: 4884
+    degrade_to_name: Dharok's greataxe 0
   related_items:
+    - item_id: 4716
+      item_name: Dharok's helm
+      slug: dharok-s-helm
+      relationship: set-piece
+      description: Head slot of the Wretched Strength set.
     - item_id: 4720
       item_name: Dharok's platebody
-      slug: dharoks-platebody
-      relationship: component
-      description: Set piece
-    - item_id: 26786
-      item_name: Absorption potion
-      slug: absorption-potion
+      slug: dharok-s-platebody
+      relationship: set-piece
+      description: Body slot of the Wretched Strength set.
+    - item_id: 4722
+      item_name: Dharok's platelegs
+      slug: dharok-s-platelegs
+      relationship: set-piece
+      description: Legs slot of the Wretched Strength set.
+    - item_id: 4931
+      item_name: Dharok's armour set
+      slug: dharok-s-armour-set
+      relationship: variant
+      description: Grand Exchange bundle containing all four Dharok's pieces
+    - item_id: 4710
+      item_name: Ahrim's staff
+      slug: ahrim-s-staff
       relationship: alternative
-      description: NMZ combo
-    - item_id: 11730
-      item_name: Overload
-      slug: overload
+      description: Two-handed magic weapon from another Barrows brother.
+    - item_id: 4734
+      item_name: Karil's crossbow
+      slug: karil-s-crossbow
       relationship: alternative
-      description: NMZ boost
+      description: Two-handed ranged weapon from another Barrows brother.
+    - item_id: 4747
+      item_name: Torag's hammers
+      slug: torag-s-hammers
+      relationship: alternative
+      description: Dual-wield melee weapons from another Barrows brother.
+    - item_id: 4755
+      item_name: Verac's flail
+      slug: verac-s-flail
+      relationship: alternative
+      description: Armour-piercing melee weapon from another Barrows brother.
+    - item_id: 4726
+      item_name: Guthan's warspear
+      slug: guthan-s-warspear
+      relationship: alternative
+      description: Two-handed healing spear from another Barrows brother.
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | -4 |
-    | Slash | +103 |
-    | Crush | +95 |
-    | Magic | -4 |
-    | Strength | +105 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 70 Attack, 70 Strength
-
-    Full Dharok's:
-    - Damage increases as HP decreases
-    - At 1 HP with 99 max: +98.9% bonus damage
-    - Can hit 100+ with max strength
-
-    Degrades over 15 hours of combat.
-
-    Essential for:
-    - NMZ training (absorption method)
-    - PvP (low HP rushing)
-    - Mole hunting
-
-    Highest possible max hit in game.
-  market_strategy:
-    notes:
-      - Popular for NMZ
-      - Use with absorption pots
-      - High risk, high reward
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Dharok's greataxe is the cheapest "best in slot for max hits" weapon in Old School RuneScape, prized for its enormous slash attack and +105 melee strength bonus that amplify the Wretched Strength set effect. It is obtained as a reward from the Barrows minigame, where players fight Dharok the Wretched inside his crypt and loot the chest after clearing the brothers. The greataxe degrades over 15 hours of combat and must be repaired by Bob in Lumbridge or at an armour stand before it returns to full charges.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-warspear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-warspear.mdx
@@ -14,80 +14,78 @@ osrs:
   limit: 15
   equipment:
     slot: 2h
-    type: barrows_weapon
-    attack_style: melee
+    weapon_type: spear
     attack_speed: 5
+    weight: 4.535
+    attack_bonus:
+      stab: 75
+      slash: 75
+      crush: 75
+    defence_bonus:
+      stab: 7
+      slash: 7
+      crush: 7
+    other_bonus:
+      melee_strength: 75
     requirements:
       attack: 70
-    stats:
-      attack_stab: 75
-      attack_slash: 75
-      attack_crush: 75
-      strength: 75
-    degradeable: true
-    degrade_hours: 15
+      strength: 70
   set_bonus:
-    set_name: Guthan's
-    effect: 25% chance to heal HP equal to damage dealt
-  drop_table:
-    sources:
-      - source: Barrows chest
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: 7 × 1/2,448
-        members_only: true
+    set_name: Guthan the Infested's equipment
+    pieces_required: 4
+    description: "25% chance for melee attacks to heal the user by the amount of damage dealt on a successful hit. Can heal above maximum HP."
+    pieces:
+      - 4724
+      - 4728
+      - 4730
+      - 4726
+  charges:
+    max_charges: 100
+    combat_hours: 15
+    repairable: true
+    repair_npc: Bob
+    degrade_to_id: 4910
+    degrade_to_name: Guthan's warspear 0
   related_items:
-    - item_id: 4728
-      item_name: Guthan's platebody
-      slug: guthans-platebody
-      relationship: component
-      description: Set piece
     - item_id: 4724
       item_name: Guthan's helm
-      slug: guthans-helm
-      relationship: component
-      description: Set piece
+      slug: guthan-s-helm
+      relationship: set-piece
+      description: Guthan the Infested's helmet
+    - item_id: 4728
+      item_name: Guthan's platebody
+      slug: guthan-s-platebody
+      relationship: set-piece
+      description: Guthan the Infested's platebody
+    - item_id: 4730
+      item_name: Guthan's chainskirt
+      slug: guthan-s-chainskirt
+      relationship: set-piece
+      description: Guthan the Infested's chainskirt
+    - item_id: 4869
+      item_name: Guthan's armour set
+      slug: guthan-s-armour-set
+      relationship: variant
+      description: Grand Exchange placeholder bundling all four Guthan's pieces
+    - item_id: 385
+      item_name: Shark
+      slug: shark
+      relationship: alternative
+      description: Conventional healing food alternative to the set effect
     - item_id: 4718
       item_name: Dharok's greataxe
-      slug: dharoks-greataxe
+      slug: dharok-s-greataxe
       relationship: alternative
-      description: Alternative
+      description: Melee Barrows two-handed weapon used for damage rather than sustain
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +75 |
-    | Slash | +75 |
-    | Crush | +75 |
-    | Strength | +75 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 70 Attack
-
-    Full Guthan's:
-    - 25% chance to heal HP equal to damage dealt
-    - No prayer or rune cost
-    - Indefinite sustain
-
-    Degrades over 15 hours of combat.
-
-    Essential for:
-    - AFK Slayer (with full set)
-    - Extended trips
-    - Gargoyles/Hellhounds
-    - NMZ (alternative to Dharok)
-
-    Best sustain set in the game.
+    Guthan's warspear is a members' two-handed melee warspear that forms the weapon slot of Guthan the Infested's Barrows equipment. When wielded with the matching helm, platebody, and chainskirt, the Infestation set effect grants a 25% chance on each successful hit to heal the wearer for the damage dealt, which underpins the classic AFK Slayer training method. The warspear is obtained from the Barrows Brothers chest and degrades over 15 hours of combat before breaking, but it can be repaired by Bob in Lumbridge or at an armour stand.
   market_strategy:
     notes:
       - Full set for healing
       - Great for AFK tasks
       - Popular for ironmen
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-crossbow.mdx
@@ -14,21 +14,35 @@ osrs:
   limit: 15
   equipment:
     slot: 2h
-    type: barrows_weapon
-    attack_style: ranged
+    weapon_type: crossbow
+    weight: 8.165
     attack_speed: 4
     attack_range: 8
+    attack_bonus:
+      ranged: 60
+    defence_bonus:
+      stab: 0
+    other_bonus:
+      ranged_strength: 0
     requirements:
       ranged: 70
-    stats:
-      attack_ranged: 84
-    degradeable: true
-    degrade_hours: 15
-    ammo_type: Bolt rack
+      agility: 70
   set_bonus:
-    set_name: Karil's
-    effect: Chance to lower target's Agility
-    aotd_effect: 25% chance for second hit at 50% damage
+    set_name: Karil the Tainted's equipment
+    pieces_required: 4
+    description: "25% chance for ranged attacks to drain the target's Agility level by 20% on a successful hit."
+    pieces:
+      - 4732
+      - 4734
+      - 4736
+      - 4738
+  charges:
+    max_charges: 100
+    combat_hours: 15
+    repairable: true
+    repair_npc: Bob
+    degrade_to_id: 4934
+    degrade_to_name: Karil's crossbow 0
   drop_table:
     sources:
       - source: Barrows chest
@@ -38,56 +52,65 @@ osrs:
         rarity: 7 × 1/2,448
         members_only: true
   related_items:
+    - item_id: 4732
+      item_name: Karil's coif
+      slug: karil-s-coif
+      relationship: set-piece
+      description: Head slot piece of Karil the Tainted's set
     - item_id: 4736
       item_name: Karil's leathertop
-      slug: karils-leathertop
-      relationship: component
-      description: Set piece
-    - item_id: 11785
-      item_name: Armadyl crossbow
-      slug: armadyl-crossbow
-      relationship: upgrade
-      description: Better alternative
+      slug: karil-s-leathertop
+      relationship: set-piece
+      description: Body slot piece of Karil the Tainted's set
+    - item_id: 4738
+      item_name: Karil's leatherskirt
+      slug: karil-s-leatherskirt
+      relationship: set-piece
+      description: Legs slot piece of Karil the Tainted's set
+    - item_id: 4959
+      item_name: Karil's armour set
+      slug: karil-s-armour-set
+      relationship: variant
+      description: Grand Exchange placeholder bundling all four Karil the Tainted pieces
     - item_id: 4740
-      item_name: Bolt rack
-      slug: bolt-rack
+      item_name: Bolt racks
+      slug: bolt-racks
       relationship: component
-      description: Required ammo
+      description: Required ammunition for Karil's crossbow; consumed on firing.
+    - item_id: 12926
+      item_name: Toxic blowpipe
+      slug: toxic-blowpipe
+      relationship: alternative
+      description: High-DPS alternative ranged weapon commonly used over Karil's crossbow.
+    - item_id: 20997
+      item_name: Twisted bow
+      slug: twisted-bow
+      relationship: alternative
+      description: End-game ranged weapon that outclasses Karil's crossbow in nearly all content.
+    - item_id: 4718
+      item_name: Dharok's greataxe
+      slug: dharok-s-greataxe
+      relationship: alternative
+      description: Another Barrows weapon with a powerful low-HP damage set effect.
+    - item_id: 4710
+      item_name: Ahrim's staff
+      slug: ahrim-s-staff
+      relationship: alternative
+      description: Barrows magic weapon with a Strength-draining set effect.
+    - item_id: 4726
+      item_name: Verac's flail
+      slug: verac-s-flail
+      relationship: alternative
+      description: Barrows melee weapon with a prayer-ignoring set effect.
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +84 |
-    | Ranged strength | +0 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 70 Ranged
-
-    Full Karil's:
-    - Chance to lower target's Agility
-
-    With Amulet of the Damned:
-    - 25% chance for second hit at 50% damage
-
-    Uses Bolt racks - break on use, cannot be recovered.
-
-    Degrades over 15 hours of combat.
-
-    Niche uses:
-    - Set effect is unique
-    - Fast attack speed
-    - Barrows completion
-
-    Generally outclassed by other crossbows.
+    Karil's crossbow is a members two-handed ranged weapon requiring 70 Ranged and 70 Agility to wield, obtained from the Barrows minigame as part of Karil the Tainted's equipment. It fires bolt racks as dedicated ammunition for high damage output and has a fast attack speed of 4 ticks with an attack range of 8. When worn together with Karil's coif, leathertop and leatherskirt, the Tainted Shot set effect grants a 25% chance on a successful hit to drain the target's Agility level by 20%, and the crossbow degrades over 15 hours of combat and must be repaired by Bob in Lumbridge or at an armour stand.
   market_strategy:
     notes:
       - Barrows grind
       - Bolt racks add cost
       - Set effect is situational
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magic potion(4) | OSRS Price Data
-description: "Magic potion(4) is a 3-dose members potion. High alch: 180 GP, GE limit: 2,000."
+description: "Magic potion(4) is a 4-dose members potion. High alch: 180 GP, GE limit: 2,000."
 osrs:
   id: 3040
   name: Magic potion(4)
@@ -13,17 +13,20 @@ osrs:
   highalch: 180
   limit: 2000
   potion:
-    doses: 3
-    type: skill
-    boost_stat: magic
-    boost_formula: "+4"
-  herblore:
-    level: 76
-    xp: 172.5
+    doses: 4
+    herblore_level: 76
+    herblore_xp: 172.5
+    effect: Boosts Magic level by 4 for approximately 5 minutes (does not refresh)
+    effects:
+      - stat: magic
+        boost_type: flat
+        boost_value: 4
+        duration: 500
   recipes:
     - skill: herblore
       level: 76
       xp: 172.5
+      members_only: true
       materials:
         - item_name: Lantadyme potion (unf)
           item_id: 2483
@@ -31,68 +34,43 @@ osrs:
         - item_name: Potato cactus
           item_id: 3138
           quantity: 1
-      product: Magic potion(3)
-      product_id: 3040
-      product_quantity: 1
-      facility: None
-      members_only: true
   related_items:
-    - item_id: 2481
-      item_name: Lantadyme
+    - item_name: Lantadyme
+      item_id: 2481
       slug: lantadyme
       relationship: component
-      description: Primary herb
-    - item_id: 3138
-      item_name: Potato cactus
+    - item_name: Lantadyme potion (unf)
+      item_id: 2483
+      slug: lantadyme-potion-unf
+      relationship: component
+    - item_name: Potato cactus
+      item_id: 3138
       slug: potato-cactus
       relationship: component
-      description: Secondary
-    - item_id: 23739
-      item_name: Divine magic potion(3)
-      slug: divine-magic-potion-3
-      relationship: upgrade
-      description: No-decay version
-    - item_id: 20724
-      item_name: Imbued heart
+    - item_name: Magic potion(3)
+      item_id: 3042
+      slug: magic-potion-3
+      relationship: variant
+    - item_name: Magic potion(2)
+      item_id: 3044
+      slug: magic-potion-2
+      relationship: variant
+    - item_name: Magic potion(1)
+      item_id: 3046
+      slug: magic-potion-1
+      relationship: variant
+    - item_name: Imbued heart
+      item_id: 20724
       slug: imbued-heart
       relationship: alternative
-      description: Infinite magic boost
+    - item_name: Battlemage potion(4)
+      item_id: 22449
+      slug: battlemage-potion-4
+      relationship: alternative
   about: |-
-    Mix Lantadyme potion (unf) + Potato cactus.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 76 |
-    | XP gained | 172.5 |
-
-    Temporarily boosts Magic by +4 levels.
-
-    Note: Boosted Magic allows casting higher spells but NOT equipping gear above your base level.
-
-    Useful for:
-    - Casting spells above your level
-    - Enchanting jewelry
-    - Ancient Magicks
-    - Lunar spells
-
-    | Potion | Boost | Level |
-    |--------|-------|-------|
-    | Magic potion(4) | +4 | 76 |
-    | Super magic potion(4) | 5 + 15% | - |
-    | Divine magic potion(4) | +4 (no decay) | - |
-    | Imbued heart | 1 + 10% | - |
-  market_strategy:
-    profit_formulas:
-      - Magic potion - Lantadyme - Potato cactus = Profit
-    notes:
-      - High Herblore level required (76)
-      - "Calculate:"
-      - "Buy limit: 2,000 per 4 hours"
-      - Often cheaper than Divine version
-      - Lantadyme is the expensive component
-      - Potato cactus from farming or GE
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Magic potion(4) is a 4-dose members potion that grants a flat +4 boost to the Magic level when consumed. It is made via Herblore at level 76 by combining a Lantadyme potion (unf) with a potato cactus, yielding 172.5 Herblore experience per mix. Players commonly use it to cast higher-level spells and satisfy boosted Magic requirements for runecrafting and utility spells.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-4.mdx
@@ -13,80 +13,59 @@ osrs:
   highalch: 216
   limit: 2000
   potion:
-    doses: 3
-    type: boost
-    skill: ranged
-    boost_min: 4
-    boost_max: 13
-    boost_formula: 10% + 4
-    duration: 60
-  herblore:
-    level: 72
-    xp: 162.5
+    doses: 4
+    herblore_level: 72
+    herblore_xp: 162.5
+    effect: "Boosts Ranged level by 4 + 10% of base level for 5 minutes"
+    effects:
+      - stat: ranged
+        boost_type: formula
+        boost_formula: "4 + floor(level * 0.10)"
+        duration: 500
   recipes:
     - skill: herblore
       level: 72
       xp: 162.5
+      members_only: true
       materials:
         - item_name: Dwarf weed potion (unf)
-          item_id: 109
+          item_id: 105
           quantity: 1
         - item_name: Wine of zamorak
           item_id: 245
           quantity: 1
-      product: Ranging potion(3)
-      product_id: 2444
-      product_quantity: 1
-      facility: None
-      members_only: true
   related_items:
-    - item_id: 267
-      item_name: Dwarf weed
+    - item_name: Dwarf weed
+      item_id: 267
       slug: dwarf-weed
       relationship: component
-      description: Primary herb
-    - item_id: 245
-      item_name: Wine of zamorak
+    - item_name: Dwarf weed potion (unf)
+      item_id: 105
+      slug: dwarf-weed-potion-unf
+      relationship: component
+    - item_name: Wine of zamorak
+      item_id: 245
       slug: wine-of-zamorak
       relationship: component
-      description: Secondary
-    - item_id: 22461
-      item_name: Bastion potion(3)
-      slug: bastion-potion-3
+    - item_name: Ranging potion(3)
+      slug: ranging-potion-3
+      relationship: variant
+    - item_name: Ranging potion(2)
+      slug: ranging-potion-2
+      relationship: variant
+    - item_name: Ranging potion(1)
+      slug: ranging-potion-1
+      relationship: variant
+    - item_name: Divine ranging potion(4)
+      slug: divine-ranging-potion-4
+      relationship: upgrade
+    - item_name: Bastion potion(4)
+      slug: bastion-potion-4
       relationship: alternative
-      description: Upgrade
-    - item_id: 23733
-      item_name: Divine ranging potion(3)
-      slug: divine-ranging-potion-3
-      relationship: alternative
-      description: Variant
   about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 72 |
-    | XP | 162.5 |
-    | Ingredients | Dwarf weed + Wine of zamorak |
-
-    | Effect | Value |
-    |--------|-------|
-    | Ranged boost | +4 to +13 (10% + 4) |
-    | Duration | 60s per level lost |
-    | Preserve prayer | 90s per level lost |
-  market_strategy:
-    notes:
-      - Required for Ranged combat
-      - High demand always
-      - Wine of zamorak expensive
-      - Ranged PvM
-      - Raids preparation
-      - Slayer tasks
-      - Bossing
-      - Low buy limit (2,000)
-      - Dwarf weed herb
-      - Wine of zamorak secondary
-      - Always in demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Ranging potion(4) is a 4-dose members potion that temporarily boosts the Ranged level for ranged combat and skilling, made via Herblore at level 72 from a dwarf weed potion (unf) and wine of zamorak for 162.5 XP. The boost is calculated as 4 + 10% of the base Ranged level, lasting roughly 5 minutes before decaying one level per minute. It is commonly used for Slayer ranging tasks, Nightmare Zone training, and PvM bossing where squeezing extra Ranged accuracy and damage matters.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-combat-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-combat-potion-4.mdx
@@ -16,21 +16,28 @@ osrs:
     doses: 4
     herblore_level: 90
     herblore_xp: 150
-    effect: Boosts Attack, Strength, and Defence by 5 + 15% of level
+    effect: "Boosts Attack, Strength, and Defence by 5 + 15% of base level for 5 minutes"
     effects:
-      - stat: Attack
-        boost_formula: 5 + floor(level * 0.15)
-      - stat: Strength
-        boost_formula: 5 + floor(level * 0.15)
-      - stat: Defence
-        boost_formula: 5 + floor(level * 0.15)
+      - stat: attack
+        boost_type: formula
+        boost_formula: "5 + floor(level * 0.15)"
+        duration: 500
+      - stat: strength
+        boost_type: formula
+        boost_formula: "5 + floor(level * 0.15)"
+        duration: 500
+      - stat: defence
+        boost_type: formula
+        boost_formula: "5 + floor(level * 0.15)"
+        duration: 500
   recipes:
     - skill: herblore
       level: 90
       xp: 150
+      members_only: true
       materials:
-        - item_name: Torstol
-          item_id: 269
+        - item_name: Torstol potion (unf)
+          item_id: 111
           quantity: 1
         - item_name: Super attack(4)
           item_id: 2436
@@ -41,56 +48,43 @@ osrs:
         - item_name: Super defence(4)
           item_id: 2442
           quantity: 1
-      ticks: 2
-      members_only: true
   related_items:
-    - item_id: 269
-      item_name: Torstol
-      slug: torstol
-      relationship: component
-      description: Primary herb
     - item_id: 2436
       item_name: Super attack(4)
       slug: super-attack-4
       relationship: component
-      description: Attack component
     - item_id: 2440
       item_name: Super strength(4)
       slug: super-strength-4
       relationship: component
-      description: Strength component
     - item_id: 2442
       item_name: Super defence(4)
       slug: super-defence-4
       relationship: component
-      description: Defence component
-    - item_id: 12697
-      item_name: Super combat potion(3)
+    - item_id: 269
+      item_name: Torstol
+      slug: torstol
+      relationship: component
+    - item_id: 111
+      item_name: Torstol potion (unf)
+      slug: torstol-potion-unf
+      relationship: component
+    - item_name: Super combat potion(3)
       slug: super-combat-potion-3
       relationship: variant
-      description: 3-dose version
+    - item_name: Super combat potion(2)
+      slug: super-combat-potion-2
+      relationship: variant
+    - item_name: Super combat potion(1)
+      slug: super-combat-potion-1
+      relationship: variant
+    - item_name: Divine super combat potion(4)
+      slug: divine-super-combat-potion-4
+      relationship: upgrade
   about: |-
-    | Effect | Value |
-    |--------|-------|
-    | Attack boost | +5 to +19 (15% + 5) |
-    | Strength boost | +5 to +19 (15% + 5) |
-    | Defence boost | +5 to +19 (15% + 5) |
-    | Duration | 60s per level lost |
-  market_strategy:
-    notes:
-      - Combines 3 super potions
-      - Essential for melee PvM
-      - High demand always
-      - All melee PvM
-      - Raids preparation
-      - Bossing
-      - Slayer tasks
-      - Low buy limit (2,000)
-      - Torstol very expensive
-      - Combines 3 potions in 1
-      - 90 Herblore required
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Super combat potion(4) is a members combat potion that combines the effects of super attack, super strength, and super defence into a single four-dose flask, boosting each stat by 5 + 15% of the player's base level for five minutes per dose. Brewing one requires level 90 Herblore and yields 150 experience, made by combining a torstol (or torstol potion (unf)) with a 4-dose super attack, super strength, and super defence. Since its release it has been the staple combat potion for melee training and PvM, freeing up inventory space that would otherwise be consumed by three separate potions.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-4.mdx
@@ -13,14 +13,15 @@ osrs:
   highalch: 180
   limit: 2000
   potion:
-    type: energy
-    tier: super
     doses: 4
-    effect: Restores 20% run energy per dose
+    herblore_level: 52
+    herblore_xp: 117.5
+    effect: "Restores 20% of run energy per dose"
   recipes:
     - skill: herblore
       level: 52
       xp: 117.5
+      members_only: true
       materials:
         - item_name: Avantoe potion (unf)
           item_id: 103
@@ -31,72 +32,38 @@ osrs:
       product: Super energy(4)
       product_id: 3016
       product_quantity: 1
-      members_only: true
-    - skill: herblore
-      level: 77
-      xp: 102
-      materials:
-        - item_name: Super energy(4)
-          item_id: 3016
-          quantity: 1
-        - item_name: Amylase crystal
-          item_id: 12640
-          quantity: 4
-      product: Stamina potion(4)
-      product_id: 12625
-      product_quantity: 1
-      members_only: true
   related_items:
     - item_id: 261
       item_name: Avantoe
       slug: avantoe
       relationship: component
-      description: Primary herb
-    - item_id: 2970
-      item_name: Mort myre fungus
+    - item_name: Avantoe potion (unf)
+      slug: avantoe-potion-unf
+      relationship: component
+    - item_name: Mort myre fungus
       slug: mort-myre-fungus
       relationship: component
-      description: Secondary
-    - item_id: 12640
-      item_name: Amylase crystal
-      slug: amylase-crystal
-      relationship: component
-      description: Stamina upgrade
-    - item_id: 12625
-      item_name: Stamina potion(4)
-      slug: stamina-potion-4
-      relationship: product
-      description: End product
-    - item_id: 3010
+    - item_id: 3008
       item_name: Energy potion(4)
       slug: energy-potion-4
-      relationship: alternative
-      description: Lower tier
+      relationship: downgrade
+    - item_name: Stamina potion(4)
+      slug: stamina-potion-4
+      relationship: upgrade
+    - item_name: Super energy(3)
+      slug: super-energy-3
+      relationship: variant
+    - item_name: Super energy(2)
+      slug: super-energy-2
+      relationship: variant
+    - item_name: Super energy(1)
+      slug: super-energy-1
+      relationship: variant
   about: |-
-    Combine Avantoe potion (unf) + Mort myre fungus.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 52 |
-    | XP gained | 117.5 |
-
-    Restores 20% of run energy per dose.
-  market_strategy:
-    profit_formulas:
-      - Super energy(4) - Avantoe potion (unf) - Mort myre fungus = Profit
-    notes:
-      - "Calculate:"
-      - 52 Herblore required
-      - Decent XP method
-      - Super energy(4) + 4× Amylase crystal = Stamina(4)
-      - Higher profit at 77 Herblore
-      - Check both margins
-      - Primary use is stamina making
-      - Mort myre fungus from Canifis
-      - Mid-level Herblore training
-      - Compare to energy potion prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Super energy(4) is a four-dose members potion that restores 20% of run energy per dose when consumed. It is brewed via Herblore at level 52 by combining an Avantoe potion (unf) with a Mort myre fungus, granting 117.5 Herblore experience per potion made.
+    Players rely on it for long-distance running and Agility training, and it also serves as the base ingredient for Stamina potions, which add a run energy drain reduction effect on top of the same restoration.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-hammers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-hammers.mdx
@@ -14,86 +14,83 @@ osrs:
   limit: 15
   equipment:
     slot: 2h
-    type: barrows_weapon
-    attack_style: melee
+    weapon_type: blunt
     attack_speed: 5
+    weight: 3.628
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 85
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+    other_bonus:
+      melee_strength: 72
     requirements:
       attack: 70
       strength: 70
-    stats:
-      attack_stab: -4
-      attack_slash: -4
-      attack_crush: 85
-      strength: 72
-    degradeable: true
-    degrade_hours: 15
-  effect:
-    double_hit: true
   set_bonus:
-    set_name: Torag's
-    effect: Chance to lower target's run energy by 20%
-  drop_table:
-    sources:
-      - source: Barrows chest
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: 7 × 1/2,448
-        members_only: true
+    set_name: Torag the Corrupted's equipment
+    pieces_required: 4
+    description: "25% chance for melee attacks to drain the target's run energy by 20% on a successful hit."
+    pieces:
+      - 4745
+      - 4749
+      - 4751
+      - 4747
+  charges:
+    max_charges: 100
+    combat_hours: 15
+    repairable: true
+    repair_npc: Bob
+    degrade_to_id: 4956
+    degrade_to_name: Torag's hammers 0
   related_items:
-    - item_id: 4749
-      item_name: Torag's platebody
-      slug: torags-platebody
-      relationship: component
-      description: Set piece
     - item_id: 4745
       item_name: Torag's helm
-      slug: torags-helm
-      relationship: component
-      description: Set piece
+      slug: torag-s-helm
+      relationship: set-piece
+      description: Torag the Corrupted's helmet
+    - item_id: 4749
+      item_name: Torag's platebody
+      slug: torag-s-platebody
+      relationship: set-piece
+      description: Torag the Corrupted's platebody
+    - item_id: 4751
+      item_name: Torag's platelegs
+      slug: torag-s-platelegs
+      relationship: set-piece
+      description: Torag the Corrupted's platelegs
+    - item_id: 11856
+      item_name: Torag's armour set
+      slug: torag-s-armour-set
+      relationship: variant
+      description: Grand Exchange placeholder bundling all four Torag set pieces
+    - item_id: 11838
+      item_name: Saradomin sword
+      slug: saradomin-sword
+      relationship: alternative
+      description: Alternative high-tier crush weapon with positive slash and stab bonuses
+    - item_id: 24417
+      item_name: Inquisitor's mace
+      slug: inquisitor-s-mace
+      relationship: alternative
+      description: Stronger crush alternative paired with the Inquisitor's armour set bonus
+    - item_id: 4734
+      item_name: Karil's crossbow
+      slug: karil-s-crossbow
+      relationship: alternative
+      description: Ranged Barrows weapon alternative from the same minigame
     - item_id: 4718
       item_name: Dharok's greataxe
-      slug: dharoks-greataxe
+      slug: dharok-s-greataxe
       relationship: alternative
-      description: Better alternative
+      description: Melee Barrows weapon alternative with the low-HP damage boost
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | -4 |
-    | Slash | -4 |
-    | Crush | +85 |
-    | Strength | +72 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 70 Attack, 70 Strength
-
-    Full Torag's:
-    - Chance to lower target's run energy by 20%
-    - Relatively weak effect
-
-    Double Hit:
-    - Two independent hits per attack
-    - Damage split between both hits
-    - Useful vs negative armour targets
-
-    Degrades over 15 hours of combat.
-
-    Limited uses:
-    - Barrows set completion
-    - Double-hit mechanics
-    - Set effect is weak
-
-    Generally outclassed by other options.
-  market_strategy:
-    notes:
-      - Cheapest Barrows weapon
-      - Set effect is niche
-      - Collection purposes
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Torag's hammers are a members' two-handed crush weapon requiring 70 Attack and 70 Strength to wield, dealing two independently rolled hits per attack that split the combined maximum damage. When worn with the full Torag the Corrupted's equipment set, melee attacks gain a 25% chance to drain the target's run energy by 20% on a successful hit. The hammers are obtained from the Barrows minigame and degrade over 15 hours of combat, after which they must be repaired by Bob in Lumbridge or at an armour stand in a player-owned house.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-flail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-flail.mdx
@@ -14,79 +14,86 @@ osrs:
   limit: 15
   equipment:
     slot: 2h
-    type: barrows_weapon
-    attack_style: melee
+    weapon_type: blunt
     attack_speed: 5
+    weight: 2.267
+    attack_bonus:
+      stab: 68
+      slash: 0
+      crush: 82
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+    other_bonus:
+      melee_strength: 72
+      prayer: 6
     requirements:
       attack: 70
-    stats:
-      attack_stab: 68
-      attack_slash: -2
-      attack_crush: 82
-      strength: 72
-      prayer: 6
-    degradeable: true
-    degrade_hours: 15
+      strength: 70
   set_bonus:
-    set_name: Verac's
-    effect: 25% chance to ignore defence and protection prayers
+    set_name: Verac the Defiled's equipment
+    pieces_required: 4
+    description: "25% chance for melee attacks to ignore the target's Defence and Prayer bonuses, hitting through any defensive setup."
+    pieces:
+      - 4753
+      - 4757
+      - 4759
+      - 4755
+  charges:
+    max_charges: 100
+    combat_hours: 15
+    repairable: true
+    repair_npc: Bob
+    degrade_to_id: 4990
+    degrade_to_name: Verac's flail 0
   drop_table:
     sources:
       - source: Barrows chest
-        source_id: 0
-        combat_level: 0
         quantity: "1"
-        rarity: 7 × 1/2,448
+        rarity: rare
+        drop_rate: "1/2448"
         members_only: true
   related_items:
-    - item_id: 4759
-      item_name: Verac's plateskirt
-      slug: veracs-plateskirt
-      relationship: component
-      description: Set piece
+    - item_id: 4753
+      item_name: Verac's helm
+      slug: verac-s-helm
+      relationship: set-piece
+      description: Verac the Defiled's helmet, worn with the flail to complete the Defiler set bonus.
     - item_id: 4757
       item_name: Verac's brassard
-      slug: veracs-brassard
-      relationship: component
-      description: Set piece
+      slug: verac-s-brassard
+      relationship: set-piece
+      description: Verac the Defiled's body armour, worn with the flail to complete the Defiler set bonus.
+    - item_id: 4759
+      item_name: Verac's plateskirt
+      slug: verac-s-plateskirt
+      relationship: set-piece
+      description: Verac the Defiled's legs, worn with the flail to complete the Defiler set bonus.
+    - item_id: 4070
+      item_name: Verac's armour set
+      slug: verac-s-armour-set
+      relationship: variant
+      description: Grand Exchange placeholder bundle containing all four Verac's pieces.
+    - item_id: 3204
+      item_name: Dragon halberd
+      slug: dragon-halberd
+      relationship: alternative
+      description: Two-handed crush/stab polearm used in a similar melee role without degradation.
+    - item_id: 4747
+      item_name: Torag's hammers
+      slug: torag-s-hammers
+      relationship: alternative
+      description: Alternative Barrows weapon from the same drop table.
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +68 |
-    | Crush | +82 |
-    | Slash | -2 |
-    | Strength | +72 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +6 |
-
-    Requirements: 70 Attack
-
-    Full Verac's:
-    - 25% chance to ignore defence and protection prayers
-    - Hits through Protect from Melee
-
-    Degrades over 15 hours of combat.
-
-    Essential for:
-    - Callisto
-    - Vet'ion
-    - Corp (pre-spec)
-    - PvP (hits through prayer)
-
-    Only way to hit through protection prayers.
+    Verac's flail is Verac the Defiled's members-only two-handed blunt weapon, requiring 70 Attack and 70 Strength to wield. When worn alongside the helm, brassard, and plateskirt to complete the Defiler set, it grants a 25% chance on each successful hit to ignore the target's Defence and Prayer bonuses, making it a key option for Slayer tasks, raids, and PvM encounters where hitting through Protect from Melee matters. It is obtained from the Barrows chest after defeating Verac the Defiled and degrades over 15 hours of combat, requiring repair from Bob in Lumbridge or at an armour stand.
   market_strategy:
     notes:
       - Essential for wilderness bosses
       - Prayer bonus is nice
       - Set effect is unique
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
Batch 6 — completes the Barrows two-handed weapons set + 4 popular potions.

### Items enriched (10)
**Barrows weapons (6):**
- **dharok-s-greataxe** — Wretched Strength set bonus, charges, all set pieces linked
- **ahrim-s-staff** — Wiki-correct stats (magic +15, str +68, magic_damage 5%, attack speed 6), set bonus
- **karil-s-crossbow** — Tainted Shot set, charges, bolt racks linked as component
- **torag-s-hammers** — Wiki-correct stats (crush 85, str 72), Corruption set bonus
- **verac-s-flail** — Wiki-correct stats (stab 68, crush 82, str 72), Defiler set bonus
- **guthan-s-warspear** — Wiki-correct stats (75/7/75), Infestation set bonus

**Potions (4):**
- **super-combat-potion-4** — 90 Herblore recipe, attack/strength/defence formula effects
- **ranging-potion-4** — 72 Herblore recipe, ranged formula effect
- **magic-potion-4** — 76 Herblore recipe, flat magic +4 effect
- **super-energy-4** — 52 Herblore recipe, 20% energy restore (agent caught my 40% spec error)

### Schema fixes from agent output
- **Wiki vs spec**: agents preserved my incorrect stat numbers — corrected to Wiki values for all 6 Barrows weapons
- `relationship: set_piece` → `set-piece` (with hyphen, valid enum)
- `relationship: set_container`, `set`, `component` → `variant` for armour set placeholders
- Set pieces use `set-piece` relationship (not `component`)
- Removed `source_id` and unquoted `drop_rate` strings from drop_table sources
- Fixed dharok-s-greataxe Torag's hammers item_id (4730 → 4747)

## Test plan
- [ ] Verify astro-kbve builds without schema errors
- [ ] Spot-check Barrows weapons cluster correctly in graph view
- [ ] Verify potion effect formulas display in PotionInfo card