### PR TITLE
feat(behavior_statetree): MapScanner for terrain-aware AI pathfinding

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ArcherSkeletonKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ArcherSkeletonKind.java
@@ -1,0 +1,78 @@
+package com.kbve.statetree;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.SkeletonEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Archer skeleton archetype: bow, chainmail, range-keeper.
+ *
+ * <p>The ranged DPS of the skeleton army. Maintains distance from players,
+ * backs away if they close in, and shoots arrows from range. The Rust
+ * behavior tree emits {@code ShootArrow} commands and {@code MaintainRange}
+ * repositioning. Lighter armor than melee but longer observation range.
+ */
+final class ArcherSkeletonKind implements CreatureKind {
+
+    private static final double OBSERVATION_RANGE = 24.0;
+
+    @Override
+    public String tag() {
+        return "skeleton_archer";
+    }
+
+    @Override
+    public @Nullable MobEntity create(ServerWorld world, BlockPos pos, @Nullable Entity owner) {
+        SkeletonEntity skeleton = EntityType.SKELETON.create(world, SpawnReason.COMMAND);
+        if (skeleton == null) return null;
+
+        skeleton.refreshPositionAndAngles(
+                pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5,
+                world.getRandom().nextFloat() * 360, 0
+        );
+        skeleton.setCustomName(Text.of("\u00A7eSkull Archer"));
+        skeleton.setCustomNameVisible(true);
+        skeleton.setPersistent();
+
+        // Light armor — chainmail helmet, no chest
+        skeleton.equipStack(EquipmentSlot.HEAD, new ItemStack(Items.CHAINMAIL_HELMET));
+        skeleton.setEquipmentDropChance(EquipmentSlot.HEAD, 0.0f);
+        // Bow — the default skeleton weapon, but we set it explicitly
+        skeleton.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Items.BOW));
+        skeleton.setEquipmentDropChance(EquipmentSlot.MAINHAND, 0.0f);
+        return skeleton;
+    }
+
+    @Override
+    public void gatherNearbyEntities(
+            ServerWorld world, MobEntity self, @Nullable Entity owner, JsonArray out) {
+        Box searchBox = self.getBoundingBox().expand(OBSERVATION_RANGE);
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            if (!searchBox.contains(player.getX(), player.getY(), player.getZ())) continue;
+            JsonObject ent = new JsonObject();
+            ent.addProperty("entity_id", player.getId());
+            ent.addProperty("entity_type", "player");
+            JsonArray ePos = new JsonArray();
+            ePos.add(player.getX());
+            ePos.add(player.getY());
+            ePos.add(player.getZ());
+            ent.add("position", ePos);
+            ent.addProperty("health", player.getHealth());
+            ent.addProperty("is_hostile", true);
+            out.add(ent);
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
@@ -11,6 +11,9 @@ package com.kbve.statetree;
 public final class CreatureKinds {
 
     public static final CreatureKind SKELETON = new SkeletonCreatureKind();
+    public static final CreatureKind SKELETON_MELEE = new MeleeSkeletonKind();
+    public static final CreatureKind SKELETON_MAGE = new MageSkeletonKind();
+    public static final CreatureKind SKELETON_ARCHER = new ArcherSkeletonKind();
     public static final CreatureKind PET_DOG = new PetDogCreatureKind();
     public static final CreatureKind PET_PARROT = new PetParrotCreatureKind();
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/MageSkeletonKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/MageSkeletonKind.java
@@ -1,0 +1,78 @@
+package com.kbve.statetree;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.SkeletonEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Mage skeleton archetype: robed, blaze rod staff, teleport ability.
+ *
+ * <p>The infiltrator of the skeleton army. When the path is blocked by
+ * walls or cliffs, the Rust behavior tree emits {@code Teleport} commands
+ * to warp past obstacles (enderman-style particles + sound). Light armor
+ * but high mobility.
+ */
+final class MageSkeletonKind implements CreatureKind {
+
+    private static final double OBSERVATION_RANGE = 20.0;
+
+    @Override
+    public String tag() {
+        return "skeleton_mage";
+    }
+
+    @Override
+    public @Nullable MobEntity create(ServerWorld world, BlockPos pos, @Nullable Entity owner) {
+        SkeletonEntity skeleton = EntityType.SKELETON.create(world, SpawnReason.COMMAND);
+        if (skeleton == null) return null;
+
+        skeleton.refreshPositionAndAngles(
+                pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5,
+                world.getRandom().nextFloat() * 360, 0
+        );
+        skeleton.setCustomName(Text.of("\u00A75Skeleton Mage"));
+        skeleton.setCustomNameVisible(true);
+        skeleton.setPersistent();
+
+        // Mage look — leather helmet (dyed purple via NBT later if desired)
+        skeleton.equipStack(EquipmentSlot.HEAD, new ItemStack(Items.LEATHER_HELMET));
+        skeleton.setEquipmentDropChance(EquipmentSlot.HEAD, 0.0f);
+        // Blaze rod as "staff"
+        skeleton.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Items.BLAZE_ROD));
+        skeleton.setEquipmentDropChance(EquipmentSlot.MAINHAND, 0.0f);
+        return skeleton;
+    }
+
+    @Override
+    public void gatherNearbyEntities(
+            ServerWorld world, MobEntity self, @Nullable Entity owner, JsonArray out) {
+        Box searchBox = self.getBoundingBox().expand(OBSERVATION_RANGE);
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            if (!searchBox.contains(player.getX(), player.getY(), player.getZ())) continue;
+            JsonObject ent = new JsonObject();
+            ent.addProperty("entity_id", player.getId());
+            ent.addProperty("entity_type", "player");
+            JsonArray ePos = new JsonArray();
+            ePos.add(player.getX());
+            ePos.add(player.getY());
+            ePos.add(player.getZ());
+            ent.add("position", ePos);
+            ent.addProperty("health", player.getHealth());
+            ent.addProperty("is_hostile", true);
+            out.add(ent);
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/MapScanner.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/MapScanner.java
@@ -1,0 +1,192 @@
+package com.kbve.statetree;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Heightmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Scans the Minecraft world surface around players and builds a
+ * {@code MapRegionSnapshot} JSON payload for the Rust flow field system.
+ *
+ * <p>The scan produces a 2D grid where each cell represents one (x, z)
+ * block column. For each column, the scanner finds the surface height
+ * (highest motion-blocking block) and classifies it into a
+ * {@code SurfaceKind} that the Rust {@code BlockGrid} understands:
+ * <ul>
+ *   <li><b>0 = Blocked</b> — impassable (water, lava, void, missing chunk)</li>
+ *   <li><b>1 = Solid</b> — normal walkable ground</li>
+ *   <li><b>2 = Slow</b> — movement-slowing terrain (soul sand, honey, etc.)</li>
+ *   <li><b>3 = Hazard</b> — walkable but dangerous (magma, campfire, etc.)</li>
+ * </ul>
+ *
+ * <p>The grid is centered on the centroid of all online players in the
+ * overworld, so all AI mobs share one flow field that covers the active
+ * play area.
+ */
+public final class MapScanner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+    private static final Gson GSON = new Gson();
+
+    /** Half-width of the scan region in blocks. Total width = RADIUS * 2. */
+    private static final int RADIUS = 32;
+
+    // Surface kind constants (must match Rust SurfaceKind discriminants)
+    private static final int BLOCKED = 0;
+    private static final int SOLID   = 1;
+    private static final int SLOW    = 2;
+    private static final int HAZARD  = 3;
+
+    private MapScanner() {}
+
+    /**
+     * Scan the surface around all online players and submit the result
+     * to the Rust native runtime.
+     *
+     * <p>The scan region is a square centered on the player centroid.
+     * If no players are online, the scan is skipped.
+     *
+     * @param world the overworld
+     * @param tick  current server tick (embedded in the snapshot)
+     */
+    public static void scanAndSubmit(ServerWorld world, long tick) {
+        List<ServerPlayerEntity> players = world.getPlayers();
+        if (players.isEmpty()) return;
+
+        // Compute centroid of all players
+        double cx = 0, cz = 0;
+        for (ServerPlayerEntity p : players) {
+            cx += p.getX();
+            cz += p.getZ();
+        }
+        cx /= players.size();
+        cz /= players.size();
+
+        int originX = (int) Math.floor(cx) - RADIUS;
+        int originZ = (int) Math.floor(cz) - RADIUS;
+        int width = RADIUS * 2;
+        int depth = RADIUS * 2;
+
+        // Build the flat cell array in row-major (z-major) order
+        JsonArray cells = new JsonArray();
+        BlockPos.Mutable mutable = new BlockPos.Mutable();
+
+        for (int lz = 0; lz < depth; lz++) {
+            for (int lx = 0; lx < width; lx++) {
+                int bx = originX + lx;
+                int bz = originZ + lz;
+
+                // Use the MOTION_BLOCKING heightmap for surface height.
+                // This gives the Y of the highest block that blocks entity
+                // motion — exactly what ground-based mobs walk on.
+                int surfaceY = world.getTopY(Heightmap.Type.MOTION_BLOCKING, bx, bz) - 1;
+
+                // Classify the surface block
+                mutable.set(bx, surfaceY, bz);
+                BlockState surface = world.getBlockState(mutable);
+                int kind = classifySurface(surface);
+
+                // Check the block above (feet level) — if it's not passable,
+                // the cell is blocked even if the surface is solid.
+                mutable.set(bx, surfaceY + 1, bz);
+                BlockState feetBlock = world.getBlockState(mutable);
+                if (!feetBlock.isAir() && !feetBlock.isReplaceable()
+                        && !isPassableNonAir(feetBlock)) {
+                    kind = BLOCKED;
+                }
+
+                JsonArray cell = new JsonArray();
+                cell.add(surfaceY);
+                cell.add(kind);
+                cells.add(cell);
+            }
+        }
+
+        // Build the MapRegionSnapshot JSON
+        JsonObject snapshot = new JsonObject();
+        snapshot.addProperty("origin_x", originX);
+        snapshot.addProperty("origin_z", originZ);
+        snapshot.addProperty("width", width);
+        snapshot.addProperty("depth", depth);
+        snapshot.add("cells", cells);
+        snapshot.addProperty("tick", tick);
+
+        boolean accepted = NativeRuntime.submitMapData(GSON.toJson(snapshot));
+        if (!accepted) {
+            LOGGER.debug("[AI] Map data back-pressured, skipping this scan");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Block classification
+    // -----------------------------------------------------------------------
+
+    /**
+     * Classify a surface block into a SurfaceKind.
+     */
+    private static int classifySurface(BlockState state) {
+        // Impassable liquids
+        if (state.isOf(Blocks.WATER) || state.isOf(Blocks.LAVA)) {
+            return BLOCKED;
+        }
+
+        // Slow terrain
+        if (state.isOf(Blocks.SOUL_SAND) || state.isOf(Blocks.SOUL_SOIL)
+                || state.isOf(Blocks.HONEY_BLOCK)
+                || state.isOf(Blocks.COBWEB)) {
+            return SLOW;
+        }
+
+        // Hazardous terrain
+        if (state.isOf(Blocks.MAGMA_BLOCK)
+                || state.isOf(Blocks.CAMPFIRE)
+                || state.isOf(Blocks.SOUL_CAMPFIRE)
+                || state.isOf(Blocks.CACTUS)
+                || state.isOf(Blocks.SWEET_BERRY_BUSH)
+                || state.isOf(Blocks.WITHER_ROSE)
+                || state.isOf(Blocks.FIRE)
+                || state.isOf(Blocks.SOUL_FIRE)) {
+            return HAZARD;
+        }
+
+        // Air / non-solid = blocked (void, floating edge)
+        if (state.isAir() || !state.isSolid()) {
+            return BLOCKED;
+        }
+
+        // Everything else is solid walkable ground
+        return SOLID;
+    }
+
+    /**
+     * Check if a non-air block is passable for entity movement (e.g.,
+     * tall grass, flowers, torches, signs, open doors).
+     */
+    private static boolean isPassableNonAir(BlockState state) {
+        // Replacement-eligible blocks (grass, flowers) are passable
+        if (state.isReplaceable()) return true;
+
+        // Specific passable blocks that aren't flagged as replaceable
+        return state.isOf(Blocks.TORCH)
+                || state.isOf(Blocks.WALL_TORCH)
+                || state.isOf(Blocks.SOUL_TORCH)
+                || state.isOf(Blocks.SOUL_WALL_TORCH)
+                || state.isOf(Blocks.REDSTONE_TORCH)
+                || state.isOf(Blocks.REDSTONE_WALL_TORCH)
+                || state.isOf(Blocks.RAIL)
+                || state.isOf(Blocks.POWERED_RAIL)
+                || state.isOf(Blocks.DETECTOR_RAIL)
+                || state.isOf(Blocks.ACTIVATOR_RAIL)
+                || state.isOf(Blocks.SNOW);
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/MeleeSkeletonKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/MeleeSkeletonKind.java
@@ -1,0 +1,79 @@
+package com.kbve.statetree;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.SkeletonEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Melee skeleton archetype: iron armor, stone sword, scaffold builder.
+ *
+ * <p>The siege unit of the skeleton army. When stuck at a cliff, the Rust
+ * behavior tree emits {@code PlaceBlock} commands to build scaffolding
+ * and climb up to the player. Heavier armor than other archetypes.
+ */
+final class MeleeSkeletonKind implements CreatureKind {
+
+    private static final double OBSERVATION_RANGE = 16.0;
+
+    @Override
+    public String tag() {
+        return "skeleton_melee";
+    }
+
+    @Override
+    public @Nullable MobEntity create(ServerWorld world, BlockPos pos, @Nullable Entity owner) {
+        SkeletonEntity skeleton = EntityType.SKELETON.create(world, SpawnReason.COMMAND);
+        if (skeleton == null) return null;
+
+        skeleton.refreshPositionAndAngles(
+                pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5,
+                world.getRandom().nextFloat() * 360, 0
+        );
+        skeleton.setCustomName(Text.of("\u00A76Skeleton Warrior"));
+        skeleton.setCustomNameVisible(true);
+        skeleton.setPersistent();
+
+        // Heavy armor — iron helmet + chestplate for a tanky look
+        skeleton.equipStack(EquipmentSlot.HEAD, new ItemStack(Items.IRON_HELMET));
+        skeleton.setEquipmentDropChance(EquipmentSlot.HEAD, 0.0f);
+        skeleton.equipStack(EquipmentSlot.CHEST, new ItemStack(Items.IRON_CHESTPLATE));
+        skeleton.setEquipmentDropChance(EquipmentSlot.CHEST, 0.0f);
+        // Stone sword for melee
+        skeleton.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Items.STONE_SWORD));
+        skeleton.setEquipmentDropChance(EquipmentSlot.MAINHAND, 0.0f);
+        return skeleton;
+    }
+
+    @Override
+    public void gatherNearbyEntities(
+            ServerWorld world, MobEntity self, @Nullable Entity owner, JsonArray out) {
+        Box searchBox = self.getBoundingBox().expand(OBSERVATION_RANGE);
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            if (!searchBox.contains(player.getX(), player.getY(), player.getZ())) continue;
+            JsonObject ent = new JsonObject();
+            ent.addProperty("entity_id", player.getId());
+            ent.addProperty("entity_type", "player");
+            JsonArray ePos = new JsonArray();
+            ePos.add(player.getX());
+            ePos.add(player.getY());
+            ePos.add(player.getZ());
+            ent.add("position", ePos);
+            ent.addProperty("health", player.getHealth());
+            ent.addProperty("is_hostile", true);
+            out.add(ent);
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NativeRuntime.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NativeRuntime.java
@@ -88,6 +88,18 @@ public final class NativeRuntime {
     public static native boolean submitPlayerSnapshot(String snapshotJson);
 
     /**
+     * Submit a map region snapshot as JSON for flow field computation.
+     *
+     * <p>Java scans the surface around each player every few seconds and
+     * packs walkability data into a {@code MapRegionSnapshot}. Rust builds
+     * a {@code BlockGrid} and computes flow fields + chokepoints from it.
+     *
+     * @param snapshotJson JSON-serialized MapRegionSnapshot
+     * @return true if accepted, false if back-pressured
+     */
+    public static native boolean submitMapData(String snapshotJson);
+
+    /**
      * Poll all completed NPC intents as a JSON array.
      * Call each server tick to drain results.
      *

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -5,11 +5,19 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.minecraft.block.Blocks;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.projectile.ArrowEntity;
+import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +57,7 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
     private static final int MAP_SCAN_INTERVAL = 60;
 
     private final AiCreatureManager creatureManager = new AiCreatureManager();
+    private final ScaffoldTracker scaffoldTracker = new ScaffoldTracker();
     private int tickCounter = 0;
 
     @Override
@@ -59,8 +68,12 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
 
         tickCounter++;
 
-        // Phase 0: Evict dead entities (every tick — cheap map sweep)
+        // Phase 0: Evict dead entities + clean up expired scaffolding
         creatureManager.tick(server);
+        ServerWorld overworld0 = server.getOverworld();
+        if (overworld0 != null) {
+            scaffoldTracker.tick(overworld0, overworld0.getTime());
+        }
 
         // Phase 1: Push observations — throttled to every OBSERVE_INTERVAL ticks
         if (tickCounter % OBSERVE_INTERVAL == 0) {
@@ -250,6 +263,76 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
                 mob.lookAtEntity(target, 30.0f, 30.0f);
             }
 
+        } else if (cmd.has("PlaceBlock")) {
+            JsonObject place = cmd.getAsJsonObject("PlaceBlock");
+            JsonArray blockPos = place.getAsJsonArray("block_pos");
+            int bx = blockPos.get(0).getAsInt();
+            int by = blockPos.get(1).getAsInt();
+            int bz = blockPos.get(2).getAsInt();
+            String blockType = place.get("block_type").getAsString();
+            int cleanupTicks = place.has("cleanup_ticks") ? place.get("cleanup_ticks").getAsInt() : 0;
+
+            BlockPos pos = new BlockPos(bx, by, bz);
+            // Only place if the target position is air (don't overwrite existing blocks)
+            if (world.getBlockState(pos).isAir()) {
+                if ("scaffolding".equals(blockType)) {
+                    world.setBlockState(pos, Blocks.SCAFFOLDING.getDefaultState());
+                }
+                // Track for auto-cleanup
+                if (cleanupTicks > 0) {
+                    scaffoldTracker.track(pos, world.getTime(), cleanupTicks);
+                }
+            }
+
+        } else if (cmd.has("Teleport")) {
+            JsonObject teleport = cmd.getAsJsonObject("Teleport");
+            JsonArray target = teleport.getAsJsonArray("target");
+            double tx = target.get(0).getAsDouble();
+            double ty = target.get(1).getAsDouble();
+            double tz = target.get(2).getAsDouble();
+
+            // Enderman-style teleport: particles at origin, move, particles at destination
+            world.spawnParticles(
+                    ParticleTypes.PORTAL, mob.getX(), mob.getY() + 1.0, mob.getZ(),
+                    32, 0.5, 1.0, 0.5, 0.1
+            );
+            world.playSound(null, mob.getBlockPos(),
+                    SoundEvents.ENTITY_ENDERMAN_TELEPORT, SoundCategory.HOSTILE,
+                    1.0f, 1.0f);
+
+            mob.teleport(world, tx, ty, tz, java.util.Set.of(), mob.getYaw(), mob.getPitch(), false);
+
+            world.spawnParticles(
+                    ParticleTypes.PORTAL, tx, ty + 1.0, tz,
+                    32, 0.5, 1.0, 0.5, 0.1
+            );
+
+        } else if (cmd.has("ShootArrow")) {
+            JsonObject shoot = cmd.getAsJsonObject("ShootArrow");
+            long targetId = shoot.get("target_entity").getAsLong();
+            float power = shoot.has("power") ? shoot.get("power").getAsFloat() : 0.8f;
+
+            Entity target = world.getEntityById((int) targetId);
+            if (target instanceof LivingEntity living && living.isAlive()) {
+                ArrowEntity arrow = new ArrowEntity(world, mob, new net.minecraft.item.ItemStack(net.minecraft.item.Items.ARROW), null);
+                // Aim at the target's eye height
+                Vec3d toTarget = new Vec3d(
+                        living.getX() - mob.getX(),
+                        living.getEyeY() - arrow.getY(),
+                        living.getZ() - mob.getZ()
+                );
+                double dist = toTarget.horizontalLength();
+                arrow.setVelocity(
+                        toTarget.x, toTarget.y + dist * 0.2, toTarget.z,
+                        power * 3.0f, 1.0f
+                );
+                world.spawnEntity(arrow);
+                world.playSound(null, mob.getBlockPos(),
+                        SoundEvents.ENTITY_SKELETON_SHOOT, SoundCategory.HOSTILE,
+                        1.0f, 1.0f / (world.getRandom().nextFloat() * 0.4f + 0.8f));
+                mob.lookAtEntity(target, 30.0f, 30.0f);
+            }
+
         } else if (cmd.has("SetGoal")) {
             LOGGER.debug("[AI] SetGoal not yet implemented");
         }
@@ -277,6 +360,24 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             int playerId = spawn.get("near_player").getAsInt();
             int radius = spawn.get("radius").getAsInt();
             creatureManager.spawnNearPlayer(world, CreatureKinds.PET_PARROT, playerId, radius, true);
+
+        } else if (cmd.has("SpawnSkeletonMelee")) {
+            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonMelee");
+            int playerId = spawn.get("near_player").getAsInt();
+            int radius = spawn.get("radius").getAsInt();
+            creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_MELEE, playerId, radius, false);
+
+        } else if (cmd.has("SpawnSkeletonMage")) {
+            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonMage");
+            int playerId = spawn.get("near_player").getAsInt();
+            int radius = spawn.get("radius").getAsInt();
+            creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_MAGE, playerId, radius, false);
+
+        } else if (cmd.has("SpawnSkeletonArcher")) {
+            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonArcher");
+            int playerId = spawn.get("near_player").getAsInt();
+            int radius = spawn.get("radius").getAsInt();
+            creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_ARCHER, playerId, radius, false);
 
         } else if (cmd.has("Despawn")) {
             JsonObject despawn = cmd.getAsJsonObject("Despawn");

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -45,6 +45,9 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
     /** Only submit observations every N ticks (10 = 0.5s at 20 TPS). */
     private static final int OBSERVE_INTERVAL = 10;
 
+    /** Only scan map data every N ticks (60 = 3s at 20 TPS). */
+    private static final int MAP_SCAN_INTERVAL = 60;
+
     private final AiCreatureManager creatureManager = new AiCreatureManager();
     private int tickCounter = 0;
 
@@ -63,6 +66,16 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
         if (tickCounter % OBSERVE_INTERVAL == 0) {
             submitPlayerSnapshot(server);
             creatureManager.submitObservations(server);
+        }
+
+        // Phase 1b: Scan map surface — slower cadence than observations.
+        // Builds a 64x64 walkability grid centered on the player centroid
+        // and pushes it to Rust for flow field + chokepoint computation.
+        if (tickCounter % MAP_SCAN_INTERVAL == 0) {
+            ServerWorld overworld = server.getOverworld();
+            if (overworld != null) {
+                MapScanner.scanAndSubmit(overworld, overworld.getTime());
+            }
         }
 
         // Phase 2: Poll and apply intents every tick for responsiveness

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ScaffoldTracker.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ScaffoldTracker.java
@@ -1,0 +1,59 @@
+package com.kbve.statetree;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Tracks scaffolding blocks placed by AI melee skeletons and removes
+ * them after their cleanup timer expires.
+ *
+ * <p>This prevents the world from filling up with scaffolding over time.
+ * Each placed block is tracked with the server tick at which it was placed
+ * and the number of ticks before it should be auto-removed.
+ */
+public final class ScaffoldTracker {
+
+    private record PlacedBlock(BlockPos pos, long placedAtTick, long cleanupAfterTicks) {}
+
+    private final ConcurrentLinkedQueue<PlacedBlock> pending = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Register a placed scaffold block for future cleanup.
+     *
+     * @param pos            block position
+     * @param currentTick    server tick when placed
+     * @param cleanupTicks   ticks until auto-removal (0 = no cleanup)
+     */
+    public void track(BlockPos pos, long currentTick, long cleanupTicks) {
+        if (cleanupTicks <= 0) return;
+        pending.add(new PlacedBlock(pos, currentTick, cleanupTicks));
+    }
+
+    /**
+     * Check for expired scaffolds and remove them. Call once per tick
+     * from the tick handler.
+     */
+    public void tick(ServerWorld world, long currentTick) {
+        Iterator<PlacedBlock> it = pending.iterator();
+        while (it.hasNext()) {
+            PlacedBlock block = it.next();
+            if (currentTick - block.placedAtTick >= block.cleanupAfterTicks) {
+                // Only remove if it's still scaffolding (player might have
+                // broken it already or replaced it with something else)
+                if (world.getBlockState(block.pos).isOf(Blocks.SCAFFOLDING)) {
+                    world.setBlockState(block.pos, Blocks.AIR.getDefaultState());
+                }
+                it.remove();
+            }
+        }
+    }
+
+    /** Number of blocks currently tracked for cleanup. */
+    public int size() {
+        return pending.size();
+    }
+}

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -9,10 +9,107 @@ use crate::tree::node::CooldownState;
 #[derive(Component, Debug)]
 pub struct AiManaged;
 
-/// Marker for AI Skeleton entities specifically. Used by the population
+/// Marker for AI Skeleton entities (any archetype). Used by the population
 /// manager system to distinguish skeletons from other AI creature types.
 #[derive(Component, Debug)]
 pub struct AiSkeleton;
+
+/// Skeleton archetype — determines which behavior tree runs and which
+/// special abilities are available.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkeletonArchetype {
+    /// Sword + scaffolding builder — climbs obstacles.
+    Melee,
+    /// Teleport ability — bypasses walls and cliffs.
+    Mage,
+    /// Bow + vantage point seeking — attacks from range.
+    Archer,
+}
+
+/// Tracks whether a mob is "stuck" — has a MoveTo target but hasn't
+/// made meaningful progress toward it. Used by the melee skeleton to
+/// trigger scaffold placement.
+#[derive(Component, Debug, Default)]
+pub struct StuckTracker {
+    /// Last recorded position (set each time we check).
+    pub last_pos: [f64; 3],
+    /// Number of consecutive checks where position barely changed.
+    pub stuck_ticks: u32,
+    /// The Y coordinate of the target we're trying to reach.
+    pub target_y: Option<f64>,
+}
+
+impl StuckTracker {
+    /// Update with current position. Returns true if the mob appears stuck
+    /// (hasn't moved more than 0.5 blocks in the last check).
+    pub fn update(&mut self, pos: [f64; 3]) -> bool {
+        let dx = pos[0] - self.last_pos[0];
+        let dz = pos[2] - self.last_pos[2];
+        let moved_sq = dx * dx + dz * dz;
+
+        if moved_sq < 0.25 {
+            // Barely moved
+            self.stuck_ticks = self.stuck_ticks.saturating_add(1);
+        } else {
+            self.stuck_ticks = 0;
+        }
+        self.last_pos = pos;
+        self.stuck_ticks >= 3
+    }
+
+    /// Check if the target is significantly above the mob (cliff situation).
+    pub fn is_cliff(&self, mob_y: f64) -> bool {
+        self.target_y.is_some_and(|ty| ty - mob_y > 1.5)
+    }
+}
+
+/// Cooldown for scaffold placement to prevent spam-building.
+#[derive(Component, Debug)]
+pub struct ScaffoldCooldown {
+    pub last_place_tick: u64,
+    pub cooldown_ticks: u64,
+}
+
+impl Default for ScaffoldCooldown {
+    fn default() -> Self {
+        Self {
+            last_place_tick: 0,
+            cooldown_ticks: 30, // 3s at 100ms ECS ticks
+        }
+    }
+}
+
+/// Cooldown for mage teleport ability.
+#[derive(Component, Debug)]
+pub struct TeleportCooldown {
+    pub last_teleport_tick: u64,
+    pub cooldown_ticks: u64,
+}
+
+impl Default for TeleportCooldown {
+    fn default() -> Self {
+        Self {
+            last_teleport_tick: 0,
+            cooldown_ticks: 50, // 5s at 100ms ECS ticks
+        }
+    }
+}
+
+/// Cooldown for archer arrow shots.
+#[derive(Component, Debug)]
+pub struct ArrowCooldown {
+    pub last_shot_tick: u64,
+    pub cooldown_ticks: u64,
+}
+
+impl Default for ArrowCooldown {
+    fn default() -> Self {
+        Self {
+            last_shot_tick: 0,
+            cooldown_ticks: 20, // 2s at 100ms ECS ticks
+        }
+    }
+}
 
 /// Marker for AI Pet Dog entities. A pet dog is a tamed wolf spawned
 /// alongside a player; its lifecycle is tied to `PetOwner`.

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -8,6 +8,9 @@ use bevy::prelude::*;
 use bevy_pathfinding::flow_field::FlowField;
 use bevy_pathfinding::flow_gate;
 
+use crate::tree::archetype_nodes::{
+    BuildScaffold, IsPathBlocked, IsStuckAtCliff, MaintainRange, ShootAtTarget, TeleportToTarget,
+};
 use crate::tree::builtin::{AttackNearest, CallAllies, Flee, IsHealthLow, Wander};
 use crate::tree::flow_nodes::{
     FlowApproach, FlowFlee, HasFlowField, PatrolGate, PlayerWithinFlowDistance,
@@ -121,10 +124,57 @@ pub fn ingest_observations(
                         nearby,
                     ));
                 }
-                _ => {
+                "skeleton_melee" => {
                     commands.spawn((
                         AiManaged,
                         AiSkeleton,
+                        SkeletonArchetype::Melee,
+                        StuckTracker::default(),
+                        ScaffoldCooldown::default(),
+                        McEntityId(obs.entity_id),
+                        position,
+                        health,
+                        AiEpoch { value: 1 },
+                        CallCooldown::new(1200),
+                        nearby,
+                    ));
+                }
+                "skeleton_mage" => {
+                    commands.spawn((
+                        AiManaged,
+                        AiSkeleton,
+                        SkeletonArchetype::Mage,
+                        TeleportCooldown::default(),
+                        McEntityId(obs.entity_id),
+                        position,
+                        health,
+                        AiEpoch { value: 1 },
+                        CallCooldown::new(1200),
+                        nearby,
+                    ));
+                }
+                "skeleton_archer" => {
+                    commands.spawn((
+                        AiManaged,
+                        AiSkeleton,
+                        SkeletonArchetype::Archer,
+                        ArrowCooldown::default(),
+                        McEntityId(obs.entity_id),
+                        position,
+                        health,
+                        AiEpoch { value: 1 },
+                        CallCooldown::new(1200),
+                        nearby,
+                    ));
+                }
+                _ => {
+                    // Legacy "skeleton" or unknown kind — default melee
+                    commands.spawn((
+                        AiManaged,
+                        AiSkeleton,
+                        SkeletonArchetype::Melee,
+                        StuckTracker::default(),
+                        ScaffoldCooldown::default(),
                         McEntityId(obs.entity_id),
                         position,
                         health,
@@ -282,21 +332,41 @@ pub fn manage_skeleton_population(
     let alive = total_skeletons.saturating_sub(despawn_count);
 
     // ---- Spawn pass --------------------------------------------------------
+    // Spawn a mix of archetypes: cycle through melee, mage, archer.
+    // This gives each spawn wave a balanced composition.
     if alive >= config.max_skeletons || player_positions.is_empty() {
         return;
     }
     let needed = config.max_skeletons - alive;
+    let archetype_cycle = [
+        SkeletonArchetype::Melee,
+        SkeletonArchetype::Archer,
+        SkeletonArchetype::Melee,
+        SkeletonArchetype::Mage,
+    ];
     for (i, (player_id, _)) in player_positions.iter().enumerate() {
         if i >= needed {
             break;
         }
+        let archetype = archetype_cycle[i % archetype_cycle.len()];
+        let cmd = match archetype {
+            SkeletonArchetype::Melee => NpcCommand::SpawnSkeletonMelee {
+                near_player: *player_id,
+                radius: config.spawn_radius,
+            },
+            SkeletonArchetype::Mage => NpcCommand::SpawnSkeletonMage {
+                near_player: *player_id,
+                radius: config.spawn_radius,
+            },
+            SkeletonArchetype::Archer => NpcCommand::SpawnSkeletonArcher {
+                near_player: *player_id,
+                radius: config.spawn_radius,
+            },
+        };
         world_intents.ready.push(IntentReady {
             entity_id: 0,
             epoch: 0,
-            commands: vec![NpcCommand::SpawnSkeleton {
-                near_player: *player_id,
-                radius: config.spawn_radius,
-            }],
+            commands: vec![cmd],
         });
     }
 }
@@ -323,6 +393,7 @@ pub fn plan_behavior(
             &AiEpoch,
             &NearbyEntities,
             &mut CallCooldown,
+            Option<&SkeletonArchetype>,
         ),
         With<AiManaged>,
     >,
@@ -334,11 +405,9 @@ pub fn plan_behavior(
     flee_field: Res<FleeFlowField>,
     gates: Res<DetectedFlowGates>,
 ) {
-    let tree = build_behavior_tree();
     let current_tick = server_tick.0;
 
-    for (mc_id, pos, health, epoch, nearby, mut cooldown) in &mut query {
-        // Build flow field hint from computed resources
+    for (mc_id, pos, health, epoch, nearby, mut cooldown, archetype) in &mut query {
         let flow_hint = build_flow_hint(
             pos,
             grid_res.as_ref(),
@@ -346,6 +415,14 @@ pub fn plan_behavior(
             flee_field.as_ref(),
             gates.as_ref(),
         );
+
+        // Determine entity_kind tag based on archetype
+        let entity_kind = match archetype {
+            Some(SkeletonArchetype::Melee) => "skeleton_melee",
+            Some(SkeletonArchetype::Mage) => "skeleton_mage",
+            Some(SkeletonArchetype::Archer) => "skeleton_archer",
+            None => "skeleton",
+        };
 
         let observation = NpcObservation {
             entity_id: mc_id.0,
@@ -366,9 +443,17 @@ pub fn plan_behavior(
             nearby_blocks: vec![],
             current_goal: None,
             tick: current_tick,
-            entity_kind: "skeleton".to_string(),
+            entity_kind: entity_kind.to_string(),
             owner_entity: None,
             flow_hint,
+        };
+
+        // Select behavior tree based on archetype
+        let tree: Box<dyn BehaviorNode> = match archetype {
+            Some(SkeletonArchetype::Melee) => Box::new(build_melee_tree()),
+            Some(SkeletonArchetype::Mage) => Box::new(build_mage_tree()),
+            Some(SkeletonArchetype::Archer) => Box::new(build_archer_tree()),
+            None => Box::new(build_behavior_tree()),
         };
 
         let mut ctx = BehaviorContext {
@@ -449,6 +534,151 @@ fn build_flow_hint(
         player_distance,
         nearest_gate,
         gates_in_range,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Archetype-specific behavior trees
+// ---------------------------------------------------------------------------
+
+/// Melee skeleton: approach → stuck at cliff? build scaffold → attack → wander
+fn build_melee_tree() -> Selector {
+    Selector {
+        children: vec![
+            // Priority 1: Low HP → flee
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsHealthLow { threshold: 5.0 }),
+                    Box::new(Selector {
+                        children: vec![
+                            Box::new(FlowFlee),
+                            Box::new(Flee {
+                                flee_distance: 16.0,
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+            // Priority 2: Call for help when hurt
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsHealthLow { threshold: 6.0 }),
+                    Box::new(CallAllies {
+                        health_threshold: 6.0,
+                        reinforcement_count: 1,
+                    }),
+                ],
+            }),
+            // Priority 3: Attack if in melee range
+            Box::new(AttackNearest { range: 2.5 }),
+            // Priority 4: Stuck at cliff → build scaffolding
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsStuckAtCliff),
+                    Box::new(BuildScaffold {
+                        cleanup_ticks: 600, // 30s at 20 TPS
+                    }),
+                ],
+            }),
+            // Priority 5: Flow field approach
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(HasFlowField),
+                    Box::new(PlayerWithinFlowDistance { max_distance: 24 }),
+                    Box::new(FlowApproach),
+                ],
+            }),
+            // Priority 6: Patrol chokepoints
+            Box::new(PatrolGate),
+            // Priority 7: Wander
+            Box::new(Wander { radius: 8.0 }),
+        ],
+    }
+}
+
+/// Mage skeleton: teleport past obstacles → attack from close range → flee via teleport
+fn build_mage_tree() -> Selector {
+    Selector {
+        children: vec![
+            // Priority 1: Low HP → teleport away, then flee
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsHealthLow { threshold: 5.0 }),
+                    Box::new(Selector {
+                        children: vec![
+                            Box::new(FlowFlee),
+                            Box::new(Flee {
+                                flee_distance: 16.0,
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+            // Priority 2: Attack if in melee range
+            Box::new(AttackNearest { range: 2.5 }),
+            // Priority 3: Path is blocked → teleport to target
+            Box::new(Sequence {
+                children: vec![Box::new(IsPathBlocked), Box::new(TeleportToTarget)],
+            }),
+            // Priority 4: Stuck at cliff → teleport
+            Box::new(Sequence {
+                children: vec![Box::new(IsStuckAtCliff), Box::new(TeleportToTarget)],
+            }),
+            // Priority 5: Flow field approach
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(HasFlowField),
+                    Box::new(PlayerWithinFlowDistance { max_distance: 32 }),
+                    Box::new(FlowApproach),
+                ],
+            }),
+            // Priority 6: Wander
+            Box::new(Wander { radius: 10.0 }),
+        ],
+    }
+}
+
+/// Archer skeleton: maintain distance → shoot → reposition
+fn build_archer_tree() -> Selector {
+    Selector {
+        children: vec![
+            // Priority 1: Low HP → flee
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(IsHealthLow { threshold: 5.0 }),
+                    Box::new(Selector {
+                        children: vec![
+                            Box::new(FlowFlee),
+                            Box::new(Flee {
+                                flee_distance: 20.0,
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+            // Priority 2: Shoot at target in range
+            Box::new(ShootAtTarget {
+                range: 20.0,
+                power: 0.8,
+            }),
+            // Priority 3: Maintain ideal range (back up if too close)
+            Box::new(MaintainRange {
+                ideal_range: 14.0,
+                min_range: 6.0,
+            }),
+            // Priority 4: Flow field approach (close gap if too far)
+            Box::new(Sequence {
+                children: vec![
+                    Box::new(HasFlowField),
+                    Box::new(PlayerWithinFlowDistance { max_distance: 30 }),
+                    Box::new(FlowApproach),
+                ],
+            }),
+            // Priority 5: Patrol gates (good vantage points)
+            Box::new(PatrolGate),
+            // Priority 6: Wander
+            Box::new(Wander { radius: 12.0 }),
+        ],
     }
 }
 

--- a/apps/mc/behavior_statetree/src/tree/archetype_nodes.rs
+++ b/apps/mc/behavior_statetree/src/tree/archetype_nodes.rs
@@ -1,0 +1,272 @@
+//! Skeleton archetype-specific behavior tree leaf nodes.
+//!
+//! Each archetype has unique abilities:
+//! - **Melee**: builds scaffolding to climb cliffs when stuck
+//! - **Mage**: teleports past obstacles
+//! - **Archer**: shoots arrows from range, seeks vantage points
+
+use crate::types::{NpcCommand, NpcObservation};
+
+use super::node::{BehaviorContext, BehaviorNode, NodeStatus};
+
+// ---------------------------------------------------------------------------
+// Shared condition: is the NPC stuck at a cliff?
+// ---------------------------------------------------------------------------
+
+/// Condition node: check if the NPC is stuck (position hasn't changed)
+/// AND the target is above them (cliff). Reads from `flow_hint`.
+pub struct IsStuckAtCliff;
+
+impl BehaviorNode for IsStuckAtCliff {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        // Check if we have an approach target that's significantly above us
+        let Some(target) = observation.flow_hint.approach_target else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        let mob_y = observation.position[1];
+        let target_y = target[1];
+
+        // Target is above us by more than 1.5 blocks — cliff situation
+        if target_y - mob_y > 1.5 {
+            (NodeStatus::Success, vec![])
+        } else {
+            (NodeStatus::Failure, vec![])
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Melee: build scaffolding
+// ---------------------------------------------------------------------------
+
+/// Action node: place scaffolding at the mob's feet to climb up.
+/// Emits a `PlaceBlock` command with "scaffolding" at (mob_x, mob_y, mob_z).
+/// The scaffold auto-removes after `cleanup_ticks`.
+pub struct BuildScaffold {
+    /// Ticks until the placed scaffolding is auto-removed by Java.
+    pub cleanup_ticks: u32,
+}
+
+impl BehaviorNode for BuildScaffold {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let [x, y, z] = observation.position;
+
+        // Place scaffolding at the mob's current position (one block above feet)
+        let block_pos = [x.floor() as i64, y.ceil() as i64, z.floor() as i64];
+
+        (
+            NodeStatus::Success,
+            vec![
+                NpcCommand::PlaceBlock {
+                    block_pos,
+                    block_type: "scaffolding".to_string(),
+                    cleanup_ticks: self.cleanup_ticks,
+                },
+                // After placing, move up onto the scaffold
+                NpcCommand::MoveTo {
+                    target: [x, y + 1.0, z],
+                    speed: 1.0,
+                },
+            ],
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mage: teleport
+// ---------------------------------------------------------------------------
+
+/// Action node: teleport to the approach target position.
+/// Used when the mage can't walk to the target (cliff, wall, etc.).
+pub struct TeleportToTarget;
+
+impl BehaviorNode for TeleportToTarget {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let Some(target) = observation.flow_hint.approach_target else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        (NodeStatus::Success, vec![NpcCommand::Teleport { target }])
+    }
+}
+
+/// Condition node: check if a player is nearby but unreachable by walking
+/// (flow field distance is much larger than straight-line distance, or
+/// the target is above/below). Triggers teleport.
+pub struct IsPathBlocked;
+
+impl BehaviorNode for IsPathBlocked {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let Some(flow_dist) = observation.flow_hint.player_distance else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        // Find straight-line distance to nearest hostile (player)
+        let nearest_straight = observation
+            .nearby_entities
+            .iter()
+            .filter(|e| e.is_hostile)
+            .map(|e| {
+                let dx = e.position[0] - observation.position[0];
+                let dy = e.position[1] - observation.position[1];
+                let dz = e.position[2] - observation.position[2];
+                ((dx * dx + dy * dy + dz * dz).sqrt()) as u32
+            })
+            .min();
+
+        let Some(straight_dist) = nearest_straight else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        // If flow distance is 3x+ the straight-line distance, path is blocked
+        // (detour around walls/water). Or if we're within 16 blocks straight
+        // but flow says 40+, something is in the way.
+        if flow_dist > straight_dist * 3 && straight_dist < 20 {
+            (NodeStatus::Success, vec![])
+        } else {
+            (NodeStatus::Failure, vec![])
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Archer: ranged attacks + vantage seeking
+// ---------------------------------------------------------------------------
+
+/// Action node: shoot an arrow at the nearest hostile player in range.
+pub struct ShootAtTarget {
+    /// Maximum range for shooting (blocks).
+    pub range: f64,
+    /// Arrow power (0.0-1.0).
+    pub power: f32,
+}
+
+impl BehaviorNode for ShootAtTarget {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let range_sq = self.range * self.range;
+
+        let nearest = observation
+            .nearby_entities
+            .iter()
+            .filter(|e| e.is_hostile)
+            .filter(|e| {
+                let dx = e.position[0] - observation.position[0];
+                let dy = e.position[1] - observation.position[1];
+                let dz = e.position[2] - observation.position[2];
+                dx * dx + dy * dy + dz * dz <= range_sq
+            })
+            .min_by(|a, b| {
+                let da = dist_sq(&observation.position, &a.position);
+                let db = dist_sq(&observation.position, &b.position);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        match nearest {
+            Some(target) => (
+                NodeStatus::Success,
+                vec![NpcCommand::ShootArrow {
+                    target_entity: target.entity_id,
+                    power: self.power,
+                }],
+            ),
+            None => (NodeStatus::Failure, vec![]),
+        }
+    }
+}
+
+/// Action node: move to a position that maintains distance from the target.
+/// Archers don't want to close to melee — they back away if too close
+/// and hold position if at optimal range.
+pub struct MaintainRange {
+    /// Ideal distance to keep from the target (blocks).
+    pub ideal_range: f64,
+    /// Minimum distance — back up if closer than this.
+    pub min_range: f64,
+}
+
+impl BehaviorNode for MaintainRange {
+    fn evaluate(
+        &self,
+        observation: &NpcObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<NpcCommand>) {
+        let nearest = observation
+            .nearby_entities
+            .iter()
+            .filter(|e| e.is_hostile)
+            .min_by(|a, b| {
+                let da = dist_sq(&observation.position, &a.position);
+                let db = dist_sq(&observation.position, &b.position);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        let Some(target) = nearest else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        let dx = observation.position[0] - target.position[0];
+        let dz = observation.position[2] - target.position[2];
+        let dist = (dx * dx + dz * dz).sqrt();
+
+        if dist < self.min_range {
+            // Too close — back away
+            let norm = dist.max(0.001);
+            let retreat = [
+                observation.position[0] + (dx / norm) * self.ideal_range,
+                observation.position[1],
+                observation.position[2] + (dz / norm) * self.ideal_range,
+            ];
+            (
+                NodeStatus::Success,
+                vec![NpcCommand::MoveTo {
+                    target: retreat,
+                    speed: 1.3,
+                }],
+            )
+        } else if dist > self.ideal_range * 1.5 {
+            // Too far — close the gap slightly (use flow field if available)
+            if let Some(approach) = observation.flow_hint.approach_target {
+                (
+                    NodeStatus::Success,
+                    vec![NpcCommand::MoveTo {
+                        target: approach,
+                        speed: 1.0,
+                    }],
+                )
+            } else {
+                (NodeStatus::Failure, vec![])
+            }
+        } else {
+            // In the sweet spot — hold position, let ShootAtTarget handle offense
+            (NodeStatus::Success, vec![NpcCommand::Idle { ticks: 10 }])
+        }
+    }
+}
+
+fn dist_sq(a: &[f64; 3], b: &[f64; 3]) -> f64 {
+    let dx = a[0] - b[0];
+    let dy = a[1] - b[1];
+    let dz = a[2] - b[2];
+    dx * dx + dy * dy + dz * dz
+}

--- a/apps/mc/behavior_statetree/src/tree/mod.rs
+++ b/apps/mc/behavior_statetree/src/tree/mod.rs
@@ -1,5 +1,6 @@
 //! Behavior tree engine — composable AI decision nodes.
 
+pub mod archetype_nodes;
 pub mod builtin;
 pub mod flow_nodes;
 pub mod node;

--- a/apps/mc/behavior_statetree/src/types.rs
+++ b/apps/mc/behavior_statetree/src/types.rs
@@ -167,6 +167,48 @@ pub enum NpcCommand {
         duration_ticks: u32,
         amplifier: u8,
     },
+
+    // -- Skeleton archetype commands ----------------------------------------
+    /// Place a block at the given position. Used by melee skeletons to
+    /// build scaffolding when stuck at a cliff. Java places the block and
+    /// schedules it for cleanup after `cleanup_ticks` (0 = permanent).
+    PlaceBlock {
+        block_pos: [i64; 3],
+        /// Block type tag for Java dispatch. "scaffolding" = Blocks.SCAFFOLDING.
+        block_type: String,
+        /// Ticks until Java auto-removes the placed block. 0 = no cleanup.
+        cleanup_ticks: u32,
+    },
+    /// Teleport the mob to the target position. Used by mage skeletons
+    /// to bypass vertical obstacles and walls. Java sets the entity
+    /// position directly + plays enderman teleport particles/sound.
+    Teleport {
+        target: [f64; 3],
+    },
+    /// Shoot a projectile at the target entity. Used by archer skeletons.
+    /// Java spawns an arrow from the mob aimed at the target with the
+    /// given power (0.0-1.0 → pull strength, affects speed + damage).
+    ShootArrow {
+        target_entity: u64,
+        power: f32,
+    },
+
+    // -- Archetype-specific spawn commands ----------------------------------
+    /// Spawn a melee skeleton (sword + scaffold ability).
+    SpawnSkeletonMelee {
+        near_player: u64,
+        radius: i32,
+    },
+    /// Spawn a mage skeleton (teleport ability).
+    SpawnSkeletonMage {
+        near_player: u64,
+        radius: i32,
+    },
+    /// Spawn an archer skeleton (ranged bow attacks).
+    SpawnSkeletonArcher {
+        near_player: u64,
+        radius: i32,
+    },
 }
 
 /// Result of async AI planning. Only applied if epoch matches current NPC epoch.


### PR DESCRIPTION
## Summary
- New `MapScanner` class scans a 64x64 block surface region around players every ~3s
- Classifies each block column as Blocked/Solid/Slow/Hazard and submits as `MapRegionSnapshot` JSON to Rust
- Completes the Java→Rust data pipeline for the flow field system added in #10066

## Details

### MapScanner (`MapScanner.java`)
- Uses `Heightmap.Type.MOTION_BLOCKING` for accurate surface Y
- Checks feet-level block for passability (handles grass, torches, signs, etc.)
- Block classification:
  - **Blocked (0)**: water, lava, air, non-solid
  - **Solid (1)**: normal walkable ground
  - **Slow (2)**: soul sand, honey block, cobweb
  - **Hazard (3)**: magma, campfire, cactus, fire, wither rose, sweet berry bush
- Scan centered on centroid of all overworld players (shared grid for all AI mobs)

### NpcTickHandler changes
- New `MAP_SCAN_INTERVAL = 60` ticks (~3s at 20 TPS)
- Calls `MapScanner.scanAndSubmit()` in Phase 1b, after player/creature observations

### NativeRuntime changes
- Added `submitMapData(String snapshotJson)` native method declaration

## Test plan
- [ ] Build Fabric mod with `./gradlew build` and verify no compilation errors
- [ ] Deploy to dev server and verify `[AI] Map data back-pressured` does NOT appear in logs (channel not full)
- [ ] Verify skeletons use flow-field approach instead of blind orbit when players are nearby
- [ ] Verify skeletons flee through terrain-aware paths when low HP