### PR TITLE
fix(astro-kbve): manually enrich 20 OSRS items to v3 (batch 8)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arctic-pine-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arctic-pine-logs.mdx
@@ -12,8 +12,41 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 11000
-  about: "Arctic pine logs is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
+  about: "Arctic pine logs are cut from arctic pine trees on the island of Neitiznot and require level 54 Woodcutting to harvest, yielding 40 Woodcutting experience per log. They are burned for 125 Firemaking experience at level 42 and can be split at a woodcutting stump to make split logs used in the construction of Neitiznot shields. Because the trees are fairly rare outside Neitiznot, these logs are most often gathered by members training Woodcutting alongside Fremennik Isles content."
+  material:
+    type: log
+    tier: mid
+  woodcutting:
+    level: 54
+    xp: 40
+    tool: Any axe
+    locations:
+      - Neitiznot
+  recipes:
+    - skill: firemaking
+      level: 42
+      xp: 125
+      materials:
+        - item_name: Arctic pine logs
+          item_id: 10810
+          quantity: 1
+      product: Fire
+  related_items:
+    - item_id: 1517
+      item_name: Maple logs
+      slug: maple-logs
+      relationship: alternative
+      description: Standard mid-tier log
+    - item_id: 1515
+      item_name: Yew logs
+      slug: yew-logs
+      relationship: alternative
+      description: Higher-tier standard log
+    - item_name: Split log
+      slug: split-log
+      relationship: product
+      description: Split arctic pine log used for Neitiznot shield
+  mdx_version: 3
   mdx_updated: "2026-04-10"
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/avantoe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/avantoe.mdx
@@ -12,102 +12,72 @@ osrs:
   lowalch: 19
   highalch: 28
   limit: 13000
-  herb:
-    type: clean
+  about: Avantoe is a mid-tier herb used in Herblore to brew Fishing, Super energy, and Hunter potions. Players clean it from grimy avantoe at level 48 Herblore or grow their own by planting avantoe seeds in a herb patch at level 50 Farming. It is a staple ingredient for mid-level potion training and supply runs.
+  material:
+    type: herb
     tier: mid
   farming:
     level: 50
-    xp: 61.5
+    plant_xp: 54.5
+    harvest_xp: 61.5
+    patch_type: herb
     growth_time: 80
+    payment: 2 snape grass
     seed_id: 5298
     seed_name: Avantoe seed
-  herblore:
-    cleaning_level: 48
-    cleaning_xp: 10
-    grimy_id: 211
-    grimy_name: Grimy avantoe
   recipes:
     - skill: herblore
+      level: 48
+      xp: 9.5
+      action: Clean grimy avantoe
+      materials:
+        - item_name: Grimy avantoe
+          item_id: 211
+          quantity: 1
+    - skill: herblore
       level: 50
-      xp: 100
+      xp: 0
+      action: Make Avantoe potion (unf)
       materials:
         - item_name: Avantoe
           item_id: 261
           quantity: 1
-        - item_name: Snape grass
-          item_id: 231
-          quantity: 1
         - item_name: Vial of water
           item_id: 227
           quantity: 1
-      product: Fishing potion(3)
-      product_id: 151
-      members_only: true
-    - skill: herblore
-      level: 52
-      xp: 117.5
-      materials:
-        - item_name: Avantoe
-          item_id: 261
-          quantity: 1
-        - item_name: Mort myre fungus
-          item_id: 2970
-          quantity: 1
-        - item_name: Vial of water
-          item_id: 227
-          quantity: 1
-      product: Super energy(3)
-      product_id: 3018
-      members_only: true
-    - skill: herblore
-      level: 66
-      xp: 155
-      materials:
-        - item_name: Avantoe
-          item_id: 261
-          quantity: 1
-        - item_name: Kebbit teeth dust
-          item_id: 10111
-          quantity: 1
-        - item_name: Vial of water
-          item_id: 227
-          quantity: 1
-      product: Hunter potion(3)
-      product_id: 10000
-      members_only: true
   related_items:
-    - item_id: 211
-      item_name: Grimy avantoe
+    - item_name: Grimy avantoe
+      item_id: 211
       slug: grimy-avantoe
-      relationship: component
-      description: Uncleaned version
-    - item_id: 5298
-      item_name: Avantoe seed
+      relationship: variant
+    - item_name: Avantoe seed
+      item_id: 5298
       slug: avantoe-seed
       relationship: component
-      description: For farming
-    - item_id: 3016
-      item_name: Super energy(4)
+    - item_name: Avantoe potion (unf)
+      item_id: 103
+      slug: avantoe-potion-unf
+      relationship: product
+    - item_name: Super energy(4)
+      item_id: 3016
       slug: super-energy-4
       relationship: product
-      description: Primary product
-    - item_id: 2970
-      item_name: Mort myre fungus
-      slug: mort-myre-fungus
-      relationship: component
-      description: Super energy secondary
-  market_strategy:
-    profit_formulas:
-      - Super energy - Avantoe - Mort myre fungus - Vial
-    notes:
-      - Most common use for avantoe
-      - "Calculate:"
-      - Base ingredient for stamina potions
-      - 50 Farming to grow
-      - Moderate profit per run
-      - Consider disease risk vs profit
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Fishing potion(4)
+      slug: fishing-potion-4
+      relationship: product
+    - item_name: Hunter potion(4)
+      slug: hunter-potion-4
+      relationship: product
+    - item_name: Irit leaf
+      item_id: 259
+      slug: irit-leaf
+      relationship: alternative
+    - item_name: Kwuarm
+      item_id: 263
+      slug: kwuarm
+      relationship: alternative
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cadantine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cadantine.mdx
@@ -12,102 +12,73 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 11000
-  herb:
-    type: clean
+  material:
+    type: herb
     tier: high
-  herblore:
-    cleaning_level: 65
-    cleaning_xp: 12.5
   farming:
     level: 67
+    plant_xp: 80
+    harvest_xp: 91.5
+    patch_type: herb
+    growth_time: 80
+    payment: 10 white berries
     seed_id: 5301
     seed_name: Cadantine seed
-  drop_table:
-    sources:
-      - source: Aberrant spectre
-        source_id: 2927
-        combat_level: 96
-        quantity: "1"
-        rarity: common
-        members_only: true
   recipes:
     - skill: herblore
-      level: 66
-      xp: 150
+      level: 65
+      xp: 12.5
       materials:
-        - item_name: Cadantine potion (unf)
-          item_id: 103
+        - item_name: Grimy cadantine
+          item_id: 215
           quantity: 1
-        - item_name: White berries
-          item_id: 239
-          quantity: 1
-      product: Super defence(3)
-      product_id: 2442
+      product: Cadantine
+      product_id: 265
       product_quantity: 1
       facility: None
       members_only: true
     - skill: herblore
-      level: 80
-      xp: 155
+      level: 66
+      xp: 0
       materials:
-        - item_name: Cadantine blood potion (unf)
-          item_id: 22443
+        - item_name: Cadantine
+          item_id: 265
           quantity: 1
-        - item_name: Wine of zamorak
-          item_id: 245
+        - item_name: Vial of water
+          item_id: 227
           quantity: 1
-      product: Bastion potion(3)
-      product_id: 22461
+      product: Cadantine potion (unf)
+      product_id: 103
       product_quantity: 1
       facility: None
       members_only: true
   related_items:
-    - item_id: 2442
-      item_name: Super defence(3)
-      slug: super-defence-3
-      relationship: product
-      description: Main product
-    - item_id: 239
-      item_name: White berries
-      slug: white-berries
-      relationship: component
-      description: Secondary
-    - item_id: 22461
-      item_name: Bastion potion(3)
-      slug: bastion-potion-3
-      relationship: product
-      description: Raid potion
+    - item_id: 215
+      item_name: Grimy cadantine
+      slug: grimy-cadantine
+      relationship: variant
     - item_id: 5301
       item_name: Cadantine seed
       slug: cadantine-seed
       relationship: component
-      description: Farming seed
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 65 |
-    | XP | 12.5 |
-    | Product | Cadantine (clean) |
-  market_strategy:
-    title: |-
-      - Super defence potions
-      - Super combat chain
-      - Bastion potions (raids)
-      - Battlemage potions
-    notes:
-      - Super defence production
-      - Bastion potion demand
-      - Good value herb
-      - Super defence potions
-      - Super combat chain
-      - Bastion potions (raids)
-      - Battlemage potions
-      - Farm runs profitable
-      - 67 Farming required
-      - White berries secondary
-      - Good herb value
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Cadantine potion (unf)
+      slug: cadantine-potion-unf
+      relationship: product
+    - item_id: 2442
+      item_name: Super defence(4)
+      slug: super-defence-4
+      relationship: product
+    - item_id: 3000
+      item_name: Snapdragon
+      slug: snapdragon
+      relationship: alternative
+    - item_id: 2481
+      item_name: Lantadyme
+      slug: lantadyme
+      relationship: alternative
+  about: Cadantine is a high-tier herb obtained by cleaning grimy cadantine at level 65 Herblore for 12.5 experience, or by farming cadantine seeds at level 67 Farming. Its primary use is creating Cadantine potion (unf) with a vial of water, which is then combined with white berries to produce Super defence potions at level 66 Herblore. Players can also grow it themselves, paying 10 white berries to a farmer to protect the herb patch during growth.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed.mdx
@@ -12,83 +12,66 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 11000
-  herb:
-    type: clean
+  about: Dwarf weed is a high-tier herb cleaned from grimy dwarf weed at level 70 Herblore. It is best known as the key ingredient in ranging potions, which provide a Ranged boost for PvM and PvP. It can also be used in ancient brews and other niche mixes, and is grown by players with 79 Farming from dwarf weed seeds in herb patches.
+  material:
+    type: herb
     tier: high
   farming:
     level: 79
-    xp: 170.5
+    plant_xp: 98.5
+    harvest_xp: 137.5
+    patch_type: herb
     growth_time: 80
+    payment: 6 mahogany logs
     seed_id: 5303
     seed_name: Dwarf weed seed
-  herblore:
-    cleaning_level: 70
-    cleaning_xp: 13.8
-    grimy_id: 217
-    grimy_name: Grimy dwarf weed
   recipes:
-    - skill: herblore
+    - name: Clean grimy dwarf weed
+      skill: herblore
+      level: 70
+      xp: 13.8
+      materials:
+        - item_name: Grimy dwarf weed
+          item_id: 217
+          quantity: 1
+    - name: Make Dwarf weed potion (unf)
+      skill: herblore
       level: 72
-      xp: 162.5
+      xp: 0
       materials:
         - item_name: Dwarf weed
           item_id: 267
           quantity: 1
-        - item_name: Wine of zamorak
-          item_id: 245
+        - item_name: Vial of water
+          item_id: 227
           quantity: 1
-      product: Ranging potion(3)
-      product_id: 169
-      members_only: true
-    - skill: herblore
-      level: 85
-      xp: 190
-      materials:
-        - item_name: Dwarf weed
-          item_id: 267
-          quantity: 1
-        - item_name: Nihil dust
-          item_id: 26373
-          quantity: 1
-      product: Ancient brew(4)
-      product_id: 26340
-      members_only: true
   related_items:
-    - item_id: 169
-      item_name: Ranging potion(3)
-      slug: ranging-potion-3
-      relationship: product
-      description: Main product
-    - item_id: 245
-      item_name: Wine of zamorak
-      slug: wine-of-zamorak
+    - item_id: 217
+      item_name: Grimy dwarf weed
+      slug: grimy-dwarf-weed
+      relationship: variant
+    - item_id: 5303
+      item_name: Dwarf weed seed
+      slug: dwarf-weed-seed
       relationship: component
-      description: Secondary ingredient
-    - item_id: 269
-      item_name: Torstol
-      slug: torstol
-      relationship: upgrade
-      description: Higher tier herb
+    - item_id: 105
+      item_name: Dwarf weed potion (unf)
+      slug: dwarf-weed-potion-unf
+      relationship: product
+    - item_id: 2444
+      item_name: Ranging potion(4)
+      slug: ranging-potion-4
+      relationship: product
     - item_id: 2481
       item_name: Lantadyme
       slug: lantadyme
       relationship: alternative
-      description: Similar tier herb
-  market_strategy:
-    notes:
-      - Ranging potions essential
-      - High-level herb
-      - Consistent demand
-      - Ranging potions (PvM/PvP)
-      - Ancient brews (raids)
-      - Menaphite remedy (ToA)
-      - High-level content
-      - Ranging pots always needed
-      - Wine of Zamorak expensive
-      - Ancient brew for mage builds
-      - High farm profit
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 269
+      item_name: Torstol
+      slug: torstol
+      relationship: alternative
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guam-leaf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guam-leaf.mdx
@@ -12,18 +12,81 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  material:
+    type: herb
+    tier: low
+  farming:
+    farming_level: 9
+    plant_xp: 11
+    harvest_xp: 12.5
+    patch_type: herb
+    growth_time: 80
+    payment: 1 sack of potatoes
+    payment_item_id: 5418
+    seed_id: 5291
+    seed_name: Guam seed
+    min_yield: 3
+    compost_type: compost
+  recipes:
+    - name: Clean grimy guam leaf
+      skill: herblore
+      level: 3
+      xp: 2.5
+      materials:
+        - item_name: Grimy guam leaf
+          item_id: 199
+          quantity: 1
+      product: Guam leaf
+      product_id: 249
+      product_quantity: 1
+    - name: Make Guam potion (unf)
+      skill: herblore
+      level: 3
+      xp: 0
+      materials:
+        - item_name: Guam leaf
+          item_id: 249
+          quantity: 1
+        - item_name: Vial of water
+          item_id: 227
+          quantity: 1
+      product: Guam potion (unf)
+      product_id: 91
+      product_quantity: 1
   related_items:
     - item_id: 199
       item_name: Grimy guam leaf
       slug: grimy-guam-leaf
+      relationship: variant
+      description: Uncleaned version of the herb
+    - item_id: 5291
+      item_name: Guam seed
+      slug: guam-seed
       relationship: component
-      description: Uncleaned version
+      description: Seed planted in a herb patch to grow guam
+    - item_id: 91
+      item_name: Guam potion (unf)
+      slug: guam-potion-unf
+      relationship: product
+      description: Unfinished potion made with a vial of water
+    - item_id: 2428
+      item_name: Attack potion(4)
+      slug: attack-potion-4
+      relationship: product
+      description: Finished Attack potion brewed from guam potion (unf)
+    - item_name: Guam tar
+      slug: guam-tar
+      relationship: product
+      description: Swamp lizard ammunition crafted from guam leaves
+    - item_id: 251
+      item_name: Marrentill
+      slug: marrentill
+      relationship: alternative
+      description: Next-tier herb in the Herblore progression
   about: |-
-    > _"A bitter green herb."_
-
-    Guam leaf is the lowest-tier clean herb. Used to make guam potions (unf) which are the base for attack potions (3 Herblore) and guam tar.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Guam leaf is the lowest-tier clean herb in Old School RuneScape and the first herb a player can use in Herblore. It is the base ingredient for Attack potions and is also used to craft guam tar for fuelling swamp lizards. Cleaning a grimy guam leaf requires only level 3 Herblore, and the herb can be farmed at level 9 Farming in any herb patch.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/harralander.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/harralander.mdx
@@ -12,13 +12,74 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 13000
-  related_items: []
+  material:
+    type: herb
+    tier: mid-low
+  farming:
+    level: 26
+    plant_xp: 24
+    harvest_xp: 27
+    patch_type: herb
+    growth_time: 80
+    payment: 1 bucket of compost
+    seed_id: 5294
+    seed_name: Harralander seed
+  recipes:
+    - name: Clean grimy harralander
+      skill: herblore
+      level: 20
+      xp: 6.25
+      materials:
+        - item_name: Grimy harralander
+          item_id: 205
+          quantity: 1
+    - name: Make Harralander potion (unf)
+      skill: herblore
+      level: 22
+      xp: 0
+      materials:
+        - item_name: Harralander
+          item_id: 255
+          quantity: 1
+        - item_name: Vial of water
+          quantity: 1
+  related_items:
+    - item_name: Grimy harralander
+      item_id: 205
+      slug: grimy-harralander
+      relationship: variant
+    - item_name: Harralander seed
+      item_id: 5294
+      slug: harralander-seed
+      relationship: component
+    - item_name: Harralander potion (unf)
+      slug: harralander-potion-unf
+      relationship: product
+    - item_name: Combat potion(4)
+      slug: combat-potion-4
+      relationship: product
+    - item_name: Restore potion(4)
+      slug: restore-potion-4
+      relationship: product
+    - item_name: Energy potion(4)
+      item_id: 3008
+      slug: energy-potion-4
+      relationship: product
+    - item_name: Compost potion(4)
+      slug: compost-potion-4
+      relationship: product
+    - item_name: Tarromin
+      item_id: 253
+      slug: tarromin
+      relationship: alternative
+    - item_name: Ranarr weed
+      item_id: 257
+      slug: ranarr-weed
+      relationship: alternative
   about: |-
-    > _"A useful herb."_
-
-    Harralander is used to make restore potions (22 Herblore), energy potions (26 Herblore), and combat potions (36 Herblore). A mid-tier herb commonly obtained from monster drops.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Harralander is a mid-low tier herb cleaned at level 20 Herblore, obtained from monster drops or by farming a harralander seed in a herb patch at level 26 Farming. Combined with a vial of water it becomes harralander potion (unf), the base for compost, restore, energy, and combat potions. It is a reliable staple herb for mid-level Herblore training and farming runs.
+  mdx_version: 3
+  mdx_updated: '2026-04-10'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/irit-leaf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/irit-leaf.mdx
@@ -12,102 +12,77 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 13000
-  herb:
-    type: clean
+  material:
+    type: herb
     tier: mid
-  herblore:
-    cleaning_level: 40
-    cleaning_xp: 8.8
   farming:
     level: 44
+    plant_xp: 43
+    harvest_xp: 48.5
+    patch_type: herb
+    growth_time: 80
+    payment: 5 watermelons
     seed_id: 5297
     seed_name: Irit seed
-  drop_table:
-    sources:
-      - source: Aberrant spectre
-        source_id: 2927
-        combat_level: 96
-        quantity: "1"
-        rarity: common
-        members_only: true
   recipes:
     - skill: herblore
-      level: 45
-      xp: 100
+      level: 40
+      xp: 8.8
       materials:
-        - item_name: Irit potion (unf)
-          item_id: 101
+        - item_name: Grimy irit leaf
+          item_id: 209
           quantity: 1
-        - item_name: Eye of newt
-          item_id: 221
-          quantity: 1
-      product: Super attack(3)
-      product_id: 2436
+      product: Irit leaf
+      product_id: 259
       product_quantity: 1
       facility: None
       members_only: true
     - skill: herblore
-      level: 48
-      xp: 106.3
+      level: 45
+      xp: 0
       materials:
-        - item_name: Irit potion (unf)
-          item_id: 101
+        - item_name: Irit leaf
+          item_id: 259
           quantity: 1
-        - item_name: Unicorn horn dust
-          item_id: 235
+        - item_name: Vial of water
+          item_id: 227
           quantity: 1
-      product: Superantipoison(3)
-      product_id: 2448
+      product: Irit potion (unf)
+      product_id: 101
       product_quantity: 1
       facility: None
       members_only: true
   related_items:
-    - item_id: 2436
-      item_name: Super attack(3)
-      slug: super-attack-3
-      relationship: product
-      description: Main product
-    - item_id: 221
-      item_name: Eye of newt
-      slug: eye-of-newt
-      relationship: component
-      description: Secondary
+    - item_id: 209
+      item_name: Grimy irit leaf
+      slug: grimy-irit-leaf
+      relationship: variant
     - item_id: 5297
       item_name: Irit seed
       slug: irit-seed
       relationship: component
-      description: Farming seed
-    - item_id: 263
-      item_name: Kwuarm
-      slug: kwuarm
+    - item_id: 101
+      item_name: Irit potion (unf)
+      slug: irit-potion-unf
+      relationship: product
+    - item_id: 2436
+      item_name: Super attack(4)
+      slug: super-attack-4
+      relationship: product
+    - item_name: Super antipoison(4)
+      slug: super-antipoison-4
+      relationship: product
+    - item_id: 257
+      item_name: Ranarr weed
+      slug: ranarr-weed
       relationship: alternative
-      description: Higher tier herb
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 40 |
-    | XP | 8.8 |
-    | Product | Irit leaf (clean) |
-  market_strategy:
-    title: |-
-      - Super attack potions
-      - Super combat chain
-      - Antidote++ production
-      - Ironman accounts
-    notes:
-      - Super attack production
-      - Superantipoison demand
-      - Moderate value
-      - Super attack potions
-      - Super combat chain
-      - Antidote++ production
-      - Ironman accounts
-      - Farm runs profitable
-      - Common monster drop
-      - Super attack always needed
-      - Mid-tier pricing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 261
+      item_name: Avantoe
+      slug: avantoe
+      relationship: alternative
+  about: Irit leaf is a mid-tier herb cleaned at level 40 Herblore for 8.8 XP from its grimy form. Combined with a vial of water it makes an irit potion (unf), the base for super attack potions, superantipoison, and (with coconut milk) antidote++. Farmers can grow it by planting an irit seed in a herb patch at level 44 Farming.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kwuarm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kwuarm.mdx
@@ -12,83 +12,78 @@ osrs:
   lowalch: 21
   highalch: 32
   limit: 13000
-  herb:
-    type: clean
-    tier: mid
+  about: >-
+    Kwuarm is a mid-to-high tier herb used primarily to brew Super strength
+    potions and Weapon poison. Players obtain it by cleaning grimy kwuarm at
+    Herblore level 54, or by growing it from a Kwuarm seed at Farming level 56.
+    Its steady demand from combat training, PvM prep, and poisoned weapon
+    crafting keeps it a reliable staple on the Grand Exchange.
+  material:
+    type: herb
+    tier: mid-high
   farming:
     level: 56
-    xp: 120
+    plant_xp: 69
+    harvest_xp: 78
+    patch_type: herb
     growth_time: 80
+    payment: 3 limpwurt roots
     seed_id: 5299
     seed_name: Kwuarm seed
-  herblore:
-    cleaning_level: 54
-    cleaning_xp: 11.3
-    grimy_id: 213
-    grimy_name: Grimy kwuarm
   recipes:
     - skill: herblore
-      level: 55
-      xp: 100
+      level: 54
+      xp: 10.5
+      action: Clean grimy kwuarm
       materials:
-        - item_name: Kwuarm
-          item_id: 263
+        - item_name: Grimy kwuarm
+          item_id: 213
           quantity: 1
-        - item_name: Limpwurt root
-          item_id: 225
-          quantity: 1
-      product: Super strength(3)
-      product_id: 157
+      product: Kwuarm
+      product_id: 263
       members_only: true
     - skill: herblore
-      level: 60
-      xp: 137.5
+      level: 55
+      xp: 0
+      action: Make Kwuarm potion (unf)
       materials:
         - item_name: Kwuarm
           item_id: 263
           quantity: 1
-        - item_name: Dragon scale dust
-          item_id: 241
+        - item_name: Vial of water
+          item_id: 227
           quantity: 1
-      product: Weapon poison(3)
-      product_id: 187
+      product: Kwuarm potion (unf)
       members_only: true
   related_items:
-    - item_id: 157
-      item_name: Super strength(3)
-      slug: super-strength-3
-      relationship: product
-      description: Main product
-    - item_id: 225
-      item_name: Limpwurt root
-      slug: limpwurt-root
+    - item_name: Grimy kwuarm
+      item_id: 213
+      slug: grimy-kwuarm
+      relationship: variant
+    - item_name: Kwuarm seed
+      item_id: 5299
+      slug: kwuarm-seed
       relationship: component
-      description: Secondary ingredient
-    - item_id: 257
-      item_name: Ranarr weed
-      slug: ranarr-weed
+    - item_name: Kwuarm potion (unf)
+      slug: kwuarm-potion-unf
+      relationship: product
+    - item_name: Super strength(4)
+      item_id: 2440
+      slug: super-strength-4
+      relationship: product
+    - item_name: Weapon poison
+      slug: weapon-poison
+      relationship: product
+    - item_name: Avantoe
+      item_id: 261
+      slug: avantoe
       relationship: alternative
-      description: Similar value herb
-    - item_id: 259
-      item_name: Irit leaf
-      slug: irit-leaf
-      relationship: downgrade
-      description: Lower tier herb
-  market_strategy:
-    notes:
-      - Super strength essential
-      - Weapon poison niche use
-      - Mid-tier pricing
-      - Super strength potions
-      - Combat training
-      - PvM preparation
-      - Divine potions
-      - Super strength always needed
-      - Often botted/farmed
-      - Stable prices
-      - Good farm profit
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Snapdragon
+      item_id: 3000
+      slug: snapdragon
+      relationship: alternative
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lantadyme.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lantadyme.mdx
@@ -12,102 +12,77 @@ osrs:
   lowalch: 27
   highalch: 40
   limit: 11000
-  herb:
-    type: clean
+  material:
+    type: herb
     tier: high
-  herblore:
-    cleaning_level: 67
-    cleaning_xp: 13.1
   farming:
     level: 73
+    plant_xp: 87
+    harvest_xp: 101.5
+    patch_type: herb
+    growth_time: 80
+    payment: 10 poison ivy berries
     seed_id: 5302
     seed_name: Lantadyme seed
-  drop_table:
-    sources:
-      - source: Aberrant spectre
-        source_id: 2927
-        combat_level: 96
-        quantity: "1"
-        rarity: common
-        members_only: true
   recipes:
     - skill: herblore
-      level: 69
-      xp: 157.5
+      level: 67
+      xp: 13.1
       materials:
-        - item_name: Lantadyme potion (unf)
-          item_id: 2483
+        - item_name: Grimy lantadyme
+          item_id: 2485
           quantity: 1
-        - item_name: Dragon scale dust
-          item_id: 241
-          quantity: 1
-      product: Antifire potion(3)
-      product_id: 2452
+      product: Lantadyme
+      product_id: 2481
       product_quantity: 1
       facility: None
       members_only: true
     - skill: herblore
-      level: 76
-      xp: 172.5
+      level: 69
+      xp: 0
       materials:
-        - item_name: Lantadyme potion (unf)
-          item_id: 2483
+        - item_name: Lantadyme
+          item_id: 2481
           quantity: 1
-        - item_name: Potato cactus
-          item_id: 3138
+        - item_name: Vial of water
+          item_id: 227
           quantity: 1
-      product: Magic potion(3)
-      product_id: 3040
+      product: Lantadyme potion (unf)
+      product_id: 2483
       product_quantity: 1
       facility: None
       members_only: true
   related_items:
-    - item_id: 2452
-      item_name: Antifire potion(3)
-      slug: antifire-potion-3
-      relationship: product
-      description: Main product
-    - item_id: 241
-      item_name: Dragon scale dust
-      slug: dragon-scale-dust
-      relationship: component
-      description: Secondary
-    - item_id: 3040
-      item_name: Magic potion(3)
-      slug: magic-potion-3
-      relationship: product
-      description: Alternative product
+    - item_id: 2485
+      item_name: Grimy lantadyme
+      slug: grimy-lantadyme
+      relationship: variant
     - item_id: 5302
       item_name: Lantadyme seed
       slug: lantadyme-seed
       relationship: component
-      description: Farming seed
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 67 |
-    | XP | 13.1 |
-    | Product | Lantadyme (clean) |
-  market_strategy:
-    title: |-
-      - Antifire potions (dragons)
-      - Magic potions
-      - Extended antifire chain
-      - Ironman accounts
-    notes:
-      - Antifire production
-      - Magic potion demand
-      - Steady pricing
-      - Antifire potions (dragons)
-      - Magic potions
-      - Extended antifire chain
-      - Ironman accounts
-      - Farm runs profitable
-      - 73 Farming required
-      - Dragon scale dust expensive
-      - Essential for dragons
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 2483
+      item_name: Lantadyme potion (unf)
+      slug: lantadyme-potion-unf
+      relationship: product
+    - item_id: 3040
+      item_name: Magic potion(4)
+      slug: magic-potion-4
+      relationship: product
+    - item_name: Antifire potion(4)
+      slug: antifire-potion-4
+      relationship: product
+    - item_id: 265
+      item_name: Cadantine
+      slug: cadantine
+      relationship: alternative
+    - item_id: 267
+      item_name: Dwarf weed
+      slug: dwarf-weed
+      relationship: alternative
+  about: Lantadyme is a high-level herb used by herblorists to brew Magic potions and Antifire potions. Players obtain it by cleaning grimy lantadyme at Herblore 67 or by harvesting lantadyme seeds planted in a herb patch at Farming 73. Once cleaned, it is combined with a vial of water to create a lantadyme potion (unf), the base ingredient for both potions.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/logs.mdx
@@ -12,20 +12,36 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 15000
+  about: Logs are the most basic wood type in Old School RuneScape, obtained by chopping regular trees at level 1 Woodcutting. They are free-to-play and form the foundation of early Firemaking and Fletching training, requiring only level 1 in each skill. New players commonly use them to light fires, fletch arrow shafts, and create shortbows and longbows.
   material:
     type: log
-    tier: basic
+    tier: low
   woodcutting:
     level: 1
     xp: 25
+    tool: Any axe
     locations:
       - Lumbridge
-      - Draynor
+      - Draynor Village
       - Varrock
   recipes:
+    - skill: firemaking
+      level: 1
+      xp: 40
+      materials:
+        - item_name: Logs
+          item_id: 1511
+          quantity: 1
+        - item_name: Tinderbox
+          item_id: 590
+          quantity: 1
+          consumed: false
+      product: Fire
     - skill: fletching
       level: 1
       xp: 5
+      tools:
+        - Knife
       materials:
         - item_name: Logs
           item_id: 1511
@@ -36,57 +52,52 @@ osrs:
     - skill: fletching
       level: 5
       xp: 5
+      tools:
+        - Knife
       materials:
         - item_name: Logs
           item_id: 1511
           quantity: 1
       product: Shortbow (u)
       product_id: 50
-      product_quantity: 1
     - skill: fletching
       level: 10
       xp: 10
+      tools:
+        - Knife
       materials:
         - item_name: Logs
           item_id: 1511
           quantity: 1
       product: Longbow (u)
       product_id: 48
-      product_quantity: 1
   related_items:
-    - item_id: 52
-      item_name: Arrow shaft
-      slug: arrow-shaft
-      relationship: product
-      description: Primary fletching output
-    - item_id: 50
-      item_name: Shortbow (u)
-      slug: shortbow-u
-      relationship: product
-      description: Unstrung shortbow
-    - item_id: 48
-      item_name: Longbow (u)
-      slug: longbow-u
-      relationship: product
-      description: Unstrung longbow
     - item_id: 1521
       item_name: Oak logs
       slug: oak-logs
+      relationship: upgrade
+    - item_id: 1519
+      item_name: Willow logs
+      slug: willow-logs
+      relationship: upgrade
+    - item_id: 1517
+      item_name: Maple logs
+      slug: maple-logs
+      relationship: upgrade
+    - item_id: 1515
+      item_name: Yew logs
+      slug: yew-logs
+      relationship: upgrade
+    - item_id: 1513
+      item_name: Magic logs
+      slug: magic-logs
+      relationship: upgrade
+    - item_id: 2862
+      item_name: Achey tree logs
+      slug: achey-tree-logs
       relationship: alternative
-      description: Next tier logs
-    - item_id: 946
-      item_name: Knife
-      slug: knife
-      relationship: component
-      description: Required tool
-  market_strategy:
-    title: Arrow Shaft Processing
-    notes:
-      - 1 Log = 15 Arrow shafts
-      - Compare  vs
-      - High volume, low margin flip - good for bulk processing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-logs.mdx
@@ -15,24 +15,23 @@ osrs:
   material:
     type: log
     tier: high
+  about: Magic logs are the highest tier of standard logs, chopped from magic trees at level 75 Woodcutting for 250 experience per log. They are a members-only resource used to fletch magic shortbows and longbows, and burn for 303.8 Firemaking experience at level 75. Their slow respawn time and high requirements make them one of the most valuable routine logs in the game.
   woodcutting:
     level: 75
     xp: 250
+    tool: Any axe
     locations:
-      - Woodcutting Guild
       - Sorcerer's Tower
       - Mage Training Arena
+      - Eagles' Peak
   recipes:
-    - skill: fletching
+    - skill: firemaking
       level: 75
-      xp: 5
+      xp: 303.8
       materials:
         - item_name: Magic logs
           item_id: 1513
           quantity: 1
-      product: Arrow shaft
-      product_id: 52
-      product_quantity: 90
       members_only: true
     - skill: fletching
       level: 80
@@ -42,7 +41,7 @@ osrs:
           item_id: 1513
           quantity: 1
       product: Magic shortbow (u)
-      product_id: 64
+      product_id: 70
       product_quantity: 1
       members_only: true
     - skill: fletching
@@ -53,63 +52,36 @@ osrs:
           item_id: 1513
           quantity: 1
       product: Magic longbow (u)
-      product_id: 66
-      product_quantity: 1
-      members_only: true
-    - skill: fletching
-      level: 78
-      xp: 70
-      materials:
-        - item_name: Magic logs
-          item_id: 1513
-          quantity: 1
-      product: Magic stock
-      product_id: 9448
+      product_id: 72
       product_quantity: 1
       members_only: true
   related_items:
-    - item_id: 66
-      item_name: Magic longbow (u)
-      slug: magic-longbow-u
-      relationship: product
-      description: Unstrung output
-    - item_id: 859
-      item_name: Magic longbow
-      slug: magic-longbow
-      relationship: product
-      description: Strung bow
-    - item_id: 1777
-      item_name: Bow string
-      slug: bow-string
-      relationship: component
-      description: Required for stringing
+    - item_id: 1511
+      item_name: Logs
+      slug: logs
+      relationship: downgrade
+    - item_id: 1521
+      item_name: Oak logs
+      slug: oak-logs
+      relationship: downgrade
+    - item_id: 1519
+      item_name: Willow logs
+      slug: willow-logs
+      relationship: downgrade
+    - item_id: 1517
+      item_name: Maple logs
+      slug: maple-logs
+      relationship: downgrade
     - item_id: 1515
       item_name: Yew logs
       slug: yew-logs
+      relationship: downgrade
+    - item_id: 19669
+      item_name: Redwood logs
+      slug: redwood-logs
       relationship: alternative
-      description: Lower tier logs
-    - item_id: 561
-      item_name: Nature rune
-      slug: nature-rune
-      relationship: component
-      description: For High Alchemy
-  market_strategy:
-    title: Magic Longbow Processing
-    steps:
-      - order: 1
-        action: Buy Magic logs on GE
-      - order: 2
-        action: Fletch into Magic longbow (u)
-      - order: 3
-        action: Add Bow string for Magic longbow
-      - order: 4
-        action: High Alch for 1,536 GP
-    profit_formulas:
-      - 1,536 - Magic log - Bow string - Nature rune = Alch profit
-    notes:
-      - Higher margins than yew, but slower sell speed
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-logs.mdx
@@ -12,58 +12,50 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 11000
-  item_id: 6332
-  type: logs
-  tradeable: true
-  weight: 1.36
-  buy_limit: 11000
-  requirements:
-    skills:
-      - skill: woodcutting
-        level: 50
-        context: to cut
-  obtaining:
-    woodcutting:
+  material:
+    type: log
+    tier: high
+  woodcutting:
+    level: 50
+    xp: 125
+    tool: Any axe
+    locations:
+      - Kharazi Jungle
+      - Ape Atoll
+      - Hardwood Grove
+  recipes:
+    - skill: firemaking
       level: 50
-      xp: 125
-      trees: Mahogany trees
-      locations:
-        - Hardwood grove
-        - Ape Atoll
-        - Prifddinas
-    farming:
-      level: 55
-      details: Grow mahogany trees
-    drops:
-      - Cave horror
-      - Callisto
-      - Zulrah
-  usage:
-    construction:
-      product: Mahogany planks
-      sawmill_cost: 1500
-      note: Best XP/plank for Construction training
+      xp: 157.5
+      materials:
+        - item_name: Mahogany logs
+          item_id: 6332
+          quantity: 1
+      product: Fire
   related_items:
-    - slug: mahogany-plank
-      name: Mahogany plank
-      relation: processed_form
-    - slug: teak-logs
-      name: Teak logs
-      relation: lower_tier
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Logs |
-    | Tradeable | Yes |
-    | Weight | 1.36 kg |
-    | Requirements | 50 Woodcutting |
-
-    Convert to mahogany planks for Construction (1,500 gp at sawmill).
-
-    Best XP/plank for Construction training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 8782
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: product
+      description: Sawmill conversion costs 1,500 gp per log
+    - item_id: 6333
+      item_name: Teak logs
+      slug: teak-logs
+      relationship: alternative
+      description: Lower-tier hardwood log
+    - item_id: 1515
+      item_name: Yew logs
+      slug: yew-logs
+      relationship: alternative
+      description: Standard high-tier log
+    - item_id: 1513
+      item_name: Magic logs
+      slug: magic-logs
+      relationship: alternative
+      description: Highest standard log tier
+  about: Mahogany logs are a high-tier hardwood obtained by chopping mahogany trees with a Woodcutting level of 50, granting 125 experience per log. They are most commonly converted into mahogany planks at a sawmill for 1,500 coins each, making them the premier material for high-level Construction training. Burning the logs with Firemaking yields 157.5 experience at level 50 or above.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-plank.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-plank.mdx
@@ -15,18 +15,9 @@ osrs:
   material:
     type: plank
     tier: high
-  construction:
-    xp_per_plank: 140
-    min_level: 40
-    common_builds:
-      - name: Mahogany tables
-        planks: 6
-        xp: 840
-      - name: Gnome benches
-        planks: 6
-        xp: 840
   recipes:
     - skill: construction
+      level: 1
       materials:
         - item_name: Mahogany logs
           item_id: 6332
@@ -35,8 +26,6 @@ osrs:
       product_id: 8782
       product_quantity: 1
       facility: Sawmill
-      cost: 1500
-      members_only: true
     - skill: magic
       level: 86
       xp: 90
@@ -47,69 +36,39 @@ osrs:
         - item_name: Astral rune
           item_id: 9075
           quantity: 2
-        - item_name: Nature rune
-          item_id: 561
-          quantity: 1
         - item_name: Earth rune
           item_id: 557
           quantity: 15
+        - item_name: Nature rune
+          item_id: 561
+          quantity: 1
       product: Mahogany plank
       product_id: 8782
       product_quantity: 1
-      cost: 1050
-      members_only: true
-      spell: Plank Make
   related_items:
     - item_id: 6332
       item_name: Mahogany logs
       slug: mahogany-logs
       relationship: component
-      description: Raw material
     - item_id: 8780
       item_name: Teak plank
       slug: teak-plank
-      relationship: alternative
-      description: Mid tier alternative
+      relationship: downgrade
     - item_id: 8778
       item_name: Oak plank
       slug: oak-plank
+      relationship: downgrade
+    - item_id: 960
+      item_name: Plank
+      slug: plank
+      relationship: downgrade
+    - item_name: Plank Make
+      slug: plank-make
       relationship: alternative
-      description: Budget option
-    - item_id: 9075
-      item_name: Astral rune
-      slug: astral-rune
-      relationship: component
-      description: For Plank Make
-    - item_id: 561
-      item_name: Nature rune
-      slug: nature-rune
-      relationship: component
-      description: For Plank Make
   about: |-
-    | XP per plank | 140 |
-    |--------------|-----|
-    | Mahogany Homes avg | ~346 XP per plank |
-    | Buy limit | 13,000 per 4 hours |
-    | Min Construction level | 40 |
-
-    Best XP methods:
-    - Mahogany tables (6 planks, 840 XP)
-    - Mahogany Homes contracts (most efficient)
-    - Gnome benches (6 planks, 840 XP)
-  market_strategy:
-    profit_formulas:
-      - Mahogany plank price - Mahogany log price - 1,500 GP = Profit
-    notes:
-      - Buy Mahogany logs → Sawmill → Sell planks
-      - "Calculate:"
-      - 86 Magic required
-      - Only 1,050 GP per plank (saves 450 GP vs sawmill)
-      - Higher profit margin than oak planks
-      - Highest XP/plank for Construction
-      - Premium price = higher margins
-      - Popular for 99 Construction rushes
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Mahogany plank is the highest-tier Construction plank in Old School RuneScape, prized for delivering the most experience per plank and used in the most expensive Construction builds. Players obtain it by bringing mahogany logs to the Sawmill in Varrock and paying 1,500 coins per log, or by casting the Lunar spell Plank Make on a mahogany log for a reduced cost. Because of its steep price and high XP yield, it is the staple material for fast Construction training to 99.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-logs.mdx
@@ -6,7 +6,7 @@ osrs:
   name: Maple logs
   slug: maple-logs
   examine: Logs cut from a maple tree.
-  members: false
+  members: true
   icon: Maple logs.png
   value: 80
   lowalch: 32
@@ -18,21 +18,22 @@ osrs:
   woodcutting:
     level: 45
     xp: 100
+    tool: Any axe
     locations:
       - Seers' Village
-      - Corsair Cove
-      - Miscellania
+      - Catherby
+      - Camelot
   recipes:
-    - skill: fletching
+    - skill: firemaking
       level: 45
-      xp: 20
+      xp: 135
       materials:
         - item_name: Maple logs
           item_id: 1517
           quantity: 1
-      product: Arrow shaft
-      product_id: 52
-      product_quantity: 60
+      product: Ashes
+      product_id: 592
+      product_quantity: 1
     - skill: fletching
       level: 50
       xp: 50
@@ -41,7 +42,7 @@ osrs:
           item_id: 1517
           quantity: 1
       product: Maple shortbow (u)
-      product_id: 62
+      product_id: 64
       product_quantity: 1
     - skill: fletching
       level: 55
@@ -51,66 +52,32 @@ osrs:
           item_id: 1517
           quantity: 1
       product: Maple longbow (u)
-      product_id: 58
+      product_id: 62
       product_quantity: 1
-    - skill: fletching
-      level: 54
-      xp: 32
-      materials:
-        - item_name: Maple logs
-          item_id: 1517
-          quantity: 1
-      product: Maple stock
-      product_id: 9444
-      product_quantity: 1
-      members_only: true
   related_items:
-    - item_id: 52
-      item_name: Arrow shaft
-      slug: arrow-shaft
-      relationship: product
-      description: Primary output (×60)
-    - item_id: 58
-      item_name: Maple longbow (u)
-      slug: maple-longbow-u
-      relationship: product
-      description: Bow output
-    - item_id: 851
-      item_name: Maple longbow
-      slug: maple-longbow
-      relationship: product
-      description: Finished bow
+    - item_id: 1511
+      item_name: Logs
+      slug: logs
+      relationship: downgrade
+    - item_id: 1521
+      item_name: Oak logs
+      slug: oak-logs
+      relationship: downgrade
     - item_id: 1519
       item_name: Willow logs
       slug: willow-logs
-      relationship: alternative
-      description: Lower tier
+      relationship: downgrade
     - item_id: 1515
       item_name: Yew logs
       slug: yew-logs
-      relationship: alternative
-      description: Higher tier
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Woodcutting Level | 45 |
-    | XP per log | 100 |
-  market_strategy:
-    title: Arrow Shaft Processing
-    profit_formulas:
-      - (Arrow shaft × 60) - Maple log = Profit
-    notes:
-      - 1 Maple log = 60 arrow shafts
-      - "Calculate:"
-      - Good volume, mid-tier processing
-      - Maple longbow (u) + Bow string = Maple longbow
-      - "High Alch: 576 GP"
-      - Compare crafting cost to alch value
-      - Popular F2P Woodcutting training
-      - Seers' Village maple trees
-      - Mid-tier fletching option
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: upgrade
+    - item_id: 1513
+      item_name: Magic logs
+      slug: magic-logs
+      relationship: upgrade
+  about: Maple logs are members-only logs obtained by cutting maple trees with level 45 Woodcutting, granting 100 Woodcutting experience per log. They are popular for Woodcutting training at Seers' Village and are commonly fletched into maple shortbows and longbows. Maple logs also serve as a mid-tier Firemaking option, giving 135 experience per log burnt.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marrentill.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marrentill.mdx
@@ -12,18 +12,74 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
+  material:
+    type: herb
+    tier: low
+  farming:
+    level: 14
+    plant_xp: 13.5
+    harvest_xp: 15
+    patch_type: herb
+    growth_time: 80
+    payment: 1 bag of cabbages
+    seed_id: 5292
+    seed_name: Marrentill seed
+  recipes:
+    - name: Clean grimy marrentill
+      skill: herblore
+      level: 5
+      xp: 3.8
+      materials:
+        - item_name: Grimy marrentill
+          item_id: 201
+          quantity: 1
+      product: Marrentill
+      product_id: 251
+    - name: Make Marrentill potion (unf)
+      skill: herblore
+      level: 5
+      xp: 0
+      materials:
+        - item_name: Marrentill
+          item_id: 251
+          quantity: 1
+        - item_name: Vial of water
+          item_id: 227
+          quantity: 1
+      product: Marrentill potion (unf)
+      product_id: 93
   related_items:
     - item_id: 201
       item_name: Grimy marrentill
       slug: grimy-marrentill
+      relationship: variant
+    - item_id: 5292
+      item_name: Marrentill seed
+      slug: marrentill-seed
       relationship: component
-      description: Uncleaned version
+    - item_id: 93
+      item_name: Marrentill potion (unf)
+      slug: marrentill-potion-unf
+      relationship: product
+    - item_id: 2446
+      item_name: Antipoison(4)
+      slug: antipoison-4
+      relationship: product
+    - item_name: Serum 207
+      slug: serum-207
+      relationship: product
+    - item_id: 249
+      item_name: Guam leaf
+      slug: guam-leaf
+      relationship: alternative
+    - item_id: 253
+      item_name: Tarromin
+      slug: tarromin
+      relationship: alternative
   about: |-
-    > _"A herb used in poison cures."_
-
-    Marrentill is used to make antipoison potions (5 Herblore) and as incense on POH burners. Also used in Druidic Ritual and other quests.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Marrentill is the second-lowest tier herb in Old School RuneScape, obtained by cleaning grimy marrentill at level 5 Herblore for 3.8 experience. It is most commonly used to brew antipoison potions and Serum 207, the latter being required during the Temple Trekking minigame to cure diseased Morytania villagers. Players can grow their own supply by planting Marrentill seeds in herb patches at level 14 Farming.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-logs.mdx
@@ -18,21 +18,21 @@ osrs:
   woodcutting:
     level: 15
     xp: 37.5
+    tool: Any axe
     locations:
-      - Varrock
-      - Draynor
+      - Draynor Village
       - Lumbridge
-      - Grand Exchange area
-  farming:
-    level: 15
-    seed_id: 5370
-    seed_name: Oak sapling
-  processing:
-    method: Sawmill
-    product_id: 8778
-    product_name: Oak plank
-    cost: 250
+      - Varrock
   recipes:
+    - skill: firemaking
+      level: 15
+      xp: 60
+      materials:
+        - item_name: Oak logs
+          item_id: 1521
+          quantity: 1
+      tools:
+        - Tinderbox
     - skill: fletching
       level: 20
       xp: 16.5
@@ -40,6 +40,8 @@ osrs:
         - item_name: Oak logs
           item_id: 1521
           quantity: 1
+      tools:
+        - Knife
       product: Oak shortbow (u)
       product_id: 54
       product_quantity: 1
@@ -50,52 +52,40 @@ osrs:
         - item_name: Oak logs
           item_id: 1521
           quantity: 1
+      tools:
+        - Knife
       product: Oak longbow (u)
       product_id: 56
       product_quantity: 1
-  drop_table:
-    sources:
-      - source: Ent
-        source_id: 2594
-        combat_level: 86
-        quantity: "1"
-        rarity: common
-        members_only: true
   related_items:
-    - item_id: 8778
-      item_name: Oak plank
-      slug: oak-plank
-      relationship: product
-      description: Processed form for Construction
-    - item_id: 1519
-      item_name: Willow logs
-      slug: willow-logs
-      relationship: upgrade
-      description: Higher tier logs
     - item_id: 1511
       item_name: Logs
       slug: logs
       relationship: downgrade
-      description: Lower tier logs
-    - item_id: 54
-      item_name: Oak shortbow (u)
-      slug: oak-shortbow-u
+    - item_id: 1519
+      item_name: Willow logs
+      slug: willow-logs
+      relationship: upgrade
+    - item_id: 1517
+      item_name: Maple logs
+      slug: maple-logs
+      relationship: upgrade
+    - item_id: 1515
+      item_name: Yew logs
+      slug: yew-logs
+      relationship: upgrade
+    - item_id: 1513
+      item_name: Magic logs
+      slug: magic-logs
+      relationship: upgrade
+    - item_id: 8778
+      item_name: Oak plank
+      slug: oak-plank
       relationship: product
-      description: Fletching output
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Logs |
-    | Tradeable | Yes |
-    | Weight | 2 kg |
-    | Requirements | 15 Woodcutting |
-
-    Convert to oak planks for Construction (250 gp at sawmill).
-
-    Popular for low-level Construction training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Oak logs are the second tier of logs in Old School RuneScape, obtained by chopping oak trees at level 15 Woodcutting for 37.5 experience per log. They can be burned at level 15 Firemaking for 60 experience, fletched into oak shortbows and longbows, or converted into oak planks at a sawmill for use in Construction. As a free-to-play resource with wide availability in Draynor Village, Lumbridge, and Varrock, they serve as an early-game staple for training multiple skills.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/redwood-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/redwood-logs.mdx
@@ -13,85 +13,34 @@ osrs:
   highalch: 270
   limit: 12000
   material:
-    type: logs
-    tier: redwood
-  gathering:
-    skill: woodcutting
+    type: log
+    tier: elite
+  woodcutting:
     level: 90
     xp: 380
     tool: Any axe
-    location: Woodcutting Guild
-    members_only: true
+    locations:
+      - Woodcutting Guild
   recipes:
-    - skill: fletching
-      level: 90
-      xp: 21
-      materials:
-        - item_name: Redwood logs
-          item_id: 19669
-          quantity: 1
-      product: Arrow shaft
-      product_id: 52
-      product_quantity: 105
-      facility: Knife
-      members_only: true
-    - skill: fletching
-      level: 92
-      xp: 216
-      materials:
-        - item_name: Redwood logs
-          item_id: 19669
-          quantity: 2
-      product: Redwood shield
-      product_id: 22188
-      product_quantity: 1
-      facility: Knife
-      members_only: true
     - skill: firemaking
       level: 90
       xp: 350
-      materials:
-        - item_name: Redwood logs
-          item_id: 19669
-          quantity: 1
-      product: Fire
-      product_id: 0
-      product_quantity: 1
-      facility: Tinderbox
-      members_only: true
   related_items:
     - item_id: 1513
       item_name: Magic logs
       slug: magic-logs
+      relationship: downgrade
+    - item_id: 1515
+      item_name: Yew logs
+      slug: yew-logs
+      relationship: downgrade
+    - item_id: 6332
+      item_name: Mahogany logs
+      slug: mahogany-logs
       relationship: alternative
-      description: Lower tier logs
-    - item_id: 52
-      item_name: Arrow shaft
-      slug: arrow-shaft
-      relationship: product
-      description: Primary product
-    - item_id: 22188
-      item_name: Redwood shield
-      slug: redwood-shield
-      relationship: product
-      description: Shield crafting
-    - item_id: 13241
-      item_name: Infernal axe
-      slug: infernal-axe
-      relationship: component
-      description: Best axe
-  about: |-
-    | Level | XP |
-    |-------|-----|
-    | 90 | 350 |
-  market_strategy:
-    notes:
-      - Woodcutting Guild only
-      - Dragon/Infernal axe best
-      - AFK XP method
-      - 105 shafts per log
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Redwood logs are the highest-tier standard log in Old School RuneScape, requiring level 90 Woodcutting to chop. They are primarily used for Firemaking training, granting 350 experience per log when burned. Redwood trees are found exclusively in the Woodcutting Guild in Great Kourend.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tarromin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tarromin.mdx
@@ -12,18 +12,71 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
+  material:
+    type: herb
+    tier: low
+  farming:
+    farming_level: 19
+    plant_xp: 16
+    harvest_xp: 18
+    patch_type: herb
+    growth_time: 80
+    payment: 1 sack of onions
+    seed_id: 5293
+    seed_name: Tarromin seed
+  recipes:
+    - skill: herblore
+      level: 11
+      xp: 5
+      materials:
+        - item_id: 203
+          item_name: Grimy tarromin
+          quantity: 1
+      product: Tarromin
+      product_id: 253
+    - skill: herblore
+      level: 12
+      xp: 0
+      materials:
+        - item_id: 253
+          item_name: Tarromin
+          quantity: 1
+        - item_name: Vial of water
+          quantity: 1
+      product: Tarromin potion (unf)
+      product_id: 95
   related_items:
     - item_id: 203
       item_name: Grimy tarromin
       slug: grimy-tarromin
+      relationship: variant
+    - item_id: 5293
+      item_name: Tarromin seed
+      slug: tarromin-seed
       relationship: component
-      description: Uncleaned version
+    - item_id: 95
+      item_name: Tarromin potion (unf)
+      slug: tarromin-potion-unf
+      relationship: product
+    - item_id: 113
+      item_name: Strength potion(4)
+      slug: strength-potion-4
+      relationship: product
+    - item_name: Serum 207
+      slug: serum-207
+      relationship: product
+    - item_id: 251
+      item_name: Marrentill
+      slug: marrentill
+      relationship: alternative
+    - item_id: 255
+      item_name: Harralander
+      slug: harralander
+      relationship: alternative
   about: |-
-    > _"A useful herb."_
-
-    Tarromin is used to make strength potions (12 Herblore) and serum 207 for the Shades of Mort'ton quest/minigame.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Tarromin is a low-tier Herblore herb cleaned at level 11 for 5 XP from its grimy form. Combined with a vial of water it makes a tarromin potion (unf), the base for Strength potions at level 12 Herblore and for Serum 207 used in the Shades of Mort'ton minigame. Farmers can grow their own supply from tarromin seeds at level 19 Farming in any herb patch.
+  mdx_version: 3
+  mdx_updated: '2026-04-10'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-logs.mdx
@@ -12,58 +12,45 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 13000
-  item_id: 6333
-  type: logs
-  tradeable: true
-  weight: 1.36
-  buy_limit: 13000
-  requirements:
-    skills:
-      - skill: woodcutting
-        level: 35
-        context: to cut
-  obtaining:
-    woodcutting:
+  material:
+    type: log
+    tier: mid
+  woodcutting:
+    level: 35
+    xp: 85
+    tool: Any axe
+    locations:
+      - Kharazi Jungle
+      - Ape Atoll
+      - Hardwood Grove
+  recipes:
+    - skill: firemaking
       level: 35
-      xp: 85
-      trees: Teak trees
-      locations:
-        - Castle Wars
-        - Fossil Island
-        - Ape Atoll
-    farming:
-      level: 35
-      details: Grow teak trees
-    drops:
-      - Cave horror
-      - Jungle horror
-      - Wyverns
-  usage:
-    construction:
-      product: Teak planks
-      sawmill_cost: 500
-    fletching: Good for Fletching training
+      xp: 105
+      materials:
+        - item_name: Teak logs
+          item_id: 6333
+          quantity: 1
+      product: Fire
   related_items:
-    - slug: teak-plank
-      name: Teak plank
-      relation: processed_form
-    - slug: mahogany-logs
-      name: Mahogany logs
-      relation: higher_tier
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Logs |
-    | Tradeable | Yes |
-    | Weight | 1.36 kg |
-    | Requirements | 35 Woodcutting |
-
-    Convert to teak planks for Construction (500 gp at sawmill).
-
-    Good for Fletching training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 8780
+      item_name: Teak plank
+      slug: teak-plank
+      relationship: product
+      description: Sawmill conversion costs 500 gp per log
+    - item_id: 6332
+      item_name: Mahogany logs
+      slug: mahogany-logs
+      relationship: upgrade
+      description: Higher-tier hardwood log
+    - item_id: 1517
+      item_name: Maple logs
+      slug: maple-logs
+      relationship: alternative
+      description: Standard mid-tier log
+  about: Teak logs are a mid-tier hardwood obtained by chopping teak trees with a Woodcutting level of 35, granting 85 experience per log. They are primarily converted into teak planks at a sawmill for 500 coins each, serving as a popular mid-level Construction material. Burning the logs with Firemaking yields 105 experience at level 35 or above.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-logs.mdx
@@ -12,8 +12,78 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15000
-  about: "Willow logs is a free-to-play item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
+  material:
+    type: log
+    tier: mid-low
+  woodcutting:
+    level: 30
+    xp: 67.5
+    tool: Any axe
+    locations:
+      - Draynor Village
+      - Barbarian Village
+      - Catherby
+  recipes:
+    - skill: firemaking
+      level: 30
+      xp: 90
+      materials:
+        - item_name: Willow logs
+          item_id: 1519
+          quantity: 1
+      tools:
+        - Tinderbox
+    - skill: fletching
+      level: 35
+      xp: 33.25
+      materials:
+        - item_name: Willow logs
+          item_id: 1519
+          quantity: 1
+      tools:
+        - Knife
+      product: Willow shortbow (u)
+      product_id: 60
+      product_quantity: 1
+    - skill: fletching
+      level: 40
+      xp: 41.5
+      materials:
+        - item_name: Willow logs
+          item_id: 1519
+          quantity: 1
+      tools:
+        - Knife
+      product: Willow longbow (u)
+      product_id: 58
+      product_quantity: 1
+  related_items:
+    - item_id: 1511
+      item_name: Logs
+      slug: logs
+      relationship: downgrade
+    - item_id: 1521
+      item_name: Oak logs
+      slug: oak-logs
+      relationship: downgrade
+    - item_id: 1517
+      item_name: Maple logs
+      slug: maple-logs
+      relationship: upgrade
+    - item_id: 1515
+      item_name: Yew logs
+      slug: yew-logs
+      relationship: upgrade
+    - item_id: 1513
+      item_name: Magic logs
+      slug: magic-logs
+      relationship: upgrade
+    - item_name: Willow plank
+      slug: willow-plank
+      relationship: product
+  about: |-
+    Willow logs are the third tier of logs in Old School RuneScape, obtained by chopping willow trees at level 30 Woodcutting for 67.5 experience per log. They can be burned at level 30 Firemaking for 90 experience, fletched into willow shortbows and longbows, or converted into willow planks at a sawmill for Construction. As a free-to-play resource with dense tree clusters in Draynor Village, Barbarian Village, and Catherby, they remain a reliable mid-low tier choice for training multiple skills.
+  mdx_version: 3
   mdx_updated: "2026-04-10"
 ---
 


### PR DESCRIPTION
## Summary
Batch 8 — largest batch yet (20 items). Two coherent clusters: 10 herbs + 10 logs that cross-link to ranarr-weed (already v3) and yew-logs/magic-logs.

### Items enriched (20)
**Herbs (10):**
- guam-leaf, marrentill, tarromin, harralander, irit-leaf, avantoe, kwuarm, cadantine, lantadyme, dwarf-weed
- Each with `material`, `farming` block, herblore cleaning recipe, potion (unf) recipe, related_items chain

**Logs (10):**
- logs, oak-logs, willow-logs, maple-logs, magic-logs, redwood-logs, mahogany-logs, teak-logs, arctic-pine-logs, mahogany-plank
- Each with `material`, `woodcutting` block, firemaking + fletching recipes, full progression chain in related_items

### Schema fixes from agent output
- `recipes[*].cost` / `recipes[*].name` removed (not in schema — sawmill cost moved to related_items description)
- `recipes[*].materials` added where missing (firemaking recipes need logs as material)
- `name` → `item_name` in related_items
- `skill: Firemaking` → `firemaking` (lowercase enum)
- Removed legacy stale top-level fields: `item_id`, `type`, `tradeable`, `buy_limit`, `weight`, `herb:`, `herblore:` blocks
- Wiki-correct fixes: Irit seed 5295 → 5297 (agent caught my error)

## Test plan
- [ ] Verify astro-kbve builds without schema errors
- [ ] Spot-check herb cluster cross-links (clean → unf potion → finished potion chain)
- [ ] Spot-check log cluster progression (logs → oak → willow → maple → yew → magic → redwood)