### PR TITLE
fix(mc): switch mc-velocity deployment strategy to Recreate

### DIFF
--- a/apps/kube/agones/mc/velocity-deployment.yaml
+++ b/apps/kube/agones/mc/velocity-deployment.yaml
@@ -18,11 +18,14 @@ spec:
     selector:
         matchLabels:
             app: mc-velocity
+    # Recreate — required because replicas=1 binds hostPort 25565 on the
+    # dedicated-server node. A rolling update can never surge: the new pod
+    # can't schedule until the old one frees the port, and the old one
+    # can't terminate until the new one is Ready. Recreate tears the old
+    # pod down first, which accepts a short (~30s plugin-download + boot)
+    # connection gap in exchange for rollouts that actually complete.
     strategy:
-        type: RollingUpdate
-        rollingUpdate:
-            maxSurge: 1
-            maxUnavailable: 0
+        type: Recreate
     template:
         metadata:
             labels:


### PR DESCRIPTION
## Summary
- Replace \`RollingUpdate (maxSurge: 1, maxUnavailable: 0)\` with \`Recreate\` on the mc-velocity Deployment
- Fixes a hostPort + single-replica rollout deadlock that stalled the LuckPerms fix in PR #10000 until an operator manually deleted the old pod

## Bug
The mc-velocity Deployment pins \`replicas: 1\` to \`hostPort: 25565\` on a dedicated-server node so players can connect to \`mc.kbve.com:25565\` directly. With \`RollingUpdate\` + \`maxSurge: 1\` + \`maxUnavailable: 0\` the rollout deadlocks on every manifest change:

1. New pod schedules → hits \`FailedScheduling: node(s) didn't have free ports for the requested pod ports\` because the old pod still owns \`hostPort: 25565\`.
2. Old pod stays up → \`maxUnavailable: 0\` blocks termination until the new one is Ready.
3. Rollout sits stuck forever.

This triggered in production when PR #10000 merged: the Fabric Fleet rolled cleanly but the Velocity Deployment stalled, and the old proxy pod kept serving traffic without \`LuckPerms-Velocity\` loaded — leaving the pre-login UUID kick bug live end-to-end until we \`kubectl delete\`'d the old pod by hand to unstick it.

## Fix
Switch to \`strategy: Recreate\`. The deployment controller now:
1. Tears down the old pod first (frees hostPort 25565).
2. Schedules the new pod.
3. itzg entrypoint downloads \`LuckPerms-Velocity-5.5.17.jar\`, Velocity boots, readiness probe passes.

Trade-off: ~30s connection gap per rollout while the new pod downloads the plugin and boots. That's acceptable for a hobby MC server that only rolls on deliberate config/mod changes, and it's strictly better than the current state (stuck rollouts + silent bug regressions).

## Test plan
- [ ] ArgoCD sync applies the new strategy
- [ ] Next manifest change to \`velocity-deployment.yaml\` rolls out automatically without operator intervention
- [ ] Velocity pod binds \`:25565\` on boot and serves the mc.kbve.com traffic after the gap