### PR TITLE
fix(axum-kbve): resolve merge fallout in proxy.rs

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -67,8 +67,9 @@ impl ServiceProxy {
     async fn forward_request(&self, path: Option<Path<String>>, req: Request<Body>) -> Response {
         let req_headers = req.headers().clone();
         let suffix = path.map(|Path(p)| p).unwrap_or_default();
-        let query = raw_query
-            .as_ref()
+        let query = req
+            .uri()
+            .query()
             .map(|q| format!("?{q}"))
             .unwrap_or_default();
         let upstream_url = format!("{}/{}{}", self.upstream, suffix, query);
@@ -1153,6 +1154,7 @@ pub fn init_firecracker_net_proxy() -> bool {
             client,
             upstream: upstream.trim_end_matches('/').to_string(),
             upstream_token: None,
+            iframe_safe: false,
         })
         .is_ok()
 }


### PR DESCRIPTION
## Summary
Two compile errors landed when #9937 (KASM iframe support) merged on top of a parallel refactor that split \`ServiceProxy::handle\` into \`handle\` + \`forward_request\` and added a new \`FIRECRACKER_NET\` proxy:

1. **\`raw_query\` undefined in \`forward_request\`** — \`raw_query\` was a local in the original \`handle()\`, but the parallel split moved the proxying logic into \`forward_request()\` without plumbing it through. Restored inline query extraction via \`req.uri().query()\` since \`forward_request\` already has the request.

2. **\`FIRECRACKER_NET\` initializer missing \`iframe_safe\`** — the new \`FIRECRACKER_NET\` proxy was added in a parallel PR and didn't have the \`iframe_safe\` field that #9937 introduced. Set to \`false\` (matches every other non-KASM proxy).

## Test plan
- [x] \`./kbve.sh -nx axum-kbve:lint\` passes (only 2 unrelated clippy warnings remain)
- [x] \`cargo check -p axum-kbve\` clean