### PR TITLE
fix(astro-kbve): enrich 20 OSRS ores & bars to v3 (batch 10)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-bar.mdx
@@ -12,20 +12,15 @@ osrs:
   lowalch: 256
   highalch: 384
   limit: 10000
+  about: Adamantite bar is smelted from one adamantite ore and six coal at Smithing level 70 for 37.5 XP. Blast Furnace halves the coal requirement to three, making it the standard method for high-volume smelters. Adamant bars feed adamant weapons, armour, dart tips (10 per bar at Anvil level 74), and Cerberus crystal charging.
   material:
     type: bar
     tier: mid-high
-  smithing:
-    level: 70
-    xp: 37.5
-    primary_ore: 449
-    primary_ore_name: Adamantite ore
-    coal_required: 6
-    blast_furnace_coal: 3
   recipes:
     - skill: smithing
       level: 70
       xp: 37.5
+      facility: Furnace
       materials:
         - item_name: Adamantite ore
           item_id: 449
@@ -36,79 +31,51 @@ osrs:
       product: Adamantite bar
       product_id: 2361
       product_quantity: 1
-      facility: Furnace
-    - skill: smithing
-      level: 70
-      xp: 37.5
-      materials:
-        - item_name: Adamantite ore
-          item_id: 449
-          quantity: 1
-        - item_name: Coal
-          item_id: 453
-          quantity: 3
-      product: Adamantite bar
-      product_id: 2361
-      product_quantity: 1
-      facility: Blast Furnace
-      members_only: true
     - skill: smithing
       level: 74
       xp: 62.5
+      facility: Anvil
+      members_only: true
       materials:
         - item_name: Adamantite bar
           item_id: 2361
           quantity: 1
+        - item_name: Hammer
+          item_id: 2347
+          quantity: 1
+          consumed: false
       product: Adamant dart tip
       product_id: 823
       product_quantity: 10
-      facility: Anvil
-      members_only: true
   related_items:
     - item_id: 449
       item_name: Adamantite ore
       slug: adamantite-ore
       relationship: component
-      description: Primary ore
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: Required for smelting
-    - item_id: 2359
-      item_name: Mithril bar
-      slug: mithril-bar
-      relationship: alternative
-      description: Lower tier
-    - item_id: 2363
-      item_name: Runite bar
-      slug: runite-bar
-      relationship: alternative
-      description: Higher tier
     - item_id: 823
       item_name: Adamant dart tip
       slug: adamant-dart-tip
       relationship: product
-      description: Popular product
-  about: |-
-    Smelt 1 Adamantite ore + 6 Coal (3 coal at Blast Furnace).
-
-    | Method | Coal Required | Smithing Level | XP |
-    |--------|---------------|----------------|-----|
-    | Regular furnace | 6 | 70 | 37.5 |
-    | Blast Furnace | 3 | 70 | 37.5 |
+    - item_id: 2359
+      item_name: Mithril bar
+      slug: mithril-bar
+      relationship: downgrade
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: upgrade
   market_strategy:
-    profit_formulas:
-      - Adamant bar - Adamantite ore - (Coal × 3) = Profit
     notes:
-      - Half coal = significant savings
-      - "Calculate:"
-      - Popular mid-level Blast Furnace method
-      - 1 bar = 10 Adamant dart tips
-      - High demand for Fletching training
-      - Check dart tip vs bar margins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Blast Furnace halves coal per bar — essential for competitive bars/hr
+      - Adamant dart tips are a top Fletching xp/hr method at Anvil level 74
+      - Cerberus crystal charging consumes adamant bars from high-level Slayer solvers
+      - Coal bag is mandatory at this tier to avoid repeated bank trips
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-ore.mdx
@@ -12,28 +12,26 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 4500
+  about: Adamantite ore is mined at level 70 from adamantite rocks, granting 95 Mining experience per ore. It smelts with six coal to create an adamantite bar at Smithing level 70, awarding 37.5 Smithing XP per bar. Adamantite ore feeds adamant weapons, armour, dart tips, and Cerberus crystal charging — making it a high-volume input throughout mid-to-late-game Smithing.
   material:
     type: ore
-    tier: adamantite
+    tier: mid-high
   mining:
+    skill: mining
     level: 70
     xp: 95
-    rocks: Adamantite rock
-    respawn_time: 240
+    tool: Any pickaxe
     locations:
       - Mining Guild
+      - Wilderness Resource Area
       - Jatizso mine
+      - Heroes' Guild basement
       - Motherlode Mine
-  smithing:
-    level: 70
-    xp: 37.5
-    method: Smelting
-    coal_required: 6
-    coal_required_bf: 3
   recipes:
     - skill: smithing
       level: 70
       xp: 37.5
+      facility: Furnace
       materials:
         - item_name: Adamantite ore
           item_id: 449
@@ -44,58 +42,31 @@ osrs:
       product: Adamantite bar
       product_id: 2361
       product_quantity: 1
-      facility: Furnace
-    - skill: smithing
-      level: 70
-      xp: 37.5
-      materials:
-        - item_name: Adamantite ore
-          item_id: 449
-          quantity: 1
-        - item_name: Coal
-          item_id: 453
-          quantity: 3
-      product: Adamantite bar
-      product_id: 2361
-      product_quantity: 1
-      facility: Blast Furnace
-      members_only: true
   related_items:
-    - item_id: 2361
-      item_name: Adamantite bar
-      slug: adamantite-bar
-      relationship: product
-      description: Smelting product
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: Required for smelting
-    - item_id: 451
-      item_name: Runite ore
-      slug: runite-ore
-      relationship: upgrade
-      description: Higher tier ore
+    - item_id: 2361
+      item_name: Adamantite bar
+      slug: adamantite-bar
+      relationship: product
     - item_id: 447
       item_name: Mithril ore
       slug: mithril-ore
       relationship: downgrade
-      description: Lower tier ore
+    - item_id: 451
+      item_name: Runite ore
+      slug: runite-ore
+      relationship: upgrade
   market_strategy:
     notes:
-      - Good Mining XP
-      - Long respawn time
-      - Blast Furnace halves coal
-      - Adamant bar production
-      - Smithing training
-      - Adamant dart tips
-      - High-level gear crafting
-      - Blast Furnace saves coal
-      - Mining Guild for extra ore
-      - 4 minute respawn limits yield
-      - Expert mining gloves help
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Coal-heavy bar (6 coal each) — Blast Furnace and coal bag are essential at scale
+      - Long ~4 minute rock respawn limits sustained gathering rates
+      - Adamant dart tips are one of the highest Fletching xp/hr methods
+      - Demand from Cerberus crystal charging and ore-pack ironman runs
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bar.mdx
@@ -12,20 +12,15 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 10000
+  about: Bronze bar is the entry-level Smithing bar in OSRS, smelted from one copper and one tin ore at Smithing level 1 for 6.2 XP. It is hammered into bronze daggers, swords, helms, and other early-game gear at the anvil, plus bronze nails for Construction. Bronze bars are mainly produced by tutorial graduates, ironmen, and new Smithing trainers.
   material:
     type: bar
-    tier: basic
-  smithing:
-    level: 1
-    xp: 6.2
-    primary_ore: 436
-    primary_ore_name: Copper ore
-    secondary_ore: 438
-    secondary_ore_name: Tin ore
+    tier: low
   recipes:
     - skill: smithing
       level: 1
       xp: 6.2
+      facility: Furnace
       materials:
         - item_name: Copper ore
           item_id: 436
@@ -36,65 +31,46 @@ osrs:
       product: Bronze bar
       product_id: 2349
       product_quantity: 1
-      facility: Furnace
     - skill: smithing
       level: 4
       xp: 12.5
+      facility: Anvil
       materials:
         - item_name: Bronze bar
           item_id: 2349
           quantity: 1
+        - item_name: Hammer
+          item_id: 2347
+          quantity: 1
+          consumed: false
       product: Bronze nails
       product_id: 4819
       product_quantity: 15
-      facility: Anvil
   related_items:
-    - item_id: 2351
-      item_name: Iron bar
-      slug: iron-bar
-      relationship: alternative
-      description: Next tier bar
     - item_id: 436
       item_name: Copper ore
       slug: copper-ore
       relationship: component
-      description: Smelting material
     - item_id: 438
       item_name: Tin ore
       slug: tin-ore
       relationship: component
-      description: Smelting material
     - item_id: 4819
       item_name: Bronze nails
       slug: bronze-nails
       relationship: product
-      description: Construction use
-    - item_id: 2347
-      item_name: Hammer
-      slug: hammer
-      relationship: component
-      description: For Smithing
-  about: |-
-    | Method | Time | XP |
-    |--------|------|-----|
-    | Furnace | 5 ticks (3s) | 6.2 |
-    | Blast Furnace | 11 ticks (6.6s) | 6.2 |
-    | Superheat Item | 3 ticks (1.8s) | 6.2 + 53 Magic |
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: upgrade
   market_strategy:
     notes:
-      - First bar for Smithing
-      - Low value but consistent
-      - Tutorial Island creates supply
-      - New player equipment
-      - Ironman early game
-      - Bronze nails for Construction
-      - F2P Smithing training
-      - Tutorial Island floods market
-      - Very low profit margins
-      - Bronze wire for crossbows
-      - Nails for early Construction
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Entry-level Smithing bar — used almost exclusively by ironmen and new players
+      - Tutorial Island graduates flood the market with cheap supply
+      - Bronze nails are the main bulk Construction consumable
+      - Profit margins are razor-thin given vendor-tier pricing
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/coal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/coal.mdx
@@ -11,22 +11,27 @@ osrs:
   value: 45
   lowalch: 18
   highalch: 27
-  limit: 13000
+  limit: 13500
+  about: Coal is a free-to-play Mining resource obtained at level 30 from coal rocks, granting 50 Mining experience per ore. It is the universal secondary ingredient for steel, mithril, adamantite, and runite bar smelting (2/4/6/8 coal per bar respectively), making it one of the highest-volume traded items in the game. Blast Furnace dwarves consume coal in massive quantities daily, keeping demand consistently high.
   material:
     type: ore
-    tier: coal
+    tier: mid
   mining:
+    skill: mining
     level: 30
     xp: 50
-    rocks: Coal rock
+    tool: Any pickaxe
     locations:
       - Mining Guild
-      - Motherlode Mine
-      - Coal trucks
+      - Lumbridge Swamp west
+      - Dwarven Mine
+      - Wilderness Resource Area
+      - Ardougne south mine
   recipes:
     - skill: smithing
       level: 30
       xp: 17.5
+      facility: Furnace
       materials:
         - item_name: Iron ore
           item_id: 440
@@ -37,43 +42,78 @@ osrs:
       product: Steel bar
       product_id: 2353
       product_quantity: 1
+    - skill: smithing
+      level: 50
+      xp: 30
       facility: Furnace
+      materials:
+        - item_name: Mithril ore
+          item_id: 447
+          quantity: 1
+        - item_name: Coal
+          item_id: 453
+          quantity: 4
+      product: Mithril bar
+      product_id: 2359
+      product_quantity: 1
+    - skill: smithing
+      level: 70
+      xp: 37.5
+      facility: Furnace
+      materials:
+        - item_name: Adamantite ore
+          item_id: 449
+          quantity: 1
+        - item_name: Coal
+          item_id: 453
+          quantity: 6
+      product: Adamantite bar
+      product_id: 2361
+      product_quantity: 1
+    - skill: smithing
+      level: 85
+      xp: 50
+      facility: Furnace
+      materials:
+        - item_name: Runite ore
+          item_id: 451
+          quantity: 1
+        - item_name: Coal
+          item_id: 453
+          quantity: 8
+      product: Runite bar
+      product_id: 2363
+      product_quantity: 1
   related_items:
     - item_id: 440
       item_name: Iron ore
       slug: iron-ore
-      relationship: alternative
-      description: For steel bars
+      relationship: component
+    - item_id: 447
+      item_name: Mithril ore
+      slug: mithril-ore
+      relationship: component
+    - item_id: 449
+      item_name: Adamantite ore
+      slug: adamantite-ore
+      relationship: component
+    - item_id: 451
+      item_name: Runite ore
+      slug: runite-ore
+      relationship: component
     - item_id: 2353
       item_name: Steel bar
       slug: steel-bar
       relationship: product
-      description: Basic coal product
-    - item_id: 2359
-      item_name: Mithril bar
-      slug: mithril-bar
-      relationship: product
-      description: Mid-tier bar (4 coal)
-    - item_id: 2363
-      item_name: Runite bar
-      slug: runite-bar
-      relationship: product
-      description: High-tier bar (8 coal)
-    - item_id: 451
-      item_name: Runite ore
-      slug: runite-ore
-      relationship: alternative
-      description: For rune bars
   market_strategy:
-    profit_formulas:
-      - Bar price - (Ore price + Coal price × amount) = Smelting profit
     notes:
-      - At Blast Furnace, coal requirement is halved
-      - "Steel: 1 coal, Mithril: 2 coal, Adamant: 3 coal, Rune: 4 coal"
-      - Major cost savings for bar production
-      - Check current coal prices vs bar margins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Highest-demand secondary ore in the game (every steel-and-up bar consumes coal)
+      - Blast Furnace halves the coal cost per bar, dramatically improving high-tier margins
+      - Coal bag (Prospector Percy reward) lets players carry 27 extra coal — essential for Blast Furnace
+      - Wilderness Resource Area and Mining Guild provide the densest sustained gathering rates
+      - Stable price floor — heavy production from miners is met by heavy consumption from smithers
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/copper-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/copper-ore.mdx
@@ -12,25 +12,26 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  about: Copper ore is a free-to-play Mining resource obtained at level 1 from copper rocks, granting 17.5 Mining experience per ore. It is smelted with tin ore to create bronze bars at Smithing level 1, making it the starter ingredient for all early-game Smithing training. Supply is dominated by new players and bots, keeping prices near the vendor value.
   material:
     type: ore
-    tier: copper
+    tier: low
   mining:
+    skill: mining
     level: 1
     xp: 17.5
-    rocks: Copper rock
+    tool: Any pickaxe
     locations:
-      - Lumbridge Swamp
-      - Varrock south-east
-      - Al Kharid
-  smithing:
-    level: 1
-    xp: 6.2
-    method: Smelting
+      - Lumbridge Swamp mine
+      - Varrock south-east mine
+      - Al Kharid mine
+      - Rimmington mine
+      - Dwarven Mine
   recipes:
     - skill: smithing
       level: 1
       xp: 6.2
+      facility: Furnace
       materials:
         - item_name: Copper ore
           item_id: 436
@@ -41,38 +42,51 @@ osrs:
       product: Bronze bar
       product_id: 2349
       product_quantity: 1
+    - skill: smithing
+      level: 74
+      xp: 42
       facility: Furnace
+      members_only: true
+      materials:
+        - item_name: Copper ore
+          item_id: 436
+          quantity: 2
+        - item_name: Nickel ore
+          item_id: 31719
+          quantity: 1
+      product: Cupronickel bar
+      product_id: 32892
+      product_quantity: 1
   related_items:
     - item_id: 438
       item_name: Tin ore
       slug: tin-ore
       relationship: component
-      description: Bronze bar partner
     - item_id: 2349
       item_name: Bronze bar
       slug: bronze-bar
       relationship: product
-      description: Smelting product
-    - item_id: 1265
-      item_name: Bronze pickaxe
-      slug: bronze-pickaxe
-      relationship: alternative
-      description: Mining tool
+    - item_id: 31719
+      item_name: Nickel ore
+      slug: nickel-ore
+      relationship: component
+    - item_id: 32892
+      item_name: Cupronickel bar
+      slug: cupronickel-bar
+      relationship: product
+    - item_id: 440
+      item_name: Iron ore
+      slug: iron-ore
+      relationship: upgrade
   market_strategy:
     notes:
-      - First ore for new players
-      - Combined with tin for bronze bars
-      - Tutorial Island creates supply
-      - New player Smithing
-      - Ironman accounts
-      - Bronze bar production
-      - Quest requirements (Doric's Quest)
-      - Very low value ore
-      - High supply from bots
-      - Minimal profit margins
-      - Best sold in bulk
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - First ore available to F2P and new players at Mining level 1
+      - Must be paired with tin ore to smelt bronze bars
+      - Also used with nickel ore for cupronickel bars (Sailing shipbuilding, level 74 Smithing)
+      - High bot-generated supply keeps prices near vendor value
+      - Primary buyers are ironmen and new players training early Smithing
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cupronickel-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cupronickel-bar.mdx
@@ -12,8 +12,66 @@ osrs:
   lowalch: 11
   highalch: 16
   limit: null
-  about: "Cupronickel bar is a members-only item in Old School RuneScape. High alchemy value: 16 coins."
-  mdx_version: 2
+  about: Cupronickel bar was added with the Sailing skill release on 19 November 2025. It is smelted from two copper ore and one nickel ore at Smithing level 74, awarding 42 Smithing XP per bar. Like lead bar, it is consumed by shipbuilding and island amenities in the Sailing economy, making it the higher-tier Sailing metal bar.
+  material:
+    type: bar
+    tier: mid-high
+  recipes:
+    - skill: smithing
+      level: 74
+      xp: 42
+      facility: Furnace
+      members_only: true
+      materials:
+        - item_name: Copper ore
+          item_id: 436
+          quantity: 2
+        - item_name: Nickel ore
+          item_id: 31719
+          quantity: 1
+      product: Cupronickel bar
+      product_id: 32892
+      product_quantity: 1
+    - skill: magic
+      level: 43
+      xp: 53
+      members_only: true
+      materials:
+        - item_name: Copper ore
+          item_id: 436
+          quantity: 2
+        - item_name: Nickel ore
+          item_id: 31719
+          quantity: 1
+        - item_name: Nature rune
+          item_id: 561
+          quantity: 1
+        - item_name: Fire rune
+          item_id: 554
+          quantity: 4
+      product: Cupronickel bar
+      product_id: 32892
+      product_quantity: 1
+  related_items:
+    - item_id: 436
+      item_name: Copper ore
+      slug: copper-ore
+      relationship: component
+    - item_id: 31719
+      item_name: Nickel ore
+      slug: nickel-ore
+      relationship: component
+    - item_id: 32889
+      item_name: Lead bar
+      slug: lead-bar
+      relationship: downgrade
+  market_strategy:
+    notes:
+      - Sailing-era bar introduced 19 November 2025 — demand tracks Sailing content and ship upgrades
+      - Blast Furnace supports batched Sailing runs — deposit 18 copper + 9 nickel per trip, withdraw every three runs for 27 bars
+      - Superheat Item (Magic 43) provides a banking-free training alternative
+      - Cupronickel is the higher-tier Sailing metal bar alongside lead bar
+  mdx_version: 3
   mdx_updated: "2026-04-10"
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-bar.mdx
@@ -12,18 +12,15 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 10000
+  about: Gold bar is smelted from one gold ore at Smithing level 40, earning 22.5 Smithing XP normally or 56.2 XP per bar with Goldsmith gauntlets (reward from the Family Crest quest). Gold bars are the universal jewellery Crafting input — rings, necklaces, amulets, and bracelets all start from a gold bar and the appropriate mould. Blast Furnace gold bars are one of the top Smithing training methods in the game.
   material:
     type: bar
-    tier: gold
-  smithing:
-    level: 40
-    xp: 22.5
-    xp_with_gauntlets: 56.2
-    method: Smelting
+    tier: mid
   recipes:
     - skill: smithing
       level: 40
       xp: 22.5
+      facility: Furnace
       materials:
         - item_name: Gold ore
           item_id: 444
@@ -31,60 +28,56 @@ osrs:
       product: Gold bar
       product_id: 2357
       product_quantity: 1
+    - skill: smithing
+      level: 40
+      xp: 56.2
       facility: Furnace
+      members_only: true
+      materials:
+        - item_name: Gold ore
+          item_id: 444
+          quantity: 1
+      product: Gold bar
+      product_id: 2357
+      product_quantity: 1
   related_items:
     - item_id: 444
       item_name: Gold ore
       slug: gold-ore
       relationship: component
-      description: Raw material
     - item_id: 776
       item_name: Goldsmith gauntlets
       slug: goldsmith-gauntlets
       relationship: alternative
-      description: 2.5x XP bonus
     - item_id: 1673
       item_name: Gold amulet (u)
       slug: gold-amulet-u
       relationship: product
-      description: Craftable jewelry
-    - item_id: 1592
-      item_name: Ring mould
-      slug: ring-mould
+    - item_id: 2355
+      item_name: Silver bar
+      slug: silver-bar
       relationship: alternative
-      description: For crafting rings
-    - item_id: 1595
-      item_name: Amulet mould
-      slug: amulet-mould
-      relationship: alternative
-      description: For crafting amulets
-  about: |-
-    Smelt Gold ore at a furnace.
-
-    | Method | Smithing Level | XP |
-    |--------|----------------|-----|
-    | Regular furnace | 40 | 22.5 |
-    | Blast Furnace | 40 | 22.5 |
-    | Goldsmith gauntlets | 40 | 56.2 |
+    - item_id: 2359
+      item_name: Mithril bar
+      slug: mithril-bar
+      relationship: upgrade
   market_strategy:
     steps:
       - order: 1
-        action: Gold bar + Mould → Jewelry
+        action: Smelt gold ore at Blast Furnace with Goldsmith gauntlets
       - order: 2
-        action: String → Unstrung amulet
+        action: Craft gold bar + mould into unstrung jewellery
       - order: 3
-        action: Enchant → Valuable amulet
+        action: String and enchant the jewellery for final value
     profit_formulas:
-      - Gold bar price - Gold ore price = Smelting profit
+      - Gold bar price - Gold ore price - Blast Furnace coins cost = Smelting profit
     notes:
-      - Buy Gold ore → Smelt at Blast Furnace with Goldsmith gauntlets
-      - Best Smithing XP in game
-      - "Calculate:"
-      - Blast Furnace is the meta for gold bars
-      - Goldsmith gauntlets from Family Crest quest
-      - High volume item for both Smithing and Crafting training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Goldsmith gauntlets (Family Crest reward) unlock 60-80k Smithing xp/hr at Blast Furnace
+      - Gold bars feed every jewellery Crafting recipe in the game
+      - High volume on the GE makes this the easiest ore-to-bar flip
+      - Blast Furnace is the meta for gold bars — Goldsmith gauntlets required for top xp/hr
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-ore.mdx
@@ -12,24 +12,26 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 30000
+  about: Gold ore is a free-to-play Mining resource obtained at level 40 from gold rocks, granting 65 Mining experience per ore. It smelts to a gold bar at Smithing level 40 with no secondary ingredient — earning 22.5 Smithing XP normally, or 56.2 XP per bar with Goldsmith gauntlets from Family Crest. Gold bars are the universal jewellery Crafting input, making gold ore one of the most consistently traded mining drops.
   material:
     type: ore
     tier: mid
   mining:
+    skill: mining
     level: 40
     xp: 65
+    tool: Any pickaxe
     locations:
       - Crafting Guild
+      - Al Kharid mine
+      - Mining Guild
       - Arzinian Mine
       - Brimhaven dungeon
-  motherlode_mine:
-    level: 30
-  blast_mine:
-    level: 75
   recipes:
     - skill: smithing
       level: 40
       xp: 22.5
+      facility: Furnace
       materials:
         - item_name: Gold ore
           item_id: 444
@@ -37,10 +39,11 @@ osrs:
       product: Gold bar
       product_id: 2357
       product_quantity: 1
-      facility: Furnace
     - skill: smithing
       level: 40
       xp: 56.2
+      facility: Furnace
+      members_only: true
       materials:
         - item_name: Gold ore
           item_id: 444
@@ -48,48 +51,31 @@ osrs:
       product: Gold bar
       product_id: 2357
       product_quantity: 1
-      facility: Blast Furnace (Goldsmith gauntlets)
-      members_only: true
   related_items:
     - item_id: 2357
       item_name: Gold bar
       slug: gold-bar
       relationship: product
-      description: Smelting product
     - item_id: 776
       item_name: Goldsmith gauntlets
       slug: goldsmith-gauntlets
       relationship: alternative
-      description: XP boost
-    - item_id: 1712
-      item_name: Amulet of glory
-      slug: amulet-of-glory
-      relationship: product
-      description: Jewelry product
-    - item_id: 2552
-      item_name: Ring of dueling
-      slug: ring-of-dueling
-      relationship: product
-      description: Jewelry product
+    - item_id: 442
+      item_name: Silver ore
+      slug: silver-ore
+      relationship: alternative
+    - item_id: 447
+      item_name: Mithril ore
+      slug: mithril-ore
+      relationship: upgrade
   market_strategy:
-    title: |-
-      - Jewelry crafting chain
-      - Goldsmith gauntlets XP
-      - High Smithing XP rates
     notes:
-      - Jewelry crafting chain
-      - Goldsmith gauntlets XP
-      - High Smithing XP rates
-      - Gold bar production
-      - Blast Furnace training
-      - Jewelry crafting
-      - Smithing XP
-      - Goldsmith gauntlets 2.5x XP
-      - Blast Furnace efficient
-      - No coal required
-      - High buy limit (30k)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Goldsmith gauntlets (Family Crest reward) deliver 60-80k Smithing xp/hr at Blast Furnace
+      - Crafting Guild has 7 free-to-play gold rocks plus the Mining Guild option
+      - Demand split between Smithing trainers and Crafting trainers keeps prices firm
+      - Highest GE buy limit in the ore tier (30,000) supports bulk flips
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bar.mdx
@@ -12,49 +12,43 @@ osrs:
   lowalch: 11
   highalch: 16
   limit: 10000
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 1.814
+  about: Iron bar is smelted from one iron ore at Smithing level 15 for 12.5 XP. The base smelt success at a regular furnace is only 50% — Ring of forging or 58 Smithing at Blast Furnace eliminates the failure rate. Iron bars are used for iron weapons, armour, dart tips, and iron nails for early Construction, making them a steady mid-tier Smithing input.
+  material:
+    type: bar
+    tier: mid-low
   recipes:
     - skill: smithing
       level: 15
       xp: 12.5
+      facility: Furnace
       materials:
         - item_name: Iron ore
           item_id: 440
           quantity: 1
-      description: Smelting iron ore (50% success rate at regular furnace)
+      product: Iron bar
+      product_id: 2351
+      product_quantity: 1
   related_items:
     - item_id: 440
       item_name: Iron ore
       slug: iron-ore
       relationship: component
-      description: Raw material
+    - item_id: 2349
+      item_name: Bronze bar
+      slug: bronze-bar
+      relationship: downgrade
     - item_id: 2353
       item_name: Steel bar
       slug: steel-bar
-      relationship: alternative
-      description: Higher tier bar
-    - item_id: 2568
-      item_name: Ring of forging
-      slug: ring-of-forging
-      relationship: alternative
-      description: Guarantees 100% success rate
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Metal Bar |
-    | Tradeable | Yes |
-    | Weight | 1.814 kg |
-    | Requirements | 15 Smithing |
-
-    Used for Smithing iron equipment and cannonballs.
-
-    Popular for Blast Furnace money making.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - 50% smelt success without Ring of forging or 58 Smithing creates two distinct supply curves
+      - Iron darts (Fletching) and iron nails (Construction) are bulk consumers
+      - Blast Furnace iron bar smelting with Ring of forging is a profitable early-Smithing method
+      - Bot supply keeps prices close to the ore-plus-cost floor
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-ore.mdx
@@ -12,26 +12,27 @@ osrs:
   lowalch: 6
   highalch: 10
   limit: 13000
+  about: Iron ore is a free-to-play Mining resource obtained at level 15 from iron rocks, granting 35 Mining experience per ore. It smelts to an iron bar at Smithing level 15, but with only 50% base success unless the smith wears a Ring of forging or has 58+ Smithing at the Blast Furnace. Combined with two coal it produces a steel bar, making iron ore one of the most heavily traded mid-tier Smithing ingredients.
   material:
     type: ore
-    tier: iron
+    tier: mid-low
   mining:
+    skill: mining
     level: 15
     xp: 35
-    rocks: Iron rock
+    tool: Any pickaxe
     locations:
       - Mining Guild
-      - Motherlode Mine
       - Al Kharid mine
-  smithing:
-    level: 15
-    xp: 12.5
-    method: Smelting
-    success_rate: 50
+      - Varrock south-east mine
+      - Dwarven Mine
+      - Wilderness Resource Area
+      - Motherlode Mine
   recipes:
     - skill: smithing
       level: 15
       xp: 12.5
+      facility: Furnace
       materials:
         - item_name: Iron ore
           item_id: 440
@@ -39,11 +40,10 @@ osrs:
       product: Iron bar
       product_id: 2351
       product_quantity: 1
-      facility: Furnace
-      success_rate: 50% (100% at Blast Furnace)
     - skill: smithing
       level: 30
       xp: 17.5
+      facility: Furnace
       materials:
         - item_name: Iron ore
           item_id: 440
@@ -54,48 +54,35 @@ osrs:
       product: Steel bar
       product_id: 2353
       product_quantity: 1
-      facility: Furnace
   related_items:
-    - item_id: 2351
-      item_name: Iron bar
-      slug: iron-bar
-      relationship: product
-      description: Basic product
-    - item_id: 2353
-      item_name: Steel bar
-      slug: steel-bar
-      relationship: product
-      description: Higher tier product
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: For steel bars
-    - item_id: 2568
-      item_name: Ring of forging
-      slug: ring-of-forging
-      relationship: alternative
-      description: 100% smelting success
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: product
+    - item_id: 2353
+      item_name: Steel bar
+      slug: steel-bar
+      relationship: product
     - item_id: 436
       item_name: Copper ore
       slug: copper-ore
-      relationship: alternative
-      description: For bronze bars
+      relationship: downgrade
+    - item_id: 447
+      item_name: Mithril ore
+      slug: mithril-ore
+      relationship: upgrade
   market_strategy:
-    profit_formulas:
-      - Iron bar price - Iron ore price = Profit
     notes:
-      - 100% success rate at Blast Furnace
-      - No ring of forging needed
-      - "Calculate:"
-      - Iron ore + Coal → Steel bar
-      - "At Blast Furnace: Only 1 coal needed"
-      - Compare margins between iron and steel bars
-      - Iron ore has very high supply from bots/players
-      - Ring of forging provides 140 charges at 100% success
-      - Blast Furnace is always more profitable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - 50% base smelt success without Ring of forging or 58 Smithing creates two distinct supply curves
+      - Used as the iron half of every steel bar — high consumption from Cannonball smithers
+      - Blast Furnace iron bars are a profitable F2P/early-members training method
+      - Wilderness Resource Area and Motherlode Mine are common high-yield gathering spots
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lead-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lead-bar.mdx
@@ -12,8 +12,60 @@ osrs:
   lowalch: 11
   highalch: 16
   limit: null
-  about: "Lead bar is a members-only item in Old School RuneScape. High alchemy value: 16 coins."
-  mdx_version: 2
+  about: Lead bar was added with the Sailing skill release on 19 November 2025. It is smelted from two lead ore at Smithing level 25, awarding 15.5 Smithing XP per bar at a regular furnace. Lead bars are the bulk metal used in shipbuilding and certain island amenities within the Sailing economy.
+  material:
+    type: bar
+    tier: mid-low
+  recipes:
+    - skill: smithing
+      level: 25
+      xp: 15.5
+      facility: Furnace
+      members_only: true
+      materials:
+        - item_name: Lead ore
+          item_id: 31716
+          quantity: 2
+      product: Lead bar
+      product_id: 32889
+      product_quantity: 1
+    - skill: magic
+      level: 43
+      xp: 53
+      members_only: true
+      materials:
+        - item_name: Lead ore
+          item_id: 31716
+          quantity: 2
+        - item_name: Nature rune
+          item_id: 561
+          quantity: 1
+        - item_name: Fire rune
+          item_id: 554
+          quantity: 4
+      product: Lead bar
+      product_id: 32889
+      product_quantity: 1
+  related_items:
+    - item_id: 31716
+      item_name: Lead ore
+      slug: lead-ore
+      relationship: component
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: alternative
+    - item_id: 32892
+      item_name: Cupronickel bar
+      slug: cupronickel-bar
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - Sailing-era bar introduced 19 November 2025 — demand tracks the Sailing content cycle
+      - Requires two lead ore per bar, making supply roughly half of lead ore throughput
+      - Can be made via Superheat Item (Magic 43) if metal is bought from the GE
+      - Blast Furnace supports batched Sailing smithing runs
+  mdx_version: 3
   mdx_updated: "2026-04-10"
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lead-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lead-ore.mdx
@@ -12,8 +12,47 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: null
-  about: "Lead ore is a members-only item in Old School RuneScape. High alchemy value: 21 coins."
-  mdx_version: 2
+  about: Lead ore was added with the Sailing skill release on 19 November 2025. It is mined at level 25 from lead rocks for 40.5 Mining experience per ore — designed to give better xp/hr than iron rocks outside the Mining Guild but lower than Mining Guild iron. Two lead ore smelt to a lead bar at Smithing level 25, providing the bulk metal for shipbuilding and island amenities.
+  material:
+    type: ore
+    tier: mid-low
+  mining:
+    skill: mining
+    level: 25
+    xp: 40.5
+    tool: Any pickaxe
+    members_only: true
+    locations:
+      - Lead rocks (Sailing region)
+  recipes:
+    - skill: smithing
+      level: 25
+      xp: 15.5
+      facility: Furnace
+      members_only: true
+      materials:
+        - item_name: Lead ore
+          item_id: 31716
+          quantity: 2
+      product: Lead bar
+      product_id: 32889
+      product_quantity: 1
+  related_items:
+    - item_id: 32889
+      item_name: Lead bar
+      slug: lead-bar
+      relationship: product
+    - item_id: 440
+      item_name: Iron ore
+      slug: iron-ore
+      relationship: alternative
+  market_strategy:
+    notes:
+      - Sailing-era ore introduced 19 November 2025 — long-term demand tied to shipbuilding economy
+      - Mining xp/hr designed to exceed iron rocks outside the Mining Guild
+      - Varrock armour 1+ grants a 10% extra-ore chance on lead rocks
+      - Mining gloves prevent rocks depleting after a number of mines
+  mdx_version: 3
   mdx_updated: "2026-04-10"
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bar.mdx
@@ -12,20 +12,15 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 10000
+  about: Mithril bar is smelted from one mithril ore and four coal at Smithing level 50, awarding 30 Smithing XP per bar. Blast Furnace halves the coal requirement to two, making it the standard smelting method. Mithril bars feed mithril weapons, armour, dart tips (10 per bar at Anvil level 54), and mithril grapples for Regicide.
   material:
     type: bar
     tier: mid
-  smithing:
-    level: 50
-    xp: 30
-    primary_ore: 447
-    primary_ore_name: Mithril ore
-    coal_required: 4
-    blast_furnace_coal: 2
   recipes:
     - skill: smithing
       level: 50
       xp: 30
+      facility: Furnace
       materials:
         - item_name: Mithril ore
           item_id: 447
@@ -36,79 +31,51 @@ osrs:
       product: Mithril bar
       product_id: 2359
       product_quantity: 1
-      facility: Furnace
-    - skill: smithing
-      level: 50
-      xp: 30
-      materials:
-        - item_name: Mithril ore
-          item_id: 447
-          quantity: 1
-        - item_name: Coal
-          item_id: 453
-          quantity: 2
-      product: Mithril bar
-      product_id: 2359
-      product_quantity: 1
-      facility: Blast Furnace
-      members_only: true
     - skill: smithing
       level: 54
       xp: 50
+      facility: Anvil
+      members_only: true
       materials:
         - item_name: Mithril bar
           item_id: 2359
           quantity: 1
+        - item_name: Hammer
+          item_id: 2347
+          quantity: 1
+          consumed: false
       product: Mithril dart tip
       product_id: 822
       product_quantity: 10
-      facility: Anvil
-      members_only: true
   related_items:
     - item_id: 447
       item_name: Mithril ore
       slug: mithril-ore
       relationship: component
-      description: Primary ore
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: Required for smelting
-    - item_id: 2353
-      item_name: Steel bar
-      slug: steel-bar
-      relationship: alternative
-      description: Lower tier
-    - item_id: 2361
-      item_name: Adamantite bar
-      slug: adamantite-bar
-      relationship: alternative
-      description: Higher tier
     - item_id: 822
       item_name: Mithril dart tip
       slug: mithril-dart-tip
       relationship: product
-      description: Popular product
-  about: |-
-    Smelt 1 Mithril ore + 4 Coal (2 coal at Blast Furnace).
-
-    | Method | Coal Required | Smithing Level | XP |
-    |--------|---------------|----------------|-----|
-    | Regular furnace | 4 | 50 | 30 |
-    | Blast Furnace | 2 | 50 | 30 |
+    - item_id: 2353
+      item_name: Steel bar
+      slug: steel-bar
+      relationship: downgrade
+    - item_id: 2361
+      item_name: Adamantite bar
+      slug: adamantite-bar
+      relationship: upgrade
   market_strategy:
-    profit_formulas:
-      - Mithril bar - Mithril ore - (Coal × 2) = Profit
     notes:
-      - Half coal = major savings
-      - "Calculate:"
-      - ~318 GP profit per bar at Blast Furnace
-      - 1 bar = 10 Mithril dart tips
-      - Popular for Fletching training
-      - Check dart tip vs bar prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Blast Furnace halves the coal cost per bar, dramatically improving margins
+      - One bar yields 10 mithril dart tips at Anvil level 54 — a top Fletching xp/hr method
+      - Mithril grapple demand spikes around Regicide and Wilderness Agility rushes
+      - Ore-pack ironman Smithing trains efficiently on mithril bars
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-ore.mdx
@@ -12,28 +12,26 @@ osrs:
   lowalch: 64
   highalch: 97
   limit: 13000
+  about: Mithril ore is mined at level 55 from mithril rocks, granting 80 Mining experience per ore. It smelts with four coal to create a mithril bar at Smithing level 50, awarding 30 Smithing XP per bar. Mithril ore feeds mithril weapons, armour, dart tips, and is consumed during ore-pack ironman runs in Prifddinas. Blast Furnace halves the coal requirement, making it the standard method for high-volume smelters.
   material:
     type: ore
-    tier: mithril
+    tier: mid
   mining:
+    skill: mining
     level: 55
     xp: 80
-    rocks: Mithril rock
-    respawn_time: 120
+    tool: Any pickaxe
     locations:
       - Mining Guild
       - Al Kharid mine
+      - Dwarven Mine
+      - Wilderness Resource Area
       - Motherlode Mine
-  smithing:
-    level: 50
-    xp: 30
-    method: Smelting
-    coal_required: 4
-    coal_required_bf: 2
   recipes:
     - skill: smithing
       level: 50
       xp: 30
+      facility: Furnace
       materials:
         - item_name: Mithril ore
           item_id: 447
@@ -44,58 +42,31 @@ osrs:
       product: Mithril bar
       product_id: 2359
       product_quantity: 1
-      facility: Furnace
-    - skill: smithing
-      level: 50
-      xp: 30
-      materials:
-        - item_name: Mithril ore
-          item_id: 447
-          quantity: 1
-        - item_name: Coal
-          item_id: 453
-          quantity: 2
-      product: Mithril bar
-      product_id: 2359
-      product_quantity: 1
-      facility: Blast Furnace
-      members_only: true
   related_items:
-    - item_id: 2359
-      item_name: Mithril bar
-      slug: mithril-bar
-      relationship: product
-      description: Smelting product
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: Required for smelting
+    - item_id: 2359
+      item_name: Mithril bar
+      slug: mithril-bar
+      relationship: product
+    - item_id: 440
+      item_name: Iron ore
+      slug: iron-ore
+      relationship: downgrade
     - item_id: 449
       item_name: Adamantite ore
       slug: adamantite-ore
       relationship: upgrade
-      description: Higher tier ore
-    - item_id: 2353
-      item_name: Steel bar
-      slug: steel-bar
-      relationship: downgrade
-      description: Lower tier bar
   market_strategy:
     notes:
-      - Decent Mining XP
-      - Requires significant coal
-      - Blast Furnace halves coal
-      - Mithril bar production
-      - Smithing training
-      - Cannonball alternatives
-      - Ironman progression
-      - Blast Furnace saves coal
-      - Mining Guild for extra ore
-      - 2 minute respawn limits spots
-      - Motherlode Mine alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Coal-heavy bar (4 coal each) — Blast Furnace and coal bag are essential for competitive xp/hr
+      - Demand from mithril dart tip Fletching is steady and high-volume
+      - Mining Guild and Wilderness Resource Area offer the densest gathering rates
+      - Used in mithril ore-pack rotations for ironman Smithing progression
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bar.mdx
@@ -12,20 +12,15 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 10000
+  about: Runite bar is smelted from one runite ore and eight coal at Smithing level 85, awarding 50 Smithing XP per bar — the highest per-smelt XP of any standard bar. Blast Furnace halves the coal to four per bar, making it the standard for high-level Smithing training. Rune bars feed rune armour, rune weapons, rune crossbow, and rune dart tips for top-tier Fletching.
   material:
     type: bar
     tier: high
-  smithing:
-    level: 85
-    xp: 50
-    primary_ore: 451
-    primary_ore_name: Runite ore
-    coal_required: 8
-    blast_furnace_coal: 4
   recipes:
     - skill: smithing
       level: 85
       xp: 50
+      facility: Furnace
       materials:
         - item_name: Runite ore
           item_id: 451
@@ -36,70 +31,51 @@ osrs:
       product: Runite bar
       product_id: 2363
       product_quantity: 1
-      facility: Furnace
     - skill: smithing
-      level: 85
-      xp: 50
-      materials:
-        - item_name: Runite ore
-          item_id: 451
-          quantity: 1
-        - item_name: Coal
-          item_id: 453
-          quantity: 4
-      product: Runite bar
-      product_id: 2363
-      product_quantity: 1
-      facility: Blast Furnace
-      members_only: true
-    - skill: smithing
-      level: 99
+      level: 89
       xp: 75
+      facility: Anvil
+      members_only: true
       materials:
         - item_name: Runite bar
           item_id: 2363
-          quantity: 5
-      product: Rune platebody
-      product_id: 1127
-      product_quantity: 1
-      facility: Anvil
+          quantity: 1
+        - item_name: Hammer
+          item_id: 2347
+          quantity: 1
+          consumed: false
+      product: Rune dart tip
+      product_id: 824
+      product_quantity: 10
   related_items:
     - item_id: 451
       item_name: Runite ore
       slug: runite-ore
       relationship: component
-      description: Primary ore
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: Required for smelting
     - item_id: 1127
       item_name: Rune platebody
       slug: rune-platebody
       relationship: product
-      description: High value product
-    - item_id: 1319
-      item_name: Rune 2h sword
-      slug: rune-2h-sword
+    - item_id: 824
+      item_name: Rune dart tip
+      slug: rune-dart-tip
       relationship: product
-      description: Popular alch item
-  about: |-
-    Smelt 1 Runite ore + 8 Coal (4 at Blast Furnace).
-
-    | Method | Coal Required | Smithing Level | XP |
-    |--------|---------------|----------------|-----|
-    | Regular furnace | 8 | 85 | 50 |
-    | Blast Furnace | 4 | 85 | 50 |
+    - item_id: 2361
+      item_name: Adamantite bar
+      slug: adamantite-bar
+      relationship: downgrade
   market_strategy:
     notes:
-      - "Calculate:"
-      - Compare smelting vs buying bars directly
-      - Rune platebody - 39,000 GP alch (5 bars)
-      - Rune platelegs - 38,400 GP alch (3 bars)
-      - Rune 2h sword - 38,400 GP alch (3 bars)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Apex tier bar — 50 XP per smelt is the highest in the standard bar chain
+      - Blast Furnace with coal bag and stamina potions is the competitive smelting setup
+      - Rune dart tips are the best Fletching xp/hr method for players with level 89 Smithing
+      - Compare smelting from ore vs buying bars directly — GE margins shift constantly
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-ore.mdx
@@ -12,28 +12,26 @@ osrs:
   lowalch: 1280
   highalch: 1920
   limit: 4500
+  about: Runite ore is the apex of the standard ore tier, mined at level 85 from runite rocks for 125 Mining experience per ore. It smelts with eight coal to a runite bar at Smithing level 85, awarding 50 Smithing XP per bar — the most XP-dense regular smelt in the game. Long respawn timers and limited natural spawns make Wilderness Resource Area, Mining Guild, and Heroes' Guild rocks highly contested.
   material:
     type: ore
-    tier: runite
+    tier: high
   mining:
+    skill: mining
     level: 85
     xp: 125
-    rocks: Runite rock
+    tool: Any pickaxe
     locations:
-      - Heroes' Guild
-      - Mining Guild (expanded)
-      - Wilderness
-      - Mor Ul Rek
-  smithing:
-    level: 85
-    xp: 50
-    method: Smelting
-    coal_required: 8
-    coal_required_bf: 4
+      - Mining Guild (Falador)
+      - Wilderness Resource Area
+      - Heroes' Guild basement
+      - Lava Maze rune rocks (Wilderness)
+      - Prifddinas (Trahaearn district)
   recipes:
     - skill: smithing
       level: 85
       xp: 50
+      facility: Furnace
       materials:
         - item_name: Runite ore
           item_id: 451
@@ -44,74 +42,28 @@ osrs:
       product: Runite bar
       product_id: 2363
       product_quantity: 1
-      facility: Furnace
-      members_only: true
-    - skill: smithing
-      level: 85
-      xp: 50
-      materials:
-        - item_name: Runite ore
-          item_id: 451
-          quantity: 1
-        - item_name: Coal
-          item_id: 453
-          quantity: 4
-      product: Runite bar
-      product_id: 2363
-      product_quantity: 1
-      facility: Blast Furnace
-      members_only: true
   related_items:
-    - item_id: 2363
-      item_name: Runite bar
-      slug: runite-bar
-      relationship: product
-      description: Smelted product
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: Smelting requirement
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: product
     - item_id: 449
       item_name: Adamantite ore
       slug: adamantite-ore
       relationship: downgrade
-      description: Lower tier ore
-    - item_id: 21347
-      item_name: Amethyst
-      slug: amethyst
-      relationship: alternative
-      description: Alternative high-level mining
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Mining Level | 85 |
-    | XP per ore | 125 |
-
-    | Method | Coal Required | Smithing Level | XP |
-    |--------|---------------|----------------|-----|
-    | Regular furnace | 8 | 85 | 50 |
-    | Blast Furnace | 4 | 85 | 50 |
-    | Superheat | 8 | 85 | 53 |
   market_strategy:
-    profit_formulas:
-      - Runite bar - Runite ore - (Coal × 4) = Profit
     notes:
-      - Half coal requirement = major savings
-      - "Calculate:"
-      - Best money-making smithing method
-      - 85 Mining required (high barrier)
-      - Low spawn rate, competitive spots
-      - Wilderness locations risky but faster
-      - Heroes' Guild (members)
-      - Mining Guild (expanded area)
-      - Wilderness (high risk)
-      - Mor Ul Rek (TzHaar city)
-      - Low buy limit = price stability
-      - Blast Furnace doubles profitability
-      - High Smithing unlocks full chain
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Apex tier ore — long respawn rocks create high per-ore value and consistent demand
+      - Wilderness Lava Maze offers the highest density F2P-accessible spawns at risk of PKers
+      - Prifddinas runite rocks require Song of the Elves and 85 Mining
+      - Blast Furnace + coal bag + stamina potions is the standard smelting setup
+      - Rune bars feed rune armour, rune crossbows, and rune dart Fletching
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bar.mdx
@@ -12,16 +12,15 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 10000
+  about: Silver bar is smelted from one silver ore at Smithing level 20 for 13.7 XP. Unlike other bars, it is never smithed into weapons or armour — it feeds Crafting recipes for holy symbols, silver sickles, tiaras, silver bolts, and silver jewellery. Demand is niche but steady, driven by Crafting trainers and Slayer task gear makers.
   material:
     type: bar
-    tier: low
-  smithing:
-    level: 20
-    xp: 13.7
+    tier: mid-low
   recipes:
     - skill: smithing
       level: 20
       xp: 13.7
+      facility: Furnace
       materials:
         - item_name: Silver ore
           item_id: 442
@@ -29,71 +28,69 @@ osrs:
       product: Silver bar
       product_id: 2355
       product_quantity: 1
-      facility: Furnace
-  crafting_products:
-    - product: Unstrung symbol
-      product_id: 1714
+    - skill: crafting
       level: 16
       xp: 50
-    - product: Silver sickle
-      product_id: 2961
-      level: 18
-      xp: 50
-    - product: Tiara
-      product_id: 5525
+      facility: Furnace
+      materials:
+        - item_name: Silver bar
+          item_id: 2355
+          quantity: 1
+      product: Unstrung symbol
+      product_id: 1714
+      product_quantity: 1
+    - skill: crafting
       level: 23
       xp: 52.5
-    - product: Silver bolts
-      product_id: 9382
+      facility: Furnace
+      materials:
+        - item_name: Silver bar
+          item_id: 2355
+          quantity: 1
+      product: Tiara
+      product_id: 5525
+      product_quantity: 1
+    - skill: crafting
       level: 21
       xp: 50
-      quantity: 10
-    - product: Lightning rod
-      product_id: 10972
-      level: 20
-      xp: 50
+      facility: Furnace
+      members_only: true
+      materials:
+        - item_name: Silver bar
+          item_id: 2355
+          quantity: 1
+      product: Silver bolts (unf)
+      product_id: 9382
+      product_quantity: 10
   related_items:
     - item_id: 442
       item_name: Silver ore
       slug: silver-ore
       relationship: component
-      description: Raw material
     - item_id: 1718
       item_name: Holy symbol
       slug: holy-symbol
       relationship: product
-      description: Prayer item
     - item_id: 5525
       item_name: Tiara
       slug: tiara
       relationship: product
-      description: RC accessory
-    - item_id: 1714
-      item_name: Unstrung symbol
-      slug: unstrung-symbol
-      relationship: product
-      description: Intermediate
-  about: |-
-    | Method | Level | XP |
-    |--------|-------|-----|
-    | Furnace smelting | 20 Smithing | 13.7 |
-    | Blast Furnace | 20 Smithing | 13.7 |
-    | Materials | Silver ore | - |
+    - item_id: 2357
+      item_name: Gold bar
+      slug: gold-bar
+      relationship: alternative
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: alternative
   market_strategy:
     notes:
-      - Holy symbol production
-      - Tiara making for RC
-      - Moderate demand
-      - Holy symbol crafting
-      - Tiara production
-      - RC training (bind tiaras)
-      - Silver bolts
-      - Lower value than gold
-      - Holy symbols for Prayer
-      - Tiaras popular for ironmen
-      - Quick to smelt
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Only consumed by Crafting outputs (holy symbols, tiaras, silver bolts, jewellery)
+      - Not used at the anvil for weapons or armour
+      - Tiara crafting is a popular Crafting + Runecraft prep route for ironmen
+      - Lower bot supply than copper, tin, or iron bars
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-ore.mdx
@@ -12,22 +12,26 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 13000
+  about: Silver ore is a free-to-play Mining resource obtained at level 20 from silver rocks, granting 40 Mining experience per ore. It smelts directly to a silver bar at Smithing level 20 with no secondary ingredient, and silver bars feed Crafting (holy symbols, tiaras, silver sickles, jewellery) rather than weapons or armour. Demand is niche compared to coal or iron, but remains steady from Crafting trainers.
   material:
     type: ore
-    tier: low
+    tier: mid-low
   mining:
+    skill: mining
     level: 20
     xp: 40
+    tool: Any pickaxe
     locations:
       - Crafting Guild
       - Al Kharid mine
       - Varrock west mine
-  motherlode_mine:
-    level: 30
+      - Edgeville dungeon
+      - Mining Guild
   recipes:
     - skill: smithing
       level: 20
       xp: 13.7
+      facility: Furnace
       materials:
         - item_name: Silver ore
           item_id: 442
@@ -35,43 +39,27 @@ osrs:
       product: Silver bar
       product_id: 2355
       product_quantity: 1
-      facility: Furnace
   related_items:
     - item_id: 2355
       item_name: Silver bar
       slug: silver-bar
       relationship: product
-      description: Smelting product
-    - item_id: 1718
-      item_name: Holy symbol
-      slug: holy-symbol
-      relationship: product
-      description: Crafting product
-    - item_id: 5525
-      item_name: Tiara
-      slug: tiara
-      relationship: product
-      description: RC training
-    - item_id: 1714
-      item_name: Unstrung symbol
-      slug: unstrung-symbol
-      relationship: product
-      description: Intermediate
+    - item_id: 444
+      item_name: Gold ore
+      slug: gold-ore
+      relationship: alternative
+    - item_id: 440
+      item_name: Iron ore
+      slug: iron-ore
+      relationship: alternative
   market_strategy:
     notes:
-      - Holy symbols demand
-      - Tiaras for Runecrafting
-      - Low-level Crafting
-      - Silver bar production
-      - Holy symbol crafting
-      - Tiara making
-      - Unstrung symbol
-      - Crafting Guild has rocks
-      - Lower demand than gold
-      - Holy symbols for Prayer
-      - Tiaras for RC training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Niche ore used exclusively for Crafting outputs rather than Smithing weapons or armour
+      - Crafting Guild has dense respawning silver rocks with minimal competition
+      - Steady demand from holy symbol, tiara, and silver bolt makers
+      - Bot supply is lighter than copper, tin, or iron
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bar.mdx
@@ -12,17 +12,15 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 10000
+  about: Steel bar is smelted from one iron ore and two coal at Smithing level 30 for 17.5 XP. It is the main input for cannonball crafting (4 cannonballs per bar at Smithing level 35) and Varrock armour 1/2/3 hourly Blast Furnace bonuses, making it one of the highest-volume mid-tier bars in the game.
   material:
     type: bar
-    tier: steel
-  smithing:
-    level: 30
-    xp: 17.5
-    method: Smelting
+    tier: mid
   recipes:
     - skill: smithing
       level: 30
       xp: 17.5
+      facility: Furnace
       materials:
         - item_name: Iron ore
           item_id: 440
@@ -33,60 +31,51 @@ osrs:
       product: Steel bar
       product_id: 2353
       product_quantity: 1
-      facility: Furnace
     - skill: smithing
-      level: 30
-      xp: 17.5
-      materials:
-        - item_name: Iron ore
-          item_id: 440
-          quantity: 1
-        - item_name: Coal
-          item_id: 453
-          quantity: 1
-      product: Steel bar
-      product_id: 2353
-      product_quantity: 1
-      facility: Blast Furnace
+      level: 35
+      xp: 25.5
+      facility: Furnace
       members_only: true
+      materials:
+        - item_name: Steel bar
+          item_id: 2353
+          quantity: 1
+        - item_name: Ammo mould
+          item_id: 4
+          quantity: 1
+          consumed: false
+      product: Cannonball
+      product_id: 2
+      product_quantity: 4
   related_items:
     - item_id: 440
       item_name: Iron ore
       slug: iron-ore
       relationship: component
-      description: Primary ore
     - item_id: 453
       item_name: Coal
       slug: coal
       relationship: component
-      description: Required for smelting
     - item_id: 2
       item_name: Cannonball
       slug: cannonball
       relationship: product
-      description: Popular product (4 per bar)
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: downgrade
     - item_id: 2359
       item_name: Mithril bar
       slug: mithril-bar
       relationship: upgrade
-      description: Next tier bar
-    - item_id: 4
-      item_name: Ammo mould
-      slug: ammo-mould
-      relationship: alternative
-      description: For cannonballs
   market_strategy:
-    profit_formulas:
-      - (Cannonball price × 4) - Steel bar price = Profit
-      - Steel bar price - Iron ore - Coal
     notes:
-      - 1 Steel bar = 4 Cannonballs
-      - Very slow but AFK
-      - "Calculate:"
-      - Half coal requirement = significant savings
-      - "Compare:  at both furnaces"
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cannonball crafting (requires Dwarf Cannon) consumes massive volumes of steel bar
+      - Varrock armour 1/2/3 Blast Furnace hourly ore bonus is a major ironman value lever
+      - Blast Furnace halves the coal requirement, significantly improving margins
+      - One steel bar produces four cannonballs at Smithing level 35 — scale the margin check per bar
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tin-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tin-ore.mdx
@@ -12,67 +12,57 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  about: Tin ore is a free-to-play Mining resource obtained at level 1 from tin rocks, granting 17.5 Mining experience per ore. It is paired with copper ore to smelt bronze bars at Smithing level 1, serving as one of the two foundational F2P Smithing ingredients. Tin ore supply is dominated by new players and bots, resulting in consistently low GE prices.
   material:
     type: ore
-    tier: tin
+    tier: low
   mining:
+    skill: mining
     level: 1
     xp: 17.5
-    rocks: Tin rock
+    tool: Any pickaxe
     locations:
-      - Lumbridge Swamp
-      - Varrock south-east
-      - Rimmington
-  smithing:
-    level: 1
-    xp: 6.2
-    method: Smelting
+      - Lumbridge Swamp mine
+      - Varrock south-east mine
+      - Al Kharid mine
+      - Rimmington mine
+      - Dwarven Mine
   recipes:
     - skill: smithing
       level: 1
       xp: 6.2
+      facility: Furnace
       materials:
-        - item_name: Tin ore
-          item_id: 438
-          quantity: 1
         - item_name: Copper ore
           item_id: 436
+          quantity: 1
+        - item_name: Tin ore
+          item_id: 438
           quantity: 1
       product: Bronze bar
       product_id: 2349
       product_quantity: 1
-      facility: Furnace
   related_items:
     - item_id: 436
       item_name: Copper ore
       slug: copper-ore
       relationship: component
-      description: Bronze bar partner
     - item_id: 2349
       item_name: Bronze bar
       slug: bronze-bar
       relationship: product
-      description: Smelting product
-    - item_id: 1265
-      item_name: Bronze pickaxe
-      slug: bronze-pickaxe
-      relationship: alternative
-      description: Mining tool
+    - item_id: 440
+      item_name: Iron ore
+      slug: iron-ore
+      relationship: upgrade
   market_strategy:
     notes:
-      - First ore for new players
-      - Combined with copper for bronze bars
-      - Tutorial Island creates supply
-      - New player Smithing
-      - Ironman accounts
-      - Bronze bar production
-      - Quest requirements
-      - Very low value ore
-      - High supply from bots
-      - Minimal profit margins
-      - Best sold in bulk
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - F2P ore available at Mining level 1, same rocks network as copper
+      - Required partner with copper ore for bronze bar smelting
+      - Supply and price closely track copper ore
+      - Primary buyers are ironmen and new players training early Smithing
+  mdx_version: 3
+  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

Batch 10 of the OSRS v2→v3 migration. Enriches the full mining/smithing progression — 10 ores and 10 bars covering bronze through rune plus the Sailing-era lead and cupronickel chain.

### Items enriched (20)

**Ores (10)** — top-level `mining:` gathering block (skill/level/xp/tool/locations) + smelting recipes:
- Copper ore (436) — F2P, Mining 1, 17.5 xp (adds cupronickel recipe for Sailing content)
- Tin ore (438) — F2P, Mining 1, 17.5 xp
- Iron ore (440) — F2P, Mining 15, 35 xp (both iron and steel recipes)
- Silver ore (442) — F2P, Mining 20, 40 xp
- Coal (453) — F2P, Mining 30, 50 xp (recipes for steel/mithril/adamant/rune bars)
- Gold ore (444) — F2P, Mining 40, 65 xp (regular + Goldsmith gauntlets recipes)
- Mithril ore (447) — Mining 55, 80 xp
- Adamantite ore (449) — Mining 70, 95 xp
- Runite ore (451) — Mining 85, 125 xp
- Lead ore (31716) — Sailing (members), Mining 25, 40.5 xp — released 19 Nov 2025

**Bars (10)** — smelting recipe + downstream anvil/dart recipes + upgrade/downgrade chain:
- Bronze bar (2349) — Smithing 1, 6.2 xp (bronze nails recipe)
- Iron bar (2351) — Smithing 15, 12.5 xp
- Steel bar (2353) — Smithing 30, 17.5 xp (cannonball recipe, level 35, 4 per bar)
- Silver bar (2355) — Smithing 20, 13.7 xp (Crafting outputs as recipes)
- Gold bar (2357) — Smithing 40, 22.5/56.2 xp (regular + Goldsmith gauntlets)
- Mithril bar (2359) — Smithing 50, 30 xp (dart tip recipe, level 54, 10 per bar)
- Adamantite bar (2361) — Smithing 70, 37.5 xp (dart tip recipe, level 74)
- Runite bar (2363) — Smithing 85, 50 xp (dart tip recipe, level 89)
- Lead bar (32889) — Sailing (members), Smithing 25, 15.5 xp (2 lead ore) — 19 Nov 2025
- Cupronickel bar (32892) — Sailing (members), Smithing 74, 42 xp (2 copper + 1 nickel)

### Schema compliance

All 20 files pass the batch scan (no top-level `smithing:` blocks, no `motherlode_mine:`/`blast_mine:`/`crafting_products:` cruft, no legacy `description:` on related_items, no `attack_bonuses` plurals, no `set_piece` underscores). Recipe `product`/`materials` use the flat-id form; `members_only:` is only used inside recipes. Relationships use the hyphenated enum (`upgrade`/`downgrade`/`component`/`product`/`alternative`).

### Wiki corrections

- Mithril/adamantite/runite ores confirmed `members: false` per Wiki infobox (item tradeable to F2P even though rocks are members-only).
- Lead ore: Mining 25 / 40.5 xp, smelts to bar with **2 ore** → 1 bar at Smithing 25 / 15.5 xp.
- Cupronickel bar: Smithing 74 / 42 xp, needs **2 copper + 1 nickel ore**.
- Steel bar cannonball recipe: 35 Smithing, 25.5 xp, 4 cannonballs per bar (not the previous bare-notes form).

## Test plan

- [ ] Verify Astro content collection parses all 20 MDX files without schema errors
- [ ] Spot-check copper-ore → bronze-bar and runite-ore → runite-bar chains for correct cross-references
- [ ] Confirm lead-ore/lead-bar/cupronickel-bar render correctly (new Sailing items with null limit)
- [ ] Confirm OSRSItemPanel renders the new `about:` text and market_strategy blocks