### PR TITLE
fix(ops): remove ServerSideApply from kube-root — unblocks entire GitOps pipeline

### DIFF
--- a/apps/kube/root.yaml
+++ b/apps/kube/root.yaml
@@ -1,23 +1,22 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: kube-root
-  namespace: argocd
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/kbve/kbve
-    targetRevision: main
-    path: apps/kube
-  destination:
-    server: https://kubernetes.default.svc
+    name: kube-root
     namespace: argocd
-  syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
-    syncOptions:
-      - CreateNamespace=true
-      - ServerSideApply=true
-      - ApplyOutOfSyncOnly=true
-      - PruneLast=true
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: main
+        path: apps/kube
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: argocd
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ApplyOutOfSyncOnly=true
+            - PruneLast=true


### PR DESCRIPTION
## Summary
Removes `ServerSideApply=true` from the `kube-root` app-of-apps Application. This unblocks the entire cluster's GitOps pipeline.

## Root Cause
SSA on the root Application triggers CRD validation on child Application status subresource fields. The ArgoCD Application CRD marks `status.sync.status` and `status.operationState.phase` as Required. Client-side apply skips status validation; SSA does not.

Error:
```
Application.argoproj.io "agones-ows" is invalid:
  [status.sync.status: Required value,
   status.operationState.phase: Required value]
```

## Impact
`kube-root` has been in Failed state, meaning **zero new changes deploy** via GitOps. The following merged PRs are all queued behind this:
- PR #10104 — ca-staleness-monitor CronJob
- PR #10106 — Reloader chart fix + kbve reload annotation
- PR #10115 — kbve-wt-lb removal (also blocking kbve sync)
- PR #10136 — ArgoCD sync guard (Lua health check + stuck sync detection)

## Why this is safe
Child apps retain their own `ServerSideApply=true` in their individual specs:
- `agones-ows/application.yaml` line 28
- `agones-mc/application.yaml` line 28

SSA is only removed from the root layer that applies Application CRs. Child apps that manage real k8s resources (Fleets, Deployments, Services) keep SSA where it's useful for conflict resolution.

## Bootstrap
This is a chicken-and-egg: `root.yaml` is managed by `kube-root`, which can't sync. After merge + promotion to main, manually apply:
```
kubectl apply -f apps/kube/root.yaml
```
After that one-time bootstrap, `kube-root` syncs itself and all queued changes cascade.

## Test plan
- [ ] Merge + promote to main
- [ ] `kubectl apply -f apps/kube/root.yaml` (bootstrap)
- [ ] `kubectl get application kube-root -n argocd` shows Synced/Healthy
- [ ] All 11 OutOfSync apps converge
- [ ] `kbve-wt-lb` is pruned, Reloader annotation lands on `kbve-deployment`, ca-staleness-monitor CronJob appears