### PR TITLE
fix(mc): RenderLayer → RenderLayers for 1.21.11 API

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/BBModelRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/BBModelRenderer.java
@@ -2,7 +2,7 @@ package com.kbve.statetree.bbmodel.render;
 
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.render.OverlayTexture;
-import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderLayers;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.entity.Entity;
@@ -34,8 +34,8 @@ public class BBModelRenderer {
     public static final FaceBufferProvider DEFAULT_FACE_BUFFER_PROVIDER =
             (source, container, face) -> source.getBuffer(
                     container.enableCulling()
-                            ? RenderLayer.getEntityCutout(face.texture.location)
-                            : RenderLayer.getEntityCutoutNoCull(face.texture.location));
+                            ? RenderLayers.entityCutout(face.texture.location)
+                            : RenderLayers.entityCutoutNoCull(face.texture.location));
 
     public static <T extends Entity> void renderModel(
             BBModel model, MatrixStack matrixStack, VertexConsumerProvider vertexConsumers,
@@ -143,7 +143,7 @@ public class BBModelRenderer {
         Matrix4f positionMatrix = entry.getPositionMatrix();
         for (BBFace face : cube.getFaces()) {
             VertexConsumer vc = vertexConsumers.getBuffer(
-                    RenderLayer.getEntityCutoutNoCull(face.texture.location));
+                    RenderLayers.entityCutoutNoCull(face.texture.location));
             for (int i = 0; i < 4; i++) {
                 BBFace.BBVertex v = face.vertices[i];
                 float distance = Math.max(Math.max(Math.abs(v.x), Math.abs(v.y)), Math.abs(v.z));

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/ModelPartRenderHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/render/ModelPartRenderHandler.java
@@ -14,7 +14,7 @@ import java.util.Map;
  */
 public class ModelPartRenderHandler<T extends Entity> {
     private final Map<String, ModelPartRenderer<T>> objects = new HashMap<>();
-    private BBModelRenderer.FaceBufferProvider vertexConsumerProvider = BBModelRenderer.DEFAULT_VERTEX_CONSUMER_PROVIDER;
+    private BBModelRenderer.FaceBufferProvider vertexConsumerProvider = BBModelRenderer.DEFAULT_FACE_BUFFER_PROVIDER;
 
     public ModelPartRenderHandler<T> add(String id, ModelPartRenderer.AnimationConsumer<T> animationConsumer) {
         return add(id, animationConsumer, null);
@@ -59,7 +59,7 @@ public class ModelPartRenderHandler<T extends Entity> {
         return this;
     }
 
-    public BBModelRenderer.FaceBufferProvider getVertexConsumerProvider() {
+    public BBModelRenderer.FaceBufferProvider getFaceBufferProvider() {
         return vertexConsumerProvider;
     }
 }


### PR DESCRIPTION
## Summary
- `RenderLayer.getEntityCutout()` → `RenderLayers.entityCutout()` (moved in 1.21.11)
- `RenderLayer.getEntityCutoutNoCull()` → `RenderLayers.entityCutoutNoCull()`
- Fixes field/method name alignment between BBModelRenderer and ModelPartRenderHandler

Fixes all 5 remaining compile errors from the BBModel port.

## Test plan
- [ ] Docker build compiles behavior_statetree JAR successfully