### PR TITLE
chore(mc): bump version to 1.0.5 to ship FabricProxy-Lite

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -12,7 +12,7 @@ tags:
 key: mc
 pipeline: docker
 app_name: mc
-version: "1.0.4"
+version: "1.0.5"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary
PR #9950 added FabricProxy-Lite to the Dockerfile but didn't bump the version. CI's version gate compared MDX (1.0.4) vs version.toml (1.0.4) and skipped the docker build. The fleet is still running \`ghcr.io/kbve/mc:1.0.4\` which **doesn't have FabricProxy-Lite**.

### Confirmed via kubectl
\`\`\`
$ kubectl exec mc-fabric-np64j-6t2gx -c mc-server -- ls /data/mods/ | grep fabricproxy
NOT FOUND
\`\`\`

That's why Velocity still gets:
\`\`\`
unable to connect to server mc — The connection to the remote server was unexpectedly closed.
This is usually because the remote server does not have BungeeCord IP forwarding correctly enabled.
\`\`\`

### Fix
Bump MDX version → 1.0.5. CI will build the new image with FabricProxy-Lite, post-publish auto-syncs `version.toml` and updates `fleet.yaml`'s image tag via `deployment_yaml`.

## Test plan
- [ ] CI dispatches mc docker build for 1.0.5
- [ ] New image contains FabricProxy-Lite-2.11.0.jar in /mods/
- [ ] Fleet rolls out, Velocity successfully forwards player connections