### PR TITLE
fix(firecracker): add kustomization.yaml to unblock ArgoCD sync

### DIFF
--- a/apps/kube/firecracker/manifests/kustomization.yaml
+++ b/apps/kube/firecracker/manifests/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+    name: firecracker-manifests
+    annotations:
+        description: 'Firecracker microVM runtime — controller, VPN-enabled variant, rootfs init, policies'
+
+namespace: firecracker
+
+resources:
+    - firecracker-namespace.yaml
+    - firecracker-pvc.yaml
+    - firecracker-resourcequota.yaml
+    - firecracker-networkpolicy.yaml
+    - firecracker-seccomp.yaml
+    - firecracker-pip-packages.yaml
+    - firecracker-vm-init.yaml
+    - firecracker-rootfs-init.yaml
+    - firecracker-pip-cache-cronjob.yaml
+    - firecracker-deployment.yaml
+    - firecracker-service.yaml
+    - firecracker-keda.yaml
+    - firecracker-net-deployment.yaml
+    - firecracker-net-service.yaml
+    - sealed-vpn-wireguard.yaml


### PR DESCRIPTION
## Summary
- ArgoCD app uses `kustomize: {}` in the source spec, which requires a `kustomization.yaml`
- Sync was failing with: \`Error: unable to find one of 'kustomization.yaml'... in directory\`
- Adds explicit kustomization listing all manifests (matches other apps in the repo)

## Context
This is blocking the firecracker-ctl-net deployment (#9940) from syncing. Once merged, ArgoCD will reconcile the namespace and create:
- firecracker-rootfs PVC (as ReadWriteMany — deleted manually to allow recreation)
- firecracker-ctl-net deployment + service
- sealed-vpn-wireguard
- All other missing resources

## Test plan
- [ ] ArgoCD sync succeeds
- [ ] Init job v7 rebuilds rootfs + pip-cache
- [ ] Both firecracker-ctl and firecracker-ctl-net come up healthy