### PR TITLE
feat(mc): skeleton horsemen pack + fix mixin package crash

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
@@ -3,8 +3,10 @@ package com.kbve.statetree;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
@@ -297,6 +299,15 @@ public class AiCreatureManager {
                 Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
                 BlockPos.ofFloored(x, 0, z)
         );
+
+        // Reject underwater spawn positions — skeletons should not appear
+        // in rivers, oceans, or any waterlogged surface.
+        BlockState surfaceState = world.getBlockState(surface);
+        BlockState belowState = world.getBlockState(surface.down());
+        if (surfaceState.getFluidState().isIn(FluidTags.WATER)
+                || belowState.getFluidState().isIn(FluidTags.WATER)) {
+            return false;
+        }
 
         MobEntity mob = kind.create(world, surface, owner);
         if (mob == null) return false;

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
@@ -14,6 +14,7 @@ public final class CreatureKinds {
     public static final CreatureKind SKELETON_MELEE = new MeleeSkeletonKind();
     public static final CreatureKind SKELETON_MAGE = new MageSkeletonKind();
     public static final CreatureKind SKELETON_ARCHER = new ArcherSkeletonKind();
+    public static final CreatureKind SKELETON_HORSEMAN = new HorsemanSkeletonKind();
     public static final CreatureKind PET_DOG = new PetDogCreatureKind();
     public static final CreatureKind PET_PARROT = new PetParrotCreatureKind();
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/HorsemanSkeletonKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/HorsemanSkeletonKind.java
@@ -1,0 +1,112 @@
+package com.kbve.statetree;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.SkeletonEntity;
+import net.minecraft.entity.mob.SkeletonHorseEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Skeleton Horseman archetype: armored skeleton riding a skeleton horse.
+ *
+ * <p>Spawns a {@link SkeletonHorseEntity} with a {@link SkeletonEntity} rider
+ * equipped with a bow and iron armor. The rider is the tracked entity — when
+ * it dies, the orphan sweep in {@link AiCreatureManager} automatically
+ * discards the horse (both carry the {@code kbve_ai_creature} tag but only
+ * the rider has a tracking slot).
+ *
+ * <p>Horsemen are designed to spawn in packs via the
+ * {@code SpawnSkeletonHorsemenPack} world command, paired with foot archers
+ * for a combined cavalry + infantry assault.
+ */
+final class HorsemanSkeletonKind implements CreatureKind {
+
+    private static final double OBSERVATION_RANGE = 28.0;
+
+    /** Scoreboard tag — must match {@link AiCreatureManager#AI_MARKER_TAG}. */
+    private static final String AI_MARKER_TAG = "kbve_ai_creature";
+
+    @Override
+    public String tag() {
+        return "skeleton_horseman";
+    }
+
+    @Override
+    public @Nullable MobEntity create(ServerWorld world, BlockPos pos, @Nullable Entity owner) {
+        // 1. Spawn the skeleton horse (vehicle)
+        SkeletonHorseEntity horse = EntityType.SKELETON_HORSE.create(world, SpawnReason.COMMAND);
+        if (horse == null) return null;
+
+        horse.refreshPositionAndAngles(
+                pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5,
+                world.getRandom().nextFloat() * 360, 0
+        );
+        horse.setPersistent();
+        horse.setTame(true);
+        // Tag the horse so the orphan sweep cleans it up when the rider dies
+        horse.addCommandTag(AI_MARKER_TAG);
+
+        if (!world.spawnEntity(horse)) return null;
+
+        // 2. Spawn the skeleton rider
+        SkeletonEntity rider = EntityType.SKELETON.create(world, SpawnReason.COMMAND);
+        if (rider == null) {
+            horse.discard();
+            return null;
+        }
+
+        rider.refreshPositionAndAngles(
+                pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5,
+                world.getRandom().nextFloat() * 360, 0
+        );
+        rider.setCustomName(Text.of("\u00A74Skull Horseman"));
+        rider.setCustomNameVisible(true);
+        rider.setPersistent();
+
+        // Iron armor — tougher than foot archers
+        rider.equipStack(EquipmentSlot.HEAD, new ItemStack(Items.IRON_HELMET));
+        rider.setEquipmentDropChance(EquipmentSlot.HEAD, 0.0f);
+        rider.equipStack(EquipmentSlot.CHEST, new ItemStack(Items.IRON_CHESTPLATE));
+        rider.setEquipmentDropChance(EquipmentSlot.CHEST, 0.0f);
+        // Bow for ranged attacks
+        rider.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Items.BOW));
+        rider.setEquipmentDropChance(EquipmentSlot.MAINHAND, 0.0f);
+
+        // 3. Mount the rider onto the horse
+        rider.startRiding(horse);
+
+        return rider;
+    }
+
+    @Override
+    public void gatherNearbyEntities(
+            ServerWorld world, MobEntity self, @Nullable Entity owner, JsonArray out) {
+        Box searchBox = self.getBoundingBox().expand(OBSERVATION_RANGE);
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            if (!searchBox.contains(player.getX(), player.getY(), player.getZ())) continue;
+            JsonObject ent = new JsonObject();
+            ent.addProperty("entity_id", player.getId());
+            ent.addProperty("entity_type", "player");
+            JsonArray ePos = new JsonArray();
+            ePos.add(player.getX());
+            ePos.add(player.getY());
+            ePos.add(player.getZ());
+            ent.add("position", ePos);
+            ent.addProperty("health", player.getHealth());
+            ent.addProperty("is_hostile", true);
+            out.add(ent);
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -385,6 +385,19 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
             int radius = spawn.get("radius").getAsInt();
             creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_ARCHER, playerId, radius, false);
 
+        } else if (cmd.has("SpawnSkeletonHorsemenPack")) {
+            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonHorsemenPack");
+            int playerId = spawn.get("near_player").getAsInt();
+            int radius = spawn.get("radius").getAsInt();
+            int horsemen = spawn.has("horsemen") ? spawn.get("horsemen").getAsInt() : 2;
+            int archers = spawn.has("archers") ? spawn.get("archers").getAsInt() : 3;
+            for (int i = 0; i < horsemen; i++) {
+                creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_HORSEMAN, playerId, radius, false);
+            }
+            for (int i = 0; i < archers; i++) {
+                creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_ARCHER, playerId, radius, false);
+            }
+
         } else if (cmd.has("MoveShip")) {
             JsonObject move = cmd.getAsJsonObject("MoveShip");
             String shipIdStr = move.get("ship_id").getAsString();

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/client/CameraMixin.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/client/CameraMixin.java
@@ -1,13 +1,11 @@
-package com.kbve.statetree.client.mixin;
+package com.kbve.statetree.mixin.client;
 
 import com.kbve.statetree.ship.ShipEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.Camera;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * Client-side camera mixin — extends third-person camera distance when

--- a/apps/mc/behavior_statetree/java/src/main/resources/behavior_statetree.mixins.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/behavior_statetree.mixins.json
@@ -1,10 +1,10 @@
 {
 	"required": true,
 	"minVersion": "0.8",
-	"package": "com.kbve.statetree",
+	"package": "com.kbve.statetree.mixin",
 	"compatibilityLevel": "JAVA_21",
-	"mixins": ["mixin.BowAttackGoalMixin"],
-	"client": ["client.mixin.CameraMixin"],
+	"mixins": ["BowAttackGoalMixin"],
+	"client": ["client.CameraMixin"],
 	"injectors": {
 		"defaultRequire": 1
 	}


### PR DESCRIPTION
## Summary
- **Critical fix**: mixin package was `com.kbve.statetree` which made Mixin treat ALL mod classes as mixin targets, crashing server startup. Narrowed to `com.kbve.statetree.mixin` and relocated `CameraMixin` into the mixin subtree.
- **HorsemanSkeletonKind**: new creature archetype — skeleton horse + iron-armored bow rider. Horse gets `kbve_ai_creature` tag so the existing orphan sweep auto-despawns it when the rider dies.
- **SpawnSkeletonHorsemenPack**: world command spawning N horsemen + M foot archers as a combined cavalry + infantry assault (defaults: 2 horsemen, 3 archers).
- **Underwater spawn prevention**: all creature types now reject surface positions in or above water.

## Test plan
- [ ] Docker build succeeds (mixin package no longer captures mod entrypoint)
- [ ] e2e tests pass — server boots and RCON responds
- [ ] Skeleton horsemen spawn mounted on skeleton horses
- [ ] Killing the rider auto-despawns the horse (orphan sweep within 0.5s)
- [ ] No creatures spawn in rivers/oceans
- [ ] Existing skeleton/archer/mage/pet spawning unaffected