### PR TITLE
fix(mc): fall back to gradle:jdk21 when mc:gradle cache is missing

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -34,12 +34,16 @@ RUN cargo build -p behavior_statetree -p mc_auth --release
 #   /build/target/release/libmc_auth.so
 
 # ── Stage 2: Build Fabric mod JARs (bundle .so via processResources) ──
-# Uses ghcr.io/kbve/mc:gradle — a pre-warmed image with the full Fabric Loom
-# dependency graph (Minecraft 1.21.11, Yarn, Loader, Fabric API) already
-# resolved into ~/.gradle/caches. Bypasses flaky Mojang/Fabric CDN round-trips
-# on every build. Rebuild via `nx run mc:container-gradle:production` whenever
-# the Loom/MC version pins in behavior_statetree/java/build.gradle change.
-FROM ghcr.io/kbve/mc:gradle AS java-builder
+# JAVA_BUILDER_IMAGE swaps in the pre-warmed Fabric Loom cache on production
+# builds (ghcr.io/kbve/mc:gradle — Minecraft 1.21.11, Yarn, Loader, Fabric
+# API already resolved into ~/.gradle/caches). Defaults to the vanilla
+# gradle:jdk21 image so local/test builds don't depend on the cache
+# existing in the registry — rebuild via `nx run mc:container-gradle:production`
+# whenever the Loom/MC version pins in behavior_statetree/java/build.gradle
+# change. CI's e2e test path stays on the default to avoid a cross-workflow
+# race against ci-mc-gradle-cache.yml.
+ARG JAVA_BUILDER_IMAGE=gradle:jdk21
+FROM ${JAVA_BUILDER_IMAGE} AS java-builder
 WORKDIR /build
 
 # Copy Java source for both Fabric mods

--- a/apps/mc/project.json
+++ b/apps/mc/project.json
@@ -26,6 +26,7 @@
 				"production": {
 					"push": true,
 					"tags": ["ghcr.io/kbve/mc:latest"],
+					"build-args": ["JAVA_BUILDER_IMAGE=ghcr.io/kbve/mc:gradle"],
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/mc:buildcache"
 					],


### PR DESCRIPTION
Closes #10100

## Problem
After #10099, `apps/mc/Dockerfile` line 42 hardcoded `FROM ghcr.io/kbve/mc:gradle`. Any `CI - Docker` run that races the `ci-mc-gradle-cache.yml` publish step fails immediately with:

```
ERROR: failed to solve: ghcr.io/kbve/mc:gradle: not found
```

Observed in run [#24492281311](https://github.com/KBVE/kbve/actions/runs/24492281311): gradle-cache workflow started at 04:34:03 (10m runtime), but the Docker test workflow dispatched at 04:37:24 — 3 minutes in, the cache image was still building.

## Fix
- Added `ARG JAVA_BUILDER_IMAGE=gradle:jdk21` to the Dockerfile. The `FROM` line now uses the ARG, so local/test builds get the vanilla gradle base image by default.
- `container:production` config in `project.json` passes `--build-arg JAVA_BUILDER_IMAGE=ghcr.io/kbve/mc:gradle` to opt into the warm cache for production release builds (where the gradle-cache workflow has already finished).
- `container:local` (e2e test path) leaves the default, so tests never race the cache workflow.

## Trade-off
Local and e2e test builds lose the pre-warmed Loom cache, so they pay the Mojang/Fabric CDN fetch cost (the exact thing the gradle-cache was built to eliminate). Production builds still use the cache, where reliability matters most. Test runs are infrequent enough that CDN fetches are an acceptable cost compared to the hard race failure we had.

## Test plan
- [ ] CI `Test Docker / Test mc Docker App` step succeeds on this PR
- [ ] Gradle cache image is NOT required for PR/test builds
- [ ] Next production release build still consumes `ghcr.io/kbve/mc:gradle`