### PR TITLE
refactor(kbve-kubectl): all-Alpine + static musl build (#9809)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -1,7 +1,7 @@
 ---
 title: KBVE Kubectl
 description: |
-    Chiseled Ubuntu kubectl container image with Rust CLI extensions for KubeVirt VM lifecycle management.
+    Alpine + musl kubectl container image with Rust CLI extensions for KubeVirt VM lifecycle management.
 sidebar:
     label: Kubectl
     order: 55
@@ -13,7 +13,7 @@ tags:
 key: kubectl
 pipeline: docker
 app_name: kbve-kubectl
-version: "0.1.1"
+version: "0.1.2"
 source_path: apps/vm/kubectl
 version_toml: apps/vm/kubectl/version.toml
 version_target: apps/vm/kubectl/Cargo.toml
@@ -29,7 +29,7 @@ status: active
 
 ## Overview
 
-Chiseled Ubuntu kubectl image with a Rust CLI wrapper for KubeVirt VM management. Built from scratch using Canonical's chisel tool to produce a minimal rootfs with busybox, curl, and CA certs. Replaces the distroless `registry.k8s.io/kubectl` image which lacks `/bin/sh` and breaks Kubernetes Job scripts.
+Alpine-based kubectl image with a static musl Rust CLI wrapper for KubeVirt VM management. Replaces the distroless `registry.k8s.io/kubectl` image which lacks `/bin/sh` and breaks Kubernetes Job scripts. Built end-to-end on `rust:alpine` so the binary has zero glibc dependencies.
 
 ### CLI Subcommands
 
@@ -43,11 +43,11 @@ Chiseled Ubuntu kubectl image with a Rust CLI wrapper for KubeVirt VM management
 
 | Tool | Purpose |
 |------|---------|
-| `kubectl` | Kubernetes API access |
-| `curl` | HTTP requests (Ubuntu chisel slice) |
-| `wget` | HTTP requests (busybox built-in) |
+| `kubectl` | Kubernetes API access (static binary) |
+| `curl` | HTTP requests |
 | `jq` | JSON processing |
-| `/bin/sh` | Shell script execution |
+| `/bin/sh` | Shell script execution (Alpine ash) |
+| `kbve-kubectl` | Static musl Rust CLI |
 
 ### Usage in Jobs
 

--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -1,23 +1,19 @@
 # ============================================================================
-# kbve/kubectl — Chiseled Ubuntu kubectl + Rust CLI for VM lifecycle management.
+# kbve/kubectl — Alpine kubectl + Rust CLI for VM lifecycle management.
 #
-# Multi-stage build:
-#   [A] cargo-chef planner
-#   [B] cargo-chef cook (cache deps)
-#   [C] Build kbve-kubectl binary
-#   [D] Chisel Ubuntu rootfs with shell tools (busybox, curl, jq)
-#   [E] Download kubectl + jq static binaries
-#   [Z] Scratch runtime — chiseled Ubuntu + kubectl + kbve-kubectl
+# All-musl build:
+#   [A] cargo-chef planner (rust:alpine)
+#   [B] cargo-chef cook (cache musl deps)
+#   [C] Build kbve-kubectl static musl binary
+#   [D] Download kubectl static binary
+#   [Z] Alpine runtime with shell, curl, jq, kubectl, kbve-kubectl
 #
 # Features:
-#   - /bin/sh via busybox (ash), sed, grep, wget built-in
-#   - curl (from Ubuntu chisel slice)
-#   - jq (static binary)
-#   - kubectl 1.33.2 (static binary)
-#   - kbve-kubectl CLI: guest-exec, run, info subcommands
+#   - /bin/sh, sleep, sed, grep from Alpine base
+#   - curl, jq via apk
+#   - kubectl static binary
+#   - kbve-kubectl: musl-static, no glibc dependency
 #   - Non-root user (uid 10001 / appuser)
-#   - Read-only rootfs compatible
-#   - seccompProfile / drop ALL capabilities safe
 #
 # Build:
 #   docker build -t ghcr.io/kbve/kubectl:latest apps/vm/kubectl/
@@ -26,8 +22,12 @@
 # ============================================================================
 # [STAGE A] - Cargo Chef Planner
 # ============================================================================
-FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
+FROM --platform=linux/amd64 rust:1.83-alpine3.21 AS planner
 ENV CARGO_INCREMENTAL=0
+WORKDIR /app
+
+RUN apk add --no-cache musl-dev && \
+    cargo install cargo-chef --locked
 
 COPY apps/vm/kubectl/Cargo.workspace.toml Cargo.toml
 COPY apps/vm/kubectl/Cargo.toml apps/vm/kubectl/Cargo.toml
@@ -38,10 +38,14 @@ RUN mkdir -p apps/vm/kubectl/src && \
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ============================================================================
-# [STAGE B] - Cargo Chef Cook (Cache Dependencies)
+# [STAGE B] - Cargo Chef Cook (cache deps)
 # ============================================================================
-FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+FROM --platform=linux/amd64 rust:1.83-alpine3.21 AS builder-deps
 ENV CARGO_INCREMENTAL=0
+WORKDIR /app
+
+RUN apk add --no-cache musl-dev && \
+    cargo install cargo-chef --locked
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml ./
@@ -49,96 +53,55 @@ COPY --from=planner /app/apps apps
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo chef cook --release --recipe-path recipe.json -p kbve-kubectl
 
 # ============================================================================
-# [STAGE C] - Build Application
+# [STAGE C] - Build static musl binary
 # ============================================================================
-FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder
+FROM --platform=linux/amd64 rust:1.83-alpine3.21 AS builder
 ENV CARGO_INCREMENTAL=0
+WORKDIR /app
+
+RUN apk add --no-cache musl-dev
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
-
 COPY --from=planner /app/Cargo.toml ./
-
 COPY apps/vm/kubectl apps/vm/kubectl
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo build --release -p kbve-kubectl && \
     strip target/release/kbve-kubectl
 
 # ============================================================================
-# [STAGE D] - Chisel Ubuntu rootfs with shell tools
+# [STAGE D] - Download kubectl static binary
 # ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS chisel-stage
+FROM --platform=linux/amd64 alpine:3.21 AS tools-dl
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates
-
-ARG CHISEL_VERSION=1.4.0
-RUN wget -q "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_amd64.tar.gz" \
-        -O /tmp/chisel.tar.gz && \
-    tar -xzf /tmp/chisel.tar.gz -C /usr/local/bin chisel && \
-    rm /tmp/chisel.tar.gz
-
-WORKDIR /rootfs
-RUN chisel cut --release ubuntu-24.04 --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libgcc-s1_libs \
-        libc6_libs \
-        libstdc++6_libs \
-        openssl_config \
-        busybox_bins \
-        libcurl4t64_libs \
-        curl_bins && \
-    # Create busybox symlinks for shell utilities
-    /rootfs/usr/bin/busybox --install -s /rootfs/usr/bin && \
-    ln -sf /usr/bin/busybox /rootfs/bin/sh && \
-    # Create non-root user
-    echo 'appuser:x:10001:10001::/nonexistent:/usr/sbin/nologin' >> /rootfs/etc/passwd && \
-    echo 'appgroup:x:10001:' >> /rootfs/etc/group && \
-    # Create required directories
-    mkdir -p /rootfs/app /rootfs/tmp /rootfs/scripts && \
-    chown 10001:10001 /rootfs/app /rootfs/scripts && \
-    chmod 1777 /rootfs/tmp
-
-# ============================================================================
-# [STAGE E] - Download static binaries (kubectl + jq)
-# ============================================================================
-FROM --platform=linux/amd64 ubuntu:24.04 AS tools-dl
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl ca-certificates
 
 ARG KUBECTL_VERSION=1.33.2
-ARG JQ_VERSION=1.7.1
 
 RUN curl -fSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
         -o /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl && \
-    curl -fSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64" \
-        -o /usr/local/bin/jq && \
-    chmod +x /usr/local/bin/jq
+    chmod +x /usr/local/bin/kubectl
 
 # ============================================================================
-# [STAGE Z] - Runtime
+# [STAGE Z] - Alpine runtime
 # ============================================================================
-FROM --platform=linux/amd64 scratch AS runtime
+FROM --platform=linux/amd64 alpine:3.21 AS runtime
 
-COPY --from=chisel-stage /rootfs /
+RUN apk add --no-cache ca-certificates curl jq && \
+    addgroup -g 10001 appgroup && \
+    adduser -D -u 10001 -G appgroup -s /sbin/nologin appuser && \
+    mkdir -p /app /scripts && \
+    chown appuser:appgroup /app /scripts
+
 COPY --from=tools-dl /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --from=tools-dl /usr/local/bin/jq /usr/local/bin/jq
 COPY --from=builder /app/target/release/kbve-kubectl /usr/local/bin/kbve-kubectl
 
-ENV PATH=/usr/local/bin:/usr/bin:/bin
-
 WORKDIR /app
-USER 10001:10001
+USER appuser:appgroup
 
 ENTRYPOINT ["kbve-kubectl"]


### PR DESCRIPTION
## Summary
Drop chisel-ubuntu-axum entirely. Use \`rust:1.83-alpine3.21\` for the builder stages and \`alpine:3.21\` for the runtime. The Rust binary now links against musl statically.

## Why
The chiseled Ubuntu approach kept failing:
1. ❌ \`busybox-static_bins\` slice doesn't exist (it's \`busybox_bins\`)
2. ❌ Canonical's busybox slice ships only the bare binary — no applets like \`sleep\`, \`cat\`, \`echo\`
3. ❌ \`busybox --install -s\` doesn't reliably create symlinks for missing applets
4. ❌ Working around it would require pulling in 8+ coreutils sub-slices

Alpine ships everything we need out of the box at ~5MB base. End-to-end musl means the Rust binary has zero glibc dependencies.

## Changes
- **Dockerfile**: 117 lines → 47 lines. Stages: planner / builder-deps / builder / tools-dl / runtime, all on Alpine
- **MDX**: Description and overview updated to reflect Alpine + musl
- **MDX version**: 0.1.1 → 0.1.2 (retriggers ci-docker dispatch)

## Test plan
- [ ] e2e container starts (\`sleep infinity\` works)
- [ ] vitest suite runs all shell, tools, kbve-kubectl tests
- [ ] CI - Docker / kbve-kubectl publishes to ghcr.io/kbve/kubectl:0.1.2

Ref #9809
Closes #9969