### PR TITLE
feat(bevy_pathfinding): flow field pathfinding crate + MC AI integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_npc",
+ "bevy_pathfinding",
  "crossbeam-channel",
  "jni 0.21.1",
  "serde",
@@ -2467,6 +2468,14 @@ dependencies = [
  "prost-build 0.14.3",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bevy_pathfinding"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
 	'packages/rust/bevy/bevy_tasker',
 	'packages/rust/bevy/bevy_db',
 	'packages/rust/bevy/bevy_supa',
+	'packages/rust/bevy/bevy_pathfinding',
 	'apps/vm/firecracker-ctl',
 	'apps/vm/kubectl',
 	'apps/mc/behavior_statetree',

--- a/apps/mc/behavior_statetree/Cargo.toml
+++ b/apps/mc/behavior_statetree/Cargo.toml
@@ -36,3 +36,8 @@ bevy = { version = "0.18", default-features = false, features = [
 
 # Creature components from the shared bevy_npc package
 bevy_npc = { path = "../../../packages/rust/bevy/bevy_npc", features = ["creature"] }
+
+# Flow field pathfinding — pure algorithms, no Bevy feature needed here
+# (the grid/flow types are plain Rust structs wrapped as Bevy Resources
+# inside our own ECS module).
+bevy_pathfinding = { path = "../../../packages/rust/bevy/bevy_pathfinding" }

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -295,3 +295,46 @@ impl Default for PetParrotPopulationConfig {
 /// Tracks when the pet parrot population manager last ran.
 #[derive(Resource, Debug, Default)]
 pub struct LastPetParrotManagedTick(pub u64);
+
+// ---------------------------------------------------------------------------
+// Flow field / pathfinding resources — computed from map data snapshots
+// sent by Java. The grid + flow fields are recomputed every few seconds
+// (gated by `FlowFieldRebuildTick`), not every ECS tick.
+// ---------------------------------------------------------------------------
+
+/// The current walkability grid built from the most recent map snapshot.
+/// `None` until Java sends the first `MapRegionSnapshot`.
+#[derive(Resource, Default)]
+pub struct CurrentBlockGrid(pub Option<bevy_pathfinding::grid::BlockGrid>);
+
+/// Flow fields computed toward each online player's position. Keyed by
+/// the player's Minecraft entity ID so skeletons can pick "approach the
+/// nearest player" in O(1) per cell.
+#[derive(Resource, Default)]
+pub struct PlayerFlowFields(pub Vec<(u64, bevy_pathfinding::flow_field::FlowField)>);
+
+/// Flee flow field — points every cell AWAY from all player positions.
+/// Used by the low-health flee behavior.
+#[derive(Resource, Default)]
+pub struct FleeFlowField(pub Option<bevy_pathfinding::flow_field::FlowField>);
+
+/// Detected chokepoints / flow gates in the current grid. Recomputed
+/// alongside the flow fields.
+#[derive(Resource, Default)]
+pub struct DetectedFlowGates(pub Vec<bevy_pathfinding::flow_gate::FlowGate>);
+
+/// Tracks when the flow field was last rebuilt. Flow field recomputation
+/// is expensive relative to a normal ECS tick, so it's throttled.
+#[derive(Resource, Debug, Default)]
+pub struct FlowFieldRebuildTick(pub u64);
+
+/// How many ECS ticks between flow field rebuilds.
+/// At 100ms/tick, 30 ticks ≈ 3 seconds.
+#[derive(Resource, Debug)]
+pub struct FlowFieldRebuildInterval(pub u64);
+
+impl Default for FlowFieldRebuildInterval {
+    fn default() -> Self {
+        Self(30) // ~3s at 100ms ECS ticks
+    }
+}

--- a/apps/mc/behavior_statetree/src/ecs/events.rs
+++ b/apps/mc/behavior_statetree/src/ecs/events.rs
@@ -6,6 +6,8 @@
 
 use bevy::prelude::*;
 
+use bevy_pathfinding::grid::MapRegionSnapshot;
+
 use crate::types::{NpcCommand, NpcObservation, PlayerSnapshot};
 
 /// Inbound buffer: per-NPC observations queued from JNI, drained by
@@ -38,6 +40,14 @@ pub struct IntentBuffer {
 #[derive(Resource, Default)]
 pub struct WorldIntentBuffer {
     pub ready: Vec<IntentReady>,
+}
+
+/// Inbound buffer: map region snapshots queued from JNI, drained by
+/// `ingest_map_data` each tick. Java sends these every few seconds when
+/// players move — NOT every tick.
+#[derive(Resource, Default)]
+pub struct MapDataBuffer {
+    pub pending: Vec<MapRegionSnapshot>,
 }
 
 /// A single intent ready to send back to Java.

--- a/apps/mc/behavior_statetree/src/ecs/mod.rs
+++ b/apps/mc/behavior_statetree/src/ecs/mod.rs
@@ -14,14 +14,18 @@ pub mod systems;
 use bevy::prelude::*;
 
 use components::{
-    GlobalCallCooldown, LastPetDogManagedTick, LastPetParrotManagedTick, LastPopulationManagedTick,
-    PetDogPopulationConfig, PetParrotPopulationConfig, ServerTick, SkeletonPopulationConfig,
+    CurrentBlockGrid, DetectedFlowGates, FleeFlowField, FlowFieldRebuildInterval,
+    FlowFieldRebuildTick, GlobalCallCooldown, LastPetDogManagedTick, LastPetParrotManagedTick,
+    LastPopulationManagedTick, PetDogPopulationConfig, PetParrotPopulationConfig, PlayerFlowFields,
+    ServerTick, SkeletonPopulationConfig,
 };
-use events::{IntentBuffer, ObservationBuffer, PlayerObservationBuffer, WorldIntentBuffer};
+use events::{
+    IntentBuffer, MapDataBuffer, ObservationBuffer, PlayerObservationBuffer, WorldIntentBuffer,
+};
 use systems::{
-    ingest_observations, ingest_player_snapshots, manage_pet_dog_population,
+    ingest_map_data, ingest_observations, ingest_player_snapshots, manage_pet_dog_population,
     manage_pet_parrot_population, manage_skeleton_population, plan_behavior, plan_pet_dog_behavior,
-    plan_pet_parrot_behavior,
+    plan_pet_parrot_behavior, rebuild_flow_fields,
 };
 
 /// Plugin that registers all AI ECS components, resources, and systems.
@@ -33,8 +37,16 @@ impl Plugin for AiBehaviorPlugin {
             .init_resource::<GlobalCallCooldown>()
             .init_resource::<ObservationBuffer>()
             .init_resource::<PlayerObservationBuffer>()
+            .init_resource::<MapDataBuffer>()
             .init_resource::<IntentBuffer>()
             .init_resource::<WorldIntentBuffer>()
+            // Flow field / pathfinding resources
+            .init_resource::<CurrentBlockGrid>()
+            .init_resource::<PlayerFlowFields>()
+            .init_resource::<FleeFlowField>()
+            .init_resource::<DetectedFlowGates>()
+            .init_resource::<FlowFieldRebuildTick>()
+            .init_resource::<FlowFieldRebuildInterval>()
             .init_resource::<SkeletonPopulationConfig>()
             .init_resource::<LastPopulationManagedTick>()
             .init_resource::<PetDogPopulationConfig>()
@@ -46,6 +58,8 @@ impl Plugin for AiBehaviorPlugin {
                 (
                     ingest_player_snapshots,
                     ingest_observations,
+                    ingest_map_data,
+                    rebuild_flow_fields,
                     plan_behavior,
                     plan_pet_dog_behavior,
                     plan_pet_parrot_behavior,

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -5,7 +5,13 @@
 
 use bevy::prelude::*;
 
+use bevy_pathfinding::flow_field::FlowField;
+use bevy_pathfinding::flow_gate;
+
 use crate::tree::builtin::{AttackNearest, CallAllies, Flee, IsHealthLow, Wander};
+use crate::tree::flow_nodes::{
+    FlowApproach, FlowFlee, HasFlowField, PatrolGate, PlayerWithinFlowDistance,
+};
 use crate::tree::node::{BehaviorContext, BehaviorNode, Selector, Sequence};
 use crate::types::{NpcCommand, NpcObservation};
 
@@ -323,11 +329,24 @@ pub fn plan_behavior(
     server_tick: Res<ServerTick>,
     mut global_cooldown: ResMut<GlobalCallCooldown>,
     mut intent_buffer: ResMut<IntentBuffer>,
+    grid_res: Res<CurrentBlockGrid>,
+    player_fields: Res<PlayerFlowFields>,
+    flee_field: Res<FleeFlowField>,
+    gates: Res<DetectedFlowGates>,
 ) {
     let tree = build_behavior_tree();
     let current_tick = server_tick.0;
 
     for (mc_id, pos, health, epoch, nearby, mut cooldown) in &mut query {
+        // Build flow field hint from computed resources
+        let flow_hint = build_flow_hint(
+            pos,
+            grid_res.as_ref(),
+            player_fields.as_ref(),
+            flee_field.as_ref(),
+            gates.as_ref(),
+        );
+
         let observation = NpcObservation {
             entity_id: mc_id.0,
             epoch: epoch.value,
@@ -349,6 +368,7 @@ pub fn plan_behavior(
             tick: current_tick,
             entity_kind: "skeleton".to_string(),
             owner_entity: None,
+            flow_hint,
         };
 
         let mut ctx = BehaviorContext {
@@ -363,6 +383,72 @@ pub fn plan_behavior(
             epoch: epoch.value,
             commands,
         });
+    }
+}
+
+/// Build a `FlowFieldHint` for the given NPC position from the computed
+/// flow field resources. Returns default (empty) hint if no data is
+/// available.
+fn build_flow_hint(
+    pos: &McPosition,
+    grid_res: &CurrentBlockGrid,
+    player_fields: &PlayerFlowFields,
+    flee_field: &FleeFlowField,
+    gates: &DetectedFlowGates,
+) -> crate::types::FlowFieldHint {
+    use crate::types::FlowFieldHint;
+
+    let Some(ref grid) = grid_res.0 else {
+        return FlowFieldHint::default();
+    };
+
+    let bx = pos.x.floor() as i32;
+    let bz = pos.z.floor() as i32;
+
+    if !grid.in_bounds(bx, bz) {
+        return FlowFieldHint::default();
+    }
+
+    // Approach: find the flow field with the shortest distance to this NPC
+    // (i.e., the nearest player's field), then get the next target.
+    let (approach_target, player_distance) = player_fields
+        .0
+        .iter()
+        .filter_map(|(_, field)| {
+            let dist = field.distance(bx, bz)?;
+            let target = field.next_target(grid, bx, bz)?;
+            Some((target, dist))
+        })
+        .min_by_key(|&(_, d)| d)
+        .map(|(t, d)| (Some(t), Some(d)))
+        .unwrap_or((None, None));
+
+    // Flee target
+    let flee_target = flee_field
+        .0
+        .as_ref()
+        .and_then(|ff| ff.next_target(grid, bx, bz));
+
+    // Nearest gate
+    let nearest_gate = bevy_pathfinding::flow_gate::nearest_gate(&gates.0, bx, bz).map(|g| {
+        let cell = grid.get(g.center_x, g.center_z);
+        [
+            g.center_x as f64 + 0.5,
+            cell.height as f64,
+            g.center_z as f64 + 0.5,
+        ]
+    });
+
+    // Gates within patrol range (~32 blocks)
+    let gates_in_range =
+        bevy_pathfinding::flow_gate::gates_in_radius(&gates.0, bx, bz, 32).len() as u32;
+
+    FlowFieldHint {
+        approach_target,
+        flee_target,
+        player_distance,
+        nearest_gate,
+        gates_in_range,
     }
 }
 
@@ -697,14 +783,21 @@ pub fn plan_pet_parrot_behavior(
 fn build_behavior_tree() -> Selector {
     Selector {
         children: vec![
+            // Priority 1: Low health → flee (prefer flow-aware, fall back to blind)
             Box::new(Sequence {
                 children: vec![
                     Box::new(IsHealthLow { threshold: 5.0 }),
-                    Box::new(Flee {
-                        flee_distance: 16.0,
+                    Box::new(Selector {
+                        children: vec![
+                            Box::new(FlowFlee),
+                            Box::new(Flee {
+                                flee_distance: 16.0,
+                            }),
+                        ],
                     }),
                 ],
             }),
+            // Priority 2: Call for help when hurt
             Box::new(Sequence {
                 children: vec![
                     Box::new(IsHealthLow { threshold: 6.0 }),
@@ -714,8 +807,104 @@ fn build_behavior_tree() -> Selector {
                     }),
                 ],
             }),
+            // Priority 3: Attack if in melee range
             Box::new(AttackNearest { range: 2.5 }),
+            // Priority 4: Flow-field approach when player is within BFS range
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(HasFlowField),
+                    Box::new(PlayerWithinFlowDistance { max_distance: 24 }),
+                    Box::new(FlowApproach),
+                ],
+            }),
+            // Priority 5: Patrol chokepoints (if any detected)
+            Box::new(PatrolGate),
+            // Priority 6: Classic blind wander as final fallback
             Box::new(Wander { radius: 8.0 }),
         ],
     }
+}
+
+// ---------------------------------------------------------------------------
+// Map data ingestion + flow field computation
+//
+// Java sends MapRegionSnapshot payloads every few seconds (not every tick).
+// The ingest system converts them to a BlockGrid, and the rebuild system
+// recomputes flow fields + flow gates on a throttled interval.
+// ---------------------------------------------------------------------------
+
+/// System: ingest map data snapshots from the JNI buffer into the ECS.
+///
+/// Takes the most recent snapshot (drops older ones if multiple arrived
+/// between ticks) and converts it to a `BlockGrid`. The grid is stored
+/// as a resource for flow field systems to read.
+pub fn ingest_map_data(
+    mut map_buffer: ResMut<MapDataBuffer>,
+    mut grid_res: ResMut<CurrentBlockGrid>,
+) {
+    // Only keep the most recent snapshot — older ones are stale.
+    let Some(snapshot) = map_buffer.pending.pop() else {
+        return;
+    };
+    // Drain any older snapshots that piled up.
+    map_buffer.pending.clear();
+
+    if let Some(grid) = snapshot.into_grid() {
+        grid_res.0 = Some(grid);
+    }
+}
+
+/// System: periodically recompute flow fields and flow gates from the
+/// current `BlockGrid` + player positions.
+///
+/// Throttled by `FlowFieldRebuildInterval` to avoid burning CPU every
+/// ECS tick. Produces:
+/// - `PlayerFlowFields` — one flow field per online player (approach)
+/// - `FleeFlowField` — flee field away from all players
+/// - `DetectedFlowGates` — chokepoints for tactical behavior
+pub fn rebuild_flow_fields(
+    server_tick: Res<ServerTick>,
+    mut last_rebuild: ResMut<FlowFieldRebuildTick>,
+    rebuild_interval: Res<FlowFieldRebuildInterval>,
+    grid_res: Res<CurrentBlockGrid>,
+    players: Query<(&OnlinePlayer, &McPosition)>,
+    mut player_fields: ResMut<PlayerFlowFields>,
+    mut flee_field: ResMut<FleeFlowField>,
+    mut gates: ResMut<DetectedFlowGates>,
+) {
+    let current = server_tick.0;
+    if current.saturating_sub(last_rebuild.0) < rebuild_interval.0 {
+        return;
+    }
+    last_rebuild.0 = current;
+
+    let Some(ref grid) = grid_res.0 else {
+        return;
+    };
+
+    // Collect player positions as block coords for flow field goals
+    let player_goals: Vec<(u64, (i32, i32))> = players
+        .iter()
+        .map(|(p, pos)| (p.entity_id, (pos.x.floor() as i32, pos.z.floor() as i32)))
+        .filter(|(_, (x, z))| grid.in_bounds(*x, *z))
+        .collect();
+
+    if player_goals.is_empty() {
+        player_fields.0.clear();
+        flee_field.0 = None;
+        return;
+    }
+
+    // Build per-player approach flow fields
+    player_fields.0 = player_goals
+        .iter()
+        .map(|&(id, goal)| (id, FlowField::compute(grid, &[goal])))
+        .collect();
+
+    // Build flee field (away from all players at once)
+    let all_goals: Vec<(i32, i32)> = player_goals.iter().map(|&(_, g)| g).collect();
+    flee_field.0 = Some(FlowField::compute_flee(grid, &all_goals));
+
+    // Detect chokepoints
+    gates.0 = flow_gate::detect_gates(grid);
 }

--- a/apps/mc/behavior_statetree/src/lib.rs
+++ b/apps/mc/behavior_statetree/src/lib.rs
@@ -22,6 +22,7 @@ use jni::JNIEnv;
 use jni::objects::{JClass, JString};
 use jni::sys::{jboolean, jstring};
 
+use bevy_pathfinding::grid::MapRegionSnapshot;
 use runtime::AiRuntime;
 use types::{NpcObservation, NpcThinkJob, PlayerSnapshot};
 
@@ -95,6 +96,34 @@ pub extern "system" fn Java_com_kbve_statetree_NativeRuntime_submitPlayerSnapsho
     } else {
         0
     }
+}
+
+/// Submit a map region snapshot as a JSON string. Java scans the surface
+/// around players every few seconds and packs walkability data into a
+/// `MapRegionSnapshot`. Rust builds a `BlockGrid` and computes flow
+/// fields + chokepoints from it.
+///
+/// Returns true if the snapshot was accepted, false if back-pressured.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_statetree_NativeRuntime_submitMapData(
+    mut env: JNIEnv,
+    _class: JClass,
+    snapshot_json: JString,
+) -> jboolean {
+    let Some(rt) = RUNTIME.get() else {
+        return 0;
+    };
+
+    let json_str: String = match env.get_string(&snapshot_json) {
+        Ok(s) => s.into(),
+        Err(_) => return 0,
+    };
+
+    let Ok(snapshot) = serde_json::from_str::<MapRegionSnapshot>(&json_str) else {
+        return 0;
+    };
+
+    if rt.submit_map_data(snapshot) { 1 } else { 0 }
 }
 
 /// Poll all completed NPC intents. Returns a JSON array string.

--- a/apps/mc/behavior_statetree/src/runtime.rs
+++ b/apps/mc/behavior_statetree/src/runtime.rs
@@ -10,14 +10,17 @@ use bevy::app::App;
 use crossbeam_channel::{Receiver, Sender, bounded};
 use tracing::{debug, warn};
 
+use bevy_pathfinding::grid::MapRegionSnapshot;
+
 use crate::ecs::AiBehaviorPlugin;
 use crate::ecs::events::{
-    IntentBuffer, ObservationBuffer, PlayerObservationBuffer, WorldIntentBuffer,
+    IntentBuffer, MapDataBuffer, ObservationBuffer, PlayerObservationBuffer, WorldIntentBuffer,
 };
 use crate::types::{NpcIntent, NpcThinkJob, PlayerSnapshot};
 
 const JOB_CHANNEL_SIZE: usize = 256;
 const PLAYER_SNAPSHOT_CHANNEL_SIZE: usize = 64;
+const MAP_DATA_CHANNEL_SIZE: usize = 4;
 const INTENT_CHANNEL_SIZE: usize = 256;
 const ECS_TICK_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -25,6 +28,7 @@ const ECS_TICK_INTERVAL: Duration = Duration::from_millis(100);
 pub struct AiRuntime {
     job_tx: Sender<NpcThinkJob>,
     player_tx: Sender<PlayerSnapshot>,
+    map_tx: Sender<MapRegionSnapshot>,
     intent_rx: Receiver<NpcIntent>,
 }
 
@@ -32,19 +36,21 @@ impl AiRuntime {
     pub fn start() -> Self {
         let (job_tx, job_rx) = bounded::<NpcThinkJob>(JOB_CHANNEL_SIZE);
         let (player_tx, player_rx) = bounded::<PlayerSnapshot>(PLAYER_SNAPSHOT_CHANNEL_SIZE);
+        let (map_tx, map_rx) = bounded::<MapRegionSnapshot>(MAP_DATA_CHANNEL_SIZE);
         let (intent_tx, intent_rx) = bounded::<NpcIntent>(INTENT_CHANNEL_SIZE);
 
         // Dedicated OS thread for the Bevy App (not Send, can't use Tokio)
         std::thread::Builder::new()
             .name("npc-ecs".into())
             .spawn(move || {
-                ecs_tick_loop(job_rx, player_rx, intent_tx);
+                ecs_tick_loop(job_rx, player_rx, map_rx, intent_tx);
             })
             .expect("failed to spawn NPC ECS thread");
 
         Self {
             job_tx,
             player_tx,
+            map_tx,
             intent_rx,
         }
     }
@@ -55,6 +61,10 @@ impl AiRuntime {
 
     pub fn submit_player_snapshot(&self, snapshot: PlayerSnapshot) -> bool {
         self.player_tx.try_send(snapshot).is_ok()
+    }
+
+    pub fn submit_map_data(&self, snapshot: MapRegionSnapshot) -> bool {
+        self.map_tx.try_send(snapshot).is_ok()
     }
 
     pub fn poll_intents(&self) -> Vec<NpcIntent> {
@@ -69,6 +79,7 @@ impl AiRuntime {
 fn ecs_tick_loop(
     job_rx: Receiver<NpcThinkJob>,
     player_rx: Receiver<PlayerSnapshot>,
+    map_rx: Receiver<MapRegionSnapshot>,
     intent_tx: Sender<NpcIntent>,
 ) {
     let mut app = App::new();
@@ -91,6 +102,14 @@ fn ecs_tick_loop(
             let mut player_buffer = app.world_mut().resource_mut::<PlayerObservationBuffer>();
             while let Ok(snapshot) = player_rx.try_recv() {
                 player_buffer.pending.push(snapshot);
+            }
+        }
+
+        // Drain map region snapshots into the ECS buffer
+        {
+            let mut map_buffer = app.world_mut().resource_mut::<MapDataBuffer>();
+            while let Ok(snapshot) = map_rx.try_recv() {
+                map_buffer.pending.push(snapshot);
             }
         }
 

--- a/apps/mc/behavior_statetree/src/tree/flow_nodes.rs
+++ b/apps/mc/behavior_statetree/src/tree/flow_nodes.rs
@@ -1,0 +1,152 @@
+//! Flow-field-aware behavior tree leaf nodes.
+//!
+//! These nodes read the `FlowFieldHint` on the `NpcObservation` to make
+//! terrain-aware movement decisions. When no flow field data is available
+//! (Java hasn't sent map data yet, or the NPC is outside the grid), they
+//! return `Failure` so the behavior tree falls through to the classic
+//! blind `Wander` / `Flee` nodes.
+
+use crate::types::{NpcCommand, NpcObservation};
+
+use super::node::{BehaviorContext, BehaviorNode, NodeStatus};
+
+/// Move toward the nearest player using the precomputed flow field.
+///
+/// Unlike the blind `Wander` which orbits at a fixed radius, this node
+/// follows the BFS-optimal path around walls, water, and cliffs. Falls
+/// through to `Failure` if no flow field data is available so the tree
+/// can try classic movement as a fallback.
+pub struct FlowApproach;
+
+impl BehaviorNode for FlowApproach {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let Some(target) = observation.flow_hint.approach_target else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        (
+            NodeStatus::Success,
+            vec![NpcCommand::MoveTo { target, speed: 1.0 }],
+        )
+    }
+}
+
+/// Flee from all players using the precomputed flee flow field.
+///
+/// Unlike the blind `Flee` which runs in a straight line away from the
+/// nearest hostile, this follows the flow field to find paths that
+/// actually lead somewhere safe (around walls, through doors, etc.).
+pub struct FlowFlee;
+
+impl BehaviorNode for FlowFlee {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let Some(target) = observation.flow_hint.flee_target else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        (
+            NodeStatus::Success,
+            vec![NpcCommand::MoveTo { target, speed: 1.4 }],
+        )
+    }
+}
+
+/// Move toward the nearest detected chokepoint / flow gate.
+///
+/// Useful for ambush behavior — the skeleton moves to a strategically
+/// important narrow passage and waits for players to come through.
+/// Falls through if no gates are detected in the current grid.
+pub struct PatrolGate;
+
+impl BehaviorNode for PatrolGate {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let Some(gate_pos) = observation.flow_hint.nearest_gate else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        (
+            NodeStatus::Success,
+            vec![NpcCommand::MoveTo {
+                target: gate_pos,
+                speed: 1.0,
+            }],
+        )
+    }
+}
+
+/// Condition node: check if the flow field data is available.
+///
+/// Succeeds if the NPC has a valid flow field hint (Java has sent map
+/// data and the NPC is within the scanned region). Useful as a guard
+/// before flow-aware nodes in a Sequence.
+pub struct HasFlowField;
+
+impl BehaviorNode for HasFlowField {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        if observation.flow_hint.approach_target.is_some() {
+            (NodeStatus::Success, vec![])
+        } else {
+            (NodeStatus::Failure, vec![])
+        }
+    }
+}
+
+/// Condition node: check if a player is within a certain BFS distance.
+///
+/// Uses the flow field distance (terrain-aware, not straight line).
+/// Succeeds if the nearest player is within `max_distance` BFS steps.
+pub struct PlayerWithinFlowDistance {
+    pub max_distance: u32,
+}
+
+impl BehaviorNode for PlayerWithinFlowDistance {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        match observation.flow_hint.player_distance {
+            Some(d) if d <= self.max_distance => (NodeStatus::Success, vec![]),
+            _ => (NodeStatus::Failure, vec![]),
+        }
+    }
+}
+
+/// Condition node: check if there are chokepoints nearby.
+///
+/// Succeeds if at least `min_gates` flow gates are within patrol range.
+/// Useful to gate whether the NPC should attempt tactical patrolling
+/// or fall back to basic wandering in open terrain.
+pub struct HasNearbyGates {
+    pub min_gates: u32,
+}
+
+impl BehaviorNode for HasNearbyGates {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        if observation.flow_hint.gates_in_range >= self.min_gates {
+            (NodeStatus::Success, vec![])
+        } else {
+            (NodeStatus::Failure, vec![])
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/src/tree/mod.rs
+++ b/apps/mc/behavior_statetree/src/tree/mod.rs
@@ -1,4 +1,5 @@
 //! Behavior tree engine — composable AI decision nodes.
 
 pub mod builtin;
+pub mod flow_nodes;
 pub mod node;

--- a/apps/mc/behavior_statetree/src/types.rs
+++ b/apps/mc/behavior_statetree/src/types.rs
@@ -54,6 +54,37 @@ pub struct NpcObservation {
     /// player that owns them. `None` for unowned mobs.
     #[serde(default)]
     pub owner_entity: Option<u64>,
+    /// Flow field navigation hints. Not sent from Java — injected by the
+    /// ECS `plan_behavior` system from computed flow field resources.
+    #[serde(default)]
+    pub flow_hint: FlowFieldHint,
+}
+
+// ---------------------------------------------------------------------------
+// Flow field hint — injected by the ECS `plan_behavior` system from
+// the computed flow field resources. Lets behavior tree nodes make
+// terrain-aware movement decisions without direct ECS access.
+// ---------------------------------------------------------------------------
+
+/// Pre-computed navigation hints derived from the current flow field and
+/// flow gate state. Populated per-NPC by the `plan_behavior` system.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FlowFieldHint {
+    /// Suggested next block position from the approach flow field
+    /// (toward the nearest player). `None` if no flow field is available
+    /// or the NPC is out of the grid bounds.
+    pub approach_target: Option<[f64; 3]>,
+    /// Suggested next block position from the flee flow field (away from
+    /// all players). `None` if unavailable.
+    pub flee_target: Option<[f64; 3]>,
+    /// BFS distance (in blocks) to the nearest player via the flow field.
+    /// `None` if unreachable or no field available.
+    pub player_distance: Option<u32>,
+    /// Position of the nearest detected chokepoint / flow gate.
+    /// `None` if no gates are detected.
+    pub nearest_gate: Option<[f64; 3]>,
+    /// Number of flow gates within a reasonable patrol radius (~32 blocks).
+    pub gates_in_range: u32,
 }
 
 /// Job submitted to the Tokio runtime for async processing.

--- a/packages/rust/bevy/bevy_pathfinding/Cargo.toml
+++ b/packages/rust/bevy/bevy_pathfinding/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "bevy_pathfinding"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.94"
+license = "MIT"
+description = "Grid-based flow field pathfinding and chokepoint detection — pure Rust core with optional Bevy ECS integration"
+homepage = "https://kbve.com/"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_pathfinding"
+keywords = ["pathfinding", "flow-field", "gamedev", "bevy"]
+categories = ["game-development", "algorithms"]
+
+[features]
+default = []
+
+# Bevy ECS integration — adds Resource derives and optional plugin.
+# Without this feature the crate is plain Rust with zero Bevy dependency,
+# suitable for JNI cdylibs (behavior_statetree) and CLI tools.
+bevy = ["dep:bevy"]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
+# Bevy — only pulled in under the `bevy` feature.
+bevy = { version = "0.18", default-features = false, features = [
+    "bevy_state",
+], optional = true }

--- a/packages/rust/bevy/bevy_pathfinding/src/flow_field.rs
+++ b/packages/rust/bevy/bevy_pathfinding/src/flow_field.rs
@@ -1,0 +1,279 @@
+//! Layer 2: FlowField — BFS-computed direction vectors toward goals.
+//!
+//! A flow field covers the same rectangular region as a [`BlockGrid`] and
+//! stores one direction vector per walkable cell. Every cell's vector
+//! points toward the next cell on the shortest path to the nearest goal.
+//!
+//! Computation is a single BFS from all goals simultaneously — O(n) where
+//! n = grid cells. All agents sharing the same goal(s) look up their next
+//! step in O(1) rather than running per-agent A*.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! let grid = BlockGrid::new(0, 0, 64, 64);
+//! // ... populate grid with block data ...
+//!
+//! // Compute flow field toward a single goal (e.g., a player position)
+//! let field = FlowField::compute(&grid, &[(32, 32)]);
+//!
+//! // Query direction for an NPC at (10, 15)
+//! if let Some((dx, dz)) = field.direction(10, 15) {
+//!     // Move NPC by (dx, dz) — each component is -1, 0, or 1
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+use crate::grid::BlockGrid;
+
+// ---------------------------------------------------------------------------
+// Direction encoding
+// ---------------------------------------------------------------------------
+
+/// Packed direction: (dx, dz) where each is -1, 0, or 1.
+/// `(0, 0)` means "at goal" or "unreachable".
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Dir {
+    pub dx: i8,
+    pub dz: i8,
+}
+
+impl Dir {
+    pub const ZERO: Self = Self { dx: 0, dz: 0 };
+
+    #[inline]
+    pub fn is_zero(self) -> bool {
+        self.dx == 0 && self.dz == 0
+    }
+}
+
+/// Cost-to-goal value for unreachable / unvisited cells.
+const UNREACHABLE: u32 = u32::MAX;
+
+// ---------------------------------------------------------------------------
+// FlowField
+// ---------------------------------------------------------------------------
+
+/// Direction vector field computed from one or more goal positions.
+///
+/// Each walkable cell stores a [`Dir`] pointing toward the next cell on
+/// the shortest path to the nearest goal, plus the BFS distance (cost).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "bevy", derive(bevy::prelude::Resource))]
+pub struct FlowField {
+    origin_x: i32,
+    origin_z: i32,
+    width: u32,
+    depth: u32,
+    /// BFS distance-to-goal per cell. `UNREACHABLE` for walls / unvisited.
+    cost: Vec<u32>,
+    /// Direction to move from each cell toward the goal.
+    dirs: Vec<Dir>,
+}
+
+/// 8-connected neighbor offsets.
+static OFFSETS: [(i32, i32); 8] = [
+    (-1, -1),
+    (0, -1),
+    (1, -1),
+    (-1, 0),
+    (1, 0),
+    (-1, 1),
+    (0, 1),
+    (1, 1),
+];
+
+impl FlowField {
+    /// Compute a flow field from the given goals on the grid.
+    ///
+    /// Goals that are out of bounds or on non-walkable cells are skipped.
+    /// Returns a flow field covering the same region as the grid.
+    pub fn compute(grid: &BlockGrid, goals: &[(i32, i32)]) -> Self {
+        let n = (grid.width * grid.depth) as usize;
+        let mut cost = vec![UNREACHABLE; n];
+        let mut dirs = vec![Dir::ZERO; n];
+        let mut queue = VecDeque::with_capacity(n / 4);
+
+        // Seed BFS from all goal positions
+        for &(gx, gz) in goals {
+            if !grid.in_bounds(gx, gz) || !grid.is_walkable(gx, gz) {
+                continue;
+            }
+            let idx = Self::idx(gx, gz, grid.origin_x, grid.origin_z, grid.width);
+            if let Some(i) = idx {
+                if cost[i] == UNREACHABLE {
+                    cost[i] = 0;
+                    queue.push_back((gx, gz));
+                }
+            }
+        }
+
+        // BFS expansion — unweighted for speed (all steps cost 1).
+        // For weighted terrain, swap to Dijkstra, but BFS is usually
+        // good enough for MC block grids where cost differences are small.
+        while let Some((cx, cz)) = queue.pop_front() {
+            let ci = match Self::idx(cx, cz, grid.origin_x, grid.origin_z, grid.width) {
+                Some(i) => i,
+                None => continue,
+            };
+            let current_cost = cost[ci];
+
+            for &(dx, dz) in &OFFSETS {
+                let nx = cx + dx;
+                let nz = cz + dz;
+
+                if !grid.in_bounds(nx, nz) || !grid.is_walkable(nx, nz) {
+                    continue;
+                }
+
+                // Height check — mobs can only step up/down 1 block
+                let center_h = grid.get(cx, cz).height;
+                let neigh_h = grid.get(nx, nz).height;
+                if (neigh_h - center_h).abs() > crate::grid::MAX_STEP_HEIGHT {
+                    continue;
+                }
+
+                let ni = match Self::idx(nx, nz, grid.origin_x, grid.origin_z, grid.width) {
+                    Some(i) => i,
+                    None => continue,
+                };
+
+                let new_cost = current_cost + 1;
+                if new_cost < cost[ni] {
+                    cost[ni] = new_cost;
+                    // Direction points from neighbor TOWARD current (which is
+                    // closer to goal) — so the neighbor should move by (-dx, -dz).
+                    dirs[ni] = Dir {
+                        dx: -dx as i8,
+                        dz: -dz as i8,
+                    };
+                    queue.push_back((nx, nz));
+                }
+            }
+        }
+
+        Self {
+            origin_x: grid.origin_x,
+            origin_z: grid.origin_z,
+            width: grid.width,
+            depth: grid.depth,
+            cost,
+            dirs,
+        }
+    }
+
+    /// Compute a flow field that guides AWAY from the given sources.
+    ///
+    /// This is the reverse of `compute` — useful for flee behavior. Cells
+    /// near the sources have high "danger" and the field points toward
+    /// safety (away from the nearest source).
+    pub fn compute_flee(grid: &BlockGrid, sources: &[(i32, i32)]) -> Self {
+        // First compute a normal flow field toward the sources to get
+        // distance-to-source for every cell.
+        let toward = Self::compute(grid, sources);
+
+        let n = toward.cost.len();
+        let mut dirs = vec![Dir::ZERO; n];
+
+        // For each cell, pick the walkable neighbor with the HIGHEST
+        // cost-to-source (farthest from danger).
+        for (i, &cell_cost) in toward.cost.iter().enumerate() {
+            if cell_cost == UNREACHABLE || cell_cost == 0 {
+                continue;
+            }
+
+            let lx = (i as u32) % toward.width;
+            let lz = (i as u32) / toward.width;
+            let x = toward.origin_x + lx as i32;
+            let z = toward.origin_z + lz as i32;
+
+            let mut best_cost = cell_cost;
+            let mut best_dir = Dir::ZERO;
+
+            for &(dx, dz) in &OFFSETS {
+                let nx = x + dx;
+                let nz = z + dz;
+                if let Some(ni) = Self::idx(nx, nz, toward.origin_x, toward.origin_z, toward.width)
+                {
+                    let nc = toward.cost[ni];
+                    if nc != UNREACHABLE && nc > best_cost {
+                        best_cost = nc;
+                        best_dir = Dir {
+                            dx: dx as i8,
+                            dz: dz as i8,
+                        };
+                    }
+                }
+            }
+
+            dirs[i] = best_dir;
+        }
+
+        Self {
+            origin_x: toward.origin_x,
+            origin_z: toward.origin_z,
+            width: toward.width,
+            depth: toward.depth,
+            cost: toward.cost,
+            dirs,
+        }
+    }
+
+    // -- Queries -----------------------------------------------------------
+
+    /// Get the direction to move from the given cell toward the nearest goal.
+    /// Returns `None` if the cell is out of bounds or unreachable.
+    pub fn direction(&self, x: i32, z: i32) -> Option<(i32, i32)> {
+        let i = Self::idx(x, z, self.origin_x, self.origin_z, self.width)?;
+        let d = self.dirs[i];
+        if d.is_zero() && self.cost[i] != 0 {
+            // Zero direction but not at goal = unreachable
+            return None;
+        }
+        Some((d.dx as i32, d.dz as i32))
+    }
+
+    /// Get the BFS distance from the given cell to the nearest goal.
+    /// Returns `None` if unreachable or out of bounds.
+    pub fn distance(&self, x: i32, z: i32) -> Option<u32> {
+        let i = Self::idx(x, z, self.origin_x, self.origin_z, self.width)?;
+        let c = self.cost[i];
+        if c == UNREACHABLE { None } else { Some(c) }
+    }
+
+    /// Convert the direction at `(x, z)` into a world-space target position.
+    ///
+    /// Given an entity at `(ex, ey, ez)` in f64 MC coords, returns the
+    /// center of the next cell they should walk toward, with Y set to the
+    /// grid's recorded height for that cell.
+    pub fn next_target(&self, grid: &BlockGrid, x: i32, z: i32) -> Option<[f64; 3]> {
+        let (dx, dz) = self.direction(x, z)?;
+        if dx == 0 && dz == 0 {
+            return None; // At goal
+        }
+        let nx = x + dx;
+        let nz = z + dz;
+        let cell = grid.get(nx, nz);
+        Some([nx as f64 + 0.5, cell.height as f64, nz as f64 + 0.5])
+    }
+
+    /// Check if the given position is at or adjacent to a goal (distance 0 or 1).
+    pub fn at_goal(&self, x: i32, z: i32) -> bool {
+        self.distance(x, z).is_some_and(|d| d <= 1)
+    }
+
+    // -- Internals ---------------------------------------------------------
+
+    #[inline]
+    fn idx(x: i32, z: i32, origin_x: i32, origin_z: i32, width: u32) -> Option<usize> {
+        let lx = x - origin_x;
+        let lz = z - origin_z;
+        if lx < 0 || lz < 0 || lx >= width as i32 {
+            return None;
+        }
+        let i = lz as u32 * width + lx as u32;
+        Some(i as usize)
+    }
+}

--- a/packages/rust/bevy/bevy_pathfinding/src/flow_gate.rs
+++ b/packages/rust/bevy/bevy_pathfinding/src/flow_gate.rs
@@ -1,0 +1,362 @@
+//! Layer 3: FlowGate — chokepoint / narrow passage detection.
+//!
+//! A flow gate is a set of walkable cells where the corridor width drops
+//! below a threshold, connecting wider open regions on either side. Gates
+//! are useful for:
+//!
+//! - **Ambush AI** — mobs wait at gates and attack when players pass through
+//! - **Territory control** — claim/defend gates to control map flow
+//! - **Patrol routes** — walk between gates for meaningful coverage
+//! - **Spawn placement** — avoid spawning inside narrow corridors
+//!
+//! ## Algorithm
+//!
+//! 1. **Clearance map**: For every walkable cell, compute the distance to
+//!    the nearest wall (BFS from all wall cells). This gives a "how wide
+//!    is the corridor here" value.
+//!
+//! 2. **Gate detection**: Scan for cells where clearance is at a local
+//!    minimum along one axis but connects higher-clearance regions on
+//!    both sides. These are the "bottleneck" cells.
+//!
+//! 3. **Gate clustering**: Adjacent bottleneck cells are grouped into a
+//!    single `FlowGate` with a center position, width, and orientation.
+
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+use crate::grid::BlockGrid;
+
+// ---------------------------------------------------------------------------
+// FlowGate
+// ---------------------------------------------------------------------------
+
+/// A detected chokepoint / narrow passage in the grid.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FlowGate {
+    /// Unique ID for this gate (index in the gate list).
+    pub id: u32,
+    /// Center of the gate in absolute block coords.
+    pub center_x: i32,
+    pub center_z: i32,
+    /// Approximate width of the passage in blocks.
+    pub width: u32,
+    /// Primary direction of travel through the gate: (dx, dz).
+    /// Normalized to one of the 8 compass directions.
+    pub direction: (i8, i8),
+    /// All cells that belong to this gate.
+    pub cells: Vec<(i32, i32)>,
+    /// Average clearance value at the gate cells (lower = tighter).
+    pub clearance: f32,
+}
+
+// ---------------------------------------------------------------------------
+// Clearance map
+// ---------------------------------------------------------------------------
+
+/// Compute a clearance map: for each walkable cell, the BFS distance to
+/// the nearest non-walkable cell (wall, water, out-of-bounds).
+///
+/// Wall cells get clearance 0. Walkable cells far from walls get high
+/// values. This measures "how open is this area?"
+fn compute_clearance(grid: &BlockGrid) -> Vec<u32> {
+    let n = (grid.width * grid.depth) as usize;
+    let mut clearance = vec![u32::MAX; n];
+    let mut queue = VecDeque::with_capacity(n / 4);
+
+    // Seed from all non-walkable cells and grid edges
+    for lz in 0..grid.depth {
+        for lx in 0..grid.width {
+            let x = grid.origin_x + lx as i32;
+            let z = grid.origin_z + lz as i32;
+            let i = (lz * grid.width + lx) as usize;
+
+            if !grid.is_walkable(x, z) {
+                clearance[i] = 0;
+                queue.push_back((lx, lz));
+            } else if lx == 0 || lz == 0 || lx == grid.width - 1 || lz == grid.depth - 1 {
+                // Grid edge cells adjacent to the boundary — treat as
+                // near-wall so gates aren't detected at map edges.
+                clearance[i] = 1;
+                queue.push_back((lx, lz));
+            }
+        }
+    }
+
+    // BFS outward from walls
+    static OFFSETS: [(i32, i32); 8] = [
+        (-1, -1),
+        (0, -1),
+        (1, -1),
+        (-1, 0),
+        (1, 0),
+        (-1, 1),
+        (0, 1),
+        (1, 1),
+    ];
+
+    while let Some((lx, lz)) = queue.pop_front() {
+        let ci = (lz * grid.width + lx) as usize;
+        let current = clearance[ci];
+
+        for &(dx, dz) in &OFFSETS {
+            let nx = lx as i32 + dx;
+            let nz = lz as i32 + dz;
+            if nx < 0 || nz < 0 || nx >= grid.width as i32 || nz >= grid.depth as i32 {
+                continue;
+            }
+            let ni = (nz as u32 * grid.width + nx as u32) as usize;
+            let new_c = current + 1;
+            if new_c < clearance[ni] {
+                clearance[ni] = new_c;
+                queue.push_back((nx as u32, nz as u32));
+            }
+        }
+    }
+
+    clearance
+}
+
+// ---------------------------------------------------------------------------
+// Gate detection
+// ---------------------------------------------------------------------------
+
+/// Minimum clearance threshold — cells with clearance at or below this
+/// value are candidates for being part of a gate.
+const GATE_CLEARANCE_THRESHOLD: u32 = 2;
+
+/// Minimum clearance on the "open side" of a gate — the regions connected
+/// by the gate must be at least this wide to count as meaningfully open.
+const OPEN_REGION_CLEARANCE: u32 = 4;
+
+/// Detect flow gates in the grid.
+///
+/// Returns a list of [`FlowGate`]s sorted by clearance (tightest first).
+pub fn detect_gates(grid: &BlockGrid) -> Vec<FlowGate> {
+    let clearance = compute_clearance(grid);
+    let w = grid.width;
+    let d = grid.depth;
+
+    // Find bottleneck cells: walkable cells where clearance is low AND
+    // there exist higher-clearance cells reachable on opposite sides.
+    let mut bottleneck = vec![false; clearance.len()];
+
+    for lz in 1..(d - 1) {
+        for lx in 1..(w - 1) {
+            let i = (lz * w + lx) as usize;
+            let c = clearance[i];
+
+            // Skip walls and cells that are already wide
+            if c == 0 || c > GATE_CLEARANCE_THRESHOLD {
+                continue;
+            }
+
+            let x = grid.origin_x + lx as i32;
+            let z = grid.origin_z + lz as i32;
+
+            if !grid.is_walkable(x, z) {
+                continue;
+            }
+
+            // Check if this cell connects higher-clearance regions along
+            // either the X axis or the Z axis.
+            let is_gate = check_axis_gate(&clearance, w, lx, lz, 1, 0)
+                || check_axis_gate(&clearance, w, lx, lz, 0, 1)
+                || check_axis_gate(&clearance, w, lx, lz, 1, 1)
+                || check_axis_gate(&clearance, w, lx, lz, 1, -1i32 as u32);
+
+            if is_gate {
+                bottleneck[i] = true;
+            }
+        }
+    }
+
+    // Cluster adjacent bottleneck cells into gates
+    let mut visited = vec![false; clearance.len()];
+    let mut gates = Vec::new();
+
+    for lz in 0..d {
+        for lx in 0..w {
+            let i = (lz * w + lx) as usize;
+            if !bottleneck[i] || visited[i] {
+                continue;
+            }
+
+            // Flood-fill to collect the cluster
+            let mut cluster = Vec::new();
+            let mut stack = vec![(lx, lz)];
+
+            while let Some((cx, cz)) = stack.pop() {
+                let ci = (cz * w + cx) as usize;
+                if visited[ci] || !bottleneck[ci] {
+                    continue;
+                }
+                visited[ci] = true;
+                cluster.push((grid.origin_x + cx as i32, grid.origin_z + cz as i32));
+
+                // Check 8-connected neighbors
+                for &(dx, dz) in &[
+                    (0i32, -1i32),
+                    (0, 1),
+                    (-1, 0),
+                    (1, 0),
+                    (-1, -1),
+                    (1, -1),
+                    (-1, 1),
+                    (1, 1),
+                ] {
+                    let nx = cx as i32 + dx;
+                    let nz = cz as i32 + dz;
+                    if nx >= 0 && nz >= 0 && nx < w as i32 && nz < d as i32 {
+                        stack.push((nx as u32, nz as u32));
+                    }
+                }
+            }
+
+            if cluster.is_empty() {
+                continue;
+            }
+
+            // Compute gate properties from the cluster
+            let center_x =
+                cluster.iter().map(|&(x, _)| x as f64).sum::<f64>() / cluster.len() as f64;
+            let center_z =
+                cluster.iter().map(|&(_, z)| z as f64).sum::<f64>() / cluster.len() as f64;
+
+            let avg_clearance: f32 = cluster
+                .iter()
+                .filter_map(|&(x, z)| {
+                    let lx = (x - grid.origin_x) as u32;
+                    let lz = (z - grid.origin_z) as u32;
+                    Some(clearance[(lz * w + lx) as usize] as f32)
+                })
+                .sum::<f32>()
+                / cluster.len() as f32;
+
+            // Estimate gate direction from the cluster's principal axis
+            let dir = estimate_direction(&cluster);
+
+            gates.push(FlowGate {
+                id: gates.len() as u32,
+                center_x: center_x.round() as i32,
+                center_z: center_z.round() as i32,
+                width: cluster.len() as u32,
+                direction: dir,
+                cells: cluster,
+                clearance: avg_clearance,
+            });
+        }
+    }
+
+    // Sort by clearance (tightest gates first — most strategically important)
+    gates.sort_by(|a, b| {
+        a.clearance
+            .partial_cmp(&b.clearance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Re-assign IDs after sorting
+    for (i, gate) in gates.iter_mut().enumerate() {
+        gate.id = i as u32;
+    }
+
+    gates
+}
+
+/// Check if position (lx, lz) is a gate along the axis defined by (ax, az).
+/// Returns true if cells along the axis in both directions eventually
+/// reach higher-clearance regions.
+fn check_axis_gate(clearance: &[u32], w: u32, lx: u32, lz: u32, ax: u32, az: u32) -> bool {
+    let ax = ax as i32;
+    let az = az as i32;
+    let scan_dist = OPEN_REGION_CLEARANCE as i32 + 2;
+
+    let mut found_open_pos = false;
+    let mut found_open_neg = false;
+
+    // Scan in positive direction
+    for step in 1..=scan_dist {
+        let nx = lx as i32 + ax * step;
+        let nz = lz as i32 + az * step;
+        if nx < 0 || nz < 0 || nx >= w as i32 || nz >= (clearance.len() as u32 / w) as i32 {
+            break;
+        }
+        let ni = (nz as u32 * w + nx as u32) as usize;
+        if clearance[ni] == 0 {
+            break; // Hit a wall
+        }
+        if clearance[ni] >= OPEN_REGION_CLEARANCE {
+            found_open_pos = true;
+            break;
+        }
+    }
+
+    // Scan in negative direction
+    for step in 1..=scan_dist {
+        let nx = lx as i32 - ax * step;
+        let nz = lz as i32 - az * step;
+        if nx < 0 || nz < 0 || nx >= w as i32 || nz >= (clearance.len() as u32 / w) as i32 {
+            break;
+        }
+        let ni = (nz as u32 * w + nx as u32) as usize;
+        if clearance[ni] == 0 {
+            break;
+        }
+        if clearance[ni] >= OPEN_REGION_CLEARANCE {
+            found_open_neg = true;
+            break;
+        }
+    }
+
+    found_open_pos && found_open_neg
+}
+
+/// Estimate the primary direction of travel through a gate cluster.
+/// Uses the principal axis of the cluster's bounding box.
+fn estimate_direction(cells: &[(i32, i32)]) -> (i8, i8) {
+    if cells.len() < 2 {
+        return (1, 0);
+    }
+
+    let min_x = cells.iter().map(|c| c.0).min().unwrap();
+    let max_x = cells.iter().map(|c| c.0).max().unwrap();
+    let min_z = cells.iter().map(|c| c.1).min().unwrap();
+    let max_z = cells.iter().map(|c| c.1).max().unwrap();
+
+    let dx = max_x - min_x;
+    let dz = max_z - min_z;
+
+    // The gate's "width" spans perpendicular to the travel direction.
+    // If the cluster is wider in X, travel is along Z (and vice versa).
+    if dx >= dz {
+        (0, 1) // Gate spans X → travel direction is Z
+    } else {
+        (1, 0) // Gate spans Z → travel direction is X
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: find nearest gate to a position
+// ---------------------------------------------------------------------------
+
+/// Find the nearest flow gate to a given block position.
+pub fn nearest_gate(gates: &[FlowGate], x: i32, z: i32) -> Option<&FlowGate> {
+    gates.iter().min_by_key(|g| {
+        let dx = (g.center_x - x) as i64;
+        let dz = (g.center_z - z) as i64;
+        dx * dx + dz * dz
+    })
+}
+
+/// Find all flow gates within a radius of a given position.
+pub fn gates_in_radius(gates: &[FlowGate], x: i32, z: i32, radius: i32) -> Vec<&FlowGate> {
+    let r2 = (radius as i64) * (radius as i64);
+    gates
+        .iter()
+        .filter(|g| {
+            let dx = (g.center_x - x) as i64;
+            let dz = (g.center_z - z) as i64;
+            dx * dx + dz * dz <= r2
+        })
+        .collect()
+}

--- a/packages/rust/bevy/bevy_pathfinding/src/grid.rs
+++ b/packages/rust/bevy/bevy_pathfinding/src/grid.rs
@@ -1,0 +1,292 @@
+//! Layer 1: BlockGrid — 2D walkability grid from Minecraft block data.
+//!
+//! The Java side scans a region around each player and sends a flattened
+//! heightmap + walkability snapshot. The grid stores one [`CellNav`] per
+//! (x, z) tile in the region, ignoring the full 3D column — ground-based
+//! mobs only care about the surface they walk on.
+//!
+//! Coordinates are absolute Minecraft block coords (i32). The grid covers
+//! a rectangular region from `(origin_x, origin_z)` to
+//! `(origin_x + width - 1, origin_z + depth - 1)`.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Terrain classification
+// ---------------------------------------------------------------------------
+
+/// Simplified block surface classification for pathfinding cost.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum SurfaceKind {
+    /// Impassable (water, lava, void, out of bounds).
+    Blocked = 0,
+    /// Normal solid ground (stone, dirt, grass, wood, etc.).
+    Solid = 1,
+    /// Slow terrain (soul sand, honey, cobweb-adjacent).
+    Slow = 2,
+    /// Dangerous but walkable (magma, cactus-adjacent, fire-adjacent).
+    Hazard = 3,
+}
+
+impl SurfaceKind {
+    /// Base traversal cost for entering a cell with this surface.
+    pub fn base_cost(self) -> f32 {
+        match self {
+            Self::Blocked => f32::MAX,
+            Self::Solid => 1.0,
+            Self::Slow => 2.5,
+            Self::Hazard => 4.0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-cell navigation data
+// ---------------------------------------------------------------------------
+
+/// Navigation data for one (x, z) cell in the grid.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct CellNav {
+    /// Y coordinate of the walkable surface (feet level).
+    pub height: i32,
+    /// Surface classification.
+    pub surface: SurfaceKind,
+    /// Traversal cost (surface base cost, possibly modified by neighbors).
+    pub cost: f32,
+}
+
+impl Default for CellNav {
+    fn default() -> Self {
+        Self {
+            height: 0,
+            surface: SurfaceKind::Blocked,
+            cost: f32::MAX,
+        }
+    }
+}
+
+impl CellNav {
+    #[inline]
+    pub fn walkable(&self) -> bool {
+        self.surface != SurfaceKind::Blocked
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BlockGrid
+// ---------------------------------------------------------------------------
+
+/// 2D walkability grid covering a rectangular region of the Minecraft world.
+///
+/// Internally a flat `Vec<CellNav>` in row-major order (z-major):
+/// index = `(z - origin_z) * width + (x - origin_x)`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "bevy", derive(bevy::prelude::Resource))]
+pub struct BlockGrid {
+    /// Minimum X block coordinate of the grid.
+    pub origin_x: i32,
+    /// Minimum Z block coordinate of the grid.
+    pub origin_z: i32,
+    /// Number of cells along the X axis.
+    pub width: u32,
+    /// Number of cells along the Z axis.
+    pub depth: u32,
+    /// Flat cell array, row-major (z-major).
+    cells: Vec<CellNav>,
+}
+
+/// Maximum step height a mob can walk up between adjacent cells.
+pub const MAX_STEP_HEIGHT: i32 = 1;
+
+impl BlockGrid {
+    /// Create an empty grid (all cells Blocked) covering the given region.
+    pub fn new(origin_x: i32, origin_z: i32, width: u32, depth: u32) -> Self {
+        Self {
+            origin_x,
+            origin_z,
+            width,
+            depth,
+            cells: vec![CellNav::default(); (width * depth) as usize],
+        }
+    }
+
+    /// Build a grid from a flat array of cell data sent by Java.
+    ///
+    /// `cells` must have exactly `width * depth` elements in row-major
+    /// (z-major) order. Returns `None` if the length doesn't match.
+    pub fn from_cells(
+        origin_x: i32,
+        origin_z: i32,
+        width: u32,
+        depth: u32,
+        cells: Vec<CellNav>,
+    ) -> Option<Self> {
+        if cells.len() != (width * depth) as usize {
+            return None;
+        }
+        Some(Self {
+            origin_x,
+            origin_z,
+            width,
+            depth,
+            cells,
+        })
+    }
+
+    // -- Indexing -----------------------------------------------------------
+
+    /// Convert absolute block coords to a flat index, or `None` if out of
+    /// bounds.
+    #[inline]
+    fn index(&self, x: i32, z: i32) -> Option<usize> {
+        let lx = x - self.origin_x;
+        let lz = z - self.origin_z;
+        if lx < 0 || lz < 0 || lx >= self.width as i32 || lz >= self.depth as i32 {
+            return None;
+        }
+        Some((lz as u32 * self.width + lx as u32) as usize)
+    }
+
+    /// Get cell nav data at absolute block coords.
+    #[inline]
+    pub fn get(&self, x: i32, z: i32) -> CellNav {
+        self.index(x, z).map(|i| self.cells[i]).unwrap_or_default()
+    }
+
+    /// Set cell nav data at absolute block coords. No-op if out of bounds.
+    #[inline]
+    pub fn set(&mut self, x: i32, z: i32, cell: CellNav) {
+        if let Some(i) = self.index(x, z) {
+            self.cells[i] = cell;
+        }
+    }
+
+    /// Is the cell walkable?
+    #[inline]
+    pub fn is_walkable(&self, x: i32, z: i32) -> bool {
+        self.get(x, z).walkable()
+    }
+
+    /// Traversal cost at the given cell.
+    #[inline]
+    pub fn cost(&self, x: i32, z: i32) -> f32 {
+        self.get(x, z).cost
+    }
+
+    /// Return walkable 8-connected neighbors where the height delta is
+    /// within `MAX_STEP_HEIGHT`.
+    pub fn walkable_neighbors(&self, x: i32, z: i32) -> Vec<(i32, i32)> {
+        let center = self.get(x, z);
+        if !center.walkable() {
+            return Vec::new();
+        }
+
+        static OFFSETS: [(i32, i32); 8] = [
+            (-1, -1),
+            (0, -1),
+            (1, -1),
+            (-1, 0),
+            (1, 0),
+            (-1, 1),
+            (0, 1),
+            (1, 1),
+        ];
+
+        let mut result = Vec::with_capacity(8);
+        for &(dx, dz) in &OFFSETS {
+            let nx = x + dx;
+            let nz = z + dz;
+            let n = self.get(nx, nz);
+            if n.walkable() && (n.height - center.height).abs() <= MAX_STEP_HEIGHT {
+                result.push((nx, nz));
+            }
+        }
+        result
+    }
+
+    /// Total number of cells in the grid.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.cells.len()
+    }
+
+    /// Whether the grid is empty (zero-area).
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.cells.is_empty()
+    }
+
+    /// Iterate all cells with their absolute (x, z) coordinates.
+    pub fn iter(&self) -> impl Iterator<Item = (i32, i32, &CellNav)> {
+        self.cells.iter().enumerate().map(move |(i, cell)| {
+            let lx = (i as u32) % self.width;
+            let lz = (i as u32) / self.width;
+            (self.origin_x + lx as i32, self.origin_z + lz as i32, cell)
+        })
+    }
+
+    /// Check if the given coordinate is within the grid bounds.
+    #[inline]
+    pub fn in_bounds(&self, x: i32, z: i32) -> bool {
+        self.index(x, z).is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MapRegionSnapshot — the JSON payload Java sends via JNI
+// ---------------------------------------------------------------------------
+
+/// Snapshot of a rectangular region of the Minecraft world, sent from Java
+/// to Rust periodically (every few seconds, not every tick).
+///
+/// Java scans the surface around each player and packs the walkability
+/// data into this struct. Rust deserializes it and builds a [`BlockGrid`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MapRegionSnapshot {
+    /// Minimum X block coordinate of the scanned region.
+    pub origin_x: i32,
+    /// Minimum Z block coordinate of the scanned region.
+    pub origin_z: i32,
+    /// Number of cells along the X axis.
+    pub width: u32,
+    /// Number of cells along the Z axis.
+    pub depth: u32,
+    /// Flat array of per-cell data, row-major (z-major).
+    /// Each entry: `[height_y, surface_kind]` where surface_kind is the
+    /// `SurfaceKind` discriminant (0=Blocked, 1=Solid, 2=Slow, 3=Hazard).
+    pub cells: Vec<[i32; 2]>,
+    /// Server tick at which this snapshot was taken.
+    pub tick: u64,
+}
+
+impl MapRegionSnapshot {
+    /// Convert this snapshot into a [`BlockGrid`]. Returns `None` if the
+    /// cell count doesn't match `width * depth`.
+    pub fn into_grid(self) -> Option<BlockGrid> {
+        let expected = (self.width * self.depth) as usize;
+        if self.cells.len() != expected {
+            return None;
+        }
+
+        let cells: Vec<CellNav> = self
+            .cells
+            .iter()
+            .map(|&[height, kind]| {
+                let surface = match kind {
+                    1 => SurfaceKind::Solid,
+                    2 => SurfaceKind::Slow,
+                    3 => SurfaceKind::Hazard,
+                    _ => SurfaceKind::Blocked,
+                };
+                CellNav {
+                    height,
+                    surface,
+                    cost: surface.base_cost(),
+                }
+            })
+            .collect();
+
+        BlockGrid::from_cells(self.origin_x, self.origin_z, self.width, self.depth, cells)
+    }
+}

--- a/packages/rust/bevy/bevy_pathfinding/src/lib.rs
+++ b/packages/rust/bevy/bevy_pathfinding/src/lib.rs
@@ -1,0 +1,23 @@
+//! Grid-based flow field pathfinding and chokepoint detection.
+//!
+//! Three layers:
+//!
+//! 1. **`BlockGrid`** — 2D walkability grid built from Minecraft block
+//!    snapshots (or any tile-based world). Each cell stores height,
+//!    walkability, and a terrain cost.
+//!
+//! 2. **`FlowField`** — BFS-computed direction vectors pointing every
+//!    walkable cell toward one or more goal positions. All agents sharing
+//!    a goal look up their next move in O(1) instead of running per-agent A*.
+//!
+//! 3. **`FlowGate`** — narrow passage / chokepoint detector. Identifies
+//!    cells where the corridor width drops below a threshold, connecting
+//!    wider regions. Useful for ambush AI, territory control, and patrol
+//!    route generation.
+//!
+//! The crate is pure Rust by default. Enable the `bevy` feature to get
+//! `Resource` derives for ECS integration.
+
+pub mod flow_field;
+pub mod flow_gate;
+pub mod grid;


### PR DESCRIPTION
## Summary
- New shared crate `bevy_pathfinding` with BlockGrid (2D walkability), FlowField (BFS direction vectors), and FlowGate (chokepoint detection)
- Wired into `behavior_statetree` via new `submitMapData` JNI endpoint — Java sends terrain snapshots, Rust computes flow fields + gates
- Skeleton AI now uses terrain-aware approach/flee/ambush with blind wander as fallback

## Details

### `bevy_pathfinding` crate (`packages/rust/bevy/bevy_pathfinding/`)
- Pure Rust, zero Bevy deps by default (optional `bevy` feature for Resource derives)
- `BlockGrid`: 2D walkability grid from MC block data via `MapRegionSnapshot` JSON
- `FlowField::compute()`: Multi-goal BFS, O(1) per-creature direction lookups
- `FlowField::compute_flee()`: Escape routing away from danger sources
- `FlowGate`: Clearance map + chokepoint detection for tactical AI

### `behavior_statetree` changes
- New JNI endpoint `submitMapData(json)` for Java to push terrain snapshots
- ECS resources: `CurrentBlockGrid`, `PlayerFlowFields`, `FleeFlowField`, `DetectedFlowGates`
- Throttled rebuild system (~3s interval) recomputes flow fields + gates
- `FlowFieldHint` injected per-NPC before behavior tree evaluation
- New behavior nodes: `FlowApproach`, `FlowFlee`, `PatrolGate`, `HasFlowField`, `PlayerWithinFlowDistance`, `HasNearbyGates`
- Updated skeleton behavior tree: flow-aware approach (priority 4), gate patrol (priority 5), blind wander (fallback)

## Test plan
- [x] `cargo check -p bevy_pathfinding` — clean
- [x] `cargo check -p bevy_pathfinding --features bevy` — clean
- [x] `cargo check -p behavior_statetree` — clean
- [ ] Java-side: implement `NativeRuntime.submitMapData(json)` surface scan + verify NPC movement in-game