### PR TITLE
feat(ci-atom): authorize Fudster for atomic branch workflow

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -26,6 +26,7 @@ jobs:
                   script: |
                       const AUTHORIZED_USERS = [
                         { username: 'h0lybyte', id: 5599058 },
+                        { username: 'Fudster', id: 5642609 },
                       ];
 
                       const actor = context.actor;
@@ -313,6 +314,7 @@ jobs:
                       // Defense-in-depth: validate PR author matches authorized users
                       const AUTHORIZED_USERS = [
                         { username: 'h0lybyte', id: 5599058 },
+                        { username: 'Fudster', id: 5642609 },
                       ];
 
                       // Get PR number from previous jobs


### PR DESCRIPTION
Adds Bradley Haljendi (@Fudster, id \`5642609\`) to the two authorization allow-lists in \`ci-atom.yml\`:

1. **\`authorize_actor\` job** — early gate that blocks unauthorized actors from running the atomic workflow at all.
2. **\`security_check\` job** — defense-in-depth check that validates the PR author before auto-merge can proceed.

Both lists previously contained only \`h0lybyte\` (id \`5599058\`).

## Verification
I hit the GitHub API directly (\`gh api users/Fudster\`) and confirmed the username ↔ id pair matches what GitHub returns for that account. The workflow's check requires **both** to match, so an incorrect id here would silently block Fudster rather than create an impersonation vector.

## Scope
No behavior change for other users. Only touches \`ci-atom.yml\`; unrelated \`h0lybyte\` references (deployment commit identity, issue template assignees, CODEOWNERS) were intentionally left alone.

## Test plan
- [ ] Fudster pushes an \`atom-*\` branch. The \`authorize_actor\` job should now pass instead of failing with "Unauthorized actor".
- [ ] Fudster opens a PR from the atomic branch. The \`security_check\` job should output \`is_authorized=true\` and the \`auto_merge\` job should run.
- [ ] h0lybyte's atomic branches still work as before (no regression).