### PR TITLE
feat(mc): add Mod Menu, FallingTree + align behavior_statetree v1.0.16

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -222,6 +222,9 @@ declare -A MODS=(
   # Wilder Flowers 1.0.4 — scatters additional wildflower variants
   # across biomes. Client + server required.
   ["wilderflowers-1.0.4+1.21.11-fabric.jar"]="6094531a6bd1fe14b3a5c34f3dce846984798f4e https://cdn.modrinth.com/data/8lUQapTY/versions/pzZ7fqlk/wilderflowers-1.0.4%2B1.21.11-fabric.jar"
+  # FallingTree 1.21.11.3 — chop entire trees by breaking a single log.
+  # Server-required, client-optional. No hard dependencies.
+  ["FallingTree-1.21.11-1.21.11.3.jar"]="9daded812605231a5e1e9461a6e04258d0424761 https://cdn.modrinth.com/data/Fb4jn8m6/versions/Hnj3s9Ez/FallingTree-1.21.11-1.21.11.3.jar"
 )
 
 for name in "${!MODS[@]}"; do

--- a/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
+++ b/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
@@ -180,6 +180,18 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
       ],
       "fileSize": 1115809,
       "env": { "client": "required", "server": "unsupported" }
+    },
+    {
+      "path": "mods/FallingTree-1.21.11-1.21.11.3.jar",
+      "hashes": {
+        "sha1": "9daded812605231a5e1e9461a6e04258d0424761",
+        "sha512": "56b8b86846e65f9e070ee08af1baf0b8871ea5eb233a43961d0f937a6147f039eed44794a6b3661b4748e4da037e40aa48b903936960585b626bc9f5e9e308d9"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Fb4jn8m6/versions/Hnj3s9Ez/FallingTree-1.21.11-1.21.11.3.jar"
+      ],
+      "fileSize": 488371,
+      "env": { "client": "optional", "server": "required" }
     }
   ]
 }

--- a/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
+++ b/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
@@ -168,6 +168,18 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
       ],
       "fileSize": 3091196,
       "env": { "client": "required", "server": "unsupported" }
+    },
+    {
+      "path": "mods/modmenu-17.0.0.jar",
+      "hashes": {
+        "sha1": "544a8b340ac3918d85bcc7d02eaff5372814354b",
+        "sha512": "146f8c356f86c32e5aab76598e021ac123779c89fc7a51a486fccd2871d2751b02046b4eea3194e52f2e7f38abbb5f78301c8f49bde6e60e1839677db9c84e33"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/mOgUt4GM/versions/Tyk71iSw/modmenu-17.0.0.jar"
+      ],
+      "fileSize": 1115809,
+      "env": { "client": "required", "server": "unsupported" }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Mod Menu 17.0.0** — client-only mod for browsing installed mods and accessing config screens. Added to mrpack manifest (not server Dockerfile since `server: unsupported`). Satisfies Forge Config API Port's recommendation warning.
- **FallingTree 1.21.11.3** — chop entire trees by breaking a single log. Server-required, client-optional. Added to both Dockerfile and mrpack.
- **behavior_statetree aligned to server version 1.0.16** — Cargo.toml version sync.

## Test plan
- [ ] `docker build` — FallingTree JAR downloads and passes SHA1 check
- [ ] Server boots cleanly — Forge Config API Port warning for modmenu no longer appears
- [ ] Build mrpack (`./mrpack/build-mrpack.sh`) — verify Mod Menu + FallingTree entries present
- [ ] Client: Mod Menu shows all installed mods in main menu
- [ ] In-game: breaking a log block fells the whole tree (FallingTree active)