### PR TITLE
fix(kubectl-e2e): tag image as :latest for ci-docker publish step (#9809)

### DIFF
--- a/apps/vm/kubectl-e2e/project.json
+++ b/apps/vm/kubectl-e2e/project.json
@@ -15,8 +15,8 @@
 			"options": {
 				"commands": [
 					"docker rm -f kubectl-e2e 2>/dev/null || true",
-					"docker buildx build --platform linux/amd64 -f apps/vm/kubectl/Dockerfile -t kbve/kubectl:e2e --load .",
-					"docker run -d --name kubectl-e2e --entrypoint sleep kbve/kubectl:e2e infinity",
+					"docker buildx build --platform linux/amd64 -f apps/vm/kubectl/Dockerfile -t kbve/kubectl:latest --load .",
+					"docker run -d --name kubectl-e2e --entrypoint sleep kbve/kubectl:latest infinity",
 					"echo 'Waiting for container...' && for i in $(seq 1 30); do if docker exec kubectl-e2e /bin/sh -c 'echo ok' >/dev/null 2>&1; then echo 'Container ready after '\"$i\"'s'; break; fi; if [ $i -eq 30 ]; then echo 'Container did not become ready'; docker logs kubectl-e2e 2>&1 | tail -20; docker rm -f kubectl-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
 					"cd apps/vm/kubectl-e2e && npx vitest run; EC=$?; docker rm -f kubectl-e2e 2>/dev/null || true; exit $EC"
 				],


### PR DESCRIPTION
## Summary
The shared \`.github/workflows/docker-test-app.yml\` workflow's "Push CI image to GHCR" step expects the e2e to leave an image tagged \`\${image}:latest\`:

\`\`\`yaml
- name: Push CI image to GHCR
  if: success() && inputs.image != ''
  run: |
    SHORT_SHA="\${GITHUB_SHA::8}"
    CI_TAG="ci-\${SHORT_SHA}"
    docker tag "\${{ inputs.image }}:latest" "ghcr.io/\${{ inputs.image }}:\${CI_TAG}"
    docker push "ghcr.io/\${{ inputs.image }}:\${CI_TAG}"
\`\`\`

We were tagging it as \`kbve/kubectl:e2e\`, so the publish step failed:
\`\`\`
Error response from daemon: No such image: kbve/kubectl:latest
\`\`\`

## Fix
Switch the e2e \`docker buildx -t\` flag and the \`docker run\` reference from \`kbve/kubectl:e2e\` → \`kbve/kubectl:latest\`. The 50 e2e tests still run against the same image — only the tag string changes.

Ref #9809