### PR TITLE
feat(mc): add GrimAC 2.3.73 (warning-only rollout)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -12,7 +12,7 @@ tags:
 key: mc
 pipeline: docker
 app_name: mc
-version: "1.0.7"
+version: "1.0.8"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -120,6 +120,15 @@ declare -A MODS=(
   ["essential_commands-0.38.6-mc1.21.11.jar"]="c10c608f7adfd566fa2908deb16fd761fe399e8b https://cdn.modrinth.com/data/6VdDUivB/versions/3s9XXmZa/essential_commands-0.38.6-mc1.21.11.jar"
   ["LuckPerms-Fabric-5.5.21.jar"]="2b899a61f216e8fd5ff9bfae98b62fcb1201e91b https://cdn.modrinth.com/data/Vebnzrzj/versions/CzCJJMuo/LuckPerms-Fabric-5.5.21.jar"
   ["ledger-1.3.19.jar"]="b53db7b817e968603adf33f8d31903a0bf5c0ea2 https://cdn.modrinth.com/data/LVN9ygNV/versions/c1d39lju/ledger-1.3.19.jar"
+  # Grim Anticheat — packet-level anticheat. Lives on the Fabric backend
+  # (not Velocity) because Grim works at the packet layer and needs the
+  # actual client movement packets after ViaVersion translation. Grim's
+  # default punishments.yml ships with ONLY [alert]/[log]/[webhook]/[proxy]
+  # tokens — no auto-kick or ban out of the box, which is exactly the
+  # "warning-only" rollout mode we want. Tune the generated
+  # /data/plugins/Grim/punishments.yml in-place on the PVC once we
+  # collect real violation data.
+  ["grimac-fabric-2.3.73.jar"]="7a6fcb37c8a2845268f8072166b929d4b963863a https://cdn.modrinth.com/data/LJNGWSvH/versions/SNnHVoFr/grimac-fabric-2.3.73.jar"
 )
 
 for name in "${!MODS[@]}"; do


### PR DESCRIPTION
## Summary

Adds **Grim Anticheat 2.3.73** to the Fabric backend in warning-only mode. Light integration to start — Grim logs every violation, alerts in-game staff (once they exist via LuckPerms), and never auto-kicks. Tuning happens in-place after we collect real data.

### Placement: backend, not proxy
Grim goes on the **Fabric backend**, not Velocity:
- Grim works at the packet layer and needs the actual client movement packets *after* ViaVersion translation — only the backend sees those
- Grim doesn't publish a Velocity build
- ViaVersion + ViaBackwards are already on the backend, which is what [Grim's docs recommend](https://github.com/GrimAnticheat/Grim)

### Warning-only by default
Pulled the shipped [\`punishments/en.yml\`](https://github.com/GrimAnticheat/Grim/blob/2.0/common/src/main/resources/punishments/en.yml) — every check group uses only \`[alert]\`, \`[log]\`, \`[webhook]\`, \`[proxy]\` tokens. No \`kick\`, \`ban\`, or \`tempban\` anywhere. Zero config baked into the image — Grim generates its \`punishments.yml\` into \`/data/plugins/Grim/\` on first boot, and that PVC-mounted file becomes the tuning surface.

### Smoke test
\`\`\`
[Server thread/INFO]: Grim Version: 2.3.73
[Server thread/INFO]: Done (2.584s)! For help, type "help"
\`\`\`
All 18 mods load, no incompatibility errors with ViaVersion / ViaBackwards / C2ME.

### Follow-up (not in this PR)
Next iteration will cover Velocity-in-the-loop e2e tests — currently the e2e bypasses Velocity entirely and connects directly to the backend RCON, so a whole class of forwarding / auth bugs is untested.

## Test plan
- [x] Docker build succeeds, GrimAC sha1 verifies
- [x] Container boots with Grim loaded
- [ ] CI publishes 1.0.8
- [ ] Production fleet rolls out + Grim starts generating violation logs