### PR TITLE
tune(mc): soften AI skeleton spawn rate and aggression

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiSkeletonManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiSkeletonManager.java
@@ -43,7 +43,7 @@ public class AiSkeletonManager {
     private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
     private static final Gson GSON = new Gson();
 
-    private static final double OBSERVATION_RANGE = 32.0;
+    private static final double OBSERVATION_RANGE = 16.0;
 
     /** Tracked skeletons keyed by entity ID. Holds only the epoch. */
     private final ConcurrentHashMap<Integer, EpochSlot> skeletons = new ConcurrentHashMap<>();

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -111,7 +111,7 @@ impl Default for GlobalCallCooldown {
     fn default() -> Self {
         Self {
             last_call_tick: 0,
-            cooldown_ticks: 400, // 20s
+            cooldown_ticks: 1200, // 60s
         }
     }
 }
@@ -147,10 +147,10 @@ pub struct SkeletonPopulationConfig {
 impl Default for SkeletonPopulationConfig {
     fn default() -> Self {
         Self {
-            max_skeletons: 3,
-            spawn_radius: 20,
+            max_skeletons: 2,
+            spawn_radius: 32,
             despawn_range: 64.0,
-            manage_interval_ticks: 50, // 5s at 100ms ECS ticks
+            manage_interval_ticks: 200, // 20s at 100ms ECS ticks
         }
     }
 }

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -73,7 +73,7 @@ pub fn ingest_observations(
                     max: 20.0,
                 },
                 AiEpoch { value: 1 },
-                CallCooldown::new(400),
+                CallCooldown::new(1200),
                 NearbyEntities {
                     entities: obs
                         .nearby_entities
@@ -337,14 +337,14 @@ fn build_behavior_tree() -> Selector {
             }),
             Box::new(Sequence {
                 children: vec![
-                    Box::new(IsHealthLow { threshold: 12.0 }),
+                    Box::new(IsHealthLow { threshold: 6.0 }),
                     Box::new(CallAllies {
-                        health_threshold: 12.0,
-                        reinforcement_count: 2,
+                        health_threshold: 6.0,
+                        reinforcement_count: 1,
                     }),
                 ],
             }),
-            Box::new(AttackNearest { range: 4.0 }),
+            Box::new(AttackNearest { range: 2.5 }),
             Box::new(Wander { radius: 8.0 }),
         ],
     }


### PR DESCRIPTION
Bring the behavior_statetree skeleton AI closer to vanilla feel:
- max_skeletons 3 -> 2, manage interval 5s -> 20s, spawn radius 20 -> 32
- Java OBSERVATION_RANGE 32 -> 16 (vanilla follow range)
- AttackNearest range 4.0 -> 2.5 (vanilla melee reach)
- CallAllies threshold 12 -> 6 HP, reinforcement_count 2 -> 1
- Per-skeleton + global call cooldown 400 -> 1200 ticks (60s cascade lockout)