### PR TITLE
fix(mc): disable pause-when-empty to prevent join failures

### DIFF
--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -134,6 +134,11 @@ spec:
                                 value: 'false'
                               - name: SERVER_PORT
                                 value: '25565'
+                              # Disable vanilla 1.21.x idle pause — it stops
+                              # the tick loop after 60s with no players,
+                              # which kills Velocity proxy handshakes.
+                              - name: PAUSE_WHEN_EMPTY_SECONDS
+                                value: '0'
                               # Pinned world seed — canonical KBVE survival seed.
                               # Source of truth for every environment (prod, dev,
                               # CI, contributor laptops). Only applies on first

--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -100,6 +100,7 @@ ENV SIMULATION_DISTANCE=8
 ENV SPAWN_PROTECTION=0
 ENV ONLINE_MODE=true
 ENV SERVER_PORT=25565
+ENV PAUSE_WHEN_EMPTY_SECONDS=0
 
 # Server operators — itzg/minecraft-server reads OPS at startup and writes
 # matching entries into /data/ops.json (level 4). EXISTING_OPS_FILE=SYNCHRONIZE


### PR DESCRIPTION
## Summary
- Disables Minecraft 1.21.x `pause-when-empty-seconds` (default 60s) by setting it to 0
- The vanilla idle pause stops the tick loop, which prevents Velocity proxy from completing handshakes to the Fabric backend
- Players see "Unable to connect you to mc" when the server is paused
- With expected active player traffic, idle pause provides no benefit

## Test plan
- [ ] Merge and let ArgoCD deploy the new mc-fabric image
- [ ] Verify Fabric server no longer logs "Server empty for 60 seconds, pausing"
- [ ] Confirm players can join via Velocity after server has been empty