### PR TITLE
feat(mc): run mc:dev as Velocity + Fabric docker-compose stack

### DIFF
--- a/apps/mc/docker-compose.dev.yml
+++ b/apps/mc/docker-compose.dev.yml
@@ -1,0 +1,83 @@
+# Local dev stack for the MC server — mirrors the prod topology of a
+# Velocity proxy fronting a single Fabric backend. Required because the
+# Fabric image ships with FabricProxy-Lite hackOnlineMode=true, which
+# rejects any connection that didn't come through Velocity with
+# "This server requires you to connect with Velocity." Running just the
+# Fabric container directly on localhost:25565 is therefore unusable.
+#
+# Topology:
+#   host:25565  → mc-velocity:25565 (Velocity proxy, modern forwarding)
+#                   → mc-fabric:25565 (Fabric server via internal network)
+#   host:25575  → mc-fabric:25575 (RCON, password=dev)
+#
+# Usage:
+#   nx run mc:dev        # builds the image + brings the stack up (attached)
+#   nx run mc:dev:down   # stops the stack, keeps the volumes
+#   nx run mc:dev:clean  # stops the stack AND wipes the Fabric world PVC
+#
+# Boot time: ~4 minutes cold (Fabric + 16 mods + library unpacking).
+# Velocity is Ready in ~30s but will hold connections until Fabric is up.
+
+name: kbve-mc-dev
+
+services:
+    mc-velocity:
+        image: itzg/bungeecord:latest
+        container_name: kbve-mc-dev-velocity
+        ports:
+            - '25565:25565'
+        environment:
+            TYPE: VELOCITY
+            VELOCITY_VERSION: '3.4.0-SNAPSHOT'
+            MEMORY: '512M'
+            REPLACE_ENV_VARIABLES: 'true'
+            # LuckPerms-Velocity — downloaded at container start. Matches the
+            # prod velocity-deployment.yaml PLUGINS env var so the dev stack
+            # exercises the same plugin-loading path.
+            PLUGINS: 'https://cdn.modrinth.com/data/Vebnzrzj/versions/GZjsuCmU/LuckPerms-Velocity-5.5.17.jar'
+            LUCKPERMS_MESSAGING_SERVICE: 'pluginmsg'
+            LUCKPERMS_STORAGE_METHOD: 'h2'
+        volumes:
+            - ./velocity-dev/velocity.toml:/config/velocity.toml:ro
+            - ./velocity-dev/forwarding.secret:/config/forwarding.secret:ro
+        depends_on:
+            - mc-fabric
+        networks:
+            - mc-dev
+
+    mc-fabric:
+        image: kbve/mc:latest
+        container_name: kbve-mc-dev-fabric
+        # RCON exposed on the host for e2e tests and manual debugging.
+        # Game port (25565) is NOT exposed — clients must connect through
+        # Velocity to exercise the modern-forwarding handshake.
+        ports:
+            - '25575:25575'
+        environment:
+            EULA: 'TRUE'
+            # Velocity handles Mojang auth on the proxy side; Fabric must
+            # be offline-mode to accept forwarded sessions.
+            ONLINE_MODE: 'false'
+            MEMORY: '3G'
+            ENABLE_RCON: 'true'
+            RCON_PORT: '25575'
+            RCON_PASSWORD: 'dev'
+            MOTD: 'KBVE Dev Server'
+            MAX_PLAYERS: '10'
+            DIFFICULTY: 'normal'
+            VIEW_DISTANCE: '8'
+            SIMULATION_DISTANCE: '6'
+        volumes:
+            # Named volume so mods + libraries + world persist across
+            # `nx run mc:dev:down` cycles. Use `nx run mc:dev:clean` to wipe.
+            - mc-fabric-data:/data
+        networks:
+            - mc-dev
+
+networks:
+    mc-dev:
+        name: kbve-mc-dev
+
+volumes:
+    mc-fabric-data:
+        name: kbve-mc-dev-fabric-data

--- a/apps/mc/project.json
+++ b/apps/mc/project.json
@@ -47,16 +47,36 @@
 			"cache": false,
 			"options": {
 				"commands": [
-					"docker rm -f mc-dev 2>/dev/null || true",
-					"echo '=== Starting MC server (offline mode) ==='",
-					"echo '  Game:  localhost:25565'",
+					"docker compose -f docker-compose.dev.yml down --remove-orphans 2>/dev/null || true",
+					"echo '=== Starting MC dev stack (Velocity + Fabric via docker compose) ==='",
+					"echo '  Game:  localhost:25565 (connect here — Velocity proxy)'",
 					"echo '  RCON:  localhost:25575 (password: dev)'",
-					"echo '  Logs:  docker logs -f mc-dev'",
-					"echo '  Stop:  docker rm -f mc-dev'",
+					"echo '  Stop:  nx run mc:dev:down   (keeps world data)'",
+					"echo '  Wipe:  nx run mc:dev:clean  (drops world volume)'",
 					"echo ''",
-					"docker run --name mc-dev -p 25565:25565 -p 25575:25575 -e EULA=TRUE -e ONLINE_MODE=false -e RCON_PASSWORD=dev -e ENABLE_RCON=true -e MOTD='KBVE Dev Server' kbve/mc:latest"
+					"docker compose -f docker-compose.dev.yml up --remove-orphans"
 				],
 				"parallel": false,
+				"cwd": "apps/mc"
+			}
+		},
+		"dev:down": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker compose -f docker-compose.dev.yml down --remove-orphans"
+				],
+				"cwd": "apps/mc"
+			}
+		},
+		"dev:clean": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker compose -f docker-compose.dev.yml down --remove-orphans --volumes"
+				],
 				"cwd": "apps/mc"
 			}
 		},

--- a/apps/mc/velocity-dev/forwarding.secret
+++ b/apps/mc/velocity-dev/forwarding.secret
@@ -1,0 +1,1 @@
+kbve-velocity-forwarding-secret-change-me

--- a/apps/mc/velocity-dev/velocity.toml
+++ b/apps/mc/velocity-dev/velocity.toml
@@ -1,0 +1,56 @@
+# Dev Velocity proxy config — mounted read-only into the mc-velocity
+# container by docker-compose.dev.yml. Mirrors the prod
+# apps/kube/agones/mc/velocity-configmap.yaml but with three dev-only
+# differences:
+#   1. online-mode = false (no Mojang auth, lets cracked clients connect)
+#   2. backend server points at the compose service name, not the k8s
+#      headless Service FQDN
+#   3. show-max-players lowered to match MAX_PLAYERS on the Fabric pod
+
+config-version = "2.7"
+
+bind = "0.0.0.0:25565"
+motd = "<#00FF00>KBVE Dev Server"
+show-max-players = 10
+# Dev mode — skip Mojang auth so local cracked clients can connect.
+online-mode = false
+force-key-authentication = false
+prevent-client-proxy-connections = false
+# Modern Velocity forwarding — backend runs FabricProxy-Lite with a
+# matching secret (shipped via ./forwarding.secret and baked into the
+# Fabric image's config/FabricProxy-Lite.toml).
+player-info-forwarding-mode = "modern"
+forwarding-secret-file = "forwarding.secret"
+announce-forge = false
+announce-proxy-commands = true
+
+[servers]
+# Points at the docker-compose service name. Docker's embedded DNS
+# resolves "mc-fabric" to the Fabric container on the shared
+# kbve-mc-dev bridge network.
+mc = "mc-fabric:25565"
+try = ["mc"]
+
+[forced-hosts]
+
+[advanced]
+compression-threshold = 256
+compression-level = -1
+login-ratelimit = 3000
+connection-timeout = 5000
+read-timeout = 30000
+haproxy-protocol = false
+tcp-fast-open = false
+bungee-plugin-message-channel = true
+show-ping-requests = false
+failover-on-unexpected-server-disconnect = true
+announce-proxy-commands = true
+log-command-executions = true
+log-player-connections = true
+accepts-transfers = false
+
+[query]
+enabled = false
+port = 25577
+map = "Velocity"
+show-plugins = false


### PR DESCRIPTION
## Summary
- Replace the one-shot \`docker run kbve/mc:latest\` in \`mc:dev\` with a \`docker compose\` stack that runs Velocity + Fabric together, mirroring the prod k8s topology
- Add \`mc:dev:down\` (keep world volume) and \`mc:dev:clean\` (wipe volume) convenience targets
- Exercise the full prod plugin-loading path in dev (LuckPerms-Velocity auto-download, modern forwarding, \`hackEarlySend\` fix from #10010)

## Why
\`mc:dev\` was broken: players couldn't connect to \`localhost:25565\`. The Fabric image ships with FabricProxy-Lite \`hackOnlineMode = true\` which rejects any connection that didn't come through Velocity and immediately disconnects with:

> This server requires you to connect with Velocity.

Dropping \`hackOnlineMode\` for dev only would drift dev from prod and hide the real forwarding handshake. The right fix is to run Velocity locally too.

## What the stack looks like

\`\`\`
host:25565  →  mc-velocity:25565  (itzg/bungeecord, modern forwarding)
                       │
                       └→  mc-fabric:25565  (kbve/mc:latest, internal network only)

host:25575  →  mc-fabric:25575  (RCON, password=dev)
\`\`\`

- Game port 25565 → Velocity, which validates cracked logins (\`online-mode = false\` in dev), does modern forwarding to Fabric with the shared secret
- RCON still exposed on host so existing tests and \`mcrcon\`/debugging tools keep working
- LuckPerms-Velocity auto-downloaded via the \`PLUGINS\` env var so the dev stack exercises the same plugin-loading path as prod
- FabricProxy-Lite \`hackEarlySend = true\` (from #10010) is baked into the image, so LuckPerms-Fabric works on first connection end-to-end

## New files

- \`apps/mc/docker-compose.dev.yml\` — stack definition
- \`apps/mc/velocity-dev/velocity.toml\` — dev Velocity config (\`online-mode=false\`, backend = \`mc-fabric:25565\`, lower player cap). Mounted read-only.
- \`apps/mc/velocity-dev/forwarding.secret\` — matches the dev placeholder already baked into \`apps/mc/config/FabricProxy-Lite.toml\`

## project.json changes

- \`mc:dev\` — \`docker compose up --remove-orphans\` attached. Still \`dependsOn\` the \`container\` target so \`nx run mc:dev\` stays one command.
- \`mc:dev:down\` — stops the stack, keeps the named volume (fast iteration)
- \`mc:dev:clean\` — stops the stack AND drops the volume (true cold boot)

## Trade-offs

- **Boot time roughly doubles.** Fabric cold start is still ~3-4 min (16 mods + library unpacking), Velocity adds ~30s on top of that. Use \`mc:dev:down\` → \`mc:dev\` to iterate without re-downloading mods.
- **Dev and prod are not byte-identical.** Dev Velocity runs with \`online-mode=false\` so cracked clients can connect; prod runs \`online-mode=true\` against Mojang. That's intentional — local Mojang auth would be miserable to set up and everyone would just disable it anyway.

## Test plan
- [ ] \`nx run mc:container:local\` builds the image
- [ ] \`nx run mc:dev\` brings up the stack, both containers reach Ready
- [ ] Connect to \`localhost:25565\` from a vanilla 1.21.11 client and reach the game world (this was broken before — verified impossible on current dev)
- [ ] RCON still works: \`mcrcon -H localhost -P 25575 -p dev list\` returns the player list
- [ ] \`nx run mc:dev:down\` → \`nx run mc:dev\` reboots fast using the cached volume
- [ ] \`nx run mc:dev:clean\` → \`nx run mc:dev\` does a full cold boot