### PR TITLE
test(kubectl-e2e): add dockerWriteFile helper, fix quoting bugs (#9809)

### DIFF
--- a/apps/vm/kubectl-e2e/e2e/helpers/docker.ts
+++ b/apps/vm/kubectl-e2e/e2e/helpers/docker.ts
@@ -43,4 +43,13 @@ export function dockerExecSafe(cmd: string): {
 	}
 }
 
+/**
+ * Write arbitrary text to a file inside the container without worrying about
+ * shell quoting. Base64-encodes on the host, decodes in the container.
+ */
+export function dockerWriteFile(path: string, content: string): void {
+	const b64 = Buffer.from(content, 'utf-8').toString('base64');
+	dockerExec(`/bin/sh -c "echo ${b64} | base64 -d > ${path}"`);
+}
+
 export { CONTAINER_NAME, IMAGE_NAME };

--- a/apps/vm/kubectl-e2e/e2e/kbve-kubectl.spec.ts
+++ b/apps/vm/kubectl-e2e/e2e/kbve-kubectl.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { dockerExec, dockerExecSafe } from './helpers/docker';
+import { dockerExec, dockerExecSafe, dockerWriteFile } from './helpers/docker';
 
 describe('kbve-kubectl CLI', () => {
 	it('should print version with info subcommand', () => {
@@ -46,23 +46,23 @@ describe('kbve-kubectl CLI', () => {
 	});
 
 	it('should execute a script via run subcommand', () => {
-		const out = dockerExec(
-			'/bin/sh -c \'printf "#!/bin/sh\\necho hello-from-run\\n" > /tmp/test.sh && chmod +x /tmp/test.sh && kbve-kubectl run /tmp/test.sh\'',
-		);
+		dockerWriteFile('/tmp/test.sh', '#!/bin/sh\necho hello-from-run\n');
+		dockerExec('chmod +x /tmp/test.sh');
+		const out = dockerExec('kbve-kubectl run /tmp/test.sh');
 		expect(out).toContain('hello-from-run');
 	});
 
 	it('should propagate script exit codes via run subcommand', () => {
-		const result = dockerExecSafe(
-			'/bin/sh -c \'printf "#!/bin/sh\\nexit 7\\n" > /tmp/exit.sh && chmod +x /tmp/exit.sh && kbve-kubectl run /tmp/exit.sh\'',
-		);
+		dockerWriteFile('/tmp/exit.sh', '#!/bin/sh\nexit 7\n');
+		dockerExec('chmod +x /tmp/exit.sh');
+		const result = dockerExecSafe('kbve-kubectl run /tmp/exit.sh');
 		expect(result.exitCode).toBe(7);
 	});
 
 	it('should pass arguments to run subcommand scripts', () => {
-		const out = dockerExec(
-			'/bin/sh -c \'printf "#!/bin/sh\\necho first=$1 second=$2\\n" > /tmp/args.sh && chmod +x /tmp/args.sh && kbve-kubectl run /tmp/args.sh hello world\'',
-		);
+		dockerWriteFile('/tmp/args.sh', '#!/bin/sh\necho first=$1 second=$2\n');
+		dockerExec('chmod +x /tmp/args.sh');
+		const out = dockerExec('kbve-kubectl run /tmp/args.sh hello world');
 		expect(out).toContain('first=hello second=world');
 	});
 

--- a/apps/vm/kubectl-e2e/e2e/tools.spec.ts
+++ b/apps/vm/kubectl-e2e/e2e/tools.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { dockerExec, dockerExecSafe } from './helpers/docker';
+import { dockerExec, dockerExecSafe, dockerWriteFile } from './helpers/docker';
 
 describe('Tools', () => {
 	it('should have kubectl available', () => {
@@ -21,9 +21,11 @@ describe('Tools', () => {
 	});
 
 	it('should parse complex JSON with jq', () => {
-		const out = dockerExec(
-			'/bin/sh -c \'echo \\\'{"items":[{"name":"a"},{"name":"b"}]}\\\' | jq -r ".items[].name"\'',
+		dockerWriteFile(
+			'/tmp/complex.json',
+			'{"items":[{"name":"a"},{"name":"b"}]}',
 		);
+		const out = dockerExec('jq -r ".items[].name" /tmp/complex.json');
 		expect(out).toBe('a\nb');
 	});
 


### PR DESCRIPTION
## Summary
Down to 2/50 failing tests. Both are shell quoting bugs that are annoying to fix inline.

## Failures
1. **"should parse complex JSON with jq"** — \`/bin/sh: 1: Syntax error: Unterminated quoted string\`. POSIX sh cannot escape single quotes inside single-quoted strings, so \`\\'...\\'\` broke the command.
2. **"should pass arguments to run subcommand scripts"** — expected \`first=hello second=world\`, got \`first= second=\`. The inner sh running \`printf "... \$1 ... \$2 ..."\` expanded \`\$1\`/\`\$2\` to empty before the script file was written.

## Fix
Add \`dockerWriteFile(path, content)\` helper that base64-encodes content on the host and decodes it inside the container. Sidesteps shell quoting completely for file writes.

Rewrite the four affected tests (three run subcommand + one jq) to use it:
\`\`\`ts
dockerWriteFile('/tmp/args.sh', '#!/bin/sh\\necho first=\$1 second=\$2\\n');
dockerExec('chmod +x /tmp/args.sh');
const out = dockerExec('kbve-kubectl run /tmp/args.sh hello world');
\`\`\`

Ref #9809