### PR TITLE
feat(bevy): scaffold bevy_behavior — shared behavior tree engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,6 +1784,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_behavior"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "serde",
+]
+
+[[package]]
 name = "bevy_cam"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
 	'packages/rust/bevy/bevy_db',
 	'packages/rust/bevy/bevy_supa',
 	'packages/rust/bevy/bevy_pathfinding',
+	'packages/rust/bevy/bevy_behavior',
 	'apps/vm/firecracker-ctl',
 	'apps/vm/kubectl',
 	'apps/mc/behavior_statetree',

--- a/packages/rust/bevy/bevy_behavior/Cargo.toml
+++ b/packages/rust/bevy/bevy_behavior/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bevy_behavior"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.94"
+license = "MIT"
+description = "Game-agnostic behavior tree engine for Bevy — composable nodes, cooldown tracking, and observation traits shared across Minecraft, Bevy Isometric, Discord MUD, and Unity."
+homepage = "https://kbve.com/"
+repository = "https://github.com/KBVE/kbve/tree/main/packages/rust/bevy/bevy_behavior"
+keywords = ["bevy", "behavior-tree", "ai", "gamedev", "npc"]
+categories = ["game-development", "game-engines"]
+readme = "README.md"
+
+[features]
+default = []
+## Adds Bevy Resource/Component derives and a BehaviorTreePlugin
+## for in-ECS tree evaluation. Without this feature the crate is
+## pure Rust with zero framework dependency.
+bevy = ["dep:bevy"]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+bevy = { version = "0.18", default-features = false, features = [
+    "bevy_state",
+], optional = true }

--- a/packages/rust/bevy/bevy_behavior/src/cooldown.rs
+++ b/packages/rust/bevy/bevy_behavior/src/cooldown.rs
@@ -1,0 +1,78 @@
+//! Tick-based cooldown system.
+//!
+//! Keeps behavior nodes decoupled from ECS types so trees can be unit-tested
+//! without a Bevy `App`. Each game's ECS cooldown components implement
+//! [`CooldownState`]; the tree only sees the trait.
+
+/// Minimal interface for cooldown tracking. ECS components/resources
+/// implement this so behavior nodes can check + bump cooldowns without
+/// knowing the concrete Bevy type.
+pub trait CooldownState: Send + Sync {
+    /// Returns `true` if enough ticks have elapsed since the last fire.
+    fn can_fire(&self, current_tick: u64) -> bool;
+
+    /// Record that the ability was fired at `current_tick`.
+    fn mark_fired(&mut self, current_tick: u64);
+}
+
+/// Simple tick-based cooldown — fires once, then blocks for `interval` ticks.
+///
+/// Starts unfired (`last_fired = None`) so the first activation always
+/// succeeds regardless of the current tick.
+#[derive(Debug, Clone)]
+pub struct TickCooldown {
+    /// Minimum ticks between activations.
+    pub interval: u64,
+    /// Tick at which the cooldown was last triggered, or `None` if never fired.
+    pub last_fired: Option<u64>,
+}
+
+impl TickCooldown {
+    pub fn new(interval: u64) -> Self {
+        Self {
+            interval,
+            last_fired: None,
+        }
+    }
+}
+
+impl CooldownState for TickCooldown {
+    fn can_fire(&self, current_tick: u64) -> bool {
+        match self.last_fired {
+            None => true,
+            Some(last) => current_tick >= last + self.interval,
+        }
+    }
+
+    fn mark_fired(&mut self, current_tick: u64) {
+        self.last_fired = Some(current_tick);
+    }
+}
+
+/// Mutable per-evaluation context passed to every behavior node.
+///
+/// Carries the current tick plus borrows of the per-NPC and global cooldown
+/// state. Nodes check + bump cooldowns through the [`CooldownState`] trait —
+/// no separate commit step.
+pub struct BehaviorContext<'a> {
+    pub current_tick: u64,
+    pub per_npc: &'a mut dyn CooldownState,
+    pub global: &'a mut dyn CooldownState,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_cooldown_respects_interval() {
+        let mut cd = TickCooldown::new(10);
+        assert!(cd.can_fire(0));
+        cd.mark_fired(0);
+        assert!(!cd.can_fire(5));
+        assert!(cd.can_fire(10));
+        cd.mark_fired(10);
+        assert!(!cd.can_fire(15));
+        assert!(cd.can_fire(20));
+    }
+}

--- a/packages/rust/bevy/bevy_behavior/src/lib.rs
+++ b/packages/rust/bevy/bevy_behavior/src/lib.rs
@@ -1,0 +1,37 @@
+//! # bevy_behavior
+//!
+//! Game-agnostic behavior tree engine. Provides the core `BehaviorNode` trait,
+//! composite nodes (`Selector`, `Sequence`), a cooldown system, and observation
+//! traits that let the same tree logic drive NPCs across Minecraft, Bevy
+//! Isometric, Discord MUD, and Unity without game-specific coupling.
+//!
+//! ## Design
+//!
+//! The tree engine is generic over three associated types:
+//!
+//! - **Observation** (`O`) — immutable snapshot of what the NPC can see.
+//!   Implement the [`Positioned`], [`Healthed`], and [`Aware`] traits on your
+//!   observation type so built-in leaves can query position, health, and
+//!   nearby entities without knowing the concrete struct.
+//!
+//! - **Action** (`A`) — a command the NPC wants to execute. Each game defines
+//!   its own enum (`NpcCommand` in MC, `BattleAction` in Isometric, etc.).
+//!
+//! - **Context** (`C`) — mutable per-evaluation state (cooldowns, tick counter).
+//!   The provided [`BehaviorContext`] covers the common case; games can extend
+//!   it or substitute their own.
+//!
+//! ## Feature flags
+//!
+//! - **`bevy`** — adds `Resource`/`Component` derives and a future
+//!   `BehaviorTreePlugin` for in-ECS evaluation. Without this flag the crate
+//!   is pure Rust with zero framework dependency.
+
+pub mod cooldown;
+pub mod observation;
+pub mod tree;
+
+// Re-exports for convenience
+pub use cooldown::{BehaviorContext, CooldownState, TickCooldown};
+pub use observation::{Aware, EntitySnapshot, Healthed, Positioned};
+pub use tree::{BehaviorNode, NodeStatus, Selector, Sequence};

--- a/packages/rust/bevy/bevy_behavior/src/observation.rs
+++ b/packages/rust/bevy/bevy_behavior/src/observation.rs
@@ -1,0 +1,55 @@
+//! Observation traits — game-agnostic interfaces that built-in behavior
+//! nodes query. Each game implements these on its own observation struct
+//! (e.g. `NpcObservation` in MC, `MobSnapshot` in Isometric).
+
+use serde::{Deserialize, Serialize};
+
+/// An entity has a 3D position.
+pub trait Positioned {
+    fn position(&self) -> [f64; 3];
+}
+
+/// An entity has a health value.
+pub trait Healthed {
+    fn current_health(&self) -> f32;
+    fn max_health(&self) -> f32;
+
+    /// Health as a 0.0–1.0 fraction.
+    fn health_fraction(&self) -> f32 {
+        let max = self.max_health();
+        if max <= 0.0 {
+            return 0.0;
+        }
+        self.current_health() / max
+    }
+}
+
+/// An entity is aware of nearby entities.
+pub trait Aware {
+    fn nearby_entities(&self) -> &[EntitySnapshot];
+}
+
+/// A tick-based observation (most game loops have a monotonic tick counter).
+pub trait Ticked {
+    fn tick(&self) -> u64;
+}
+
+/// Minimal snapshot of a nearby entity — enough for built-in leaves to decide
+/// whether to flee, attack, or ignore. Games can extend their own snapshot
+/// structs with richer data; the built-in nodes only need this.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntitySnapshot {
+    pub entity_id: u64,
+    pub entity_type: String,
+    pub position: [f64; 3],
+    pub health: f32,
+    pub is_hostile: bool,
+}
+
+/// Squared distance between two 3D points (avoids sqrt for comparisons).
+pub fn dist_sq(a: &[f64; 3], b: &[f64; 3]) -> f64 {
+    let dx = a[0] - b[0];
+    let dy = a[1] - b[1];
+    let dz = a[2] - b[2];
+    dx * dx + dy * dy + dz * dz
+}

--- a/packages/rust/bevy/bevy_behavior/src/tree/builtin.rs
+++ b/packages/rust/bevy/bevy_behavior/src/tree/builtin.rs
@@ -1,0 +1,196 @@
+//! Built-in behavior tree leaf nodes.
+//!
+//! These are generic over any observation type that implements the
+//! [`Positioned`], [`Healthed`], [`Aware`], and [`Ticked`] traits, plus
+//! any action type that can be constructed from the provided factory
+//! closures. This keeps the leaves game-agnostic while each game
+//! supplies its own command enum (MC's `NpcCommand`, Isometric's
+//! `BattleAction`, etc.).
+
+use crate::cooldown::BehaviorContext;
+use crate::observation::{Aware, Healthed, Positioned, Ticked, dist_sq};
+
+use super::{BehaviorNode, NodeStatus};
+
+// ── Conditions ──────────────────────────────────────────────────────
+
+/// Succeeds if health is below `threshold` (absolute HP, not fraction).
+pub struct IsHealthLow {
+    pub threshold: f32,
+}
+
+impl<O, A> BehaviorNode<O, BehaviorContext<'_>, A> for IsHealthLow
+where
+    O: Healthed + Send + Sync,
+    A: Send + Sync,
+{
+    fn evaluate(&self, observation: &O, _ctx: &mut BehaviorContext<'_>) -> (NodeStatus, Vec<A>) {
+        if observation.current_health() < self.threshold {
+            (NodeStatus::Success, vec![])
+        } else {
+            (NodeStatus::Failure, vec![])
+        }
+    }
+}
+
+/// Succeeds if any hostile entity is within the observation's nearby list.
+pub struct HasHostileNearby;
+
+impl<O, A> BehaviorNode<O, BehaviorContext<'_>, A> for HasHostileNearby
+where
+    O: Aware + Send + Sync,
+    A: Send + Sync,
+{
+    fn evaluate(&self, observation: &O, _ctx: &mut BehaviorContext<'_>) -> (NodeStatus, Vec<A>) {
+        if observation.nearby_entities().iter().any(|e| e.is_hostile) {
+            (NodeStatus::Success, vec![])
+        } else {
+            (NodeStatus::Failure, vec![])
+        }
+    }
+}
+
+// ── Actions (closure-driven) ────────────────────────────────────────
+
+/// Wander randomly within `radius` of the current position.
+///
+/// The caller supplies `make_move` — a closure that turns a target
+/// position into the game's action type.
+pub struct Wander<F> {
+    pub radius: f64,
+    pub make_move: F,
+}
+
+impl<O, A, F> BehaviorNode<O, BehaviorContext<'_>, A> for Wander<F>
+where
+    O: Positioned + Ticked + Send + Sync,
+    A: Send + Sync,
+    F: Fn([f64; 3], f64) -> A + Send + Sync,
+{
+    fn evaluate(&self, observation: &O, _ctx: &mut BehaviorContext<'_>) -> (NodeStatus, Vec<A>) {
+        let [x, y, z] = observation.position();
+        let angle = (observation.tick() as f64 * 0.1) % std::f64::consts::TAU;
+        let target = [
+            x + angle.cos() * self.radius,
+            y,
+            z + angle.sin() * self.radius,
+        ];
+        (NodeStatus::Success, vec![(self.make_move)(target, 1.0)])
+    }
+}
+
+/// Flee from the nearest hostile entity.
+///
+/// `make_move` converts (target_pos, speed) into the game's action type.
+pub struct Flee<F> {
+    pub flee_distance: f64,
+    pub make_move: F,
+}
+
+impl<O, A, F> BehaviorNode<O, BehaviorContext<'_>, A> for Flee<F>
+where
+    O: Positioned + Aware + Send + Sync,
+    A: Send + Sync,
+    F: Fn([f64; 3], f64) -> A + Send + Sync,
+{
+    fn evaluate(&self, observation: &O, _ctx: &mut BehaviorContext<'_>) -> (NodeStatus, Vec<A>) {
+        let pos = observation.position();
+        let nearest_hostile = observation
+            .nearby_entities()
+            .iter()
+            .filter(|e| e.is_hostile)
+            .min_by(|a, b| {
+                let da = dist_sq(&pos, &a.position);
+                let db = dist_sq(&pos, &b.position);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        let Some(hostile) = nearest_hostile else {
+            return (NodeStatus::Failure, vec![]);
+        };
+
+        let [nx, ny, nz] = pos;
+        let [hx, _hy, hz] = hostile.position;
+        let dx = nx - hx;
+        let dz = nz - hz;
+        let dist = (dx * dx + dz * dz).sqrt().max(0.001);
+        let target = [
+            nx + (dx / dist) * self.flee_distance,
+            ny,
+            nz + (dz / dist) * self.flee_distance,
+        ];
+
+        (NodeStatus::Success, vec![(self.make_move)(target, 1.4)])
+    }
+}
+
+/// Attack the nearest hostile entity within `range`.
+///
+/// `make_attack` converts a target entity_id into the game's action type.
+pub struct AttackNearest<F> {
+    pub range: f64,
+    pub make_attack: F,
+}
+
+impl<O, A, F> BehaviorNode<O, BehaviorContext<'_>, A> for AttackNearest<F>
+where
+    O: Positioned + Aware + Send + Sync,
+    A: Send + Sync,
+    F: Fn(u64) -> A + Send + Sync,
+{
+    fn evaluate(&self, observation: &O, _ctx: &mut BehaviorContext<'_>) -> (NodeStatus, Vec<A>) {
+        let pos = observation.position();
+        let nearest = observation
+            .nearby_entities()
+            .iter()
+            .filter(|e| e.is_hostile)
+            .filter(|e| dist_sq(&pos, &e.position).sqrt() <= self.range)
+            .min_by(|a, b| {
+                let da = dist_sq(&pos, &a.position);
+                let db = dist_sq(&pos, &b.position);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        match nearest {
+            Some(hostile) => (
+                NodeStatus::Success,
+                vec![(self.make_attack)(hostile.entity_id)],
+            ),
+            None => (NodeStatus::Failure, vec![]),
+        }
+    }
+}
+
+/// Call for help when health drops below threshold + hostiles nearby.
+///
+/// Checks both per-NPC and global cooldowns. `make_actions` produces the
+/// game-specific commands (chat broadcast + spawn reinforcements, etc.).
+pub struct CallAllies<F> {
+    pub health_threshold: f32,
+    pub make_actions: F,
+}
+
+impl<O, A, F> BehaviorNode<O, BehaviorContext<'_>, A> for CallAllies<F>
+where
+    O: Healthed + Aware + Send + Sync,
+    A: Send + Sync,
+    F: Fn() -> Vec<A> + Send + Sync,
+{
+    fn evaluate(&self, observation: &O, ctx: &mut BehaviorContext<'_>) -> (NodeStatus, Vec<A>) {
+        let has_hostiles = observation.nearby_entities().iter().any(|e| e.is_hostile);
+
+        if !has_hostiles || observation.current_health() >= self.health_threshold {
+            return (NodeStatus::Failure, vec![]);
+        }
+
+        let tick = ctx.current_tick;
+        if !ctx.per_npc.can_fire(tick) || !ctx.global.can_fire(tick) {
+            return (NodeStatus::Failure, vec![]);
+        }
+
+        ctx.per_npc.mark_fired(tick);
+        ctx.global.mark_fired(tick);
+
+        (NodeStatus::Success, (self.make_actions)())
+    }
+}

--- a/packages/rust/bevy/bevy_behavior/src/tree/mod.rs
+++ b/packages/rust/bevy/bevy_behavior/src/tree/mod.rs
@@ -1,0 +1,82 @@
+//! Core behavior tree trait and composite nodes.
+//!
+//! Everything here is generic over `O` (observation), `C` (context), and
+//! `A` (action) so games can plug in their own types without touching this
+//! crate.
+
+mod builtin;
+
+pub use builtin::*;
+
+/// Result of evaluating a single behavior tree node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeStatus {
+    /// The node completed its goal.
+    Success,
+    /// The node cannot achieve its goal right now.
+    Failure,
+    /// The node is mid-execution and should be re-evaluated next tick.
+    Running,
+}
+
+/// A single node in a behavior tree.
+///
+/// Generic over:
+/// - `O` — observation (immutable snapshot the NPC sees)
+/// - `C` — context (mutable per-evaluation state: cooldowns, tick, etc.)
+/// - `A` — action/command the NPC wants to execute
+pub trait BehaviorNode<O, C, A>: Send + Sync {
+    fn evaluate(&self, observation: &O, ctx: &mut C) -> (NodeStatus, Vec<A>);
+}
+
+/// Runs children in order until one succeeds (OR / fallback).
+///
+/// Returns the status + commands of the first child that doesn't fail.
+/// If every child fails, the selector itself fails.
+pub struct Selector<O, C, A> {
+    pub children: Vec<Box<dyn BehaviorNode<O, C, A>>>,
+}
+
+impl<O, C, A> BehaviorNode<O, C, A> for Selector<O, C, A>
+where
+    O: Send + Sync,
+    C: Send + Sync,
+    A: Send + Sync,
+{
+    fn evaluate(&self, observation: &O, ctx: &mut C) -> (NodeStatus, Vec<A>) {
+        for child in &self.children {
+            let (status, commands) = child.evaluate(observation, ctx);
+            if status != NodeStatus::Failure {
+                return (status, commands);
+            }
+        }
+        (NodeStatus::Failure, vec![])
+    }
+}
+
+/// Runs children in order until one fails (AND / sequence).
+///
+/// Accumulates commands from all successful children. Returns failure
+/// (plus whatever was accumulated so far) as soon as one child fails.
+pub struct Sequence<O, C, A> {
+    pub children: Vec<Box<dyn BehaviorNode<O, C, A>>>,
+}
+
+impl<O, C, A> BehaviorNode<O, C, A> for Sequence<O, C, A>
+where
+    O: Send + Sync,
+    C: Send + Sync,
+    A: Send + Sync,
+{
+    fn evaluate(&self, observation: &O, ctx: &mut C) -> (NodeStatus, Vec<A>) {
+        let mut all_commands = Vec::new();
+        for child in &self.children {
+            let (status, commands) = child.evaluate(observation, ctx);
+            all_commands.extend(commands);
+            if status != NodeStatus::Success {
+                return (status, all_commands);
+            }
+        }
+        (NodeStatus::Success, all_commands)
+    }
+}


### PR DESCRIPTION
## Summary

New crate: `packages/rust/bevy/bevy_behavior/` — the game-agnostic behavior tree engine that will unify skeleton AI logic across Minecraft, Bevy Isometric, Discord MUD, and Unity.

### What's in the crate

| Module | Contents |
|---|---|
| `tree` | `BehaviorNode<O,C,A>` trait (generic over observation/context/action), `Selector` (OR), `Sequence` (AND), `NodeStatus` |
| `cooldown` | `CooldownState` trait, `TickCooldown` (first-fire-free via `Option<u64>`), `BehaviorContext` (per-NPC + global cooldown borrows) |
| `observation` | Traits: `Positioned`, `Healthed`, `Aware`, `Ticked`; `EntitySnapshot` struct; `dist_sq` helper |
| `tree::builtin` | `IsHealthLow`, `HasHostileNearby`, `Wander`, `Flee`, `AttackNearest`, `CallAllies` — all closure-driven so each game supplies its own command type |

### Design decisions

- **Generic `BehaviorNode<O, C, A>`** rather than the current MC-hardwired `BehaviorNode` that takes `NpcObservation` + `NpcCommand` directly. Each game implements the observation traits on its own snapshot struct and passes its own action enum. The tree engine doesn't know what game it's driving.
- **Optional `bevy` feature** — without it, the crate is pure Rust. This lets the Discord MUD (Tokio-only, no Bevy ECS) use the same tree engine.
- **Closure-driven leaves** — `Wander`, `Flee`, `AttackNearest` take factory closures (`make_move`, `make_attack`) instead of constructing MC-specific `NpcCommand` variants. Each game maps (target, speed) → its own move command.

### Relationship to existing crates

```
bevy_behavior (NEW — this PR)
    ↑ imported by
behavior_statetree (MC bridge — future refactor PR)
bevy_battle (Isometric — future integration)
discordsh-bot (Discord MUD — future integration)
uniti (Unity FFI — future integration)
```

`bevy_npc` (proto NPC definitions) and `bevy_pathfinding` (flow fields) remain separate concerns — `bevy_behavior` is the tree engine only.

## Test plan

- [x] `cargo check -p bevy_behavior` — zero warnings
- [x] `cargo test -p bevy_behavior` — `tick_cooldown_respects_interval` passes
- [ ] Follow-up PR: refactor `behavior_statetree` to depend on `bevy_behavior` and delete its duplicated tree engine