### PR TITLE
feat(mc): add players page with live R3F skin viewer

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
@@ -52,6 +52,12 @@ layer for NPCs and mobs.
 />
 
 <LinkCard
+  title="Online players"
+  description="Live player list with interactive 3D skin viewer."
+  href="/mc/players/"
+/>
+
+<LinkCard
   title="Agents & operators"
   description="Reference for AI agents and human operators working on the Minecraft server."
   href="/mc/agents/"

--- a/apps/kbve/astro-kbve/src/content/docs/mc/players.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/players.mdx
@@ -1,0 +1,27 @@
+---
+title: Minecraft Players
+description: See who is currently playing on the KBVE Minecraft server — live player list with 3D skin viewer.
+sidebar:
+    label: Players
+    order: 2
+tags:
+    - minecraft
+    - mc
+    - players
+---
+
+import McPlayerList from '@/components/mc/McPlayerList.tsx';
+
+## Online Players
+
+See who is currently playing on **mc.kbve.com** — data refreshes automatically.
+
+<McPlayerList client:load />
+
+## How to Connect
+
+1. Open **Minecraft Java Edition** and go to **Multiplayer**
+2. Add server address **mc.kbve.com**
+3. Join and start playing
+
+Click on any player card above to view their full 3D skin model.


### PR DESCRIPTION
## Summary
- Restores `/mc/players/` page removed in d712cab38
- Uses existing `McPlayerList` + `McSkinViewer` components (R3F + Three.js)
- Live auto-refreshing player grid with click-to-expand 3D skin viewer
- Adds "Online players" link card to MC overview page
- Build verified clean (5363 pages, no errors)

## Test plan
- [ ] Verify `/mc/players/` renders the player list component
- [ ] Check player cards show avatars from mc-heads.net
- [ ] Click a player card and confirm 3D skin viewer opens in slide panel
- [ ] Verify auto-refresh polling works (20s interval)
- [ ] Check MC overview page shows the new "Online players" link card