### PR TITLE
fix(mc): move JAVA_BUILDER_IMAGE ARG to pre-FROM scope

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -1,3 +1,16 @@
+# JAVA_BUILDER_IMAGE swaps in the pre-warmed Fabric Loom cache on production
+# builds (ghcr.io/kbve/mc:gradle — Minecraft 1.21.11, Yarn, Loader, Fabric
+# API already resolved into ~/.gradle/caches). Defaults to the vanilla
+# gradle:jdk21 image so local/test builds don't depend on the cache existing
+# in the registry — rebuild via `nx run mc:container-gradle:production`
+# whenever the Loom/MC version pins in behavior_statetree/java/build.gradle
+# change. CI's e2e test path stays on the default to avoid a cross-workflow
+# race against ci-mc-gradle-cache.yml.
+#
+# Must be declared before the first FROM — Docker scopes a post-FROM ARG to
+# the preceding stage, so a FROM later in the file would see it as blank.
+ARG JAVA_BUILDER_IMAGE=gradle:jdk21
+
 # ── Stage 1: Build Rust native libraries (.so) ────────────────────────
 FROM rust:1.94-bookworm AS rust-builder
 WORKDIR /build
@@ -34,15 +47,7 @@ RUN cargo build -p behavior_statetree -p mc_auth --release
 #   /build/target/release/libmc_auth.so
 
 # ── Stage 2: Build Fabric mod JARs (bundle .so via processResources) ──
-# JAVA_BUILDER_IMAGE swaps in the pre-warmed Fabric Loom cache on production
-# builds (ghcr.io/kbve/mc:gradle — Minecraft 1.21.11, Yarn, Loader, Fabric
-# API already resolved into ~/.gradle/caches). Defaults to the vanilla
-# gradle:jdk21 image so local/test builds don't depend on the cache
-# existing in the registry — rebuild via `nx run mc:container-gradle:production`
-# whenever the Loom/MC version pins in behavior_statetree/java/build.gradle
-# change. CI's e2e test path stays on the default to avoid a cross-workflow
-# race against ci-mc-gradle-cache.yml.
-ARG JAVA_BUILDER_IMAGE=gradle:jdk21
+# JAVA_BUILDER_IMAGE is declared at the top of this file (pre-FROM ARG).
 FROM ${JAVA_BUILDER_IMAGE} AS java-builder
 WORKDIR /build
 


### PR DESCRIPTION
## Summary

PR #10101 added `ARG JAVA_BUILDER_IMAGE=gradle:jdk21` as a fallback so the main Dockerfile wouldn't hard-depend on `ghcr.io/kbve/mc:gradle`, but placed the ARG between the two build stages. Docker scopes a post-FROM ARG to the preceding stage — it doesn't carry into a later FROM. The `ci-docker` run for `mc` failed with:

```
WARN: UndefinedArgInFrom: FROM argument 'JAVA_BUILDER_IMAGE' is not declared
ERROR: failed to build: base name (${JAVA_BUILDER_IMAGE}) should not be blank
```

See [run 24496489655](https://github.com/KBVE/kbve/actions/runs/24496489655).

Moving the ARG above the first FROM (global scope) lets both stages see it, while keeping the `gradle:jdk21` default so local/CI builds still work without the cache image.

## Test plan

- [ ] `ci-docker / mc` passes the e2e test job (uses default `gradle:jdk21`).
- [ ] `ci-mc-gradle-cache` still builds the cache image with the ARG unchanged.
- [ ] Production build with `--build-arg JAVA_BUILDER_IMAGE=ghcr.io/kbve/mc:gradle` pulls the cache.