### PR TITLE
chore(ci): regenerate dispatch manifest from astro-kbve content

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.106",
+			"version": "1.0.108",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -70,7 +70,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -149,7 +149,7 @@
 		{
 			"key": "kubectl",
 			"app_name": "kbve-kubectl",
-			"version": "0.1.0",
+			"version": "0.1.2",
 			"version_toml": "apps/vm/kubectl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx",
 			"version_target": "apps/vm/kubectl/Cargo.toml",
@@ -162,7 +162,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.2",
+			"version": "1.0.12",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",
@@ -194,9 +194,9 @@
 			"source_path": "apps/mc/velocity",
 			"runner": "ubuntu-latest",
 			"image": "kbve/mc-velocity",
+			"e2e_name": "mc-velocity",
 			"deployment_yaml": "apps/kube/agones/mc/velocity-deployment.yaml",
-			"has_test": true,
-			"e2e_name": "mc-velocity"
+			"has_test": true
 		},
 		{
 			"key": "memes",


### PR DESCRIPTION
## Summary

- Follow-up to #10040. That PR hand-edited `.github/ci-dispatch-manifest.json` directly to add `mc_lobby` / `mc_velocity` entries — the manifest is a generated artifact (`nx run astro-kbve:build` + `astro-kbve:sync:ci-manifest`), not a source-of-truth file.
- Ran the proper pipeline against current MDX frontmatter and committed the output.

## Drift surfaced by the regeneration

Four projects had stale `version` fields in the committed manifest vs their MDX source of truth:

| project | manifest was | MDX now says |
|---|---|---|
| `astro_kbve` (axum-kbve) | 1.0.106 | **1.0.108** |
| `discordsh_bot` | 0.1.8 | **0.1.9** |
| `kubectl` | 0.1.0 | **0.1.2** |
| `mc` | 1.0.2 | **1.0.12** (ten versions behind) |

Plus `mc_velocity` field ordering (my `e2e_name` insertion in #10040 was tail-appended; the generator emits it in canonical position).

`ci-main.yml` reads `version_source` (the MDX file) directly for the version gate, so these stale `version` fields were cosmetic rather than functional — CI was still dispatching correctly. But the manifest should faithfully reflect its generator input.

## Test plan

- [ ] `nx run astro-kbve:build` passes
- [ ] `nx run astro-kbve:sync:ci-manifest` emits a manifest identical to this diff
- [ ] `ci-main.yml` still resolves all 49 tracked projects