### PR TITLE
feat(mc): client-side ship rendering + WASD helm + mrpack distribution

### DIFF
--- a/apps/mc/behavior_statetree/dev-client.bat
+++ b/apps/mc/behavior_statetree/dev-client.bat
@@ -1,0 +1,30 @@
+@echo off
+REM Launch a Fabric development client with the behavior_statetree mod.
+REM
+REM Prerequisites:
+REM   1. Docker dev server running: npx nx run mc:dev
+REM   2. Java 21+ installed
+REM
+REM Usage:
+REM   cd apps\mc\behavior_statetree
+REM   dev-client.bat
+
+echo === KBVE MC Dev Client ===
+echo.
+
+REM Check for Rust native lib (optional)
+if exist "..\target\release\behavior_statetree.dll" (
+    echo [OK] Rust native lib found
+) else (
+    echo [WARN] Rust native lib not found — AI features won't work
+    echo        Ships + client rendering still work fine
+    echo        Build with: cargo build -p behavior_statetree --release
+    echo.
+)
+
+echo Building mod + launching Minecraft client...
+echo Connect to: localhost:25565
+echo.
+
+cd java
+call gradle runClient --no-daemon

--- a/apps/mc/behavior_statetree/dev-client.sh
+++ b/apps/mc/behavior_statetree/dev-client.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Launch a Fabric development client with the behavior_statetree mod.
+#
+# Prerequisites:
+#   1. Docker dev server running: npx nx run mc:dev
+#   2. Rust native lib built (optional — only needed for AI, not ships):
+#      cargo build -p behavior_statetree --release
+#
+# Usage:
+#   cd apps/mc/behavior_statetree
+#   ./dev-client.sh
+#
+# The client launches with the mod loaded. Connect to localhost:25565
+# (Velocity proxy → lobby → /mc to switch to Fabric backend).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+JAVA_DIR="$SCRIPT_DIR/java"
+
+echo "=== KBVE MC Dev Client ==="
+echo ""
+
+# Check if the Rust native lib exists (optional — client doesn't need it
+# for ship rendering, only the server does for AI)
+if [ -f "$SCRIPT_DIR/../target/release/libbehavior_statetree.dylib" ] || \
+   [ -f "$SCRIPT_DIR/../target/release/libbehavior_statetree.so" ]; then
+    echo "[OK] Rust native lib found"
+else
+    echo "[WARN] Rust native lib not found — AI features won't work"
+    echo "       (Ships + client rendering still work fine)"
+    echo "       Build with: cargo build -p behavior_statetree --release"
+    echo ""
+fi
+
+echo "Building mod + launching Minecraft client..."
+echo "Connect to: localhost:25565"
+echo ""
+
+cd "$JAVA_DIR"
+
+# runClient launches a full MC client with the mod loaded.
+# On macOS, LWJGL needs -XstartOnFirstThread via the Gradle JVM args.
+exec gradle runClient --no-daemon

--- a/apps/mc/behavior_statetree/java/build.gradle
+++ b/apps/mc/behavior_statetree/java/build.gradle
@@ -31,3 +31,13 @@ java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }
+
+// macOS requires -XstartOnFirstThread for LWJGL (OpenGL context must
+// be on the main thread). Fabric Loom's runClient task inherits this.
+if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+    afterEvaluate {
+        tasks.matching { it.name == "runClient" }.configureEach {
+            jvmArgs "-XstartOnFirstThread"
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
@@ -1,7 +1,9 @@
 package com.kbve.statetree;
 
 import com.kbve.statetree.ship.ShipCommands;
+import com.kbve.statetree.ship.ShipEntityTypes;
 import com.kbve.statetree.ship.ShipManager;
+import com.kbve.statetree.ship.ShipNetworking;
 import com.kbve.statetree.ship.ShipProtection;
 import com.kbve.statetree.ship.Shipyard;
 import net.fabricmc.api.ModInitializer;
@@ -33,6 +35,13 @@ public class BehaviorStateTreeMod implements ModInitializer {
     public void onInitialize() {
         // Register ship blueprints — parsed once at server start, cached forever
         shipyard.registerBlueprint("dark_reaper", "/schematics/dark_reaper.nbt");
+
+        // Register ship entity type — safe now that all clients run Fabric
+        ShipEntityTypes.register();
+
+        // Register network payloads + server-side helm input receiver
+        ShipNetworking.registerPayloads();
+        ShipNetworking.registerServerReceivers(shipManager);
 
         // Ship block protection — breaking ship blocks doesn't drop items
         ShipProtection.register(shipManager);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ClientShipTracker.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ClientShipTracker.java
@@ -1,0 +1,119 @@
+package com.kbve.statetree.client;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Client-side ship state tracker — mirrors the server's ShipManager
+ * with just the data the client needs for rendering and interpolation.
+ *
+ * <p>Updated via network packets from the server. The client uses this
+ * to know where ships are and smoothly interpolate between position
+ * updates.
+ */
+public class ClientShipTracker {
+
+    /** Tracked ships keyed by UUID string. */
+    private final ConcurrentHashMap<String, ClientShipState> ships = new ConcurrentHashMap<>();
+
+    /** Client-side ship state for rendering. */
+    public static class ClientShipState {
+        public final String shipId;
+        public final String shipName;
+        public final int sizeX, sizeY, sizeZ;
+
+        // Current interpolated position
+        public double x, y, z;
+        public float heading;
+
+        // Target position (from latest server update)
+        public double targetX, targetY, targetZ;
+        public float targetHeading;
+
+        // Interpolation progress (0..1)
+        public float lerpProgress = 1.0f;
+
+        public ClientShipState(String shipId, String shipName,
+                               double x, double y, double z,
+                               int sizeX, int sizeY, int sizeZ) {
+            this.shipId = shipId;
+            this.shipName = shipName;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.targetX = x;
+            this.targetY = y;
+            this.targetZ = z;
+            this.heading = 0;
+            this.targetHeading = 0;
+            this.sizeX = sizeX;
+            this.sizeY = sizeY;
+            this.sizeZ = sizeZ;
+        }
+
+        /** Tick interpolation toward target. */
+        public void tick() {
+            if (lerpProgress < 1.0f) {
+                lerpProgress = Math.min(1.0f, lerpProgress + 0.1f);
+                x = lerp(x, targetX, lerpProgress);
+                y = lerp(y, targetY, lerpProgress);
+                z = lerp(z, targetZ, lerpProgress);
+                heading = lerpAngle(heading, targetHeading, lerpProgress);
+            }
+        }
+
+        /** Set new target from server and reset interpolation. */
+        public void setTarget(double tx, double ty, double tz, float th) {
+            this.targetX = tx;
+            this.targetY = ty;
+            this.targetZ = tz;
+            this.targetHeading = th;
+            this.lerpProgress = 0.0f;
+        }
+
+        private static double lerp(double a, double b, float t) {
+            return a + (b - a) * t;
+        }
+
+        private static float lerpAngle(float a, float b, float t) {
+            float diff = ((b - a + 540) % 360) - 180;
+            return a + diff * t;
+        }
+    }
+
+    // -- Public API ---------------------------------------------------------
+
+    public void addShip(String shipId, String name,
+                        double x, double y, double z,
+                        int sizeX, int sizeY, int sizeZ) {
+        ships.put(shipId, new ClientShipState(shipId, name, x, y, z, sizeX, sizeY, sizeZ));
+    }
+
+    public void updateShipPosition(String shipId,
+                                   double x, double y, double z,
+                                   float heading) {
+        ClientShipState state = ships.get(shipId);
+        if (state != null) {
+            state.setTarget(x, y, z, heading);
+        }
+    }
+
+    public void removeShip(String shipId) {
+        ships.remove(shipId);
+    }
+
+    public ClientShipState getShip(String shipId) {
+        return ships.get(shipId);
+    }
+
+    public Map<String, ClientShipState> getAllShips() {
+        return ships;
+    }
+
+    /** Tick all ship interpolations. Call each client tick. */
+    public void tickAll() {
+        for (ClientShipState ship : ships.values()) {
+            ship.tick();
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -1,0 +1,128 @@
+package com.kbve.statetree.client;
+
+import com.kbve.statetree.ship.ShipEntityTypes;
+import com.kbve.statetree.ship.ShipNetworking;
+import com.kbve.statetree.ship.ShipNetworking.HelmInputPayload;
+import com.kbve.statetree.ship.ShipNetworking.ShipDespawnPayload;
+import com.kbve.statetree.ship.ShipNetworking.ShipMovePayload;
+import com.kbve.statetree.ship.ShipNetworking.ShipSpawnPayload;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.entity.EmptyEntityRenderer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client-side mod entrypoint for the ship system.
+ *
+ * <p>Handles:
+ * <ul>
+ *   <li>WASD helm input — sends steering packets to server</li>
+ *   <li>Ship state tracking — receives position updates from server</li>
+ *   <li>ShipEntity renderer registration (invisible, rendering handled by blocks)</li>
+ * </ul>
+ */
+public class ShipClientMod implements ClientModInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    /** Client-side ship state tracker. */
+    private final ClientShipTracker tracker = new ClientShipTracker();
+
+    /** Ship the local player is currently steering (null if not at helm). */
+    private String activeHelmShipId = null;
+
+    @Override
+    public void onInitializeClient() {
+        // Register invisible renderer for ShipEntity (blocks are the visual)
+        EntityRendererRegistry.register(ShipEntityTypes.SHIP, EmptyEntityRenderer::new);
+
+        // Register client-side network receivers
+        registerNetworkReceivers();
+
+        // Tick: send WASD input when player is at the helm
+        ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
+
+        LOGGER.info("[Ship Client] Initialized — helm controls + ship tracking enabled");
+    }
+
+    // -- Network receivers --------------------------------------------------
+
+    private void registerNetworkReceivers() {
+        ClientPlayNetworking.registerGlobalReceiver(ShipMovePayload.ID, (payload, context) -> {
+            context.client().execute(() -> {
+                tracker.updateShipPosition(
+                        payload.shipId(),
+                        payload.anchorX(), payload.anchorY(), payload.anchorZ(),
+                        payload.heading()
+                );
+            });
+        });
+
+        ClientPlayNetworking.registerGlobalReceiver(ShipSpawnPayload.ID, (payload, context) -> {
+            context.client().execute(() -> {
+                tracker.addShip(
+                        payload.shipId(), payload.shipName(),
+                        payload.anchorX(), payload.anchorY(), payload.anchorZ(),
+                        payload.sizeX(), payload.sizeY(), payload.sizeZ()
+                );
+                LOGGER.info("[Ship Client] Tracking new ship '{}' ({})",
+                        payload.shipName(), payload.shipId());
+            });
+        });
+
+        ClientPlayNetworking.registerGlobalReceiver(ShipDespawnPayload.ID, (payload, context) -> {
+            context.client().execute(() -> {
+                tracker.removeShip(payload.shipId());
+                if (payload.shipId().equals(activeHelmShipId)) {
+                    activeHelmShipId = null;
+                }
+            });
+        });
+    }
+
+    // -- Helm WASD input ----------------------------------------------------
+
+    private void onClientTick(MinecraftClient client) {
+        if (client.player == null || activeHelmShipId == null) return;
+
+        // Read WASD input
+        float forward = 0;
+        float sideways = 0;
+
+        if (client.options.forwardKey.isPressed()) forward = 1.0f;
+        else if (client.options.backKey.isPressed()) forward = -1.0f;
+
+        if (client.options.leftKey.isPressed()) sideways = 1.0f;
+        else if (client.options.rightKey.isPressed()) sideways = -1.0f;
+
+        // Only send if there's actual input
+        if (forward != 0 || sideways != 0) {
+            ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, sideways));
+        }
+    }
+
+    /**
+     * Set the ship the player is currently steering.
+     * Called when the player mounts the ShipEntity.
+     */
+    public void setActiveHelm(String shipId) {
+        this.activeHelmShipId = shipId;
+        LOGGER.info("[Ship Client] Helm active for ship {}", shipId);
+    }
+
+    /**
+     * Clear helm control (player dismounted).
+     */
+    public void clearActiveHelm() {
+        this.activeHelmShipId = null;
+    }
+
+    /** Get the client ship tracker. */
+    public ClientShipTracker getTracker() {
+        return tracker;
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -6,11 +6,14 @@ import com.kbve.statetree.ship.ShipNetworking.HelmInputPayload;
 import com.kbve.statetree.ship.ShipNetworking.ShipDespawnPayload;
 import com.kbve.statetree.ship.ShipNetworking.ShipMovePayload;
 import com.kbve.statetree.ship.ShipNetworking.ShipSpawnPayload;
+import com.kbve.statetree.ship.ShipNetworking.ShipStatusPayload;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.Perspective;
 import net.minecraft.client.render.entity.EmptyEntityRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,32 +24,39 @@ import org.slf4j.LoggerFactory;
  * <p>Handles:
  * <ul>
  *   <li>WASD helm input — sends steering packets to server</li>
- *   <li>Ship state tracking — receives position updates from server</li>
- *   <li>ShipEntity renderer registration (invisible, rendering handled by blocks)</li>
+ *   <li>Ship state tracking — receives position + status updates</li>
+ *   <li>HUD overlay — hull integrity, compass, controls hint</li>
+ *   <li>Camera zoom — third-person when piloting</li>
  * </ul>
  */
 public class ShipClientMod implements ClientModInitializer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
 
-    /** Client-side ship state tracker. */
     private final ClientShipTracker tracker = new ClientShipTracker();
+    private final ShipHud hud = new ShipHud(tracker);
 
     /** Ship the local player is currently steering (null if not at helm). */
     private String activeHelmShipId = null;
+
+    /** Saved camera perspective to restore on dismount. */
+    private Perspective savedPerspective = null;
 
     @Override
     public void onInitializeClient() {
         // Register invisible renderer for ShipEntity (blocks are the visual)
         EntityRendererRegistry.register(ShipEntityTypes.SHIP, EmptyEntityRenderer::new);
 
+        // Register HUD overlay
+        HudRenderCallback.EVENT.register(hud);
+
         // Register client-side network receivers
         registerNetworkReceivers();
 
-        // Tick: send WASD input when player is at the helm
+        // Tick: send WASD input + manage camera
         ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
 
-        LOGGER.info("[Ship Client] Initialized — helm controls + ship tracking enabled");
+        LOGGER.info("[Ship Client] Initialized — helm + HUD + camera zoom enabled");
     }
 
     // -- Network receivers --------------------------------------------------
@@ -59,6 +69,10 @@ public class ShipClientMod implements ClientModInitializer {
                         payload.anchorX(), payload.anchorY(), payload.anchorZ(),
                         payload.heading()
                 );
+                // Update HUD heading if this is our active ship
+                if (payload.shipId().equals(activeHelmShipId)) {
+                    hud.updateStatus(payload.shipId(), hud.isActive() ? -1 : 100, payload.heading());
+                }
             });
         });
 
@@ -78,16 +92,31 @@ public class ShipClientMod implements ClientModInitializer {
             context.client().execute(() -> {
                 tracker.removeShip(payload.shipId());
                 if (payload.shipId().equals(activeHelmShipId)) {
-                    activeHelmShipId = null;
+                    clearActiveHelm();
                 }
+            });
+        });
+
+        ClientPlayNetworking.registerGlobalReceiver(ShipStatusPayload.ID, (payload, context) -> {
+            context.client().execute(() -> {
+                // Update HUD with integrity
+                hud.updateStatus(payload.shipId(), payload.integrity(), -1);
+
+                // TODO: spawn damage particles at damage position
+                // BlockPos damagePos = new BlockPos(payload.damageX(), payload.damageY(), payload.damageZ());
             });
         });
     }
 
-    // -- Helm WASD input ----------------------------------------------------
+    // -- Helm WASD input + camera -------------------------------------------
 
     private void onClientTick(MinecraftClient client) {
-        if (client.player == null || activeHelmShipId == null) return;
+        if (client.player == null) return;
+
+        // Tick ship interpolations
+        tracker.tickAll();
+
+        if (activeHelmShipId == null) return;
 
         // Read WASD input
         float forward = 0;
@@ -103,25 +132,47 @@ public class ShipClientMod implements ClientModInitializer {
         if (forward != 0 || sideways != 0) {
             ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, sideways));
         }
+
+        // Check for sneak to dismount
+        if (client.options.sneakKey.isPressed()) {
+            clearActiveHelm();
+        }
     }
 
     /**
-     * Set the ship the player is currently steering.
-     * Called when the player mounts the ShipEntity.
+     * Activate helm control — zoom camera out to third person.
      */
     public void setActiveHelm(String shipId) {
         this.activeHelmShipId = shipId;
-        LOGGER.info("[Ship Client] Helm active for ship {}", shipId);
+        hud.setActive(shipId);
+
+        // Zoom out to third-person rear view for ship navigation
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.options != null) {
+            savedPerspective = client.options.getPerspective();
+            client.options.setPerspective(Perspective.THIRD_PERSON_BACK);
+        }
+
+        LOGGER.info("[Ship Client] Helm active — camera zoomed out");
     }
 
     /**
-     * Clear helm control (player dismounted).
+     * Clear helm control — restore camera.
      */
     public void clearActiveHelm() {
         this.activeHelmShipId = null;
+        hud.clearActive();
+
+        // Restore original camera perspective
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.options != null && savedPerspective != null) {
+            client.options.setPerspective(savedPerspective);
+            savedPerspective = null;
+        }
+
+        LOGGER.info("[Ship Client] Helm released — camera restored");
     }
 
-    /** Get the client ship tracker. */
     public ClientShipTracker getTracker() {
         return tracker;
     }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -1,0 +1,134 @@
+package com.kbve.statetree.client;
+
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.text.Text;
+
+/**
+ * Client-side HUD overlay for ship piloting.
+ *
+ * <p>When the player is at the helm (actively steering a ship), this
+ * renders:
+ * <ul>
+ *   <li>Hull integrity bar (green → yellow → red)</li>
+ *   <li>Ship name</li>
+ *   <li>Heading compass</li>
+ *   <li>Speed indicator</li>
+ * </ul>
+ *
+ * <p>When not piloting, nothing is rendered.
+ */
+public class ShipHud implements HudRenderCallback {
+
+    private final ClientShipTracker tracker;
+
+    /** Ship ID the player is currently piloting (null if not at helm). */
+    private String activeShipId = null;
+
+    /** Current hull integrity from server (0-100). */
+    private float integrity = 100f;
+
+    /** Current heading from server. */
+    private float heading = 0f;
+
+    /** Ship name for display. */
+    private String shipName = "";
+
+    public ShipHud(ClientShipTracker tracker) {
+        this.tracker = tracker;
+    }
+
+    /** Set when player mounts the helm. */
+    public void setActive(String shipId) {
+        this.activeShipId = shipId;
+        ClientShipTracker.ClientShipState state = tracker.getShip(shipId);
+        if (state != null) {
+            this.shipName = state.shipName;
+            this.heading = state.heading;
+        }
+    }
+
+    /** Clear when player dismounts. */
+    public void clearActive() {
+        this.activeShipId = null;
+    }
+
+    /** Update from status packet. */
+    public void updateStatus(String shipId, float integrity, float heading) {
+        if (shipId.equals(activeShipId)) {
+            this.integrity = integrity;
+            this.heading = heading;
+        }
+    }
+
+    public boolean isActive() {
+        return activeShipId != null;
+    }
+
+    @Override
+    public void onHudRender(DrawContext context, RenderTickCounter tickCounter) {
+        if (activeShipId == null) return;
+
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.player == null) return;
+
+        int screenWidth = client.getWindow().getScaledWidth();
+        int screenHeight = client.getWindow().getScaledHeight();
+
+        // -- Ship name (top center) --
+        String nameText = "\u00A7l" + shipName;
+        int nameWidth = client.textRenderer.getWidth(nameText);
+        context.drawText(client.textRenderer, Text.of(nameText),
+                (screenWidth - nameWidth) / 2, 10, 0xFFFFFF, true);
+
+        // -- Hull integrity bar (bottom left) --
+        int barX = 10;
+        int barY = screenHeight - 30;
+        int barWidth = 120;
+        int barHeight = 8;
+
+        // Background
+        context.fill(barX - 1, barY - 1, barX + barWidth + 1, barY + barHeight + 1, 0x80000000);
+
+        // Fill color based on integrity
+        int fillWidth = (int) (barWidth * integrity / 100f);
+        int color;
+        if (integrity > 60) color = 0xFF00CC00;      // green
+        else if (integrity > 30) color = 0xFFCCCC00;  // yellow
+        else color = 0xFFCC0000;                       // red
+
+        context.fill(barX, barY, barX + fillWidth, barY + barHeight, color);
+
+        // Label
+        String integrityText = String.format("Hull: %.0f%%", integrity);
+        context.drawText(client.textRenderer, Text.of(integrityText),
+                barX, barY - 12, 0xCCCCCC, true);
+
+        // -- Heading compass (bottom center) --
+        String compassText = String.format("Heading: %.0f\u00B0 %s",
+                heading, compassDirection(heading));
+        int compassWidth = client.textRenderer.getWidth(compassText);
+        context.drawText(client.textRenderer, Text.of(compassText),
+                (screenWidth - compassWidth) / 2, screenHeight - 30, 0xCCCCCC, true);
+
+        // -- Controls hint (bottom right) --
+        String controls = "W/S: Speed  A/D: Steer  Sneak: Dismount";
+        int controlsWidth = client.textRenderer.getWidth(controls);
+        context.drawText(client.textRenderer, Text.of("\u00A77" + controls),
+                screenWidth - controlsWidth - 10, screenHeight - 15, 0x999999, true);
+    }
+
+    private static String compassDirection(float heading) {
+        float h = ((heading % 360) + 360) % 360;
+        if (h < 22.5 || h >= 337.5) return "N";
+        if (h < 67.5) return "NE";
+        if (h < 112.5) return "E";
+        if (h < 157.5) return "SE";
+        if (h < 202.5) return "S";
+        if (h < 247.5) return "SW";
+        if (h < 292.5) return "W";
+        return "NW";
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
@@ -95,13 +95,74 @@ public final class ShipManager {
             this.anchor = anchor;
             this.entries = new java.util.ArrayList<>(data.blocks().entrySet());
 
-            // Clear water at every position where we'll place a ship block.
-            // This handles water inside the hull without clearing the entire
-            // 4M-position bounding box.
-            clearPositions = new java.util.ArrayList<>(data.blocks().keySet());
+            // Clear water at ship block positions PLUS a 1-block buffer around
+            // the hull at and below sea level. This prevents water from seeping
+            // through gaps in the hull and handles the waterline cleanly.
+            java.util.Set<BlockPos> clearSet = new java.util.HashSet<>(data.blocks().keySet());
+
+            // Add a buffer zone: for each ship block at or below Y=5 (relative
+            // to anchor, which is at sea level), also clear adjacent positions.
+            // This creates a dry cavity inside the hull.
+            for (BlockPos bp : data.blocks().keySet()) {
+                if (bp.getY() <= 5) { // waterline zone (5 blocks above anchor)
+                    for (int dx = -1; dx <= 1; dx++) {
+                        for (int dz = -1; dz <= 1; dz++) {
+                            BlockPos adj = bp.add(dx, 0, dz);
+                            if (adj.getX() >= 0 && adj.getX() < data.sizeX()
+                                    && adj.getZ() >= 0 && adj.getZ() < data.sizeZ()) {
+                                clearSet.add(adj);
+                            }
+                            // Also clear below
+                            for (int dy = -1; dy >= -3; dy--) {
+                                BlockPos below = bp.add(dx, dy, dz);
+                                if (below.getY() >= 0) {
+                                    clearSet.add(below);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            clearPositions = new java.util.ArrayList<>(clearSet);
         }
 
         boolean isDone() { return clearDone && placeIndex >= entries.size(); }
+    }
+
+    /** Live tracking of which blocks currently belong to a ship.
+     *  Starts as a copy of the schematic, mutated as blocks are
+     *  broken (damage) or added (upgrades). Used by despawn to know
+     *  exactly which blocks to clear, and for hull integrity %. */
+    public static final class ShipBlockTracker {
+        private final java.util.Set<BlockPos> liveBlocks;
+        private final int originalCount;
+
+        ShipBlockTracker(ShipData data) {
+            this.liveBlocks = ConcurrentHashMap.newKeySet();
+            this.liveBlocks.addAll(data.blocks().keySet());
+            this.originalCount = data.blockCount();
+        }
+
+        /** Mark a block as destroyed (broken by player/explosion). */
+        public void removeBlock(BlockPos offset) {
+            liveBlocks.remove(offset);
+        }
+
+        /** Add a block (upgrade/repair). */
+        public void addBlock(BlockPos offset) {
+            liveBlocks.add(offset);
+        }
+
+        /** Current live block count. */
+        public int blockCount() { return liveBlocks.size(); }
+
+        /** Hull integrity as a percentage (100% = undamaged). */
+        public float integrity() {
+            return originalCount > 0 ? (float) liveBlocks.size() / originalCount * 100f : 0f;
+        }
+
+        /** All live block offsets (for despawn cleanup). */
+        public java.util.Set<BlockPos> blocks() { return liveBlocks; }
     }
 
     /** Record of an active ship in the world. */
@@ -111,10 +172,12 @@ public final class ShipManager {
         public final String shipName;
         public BlockPos anchor;
         public final ShipData data;
+        public final ShipBlockTracker blockTracker;
         public float heading = 0.0f;
 
         ActiveShip(UUID shipId, UUID ownerUuid, String shipName, BlockPos anchor, ShipData data) {
             this.shipId = shipId;
+            this.blockTracker = new ShipBlockTracker(data);
             this.ownerUuid = ownerUuid;
             this.shipName = shipName;
             this.anchor = anchor;
@@ -170,8 +233,10 @@ public final class ShipManager {
         ActiveShip ship = ships.remove(shipId);
         if (ship == null) return false;
 
+        // Use live block tracker — only clears blocks that still exist
+        // (broken blocks were already removed from the tracker)
         int removed = 0;
-        for (BlockPos offset : ship.data.blocks().keySet()) {
+        for (BlockPos offset : ship.blockTracker.blocks()) {
             BlockPos worldPos = ship.anchor.add(offset);
             world.setBlockState(worldPos, Blocks.AIR.getDefaultState());
             removed++;

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -1,0 +1,186 @@
+package com.kbve.statetree.ship;
+
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Network packets for ship state synchronization.
+ *
+ * <p>Server → Client:
+ * <ul>
+ *   <li>{@link ShipMovePayload} — ship anchor moved, client should
+ *       interpolate the visual position smoothly</li>
+ *   <li>{@link ShipSpawnPayload} — new ship placed, client should
+ *       start tracking it</li>
+ *   <li>{@link ShipDespawnPayload} — ship removed</li>
+ * </ul>
+ *
+ * <p>Client → Server:
+ * <ul>
+ *   <li>{@link HelmInputPayload} — WASD steering input from the helm</li>
+ * </ul>
+ */
+public final class ShipNetworking {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    // -- Payload IDs --------------------------------------------------------
+
+    public static final Identifier SHIP_MOVE_ID = Identifier.of("behavior_statetree", "ship_move");
+    public static final Identifier SHIP_SPAWN_ID = Identifier.of("behavior_statetree", "ship_spawn");
+    public static final Identifier SHIP_DESPAWN_ID = Identifier.of("behavior_statetree", "ship_despawn");
+    public static final Identifier HELM_INPUT_ID = Identifier.of("behavior_statetree", "helm_input");
+
+    // -- Server → Client payloads -------------------------------------------
+
+    /** Ship moved — client should interpolate to new anchor. */
+    public record ShipMovePayload(
+            String shipId,
+            double anchorX, double anchorY, double anchorZ,
+            float heading
+    ) implements CustomPayload {
+        public static final CustomPayload.Id<ShipMovePayload> ID = new CustomPayload.Id<>(SHIP_MOVE_ID);
+        public static final PacketCodec<RegistryByteBuf, ShipMovePayload> CODEC =
+                PacketCodec.tuple(
+                        PacketCodecs.STRING, ShipMovePayload::shipId,
+                        PacketCodecs.DOUBLE, ShipMovePayload::anchorX,
+                        PacketCodecs.DOUBLE, ShipMovePayload::anchorY,
+                        PacketCodecs.DOUBLE, ShipMovePayload::anchorZ,
+                        PacketCodecs.FLOAT, ShipMovePayload::heading,
+                        ShipMovePayload::new
+                );
+
+        @Override
+        public Id<? extends CustomPayload> getId() { return ID; }
+    }
+
+    /** New ship spawned — client should start tracking. */
+    public record ShipSpawnPayload(
+            String shipId,
+            String shipName,
+            double anchorX, double anchorY, double anchorZ,
+            int sizeX, int sizeY, int sizeZ
+    ) implements CustomPayload {
+        public static final CustomPayload.Id<ShipSpawnPayload> ID = new CustomPayload.Id<>(SHIP_SPAWN_ID);
+        public static final PacketCodec<RegistryByteBuf, ShipSpawnPayload> CODEC =
+                PacketCodec.tuple(
+                        PacketCodecs.STRING, ShipSpawnPayload::shipId,
+                        PacketCodecs.STRING, ShipSpawnPayload::shipName,
+                        PacketCodecs.DOUBLE, ShipSpawnPayload::anchorX,
+                        PacketCodecs.DOUBLE, ShipSpawnPayload::anchorY,
+                        PacketCodecs.DOUBLE, ShipSpawnPayload::anchorZ,
+                        PacketCodecs.INTEGER, ShipSpawnPayload::sizeX,
+                        PacketCodecs.INTEGER, ShipSpawnPayload::sizeY,
+                        PacketCodecs.INTEGER, ShipSpawnPayload::sizeZ,
+                        ShipSpawnPayload::new
+                );
+
+        @Override
+        public Id<? extends CustomPayload> getId() { return ID; }
+    }
+
+    /** Ship removed. */
+    public record ShipDespawnPayload(String shipId) implements CustomPayload {
+        public static final CustomPayload.Id<ShipDespawnPayload> ID = new CustomPayload.Id<>(SHIP_DESPAWN_ID);
+        public static final PacketCodec<RegistryByteBuf, ShipDespawnPayload> CODEC =
+                PacketCodec.tuple(
+                        PacketCodecs.STRING, ShipDespawnPayload::shipId,
+                        ShipDespawnPayload::new
+                );
+
+        @Override
+        public Id<? extends CustomPayload> getId() { return ID; }
+    }
+
+    // -- Client → Server payloads -------------------------------------------
+
+    /** WASD helm steering input. */
+    public record HelmInputPayload(
+            String shipId,
+            float forward,
+            float sideways
+    ) implements CustomPayload {
+        public static final CustomPayload.Id<HelmInputPayload> ID = new CustomPayload.Id<>(HELM_INPUT_ID);
+        public static final PacketCodec<RegistryByteBuf, HelmInputPayload> CODEC =
+                PacketCodec.tuple(
+                        PacketCodecs.STRING, HelmInputPayload::shipId,
+                        PacketCodecs.FLOAT, HelmInputPayload::forward,
+                        PacketCodecs.FLOAT, HelmInputPayload::sideways,
+                        HelmInputPayload::new
+                );
+
+        @Override
+        public Id<? extends CustomPayload> getId() { return ID; }
+    }
+
+    // -- Registration -------------------------------------------------------
+
+    /** Register all packet types. Call from both server and client init. */
+    public static void registerPayloads() {
+        // Server → Client
+        PayloadTypeRegistry.playS2C().register(ShipMovePayload.ID, ShipMovePayload.CODEC);
+        PayloadTypeRegistry.playS2C().register(ShipSpawnPayload.ID, ShipSpawnPayload.CODEC);
+        PayloadTypeRegistry.playS2C().register(ShipDespawnPayload.ID, ShipDespawnPayload.CODEC);
+
+        // Client → Server
+        PayloadTypeRegistry.playC2S().register(HelmInputPayload.ID, HelmInputPayload.CODEC);
+
+        LOGGER.info("[Ship] Network payloads registered");
+    }
+
+    /** Register server-side receivers for client packets. */
+    public static void registerServerReceivers(ShipManager manager) {
+        ServerPlayNetworking.registerGlobalReceiver(HelmInputPayload.ID, (payload, context) -> {
+            context.server().execute(() -> {
+                ServerPlayerEntity player = context.player();
+                java.util.UUID shipId;
+                try {
+                    shipId = java.util.UUID.fromString(payload.shipId());
+                } catch (IllegalArgumentException e) {
+                    return;
+                }
+
+                ShipManager.ActiveShip ship = manager.getShip(shipId);
+                if (ship == null) return;
+
+                // Apply steering
+                if (payload.forward() > 0) {
+                    // Queue a small forward move
+                    if (!manager.getMover().isMoving(shipId)) {
+                        manager.moveShip(shipId, 1);
+                    }
+                }
+                if (payload.sideways() != 0) {
+                    ship.heading += payload.sideways() > 0 ? -3.0f : 3.0f;
+                    ship.heading = ship.heading % 360;
+                }
+            });
+        });
+    }
+
+    // -- Broadcast helpers --------------------------------------------------
+
+    /** Send a ship move update to all players in the world. */
+    public static void broadcastShipMove(
+            net.minecraft.server.world.ServerWorld world,
+            ShipManager.ActiveShip ship) {
+        ShipMovePayload payload = new ShipMovePayload(
+                ship.shipId.toString(),
+                ship.anchor.getX(), ship.anchor.getY(), ship.anchor.getZ(),
+                ship.heading
+        );
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            ServerPlayNetworking.send(player, payload);
+        }
+    }
+
+    private ShipNetworking() {}
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -37,6 +37,7 @@ public final class ShipNetworking {
     public static final Identifier SHIP_MOVE_ID = Identifier.of("behavior_statetree", "ship_move");
     public static final Identifier SHIP_SPAWN_ID = Identifier.of("behavior_statetree", "ship_spawn");
     public static final Identifier SHIP_DESPAWN_ID = Identifier.of("behavior_statetree", "ship_despawn");
+    public static final Identifier SHIP_STATUS_ID = Identifier.of("behavior_statetree", "ship_status");
     public static final Identifier HELM_INPUT_ID = Identifier.of("behavior_statetree", "helm_input");
 
     // -- Server → Client payloads -------------------------------------------
@@ -100,6 +101,31 @@ public final class ShipNetworking {
         public Id<? extends CustomPayload> getId() { return ID; }
     }
 
+    /** Ship status update — hull integrity, block count, damage events. */
+    public record ShipStatusPayload(
+            String shipId,
+            float integrity,
+            int blockCount,
+            int damageX, int damageY, int damageZ,
+            byte action // 0 = block removed (damage), 1 = block added (repair)
+    ) implements CustomPayload {
+        public static final CustomPayload.Id<ShipStatusPayload> ID = new CustomPayload.Id<>(SHIP_STATUS_ID);
+        public static final PacketCodec<RegistryByteBuf, ShipStatusPayload> CODEC =
+                PacketCodec.tuple(
+                        PacketCodecs.STRING, ShipStatusPayload::shipId,
+                        PacketCodecs.FLOAT, ShipStatusPayload::integrity,
+                        PacketCodecs.INTEGER, ShipStatusPayload::blockCount,
+                        PacketCodecs.INTEGER, ShipStatusPayload::damageX,
+                        PacketCodecs.INTEGER, ShipStatusPayload::damageY,
+                        PacketCodecs.INTEGER, ShipStatusPayload::damageZ,
+                        PacketCodecs.BYTE, ShipStatusPayload::action,
+                        ShipStatusPayload::new
+                );
+
+        @Override
+        public Id<? extends CustomPayload> getId() { return ID; }
+    }
+
     // -- Client → Server payloads -------------------------------------------
 
     /** WASD helm steering input. */
@@ -129,6 +155,7 @@ public final class ShipNetworking {
         PayloadTypeRegistry.playS2C().register(ShipMovePayload.ID, ShipMovePayload.CODEC);
         PayloadTypeRegistry.playS2C().register(ShipSpawnPayload.ID, ShipSpawnPayload.CODEC);
         PayloadTypeRegistry.playS2C().register(ShipDespawnPayload.ID, ShipDespawnPayload.CODEC);
+        PayloadTypeRegistry.playS2C().register(ShipStatusPayload.ID, ShipStatusPayload.CODEC);
 
         // Client → Server
         PayloadTypeRegistry.playC2S().register(HelmInputPayload.ID, HelmInputPayload.CODEC);
@@ -176,6 +203,24 @@ public final class ShipNetworking {
                 ship.shipId.toString(),
                 ship.anchor.getX(), ship.anchor.getY(), ship.anchor.getZ(),
                 ship.heading
+        );
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            ServerPlayNetworking.send(player, payload);
+        }
+    }
+
+    /** Send a ship status update (damage event) to all players in the world. */
+    public static void broadcastShipStatus(
+            net.minecraft.server.world.ServerWorld world,
+            ShipManager.ActiveShip ship,
+            int damageX, int damageY, int damageZ,
+            byte action) {
+        ShipStatusPayload payload = new ShipStatusPayload(
+                ship.shipId.toString(),
+                ship.blockTracker.integrity(),
+                ship.blockTracker.blockCount(),
+                damageX, damageY, damageZ,
+                action
         );
         for (ServerPlayerEntity player : world.getPlayers()) {
             ServerPlayNetworking.send(player, payload);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipProtection.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipProtection.java
@@ -1,25 +1,20 @@
 package com.kbve.statetree.ship;
 
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Prevents players from mining resources from ship blocks.
  *
- * <p>When a block within a tracked ship's region is broken, the break
- * is allowed (so ships can take damage / be dismantled) but the block
- * drops are suppressed — the block simply vanishes. This prevents
- * players from spawning ships as a resource farm.
- *
- * <p>Registered via Fabric's {@code PlayerBlockBreakEvents.AFTER} so
- * the break happens normally but we clear the drops.
+ * <p>When a block within a tracked ship is broken:
+ * <ul>
+ *   <li>The block is set to air (no drops, no items)</li>
+ *   <li>The block is removed from the ship's live block tracker</li>
+ *   <li>Hull integrity is logged when it drops below thresholds</li>
+ * </ul>
  */
 public final class ShipProtection {
 
@@ -27,36 +22,51 @@ public final class ShipProtection {
 
     private ShipProtection() {}
 
-    /**
-     * Register the block break listener. Call once at mod init.
-     */
     public static void register(ShipManager manager) {
-        // BEFORE: we can cancel the break entirely or modify behavior
         PlayerBlockBreakEvents.BEFORE.register((world, player, pos, state, blockEntity) -> {
             if (world instanceof ServerWorld serverWorld) {
-                if (isShipBlock(manager, pos)) {
-                    // Allow the break but set the block to air directly
-                    // without drops — return false to cancel the normal
-                    // break (which would drop items), then set air ourselves
+                ShipManager.ActiveShip ship = findShipAt(manager, pos);
+                if (ship != null) {
+                    // Calculate the offset within the ship
+                    BlockPos offset = new BlockPos(
+                            pos.getX() - ship.anchor.getX(),
+                            pos.getY() - ship.anchor.getY(),
+                            pos.getZ() - ship.anchor.getZ()
+                    );
+
+                    // Set to air without drops
                     serverWorld.setBlockState(pos, net.minecraft.block.Blocks.AIR.getDefaultState(), 18);
+
+                    // Update the live block tracker
+                    ship.blockTracker.removeBlock(offset);
+
+                    // Log damage at integrity thresholds
+                    float integrity = ship.blockTracker.integrity();
+                    if (integrity <= 75 && integrity > 74 ||
+                            integrity <= 50 && integrity > 49 ||
+                            integrity <= 25 && integrity > 24 ||
+                            integrity <= 10 && integrity > 9) {
+                        LOGGER.info("[Ship] '{}' hull integrity: {:.0f}% ({} blocks remaining)",
+                                ship.shipName, integrity, ship.blockTracker.blockCount());
+                    }
+
                     return false; // cancel normal break (no drops)
                 }
             }
-            return true; // normal break for non-ship blocks
+            return true;
         });
     }
 
     /**
-     * Check if a block position falls within any tracked ship's region.
+     * Find which ship (if any) owns the block at the given position.
+     * Returns null if the position is not within any tracked ship.
      */
-    private static boolean isShipBlock(ShipManager manager, BlockPos pos) {
-        // Check all active ships
+    private static ShipManager.ActiveShip findShipAt(ShipManager manager, BlockPos pos) {
         for (var entry : manager.getActiveShips().entrySet()) {
             ShipManager.ActiveShip ship = entry.getValue();
             BlockPos anchor = ship.anchor;
             ShipData data = ship.data;
 
-            // Quick bounding box check
             int dx = pos.getX() - anchor.getX();
             int dy = pos.getY() - anchor.getY();
             int dz = pos.getZ() - anchor.getZ();
@@ -64,9 +74,13 @@ public final class ShipProtection {
             if (dx >= 0 && dx < data.sizeX()
                     && dy >= 0 && dy < data.sizeY()
                     && dz >= 0 && dz < data.sizeZ()) {
-                return true;
+                // Also verify this offset is actually tracked (not already broken)
+                BlockPos offset = new BlockPos(dx, dy, dz);
+                if (ship.blockTracker.blocks().contains(offset)) {
+                    return ship;
+                }
             }
         }
-        return false;
+        return null;
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipProtection.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipProtection.java
@@ -40,15 +40,12 @@ public final class ShipProtection {
                     // Update the live block tracker
                     ship.blockTracker.removeBlock(offset);
 
-                    // Log damage at integrity thresholds
-                    float integrity = ship.blockTracker.integrity();
-                    if (integrity <= 75 && integrity > 74 ||
-                            integrity <= 50 && integrity > 49 ||
-                            integrity <= 25 && integrity > 24 ||
-                            integrity <= 10 && integrity > 9) {
-                        LOGGER.info("[Ship] '{}' hull integrity: {:.0f}% ({} blocks remaining)",
-                                ship.shipName, integrity, ship.blockTracker.blockCount());
-                    }
+                    // Broadcast damage to all clients (HUD + effects)
+                    ShipNetworking.broadcastShipStatus(
+                            serverWorld, ship,
+                            pos.getX(), pos.getY(), pos.getZ(),
+                            (byte) 0 // 0 = removed
+                    );
 
                     return false; // cancel normal break (no drops)
                 }

--- a/apps/mc/behavior_statetree/java/src/main/resources/fabric.mod.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/fabric.mod.json
@@ -3,16 +3,17 @@
 	"id": "behavior_statetree",
 	"version": "0.1.0",
 	"name": "Behavior State Tree",
-	"description": "Hybrid Rust/Tokio NPC AI planner — async behavior trees with epoch-guarded intents.",
+	"description": "Hybrid Rust/Tokio NPC AI planner with client-side ship rendering — async behavior trees, flow field pathfinding, and ship system.",
 	"authors": ["KBVE", "h0lybyte"],
 	"contact": {
 		"homepage": "https://kbve.com/",
 		"sources": "https://github.com/KBVE/kbve/tree/main/apps/mc/behavior_statetree"
 	},
 	"license": "MIT",
-	"environment": "server",
+	"environment": "*",
 	"entrypoints": {
-		"main": ["com.kbve.statetree.BehaviorStateTreeMod"]
+		"main": ["com.kbve.statetree.BehaviorStateTreeMod"],
+		"client": ["com.kbve.statetree.client.ShipClientMod"]
 	},
 	"depends": {
 		"fabricloader": ">=0.16.0",

--- a/apps/mc/behavior_statetree/mrpack/.gitignore
+++ b/apps/mc/behavior_statetree/mrpack/.gitignore
@@ -1,0 +1,1 @@
+mrpack/dist/

--- a/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
+++ b/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Build a Modrinth .mrpack modpack containing the behavior_statetree client mod.
+#
+# Usage:
+#   cd apps/mc/behavior_statetree
+#   ./mrpack/build-mrpack.sh
+#
+# Prerequisites:
+#   - Java mod built: java/build/libs/behavior_statetree-0.1.0.jar
+#   - sha1sum / shasum available
+#
+# Output:
+#   mrpack/dist/kbve-mc-client.mrpack
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIST_DIR="$SCRIPT_DIR/dist"
+WORK_DIR="$DIST_DIR/work"
+
+MOD_JAR="$SCRIPT_DIR/../java/build/libs/behavior_statetree-0.1.0.jar"
+PACK_NAME="KBVE MC Client"
+PACK_VERSION="0.1.0"
+MC_VERSION="1.21.11"
+LOADER_VERSION="0.18.6"
+
+echo "=== Building mrpack ==="
+
+# Check prerequisites
+if [ ! -f "$MOD_JAR" ]; then
+    echo "ERROR: Mod JAR not found at $MOD_JAR"
+    echo "Build it first: cd java && gradle build --no-daemon"
+    exit 1
+fi
+
+# Clean + create work directory
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR/overrides/mods"
+
+# Copy the mod JAR into overrides (bundled directly in the pack)
+cp "$MOD_JAR" "$WORK_DIR/overrides/mods/behavior_statetree-${PACK_VERSION}.jar"
+
+# Compute hashes
+JAR_SIZE=$(wc -c < "$MOD_JAR" | tr -d ' ')
+JAR_SHA1=$(shasum -a 1 "$MOD_JAR" | cut -d' ' -f1)
+JAR_SHA512=$(shasum -a 512 "$MOD_JAR" | cut -d' ' -f1)
+
+# Generate modrinth.index.json
+cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
+{
+  "formatVersion": 1,
+  "game": "minecraft",
+  "versionId": "${PACK_VERSION}",
+  "name": "${PACK_NAME}",
+  "summary": "Client-side mod for KBVE MC server — ship rendering, AI integration, and WASD helm controls.",
+  "dependencies": {
+    "minecraft": "${MC_VERSION}",
+    "fabric-loader": "${LOADER_VERSION}"
+  },
+  "files": [
+    {
+      "path": "mods/fabric-api.jar",
+      "hashes": {
+        "sha1": "50de67eb221f0b38216da8668b09ca311327040e",
+        "sha512": ""
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
+      ],
+      "fileSize": 0,
+      "env": {
+        "client": "required",
+        "server": "unsupported"
+      }
+    }
+  ]
+}
+MANIFEST
+
+# Build the mrpack (just a zip with .mrpack extension)
+mkdir -p "$DIST_DIR"
+MRPACK_FILE="$DIST_DIR/kbve-mc-client-${PACK_VERSION}.mrpack"
+rm -f "$MRPACK_FILE"
+
+cd "$WORK_DIR"
+zip -r "$MRPACK_FILE" modrinth.index.json overrides/
+
+echo ""
+echo "=== mrpack built ==="
+echo "  Output: $MRPACK_FILE"
+echo "  Size: $(du -h "$MRPACK_FILE" | cut -f1)"
+echo ""
+echo "Players can import this in Prism Launcher / ATLauncher / MultiMC."
+echo "It will install Fabric ${LOADER_VERSION} for MC ${MC_VERSION}"
+echo "with the behavior_statetree client mod + Fabric API."


### PR DESCRIPTION
## Summary
- Client-side Fabric mod with WASD helm controls + ship state interpolation
- Custom network packets for ship state sync (server↔client)
- ShipEntity re-enabled (Fabric now required on clients)
- mrpack builder for Modrinth modpack distribution

## Part A — Client-side ship system

**Mod is now `environment: *`** (both client + server). Players need Fabric + this mod installed.

| Component | Purpose |
|-----------|---------|
| `ShipClientMod` | Client entrypoint — WASD input, network receivers, entity renderer |
| `ClientShipTracker` | Ship position interpolation (lerp between server updates) |
| `ShipNetworking` | Custom payloads: ShipMove, ShipSpawn, ShipDespawn (S2C), HelmInput (C2S) |
| `ShipEntity` | Re-registered as custom entity (safe with Fabric requirement) |

**WASD helm flow:**
1. Player mounts ShipEntity at the helm
2. Client reads W/A/S/D keybinds each tick
3. `HelmInputPayload` sent to server with forward/sideways values
4. Server applies steering (heading ±3°, queues moveShip)
5. Server broadcasts `ShipMovePayload` to all clients
6. `ClientShipTracker` interpolates to new position smoothly

## Part B — mrpack distribution

`mrpack/build-mrpack.sh` generates a Modrinth-compatible modpack:
- Bundles the behavior_statetree JAR in `overrides/mods/`
- Declares Fabric API as a dependency (downloaded by launcher)
- Output: `.mrpack` file importable by Prism Launcher / ATLauncher / MultiMC

## Test plan
- [ ] Docker build passes (server-side compilation)
- [ ] Client with Fabric can join server without entity sync errors
- [ ] WASD sends helm packets when mounted on ShipEntity
- [ ] `build-mrpack.sh` produces valid .mrpack