### PR TITLE
fix(mc): copy version.toml into Docker build so JAR gets real version

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -55,6 +55,12 @@ WORKDIR /build
 COPY apps/mc/behavior_statetree/java/ behavior_statetree/java/
 COPY apps/mc/mc_auth/java/ mc_auth/java/
 
+# version.toml — single source of truth for the MC stack version.
+# build.gradle reads ../../version.toml relative to java/ so it
+# needs to land at /build/version.toml. Without this, the JAR
+# falls back to 0.0.0-dev and Modrinth publishes break.
+COPY apps/mc/version.toml version.toml
+
 # Place each .so where its Gradle processResources expects it.
 # build.gradle: from("../../target/release") relative to java/
 # behavior_statetree/java/ → ../../target/release = /build/target/release/


### PR DESCRIPTION
## Summary
`build.gradle` reads `../../version.toml` for the mod JAR version, but the Dockerfile never copied it into the Java builder stage. Result: the JAR always fell back to `0.0.0-dev`, and the Modrinth PostSync jobs published with the wrong version.

One-line fix: `COPY apps/mc/version.toml version.toml` into the java-builder stage at `/build/version.toml`.

### Impact
- JAR will now be named `behavior_statetree-1.0.22.jar` (matching version.toml)
- Modrinth JAR publish will use the correct version
- Modrinth mrpack publish will stop getting 400 errors

## Test plan
- [ ] Docker build produces `behavior_statetree-1.0.22.jar` (not `0.0.0-dev`)
- [ ] e2e passes
- [ ] Next PostSync: JAR publishes as v1.0.22, mrpack uploads successfully