### PR TITLE
fix(kbve-kubectl): use busybox_bins chisel slice (#9809)

### DIFF
--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -93,7 +93,7 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
         libc6_libs \
         libstdc++6_libs \
         openssl_config \
-        busybox-static_bins \
+        busybox_bins \
         libcurl4t64_libs \
         curl_bins && \
     # Create busybox symlinks for shell utilities


### PR DESCRIPTION
## Summary
The Dockerfile referenced `busybox-static_bins` but the chisel slice is named `busybox_bins`. The Ubuntu 24.04 chisel release has a package called `busybox` (not `busybox-static`) with a single bin slice.

## Failure
\`\`\`
error: slices of package "busybox-static" not found
ERROR: failed to build: failed to solve: process "/bin/sh -c chisel cut --release ubuntu-24.04 ..." did not complete successfully: exit code: 1
\`\`\`

## Fix
Change `busybox-static_bins` → `busybox_bins`. Verified against `canonical/chisel-releases` ubuntu-24.04 branch — `busybox.yaml` defines slices: `bins`, `copyright`.

## Test plan
- [ ] CI - Docker / kbve-kubectl chisel stage builds successfully
- [ ] /bin/sh resolves via busybox in the runtime image
- [ ] e2e tests pass

Ref #9809