### PR TITLE
feat(ops): ArgoCD sync guard — prevent + detect sync deadlocks

### DIFF
--- a/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
+++ b/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
@@ -116,3 +116,25 @@ data:
         hs.status = "Healthy"
         hs.message = "Runner set configured"
         return hs
+    # LoadBalancer Services with a pending external IP should not block
+    # ArgoCD sync completion. Cilium LB-IPAM may take time to allocate
+    # or the IP pool may be exhausted — neither should deadlock the
+    # entire Application's sync wave. Treat pending as Progressing so
+    # other resources in the same app can still land.
+    resource.customizations.health.Service: |
+        hs = {}
+        if obj.spec.type == "LoadBalancer" then
+          if obj.status and obj.status.loadBalancer and obj.status.loadBalancer.ingress then
+            local ingress = obj.status.loadBalancer.ingress
+            if #ingress > 0 and (ingress[1].ip or ingress[1].hostname) then
+              hs.status = "Healthy"
+              hs.message = "LoadBalancer IP assigned"
+              return hs
+            end
+          end
+          hs.status = "Progressing"
+          hs.message = "Waiting for LoadBalancer IP (non-blocking)"
+          return hs
+        end
+        hs.status = "Healthy"
+        return hs

--- a/apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml
+++ b/apps/kube/ca-staleness-monitor/manifests/ca-staleness-monitor.yaml
@@ -45,6 +45,10 @@ rules:
       resources: ['configmaps']
       verbs: ['get']
       resourceNames: ['kube-root-ca.crt']
+    # Read ArgoCD Applications to detect stuck syncs (>1h in Running).
+    - apiGroups: ['argoproj.io']
+      resources: ['applications']
+      verbs: ['get', 'list']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -203,7 +207,43 @@ spec:
                                       --argjson total "${TOTAL_COUNT}" \
                                       --argjson skipped "${SKIPPED_COUNT}" \
                                       --argjson ca_age "${CA_AGE_S}" \
-                                      '{level:"info",component:"ca-staleness-monitor",event:"scan_complete",scan_ts:$ts,ca_not_before:$not_before,ca_age_seconds:$ca_age,stale_pods:$stale,total_pods:$total,skipped_pods:$skipped}'
+                                      '{level:"info",component:"ca-staleness-monitor",event:"ca_scan_complete",scan_ts:$ts,ca_not_before:$not_before,ca_age_seconds:$ca_age,stale_pods:$stale,total_pods:$total,skipped_pods:$skipped}'
+
+                                  # ── ArgoCD sync stall detection ────────────────
+                                  # Any Application stuck in a Running sync phase
+                                  # for over 1 hour is likely deadlocked (health
+                                  # check wait on a resource that will never heal).
+                                  STUCK_THRESHOLD=3600
+                                  STUCK_COUNT=0
+
+                                  APPS=$(kubectl get applications.argoproj.io -n argocd \
+                                      -o jsonpath='{range .items[*]}{.metadata.name}|{.status.operationState.phase}|{.status.operationState.startedAt}|{.status.sync.status}|{.status.operationState.message}{"\n"}{end}' \
+                                      2>/dev/null || echo "")
+
+                                  while IFS='|' read -r APP_NAME PHASE STARTED SYNC_STATUS MSG; do
+                                      [ -z "${APP_NAME}" ] && continue
+                                      [ "${PHASE}" != "Running" ] && continue
+
+                                      STARTED_EPOCH=$(date -u -d "${STARTED}" +%s 2>/dev/null || echo 0)
+                                      [ "${STARTED_EPOCH}" = "0" ] && continue
+
+                                      ELAPSED=$((NOW - STARTED_EPOCH))
+                                      if [ "${ELAPSED}" -ge "${STUCK_THRESHOLD}" ]; then
+                                          jq -cn \
+                                              --arg ts "${SCAN_TS}" \
+                                              --arg app "${APP_NAME}" \
+                                              --arg sync "${SYNC_STATUS}" \
+                                              --arg msg "${MSG}" \
+                                              --argjson elapsed "${ELAPSED}" \
+                                              '{level:"warn",component:"ca-staleness-monitor",event:"argocd_sync_stuck",scan_ts:$ts,application:$app,sync_status:$sync,elapsed_seconds:$elapsed,blocking_message:$msg,recommendation:"Terminate the stuck operation and investigate the blocking resource"}'
+                                          STUCK_COUNT=$((STUCK_COUNT + 1))
+                                      fi
+                                  done <<< "${APPS}"
+
+                                  jq -cn \
+                                      --arg ts "${SCAN_TS}" \
+                                      --argjson stuck "${STUCK_COUNT}" \
+                                      '{level:"info",component:"ca-staleness-monitor",event:"argocd_scan_complete",scan_ts:$ts,stuck_syncs:$stuck}'
                     volumes:
                         - name: tmp
                           emptyDir: {}


### PR DESCRIPTION
## Summary
Belt-and-suspenders for the ArgoCD sync stall class of failure that blocked our Reloader annotation from deploying for 24+ hours.

## Belt: LoadBalancer health check (prevents deadlock)
Adds a custom Lua health assessment for `Service` in the ArgoCD ConfigMap (`patch-argocd-cm-cert-health.yaml`). LoadBalancer Services with pending external IPs now return `Progressing` instead of blocking the sync wave.

This directly prevents the deadlock where `kbve-wt-lb` (pending IP for 23 days due to Cilium LB-IPAM) blocked every sync of the `kbve` Application. The Reloader annotation from PR #10106 sat undeployed for 24h because of it.

Follows the exact Lua pattern used for cert-manager, ExternalSecret, KEDA, and ARC health checks already in the same ConfigMap.

## Suspenders: stuck sync detection (catches it if prevention fails)
Extends the `ca-staleness-monitor` CronJob to also scan ArgoCD Applications for sync operations stuck in `Running` phase for >1 hour. Emits structured JSON with the blocking resource message:

```json
{"level":"warn","component":"ca-staleness-monitor","event":"argocd_sync_stuck","application":"kbve","elapsed_seconds":90000,"blocking_message":"waiting for healthy state of /Service/kbve-wt-lb"}
```

Same CronJob, same 15-min schedule, same Vector pipeline — no new moving parts. RBAC extended with read-only `get/list` on `applications.argoproj.io`.

## Security posture
- ArgoCD ConfigMap change: config-only, no new RBAC
- Monitor RBAC addition: read-only on ArgoCD Application CRs, no write access

## Test plan
- [ ] ArgoCD picks up the Service health Lua — `kubectl get cm argocd-cm -n argocd -o yaml` includes the new key
- [ ] A LoadBalancer Service with `<pending>` IP shows as `Progressing` in ArgoCD UI (not `Unknown`)
- [ ] `kbve` Application sync completes without hanging
- [ ] Manual CronJob run: `kubectl create job --from=cronjob/ca-staleness-monitor test-sync -n kube-system` — emits `argocd_sync_stuck` events for any stuck apps