### PR TITLE
fix(kasm): allow kbve namespace to reach KASM 6901 (fix /dashboard/kasm/proxy 502)

### DIFF
--- a/apps/kube/kasm/manifest/network-policy.yaml
+++ b/apps/kube/kasm/manifest/network-policy.yaml
@@ -41,9 +41,14 @@ spec:
         # All other egress is BLOCKED — no direct TCP/UDP to the internet.
         # Traffic exits only through the WireGuard tunnel inside the pod.
     ingress:
-        # Allow inbound to KASM web port from within cluster
+        # Allow inbound to KASM web port from within cluster.
+        # CiliumNetworkPolicy is namespace-scoped — bare `{}` only
+        # matches pods in the kasm namespace. The kbve namespace
+        # selector lets the axum-kbve reverse proxy reach port 6901.
         - fromEndpoints:
               - {}
+              - matchLabels:
+                    k8s:io.kubernetes.pod.namespace: kbve
           toPorts:
               - ports:
                     - port: '6901'


### PR DESCRIPTION
## Summary
Fixes 502 errors on `kbve.com/dashboard/kasm/proxy`.

The axum-kbve reverse proxy in the `kbve` namespace was unable to reach `kasm-vpn-service:6901` in the `kasm` namespace. Connections hung at TCP connect, surfacing as `error sending request for url (...) reason=connection failed` in the axum logs.

## Root Cause
The `kasm-vpn-egress-lockdown` CiliumNetworkPolicy had:
```yaml
ingress:
  - fromEndpoints:
      - {}
```

A bare `{}` in a namespace-scoped CiliumNetworkPolicy only matches pods **in the same namespace** (kasm). Cross-namespace traffic is implicitly denied unless namespace labels are specified. The reverse proxy (kbve ns) was silently blocked.

Verified via:
- curl test from `kasm` namespace → 401 (works)
- curl test from `kbve` / `default` namespace → hangs at TCP connect

## Fix
Add an explicit namespace selector for `kbve` to the ingress rule:
```yaml
fromEndpoints:
  - {}
  - matchLabels:
      k8s:io.kubernetes.pod.namespace: kbve
```

## Test plan
- [ ] ArgoCD syncs the `kasm` Application
- [ ] `kubectl describe ciliumnetworkpolicy kasm-vpn-egress-lockdown -n kasm` shows the new selector
- [ ] Test pod in `kbve` ns can curl `kasm-vpn-service.kasm.svc:6901` and get 401
- [ ] `https://kbve.com/dashboard/kasm/proxy` no longer 502s