### PR TITLE
feat(reloader): add Stakater Reloader for auto-restart on config changes

### DIFF
--- a/apps/kube/agones/mc/velocity-deployment.yaml
+++ b/apps/kube/agones/mc/velocity-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     labels:
         app: mc-velocity
         app.kubernetes.io/part-of: mc
+    annotations:
+        # Stakater Reloader — auto rolling-restart when mc-velocity-config
+        # ConfigMap changes (velocity.toml or forwarding.secret).
+        configmap.reloader.stakater.com/reload: 'mc-velocity-config'
 spec:
     replicas: 1
     selector:

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
     # ingress-nginx removed — Cilium Gateway API handles ingress + ACME HTTP-01 challenges
     - cert-manager/application.yaml
     - sealed-secrets/application.yaml
+    # Stakater Reloader — auto-restart deployments when configmaps/secrets change
+    - reloader/application.yaml
     - keda/application.yaml
     - crossplane/application.yaml
     - crossplane/providers-application.yaml

--- a/apps/kube/reloader/application.yaml
+++ b/apps/kube/reloader/application.yaml
@@ -1,0 +1,58 @@
+# Stakater Reloader — watches ConfigMaps/Secrets and triggers rolling
+# restarts on Deployments/StatefulSets/DaemonSets when they change.
+#
+# Usage on a Deployment:
+#   metadata:
+#     annotations:
+#       configmap.reloader.stakater.com/reload: "mc-velocity-config"
+#       secret.reloader.stakater.com/reload: "mc-gameserver-secrets"
+#
+# Or auto-watch all referenced configmaps/secrets:
+#   metadata:
+#     annotations:
+#       reloader.stakater.com/auto: "true"
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: reloader
+    namespace: argocd
+spec:
+    project: default
+    source:
+        repoURL: https://stakater.github.io/stakater-charts
+        targetRevision: 2.1.6
+        chart: reloader
+        helm:
+            releaseName: reloader
+            values: |
+                reloader:
+                  watchGlobally: true
+                  reloadStrategy: env-vars
+                  deployment:
+                    replicas: 1
+                    resources:
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                      limits:
+                        cpu: 100m
+                        memory: 128Mi
+                  serviceMonitor:
+                    enabled: false
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: reloader
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true
+        retry:
+            limit: 5
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m


### PR DESCRIPTION
## Summary
Adds the Stakater Reloader operator cluster-wide. Reloader watches ConfigMaps and Secrets, and triggers rolling restarts on Deployments / StatefulSets / DaemonSets that reference them — so changing a configmap actually causes the consuming pods to pick up the new values without manual intervention.

### How to use it
On any deployment, add an annotation:
\`\`\`yaml
metadata:
  annotations:
    configmap.reloader.stakater.com/reload: "my-config"
    secret.reloader.stakater.com/reload: "my-secret"
\`\`\`
Or auto-watch all referenced configmaps/secrets:
\`\`\`yaml
metadata:
  annotations:
    reloader.stakater.com/auto: "true"
\`\`\`

### First consumer: mc-velocity
Wired up the Velocity Deployment with `configmap.reloader.stakater.com/reload: "mc-velocity-config"` so editing `velocity.toml` or `forwarding.secret` triggers an automatic rolling restart of the Velocity proxy.

### Note on Agones
Reloader doesn't watch Agones `Fleet` resources (not a standard workload kind). Fabric server restarts continue to flow through image tag bumps managed by CI's `deployment_yaml` field.

## ONLINE_MODE
Already `false` on the fleet from the earlier velocity PR — verified live.

## Test plan
- [ ] Reloader pod runs in `reloader` namespace
- [ ] Editing `mc-velocity-config` ConfigMap triggers Velocity rolling restart