### PR TITLE
feat(kubevirt-autologon): use ghcr.io/kbve/kubectl:0.1.2 + pod security (#9809)

### DIFF
--- a/apps/kube/kubevirt/autologon/job.yaml
+++ b/apps/kube/kubevirt/autologon/job.yaml
@@ -36,10 +36,21 @@ spec:
         spec:
             serviceAccountName: vm-scaler
             restartPolicy: OnFailure
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: autologon
-                  image: registry.k8s.io/kubectl:v1.33.2
+                  image: ghcr.io/kbve/kubectl:0.1.2
                   command: ['/bin/sh', '/scripts/autologon.sh']
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop: ['ALL']
                   env:
                       - name: VM_NAME
                         value: windows-builder
@@ -53,8 +64,12 @@ spec:
                   volumeMounts:
                       - name: script
                         mountPath: /scripts
+                      - name: tmp
+                        mountPath: /tmp
             volumes:
                 - name: script
                   configMap:
                       name: vm-autologon-script
                       defaultMode: 0755
+                - name: tmp
+                  emptyDir: {}


### PR DESCRIPTION
## Summary
Swap the Windows VM autologon Job image from the distroless \`registry.k8s.io/kubectl:v1.33.2\` (which has no \`/bin/sh\` and broke the script on first apply) to our newly-published \`ghcr.io/kbve/kubectl:0.1.2\`.

Also add the restricted PodSecurity fields that were throwing warnings the last time we applied the Job:
\`\`\`
Warning: would violate PodSecurity "restricted:latest":
  allowPrivilegeEscalation != false
  capabilities drop=["ALL"] missing
  runAsNonRoot != true
  seccompProfile missing
\`\`\`

## Changes
- **Image**: \`registry.k8s.io/kubectl:v1.33.2\` → \`ghcr.io/kbve/kubectl:0.1.2\`
- **Pod securityContext**: \`runAsNonRoot: true\`, \`runAsUser: 10001\`, \`seccompProfile: RuntimeDefault\`
- **Container securityContext**: \`allowPrivilegeEscalation: false\`, \`readOnlyRootFilesystem: true\`, \`capabilities.drop: ['ALL']\`
- **Volume**: Added emptyDir \`tmp\` mount because \`readOnlyRootFilesystem\` blocks writes to \`/tmp\`

## Test plan
- [ ] \`kubectl apply -f apps/kube/kubevirt/autologon/ -n angelscript\` — no PodSecurity warnings
- [ ] Job pod starts, runs \`/scripts/autologon.sh\` via \`/bin/sh\`
- [ ] Registry keys set via QEMU Guest Agent
- [ ] Windows VM auto-logs in on next reboot — no VNC password prompt

Ref #9809