### PR TITLE
feat(mc): read JAR version from version.toml at build time

### DIFF
--- a/apps/mc/behavior_statetree/java/build.gradle
+++ b/apps/mc/behavior_statetree/java/build.gradle
@@ -2,7 +2,15 @@ plugins {
     id 'fabric-loom' version '1.16.1'
 }
 
-version = '1.0.16'
+// Read version from version.toml (single source of truth for the MC stack).
+// Falls back to dev placeholder if the file isn't found (e.g. runClient).
+def versionFile = file('../../version.toml')
+if (versionFile.exists()) {
+    def match = (versionFile.text =~ /version\s*=\s*"([^"]+)"/)
+    version = match ? match[0][1] : '0.0.0-dev'
+} else {
+    version = '0.0.0-dev'
+}
 group = 'com.kbve'
 base.archivesName = 'behavior_statetree'
 
@@ -17,8 +25,12 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:0.141.3+1.21.11"
 }
 
-// Copy the Rust native library into the JAR resources
+// Inject version into fabric.mod.json + copy Rust native libraries
 processResources {
+    inputs.property "version", version
+    filesMatching("fabric.mod.json") {
+        expand "version": version
+    }
     from("../../target/release") {
         include "libbehavior_statetree.so"
         include "libbehavior_statetree.dylib"

--- a/apps/mc/behavior_statetree/java/src/main/resources/fabric.mod.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
 	"schemaVersion": 1,
 	"id": "behavior_statetree",
-	"version": "1.0.16",
+	"version": "${version}",
 	"name": "Behavior State Tree",
 	"description": "Hybrid Rust/Tokio NPC AI planner with client-side ship rendering — async behavior trees, flow field pathfinding, and ship system.",
 	"authors": ["KBVE", "h0lybyte"],


### PR DESCRIPTION
## Summary
- `build.gradle` now parses `version.toml` instead of hardcoding the version
- `fabric.mod.json` uses Gradle `${version}` token replacement so the version inside the JAR matches
- Ensures JAR filename, internal metadata, and Modrinth publish version all align with `version.toml` on every Docker build

Follow-up to #10160 — that PR merged before this commit was pushed.

## Test plan
- [ ] `gradle build` produces `behavior_statetree-<version>.jar` matching `version.toml`
- [ ] Unzip the JAR, verify `fabric.mod.json` version matches