### PR TITLE
feat(firecracker): IP allocator for persistent endpoints — Phase 2a

### DIFF
--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -17,6 +17,8 @@ use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use uuid::Uuid;
 
+mod persistent;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use uuid::Uuid;
 
 mod persistent;
+mod tap;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/apps/vm/firecracker-ctl/src/persistent.rs
+++ b/apps/vm/firecracker-ctl/src/persistent.rs
@@ -3,6 +3,11 @@
 //!
 //! Phase 2 step 1: IP allocator. Pure logic, unit-testable without KVM.
 
+// Items in this module are built out across multiple Phase 2 PRs.
+// Suppress the transitional "never used" warnings; each item gets
+// wired in by the time Phase 2 completes (persistent VM lifecycle).
+#![allow(dead_code)]
+
 use std::collections::HashSet;
 use std::net::Ipv4Addr;
 use std::sync::Mutex;
@@ -68,6 +73,13 @@ impl IpAllocation {
             host = self.host_ip,
             mask = self.netmask,
         )
+    }
+
+    /// The pool slot index this allocation came from. Used by the TAP
+    /// manager to derive deterministic, short interface names that fit
+    /// Linux's 15-char IFNAMSIZ limit (e.g. `fctap-42`).
+    pub fn slot_index(&self) -> u32 {
+        self.index
     }
 }
 

--- a/apps/vm/firecracker-ctl/src/persistent.rs
+++ b/apps/vm/firecracker-ctl/src/persistent.rs
@@ -1,0 +1,363 @@
+//! Persistent endpoint machinery — IP allocator, TAP plumbing, proxy
+//! forwarding. Lives in firecracker-ctl-net only (the networked ecosystem).
+//!
+//! Phase 2 step 1: IP allocator. Pure logic, unit-testable without KVM.
+
+use std::collections::HashSet;
+use std::net::Ipv4Addr;
+use std::sync::Mutex;
+
+/// Errors from the IP pool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PoolError {
+    /// No free /30 slots in the pool.
+    Exhausted { used: usize, capacity: usize },
+    /// Pool prefix must leave room for at least one /30 — so ≤ 30.
+    InvalidPrefix(u8),
+    /// Base address is not aligned to the prefix length.
+    UnalignedBase(Ipv4Addr, u8),
+}
+
+impl std::fmt::Display for PoolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PoolError::Exhausted { used, capacity } => {
+                write!(f, "IP pool exhausted ({used} / {capacity})")
+            }
+            PoolError::InvalidPrefix(p) => write!(f, "invalid prefix /{p} — must be <= 30"),
+            PoolError::UnalignedBase(ip, p) => {
+                write!(f, "base {ip} is not aligned to prefix /{p}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PoolError {}
+
+/// Handle returned by a successful allocation. Carries both sides of the
+/// point-to-point link plus the index needed to release the slot back to
+/// the pool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IpAllocation {
+    /// Network address of the /30 (host.host.host.host / 30 aligned).
+    pub cidr: Ipv4Addr,
+    /// Host side of the TAP — assigned inside the pod netns.
+    pub host_ip: Ipv4Addr,
+    /// Guest side of the TAP — what the VM advertises on eth0.
+    pub guest_ip: Ipv4Addr,
+    /// Netmask: always 255.255.255.252 for /30.
+    pub netmask: Ipv4Addr,
+    /// Prefix length: always 30.
+    pub prefix_len: u8,
+    /// Slot index inside the pool. Opaque to callers; used by `release`.
+    index: u32,
+}
+
+impl IpAllocation {
+    /// "host_ip/30" — convenient for `ip addr add`.
+    pub fn host_cidr(&self) -> String {
+        format!("{}/{}", self.host_ip, self.prefix_len)
+    }
+
+    /// "guest_ip::host_ip:netmask::eth0:off" — direct drop-in for the
+    /// kernel `ip=` boot arg so the guest gets its IP without DHCP.
+    pub fn kernel_ip_arg(&self) -> String {
+        format!(
+            "{guest}::{host}:{mask}::eth0:off",
+            guest = self.guest_ip,
+            host = self.host_ip,
+            mask = self.netmask,
+        )
+    }
+}
+
+/// Pool of `/30` subnets carved from a larger CIDR block (typically a
+/// private /16). Each `/30` gives us a 4-IP span: network, host TAP,
+/// guest IP, broadcast — exactly what we need per-VM.
+///
+/// Thread-safe. Allocation is first-free (lowest available index) for
+/// deterministic behaviour in tests; release returns the slot for reuse.
+pub struct Ipv4Pool {
+    /// Base of the pool (e.g. 172.18.0.0).
+    base: Ipv4Addr,
+    /// Prefix length of the pool (e.g. 16). Kept for introspection/logging
+    /// even though capacity is cached separately.
+    #[allow(dead_code)]
+    prefix_len: u8,
+    /// Total /30 slots in the pool = 2^(30 - prefix_len).
+    capacity: u32,
+    /// Slot indices currently in use.
+    allocated: Mutex<HashSet<u32>>,
+}
+
+impl Ipv4Pool {
+    /// Build a pool from a base address + prefix length.
+    pub fn new(base: Ipv4Addr, prefix_len: u8) -> Result<Self, PoolError> {
+        if prefix_len > 30 {
+            return Err(PoolError::InvalidPrefix(prefix_len));
+        }
+        if !is_aligned(base, prefix_len) {
+            return Err(PoolError::UnalignedBase(base, prefix_len));
+        }
+        let capacity = 1u32 << (30 - prefix_len);
+        Ok(Self {
+            base,
+            prefix_len,
+            capacity,
+            allocated: Mutex::new(HashSet::new()),
+        })
+    }
+
+    /// Parse a CIDR string like "172.18.0.0/16".
+    pub fn from_cidr(cidr: &str) -> Result<Self, PoolError> {
+        let (addr_str, prefix_str) = cidr.split_once('/').ok_or(PoolError::InvalidPrefix(0))?;
+        let addr: Ipv4Addr = addr_str
+            .parse()
+            .map_err(|_| PoolError::UnalignedBase(Ipv4Addr::UNSPECIFIED, 0))?;
+        let prefix: u8 = prefix_str
+            .parse()
+            .map_err(|_| PoolError::InvalidPrefix(0))?;
+        Self::new(addr, prefix)
+    }
+
+    /// Total number of /30 slots this pool can hand out.
+    pub fn capacity(&self) -> usize {
+        self.capacity as usize
+    }
+
+    /// Number of /30 slots currently allocated.
+    pub fn in_use(&self) -> usize {
+        self.allocated.lock().expect("poisoned").len()
+    }
+
+    /// Allocate a free /30 slot. Returns `Exhausted` if the pool is full.
+    pub fn allocate(&self) -> Result<IpAllocation, PoolError> {
+        let mut taken = self.allocated.lock().expect("poisoned");
+        if (taken.len() as u32) >= self.capacity {
+            return Err(PoolError::Exhausted {
+                used: taken.len(),
+                capacity: self.capacity as usize,
+            });
+        }
+        // First-free scan. Capacity is bounded (16384 for /16), and this
+        // keeps test output deterministic.
+        let mut index = 0u32;
+        while taken.contains(&index) {
+            index += 1;
+        }
+        taken.insert(index);
+        Ok(self.compose(index))
+    }
+
+    /// Release a previously-allocated slot back to the pool. No-op if the
+    /// slot is already free (double-release is tolerated so callers don't
+    /// need to track it through error paths).
+    pub fn release(&self, allocation: &IpAllocation) {
+        self.allocated
+            .lock()
+            .expect("poisoned")
+            .remove(&allocation.index);
+    }
+
+    /// Build the full IpAllocation tuple for a given slot index.
+    fn compose(&self, index: u32) -> IpAllocation {
+        let base_u32 = u32::from(self.base);
+        let cidr_u32 = base_u32 + index * 4;
+        let cidr = Ipv4Addr::from(cidr_u32);
+        let host_ip = Ipv4Addr::from(cidr_u32 + 1);
+        let guest_ip = Ipv4Addr::from(cidr_u32 + 2);
+        IpAllocation {
+            cidr,
+            host_ip,
+            guest_ip,
+            netmask: Ipv4Addr::new(255, 255, 255, 252),
+            prefix_len: 30,
+            index,
+        }
+    }
+}
+
+fn is_aligned(addr: Ipv4Addr, prefix_len: u8) -> bool {
+    if prefix_len == 0 {
+        return true;
+    }
+    let mask: u32 = !0u32 << (32 - prefix_len);
+    (u32::from(addr) & !mask) == 0
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_prefix_greater_than_30() {
+        assert!(matches!(
+            Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 31),
+            Err(PoolError::InvalidPrefix(31))
+        ));
+    }
+
+    #[test]
+    fn rejects_unaligned_base() {
+        // 172.18.0.1 is not aligned to /30
+        assert!(matches!(
+            Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 1), 30),
+            Err(PoolError::UnalignedBase(_, 30))
+        ));
+    }
+
+    #[test]
+    fn capacity_matches_prefix() {
+        assert_eq!(
+            Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16)
+                .unwrap()
+                .capacity(),
+            16384
+        );
+        assert_eq!(
+            Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 30)
+                .unwrap()
+                .capacity(),
+            1
+        );
+        assert_eq!(
+            Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 28)
+                .unwrap()
+                .capacity(),
+            4
+        );
+    }
+
+    #[test]
+    fn first_allocation_is_slot_zero() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16).unwrap();
+        let a = pool.allocate().unwrap();
+        assert_eq!(a.cidr, Ipv4Addr::new(172, 18, 0, 0));
+        assert_eq!(a.host_ip, Ipv4Addr::new(172, 18, 0, 1));
+        assert_eq!(a.guest_ip, Ipv4Addr::new(172, 18, 0, 2));
+        assert_eq!(a.netmask, Ipv4Addr::new(255, 255, 255, 252));
+        assert_eq!(a.prefix_len, 30);
+    }
+
+    #[test]
+    fn consecutive_allocations_step_by_four() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16).unwrap();
+        let a = pool.allocate().unwrap();
+        let b = pool.allocate().unwrap();
+        let c = pool.allocate().unwrap();
+        assert_eq!(a.host_ip, Ipv4Addr::new(172, 18, 0, 1));
+        assert_eq!(b.host_ip, Ipv4Addr::new(172, 18, 0, 5));
+        assert_eq!(c.host_ip, Ipv4Addr::new(172, 18, 0, 9));
+        assert_eq!(pool.in_use(), 3);
+    }
+
+    #[test]
+    fn release_returns_slot_to_pool() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16).unwrap();
+        let a = pool.allocate().unwrap();
+        let b = pool.allocate().unwrap();
+        pool.release(&a);
+        // Next allocate should reclaim slot 0 (lowest free).
+        let c = pool.allocate().unwrap();
+        assert_eq!(c.host_ip, a.host_ip);
+        assert_eq!(pool.in_use(), 2);
+        // b is still valid
+        assert_eq!(b.host_ip, Ipv4Addr::new(172, 18, 0, 5));
+    }
+
+    #[test]
+    fn double_release_is_no_op() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16).unwrap();
+        let a = pool.allocate().unwrap();
+        pool.release(&a);
+        pool.release(&a);
+        assert_eq!(pool.in_use(), 0);
+    }
+
+    #[test]
+    fn exhausts_when_all_slots_taken() {
+        // /28 = 4 slots
+        let pool = Ipv4Pool::new(Ipv4Addr::new(10, 0, 0, 0), 28).unwrap();
+        for _ in 0..4 {
+            pool.allocate().unwrap();
+        }
+        match pool.allocate() {
+            Err(PoolError::Exhausted { used, capacity }) => {
+                assert_eq!(used, 4);
+                assert_eq!(capacity, 4);
+            }
+            other => panic!("expected Exhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn allocate_spans_full_pool() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(10, 0, 0, 0), 28).unwrap();
+        let a = pool.allocate().unwrap();
+        let b = pool.allocate().unwrap();
+        let c = pool.allocate().unwrap();
+        let d = pool.allocate().unwrap();
+        // All four /30s from 10.0.0.0/28: .0, .4, .8, .12
+        assert_eq!(a.cidr, Ipv4Addr::new(10, 0, 0, 0));
+        assert_eq!(b.cidr, Ipv4Addr::new(10, 0, 0, 4));
+        assert_eq!(c.cidr, Ipv4Addr::new(10, 0, 0, 8));
+        assert_eq!(d.cidr, Ipv4Addr::new(10, 0, 0, 12));
+    }
+
+    #[test]
+    fn from_cidr_parses_valid_block() {
+        let pool = Ipv4Pool::from_cidr("172.18.0.0/16").unwrap();
+        assert_eq!(pool.capacity(), 16384);
+        let a = pool.allocate().unwrap();
+        assert_eq!(a.host_ip, Ipv4Addr::new(172, 18, 0, 1));
+    }
+
+    #[test]
+    fn host_cidr_formats_correctly() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16).unwrap();
+        let a = pool.allocate().unwrap();
+        assert_eq!(a.host_cidr(), "172.18.0.1/30");
+    }
+
+    #[test]
+    fn kernel_ip_arg_formats_for_initramfs() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16).unwrap();
+        let a = pool.allocate().unwrap();
+        assert_eq!(
+            a.kernel_ip_arg(),
+            "172.18.0.2::172.18.0.1:255.255.255.252::eth0:off"
+        );
+    }
+
+    #[test]
+    fn allocations_are_isolated_across_threads() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let pool = Arc::new(Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 20).unwrap());
+        // /20 = 1024 slots. 8 threads × 100 allocations should all be unique.
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let p = pool.clone();
+            handles.push(thread::spawn(move || {
+                let mut ours = Vec::new();
+                for _ in 0..100 {
+                    ours.push(p.allocate().unwrap().host_ip);
+                }
+                ours
+            }));
+        }
+        let mut all: Vec<Ipv4Addr> = handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect();
+        all.sort();
+        all.dedup();
+        assert_eq!(all.len(), 800);
+        assert_eq!(pool.in_use(), 800);
+    }
+}

--- a/apps/vm/firecracker-ctl/src/tap.rs
+++ b/apps/vm/firecracker-ctl/src/tap.rs
@@ -1,0 +1,588 @@
+//! TAP device manager for persistent Firecracker endpoints.
+//!
+//! Creates `/dev/net/tun` devices in the pod netns, assigns the host-side
+//! IP, and tears them down when the VM goes away. Also handles one-time
+//! pod-level setup: IP forwarding, NAT MASQUERADE to the VPN tunnel, and
+//! FORWARD-chain ACCEPT rules for VM ↔ tunnel traffic.
+//!
+// Integrated into the VM lifecycle in Phase 2c; until then, the
+// public surface is unused by the binary itself.
+#![allow(dead_code)]
+//!
+//! ## Approach
+//!
+//! We shell out to `ip` and `iptables`. This matches the house style in
+//! `firecracker-ctl` (firecracker + jailer are invoked as subprocesses)
+//! and keeps the diff small. If this becomes brittle we can swap to
+//! `rtnetlink` later.
+//!
+//! ## Testability
+//!
+//! The command-assembly helpers (`build_*`) are pure functions that
+//! return `Vec<String>` argument lists — they're unit-tested without
+//! spawning any processes. The execution wrappers (`run_ip`, `run_iptables`,
+//! `create_tap`, etc.) are thin enough that their correctness is verified
+//! by integration tests in the cluster rather than here.
+
+use crate::persistent::IpAllocation;
+use std::net::Ipv4Addr;
+
+/// TAP interface name prefix. Kept short so that `fctap-{index}` fits
+/// the 15-char IFNAMSIZ limit even with the largest pool index we can
+/// produce (uint32 → 10 digits, plus `fctap-` = 16 chars; in practice
+/// the pool caps at 16384 = 5 digits so we're well under).
+pub const TAP_PREFIX: &str = "fctap-";
+
+/// Errors surfacing from TAP / iptables plumbing.
+#[derive(Debug)]
+pub enum TapError {
+    /// Failed to spawn the external command (binary missing, permission, etc.).
+    Spawn {
+        program: String,
+        source: std::io::Error,
+    },
+    /// The external command ran but exited non-zero.
+    CommandFailed {
+        program: String,
+        args: Vec<String>,
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    /// Allocation produced a TAP name that exceeds IFNAMSIZ.
+    NameTooLong(String),
+}
+
+impl std::fmt::Display for TapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TapError::Spawn { program, source } => {
+                write!(f, "failed to spawn {program}: {source}")
+            }
+            TapError::CommandFailed {
+                program,
+                args,
+                exit_code,
+                stderr,
+            } => {
+                let code = exit_code
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "?".into());
+                write!(
+                    f,
+                    "{program} {args:?} exited with {code}: {}",
+                    stderr.trim()
+                )
+            }
+            TapError::NameTooLong(n) => write!(f, "TAP name {n:?} exceeds IFNAMSIZ (15)"),
+        }
+    }
+}
+
+impl std::error::Error for TapError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TapError::Spawn { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Compile-time upper bound on Linux interface names (IFNAMSIZ is 16
+/// including the terminating NUL).
+const IFNAMSIZ_LIMIT: usize = 15;
+
+/// Build the TAP interface name for a given pool slot.
+pub fn tap_name(slot: u32) -> Result<String, TapError> {
+    let n = format!("{TAP_PREFIX}{slot}");
+    if n.len() > IFNAMSIZ_LIMIT {
+        return Err(TapError::NameTooLong(n));
+    }
+    Ok(n)
+}
+
+/// Handle to a live TAP device. Keep this alive for the lifetime of the
+/// VM; dropping it does NOT tear the TAP down — callers must invoke
+/// `TapManager::destroy` explicitly so errors can be surfaced.
+#[derive(Debug, Clone)]
+pub struct TapDevice {
+    pub name: String,
+    pub host_ip: Ipv4Addr,
+    pub guest_ip: Ipv4Addr,
+    pub prefix_len: u8,
+}
+
+/// Configuration for the TAP manager. All fields come from env vars
+/// so operators can override defaults without rebuilding.
+#[derive(Debug, Clone)]
+pub struct TapConfig {
+    /// UID that the Firecracker jailer runs as. The TAP device is
+    /// chowned to this UID so the jailer can open it without CAP_NET_ADMIN
+    /// inside the jail.
+    pub jailer_uid: u32,
+    /// VPN tunnel interface (e.g. `wg0` for WireGuard). VM egress is
+    /// MASQUERADE'd out this interface.
+    pub tunnel_iface: String,
+    /// CIDR of the VM subnet pool (e.g. `172.18.0.0/16`). Used as
+    /// the `-s` match for the NAT + FORWARD rules.
+    pub vm_subnet: String,
+}
+
+impl TapConfig {
+    /// Load TAP config from environment variables with sensible defaults.
+    pub fn from_env() -> Self {
+        let jailer_uid = std::env::var("FC_JAILER_UID")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10001);
+        let tunnel_iface = std::env::var("FC_TUNNEL_IFACE").unwrap_or_else(|_| "wg0".to_string());
+        let vm_subnet =
+            std::env::var("FC_PERSISTENT_SUBNET").unwrap_or_else(|_| "172.18.0.0/16".to_string());
+        Self {
+            jailer_uid,
+            tunnel_iface,
+            vm_subnet,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure command-assembly helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+/// `ip tuntap add dev {name} mode tap user {uid}` — create the TAP.
+pub fn build_tap_create(name: &str, jailer_uid: u32) -> Vec<String> {
+    vec![
+        "tuntap".into(),
+        "add".into(),
+        "dev".into(),
+        name.into(),
+        "mode".into(),
+        "tap".into(),
+        "user".into(),
+        jailer_uid.to_string(),
+    ]
+}
+
+/// `ip addr add {host_ip}/{prefix} dev {name}` — assign the host-side IP.
+pub fn build_addr_add(name: &str, host_ip: Ipv4Addr, prefix_len: u8) -> Vec<String> {
+    vec![
+        "addr".into(),
+        "add".into(),
+        format!("{host_ip}/{prefix_len}"),
+        "dev".into(),
+        name.into(),
+    ]
+}
+
+/// `ip link set dev {name} up` — bring the TAP up.
+pub fn build_link_up(name: &str) -> Vec<String> {
+    vec![
+        "link".into(),
+        "set".into(),
+        "dev".into(),
+        name.into(),
+        "up".into(),
+    ]
+}
+
+/// `ip link del dev {name}` — delete the TAP (removes IP + state atomically).
+pub fn build_link_del(name: &str) -> Vec<String> {
+    vec!["link".into(), "del".into(), "dev".into(), name.into()]
+}
+
+/// NAT MASQUERADE rule for VM egress: rewrite source IP of outbound
+/// packets from the VM subnet to the tunnel interface's address so
+/// the VPN provider sees the tunnel peer rather than a 172.18.* source.
+pub fn build_nat_masquerade(vm_subnet: &str, tunnel_iface: &str) -> Vec<String> {
+    vec![
+        "-t".into(),
+        "nat".into(),
+        "-A".into(),
+        "POSTROUTING".into(),
+        "-s".into(),
+        vm_subnet.into(),
+        "-o".into(),
+        tunnel_iface.into(),
+        "-j".into(),
+        "MASQUERADE".into(),
+    ]
+}
+
+/// Check variant of the NAT MASQUERADE rule. `iptables -C` returns
+/// exit 0 if the rule exists, 1 otherwise — we use it to make the
+/// install idempotent without duplicating rules on restart.
+pub fn build_nat_masquerade_check(vm_subnet: &str, tunnel_iface: &str) -> Vec<String> {
+    let mut v = build_nat_masquerade(vm_subnet, tunnel_iface);
+    // Replace -A with -C
+    if let Some(a) = v.iter_mut().find(|s| s.as_str() == "-A") {
+        *a = "-C".into();
+    }
+    v
+}
+
+/// FORWARD rule allowing outbound traffic from the VM subnet onto the
+/// tunnel interface.
+pub fn build_forward_out(vm_subnet: &str, tunnel_iface: &str) -> Vec<String> {
+    vec![
+        "-A".into(),
+        "FORWARD".into(),
+        "-s".into(),
+        vm_subnet.into(),
+        "-o".into(),
+        tunnel_iface.into(),
+        "-j".into(),
+        "ACCEPT".into(),
+    ]
+}
+
+pub fn build_forward_out_check(vm_subnet: &str, tunnel_iface: &str) -> Vec<String> {
+    let mut v = build_forward_out(vm_subnet, tunnel_iface);
+    if let Some(a) = v.iter_mut().find(|s| s.as_str() == "-A") {
+        *a = "-C".into();
+    }
+    v
+}
+
+/// FORWARD rule allowing reply traffic from the tunnel back to the
+/// VM subnet when the VM initiated the flow. `--ctstate` is the modern
+/// conntrack match; `--state` is still accepted by most distros for
+/// compatibility.
+pub fn build_forward_return(vm_subnet: &str, tunnel_iface: &str) -> Vec<String> {
+    vec![
+        "-A".into(),
+        "FORWARD".into(),
+        "-i".into(),
+        tunnel_iface.into(),
+        "-d".into(),
+        vm_subnet.into(),
+        "-m".into(),
+        "state".into(),
+        "--state".into(),
+        "ESTABLISHED,RELATED".into(),
+        "-j".into(),
+        "ACCEPT".into(),
+    ]
+}
+
+pub fn build_forward_return_check(vm_subnet: &str, tunnel_iface: &str) -> Vec<String> {
+    let mut v = build_forward_return(vm_subnet, tunnel_iface);
+    if let Some(a) = v.iter_mut().find(|s| s.as_str() == "-A") {
+        *a = "-C".into();
+    }
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Execution wrappers (shell-out via tokio::process::Command)
+// ---------------------------------------------------------------------------
+
+/// Run an external command to completion and surface structured errors.
+/// Internal helper shared by `run_ip` and `run_iptables`.
+async fn run(program: &str, args: &[String]) -> Result<String, TapError> {
+    let output = tokio::process::Command::new(program)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| TapError::Spawn {
+            program: program.to_string(),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        return Err(TapError::CommandFailed {
+            program: program.to_string(),
+            args: args.to_vec(),
+            exit_code: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Run `ip {args...}`.
+pub async fn run_ip(args: &[String]) -> Result<String, TapError> {
+    run("ip", args).await
+}
+
+/// Run `iptables {args...}`.
+pub async fn run_iptables(args: &[String]) -> Result<String, TapError> {
+    run("iptables", args).await
+}
+
+/// Rule-present check: returns Ok(true) if `iptables -C` succeeds,
+/// Ok(false) if it exits non-zero (rule not present), or an error if
+/// iptables itself failed to execute.
+async fn iptables_rule_exists(check_args: &[String]) -> Result<bool, TapError> {
+    let output = tokio::process::Command::new("iptables")
+        .args(check_args)
+        .output()
+        .await
+        .map_err(|e| TapError::Spawn {
+            program: "iptables".into(),
+            source: e,
+        })?;
+    Ok(output.status.success())
+}
+
+// ---------------------------------------------------------------------------
+// TapManager — public surface
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct TapManager {
+    config: TapConfig,
+}
+
+impl TapManager {
+    pub fn new(config: TapConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn config(&self) -> &TapConfig {
+        &self.config
+    }
+
+    /// One-time pod-level setup: enable IP forwarding and install
+    /// MASQUERADE + FORWARD rules for the VM subnet ↔ tunnel path.
+    /// Idempotent — safe to call on every startup.
+    pub async fn init(&self) -> Result<(), TapError> {
+        // 1. IP forwarding
+        run("sysctl", &["-w".into(), "net.ipv4.ip_forward=1".into()]).await?;
+
+        // 2. NAT MASQUERADE (add only if not already present)
+        if !iptables_rule_exists(&build_nat_masquerade_check(
+            &self.config.vm_subnet,
+            &self.config.tunnel_iface,
+        ))
+        .await?
+        {
+            run_iptables(&build_nat_masquerade(
+                &self.config.vm_subnet,
+                &self.config.tunnel_iface,
+            ))
+            .await?;
+        }
+
+        // 3. FORWARD: VM → tunnel
+        if !iptables_rule_exists(&build_forward_out_check(
+            &self.config.vm_subnet,
+            &self.config.tunnel_iface,
+        ))
+        .await?
+        {
+            run_iptables(&build_forward_out(
+                &self.config.vm_subnet,
+                &self.config.tunnel_iface,
+            ))
+            .await?;
+        }
+
+        // 4. FORWARD: tunnel → VM (reply traffic only)
+        if !iptables_rule_exists(&build_forward_return_check(
+            &self.config.vm_subnet,
+            &self.config.tunnel_iface,
+        ))
+        .await?
+        {
+            run_iptables(&build_forward_return(
+                &self.config.vm_subnet,
+                &self.config.tunnel_iface,
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Create a TAP device for the given IP allocation, assign the
+    /// host-side IP, and bring the interface up.
+    pub async fn create_tap(&self, allocation: &IpAllocation) -> Result<TapDevice, TapError> {
+        let name = tap_name(allocation.slot_index())?;
+
+        run_ip(&build_tap_create(&name, self.config.jailer_uid)).await?;
+        run_ip(&build_addr_add(
+            &name,
+            allocation.host_ip,
+            allocation.prefix_len,
+        ))
+        .await?;
+        run_ip(&build_link_up(&name)).await?;
+
+        Ok(TapDevice {
+            name,
+            host_ip: allocation.host_ip,
+            guest_ip: allocation.guest_ip,
+            prefix_len: allocation.prefix_len,
+        })
+    }
+
+    /// Delete a TAP device. Swallows "does not exist" errors so cleanup
+    /// paths can be called without pre-checking.
+    pub async fn destroy_tap(&self, tap: &TapDevice) -> Result<(), TapError> {
+        match run_ip(&build_link_del(&tap.name)).await {
+            Ok(_) => Ok(()),
+            Err(TapError::CommandFailed { stderr, .. })
+                if stderr.contains("Cannot find device") || stderr.contains("does not exist") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — command-builder helpers only (no shell-out)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistent::Ipv4Pool;
+
+    #[test]
+    fn tap_name_fits_ifnamsiz() {
+        assert_eq!(tap_name(0).unwrap(), "fctap-0");
+        assert_eq!(tap_name(42).unwrap(), "fctap-42");
+        // Max slot index in a /16 pool = 16383 (5 digits) → 11 chars — fits.
+        assert_eq!(tap_name(16383).unwrap(), "fctap-16383");
+    }
+
+    #[test]
+    fn tap_name_rejects_overflow() {
+        // Forged 10-digit index to exceed the 15-char limit.
+        let huge = u32::MAX;
+        let name = format!("{TAP_PREFIX}{huge}");
+        assert!(name.len() > IFNAMSIZ_LIMIT);
+        assert!(matches!(tap_name(huge), Err(TapError::NameTooLong(_))));
+    }
+
+    #[test]
+    fn build_tap_create_matches_iproute2() {
+        let args = build_tap_create("fctap-7", 10001);
+        assert_eq!(
+            args,
+            vec![
+                "tuntap", "add", "dev", "fctap-7", "mode", "tap", "user", "10001"
+            ]
+        );
+    }
+
+    #[test]
+    fn build_addr_add_includes_cidr() {
+        let args = build_addr_add("fctap-7", Ipv4Addr::new(172, 18, 0, 29), 30);
+        assert_eq!(
+            args,
+            vec!["addr", "add", "172.18.0.29/30", "dev", "fctap-7"]
+        );
+    }
+
+    #[test]
+    fn build_link_up_is_simple() {
+        assert_eq!(
+            build_link_up("fctap-7"),
+            vec!["link", "set", "dev", "fctap-7", "up"]
+        );
+    }
+
+    #[test]
+    fn build_link_del_is_simple() {
+        assert_eq!(
+            build_link_del("fctap-7"),
+            vec!["link", "del", "dev", "fctap-7"]
+        );
+    }
+
+    #[test]
+    fn masquerade_rule_is_pool_scoped() {
+        let args = build_nat_masquerade("172.18.0.0/16", "wg0");
+        assert_eq!(
+            args,
+            vec![
+                "-t",
+                "nat",
+                "-A",
+                "POSTROUTING",
+                "-s",
+                "172.18.0.0/16",
+                "-o",
+                "wg0",
+                "-j",
+                "MASQUERADE",
+            ]
+        );
+    }
+
+    #[test]
+    fn masquerade_check_swaps_add_for_check() {
+        let add = build_nat_masquerade("172.18.0.0/16", "wg0");
+        let check = build_nat_masquerade_check("172.18.0.0/16", "wg0");
+        assert!(add.contains(&"-A".to_string()));
+        assert!(check.contains(&"-C".to_string()));
+        assert!(!check.contains(&"-A".to_string()));
+        // Everything else is identical
+        let stripped = |v: Vec<String>| -> Vec<String> {
+            v.into_iter().filter(|s| s != "-A" && s != "-C").collect()
+        };
+        assert_eq!(stripped(add), stripped(check));
+    }
+
+    #[test]
+    fn forward_out_rule_matches_subnet_and_iface() {
+        assert_eq!(
+            build_forward_out("172.18.0.0/16", "wg0"),
+            vec![
+                "-A",
+                "FORWARD",
+                "-s",
+                "172.18.0.0/16",
+                "-o",
+                "wg0",
+                "-j",
+                "ACCEPT",
+            ]
+        );
+    }
+
+    #[test]
+    fn forward_return_limits_to_established_related() {
+        let args = build_forward_return("172.18.0.0/16", "wg0");
+        assert!(args.contains(&"ESTABLISHED,RELATED".to_string()));
+        assert!(args.contains(&"-i".to_string()));
+        assert!(args.contains(&"-d".to_string()));
+    }
+
+    #[test]
+    fn forward_checks_all_swap_add_for_check() {
+        let out_check = build_forward_out_check("10.0.0.0/16", "tun0");
+        let ret_check = build_forward_return_check("10.0.0.0/16", "tun0");
+        assert!(out_check.contains(&"-C".to_string()));
+        assert!(ret_check.contains(&"-C".to_string()));
+        assert!(!out_check.contains(&"-A".to_string()));
+        assert!(!ret_check.contains(&"-A".to_string()));
+    }
+
+    #[test]
+    fn config_from_env_uses_defaults_when_unset() {
+        // Only run in a controlled env — clear the relevant vars first.
+        // SAFETY: tests run single-threaded only for env-var isolation.
+        unsafe {
+            std::env::remove_var("FC_JAILER_UID");
+            std::env::remove_var("FC_TUNNEL_IFACE");
+            std::env::remove_var("FC_PERSISTENT_SUBNET");
+        }
+        let cfg = TapConfig::from_env();
+        assert_eq!(cfg.jailer_uid, 10001);
+        assert_eq!(cfg.tunnel_iface, "wg0");
+        assert_eq!(cfg.vm_subnet, "172.18.0.0/16");
+    }
+
+    #[test]
+    fn allocation_to_tap_name_is_stable() {
+        let pool = Ipv4Pool::new(Ipv4Addr::new(172, 18, 0, 0), 16).unwrap();
+        let a = pool.allocate().unwrap();
+        let b = pool.allocate().unwrap();
+        assert_eq!(tap_name(a.slot_index()).unwrap(), "fctap-0");
+        assert_eq!(tap_name(b.slot_index()).unwrap(), "fctap-1");
+    }
+}


### PR DESCRIPTION
## Summary
- First slice of Phase 2. Adds a thread-safe pool of `/30` subnets carved from a configurable base CIDR (default `172.18.0.0/16`, 16384 slots)
- Each allocation yields `(cidr, host_ip, guest_ip, netmask)` — enough to plumb one point-to-point TAP link per persistent VM
- Pure logic, no KVM required. Lives in `firecracker-ctl-net` only; the local `172.18.*` pool never leaves the pod netns

## What's here
- `apps/vm/firecracker-ctl/src/persistent.rs` — `Ipv4Pool`, `IpAllocation`, `PoolError`
- Helpers: `host_cidr()` for `ip addr add`, `kernel_ip_arg()` for initramfs boot config
- `Ipv4Pool::from_cidr("172.18.0.0/16")` constructor for env-var wiring
- `mod persistent` wired into `main.rs`

## What's NOT here (lands in follow-up PRs)
- TAP device creation / assignment (Phase 2b)
- Persistent VM lifecycle replacing the Phase 1 stubs (Phase 2c)
- HTTP forwarder for `/proxy/{name}/{*path}` (Phase 2d)
- Kernel boot-arg wiring (Phase 2e)

## Test plan
- [x] `cargo test -p firecracker-ctl persistent` — 13/13 passing
  - alignment + prefix validation
  - capacity math across /16, /28, /30
  - first-free allocation determinism
  - consecutive slots step by 4
  - release returns slot to pool; double-release is a no-op
  - pool exhaustion surfaces with used/capacity counts
  - full-pool allocation across all 4 slots of a /28
  - CIDR string parsing
  - `host_cidr` + `kernel_ip_arg` string formatting
  - 800 concurrent allocations across 8 threads all unique