### PR TITLE
fix(astro-kbve): drop trailing slash from KASM iframe proxy URL

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmViewer.tsx
@@ -33,10 +33,14 @@ export default function ReactKasmViewer() {
 		? (workspace.state & KasmState.CAN_CONNECT) !== 0
 		: false;
 
-	// Build the proxy URL for the iframe
+	// Build the proxy URL for the iframe.
+	// No trailing slash: axum's route `/dashboard/kasm/proxy/{*path}` requires
+	// a non-empty path segment, and `/dashboard/kasm/proxy` (no slash) is the
+	// only route that matches a bare request. A trailing slash falls through
+	// to the Astro static handler and returns a 404 with X-Frame-Options: DENY.
 	const proxyUrl = useMemo(() => {
 		if (!workspaceName || !token) return null;
-		return `/dashboard/kasm/proxy/?access_token=${encodeURIComponent(token)}`;
+		return `/dashboard/kasm/proxy?access_token=${encodeURIComponent(token)}`;
 	}, [workspaceName, token]);
 
 	// --- No workspace name in URL ---


### PR DESCRIPTION
## Summary
The KASM iframe was loading \`/dashboard/kasm/proxy/?access_token=...\` (note the trailing slash before the query string). Axum's bypass router registers the KASM proxy as two routes:

\`\`\`
/dashboard/kasm/proxy            // bare
/dashboard/kasm/proxy/{*path}    // wildcard, requires non-empty path
\`\`\`

The \`{*path}\` wildcard does not match an empty path segment, so \`/dashboard/kasm/proxy/\` matches **neither** route. The request falls through to the Astro static fallback and returns a 404 HTML page with \`X-Frame-Options: DENY\` applied by the main_app middleware — which is exactly the two errors reported in the browser console:

\`\`\`
Failed to load resource: the server responded with a status of 404 () (proxy, line 0)
Refused to display 'https://kbve.com/dashboard/kasm/proxy/...' in a frame
because it set 'X-Frame-Options' to 'DENY'.
\`\`\`

### Verified directly against production
\`\`\`
$ curl -sI https://kbve.com/dashboard/kasm/proxy    (no slash) → 401 JSON (correct — KASM proxy, auth required)
$ curl -sI https://kbve.com/dashboard/kasm/proxy/   (trailing) → 404 HTML, X-Frame-Options: DENY (wrong — Astro fallback)
$ curl -sI https://kbve.com/dashboard/kasm/proxy/foo           → 401 JSON (correct — KASM proxy, auth required)
\`\`\`

## Fix
Drop the trailing slash from the proxy URL in \`ReactKasmViewer.tsx\` so the request matches the bare \`/dashboard/kasm/proxy\` route. The KASM proxy handler then runs normally with \`iframe_safe\` header stripping.

## Test plan
- [ ] Open a KASM workspace viewer at \`/dashboard/vm/kasm/?workspace=...\` as a staff user
- [ ] Verify the iframe loads (no more 404 or X-Frame-Options DENY)
- [ ] Verify the JWT auth gate still runs (access_token query fallback works)

## Follow-up (not in this PR)
KASM's internal HTML likely references absolute paths like \`/static/...\` that won't route back through \`/dashboard/kasm/proxy/...\`. If the initial page loads but its assets 404, a future PR will need path rewriting at the proxy layer (or KASM config for a base path).