### PR TITLE
fix(mc): disable pause-when-empty on lobby server

### DIFF
--- a/apps/kube/agones/mc/lobby-deployment.yaml
+++ b/apps/kube/agones/mc/lobby-deployment.yaml
@@ -83,6 +83,8 @@ spec:
                         value: 'false'
                       - name: SERVER_PORT
                         value: '25565'
+                      - name: PAUSE_WHEN_EMPTY_SECONDS
+                        value: '0'
                       # Superflat peaceful world — no mobs, no damage.
                       - name: LEVEL_TYPE
                         value: 'minecraft:flat'

--- a/apps/mc/lobby/Dockerfile
+++ b/apps/mc/lobby/Dockerfile
@@ -32,6 +32,7 @@ ENV SPAWN_PROTECTION=16
 # forwarded sessions (same pattern as apps/mc Fabric backend).
 ENV ONLINE_MODE=false
 ENV SERVER_PORT=25565
+ENV PAUSE_WHEN_EMPTY_SECONDS=0
 
 # ── Superflat peaceful world ──────────────────────────────────────────
 # Vanilla flat preset: bedrock + 2 dirt + grass, plains biome, no


### PR DESCRIPTION
## Summary
- Adds `PAUSE_WHEN_EMPTY_SECONDS=0` to lobby Dockerfile and Deployment manifest
- Lobby is the first Velocity hop (`try = ["lobby", "mc"]`) — if lobby pauses, no player can connect at all
- Same belt-and-suspenders pattern as #10127 (mc-fabric)

## Test plan
- [ ] Merge and let ArgoCD sync the lobby Deployment
- [ ] Verify lobby no longer logs "Server empty for 60 seconds, pausing"
- [ ] Confirm players can join via Velocity after lobby has been empty