### PR TITLE
fix(mc): enable FabricProxy-Lite hackEarlySend to fix LuckPerms pre-login kick

### DIFF
--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -48,6 +48,28 @@ spec:
                 spec:
                     nodeSelector:
                         node.kbve.com/type: dedicated-server
+                    # Force-sync FabricProxy-Lite.toml from the Docker image
+                    # onto the PVC on every pod start. itzg's /config/ → /data/config/
+                    # copy is first-boot-only, so any change to the template
+                    # (like flipping hackEarlySend to true for the LuckPerms
+                    # pre-login UUID fix) would otherwise be ignored by existing
+                    # PVCs. This initContainer pulls the template from the same
+                    # image the main container uses and overwrites the PVC copy
+                    # so the Docker template is the single source of truth.
+                    initContainers:
+                        - name: sync-fabricproxy-config
+                          image: ghcr.io/kbve/mc:1.0.8
+                          command:
+                              - sh
+                              - -c
+                              - |
+                                  set -eu
+                                  mkdir -p /data/config
+                                  cp /config/FabricProxy-Lite.toml /data/config/FabricProxy-Lite.toml
+                                  echo "synced FabricProxy-Lite.toml from image template"
+                          volumeMounts:
+                              - name: mc-data
+                                mountPath: /data
                     containers:
                         - name: mc-server
                           image: ghcr.io/kbve/mc:1.0.8
@@ -87,24 +109,6 @@ spec:
                                 value: 'false'
                               - name: SERVER_PORT
                                 value: '25565'
-                              # LuckPerms config via env vars (no PVC mutation).
-                              # EnvironmentVariableConfigAdapter reads LUCKPERMS_*
-                              # and overrides the on-disk luckperms.conf. Pairing
-                              # this messaging-service=pluginmsg with the matching
-                              # env var on mc-velocity makes Velocity's LuckPerms
-                              # authoritative for user data — the proxy loads
-                              # permissions against the real online UUID before
-                              # forwarding, and the Fabric LuckPerms receives
-                              # them over the plugin-message channel. This fixes
-                              # the "[LP] Permissions data for your user was not
-                              # loaded during the pre-login stage" kick caused
-                              # by FabricProxy-Lite swapping the offline UUID for
-                              # the online one after LuckPerms already tried to
-                              # pre-load under the offline ID.
-                              - name: LUCKPERMS_MESSAGING_SERVICE
-                                value: 'pluginmsg'
-                              - name: LUCKPERMS_STORAGE_METHOD
-                                value: 'h2'
                           resources:
                               requests:
                                   memory: 2Gi

--- a/apps/mc/config/FabricProxy-Lite.toml
+++ b/apps/mc/config/FabricProxy-Lite.toml
@@ -6,8 +6,16 @@
 # but the server still validates Velocity's forwarding signature.
 hackOnlineMode = true
 
-# Hack early send — works around connection edge cases.
-hackEarlySend = false
+# Hack early send — MUST be true for LuckPerms compatibility.
+# When false, the modern-forwarding profile swap happens AFTER
+# LuckPerms-Fabric's onPreLogin mixin reads the authenticated profile,
+# so LuckPerms loads user data under the offline UUID, then onLogin
+# looks up under the real online UUID, finds null, and kicks the player
+# with "[LP] Permissions data for your user was not loaded during the
+# pre-login stage". Setting this true makes FabricProxy-Lite install the
+# online UUID on the profile before LuckPerms's hook fires. Cross-
+# confirmed by LuckPerms issue #4188 and FabricProxy-Lite README.
+hackEarlySend = true
 
 # Hack message chain — ensures chat signing works with forwarded sessions.
 hackMessageChain = true


### PR DESCRIPTION
## Summary
- Flip \`hackEarlySend\` to \`true\` in the FabricProxy-Lite template so the modern-forwarding profile swap lands before LuckPerms-Fabric's \`onPreLogin\` mixin reads the UUID
- Add a \`sync-fabricproxy-config\` initContainer to the Agones Fleet so existing PVCs actually pick up the template change (itzg's \`/config/\` → \`/data/config/\` copy is first-boot-only)
- Remove the speculative \`LUCKPERMS_*\` env vars added to the Fabric fleet in #10000 — they were no-ops under a wrong mental model

## Why #10000 didn't actually fix it
PR #10000 wired LuckPerms plugin messaging between Velocity and Fabric on the theory that Velocity would become authoritative for pre-login data. That theory is wrong: plugin messaging only propagates *change events* between running instances. Each instance still does its own storage read during \`onPreLogin\`, under whatever UUID it sees at that point in the login flow.

Production post-merge proved it: player connected at 19:16:41 and was still kicked with the exact same \`[LP] Permissions data for your user was not loaded during the pre-login stage\` message. Both the new Velocity pod (with LuckPerms-Velocity loaded) and the new Fabric pod (with the \`LUCKPERMS_*\` env vars set) were live at the time.

## Real root cause
LuckPerms-Fabric \`FabricConnectionListener.onPreLogin\` reads \`profile.id()\` from the authenticated game profile — at that point in the login flow this is the **offline** UUID derived from the username. FabricProxy-Lite *does* swap the profile to the online UUID via modern forwarding, but with its default \`hackEarlySend = false\` the swap lands **after** LuckPerms's hook has already fired and cached a null user. \`onLogin\` then looks up the cached user under the real online UUID, finds null, and kicks.

Confirmed by reading \`FabricConnectionListener.java\` on the LuckPerms master branch — the kick path is unconditional, there is no LuckPerms config key that defers or softens it on Fabric.

## Fix
FabricProxy-Lite ships a README-documented workaround: \`hackEarlySend = true\` makes the profile swap fire early enough for LuckPerms's mixin to read the already-correct online UUID. Cross-confirmed by:
- [LuckPerms#4188](https://github.com/LuckPerms/LuckPerms/issues/4188) — maintainer comment from 2026-04-04 explicitly recommends this setting for MC 1.21.11
- [FabricProxy-Lite README](https://github.com/OKTW-Network/FabricProxy-Lite#luckperms-compatibility)
- [FabricProxy-Lite#141](https://github.com/OKTW-Network/FabricProxy-Lite/issues/141) — tracks the underlying timing issue

## Why the initContainer
The template lives in the Docker image at \`/config/FabricProxy-Lite.toml\`. itzg/minecraft-server only copies \`/config/\` → \`/data/config/\` on first boot; subsequent boots skip existing files so the PVC retains the stale \`hackEarlySend = false\`. The \`sync-fabricproxy-config\` initContainer forces the sync on every start so the Docker template remains the single source of truth.

## Test plan
- [ ] ArgoCD sync applies the new fleet.yaml (initContainer added, env vars removed)
- [ ] Next Fabric pod (Agones Fleet respawn after PVC sync via kubectl delete pod) shows initContainer running and logging "synced FabricProxy-Lite.toml from image template"
- [ ] \`kubectl exec <fabric-pod> -- cat /data/config/FabricProxy-Lite.toml\` shows \`hackEarlySend = true\`
- [ ] Player connects to mc.kbve.com:25565 and reaches the game world without the pre-login kick
- [ ] Fabric log shows \`<player> joined the game\` without a subsequent \`lost connection: [LP]\` line