### PR TITLE
feat(mc): in-cluster Modrinth publish via ArgoCD PostSync hook

### DIFF
--- a/apps/kube/agones/mc/modrinth-publish-config.yaml
+++ b/apps/kube/agones/mc/modrinth-publish-config.yaml
@@ -11,9 +11,8 @@ metadata:
 data:
     # Modrinth project ID (NOT the slug). Look up via:
     #   curl https://api.modrinth.com/v2/project/<your-slug> | jq .id
-    # Leave empty until the project is registered on modrinth.com — the
-    # publish Job no-ops cleanly so syncs don't fail before then.
-    MODRINTH_PROJECT_ID: ''
+    # Project type: server-side mod (server_side=required, client_side=optional).
+    MODRINTH_PROJECT_ID: '86Wqkiak'
 
     # alpha | beta | release — the Modrinth channel new uploads land in.
     # Stay on alpha while the mod is in active development.

--- a/apps/kube/agones/mc/modrinth-publish-config.yaml
+++ b/apps/kube/agones/mc/modrinth-publish-config.yaml
@@ -1,0 +1,31 @@
+---
+# Tunables for the in-cluster Modrinth publishing Job
+# (modrinth-publish-job.yaml). Kept as a ConfigMap so admins can adjust
+# loaders / game versions / channel without re-sealing the token secret
+# or rebuilding the publisher image.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: mc-modrinth-config
+    namespace: mc
+data:
+    # Modrinth project ID (NOT the slug). Look up via:
+    #   curl https://api.modrinth.com/v2/project/<your-slug> | jq .id
+    # Leave empty until the project is registered on modrinth.com — the
+    # publish Job no-ops cleanly so syncs don't fail before then.
+    MODRINTH_PROJECT_ID: ''
+
+    # alpha | beta | release — the Modrinth channel new uploads land in.
+    # Stay on alpha while the mod is in active development.
+    VERSION_TYPE: 'alpha'
+
+    # Stringified JSON arrays — interpolated verbatim into the multipart
+    # JSON body posted to /v2/version. Keep in sync with the Fabric
+    # mod's `build.gradle` minecraft + loader pins.
+    LOADERS: '["fabric"]'
+    GAME_VERSIONS: '["1.21.11"]'
+
+    # Required runtime dependencies declared on every published version.
+    # Fabric API project id P7dR8mSH is canonical (not the slug, which
+    # can be re-pointed by the Modrinth team).
+    DEPENDENCIES: '[{"project_id":"P7dR8mSH","dependency_type":"required"}]'

--- a/apps/kube/agones/mc/modrinth-publish-job.yaml
+++ b/apps/kube/agones/mc/modrinth-publish-job.yaml
@@ -1,0 +1,137 @@
+---
+# In-cluster Modrinth publisher.
+#
+# Trigger: ArgoCD PostSync hook on the agones-mc Application — fires after
+# every sync (including the post-publish bump that retags fleet.yaml's
+# image to a new kbve/mc version). The Job is idempotent: it queries
+# Modrinth for the JAR's version_number and exits 0 if it's already
+# uploaded, so frequent syncs don't double-post.
+#
+# Flow:
+#   1. initContainer pulls ghcr.io/kbve/mc:latest (the same image that
+#      runs in the Fleet) and copies the bundled behavior_statetree JAR
+#      out of /mods/ into a shared emptyDir.
+#   2. main container reads MODRINTH_TOKEN from the sealed secret +
+#      MODRINTH_PROJECT_ID from the config map, checks for an existing
+#      version on Modrinth, and POSTs the JAR if missing.
+#
+# Until MODRINTH_PROJECT_ID is populated in mc-modrinth-config (the
+# project must be created manually on modrinth.com first), the Job
+# logs a notice and exits 0 — it does not block syncs.
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: mc-modrinth-publish
+    namespace: mc
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/sync-wave: '10'
+    labels:
+        app.kubernetes.io/part-of: mc
+        app.kubernetes.io/component: modrinth-publisher
+spec:
+    ttlSecondsAfterFinished: 86400
+    backoffLimit: 1
+    template:
+        metadata:
+            labels:
+                app.kubernetes.io/part-of: mc
+                app.kubernetes.io/component: modrinth-publisher
+        spec:
+            restartPolicy: Never
+            initContainers:
+                - name: extract-jar
+                  image: ghcr.io/kbve/mc:latest
+                  imagePullPolicy: Always
+                  command: ['sh', '-c']
+                  args:
+                      - |
+                          set -e
+                          JAR=$(ls /mods/behavior_statetree-*.jar 2>/dev/null | head -1)
+                          if [ -z "$JAR" ]; then
+                            echo "No behavior_statetree JAR found in /mods/ — image build is broken."
+                            ls -la /mods/
+                            exit 1
+                          fi
+                          cp "$JAR" /shared/
+                          echo "Extracted $(basename "$JAR") ($(du -h "$JAR" | cut -f1))"
+                  volumeMounts:
+                      - name: shared
+                        mountPath: /shared
+            containers:
+                - name: publish
+                  image: alpine:3.20
+                  command: ['sh', '-c']
+                  args:
+                      - |
+                          set -euo pipefail
+                          apk add --no-cache curl jq > /dev/null
+
+                          JAR=$(ls /shared/behavior_statetree-*.jar 2>/dev/null | head -1)
+                          VERSION=$(basename "$JAR" .jar | sed 's/^behavior_statetree-//')
+                          echo "Mod JAR: $(basename "$JAR")  →  version $VERSION"
+
+                          if [ -z "${MODRINTH_PROJECT_ID:-}" ]; then
+                            echo "MODRINTH_PROJECT_ID is empty — create the project on modrinth.com,"
+                            echo "then update mc-modrinth-config with the project .id. Skipping."
+                            exit 0
+                          fi
+
+                          # Idempotency — Modrinth rejects duplicate version_number anyway,
+                          # but checking first turns the no-op into a clean log instead of an
+                          # API error.
+                          EXISTING=$(curl -fsSL -H "Authorization: $MODRINTH_TOKEN" \
+                            "https://api.modrinth.com/v2/project/$MODRINTH_PROJECT_ID/version" \
+                            | jq -r --arg v "$VERSION" '.[] | select(.version_number == $v) | .id' \
+                            | head -1)
+
+                          if [ -n "$EXISTING" ]; then
+                            echo "v$VERSION already on Modrinth (id=$EXISTING) — no-op."
+                            exit 0
+                          fi
+
+                          cat > /tmp/data.json <<JSON
+                          {
+                            "name": "behavior_statetree $VERSION",
+                            "version_number": "$VERSION",
+                            "version_type": "$VERSION_TYPE",
+                            "project_id": "$MODRINTH_PROJECT_ID",
+                            "loaders": $LOADERS,
+                            "game_versions": $GAME_VERSIONS,
+                            "featured": false,
+                            "dependencies": $DEPENDENCIES,
+                            "file_parts": ["jar"]
+                          }
+                          JSON
+
+                          echo "Uploading v$VERSION → project $MODRINTH_PROJECT_ID..."
+                          RESPONSE=$(curl -fsSL -X POST "https://api.modrinth.com/v2/version" \
+                            -H "Authorization: $MODRINTH_TOKEN" \
+                            -F "data=@/tmp/data.json;type=application/json" \
+                            -F "jar=@$JAR;type=application/java-archive")
+
+                          VERSION_ID=$(echo "$RESPONSE" | jq -r '.id')
+                          echo "Published — version id $VERSION_ID"
+                  env:
+                      - name: MODRINTH_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: mc-modrinth-token
+                                key: token
+                  envFrom:
+                      - configMapRef:
+                            name: mc-modrinth-config
+                  volumeMounts:
+                      - name: shared
+                        mountPath: /shared
+                  resources:
+                      requests:
+                          memory: 64Mi
+                          cpu: 50m
+                      limits:
+                          memory: 256Mi
+                          cpu: 500m
+            volumes:
+                - name: shared
+                  emptyDir: {}


### PR DESCRIPTION
## Summary

Drop GitHub Actions out of the Modrinth path entirely — publish from inside the cluster instead, reusing the sealed token landed in #10122.

Two new manifests in `apps/kube/agones/mc/`:

- **`modrinth-publish-config.yaml`** — ConfigMap with `MODRINTH_PROJECT_ID` (placeholder), `VERSION_TYPE=alpha`, loaders, game versions, and the Fabric API dependency. Tunables live here so we can flip channels or expand MC compat without touching the Job.
- **`modrinth-publish-job.yaml`** — ArgoCD PostSync hook Job:
    - **initContainer** pulls `ghcr.io/kbve/mc:latest` (same image the Fleet runs) and copies `behavior_statetree-*.jar` out of `/mods/` into a shared `emptyDir`.
    - **publish** container reads `MODRINTH_TOKEN` from `mc-modrinth-token`, queries `/v2/project/<id>/version` for the JAR's `version_number`, and POSTs the JAR via `/v2/version` if missing.
    - Idempotent — repeated syncs no-op cleanly.
    - `BeforeHookCreation` deletion policy keeps a single Job pod in flight per sync; `ttlSecondsAfterFinished: 86400` keeps logs around for a day.

## Bootstrap

1. Create the `behavior_statetree` project at https://modrinth.com → grab its `.id`.
2. Edit `mc-modrinth-config` (or commit a new value) — `MODRINTH_PROJECT_ID: "xxxxxxxx"`.
3. Next agones-mc sync → Job uploads the current JAR.

Until step 2 lands, the Job exits 0 with a notice — syncs aren't blocked.

## Why PostSync (not CronJob, not Argo Workflows)

- Couples naturally to the existing post-publish flow: bumping `version.toml` retags `fleet.yaml`, ArgoCD syncs, hook fires, Modrinth gets the new JAR. No second scheduler to reason about.
- CronJob would add latency (up to the cron interval) and run on noise schedules; PostSync runs exactly when the manifests change.
- Argo Workflows / Events would solve this too but require a new install — overkill for one publish step.

## Test plan

- [ ] Merge this PR → ArgoCD agones-mc sync triggers the Job → log shows `MODRINTH_PROJECT_ID is empty — ... Skipping.` (because the project isn't created yet).
- [ ] Create the Modrinth project, populate `MODRINTH_PROJECT_ID`, sync → log shows `Uploading v0.1.0 → project xxxxxxxx...` and `Published — version id ...`.
- [ ] Trigger another sync without changing the JAR version → log shows `v0.1.0 already on Modrinth (id=...) — no-op.`