### PR TITLE
docs(mc): add public Minecraft landing + agents/operators stub

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/mc/agents.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/agents.mdx
@@ -1,0 +1,69 @@
+---
+title: Agents & Operators
+description: Reference for AI agents and human operators working on the KBVE Minecraft server.
+sidebar:
+    label: Agents
+    order: 2
+tags:
+    - minecraft
+    - mc
+    - agents
+    - operators
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This page is a working reference for **AI agents and human operators**
+interacting with the KBVE Minecraft server. It is intentionally written
+as stable prose — no islands, no heavy embeds — so it stays easy to
+parse programmatically.
+
+<Aside type="note">
+  This is an initial stub. The sections below are placeholders that
+  will be filled in as operational patterns stabilise. If a section is
+  empty, prefer the sources linked from the [technical notes](/project/mc/)
+  over making assumptions.
+</Aside>
+
+## Scope
+
+Anything touching the live Minecraft server — joining, running admin
+commands, editing world config, rolling out a new mod, rebuilding the
+image, or scaling the Agones fleet — should be documented here or
+linked from here.
+
+## Quick facts
+
+- **Edition:** Fabric, Minecraft 1.21.11
+- **Runtime:** Docker image `kbve/mc`, based on `itzg/minecraft-server:java21`
+- **Deployment:** Agones Fleet (`arc-runners` namespace) on Kubernetes
+- **AI mod:** `behavior_statetree` — Rust cdylib loaded through JNI
+- **Source of truth for infra:** [/project/mc/](/project/mc/)
+
+## For AI agents
+
+When reasoning about this server:
+
+- The authoritative mod stack and image source live in the
+  [technical notes](/project/mc/).
+- Server-side game logic in the behavior-tree mod is in
+  `apps/mc/behavior_statetree/` in the monorepo.
+- Fleet and Kubernetes manifests are in `apps/kube/agones/mc/`.
+- Do not infer version numbers — read them from
+  `apps/mc/version.toml` in the repo.
+
+## For operators
+
+<Aside type="caution">
+  Operator runbooks (start/stop, scale fleet, rotate world, restore
+  backup) have not been written yet. Do not act on assumption —
+  ask in the team channel or read the source.
+</Aside>
+
+Planned sections:
+
+- **Day-to-day** — checking fleet health, reading logs
+- **Deploys** — how a new image rolls out
+- **Incidents** — crash loops, OOM, chunk corruption recovery
+- **World management** — backups, restores, pruning
+- **Player management** — whitelist, bans, permissions

--- a/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
@@ -1,0 +1,58 @@
+---
+title: Minecraft
+description: The KBVE Minecraft server — how to join, what to expect, and where to find the technical notes.
+sidebar:
+    label: Overview
+    order: 1
+tags:
+    - minecraft
+    - mc
+---
+
+import { Card, CardGrid, Aside, LinkCard } from '@astrojs/starlight/components';
+
+The KBVE Minecraft server is a public, community-run Fabric 1.21.11 world
+with performance mods, old-combat mechanics, and a custom Rust-powered AI
+layer for NPCs and mobs.
+
+## How to join
+
+<Aside title="Server address" type="tip">
+  Coming soon. Connection details, whitelist policy, and Discord-linked
+  onboarding will land here as the server opens its public slots.
+</Aside>
+
+## What to expect
+
+<CardGrid>
+  <Card title="Fabric 1.21.11" icon="puzzle">
+    Modded Fabric server with performance mods (C2ME, Lithium, FerriteCore,
+    ServerCore, VMP) so large player counts and busy chunks stay smooth.
+  </Card>
+  <Card title="Old-style combat" icon="seti:shield">
+    The Old Combat Mod restores 1.8-era PvP mechanics — no attack cooldown,
+    classic hit registration.
+  </Card>
+  <Card title="Smarter NPCs" icon="seti:rust">
+    NPCs and select mobs run on a Rust behavior-tree mod loaded through
+    JNI. See the [technical notes](/project/mc/) for how the mod ships.
+  </Card>
+  <Card title="Run on Agones" icon="rocket">
+    Fleet-managed by Agones on Kubernetes. Every player session lands on
+    a fresh, clean game server.
+  </Card>
+</CardGrid>
+
+## Dig deeper
+
+<LinkCard
+  title="Technical notes"
+  description="Infra, CI/CD, Docker build, Agones fleet config, behavior_statetree mod source."
+  href="/project/mc/"
+/>
+
+<LinkCard
+  title="Agents & operators"
+  description="Reference for AI agents and human operators working on the Minecraft server."
+  href="/mc/agents/"
+/>


### PR DESCRIPTION
Creates a new content section at \`src/content/docs/mc/\` which the Starlight sidebar config in \`astro.config.mjs\` already has wired up via \`autogenerate: { directory: 'mc' }\` (around line 126) but which had no directory to populate it until now.

## Files

- **\`mc/index.mdx\`** — public landing for the Minecraft server. Lists what the server is, how to join (placeholder for the address), and high-level feature cards. Links out to the existing infra page at [/project/mc/](/project/mc/) for technical notes and to \`/mc/agents/\` for the operator doc below.
- **\`mc/agents.mdx\`** — reference stub for AI agents and human operators. Deliberately sparse: quick facts, source-of-truth pointers (repo paths), and placeholder sections for runbooks that will be filled in as operational patterns stabilise.

## Not in this PR
- The existing \`/project/mc/\` infra page is untouched. The two audiences (end users vs. CI/infra) stay cleanly separated.
- No runbook content yet — \`agents.mdx\` is explicit about what's still TBD and tells agents to read the source rather than assume.

## Verified
- \`./kbve.sh -nx astro-kbve:build\` → 5360 pages (previously 5358, so both new pages are indexed).
- Both \`dist/apps/astro-kbve/mc/index.html\` and \`dist/apps/astro-kbve/mc/agents/index.html\` exist with the correct title + description metadata.
- The Minecraft sidebar group was already declared in \`astro.config.mjs\` and now populates automatically.

## Test plan
- [ ] Confirm the Minecraft section appears in the Starlight sidebar after merge.
- [ ] Verify the LinkCard from \`/mc/\` → \`/project/mc/\` resolves correctly.