### PR TITLE
fix(mc-lobby): correct Modrinth slugs for antibuild + advanced-portals

### DIFF
--- a/apps/mc/lobby/Dockerfile
+++ b/apps/mc/lobby/Dockerfile
@@ -61,7 +61,7 @@ ENV CFG_VELOCITY_SECRET="kbve-velocity-forwarding-secret-change-me"
 #                        decorative portals in the lobby that teleport
 #                        players to other backends. Requires one-time
 #                        in-game `/portal create` setup after first boot.
-ENV MODRINTH_PROJECTS=luckperms,essentialsx,essentialsxantibuild,worldedit,advancedportals
+ENV MODRINTH_PROJECTS=luckperms,essentialsx,essentialsx-antibuild,worldedit,advanced-portals
 ENV LUCKPERMS_MESSAGING_SERVICE=pluginmsg
 ENV LUCKPERMS_STORAGE_METHOD=h2
 


### PR DESCRIPTION
## Summary

- CI run [24292651600](https://github.com/KBVE/kbve/actions/runs/24292651600) for `mc-lobby` failed the e2e smoke test added in #10040 — the container never reached "RCON running" and timed out after 300s. Root cause in the logs:
  ```
  [mc-image-helper] ERROR : Invalid parameter provided for 'modrinth' command:
  Project(s) could not be located: [essentialsxantibuild, advancedportals]
  ```
- [apps/mc/lobby/Dockerfile](apps/mc/lobby/Dockerfile) lists the two plugins without their canonical Modrinth slugs. Verified via `https://api.modrinth.com/v2/search`:
  - `essentialsxantibuild` → **`essentialsx-antibuild`**
  - `advancedportals` → **`advanced-portals`**
- This was a latent bug in #10037 but nobody caught it because `mc-lobby` had `has_test: false` at the time. The e2e wired up in #10040 is what surfaced it.

## No version bump needed

dev currently has `apps/mc/lobby/version.toml = 1.0.0` and MDX `version = 1.0.1` — the previous publish was blocked at the test step so `version.toml` never got synced. The version gate will still trip `1.0.1 > 1.0.0` on the next main push and redispatch automatically.

## Test plan

- [ ] Local `nx run mc-lobby:e2e` reaches RCON and all three specs pass (`list`, `difficulty peaceful`, `version paper`)
- [ ] `ci-docker.yml / mc-lobby` goes green on next main push
- [ ] Post-publish syncs `lobby-deployment.yaml` from `:1.0.0` → `:1.0.1`
- [ ] `mc-lobby` pod Running in `arc-runners`, reachable via Velocity fallback