### PR TITLE
feat(sql): mode lock — prevent simultaneous Discord + isometric play

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
@@ -56,22 +56,27 @@ async fn start(
 
     // Claim the play mode lock — prevents the same player from being in
     // both Discord dungeon AND isometric game at the same time (data race
-    // on profile saves). Gracefully degrades to success if Supabase is down.
-    if let Err(reason) = ctx
+    // on profile saves). Returns a RAII guard that releases on drop unless
+    // we explicitly commit() after the session is fully created.
+    // Gracefully degrades to a no-op guard if Supabase is down.
+    let mode_guard = match ctx
         .data()
         .app
         .profiles
         .claim_mode(user.get(), &short_id, false)
         .await
     {
-        ctx.send(
-            poise::CreateReply::default()
-                .content(format!("Cannot start dungeon: {}", reason))
-                .ephemeral(true),
-        )
-        .await?;
-        return Ok(());
-    }
+        Ok(g) => g,
+        Err(reason) => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content(format!("Cannot start dungeon: {}", reason))
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
 
     let map = content::generate_initial_map(&id);
     let room = content::room_from_tile(map.tiles.get(&map.position).unwrap());
@@ -190,6 +195,11 @@ async fn start(
 
     ctx.data().app.sessions.create(final_state);
 
+    // Session is fully registered — release the lock from the guard's
+    // ownership. Future release will happen via save_all_players when
+    // the session ends naturally.
+    mode_guard.commit();
+
     // One-time guest notice
     if let MemberStatus::Guest { notified } = &member_status_raw
         && !notified
@@ -283,22 +293,26 @@ async fn join(
 
     // Claim the play mode lock for the joining party member.
     // Each player has their own lock — joining a party means claiming
-    // the discord mode for that player too.
-    if let Err(reason) = ctx
+    // the discord mode for that player too. Returns a RAII guard that
+    // auto-releases on drop unless we commit() after the player is added.
+    let mode_guard = match ctx
         .data()
         .app
         .profiles
         .claim_mode(user.get(), &sid, false)
         .await
     {
-        ctx.send(
-            poise::CreateReply::default()
-                .content(format!("Cannot join dungeon: {}", reason))
-                .ephemeral(true),
-        )
-        .await?;
-        return Ok(());
-    }
+        Ok(g) => g,
+        Err(reason) => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content(format!("Cannot join dungeon: {}", reason))
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
 
     // Membership lookup for joining player
     let member_status_raw = ctx.data().app.members.lookup(user.get()).await;
@@ -384,6 +398,11 @@ async fn join(
 
     // Drop lock before sending response
     drop(session);
+
+    // Player is now in the session — commit the mode lock guard so it
+    // doesn't release on drop. Future release will happen via save_all_players
+    // when the session ends.
+    mode_guard.commit();
 
     ctx.send(
         poise::CreateReply::default()

--- a/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
@@ -53,6 +53,26 @@ async fn start(
     };
 
     let (id, short_id) = game::new_short_sid();
+
+    // Claim the play mode lock — prevents the same player from being in
+    // both Discord dungeon AND isometric game at the same time (data race
+    // on profile saves). Gracefully degrades to success if Supabase is down.
+    if let Err(reason) = ctx
+        .data()
+        .app
+        .profiles
+        .claim_mode(user.get(), &short_id, false)
+        .await
+    {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(format!("Cannot start dungeon: {}", reason))
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
     let map = content::generate_initial_map(&id);
     let room = content::room_from_tile(map.tiles.get(&map.position).unwrap());
     let phase = GamePhase::City;
@@ -261,6 +281,25 @@ async fn join(
         }
     } // Lock dropped here before async lookup
 
+    // Claim the play mode lock for the joining party member.
+    // Each player has their own lock — joining a party means claiming
+    // the discord mode for that player too.
+    if let Err(reason) = ctx
+        .data()
+        .app
+        .profiles
+        .claim_mode(user.get(), &sid, false)
+        .await
+    {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(format!("Cannot join dungeon: {}", reason))
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
     // Membership lookup for joining player
     let member_status_raw = ctx.data().app.members.lookup(user.get()).await;
     let (joiner_name, joiner_tag) = match &member_status_raw {
@@ -418,6 +457,11 @@ async fn leave(ctx: Context<'_>) -> Result<(), Error> {
             );
             ctx.data().app.profiles.save_async(profile, run);
         }
+        // Release the leaving player's mode lock so they can switch modes.
+        ctx.data()
+            .app
+            .profiles
+            .release_mode_async(user.get(), session.short_id.clone());
         session.party.retain(|&id| id != user);
         session.players.remove(&user);
         session

--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -226,6 +226,105 @@ impl ProfileStore {
         });
     }
 
+    /// Try to claim the play mode lock for a player.
+    ///
+    /// Returns `Ok(())` if the lock was granted (player can start a Discord
+    /// dungeon session), or `Err(message)` describing why the claim was
+    /// rejected. If Supabase is unavailable, claims always succeed (graceful
+    /// degradation — the bot still works without persistence).
+    ///
+    /// Set `force=true` to override stale claims unconditionally (admin only).
+    pub async fn claim_mode(
+        &self,
+        discord_id: u64,
+        session_id: &str,
+        force: bool,
+    ) -> Result<(), String> {
+        let Some(client) = self.client.as_ref() else {
+            return Ok(());
+        };
+        let params = serde_json::json!({
+            "p_discord_id": discord_id as i64,
+            "p_mode": "discord",
+            "p_session_id": session_id,
+            "p_force": force,
+        });
+        match client
+            .rpc_schema("service_claim_mode", params, SCHEMA)
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                #[derive(Deserialize)]
+                struct ClaimResult {
+                    success: bool,
+                    #[serde(default)]
+                    message: String,
+                }
+                match resp.json::<Vec<ClaimResult>>().await {
+                    Ok(rows) => match rows.into_iter().next() {
+                        Some(r) if r.success => {
+                            debug!(discord_id, "Mode lock claimed");
+                            Ok(())
+                        }
+                        Some(r) => Err(r.message),
+                        None => Err("Empty claim_mode response".to_owned()),
+                    },
+                    Err(e) => {
+                        warn!(error = %e, discord_id, "Failed to parse claim_mode response");
+                        Ok(())
+                    }
+                }
+            }
+            Ok(resp) => {
+                warn!(
+                    status = %resp.status(),
+                    discord_id,
+                    "service_claim_mode returned non-200"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!(error = %e, discord_id, "service_claim_mode RPC failed");
+                Ok(())
+            }
+        }
+    }
+
+    /// Release the play mode lock for a player (fire-and-forget).
+    ///
+    /// Called when a Discord dungeon session ends (game over, leave, expire).
+    /// Silently no-ops if Supabase is unavailable or the caller doesn't own
+    /// the lock — both are non-fatal for the player flow.
+    pub fn release_mode_async(&self, discord_id: u64, session_id: String) {
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let params = serde_json::json!({
+                "p_discord_id": discord_id as i64,
+                "p_session_id": session_id,
+            });
+            match client
+                .rpc_schema("service_release_mode", params, SCHEMA)
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    debug!(discord_id, "Mode lock released");
+                }
+                Ok(resp) => {
+                    warn!(
+                        status = %resp.status(),
+                        discord_id,
+                        "service_release_mode returned non-200"
+                    );
+                }
+                Err(e) => {
+                    warn!(error = %e, discord_id, "service_release_mode RPC failed");
+                }
+            }
+        });
+    }
+
     /// Fetch leaderboard (always fresh, no cache).
     pub async fn leaderboard(&self, category: i16, limit: i32) -> Vec<LeaderboardEntry> {
         let Some(client) = self.client.as_ref() else {
@@ -448,6 +547,10 @@ pub fn save_all_players(
             session,
         );
         profiles.save_async(profile, run);
+        // Release the play mode lock so the player can switch to isometric
+        // (or restart Discord). Each player owns their own lock keyed on
+        // the session's short_id.
+        profiles.release_mode_async(uid.get(), session.short_id.clone());
     }
 
     // Invalidate cache for all players

--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -228,10 +228,17 @@ impl ProfileStore {
 
     /// Try to claim the play mode lock for a player.
     ///
-    /// Returns `Ok(())` if the lock was granted (player can start a Discord
-    /// dungeon session), or `Err(message)` describing why the claim was
-    /// rejected. If Supabase is unavailable, claims always succeed (graceful
-    /// degradation — the bot still works without persistence).
+    /// Returns a [`ModeLockGuard`] if the lock was granted, or `Err(message)`
+    /// if rejected. The guard releases the lock automatically on drop unless
+    /// you call [`ModeLockGuard::commit`] first.
+    ///
+    /// **RAII pattern**: if any error path between claim and session creation
+    /// returns early or panics, the guard's `Drop` impl spawns a release so
+    /// the player isn't locked out for the full 30-min TTL. Call `commit()`
+    /// only after the session is fully registered in `SessionStore`.
+    ///
+    /// If Supabase is unavailable, the guard is created in a no-op state
+    /// (graceful degradation — the bot still works without persistence).
     ///
     /// Set `force=true` to override stale claims unconditionally (admin only).
     pub async fn claim_mode(
@@ -239,9 +246,15 @@ impl ProfileStore {
         discord_id: u64,
         session_id: &str,
         force: bool,
-    ) -> Result<(), String> {
+    ) -> Result<ModeLockGuard, String> {
         let Some(client) = self.client.as_ref() else {
-            return Ok(());
+            // No Supabase: return a no-op guard
+            return Ok(ModeLockGuard {
+                client: None,
+                discord_id,
+                session_id: session_id.to_owned(),
+                committed: false,
+            });
         };
         let params = serde_json::json!({
             "p_discord_id": discord_id as i64,
@@ -264,14 +277,26 @@ impl ProfileStore {
                     Ok(rows) => match rows.into_iter().next() {
                         Some(r) if r.success => {
                             debug!(discord_id, "Mode lock claimed");
-                            Ok(())
+                            Ok(ModeLockGuard {
+                                client: Some(client.clone()),
+                                discord_id,
+                                session_id: session_id.to_owned(),
+                                committed: false,
+                            })
                         }
                         Some(r) => Err(r.message),
                         None => Err("Empty claim_mode response".to_owned()),
                     },
                     Err(e) => {
                         warn!(error = %e, discord_id, "Failed to parse claim_mode response");
-                        Ok(())
+                        // Parsing failed but the RPC may have succeeded — return a guard
+                        // so we still release on drop.
+                        Ok(ModeLockGuard {
+                            client: Some(client.clone()),
+                            discord_id,
+                            session_id: session_id.to_owned(),
+                            committed: false,
+                        })
                     }
                 }
             }
@@ -281,11 +306,23 @@ impl ProfileStore {
                     discord_id,
                     "service_claim_mode returned non-200"
                 );
-                Ok(())
+                // RPC failed at HTTP level — assume no lock was acquired
+                Ok(ModeLockGuard {
+                    client: None,
+                    discord_id,
+                    session_id: session_id.to_owned(),
+                    committed: false,
+                })
             }
             Err(e) => {
                 warn!(error = %e, discord_id, "service_claim_mode RPC failed");
-                Ok(())
+                // Network/transport error — assume no lock acquired
+                Ok(ModeLockGuard {
+                    client: None,
+                    discord_id,
+                    session_id: session_id.to_owned(),
+                    committed: false,
+                })
             }
         }
     }
@@ -357,6 +394,94 @@ impl ProfileStore {
     /// Invalidate a cached profile (called after save).
     pub async fn invalidate(&self, discord_id: u64) {
         self.cache.lock().await.pop(&discord_id);
+    }
+}
+
+// ── ModeLockGuard ──────────────────────────────────────────────────────
+
+/// RAII guard for the play mode lock.
+///
+/// Returned by [`ProfileStore::claim_mode`]. Releases the lock automatically
+/// when dropped unless [`commit`](Self::commit) was called first. This
+/// prevents the lock from leaking when error paths between claim and session
+/// creation return early or panic.
+///
+/// # Usage
+///
+/// ```ignore
+/// let guard = profiles.claim_mode(user.get(), &session_id, false).await?;
+///
+/// // ... do all the fallible setup work ...
+/// let session = build_session(...)?;
+/// store.create(session);
+///
+/// // Only NOW commit — the lock will outlive this scope.
+/// guard.commit();
+/// ```
+///
+/// If any `?` between the claim and `commit()` returns early, the guard's
+/// `Drop` impl spawns a release task to free the lock immediately instead
+/// of waiting 30 minutes for the TTL.
+pub struct ModeLockGuard {
+    /// Supabase client for the release call. `None` if Supabase was
+    /// unavailable at claim time (no-op guard, drop does nothing).
+    client: Option<SupabaseClient>,
+    discord_id: u64,
+    session_id: String,
+    /// When true, drop is a no-op (the caller successfully created the session).
+    committed: bool,
+}
+
+impl ModeLockGuard {
+    /// Mark the lock as committed — drop will NOT release.
+    ///
+    /// Call this only after the session is fully registered and the player
+    /// can be expected to release the lock through normal session lifecycle
+    /// (game over, leave, expire).
+    pub fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for ModeLockGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        let discord_id = self.discord_id;
+        let session_id = std::mem::take(&mut self.session_id);
+        debug!(
+            discord_id,
+            session_id = %session_id,
+            "ModeLockGuard dropped without commit — spawning release"
+        );
+        tokio::spawn(async move {
+            let params = serde_json::json!({
+                "p_discord_id": discord_id as i64,
+                "p_session_id": session_id,
+            });
+            match client
+                .rpc_schema("service_release_mode", params, SCHEMA)
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    debug!(discord_id, "Mode lock released via guard drop");
+                }
+                Ok(resp) => {
+                    warn!(
+                        status = %resp.status(),
+                        discord_id,
+                        "ModeLockGuard release returned non-200"
+                    );
+                }
+                Err(e) => {
+                    warn!(error = %e, discord_id, "ModeLockGuard release RPC failed");
+                }
+            }
+        });
     }
 }
 

--- a/packages/data/sql/dbmate/migrations/20260409210000_discordsh_cross_platform_profiles.sql
+++ b/packages/data/sql/dbmate/migrations/20260409210000_discordsh_cross_platform_profiles.sql
@@ -52,6 +52,28 @@ CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_auth_user
     WHERE auth_user_id IS NOT NULL;
 
 -- ===========================================
+-- HOTFIX: grant table privileges to service_role
+--
+-- The baseline migration (20260316210000) created the tables with
+-- REVOKE FROM PUBLIC + an RLS policy granting service_role access, but
+-- never explicitly GRANTed table privileges to service_role. In production
+-- (where service_role is a normal role, not a superuser), this means all
+-- service_* RPCs marked SECURITY DEFINER fail with "permission denied for
+-- table dungeon_profiles" because the function owner doesn't have the
+-- underlying SELECT/INSERT/UPDATE grants needed to satisfy SECURITY DEFINER.
+--
+-- Local dev hides this because the local service_role is a superuser stub
+-- (init/00-roles.sql) that bypasses all grants and RLS.
+--
+-- These GRANTs are idempotent and stay scoped to service_role — no
+-- privilege escalation, no superuser access. The functions remain
+-- service_role-owned so SECURITY DEFINER bounds the blast radius.
+-- ===========================================
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON discordsh.dungeon_profiles TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON discordsh.dungeon_runs TO service_role;
+
+-- ===========================================
 -- UPDATE: service_load_profile — add new columns to output
 --
 -- Postgres does not allow CREATE OR REPLACE FUNCTION to change the return
@@ -644,6 +666,12 @@ ALTER TABLE discordsh.dungeon_profiles
     DROP COLUMN IF EXISTS auth_user_id,
     DROP COLUMN IF EXISTS faction_standing,
     DROP COLUMN IF EXISTS skills;
+
+-- NOTE: We intentionally do NOT REVOKE the table grants from service_role
+-- in the down migration. The grants fix a latent bug in the baseline
+-- migration (service_role lacked direct table privileges, causing
+-- service_upsert_profile to silently fail in production). Rolling back
+-- our migration shouldn't re-break the baseline RPCs.
 
 -- Recreate the original service_load_profile (without skills/faction/auth_user_id columns)
 -- to restore the prior schema state.

--- a/packages/data/sql/dbmate/migrations/20260409210000_discordsh_cross_platform_profiles.sql
+++ b/packages/data/sql/dbmate/migrations/20260409210000_discordsh_cross_platform_profiles.sql
@@ -22,7 +22,12 @@
 ALTER TABLE discordsh.dungeon_profiles
     ADD COLUMN IF NOT EXISTS skills          JSONB NOT NULL DEFAULT '{}'::JSONB,
     ADD COLUMN IF NOT EXISTS faction_standing JSONB NOT NULL DEFAULT '{}'::JSONB,
-    ADD COLUMN IF NOT EXISTS auth_user_id    UUID UNIQUE;
+    ADD COLUMN IF NOT EXISTS auth_user_id    UUID UNIQUE,
+    -- Mode lock: prevents simultaneous Discord + isometric play (data race prevention)
+    ADD COLUMN IF NOT EXISTS active_mode            TEXT
+        CHECK (active_mode IS NULL OR active_mode IN ('discord', 'isometric')),
+    ADD COLUMN IF NOT EXISTS active_mode_session_id TEXT,
+    ADD COLUMN IF NOT EXISTS active_mode_started_at TIMESTAMPTZ;
 
 COMMENT ON COLUMN discordsh.dungeon_profiles.skills IS
     'Serialized bevy_skills::SkillProfile — shared across Discord and isometric game';
@@ -30,6 +35,16 @@ COMMENT ON COLUMN discordsh.dungeon_profiles.faction_standing IS
     'Faction reputation: {"crystal-order": 25, "shadow-court": -10, "deep-wardens": 50}';
 COMMENT ON COLUMN discordsh.dungeon_profiles.auth_user_id IS
     'Optional link to auth.users(id) — enables isometric game to load this profile via JWT';
+COMMENT ON COLUMN discordsh.dungeon_profiles.active_mode IS
+    'Currently active play mode: discord or isometric. NULL means no active session. '
+    'Enforced via service_claim_mode/service_release_mode RPCs to prevent data races '
+    'when the same player has Discord dungeon and isometric game open simultaneously.';
+COMMENT ON COLUMN discordsh.dungeon_profiles.active_mode_session_id IS
+    'Opaque session identifier owned by the claiming client. Used by service_release_mode '
+    'to verify the caller still owns the lock before releasing.';
+COMMENT ON COLUMN discordsh.dungeon_profiles.active_mode_started_at IS
+    'When the active mode was claimed. Stale claims (older than MODE_LOCK_TTL_MINUTES) '
+    'can be force-overridden by the next claimant.';
 
 -- Index for isometric game profile lookup by auth user
 CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_auth_user
@@ -362,6 +377,183 @@ GRANT EXECUTE ON FUNCTION discordsh.service_link_auth(BIGINT, UUID) TO service_r
 ALTER FUNCTION discordsh.service_link_auth(BIGINT, UUID) OWNER TO service_role;
 
 -- ===========================================
+-- MODE LOCK: prevents simultaneous Discord + isometric play
+--
+-- Rationale: when a player has both clients open, both can call
+-- service_upsert_profile concurrently. The advisory lock keyed on
+-- discord_id only prevents torn writes, not last-write-wins clobbering
+-- of fields the other client just changed (gold, inventory, skills).
+--
+-- The mode lock forces sessions to be serial: player can be in Discord
+-- OR isometric, never both. Stale claims auto-expire after 30 minutes
+-- (covers crash recovery without locking the player out forever).
+--
+-- TTL: 30 minutes
+-- ===========================================
+
+-- service_claim_mode — atomic CAS to grab the mode lock for a session
+CREATE OR REPLACE FUNCTION discordsh.service_claim_mode(
+    p_discord_id  BIGINT,
+    p_mode        TEXT,           -- 'discord' or 'isometric'
+    p_session_id  TEXT,           -- opaque session id owned by caller
+    p_force       BOOLEAN DEFAULT FALSE  -- override stale claim (>30min)
+)
+RETURNS TABLE(success BOOLEAN, current_mode TEXT, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_existing_mode       TEXT;
+    v_existing_session_id TEXT;
+    v_existing_started_at TIMESTAMPTZ;
+    v_lock_age_minutes    NUMERIC;
+    v_ttl_minutes         CONSTANT INT := 30;
+BEGIN
+    -- Validate mode value
+    IF p_mode NOT IN ('discord', 'isometric') THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid mode (must be discord or isometric).'::TEXT;
+        RETURN;
+    END IF;
+
+    IF p_session_id IS NULL OR p_session_id = '' THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'session_id is required.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Serialize per-player to avoid concurrent claims racing
+    PERFORM pg_advisory_xact_lock(p_discord_id);
+
+    SELECT active_mode, active_mode_session_id, active_mode_started_at
+      INTO v_existing_mode, v_existing_session_id, v_existing_started_at
+      FROM discordsh.dungeon_profiles
+     WHERE discord_id = p_discord_id;
+
+    -- Profile doesn't exist yet — auto-create with the claim
+    IF NOT FOUND THEN
+        INSERT INTO discordsh.dungeon_profiles (
+            discord_id, discord_name, active_mode, active_mode_session_id, active_mode_started_at
+        )
+        VALUES (
+            p_discord_id, 'Adventurer'::TEXT, p_mode, p_session_id, NOW()
+        );
+        RETURN QUERY SELECT true, p_mode, 'Mode claimed (new profile).'::TEXT;
+        RETURN;
+    END IF;
+
+    -- No active claim → grant immediately
+    IF v_existing_mode IS NULL THEN
+        UPDATE discordsh.dungeon_profiles
+           SET active_mode = p_mode,
+               active_mode_session_id = p_session_id,
+               active_mode_started_at = NOW()
+         WHERE discord_id = p_discord_id;
+        RETURN QUERY SELECT true, p_mode, 'Mode claimed.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Same mode + same session = idempotent re-claim (refresh timestamp)
+    IF v_existing_mode = p_mode AND v_existing_session_id = p_session_id THEN
+        UPDATE discordsh.dungeon_profiles
+           SET active_mode_started_at = NOW()
+         WHERE discord_id = p_discord_id;
+        RETURN QUERY SELECT true, p_mode, 'Mode reclaimed (refreshed).'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Different claim exists — check if it's stale
+    v_lock_age_minutes := EXTRACT(EPOCH FROM (NOW() - v_existing_started_at)) / 60;
+
+    IF v_lock_age_minutes > v_ttl_minutes OR p_force THEN
+        -- Stale or forced override
+        UPDATE discordsh.dungeon_profiles
+           SET active_mode = p_mode,
+               active_mode_session_id = p_session_id,
+               active_mode_started_at = NOW()
+         WHERE discord_id = p_discord_id;
+        RETURN QUERY SELECT
+            true,
+            p_mode,
+            FORMAT('Mode claimed (overrode stale %s claim, age %s min).',
+                   v_existing_mode, ROUND(v_lock_age_minutes, 1))::TEXT;
+        RETURN;
+    END IF;
+
+    -- Lock held by another active session — reject
+    RETURN QUERY SELECT
+        false,
+        v_existing_mode,
+        FORMAT('Player is already in %s (claim age %s min). Finish that session first.',
+               v_existing_mode, ROUND(v_lock_age_minutes, 1))::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_claim_mode IS
+    'Atomically claim the play mode lock for a player. Prevents simultaneous '
+    'Discord + isometric sessions. Stale claims (>30min) auto-override.';
+
+REVOKE ALL ON FUNCTION discordsh.service_claim_mode(BIGINT, TEXT, TEXT, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_claim_mode(BIGINT, TEXT, TEXT, BOOLEAN)
+    TO service_role;
+ALTER FUNCTION discordsh.service_claim_mode(BIGINT, TEXT, TEXT, BOOLEAN)
+    OWNER TO service_role;
+
+-- service_release_mode — release the lock if the caller still owns it
+CREATE OR REPLACE FUNCTION discordsh.service_release_mode(
+    p_discord_id BIGINT,
+    p_session_id TEXT
+)
+RETURNS TABLE(success BOOLEAN, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_existing_session_id TEXT;
+BEGIN
+    PERFORM pg_advisory_xact_lock(p_discord_id);
+
+    SELECT active_mode_session_id INTO v_existing_session_id
+      FROM discordsh.dungeon_profiles
+     WHERE discord_id = p_discord_id;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT false, 'Profile not found.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF v_existing_session_id IS NULL THEN
+        RETURN QUERY SELECT true, 'No active claim.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF v_existing_session_id <> p_session_id THEN
+        RETURN QUERY SELECT false, 'Lock owned by another session.'::TEXT;
+        RETURN;
+    END IF;
+
+    UPDATE discordsh.dungeon_profiles
+       SET active_mode = NULL,
+           active_mode_session_id = NULL,
+           active_mode_started_at = NULL
+     WHERE discord_id = p_discord_id;
+
+    RETURN QUERY SELECT true, 'Mode released.'::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_release_mode IS
+    'Release the play mode lock if the caller still owns the session.';
+
+REVOKE ALL ON FUNCTION discordsh.service_release_mode(BIGINT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_release_mode(BIGINT, TEXT)
+    TO service_role;
+ALTER FUNCTION discordsh.service_release_mode(BIGINT, TEXT)
+    OWNER TO service_role;
+
+-- ===========================================
 -- VERIFICATION
 -- ===========================================
 
@@ -391,15 +583,42 @@ BEGIN
         RAISE EXCEPTION 'auth_user_id column not found on discordsh.dungeon_profiles';
     END IF;
 
-    -- Verify new function exists
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'active_mode'
+    ) THEN
+        RAISE EXCEPTION 'active_mode column not found on discordsh.dungeon_profiles';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'active_mode_session_id'
+    ) THEN
+        RAISE EXCEPTION 'active_mode_session_id column not found on discordsh.dungeon_profiles';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'active_mode_started_at'
+    ) THEN
+        RAISE EXCEPTION 'active_mode_started_at column not found on discordsh.dungeon_profiles';
+    END IF;
+
+    -- Verify new functions exist
     PERFORM 'discordsh.service_load_profile_by_auth(uuid)'::regprocedure;
     PERFORM 'discordsh.service_link_auth(bigint, uuid)'::regprocedure;
+    PERFORM 'discordsh.service_claim_mode(bigint, text, text, boolean)'::regprocedure;
+    PERFORM 'discordsh.service_release_mode(bigint, text)'::regprocedure;
 
     RAISE NOTICE 'cross_platform_profiles migration verified successfully.';
 END;
 $$ LANGUAGE plpgsql;
 
 -- migrate:down
+
+-- Drop mode lock functions
+DROP FUNCTION IF EXISTS discordsh.service_release_mode(BIGINT, TEXT);
+DROP FUNCTION IF EXISTS discordsh.service_claim_mode(BIGINT, TEXT, TEXT, BOOLEAN);
 
 -- Drop new helper functions
 DROP FUNCTION IF EXISTS discordsh.service_link_auth(BIGINT, UUID);
@@ -417,8 +636,11 @@ DROP FUNCTION IF EXISTS discordsh.service_upsert_profile(
 -- Drop index
 DROP INDEX IF EXISTS discordsh.idx_discordsh_dungeon_profiles_auth_user;
 
--- Remove columns
+-- Remove columns (mode lock first, then cross-platform fields)
 ALTER TABLE discordsh.dungeon_profiles
+    DROP COLUMN IF EXISTS active_mode_started_at,
+    DROP COLUMN IF EXISTS active_mode_session_id,
+    DROP COLUMN IF EXISTS active_mode,
     DROP COLUMN IF EXISTS auth_user_id,
     DROP COLUMN IF EXISTS faction_standing,
     DROP COLUMN IF EXISTS skills;

--- a/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
+++ b/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
@@ -200,6 +200,25 @@ COMMENT ON COLUMN discordsh.dungeon_runs.outcome IS
 REVOKE ALL ON discordsh.dungeon_runs FROM PUBLIC, anon, authenticated;
 
 -- ===========================================
+-- GRANT table privileges to service_role
+--
+-- service_role needs direct table access for SECURITY DEFINER functions
+-- to work in production. Without these grants, every service_* RPC fails
+-- with "permission denied for table dungeon_profiles" because the function
+-- owner can't read the underlying tables, even with the RLS policy below.
+--
+-- Local dev hides this because the local service_role is a superuser stub
+-- (init/00-roles.sql) that bypasses all checks. Production has proper
+-- role isolation, so explicit GRANTs are required.
+--
+-- The functions stay service_role-owned (not postgres) so SECURITY DEFINER
+-- bounds the blast radius — no privilege escalation surface.
+-- ===========================================
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON discordsh.dungeon_profiles TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON discordsh.dungeon_runs TO service_role;
+
+-- ===========================================
 -- INDEXES
 -- ===========================================
 

--- a/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
+++ b/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
@@ -103,6 +103,19 @@ CREATE TABLE IF NOT EXISTS discordsh.dungeon_profiles (
     -- Completed quest slugs
     completed_quests        TEXT[] NOT NULL DEFAULT '{}',
 
+    -- Cross-platform: shared with isometric game
+    skills                  JSONB NOT NULL DEFAULT '{}'::JSONB,
+    faction_standing        JSONB NOT NULL DEFAULT '{}'::JSONB,
+    auth_user_id            UUID UNIQUE,
+
+    -- Mode lock: prevents simultaneous Discord + isometric play
+    -- Enforced via service_claim_mode/service_release_mode RPCs.
+    -- Stale claims (>30 min) are auto-overridable.
+    active_mode             TEXT
+                            CHECK (active_mode IS NULL OR active_mode IN ('discord', 'isometric')),
+    active_mode_session_id  TEXT,
+    active_mode_started_at  TIMESTAMPTZ,
+
     -- Timestamps
     created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at              TIMESTAMPTZ
@@ -116,6 +129,27 @@ COMMENT ON COLUMN discordsh.dungeon_profiles.class_id IS
     'DungeonClass proto enum: 1=warrior, 2=rogue, 3=cleric';
 COMMENT ON COLUMN discordsh.dungeon_profiles.inventory IS
     'JSONB array: [{item_id: string, qty: int}, ...] — shape-validated via CHECK';
+COMMENT ON COLUMN discordsh.dungeon_profiles.skills IS
+    'Serialized bevy_skills::SkillProfile — shared across Discord and isometric game';
+COMMENT ON COLUMN discordsh.dungeon_profiles.faction_standing IS
+    'Faction reputation: {"crystal-order": 25, "shadow-court": -10, "deep-wardens": 50}';
+COMMENT ON COLUMN discordsh.dungeon_profiles.auth_user_id IS
+    'Optional link to auth.users(id) — enables isometric game to load this profile via JWT';
+COMMENT ON COLUMN discordsh.dungeon_profiles.active_mode IS
+    'Currently active play mode: discord or isometric. NULL means no active session. '
+    'Enforced via service_claim_mode/service_release_mode RPCs to prevent data races '
+    'when the same player has Discord dungeon and isometric game open simultaneously.';
+COMMENT ON COLUMN discordsh.dungeon_profiles.active_mode_session_id IS
+    'Opaque session identifier owned by the claiming client. Used by service_release_mode '
+    'to verify the caller still owns the lock before releasing.';
+COMMENT ON COLUMN discordsh.dungeon_profiles.active_mode_started_at IS
+    'When the active mode was claimed. Stale claims (older than 30 minutes) '
+    'can be force-overridden by the next claimant.';
+
+-- Index for isometric game profile lookup by auth user
+CREATE INDEX IF NOT EXISTS idx_discordsh_dungeon_profiles_auth_user
+    ON discordsh.dungeon_profiles (auth_user_id)
+    WHERE auth_user_id IS NOT NULL;
 
 -- Explicit revoke for defense in depth
 REVOKE ALL ON discordsh.dungeon_profiles FROM PUBLIC, anon, authenticated;
@@ -327,6 +361,8 @@ CREATE POLICY "service_role_full_access" ON discordsh.dungeon_runs
 -- Called by the bot's ProfileStore via PostgREST RPC.
 -- ===========================================
 
+DROP FUNCTION IF EXISTS discordsh.service_load_profile(BIGINT);
+
 CREATE OR REPLACE FUNCTION discordsh.service_load_profile(
     p_discord_id BIGINT
 )
@@ -349,6 +385,9 @@ RETURNS TABLE(
     armor_gear TEXT,
     inventory JSONB,
     completed_quests TEXT[],
+    skills JSONB,
+    faction_standing JSONB,
+    auth_user_id UUID,
     created_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ
 )
@@ -377,6 +416,9 @@ BEGIN
         p.armor_gear,
         p.inventory,
         p.completed_quests,
+        p.skills,
+        p.faction_standing,
+        p.auth_user_id,
         p.created_at,
         p.updated_at
     FROM discordsh.dungeon_profiles p
@@ -399,6 +441,13 @@ ALTER FUNCTION discordsh.service_load_profile(BIGINT) OWNER TO service_role;
 -- concurrent save races (e.g., timeout cleanup vs explicit /dungeon end).
 -- ===========================================
 
+DROP FUNCTION IF EXISTS discordsh.service_upsert_profile(
+    BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
+    INT, INT, INT, INT, INT, INT, INT,
+    TEXT, TEXT, JSONB, TEXT[],
+    SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
+);
+
 CREATE OR REPLACE FUNCTION discordsh.service_upsert_profile(
     -- Profile fields
     p_discord_id            BIGINT,
@@ -419,6 +468,8 @@ CREATE OR REPLACE FUNCTION discordsh.service_upsert_profile(
     p_armor_gear            TEXT DEFAULT NULL,
     p_inventory             JSONB DEFAULT '[]'::JSONB,
     p_completed_quests      TEXT[] DEFAULT '{}',
+    p_skills                JSONB DEFAULT '{}'::JSONB,
+    p_faction_standing      JSONB DEFAULT '{}'::JSONB,
     -- Run fields
     p_run_outcome           SMALLINT DEFAULT NULL,
     p_run_rooms_cleared     INT DEFAULT 0,
@@ -444,13 +495,15 @@ BEGIN
         discord_id, discord_name, class_id, level, xp, xp_to_next, gold,
         lifetime_kills, lifetime_gold_earned, lifetime_rooms_cleared,
         lifetime_bosses_defeated, lifetime_deaths, lifetime_victories,
-        lifetime_escapes, weapon, armor_gear, inventory, completed_quests
+        lifetime_escapes, weapon, armor_gear, inventory, completed_quests,
+        skills, faction_standing
     )
     VALUES (
         p_discord_id, p_discord_name, p_class_id, p_level, p_xp, p_xp_to_next, p_gold,
         p_lifetime_kills, p_lifetime_gold_earned, p_lifetime_rooms_cleared,
         p_lifetime_bosses_defeated, p_lifetime_deaths, p_lifetime_victories,
-        p_lifetime_escapes, p_weapon, p_armor_gear, p_inventory, p_completed_quests
+        p_lifetime_escapes, p_weapon, p_armor_gear, p_inventory, p_completed_quests,
+        p_skills, p_faction_standing
     )
     ON CONFLICT (discord_id) DO UPDATE SET
         discord_name            = EXCLUDED.discord_name,
@@ -469,7 +522,9 @@ BEGIN
         weapon                  = EXCLUDED.weapon,
         armor_gear              = EXCLUDED.armor_gear,
         inventory               = EXCLUDED.inventory,
-        completed_quests        = EXCLUDED.completed_quests;
+        completed_quests        = EXCLUDED.completed_quests,
+        skills                  = EXCLUDED.skills,
+        faction_standing        = EXCLUDED.faction_standing;
 
     -- Insert run log (if outcome provided)
     IF p_run_outcome IS NOT NULL THEN
@@ -499,19 +554,19 @@ COMMENT ON FUNCTION discordsh.service_upsert_profile IS
 REVOKE ALL ON FUNCTION discordsh.service_upsert_profile(
     BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
     INT, INT, INT, INT, INT, INT, INT,
-    TEXT, TEXT, JSONB, TEXT[],
+    TEXT, TEXT, JSONB, TEXT[], JSONB, JSONB,
     SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
 ) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION discordsh.service_upsert_profile(
     BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
     INT, INT, INT, INT, INT, INT, INT,
-    TEXT, TEXT, JSONB, TEXT[],
+    TEXT, TEXT, JSONB, TEXT[], JSONB, JSONB,
     SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
 ) TO service_role;
 ALTER FUNCTION discordsh.service_upsert_profile(
     BIGINT, TEXT, SMALLINT, SMALLINT, INT, INT, INT,
     INT, INT, INT, INT, INT, INT, INT,
-    TEXT, TEXT, JSONB, TEXT[],
+    TEXT, TEXT, JSONB, TEXT[], JSONB, JSONB,
     SMALLINT, INT, INT, INT, INT, INT, INT, SMALLINT, INT
 ) OWNER TO service_role;
 
@@ -629,6 +684,269 @@ GRANT EXECUTE ON FUNCTION discordsh.service_leaderboard(SMALLINT, INT) TO servic
 ALTER FUNCTION discordsh.service_leaderboard(SMALLINT, INT) OWNER TO service_role;
 
 -- ===========================================
+-- SERVICE FUNCTION: Load profile by Supabase auth UUID
+--
+-- Used by the isometric game to load a profile via JWT.
+-- Returns empty if no profile is linked (guest mode).
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_load_profile_by_auth(
+    p_auth_user_id UUID
+)
+RETURNS TABLE(
+    discord_id BIGINT,
+    discord_name TEXT,
+    class_id SMALLINT,
+    level SMALLINT,
+    xp INT,
+    xp_to_next INT,
+    gold INT,
+    lifetime_kills INT,
+    lifetime_gold_earned INT,
+    lifetime_rooms_cleared INT,
+    lifetime_bosses_defeated INT,
+    lifetime_deaths INT,
+    lifetime_victories INT,
+    lifetime_escapes INT,
+    weapon TEXT,
+    armor_gear TEXT,
+    inventory JSONB,
+    completed_quests TEXT[],
+    skills JSONB,
+    faction_standing JSONB,
+    auth_user_id UUID,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        p.discord_id, p.discord_name, p.class_id, p.level, p.xp, p.xp_to_next, p.gold,
+        p.lifetime_kills, p.lifetime_gold_earned, p.lifetime_rooms_cleared,
+        p.lifetime_bosses_defeated, p.lifetime_deaths, p.lifetime_victories, p.lifetime_escapes,
+        p.weapon, p.armor_gear, p.inventory, p.completed_quests,
+        p.skills, p.faction_standing, p.auth_user_id, p.created_at, p.updated_at
+    FROM discordsh.dungeon_profiles p
+    WHERE p.auth_user_id = p_auth_user_id;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_load_profile_by_auth IS
+    'Load a dungeon profile by Supabase auth UUID. Returns empty if no linked profile (guest mode).';
+
+REVOKE ALL ON FUNCTION discordsh.service_load_profile_by_auth(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_load_profile_by_auth(UUID) TO service_role;
+ALTER FUNCTION discordsh.service_load_profile_by_auth(UUID) OWNER TO service_role;
+
+-- ===========================================
+-- SERVICE FUNCTION: Link Supabase auth account to Discord profile
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_link_auth(
+    p_discord_id    BIGINT,
+    p_auth_user_id  UUID
+)
+RETURNS TABLE(success BOOLEAN, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    UPDATE discordsh.dungeon_profiles
+    SET auth_user_id = p_auth_user_id
+    WHERE discord_id = p_discord_id;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT false, 'Discord profile not found.'::TEXT;
+        RETURN;
+    END IF;
+
+    RETURN QUERY SELECT true, 'Account linked.'::TEXT;
+
+EXCEPTION
+    WHEN unique_violation THEN
+        RETURN QUERY SELECT false, 'Auth account already linked to another profile.'::TEXT;
+    WHEN OTHERS THEN
+        RETURN QUERY SELECT false, SQLERRM::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_link_auth IS
+    'Link a Supabase auth.users UUID to a Discord dungeon profile. Enables cross-platform persistence.';
+
+REVOKE ALL ON FUNCTION discordsh.service_link_auth(BIGINT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_link_auth(BIGINT, UUID) TO service_role;
+ALTER FUNCTION discordsh.service_link_auth(BIGINT, UUID) OWNER TO service_role;
+
+-- ===========================================
+-- MODE LOCK: prevents simultaneous Discord + isometric play
+--
+-- The same player should never have a Discord dungeon session AND an
+-- isometric game session running at the same time — both writes to the
+-- same profile would race and clobber each other (gold, inventory, skills).
+--
+-- service_claim_mode atomically claims the lock for one mode at a time.
+-- service_release_mode releases the lock when the session ends.
+-- Stale claims auto-expire after 30 minutes (covers crash recovery).
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_claim_mode(
+    p_discord_id  BIGINT,
+    p_mode        TEXT,
+    p_session_id  TEXT,
+    p_force       BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE(success BOOLEAN, current_mode TEXT, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_existing_mode       TEXT;
+    v_existing_session_id TEXT;
+    v_existing_started_at TIMESTAMPTZ;
+    v_lock_age_minutes    NUMERIC;
+    v_ttl_minutes         CONSTANT INT := 30;
+BEGIN
+    IF p_mode NOT IN ('discord', 'isometric') THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'Invalid mode (must be discord or isometric).'::TEXT;
+        RETURN;
+    END IF;
+
+    IF p_session_id IS NULL OR p_session_id = '' THEN
+        RETURN QUERY SELECT false, NULL::TEXT, 'session_id is required.'::TEXT;
+        RETURN;
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(p_discord_id);
+
+    SELECT active_mode, active_mode_session_id, active_mode_started_at
+      INTO v_existing_mode, v_existing_session_id, v_existing_started_at
+      FROM discordsh.dungeon_profiles
+     WHERE discord_id = p_discord_id;
+
+    IF NOT FOUND THEN
+        INSERT INTO discordsh.dungeon_profiles (
+            discord_id, discord_name, active_mode, active_mode_session_id, active_mode_started_at
+        )
+        VALUES (
+            p_discord_id, 'Adventurer'::TEXT, p_mode, p_session_id, NOW()
+        );
+        RETURN QUERY SELECT true, p_mode, 'Mode claimed (new profile).'::TEXT;
+        RETURN;
+    END IF;
+
+    IF v_existing_mode IS NULL THEN
+        UPDATE discordsh.dungeon_profiles
+           SET active_mode = p_mode,
+               active_mode_session_id = p_session_id,
+               active_mode_started_at = NOW()
+         WHERE discord_id = p_discord_id;
+        RETURN QUERY SELECT true, p_mode, 'Mode claimed.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF v_existing_mode = p_mode AND v_existing_session_id = p_session_id THEN
+        UPDATE discordsh.dungeon_profiles
+           SET active_mode_started_at = NOW()
+         WHERE discord_id = p_discord_id;
+        RETURN QUERY SELECT true, p_mode, 'Mode reclaimed (refreshed).'::TEXT;
+        RETURN;
+    END IF;
+
+    v_lock_age_minutes := EXTRACT(EPOCH FROM (NOW() - v_existing_started_at)) / 60;
+
+    IF v_lock_age_minutes > v_ttl_minutes OR p_force THEN
+        UPDATE discordsh.dungeon_profiles
+           SET active_mode = p_mode,
+               active_mode_session_id = p_session_id,
+               active_mode_started_at = NOW()
+         WHERE discord_id = p_discord_id;
+        RETURN QUERY SELECT
+            true,
+            p_mode,
+            FORMAT('Mode claimed (overrode stale %s claim, age %s min).',
+                   v_existing_mode, ROUND(v_lock_age_minutes, 1))::TEXT;
+        RETURN;
+    END IF;
+
+    RETURN QUERY SELECT
+        false,
+        v_existing_mode,
+        FORMAT('Player is already in %s (claim age %s min). Finish that session first.',
+               v_existing_mode, ROUND(v_lock_age_minutes, 1))::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_claim_mode IS
+    'Atomically claim the play mode lock for a player. Prevents simultaneous '
+    'Discord + isometric sessions. Stale claims (>30min) auto-override.';
+
+REVOKE ALL ON FUNCTION discordsh.service_claim_mode(BIGINT, TEXT, TEXT, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_claim_mode(BIGINT, TEXT, TEXT, BOOLEAN)
+    TO service_role;
+ALTER FUNCTION discordsh.service_claim_mode(BIGINT, TEXT, TEXT, BOOLEAN)
+    OWNER TO service_role;
+
+CREATE OR REPLACE FUNCTION discordsh.service_release_mode(
+    p_discord_id BIGINT,
+    p_session_id TEXT
+)
+RETURNS TABLE(success BOOLEAN, message TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_existing_session_id TEXT;
+BEGIN
+    PERFORM pg_advisory_xact_lock(p_discord_id);
+
+    SELECT active_mode_session_id INTO v_existing_session_id
+      FROM discordsh.dungeon_profiles
+     WHERE discord_id = p_discord_id;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT false, 'Profile not found.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF v_existing_session_id IS NULL THEN
+        RETURN QUERY SELECT true, 'No active claim.'::TEXT;
+        RETURN;
+    END IF;
+
+    IF v_existing_session_id <> p_session_id THEN
+        RETURN QUERY SELECT false, 'Lock owned by another session.'::TEXT;
+        RETURN;
+    END IF;
+
+    UPDATE discordsh.dungeon_profiles
+       SET active_mode = NULL,
+           active_mode_session_id = NULL,
+           active_mode_started_at = NULL
+     WHERE discord_id = p_discord_id;
+
+    RETURN QUERY SELECT true, 'Mode released.'::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_release_mode IS
+    'Release the play mode lock if the caller still owns the session.';
+
+REVOKE ALL ON FUNCTION discordsh.service_release_mode(BIGINT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION discordsh.service_release_mode(BIGINT, TEXT)
+    TO service_role;
+ALTER FUNCTION discordsh.service_release_mode(BIGINT, TEXT)
+    OWNER TO service_role;
+
+-- ===========================================
 -- VERIFICATION
 -- ===========================================
 
@@ -653,8 +971,34 @@ BEGIN
 
     -- Verify service functions exist
     PERFORM 'discordsh.service_load_profile(bigint)'::regprocedure;
-    PERFORM 'discordsh.service_upsert_profile(bigint, text, smallint, smallint, int, int, int, int, int, int, int, int, int, int, text, text, jsonb, text[], smallint, int, int, int, int, int, int, smallint, int)'::regprocedure;
+    PERFORM 'discordsh.service_upsert_profile(bigint, text, smallint, smallint, int, int, int, int, int, int, int, int, int, int, text, text, jsonb, text[], jsonb, jsonb, smallint, int, int, int, int, int, int, smallint, int)'::regprocedure;
     PERFORM 'discordsh.service_leaderboard(smallint, int)'::regprocedure;
+    PERFORM 'discordsh.service_load_profile_by_auth(uuid)'::regprocedure;
+    PERFORM 'discordsh.service_link_auth(bigint, uuid)'::regprocedure;
+    PERFORM 'discordsh.service_claim_mode(bigint, text, text, boolean)'::regprocedure;
+    PERFORM 'discordsh.service_release_mode(bigint, text)'::regprocedure;
+
+    -- Verify cross-platform columns exist
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'skills'
+    ) THEN
+        RAISE EXCEPTION 'skills column missing on discordsh.dungeon_profiles';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'faction_standing'
+    ) THEN
+        RAISE EXCEPTION 'faction_standing column missing on discordsh.dungeon_profiles';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'discordsh' AND table_name = 'dungeon_profiles' AND column_name = 'active_mode'
+    ) THEN
+        RAISE EXCEPTION 'active_mode column missing on discordsh.dungeon_profiles';
+    END IF;
 
     -- Verify validation function exists
     PERFORM 'discordsh.is_valid_inventory(jsonb)'::regprocedure;
@@ -743,7 +1087,7 @@ BEGIN
 
     IF EXISTS (
         SELECT 1 FROM pg_proc
-        WHERE oid = 'discordsh.service_upsert_profile(bigint, text, smallint, smallint, int, int, int, int, int, int, int, int, int, int, text, text, jsonb, text[], smallint, int, int, int, int, int, int, smallint, int)'::regprocedure
+        WHERE oid = 'discordsh.service_upsert_profile(bigint, text, smallint, smallint, int, int, int, int, int, int, int, int, int, int, text, text, jsonb, text[], jsonb, jsonb, smallint, int, int, int, int, int, int, smallint, int)'::regprocedure
           AND pg_get_userbyid(proowner) <> 'service_role'
     ) THEN
         RAISE EXCEPTION 'discordsh.service_upsert_profile must be owned by service_role';


### PR DESCRIPTION
## Summary
Adds an \`active_mode\` lock to \`discordsh.dungeon_profiles\` to prevent the same player from being in **both** the Discord embed dungeon AND the isometric game at the same time. Without this, both clients race on every save (gold, inventory, skills, faction_standing) — last write wins clobbers.

Follow-up to #9870 / #9965.

### New columns
| Column | Type | Purpose |
|--------|------|---------|
| \`active_mode\` | TEXT | \`'discord'\` \\| \`'isometric'\` \\| NULL |
| \`active_mode_session_id\` | TEXT | Opaque session id owned by claimant |
| \`active_mode_started_at\` | TIMESTAMPTZ | For stale claim detection (TTL = 30 min) |

### New RPCs
- **\`service_claim_mode(discord_id, mode, session_id, force)\`** — atomic CAS
  - Auto-creates profile if missing
  - Idempotent re-claim by same session (refreshes timestamp)
  - Rejects if another session holds the lock
  - Auto-overrides stale claims (>30 min)
  - \`force=true\` bypasses age check
- **\`service_release_mode(discord_id, session_id)\`** — releases if caller still owns it
  - Rejects if another session owns the lock (prevents races)

### TTL: 30 minutes
Stale claims auto-expire after 30 minutes — covers crash recovery without locking the player out forever. Discord bot calls release on session end (game over, leave, expire). Isometric game calls release on WebSocket disconnect.

### Files updated
- **Migration** (\`20260409210000_discordsh_cross_platform_profiles.sql\`): adds columns, creates RPCs, drops on rollback
- **Schema source-of-truth** (\`discordsh_dungeon_profiles.sql\`): matches the post-migration state for fresh installs

### Local test results

| Test | Result |
|------|--------|
| Migration applies cleanly | ✅ |
| All 6 columns present | ✅ |
| All 6 RPCs created | ✅ |
| New profile auto-create on claim | ✅ |
| Idempotent re-claim by same session | ✅ |
| Conflict rejection with helpful error | ✅ |
| Release + transfer to other mode | ✅ |
| Wrong session release rejection | ✅ |
| Invalid mode rejected | ✅ |
| Empty session_id rejected | ✅ |
| Force override | ✅ |
| Stale auto-override (35min backdated) | ✅ |
| Rollback clean | ✅ |
| Re-apply clean (idempotent) | ✅ |

## Test plan
- [x] Local apply against postgres 17 dev-docker-compose
- [x] All 9 mode lock test cases pass
- [x] Rollback verified clean
- [x] Re-apply after rollback verified clean
- [ ] Discord bot integration: claim on /dungeon start, release on session end
- [ ] Isometric integration: claim on connect, release on disconnect
- [ ] Production deploy via port-forward