### PR TITLE
fix(kbve): restore nginx Ingress for kbve.com — root domain 404

### DIFF
--- a/apps/kube/kbve/manifest/kbve-ingress.yaml
+++ b/apps/kube/kbve/manifest/kbve-ingress.yaml
@@ -1,0 +1,62 @@
+# Ingress: kbve.com routing via ingress-nginx
+#
+# Mirrors the kbve-routes HTTPRoute (kbve-gateway.yaml) so traffic
+# reaches kbve-service whether DNS points at the nginx LoadBalancer
+# or the Cilium Gateway. Until the Gateway API migration is complete
+# and the Cilium gateway IP is verified reachable from the public
+# internet, this Ingress is the path that actually serves kbve.com.
+#
+# Cloudflare proxies kbve.com to the ingress-nginx LoadBalancer.
+# cert-manager mints the origin cert via letsencrypt-http.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: kbve-ingress
+    namespace: kbve
+    annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-http
+        nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+        # Long timeouts for /ws and /dashboard WebSocket paths so the
+        # nginx proxy doesn't kill long-lived game/VNC/Guacamole
+        # connections. Mirrors the 3600s backendRequest timeout on the
+        # HTTPRoute.
+        nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
+        nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
+spec:
+    ingressClassName: nginx
+    tls:
+        - hosts:
+              - kbve.com
+          secretName: kbve-tls
+    rules:
+        - host: kbve.com
+          http:
+              paths:
+                  - path: /ws
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 5000
+                  - path: /dashboard/vm/vnc
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 4321
+                  - path: /dashboard/guac/proxy/guacamole/websocket-tunnel
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 4321
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 4321

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
     - kubevirt-rbac.yaml
     - kbve-deployment.yaml
     - kbve-gateway.yaml
+    - kbve-ingress.yaml
     - kbve-wt-lb.yaml
     - kbve-wt-selfsigned-cronjob.yaml
     - cf-cache-purge-externalsecret.yaml


### PR DESCRIPTION
## Summary
Restores `kbve-ingress` in the `kbve` namespace so kbve.com stops returning a default nginx 404. The Cilium Gateway API migration removed the original Ingress but left DNS pointing at the ingress-nginx LoadBalancer (via `talos.kbve.com` → `142.132.206.74`), so nginx had no rule matching `kbve.com` and fell through to its default 404.

## Why an Ingress instead of just fixing the HTTPRoute
The HTTPRoute exists and is healthy, but its Gateway LoadBalancer IP (`142.132.206.71`) is not reachable from the public internet — direct curl to `.71:443` times out even bypassing Cloudflare. Until that's diagnosed (Hetzner floating IP / firewall), the nginx path on `.74` is the only working route into the cluster, and it's what every other subdomain (n8n, supabase, bugwars, staryo) already uses.

The HTTPRoute stays in place. Once `.71` is verified reachable, the cutover is just a DNS edit.

## Changes
- New `apps/kube/kbve/manifest/kbve-ingress.yaml` mirroring the four HTTPRoute path matches (`/ws`, `/dashboard/vm/vnc`, `/dashboard/guac/proxy/guacamole/websocket-tunnel`, `/`)
- 3600s nginx proxy timeouts for WebSocket paths (matches HTTPRoute `backendRequest: 3600s`)
- TLS via cert-manager `letsencrypt-http`, secret `kbve-tls`
- Added to `kustomization.yaml`

## Test plan
- [ ] ArgoCD syncs `kbve` Application
- [ ] `kubectl get ingress -n kbve` shows `kbve-ingress` with hosts `kbve.com`
- [ ] `kubectl get certificate -n kbve kbve-tls` reaches Ready
- [ ] `curl -I https://kbve.com` returns 200 with Astro HTML
- [ ] `/ws` upgrade still works for game clients (long-lived WS)

## Followups (not in this PR)
- Diagnose why `142.132.206.71` (Cilium Gateway LB) is unreachable from public internet — likely Hetzner floating IP not attached or firewall
- Add synthetic monitor on `https://kbve.com` so root-domain regressions page someone within minutes instead of being noticed manually
- Pick one routing pattern (Ingress *or* Gateway API) for this cluster — current mix makes "where does X route" detective work