### PR TITLE
harden(firecracker): wait-rootfs initContainer + seccomp comment fix

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-deployment.yaml
@@ -18,6 +18,40 @@ spec:
             nodeSelector:
                 kvm: 'true'
             automountServiceAccountToken: false
+            # Wait for the rootfs init job (PostSync hook) to populate
+            # vmlinux + rootfs images before the main container starts.
+            # Without this, a pod restart after PVC recreation would race
+            # the init job — init_jailer() would fall back to direct mode
+            # because it can't find /var/lib/firecracker/rootfs/vmlinux.
+            initContainers:
+                - name: wait-rootfs
+                  image: busybox:1.37
+                  command:
+                      - /bin/sh
+                      - -c
+                      - |
+                          for i in $(seq 1 60); do
+                            if [ -f /var/lib/firecracker/rootfs/vmlinux ] && \
+                               [ -f /var/lib/firecracker/rootfs/alpine-minimal.ext4 ]; then
+                              echo "rootfs ready after ${i}s"
+                              exit 0
+                            fi
+                            echo "waiting for rootfs init job... ${i}/60"
+                            sleep 2
+                          done
+                          echo "rootfs not ready after 120s, proceeding anyway"
+                          exit 0
+                  volumeMounts:
+                      - name: rootfs-cache
+                        mountPath: /var/lib/firecracker/rootfs
+                        readOnly: true
+                  resources:
+                      requests:
+                          cpu: 10m
+                          memory: 16Mi
+                      limits:
+                          cpu: 100m
+                          memory: 32Mi
             containers:
                 - name: firecracker-ctl
                   image: ghcr.io/kbve/firecracker-ctl:0.1.28
@@ -44,8 +78,14 @@ spec:
                   securityContext:
                       # The jailer's pivot_root syscall is blocked by the default
                       # seccomp profile. Unconfined is required because:
-                      #   - Talos does not support Localhost seccomp profiles
-                      #   - No Security Profiles Operator is installed
+                      #   - Talos does not support Localhost seccomp profile
+                      #     file paths on nodes
+                      #   - SPO (Security Profiles Operator) IS installed but
+                      #     its spod DaemonSet is incompatible with Talos
+                      #     (sets seLinuxOptions spc_t which Talos's AppArmor
+                      #     kernel config rejects; runc errors on fsmount
+                      #     /proc operations). See [VM][Firecracker] Audit
+                      #     issue for the SPO/Talos compatibility follow-up.
                       # Mitigations: NetworkPolicy default-deny, KVM hardware
                       # isolation, jailer per-VM cgroup+chroot+PID namespace,
                       # read-only rootfs, no outbound network for VMs.

--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -29,6 +29,38 @@ spec:
             nodeSelector:
                 kvm: 'true'
             automountServiceAccountToken: false
+            # Wait for the rootfs init job (PostSync hook) to populate
+            # vmlinux + rootfs images before the main container starts.
+            # Matches the firecracker-ctl deployment pattern.
+            initContainers:
+                - name: wait-rootfs
+                  image: busybox:1.37
+                  command:
+                      - /bin/sh
+                      - -c
+                      - |
+                          for i in $(seq 1 60); do
+                            if [ -f /var/lib/firecracker/rootfs/vmlinux ] && \
+                               [ -f /var/lib/firecracker/rootfs/alpine-minimal.ext4 ]; then
+                              echo "rootfs ready after ${i}s"
+                              exit 0
+                            fi
+                            echo "waiting for rootfs init job... ${i}/60"
+                            sleep 2
+                          done
+                          echo "rootfs not ready after 120s, proceeding anyway"
+                          exit 0
+                  volumeMounts:
+                      - name: rootfs-cache
+                        mountPath: /var/lib/firecracker/rootfs
+                        readOnly: true
+                  resources:
+                      requests:
+                          cpu: 10m
+                          memory: 16Mi
+                      limits:
+                          cpu: 100m
+                          memory: 32Mi
             containers:
                 # ── Gluetun VPN sidecar ──
                 # Establishes WireGuard tunnel. firecracker-ctl shares this


### PR DESCRIPTION
## Summary
- Adds a `wait-rootfs` initContainer (busybox) to both `firecracker-ctl` and `firecracker-ctl-net` that polls for `vmlinux` + `alpine-minimal.ext4` before the main container starts
- Prevents jailer init falling back to direct mode when a pod restart races the PostSync init job
- Observed this exact issue after the recent RWX PVC recreation — both pods came up in direct mode and needed a manual restart once the init job finished
- Also updates the seccomp rationale comment to reflect that SPO IS installed but is incompatible with Talos (SELinux spc_t); tracked in the upcoming [VM][Firecracker] Audit issue

## Background — why SeccompProfile CR adoption is blocked
While working on this, I tried to replace `Unconfined` with a Localhost SeccompProfile CR managed by SPO. The SPO operator pods are running but the `spod` DaemonSet (which actually writes profile JSON to nodes) fails with:
```
cannot start a stopped process
statx fsmount:fscontext:proc/: operation not permitted
```
Root cause: spod sets `seLinuxOptions: { type: "spc_t" }` (Red Hat / SELinux label), but Talos uses AppArmor and runc can't set up the /proc mount namespace under Talos's hardened kernel config. Not a trivial fix — moved to the audit issue for future work.

## Test plan
- [ ] ArgoCD syncs, both deployments restart with initContainer
- [ ] Verify `kubectl logs <pod> -c wait-rootfs` shows "rootfs ready after Ns"
- [ ] Verify main container starts with `Jailer mode ENABLED` (no direct-mode fallback)