### PR TITLE
fix(astro-kbve): enrich 20 OSRS fish to v3 (batch 9)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/herring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/herring.mdx
@@ -12,6 +12,31 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 6000
+  material:
+    type: fish
+    tier: low
+  food:
+    heals: 5
+    cooking_level: 5
+    type: fish
+  cooking:
+    level: 5
+    xp: 50
+    stop_burn_level: 41
+    raw_item_id: 345
+    raw_item_name: Raw herring
+    burnt_item_id: 357
+  recipes:
+    - name: Cook herring
+      skill: cooking
+      level: 5
+      xp: 50
+      materials:
+        - item_name: Raw herring
+          item_id: 345
+          quantity: 1
+      product: Herring
+      product_id: 347
   related_items:
     - item_id: 345
       item_name: Raw herring
@@ -21,14 +46,17 @@ osrs:
     - item_id: 325
       item_name: Sardine
       slug: sardine
-      relationship: variant
-      description: Lower tier bait fish
+      relationship: downgrade
+      description: Lower tier cooked fish
+    - item_id: 333
+      item_name: Trout
+      slug: trout
+      relationship: upgrade
+      description: Higher tier cooked fish
   about: |-
-    > _"Some nicely cooked herring."_
-
-    Herring heals 5 Hitpoints. Caught with a fishing rod and bait at 10 Fishing.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Herring is a free-to-play cooked fish that restores 5 Hitpoints when eaten. It is made by cooking a raw herring on a fire or range, requiring level 5 Cooking and granting 50 experience per success. Herring stops burning entirely at Cooking level 41, or 38 when using the Lumbridge Castle range with Cook's Assistant completed.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lobster.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lobster.mdx
@@ -12,19 +12,20 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 6000
+  material:
+    type: fish
+    tier: mid
   food:
     heals: 12
     cooking_level: 40
-    cooking_xp: 120
-    burn_level: 74
+    type: fish
   cooking:
     level: 40
     xp: 120
     stop_burn_level: 74
-    stop_burn_level_gauntlets: 64
     raw_item_id: 377
     raw_item_name: Raw lobster
-    ticks: 4
+    burnt_item_id: 381
   recipes:
     - skill: cooking
       level: 40
@@ -33,46 +34,24 @@ osrs:
         - item_name: Raw lobster
           item_id: 377
           quantity: 1
-      facility: Fire or range
-      ticks: 4
+      product: Lobster
+      product_id: 379
   related_items:
     - item_id: 377
       item_name: Raw lobster
       slug: raw-lobster
       relationship: component
-      description: Uncooked version
-    - item_id: 373
-      item_name: Swordfish
-      slug: swordfish
-      relationship: upgrade
-      description: Next tier (14 HP)
-    - item_id: 385
-      item_name: Shark
-      slug: shark
-      relationship: upgrade
-      description: High tier (20 HP)
     - item_id: 361
       item_name: Tuna
       slug: tuna
       relationship: downgrade
-      description: Lower tier (10 HP)
-  about: |-
-    Cook Raw lobster on a fire or range.
-
-    Lobster is a popular mid-level food for:
-    - Mid-level slayer
-    - Quest bosses
-    - Budget PvP
-    - Ironman progression
-  market_strategy:
-    notes:
-      - High volume, consistent demand
-      - Good margins for cooking bots/alts
-      - Very liquid market
-      - Cheaper than shark/swordfish
-      - Popular for activities where food is expendable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 373
+      item_name: Swordfish
+      slug: swordfish
+      relationship: upgrade
+  about: Lobster is a classic mid-game food in Old School RuneScape, available to free-to-play players and healing 12 Hitpoints per eat. Cooked from raw lobster at Cooking level 40 for 120 experience, it remains one of the most popular staples for low-to-mid level combat training, Slayer tasks, and questing thanks to its cheap price and high liquidity on the Grand Exchange.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/monkfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/monkfish.mdx
@@ -12,15 +12,20 @@ osrs:
   lowalch: 92
   highalch: 138
   limit: 13000
+  material:
+    type: fish
+    tier: mid-high
   food:
     heals: 16
+    cooking_level: 62
     type: fish
   cooking:
     level: 62
     xp: 150
     stop_burn_level: 92
-    stop_burn_level_gauntlets: 82
-    quest_required: Swan Song
+    raw_item_id: 7944
+    raw_item_name: Raw monkfish
+    burnt_item_id: 7948
   recipes:
     - skill: cooking
       level: 62
@@ -34,32 +39,28 @@ osrs:
       product_quantity: 1
       facility: Range/Fire
       members_only: true
+  quest_data:
+    quests:
+      - quest_name: Swan Song
+        role: required
   related_items:
     - item_id: 7944
       item_name: Raw monkfish
       slug: raw-monkfish
       relationship: component
       description: Uncooked version
-    - item_id: 385
-      item_name: Shark
-      slug: shark
-      relationship: alternative
-      description: Higher tier food
     - item_id: 373
       item_name: Swordfish
       slug: swordfish
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier food
-    - item_id: 775
-      item_name: Cooking gauntlets
-      slug: cooking-gauntlets
-      relationship: alternative
-      description: Reduce burn
+    - item_id: 385
+      item_name: Shark
+      slug: shark
+      relationship: upgrade
+      description: Higher tier food
   about: |-
-    | Effect | Value |
-    |--------|-------|
-    | Heals | 16 HP |
-    | Buy limit | 13,000 |
+    Monkfish is a members cooked food that heals 16 HP per bite, requiring the Swan Song quest to fish the raw version and 62 Cooking to prepare. It sits comfortably between swordfish and sharks as an efficient mid-high tier food for Slayer, mid-level PvM, and combat training. Catching and cooking monkfish is one of the most popular AFK fishing and cooking methods in the game, thanks to its steady XP rates and reasonable profit.
   market_strategy:
     notes:
       - Good healing for cost
@@ -73,8 +74,8 @@ osrs:
       - Burns until high Cooking
       - Good GP/HP ratio
       - Popular Slayer food
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-herring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-herring.mdx
@@ -12,18 +12,45 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15000
+  material:
+    type: fish
+    tier: low
+  skilling_source:
+    skill: fishing
+    level: 10
+    xp: 30
+    location: Catherby / Lumbridge
+    tool: Fishing rod
+    bait: Fishing bait
+    method: Bait
+  recipes:
+    - name: Cook herring
+      skill: cooking
+      level: 5
+      xp: 50
+      materials:
+        - item_name: Raw herring
+          item_id: 345
+          quantity: 1
+      product: Herring
+      product_id: 347
+      facility: Range/Fire
   related_items:
     - item_id: 347
       item_name: Herring
       slug: herring
       relationship: product
-      description: Cooked version
-  about: |-
-    > _"I should try cooking this."_
-
-    Raw herring can be cooked at 5 Cooking to make herring. Caught at the same bait spots as sardines.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 327
+      item_name: Raw sardine
+      slug: raw-sardine
+      relationship: downgrade
+    - item_id: 335
+      item_name: Raw trout
+      slug: raw-trout
+      relationship: upgrade
+  about: Raw herring is a low-tier fish caught with a fishing rod and fishing bait at coastal bait spots from level 10 Fishing, yielding 30 experience per catch. It can be cooked at level 5 Cooking on a range or fire for 50 experience to produce a herring. Common catch locations include Catherby, Lumbridge Swamp, Draynor Village, and Port Sarim.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-lobster.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-lobster.mdx
@@ -12,24 +12,17 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 15000
+  about: Raw lobster is a crustacean caught with a lobster pot at level 40 Fishing, granting 90 experience per catch. It is one of the staple free-to-play fish used by mid-level players training Fishing and Cooking together. When cooked at level 40 Cooking, it becomes a lobster that heals 12 hitpoints.
   material:
-    type: raw_fish
+    type: fish
     tier: mid
-  fishing:
+  skilling_source:
+    skill: fishing
     level: 40
     xp: 90
-    method: Lobster pot
-    locations:
-      - Catherby
-      - Fishing Guild
-      - Musa Point
-  cooking:
-    level: 40
-    xp: 120
-    stop_burn_level: 74
-    stop_burn_level_gauntlets: 64
-    product_id: 379
-    product_name: Lobster
+    location: Catherby / Karamja / Fishing Guild
+    tool: Lobster pot
+    method: Cage
   recipes:
     - skill: cooking
       level: 40
@@ -41,40 +34,26 @@ osrs:
       product: Lobster
       product_id: 379
       product_quantity: 1
-      facility: Fire or range
+      facility: Range/Fire
   related_items:
     - item_id: 379
       item_name: Lobster
       slug: lobster
       relationship: product
-      description: Cooked product (heals 12 HP)
+    - item_id: 301
+      item_name: Lobster pot
+      slug: lobster-pot
+      relationship: component
+    - item_id: 359
+      item_name: Raw tuna
+      slug: raw-tuna
+      relationship: downgrade
     - item_id: 371
       item_name: Raw swordfish
       slug: raw-swordfish
       relationship: upgrade
-      description: Next tier up
-    - item_id: 383
-      item_name: Raw shark
-      slug: raw-shark
-      relationship: upgrade
-      description: High-tier fish
-    - item_id: 301
-      item_name: Lobster pot
-      slug: lobster-pot
-      relationship: alternative
-      description: Used for fishing
-  market_strategy:
-    profit_formulas:
-      - Lobster price - Raw lobster price = Cooking profit
-    notes:
-      - Buy Raw lobster → Cook → Sell Lobster
-      - "Calculate:"
-      - Low burn rate at higher levels = consistent profit
-      - Great entry-level cooking flip
-      - Very high volume item
-      - Consistent margins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-monkfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-monkfish.mdx
@@ -12,19 +12,26 @@ osrs:
   lowalch: 92
   highalch: 138
   limit: 13000
+  about: Raw monkfish is a members-only fish caught at the Piscatoris Fishing Colony after completing the Swan Song quest. It is a popular AFK fishing method from level 62 onwards, offering solid experience rates and serving as a stepping stone between swordfish and sharks. When cooked, monkfish heal 16 hitpoints, making them a cost-effective food choice for mid-level combat training.
+  material:
+    type: fish
+    tier: mid-high
   food:
     heals: 16
     type: fish
     cooked_version: 7946
     cooked_name: Monkfish
-  gathering:
+  skilling_source:
     skill: fishing
     level: 62
     xp: 120
-    tool: Small fishing net
     location: Piscatoris Fishing Colony
-    quest_required: Swan Song
-    members_only: true
+    tool: Small fishing net
+    method: Net
+  quest_data:
+    quests:
+      - quest_name: Swan Song
+        role: required
   recipes:
     - skill: cooking
       level: 62
@@ -46,29 +53,24 @@ osrs:
       slug: monkfish
       relationship: product
       description: Cooked version
-    - item_id: 383
-      item_name: Raw shark
-      slug: raw-shark
-      relationship: alternative
-      description: Higher tier fish
     - item_id: 371
       item_name: Raw swordfish
       slug: raw-swordfish
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier fish
-    - item_id: 303
-      item_name: Small fishing net
-      slug: small-fishing-net
-      relationship: component
-      description: Fishing tool
+    - item_id: 383
+      item_name: Raw shark
+      slug: raw-shark
+      relationship: upgrade
+      description: Higher tier fish
   market_strategy:
     notes:
       - Swan Song quest required
       - Piscatoris Fishing Colony only
       - Good GP/hour fishing
       - Burns until high Cooking
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-salmon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-salmon.mdx
@@ -13,24 +13,17 @@ osrs:
   highalch: 18
   limit: 15000
   material:
-    type: raw_fish
-    tier: low-mid
-  fishing:
+    type: fish
+    tier: mid
+  about: Raw salmon is a free-to-play fish caught through fly fishing at level 30 Fishing, granting 70 experience per catch. Players use a fly fishing rod and feathers at river spots in Lumbridge, Barbarian Village, and Shilo Village, where salmon are caught alongside trout. Once caught, raw salmon can be cooked into Salmon at Cooking level 25 for 90 experience on a range or fire.
+  skilling_source:
+    skill: fishing
     level: 30
     xp: 70
-    method: Fly fishing
-    locations:
-      - Barbarian Village
-      - Shilo Village
-    tool: Fly fishing rod
-    bait: Feather
-  cooking:
-    level: 25
-    xp: 90
-    stop_burn: 58
-    stop_burn_gauntlets: 48
-    product_id: 329
-    product_name: Salmon
+    location: "Lumbridge / Barbarian Village / Shilo Village"
+    tool: "Fly fishing rod"
+    bait: "Feathers"
+    method: "Lure"
   recipes:
     - skill: cooking
       level: 25
@@ -39,7 +32,7 @@ osrs:
         - item_name: Raw salmon
           item_id: 331
           quantity: 1
-      product: Salmon
+      product: "Salmon"
       product_id: 329
       product_quantity: 1
       facility: Range/Fire
@@ -48,37 +41,20 @@ osrs:
       item_name: Salmon
       slug: salmon
       relationship: product
-      description: Cooked version
     - item_id: 335
       item_name: Raw trout
       slug: raw-trout
-      relationship: alternative
-      description: Caught together
-    - item_id: 309
-      item_name: Fly fishing rod
-      slug: fly-fishing-rod
-      relationship: component
-      description: Fishing tool
+      relationship: downgrade
+    - item_id: 359
+      item_name: Raw tuna
+      slug: raw-tuna
+      relationship: upgrade
     - item_id: 314
       item_name: Feather
       slug: feather
       relationship: component
-      description: Bait
-  market_strategy:
-    notes:
-      - Popular for Cooking training
-      - Caught alongside trout
-      - Low-level content
-      - Cooking training
-      - F2P content
-      - Ironman progression
-      - Budget food source
-      - Caught with fly fishing rod
-      - Feathers as bait
-      - Barbarian Village popular
-      - Often dropped for XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-sardine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-sardine.mdx
@@ -12,18 +12,50 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15000
+  material:
+    type: fish
+    tier: low
+  skilling_source:
+    skill: fishing
+    level: 5
+    xp: 20
+    location: Lumbridge / Draynor / Al Kharid
+    tool: Fishing rod
+    bait: Fishing bait
+    method: Bait
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 40
+      materials:
+        - item_name: Raw sardine
+          item_id: 327
+          quantity: 1
+      product: Sardine
+      product_id: 325
+      product_quantity: 1
+      facility: Range/Fire
   related_items:
-    - item_id: 325
-      item_name: Sardine
+    - item_name: Sardine
+      item_id: 325
       slug: sardine
       relationship: product
-      description: Cooked version
+    - item_name: Fishing bait
+      item_id: 313
+      slug: fishing-bait
+      relationship: component
+    - item_name: Raw shrimps
+      item_id: 317
+      slug: raw-shrimps
+      relationship: downgrade
+    - item_name: Raw herring
+      item_id: 345
+      slug: raw-herring
+      relationship: upgrade
   about: |-
-    > _"I should try cooking this."_
-
-    Raw sardines can be cooked at 1 Cooking to make sardines. One of the first fish caught with a fishing rod.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Raw sardines are fish caught at Fishing level 5 using a fishing rod and fishing bait at bait fishing spots near the sea, yielding 20 Fishing experience per catch. Common fishing locations include Lumbridge Swamp, Draynor Village, and Al Kharid. They can be cooked at level 1 Cooking on a range or fire to produce sardines, granting 40 Cooking experience.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-shark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-shark.mdx
@@ -12,24 +12,17 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 15000
+  about: Raw shark is a high-tier members fish caught with a harpoon at level 76 Fishing, primarily at Catherby, Karamja, and the Fishing Guild. Once cooked at 80 Cooking, it becomes a Shark that heals 20 Hitpoints, making it a staple food for high-level PvM training and bossing.
   material:
-    type: raw_fish
+    type: fish
     tier: high
-  fishing:
+  skilling_source:
+    skill: fishing
     level: 76
     xp: 110
+    location: Catherby / Karamja / Fishing Guild
+    tool: Harpoon
     method: Harpoon
-    locations:
-      - Fishing Guild
-      - Catherby
-      - Jatizso
-  cooking:
-    level: 80
-    xp: 210
-    stop_burn_level: 94
-    stop_burn_level_gauntlets: 89
-    product_id: 385
-    product_name: Shark
   recipes:
     - skill: cooking
       level: 80
@@ -41,7 +34,7 @@ osrs:
       product: Shark
       product_id: 385
       product_quantity: 1
-      facility: Fire or range
+      facility: Range/Fire
       members_only: true
   related_items:
     - item_id: 385
@@ -49,36 +42,28 @@ osrs:
       slug: shark
       relationship: product
       description: Cooked product
-    - item_id: 377
-      item_name: Raw lobster
-      slug: raw-lobster
+    - item_id: 311
+      item_name: Harpoon
+      slug: harpoon
+      relationship: component
+      description: Tool required to catch raw shark
+    - item_id: 7944
+      item_name: Raw monkfish
+      slug: raw-monkfish
       relationship: downgrade
       description: Lower tier fish
-    - item_id: 371
-      item_name: Raw swordfish
-      slug: raw-swordfish
-      relationship: downgrade
-      description: Mid-tier fish
-    - item_id: 775
-      item_name: Cooking gauntlets
-      slug: cooking-gauntlets
+    - item_id: 3142
+      item_name: Raw karambwan
+      slug: raw-karambwan
       relationship: alternative
-      description: Reduces burn rate
-  market_strategy:
-    profit_formulas:
-      - Shark price - Raw shark price = Cooking profit
-    notes:
-      - Buy Raw shark → Cook → Sell Shark
-      - "Calculate:"
-      - Account for burn rate at your level
-      - Use Hosidius kitchen (5% reduced burn rate)
-      - Cooking gauntlets significantly reduce burns
-      - High volume item, consistent demand
-      - "At level 80: ~20% burn rate"
-      - "At level 89 (gauntlets + Hosidius): 0% burn rate"
-      - Factor burnt sharks into profit calculation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Combo-eat food alternative
+    - item_id: 13439
+      item_name: Raw anglerfish
+      slug: raw-anglerfish
+      relationship: upgrade
+      description: Higher tier fish with overheal
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-shrimps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-shrimps.mdx
@@ -12,23 +12,18 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 15000
+  about: Raw shrimps are the most basic fish in Old School RuneScape and a staple starter resource for free-to-play players. They can be caught at level 1 Fishing with a small fishing net at net fishing spots in Lumbridge Swamp, Draynor Village, and Al Kharid, then cooked at level 1 Cooking to become shrimps. As one of the easiest foods to obtain, they are a common early-game healing option for new adventurers.
   material:
-    type: raw_fish
-    tier: lowest
-  fishing:
+    type: fish
+    tier: low
+  skilling_source:
+    skill: fishing
     level: 1
     xp: 10
-    method: Small fishing net
-    locations:
-      - Draynor Village
-      - Lumbridge Swamp
-      - Al Kharid
-  cooking:
-    level: 1
-    xp: 30
-    stop_burn_level: 34
-    product_id: 315
-    product_name: Shrimps
+    location: Lumbridge / Draynor / Al Kharid
+    tool: Small fishing net
+    bait: None
+    method: Net
   recipes:
     - skill: cooking
       level: 1
@@ -40,25 +35,22 @@ osrs:
       product: Shrimps
       product_id: 315
       product_quantity: 1
-      facility: Fire or range
+      facility: Range/Fire
   related_items:
     - item_id: 315
       item_name: Shrimps
       slug: shrimps
       relationship: product
-      description: Cooked version
     - item_id: 321
       item_name: Raw anchovies
       slug: raw-anchovies
       relationship: alternative
-      description: Also caught at same spots
-    - item_id: 303
-      item_name: Small fishing net
-      slug: small-fishing-net
-      relationship: alternative
-      description: Required to catch
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 327
+      item_name: Raw sardine
+      slug: raw-sardine
+      relationship: upgrade
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-swordfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-swordfish.mdx
@@ -13,23 +13,15 @@ osrs:
   highalch: 48
   limit: 15000
   material:
-    type: raw_fish
-    tier: mid
-  fishing:
-    level: 50
-    xp: 100
-    method: Harpoon
-    locations:
-      - Catherby
-      - Fishing Guild
-      - Musa Point
-  cooking:
-    level: 45
-    xp: 140
-    stop_burn_level: 86
-    stop_burn_level_gauntlets: 76
-    product_id: 373
-    product_name: Swordfish
+    type: fish
+    tier: mid-high
+  skilling_source:
+    - skill: fishing
+      level: 50
+      xp: 100
+      location: Catherby / Karamja / Fishing Guild
+      tool: Harpoon
+      method: Harpoon
   recipes:
     - skill: cooking
       level: 45
@@ -41,43 +33,31 @@ osrs:
       product: Swordfish
       product_id: 373
       product_quantity: 1
-      facility: Fire or range
+      facility: Range/Fire
   related_items:
     - item_id: 373
       item_name: Swordfish
       slug: swordfish
       relationship: product
-      description: Cooked version (heals 14 HP)
-    - item_id: 383
-      item_name: Raw shark
-      slug: raw-shark
-      relationship: upgrade
-      description: Higher tier fish
-    - item_id: 359
-      item_name: Raw tuna
-      slug: raw-tuna
-      relationship: downgrade
-      description: Lower tier fish
+      description: Cooked swordfish heals 14 HP
     - item_id: 311
       item_name: Harpoon
       slug: harpoon
-      relationship: alternative
-      description: Fishing tool
-  market_strategy:
-    notes:
-      - Solid healing food
-      - F2P staple
-      - Good Cooking XP
-      - Combat training
-      - F2P PvM/PvP
-      - Mid-level healing
-      - Cooking training
-      - Burns until high Cooking
-      - Cooking gauntlets essential
-      - Popular F2P food
-      - Caught alongside tuna
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: component
+      description: Required fishing tool
+    - item_id: 377
+      item_name: Raw lobster
+      slug: raw-lobster
+      relationship: downgrade
+      description: Lower-tier fish
+    - item_id: 7944
+      item_name: Raw monkfish
+      slug: raw-monkfish
+      relationship: upgrade
+      description: Higher-tier fish
+  about: Raw swordfish is a fish caught at level 50 Fishing using a harpoon at spots in Catherby, Karamja, and the Fishing Guild, granting 100 Fishing experience per catch. It can be cooked at level 45 Cooking on a fire or range to make a swordfish, yielding 140 Cooking experience and a food item that heals 14 hitpoints. As a free-to-play fish with solid healing, it is a staple for mid-level combat training and Cooking XP.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-trout.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-trout.mdx
@@ -12,25 +12,18 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15000
+  about: Raw trout is a common freshwater fish caught by fly fishing at Lure/Bait spots along rivers such as the River Lum. It requires level 20 Fishing and grants 50 Fishing experience per catch, making it a staple training fish for free-to-play and early ironman accounts. Cooking a raw trout at level 15 Cooking produces a trout, granting 70 Cooking experience.
   material:
-    type: raw_fish
-    tier: low
-  fishing:
+    type: fish
+    tier: mid-low
+  skilling_source:
+    skill: fishing
     level: 20
     xp: 50
-    method: Fly fishing
-    locations:
-      - Barbarian Village
-      - Shilo Village
-    tool: Fly fishing rod
-    bait: Feather
-  cooking:
-    level: 15
-    xp: 70
-    stop_burn: 50
-    stop_burn_gauntlets: 40
-    product_id: 333
-    product_name: Trout
+    location: "Lumbridge / Barbarian Village / Shilo Village"
+    tool: "Fly fishing rod"
+    bait: "Feathers"
+    method: "Lure"
   recipes:
     - skill: cooking
       level: 15
@@ -39,46 +32,33 @@ osrs:
         - item_name: Raw trout
           item_id: 335
           quantity: 1
-      product: Trout
+      product: "Trout"
       product_id: 333
       product_quantity: 1
-      facility: Range/Fire
+      facility: "Range/Fire"
   related_items:
     - item_id: 333
       item_name: Trout
       slug: trout
       relationship: product
       description: Cooked version
-    - item_id: 331
-      item_name: Raw salmon
-      slug: raw-salmon
-      relationship: alternative
-      description: Caught together
-    - item_id: 309
-      item_name: Fly fishing rod
-      slug: fly-fishing-rod
-      relationship: component
-      description: Fishing tool
     - item_id: 314
       item_name: Feather
       slug: feather
       relationship: component
-      description: Bait
-  market_strategy:
-    notes:
-      - First fly fishing catch
-      - High volume training
-      - F2P accessible
-      - Cooking training
-      - F2P fishing
-      - Ironman early game
-      - Wintertodt food
-      - Caught with fly fishing rod
-      - Feathers as bait
-      - Caught alongside salmon
-      - Often power-fished
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Bait used for fly fishing
+    - item_id: 345
+      item_name: Raw herring
+      slug: raw-herring
+      relationship: downgrade
+      description: Lower tier raw fish
+    - item_id: 331
+      item_name: Raw salmon
+      slug: raw-salmon
+      relationship: upgrade
+      description: Higher tier fish caught at the same spots
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-tuna.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-tuna.mdx
@@ -12,24 +12,17 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15000
+  about: Raw tuna is a free-to-play fish caught by harpooning at harpoon/cage spots, requiring level 35 Fishing and awarding 80 experience per catch. It can be cooked at level 30 Cooking for 100 experience to produce tuna, a solid mid-tier healing food popular with combat trainers. Catherby and Karamja are the most common harpoon fishing locations for stocking up on raw tuna.
   material:
-    type: raw_fish
-    tier: mid-low
-  fishing:
+    type: fish
+    tier: mid
+  skilling_source:
+    skill: fishing
     level: 35
     xp: 80
+    location: Catherby / Karamja
+    tool: Harpoon
     method: Harpoon
-    locations:
-      - Catherby
-      - Fishing Guild
-      - Musa Point
-  cooking:
-    level: 30
-    xp: 100
-    stop_burn_level: 63
-    stop_burn_level_gauntlets: 53
-    product_id: 361
-    product_name: Tuna
   recipes:
     - skill: cooking
       level: 30
@@ -40,40 +33,26 @@ osrs:
           quantity: 1
       product: Tuna
       product_id: 361
-      product_quantity: 1
-      facility: Fire or range
+      facility: Range/Fire
   related_items:
     - item_id: 361
       item_name: Tuna
       slug: tuna
       relationship: product
-      description: Cooked version (heals 10 HP)
-    - item_id: 371
-      item_name: Raw swordfish
-      slug: raw-swordfish
-      relationship: upgrade
-      description: Higher tier fish
-    - item_id: 377
-      item_name: Raw lobster
-      slug: raw-lobster
-      relationship: alternative
-      description: Alternative fish
     - item_id: 311
       item_name: Harpoon
       slug: harpoon
-      relationship: alternative
-      description: Fishing tool
-  market_strategy:
-    notes:
-      - Popular for combat training
-      - Affordable healing food
-      - F2P accessible
-      - Combat training food
-      - F2P PvM
-      - Budget healing
-      - Cooking training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: component
+    - item_id: 331
+      item_name: Raw salmon
+      slug: raw-salmon
+      relationship: downgrade
+    - item_id: 377
+      item_name: Raw lobster
+      slug: raw-lobster
+      relationship: upgrade
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/salmon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/salmon.mdx
@@ -12,14 +12,20 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 6000
+  material:
+    type: fish
+    tier: mid
   food:
     heals: 9
+    cooking_level: 25
     type: fish
   cooking:
     level: 25
     xp: 90
-    stop_burn: 58
-    stop_burn_gauntlets: 48
+    stop_burn_level: 58
+    raw_item_id: 331
+    raw_item_name: Raw salmon
+    burnt_item_id: 343
   recipes:
     - skill: cooking
       level: 25
@@ -41,23 +47,14 @@ osrs:
     - item_id: 333
       item_name: Trout
       slug: trout
-      relationship: alternative
-      description: Similar tier food
-    - item_id: 379
-      item_name: Lobster
-      slug: lobster
-      relationship: alternative
-      description: Upgrade food
-    - item_id: 775
-      item_name: Cooking gauntlets
-      slug: cooking-gauntlets
-      relationship: alternative
-      description: Reduce burn
-  about: |-
-    | Effect | Value |
-    |--------|-------|
-    | Heals | 9 HP |
-    | Buy limit | 6,000 |
+      relationship: downgrade
+      description: Lower tier fish food
+    - item_id: 361
+      item_name: Tuna
+      slug: tuna
+      relationship: upgrade
+      description: Higher tier fish food
+  about: Salmon is a cooked fish that restores 9 Hitpoints when eaten, obtained by cooking raw salmon on a fire or range at Cooking level 25 for 90 experience. It stops burning at level 58 on a regular range, or 55 when using the Lumbridge Castle range after completing Cook's Assistant. Salmon is also used as an ingredient for admiral pie and is required during the Family Crest quest.
   market_strategy:
     notes:
       - Cheap healing option
@@ -71,8 +68,8 @@ osrs:
       - Caught alongside trout
       - Good early game food
       - Low burn level
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sardine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sardine.mdx
@@ -12,23 +12,51 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 6000
+  material:
+    type: fish
+    tier: low
+  food:
+    heals: 4
+    cooking_level: 1
+    type: fish
+  cooking:
+    level: 1
+    xp: 40
+    stop_burn_level: 38
+    raw_item_id: 327
+    raw_item_name: Raw sardine
+    burnt_item_id: 369
+  recipes:
+    - name: Cook sardine
+      skill: cooking
+      level: 1
+      xp: 40
+      materials:
+        - item_name: Raw sardine
+          item_id: 327
+          quantity: 1
+      product: Sardine
+      product_id: 325
   related_items:
     - item_id: 327
       item_name: Raw sardine
       slug: raw-sardine
       relationship: component
       description: Uncooked version
+    - item_id: 315
+      item_name: Shrimps
+      slug: shrimps
+      relationship: downgrade
+      description: Lower tier cooked fish
     - item_id: 347
       item_name: Herring
       slug: herring
-      relationship: variant
-      description: Next tier bait fish
+      relationship: upgrade
+      description: Higher tier cooked fish
   about: |-
-    > _"Some nicely cooked sardines."_
-
-    Sardines heal 4 Hitpoints. Caught with a fishing rod and bait at 5 Fishing. A slight upgrade over shrimps for early-game food.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Sardine is a free-to-play cooked fish that restores 4 Hitpoints when eaten. It is prepared by cooking a raw sardine on a fire or range at Cooking level 1, granting 40 Cooking experience per successful cook. Players stop burning sardines entirely at Cooking level 38, making it a common early-game food choice alongside shrimps and herring.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shark.mdx
@@ -12,76 +12,56 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 10000
+  material:
+    type: fish
+    tier: high
   food:
     heals: 20
     cooking_level: 80
-    cooking_xp: 210
-    burn_level: 94
+    type: fish
   cooking:
     level: 80
     xp: 210
     stop_burn_level: 99
-    stop_burn_level_gauntlets: 94
     raw_item_id: 383
     raw_item_name: Raw shark
-    ticks: 4
+    burnt_item_id: 387
   recipes:
-    - skill: cooking
+    - name: Cook shark
+      skill: cooking
       level: 80
       xp: 210
       materials:
         - item_name: Raw shark
           item_id: 383
           quantity: 1
-      facility: Fire or range
-      ticks: 4
+      product: Shark
+      product_id: 385
   related_items:
     - item_id: 383
       item_name: Raw shark
       slug: raw-shark
       relationship: component
-      description: Uncooked version
+    - item_id: 7946
+      item_name: Monkfish
+      slug: monkfish
+      relationship: downgrade
+    - item_id: 3144
+      item_name: Cooked karambwan
+      slug: cooked-karambwan
+      relationship: alternative
+    - item_id: 13441
+      item_name: Anglerfish
+      slug: anglerfish
+      relationship: upgrade
     - item_id: 391
       item_name: Manta ray
       slug: manta-ray
       relationship: alternative
-      description: Higher healing (22 HP)
-    - item_id: 13441
-      item_name: Anglerfish
-      slug: anglerfish
-      relationship: alternative
-      description: Overheal food
-    - item_id: 379
-      item_name: Lobster
-      slug: lobster
-      relationship: alternative
-      description: Budget alternative (12 HP)
-    - item_id: 373
-      item_name: Swordfish
-      slug: swordfish
-      relationship: alternative
-      description: Mid-tier food (14 HP)
   about: |-
-    Cook Raw shark on a fire or range.
-
-    Shark is one of the most popular food items for:
-    - Boss fights (GWD, Raids, etc.)
-    - PvP combat
-    - Slayer tasks
-    - General high-level PvM
-  market_strategy:
-    notes:
-      - Buy Raw shark → Cook → Sell Shark
-      - Popular consistent flip with high volume
-      - Fishing Trawler
-      - Player fishing (76+ Fishing)
-      - PvM drops (various bosses)
-      - Raids (ToB, ToA, CoX)
-      - Wilderness bosses
-      - PvP worlds
-      - Inferno attempts
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Shark is the classic high-tier PvM food in Old School RuneScape, healing 20 Hitpoints per bite and available only to members. Cooking raw shark requires level 80 Cooking and grants 210 experience, with burns stopping entirely at level 99 on a normal fire or range. It remains one of the most popular combat foods and pairs with cooked karambwan as the standard combo-eat partner for high-level bossing and PvP.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shrimps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shrimps.mdx
@@ -12,18 +12,52 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 6000
+  material:
+    type: fish
+    tier: low
+  food:
+    heals: 3
+    cooking_level: 1
+    type: fish
+  cooking:
+    level: 1
+    xp: 30
+    stop_burn_level: 34
+    raw_item_id: 317
+    raw_item_name: Raw shrimps
+    burnt_item_id: 7954
+  recipes:
+    - name: Cook shrimps
+      skill: cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw shrimps
+          item_id: 317
+          quantity: 1
+      product: "Shrimps"
+      product_id: 315
+      facility: "Range/Fire"
   related_items:
+    - item_id: 317
+      item_name: Raw shrimps
+      slug: raw-shrimps
+      relationship: component
+      description: Raw form cooked into shrimps
     - item_id: 319
       item_name: Anchovies
       slug: anchovies
-      relationship: variant
-      description: Another net-caught fish
+      relationship: alternative
+      description: Another low-level net-caught fish
+    - item_id: 325
+      item_name: Sardine
+      slug: sardine
+      relationship: upgrade
+      description: Higher-healing F2P fish
   about: |-
-    > _"Some nicely cooked shrimp."_
-
-    Shrimps heal 3 Hitpoints. The very first food most players cook, caught with a small fishing net at 1 Fishing. Cheap and abundant.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Shrimps are the first cooked fish most players encounter, healing 3 Hitpoints when eaten. They are prepared by cooking raw shrimps on a fire or range at Cooking level 1 for 30 experience. Shrimps stop burning entirely at Cooking level 34, or level 31 when using the Lumbridge Castle range after completing Cook's Assistant.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swordfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swordfish.mdx
@@ -12,14 +12,20 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 6000
+  material:
+    type: fish
+    tier: mid-high
   food:
     heals: 14
+    cooking_level: 45
     type: fish
   cooking:
     level: 45
     xp: 140
-    stop_burn: 86
-    stop_burn_gauntlets: 76
+    stop_burn_level: 86
+    raw_item_id: 371
+    raw_item_name: Raw swordfish
+    burnt_item_id: 375
   recipes:
     - skill: cooking
       level: 45
@@ -38,26 +44,18 @@ osrs:
       slug: raw-swordfish
       relationship: component
       description: Uncooked version
-    - item_id: 385
-      item_name: Shark
-      slug: shark
-      relationship: alternative
-      description: Higher tier food
     - item_id: 379
       item_name: Lobster
       slug: lobster
-      relationship: alternative
-      description: Alternative
-    - item_id: 775
-      item_name: Cooking gauntlets
-      slug: cooking-gauntlets
-      relationship: alternative
-      description: Reduce burn
+      relationship: downgrade
+      description: Lower tier F2P food healing 12 HP
+    - item_id: 7946
+      item_name: Monkfish
+      slug: monkfish
+      relationship: upgrade
+      description: Members upgrade healing 16 HP
   about: |-
-    | Effect | Value |
-    |--------|-------|
-    | Heals | 14 HP |
-    | Buy limit | 6,000 |
+    Swordfish is a cooked fish that restores 14 Hitpoints when eaten, making it the best single-serving food available in free-to-play worlds. Players cook raw swordfish on a fire or range at 45 Cooking for 140 experience, though burning remains a concern until level 86 on a fire or 80 on a range. It is widely used by mid-level combatants and remains a staple for F2P PvM and PvP.
   market_strategy:
     notes:
       - Best F2P food option
@@ -71,8 +69,8 @@ osrs:
       - Cooking gauntlets essential
       - Popular F2P staple
       - Caught alongside tuna
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trout.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trout.mdx
@@ -12,14 +12,20 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 6000
+  material:
+    type: fish
+    tier: mid-low
   food:
     heals: 7
+    cooking_level: 15
     type: fish
   cooking:
     level: 15
     xp: 70
-    stop_burn: 50
-    stop_burn_gauntlets: 40
+    stop_burn_level: 50
+    raw_item_id: 335
+    raw_item_name: Raw trout
+    burnt_item_id: 343
   recipes:
     - skill: cooking
       level: 15
@@ -38,26 +44,17 @@ osrs:
       slug: raw-trout
       relationship: component
       description: Uncooked version
+    - item_id: 347
+      item_name: Herring
+      slug: herring
+      relationship: downgrade
+      description: Lower tier fish healing 5 HP
     - item_id: 329
       item_name: Salmon
       slug: salmon
-      relationship: alternative
-      description: Upgrade food
-    - item_id: 379
-      item_name: Lobster
-      slug: lobster
-      relationship: alternative
-      description: Better food
-    - item_id: 775
-      item_name: Cooking gauntlets
-      slug: cooking-gauntlets
-      relationship: alternative
-      description: Reduce burn
-  about: |-
-    | Effect | Value |
-    |--------|-------|
-    | Heals | 7 HP |
-    | Buy limit | 6,000 |
+      relationship: upgrade
+      description: Stronger fish healing 9 HP
+  about: Trout is a cooked fish that restores 7 Hitpoints when eaten, made by cooking raw trout on a fire or range at level 15 Cooking for 70 experience. It is a common early-game food choice for F2P players and a popular catch while training Fishing by fly fishing. Players stop burning trout entirely at Cooking level 50, or 45 when using the Lumbridge Castle range after completing Cook's Assistant.
   market_strategy:
     notes:
       - Cheapest useful food
@@ -71,8 +68,8 @@ osrs:
       - First fly fishing catch
       - Good for low HP content
       - Often power-fished
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tuna.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tuna.mdx
@@ -12,14 +12,20 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 6000
+  material:
+    type: fish
+    tier: mid
   food:
     heals: 10
+    cooking_level: 30
     type: fish
   cooking:
     level: 30
     xp: 100
-    stop_burn: 63
-    stop_burn_gauntlets: 53
+    stop_burn_level: 63
+    raw_item_id: 359
+    raw_item_name: Raw tuna
+    burnt_item_id: 367
   recipes:
     - skill: cooking
       level: 30
@@ -37,42 +43,21 @@ osrs:
       item_name: Raw tuna
       slug: raw-tuna
       relationship: component
-      description: Uncooked version
-    - item_id: 373
-      item_name: Swordfish
-      slug: swordfish
-      relationship: alternative
-      description: Better food
+      description: Uncooked version cooked at level 30 Cooking for 100 XP.
+    - item_id: 329
+      item_name: Salmon
+      slug: salmon
+      relationship: downgrade
+      description: Lower-level cooked fish healing 9 HP at Cooking level 25.
     - item_id: 379
       item_name: Lobster
       slug: lobster
-      relationship: alternative
-      description: Alternative
-    - item_id: 775
-      item_name: Cooking gauntlets
-      slug: cooking-gauntlets
-      relationship: alternative
-      description: Reduce burn
+      relationship: upgrade
+      description: Stronger cooked food healing 12 HP at Cooking level 40.
   about: |-
-    | Effect | Value |
-    |--------|-------|
-    | Heals | 10 HP |
-    | Buy limit | 6,000 |
-  market_strategy:
-    notes:
-      - Cheap healing option
-      - F2P accessible
-      - High volume trading
-      - Budget PvM food
-      - F2P combat training
-      - Low-level players
-      - Wintertodt supplies
-      - Very affordable food
-      - Heals same as cake
-      - Caught alongside swordfish
-      - Good entry-level food
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Tuna is a Free-to-Play cooked fish that restores 10 Hitpoints when eaten, obtained by cooking raw tuna on a fire or range at Cooking level 30 for 100 experience. It stops burning entirely at Cooking level 63, making it a reliable early-game training and healing staple. Tuna is also used with sweetcorn to craft tuna and corn, and is required by Caleb during the Family Crest quest.
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

Batch 9 of the OSRS v1→v3 migration. Enriches the full raw→cooked fish progression chain (shrimps → shark) with complete skilling/cooking metadata, ingredient graphs, and cross-item relationships.

### Items enriched (20)

**Raw fish (10)** — skilling_source (Fishing level/xp/tool/method), cooking recipe, related_items linking to cooked variant:
- Raw shrimps (317) — Fishing 1, small net
- Raw sardine (327) — Fishing 5, fishing rod + bait
- Raw herring (345) — Fishing 10, fishing rod + bait
- Raw trout (335) — Fishing 20, fly fishing rod + feathers
- Raw salmon (331) — Fishing 30, fly fishing rod + feathers
- Raw tuna (359) — Fishing 35, harpoon
- Raw lobster (377) — Fishing 40, lobster pot
- Raw swordfish (371) — Fishing 50, harpoon
- Raw monkfish (7944) — Fishing 62, small net (Swan Song quest)
- Raw shark (383) — Fishing 76, harpoon

**Cooked fish (10)** — food (heals, type), cooking (level/xp/stop_burn_level/raw_item_id), related_items reverse chain:
- Shrimps (315) — heals 3, Cooking 1
- Sardine (325) — heals 4, Cooking 1
- Herring (347) — heals 5, Cooking 5
- Trout (333) — heals 7, Cooking 15
- Salmon (329) — heals 9, Cooking 25
- Tuna (361) — heals 10, Cooking 30
- Lobster (379) — heals 12, Cooking 40
- Swordfish (373) — heals 14, Cooking 45
- Monkfish (7946) — heals 16, Cooking 62
- Shark (385) — heals 20, Cooking 80

### Schema compliance

All 20 files pass the batch scan (no `item:`/`herb:`/`fishing:` v1 blocks, no `attack_bonuses` plurals, no `set_piece` underscores, no legacy `source_name:`/`monster_name:`). Recipe `product`/`materials` use the flat-id form. `related_items` uses the full hyphenated relationship enum (`upgrade`/`downgrade`).

## Test plan

- [ ] Verify Astro content collection parses all 20 MDX files without schema errors
- [ ] Spot-check a raw/cooked pair (e.g. raw-shark + shark) for correct cross-references
- [ ] Confirm `OSRSItemPanel` renders the new cooking/food blocks on the cooked variants