### PR TITLE
fix(ci): pin pnpm to 10.33.0 — action-setup v6 resolves v10 to v11-rc

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -90,7 +90,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -85,7 +85,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Install pnpm Dependencies
@@ -307,7 +307,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path
@@ -1043,7 +1043,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Install dependencies
@@ -1282,7 +1282,7 @@ jobs:
               if: steps.pr.outputs.pr_number != ''
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
 
             - name: Setup Node v24 with pnpm cache
               if: steps.pr.outputs.pr_number != ''

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -49,7 +49,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Install dependencies

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/npm-test-package.yml
+++ b/.github/workflows/npm-test-package.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -44,7 +44,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/utils-astro-deployment.yml
+++ b/.github/workflows/utils-astro-deployment.yml
@@ -11,7 +11,7 @@ on:
             pnpm_version:
                 description: 'PNPM version'
                 required: false
-                default: '10'
+                default: '10.33.0'
                 type: string
             build_command:
                 description: 'Build command for the project'

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -56,7 +56,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/utils-npm-publish.yml
+++ b/.github/workflows/utils-npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store

--- a/.github/workflows/utils-nx-kbve-shell.yml
+++ b/.github/workflows/utils-nx-kbve-shell.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -143,7 +143,7 @@ jobs:
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store

--- a/.github/workflows/utils-python-publish.yml
+++ b/.github/workflows/utils-python-publish.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store

--- a/.github/workflows/utils-self-hosted-job.yml
+++ b/.github/workflows/utils-self-hosted-job.yml
@@ -167,7 +167,7 @@ jobs:
               if: inputs.setup_node
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path

--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -130,7 +130,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path
@@ -231,7 +231,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path
@@ -329,7 +329,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path
@@ -419,7 +419,7 @@ jobs:
             - name: Setup pnpm v10
               uses: pnpm/action-setup@v6
               with:
-                  version: 10
+                  version: 10.33.0
                   run_install: false
 
             - name: Get pnpm Store Path


### PR DESCRIPTION
## Summary
- `pnpm/action-setup@v6` with `version: 10` installs pnpm **11.0.0-rc.0** instead of the latest 10.x (10.33.0)
- pnpm v11 uses a different lockfile config validation for overrides, causing `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on every frozen install in CI
- Pins all 15 workflow files to the exact version `10.33.0` to prevent the action from resolving to a prerelease major version

## Root Cause
The `pnpm/action-setup` bump from v5→v6 (PR #10071) changed how `version: 10` is resolved. Confirmed by:
- CI store path shows `v11/` (pnpm 11 store format) vs local `v10/` (pnpm 10 store format)
- `CI=true pnpm@11.0.0-rc.0 install --frozen-lockfile` reproduces the exact error locally
- `CI=true pnpm@10.33.0 install --frozen-lockfile` works fine

## Test plan
- [ ] CI lint-and-test job passes with pinned version
- [ ] Dev→Main PR check no longer fails with lockfile mismatch