### PR TITLE
feat(mc): restore MC edge functions for lobby and survival servers

### DIFF
--- a/apps/kbve/edge/functions/mc/_shared.ts
+++ b/apps/kbve/edge/functions/mc/_shared.ts
@@ -1,0 +1,56 @@
+// Re-export all shared utilities from the centralized module
+export {
+  createServiceClient,
+  createUserClient,
+  extractToken,
+  jsonResponse,
+  type JwtClaims,
+  parseJwt,
+  requireServiceRole,
+  requireUserToken,
+} from "../_shared/supabase.ts";
+
+import { jsonResponse } from "../_shared/supabase.ts";
+
+// MC-specific request type
+export interface McRequest {
+  token: string;
+  claims: import("../_shared/supabase.ts").JwtClaims;
+  body: Record<string, unknown>;
+  action: string;
+}
+
+// MC UUID format: 32 lowercase hex characters (no dashes), matches SQL CHECK
+const MC_UUID_RE = /^[a-f0-9]{32}$/;
+
+export function isValidMcUuid(uuid: unknown): boolean {
+  return typeof uuid === "string" && MC_UUID_RE.test(uuid);
+}
+
+export function validateMcUuid(
+  uuid: unknown,
+  field = "mc_uuid",
+): Response | null {
+  if (!uuid || typeof uuid !== "string") {
+    return jsonResponse({ error: `${field} is required` }, 400);
+  }
+  // Accept dashed UUIDs (normalize by stripping dashes)
+  const clean = uuid.replace(/-/g, "").toLowerCase();
+  if (!MC_UUID_RE.test(clean)) {
+    return jsonResponse(
+      { error: `${field} must be a valid Minecraft UUID (32 hex chars)` },
+      400,
+    );
+  }
+  return null;
+}
+
+export function requireNonEmpty(
+  value: unknown,
+  field: string,
+): Response | null {
+  if (!value || (typeof value === "string" && value.trim() === "")) {
+    return jsonResponse({ error: `${field} is required` }, 400);
+  }
+  return null;
+}

--- a/apps/kbve/edge/functions/mc/auth.ts
+++ b/apps/kbve/edge/functions/mc/auth.ts
@@ -1,0 +1,157 @@
+import {
+  createServiceClient,
+  createUserClient,
+  jsonResponse,
+  type McRequest,
+  requireServiceRole,
+  requireUserToken,
+  validateMcUuid,
+} from "./_shared.ts";
+import { safeRpcError } from "../_shared/validators.ts";
+
+// ---------------------------------------------------------------------------
+// MC Auth Module
+//
+// Actions:
+//   request_link  — Authenticated user requests MC account link (returns 6-digit code)
+//   verify        — MC server (service_role) verifies a player's code
+//   status        — Authenticated user checks their link status
+//   lookup        — MC server (service_role) looks up a user by MC UUID
+//   unlink        — Authenticated user unlinks their MC account
+// ---------------------------------------------------------------------------
+
+type Handler = (mcReq: McRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+  async request_link({ claims, token, body }) {
+    const denied = requireUserToken(claims);
+    if (denied) return denied;
+
+    const { mc_uuid } = body;
+    const uuidErr = validateMcUuid(mc_uuid, "mc_uuid");
+    if (uuidErr) return uuidErr;
+
+    const supabase = createUserClient(token);
+    const { data, error } = await supabase.rpc("proxy_request_link", {
+      p_mc_uuid: mc_uuid as string,
+    });
+
+    if (error) {
+      return safeRpcError(error, "proxy_request_link");
+    }
+
+    return jsonResponse({ success: true, verification_code: data });
+  },
+
+  async verify({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { mc_uuid, code } = body;
+    const uuidErr = validateMcUuid(mc_uuid, "mc_uuid");
+    if (uuidErr) return uuidErr;
+
+    const numCode = Number(code);
+    if (
+      code === undefined ||
+      !Number.isFinite(numCode) ||
+      !Number.isInteger(numCode)
+    ) {
+      return jsonResponse({ error: "code must be an integer" }, 400);
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_verify_link", {
+      p_mc_uuid: mc_uuid as string,
+      p_code: numCode,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_verify_link");
+    }
+
+    if (data) {
+      return jsonResponse({ success: true, user_id: data });
+    }
+    return jsonResponse({
+      success: false,
+      error: "Verification failed (invalid code, expired, or locked)",
+    });
+  },
+
+  async status({ claims, token }) {
+    const denied = requireUserToken(claims);
+    if (denied) return denied;
+
+    const supabase = createUserClient(token);
+    const { data, error } = await supabase.rpc("proxy_get_link_status");
+
+    if (error) {
+      return safeRpcError(error, "proxy_get_link_status");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse({ found: false });
+    }
+
+    const link = Array.isArray(data) ? data[0] : data;
+    return jsonResponse({ found: true, link });
+  },
+
+  async lookup({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { mc_uuid } = body;
+    const uuidErr = validateMcUuid(mc_uuid, "mc_uuid");
+    if (uuidErr) return uuidErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc(
+      "service_get_user_by_mc_uuid",
+      { p_mc_uuid: mc_uuid as string },
+    );
+
+    if (error) {
+      return safeRpcError(error, "service_get_user_by_mc_uuid");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse({ found: false });
+    }
+
+    const link = Array.isArray(data) ? data[0] : data;
+    return jsonResponse({ found: true, link });
+  },
+
+  async unlink({ claims, token }) {
+    const denied = requireUserToken(claims);
+    if (denied) return denied;
+
+    const supabase = createUserClient(token);
+    const { data, error } = await supabase.rpc("proxy_unlink");
+
+    if (error) {
+      return safeRpcError(error, "proxy_unlink");
+    }
+
+    return jsonResponse({ success: true, was_linked: data });
+  },
+};
+
+export const AUTH_ACTIONS = Object.keys(handlers);
+
+export async function handleAuth(mcReq: McRequest): Promise<Response> {
+  const handler = handlers[mcReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown auth action: ${mcReq.action}. Use: ${
+          AUTH_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(mcReq);
+}

--- a/apps/kbve/edge/functions/mc/character.ts
+++ b/apps/kbve/edge/functions/mc/character.ts
@@ -1,0 +1,186 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  type McRequest,
+  requireNonEmpty,
+  requireServiceRole,
+  validateMcUuid,
+} from "./_shared.ts";
+import { safeRpcError } from "../_shared/validators.ts";
+
+// ---------------------------------------------------------------------------
+// MC Character Module — DND-style RPG character system
+//
+// Actions:
+//   save    — MC server persists a full character sheet
+//   load    — MC server loads a character by player_uuid + server_id
+//   add_xp  — MC server atomically adds XP and auto-levels
+// ---------------------------------------------------------------------------
+
+type Handler = (mcReq: McRequest) => Promise<Response>;
+
+// Edge-level stat validation (belt & suspenders with SQL constraints)
+function validateStats(stats: Record<string, unknown>): string | null {
+  const STAT_NAMES = [
+    "strength",
+    "dexterity",
+    "constitution",
+    "intelligence",
+    "wisdom",
+    "charisma",
+  ];
+  for (const name of STAT_NAMES) {
+    const val = stats[name];
+    if (val !== undefined && val !== null) {
+      const num = Number(val);
+      if (!Number.isInteger(num) || num < 1 || num > 999) {
+        return `${name} must be an integer between 1 and 999`;
+      }
+    }
+  }
+  return null;
+}
+
+const handlers: Record<string, Handler> = {
+  async save({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { character } = body;
+    if (!character || typeof character !== "object") {
+      return jsonResponse({ error: "character object is required" }, 400);
+    }
+
+    const char = character as Record<string, unknown>;
+    const uuidErr = validateMcUuid(char.player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(char.server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    // Edge-level stat validation
+    if (char.base_stats && typeof char.base_stats === "object") {
+      const statErr = validateStats(
+        char.base_stats as Record<string, unknown>,
+      );
+      if (statErr) {
+        return jsonResponse({ error: statErr }, 400);
+      }
+    }
+
+    // Edge-level XP validation
+    if (char.experience !== undefined) {
+      const xp = Number(char.experience);
+      if (!Number.isFinite(xp) || xp < 0) {
+        return jsonResponse(
+          { error: "experience must be a non-negative number" },
+          400,
+        );
+      }
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_save_character", {
+      p_character: character,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_save_character");
+    }
+
+    return jsonResponse({ success: true, player_uuid: data });
+  },
+
+  async load({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { player_uuid, server_id } = body;
+    const uuidErr = validateMcUuid(player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_load_character", {
+      p_player_uuid: player_uuid as string,
+      p_server_id: server_id as string,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_load_character");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse({ found: false });
+    }
+
+    const character = Array.isArray(data) ? data[0] : data;
+    return jsonResponse({ found: true, character });
+  },
+
+  async add_xp({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { player_uuid, server_id, xp_amount } = body;
+    const uuidErr = validateMcUuid(player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    // Edge-level XP validation
+    const xp = Number(xp_amount);
+    if (!Number.isFinite(xp) || !Number.isInteger(xp) || xp <= 0) {
+      return jsonResponse(
+        { error: "xp_amount must be a positive integer" },
+        400,
+      );
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_add_experience", {
+      p_player_uuid: player_uuid as string,
+      p_server_id: server_id as string,
+      p_xp_amount: xp,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_add_experience");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse(
+        { success: false, error: "Character operation failed" },
+        400,
+      );
+    }
+
+    const result = Array.isArray(data) ? data[0] : data;
+    return jsonResponse({
+      success: true,
+      new_level: result.new_level,
+      total_experience: result.total_experience,
+      leveled_up: result.leveled_up,
+    });
+  },
+};
+
+export const CHARACTER_ACTIONS = Object.keys(handlers);
+
+export async function handleCharacter(mcReq: McRequest): Promise<Response> {
+  const handler = handlers[mcReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown character action: ${mcReq.action}. Use: ${
+          CHARACTER_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(mcReq);
+}

--- a/apps/kbve/edge/functions/mc/container.ts
+++ b/apps/kbve/edge/functions/mc/container.ts
@@ -1,0 +1,106 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  type McRequest,
+  requireNonEmpty,
+  requireServiceRole,
+} from "./_shared.ts";
+import { safeRpcError } from "../_shared/validators.ts";
+
+// ---------------------------------------------------------------------------
+// MC Container Module
+//
+// Actions:
+//   save  — MC server persists container state (chests, barrels, etc.)
+//   load  — MC server loads container state by ID + server
+// ---------------------------------------------------------------------------
+
+type Handler = (mcReq: McRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+  async save({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { container, server_id } = body;
+    if (!container || typeof container !== "object") {
+      return jsonResponse({ error: "container object is required" }, 400);
+    }
+
+    const serverErr = requireNonEmpty(server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    const c = container as Record<string, unknown>;
+    const cidErr = requireNonEmpty(c.container_id, "container_id");
+    if (cidErr) return cidErr;
+
+    // Validate container_type range if provided
+    if (c.type !== undefined) {
+      const t = Number(c.type);
+      if (!Number.isInteger(t) || t < 0 || t > 13) {
+        return jsonResponse(
+          { error: "container type must be 0-13" },
+          400,
+        );
+      }
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_save_container", {
+      p_container: container,
+      p_server_id: server_id as string,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_save_container");
+    }
+
+    return jsonResponse({ success: true, container_id: data });
+  },
+
+  async load({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { container_id, server_id } = body;
+    const cidErr = requireNonEmpty(container_id, "container_id");
+    if (cidErr) return cidErr;
+
+    const serverErr = requireNonEmpty(server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_load_container", {
+      p_container_id: container_id as string,
+      p_server_id: server_id as string,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_load_container");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse({ found: false });
+    }
+
+    const container = Array.isArray(data) ? data[0] : data;
+    return jsonResponse({ found: true, container });
+  },
+};
+
+export const CONTAINER_ACTIONS = Object.keys(handlers);
+
+export async function handleContainer(mcReq: McRequest): Promise<Response> {
+  const handler = handlers[mcReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown container action: ${mcReq.action}. Use: ${
+          CONTAINER_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(mcReq);
+}

--- a/apps/kbve/edge/functions/mc/index.ts
+++ b/apps/kbve/edge/functions/mc/index.ts
@@ -1,0 +1,119 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import { requireJsonContentType, enforceBodySizeLimit } from "../_shared/validators.ts";
+import { extractToken, jsonResponse, parseJwt } from "./_shared.ts";
+import { AUTH_ACTIONS, handleAuth } from "./auth.ts";
+import { handlePlayer, PLAYER_ACTIONS } from "./player.ts";
+import { CONTAINER_ACTIONS, handleContainer } from "./container.ts";
+import { handleTransfer, TRANSFER_ACTIONS } from "./transfer.ts";
+import { CHARACTER_ACTIONS, handleCharacter } from "./character.ts";
+import { handleSkill, SKILL_ACTIONS } from "./skill.ts";
+
+// ---------------------------------------------------------------------------
+// MC Edge Function — Unified Router
+//
+// Command format: "module.action"
+//   auth:      request_link, verify, status, lookup, unlink
+//   player:    save, load
+//   container: save, load
+//   transfer:  record, history
+//   character: save, load, add_xp
+//   skill:     save, load, add_xp
+// ---------------------------------------------------------------------------
+
+const MODULES: Record<
+  string,
+  {
+    handler: (mcReq: import("./_shared.ts").McRequest) => Promise<Response>;
+    actions: string[];
+  }
+> = {
+  auth: { handler: handleAuth, actions: AUTH_ACTIONS },
+  player: { handler: handlePlayer, actions: PLAYER_ACTIONS },
+  container: { handler: handleContainer, actions: CONTAINER_ACTIONS },
+  transfer: { handler: handleTransfer, actions: TRANSFER_ACTIONS },
+  character: { handler: handleCharacter, actions: CHARACTER_ACTIONS },
+  skill: { handler: handleSkill, actions: SKILL_ACTIONS },
+};
+
+function buildHelpText(): string {
+  const commands: string[] = [];
+  for (const [mod, { actions }] of Object.entries(MODULES)) {
+    for (const action of actions) {
+      commands.push(`${mod}.${action}`);
+    }
+  }
+  return commands.join(", ");
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+  }
+
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+
+  try {
+    const token = extractToken(req);
+    const claims = await parseJwt(token);
+    const sizeErr = enforceBodySizeLimit(req);
+    if (sizeErr) return sizeErr;
+
+    const body = await req.json();
+    const { command } = body;
+
+    if (!command || typeof command !== "string") {
+      return jsonResponse(
+        {
+          error:
+            `command is required (format: "module.action"). Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const dotIndex = command.indexOf(".");
+    if (dotIndex === -1) {
+      return jsonResponse(
+        {
+          error:
+            `Invalid command format. Use "module.action" (e.g. "auth.request_link"). Available: ${buildHelpText()}`,
+        },
+        400,
+      );
+    }
+
+    const moduleName = command.slice(0, dotIndex);
+    const action = command.slice(dotIndex + 1);
+
+    const mod = MODULES[moduleName];
+    if (!mod) {
+      return jsonResponse(
+        {
+          error: `Unknown module: ${moduleName}. Available modules: ${
+            Object.keys(MODULES).join(", ")
+          }`,
+        },
+        400,
+      );
+    }
+
+    return mod.handler({ token, claims, body, action });
+  } catch (err) {
+    console.error("mc error:", err);
+    const rawMessage = err instanceof Error
+      ? err.message
+      : "Internal server error";
+    const isAuthError =
+      rawMessage.includes("authorization") || rawMessage.includes("JWT");
+    if (isAuthError) {
+      return jsonResponse({ error: rawMessage }, 401);
+    }
+    return jsonResponse({ error: "Internal server error" }, 500);
+  }
+});

--- a/apps/kbve/edge/functions/mc/player.ts
+++ b/apps/kbve/edge/functions/mc/player.ts
@@ -1,0 +1,95 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  type McRequest,
+  requireNonEmpty,
+  requireServiceRole,
+  validateMcUuid,
+} from "./_shared.ts";
+import { safeRpcError } from "../_shared/validators.ts";
+
+// ---------------------------------------------------------------------------
+// MC Player Module
+//
+// Actions:
+//   save  — MC server persists a full player snapshot
+//   load  — MC server loads a player snapshot by UUID + server
+// ---------------------------------------------------------------------------
+
+type Handler = (mcReq: McRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+  async save({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { snapshot } = body;
+    if (!snapshot || typeof snapshot !== "object") {
+      return jsonResponse({ error: "snapshot object is required" }, 400);
+    }
+
+    const snap = snapshot as Record<string, unknown>;
+    const uuidErr = validateMcUuid(snap.player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(snap.server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_save_player", {
+      p_snapshot: snapshot,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_save_player");
+    }
+
+    return jsonResponse({ success: true, player_uuid: data });
+  },
+
+  async load({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { player_uuid, server_id } = body;
+    const uuidErr = validateMcUuid(player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_load_player", {
+      p_player_uuid: player_uuid as string,
+      p_server_id: server_id as string,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_load_player");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse({ found: false });
+    }
+
+    const snapshot = Array.isArray(data) ? data[0] : data;
+    return jsonResponse({ found: true, snapshot });
+  },
+};
+
+export const PLAYER_ACTIONS = Object.keys(handlers);
+
+export async function handlePlayer(mcReq: McRequest): Promise<Response> {
+  const handler = handlers[mcReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown player action: ${mcReq.action}. Use: ${
+          PLAYER_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(mcReq);
+}

--- a/apps/kbve/edge/functions/mc/skill.ts
+++ b/apps/kbve/edge/functions/mc/skill.ts
@@ -1,0 +1,227 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  type McRequest,
+  requireNonEmpty,
+  requireServiceRole,
+  validateMcUuid,
+} from "./_shared.ts";
+import { safeRpcError } from "../_shared/validators.ts";
+
+// ---------------------------------------------------------------------------
+// MC Skill Module — Per-skill progression (skill tree)
+//
+// Actions:
+//   save    — MC server persists a full skill tree (bulk upsert)
+//   load    — MC server loads all skills for a player on a server
+//   add_xp  — MC server atomically adds XP to a specific skill
+// ---------------------------------------------------------------------------
+
+type Handler = (mcReq: McRequest) => Promise<Response>;
+
+// Valid skill categories (McSkillCategory enum)
+const VALID_CATEGORIES = [0, 1, 2, 3, 4];
+
+// Edge-level skill_id format validation
+function isValidSkillId(id: unknown): boolean {
+  return (
+    typeof id === "string" &&
+    id.length >= 1 &&
+    id.length <= 64 &&
+    /^[a-z0-9_]+$/.test(id)
+  );
+}
+
+const handlers: Record<string, Handler> = {
+  async save({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { skill_tree } = body;
+    if (!skill_tree || typeof skill_tree !== "object") {
+      return jsonResponse(
+        { error: "skill_tree object is required" },
+        400,
+      );
+    }
+
+    const tree = skill_tree as Record<string, unknown>;
+    const uuidErr = validateMcUuid(tree.player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(tree.server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    // Edge-level skills array validation
+    const skills = tree.skills;
+    if (!Array.isArray(skills)) {
+      return jsonResponse({ error: "skills must be an array" }, 400);
+    }
+
+    if (skills.length > 200) {
+      return jsonResponse(
+        { error: "Skill tree exceeds limit of 200 skills" },
+        400,
+      );
+    }
+
+    for (const skill of skills) {
+      const s = skill as Record<string, unknown>;
+      if (!isValidSkillId(s.skill_id)) {
+        return jsonResponse(
+          {
+            error:
+              `Invalid skill_id: ${s.skill_id}. Must be 1-64 lowercase alphanumeric/underscores.`,
+          },
+          400,
+        );
+      }
+      if (
+        s.category !== undefined &&
+        !VALID_CATEGORIES.includes(Number(s.category))
+      ) {
+        return jsonResponse(
+          {
+            error: `Invalid category for skill ${s.skill_id}. Must be 0-4.`,
+          },
+          400,
+        );
+      }
+      if (s.experience !== undefined) {
+        const xp = Number(s.experience);
+        if (!Number.isFinite(xp) || xp < 0) {
+          return jsonResponse(
+            {
+              error: `experience for skill ${s.skill_id} must be non-negative`,
+            },
+            400,
+          );
+        }
+      }
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_save_skill_tree", {
+      p_skill_tree: skill_tree,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_save_skill_tree");
+    }
+
+    return jsonResponse({ success: true, skills_saved: data });
+  },
+
+  async load({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { player_uuid, server_id } = body;
+    const uuidErr = validateMcUuid(player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_load_skill_tree", {
+      p_player_uuid: player_uuid as string,
+      p_server_id: server_id as string,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_load_skill_tree");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse({ found: false, skills: [] });
+    }
+
+    const skills = Array.isArray(data) ? data : [data];
+    return jsonResponse({ found: true, skills });
+  },
+
+  async add_xp({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { player_uuid, server_id, skill_id, category, xp_amount } = body;
+
+    const uuidErr = validateMcUuid(player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    const serverErr = requireNonEmpty(server_id, "server_id");
+    if (serverErr) return serverErr;
+
+    if (!isValidSkillId(skill_id)) {
+      return jsonResponse(
+        {
+          error:
+            "skill_id is required and must be 1-64 lowercase alphanumeric/underscores",
+        },
+        400,
+      );
+    }
+
+    if (
+      category !== undefined &&
+      !VALID_CATEGORIES.includes(Number(category))
+    ) {
+      return jsonResponse({ error: "category must be 0-4" }, 400);
+    }
+
+    const xp = Number(xp_amount);
+    if (!Number.isFinite(xp) || !Number.isInteger(xp) || xp <= 0) {
+      return jsonResponse(
+        { error: "xp_amount must be a positive integer" },
+        400,
+      );
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_add_skill_xp", {
+      p_player_uuid: player_uuid as string,
+      p_server_id: server_id as string,
+      p_skill_id: skill_id as string,
+      p_category: Number(category) || 0,
+      p_xp_amount: xp,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_add_skill_xp");
+    }
+
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      return jsonResponse(
+        { success: false, error: "Skill XP operation failed" },
+        400,
+      );
+    }
+
+    const result = Array.isArray(data) ? data[0] : data;
+    return jsonResponse({
+      success: true,
+      skill_id,
+      new_level: result.new_level,
+      total_experience: result.total_experience,
+      leveled_up: result.leveled_up,
+    });
+  },
+};
+
+export const SKILL_ACTIONS = Object.keys(handlers);
+
+export async function handleSkill(mcReq: McRequest): Promise<Response> {
+  const handler = handlers[mcReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown skill action: ${mcReq.action}. Use: ${
+          SKILL_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(mcReq);
+}

--- a/apps/kbve/edge/functions/mc/transfer.ts
+++ b/apps/kbve/edge/functions/mc/transfer.ts
@@ -1,0 +1,104 @@
+import {
+  createServiceClient,
+  jsonResponse,
+  type McRequest,
+  requireServiceRole,
+  validateMcUuid,
+} from "./_shared.ts";
+import { safeRpcError } from "../_shared/validators.ts";
+
+// ---------------------------------------------------------------------------
+// MC Transfer Module
+//
+// Actions:
+//   record   — MC server records a batch of item transfer events
+//   history  — MC server queries transfer history for a player
+// ---------------------------------------------------------------------------
+
+type Handler = (mcReq: McRequest) => Promise<Response>;
+
+const handlers: Record<string, Handler> = {
+  async record({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { batch } = body;
+    if (!batch || !Array.isArray(batch)) {
+      return jsonResponse({ error: "batch must be a JSON array" }, 400);
+    }
+
+    if (batch.length === 0) {
+      return jsonResponse({ success: true, recorded_count: 0 });
+    }
+
+    if (batch.length > 1000) {
+      return jsonResponse(
+        { error: "Batch size exceeds limit of 1000 transfers" },
+        400,
+      );
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("service_record_transfers", {
+      p_batch: batch,
+    });
+
+    if (error) {
+      return safeRpcError(error, "service_record_transfers");
+    }
+
+    return jsonResponse({ success: true, recorded_count: data });
+  },
+
+  async history({ claims, body }) {
+    const denied = requireServiceRole(claims);
+    if (denied) return denied;
+
+    const { player_uuid } = body;
+    const uuidErr = validateMcUuid(player_uuid, "player_uuid");
+    if (uuidErr) return uuidErr;
+
+    // Clamp pagination parameters at edge (mirrors SQL clamping)
+    const rawLimit = Number(body.limit) || 50;
+    const limit = Math.min(Math.max(rawLimit, 1), 500);
+
+    const rawOffset = Number(body.offset) || 0;
+    const offset = Math.max(rawOffset, 0);
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc(
+      "service_get_transfer_history",
+      {
+        p_player_uuid: player_uuid as string,
+        p_server_id: (body.server_id as string) || null,
+        p_since: (body.since as string) || null,
+        p_limit: limit,
+        p_offset: offset,
+      },
+    );
+
+    if (error) {
+      return safeRpcError(error, "service_get_transfer_history");
+    }
+
+    const transfers = Array.isArray(data) ? data : [];
+    return jsonResponse({ transfers, total_count: transfers.length });
+  },
+};
+
+export const TRANSFER_ACTIONS = Object.keys(handlers);
+
+export async function handleTransfer(mcReq: McRequest): Promise<Response> {
+  const handler = handlers[mcReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown transfer action: ${mcReq.action}. Use: ${
+          TRANSFER_ACTIONS.join(", ")
+        }`,
+      },
+      400,
+    );
+  }
+  return handler(mcReq);
+}


### PR DESCRIPTION
## Summary
- Restores the modular MC edge function suite that was removed in d712cab38 (#9364)
- 8 files under `apps/kbve/edge/functions/mc/`: unified router + auth, player, container, character, skill, and transfer modules
- All modules use `server_id` to support both Pumpkin (lobby) and Fabric (survival) servers through a single endpoint

## Modules
| Module | Actions | Purpose |
|--------|---------|---------|
| **auth** | request_link, verify, status, lookup, unlink | MC account linking (6-digit codes) |
| **player** | save, load | Player snapshot persistence |
| **container** | save, load | Chest/barrel state (types 0-13) |
| **character** | save, load, add_xp | DND-style RPG stats + leveling |
| **skill** | save, load, add_xp | Skill tree progression (5 categories) |
| **transfer** | record, history | Item transfer ledger |

## Test plan
- [ ] Verify edge function deploys to Supabase staging
- [ ] Test auth flow (request_link → verify) against lobby server
- [ ] Test player save/load with both lobby and survival server_ids
- [ ] Test character and skill XP progression