### PR TITLE
fix(kbve-kubectl): bump rust to 1.94 for edition2024 (#9809)

### DIFF
--- a/apps/vm/kubectl/Dockerfile
+++ b/apps/vm/kubectl/Dockerfile
@@ -22,7 +22,7 @@
 # ============================================================================
 # [STAGE A] - Cargo Chef Planner
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.83-alpine3.21 AS planner
+FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS planner
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ============================================================================
 # [STAGE B] - Cargo Chef Cook (cache deps)
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.83-alpine3.21 AS builder-deps
+FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS builder-deps
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 # [STAGE C] - Build static musl binary
 # ============================================================================
-FROM --platform=linux/amd64 rust:1.83-alpine3.21 AS builder
+FROM --platform=linux/amd64 rust:1.94-alpine3.21 AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Bump all three Dockerfile builder stages from \`rust:1.83-alpine3.21\` → \`rust:1.94-alpine3.21\`.

## Failure
\`\`\`
The package requires the Cargo feature called \`edition2024\`, but that feature
is not stabilized in this version of Cargo (1.83.0).
failed to parse manifest at /usr/local/cargo/registry/.../target-spec-3.5.7/Cargo.toml
\`\`\`

\`cargo install cargo-chef\` pulls a newer transitive dep (\`target-spec\`) that needs edition2024, stable since Rust 1.85.

Ref #9809