### PR TITLE
fix(kubevirt): drop app=angelscript on autologon/runner Jobs so kubectl can reach apiserver (#9809)

### DIFF
--- a/apps/kube/kubevirt/autologon/job.yaml
+++ b/apps/kube/kubevirt/autologon/job.yaml
@@ -17,6 +17,13 @@
 #   kubectl apply -f apps/kube/kubevirt/autologon/ -n angelscript
 #
 # The autologon config persists across reboots — only needs to run once.
+#
+# Note: the pod template intentionally does NOT carry `app: angelscript`
+# because the namespace NetworkPolicy (podSelector app=angelscript) only
+# allows egress on ports 53 + 443 for game-server workloads. kube-proxy
+# DNATs kubernetes.default.svc to the real apiserver endpoint on port 6443,
+# which is blocked — so any kubectl from inside a policy-scoped pod times
+# out. Management jobs live outside the game-server network policy.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,7 +38,6 @@ spec:
     template:
         metadata:
             labels:
-                app: angelscript
                 component: vm-autologon
         spec:
             serviceAccountName: vm-scaler

--- a/apps/kube/kubevirt/runner/job.yaml
+++ b/apps/kube/kubevirt/runner/job.yaml
@@ -18,6 +18,11 @@
 # Override runner version:
 #   Edit RUNNER_VERSION env below, or:
 #   kubectl set env job/vm-runner-install RUNNER_VERSION=2.335.0 (before apply)
+#
+# Note: pod template intentionally does NOT carry `app: angelscript` so it's
+# not scoped by the namespace NetworkPolicy (which only allows egress on
+# ports 53/443 for the game-server workloads and blocks the kube-apiserver
+# endpoint at port 6443).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -32,15 +37,25 @@ spec:
     template:
         metadata:
             labels:
-                app: angelscript
                 component: vm-runner
         spec:
             serviceAccountName: vm-scaler
             restartPolicy: OnFailure
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: runner-install
-                  image: registry.k8s.io/kubectl:v1.33.2
+                  image: ghcr.io/kbve/kubectl:0.1.2
                   command: ['/bin/sh', '/scripts/install-runner.sh']
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop: ['ALL']
                   env:
                       - name: VM_NAME
                         value: windows-builder
@@ -62,8 +77,12 @@ spec:
                   volumeMounts:
                       - name: script
                         mountPath: /scripts
+                      - name: tmp
+                        mountPath: /tmp
             volumes:
                 - name: script
                   configMap:
                       name: vm-runner-install-script
                       defaultMode: 0755
+                - name: tmp
+                  emptyDir: {}


### PR DESCRIPTION
## Summary
Remove \`app: angelscript\` from the pod template labels on the \`vm-autologon-windows\` and \`vm-runner-install\` Jobs so they're not scoped by the namespace NetworkPolicy. Also bring the runner install Job up to parity with autologon (ghcr.io/kbve/kubectl image + restricted pod security).

## Root cause
Observed from inside the autologon pod:
\`\`\`
E0411 13:16:08.751938     320 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list:
  Get \"https://10.96.0.1:443/api?timeout=32s\": dial tcp 10.96.0.1:443: i/o timeout"
\`\`\`

Autologon script output:
\`\`\`
=== Configuring Windows autologon: windows-builder ===
Waiting for VM to be running...
  Phase: not found (1/60)
  Phase: not found (2/60)
  ...
\`\`\`

The \`angelscript-network\` NetworkPolicy:
\`\`\`yaml
podSelector:
    matchLabels:
        app: angelscript
egress:
    - ports:
        - port: 53
        - port: 443
\`\`\`

\`kubernetes.default.svc\` resolves to \`10.96.0.1:443\`, but kube-proxy DNATs that to the **real apiserver endpoint on port 6443** (\`142.132.206.74:6443\` in our cluster). The policy has no allowance for 6443, so every \`kubectl\` call from an \`app=angelscript\` pod silently times out.

The KEDA ScaledJobs (\`vm-stop-windows-builder\`) don't hit this because their pod template doesn't set \`app: angelscript\` at all.

## Fix
Management jobs shouldn't inherit the game-server NetworkPolicy. Remove the label from the pod template (keep it on the Job metadata for organization) so the pod is outside the policy scope, matching the KEDA pattern.

## Runner install Job parity
While touching \`runner/job.yaml\`, also bring it up to the same standard as autologon (which we hardened in #9999):
- Image: \`registry.k8s.io/kubectl:v1.33.2\` → \`ghcr.io/kbve/kubectl:0.1.2\`
- Pod security: \`runAsNonRoot\`, \`runAsUser: 10001\`, \`seccompProfile: RuntimeDefault\`
- Container security: \`allowPrivilegeEscalation: false\`, \`readOnlyRootFilesystem: true\`, \`capabilities.drop: ['ALL']\`
- Volume: emptyDir \`tmp\` mount for writable scratch

## Test plan
After merge + re-apply:
- [ ] \`kubectl apply -f apps/kube/kubevirt/autologon/ -n angelscript\`
- [ ] Autologon pod logs show \`Phase: Running\` (not \`not found\`)
- [ ] Script transitions to \"Waiting for guest agent\" then \"Guest agent connected\"
- [ ] Registry keys get set via \`virsh qemu-agent-command\`
- [ ] Job completes successfully

Ref #9809