### PR TITLE
fix(mc): wire LuckPerms plugin messaging via Velocity to fix pre-login UUID kick

### DIFF
--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -87,6 +87,24 @@ spec:
                                 value: 'false'
                               - name: SERVER_PORT
                                 value: '25565'
+                              # LuckPerms config via env vars (no PVC mutation).
+                              # EnvironmentVariableConfigAdapter reads LUCKPERMS_*
+                              # and overrides the on-disk luckperms.conf. Pairing
+                              # this messaging-service=pluginmsg with the matching
+                              # env var on mc-velocity makes Velocity's LuckPerms
+                              # authoritative for user data — the proxy loads
+                              # permissions against the real online UUID before
+                              # forwarding, and the Fabric LuckPerms receives
+                              # them over the plugin-message channel. This fixes
+                              # the "[LP] Permissions data for your user was not
+                              # loaded during the pre-login stage" kick caused
+                              # by FabricProxy-Lite swapping the offline UUID for
+                              # the online one after LuckPerms already tried to
+                              # pre-load under the offline ID.
+                              - name: LUCKPERMS_MESSAGING_SERVICE
+                                value: 'pluginmsg'
+                              - name: LUCKPERMS_STORAGE_METHOD
+                                value: 'h2'
                           resources:
                               requests:
                                   memory: 2Gi

--- a/apps/kube/agones/mc/velocity-deployment.yaml
+++ b/apps/kube/agones/mc/velocity-deployment.yaml
@@ -45,6 +45,26 @@ spec:
                         value: '512M'
                       - name: REPLACE_ENV_VARIABLES
                         value: 'true'
+                      # LuckPerms-Velocity — downloaded at container start via
+                      # itzg's PLUGINS env var. Makes Velocity the authoritative
+                      # owner of LuckPerms user data (keyed by the real online
+                      # UUID from Mojang auth) and pushes updates to the backend
+                      # LuckPerms-Fabric over the plugin-message channel. This
+                      # fixes the pre-login UUID mismatch kick that was caused
+                      # by FabricProxy-Lite swapping UUIDs after LuckPerms on
+                      # the backend had already tried to pre-load user data.
+                      # 5.5.17 is the latest Velocity release; 5.5.x versions
+                      # share a stable plugin-messaging wire format so the
+                      # 4-patch gap to Fabric 5.5.21 is safe.
+                      - name: PLUGINS
+                        value: 'https://cdn.modrinth.com/data/Vebnzrzj/versions/GZjsuCmU/LuckPerms-Velocity-5.5.17.jar'
+                      # Matches the LuckPerms env vars on the Fabric fleet pod.
+                      # EnvironmentVariableConfigAdapter overrides the on-disk
+                      # luckperms.conf without touching the PVC.
+                      - name: LUCKPERMS_MESSAGING_SERVICE
+                        value: 'pluginmsg'
+                      - name: LUCKPERMS_STORAGE_METHOD
+                        value: 'h2'
                   ports:
                       # hostPort exposes Velocity directly on the node IP at
                       # the standard Minecraft port 25565. Bypasses Service /

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -118,6 +118,13 @@ declare -A MODS=(
   ["old_combat_mod-fabric-1.21.11-1.2.jar"]="5908493d5f019497864b6a8834fcfd4b2aa95213 https://cdn.modrinth.com/data/dZ1APLkO/versions/TzHDocwD/old_combat_mod-fabric-1.21.11-1.2.jar"
   ["FabricProxy-Lite-2.11.0.jar"]="2c6674b1561b9b263b332607ef25b7db469133ec https://cdn.modrinth.com/data/8dI2tmqs/versions/nR8AIdvx/FabricProxy-Lite-2.11.0.jar"
   ["essential_commands-0.38.6-mc1.21.11.jar"]="c10c608f7adfd566fa2908deb16fd761fe399e8b https://cdn.modrinth.com/data/6VdDUivB/versions/3s9XXmZa/essential_commands-0.38.6-mc1.21.11.jar"
+  # LuckPerms-Fabric 5.5.21 — the only LuckPerms Fabric build that
+  # supports MC 1.21.11 (5.5.17 tops out at 1.21.10, 5.5.42 dropped
+  # 1.21). Paired with LuckPerms-Velocity 5.5.17 on the proxy via
+  # plugin messaging; see fleet.yaml and velocity-deployment.yaml for
+  # the LUCKPERMS_MESSAGING_SERVICE=pluginmsg env vars that wire the
+  # two instances together and bypass the FabricProxy-Lite pre-login
+  # UUID mismatch.
   ["LuckPerms-Fabric-5.5.21.jar"]="2b899a61f216e8fd5ff9bfae98b62fcb1201e91b https://cdn.modrinth.com/data/Vebnzrzj/versions/CzCJJMuo/LuckPerms-Fabric-5.5.21.jar"
   ["ledger-1.3.19.jar"]="b53db7b817e968603adf33f8d31903a0bf5c0ea2 https://cdn.modrinth.com/data/LVN9ygNV/versions/c1d39lju/ledger-1.3.19.jar"
   # Grim Anticheat — packet-level anticheat. Lives on the Fabric backend


### PR DESCRIPTION
## Summary
- Install LuckPerms-Velocity 5.5.17 on the proxy via itzg \`PLUGINS\` auto-download
- Set \`LUCKPERMS_MESSAGING_SERVICE=pluginmsg\` + \`LUCKPERMS_STORAGE_METHOD=h2\` on both Velocity and the Fabric fleet so Velocity (real online UUID) is authoritative and pushes user data to Fabric over plugin messaging
- Manifest-only change — LuckPerms-Fabric 5.5.21 is already baked into the running \`ghcr.io/kbve/mc:1.0.8\` image, so no Docker rebuild or version bump is needed

## Bug
Players were kicked on join with:

> [LP] Permissions data for your user was not loaded during the pre-login stage

Root cause: LuckPerms-Fabric \`onPreLogin\` pre-loads under the offline UUID from the authenticated profile, but FabricProxy-Lite swaps the profile for the online UUID later in the login flow. The subsequent \`onLogin\` lookup under the online UUID misses the pre-loaded data and disconnects the player.

## Fix
Make Velocity — which has already done Mojang auth and knows the real online UUID before the backend ever sees the player — the authoritative LuckPerms instance, and wire it to Fabric over the LuckPerms plugin-message channel. Fabric becomes a passive receiver keyed on the online UUID, so the pre-login/onLogin UUID race goes away.

\`EnvironmentVariableConfigAdapter\` reads \`LUCKPERMS_*\` env vars and overrides the on-disk \`luckperms.conf\`, so we don't have to mutate the PVC or rebuild the image.

## Version note
LuckPerms-Fabric is pinned at 5.5.21 (the only build that supports 1.21.11 — 5.5.17 tops out at 1.21.10, 5.5.42 dropped 1.21). LuckPerms-Velocity only has 5.5.17 as the latest release. The 4-patch gap is safe: the 5.5.x series shares a stable plugin-messaging wire format.

## Test plan
- [ ] ArgoCD sync applies \`fleet.yaml\` and \`velocity-deployment.yaml\`
- [ ] Velocity pod logs show LuckPerms-Velocity plugin downloaded and loaded
- [ ] Fabric pod logs show \`messaging-service: pluginmsg\` picked up from env
- [ ] Player connects to \`mc.kbve.com:25565\` without the pre-login kick
- [ ] \`/lp\` commands work from in-game on both proxy and backend