### PR TITLE
feat(mc): pet parrot sidekick with poop poison + melee gate for dog

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKind.java
@@ -1,11 +1,17 @@
 package com.kbve.statetree;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Adapter describing one AI-managed creature archetype.
@@ -30,17 +36,19 @@ public interface CreatureKind {
 
     /**
      * Build and configure a ready-to-spawn mob at {@code pos}. Return
-     * {@code null} if this kind can't spawn right now (e.g. pet dog whose
-     * owner vanished between the command and the actuator running).
+     * {@code null} if this kind can't spawn right now (e.g. an owned
+     * creature whose owner vanished between the command and the actuator
+     * running).
      *
-     * @param owner nullable — present only for owned archetypes (pet dog)
+     * @param owner nullable — present only for owned archetypes (pet dog,
+     *              pet parrot)
      */
     @Nullable
     MobEntity create(ServerWorld world, BlockPos pos, @Nullable Entity owner);
 
     /**
      * Append entities relevant to this archetype's decisions into
-     * {@code out}. Skeletons care about players; pet dogs care about
+     * {@code out}. Skeletons care about players; owned pets care about
      * hostile mobs near themselves or their owner.
      */
     void gatherNearbyEntities(
@@ -48,4 +56,53 @@ public interface CreatureKind {
             MobEntity self,
             @Nullable Entity owner,
             JsonArray out);
+
+    // -----------------------------------------------------------------------
+    // Shared observation helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Populate {@code out} with every living {@link HostileEntity} within
+     * {@code range} blocks of either the creature itself or its owner.
+     * Shared by owned archetypes (pet dog, pet parrot, ...) that all need
+     * the same "mobs threatening me or my human" observation window.
+     */
+    static void gatherHostilesNearMobAndOwner(
+            ServerWorld world,
+            MobEntity self,
+            @Nullable Entity owner,
+            double range,
+            JsonArray out) {
+        Set<Integer> seen = new HashSet<>();
+        appendHostiles(world, self.getBoundingBox().expand(range), out, seen);
+        if (owner != null && owner.isAlive()) {
+            appendHostiles(world, owner.getBoundingBox().expand(range), out, seen);
+        }
+    }
+
+    private static void appendHostiles(
+            ServerWorld world,
+            Box box,
+            JsonArray out,
+            Set<Integer> seen) {
+        for (HostileEntity hostile : world.getEntitiesByClass(
+                HostileEntity.class,
+                box,
+                h -> h != null && h.isAlive())) {
+            if (!seen.add(hostile.getId())) continue;
+            JsonObject ent = new JsonObject();
+            ent.addProperty("entity_id", hostile.getId());
+            ent.addProperty("entity_type", hostile.getType().toString());
+
+            JsonArray ePos = new JsonArray();
+            ePos.add(hostile.getX());
+            ePos.add(hostile.getY());
+            ePos.add(hostile.getZ());
+            ent.add("position", ePos);
+
+            ent.addProperty("health", hostile.getHealth());
+            ent.addProperty("is_hostile", true);
+            out.add(ent);
+        }
+    }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
@@ -12,6 +12,7 @@ public final class CreatureKinds {
 
     public static final CreatureKind SKELETON = new SkeletonCreatureKind();
     public static final CreatureKind PET_DOG = new PetDogCreatureKind();
+    public static final CreatureKind PET_PARROT = new PetParrotCreatureKind();
 
     private CreatureKinds() {}
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -197,6 +197,42 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             int count = call.get("count").getAsInt();
             creatureManager.spawnReinforcements(world, mob.getId(), count);
 
+        } else if (cmd.has("PoopPoison")) {
+            // Rust already gated this via PoopCooldown — Java just applies
+            // the status effect and plays the splat feedback.
+            JsonObject poop = cmd.getAsJsonObject("PoopPoison");
+            long targetId = poop.get("target_entity").getAsLong();
+            int durationTicks = poop.get("duration_ticks").getAsInt();
+            int amplifier = poop.get("amplifier").getAsInt();
+            Entity target = world.getEntityById((int) targetId);
+            if (target instanceof net.minecraft.entity.LivingEntity living && living.isAlive()) {
+                living.addStatusEffect(new net.minecraft.entity.effect.StatusEffectInstance(
+                        net.minecraft.entity.effect.StatusEffects.POISON,
+                        durationTicks,
+                        amplifier
+                ));
+                // Splat feedback: slime particles from the attacker's mouth
+                // and a squish sound so watching players can see it land.
+                world.spawnParticles(
+                        net.minecraft.particle.ParticleTypes.ITEM_SLIME,
+                        mob.getX(),
+                        mob.getY() + mob.getStandingEyeHeight() * 0.5,
+                        mob.getZ(),
+                        8,
+                        0.3, 0.2, 0.3,
+                        0.02
+                );
+                world.playSound(
+                        null,
+                        mob.getBlockPos(),
+                        net.minecraft.sound.SoundEvents.BLOCK_SLIME_BLOCK_BREAK,
+                        net.minecraft.sound.SoundCategory.NEUTRAL,
+                        1.0f,
+                        1.6f
+                );
+                mob.lookAtEntity(target, 30.0f, 30.0f);
+            }
+
         } else if (cmd.has("SetGoal")) {
             LOGGER.debug("[AI] SetGoal not yet implemented");
         }
@@ -218,6 +254,12 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             int playerId = spawn.get("near_player").getAsInt();
             int radius = spawn.get("radius").getAsInt();
             creatureManager.spawnNearPlayer(world, CreatureKinds.PET_DOG, playerId, radius, true);
+
+        } else if (cmd.has("SpawnPetParrot")) {
+            JsonObject spawn = cmd.getAsJsonObject("SpawnPetParrot");
+            int playerId = spawn.get("near_player").getAsInt();
+            int radius = spawn.get("radius").getAsInt();
+            creatureManager.spawnNearPlayer(world, CreatureKinds.PET_PARROT, playerId, radius, true);
 
         } else if (cmd.has("Despawn")) {
             JsonObject despawn = cmd.getAsJsonObject("Despawn");

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/PetDogCreatureKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/PetDogCreatureKind.java
@@ -1,22 +1,16 @@
 package com.kbve.statetree;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnReason;
-import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.WolfEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Pet Dog archetype: tamed wolf, owned by a player, proactively hostile.
@@ -67,36 +61,6 @@ final class PetDogCreatureKind implements CreatureKind {
             MobEntity self,
             @Nullable Entity owner,
             JsonArray out) {
-        Set<Integer> seen = new HashSet<>();
-        addHostilesInBox(world, self.getBoundingBox().expand(OBSERVATION_RANGE), out, seen);
-        if (owner != null && owner.isAlive()) {
-            addHostilesInBox(world, owner.getBoundingBox().expand(OBSERVATION_RANGE), out, seen);
-        }
-    }
-
-    private void addHostilesInBox(
-            ServerWorld world,
-            Box box,
-            JsonArray out,
-            Set<Integer> seen) {
-        for (HostileEntity hostile : world.getEntitiesByClass(
-                HostileEntity.class,
-                box,
-                h -> h != null && h.isAlive())) {
-            if (!seen.add(hostile.getId())) continue;
-            JsonObject ent = new JsonObject();
-            ent.addProperty("entity_id", hostile.getId());
-            ent.addProperty("entity_type", hostile.getType().toString());
-
-            JsonArray ePos = new JsonArray();
-            ePos.add(hostile.getX());
-            ePos.add(hostile.getY());
-            ePos.add(hostile.getZ());
-            ent.add("position", ePos);
-
-            ent.addProperty("health", hostile.getHealth());
-            ent.addProperty("is_hostile", true);
-            out.add(ent);
-        }
+        CreatureKind.gatherHostilesNearMobAndOwner(world, self, owner, OBSERVATION_RANGE, out);
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/PetParrotCreatureKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/PetParrotCreatureKind.java
@@ -1,0 +1,75 @@
+package com.kbve.statetree;
+
+import com.google.gson.JsonArray;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.ParrotEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Pet Parrot archetype: tamed parrot, owned by a player, drops a ranged
+ * "poop poison" attack on hostiles.
+ *
+ * <p>Unlike the pet dog, the parrot is a flying, ranged companion — it
+ * doesn't need to close with its target to land damage. Rust's
+ * {@code plan_pet_parrot_behavior} system gates the poop ability behind
+ * a per-parrot cooldown and picks the nearest hostile within the
+ * configured aggro range. Vanilla parrot AI handles flight, idling, and
+ * the natural hover-near-owner drift; Rust only steers the parrot toward
+ * a target when it's time to drop on one.
+ */
+final class PetParrotCreatureKind implements CreatureKind {
+
+    /** Range (in blocks) around the parrot and owner used to gather hostiles. */
+    private static final double OBSERVATION_RANGE = 18.0;
+
+    @Override
+    public String tag() {
+        return "parrot";
+    }
+
+    @Override
+    public @Nullable MobEntity create(ServerWorld world, BlockPos pos, @Nullable Entity owner) {
+        if (!(owner instanceof ServerPlayerEntity player) || !player.isAlive()) {
+            return null;
+        }
+
+        ParrotEntity parrot = EntityType.PARROT.create(world, SpawnReason.COMMAND);
+        if (parrot == null) return null;
+
+        // Hover the spawn point ~1.5 blocks above the player's head so the
+        // parrot appears already in-flight instead of belly-flopping onto
+        // the ground before vanilla flight AI kicks in.
+        parrot.refreshPositionAndAngles(
+                pos.getX() + 0.5,
+                pos.getY() + 1.5,
+                pos.getZ() + 0.5,
+                world.getRandom().nextFloat() * 360,
+                0
+        );
+        // Parrot variant is private in ParrotEntity — the DataTracker default
+        // is 0 (RED_BLUE), which is exactly what we want for the Sidekick.
+        parrot.setOwner(player);
+        parrot.setTamed(true, true);
+        parrot.setHealth(parrot.getMaxHealth());
+        parrot.setCustomName(Text.of("\u00A7d" + player.getNameForScoreboard() + "'s Sidekick"));
+        parrot.setCustomNameVisible(true);
+        parrot.setPersistent();
+        return parrot;
+    }
+
+    @Override
+    public void gatherNearbyEntities(
+            ServerWorld world,
+            MobEntity self,
+            @Nullable Entity owner,
+            JsonArray out) {
+        CreatureKind.gatherHostilesNearMobAndOwner(world, self, owner, OBSERVATION_RANGE, out);
+    }
+}

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -23,6 +23,14 @@ pub struct AiSkeleton;
 #[derive(Component, Debug)]
 pub struct AiPetDog;
 
+/// Marker for AI Pet Parrot entities. A pet parrot is a tamed parrot
+/// spawned alongside a player that flies nearby and drops a ranged
+/// "poop" poison attack on hostiles. Like pet dogs, parrots skip the
+/// `AiManaged` marker so the skeleton behavior tree ignores them —
+/// their decisions come from `plan_pet_parrot_behavior`.
+#[derive(Component, Debug)]
+pub struct AiPetParrot;
+
 /// Owner relationship for a pet creature. `player_id` is the Minecraft
 /// entity ID of the owning player, matched against `OnlinePlayer` rows
 /// each tick to decide follow targets and lifecycle.
@@ -223,3 +231,62 @@ impl Default for PetDogPopulationConfig {
 /// Tracks when the pet dog population manager last ran.
 #[derive(Resource, Debug, Default)]
 pub struct LastPetDogManagedTick(pub u64);
+
+// ---------------------------------------------------------------------------
+// Pet parrot components + config — drives the 1-parrot-per-player spawn
+// loop and the ranged "poop poison" ability's cooldown.
+// ---------------------------------------------------------------------------
+
+/// Per-parrot cooldown tracker for the ranged poison ability. State only —
+/// the cooldown window itself lives in `PetParrotPopulationConfig` so a
+/// runtime config change affects every parrot immediately.
+#[derive(Component, Debug, Default)]
+pub struct PoopCooldown {
+    pub last_poop_tick: u64,
+}
+
+/// Tunable parameters for the Pet Parrot population + behavior systems.
+#[derive(Resource, Debug)]
+pub struct PetParrotPopulationConfig {
+    /// Target number of pet parrots per online player.
+    pub parrots_per_player: usize,
+    /// Offset (in blocks) from the player where a new parrot spawns.
+    pub spawn_radius: i32,
+    /// Radius around the parrot or owner that triggers a proactive
+    /// ranged attack on a hostile mob.
+    pub aggro_range: f64,
+    /// Distance from the owner beyond which the parrot is nudged back
+    /// via an explicit MoveTo intent (vanilla follow-owner handles the
+    /// closer range on its own).
+    pub follow_distance: f64,
+    /// Cooldown (in ECS ticks) between successive poop intents for a
+    /// given parrot. Prevents per-tick spam while still feeling snappy.
+    pub poop_cooldown_ticks: u64,
+    /// Duration (in game ticks, 20/sec) of the applied POISON effect.
+    pub poison_duration_ticks: u32,
+    /// Poison amplifier: 0 = Poison I, 1 = Poison II, ...
+    pub poison_amplifier: u8,
+    /// Run the spawn/despawn pass every N ECS ticks (~4s at 100ms ticks).
+    pub manage_interval_ticks: u64,
+}
+
+impl Default for PetParrotPopulationConfig {
+    fn default() -> Self {
+        Self {
+            parrots_per_player: 1,
+            spawn_radius: 2,
+            aggro_range: 14.0,
+            follow_distance: 10.0,
+            // ECS ticks = 100ms each, so 15 ticks ≈ 1.5s between poops.
+            poop_cooldown_ticks: 15,
+            // 20 TPS → 80 ticks = 4s of poison ticks (one damage tick/second).
+            poison_duration_ticks: 80,
+            poison_amplifier: 0,
+            manage_interval_ticks: 40,
+        }
+    }
+}
+
+/// Tracks when the pet parrot population manager last ran.
+#[derive(Resource, Debug, Default)]
+pub struct LastPetParrotManagedTick(pub u64);

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -189,9 +189,16 @@ pub struct PetDogPopulationConfig {
     pub dogs_per_player: usize,
     /// Offset (in blocks) from the player where a new dog is placed.
     pub spawn_radius: i32,
-    /// Radius around the owner (or dog) that triggers a proactive attack
+    /// Radius around the owner (or dog) that triggers a proactive chase
     /// on a hostile mob — beyond a vanilla tamed wolf's revenge target.
+    /// Inside this radius the dog runs at the hostile; attacks only land
+    /// once it has closed to `melee_range`.
     pub aggro_range: f64,
+    /// Distance at which the dog's bite can actually connect. Rust only
+    /// emits `Attack` intents when the dog is within this range of the
+    /// target; outside it the dog just gets `MoveTo` intents and closes
+    /// the gap. Matches a tamed wolf's melee reach.
+    pub melee_range: f64,
     /// Distance from the owner beyond which the dog is nudged back via
     /// an explicit MoveTo intent (vanilla follow-owner still handles the
     /// shorter range case on its own).
@@ -206,6 +213,7 @@ impl Default for PetDogPopulationConfig {
             dogs_per_player: 1,
             spawn_radius: 3,
             aggro_range: 12.0,
+            melee_range: 2.5,
             follow_distance: 8.0,
             manage_interval_ticks: 40,
         }

--- a/apps/mc/behavior_statetree/src/ecs/mod.rs
+++ b/apps/mc/behavior_statetree/src/ecs/mod.rs
@@ -14,13 +14,14 @@ pub mod systems;
 use bevy::prelude::*;
 
 use components::{
-    GlobalCallCooldown, LastPetDogManagedTick, LastPopulationManagedTick, PetDogPopulationConfig,
-    ServerTick, SkeletonPopulationConfig,
+    GlobalCallCooldown, LastPetDogManagedTick, LastPetParrotManagedTick, LastPopulationManagedTick,
+    PetDogPopulationConfig, PetParrotPopulationConfig, ServerTick, SkeletonPopulationConfig,
 };
 use events::{IntentBuffer, ObservationBuffer, PlayerObservationBuffer, WorldIntentBuffer};
 use systems::{
     ingest_observations, ingest_player_snapshots, manage_pet_dog_population,
-    manage_skeleton_population, plan_behavior, plan_pet_dog_behavior,
+    manage_pet_parrot_population, manage_skeleton_population, plan_behavior, plan_pet_dog_behavior,
+    plan_pet_parrot_behavior,
 };
 
 /// Plugin that registers all AI ECS components, resources, and systems.
@@ -38,6 +39,8 @@ impl Plugin for AiBehaviorPlugin {
             .init_resource::<LastPopulationManagedTick>()
             .init_resource::<PetDogPopulationConfig>()
             .init_resource::<LastPetDogManagedTick>()
+            .init_resource::<PetParrotPopulationConfig>()
+            .init_resource::<LastPetParrotManagedTick>()
             .add_systems(
                 Update,
                 (
@@ -45,8 +48,10 @@ impl Plugin for AiBehaviorPlugin {
                     ingest_observations,
                     plan_behavior,
                     plan_pet_dog_behavior,
+                    plan_pet_parrot_behavior,
                     manage_skeleton_population,
                     manage_pet_dog_population,
+                    manage_pet_parrot_population,
                 )
                     .chain(),
             );

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -442,6 +442,7 @@ pub fn plan_pet_dog_behavior(
     mut intent_buffer: ResMut<IntentBuffer>,
 ) {
     let aggro_sq = config.aggro_range * config.aggro_range;
+    let melee_sq = config.melee_range * config.melee_range;
     let follow_sq = config.follow_distance * config.follow_distance;
 
     for (dog_id, dog_pos, epoch, nearby, owner) in &dogs {
@@ -470,14 +471,19 @@ pub fn plan_pet_dog_behavior(
             });
 
         let commands = if let Some(target) = best_target {
-            vec![
-                NpcCommand::MoveTo {
-                    target: target.position,
-                },
-                NpcCommand::Attack {
+            // Always chase the target. Only emit Attack once the dog has
+            // closed to within its actual bite reach — otherwise Java's
+            // `mob.tryAttack(target)` lands damage from across the aggro
+            // radius, which doesn't make sense for a melee pet.
+            let mut cmds = vec![NpcCommand::MoveTo {
+                target: target.position,
+            }];
+            if dist_sq(dog_xyz, target.position) <= melee_sq {
+                cmds.push(NpcCommand::Attack {
                     target_entity: target.entity_id,
-                },
-            ]
+                });
+            }
+            cmds
         } else if dist_sq(dog_xyz, owner_pos) > follow_sq {
             vec![NpcCommand::MoveTo { target: owner_pos }]
         } else {

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -97,6 +97,24 @@ pub fn ingest_observations(
                         nearby,
                     ));
                 }
+                "parrot" => {
+                    let Some(owner_id) = obs.owner_entity else {
+                        // Parrot with no owner — same story as dog.
+                        continue;
+                    };
+                    commands.spawn((
+                        AiPetParrot,
+                        PetOwner {
+                            player_id: owner_id,
+                        },
+                        McEntityId(obs.entity_id),
+                        position,
+                        health,
+                        AiEpoch { value: 1 },
+                        PoopCooldown::default(),
+                        nearby,
+                    ));
+                }
                 _ => {
                     commands.spawn((
                         AiManaged,
@@ -496,6 +514,167 @@ pub fn plan_pet_dog_behavior(
 
         intent_buffer.ready.push(IntentReady {
             entity_id: dog_id.0,
+            epoch: epoch.value,
+            commands,
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pet parrot population + behavior
+//
+// Each player gets one tamed parrot that flies near them and drops a
+// ranged "poop poison" attack on any hostile within `aggro_range` of
+// the parrot or owner. Unlike the dog (melee), the parrot doesn't need
+// to close with its target — the ability is ranged, so the only gate
+// is a per-parrot cooldown so it doesn't spam every ECS tick.
+// ---------------------------------------------------------------------------
+
+/// System: maintain pet-parrot population, one parrot per online player.
+///
+/// Mirrors `manage_pet_dog_population` for the parrot archetype. Emits
+/// `SpawnPetParrot` for players without a parrot and `Despawn` for
+/// parrots whose owner has left the player snapshot.
+pub fn manage_pet_parrot_population(
+    parrots: Query<(&McEntityId, &PetOwner), With<AiPetParrot>>,
+    players: Query<&OnlinePlayer>,
+    config: Res<PetParrotPopulationConfig>,
+    server_tick: Res<ServerTick>,
+    mut last_managed: ResMut<LastPetParrotManagedTick>,
+    mut world_intents: ResMut<WorldIntentBuffer>,
+) {
+    use std::collections::HashSet;
+
+    let current_tick = server_tick.0;
+    if current_tick.saturating_sub(last_managed.0) < config.manage_interval_ticks {
+        return;
+    }
+    last_managed.0 = current_tick;
+
+    let online_ids: HashSet<u64> = players.iter().map(|p| p.entity_id).collect();
+
+    let mut owned_by_online: HashSet<u64> = HashSet::new();
+    for (parrot_mc_id, owner) in &parrots {
+        if online_ids.contains(&owner.player_id) {
+            owned_by_online.insert(owner.player_id);
+        } else {
+            world_intents.ready.push(IntentReady {
+                entity_id: 0,
+                epoch: 0,
+                commands: vec![NpcCommand::Despawn {
+                    target_entity: parrot_mc_id.0,
+                }],
+            });
+        }
+    }
+
+    if config.parrots_per_player == 0 {
+        return;
+    }
+    for player in &players {
+        if !owned_by_online.contains(&player.entity_id) {
+            world_intents.ready.push(IntentReady {
+                entity_id: 0,
+                epoch: 0,
+                commands: vec![NpcCommand::SpawnPetParrot {
+                    near_player: player.entity_id,
+                    radius: config.spawn_radius,
+                }],
+            });
+        }
+    }
+}
+
+/// System: evaluate the pet-parrot behavior for every tracked parrot.
+///
+/// Decision order per parrot:
+/// 1. Pick the nearest hostile within `aggro_range` of the parrot or
+///    owner. If the per-parrot poop cooldown is clear, emit a
+///    `PoopPoison` intent at that target and bump the cooldown.
+///    A `MoveTo` above the target is also emitted so the parrot
+///    visually "perches" over whatever it's dumping on.
+/// 2. Otherwise, if the parrot has drifted past `follow_distance`,
+///    nudge it back toward the owner with a `MoveTo` (vanilla parrot
+///    flight AI handles the closer range and the hover-above idle).
+/// 3. Otherwise, emit nothing and let vanilla AI drift around.
+pub fn plan_pet_parrot_behavior(
+    mut parrots: Query<
+        (
+            &McEntityId,
+            &McPosition,
+            &AiEpoch,
+            &NearbyEntities,
+            &PetOwner,
+            &mut PoopCooldown,
+        ),
+        With<AiPetParrot>,
+    >,
+    players: Query<(&OnlinePlayer, &McPosition)>,
+    config: Res<PetParrotPopulationConfig>,
+    server_tick: Res<ServerTick>,
+    mut intent_buffer: ResMut<IntentBuffer>,
+) {
+    let current_tick = server_tick.0;
+    let aggro_sq = config.aggro_range * config.aggro_range;
+    let follow_sq = config.follow_distance * config.follow_distance;
+
+    for (parrot_id, parrot_pos, epoch, nearby, owner, mut cooldown) in &mut parrots {
+        let Some(owner_pos) = players
+            .iter()
+            .find_map(|(p, pos)| (p.entity_id == owner.player_id).then_some([pos.x, pos.y, pos.z]))
+        else {
+            continue;
+        };
+        let parrot_xyz = [parrot_pos.x, parrot_pos.y, parrot_pos.z];
+
+        let best_target = nearby
+            .entities
+            .iter()
+            .filter(|e| e.is_hostile)
+            .filter(|e| {
+                dist_sq(parrot_xyz, e.position) <= aggro_sq
+                    || dist_sq(owner_pos, e.position) <= aggro_sq
+            })
+            .min_by(|a, b| {
+                let da = dist_sq(parrot_xyz, a.position);
+                let db = dist_sq(parrot_xyz, b.position);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        let commands = if let Some(target) = best_target {
+            // Hover slightly above the target so the "poop from above"
+            // framing reads correctly for any watching players.
+            let mut cmds = vec![NpcCommand::MoveTo {
+                target: [
+                    target.position[0],
+                    target.position[1] + 3.0,
+                    target.position[2],
+                ],
+            }];
+            if current_tick.saturating_sub(cooldown.last_poop_tick) >= config.poop_cooldown_ticks {
+                cmds.push(NpcCommand::PoopPoison {
+                    target_entity: target.entity_id,
+                    duration_ticks: config.poison_duration_ticks,
+                    amplifier: config.poison_amplifier,
+                });
+                cooldown.last_poop_tick = current_tick;
+            }
+            cmds
+        } else if dist_sq(parrot_xyz, owner_pos) > follow_sq {
+            // Hover ~1.5 blocks above the owner's head when returning.
+            vec![NpcCommand::MoveTo {
+                target: [owner_pos[0], owner_pos[1] + 1.5, owner_pos[2]],
+            }]
+        } else {
+            vec![]
+        };
+
+        if commands.is_empty() {
+            continue;
+        }
+
+        intent_buffer.ready.push(IntentReady {
+            entity_id: parrot_id.0,
             epoch: epoch.value,
             commands,
         });

--- a/apps/mc/behavior_statetree/src/types.rs
+++ b/apps/mc/behavior_statetree/src/types.rs
@@ -109,6 +109,22 @@ pub enum NpcCommand {
         near_player: u64,
         radius: i32,
     },
+    /// Spawn a pet parrot for the given player entity ID. Java creates
+    /// a tamed parrot within `radius` blocks of the player and wires
+    /// the owner relationship up on the Minecraft side.
+    SpawnPetParrot {
+        near_player: u64,
+        radius: i32,
+    },
+    /// Ranged "poop" attack: apply the Minecraft POISON status effect
+    /// to `target_entity` for `duration_ticks` at the given amplifier.
+    /// Java also plays the splat particles + sound at the attacker's
+    /// position. Rust owns the cooldown that throttles this ability.
+    PoopPoison {
+        target_entity: u64,
+        duration_ticks: u32,
+        amplifier: u8,
+    },
 }
 
 /// Result of async AI planning. Only applied if epoch matches current NPC epoch.


### PR DESCRIPTION
## Summary

Two changes stacked on top of #10026. Ships a new pet archetype and fixes the dog's engagement range.

### 1. Pet parrot sidekick (new)

A second guardian per player — each online player auto-spawns a tamed parrot alongside their pet dog. The parrot flies near the owner, rides on vanilla parrot flight AI for pathing/idling, and drops a ranged **`PoopPoison`** attack on any hostile within aggro range of the parrot or owner. Rust owns all policy (lifecycle, aggro detection, cooldown, poison strength); Java is a dumb actuator.

- `PetParrotPopulationConfig` — 1 per player, aggro radius 14, cooldown ~1.5s between poops, Poison I for 4s.
- `plan_pet_parrot_behavior` — picks the nearest hostile, hovers ~3 blocks above it, fires `PoopPoison` when the per-parrot `PoopCooldown` is clear.
- `PoopPoison` actuator applies vanilla `StatusEffects.POISON` to the target and plays `ITEM_SLIME` particles + a slime-block break sound from the parrot's position for the splat feedback.
- `PetParrotCreatureKind` (tamed RED_BLUE parrot, "Sidekick" name) registered in `CreatureKinds.PET_PARROT`.
- Hoisted the nearby-hostile observation helper into `CreatureKind.gatherHostilesNearMobAndOwner` so the dog and parrot (and future owned archetypes) share it — `PetDogCreatureKind` now delegates to the helper.
- Adding a third owned pet is now: new `CreatureKind`, new Rust population+behavior systems, new `NpcCommand` variant for any unique ability. No new manager, no new tracking map, no new observation loop.

### 2. Pet dog melee gate (fix)

Previously `plan_pet_dog_behavior` emitted `Attack` whenever a hostile sat inside `aggro_range` (12 blocks), but the Java actuator calls `mob.tryAttack(target)` which applies melee damage without an implicit distance check — the dog was landing bites from across the aggro radius, which makes no sense for a melee pet.

- Added `melee_range` (default `2.5`) to `PetDogPopulationConfig`.
- Only emit `Attack` once the dog has closed to within `melee_range`. Outside melee, the dog still receives `MoveTo` and chases the hostile, so the engagement loop is now **aggro → chase → bite when in reach → return**.

## Test plan

- [x] `docker build --target java-builder` — Rust `.so` + both Fabric JARs compile
- [ ] `nx run mc:dev` — log in, confirm a Guardian dog and Sidekick parrot both spawn
- [ ] Put a zombie ~8 blocks away; dog runs toward it but only damages it once adjacent
- [ ] Parrot hovers above the zombie and periodically poops (particles + sound + POISON status effect applied to the zombie)
- [ ] Kill the zombie; both pets stop engaging and drift back toward the owner
- [ ] Walk away; both pets are nudged back past their respective `follow_distance`
- [ ] Log out; both despawn on the next population pass (~4s)