### PR TITLE
fix(security): sanitize WebSocket payload before logging (CWE-117)

### DIFF
--- a/apps/kbve/astro-kbve/src/workers/supabase.shared.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.shared.ts
@@ -248,7 +248,10 @@ async function connectWebSocket(wsUrl?: string) {
 		ws.onmessage = (event) => {
 			try {
 				const message = JSON.parse(event.data);
-				console.log('[SharedWorker] WebSocket message:', message);
+				console.log(
+					'[SharedWorker] WebSocket message:',
+					JSON.stringify(message),
+				);
 
 				// Handle pong response
 				if (message.type === 'pong') {


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#226](https://github.com/KBVE/kbve/security/code-scanning/226) — `js/log-injection` in `apps/kbve/astro-kbve/src/workers/supabase.shared.ts:251`.

The parsed WebSocket message (`JSON.parse(event.data)`) was logged directly via `console.log()`. An attacker-controlled payload with embedded newlines or ANSI escape sequences could forge log entries (CWE-117). Fix wraps the object in `JSON.stringify()` before logging, which escapes all control characters and is recognized by CodeQL as a sanitizer.

## Test plan

- [ ] CodeQL re-scan on this PR closes alert #226.
- [ ] SharedWorker WebSocket debug output still readable in DevTools console.