### PR TITLE
fix(kbve-kubectl): set PATH in runtime, drop unused import (#9809)

### DIFF
--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -136,6 +136,8 @@ COPY --from=tools-dl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=tools-dl /usr/local/bin/jq /usr/local/bin/jq
 COPY --from=builder /app/target/release/kbve-kubectl /usr/local/bin/kbve-kubectl
 
+ENV PATH=/usr/local/bin:/usr/bin:/bin
+
 WORKDIR /app
 USER 10001:10001
 

--- a/apps/vm/kubectl/src/main.rs
+++ b/apps/vm/kubectl/src/main.rs
@@ -1,6 +1,6 @@
 use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
 use clap::{Parser, Subcommand};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
 use std::{process::ExitCode, time::Duration};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};


### PR DESCRIPTION
## Summary
- **Runtime fix**: Set `PATH=/usr/local/bin:/usr/bin:/bin` in the chiseled scratch image. Without this, `docker run --entrypoint sleep` failed with `sleep: executable file not found in PATH`. The chisel-based scratch image inherits no environment variables, and busybox symlinks live in `/usr/bin/`.
- **Build cleanup**: Remove unused `Serialize` import from `main.rs` that was producing a compile warning.

## Failure
\`\`\`
docker: Error response from daemon: failed to create task for container: failed to create shim task:
OCI runtime create failed: runc create failed: unable to start container process:
error during container init: exec: "sleep": executable file not found in $PATH
\`\`\`

## Test plan
- [ ] Image builds without warnings
- [ ] `docker run --entrypoint sleep kbve/kubectl:e2e infinity` keeps the container running
- [ ] e2e suite executes (shell, tools, kbve-kubectl CLI)
- [ ] CI - Docker / kbve-kubectl publishes to ghcr.io

Ref #9809