### PR TITLE
chore(kube): trim CPU requests so macos-builder VM can schedule

### DIFF
--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -68,8 +68,11 @@ template:
                       cpu: '12'
                       memory: 24Gi
                   requests:
-                      cpu: '4'
-                      memory: 8Gi
+                      # Idle runners only burn ~100m. Reserve 1 CPU so the pod
+                      # schedules but doesn't squat on capacity. Heavy jobs still
+                      # burst up to the 12-CPU limit.
+                      cpu: '1'
+                      memory: 4Gi
               securityContext:
                   # Run as root for sudo/apt-get (Unity builder requirement)
                   # Not privileged - no host access, just root inside container
@@ -102,8 +105,10 @@ template:
                       cpu: '12'
                       memory: 32Gi
                   requests:
-                      cpu: '2'
-                      memory: 4Gi
+                      # DinD daemon idles around 50m; reserve 500m for headroom
+                      # while letting builds burst into the 12-CPU limit.
+                      cpu: 500m
+                      memory: 2Gi
               volumeMounts:
                   - name: work
                     mountPath: /home/runner/_work

--- a/apps/kube/herbmail/manifest/herbmail-deployment.yaml
+++ b/apps/kube/herbmail/manifest/herbmail-deployment.yaml
@@ -1,65 +1,65 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: herbmail-deployment
-  namespace: herbmail
-  labels:
-    app: herbmail
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: herbmail
-  template:
-    metadata:
-      annotations:
-        rollout-restart: "2026-04-03T22:24:57Z"
-      labels:
+    name: herbmail-deployment
+    namespace: herbmail
+    labels:
         app: herbmail
-        version: "0.1.1"
-    spec:
-      containers:
-      - name: herbmail
-        image: ghcr.io/kbve/herbmail:0.1.1
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 4321
-          protocol: TCP
-        env:
-        - name: PORT
-          value: "4321"
-        - name: SUPABASE_URL
-          value: "http://kong.kilobase.svc.cluster.local:8000"
-        - name: SUPABASE_ANON_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: anon-key
-        - name: SUPABASE_SERVICE_ROLE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: service-role-key
-        resources:
-          requests:
-            memory: "512Mi"
-            cpu: "2000m"
-          limits:
-            memory: "1024Mi"
-            cpu: "4000m"
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: herbmail
+    template:
+        metadata:
+            annotations:
+                rollout-restart: '2026-04-03T22:24:57Z'
+            labels:
+                app: herbmail
+                version: '0.1.1'
+        spec:
+            containers:
+                - name: herbmail
+                  image: ghcr.io/kbve/herbmail:0.1.1
+                  imagePullPolicy: Always
+                  ports:
+                      - containerPort: 4321
+                        protocol: TCP
+                  env:
+                      - name: PORT
+                        value: '4321'
+                      - name: SUPABASE_URL
+                        value: 'http://kong.kilobase.svc.cluster.local:8000'
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: anon-key
+                      - name: SUPABASE_SERVICE_ROLE_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: service-role-key
+                  resources:
+                      requests:
+                          memory: '512Mi'
+                          cpu: '250m'
+                      limits:
+                          memory: '1024Mi'
+                          cpu: '2000m'
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: herbmail-service
-  namespace: herbmail
-  labels:
-    app: herbmail
+    name: herbmail-service
+    namespace: herbmail
+    labels:
+        app: herbmail
 spec:
-  type: ClusterIP
-  selector:
-    app: herbmail
-  ports:
-  - port: 4321
-    targetPort: 4321
-    protocol: TCP
+    type: ClusterIP
+    selector:
+        app: herbmail
+    ports:
+        - port: 4321
+          targetPort: 4321
+          protocol: TCP

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -137,10 +137,10 @@ spec:
                   resources:
                       requests:
                           memory: '512Mi'
-                          cpu: '2000m'
+                          cpu: '250m'
                       limits:
                           memory: '1024Mi'
-                          cpu: '4000m'
+                          cpu: '2000m'
             volumes:
                 - name: argocd-ca
                   secret:

--- a/apps/kube/memes/manifest/memes-deployment.yaml
+++ b/apps/kube/memes/manifest/memes-deployment.yaml
@@ -1,65 +1,65 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: memes-deployment
-  namespace: memes
-  labels:
-    app: memes
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: memes
-  template:
-    metadata:
-      annotations:
-        rollout-restart: "2026-04-03T22:25:16Z"
-      labels:
+    name: memes-deployment
+    namespace: memes
+    labels:
         app: memes
-        version: "0.1.8"
-    spec:
-      containers:
-      - name: memes
-        image: ghcr.io/kbve/memes:0.1.8
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 4321
-          protocol: TCP
-        env:
-        - name: PORT
-          value: "4321"
-        - name: SUPABASE_URL
-          value: "http://kong.kilobase.svc.cluster.local:8000"
-        - name: SUPABASE_ANON_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: anon-key
-        - name: SUPABASE_SERVICE_ROLE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: service-role-key
-        resources:
-          requests:
-            memory: "512Mi"
-            cpu: "2000m"
-          limits:
-            memory: "1024Mi"
-            cpu: "4000m"
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: memes
+    template:
+        metadata:
+            annotations:
+                rollout-restart: '2026-04-03T22:25:16Z'
+            labels:
+                app: memes
+                version: '0.1.8'
+        spec:
+            containers:
+                - name: memes
+                  image: ghcr.io/kbve/memes:0.1.8
+                  imagePullPolicy: Always
+                  ports:
+                      - containerPort: 4321
+                        protocol: TCP
+                  env:
+                      - name: PORT
+                        value: '4321'
+                      - name: SUPABASE_URL
+                        value: 'http://kong.kilobase.svc.cluster.local:8000'
+                      - name: SUPABASE_ANON_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: anon-key
+                      - name: SUPABASE_SERVICE_ROLE_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: service-role-key
+                  resources:
+                      requests:
+                          memory: '512Mi'
+                          cpu: '250m'
+                      limits:
+                          memory: '1024Mi'
+                          cpu: '2000m'
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: memes-service
-  namespace: memes
-  labels:
-    app: memes
+    name: memes-service
+    namespace: memes
+    labels:
+        app: memes
 spec:
-  type: ClusterIP
-  selector:
-    app: memes
-  ports:
-  - port: 4321
-    targetPort: 4321
-    protocol: TCP
+    type: ClusterIP
+    selector:
+        app: memes
+    ports:
+        - port: 4321
+          targetPort: 4321
+          protocol: TCP

--- a/apps/kube/rentearth/manifest/rentearth-deployment.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-deployment.yaml
@@ -52,10 +52,10 @@ spec:
                   resources:
                       requests:
                           memory: '512Mi'
-                          cpu: '2000m'
+                          cpu: '250m'
                       limits:
                           memory: '1024Mi'
-                          cpu: '4000m'
+                          cpu: '2000m'
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
The single cluster node was at **92% CPU committed** (59 / 64 cores) even though actual usage sat around **23%**. The `macos-builder` VM's 8-core guaranteed request couldn't fit, so virt-launcher was stuck Pending with `Insufficient cpu`.

Lowered requests to match observed idle usage while keeping limits generous so traffic spikes and CI bursts still work.

### ARC runner pods (4 currently running)
| Container | Request CPU | Request Mem | Limit (unchanged) |
|---|---|---|---|
| `runner` | 4 → **1** | 8Gi → **4Gi** | 12 CPU / 24Gi |
| `dind` | 2 → **500m** | 4Gi → **2Gi** | 12 CPU / 32Gi |

Frees ~18 CPU across 4 pods.

### Astro web pods (kbve, herbmail, memes, rentearth)
| Field | Before | After |
|---|---|---|
| `requests.cpu` | 2000m | **250m** |
| `limits.cpu` | 4000m | **2000m** |
| memory | unchanged | unchanged |

Frees ~7 CPU across 4 pods. These are SSR Astro sites that idle at ~50m and burst on traffic — 250m guaranteed + 2000m burst is ample.

**Total freed: ~25 CPU** → macos-builder's 8-CPU request fits with headroom.

## Test plan
- [ ] ArgoCD sync `runners`, `kbve`, `herbmail`, `memes`, `rentearth` apps
- [ ] Confirm all 4 web pods + ARC runner pods restart cleanly
- [ ] `kubectl describe node talos-4bn-whr | grep -A4 Allocated` — committed CPU should drop from 92% to ~50%
- [ ] `virtctl start macos-builder -n angelscript` — virt-launcher pod should reach Running

Ref #9943