### PR TITLE
fix(mc): remap BBModel port to Yarn mappings

### DIFF
--- a/apps/mc/behavior_statetree/java/build.gradle
+++ b/apps/mc/behavior_statetree/java/build.gradle
@@ -23,6 +23,10 @@ dependencies {
     mappings "net.fabricmc:yarn:1.21.11+build.4:v2"
     modImplementation "net.fabricmc:fabric-loader:0.18.6"
     modImplementation "net.fabricmc.fabric-api:fabric-api:0.141.3+1.21.11"
+
+    // mXparser — math expression evaluator for BBModel animation variables
+    // (Blockbench keyframes use string expressions like "variable.speed * 0.5")
+    include implementation("org.mariuszgromada.math:MathParser.org-mXparser:6.1.0")
 }
 
 // Inject version into fabric.mod.json + copy Rust native libraries

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBMesh.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBMesh.java
@@ -1,17 +1,34 @@
 package com.kbve.statetree.bbmodel;
 
 import com.google.gson.JsonArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.google.gson.JsonElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.kbve.statetree.bbmodel.BBModelUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.LinkedList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BBMesh extends BBObject implements BBFaceContainer {
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
     public final List<BBFace> faces = new LinkedList<>();
 
     private static Map<String, float[]> getArrayMap(JsonElement element, int size) {
@@ -73,7 +90,7 @@ public class BBMesh extends BBObject implements BBFaceContainer {
                 }
 
                 if (vertexIdentifiers.size() != 4) {
-                    Main.LOGGER.warn("Non-quad face found in model: {}!", model.id);
+                    LOGGER.warn("Non-quad face found in model: {}!", model.id);
                 } else {
                     // Get normal vector
                     float[] n = getNormal(vertexIdentifiers, positions);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBModel.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBModel.java
@@ -1,16 +1,29 @@
 package com.kbve.statetree.bbmodel;
 
 import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.LinkedList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.kbve.statetree.bbmodel.BBTexture.MISSING;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BBModel {
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
     public final BBMeta meta;
     public final List<BBTexture> textures = new LinkedList<>();
     public final LinkedList<BBObject> root;
@@ -18,9 +31,9 @@ public class BBModel {
     public final HashMap<String, BBObject> objectsByName;
     public final List<BBAnimation> animations = new LinkedList<>();
     public final float textureWidth, textureHeight;
-    public final ResourceLocation id;
+    public final Identifier id;
 
-    public BBModel(JsonObject model, ResourceLocation identifier) {
+    public BBModel(JsonObject model, Identifier identifier) {
         this.meta = new BBMeta(model.get("meta"));
         this.root = new LinkedList<>();
         this.objects = new HashMap<>();
@@ -47,7 +60,7 @@ public class BBModel {
                 this.objects.put(object.uuid, object);
                 this.objectsByName.put(object.name, object);
             } else {
-                Main.LOGGER.warn("Unknown object type {}", type);
+                LOGGER.warn("Unknown object type {}", type);
             }
         });
 
@@ -57,7 +70,7 @@ public class BBModel {
                 if (object != null) {
                     this.root.add(object);
                 } else {
-                    Main.LOGGER.warn("Object with uuid {} not found", element.getAsString());
+                    LOGGER.warn("Object with uuid {} not found", element.getAsString());
                 }
             } else {
                 BBObject bone = new BBBone(element.getAsJsonObject(), this);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBModelLoader.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBModelLoader.java
@@ -1,17 +1,14 @@
 package com.kbve.statetree.bbmodel;
 
-import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-
-import com.kbve.statetree.bbmodel.BBModel;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.Resource;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
-import net.minecraft.util.GsonHelper;
-import net.minecraft.util.profiling.ProfilerFiller;
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import net.minecraft.resource.Resource;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -19,42 +16,44 @@ import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
 
-public class BBModelLoader extends SimplePreparableReloadListener<Map<ResourceLocation, JsonElement>> {
-    protected static final int PATH_SUFFIX_LENGTH = 8;
-    protected static final int PATH_PREFIX_LENGTH = 8;
+/**
+ * Loads .bbmodel files from resource packs at startup.
+ *
+ * <p>Adapted from ImmersiveAircraft (GPL-3.0).
+ */
+public class BBModelLoader implements SimpleSynchronousResourceReloadListener {
 
-    public static final Map<ResourceLocation, BBModel> MODELS = new HashMap<>();
-    private final Gson gson;
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+    private static final int PATH_SUFFIX_LENGTH = ".bbmodel".length();
+    private static final int PATH_PREFIX_LENGTH = "objects/".length();
 
-    public BBModelLoader() {
-        gson = new Gson();
+    public static final Map<Identifier, BBModel> MODELS = new HashMap<>();
+    private final Gson gson = new Gson();
+
+    @Override
+    public Identifier getFabricId() {
+        return Identifier.of("behavior_statetree", "bbmodel_loader");
     }
 
     @Override
-    protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
-        HashMap<ResourceLocation, JsonElement> map = Maps.newHashMap();
-        for (Map.Entry<ResourceLocation, Resource> entry : resourceManager.listResources("objects", n -> n.getPath().endsWith(".bbmodel")).entrySet()) {
-            ResourceLocation location = entry.getKey();
-            String name = location.getPath();
-            ResourceLocation id = new ResourceLocation(location.getNamespace(), name.substring(PATH_PREFIX_LENGTH, name.length() - PATH_SUFFIX_LENGTH));
-            try {
-                BufferedReader reader = entry.getValue().openAsReader();
-                try {
-                    JsonElement jsonElement = GsonHelper.fromJson(this.gson, reader, JsonElement.class);
-                    map.put(id, jsonElement);
-                } finally {
-                    ((Reader) reader).close();
-                }
-            } catch (JsonParseException | IOException | IllegalArgumentException exception) {
-                Main.LOGGER.error("Couldn't parse data file {} from {}", id, location, exception);
+    public void reload(ResourceManager manager) {
+        MODELS.clear();
+        for (Map.Entry<Identifier, Resource> entry :
+                manager.findResources("objects", id -> id.getPath().endsWith(".bbmodel")).entrySet()) {
+            Identifier location = entry.getKey();
+            String path = location.getPath();
+            Identifier modelId = Identifier.of(
+                    location.getNamespace(),
+                    path.substring(PATH_PREFIX_LENGTH, path.length() - PATH_SUFFIX_LENGTH)
+            );
+            try (BufferedReader reader = entry.getValue().getReader()) {
+                JsonElement json = gson.fromJson(reader, JsonElement.class);
+                MODELS.put(modelId, new BBModel(json.getAsJsonObject(), modelId));
+                LOGGER.info("[BBModel] Loaded model '{}'", modelId);
+            } catch (JsonParseException | IOException e) {
+                LOGGER.error("[BBModel] Failed to load '{}' from {}: {}", modelId, location, e.getMessage());
             }
         }
-        return map;
-    }
-
-    @Override
-    protected void apply(Map<ResourceLocation, JsonElement> jsonMap, ResourceManager resourceManager, ProfilerFiller profiler) {
-        MODELS.clear();
-        jsonMap.forEach((identifier, jsonElement) -> MODELS.put(identifier, new BBModel(jsonElement.getAsJsonObject(), identifier)));
+        LOGGER.info("[BBModel] Loaded {} models total", MODELS.size());
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBTexture.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBTexture.java
@@ -2,7 +2,7 @@ package com.kbve.statetree.bbmodel;
 
 import com.google.gson.JsonObject;
 import com.kbve.statetree.bbmodel.BBModelUtils;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Identifier;
 
 public class BBTexture {
     public static final BBTexture MISSING = new BBTexture();
@@ -15,7 +15,7 @@ public class BBTexture {
     public final int uvWidth;
     public final int uvHeight;
 
-    public final ResourceLocation location;
+    public final Identifier location;
 
     public BBTexture() {
         this.uuid = "";
@@ -26,10 +26,10 @@ public class BBTexture {
         this.uvWidth = 16;
         this.uvHeight = 16;
 
-        this.location = new ResourceLocation("missing");
+        this.location = Identifier.of("missing");
     }
 
-    public BBTexture(JsonObject element, ResourceLocation identifier) {
+    public BBTexture(JsonObject element, Identifier identifier) {
         this.uuid = element.getAsJsonPrimitive("uuid").getAsString();
         this.id = element.getAsJsonPrimitive("id").getAsString();
         this.name = element.getAsJsonPrimitive("name").getAsString();
@@ -39,9 +39,9 @@ public class BBTexture {
         this.uvHeight = BBModelUtils.getIntElement(element, "uv_height", 16);
 
         if (this.name.contains(":")) {
-            this.location = new ResourceLocation(this.name);
+            this.location = Identifier.of(this.name);
         } else {
-            this.location = new ResourceLocation(identifier.getNamespace(), "textures/entity/" + this.name);
+            this.location = Identifier.of(identifier.getNamespace(), "textures/entity/" + this.name);
         }
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/BBModelRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/BBModelRenderer.java
@@ -1,18 +1,18 @@
 package com.kbve.statetree.bbmodel.render;
 
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.render.VertexConsumer;
 import com.mojang.datafixers.util.Pair;
-import com.kbve.statetree.ship.ShipEntity;
+
 import com.kbve.statetree.bbmodel.*;
 import com.kbve.statetree.bbmodel.BBModelUtils;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.Sheets;
-import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.core.Holder;
-import net.minecraft.world.item.DyeColor;
-import net.minecraft.world.level.block.entity.BannerPattern;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.TexturedRenderLayers;
+import net.minecraft.client.render.net.minecraft.client.render.OverlayTexture;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.DyeColor;
+import net.minecraft.block.entity.BannerPattern;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
@@ -21,19 +21,19 @@ import java.util.List;
 
 public class BBModelRenderer {
     public interface VertexConsumerProvider {
-        VertexConsumer getBuffer(MultiBufferSource source, BBFaceContainer container, BBFace face);
+        VertexConsumer getBuffer(VertexConsumerProvider source, BBFaceContainer container, BBFace face);
     }
 
-    public static final VertexConsumerProvider DEFAULT_VERTEX_CONSUMER_PROVIDER = (source, container, face) -> source.getBuffer(container.enableCulling() ? RenderType.entityCutout(face.texture.location) : RenderType.entityCutoutNoCull(face.texture.location));
+    public static final VertexConsumerProvider DEFAULT_VERTEX_CONSUMER_PROVIDER = (source, container, face) -> source.getBuffer(container.enableCulling() ? RenderLayer.entityCutout(face.texture.location) : RenderLayer.entityCutoutNoCull(face.texture.location));
 
-    public static <T extends VehicleEntity> void renderModel(BBModel model, PoseStack matrixStack, MultiBufferSource vertexConsumerProvider, int light, float time, T entity, ModelPartRenderHandler<T> modelPartRenderer, float red, float green, float blue, float alpha) {
+    public static <T extends Entity> void renderModel(BBModel model, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, float time, T entity, ModelPartRenderHandler<T> modelPartRenderer, float red, float green, float blue, float alpha) {
         model.root.forEach(object -> renderObject(model, object, matrixStack, vertexConsumerProvider, light, time, entity, modelPartRenderer, red, green, blue, alpha));
     }
 
     /**
      * Apply transformations, animations, and callbacks, and render the object.
      */
-    public static <T extends VehicleEntity> void renderObject(BBModel model, BBObject object, PoseStack matrixStack, MultiBufferSource vertexConsumerProvider, int light, float time, T entity, ModelPartRenderHandler<T> modelPartRenderer, float red, float green, float blue, float alpha) {
+    public static <T extends Entity> void renderObject(BBModel model, BBObject object, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, float time, T entity, ModelPartRenderHandler<T> modelPartRenderer, float red, float green, float blue, float alpha) {
         matrixStack.pushPose();
         matrixStack.translate(object.origin.x(), object.origin.y(), object.origin.z());
 
@@ -47,7 +47,7 @@ public class BBModelRenderer {
 
                 Vector3f rotation = animation.sample(object.uuid, BBAnimator.Channel.ROTATION, time);
                 rotation.mul(1.0f / 180.0f * (float) Math.PI);
-                matrixStack.mulPose(BBModelUtils.fromXYZ(rotation));
+                matrixStack.multiply(BBModelUtils.fromXYZ(rotation));
 
                 Vector3f scale = animation.sample(object.uuid, BBAnimator.Channel.SCALE, time);
                 matrixStack.scale(scale.x(), scale.y(), scale.z());
@@ -55,7 +55,7 @@ public class BBModelRenderer {
         }
 
         // Apply object rotation
-        matrixStack.mulPose(BBModelUtils.fromXYZ(object.rotation));
+        matrixStack.multiply(BBModelUtils.fromXYZ(object.rotation));
 
         // Apply additional, complex animations
         if (object instanceof BBBone bone && modelPartRenderer != null) {
@@ -78,7 +78,7 @@ public class BBModelRenderer {
     /**
      * Render the object without applying transformations, animations, or callbacks.
      */
-    public static <T extends VehicleEntity> void renderObjectInner(BBModel model, BBObject object, PoseStack matrixStack, MultiBufferSource vertexConsumerProvider, int light, float time, T entity, ModelPartRenderHandler<T> modelPartRenderer, float red, float green, float blue, float alpha) {
+    public static <T extends Entity> void renderObjectInner(BBModel model, BBObject object, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, float time, T entity, ModelPartRenderHandler<T> modelPartRenderer, float red, float green, float blue, float alpha) {
         if (object instanceof BBFaceContainer cube) {
             renderFaces(cube, matrixStack, vertexConsumerProvider, light, red, green, blue, alpha, modelPartRenderer == null ? DEFAULT_VERTEX_CONSUMER_PROVIDER : modelPartRenderer.getVertexConsumerProvider());
         } else if (object instanceof BBBone bone) {
@@ -95,8 +95,8 @@ public class BBModelRenderer {
         }
     }
 
-    public static void renderFaces(BBFaceContainer cube, PoseStack matrixStack, MultiBufferSource source, int light, float red, float green, float blue, float alpha, VertexConsumerProvider provider) {
-        PoseStack.Pose last = matrixStack.last();
+    public static void renderFaces(BBFaceContainer cube, MatrixStack matrixStack, VertexConsumerProvider source, int light, float red, float green, float blue, float alpha, VertexConsumerProvider provider) {
+        MatrixStack.Pose last = matrixStack.peek();
         Matrix4f positionMatrix = last.pose();
         Matrix3f normalMatrix = last.normal();
         for (BBFace face : cube.getFaces()) {
@@ -106,15 +106,15 @@ public class BBModelRenderer {
                 vertexConsumer.vertex(positionMatrix, v.x, v.y, v.z);
                 vertexConsumer.color(red, green, blue, alpha);
                 vertexConsumer.uv(v.u, v.v);
-                vertexConsumer.overlayCoords(OverlayTexture.NO_OVERLAY);
+                vertexConsumer.overlay(net.minecraft.client.render.OverlayTexture.DEFAULT_UV);
                 vertexConsumer.uv2(light);
                 vertexConsumer.normal(normalMatrix, v.nx, v.ny, v.nz);
-                vertexConsumer.endVertex();
+                vertexConsumer.next();
             }
         }
     }
 
-    public static void renderBanner(BBFaceContainer cube, PoseStack matrixStack, MultiBufferSource vertexConsumers, int light, boolean isBanner, List<Pair<Holder<BannerPattern>, DyeColor>> patterns) {
+    public static void renderBanner(BBFaceContainer cube, MatrixStack matrixStack, VertexConsumerProvider vertexConsumers, int light, boolean isBanner, List<Pair<RegistryEntry<BannerPattern>, DyeColor>> patterns) {
         matrixStack.pushPose();
 
         if (cube instanceof BBObject object) {
@@ -122,31 +122,31 @@ public class BBModelRenderer {
         }
 
         for (int i = 0; i < 17 && i < patterns.size(); ++i) {
-            Pair<Holder<BannerPattern>, DyeColor> pair = patterns.get(i);
-            Holder<BannerPattern> bannerPattern = pair.getFirst();
+            Pair<RegistryEntry<BannerPattern>, DyeColor> pair = patterns.get(i);
+            RegistryEntry<BannerPattern> bannerPattern = pair.getFirst();
             bannerPattern.unwrapKey()
-                    .map(key -> isBanner ? Sheets.getBannerMaterial(key) : Sheets.getShieldMaterial(key))
+                    .map(key -> isBanner ? TexturedRenderLayers.getBannerPatternTexturedRenderLayer(key) : TexturedRenderLayers.getShieldPatternTexturedRenderLayer(key))
                     .ifPresent(material -> {
                         float[] fs = pair.getSecond().getTextureDiffuseColors();
                         renderFaces(cube, matrixStack, vertexConsumers, light,
                                 fs[0], fs[1], fs[2], 1.0f,
-                                (source, container, face) -> material.buffer(vertexConsumers, RenderType::entityNoOutline));
+                                (source, container, face) -> material.buffer(vertexConsumers, RenderLayer::entityNoOutline));
                     });
         }
 
         matrixStack.popPose();
     }
 
-    public static void renderSailObject(BBMesh cube, PoseStack matrixStack, MultiBufferSource vertexConsumerProvider, int light, float time, float red, float green, float blue, float alpha) {
+    public static void renderSailObject(BBMesh cube, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, float time, float red, float green, float blue, float alpha) {
         renderSailObject(cube, matrixStack, vertexConsumerProvider, light, time, red, green, blue, alpha, 0.025f, 0.0f);
     }
 
-    public static void renderSailObject(BBMesh cube, PoseStack matrixStack, MultiBufferSource vertexConsumerProvider, int light, float time, float red, float green, float blue, float alpha, float distanceScale, float baseScale) {
-        PoseStack.Pose last = matrixStack.last();
+    public static void renderSailObject(BBMesh cube, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, float time, float red, float green, float blue, float alpha, float distanceScale, float baseScale) {
+        MatrixStack.Pose last = matrixStack.peek();
         Matrix4f positionMatrix = last.pose();
         Matrix3f normalMatrix = last.normal();
         for (BBFace face : cube.getFaces()) {
-            VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderType.entityCutoutNoCull(face.texture.location));
+            VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderLayer.entityCutoutNoCull(face.texture.location));
             for (int i = 0; i < 4; i++) {
                 BBFace.BBVertex v = face.vertices[i];
                 float distance = Math.max(
@@ -165,10 +165,10 @@ public class BBModelRenderer {
                         .vertex(positionMatrix, v.x + x, v.y, v.z + z)
                         .color(red, green, blue, alpha)
                         .uv(v.u, v.v)
-                        .overlayCoords(OverlayTexture.NO_OVERLAY)
+                        .overlay(net.minecraft.client.render.OverlayTexture.DEFAULT_UV)
                         .uv2(light)
                         .normal(normalMatrix, v.nx, v.ny, v.nz)
-                        .endVertex();
+                        .next();
             }
         }
     }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/ModelPartRenderHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/ModelPartRenderHandler.java
@@ -1,10 +1,10 @@
 package com.kbve.statetree.bbmodel.render;
 
-import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.util.math.MatrixStack;
 import com.kbve.statetree.bbmodel.BBModel;
 import com.kbve.statetree.bbmodel.BBObject;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.world.entity.Entity;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.entity.Entity;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,14 +34,14 @@ public class ModelPartRenderHandler<T extends Entity> {
         return objects;
     }
 
-    public void animate(String name, T entity, PoseStack matrixStack, float time) {
+    public void animate(String name, T entity, MatrixStack matrixStack, float time) {
         ModelPartRenderer<T> o = objects.get(name);
         if (o != null && o.animationConsumer() != null) {
             o.animationConsumer().run(entity, 0, time, matrixStack);
         }
     }
 
-    public boolean render(String name, BBModel model, BBObject object, MultiBufferSource vertexConsumerProvider, T entity, PoseStack matrixStack, int light, float time, ModelPartRenderHandler<T> modelPartRenderer) {
+    public boolean render(String name, BBModel model, BBObject object, VertexConsumerProvider vertexConsumerProvider, T entity, MatrixStack matrixStack, int light, float time, ModelPartRenderHandler<T> modelPartRenderer) {
         ModelPartRenderer<T> o = objects.get(name);
         if (o != null && o.renderConsumer() != null) {
             o.renderConsumer().run(model, object, vertexConsumerProvider, entity, matrixStack, light, time, modelPartRenderer);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/ModelPartRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/ModelPartRenderer.java
@@ -1,10 +1,10 @@
 package com.kbve.statetree.bbmodel.render;
 
-import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.util.math.MatrixStack;
 import com.kbve.statetree.bbmodel.BBModel;
 import com.kbve.statetree.bbmodel.BBObject;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.world.entity.Entity;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.entity.Entity;
 
 public record ModelPartRenderer<T extends Entity>(
         String id,
@@ -12,10 +12,10 @@ public record ModelPartRenderer<T extends Entity>(
         ModelPartRenderer.RenderConsumer<T> renderConsumer
 ) {
     public interface AnimationConsumer<T> {
-        void run(T entity, float yaw, float time, PoseStack matrixStack);
+        void run(T entity, float yaw, float time, MatrixStack matrixStack);
     }
 
     public interface RenderConsumer<T extends Entity> {
-        void run(BBModel model, BBObject object, MultiBufferSource vertexConsumerProvider, T entity, PoseStack matrixStack, int light, float time, ModelPartRenderHandler<T> modelPartRenderer);
+        void run(BBModel model, BBObject object, VertexConsumerProvider vertexConsumerProvider, T entity, MatrixStack matrixStack, int light, float time, ModelPartRenderHandler<T> modelPartRenderer);
     }
 }


### PR DESCRIPTION
## Summary
- Remaps all Mojang→Yarn class names in the BBModel port (PoseStack→MatrixStack, etc.)
- Rewrites BBModelLoader for Fabric resource reload API
- Adds mXparser dependency for animation expression evaluation
- Fixes Identifier.of() for 1.21+ API

Follow-up to #10178 which ported the files but used Mojang mappings.

## Test plan
- [ ] `gradle build` succeeds in Docker multi-stage build
- [ ] BBModelLoader loads .bbmodel files from resources on client init