### PR TITLE
ci(mc): pre-cache Fabric Loom deps via ghcr.io/kbve/mc:gradle

### DIFF
--- a/.github/workflows/ci-mc-gradle-cache.yml
+++ b/.github/workflows/ci-mc-gradle-cache.yml
@@ -1,0 +1,115 @@
+name: CI - MC Gradle Cache
+
+# Builds and publishes ghcr.io/kbve/mc:gradle — the pre-warmed Fabric Loom
+# dependency cache that apps/mc/Dockerfile's java-builder stage pulls from.
+# This is infrastructure, not a versioned app, so it lives outside the
+# ci-dispatch-manifest.json flow. Rebuild is only needed when Fabric Loom /
+# Minecraft / Yarn / Loader / Fabric API version pins in build.gradle change.
+
+on:
+    workflow_dispatch:
+    push:
+        branches: [main, dev]
+        paths:
+            - 'apps/mc/Dockerfile.gradle'
+            - 'apps/mc/behavior_statetree/java/build.gradle'
+            - 'apps/mc/behavior_statetree/java/settings.gradle'
+            - 'apps/mc/mc_auth/java/build.gradle'
+            - 'apps/mc/mc_auth/java/settings.gradle'
+            - 'apps/mc/project.json'
+            - '.github/workflows/ci-mc-gradle-cache.yml'
+    pull_request:
+        branches: [main, dev]
+        paths:
+            - 'apps/mc/Dockerfile.gradle'
+            - 'apps/mc/behavior_statetree/java/build.gradle'
+            - 'apps/mc/behavior_statetree/java/settings.gradle'
+            - 'apps/mc/mc_auth/java/build.gradle'
+            - 'apps/mc/mc_auth/java/settings.gradle'
+            - 'apps/mc/project.json'
+            - '.github/workflows/ci-mc-gradle-cache.yml'
+
+concurrency:
+    group: mc-gradle-cache
+    cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+    build:
+        name: Build + Push ghcr.io/kbve/mc:gradle
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
+        env:
+            NX_NO_CLOUD: true
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Free disk space
+              uses: jlumbroso/free-disk-space@main
+              with:
+                  tool-cache: false
+                  android: true
+                  dotnet: true
+                  haskell: true
+                  large-packages: false
+                  swap-storage: false
+                  docker-images: true
+
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Setup Docker Buildx
+              uses: docker/setup-buildx-action@v4
+
+            - name: Login to GHCR
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ github.token }}
+
+            - name: Setup Node v24
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - name: Setup pnpm v10
+              uses: pnpm/action-setup@v5
+              with:
+                  version: 10.33.0
+                  run_install: false
+
+            - name: Get pnpm Store Path
+              id: pnpm-store
+              run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+            - name: Setup pnpm Cache
+              uses: actions/cache@v5
+              with:
+                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+
+            - name: Install pnpm Dependencies
+              run: pnpm install
+              env:
+                  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+
+            # Pull requests build-only to validate the Dockerfile, but skip
+            # pushing so PR runs can't overwrite the :gradle tag that main
+            # builds depend on. Push is gated on event_name != pull_request.
+            - name: Build ghcr.io/kbve/mc:gradle (local)
+              if: ${{ github.event_name == 'pull_request' }}
+              env:
+                  INPUT_GITHUB_TOKEN: ${{ github.token }}
+              run: pnpm nx run mc:container-gradle --configuration=local --no-cloud
+
+            - name: Build + Push ghcr.io/kbve/mc:gradle
+              if: ${{ github.event_name != 'pull_request' }}
+              env:
+                  INPUT_GITHUB_TOKEN: ${{ github.token }}
+              run: pnpm nx run mc:container-gradle --configuration=production --no-cloud

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -34,7 +34,12 @@ RUN cargo build -p behavior_statetree -p mc_auth --release
 #   /build/target/release/libmc_auth.so
 
 # ── Stage 2: Build Fabric mod JARs (bundle .so via processResources) ──
-FROM gradle:jdk21 AS java-builder
+# Uses ghcr.io/kbve/mc:gradle — a pre-warmed image with the full Fabric Loom
+# dependency graph (Minecraft 1.21.11, Yarn, Loader, Fabric API) already
+# resolved into ~/.gradle/caches. Bypasses flaky Mojang/Fabric CDN round-trips
+# on every build. Rebuild via `nx run mc:container-gradle:production` whenever
+# the Loom/MC version pins in behavior_statetree/java/build.gradle change.
+FROM ghcr.io/kbve/mc:gradle AS java-builder
 WORKDIR /build
 
 # Copy Java source for both Fabric mods

--- a/apps/mc/Dockerfile.gradle
+++ b/apps/mc/Dockerfile.gradle
@@ -1,0 +1,57 @@
+# ghcr.io/kbve/mc:gradle — pre-cached Gradle + Fabric Loom build environment.
+#
+# Why: Fabric Loom's first run pulls Minecraft client+server jars from Mojang,
+# Yarn mappings + intermediary from maven.fabricmc.net, and Fabric API from
+# Modrinth's maven. Those CDNs are flaky; random SSL resets there have killed
+# enough CI builds that caching the full dependency graph into a published
+# image is worth the extra pipeline step.
+#
+# Bump this image whenever build.gradle in behavior_statetree/java or
+# mc_auth/java changes its Minecraft / Yarn / Loader / Fabric API / Loom
+# version pins. Source-only changes don't need a rebuild.
+FROM gradle:jdk21
+
+WORKDIR /warmup
+
+# build.gradle's processResources references ../../target/release/lib*.so. The
+# real natives come from the rust-builder stage in the main Dockerfile — here
+# we just need empty placeholders so Loom can evaluate the project graph.
+RUN mkdir -p target/release \
+    && touch target/release/libbehavior_statetree.so \
+             target/release/libmc_auth.so
+
+# Only Gradle metadata — source edits must not invalidate this layer.
+COPY apps/mc/behavior_statetree/java/build.gradle \
+     apps/mc/behavior_statetree/java/settings.gradle \
+     behavior_statetree/java/
+COPY apps/mc/mc_auth/java/build.gradle \
+     apps/mc/mc_auth/java/settings.gradle \
+     mc_auth/java/
+
+# Minimal stub sources + fabric.mod.json so `gradle build` drives the full
+# Loom task graph (downloads MC, remaps, genSources) to completion without
+# depending on real mod code.
+RUN mkdir -p behavior_statetree/java/src/main/java/com/kbve/warmup \
+             behavior_statetree/java/src/main/resources \
+             mc_auth/java/src/main/java/com/kbve/warmup \
+             mc_auth/java/src/main/resources \
+    && printf 'package com.kbve.warmup; public class Warmup {}\n' \
+         > behavior_statetree/java/src/main/java/com/kbve/warmup/Warmup.java \
+    && printf 'package com.kbve.warmup; public class Warmup {}\n' \
+         > mc_auth/java/src/main/java/com/kbve/warmup/Warmup.java \
+    && printf '{"schemaVersion":1,"id":"warmup","version":"0.0.0","name":"warmup","environment":"*"}\n' \
+         > behavior_statetree/java/src/main/resources/fabric.mod.json \
+    && printf '{"schemaVersion":1,"id":"warmup","version":"0.0.0","name":"warmup","environment":"*"}\n' \
+         > mc_auth/java/src/main/resources/fabric.mod.json
+
+# One-shot cache warmup. -x test skips anything test-related (there is none
+# yet, but keeps the contract explicit). GRADLE_USER_HOME defaults to
+# /home/gradle/.gradle on the base image and that directory is what gets
+# inherited by downstream `FROM ghcr.io/kbve/mc:gradle` builds.
+RUN cd behavior_statetree/java && gradle --no-daemon build -x test
+RUN cd mc_auth/java && gradle --no-daemon build -x test
+
+# Drop the warmup scratch tree so downstream builds don't see stale stubs.
+# The Gradle cache at ~/.gradle/caches stays — that's the whole point.
+RUN rm -rf /warmup
+WORKDIR /

--- a/apps/mc/project.json
+++ b/apps/mc/project.json
@@ -35,6 +35,27 @@
 				}
 			}
 		},
+		"container-gradle": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/mc/Dockerfile.gradle",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/mc:gradle"]
+				},
+				"production": {
+					"push": true,
+					"tags": ["ghcr.io/kbve/mc:gradle"]
+				}
+			}
+		},
 		"dev": {
 			"executor": "nx:run-commands",
 			"dependsOn": [


### PR DESCRIPTION
## Summary

- New `apps/mc/Dockerfile.gradle` warms Gradle + Fabric Loom's cache (MC 1.21.11, Yarn, Loader, Fabric API) by running a throwaway `gradle build` over stub sources. Downstream `FROM ghcr.io/kbve/mc:gradle` inherits `~/.gradle/caches` and skips the flaky Mojang/Fabric CDN fetches.
- Main `apps/mc/Dockerfile` java-builder now `FROM ghcr.io/kbve/mc:gradle` so every mc container build reuses the resolved dependency graph.
- Nx `container-gradle` target (local/production) builds and pushes the image.
- New workflow `ci-mc-gradle-cache.yml` rebuilds + pushes the image on pushes to `main`/`dev` when the Loom/MC/Yarn/Loader pins change (or on manual dispatch). PR runs build-only — no push — so they can't overwrite the shared `:gradle` tag that main depends on.

Rebuild cadence: only when `build.gradle` version pins move. Source-only mc edits don't invalidate the cache image.

## Bootstrap sequence

1. Merge this PR into `dev`.
2. Merge `dev` → `main`. The push-to-main trigger on `ci-mc-gradle-cache.yml` builds + pushes `ghcr.io/kbve/mc:gradle` for the first time.
3. Next `ci-docker` dispatch for `mc` pulls the cache image and builds much faster.

If someone dispatches `mc` in between steps 2 and 3 and the cache image doesn't exist yet, the main Dockerfile's `FROM` will fail — re-dispatch after the gradle-cache workflow completes.

## Test plan

- [ ] PR CI runs the gradle-cache workflow in build-only mode and passes (validates Dockerfile.gradle syntax + Loom dependency resolution).
- [ ] After merge to `main`, `ci-mc-gradle-cache` runs and publishes `ghcr.io/kbve/mc:gradle`.
- [ ] Manual dispatch of `ci-main` → `ci-docker` for `mc` pulls the cache image and produces a working server container.
- [ ] `nx run mc:dev` (local) picks up the cache image on next rebuild.