### PR TITLE
refactor(mc): Phase 1 boundary refactor — typed commands, split appliers, bounded queue

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -1,54 +1,37 @@
 package com.kbve.statetree;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.kbve.statetree.command.*;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.minecraft.block.Blocks;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.mob.MobEntity;
-import net.minecraft.entity.projectile.ArrowEntity;
-import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Server tick handler — the sync boundary between Fabric and Tokio.
  *
- * <p>Each observation tick (every {@link #OBSERVE_INTERVAL} ticks) Java
- * pushes two things to Rust:
+ * <p>This class is deliberately boring. It orchestrates four concerns
+ * on a schedule and delegates all real work:
  * <ol>
- *   <li>A snapshot of all online players (positions, health) so the Rust
- *       ECS has the world state it needs for spawn/despawn policy.</li>
- *   <li>One per-creature observation per tracked mob (skeleton, pet dog, ...).</li>
+ *   <li><b>Lifecycle</b> — evict dead entities, clean scaffolding.</li>
+ *   <li><b>Observations</b> — publish player/creature snapshots to Rust
+ *       on a throttled cadence.</li>
+ *   <li><b>Ingest</b> — poll Rust for intents, decode JSON into typed
+ *       DTOs, enqueue into the bounded inbox.</li>
+ *   <li><b>Execute</b> — drain a budgeted batch of commands from the
+ *       inbox and apply them through typed registries.</li>
  * </ol>
  *
- * <p>Every game tick Java polls and applies intents from Rust:
- * <ul>
- *   <li><b>Per-NPC intents</b> — {@code entity_id != 0}, target a specific
- *       tracked mob. Dispatched to {@link #applyMobCommand}.</li>
- *   <li><b>World intents</b> — {@code entity_id == 0}, not tied to any
- *       single mob (e.g. {@code SpawnSkeleton}, {@code SpawnPetDog},
- *       {@code Despawn}). Dispatched to {@link #applyWorldCommand}.</li>
- * </ul>
- *
- * <p>A single {@link AiCreatureManager} handles every creature archetype —
- * new creature types plug in via {@link CreatureKind} without touching
- * this class (aside from a new world-command branch).
+ * <p>Game logic (particles, projectiles, spawning, ship ops) lives in
+ * {@link MobCommandApplier} and {@link WorldCommandApplier}. JSON
+ * decoding lives in {@link IntentDecoder}. Budget enforcement lives
+ * in {@link IntentExecutor}. This class touches none of that.
  */
 public class NpcTickHandler implements ServerTickEvents.EndTick {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
-    private static final Gson GSON = new Gson();
 
     /** Only submit observations every N ticks (10 = 0.5s at 20 TPS). */
     private static final int OBSERVE_INTERVAL = 10;
@@ -56,385 +39,61 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
     /** Only scan map data every N ticks (60 = 3s at 20 TPS). */
     private static final int MAP_SCAN_INTERVAL = 60;
 
+    // ── Owned components ─────────────────────────────────────────────
     private final AiCreatureManager creatureManager = new AiCreatureManager();
     private final ScaffoldTracker scaffoldTracker = new ScaffoldTracker();
+    private final ObservationPublisher observationPublisher;
+    private final IntentInbox inbox = new IntentInbox();
+    private final MobCommandApplier mobApplier = new MobCommandApplier();
+    private final WorldCommandApplier worldApplier = new WorldCommandApplier();
+    private final IntentExecutor executor;
+
     private com.kbve.statetree.ship.ShipManager shipManager;
     private int tickCounter = 0;
 
-    /** Inject the ship manager so world commands can dispatch ship ops. */
+    public NpcTickHandler() {
+        this.observationPublisher = new ObservationPublisher(creatureManager);
+        this.executor = new IntentExecutor(inbox, mobApplier, worldApplier, creatureManager);
+    }
+
+    /** Inject the ship manager (called once during mod init). */
     public void setShipManager(com.kbve.statetree.ship.ShipManager manager) {
         this.shipManager = manager;
     }
 
     @Override
     public void onEndTick(MinecraftServer server) {
-        if (!NativeRuntime.isLoaded()) {
-            return;
-        }
+        if (!NativeRuntime.isLoaded()) return;
 
         tickCounter++;
 
-        // Phase 0: Evict dead entities + clean up expired scaffolding
+        // 1. Lifecycle — evict dead entities, clean expired scaffolding
         creatureManager.tick(server);
-        ServerWorld overworld0 = server.getOverworld();
-        if (overworld0 != null) {
-            scaffoldTracker.tick(overworld0, overworld0.getTime());
+        ServerWorld overworld = server.getOverworld();
+        if (overworld != null) {
+            scaffoldTracker.tick(overworld, overworld.getTime());
         }
 
-        // Phase 1: Push observations — throttled to every OBSERVE_INTERVAL ticks
+        // 2. Observations — throttled publish to Rust
         if (tickCounter % OBSERVE_INTERVAL == 0) {
-            submitPlayerSnapshot(server);
-            creatureManager.submitObservations(server);
+            observationPublisher.publishObservations(server);
         }
-
-        // Phase 1b: Scan map surface — slower cadence than observations.
-        // Builds a 64x64 walkability grid centered on the player centroid
-        // and pushes it to Rust for flow field + chokepoint computation.
         if (tickCounter % MAP_SCAN_INTERVAL == 0) {
-            ServerWorld overworld = server.getOverworld();
-            if (overworld != null) {
-                MapScanner.scanAndSubmit(overworld, overworld.getTime());
-            }
+            observationPublisher.publishMapScan(server);
         }
 
-        // Phase 2: Poll and apply intents every tick for responsiveness
-        String intentsJson = NativeRuntime.pollIntents();
-        if (intentsJson == null || intentsJson.equals("[]")) {
-            return;
-        }
-        applyIntents(server, intentsJson);
-    }
-
-    // -----------------------------------------------------------------------
-    // Player snapshot push — gives Rust the world model it needs for
-    // spawn/despawn policy without asking Java per-decision
-    // -----------------------------------------------------------------------
-
-    private void submitPlayerSnapshot(MinecraftServer server) {
-        ServerWorld overworld = server.getOverworld();
-        if (overworld == null) return;
-
-        long currentTick = overworld.getTime();
-
-        JsonArray players = new JsonArray();
-        for (ServerPlayerEntity player : overworld.getPlayers()) {
-            JsonObject p = new JsonObject();
-            p.addProperty("entity_id", player.getId());
-            p.addProperty("username", player.getNameForScoreboard());
-
-            JsonArray pos = new JsonArray();
-            pos.add(player.getX());
-            pos.add(player.getY());
-            pos.add(player.getZ());
-            p.add("position", pos);
-
-            p.addProperty("health", player.getHealth());
-            players.add(p);
+        // 3. Ingest — poll, decode, enqueue
+        String payload = NativeRuntime.pollIntents();
+        if (payload != null && !payload.equals("[]")) {
+            List<DecodedIntent> intents = IntentDecoder.decode(payload);
+            inbox.enqueue(intents);
         }
 
-        JsonObject snapshot = new JsonObject();
-        snapshot.add("players", players);
-        snapshot.addProperty("tick", currentTick);
-
-        NativeRuntime.submitPlayerSnapshot(GSON.toJson(snapshot));
-    }
-
-    // -----------------------------------------------------------------------
-    // Intent application
-    // -----------------------------------------------------------------------
-
-    private void applyIntents(MinecraftServer server, String intentsJson) {
-        ServerWorld overworld = server.getOverworld();
-        if (overworld == null) return;
-
-        JsonArray intents;
-        try {
-            intents = GSON.fromJson(intentsJson, JsonArray.class);
-        } catch (Exception e) {
-            LOGGER.warn("[AI] Failed to parse intents JSON: {}", e.getMessage());
-            return;
-        }
-
-        for (JsonElement elem : intents) {
-            JsonObject intent = elem.getAsJsonObject();
-            int entityId = intent.get("entity_id").getAsInt();
-            long epoch = intent.get("epoch").getAsLong();
-
-            JsonArray commands = intent.getAsJsonArray("commands");
-            if (commands == null) continue;
-
-            // World intents: entity_id == 0 means "not tied to a specific mob"
-            if (entityId == 0) {
-                for (JsonElement cmdElem : commands) {
-                    applyWorldCommand(overworld, cmdElem.getAsJsonObject());
-                }
-                continue;
-            }
-
-            // Per-NPC intents: epoch-validated then dispatched per mob.
-            if (!creatureManager.isManaged(entityId)) continue;
-            if (epoch != creatureManager.getEpoch(entityId)) continue;
-
-            Entity entity = overworld.getEntityById(entityId);
-            if (entity == null || !entity.isAlive()) continue;
-            if (!(entity instanceof MobEntity mob)) continue;
-
-            for (JsonElement cmdElem : commands) {
-                applyMobCommand(overworld, mob, cmdElem.getAsJsonObject());
-            }
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Per-NPC commands — operate on a specific mob
-    // -----------------------------------------------------------------------
-
-    private void applyMobCommand(ServerWorld world, MobEntity mob, JsonObject cmd) {
-        if (cmd.has("MoveTo")) {
-            JsonObject moveTo = cmd.getAsJsonObject("MoveTo");
-            JsonArray target = moveTo.getAsJsonArray("target");
-            double tx = target.get(0).getAsDouble();
-            double ty = target.get(1).getAsDouble();
-            double tz = target.get(2).getAsDouble();
-            // Rust picks the speed multiplier per intent (1.0 = walk,
-            // 1.3-1.5 reads as a sprint). Defaults to 1.0 for legacy
-            // JSON written before the speed field was added.
-            double speed = moveTo.has("speed") ? moveTo.get("speed").getAsDouble() : 1.0;
-            mob.getNavigation().startMovingTo(tx, ty, tz, speed);
-
-        } else if (cmd.has("Attack")) {
-            JsonObject attack = cmd.getAsJsonObject("Attack");
-            long targetId = attack.get("target_entity").getAsLong();
-            Entity target = world.getEntityById((int) targetId);
-            if (target != null && target.isAlive()) {
-                mob.tryAttack(world, target);
-                mob.lookAtEntity(target, 30.0f, 30.0f);
-            }
-
-        } else if (cmd.has("Idle")) {
-            mob.getNavigation().stop();
-
-        } else if (cmd.has("Speak")) {
-            JsonObject speak = cmd.getAsJsonObject("Speak");
-            String message = speak.get("message").getAsString();
-            for (var player : world.getPlayers()) {
-                if (mob.squaredDistanceTo(player) < 32 * 32) {
-                    player.sendMessage(
-                            net.minecraft.text.Text.of("\u00A7c<AI> " + message),
-                            false
-                    );
-                }
-            }
-
-        } else if (cmd.has("CallForHelp")) {
-            // Rust already gated this through CallCooldown + GlobalCallCooldown.
-            // The creature manager matches the reinforcement kind to the caller's.
-            JsonObject call = cmd.getAsJsonObject("CallForHelp");
-            int count = call.get("count").getAsInt();
-            creatureManager.spawnReinforcements(world, mob.getId(), count);
-
-        } else if (cmd.has("PoopPoison")) {
-            // Rust already gated this via PoopCooldown — Java just applies
-            // the status effect and plays the splat feedback.
-            JsonObject poop = cmd.getAsJsonObject("PoopPoison");
-            long targetId = poop.get("target_entity").getAsLong();
-            int durationTicks = poop.get("duration_ticks").getAsInt();
-            int amplifier = poop.get("amplifier").getAsInt();
-            Entity target = world.getEntityById((int) targetId);
-            if (target instanceof net.minecraft.entity.LivingEntity living && living.isAlive()) {
-                living.addStatusEffect(new net.minecraft.entity.effect.StatusEffectInstance(
-                        net.minecraft.entity.effect.StatusEffects.POISON,
-                        durationTicks,
-                        amplifier
-                ));
-                // Splat feedback: slime particles from the attacker's mouth
-                // and a squish sound so watching players can see it land.
-                world.spawnParticles(
-                        net.minecraft.particle.ParticleTypes.ITEM_SLIME,
-                        mob.getX(),
-                        mob.getY() + mob.getStandingEyeHeight() * 0.5,
-                        mob.getZ(),
-                        8,
-                        0.3, 0.2, 0.3,
-                        0.02
-                );
-                world.playSound(
-                        null,
-                        mob.getBlockPos(),
-                        net.minecraft.sound.SoundEvents.BLOCK_SLIME_BLOCK_BREAK,
-                        net.minecraft.sound.SoundCategory.NEUTRAL,
-                        1.0f,
-                        1.6f
-                );
-                mob.lookAtEntity(target, 30.0f, 30.0f);
-            }
-
-        } else if (cmd.has("PlaceBlock")) {
-            JsonObject place = cmd.getAsJsonObject("PlaceBlock");
-            JsonArray blockPos = place.getAsJsonArray("block_pos");
-            int bx = blockPos.get(0).getAsInt();
-            int by = blockPos.get(1).getAsInt();
-            int bz = blockPos.get(2).getAsInt();
-            String blockType = place.get("block_type").getAsString();
-            int cleanupTicks = place.has("cleanup_ticks") ? place.get("cleanup_ticks").getAsInt() : 0;
-
-            BlockPos pos = new BlockPos(bx, by, bz);
-            // Only place if the target position is air (don't overwrite existing blocks)
-            if (world.getBlockState(pos).isAir()) {
-                if ("scaffolding".equals(blockType)) {
-                    world.setBlockState(pos, Blocks.SCAFFOLDING.getDefaultState());
-                }
-                // Track for auto-cleanup
-                if (cleanupTicks > 0) {
-                    scaffoldTracker.track(pos, world.getTime(), cleanupTicks);
-                }
-            }
-
-        } else if (cmd.has("Teleport")) {
-            JsonObject teleport = cmd.getAsJsonObject("Teleport");
-            JsonArray target = teleport.getAsJsonArray("target");
-            double tx = target.get(0).getAsDouble();
-            double ty = target.get(1).getAsDouble();
-            double tz = target.get(2).getAsDouble();
-
-            // Enderman-style teleport: particles at origin, move, particles at destination
-            world.spawnParticles(
-                    ParticleTypes.PORTAL, mob.getX(), mob.getY() + 1.0, mob.getZ(),
-                    32, 0.5, 1.0, 0.5, 0.1
-            );
-            world.playSound(null, mob.getBlockPos(),
-                    SoundEvents.ENTITY_ENDERMAN_TELEPORT, SoundCategory.HOSTILE,
-                    1.0f, 1.0f);
-
-            mob.teleport(world, tx, ty, tz, java.util.Set.of(), mob.getYaw(), mob.getPitch(), false);
-
-            world.spawnParticles(
-                    ParticleTypes.PORTAL, tx, ty + 1.0, tz,
-                    32, 0.5, 1.0, 0.5, 0.1
-            );
-
-        } else if (cmd.has("ShootArrow")) {
-            JsonObject shoot = cmd.getAsJsonObject("ShootArrow");
-            long targetId = shoot.get("target_entity").getAsLong();
-            float power = shoot.has("power") ? shoot.get("power").getAsFloat() : 0.8f;
-
-            Entity target = world.getEntityById((int) targetId);
-            if (target instanceof LivingEntity living && living.isAlive()) {
-                ArrowEntity arrow = new ArrowEntity(world, mob, new net.minecraft.item.ItemStack(net.minecraft.item.Items.ARROW), null);
-                // Aim at the target's eye height
-                Vec3d toTarget = new Vec3d(
-                        living.getX() - mob.getX(),
-                        living.getEyeY() - arrow.getY(),
-                        living.getZ() - mob.getZ()
-                );
-                double dist = toTarget.horizontalLength();
-                arrow.setVelocity(
-                        toTarget.x, toTarget.y + dist * 0.2, toTarget.z,
-                        power * 3.0f, 1.0f
-                );
-                world.spawnEntity(arrow);
-                world.playSound(null, mob.getBlockPos(),
-                        SoundEvents.ENTITY_SKELETON_SHOOT, SoundCategory.HOSTILE,
-                        1.0f, 1.0f / (world.getRandom().nextFloat() * 0.4f + 0.8f));
-                mob.lookAtEntity(target, 30.0f, 30.0f);
-            }
-
-        } else if (cmd.has("SetGoal")) {
-            LOGGER.debug("[AI] SetGoal not yet implemented");
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // World commands — operate on world state, not a specific mob
-    // -----------------------------------------------------------------------
-
-    private void applyWorldCommand(ServerWorld world, JsonObject cmd) {
-        if (cmd.has("SpawnSkeleton")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeleton");
-            int playerId = spawn.get("near_player").getAsInt();
-            int radius = spawn.get("radius").getAsInt();
-            creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON, playerId, radius, false);
-
-        } else if (cmd.has("SpawnPetDog")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnPetDog");
-            int playerId = spawn.get("near_player").getAsInt();
-            int radius = spawn.get("radius").getAsInt();
-            creatureManager.spawnNearPlayer(world, CreatureKinds.PET_DOG, playerId, radius, true);
-
-        } else if (cmd.has("SpawnPetParrot")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnPetParrot");
-            int playerId = spawn.get("near_player").getAsInt();
-            int radius = spawn.get("radius").getAsInt();
-            creatureManager.spawnNearPlayer(world, CreatureKinds.PET_PARROT, playerId, radius, true);
-
-        } else if (cmd.has("SpawnSkeletonMelee")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonMelee");
-            int playerId = spawn.get("near_player").getAsInt();
-            int radius = spawn.get("radius").getAsInt();
-            creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_MELEE, playerId, radius, false);
-
-        } else if (cmd.has("SpawnSkeletonMage")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonMage");
-            int playerId = spawn.get("near_player").getAsInt();
-            int radius = spawn.get("radius").getAsInt();
-            creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_MAGE, playerId, radius, false);
-
-        } else if (cmd.has("SpawnSkeletonArcher")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonArcher");
-            int playerId = spawn.get("near_player").getAsInt();
-            int radius = spawn.get("radius").getAsInt();
-            creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_ARCHER, playerId, radius, false);
-
-        } else if (cmd.has("SpawnSkeletonHorsemenPack")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnSkeletonHorsemenPack");
-            int playerId = spawn.get("near_player").getAsInt();
-            int radius = spawn.get("radius").getAsInt();
-            int horsemen = spawn.has("horsemen") ? spawn.get("horsemen").getAsInt() : 2;
-            int archers = spawn.has("archers") ? spawn.get("archers").getAsInt() : 3;
-            for (int i = 0; i < horsemen; i++) {
-                creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_HORSEMAN, playerId, radius, false);
-            }
-            for (int i = 0; i < archers; i++) {
-                creatureManager.spawnNearPlayer(world, CreatureKinds.SKELETON_ARCHER, playerId, radius, false);
-            }
-
-        } else if (cmd.has("MoveShip")) {
-            JsonObject move = cmd.getAsJsonObject("MoveShip");
-            String shipIdStr = move.get("ship_id").getAsString();
-            int distance = move.get("distance").getAsInt();
-            try {
-                shipManager.moveShip(java.util.UUID.fromString(shipIdStr), distance);
-            } catch (IllegalArgumentException e) {
-                LOGGER.warn("[AI] Invalid ship UUID in MoveShip: {}", shipIdStr);
-            }
-
-        } else if (cmd.has("DespawnShip")) {
-            JsonObject despawn = cmd.getAsJsonObject("DespawnShip");
-            String shipIdStr = despawn.get("ship_id").getAsString();
-            try {
-                shipManager.removeShip(world, java.util.UUID.fromString(shipIdStr));
-            } catch (IllegalArgumentException e) {
-                LOGGER.warn("[AI] Invalid ship UUID in DespawnShip: {}", shipIdStr);
-            }
-
-        } else if (cmd.has("SpawnShip")) {
-            JsonObject spawn = cmd.getAsJsonObject("SpawnShip");
-            String shipName = spawn.get("ship_name").getAsString();
-            int playerId = (int) spawn.get("near_player").getAsLong();
-            Entity player = world.getEntityById(playerId);
-            if (player != null) {
-                com.kbve.statetree.ship.ShipData data =
-                        com.kbve.statetree.ship.SchematicLoader.loadFromResource(
-                                shipName, "/schematics/" + shipName + ".nbt");
-                if (data != null) {
-                    shipManager.placeShip(world, data, player.getUuid(), player.getBlockPos());
-                }
-            }
-
-        } else if (cmd.has("Despawn")) {
-            JsonObject despawn = cmd.getAsJsonObject("Despawn");
-            int targetId = (int) despawn.get("target_entity").getAsLong();
-            creatureManager.despawnEntity(world, targetId);
+        // 4. Execute — budgeted drain from inbox
+        if (!inbox.isEmpty() && overworld != null) {
+            CommandContext ctx = CommandContext.forWorld(
+                    overworld, creatureManager, scaffoldTracker, shipManager);
+            executor.applyBudgeted(ctx);
         }
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/AiCommand.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/AiCommand.java
@@ -1,0 +1,100 @@
+package com.kbve.statetree.command;
+
+/**
+ * Typed command model — the sealed interface that every command Rust can
+ * emit implements. String-keyed JSON only exists at the decode boundary;
+ * after decoding, everything is a typed record.
+ *
+ * <p>Mob commands carry an {@code entityId} + {@code epoch} for the target
+ * mob. World commands carry {@code entityId == 0}.
+ */
+public sealed interface AiCommand {
+
+    /** Which kind this command is — used for registry dispatch. */
+    CommandKind kind();
+
+    // =====================================================================
+    // Mob commands (entity-scoped)
+    // =====================================================================
+
+    record MoveTo(double x, double y, double z, double speed) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.MOVE_TO; }
+    }
+
+    record Attack(int targetEntityId) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.ATTACK; }
+    }
+
+    record Idle() implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.IDLE; }
+    }
+
+    record Speak(String message) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.SPEAK; }
+    }
+
+    record CallForHelp(int count) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.CALL_FOR_HELP; }
+    }
+
+    record PoopPoison(int targetEntityId, int durationTicks, int amplifier) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.POOP_POISON; }
+    }
+
+    record PlaceBlock(int x, int y, int z, String blockType, int cleanupTicks) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.PLACE_BLOCK; }
+    }
+
+    record Teleport(double x, double y, double z) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.TELEPORT; }
+    }
+
+    record ShootArrow(int targetEntityId, float power) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.SHOOT_ARROW; }
+    }
+
+    record SetGoal(String goal) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.SET_GOAL; }
+    }
+
+    // =====================================================================
+    // World commands (world-scoped)
+    // =====================================================================
+
+    /**
+     * Generic spawn command — replaces all per-creature spawn branches.
+     * {@code creatureTag} is resolved to a {@link com.kbve.statetree.CreatureKind}
+     * via the registry.
+     */
+    record SpawnCreature(String creatureTag, int nearPlayer, int radius,
+                         boolean tamed, int count) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.SPAWN_CREATURE; }
+    }
+
+    /**
+     * Spawn a mixed pack of creatures. Each entry is a (tag, count) pair.
+     * Supports cavalry + infantry combos like horsemen + foot archers.
+     */
+    record SpawnCreaturePack(int nearPlayer, int radius,
+                             java.util.List<PackEntry> entries) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.SPAWN_CREATURE_PACK; }
+
+        public record PackEntry(String creatureTag, int count, boolean tamed) {}
+    }
+
+    record Despawn(int targetEntityId) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.DESPAWN; }
+    }
+
+    record MoveShip(String shipId, int distance) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.MOVE_SHIP; }
+    }
+
+    record DespawnShip(String shipId) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.DESPAWN_SHIP; }
+    }
+
+    record SpawnShip(String shipName, int nearPlayer) implements AiCommand {
+        @Override public CommandKind kind() { return CommandKind.SPAWN_SHIP; }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/CommandApplier.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/CommandApplier.java
@@ -1,0 +1,18 @@
+package com.kbve.statetree.command;
+
+/**
+ * Applies a single typed command to the world. Each applier handles
+ * exactly one {@link CommandKind} and receives a strongly-typed DTO.
+ *
+ * @param <T> the specific {@link AiCommand} subtype this applier handles
+ */
+@FunctionalInterface
+public interface CommandApplier<T extends AiCommand> {
+
+    /**
+     * Execute the command. Appliers may assume the context is valid
+     * (world non-null, mob non-null for mob commands) because the
+     * executor validates before dispatching.
+     */
+    void apply(CommandContext ctx, T command);
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/CommandContext.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/CommandContext.java
@@ -1,0 +1,34 @@
+package com.kbve.statetree.command;
+
+import com.kbve.statetree.AiCreatureManager;
+import com.kbve.statetree.ScaffoldTracker;
+import com.kbve.statetree.ship.ShipManager;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.world.ServerWorld;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Execution context passed to every {@link CommandApplier}. Provides
+ * access to the world, the target mob (for mob commands), and shared
+ * services without appliers needing to hold references themselves.
+ */
+public record CommandContext(
+        ServerWorld world,
+        @Nullable MobEntity mob,
+        AiCreatureManager creatureManager,
+        ScaffoldTracker scaffoldTracker,
+        @Nullable ShipManager shipManager
+) {
+    /** Convenience — world commands use this. */
+    public static CommandContext forWorld(ServerWorld world,
+                                         AiCreatureManager creatureManager,
+                                         ScaffoldTracker scaffoldTracker,
+                                         @Nullable ShipManager shipManager) {
+        return new CommandContext(world, null, creatureManager, scaffoldTracker, shipManager);
+    }
+
+    /** Convenience — mob commands use this. */
+    public CommandContext withMob(MobEntity mob) {
+        return new CommandContext(world, mob, creatureManager, scaffoldTracker, shipManager);
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/CommandKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/CommandKind.java
@@ -1,0 +1,66 @@
+package com.kbve.statetree.command;
+
+/**
+ * Every command Rust can emit. The string exists only at the JSON decode
+ * boundary — after that, dispatch is by enum ordinal.
+ *
+ * <p>Mob commands target a specific tracked entity ({@code entity_id != 0}).
+ * World commands target the world itself ({@code entity_id == 0}).
+ */
+public enum CommandKind {
+
+    // ── Mob commands (entity-scoped) ─────────────────────────────────────
+    MOVE_TO("MoveTo"),
+    ATTACK("Attack"),
+    IDLE("Idle"),
+    SPEAK("Speak"),
+    CALL_FOR_HELP("CallForHelp"),
+    POOP_POISON("PoopPoison"),
+    PLACE_BLOCK("PlaceBlock"),
+    TELEPORT("Teleport"),
+    SHOOT_ARROW("ShootArrow"),
+    SET_GOAL("SetGoal"),
+
+    // ── World commands (world-scoped) ────────────────────────────────────
+    SPAWN_CREATURE("SpawnCreature"),
+    SPAWN_CREATURE_PACK("SpawnCreaturePack"),
+    DESPAWN("Despawn"),
+    MOVE_SHIP("MoveShip"),
+    DESPAWN_SHIP("DespawnShip"),
+    SPAWN_SHIP("SpawnShip"),
+
+    // ── Legacy spawn commands (decoded into SPAWN_CREATURE) ──────────────
+    // Kept for backward compatibility with existing Rust emitters.
+    // IntentDecoder normalizes these to SPAWN_CREATURE before enqueueing.
+    SPAWN_SKELETON("SpawnSkeleton"),
+    SPAWN_PET_DOG("SpawnPetDog"),
+    SPAWN_PET_PARROT("SpawnPetParrot"),
+    SPAWN_SKELETON_MELEE("SpawnSkeletonMelee"),
+    SPAWN_SKELETON_MAGE("SpawnSkeletonMage"),
+    SPAWN_SKELETON_ARCHER("SpawnSkeletonArcher"),
+    SPAWN_SKELETON_HORSEMEN_PACK("SpawnSkeletonHorsemenPack");
+
+    private final String wireKey;
+
+    CommandKind(String wireKey) {
+        this.wireKey = wireKey;
+    }
+
+    /** JSON key as it appears on the wire from Rust. */
+    public String wireKey() {
+        return wireKey;
+    }
+
+    /**
+     * Resolve a JSON key to its enum. Returns {@code null} for unknown keys
+     * (forward compatibility — new Rust commands won't crash old Java).
+     */
+    public static CommandKind fromWireKey(String key) {
+        for (CommandKind kind : VALUES) {
+            if (kind.wireKey.equals(key)) return kind;
+        }
+        return null;
+    }
+
+    private static final CommandKind[] VALUES = values();
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/DecodedIntent.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/DecodedIntent.java
@@ -1,0 +1,9 @@
+package com.kbve.statetree.command;
+
+import java.util.List;
+
+/**
+ * One decoded intent from Rust — an entity target (or 0 for world) plus
+ * a list of typed commands to apply. Epoch is used for staleness checks.
+ */
+public record DecodedIntent(int entityId, long epoch, List<AiCommand> commands) {}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentDecoder.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentDecoder.java
@@ -1,0 +1,236 @@
+package com.kbve.statetree.command;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Decodes raw JSON from {@code NativeRuntime.pollIntents()} into typed
+ * {@link DecodedIntent} records. This is the <b>only</b> place in the
+ * codebase that touches the wire format — everything downstream works
+ * with typed {@link AiCommand} instances.
+ *
+ * <p>Legacy per-creature spawn commands ({@code SpawnSkeleton},
+ * {@code SpawnPetDog}, etc.) are normalized into the generic
+ * {@link AiCommand.SpawnCreature} during decode so appliers only need
+ * to handle one spawn path.
+ */
+public final class IntentDecoder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+    private static final Gson GSON = new Gson();
+
+    /** Legacy wire key → (creatureTag, tamed). */
+    private static final Map<String, LegacySpawn> LEGACY_SPAWNS = Map.of(
+            "SpawnSkeleton", new LegacySpawn("skeleton", false),
+            "SpawnPetDog", new LegacySpawn("pet_dog", true),
+            "SpawnPetParrot", new LegacySpawn("pet_parrot", true),
+            "SpawnSkeletonMelee", new LegacySpawn("skeleton_melee", false),
+            "SpawnSkeletonMage", new LegacySpawn("skeleton_mage", false),
+            "SpawnSkeletonArcher", new LegacySpawn("skeleton_archer", false)
+    );
+
+    private record LegacySpawn(String creatureTag, boolean tamed) {}
+
+    private IntentDecoder() {}
+
+    /**
+     * Decode the raw JSON payload into a list of typed intents.
+     * Returns an empty list on parse failure (never null).
+     */
+    public static List<DecodedIntent> decode(String json) {
+        if (json == null || json.equals("[]")) return Collections.emptyList();
+
+        JsonArray intents;
+        try {
+            intents = GSON.fromJson(json, JsonArray.class);
+        } catch (Exception e) {
+            LOGGER.warn("[AI] Failed to parse intents JSON: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+
+        List<DecodedIntent> result = new ArrayList<>(intents.size());
+        for (JsonElement elem : intents) {
+            try {
+                result.add(decodeIntent(elem.getAsJsonObject()));
+            } catch (Exception e) {
+                LOGGER.warn("[AI] Skipping malformed intent: {}", e.getMessage());
+            }
+        }
+        return result;
+    }
+
+    private static DecodedIntent decodeIntent(JsonObject intent) {
+        int entityId = intent.get("entity_id").getAsInt();
+        long epoch = intent.get("epoch").getAsLong();
+
+        JsonArray rawCommands = intent.getAsJsonArray("commands");
+        if (rawCommands == null || rawCommands.isEmpty()) {
+            return new DecodedIntent(entityId, epoch, Collections.emptyList());
+        }
+
+        List<AiCommand> commands = new ArrayList<>(rawCommands.size());
+        for (JsonElement cmdElem : rawCommands) {
+            AiCommand cmd = decodeCommand(cmdElem.getAsJsonObject());
+            if (cmd != null) commands.add(cmd);
+        }
+        return new DecodedIntent(entityId, epoch, commands);
+    }
+
+    private static AiCommand decodeCommand(JsonObject raw) {
+        // Try each key in the JSON object to find the command kind.
+        // The wire format is { "CommandName": { ...payload } }.
+        for (String key : raw.keySet()) {
+            // Check legacy spawn commands first — normalize to SpawnCreature
+            LegacySpawn legacy = LEGACY_SPAWNS.get(key);
+            if (legacy != null) {
+                return decodeLegacySpawn(raw.getAsJsonObject(key), legacy);
+            }
+
+            CommandKind kind = CommandKind.fromWireKey(key);
+            if (kind == null) {
+                LOGGER.debug("[AI] Unknown command key '{}', skipping", key);
+                return null;
+            }
+
+            JsonObject payload = raw.getAsJsonObject(key);
+            return switch (kind) {
+                // Mob commands
+                case MOVE_TO -> decodeMoveToCommand(payload);
+                case ATTACK -> new AiCommand.Attack(payload.get("target_entity").getAsInt());
+                case IDLE -> new AiCommand.Idle();
+                case SPEAK -> new AiCommand.Speak(payload.get("message").getAsString());
+                case CALL_FOR_HELP -> new AiCommand.CallForHelp(payload.get("count").getAsInt());
+                case POOP_POISON -> decodePoopPoison(payload);
+                case PLACE_BLOCK -> decodePlaceBlock(payload);
+                case TELEPORT -> decodeTeleport(payload);
+                case SHOOT_ARROW -> decodeShootArrow(payload);
+                case SET_GOAL -> new AiCommand.SetGoal(
+                        payload.has("goal") ? payload.get("goal").getAsString() : "");
+
+                // World commands
+                case SPAWN_CREATURE -> decodeSpawnCreature(payload);
+                case SPAWN_CREATURE_PACK -> decodeSpawnCreaturePack(payload);
+                case DESPAWN -> new AiCommand.Despawn(payload.get("target_entity").getAsInt());
+                case MOVE_SHIP -> new AiCommand.MoveShip(
+                        payload.get("ship_id").getAsString(),
+                        payload.get("distance").getAsInt());
+                case DESPAWN_SHIP -> new AiCommand.DespawnShip(
+                        payload.get("ship_id").getAsString());
+                case SPAWN_SHIP -> new AiCommand.SpawnShip(
+                        payload.get("ship_name").getAsString(),
+                        payload.get("near_player").getAsInt());
+
+                // Legacy spawns handled above; these enum variants exist for
+                // backward compat but should never reach here.
+                case SPAWN_SKELETON_HORSEMEN_PACK -> decodeLegacyHorsemenPack(payload);
+                default -> null;
+            };
+        }
+        return null;
+    }
+
+    // ------------------------------------------------------------------
+    // Mob command decoders
+    // ------------------------------------------------------------------
+
+    private static AiCommand.MoveTo decodeMoveToCommand(JsonObject payload) {
+        JsonArray target = payload.getAsJsonArray("target");
+        double speed = payload.has("speed") ? payload.get("speed").getAsDouble() : 1.0;
+        return new AiCommand.MoveTo(
+                target.get(0).getAsDouble(),
+                target.get(1).getAsDouble(),
+                target.get(2).getAsDouble(),
+                speed);
+    }
+
+    private static AiCommand.PoopPoison decodePoopPoison(JsonObject payload) {
+        return new AiCommand.PoopPoison(
+                payload.get("target_entity").getAsInt(),
+                payload.get("duration_ticks").getAsInt(),
+                payload.get("amplifier").getAsInt());
+    }
+
+    private static AiCommand.PlaceBlock decodePlaceBlock(JsonObject payload) {
+        JsonArray pos = payload.getAsJsonArray("block_pos");
+        return new AiCommand.PlaceBlock(
+                pos.get(0).getAsInt(),
+                pos.get(1).getAsInt(),
+                pos.get(2).getAsInt(),
+                payload.get("block_type").getAsString(),
+                payload.has("cleanup_ticks") ? payload.get("cleanup_ticks").getAsInt() : 0);
+    }
+
+    private static AiCommand.Teleport decodeTeleport(JsonObject payload) {
+        JsonArray target = payload.getAsJsonArray("target");
+        return new AiCommand.Teleport(
+                target.get(0).getAsDouble(),
+                target.get(1).getAsDouble(),
+                target.get(2).getAsDouble());
+    }
+
+    private static AiCommand.ShootArrow decodeShootArrow(JsonObject payload) {
+        return new AiCommand.ShootArrow(
+                payload.get("target_entity").getAsInt(),
+                payload.has("power") ? payload.get("power").getAsFloat() : 0.8f);
+    }
+
+    // ------------------------------------------------------------------
+    // World command decoders
+    // ------------------------------------------------------------------
+
+    private static AiCommand.SpawnCreature decodeSpawnCreature(JsonObject payload) {
+        return new AiCommand.SpawnCreature(
+                payload.get("creature_tag").getAsString(),
+                payload.get("near_player").getAsInt(),
+                payload.get("radius").getAsInt(),
+                payload.has("tamed") && payload.get("tamed").getAsBoolean(),
+                payload.has("count") ? payload.get("count").getAsInt() : 1);
+    }
+
+    private static AiCommand.SpawnCreaturePack decodeSpawnCreaturePack(JsonObject payload) {
+        int nearPlayer = payload.get("near_player").getAsInt();
+        int radius = payload.get("radius").getAsInt();
+        JsonArray rawEntries = payload.getAsJsonArray("entries");
+        List<AiCommand.SpawnCreaturePack.PackEntry> entries = new ArrayList<>();
+        for (JsonElement e : rawEntries) {
+            JsonObject entry = e.getAsJsonObject();
+            entries.add(new AiCommand.SpawnCreaturePack.PackEntry(
+                    entry.get("creature_tag").getAsString(),
+                    entry.has("count") ? entry.get("count").getAsInt() : 1,
+                    entry.has("tamed") && entry.get("tamed").getAsBoolean()));
+        }
+        return new AiCommand.SpawnCreaturePack(nearPlayer, radius, entries);
+    }
+
+    // ------------------------------------------------------------------
+    // Legacy normalizers — convert old per-creature commands into generic
+    // ------------------------------------------------------------------
+
+    private static AiCommand.SpawnCreature decodeLegacySpawn(JsonObject payload, LegacySpawn legacy) {
+        return new AiCommand.SpawnCreature(
+                legacy.creatureTag(),
+                payload.get("near_player").getAsInt(),
+                payload.get("radius").getAsInt(),
+                legacy.tamed(),
+                1);
+    }
+
+    private static AiCommand.SpawnCreaturePack decodeLegacyHorsemenPack(JsonObject payload) {
+        int nearPlayer = payload.get("near_player").getAsInt();
+        int radius = payload.get("radius").getAsInt();
+        int horsemen = payload.has("horsemen") ? payload.get("horsemen").getAsInt() : 2;
+        int archers = payload.has("archers") ? payload.get("archers").getAsInt() : 3;
+        return new AiCommand.SpawnCreaturePack(nearPlayer, radius, List.of(
+                new AiCommand.SpawnCreaturePack.PackEntry("skeleton_horseman", horsemen, false),
+                new AiCommand.SpawnCreaturePack.PackEntry("skeleton_archer", archers, false)));
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentExecutor.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentExecutor.java
@@ -1,0 +1,95 @@
+package com.kbve.statetree.command;
+
+import com.kbve.statetree.AiCreatureManager;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.world.ServerWorld;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Budgeted command executor. Each tick, drains a bounded number of intents
+ * from the {@link IntentInbox} and applies them through the typed applier
+ * registries. Stale commands (epoch mismatch, dead entity) are dropped on
+ * dequeue, not wasted on execution.
+ *
+ * <p>Per-tick budget caps:
+ * <ul>
+ *   <li>{@link #MAX_INTENTS_PER_TICK} — max intent envelopes processed</li>
+ *   <li>{@link #MAX_COMMANDS_PER_TICK} — max individual commands applied</li>
+ * </ul>
+ * Anything beyond rolls to the next tick.
+ */
+public final class IntentExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    /** Max intent envelopes (each may contain multiple commands) per tick. */
+    private static final int MAX_INTENTS_PER_TICK = 64;
+
+    /** Max individual commands applied per tick across all intents. */
+    private static final int MAX_COMMANDS_PER_TICK = 128;
+
+    private final IntentInbox inbox;
+    private final MobCommandApplier mobApplier;
+    private final WorldCommandApplier worldApplier;
+    private final AiCreatureManager creatureManager;
+
+    private int commandsThisTick;
+
+    public IntentExecutor(IntentInbox inbox,
+                          MobCommandApplier mobApplier,
+                          WorldCommandApplier worldApplier,
+                          AiCreatureManager creatureManager) {
+        this.inbox = inbox;
+        this.mobApplier = mobApplier;
+        this.worldApplier = worldApplier;
+        this.creatureManager = creatureManager;
+    }
+
+    /**
+     * Drain and apply a budgeted batch of commands for this tick.
+     * Call once per server tick from the orchestrator.
+     */
+    public void applyBudgeted(CommandContext worldCtx) {
+        commandsThisTick = 0;
+
+        List<DecodedIntent> batch = inbox.drain(MAX_INTENTS_PER_TICK);
+        for (DecodedIntent intent : batch) {
+            if (commandsThisTick >= MAX_COMMANDS_PER_TICK) break;
+            applyIntent(worldCtx, intent);
+        }
+    }
+
+    private void applyIntent(CommandContext worldCtx, DecodedIntent intent) {
+        ServerWorld world = worldCtx.world();
+
+        // World intents (entity_id == 0)
+        if (intent.entityId() == 0) {
+            for (AiCommand cmd : intent.commands()) {
+                if (commandsThisTick >= MAX_COMMANDS_PER_TICK) break;
+                worldApplier.apply(worldCtx, cmd);
+                commandsThisTick++;
+            }
+            return;
+        }
+
+        // Mob intents — validate epoch + entity before applying
+        int entityId = intent.entityId();
+        if (!creatureManager.isManaged(entityId)) return;
+        if (intent.epoch() != creatureManager.getEpoch(entityId)) return;
+
+        Entity entity = world.getEntityById(entityId);
+        if (entity == null || !entity.isAlive()) return;
+        if (!(entity instanceof MobEntity mob)) return;
+
+        CommandContext mobCtx = worldCtx.withMob(mob);
+        for (AiCommand cmd : intent.commands()) {
+            if (commandsThisTick >= MAX_COMMANDS_PER_TICK) break;
+            mobApplier.apply(mobCtx, cmd);
+            commandsThisTick++;
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentInbox.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentInbox.java
@@ -1,0 +1,71 @@
+package com.kbve.statetree.command;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Bounded queue between {@code NativeRuntime.pollIntents()} and command
+ * application. Decoded intents are enqueued here; the executor drains a
+ * budgeted amount per tick.
+ *
+ * <p>Provides backpressure: if the queue exceeds {@link #MAX_QUEUED_INTENTS},
+ * the oldest intents are dropped (they're likely stale anyway). This is
+ * the thin-B safety valve — prevents one burst from Rust blowing TPS.
+ */
+public final class IntentInbox {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    /** Max intents buffered across ticks. Beyond this, oldest are dropped. */
+    private static final int MAX_QUEUED_INTENTS = 512;
+
+    private final Deque<DecodedIntent> queue = new ArrayDeque<>();
+    private long droppedTotal = 0;
+
+    /**
+     * Enqueue decoded intents. If the queue would exceed the cap, the
+     * oldest entries are evicted first.
+     */
+    public void enqueue(List<DecodedIntent> intents) {
+        for (DecodedIntent intent : intents) {
+            if (intent.commands().isEmpty()) continue;
+            queue.addLast(intent);
+        }
+        // Evict oldest if over capacity
+        while (queue.size() > MAX_QUEUED_INTENTS) {
+            queue.pollFirst();
+            droppedTotal++;
+        }
+        if (droppedTotal > 0 && droppedTotal % 100 == 0) {
+            LOGGER.warn("[AI] Intent inbox overflow — {} intents dropped total", droppedTotal);
+        }
+    }
+
+    /** Poll up to {@code limit} intents from the front of the queue. */
+    public List<DecodedIntent> drain(int limit) {
+        int count = Math.min(limit, queue.size());
+        if (count == 0) return List.of();
+
+        List<DecodedIntent> batch = new java.util.ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            batch.add(queue.pollFirst());
+        }
+        return batch;
+    }
+
+    public int size() {
+        return queue.size();
+    }
+
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    public long droppedTotal() {
+        return droppedTotal;
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/MobCommandApplier.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/MobCommandApplier.java
@@ -1,0 +1,165 @@
+package com.kbve.statetree.command;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.ArrowEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Registry-backed applier for mob-scoped commands. Each command kind maps
+ * to a typed {@link CommandApplier} — no if/else chain.
+ */
+public final class MobCommandApplier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    @SuppressWarnings("rawtypes")
+    private final Map<CommandKind, CommandApplier> registry = new EnumMap<>(CommandKind.class);
+
+    public MobCommandApplier() {
+        register(CommandKind.MOVE_TO, this::applyMoveTo);
+        register(CommandKind.ATTACK, this::applyAttack);
+        register(CommandKind.IDLE, this::applyIdle);
+        register(CommandKind.SPEAK, this::applySpeak);
+        register(CommandKind.CALL_FOR_HELP, this::applyCallForHelp);
+        register(CommandKind.POOP_POISON, this::applyPoopPoison);
+        register(CommandKind.PLACE_BLOCK, this::applyPlaceBlock);
+        register(CommandKind.TELEPORT, this::applyTeleport);
+        register(CommandKind.SHOOT_ARROW, this::applyShootArrow);
+        register(CommandKind.SET_GOAL, this::applySetGoal);
+    }
+
+    private <T extends AiCommand> void register(CommandKind kind, CommandApplier<T> applier) {
+        registry.put(kind, applier);
+    }
+
+    @SuppressWarnings("unchecked")
+    public boolean apply(CommandContext ctx, AiCommand command) {
+        CommandApplier applier = registry.get(command.kind());
+        if (applier == null) return false;
+        applier.apply(ctx, command);
+        return true;
+    }
+
+    // ------------------------------------------------------------------
+    // Individual appliers — pure game logic, no JSON
+    // ------------------------------------------------------------------
+
+    private void applyMoveTo(CommandContext ctx, AiCommand.MoveTo cmd) {
+        ctx.mob().getNavigation().startMovingTo(cmd.x(), cmd.y(), cmd.z(), cmd.speed());
+    }
+
+    private void applyAttack(CommandContext ctx, AiCommand.Attack cmd) {
+        Entity target = ctx.world().getEntityById(cmd.targetEntityId());
+        if (target != null && target.isAlive()) {
+            ctx.mob().tryAttack(ctx.world(), target);
+            ctx.mob().lookAtEntity(target, 30.0f, 30.0f);
+        }
+    }
+
+    private void applyIdle(CommandContext ctx, AiCommand.Idle cmd) {
+        ctx.mob().getNavigation().stop();
+    }
+
+    private void applySpeak(CommandContext ctx, AiCommand.Speak cmd) {
+        for (var player : ctx.world().getPlayers()) {
+            if (ctx.mob().squaredDistanceTo(player) < 32 * 32) {
+                player.sendMessage(Text.of("\u00A7c<AI> " + cmd.message()), false);
+            }
+        }
+    }
+
+    private void applyCallForHelp(CommandContext ctx, AiCommand.CallForHelp cmd) {
+        ctx.creatureManager().spawnReinforcements(ctx.world(), ctx.mob().getId(), cmd.count());
+    }
+
+    private void applyPoopPoison(CommandContext ctx, AiCommand.PoopPoison cmd) {
+        Entity target = ctx.world().getEntityById(cmd.targetEntityId());
+        if (target instanceof LivingEntity living && living.isAlive()) {
+            living.addStatusEffect(new net.minecraft.entity.effect.StatusEffectInstance(
+                    net.minecraft.entity.effect.StatusEffects.POISON,
+                    cmd.durationTicks(),
+                    cmd.amplifier()
+            ));
+            ServerWorld world = ctx.world();
+            world.spawnParticles(
+                    net.minecraft.particle.ParticleTypes.ITEM_SLIME,
+                    ctx.mob().getX(),
+                    ctx.mob().getY() + ctx.mob().getStandingEyeHeight() * 0.5,
+                    ctx.mob().getZ(),
+                    8, 0.3, 0.2, 0.3, 0.02
+            );
+            world.playSound(null, ctx.mob().getBlockPos(),
+                    SoundEvents.BLOCK_SLIME_BLOCK_BREAK, SoundCategory.NEUTRAL,
+                    1.0f, 1.6f);
+            ctx.mob().lookAtEntity(target, 30.0f, 30.0f);
+        }
+    }
+
+    private void applyPlaceBlock(CommandContext ctx, AiCommand.PlaceBlock cmd) {
+        BlockPos pos = new BlockPos(cmd.x(), cmd.y(), cmd.z());
+        if (ctx.world().getBlockState(pos).isAir()) {
+            if ("scaffolding".equals(cmd.blockType())) {
+                ctx.world().setBlockState(pos, Blocks.SCAFFOLDING.getDefaultState());
+            }
+            if (cmd.cleanupTicks() > 0) {
+                ctx.scaffoldTracker().track(pos, ctx.world().getTime(), cmd.cleanupTicks());
+            }
+        }
+    }
+
+    private void applyTeleport(CommandContext ctx, AiCommand.Teleport cmd) {
+        ServerWorld world = ctx.world();
+        var mob = ctx.mob();
+        world.spawnParticles(ParticleTypes.PORTAL,
+                mob.getX(), mob.getY() + 1.0, mob.getZ(),
+                32, 0.5, 1.0, 0.5, 0.1);
+        world.playSound(null, mob.getBlockPos(),
+                SoundEvents.ENTITY_ENDERMAN_TELEPORT, SoundCategory.HOSTILE, 1.0f, 1.0f);
+
+        mob.teleport(world, cmd.x(), cmd.y(), cmd.z(),
+                java.util.Set.of(), mob.getYaw(), mob.getPitch(), false);
+
+        world.spawnParticles(ParticleTypes.PORTAL,
+                cmd.x(), cmd.y() + 1.0, cmd.z(),
+                32, 0.5, 1.0, 0.5, 0.1);
+    }
+
+    private void applyShootArrow(CommandContext ctx, AiCommand.ShootArrow cmd) {
+        Entity target = ctx.world().getEntityById(cmd.targetEntityId());
+        if (target instanceof LivingEntity living && living.isAlive()) {
+            var mob = ctx.mob();
+            ArrowEntity arrow = new ArrowEntity(ctx.world(), mob, new ItemStack(Items.ARROW), null);
+            Vec3d toTarget = new Vec3d(
+                    living.getX() - mob.getX(),
+                    living.getEyeY() - arrow.getY(),
+                    living.getZ() - mob.getZ());
+            double dist = toTarget.horizontalLength();
+            arrow.setVelocity(toTarget.x, toTarget.y + dist * 0.2, toTarget.z,
+                    cmd.power() * 3.0f, 1.0f);
+            ctx.world().spawnEntity(arrow);
+            ctx.world().playSound(null, mob.getBlockPos(),
+                    SoundEvents.ENTITY_SKELETON_SHOOT, SoundCategory.HOSTILE,
+                    1.0f, 1.0f / (ctx.world().getRandom().nextFloat() * 0.4f + 0.8f));
+            mob.lookAtEntity(target, 30.0f, 30.0f);
+        }
+    }
+
+    private void applySetGoal(CommandContext ctx, AiCommand.SetGoal cmd) {
+        LOGGER.debug("[AI] SetGoal not yet implemented: {}", cmd.goal());
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/ObservationPublisher.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/ObservationPublisher.java
@@ -1,0 +1,69 @@
+package com.kbve.statetree.command;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.kbve.statetree.AiCreatureManager;
+import com.kbve.statetree.MapScanner;
+import com.kbve.statetree.NativeRuntime;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * Publishes observation snapshots to Rust on a throttled schedule.
+ * Extracted from NpcTickHandler to keep the orchestrator thin.
+ */
+public final class ObservationPublisher {
+
+    private static final Gson GSON = new Gson();
+
+    private final AiCreatureManager creatureManager;
+
+    public ObservationPublisher(AiCreatureManager creatureManager) {
+        this.creatureManager = creatureManager;
+    }
+
+    /** Push player snapshot + per-creature observations to Rust. */
+    public void publishObservations(MinecraftServer server) {
+        submitPlayerSnapshot(server);
+        creatureManager.submitObservations(server);
+    }
+
+    /** Push a 64x64 walkability grid to Rust for flow fields. */
+    public void publishMapScan(MinecraftServer server) {
+        ServerWorld overworld = server.getOverworld();
+        if (overworld != null) {
+            MapScanner.scanAndSubmit(overworld, overworld.getTime());
+        }
+    }
+
+    private void submitPlayerSnapshot(MinecraftServer server) {
+        ServerWorld overworld = server.getOverworld();
+        if (overworld == null) return;
+
+        long currentTick = overworld.getTime();
+
+        JsonArray players = new JsonArray();
+        for (ServerPlayerEntity player : overworld.getPlayers()) {
+            JsonObject p = new JsonObject();
+            p.addProperty("entity_id", player.getId());
+            p.addProperty("username", player.getNameForScoreboard());
+
+            JsonArray pos = new JsonArray();
+            pos.add(player.getX());
+            pos.add(player.getY());
+            pos.add(player.getZ());
+            p.add("position", pos);
+
+            p.addProperty("health", player.getHealth());
+            players.add(p);
+        }
+
+        JsonObject snapshot = new JsonObject();
+        snapshot.add("players", players);
+        snapshot.addProperty("tick", currentTick);
+
+        NativeRuntime.submitPlayerSnapshot(GSON.toJson(snapshot));
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/WorldCommandApplier.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/WorldCommandApplier.java
@@ -1,0 +1,142 @@
+package com.kbve.statetree.command;
+
+import com.kbve.statetree.CreatureKind;
+import com.kbve.statetree.CreatureKinds;
+import com.kbve.statetree.ship.SchematicLoader;
+import com.kbve.statetree.ship.ShipData;
+import net.minecraft.entity.Entity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registry-backed applier for world-scoped commands. Handles generic
+ * creature spawning via tag-based {@link CreatureKind} lookup, ship
+ * operations, and entity despawning.
+ */
+public final class WorldCommandApplier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+
+    /** Creature tag → CreatureKind. Populated once at construction. */
+    private final Map<String, CreatureKindEntry> creatureRegistry = new HashMap<>();
+
+    @SuppressWarnings("rawtypes")
+    private final Map<CommandKind, CommandApplier> registry = new EnumMap<>(CommandKind.class);
+
+    private record CreatureKindEntry(CreatureKind kind, boolean defaultTamed) {}
+
+    public WorldCommandApplier() {
+        // Creature tag registry — add new creature types here, not in
+        // the command dispatch. Tags must match CreatureKind.tag().
+        registerCreature(CreatureKinds.SKELETON, false);
+        registerCreature(CreatureKinds.SKELETON_MELEE, false);
+        registerCreature(CreatureKinds.SKELETON_MAGE, false);
+        registerCreature(CreatureKinds.SKELETON_ARCHER, false);
+        registerCreature(CreatureKinds.SKELETON_HORSEMAN, false);
+        registerCreature(CreatureKinds.PET_DOG, true);
+        registerCreature(CreatureKinds.PET_PARROT, true);
+
+        // Command registry
+        register(CommandKind.SPAWN_CREATURE, this::applySpawnCreature);
+        register(CommandKind.SPAWN_CREATURE_PACK, this::applySpawnCreaturePack);
+        register(CommandKind.DESPAWN, this::applyDespawn);
+        register(CommandKind.MOVE_SHIP, this::applyMoveShip);
+        register(CommandKind.DESPAWN_SHIP, this::applyDespawnShip);
+        register(CommandKind.SPAWN_SHIP, this::applySpawnShip);
+    }
+
+    private void registerCreature(CreatureKind kind, boolean defaultTamed) {
+        creatureRegistry.put(kind.tag(), new CreatureKindEntry(kind, defaultTamed));
+    }
+
+    private <T extends AiCommand> void register(CommandKind kind, CommandApplier<T> applier) {
+        registry.put(kind, applier);
+    }
+
+    @SuppressWarnings("unchecked")
+    public boolean apply(CommandContext ctx, AiCommand command) {
+        CommandApplier applier = registry.get(command.kind());
+        if (applier == null) return false;
+        applier.apply(ctx, command);
+        return true;
+    }
+
+    // ------------------------------------------------------------------
+    // Appliers
+    // ------------------------------------------------------------------
+
+    private void applySpawnCreature(CommandContext ctx, AiCommand.SpawnCreature cmd) {
+        CreatureKindEntry entry = creatureRegistry.get(cmd.creatureTag());
+        if (entry == null) {
+            LOGGER.warn("[AI] Unknown creature tag '{}' in SpawnCreature", cmd.creatureTag());
+            return;
+        }
+        boolean tamed = cmd.tamed() || entry.defaultTamed();
+        for (int i = 0; i < cmd.count(); i++) {
+            ctx.creatureManager().spawnNearPlayer(
+                    ctx.world(), entry.kind(), cmd.nearPlayer(), cmd.radius(), tamed);
+        }
+    }
+
+    private void applySpawnCreaturePack(CommandContext ctx, AiCommand.SpawnCreaturePack cmd) {
+        for (var packEntry : cmd.entries()) {
+            CreatureKindEntry entry = creatureRegistry.get(packEntry.creatureTag());
+            if (entry == null) {
+                LOGGER.warn("[AI] Unknown creature tag '{}' in pack", packEntry.creatureTag());
+                continue;
+            }
+            boolean tamed = packEntry.tamed() || entry.defaultTamed();
+            for (int i = 0; i < packEntry.count(); i++) {
+                ctx.creatureManager().spawnNearPlayer(
+                        ctx.world(), entry.kind(), cmd.nearPlayer(), cmd.radius(), tamed);
+            }
+        }
+    }
+
+    private void applyDespawn(CommandContext ctx, AiCommand.Despawn cmd) {
+        ctx.creatureManager().despawnEntity(ctx.world(), cmd.targetEntityId());
+    }
+
+    private void applyMoveShip(CommandContext ctx, AiCommand.MoveShip cmd) {
+        if (ctx.shipManager() == null) {
+            LOGGER.warn("[AI] MoveShip ignored: ship manager not initialized");
+            return;
+        }
+        try {
+            ctx.shipManager().moveShip(java.util.UUID.fromString(cmd.shipId()), cmd.distance());
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("[AI] Invalid ship UUID in MoveShip: {}", cmd.shipId());
+        }
+    }
+
+    private void applyDespawnShip(CommandContext ctx, AiCommand.DespawnShip cmd) {
+        if (ctx.shipManager() == null) {
+            LOGGER.warn("[AI] DespawnShip ignored: ship manager not initialized");
+            return;
+        }
+        try {
+            ctx.shipManager().removeShip(ctx.world(), java.util.UUID.fromString(cmd.shipId()));
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("[AI] Invalid ship UUID in DespawnShip: {}", cmd.shipId());
+        }
+    }
+
+    private void applySpawnShip(CommandContext ctx, AiCommand.SpawnShip cmd) {
+        if (ctx.shipManager() == null) {
+            LOGGER.warn("[AI] SpawnShip ignored: ship manager not initialized");
+            return;
+        }
+        Entity player = ctx.world().getEntityById(cmd.nearPlayer());
+        if (player != null) {
+            ShipData data = SchematicLoader.loadFromResource(
+                    cmd.shipName(), "/schematics/" + cmd.shipName() + ".nbt");
+            if (data != null) {
+                ctx.shipManager().placeShip(ctx.world(), data, player.getUuid(), player.getBlockPos());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the behavior_statetree boundary refactor (A+D+thin B). Replaces the monolithic NpcTickHandler with a layered architecture.

### Before
- 440-line god-class with JSON parsing, if/else dispatch, game logic, ship ops
- Stringly-typed `cmd.has("MoveTo")` chain (20+ branches)
- Unbounded command application — one Rust poll could spike TPS
- Adding a creature type required editing the dispatcher

### After
```
NpcTickHandler (99 lines, boring orchestrator)
  → ObservationPublisher
  → IntentDecoder (JSON → typed DTOs)
  → IntentInbox (bounded queue, 512 cap)
  → IntentExecutor (64 intents / 128 cmds per tick budget)
    → MobCommandApplier (10 commands, registry dispatch)
    → WorldCommandApplier (6 commands + creature tag registry)
```

### Key architectural wins
- **`sealed interface AiCommand`** with 14 typed record commands — string only at decode boundary
- **`CommandKind` enum** — dispatch by ordinal, not string comparison
- **Generic `SpawnCreature`** command replaces 7 per-creature spawn branches. Rust sends `{ creature_tag: "skeleton_archer" }`, Java resolves tag → CreatureKind
- **`SpawnCreaturePack`** for mixed cavalry/infantry combos
- **Legacy backward compat** — old `SpawnSkeleton`, `SpawnPetDog` etc. normalized to `SpawnCreature` during decode
- **Per-tick budget** — max 64 intents, max 128 commands per tick. Overflow rolls to next tick.
- **Bounded inbox** — 512 cap with oldest-drop backpressure
- **Epoch-stale drop on dequeue** — wasted execution eliminated
- **Ship manager null-guarded** in all ship command appliers
- **Adding a new creature type** = register tag in `WorldCommandApplier`, no dispatcher edit

### What didn't change
- Rust wire format (backward compatible)
- JNI bridge (NativeRuntime unchanged)
- Observation throttle cadence (10 ticks / 60 ticks)
- All existing command behavior preserved

## Test plan
- [ ] `gradlew build` passes locally (verified)
- [ ] Docker build succeeds
- [ ] e2e tests pass — server boots, RCON responds
- [ ] Existing skeleton/pet/ship AI behavior unchanged
- [ ] Legacy spawn commands (SpawnSkeleton etc.) still work through normalizer