### PR TITLE
fix(ci): revert pnpm/action-setup to v5 — v6 installs wrong pnpm version

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -88,7 +88,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -83,7 +83,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false
@@ -305,7 +305,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false
@@ -1041,7 +1041,7 @@ jobs:
                   protoc --version
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false
@@ -1280,7 +1280,7 @@ jobs:
             # Build gate + auto-merge (same pattern as kanban-sync)
             - name: Setup pnpm
               if: steps.pr.outputs.pr_number != ''
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -47,7 +47,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -96,7 +96,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/npm-test-package.yml
+++ b/.github/workflows/npm-test-package.yml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -26,7 +26,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -42,7 +42,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/utils-astro-deployment.yml
+++ b/.github/workflows/utils-astro-deployment.yml
@@ -57,7 +57,7 @@ jobs:
                   node-version: ${{ inputs.node_version }}
 
             - name: Setup pnpm ${{ inputs.pnpm_version }}
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: ${{ inputs.pnpm_version }}
                   run_install: false

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -54,7 +54,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/utils-npm-publish.yml
+++ b/.github/workflows/utils-npm-publish.yml
@@ -44,7 +44,7 @@ jobs:
                   registry-url: https://registry.npmjs.org/
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/utils-nx-kbve-shell.yml
+++ b/.github/workflows/utils-nx-kbve-shell.yml
@@ -55,7 +55,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -141,7 +141,7 @@ jobs:
 
             - name: Setup pnpm v10
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/utils-python-publish.yml
+++ b/.github/workflows/utils-python-publish.yml
@@ -46,7 +46,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/utils-self-hosted-job.yml
+++ b/.github/workflows/utils-self-hosted-job.yml
@@ -165,7 +165,7 @@ jobs:
 
             - name: Setup pnpm v10
               if: inputs.setup_node
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false

--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -128,7 +128,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false
@@ -229,7 +229,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false
@@ -327,7 +327,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false
@@ -417,7 +417,7 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm v10
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
               with:
                   version: 10.33.0
                   run_install: false


### PR DESCRIPTION
## Summary
- `pnpm/action-setup@v6` installs pnpm **11.0.0-rc.0** regardless of the `version` input — even an exact pin like `10.33.0` is ignored
- The v6 self-installer uses npm 11 (from Node 24) which resolves to the wrong major version, confirmed by `v11/` store format in CI logs vs `v10/` locally
- Reverting all 15 workflow files to `@v5` which correctly respects the version input

## Evidence
- Run [24374519955](https://github.com/KBVE/kbve/actions/runs/24374519955) shows `version: 10.33.0` in action inputs but `v11/` store path in output
- pnpm 10.x uses store `v10/`, pnpm 11.x uses store `v11/` — confirmed locally
- `CI=true pnpm@11.0.0-rc.0 install --frozen-lockfile` reproduces the exact `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` error

## Test plan
- [ ] CI lint-and-test passes with action-setup v5
- [ ] Dev→Main PR check passes