### PR TITLE
fix(mc): FabricProxy-Lite + Velocity modern forwarding

### DIFF
--- a/apps/kube/agones/mc/velocity-configmap.yaml
+++ b/apps/kube/agones/mc/velocity-configmap.yaml
@@ -20,10 +20,9 @@ data:
         online-mode = true
         force-key-authentication = true
         prevent-client-proxy-connections = false
-        # Modern forwarding requires FabricProxy-Lite mod on backend.
-        # Until that's bundled, use legacy bungeecord forwarding which
-        # most Fabric servers support natively (with bungeecord = true on backend).
-        player-info-forwarding-mode = "legacy"
+        # Modern Velocity forwarding — backend Fabric server runs
+        # FabricProxy-Lite to validate the forwarding signature.
+        player-info-forwarding-mode = "modern"
         forwarding-secret-file = "forwarding.secret"
         announce-forge = false
         announce-proxy-commands = true

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -75,6 +75,7 @@ declare -A MODS=(
   ["servercore-fabric-1.5.15+1.21.11.jar"]="c3c6ec10b0ceddaa8f1ef53ffe57db57b4e8638f https://cdn.modrinth.com/data/4WWQxlQP/versions/zg8VIycZ/servercore-fabric-1.5.15%2B1.21.11.jar"
   ["Chunky-Fabric-1.4.55.jar"]="19c34a23a5c1b2f6c73117b8eb4524b521e1926b https://cdn.modrinth.com/data/fALzjamp/versions/1CpEkmcD/Chunky-Fabric-1.4.55.jar"
   ["old_combat_mod-fabric-1.21.11-1.2.jar"]="5908493d5f019497864b6a8834fcfd4b2aa95213 https://cdn.modrinth.com/data/dZ1APLkO/versions/TzHDocwD/old_combat_mod-fabric-1.21.11-1.2.jar"
+  ["FabricProxy-Lite-2.11.0.jar"]="2c6674b1561b9b263b332607ef25b7db469133ec https://cdn.modrinth.com/data/8dI2tmqs/versions/nR8AIdvx/FabricProxy-Lite-2.11.0.jar"
 )
 
 for name in "${!MODS[@]}"; do

--- a/apps/mc/config/FabricProxy-Lite.toml
+++ b/apps/mc/config/FabricProxy-Lite.toml
@@ -1,0 +1,20 @@
+# FabricProxy-Lite — accepts forwarded player info from Velocity proxy.
+# Must use modern (Velocity-style) forwarding mode + matching secret.
+# Server's online-mode must be false (Velocity handles Mojang auth).
+
+# Hack online mode — set this true so Mojang authentication is bypassed
+# but the server still validates Velocity's forwarding signature.
+hackOnlineMode = true
+
+# Hack early send — works around connection edge cases.
+hackEarlySend = false
+
+# Hack message chain — ensures chat signing works with forwarded sessions.
+hackMessageChain = true
+
+# Disable secure chat profile lookups (Mojang) since Velocity handles auth.
+disableSecureChat = false
+
+# Modern Velocity forwarding secret — must match Velocity's
+# /server/forwarding.secret value.
+secret = "kbve-velocity-forwarding-secret-change-me"


### PR DESCRIPTION
## Summary
Players couldn't connect through Velocity — backend was rejecting forwarded sessions:
\`\`\`
[server connection] wwwKBVEcom -> mc has disconnected
ERROR: unable to connect to server mc
The connection to the remote server was unexpectedly closed.
This is usually because the remote server does not have BungeeCord IP forwarding correctly enabled.
\`\`\`

Fabric servers don't support BungeeCord/legacy forwarding natively — they need a mod.

### Fix
1. **Add FabricProxy-Lite 2.11.0** mod via Modrinth ADD (sha1 verified)
2. **Bake `FabricProxy-Lite.toml`** into the image at `/config/` with the forwarding secret
3. **Switch Velocity** from `legacy` → `modern` forwarding mode
4. Both sides share the same secret (`kbve-velocity-forwarding-secret-change-me` — TODO: rotate via SealedSecret)

### Connection flow
\`\`\`
Player → mc.kbve.com:25565
            │ (Velocity hostPort on dedicated-server node)
            ▼
        Velocity (modern forwarding, signs session w/ secret)
            │
            ▼
        mc-fabric-backend headless Service
            │
            ▼
        Fabric pod + FabricProxy-Lite mod (validates signature)
            │
            ▼
        Player joins as authenticated Mojang user
\`\`\`

## Test plan
- [x] Docker build passes
- [x] FabricProxy-Lite + config baked into image
- [ ] Player can join via mc.kbve.com:25565