### PR TITLE
fix(mc): publish mc-velocity and mc-lobby images + add e2e smoke tests

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -175,7 +175,7 @@
 		{
 			"key": "mc_lobby",
 			"app_name": "mc-lobby",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"version_toml": "apps/mc/lobby/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc-lobby.mdx",
 			"source_path": "apps/mc/lobby",
@@ -183,19 +183,20 @@
 			"image": "kbve/mc-lobby",
 			"e2e_name": "mc-lobby",
 			"deployment_yaml": "apps/kube/agones/mc/lobby-deployment.yaml",
-			"has_test": false
+			"has_test": true
 		},
 		{
 			"key": "mc_velocity",
 			"app_name": "mc-velocity",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"version_toml": "apps/mc/velocity/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc-velocity.mdx",
 			"source_path": "apps/mc/velocity",
 			"runner": "ubuntu-latest",
 			"image": "kbve/mc-velocity",
 			"deployment_yaml": "apps/kube/agones/mc/velocity-deployment.yaml",
-			"has_test": false
+			"has_test": true,
+			"e2e_name": "mc-velocity"
 		},
 		{
 			"key": "memes",

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc-lobby.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc-lobby.mdx
@@ -13,13 +13,14 @@ tags:
 key: mc_lobby
 pipeline: docker
 app_name: mc-lobby
-version: "1.0.0"
+version: "1.0.1"
 source_path: apps/mc/lobby
 version_toml: apps/mc/lobby/version.toml
 runner: ubuntu-latest
 image: kbve/mc-lobby
+e2e_name: mc-lobby
 deployment_yaml: apps/kube/agones/mc/lobby-deployment.yaml
-has_test: false
+has_test: true
 ---
 
 ## Overview

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc-velocity.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc-velocity.mdx
@@ -13,13 +13,14 @@ tags:
 key: mc_velocity
 pipeline: docker
 app_name: mc-velocity
-version: "1.0.0"
+version: "1.0.1"
 source_path: apps/mc/velocity
 version_toml: apps/mc/velocity/version.toml
 runner: ubuntu-latest
 image: kbve/mc-velocity
+e2e_name: mc-velocity
 deployment_yaml: apps/kube/agones/mc/velocity-deployment.yaml
-has_test: false
+has_test: true
 ---
 
 ## Overview

--- a/apps/mc/lobby/e2e/global-setup.ts
+++ b/apps/mc/lobby/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { waitForRcon } from './helpers/rcon';
+
+export async function setup() {
+	await waitForRcon();
+}

--- a/apps/mc/lobby/e2e/health.spec.ts
+++ b/apps/mc/lobby/e2e/health.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { RconClient, waitForRcon } from './helpers/rcon';
+
+describe('MC lobby health', () => {
+	let rcon: RconClient;
+
+	beforeAll(async () => {
+		await waitForRcon();
+		rcon = new RconClient();
+		await rcon.connect();
+		await rcon.authenticate();
+	});
+
+	afterAll(() => {
+		rcon?.disconnect();
+	});
+
+	it('responds to RCON list command', async () => {
+		const response = await rcon.command('list');
+		expect(response).toContain('players online');
+	});
+
+	it('reports peaceful difficulty', async () => {
+		const response = await rcon.command('difficulty');
+		expect(response.toLowerCase()).toContain('peaceful');
+	});
+
+	it('reports PaperMC server version', async () => {
+		const response = await rcon.command('version');
+		expect(response.toLowerCase()).toContain('paper');
+	});
+});

--- a/apps/mc/lobby/e2e/helpers/rcon.ts
+++ b/apps/mc/lobby/e2e/helpers/rcon.ts
@@ -1,0 +1,93 @@
+import { Socket } from 'net';
+
+const RCON_HOST = process.env.RCON_HOST ?? '127.0.0.1';
+const RCON_PORT = parseInt(process.env.RCON_PORT ?? '25575', 10);
+const RCON_PASSWORD = process.env.RCON_PASSWORD ?? 'test';
+
+const SERVERDATA_AUTH = 3;
+const SERVERDATA_AUTH_RESPONSE = 2;
+const SERVERDATA_EXECCOMMAND = 2;
+
+function encodePacket(id: number, type: number, body: string): Buffer {
+	const bodyBuf = Buffer.from(body, 'utf8');
+	const size = 4 + 4 + bodyBuf.length + 2;
+	const buf = Buffer.alloc(4 + size);
+	buf.writeInt32LE(size, 0);
+	buf.writeInt32LE(id, 4);
+	buf.writeInt32LE(type, 8);
+	bodyBuf.copy(buf, 12);
+	buf.writeUInt8(0, 12 + bodyBuf.length);
+	buf.writeUInt8(0, 13 + bodyBuf.length);
+	return buf;
+}
+
+function decodePacket(buf: Buffer): { id: number; type: number; body: string } {
+	const id = buf.readInt32LE(4);
+	const type = buf.readInt32LE(8);
+	const body = buf.toString('utf8', 12, buf.length - 2);
+	return { id, type, body };
+}
+
+export class RconClient {
+	private socket: Socket | null = null;
+	private requestId = 0;
+
+	async connect(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			this.socket = new Socket();
+			this.socket.connect(RCON_PORT, RCON_HOST, () => resolve());
+			this.socket.once('error', reject);
+		});
+	}
+
+	async authenticate(): Promise<boolean> {
+		const id = ++this.requestId;
+		return new Promise((resolve, reject) => {
+			if (!this.socket) return reject(new Error('Not connected'));
+			this.socket.write(encodePacket(id, SERVERDATA_AUTH, RCON_PASSWORD));
+			this.socket.once('data', (data) => {
+				const pkt = decodePacket(data);
+				resolve(pkt.id === id && pkt.type === SERVERDATA_AUTH_RESPONSE);
+			});
+			this.socket.once('error', reject);
+		});
+	}
+
+	async command(cmd: string): Promise<string> {
+		const id = ++this.requestId;
+		return new Promise((resolve, reject) => {
+			if (!this.socket) return reject(new Error('Not connected'));
+			this.socket.write(encodePacket(id, SERVERDATA_EXECCOMMAND, cmd));
+			this.socket.once('data', (data) => {
+				const pkt = decodePacket(data);
+				resolve(pkt.body);
+			});
+			this.socket.once('error', reject);
+		});
+	}
+
+	disconnect(): void {
+		this.socket?.destroy();
+		this.socket = null;
+	}
+}
+
+export async function waitForRcon(
+	timeoutMs = 180_000,
+	intervalMs = 3_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const client = new RconClient();
+			await client.connect();
+			const authed = await client.authenticate();
+			client.disconnect();
+			if (authed) return;
+		} catch {
+			// Server not ready yet
+		}
+		await new Promise((r) => setTimeout(r, intervalMs));
+	}
+	throw new Error(`RCON not ready after ${timeoutMs}ms`);
+}

--- a/apps/mc/lobby/tsconfig.e2e.json
+++ b/apps/mc/lobby/tsconfig.e2e.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true
+	},
+	"include": ["e2e/**/*.ts", "vitest.config.ts"]
+}

--- a/apps/mc/lobby/vitest.config.ts
+++ b/apps/mc/lobby/vitest.config.ts
@@ -1,0 +1,9 @@
+export default {
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 30_000,
+		hookTimeout: 200_000,
+		fileParallelism: false,
+		globalSetup: ['e2e/global-setup.ts'],
+	},
+};

--- a/apps/mc/velocity/e2e/health.spec.ts
+++ b/apps/mc/velocity/e2e/health.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { tcpConnect, mcStatusPing, getVelocityAddress } from './helpers/tcp';
+
+describe('MC velocity proxy health', () => {
+	it('accepts TCP connections on the proxy port', async () => {
+		await expect(tcpConnect()).resolves.toBeUndefined();
+	});
+
+	it('responds to a Minecraft server list ping', async () => {
+		const { host, port } = getVelocityAddress();
+		const response = await mcStatusPing(host, port);
+		expect(response.length).toBeGreaterThan(4);
+	});
+});

--- a/apps/mc/velocity/e2e/helpers/tcp.ts
+++ b/apps/mc/velocity/e2e/helpers/tcp.ts
@@ -1,0 +1,92 @@
+import { Socket } from 'net';
+
+const HOST = process.env.VELOCITY_HOST ?? '127.0.0.1';
+const PORT = parseInt(process.env.VELOCITY_PORT ?? '25578', 10);
+
+export function getVelocityAddress() {
+	return { host: HOST, port: PORT };
+}
+
+export async function tcpConnect(
+	host = HOST,
+	port = PORT,
+	timeoutMs = 5_000,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const socket = new Socket();
+		const timer = setTimeout(() => {
+			socket.destroy();
+			reject(new Error(`TCP connect to ${host}:${port} timed out`));
+		}, timeoutMs);
+		socket.once('error', (err) => {
+			clearTimeout(timer);
+			socket.destroy();
+			reject(err);
+		});
+		socket.connect(port, host, () => {
+			clearTimeout(timer);
+			socket.end();
+			resolve();
+		});
+	});
+}
+
+/**
+ * Sends a Minecraft Server List Ping handshake + status request and
+ * resolves with the raw response bytes if the server responds. Only
+ * asserts that the proxy speaks the MC protocol — does not parse JSON.
+ */
+export async function mcStatusPing(
+	host = HOST,
+	port = PORT,
+	timeoutMs = 10_000,
+): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const socket = new Socket();
+		const chunks: Buffer[] = [];
+		const timer = setTimeout(() => {
+			socket.destroy();
+			reject(new Error(`MC status ping to ${host}:${port} timed out`));
+		}, timeoutMs);
+
+		socket.once('error', (err) => {
+			clearTimeout(timer);
+			socket.destroy();
+			reject(err);
+		});
+
+		socket.on('data', (buf) => {
+			chunks.push(buf);
+			if (Buffer.concat(chunks).length > 4) {
+				clearTimeout(timer);
+				socket.end();
+				resolve(Buffer.concat(chunks));
+			}
+		});
+
+		socket.connect(port, host, () => {
+			const addr = Buffer.from(host, 'utf8');
+			// Handshake: packetId 0x00, protoVersion 770 (1.21.11), addr, port, nextState 1
+			const handshake = Buffer.concat([
+				Buffer.from([0x00, 0x82, 0x06]),
+				varInt(addr.length),
+				addr,
+				Buffer.from([(port >> 8) & 0xff, port & 0xff, 0x01]),
+			]);
+			socket.write(Buffer.concat([varInt(handshake.length), handshake]));
+			// Status request: packetId 0x00, empty body
+			socket.write(Buffer.from([0x01, 0x00]));
+		});
+	});
+}
+
+function varInt(value: number): Buffer {
+	const bytes: number[] = [];
+	let v = value;
+	while ((v & ~0x7f) !== 0) {
+		bytes.push((v & 0x7f) | 0x80);
+		v >>>= 7;
+	}
+	bytes.push(v);
+	return Buffer.from(bytes);
+}

--- a/apps/mc/velocity/project.json
+++ b/apps/mc/velocity/project.json
@@ -34,6 +34,31 @@
 					]
 				}
 			}
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"dependsOn": [
+				{
+					"target": "container",
+					"projects": ["mc-velocity"],
+					"params": "forward"
+				}
+			],
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker rm -f mc-velocity-e2e 2>/dev/null || true",
+					"docker run -d --name mc-velocity-e2e -p 25578:25577 -e TYPE=VELOCITY -e MEMORY=512M kbve/mc-velocity:latest",
+					"echo 'Waiting for Velocity to come up...' && for i in $(seq 1 300); do if docker logs mc-velocity-e2e 2>&1 | grep -q 'Done ('; then echo 'Velocity ready after '\"$i\"'s'; break; fi; if [ $i -eq 300 ]; then echo 'Velocity did not start in 300s'; docker logs mc-velocity-e2e 2>&1 | tail -80; docker rm -f mc-velocity-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
+					"docker logs mc-velocity-e2e 2>&1 | grep -q 'KBVE Velocity Commands' || { echo 'kbve-velocity-commands plugin did not load'; docker logs mc-velocity-e2e 2>&1 | tail -80; docker rm -f mc-velocity-e2e 2>/dev/null || true; exit 1; }",
+					"VELOCITY_HOST=127.0.0.1 VELOCITY_PORT=25578 npx vitest run; EC=$?; echo '--- container logs ---'; docker logs mc-velocity-e2e 2>&1 | tail -50; docker rm -f mc-velocity-e2e 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false,
+				"cwd": "apps/mc/velocity"
+			},
+			"configurations": {
+				"ci": {}
+			}
 		}
 	},
 	"tags": ["scope:mc"]

--- a/apps/mc/velocity/tsconfig.e2e.json
+++ b/apps/mc/velocity/tsconfig.e2e.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true
+	},
+	"include": ["e2e/**/*.ts", "vitest.config.ts"]
+}

--- a/apps/mc/velocity/vitest.config.ts
+++ b/apps/mc/velocity/vitest.config.ts
@@ -1,0 +1,8 @@
+export default {
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 30_000,
+		hookTimeout: 60_000,
+		fileParallelism: false,
+	},
+};


### PR DESCRIPTION
## Summary

- Production MC connect error ("Unable to connect you to mc") traced to `mc-velocity` and `mc-lobby` pods stuck in `ImagePullBackOff` — `ghcr.io/kbve/mc-velocity:1.0.0` and `ghcr.io/kbve/mc-lobby:1.0.0` **never existed**. PR #10037 landed with matching `1.0.0` in both the MDX version source and `version.toml`, so the CI version gate saw `local == published` and skipped publish. `has_test: false` also meant no CI image was ever staged.
- Bump both MDX versions to `1.0.1` so the gate trips `local > published`, flip `has_test: true`, and add `e2e_name` so `ci-docker.yml` can resolve the e2e target.
- Add e2e smoke tests for both:
  - **mc-lobby**: RCON-based vitest suite mirroring `apps/mc/e2e` — asserts `list`, `difficulty peaceful`, and PaperMC version.
  - **mc-velocity**: new shell + vitest e2e — boots the container, waits for Velocity `Done (` ready log, asserts the `KBVE Velocity Commands` plugin registered, then runs a vitest TCP connect + MC server-list-ping against `25577`.
- `.github/ci-dispatch-manifest.json` mirrors the MDX changes (CI reads this file directly).

## Fix path

`merge to dev` → `dev sync PR to main` → `ci-main.yml` dispatches `ci-docker.yml` for both apps → test job runs the new e2e → publish stages `:1.0.1` and `:latest` in GHCR → `utils-post-publish.yml` opens a follow-up PR bumping `version.toml` and the deployment manifests (`:1.0.0` → `:1.0.1`) → ArgoCD rolls the pods on the next sync.

## Test plan

- [ ] `nx run mc-lobby:e2e` green locally (PaperMC + RCON smoke)
- [ ] `nx run mc-velocity:e2e` green locally (Velocity boot + plugin load + MC SLP)
- [ ] CI dispatches `mc_lobby` and `mc_velocity` after this lands on `main`
- [ ] GHCR shows `ghcr.io/kbve/mc-velocity:1.0.1` and `ghcr.io/kbve/mc-lobby:1.0.1`
- [ ] Post-publish PR updates `velocity-deployment.yaml` and `lobby-deployment.yaml` to `:1.0.1`
- [ ] `mc-velocity` and `mc-lobby` pods Running in `arc-runners` namespace
- [ ] Client connecting to `mc.kbve.com:25565` lands in the lobby