### PR TITLE
feat(mc): seal Modrinth API token for client mod publishing

### DIFF
--- a/apps/kube/agones/mc/modrinth-sealed-secret.yaml
+++ b/apps/kube/agones/mc/modrinth-sealed-secret.yaml
@@ -1,0 +1,23 @@
+---
+# Modrinth API token used by the client-side mod publish pipeline to upload
+# behavior_statetree JARs as releases on the Modrinth project page. The CI
+# workflow (ci-mc-modrinth.yml — added separately) reads this via a Job that
+# mounts the unsealed Secret into a Modrinth `mc-publish` step.
+#
+# Rotate by generating a new PAT at https://modrinth.com/settings/pats and
+# re-sealing with:
+#   printf '%s' "<new-token>" | kubeseal --raw --namespace mc \
+#     --name mc-modrinth-token --from-file=/dev/stdin
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: mc-modrinth-token
+    namespace: mc
+spec:
+    encryptedData:
+        token: AgB7VqOoagci4ObDJ5aK3CQFfjgvGwkEOy67QFpgQDts4pj/RvDzMzHTSemG819mi3qdO3/miXQV2IX6CuEBWopDEm7QcCywLoCXtmt2nEKKYDkmT7DdZ551I8ljjnbBo+m3xlio3ICmMYEDHJV1WDNVpoDfFxyKUq5Fm8PtViIdvGSEMX4kMwn9Wh1HXjROz05JZBxL8e3JVBSz6KUSwkz24lN+1FNpL5Ys36eHvLpEsr3GElDbQm/yllL6mxp3gPDF8DGJ4kVWKFu8BB1cdpqW+OGhD7Su6OON8WT333vB4r3MLGn1XUXXY5q3wHxGmCB+hF2LMQCUqf6lhM97Ewdk8aBrlNfj10e9hRLzL2BXhzt3iDGsGo/6C6J6JVODdNV94Av0Qb68UBlFgEsaexCxXoKvcmcwnIZsMk0DoMCxj8aSyAfOhqx+Z1HZLl4whI3uve1qDT1LeekJZS3DjoC94zkfe8PX1cwCHbRtKWgZRknE9sRDQAkjPixbyNr5FW+TBgYai9J1zzTdjPu4K6RpKEaZ3xkEJrKQZl6BEuCMhlCyS48Oc5dkIbbDL/CMITlbhPo/2EKjeeW+Hv3EG2E7NWO+VP0kf3Z4LWbD6fZ0h9e6Qoe9ODOG8UKxrCmh6tMmqlLVLZhOFkc/7Nyl9BTK0e7NMLMlsZf9AfECZuDg3grThDeqXpnTNQWVuHGamBSkAwXjFCcN/EqdO+58SI+3nDzio3PVKluYmh7DcjtmJZm9jun6qDCGbWaFJ0p7cThAmrpJCgik1FrOA2Rq+9Ig
+    template:
+        metadata:
+            name: mc-modrinth-token
+            namespace: mc
+        type: Opaque


### PR DESCRIPTION
## Summary

Adds `apps/kube/agones/mc/modrinth-sealed-secret.yaml` — a SealedSecret named `mc-modrinth-token` in the `mc` namespace that holds the Modrinth PAT for the upcoming `ci-mc-modrinth` workflow.

The agones-mc ArgoCD Application syncs everything under `apps/kube/agones/mc/` directly (no kustomization.yaml), so dropping the file in is enough — same pattern as `rcon-sealed-secret.yaml`.

## Rotation

```bash
printf '%s' "<new-token>" | kubeseal --raw --namespace mc \
  --name mc-modrinth-token --from-file=/dev/stdin
```

The plaintext never touches disk — the rotated ciphertext replaces the `token:` value in the YAML and a new commit lands.

## Next steps (separate PRs)

- `ci-mc-modrinth.yml` workflow that runs an in-cluster Job mounting `mc-modrinth-token` and shelling out to `mc-publish` to upload the JAR built by the existing `mc:container` pipeline.
- Decide whether mc_auth ships to Modrinth too (lean: GitHub Releases only — it bridges Supabase).

## Test plan

- [ ] ArgoCD agones-mc Application syncs without errors after merge.
- [ ] `kubectl get sealedsecret -n mc mc-modrinth-token` shows STATUS=True / SYNCED=True.
- [ ] `kubectl get secret -n mc mc-modrinth-token -o jsonpath='{.data.token}' | base64 -d | head -c 4` returns `mrp_`.