### PR TITLE
fix(kubevirt): pivot macos-builder from Sequoia to Sonoma

### DIFF
--- a/apps/kube/angelscript/manifest/vm-macos-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-macos-builder.yaml
@@ -9,35 +9,41 @@
 # OpenCore bootloader as a separate disk. Plain EFI cannot load the macOS
 # kernel directly. The boot order is OpenCore → rootdisk → BaseSystem.
 #
-# Target version: macOS Sequoia (15.x, Darwin 24).
-#   - Tahoe (26.x) was attempted first but boot.efi requires x86legacyap.im4m
-#     which is missing from the Tahoe BaseSystem recovery image. The OSX-KVM
-#     bundled OpenCore.qcow2 also lacks Tahoe-specific patches; community work
-#     is unfinished as of April 2026 (see kholia/OSX-KVM PR #273 + Dortania
-#     Tahoe install guide). Sequoia is the boring known-working choice.
+# Target version: macOS Sonoma (14.x, Darwin 23).
+#   - Tahoe (26.x) is unworkable: boot.efi requires x86legacyap.im4m, the
+#     bundled OpenCore.qcow2 lacks Tahoe patches (see kholia/OSX-KVM PR #273).
+#   - Sequoia (15.x) needs -cpu Skylake-Client per OSX-KVM's boot script, but
+#     our AMD EPYC Rome node only advertises Penryn/EPYC/Nehalem/etc in the
+#     schedulable cpu-model.node.kubevirt.io labels — no Skylake. Sequoia
+#     hangs at the Apple logo because the kernel can't match expected CPUID.
+#   - Sonoma works with Penryn/Haswell-noTSX CPU models and still supports
+#     Xcode 16 (requires macOS 14.5+), so UE5 plugin builds work identically.
 #
 # Provisioning steps (one-time, after KubeVirt + CDI are running):
 #   1. Prepare a macOS install image and OpenCore boot disk using OSX-KVM:
 #        - Clone https://github.com/kholia/OSX-KVM
-#        - Run: python3 fetch-macOS-v2.py --action download -s sequoia -os latest
+#        - Run: python3 fetch-macOS-v2.py --action download -s sonoma -os latest
 #          Output: com.apple.recovery.boot/BaseSystem.dmg (~900 MB)
-#        - Convert to raw: qemu-img convert -f dmg -O raw BaseSystem.dmg BaseSystem-sequoia.img
+#        - Convert to raw: qemu-img convert -f dmg -O raw BaseSystem.dmg BaseSystem-sonoma.img
 #          (~2.5 GB raw)
-#        - Copy the bundled OpenCore.qcow2 from the OSX-KVM repo (do NOT modify it)
+#        - Copy the bundled OpenCore.qcow2 from the OSX-KVM repo AND enable
+#          SurPlus v1 patches (both PART 1 and PART 2) in EFI/OC/config.plist.
+#          The bundled config ships these DISABLED — they're required on AMD
+#          hosts to work around read_erandom / _early_random hangs.
 #   2. Port-forward the CDI upload proxy:
 #        kubectl port-forward -n cdi svc/cdi-uploadproxy 8443:443
-#   3. Upload the OpenCore bootloader (one-time, pristine OSX-KVM image):
+#   3. Upload the OpenCore bootloader with SurPlus enabled (one-time):
 #        virtctl image-upload dv macos-opencore \
 #          --size=1Gi \
-#          --image-path=/path/to/OSX-KVM/OpenCore/OpenCore.qcow2 \
+#          --image-path=/path/to/OpenCore-surplus.qcow2 \
 #          --storage-class=longhorn \
 #          --namespace=angelscript \
 #          --uploadproxy-url=https://localhost:8443 \
 #          --insecure
-#   4. Upload the Sequoia install image (~2.5 GB raw, takes a few minutes):
-#        virtctl image-upload dv macos-sequoia-installer \
+#   4. Upload the Sonoma install image (~2.5 GB raw, takes a few minutes):
+#        virtctl image-upload dv macos-sonoma-installer \
 #          --size=4Gi \
-#          --image-path=./BaseSystem-sequoia.img \
+#          --image-path=./BaseSystem-sonoma.img \
 #          --storage-class=longhorn \
 #          --namespace=angelscript \
 #          --uploadproxy-url=https://localhost:8443 \
@@ -175,7 +181,7 @@ spec:
                       claimName: macos-builder-rootdisk
                 - name: installer
                   dataVolume:
-                      name: macos-sequoia-installer
+                      name: macos-sonoma-installer
                 - name: shared-storage
                   persistentVolumeClaim:
                       claimName: builder-shared-storage


### PR DESCRIPTION
## Summary
Sequoia (15.x, Darwin 24) hangs at the Apple logo on our **AMD EPYC Rome** node. Root cause: OSX-KVM's Sequoia path requires `-cpu Skylake-Client`, but KubeVirt's schedulable CPU model labels on the host only cover Penryn / EPYC-Rome / Nehalem / Westmere / SandyBridge — no Skylake/Haswell without policy overrides.

Sonoma (14.x, Darwin 23) is the AMD-friendly fallback:
- Still supports **Xcode 16** (min macOS 14.5), so UE5 plugin builds are functionally identical
- Works with `-cpu Penryn` per OSX-KVM's historical path
- AMD_Vanilla patches apply unmodified (Darwin 23 within existing MaxKernel coverage)

## SurPlus patches required
The bundled `OpenCore.qcow2` ships SurPlus v1 patches **disabled** (default target is Intel). On AMD these two patches are required to get past early kernel init — without them the kernel hangs at `read_erandom` / `_early_random`. Both patches are already present in the bundled config; just need `Enabled = true`.

## Test plan
- [x] `python3 fetch-macOS-v2.py --action download -s sonoma -os latest`
- [x] `qemu-img convert -f dmg -O raw BaseSystem.dmg BaseSystem-sonoma.img` (~2.5 GB)
- [x] Upload `macos-sonoma-installer` DV via virtctl (running)
- [x] Re-upload OpenCore DV with SurPlus enabled (separate disk edit)
- [ ] ArgoCD sync `angelscript` app
- [ ] `virtctl start macos-builder -n angelscript`
- [ ] Verify OpenCore picker shows the Sonoma BaseSystem entry
- [ ] Boot past Apple logo to Recovery menu
- [ ] Partition rootdisk as APFS, install Sonoma

Ref #9978