### PR TITLE
fix(ci): disable Playwright install for axum-kbve docker test

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -212,6 +212,7 @@ jobs:
             image: ${{ needs.config.outputs.image }}
             version_source: ${{ needs.config.outputs.version_source }}
             version_target: ${{ needs.config.outputs.version_target }}
+            install_playwright: false
 
     # ---------------------------------------------------------------------------
     # Publish — promotes the ci-{sha} tag built in test to the release tag.


### PR DESCRIPTION
## Summary
- axum-kbve-e2e uses Vitest with HTTP `fetch()`, not Playwright browser automation
- `ci-docker.yml` wasn't passing `install_playwright` to `docker-test-app.yml`, so it defaulted to `true`
- The `--with-deps` flag tried to `apt-get` system libraries from `archive.ubuntu.com`, which is unreachable from `arc-runner-set` (IPv6 "Network is unreachable", IPv4 connection timeouts)
- Fix: pass `install_playwright: false` since this e2e project doesn't need browsers

Closes #10132

## Test plan
- [ ] Re-run `ci-docker` workflow for `axum-kbve` — should skip the Playwright install step and proceed to Vitest e2e