### PR TITLE
feat(mc): graceful restart PreSync hook with RCON countdown

### DIFF
--- a/apps/kube/agones/mc/graceful-restart-job.yaml
+++ b/apps/kube/agones/mc/graceful-restart-job.yaml
@@ -1,0 +1,102 @@
+---
+# Graceful restart — ArgoCD PreSync hook.
+#
+# Runs BEFORE the fleet.yaml update so players get a warning and are
+# moved to the lobby (via Velocity fallback) before the old pod dies.
+#
+# Flow:
+#   1. Broadcast "restarting in 30s" via RCON
+#   2. Sleep 20s
+#   3. Broadcast "restarting in 10s"
+#   4. Sleep 10s
+#   5. Kick all players with a message (Velocity routes them to lobby)
+#   6. Job completes → ArgoCD proceeds with fleet rolling update
+#
+# If no GameServer pods are running (fleet at 0 replicas), the Job
+# exits cleanly — the RCON connection failure is not fatal.
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: mc-graceful-restart
+    namespace: arc-runners
+    annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/sync-wave: '1'
+    labels:
+        app.kubernetes.io/part-of: mc
+        app.kubernetes.io/component: graceful-restart
+spec:
+    ttlSecondsAfterFinished: 3600
+    backoffLimit: 0
+    template:
+        metadata:
+            labels:
+                app.kubernetes.io/part-of: mc
+                app.kubernetes.io/component: graceful-restart
+        spec:
+            restartPolicy: Never
+            containers:
+                - name: rcon-restart
+                  image: alpine:3.20
+                  command: ['sh', '-c']
+                  args:
+                      - |
+                          set -eu
+
+                          # Install mcrcon (lightweight C RCON client)
+                          apk add --no-cache gcc musl-dev git > /dev/null 2>&1
+                          git clone --depth 1 https://github.com/Tiiffi/mcrcon.git /tmp/mcrcon
+                          gcc -std=gnu11 -pedantic -Wall -Wextra -O2 -s \
+                              -o /usr/local/bin/mcrcon /tmp/mcrcon/mcrcon.c
+                          rm -rf /tmp/mcrcon
+
+                          # Resolve target — find any running mc-gameserver pod
+                          # via DNS. If none are running, exit cleanly.
+                          RCON_HOST="${RCON_HOST:-mc-fabric-rcon.arc-runners.svc.cluster.local}"
+                          RCON_PORT="${RCON_PORT:-25575}"
+
+                          rcon() {
+                              mcrcon -H "$RCON_HOST" -P "$RCON_PORT" -p "$RCON_PASSWORD" "$@" 2>/dev/null
+                          }
+
+                          # Test connectivity — if no server is running, skip gracefully
+                          if ! rcon "list" > /dev/null 2>&1; then
+                              echo "No MC server reachable on $RCON_HOST:$RCON_PORT — skipping graceful restart."
+                              exit 0
+                          fi
+
+                          echo "Connected to MC server. Starting graceful restart sequence..."
+
+                          # Phase 1: 30-second warning
+                          rcon 'tellraw @a {"text":"[Server] ","color":"gold","extra":[{"text":"Restarting for an update in 30 seconds...","color":"white"}]}'
+                          rcon 'title @a times 10 70 20'
+                          rcon 'title @a title {"text":"Server Update","color":"gold"}'
+                          rcon 'title @a subtitle {"text":"Restarting in 30 seconds","color":"white"}'
+                          echo "Broadcast: 30 seconds"
+                          sleep 20
+
+                          # Phase 2: 10-second warning
+                          rcon 'tellraw @a {"text":"[Server] ","color":"gold","extra":[{"text":"Restarting in 10 seconds!","color":"red"}]}'
+                          rcon 'title @a times 10 70 20'
+                          rcon 'title @a title {"text":"Server Update","color":"red"}'
+                          rcon 'title @a subtitle {"text":"Restarting in 10 seconds!","color":"white"}'
+                          echo "Broadcast: 10 seconds"
+                          sleep 10
+
+                          # Phase 3: Kick all players (Velocity routes them to lobby)
+                          rcon 'kick @a Server is restarting for an update. Returning to lobby...'
+                          echo "All players kicked. Graceful restart complete."
+                  env:
+                      - name: RCON_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: mc-gameserver-secrets
+                                key: rcon-password
+                  resources:
+                      requests:
+                          memory: 32Mi
+                          cpu: 50m
+                      limits:
+                          memory: 128Mi
+                          cpu: 200m

--- a/apps/kube/agones/mc/rcon-networkpolicy.yaml
+++ b/apps/kube/agones/mc/rcon-networkpolicy.yaml
@@ -55,3 +55,11 @@ spec:
           ports:
               - port: 25575
                 protocol: TCP
+        # Graceful restart / admin Jobs → RCON
+        - from:
+              - podSelector:
+                    matchLabels:
+                        app.kubernetes.io/component: graceful-restart
+          ports:
+              - port: 25575
+                protocol: TCP

--- a/apps/kube/agones/mc/rcon-service.yaml
+++ b/apps/kube/agones/mc/rcon-service.yaml
@@ -1,0 +1,25 @@
+---
+# Headless RCON Service — allows in-cluster Jobs (graceful restart,
+# admin scripts) to reach the Fabric GameServer's RCON port via DNS
+# instead of discovering pod IPs through the Agones API.
+#
+# Headless (clusterIP: None) because the fleet may have 0-N replicas.
+# DNS returns the pod IPs directly so callers can detect "no endpoints"
+# as "no servers running" and exit gracefully.
+apiVersion: v1
+kind: Service
+metadata:
+    name: mc-fabric-rcon
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/part-of: mc
+        app.kubernetes.io/component: rcon
+spec:
+    clusterIP: None
+    selector:
+        app: mc-gameserver
+    ports:
+        - name: rcon
+          port: 25575
+          targetPort: 25575
+          protocol: TCP


### PR DESCRIPTION
## Summary
ArgoCD PreSync hook that gracefully transitions players to the lobby before the Fabric server fleet update.

### Flow
```
PreSync Job starts
  → RCON: "Restarting in 30 seconds" + title overlay
  → sleep 20s
  → RCON: "Restarting in 10 seconds!" + red title
  → sleep 10s
  → RCON: kick @a (Velocity routes all players to lobby)
  → Job completes
ArgoCD proceeds with fleet rolling update
```

### New files
- **graceful-restart-job.yaml** — PreSync hook Job (sync-wave 1). Compiles `mcrcon` at runtime, connects via headless Service DNS, broadcasts warnings with JSON text + title overlays, kicks all players.
- **rcon-service.yaml** — Headless ClusterIP Service targeting `app: mc-gameserver` pods on port 25575. Enables DNS-based RCON discovery without Agones API access.

### Modified
- **rcon-networkpolicy.yaml** — Added ingress rule for `app.kubernetes.io/component: graceful-restart` pods to access RCON.

### Graceful degradation
If no GameServer is running (fleet at 0 replicas), the RCON connectivity test fails and the Job exits cleanly (exit 0) so ArgoCD can still proceed with the sync.

## Test plan
- [ ] With active GameServer: players see 30s/10s countdown with title overlays, then get kicked to lobby
- [ ] Without active GameServer: Job exits cleanly, ArgoCD proceeds
- [ ] NetworkPolicy allows the Job pod to reach RCON
- [ ] Fleet rolling update proceeds after Job completes