### PR TITLE
feat(ops): register ca-staleness-monitor + fix Reloader chart + CA auto-restart on kbve

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
     namespace: kbve
     labels:
         app: kbve
+    annotations:
+        # Restart on cluster CA rotation so the axum-kbve KubeVirt client
+        # picks up the new kube-apiserver cert. Without this, a rotation
+        # silently 502s the /dashboard/vm/* paths until manual restart.
+        configmap.reloader.stakater.com/reload: 'kube-root-ca.crt'
 spec:
     replicas: 1
     strategy:

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -20,6 +20,9 @@ resources:
     - sealed-secrets/application.yaml
     # Stakater Reloader — auto-restart deployments when configmaps/secrets change
     - reloader/application.yaml
+    # CA staleness monitor — detects pods with stale serviceaccount CA mounts
+    # after a cluster CA rotation. Read-only CronJob, emits JSON to Vector.
+    - ca-staleness-monitor/application.yaml
     - keda/application.yaml
     - crossplane/application.yaml
     - crossplane/providers-application.yaml

--- a/apps/kube/reloader/application.yaml
+++ b/apps/kube/reloader/application.yaml
@@ -20,7 +20,11 @@ spec:
     project: default
     source:
         repoURL: https://stakater.github.io/stakater-charts
-        targetRevision: 2.1.6
+        # Chart version 2.1.6 never existed in the Stakater repo — this
+        # Application has been stuck on ComparisonError, meaning Reloader
+        # was never deployed. That's why yesterday's CA rotation silently
+        # broke things with no auto-recovery. Pinning to a real version.
+        targetRevision: 2.2.11
         chart: reloader
         helm:
             releaseName: reloader


### PR DESCRIPTION
## Summary
Completes Phase 1 of the CA-rotation defense story and fixes an adjacent issue found while wiring it up. Three coupled changes, one PR.

## 1. Register the ca-staleness-monitor Application

PR #10104 added the manifests but didn't touch the `kube-root` app-of-apps kustomization, so nothing would deploy. This PR adds the entry so ArgoCD picks it up on the next dev→main promotion.

## 2. Fix the Reloader chart version

While setting up the auto-restart path I discovered Reloader isn't actually running:

```
kubectl get application reloader -n argocd -o jsonpath='{.status.conditions[*].message}'
Failed to load target state: ... chart "reloader" version "2.1.6" not found
in https://stakater.github.io/stakater-charts repository
```

Chart version `2.1.6` never existed — the Stakater repo jumps from 1.x to 2.2.x. The Application has been stuck in `ComparisonError` since creation. **This is why yesterday's CA rotation had no auto-recovery at all** — the tool that would have cycled our stale pods wasn't running.

Bumped to `2.2.11` (current latest). Values format is unchanged; `watchGlobally: true` + `reloadStrategy: env-vars` still valid.

## 3. Annotate `kbve-deployment` for CA auto-restart

Added `configmap.reloader.stakater.com/reload: "kube-root-ca.crt"` to the Deployment metadata. Next cluster CA rotation, Reloader sees the updated ConfigMap and rolls the Pod automatically — the axum-kbve KubeVirt client re-reads the fresh CA on startup, and `/dashboard/vm/*` never 502s.

This is the workload we most recently had to restart by hand. Starting with it and extending to other API-talking workloads we control in follow-up PRs (kept small per PR for easy review and rollback).

## Why all three in one PR
They're a single unit of work from a GitOps-and-review standpoint. Registering a monitor that detects a problem the cluster can't auto-fix would be a weird half-step. Fixing Reloader without annotating at least one consumer leaves the capability unused. Annotating a workload without Reloader running does nothing. Together they form the first full loop: detect → notify → restart.

## Test plan
- [ ] Merge + dev→main promotion
- [ ] `kubectl get application -n argocd reloader` shows Synced/Healthy (not ComparisonError)
- [ ] `kubectl get pods -n reloader` shows the controller Running
- [ ] `kubectl get application -n argocd ca-staleness-monitor` shows Synced/Healthy
- [ ] `kubectl get cronjob -n kube-system ca-staleness-monitor` exists
- [ ] Manual validation of auto-restart: `kubectl patch configmap kube-root-ca.crt -n kbve --type merge -p '{"metadata":{"annotations":{"test":"reload"}}}'` → `kbve-deployment` pod recycles within ~1min

## Followups not in this PR
- Extend reload annotation to other API-talking workloads we control
- Phase 2: log-pattern alert on `x509: certificate signed by unknown authority` in Vector, as a second-line detector for workloads that can't be safely auto-restarted