### PR TITLE
feat(mc): pin canonical survival seed across prod + local dev

### DIFF
--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -134,6 +134,14 @@ spec:
                                 value: 'false'
                               - name: SERVER_PORT
                                 value: '25565'
+                              # Pinned world seed — canonical KBVE survival seed.
+                              # Source of truth for every environment (prod, dev,
+                              # CI, contributor laptops). Only applies on first
+                              # world generation; existing PVCs must be wiped via
+                              # the map-rotation Job (with level.dat reset) to
+                              # pick up a seed change.
+                              - name: SEED
+                                value: '-4470905440626961808'
                           resources:
                               requests:
                                   memory: 2Gi

--- a/apps/mc/docker-compose.dev.yml
+++ b/apps/mc/docker-compose.dev.yml
@@ -123,6 +123,12 @@ services:
             DIFFICULTY: 'normal'
             VIEW_DISTANCE: '8'
             SIMULATION_DISTANCE: '6'
+            # Pinned seed — matches the canonical KBVE survival seed set on the
+            # prod fleet (apps/kube/agones/mc/fleet.yaml). Keeping these in
+            # sync guarantees terrain generated locally matches production,
+            # which matters when building city/port schematics that need the
+            # coastline and landmarks to be in the same place everywhere.
+            SEED: '-4470905440626961808'
             # mc_auth → Supabase. Pulled from apps/mc/.env via Compose's
             # automatic variable substitution. Both values default to an
             # empty string if unset, which makes the bevy_supa client fall


### PR DESCRIPTION
## Summary
- Pins the canonical KBVE survival world seed as `SEED=-4470905440626961808` in both:
  - `apps/kube/agones/mc/fleet.yaml` (prod Fabric fleet)
  - `apps/mc/docker-compose.dev.yml` (local dev stack)
- Seed sourced from the current live prod world's `level.dat`
- Guarantees terrain, coastlines, and landmarks match across prod / dev / CI / contributor laptops
- Prerequisite for building city/port schematics that paste cleanly on any environment

## Why this matters
Without a pinned seed, every fresh world boot gets a random seed. Dev and prod diverge immediately, so anything built or exported from a dev server won't line up with prod terrain. With the seed locked in git, every map rotation (or fresh PVC) regenerates to identical terrain.

## Important caveat
`SEED` only applies on **first world generation**. Existing PVCs already have a world, so this env var is a no-op until the world is wiped. To actually apply:
- **Dev**: `nx run mc:dev:clean` wipes volumes; next boot uses the pinned seed
- **Prod**: follow-up work to extend the map-rotation job to also delete `level.dat` before regen

## Test plan
- [ ] `nx run mc:dev:clean && nx run mc:dev` — verify dev world spawns at the expected terrain
- [ ] Cross-check `/seed` in-game matches `-4470905440626961808`
- [ ] Follow-up PR: rotation job option to reset `level.dat` for seed changes