### PR TITLE
fix(kubevirt): drop virtio-drivers containerDisk from windows-builder VM (#9809)

### DIFF
--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -16,10 +16,19 @@
 #   4. Connect via VNC and install Windows:
 #        virtctl vnc windows-builder -n angelscript
 #   5. Inside Windows, install:
-#      - virtio-win drivers (from the virtio CD-ROM attached below)
+#      - virtio-win drivers (requires temporarily re-attaching the virtio-drivers
+#        containerDisk — see the removed block below)
 #      - Visual Studio Build Tools (MSVC)
 #      - GitHub Actions runner (configured for KBVE/UnrealEngine-Angelscript)
 #   6. After setup, the VM runs as a persistent self-hosted runner.
+#
+# Note: the virtio-drivers containerDisk sidecar (quay.io/kubevirt/virtio-container-disk)
+# was removed from this manifest because it has a reproducible startup race on
+# cold-start under KubeVirt v1.7.2: the sidecar terminates with
+# "socket disk_2.sock does not exist anymore", leaving the VMI stuck in
+# Scheduled phase and the pod 2/3 NotReady. Drivers are already installed
+# inside Windows, so the ISO is no longer needed at runtime. If you ever need
+# to reinstall or refresh drivers, re-add the disk + volume entries temporarily.
 ---
 # Root disk — blank Longhorn volume for the Windows installation
 apiVersion: v1
@@ -74,11 +83,6 @@ spec:
                           cdrom:
                               bus: sata
                           bootOrder: 2
-                        # virtio-win drivers ISO — needed during Windows install
-                        - name: virtio-drivers
-                          cdrom:
-                              bus: sata
-                          bootOrder: 3
                         # Shared storage — ISOs, installers, Xcode .xip staging
                         - name: shared-storage
                           disk:
@@ -129,9 +133,6 @@ spec:
                 - name: iso
                   dataVolume:
                       name: windows-server-builder-iso
-                - name: virtio-drivers
-                  containerDisk:
-                      image: quay.io/kubevirt/virtio-container-disk:v1.7.2
                 - name: shared-storage
                   persistentVolumeClaim:
                       claimName: builder-shared-storage


### PR DESCRIPTION
## Summary
Remove the \`virtio-drivers\` containerDisk sidecar from the \`windows-builder\` VM manifest. It has a reproducible cold-start race under KubeVirt v1.7.2 that leaves the VMI stuck in \`Scheduled\` phase indefinitely.

## Evidence
Every cold-start produces identical container statuses after ~10s:
\`\`\`
compute=ready:true state:{"running":{"startedAt":"..."}}
volumevirtio-drivers=ready:false state:{"terminated":{"exitCode":0,"reason":"Completed",...}}
\`\`\`

Sidecar log:
\`\`\`
error: socket /var/run/kubevirt-ephemeral-disks/container-disk-data/<uid>/disk_2.sock does not exist anymore
\`\`\`

The sidecar exits with code 0 (Completed) ~3 seconds after starting, but its lifecycle is supposed to be persistent — it should serve the virtio-win ISO over NBD for the compute container. Once it terminates, the virt-launcher pod is \`2/3 NotReady\` and the VMI never transitions from \`Scheduled\` to \`Running\`. The guest agent \`AgentConnected\` condition stays \`UNKNOWN\`, so the autologon Job polls forever.

Confirmed reproducible: \`virtctl stop + virtctl start\` produces the same failure on every attempt.

## Why it's safe to remove
The virtio-win drivers were only needed during the **initial Windows install** (steps 4–5 in the header comment). Windows is already installed with all required drivers (storage, network, balloon) baked into the image. The ISO attachment is dead weight at runtime and now actively breaking cold-start.

If drivers ever need to be reinstalled, the disk + volume blocks can be temporarily re-added — documented in the updated manifest header.

## Changes
- Remove the \`virtio-drivers\` disk entry (bootOrder: 3)
- Remove the \`virtio-drivers\` containerDisk volume entry
- Update the header comment with the context above

## Test plan
After merge + re-applying the VM manifest to the cluster:
- [ ] \`virtctl stop windows-builder -n angelscript\`
- [ ] \`virtctl start windows-builder -n angelscript\`
- [ ] \`kubectl get vmi windows-builder -n angelscript\` → reaches \`Running\` phase
- [ ] Autologon Job completes successfully (was stuck in 'Waiting for VM')
- [ ] VNC into VM → auto-logs in as Administrator without password prompt

Ref #9809