### PR TITLE
feat(legal): add MIT, Apache-2.0, GPL-3.0 license pages and update EULA

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/legal/apache-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/apache-2.mdx
@@ -1,0 +1,231 @@
+---
+title: Apache License 2.0
+description: The Apache License 2.0 as used by open-source components within the KBVE monorepo.
+sidebar:
+    label: Apache 2.0
+    order: 11
+tags:
+    - legal
+    - license
+    - apache
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Apache License, Version 2.0
+
+<Aside type="note" title="Scope">
+  This license applies to KBVE monorepo components explicitly marked with an
+  Apache-2.0 license header or that reference this document in their
+  `Cargo.toml`, `package.json`, or source file headers. Some Rust crates in
+  this monorepo are dual-licensed under MIT OR Apache-2.0 to match the broader
+  Rust ecosystem convention. See the [EULA](/legal/eula/) for the proprietary
+  application license.
+</Aside>
+
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work.
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by the Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding any notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+Copyright (c) 2024-2026 KBVE Holdings LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+### What this means
+
+The Apache License 2.0 is a permissive open-source license that allows free use,
+modification, and distribution. It additionally provides an express grant of
+patent rights from contributors and requires that modified files carry prominent
+notices. Unlike the MIT License, Apache 2.0 includes explicit patent protection
+and trademark use restrictions.
+
+### Dual licensing (MIT OR Apache-2.0)
+
+Many Rust crates in this monorepo are dual-licensed under `MIT OR Apache-2.0`,
+following the convention established by the Rust standard library and most of
+the Rust ecosystem. Users may choose either license at their discretion.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/eula.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/eula.mdx
@@ -97,6 +97,28 @@ The Application, including without limitation all copyrights, patents, trademark
 
 The Company shall not be obligated to indemnify or defend You with respect to any third party claim arising out of or relating to the Application. To the extent the Company is required to provide indemnification by applicable law, the Company, not the Application Store, shall be solely responsible for the investigation, defense, settlement and discharge of any claim that the Application or your use of it infringes any third party intellectual property rights.
 
+## Open-Source Components
+
+The Application may include or depend on open-source software components that
+are licensed under their own terms, separate from this Agreement. Where an
+open-source component's license conflicts with this EULA, the open-source
+license governs solely for that component.
+
+The following open-source licenses may apply to components within the KBVE
+monorepo and distributed applications:
+
+-   [MIT License](/legal/mit/) — permissive; allows use, modification, and redistribution with attribution.
+-   [Apache License 2.0](/legal/apache-2/) — permissive with patent grant; allows use, modification, and redistribution.
+-   [GNU General Public License v3.0](/legal/gpl-3/) — copyleft; derivative works must be distributed under the same license.
+
+Each component's `Cargo.toml`, `package.json`, or `LICENSE` file specifies
+which license applies. Components that do not specify a license are governed
+by this EULA. Where a distributed binary incorporates a GPL-3.0 dependency,
+the relevant source code is made available as required by that license, and
+the GPL-licensed portions are excluded from the scope of this EULA.
+
+You may review the full text of each license on the pages linked above.
+
 ## Modifications to the Application
 
 The Company reserves the right to modify, suspend or discontinue, temporarily or permanently, the Application or any service to which it connects, with or without notice and without liability to You.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/gpl-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/gpl-3.mdx
@@ -1,0 +1,98 @@
+---
+title: GNU General Public License v3.0
+description: The GPL-3.0 license as used by open-source components within the KBVE monorepo.
+sidebar:
+    label: GPL-3.0
+    order: 12
+tags:
+    - legal
+    - license
+    - gpl
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## GNU General Public License v3.0
+
+<Aside type="caution" title="Copyleft">
+  GPL-3.0 is a copyleft license. Derivative works that link to or incorporate
+  GPL-3.0 code must also be distributed under GPL-3.0 or a compatible license.
+  This is a stronger requirement than the permissive MIT and Apache-2.0 licenses.
+  See the [EULA](/legal/eula/) for how proprietary KBVE applications interact
+  with GPL-licensed components.
+</Aside>
+
+```
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+```
+
+The full text of the GNU General Public License v3.0 is available at
+[https://www.gnu.org/licenses/gpl-3.0.en.html](https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+The preamble above is excerpted for reference. The complete license terms,
+including all 18 sections covering definitions, source code requirements,
+copyleft obligations, patent protections, and termination conditions, are
+incorporated by reference from the FSF's canonical copy.
+
+### What this means
+
+The GPL-3.0 is a copyleft license that requires anyone who distributes
+GPL-licensed code — or derivative works based on it — to make the complete
+source code available under the same license. Key provisions include:
+
+- **Freedom to use**: Run the software for any purpose
+- **Freedom to study**: Access and modify source code
+- **Freedom to share**: Distribute copies of the original
+- **Freedom to improve**: Distribute modified versions
+- **Copyleft**: Derivative works must carry the same GPL-3.0 license
+- **Patent grant**: Contributors grant patent rights for their contributions
+- **Anti-Tivoization**: Hardware restrictions that prevent users from running
+  modified versions are prohibited
+
+### Which components use GPL-3.0
+
+Components in the KBVE monorepo that incorporate GPL-3.0 licensed dependencies
+or are themselves released under GPL-3.0 include select game mods, tools, and
+plugins where the upstream dependency requires copyleft compliance. Each
+component's `Cargo.toml`, `package.json`, or `LICENSE` file specifies its
+license. When a KBVE-authored component links against a GPL-3.0 library, the
+resulting binary is distributed under GPL-3.0 terms.
+
+### Interaction with the EULA
+
+Proprietary KBVE applications covered by the [EULA](/legal/eula/) are distributed
+separately from GPL-3.0 components. Where a proprietary application incorporates
+a GPL-3.0 dependency, the relevant source code is made available as required by
+the license, and the EULA's scope explicitly excludes those GPL-licensed portions.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/index.mdx
@@ -39,6 +39,24 @@ import {
   </LinkCard>
 </CardGrid>
 
+## Open-Source Licenses
+
+The KBVE monorepo and distributed applications include open-source components
+released under the following licenses. Each component specifies its license in
+its `Cargo.toml`, `package.json`, or `LICENSE` file.
+
+<CardGrid>
+  <LinkCard href="/legal/mit" title="MIT License" icon="open-book">
+    Permissive license allowing use, modification, and redistribution with attribution.
+  </LinkCard>
+  <LinkCard href="/legal/apache-2" title="Apache License 2.0" icon="open-book">
+    Permissive license with an express patent grant and trademark protections.
+  </LinkCard>
+  <LinkCard href="/legal/gpl-3" title="GPL-3.0" icon="open-book">
+    Copyleft license requiring derivative works to carry the same license.
+  </LinkCard>
+</CardGrid>
+
 
 <Aside type="note" title="Important">
   Please read each document carefully to fully understand your rights and obligations.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/mit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/mit.mdx
@@ -1,0 +1,61 @@
+---
+title: MIT License
+description: The MIT License as used by open-source components within the KBVE monorepo.
+sidebar:
+    label: MIT License
+    order: 10
+tags:
+    - legal
+    - license
+    - mit
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## MIT License
+
+<Aside type="note" title="Scope">
+  This license applies to KBVE monorepo components explicitly marked with an MIT
+  license header or that reference this document in their `Cargo.toml`,
+  `package.json`, or source file headers. See the [EULA](/legal/eula/) for the
+  proprietary application license and how it interacts with open-source components.
+</Aside>
+
+```
+MIT License
+
+Copyright (c) 2024-2026 KBVE Holdings LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### What this means
+
+The MIT License is a short, permissive open-source license. It allows anyone to
+use, copy, modify, merge, publish, distribute, sublicense, or sell copies of the
+licensed software, provided the original copyright notice and permission notice
+are included in all copies or substantial portions.
+
+### Which components use MIT
+
+Components in the KBVE monorepo that are released under the MIT License include
+select Bevy packages, shared utility crates, and npm packages. Each component's
+`Cargo.toml` or `package.json` specifies its license field. When a component
+does not specify a license, it falls under the [EULA](/legal/eula/) by default.


### PR DESCRIPTION
## Summary
- Adds 3 new license reference pages under `/legal/`:
  - **MIT License** (`/legal/mit/`) — full text + scope explanation
  - **Apache License 2.0** (`/legal/apache-2/`) — full text + dual-licensing note for Rust crates
  - **GPL-3.0** (`/legal/gpl-3/`) — preamble + FSF canonical reference + copyleft explanation
- Updates the **EULA** with a new "Open-Source Components" section that:
  - Links to each license page
  - Scopes open-source licenses to their respective components
  - Sets the EULA as fallback for components without a specified license
  - Clarifies that GPL-3.0 portions are excluded from EULA scope
- Updates the **legal index** with an "Open-Source Licenses" card grid

## Why
The monorepo ships Rust crates (MIT/Apache-2.0), Fabric mods (potentially GPL deps), and npm packages under various licenses. Having canonical reference pages on kbve.com and scoping them in the EULA ensures compliance and makes it clear which license governs which component.

## Test plan
- [x] Build passes clean (5364 pages, no errors)
- [ ] Verify `/legal/mit/`, `/legal/apache-2/`, `/legal/gpl-3/` render correctly
- [ ] Verify `/legal/eula/` shows the new Open-Source Components section
- [ ] Verify `/legal/` index shows the new license card grid