### PR TITLE
feat(kubevirt): VNC autologin hardening + multi-viewer session info

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import { vmService } from './vmService';
-import { X, Maximize2, Minimize2, Keyboard } from 'lucide-react';
+import { X, Maximize2, Minimize2, Keyboard, Users, Crown } from 'lucide-react';
 
 // noVNC RFB client — loaded from vendored ESM in public/vendor/novnc/.
 // The npm package (@novnc/novnc) ships CJS with a top-level await in
@@ -38,6 +38,9 @@ async function loadRFB() {
 	return RFB;
 }
 
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_DELAY_MS = 2000;
+
 export default function ReactVMVncViewer() {
 	const vncTarget = useStore(vmService.$vncTarget);
 	const rfbRef = useRef<InstanceType<typeof RFB> | null>(null);
@@ -47,82 +50,159 @@ export default function ReactVMVncViewer() {
 	const [connected, setConnected] = useState(false);
 	const [status, setStatus] = useState('Connecting...');
 	const [keyboardVisible, setKeyboardVisible] = useState(false);
+	const [viewerCount, setViewerCount] = useState(0);
+	const [isPrimary, setIsPrimary] = useState(false);
+	const reconnectAttemptRef = useRef(0);
+	const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const intentionalCloseRef = useRef(false);
+
+	// Poll viewer count while connected
+	useEffect(() => {
+		if (!vncTarget || !connected) {
+			setViewerCount(0);
+			setIsPrimary(false);
+			return;
+		}
+
+		const pollViewerCount = async () => {
+			try {
+				const info = await vmService.getVNCSessionInfo(vncTarget);
+				if (info) {
+					setViewerCount(info.viewers);
+					setIsPrimary(info.has_primary);
+				}
+			} catch {
+				// Silently ignore — the connection may have dropped
+			}
+		};
+
+		pollViewerCount();
+		const interval = setInterval(pollViewerCount, 5000);
+		return () => clearInterval(interval);
+	}, [vncTarget, connected]);
 
 	const cleanup = useCallback(() => {
+		if (reconnectTimerRef.current) {
+			clearTimeout(reconnectTimerRef.current);
+			reconnectTimerRef.current = null;
+		}
 		if (rfbRef.current) {
 			rfbRef.current.disconnect();
 			rfbRef.current = null;
 		}
 		setConnected(false);
 		setStatus('Disconnected');
+		setViewerCount(0);
+		setIsPrimary(false);
+	}, []);
+
+	const connectVNC = useCallback(async (target: string) => {
+		const viewerEl = viewerRef.current;
+		if (!viewerEl) return;
+
+		viewerEl.innerHTML = '';
+
+		const wsUrl = vmService.getVNCWebSocketURL(target);
+		setStatus(
+			reconnectAttemptRef.current > 0
+				? `Reconnecting (${reconnectAttemptRef.current}/${MAX_RECONNECT_ATTEMPTS})...`
+				: 'Connecting...',
+		);
+
+		try {
+			const RFBClass = await loadRFB();
+			const rfb = new RFBClass(viewerEl, wsUrl, {
+				wsProtocols: ['binary.k8s.io', 'base64.binary.k8s.io'],
+			});
+
+			rfb.scaleViewport = true;
+			rfb.resizeSession = false;
+			rfb.clipViewport = false;
+			rfb.showDotCursor = true;
+			rfb.qualityLevel = 6;
+			rfb.compressionLevel = 2;
+
+			rfb.addEventListener('connect', () => {
+				setConnected(true);
+				setStatus(`Connected to ${target}`);
+				reconnectAttemptRef.current = 0;
+			});
+
+			rfb.addEventListener(
+				'disconnect',
+				(e: { detail: { clean: boolean } }) => {
+					setConnected(false);
+					rfbRef.current = null;
+
+					if (intentionalCloseRef.current) {
+						setStatus('Disconnected');
+						return;
+					}
+
+					if (e.detail.clean) {
+						setStatus('Disconnected — server closed connection');
+					} else {
+						setStatus('Connection lost — attempting reconnect...');
+					}
+
+					// Auto-reconnect on unexpected disconnects
+					if (reconnectAttemptRef.current < MAX_RECONNECT_ATTEMPTS) {
+						reconnectAttemptRef.current += 1;
+						const delay =
+							RECONNECT_BASE_DELAY_MS *
+							Math.pow(1.5, reconnectAttemptRef.current - 1);
+						setStatus(
+							`Reconnecting in ${Math.round(delay / 1000)}s (${reconnectAttemptRef.current}/${MAX_RECONNECT_ATTEMPTS})...`,
+						);
+						reconnectTimerRef.current = setTimeout(() => {
+							connectVNC(target);
+						}, delay);
+					} else {
+						setStatus(
+							'Connection lost — max reconnect attempts reached. Click to retry.',
+						);
+					}
+				},
+			);
+
+			rfb.addEventListener('securityfailure', () => {
+				setStatus('Security handshake failed');
+			});
+
+			rfbRef.current = rfb;
+		} catch (err) {
+			setStatus(
+				`Failed to connect: ${err instanceof Error ? err.message : 'Unknown error'}`,
+			);
+		}
 	}, []);
 
 	useEffect(() => {
 		if (!vncTarget) {
+			intentionalCloseRef.current = false;
 			cleanup();
 			return;
 		}
 
-		const target = viewerRef.current;
-		if (!target) return;
+		reconnectAttemptRef.current = 0;
+		intentionalCloseRef.current = false;
+		connectVNC(vncTarget);
 
-		// Clear previous content
-		target.innerHTML = '';
+		return () => {
+			intentionalCloseRef.current = true;
+			cleanup();
+		};
+	}, [vncTarget, connectVNC, cleanup]);
 
-		const wsUrl = vmService.getVNCWebSocketURL(vncTarget);
-		setStatus('Connecting...');
-
-		(async () => {
-			try {
-				const RFBClass = await loadRFB();
-				const rfb = new RFBClass(target, wsUrl, {
-					wsProtocols: ['binary.k8s.io', 'base64.binary.k8s.io'],
-				});
-
-				rfb.scaleViewport = true;
-				rfb.resizeSession = false;
-				rfb.clipViewport = false;
-				rfb.showDotCursor = true;
-				rfb.qualityLevel = 6;
-				rfb.compressionLevel = 2;
-
-				rfb.addEventListener('connect', () => {
-					setConnected(true);
-					setStatus(`Connected to ${vncTarget}`);
-				});
-
-				rfb.addEventListener(
-					'disconnect',
-					(e: { detail: { clean: boolean } }) => {
-						const wasConnected = connected;
-						setConnected(false);
-						if (e.detail.clean) {
-							setStatus('Disconnected cleanly');
-						} else if (!wasConnected) {
-							setStatus(
-								'WebSocket failed — VM may not be running or K8s API unreachable',
-							);
-						} else {
-							setStatus('Connection lost — VM may have stopped');
-						}
-						rfbRef.current = null;
-					},
-				);
-
-				rfb.addEventListener('securityfailure', () => {
-					setStatus('Security handshake failed');
-				});
-
-				rfbRef.current = rfb;
-			} catch (err) {
-				setStatus(
-					`Failed to connect: ${err instanceof Error ? err.message : 'Unknown error'}`,
-				);
-			}
-		})();
-
-		return cleanup;
-	}, [vncTarget, cleanup]);
+	// Manual retry handler
+	const handleRetry = useCallback(() => {
+		if (vncTarget && !connected) {
+			reconnectAttemptRef.current = 0;
+			connectVNC(vncTarget);
+		}
+	}, [vncTarget, connected, connectVNC]);
 
 	// Ctrl+Alt+Del sender
 	const sendCtrlAltDel = useCallback(() => {
@@ -162,12 +242,17 @@ export default function ReactVMVncViewer() {
 			{/* noVNC renders into this container */}
 			<div
 				ref={viewerRef}
+				onClick={!connected ? handleRetry : undefined}
 				style={{
 					flex: 1,
 					minHeight: fullscreen ? undefined : 480,
 					height: fullscreen ? undefined : 480,
 					background: '#0a0a0a',
-					cursor: connected ? 'default' : 'not-allowed',
+					cursor: connected
+						? 'default'
+						: status.includes('Click to retry')
+							? 'pointer'
+							: 'not-allowed',
 				}}
 			/>
 
@@ -210,6 +295,34 @@ export default function ReactVMVncViewer() {
 							}}>
 							{status}
 						</span>
+						{/* Viewer count badge */}
+						{connected && viewerCount > 0 && (
+							<span
+								style={{
+									display: 'inline-flex',
+									alignItems: 'center',
+									gap: 3,
+									padding: '1px 6px',
+									borderRadius: 4,
+									fontSize: '0.65rem',
+									fontWeight: 600,
+									background: 'rgba(6, 182, 212, 0.15)',
+									border: '1px solid rgba(6, 182, 212, 0.3)',
+									color: '#06b6d4',
+								}}>
+								<Users size={10} />
+								{viewerCount}
+								{isPrimary && (
+									<Crown
+										size={9}
+										style={{
+											color: '#f59e0b',
+											marginLeft: 1,
+										}}
+									/>
+								)}
+							</span>
+						)}
 					</div>
 					<div style={{ display: 'flex', gap: 4 }}>
 						{connected && (
@@ -245,7 +358,10 @@ export default function ReactVMVncViewer() {
 						</ToolbarButton>
 						<ToolbarButton
 							title="Close VNC"
-							onClick={() => vmService.closeVNC()}
+							onClick={() => {
+								intentionalCloseRef.current = true;
+								vmService.closeVNC();
+							}}
 							color="#ef4444">
 							<X size={14} />
 						</ToolbarButton>
@@ -259,8 +375,10 @@ export default function ReactVMVncViewer() {
 						textAlign: 'center',
 					}}>
 					{connected
-						? 'Click inside to capture keyboard · Ctrl+Alt+Del via toolbar'
-						: 'Waiting for VNC connection...'}
+						? `Click inside to capture keyboard · Ctrl+Alt+Del via toolbar${viewerCount > 1 ? ` · ${viewerCount} viewers connected` : ''}`
+						: status.includes('Click to retry')
+							? 'Click the viewer area to retry connection'
+							: 'Waiting for VNC connection...'}
 				</div>
 			</div>
 		</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
@@ -751,6 +751,31 @@ class VMService {
 		return `${proto}//${window.location.host}/dashboard/vm/vnc/${name}?access_token=${token}`;
 	}
 
+	public async getVNCSessionInfo(
+		name: string,
+	): Promise<{
+		vm_key: string;
+		viewers: number;
+		has_primary: boolean;
+	} | null> {
+		const token = this.$accessToken.get();
+		if (!token) return null;
+		try {
+			const resp = await fetch(
+				`/dashboard/vm/vnc-info/${name}?access_token=${token}`,
+				{ signal: AbortSignal.timeout(5000) },
+			);
+			if (!resp.ok) return null;
+			return (await resp.json()) as {
+				vm_key: string;
+				viewers: number;
+				has_primary: boolean;
+			};
+		} catch {
+			return null;
+		}
+	}
+
 	private _startAutoRefresh(): void {
 		if (this._refreshInterval) clearInterval(this._refreshInterval);
 		this._refreshInterval = setInterval(

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -256,6 +256,14 @@ fn router(state: AppState) -> Router {
             axum::routing::get(super::proxy::kubevirt_vnc_handler),
         )
         .route(
+            "/dashboard/vm/vnc-info/{name}",
+            axum::routing::get(super::proxy::kubevirt_vnc_info_handler),
+        )
+        .route(
+            "/dashboard/vm/vnc-sessions",
+            axum::routing::get(super::proxy::kubevirt_vnc_sessions_handler),
+        )
+        .route(
             "/dashboard/firecracker/proxy/{*path}",
             any(super::proxy::firecracker_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -772,6 +772,47 @@ const VM_NAMESPACE: &str = "angelscript";
 const KASM_NAMESPACE: &str = "kasm";
 
 // ---------------------------------------------------------------------------
+// VNC session info endpoints — viewer count + primary status
+// ---------------------------------------------------------------------------
+
+/// GET /dashboard/vm/vnc-info/{name} — returns viewer count for a specific VM
+pub async fn kubevirt_vnc_info_handler(
+    Path(vm_name): Path<String>,
+    req: Request<Body>,
+) -> Response {
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(|q| q.to_string());
+
+    if let Err(resp) =
+        require_dashboard_view_with_query(&headers, query.as_deref(), "VNC-Info").await
+    {
+        return resp;
+    }
+
+    let vm_key = format!("{VM_NAMESPACE}/{vm_name}");
+    match super::vnc_hub::get_session_info(&vm_key) {
+        Some(info) => axum::Json(info).into_response(),
+        None => axum::Json(json!({"vm_key": vm_key, "viewers": 0, "has_primary": false}))
+            .into_response(),
+    }
+}
+
+/// GET /dashboard/vm/vnc-sessions — returns all active VNC sessions
+pub async fn kubevirt_vnc_sessions_handler(req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(|q| q.to_string());
+
+    if let Err(resp) =
+        require_dashboard_view_with_query(&headers, query.as_deref(), "VNC-Sessions").await
+    {
+        return resp;
+    }
+
+    let sessions = super::vnc_hub::list_sessions();
+    axum::Json(json!({"sessions": sessions})).into_response()
+}
+
+// ---------------------------------------------------------------------------
 // KASM workspace proxy singleton (reverse proxy to KASM web UI)
 // ---------------------------------------------------------------------------
 

--- a/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
+++ b/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
@@ -44,6 +44,7 @@ use axum::body::Bytes;
 use axum::extract::ws::{Message as AxumMsg, WebSocket};
 use dashmap::DashMap;
 use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::{Mutex, broadcast};
@@ -83,6 +84,41 @@ static NEXT_CLIENT_ID: AtomicUsize = AtomicUsize::new(1);
 
 fn sessions() -> &'static DashMap<String, Arc<VncSession>> {
     SESSIONS.get_or_init(DashMap::new)
+}
+
+/// Snapshot of a VNC session's state, returned by the info endpoint.
+#[derive(Serialize)]
+pub struct SessionInfo {
+    pub vm_key: String,
+    pub viewers: usize,
+    pub has_primary: bool,
+}
+
+/// Query session info for a specific VM key. Returns `None` if no active
+/// session exists (i.e. no one is currently connected to that VM's VNC).
+pub fn get_session_info(vm_key: &str) -> Option<SessionInfo> {
+    let registry = sessions();
+    registry.get(vm_key).map(|session| SessionInfo {
+        vm_key: session.vm_key.clone(),
+        viewers: session.clients.load(Ordering::Relaxed),
+        has_primary: session.primary_id.load(Ordering::Relaxed) != 0,
+    })
+}
+
+/// List all active VNC sessions with their viewer counts.
+pub fn list_sessions() -> Vec<SessionInfo> {
+    let registry = sessions();
+    registry
+        .iter()
+        .map(|entry| {
+            let session = entry.value();
+            SessionInfo {
+                vm_key: session.vm_key.clone(),
+                viewers: session.clients.load(Ordering::Relaxed),
+                has_primary: session.primary_id.load(Ordering::Relaxed) != 0,
+            }
+        })
+        .collect()
 }
 
 /// Entry point used by the HTTP handler. Finds or creates the session for

--- a/apps/kube/kubevirt/autologon/configmap.yaml
+++ b/apps/kube/kubevirt/autologon/configmap.yaml
@@ -1,7 +1,11 @@
-# ConfigMap with the Windows autologon configuration script.
+# ConfigMap with the Windows autologon + VNC-ready configuration script.
 #
 # Uses the QEMU Guest Agent (via virsh in the virt-launcher pod) to set
-# Windows registry keys for automatic Administrator login at boot.
+# Windows registry keys for:
+#   1. Automatic Administrator login at boot (no lock screen)
+#   2. Disable Ctrl+Alt+Del requirement (Windows Server default)
+#   3. Disable screen lock, screensaver, and idle timeout
+#   4. Disable Server Manager auto-start (cleans up the VNC desktop)
 #
 # The admin password is injected as ADMIN_PASSWORD env var from a Secret —
 # it never appears in this ConfigMap or anywhere in the repo.
@@ -23,7 +27,7 @@ data:
         NAMESPACE="${NAMESPACE:-angelscript}"
         ADMIN_PASSWORD="${ADMIN_PASSWORD:?ADMIN_PASSWORD required}"
 
-        echo "=== Configuring Windows autologon: ${VM_NAME} ==="
+        echo "=== Configuring Windows autologon + VNC-ready: ${VM_NAME} ==="
 
         # ── Wait for VMI to be running ──
         echo "Waiting for VM to be running..."
@@ -84,41 +88,90 @@ data:
         # ── Escape password for JSON ──
         ESCAPED_PWD=$(printf '%s' "${ADMIN_PASSWORD}" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
-        # ── Build PowerShell command ──
-        # Sets three Winlogon registry keys that enable automatic login:
-        #   AutoAdminLogon  = "1"        → enable auto-login
-        #   DefaultUserName = "Administrator"
-        #   DefaultPassword = <from secret>
-        PS_CMD="\$path = 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'; Set-ItemProperty -Path \$path -Name AutoAdminLogon -Value '1' -Force; Set-ItemProperty -Path \$path -Name DefaultUserName -Value 'Administrator' -Force; Set-ItemProperty -Path \$path -Name DefaultPassword -Value '${ESCAPED_PWD}' -Force; Write-Output 'Autologon configured'"
+        # ── Helper: run a PowerShell command via guest agent and verify ──
+        run_ps() {
+            STEP_NAME="$1"
+            PS_SCRIPT="$2"
+            echo ""
+            echo "--- ${STEP_NAME} ---"
 
-        # ── Execute via QEMU guest agent (virsh in compute container) ──
-        echo "Setting autologon registry keys via guest agent..."
-        RESULT=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
-            virsh qemu-agent-command "${DOMAIN}" \
-            "{\"execute\":\"guest-exec\",\"arguments\":{\"path\":\"powershell.exe\",\"arg\":[\"-NoProfile\",\"-Command\",\"${PS_CMD}\"],\"capture-output\":true}}" \
-            2>&1)
-        echo "Guest agent response: ${RESULT}"
+            RESULT=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
+                virsh qemu-agent-command "${DOMAIN}" \
+                "{\"execute\":\"guest-exec\",\"arguments\":{\"path\":\"powershell.exe\",\"arg\":[\"-NoProfile\",\"-Command\",\"${PS_SCRIPT}\"],\"capture-output\":true}}" \
+                2>&1)
 
-        # ── Check exec status ──
-        PID=$(echo "${RESULT}" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')
-        if [ -n "${PID}" ]; then
+            PID=$(echo "${RESULT}" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')
+            if [ -z "${PID}" ]; then
+                echo "  WARNING: Could not parse PID — command may still have succeeded"
+                return 0
+            fi
+
             sleep 3
             STATUS_RESULT=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
                 virsh qemu-agent-command "${DOMAIN}" \
                 "{\"execute\":\"guest-exec-status\",\"arguments\":{\"pid\":${PID}}}" \
                 2>&1)
-            echo "Exec status: ${STATUS_RESULT}"
 
             EXITCODE=$(echo "${STATUS_RESULT}" | sed -n 's/.*"exitcode":\([0-9]*\).*/\1/p')
             if [ "${EXITCODE}" = "0" ]; then
-                echo "=== SUCCESS: Autologon configured for ${VM_NAME} ==="
-                echo "Windows will auto-login as Administrator on next boot."
+                echo "  OK: ${STEP_NAME}"
             else
-                echo "WARNING: PowerShell exited with code ${EXITCODE}"
-                echo "Check the exec status output above for details."
-                exit 1
+                echo "  FAILED (exit ${EXITCODE}): ${STEP_NAME}"
+                echo "  Response: ${STATUS_RESULT}"
+                return 1
             fi
+        }
+
+        FAILED=0
+
+        # ── Step 1: Autologon registry keys ──
+        # AutoAdminLogon  = "1"        → enable auto-login
+        # DefaultUserName = "Administrator"
+        # DefaultPassword = <from secret>
+        PS_AUTOLOGON="\$p = 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'; Set-ItemProperty -Path \$p -Name AutoAdminLogon -Value '1' -Force; Set-ItemProperty -Path \$p -Name DefaultUserName -Value 'Administrator' -Force; Set-ItemProperty -Path \$p -Name DefaultPassword -Value '${ESCAPED_PWD}' -Force; Write-Output 'done'"
+        run_ps "Autologon registry keys" "${PS_AUTOLOGON}" || FAILED=1
+
+        # ── Step 2: Disable Ctrl+Alt+Del requirement ──
+        # Windows Server requires Ctrl+Alt+Del before login by default.
+        # DisableCAD=1 in Winlogon bypasses this for VNC usability.
+        PS_DISABLE_CAD="\$p = 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'; Set-ItemProperty -Path \$p -Name DisableCAD -Value 1 -Type DWord -Force; Write-Output 'done'"
+        run_ps "Disable Ctrl+Alt+Del" "${PS_DISABLE_CAD}" || FAILED=1
+
+        # ── Step 3: Disable lock screen ──
+        # Prevents Windows from showing the lock screen on resume/idle.
+        PS_DISABLE_LOCK="\$p = 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Personalization'; if (-not (Test-Path \$p)) { New-Item -Path \$p -Force | Out-Null }; Set-ItemProperty -Path \$p -Name NoLockScreen -Value 1 -Type DWord -Force; Write-Output 'done'"
+        run_ps "Disable lock screen" "${PS_DISABLE_LOCK}" || FAILED=1
+
+        # ── Step 4: Disable screensaver ──
+        # Prevents screensaver from activating and locking the session.
+        PS_DISABLE_SS="Set-ItemProperty -Path 'HKCU:\\Control Panel\\Desktop' -Name ScreenSaveActive -Value '0' -Force; Set-ItemProperty -Path 'HKCU:\\Control Panel\\Desktop' -Name ScreenSaverIsSecure -Value '0' -Force; Set-ItemProperty -Path 'HKCU:\\Control Panel\\Desktop' -Name ScreenSaveTimeOut -Value '0' -Force; Write-Output 'done'"
+        run_ps "Disable screensaver" "${PS_DISABLE_SS}" || FAILED=1
+
+        # ── Step 5: Disable idle lock timeout via power policy ──
+        # Sets console lock display off timeout to 0 (never lock on display off).
+        PS_POWER="powercfg /change standby-timeout-ac 0; powercfg /change monitor-timeout-ac 0; powercfg /x -hibernate-timeout-ac 0; Write-Output 'done'"
+        run_ps "Disable power idle timeouts" "${PS_POWER}" || FAILED=1
+
+        # ── Step 6: Disable Server Manager auto-start ──
+        # Server Manager opens on every login by default and clutters the VNC desktop.
+        PS_SRVMGR="\$p = 'HKLM:\\SOFTWARE\\Microsoft\\ServerManager'; Set-ItemProperty -Path \$p -Name DoNotOpenServerManagerAtLogon -Value 1 -Type DWord -Force; Write-Output 'done'"
+        run_ps "Disable Server Manager auto-start" "${PS_SRVMGR}" || FAILED=1
+
+        # ── Step 7: Disable machine inactivity limit (Group Policy) ──
+        # Prevents Windows from locking after X seconds of inactivity
+        # via the security policy InactivityTimeoutSecs.
+        PS_INACTIVITY="\$p = 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System'; Set-ItemProperty -Path \$p -Name InactivityTimeoutSecs -Value 0 -Type DWord -Force; Write-Output 'done'"
+        run_ps "Disable inactivity lock" "${PS_INACTIVITY}" || FAILED=1
+
+        # ── Summary ──
+        echo ""
+        if [ "${FAILED}" = "0" ]; then
+            echo "=== SUCCESS: All VNC-ready settings applied to ${VM_NAME} ==="
+            echo "Windows will auto-login and never lock the screen."
+            echo "Changes take full effect after the next reboot."
         else
-            echo "WARNING: Could not parse PID from guest-exec response"
-            echo "The command may still have succeeded — verify via VNC."
+            echo "=== PARTIAL: Some steps failed for ${VM_NAME} ==="
+            echo "Review the output above. Autologon may still work."
+            echo "Re-run after fixing any issues."
+            exit 1
         fi

--- a/apps/kube/kubevirt/autologon/job.yaml
+++ b/apps/kube/kubevirt/autologon/job.yaml
@@ -1,7 +1,18 @@
-# One-shot Job to configure Windows autologon on the builder VM.
+# One-shot Job to configure Windows autologon + VNC-ready settings on the builder VM.
 #
 # Uses the QEMU Guest Agent to set registry keys inside Windows so the
-# VM auto-logs in as Administrator on every boot — no VNC password prompt.
+# VM auto-logs in as Administrator on every boot — no lock screen, no
+# Ctrl+Alt+Del prompt, no screensaver, no idle lock. VNC users see the
+# desktop immediately without any interaction.
+#
+# What it configures (7 steps):
+#   1. Autologon registry keys (AutoAdminLogon, DefaultUserName, DefaultPassword)
+#   2. Disable Ctrl+Alt+Del requirement (DisableCAD)
+#   3. Disable lock screen (NoLockScreen policy)
+#   4. Disable screensaver (ScreenSaveActive=0)
+#   5. Disable power idle timeouts (standby, monitor, hibernate all to 0)
+#   6. Disable Server Manager auto-start (DoNotOpenServerManagerAtLogon)
+#   7. Disable machine inactivity lock (InactivityTimeoutSecs=0)
 #
 # Prerequisites:
 #   1. windows-builder VM is running with QEMU Guest Agent installed
@@ -16,7 +27,7 @@
 #   kubectl delete job vm-autologon-windows -n angelscript
 #   kubectl apply -f apps/kube/kubevirt/autologon/ -n angelscript
 #
-# The autologon config persists across reboots — only needs to run once.
+# The settings persist across reboots — only needs to run once.
 #
 # Note: the pod template intentionally does NOT carry `app: angelscript`
 # because the namespace NetworkPolicy (podSelector app=angelscript) only


### PR DESCRIPTION
## Summary
- Expand Windows autologon job from 3 registry keys to 7-step VNC-ready config: disable Ctrl+Alt+Del, lock screen, screensaver, power idle timeouts, Server Manager auto-start, and inactivity lock — VNC users see the desktop immediately with zero interaction
- Add viewer count tracking to the VNC hub backend (`SessionInfo` + two new endpoints: `GET /dashboard/vm/vnc-info/{name}` and `GET /dashboard/vm/vnc-sessions`)
- Enhance React VNC viewer with auto-reconnect (exponential backoff, 5 attempts), live viewer count badge with primary/observer indicator, and click-to-retry after max attempts

## Test plan
- [ ] Apply autologon job on running Windows builder VM (`kubectl apply -f apps/kube/kubevirt/autologon/`), verify all 7 steps succeed
- [ ] Reboot VM, confirm auto-login to desktop with no Ctrl+Alt+Del or lock screen
- [ ] Open VNC from dashboard, confirm connection and viewer count badge shows `1`
- [ ] Open VNC in a second browser tab, confirm both stay connected and count shows `2`
- [ ] Kill one tab, confirm the other stays connected and count decrements
- [ ] Disconnect network briefly, confirm auto-reconnect kicks in with status messages
- [ ] After 5 failed reconnects, confirm "Click to retry" message appears and works