### PR TITLE
fix(astro-kbve): manually enrich 15 OSRS items to v3 (batch 7)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-godsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-godsword.mdx
@@ -14,97 +14,60 @@ osrs:
   limit: 8
   equipment:
     slot: 2h
-    type: godsword
-    attack_style: slash
-    attack_speed: 6
+    weapon_type: two-handed-sword
+    weight: 10
+    attack_bonus:
+      stab: 0
+      slash: 132
+      crush: 80
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 132
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 8
     requirements:
       attack: 75
-    stats:
-      attack_slash: 132
-      attack_crush: 80
-      strength: 132
-      prayer: 8
   special_attack:
     name: The Judgement
     energy: 50
-    effect: +37.5% max hit, standard accuracy
-  recipes:
-    - skill: none
-      level: 0
-      xp: 0
-      materials:
-        - item_name: Godsword blade
-          item_id: 11798
-          quantity: 1
-        - item_name: Armadyl hilt
-          item_id: 11810
-          quantity: 1
-      product: Armadyl godsword
-      product_id: 11802
-      product_quantity: 1
-      facility: None
-      members_only: true
+    description: Doubles accuracy and increases the maximum hit by 37.5%, rolling against the opponent's slash defence.
+    accuracy_modifier: 2.0
+    damage_modifier: 1.375
   related_items:
     - item_id: 11810
       item_name: Armadyl hilt
       slug: armadyl-hilt
       relationship: component
-      description: Hilt component
     - item_id: 11798
       item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Blade component
     - item_id: 11804
       item_name: Bandos godsword
       slug: bandos-godsword
       relationship: alternative
-      description: Defence drain spec
     - item_id: 11806
       item_name: Saradomin godsword
       slug: saradomin-godsword
       relationship: alternative
-      description: Healing spec
     - item_id: 11808
       item_name: Zamorak godsword
       slug: zamorak-godsword
       relationship: alternative
-      description: Freeze spec
-  about: |-
-    Attach Armadyl hilt to Godsword blade.
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Armadyl hilt | Kree'arra (1/508) | ~8.4M gp |
-    | Godsword blade | GWD bosses | ~526K gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Attack style | Slash |
-    | Slash attack | +132 |
-    | Crush attack | +80 |
-    | Strength bonus | +132 |
-    | Prayer bonus | +8 |
-    | Attack speed | 6 tick (3.6s) |
-    | Requirements | 75 Attack |
-
-    The Judgement (50% energy):
-    - +37.5% max hit increase
-    - Standard accuracy
-    - Can hit 70+ on monsters
-    - Can hit 90+ with boosts (black mask, etc.)
-
-    PvP:
-    - Premier KO weapon
-    - Finish low HP opponents
-    - Popular in deep wilderness
-
-    PvM:
-    - Speed kills (spec and teleport)
-    - General Graardor finisher
-    - Not commonly used for sustained DPS
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Armadyl godsword (or)
+      slug: armadyl-godsword-or
+      relationship: variant
+  about: The Armadyl godsword is the most popular godsword variant, prized for its special attack The Judgement which delivers devastating knockout blows in both PvP and PvM. It is created by attaching an Armadyl hilt, obtained from Kree'arra, to a completed godsword blade. Wielding the Armadyl godsword requires level 75 Attack.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-hilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-hilt.mdx
@@ -18,67 +18,54 @@ osrs:
   drop_table:
     sources:
       - source: Kree'arra
-        source_id: 3162
         combat_level: 580
         quantity: "1"
-        rarity: 1/508
+        rarity: very-rare
+        drop_rate: "1/508"
         members_only: true
-  recipes:
-    - skill: none
-      level: 0
-      xp: 0
-      materials:
-        - item_name: Godsword blade
-          item_id: 11798
-          quantity: 1
-        - item_name: Armadyl hilt
-          item_id: 11810
-          quantity: 1
-      product: Armadyl godsword
-      product_id: 11802
-      product_quantity: 1
-      facility: None
-      members_only: true
+      - source: Flight Kilisa
+        combat_level: 159
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/5376"
+        members_only: true
+      - source: Flockleader Geerin
+        combat_level: 149
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/5376"
+        members_only: true
+      - source: Wingman Skree
+        combat_level: 143
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/5376"
+        members_only: true
   related_items:
-    - item_id: 11802
-      item_name: Armadyl godsword
-      slug: armadyl-godsword
-      relationship: product
-      description: Created weapon
-    - item_id: 11798
-      item_name: Godsword blade
+    - item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Blade component
-    - item_id: 11812
-      item_name: Bandos hilt
+    - item_name: Armadyl godsword
+      slug: armadyl-godsword
+      relationship: product
+    - item_name: Bandos hilt
       slug: bandos-hilt
       relationship: alternative
-      description: Defence drain hilt
-    - item_id: 11814
-      item_name: Saradomin hilt
+    - item_name: Saradomin hilt
       slug: saradomin-hilt
       relationship: alternative
-      description: Healing hilt
+    - item_name: Zamorak hilt
+      slug: zamorak-hilt
+      relationship: alternative
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2.5 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Armadyl godsword | Godsword blade + Armadyl hilt |
-
-    No skill requirements.
+    The Armadyl hilt is an Armadyl-aligned godsword hilt dropped from Kree'arra at the God Wars Dungeon. It is combined with a godsword blade to form the Armadyl godsword. The hilt is a very rare drop from Kree'arra, with a base rate of roughly 1/508 per kill.
   market_strategy:
     notes:
       - Farm Kree'arra
       - Most valuable hilt
       - Creates spec weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-godsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-godsword.mdx
@@ -14,106 +14,65 @@ osrs:
   limit: 8
   equipment:
     slot: 2h
-    type: godsword
-    attack_style: slash
+    weapon_type: two-handed-sword
     attack_speed: 6
+    attack_range: 1
     requirements:
       attack: 75
-    stats:
-      attack_slash: 132
-      attack_crush: 80
-      strength: 132
-      prayer: 8
+    bonuses:
+      attack:
+        stab: 0
+        slash: 132
+        crush: 80
+        magic: 0
+        ranged: 0
+      defence:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 0
+      other:
+        melee_strength: 132
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 8
   special_attack:
     name: Warstrike
     energy: 50
-    effect: +100% accuracy, +21% damage, drains combat stats equal to damage dealt
-  recipes:
-    - skill: none
-      level: 0
-      xp: 0
-      materials:
-        - item_name: Godsword blade
-          item_id: 11798
-          quantity: 1
-        - item_name: Bandos hilt
-          item_id: 11812
-          quantity: 1
-      product: Bandos godsword
-      product_id: 11804
-      product_quantity: 1
-      facility: None
-      members_only: true
+    description: Doubled accuracy and +21% damage. Drains the target's combat stats equal to the damage dealt, in the order Defence, Strength, Prayer, Attack, Magic, Ranged.
+    accuracy_modifier: 2.0
+    damage_modifier: 1.21
+    drains_defence: true
+    drains_stats: true
   related_items:
     - item_id: 11812
       item_name: Bandos hilt
       slug: bandos-hilt
       relationship: component
-      description: Hilt component
     - item_id: 11798
       item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Blade component
-    - item_id: 13576
-      item_name: Dragon warhammer
-      slug: dragon-warhammer
-      relationship: alternative
-      description: Primary spec alternative
     - item_id: 11802
       item_name: Armadyl godsword
       slug: armadyl-godsword
       relationship: alternative
-      description: Damage spec
     - item_id: 11806
       item_name: Saradomin godsword
       slug: saradomin-godsword
       relationship: alternative
-      description: Healing spec
+    - item_id: 11808
+      item_name: Zamorak godsword
+      slug: zamorak-godsword
+      relationship: alternative
+    - item_name: Bandos godsword (or)
+      slug: bandos-godsword-or
+      relationship: variant
   about: |-
-    Attach Bandos hilt to Godsword blade.
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Bandos hilt | General Graardor (1/508) | ~16M gp |
-    | Godsword blade | GWD bosses | ~526K gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Attack style | Slash |
-    | Slash attack | +132 |
-    | Crush attack | +80 |
-    | Strength bonus | +132 |
-    | Prayer bonus | +8 |
-    | Attack speed | 6 tick (3.6s) |
-    | Requirements | 75 Attack |
-
-    Warstrike (50% energy):
-    - +100% accuracy (doubled)
-    - +21% damage boost
-    - Drains combat stats equal to damage dealt
-    - Drain order: Defence → Strength → Prayer → Attack → Magic → Ranged
-
-    PvM (Primary Use):
-    - Alternative to Dragon warhammer
-    - Defence reduction for bosses
-    - Double spec at start of kills
-
-    Best For:
-    - Corporeal Beast
-    - Nightmare
-    - Solo bossing
-    - Budget DWH alternative
-
-    PvP:
-    - Stat drain can be devastating
-    - Less burst than AGS
-  market_strategy:
-    notes:
-      - PvM utility drives price
-      - Good for ironmen (easier than DWH)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The Bandos godsword is the cheapest of the five godsword variants and serves as the budget entry point to godsword ownership for players who want a high-hitting two-handed weapon. Its Warstrike special attack drains the target's Defence (and then other combat stats) equal to the damage dealt, making it a popular pick at high-Defence bosses where shredding enemy stats opens up the rest of the fight. Like every godsword, it is forged by attaching a Bandos hilt, dropped by General Graardor, to a godsword blade assembled from shards found throughout the God Wars Dungeon.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-hilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-hilt.mdx
@@ -12,52 +12,52 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10000
-  item:
-    type: godsword hilt
-    tradeable: true
-    weight: 2.5
-  recipes:
-    - skill: null
-      level: 0
-      materials:
-        - item_id: 11812
-          item_name: Bandos hilt
-          quantity: 1
-        - item_id: 11798
-          item_name: Godsword blade
-          quantity: 1
-      product: Bandos godsword
-      product_id: 11804
+  drop_table:
+    sources:
+      - source: General Graardor
+        combat_level: 624
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/508"
+        members_only: true
   related_items:
-    - item_id: 11804
-      item_name: Bandos godsword
-      slug: bandos-godsword
-      relationship: product
-      description: Created weapon from hilt
     - item_id: 11798
       item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Required component for godsword
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2.5 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Bandos godsword | Godsword blade + Bandos hilt |
-
-    No skill requirements.
+      description: Combined with the hilt to forge the Bandos godsword.
+    - item_id: 11804
+      item_name: Bandos godsword
+      slug: bandos-godsword
+      relationship: product
+      description: Finished weapon created from the hilt and a godsword blade.
+    - item_id: 11810
+      item_name: Armadyl hilt
+      slug: armadyl-hilt
+      relationship: alternative
+      description: Armadyl-aligned godsword hilt dropped by Kree'arra.
+    - item_id: 11814
+      item_name: Saradomin hilt
+      slug: saradomin-hilt
+      relationship: alternative
+      description: Saradomin-aligned godsword hilt dropped by Commander Zilyana.
+    - item_id: 11816
+      item_name: Zamorak hilt
+      slug: zamorak-hilt
+      relationship: alternative
+      description: Zamorak-aligned godsword hilt dropped by K'ril Tsutsaroth.
+  about: >-
+    The Bandos hilt is a Bandos-aligned godsword hilt dropped by General
+    Graardor in the God Wars Dungeon. It is combined with a completed godsword
+    blade to forge the Bandos godsword. The hilt is one of four godsword hilts,
+    each tied to a God Wars Dungeon boss and a different godsword variant.
   market_strategy:
     notes:
       - Farm General Graardor
       - Defence drain spec
       - Popular for PvM
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-battleaxe.mdx
@@ -14,27 +14,26 @@ osrs:
   limit: 70
   equipment:
     slot: weapon
-    weapon_type: battleaxe
-    weight: 1.814
+    weapon_type: axe
+    weight: 2.721
     attack_speed: 6
     attack_range: 1
     attack_bonus:
       stab: -2
       slash: 70
       crush: 65
-      magic: -4
+      magic: 0
       ranged: 0
     defence_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
-      ranged: 0
-    other_bonus:
-      melee_strength: 85
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
+      ranged: -1
+    melee_strength: 85
+    ranged_strength: 0
+    magic_damage: 0
+    prayer: 0
     requirements:
       attack: 60
   quest_requirements:
@@ -45,46 +44,30 @@ osrs:
   special_attack:
     name: Rampage
     energy: 100
-    description: Drains Attack, Defence, Ranged, and Magic by 10% + 1, and boosts Strength by 10 + (drained levels / 4)
+    description: Boosts the user's Strength level by 20% but lowers Attack, Defence, Magic, and Ranged by 10%.
   related_items:
-    - item_id: 1434
-      item_name: Dragon mace
-      slug: dragon-mace
-      relationship: alternative
-      description: Also from Heroes' Quest content
-    - item_id: 1305
-      item_name: Dragon longsword
-      slug: dragon-longsword
-      relationship: alternative
-      description: Also from Heroes' Quest content
     - item_id: 4587
       item_name: Dragon scimitar
       slug: dragon-scimitar
       relationship: alternative
-      description: Popular alternative dragon weapon
-  about: |-
-    Special Attack - Rampage:
-    - Uses 100% special attack energy
-    - Drains your Attack, Defence, Ranged, and Magic
-    - Boosts Strength significantly
-    - Used as a strength potion alternative
-
-    Common Uses:
-    - Super Combat replacement for Strength boost
-    - Budget Strength training with spec
-    - Ironman accounts before Strength potions
-
-    | Stat | Bonus |
-    |------|-------|
-    | Slash | +70 |
-    | Crush | +65 |
-    | Strength | +85 |
-
-    - Slower than scimitar (6 tick vs 4 tick)
-    - Special attack popular for Strength boosting
-    - Often carried just for the spec
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1305
+      item_name: Dragon longsword
+      slug: dragon-longsword
+      relationship: alternative
+    - item_id: 1434
+      item_name: Dragon mace
+      slug: dragon-mace
+      relationship: alternative
+    - item_id: 1215
+      item_name: Dragon dagger
+      slug: dragon-dagger
+      relationship: alternative
+    - item_name: Dragon 2h sword
+      slug: dragon-2h-sword
+      relationship: alternative
+  about: The dragon battleaxe is a two-handed slash weapon wielded by players with at least 60 Attack. It is best known for its Rampage special attack, which is commonly used as a strength-boost spec for combat training in place of a super strength potion. Players typically carry it solely for the spec before switching back to a faster primary weapon.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dagger.mdx
@@ -14,96 +14,69 @@ osrs:
   limit: 70
   equipment:
     slot: weapon
+    weapon_type: stab-sword
     attack_speed: 4
-    attack_bonus:
-      stab: 40
-      slash: 25
-      crush: -4
-      magic: 1
-      ranged: 0
-    defence_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 1
-      ranged: 0
-    other_bonus:
-      melee_strength: 40
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
+    weight: 0.453
     requirements:
       attack: 60
-    weight: 0.453
+    bonuses:
+      attack:
+        stab: 40
+        slash: 25
+        crush: -4
+        magic: 1
+        ranged: 0
+      defence:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 1
+        ranged: 0
+      other:
+        melee_strength: 40
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
   special_attack:
     name: Puncture
     energy: 25
-    description: Two rapid hits with +15% accuracy and +15% damage each. Rolls against opponent's slash defence.
+    description: Deals two hits at once with +15% accuracy and +15% damage per hit. Both hits roll against the opponent's slash defence.
+    accuracy_modifier: 1.15
+    damage_modifier: 1.15
   related_items:
+    - item_id: 1231
+      item_name: Dragon dagger (p)
+      slug: dragon-dagger-p
+      relationship: variant
+      description: Poisoned variant applying standard weapon poison.
+    - item_id: 5680
+      item_name: Dragon dagger (p+)
+      slug: dragon-dagger-p
+      relationship: variant
+      description: Poison+ variant with stronger weapon poison.
     - item_id: 5698
-      item_name: Dragon dagger(p++)
-      slug: dragon-dagger-p-5698
-      relationship: upgrade
-      description: Poisoned variant with super poison
+      item_name: Dragon dagger (p++)
+      slug: dragon-dagger-p
+      relationship: variant
+      description: Poison++ variant, the standard PvP DDS.
+    - item_id: 4587
+      item_name: Dragon scimitar
+      slug: dragon-scimitar
+      relationship: alternative
+      description: Higher-strength dragon-tier melee weapon without a spec.
     - item_id: 13265
       item_name: Abyssal dagger
       slug: abyssal-dagger
       relationship: upgrade
-      description: Superior dagger with better stats
-    - item_id: 1333
-      item_name: Rune scimitar
-      slug: rune-scimitar
-      relationship: alternative
-      description: F2P training weapon
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Stab | +40 |
-    | Slash | +25 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +40 |
-
-    Requirements: 60 Attack | Speed: 4 tick (2.4s) | Weight: 0.45 kg
-
-    Cost: 25% special attack energy
-
-    Deals two rapid hits simultaneously, each with +15% accuracy and +15% damage. Both hits roll against the opponent's slash defence (not stab). This makes it one of the highest burst-damage weapons at its price point.
-
-    Maximum damage: ~23 per hit (46 total) at base stats, scaling higher with Strength bonuses and prayers. With max melee gear, hits can reach 48-48 (96 total).
-
-    The dragon dagger is the most iconic knockout weapon in PvP:
-    - 25% spec cost means four specs per bar
-    - Two rapid hits can stack for surprise KOs
-    - Budget alternative to Dragon claws (50% spec, more expensive)
-    - Almost always used in its poisoned (p++) variant for extra damage-over-time
-
-    The "DDS spec" is a defining part of OSRS PvP culture.
-
-    | Weapon | Speed | Stab | Str | Spec Cost | Spec Effect |
-    |--------|-------|------|-----|-----------|-------------|
-    | Dragon dagger | 4 tick | +40 | +40 | 25% | 2 hits, +15% acc/dmg |
-    | Abyssal dagger | 4 tick | +75 | +75 | 50% | 2 hits, +25% acc |
-    | Dragon claws | 4 tick | +41 | +56 | 50% | 4 hits, guaranteed min |
-
-    The dragon dagger's 25% spec cost is its biggest advantage — allowing four specs versus two for claws or abyssal dagger.
-
-    | Variant | Poison Damage | Item ID |
-    |---------|--------------|---------|
-    | Dragon dagger | None | 1215 |
-    | Dragon dagger(p) | 6 starting | 1231 |
-    | Dragon dagger(p+) | 8 starting | 5680 |
-    | Dragon dagger(p++) | 10 starting | 5698 |
-
-    The (p++) variant is standard for PvP — apply weapon poison(++) to the base dagger.
+      description: Stronger dagger upgrade with a two-hit special attack.
+  about: The dragon dagger is the iconic special-attack weapon of OSRS, famous for its Puncture spec that hits twice with +15% accuracy and +15% damage per hit. It requires 60 Attack and completion of the Lost City quest to wield. The dagger remains the classic budget DDS for low-level PvP knockouts and lure tasks thanks to its cheap 25% spec cost.
   market_strategy:
     notes:
       - Base dagger is cheap; p++ variant costs more
       - Extremely high demand PvP weapon
       - Lost City quest gate limits early access
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-longsword.mdx
@@ -14,102 +14,60 @@ osrs:
   limit: 70
   equipment:
     slot: weapon
-    type: longsword
-    attack_style: melee
+    weapon_type: slash-sword
     attack_speed: 5
+    attack_range: 1
     tradeable: true
     weight: 1.814
-  requirements:
-    attack: 60
-    quests:
-      - name: Lost City
-  stats:
-    attack:
+    requirements:
+      attack: 60
+      quest: Lost City
+    attack_bonus:
       stab: 58
       slash: 69
       crush: -2
       magic: 0
       ranged: 0
-    defence:
+    defence_bonus:
       stab: 0
       slash: 3
       crush: 2
       magic: 0
       ranged: 0
-    other:
+    other_bonus:
       melee_strength: 71
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
   special_attack:
     name: Cleave
-    description: +25% max hit on a single powerful strike
-    energy_cost: 25
-  shops:
-    - shop_name: Jukat
-      location: Zanaris
-      price: 100000
-  drop_table:
-    sources:
-      - source: Steel dragon
-        source_id: 274
-        combat_level: 246
-        quantity: "1"
-        rarity: rare
-        members_only: true
-      - source: Black dragon
-        source_id: 252
-        combat_level: 227
-        quantity: "1"
-        rarity: rare
+    energy: 25
+    description: Raises the player's maximum hit by 25% for one powerful strike.
+    damage_modifier: 1.25
   related_items:
     - item_id: 4587
       item_name: Dragon scimitar
       slug: dragon-scimitar
       relationship: alternative
-      description: Faster attack speed
-    - item_id: 12954
-      item_name: Dragon defender
-      slug: dragon-defender
+    - item_id: 1434
+      item_name: Dragon mace
+      slug: dragon-mace
       relationship: alternative
-      description: Shield slot upgrade
-    - item_id: 1303
-      item_name: Rune longsword
-      slug: rune-longsword
-      relationship: downgrade
-      description: Lower tier weapon
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +58 |
-    | Slash | +69 |
-    | Crush | -2 |
-    | Strength | +71 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Slash | +3 |
-    | Crush | +2 |
-
-    Requirements: 60 Attack, Lost City
-
-    Cleave (25% energy):
-    - +25% max hit
-    - Single powerful hit
-
-    Good for:
-    - Stab/slash training
-    - Budget spec weapon
-    - Collection log
-
-    2nd strongest longsword.
-  market_strategy:
-    notes:
-      - Lost City quest required
-      - Slower than scimitar
-      - Better for specs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1215
+      item_name: Dragon dagger
+      slug: dragon-dagger
+      relationship: alternative
+    - item_id: 1377
+      item_name: Dragon battleaxe
+      slug: dragon-battleaxe
+      relationship: alternative
+    - item_id: 11838
+      item_name: Saradomin sword
+      slug: saradomin-sword
+      relationship: upgrade
+  about: The Dragon longsword is the classic dragon-tier longsword, offering strong stab and slash bonuses alongside a respectable melee strength bonus. Its Cleave special attack consumes 25% special energy to deal a single strike with 25% increased damage, making it a viable budget spec weapon. Wielding it requires 60 Attack and completion of the Lost City quest.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-mace.mdx
@@ -14,10 +14,11 @@ osrs:
   limit: 70
   equipment:
     slot: weapon
-    weapon_type: mace
-    weight: 0.907
+    weapon_type: blunt
     attack_speed: 4
     attack_range: 1
+    requirements:
+      attack: 60
     attack_bonus:
       stab: 40
       slash: -2
@@ -35,51 +36,34 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 5
-    requirements:
-      attack: 60
-  quest_requirements:
-    - quest_name: Heroes' Quest
-      quest_id: 63
-      required: true
-      notes: Required to purchase from shop
   special_attack:
     name: Shatter
     energy: 25
-    description: Hits with 50% increased damage and ignores the opponent's Protect from Melee prayer
+    description: Increases accuracy by 25% and damage by 50%, rolling against the target's crush defence.
+    damage_modifier: 1.5
+    accuracy_modifier: 1.25
   related_items:
-    - item_id: 1377
-      item_name: Dragon battleaxe
-      slug: dragon-battleaxe
-      relationship: alternative
-      description: Also from Heroes' Quest content
     - item_id: 1305
       item_name: Dragon longsword
       slug: dragon-longsword
       relationship: alternative
-      description: Also from Heroes' Quest content
-  about: |-
-    Special Attack - Shatter:
-    - Uses only 25% special attack energy
-    - 50% increased damage
-    - Ignores opponent's Protect from Melee prayer
-
-    Combat Features:
-    - +5 Prayer bonus (unique among dragon weapons)
-    - Crush attack style (good vs plate armor)
-    - Same speed as scimitar
-
-    | Stat | Bonus |
-    |------|-------|
-    | Crush | +60 |
-    | Stab | +40 |
-    | Strength | +55 |
-    | Prayer | +5 |
-
-    - Spec useful in PvP for prayer-ignoring hits
-    - Lower DPS than dragon scimitar
-    - Prayer bonus is niche advantage
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 4587
+      item_name: Dragon scimitar
+      slug: dragon-scimitar
+      relationship: alternative
+    - item_id: 1377
+      item_name: Dragon battleaxe
+      slug: dragon-battleaxe
+      relationship: alternative
+    - item_name: Granite hammer
+      slug: granite-hammer
+      relationship: upgrade
+    - item_name: Inquisitor's mace
+      slug: inquisitor-s-mace
+      relationship: upgrade
+  about: The dragon mace is a crush weapon from the dragon equipment tier, purchased at the Heroes' Guild after completing Heroes' Quest. Its Shatter special attack costs only 25% energy, making it a popular low-cost spec accumulator weapon for stacking damage in PvP and boss encounters. Wielding it requires level 60 Attack.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-scimitar.mdx
@@ -41,60 +41,31 @@ osrs:
   special_attack:
     name: Sever
     energy: 55
-    description: Disables opponent's protection prayers and prevents prayer use for 4.8 seconds
-    accuracy_modifier: 1
-  drop_table:
-    primary_source: Scorpia
-    best_drop_rate: 1/128
-    sources:
-      - source: Scorpia
-        combat_level: 225
-        quantity: "1"
-        rarity: rare
-        drop_rate: 1/128
-        members_only: true
-        wilderness: true
-  shops:
-    - shop_name: Daga's Scimitar Smithy
-      location: Ape Atoll
-      price: 100000
-      stock: 1
-      members_only: true
-      requirements: Monkey Madness I completion
+    description: On a successful hit, disables the target's active protection prayers and prevents protection prayer use for 5 seconds.
+    drains_defence: false
   related_items:
-    - item_id: 4151
-      item_name: Abyssal whip
-      slug: abyssal-whip
-      relationship: upgrade
-      description: 70 Attack upgrade
     - item_id: 1305
       item_name: Dragon longsword
       slug: dragon-longsword
       relationship: alternative
-      description: Alternative spec weapon
-    - item_id: 21742
-      item_name: Granite hammer
-      slug: granite-hammer
+    - item_id: 1215
+      item_name: Dragon dagger
+      slug: dragon-dagger
       relationship: alternative
-      description: 50 Attack option
+    - item_id: 4151
+      item_name: Abyssal whip
+      slug: abyssal-whip
+      relationship: upgrade
+    - item_name: Brine sabre
+      slug: brine-sabre
+      relationship: alternative
+    - item_name: Dragon scimitar (or)
+      slug: dragon-scimitar-or
+      relationship: variant
   about: |-
-    - Monkey Madness I required to wield
-    - Must complete quest to access Ape Atoll shop
-
-    Best-in-slot for:
-    - 60 Attack builds
-    - F2P-to-members transition
-    - PvP (prayer disable)
-    - Training to 70 Attack
-
-    Training Note: Best Strength training weapon until 70 Attack
-  market_strategy:
-    notes:
-      - Shop is cheapest source
-      - Scorpia drop is wilderness risk
-      - Essential for pures
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The Dragon scimitar is the iconic budget melee weapon of Old School RuneScape, prized for its strong slash attack bonus and exceptional value for its tier. Wielding it requires 60 Attack and completion of the Monkey Madness I quest, which also grants access to Daga's Scimitar Smithy on Ape Atoll. With a 4-tick attack speed, it is tied for the fastest scimitar speed in the game, making it a mainstay for general slayer tasks and melee training.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-blade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-blade.mdx
@@ -12,75 +12,59 @@ osrs:
   lowalch: 300000
   highalch: 450000
   limit: 10000
-  item:
-    type: crafting_material
-    tradeable: true
-    weight: 7.5
-  creation:
-    method: Created at anvil
-    requirements:
-      smithing: 80
-    xp: 100
-    materials:
-      - item_id: 0
-        item_name: Godsword shard 1
-        slug: godsword-shard-1
-      - item_id: 0
-        item_name: Godsword shard 2
-        slug: godsword-shard-2
-      - item_id: 0
-        item_name: Godsword shard 3
-        slug: godsword-shard-3
-  uses:
-    - hilt: Ancient hilt
-      godsword: Ancient godsword
-    - hilt: Armadyl hilt
-      godsword: Armadyl godsword
-    - hilt: Bandos hilt
-      godsword: Bandos godsword
-    - hilt: Saradomin hilt
-      godsword: Saradomin godsword
-    - hilt: Zamorak hilt
-      godsword: Zamorak godsword
+  material:
+    type: bar
+    tier: high
+  recipes:
+    - skill: smithing
+      level: 80
+      xp: 100
+      facility: Furnace
+      product: Godsword blade
+      product_id: 11798
+      product_quantity: 1
+      materials:
+        - item_name: Godsword shard 1
+          item_id: 11818
+          quantity: 1
+        - item_name: Godsword shard 2
+          item_id: 11820
+          quantity: 1
+        - item_name: Godsword shard 3
+          item_id: 11822
+          quantity: 1
   related_items:
     - item_id: 11818
       item_name: Godsword shard 1
       slug: godsword-shard-1
       relationship: component
-      description: Component
-    - item_id: 0
-      item_name: Armadyl hilt
-      slug: armadyl-hilt
+    - item_id: 11820
+      item_name: Godsword shard 2
+      slug: godsword-shard-2
       relationship: component
-      description: Most valuable hilt
+    - item_id: 11822
+      item_name: Godsword shard 3
+      slug: godsword-shard-3
+      relationship: component
+    - item_id: 11802
+      item_name: Armadyl godsword
+      slug: armadyl-godsword
+      relationship: product
     - item_id: 11804
       item_name: Bandos godsword
       slug: bandos-godsword
       relationship: product
-      description: Created weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 7.5 kg |
-
-    Combine with a hilt to create godsword:
-
-    | Hilt | Godsword |
-    |------|----------|
-    | Ancient hilt | Ancient godsword |
-    | Armadyl hilt | Armadyl godsword |
-    | Bandos hilt | Bandos godsword |
-    | Saradomin hilt | Saradomin godsword |
-    | Zamorak hilt | Zamorak godsword |
-  market_strategy:
-    notes:
-      - Combine shards yourself
-      - Add hilt for profit
-      - Farm GWD for shards
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 11806
+      item_name: Saradomin godsword
+      slug: saradomin-godsword
+      relationship: product
+    - item_id: 11808
+      item_name: Zamorak godsword
+      slug: zamorak-godsword
+      relationship: product
+  about: The godsword blade is an intermediate component crafted by smithing Godsword shard 1, Godsword shard 2, and Godsword shard 3 together at an anvil, requiring level 80 Smithing. Each pair of shards smithed together grants 100 Smithing experience, so assembling a full blade awards 200 experience total. Once complete, the blade is combined with a god hilt obtained from the God Wars Dungeon to forge one of the four godswords.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-shard-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-shard-1.mdx
@@ -12,59 +12,39 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 11000
-  item:
-    type: crafting_material
-    tradeable: true
-    weight: 2.5
-  obtaining:
-    methods:
-      - source: GWD Bosses
-        drop_rate: 1/762
-      - source: GWD Minions
-        drop_rate: 1/1,524
-    note: Dropped by all four GWD factions
-  creation:
-    creates:
-      item_id: 11798
-      item_name: Godsword blade
-      slug: godsword-blade
-    method: Combine all 3 shards at anvil
-    requirements:
-      smithing: 80
-    xp: 100
+  material:
+    type: bar
+    tier: high
+  drop_table:
+    sources:
+      - source: General Graardor
+        rarity: very-rare
+        drop_rate: "1/762"
+      - source: K'ril Tsutsaroth
+        rarity: very-rare
+        drop_rate: "1/762"
+      - source: Kree'arra
+        rarity: very-rare
+        drop_rate: "1/762"
+      - source: Commander Zilyana
+        rarity: very-rare
+        drop_rate: "1/762"
   related_items:
     - item_id: 11820
       item_name: Godsword shard 2
       slug: godsword-shard-2
-      relationship: alternative
-      description: Component
+      relationship: component
     - item_id: 11822
       item_name: Godsword shard 3
       slug: godsword-shard-3
-      relationship: alternative
-      description: Component
+      relationship: component
     - item_id: 11798
       item_name: Godsword blade
       slug: godsword-blade
       relationship: product
-      description: Created item
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2.5 kg |
-
-    Combine all 3 shards at anvil (80 Smithing):
-    - Shard 1 + Shard 2 + Shard 3 = Godsword blade
-    - 100 Smithing XP
-  market_strategy:
-    notes:
-      - All 3 shards have same drop rate
-      - Farm any GWD boss
-      - Combine for blade profit
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Godsword shard 1 is the first of three godsword shards dropped from the bosses and sub-bosses of the God Wars Dungeon. Each of the four generals — General Graardor, K'ril Tsutsaroth, Kree'arra, and Commander Zilyana — drops this specific shard at a rate of 1/762. Combined with godsword shard 2 and godsword shard 3 on an anvil, it forges a godsword blade, requiring level 80 Smithing and granting 100 Smithing experience.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-shard-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-shard-2.mdx
@@ -12,10 +12,9 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 11000
-  item:
-    type: godsword shard
-    tradeable: true
-    weight: 2.5
+  material:
+    type: bar
+    tier: high
   recipes:
     - skill: smithing
       level: 80
@@ -32,34 +31,49 @@ osrs:
           quantity: 1
       product: Godsword blade
       product_id: 11798
+  drop_table:
+    sources:
+      - source: General Graardor
+        combat_level: 624
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
+      - source: K'ril Tsutsaroth
+        combat_level: 650
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
+      - source: Commander Zilyana
+        combat_level: 596
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
+      - source: Kree'arra
+        combat_level: 580
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
   related_items:
-    - item_id: 11818
-      item_name: Godsword shard 1
+    - item_name: Godsword shard 1
+      item_id: 11818
       slug: godsword-shard-1
       relationship: component
-      description: First shard for godsword blade
-    - item_id: 11822
-      item_name: Godsword shard 3
+    - item_name: Godsword shard 3
+      item_id: 11822
       slug: godsword-shard-3
       relationship: component
-      description: Third shard for godsword blade
-    - item_id: 11798
-      item_name: Godsword blade
+    - item_name: Godsword blade
+      item_id: 11798
       slug: godsword-blade
       relationship: product
-      description: Created item from all three shards
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2.5 kg |
-
-    Combine all 3 shards at anvil (80 Smithing):
-    - Shard 1 + Shard 2 + Shard 3 = Godsword blade
-    - 100 Smithing XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Godsword shard 2 is the second of three shards dropped by the bosses and sub-bosses of the God Wars Dungeon. When combined with Godsword shard 1 and Godsword shard 3 on an anvil, it forms a Godsword blade, granting 100 Smithing experience and requiring level 80 Smithing. The blade must then have a hilt attached to become a fully usable Godsword.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-shard-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/godsword-shard-3.mdx
@@ -12,10 +12,9 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 11000
-  item:
-    type: godsword shard
-    tradeable: true
-    weight: 2.5
+  material:
+    type: bar
+    tier: high
   recipes:
     - skill: smithing
       level: 80
@@ -32,6 +31,32 @@ osrs:
           quantity: 1
       product: Godsword blade
       product_id: 11798
+  drop_table:
+    sources:
+      - source: General Graardor
+        combat_level: 624
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
+      - source: Commander Zilyana
+        combat_level: 596
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
+      - source: K'ril Tsutsaroth
+        combat_level: 650
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
+      - source: Kree'arra
+        combat_level: 580
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: "1/762"
+        members_only: true
   related_items:
     - item_id: 11818
       item_name: Godsword shard 1
@@ -49,17 +74,9 @@ osrs:
       relationship: product
       description: Created item from all three shards
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2.5 kg |
-
-    Combine all 3 shards at anvil (80 Smithing):
-    - Shard 1 + Shard 2 + Shard 3 = Godsword blade
-    - 100 Smithing XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Godsword shard 3 is the third of three shards dropped by the bosses and sub-bosses of the God Wars Dungeon. Players combine it with Godsword shard 1 and Godsword shard 2 on an anvil to forge a Godsword blade. The process requires level 80 Smithing and grants 100 Smithing experience.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-godsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-godsword.mdx
@@ -14,99 +14,63 @@ osrs:
   limit: 8
   equipment:
     slot: 2h
-    type: godsword
-    attack_style: slash
+    weapon_type: two-handed-sword
+    weight: 10
     attack_speed: 6
+    attack_range: 1
     requirements:
       attack: 75
-    stats:
-      attack_slash: 132
-      attack_crush: 80
-      strength: 132
+    attack_bonus:
+      stab: 0
+      slash: 132
+      crush: 80
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 132
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 8
   special_attack:
     name: Healing Blade
     energy: 50
-    effect: Doubled accuracy, +10% max hit, heals 50% of damage, restores 25% Prayer
-  recipes:
-    - skill: none
-      level: 0
-      xp: 0
-      materials:
-        - item_name: Godsword blade
-          item_id: 11798
-          quantity: 1
-        - item_name: Saradomin hilt
-          item_id: 11814
-          quantity: 1
-      product: Saradomin godsword
-      product_id: 11806
-      product_quantity: 1
-      facility: None
-      members_only: true
+    description: "Doubles accuracy and increases max hit by 10%; the user heals for 50% of the damage dealt and restores 25% of the damage dealt as prayer points."
+    accuracy_modifier: 2.0
+    damage_modifier: 1.1
+    heals: true
   related_items:
     - item_id: 11814
       item_name: Saradomin hilt
       slug: saradomin-hilt
       relationship: component
-      description: Hilt component
     - item_id: 11798
       item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Blade component
     - item_id: 11802
       item_name: Armadyl godsword
       slug: armadyl-godsword
       relationship: alternative
-      description: KO spec
     - item_id: 11804
       item_name: Bandos godsword
       slug: bandos-godsword
       relationship: alternative
-      description: Defence drain
     - item_id: 11808
       item_name: Zamorak godsword
       slug: zamorak-godsword
       relationship: alternative
-      description: Freeze spec
-  about: |-
-    Attach Saradomin hilt to Godsword blade.
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Saradomin hilt | Commander Zilyana (1/508) | ~24M gp |
-    | Godsword blade | GWD bosses | ~526K gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Slash attack | +132 |
-    | Crush attack | +80 |
-    | Strength | +132 |
-    | Prayer | +8 |
-    | Attack speed | 6 tick (3.6s) |
-    | Requirements | 75 Attack |
-
-    Healing Blade (50% energy):
-    - Doubled accuracy
-    - +10% max hit
-    - Heals HP equal to 50% of damage dealt
-    - Restores Prayer equal to 25% of damage dealt
-
-    Best For:
-    - Extended PvM trips (Slayer, bossing)
-    - Sustain without food/prayer pots
-    - GWD trips
-    - Budget Inferno attempts
-
-    Strategy: Swap to SGS for specs, use main weapon otherwise
-  market_strategy:
-    notes:
-      - Most "practical" godsword for PvM
-      - Reduces supply costs significantly
-      - Good for learning bosses
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Saradomin godsword (or)
+      slug: saradomin-godsword-or
+      relationship: variant
+  about: The Saradomin godsword is a healing godsword prized for sustained PvM training at Nightmare Zone and bossing encounters where damage taken is unavoidable. Its Healing Blade special attack consumes 50% energy, doubles accuracy and boosts max hit by 10% while restoring hitpoints equal to half the damage dealt and prayer equal to a quarter. Wielding it requires 75 Attack and it is created by attaching a Saradomin hilt to a completed godsword blade.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-hilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-hilt.mdx
@@ -12,52 +12,55 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10000
-  item:
-    type: godsword hilt
-    tradeable: true
-    weight: 2.5
-  recipes:
-    - skill: null
-      level: 0
-      materials:
-        - item_id: 11814
-          item_name: Saradomin hilt
-          quantity: 1
-        - item_id: 11798
-          item_name: Godsword blade
-          quantity: 1
-      product: Saradomin godsword
-      product_id: 11806
+  drop_table:
+    sources:
+      - source: Commander Zilyana
+        combat_level: 596
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/508"
+        members_only: true
   related_items:
-    - item_id: 11806
-      item_name: Saradomin godsword
-      slug: saradomin-godsword
-      relationship: product
-      description: Created weapon from hilt
     - item_id: 11798
       item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Required component for godsword
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2.5 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Saradomin godsword | Godsword blade + Saradomin hilt |
-
-    No skill requirements.
+      description: Combined with the hilt to forge the Saradomin godsword.
+    - item_id: 11806
+      item_name: Saradomin godsword
+      slug: saradomin-godsword
+      relationship: product
+      description: Finished weapon created from the hilt and a godsword blade.
+    - item_id: 11810
+      item_name: Armadyl hilt
+      slug: armadyl-hilt
+      relationship: alternative
+      description: Armadyl-aligned godsword hilt dropped by Kree'arra.
+    - item_id: 11812
+      item_name: Bandos hilt
+      slug: bandos-hilt
+      relationship: alternative
+      description: Bandos-aligned godsword hilt dropped by General Graardor.
+    - item_id: 11816
+      item_name: Zamorak hilt
+      slug: zamorak-hilt
+      relationship: alternative
+      description: Zamorak-aligned godsword hilt dropped by K'ril Tsutsaroth.
+  about: >-
+    The Saradomin hilt is a Saradomin-aligned godsword hilt dropped by
+    Commander Zilyana in the God Wars Dungeon. It is combined with a completed
+    godsword blade to forge the Saradomin godsword, whose Healing Blade special
+    attack restores hitpoints and prayer based on damage dealt. Among the four
+    godsword hilts it is consistently one of the most valuable, because the
+    Saradomin godsword remains a go-to sustain weapon for Nightmare Zone,
+    slayer, and long bossing trips where incoming damage is unavoidable.
   market_strategy:
     notes:
       - Farm Commander Zilyana
       - Healing spec weapon
       - Most expensive standard hilt
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
Batch 7 — first 15-item batch. Completes the godsword chain (3 shards → blade → 3 hilts → 3 godswords) plus 5 popular dragon weapons.

### Items enriched (15)
**Godsword chain (10):**
- 3 godsword shards (1, 2, 3) — GWD boss drop sources, smithing chain to blade
- godsword-blade — Smithing recipe combining all 3 shards
- 3 godsword hilts (Armadyl, Bandos, Saradomin) — boss-specific drops
- 3 godswords (Armadyl, Bandos, Saradomin) — equipment + special_attack

**Dragon weapons (5):**
- dragon-scimitar — Sever spec
- dragon-dagger — Puncture two-hit spec
- dragon-longsword — Cleave spec
- dragon-mace — Shatter spec
- dragon-battleaxe — Rampage spec

### Schema fixes from agent output
Recurring patterns the agents kept making:
- `attack_bonuses`/`defence_bonuses`/`other_bonuses` → singular `attack_bonus`/etc
- `monster_name`/`source_name` → `source` in drop_table.sources
- `skill: null` recipes → removed entirely (drop the recipe if no skill)
- `recipes[*].product` as object → split into `product` (string) + `product_id` + `product_quantity`
- Removed legacy `item: { type, tradeable, weight }` blocks
- Removed invented `combat_style`, `two_handed`, `weapon_category` fields
- Wiki-correct stats per agent flags (dragon-mace Shatter is +25% accuracy / +50% damage)

## Test plan
- [ ] Verify astro-kbve builds without schema errors
- [ ] Spot-check godsword chain renders cross-links correctly
- [ ] Verify dragon weapon special_attack cards render