### PR TITLE
feat(mc): bulk add 17 mods + libraries for next server version

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -225,6 +225,55 @@ declare -A MODS=(
   # FallingTree 1.21.11.3 — chop entire trees by breaking a single log.
   # Server-required, client-optional. No hard dependencies.
   ["FallingTree-1.21.11-1.21.11.3.jar"]="9daded812605231a5e1e9461a6e04258d0424761 https://cdn.modrinth.com/data/Fb4jn8m6/versions/Hnj3s9Ez/FallingTree-1.21.11-1.21.11.3.jar"
+  # Configurable — config library required by Neruina.
+  ["configurable-3.3.2+1.21.11-fabric.jar"]="59e3c7c8457673516a82ab36f5ee352f759f0e3e https://cdn.modrinth.com/data/lGffrQ3O/versions/jIjsSVfP/configurable-3.3.2%2B1.21.11-fabric.jar"
+  # Neruina 3.2.2 — ticking entity crash prevention. Suspends
+  # problematic entities/block-entities instead of crashing the server.
+  # Client-optional, server-optional (most useful server-side).
+  ["neruina-3.2.2+1.21.11-fabric.jar"]="189f0f41dbbdc0a80ed6471c66e184d3bf9f40f2 https://cdn.modrinth.com/data/1s5x833P/versions/o8Ej08oB/neruina-3.2.2%2B1.21.11-fabric.jar"
+  # Blahaj Replushed 4.0.0 — IKEA-inspired plushie items (Blåhaj shark
+  # and friends). Craftable, placeable, personalizable. Client + server.
+  ["blahaj-replushed-4.0.0+1.21.11.jar"]="e02c9d72077cb84d11f0de9d5127f53fc729ff8f https://cdn.modrinth.com/data/5bb5rG4b/versions/enjEypbi/blahaj-replushed-4.0.0%2B1.21.11.jar"
+  # ── Libraries for mods below ───────────────────────────────────────
+  # MidnightLib — config/utility library. Required by Repurposed
+  # Structures and TslatEntityStatus.
+  ["midnightlib-fabric-1.9.2+1.21.11.jar"]="b9617fa5722a8cdc321781a2b6dd97217fcfdc2a https://cdn.modrinth.com/data/codAaoxh/versions/OeTayxh3/midnightlib-fabric-1.9.2%2B1.21.11.jar"
+  # Puzzles Lib — multi-loader abstraction library. Required by
+  # Magnum Torch.
+  ["PuzzlesLib-v21.11.12-mc1.21.11-Fabric.jar"]="f502faff2063b34cfca40cfada13e4fecf69e7fc https://cdn.modrinth.com/data/QAGBst4M/versions/owXZpJai/PuzzlesLib-v21.11.12-mc1.21.11-Fabric.jar"
+  # ── Food & cooking ─────────────────────────────────────────────────
+  # Farmer's Delight Refabricated 3.4.9 — farming + cooking expansion
+  # with new crops, meals, and kitchen blocks. Client + server.
+  ["FarmersDelight-1.21.11-3.4.9+refabricated.jar"]="7c51a74bed32f4c55a22cc87690109c9379c682e https://cdn.modrinth.com/data/7vxePowz/versions/ZP4Uof9C/FarmersDelight-1.21.11-3.4.9%2Brefabricated.jar"
+  # Chef's Delight 1.0.5 — Farmer's Delight addon adding chef villager
+  # trades. Client + server.
+  ["chefs-delight-1.0.5-fabric-1.21.11.jar"]="7848579a9cc8be4299de98010741e03edca7d4d8 https://cdn.modrinth.com/data/pvcsfne4/versions/EXu0Q4KH/chefs-delight-1.0.5-fabric-1.21.11.jar"
+  # ── Structure & worldgen ───────────────────────────────────────────
+  # Repurposed Structures 7.6.2 — adds biome-themed variants of vanilla
+  # structures (villages, temples, strongholds, etc). Server-only.
+  ["repurposed_structures-7.6.2+1.21.11-fabric.jar"]="dc88e4bea42a5e007eb5c2d0107271a43f1db363 https://cdn.modrinth.com/data/muf0XoRe/versions/LgshXq1u/repurposed_structures-7.6.2%2B1.21.11-fabric.jar"
+  # ChoiceTheorem's Overhauled Village 3.6.2a — replaces vanilla village
+  # generation with larger, more detailed layouts. Server-only.
+  ["[fabric]ctov-1.21.11-3.6.2a.jar"]="6aad41978d561c9e766ae38013b916164473a60a https://cdn.modrinth.com/data/fgmhI8kH/versions/K2dNRnIZ/%5Bfabric%5Dctov-1.21.11-3.6.2a.jar"
+  # ── Utility ────────────────────────────────────────────────────────
+  # Magnum Torch 21.11.0 — mega torch that prevents mob spawning in a
+  # large radius. Client + server.
+  ["MagnumTorch-v21.11.0-mc1.21.11-Fabric.jar"]="cf3f0ae62a8c9122b81d54b0bc834183e4a0bc5a https://cdn.modrinth.com/data/jorDmSKv/versions/ggEj5Dcf/MagnumTorch-v21.11.0-mc1.21.11-Fabric.jar"
+  # TslatEntityStatus 1.9.2 — shows entity health/status on HUD.
+  # Client + server.
+  ["TslatEntityStatus-fabric-1.21.11-1.9.2.jar"]="ac77b9ae97686f601cbb4cba1c34b6c1587eaadc https://cdn.modrinth.com/data/4A86JsDZ/versions/gC9DblyC/TslatEntityStatus-fabric-1.21.11-1.9.2.jar"
+  # JEI 27.4.0.22 — recipe viewer. Shows crafting recipes, usages,
+  # and ingredient lookups. Enhances Farmer's Delight recipe discovery.
+  ["jei-1.21.11-fabric-27.4.0.22.jar"]="dba6319ab4cad596d74f520ae608a5cae84ba245 https://cdn.modrinth.com/data/u6dRKJwZ/versions/oHe0elMI/jei-1.21.11-fabric-27.4.0.22.jar"
+  # AppleSkin 3.0.8 — food/hunger HUD overlay showing saturation and
+  # exhaustion. Server install provides accurate values to clients.
+  ["appleskin-fabric-mc1.21.11-3.0.8.jar"]="441fdbf4e9c34fb61517ceb8e15618950dc4d314 https://cdn.modrinth.com/data/EsAfCjCV/versions/59ti1rvg/appleskin-fabric-mc1.21.11-3.0.8.jar"
+  # Traveler's Backpack 10.11.9 — unique upgradeable backpacks with
+  # crafting, fluid tanks, and tool slots. Client + server.
+  ["travelersbackpack-fabric-1.21.11-10.11.9.jar"]="fb2d5a2fd919ee127d9a170e3e85f798edb852a5 https://cdn.modrinth.com/data/rlloIFEV/versions/XbEGJQSG/travelersbackpack-fabric-1.21.11-10.11.9.jar"
+  # Macaw's Paintings 1.1.0 — adds 40+ new painting variants in
+  # multiple sizes. Client + server.
+  ["mcw-paintings-1.1.0-mc1.21.11fabric.jar"]="580ba60f2811796b7906ebc7edea053849a0d1fd https://cdn.modrinth.com/data/okE6QVAY/versions/VPvufXfe/mcw-paintings-1.1.0-mc1.21.11fabric.jar"
 )
 
 for name in "${!MODS[@]}"; do

--- a/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
+++ b/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
@@ -192,6 +192,198 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
       ],
       "fileSize": 488371,
       "env": { "client": "optional", "server": "required" }
+    },
+    {
+      "path": "mods/configurable-3.3.2+1.21.11-fabric.jar",
+      "hashes": {
+        "sha1": "59e3c7c8457673516a82ab36f5ee352f759f0e3e",
+        "sha512": "92a895c5e07a65541b53a3258c1f80ebb13893d079d5985abce69d66eaa8d7af609e67b0f04c410280d33ef137f7d626a63d7ae08c5e2e0e18c53aa64e3e14fc"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/lGffrQ3O/versions/jIjsSVfP/configurable-3.3.2%2B1.21.11-fabric.jar"
+      ],
+      "fileSize": 531167,
+      "env": { "client": "optional", "server": "optional" }
+    },
+    {
+      "path": "mods/neruina-3.2.2+1.21.11-fabric.jar",
+      "hashes": {
+        "sha1": "189f0f41dbbdc0a80ed6471c66e184d3bf9f40f2",
+        "sha512": "af1448fb3dd6d814d0acd6cf40097d323dfaf5ca9ca470a7575f76e3efd21ea861690eddeea26483c93a24d456c20430b08f29b13ab936898f1e79fb7591296c"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/1s5x833P/versions/o8Ej08oB/neruina-3.2.2%2B1.21.11-fabric.jar"
+      ],
+      "fileSize": 1801159,
+      "env": { "client": "optional", "server": "optional" }
+    },
+    {
+      "path": "mods/blahaj-replushed-4.0.0+1.21.11.jar",
+      "hashes": {
+        "sha1": "e02c9d72077cb84d11f0de9d5127f53fc729ff8f",
+        "sha512": "3f318a4d66407497035bdd6b1b3af891f1e61280115e89c87dc168c159be72db6a644b1142fe231ae434089b3660cab318800f033a5929c11951480b1cb01199"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5bb5rG4b/versions/enjEypbi/blahaj-replushed-4.0.0%2B1.21.11.jar"
+      ],
+      "fileSize": 176248,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/skyboxify-2.7+1.21.11-fabric.jar",
+      "hashes": {
+        "sha1": "a127d9ebdc3cbd67f52dc14315b5bec46737d3fd",
+        "sha512": "3f6cec0b1f5d20f2eb6a7d7a66607430e6bd361f93130e6df3a322209a567291bcbfd1f954fff54f91d637690a545d7cabecf4968e28fbb097592334f01dc55e"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/DWuwk8aA/versions/A78kPZ7I/skyboxify-2.7%2B1.21.11-fabric.jar"
+      ],
+      "fileSize": 424802,
+      "env": { "client": "required", "server": "unsupported" }
+    },
+    {
+      "path": "mods/midnightlib-fabric-1.9.2+1.21.11.jar",
+      "hashes": {
+        "sha1": "b9617fa5722a8cdc321781a2b6dd97217fcfdc2a",
+        "sha512": "2a9a14bc6e41ec84f4eb017f3b41ba0b2bf9a4c98ba1b677775c051dcc755c1694cf55a0758f49e91c6792de84198142ba678d57ae0f7def54bdaad4a7e7a182"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/codAaoxh/versions/OeTayxh3/midnightlib-fabric-1.9.2%2B1.21.11.jar"
+      ],
+      "fileSize": 58944,
+      "env": { "client": "optional", "server": "optional" }
+    },
+    {
+      "path": "mods/PuzzlesLib-v21.11.12-mc1.21.11-Fabric.jar",
+      "hashes": {
+        "sha1": "f502faff2063b34cfca40cfada13e4fecf69e7fc",
+        "sha512": "dbf4c97191455fe8e3c6801ddacc17d5157b5922f15a40e490ee0e2b172fe4718f4e5ec93ed244224aa077c7f53dcf30657ca68ac2d7f5692066ea7020af1542"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/QAGBst4M/versions/owXZpJai/PuzzlesLib-v21.11.12-mc1.21.11-Fabric.jar"
+      ],
+      "fileSize": 1124024,
+      "env": { "client": "optional", "server": "optional" }
+    },
+    {
+      "path": "mods/FarmersDelight-1.21.11-3.4.9+refabricated.jar",
+      "hashes": {
+        "sha1": "7c51a74bed32f4c55a22cc87690109c9379c682e",
+        "sha512": "732255187fdb84f71a5e22cb331d068a1a513e51c90e5970f2d31c424973dda3c2c16da49b02df582e23f5af9b8080bef79ef8e627b8ede6ddfcaddccaf245da"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/7vxePowz/versions/ZP4Uof9C/FarmersDelight-1.21.11-3.4.9%2Brefabricated.jar"
+      ],
+      "fileSize": 3223675,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/chefs-delight-1.0.5-fabric-1.21.11.jar",
+      "hashes": {
+        "sha1": "7848579a9cc8be4299de98010741e03edca7d4d8",
+        "sha512": "cae5e68b53dde6cb9320d4ef33ca764fc69e52b64a3ce63c5f2aa75012430f3866e86401d0b0dea74b702a4ff9999e9bba5bdf28729ed68348afb3c75f6e758b"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/pvcsfne4/versions/EXu0Q4KH/chefs-delight-1.0.5-fabric-1.21.11.jar"
+      ],
+      "fileSize": 110671,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/MagnumTorch-v21.11.0-mc1.21.11-Fabric.jar",
+      "hashes": {
+        "sha1": "cf3f0ae62a8c9122b81d54b0bc834183e4a0bc5a",
+        "sha512": "22116a60f38f832a799bb9abe4174fc5261d8e551671420c562809f91dff07bb32d37552656a017662afa1d3aee1a8ca7a00be1e581ce61e8a87c72a03fe9710"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/jorDmSKv/versions/ggEj5Dcf/MagnumTorch-v21.11.0-mc1.21.11-Fabric.jar"
+      ],
+      "fileSize": 94375,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/TslatEntityStatus-fabric-1.21.11-1.9.2.jar",
+      "hashes": {
+        "sha1": "ac77b9ae97686f601cbb4cba1c34b6c1587eaadc",
+        "sha512": "ed12d8678b89781772fd50972a8bab4a781a91ff9e879f2d39a3212df46c135eff7f4283291d040ce3b812126ad9b2c53f9505ff0d945d5f473fb277aa66585a"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/4A86JsDZ/versions/gC9DblyC/TslatEntityStatus-fabric-1.21.11-1.9.2.jar"
+      ],
+      "fileSize": 188145,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/jei-1.21.11-fabric-27.4.0.22.jar",
+      "hashes": {
+        "sha1": "dba6319ab4cad596d74f520ae608a5cae84ba245",
+        "sha512": "4de9d355a9a7325590b2064d84e93e217051dc44e2b38f063ad347998af3f0f3a4d1655a020b23d955d78cc66b5443d4f4d5f63a82ac2c0b206b23d9dc1d30ce"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/u6dRKJwZ/versions/oHe0elMI/jei-1.21.11-fabric-27.4.0.22.jar"
+      ],
+      "fileSize": 1530964,
+      "env": { "client": "optional", "server": "optional" }
+    },
+    {
+      "path": "mods/appleskin-fabric-mc1.21.11-3.0.8.jar",
+      "hashes": {
+        "sha1": "441fdbf4e9c34fb61517ceb8e15618950dc4d314",
+        "sha512": "d32206cb8d6fac7f0b579f7269203135777283e1639ccb68f8605e9f5469b5b54305fd36ba82c64b48b89ae4f1a38501bfb5827284520c3ec622d95edcfa34de"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/EsAfCjCV/versions/59ti1rvg/appleskin-fabric-mc1.21.11-3.0.8.jar"
+      ],
+      "fileSize": 180107,
+      "env": { "client": "optional", "server": "optional" }
+    },
+    {
+      "path": "mods/travelersbackpack-fabric-1.21.11-10.11.9.jar",
+      "hashes": {
+        "sha1": "fb2d5a2fd919ee127d9a170e3e85f798edb852a5",
+        "sha512": "308ae2d6b0118173fb17b18d1ada137d11de38190171962a4d763d948db30c54543f205a5d5d1c9c5415bab33b4e3a222bbab230be80eb0cf68c8b86593e3567"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/rlloIFEV/versions/XbEGJQSG/travelersbackpack-fabric-1.21.11-10.11.9.jar"
+      ],
+      "fileSize": 1573637,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/mcw-paintings-1.1.0-mc1.21.11fabric.jar",
+      "hashes": {
+        "sha1": "580ba60f2811796b7906ebc7edea053849a0d1fd",
+        "sha512": "e92b728a3852a585238189bd29a1c35f907b780a31a56b246246d1fdba499850d3bba434b0383461d328ceda0b2f8d193cd50d5eb4ef890b28163f17fdac9e48"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/okE6QVAY/versions/VPvufXfe/mcw-paintings-1.1.0-mc1.21.11fabric.jar"
+      ],
+      "fileSize": 179390,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/fabric-language-kotlin-1.13.10+kotlin.2.3.20.jar",
+      "hashes": {
+        "sha1": "9873294abf498f509453d37b0a5ba019f4570ffb",
+        "sha512": "e4eaf7594de08eb4f3ea8af2e939f3ee61d07597afb4d5f420c3fbadcb381c7bbad4b1afd5919b3087b73ed9636fb018b1c978858a112bd4f6acdcb42e9eedaa"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Ha28R6CL/versions/21TRTKmh/fabric-language-kotlin-1.13.10%2Bkotlin.2.3.20.jar"
+      ],
+      "fileSize": 7796348,
+      "env": { "client": "required", "server": "unsupported" }
+    },
+    {
+      "path": "mods/optigui-2.3.0-beta.10+1.21.9.jar",
+      "hashes": {
+        "sha1": "1e209418863e8fda53508e33a3251a59b1db7220",
+        "sha512": "18e78345450df72a499f3788f88d7d740dd83e4106a3c6c1a40e1f3424ba2e11b24c072c46e6b21a69a9bff913ea82153c4d33fb731665b9a1aac824ab63192b"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/JuksLGBQ/versions/QM4pzEcr/optigui-2.3.0-beta.10%2B1.21.9.jar"
+      ],
+      "fileSize": 611547,
+      "env": { "client": "required", "server": "unsupported" }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bulk mod addition preparing for the next server version. 15 new server-side mods + 16 client mrpack entries.

### Server-side (Dockerfile)
- **Crash prevention**: Neruina + Configurable
- **Food & cooking**: Farmer's Delight Refabricated, Chef's Delight, AppleSkin, JEI
- **Structures & worldgen**: Repurposed Structures (server-only), ChoiceTheorem's Overhauled Village (server-only)
- **Utility**: Magnum Torch, TslatEntityStatus, FallingTree (already merged), Traveler's Backpack
- **Decorative**: Blahaj Replushed, Macaw's Paintings
- **Libraries**: MidnightLib, Puzzles Lib

### Client mrpack only
- **Skyboxify** — OptiFine skybox support
- **OptiGUI** + Fabric Language Kotlin — custom GUI textures for future resource pack work
- **Mod Menu** (already merged) — in-game mod browser

All mods pinned to Fabric 1.21.11 with SHA1/SHA512 verified Modrinth CDN downloads.

## Test plan
- [ ] `docker build` — all 15 new JARs download and pass SHA1 checks
- [ ] Server boots without mod resolution errors
- [ ] Farmer's Delight items craftable in-game, JEI shows recipes
- [ ] Repurposed Structures + CT Overhaul Village generate in new chunks
- [ ] Build mrpack — verify all 16 new client entries present
- [ ] Client: OptiGUI, Skyboxify, AppleSkin HUD all functional
- [ ] Traveler's Backpack craftable and opens GUI