### PR TITLE
fix(ops): LB health Lua must return Healthy not Progressing

### DIFF
--- a/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
+++ b/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
@@ -116,11 +116,10 @@ data:
         hs.status = "Healthy"
         hs.message = "Runner set configured"
         return hs
-    # LoadBalancer Services with a pending external IP should not block
-    # ArgoCD sync completion. Cilium LB-IPAM may take time to allocate
-    # or the IP pool may be exhausted — neither should deadlock the
-    # entire Application's sync wave. Treat pending as Progressing so
-    # other resources in the same app can still land.
+    # LoadBalancer Services with a pending external IP must not block
+    # ArgoCD sync completion. Return Healthy (not Progressing) because
+    # ArgoCD waits for Progressing→Healthy before completing a sync,
+    # which deadlocks PruneLast when the Service is being removed.
     resource.customizations.health.Service: |
         hs = {}
         if obj.spec.type == "LoadBalancer" then
@@ -132,8 +131,8 @@ data:
               return hs
             end
           end
-          hs.status = "Progressing"
-          hs.message = "Waiting for LoadBalancer IP (non-blocking)"
+          hs.status = "Healthy"
+          hs.message = "LoadBalancer IP pending (non-blocking)"
           return hs
         end
         hs.status = "Healthy"


### PR DESCRIPTION
## Summary
One-line fix: pending LoadBalancer health check returns `Healthy` instead of `Progressing`.

## Why
ArgoCD waits for `Progressing` resources to reach `Healthy` before completing a sync. With `PruneLast=true`, a pending LB scheduled for removal creates a deadlock:
1. Sync waits for LB to be Healthy (it never will)
2. PruneLast can't delete it until sync completes
3. Deadlock — same pattern that blocked `kbve` for 2+ days

We saw this live: after the SSA fix unblocked `kube-root`, the `kbve` app sync immediately re-stuck on `waiting for healthy state of /Service/kbve-wt-lb` because the Lua returned `Progressing`.

## Fix
`Progressing` → `Healthy` for pending LBs. A LoadBalancer waiting for an IP isn't unhealthy — it's just not fully provisioned. It should never block other resources from deploying.