### PR TITLE
feat(legal): add BSD, ISC, MPL, LGPL, CC, and Unlicense reference pages

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/legal/bsd-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/bsd-2.mdx
@@ -1,0 +1,63 @@
+---
+title: BSD 2-Clause License
+description: The BSD 2-Clause "Simplified" License as referenced by dependencies within the KBVE monorepo.
+sidebar:
+    label: BSD 2-Clause
+    order: 13
+tags:
+    - legal
+    - license
+    - bsd
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## BSD 2-Clause "Simplified" License
+
+<Aside type="note" title="Scope">
+  This page is a reference for third-party dependencies and components that use
+  the BSD 2-Clause License. It does not apply to KBVE-authored code unless
+  explicitly stated in a component's license file.
+</Aside>
+
+```
+BSD 2-Clause License
+
+Copyright (c) <year>, <copyright holder>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### What this means
+
+The BSD 2-Clause License is a minimal permissive license with only two
+conditions: retain the copyright notice in source distributions and reproduce it
+in binary distributions. There are no patent grant provisions and no restriction
+on use of the licensor's name for endorsement (unlike BSD 3-Clause).
+
+### Where this applies
+
+Common in C/C++ libraries, system-level dependencies, and cryptographic tooling
+(e.g., OpenSSL derivatives, libc wrappers). When the KBVE monorepo depends on a
+BSD-2-Clause library, the binary distribution includes the required copyright
+notice in its attribution.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/bsd-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/bsd-3.mdx
@@ -1,0 +1,66 @@
+---
+title: BSD 3-Clause License
+description: The BSD 3-Clause "New" or "Revised" License as referenced by dependencies within the KBVE monorepo.
+sidebar:
+    label: BSD 3-Clause
+    order: 14
+tags:
+    - legal
+    - license
+    - bsd
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## BSD 3-Clause "New" or "Revised" License
+
+<Aside type="note" title="Scope">
+  This page is a reference for third-party dependencies and components that use
+  the BSD 3-Clause License. It does not apply to KBVE-authored code unless
+  explicitly stated in a component's license file.
+</Aside>
+
+```
+BSD 3-Clause License
+
+Copyright (c) <year>, <copyright holder>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### What this means
+
+The BSD 3-Clause License adds a third clause to the 2-Clause variant: the
+copyright holder's name (and contributors' names) cannot be used to endorse or
+promote derived products without explicit written permission. This is the
+"no-endorsement" clause.
+
+### Where this applies
+
+Common in scientific computing libraries, networking stacks, and game engine
+dependencies. The additional clause prevents implying official endorsement
+when redistributing modified versions.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-4.mdx
@@ -1,0 +1,48 @@
+---
+title: Creative Commons Attribution 4.0
+description: The CC BY 4.0 License as referenced for assets and documentation within the KBVE monorepo.
+sidebar:
+    label: CC BY 4.0
+    order: 18
+tags:
+    - legal
+    - license
+    - creative-commons
+    - assets
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+<Aside type="note" title="Scope">
+  CC BY 4.0 applies to non-code assets: documentation, textures, sprites,
+  schematics, 3D models, audio, and other creative works. It does not typically
+  apply to source code — use [MIT](/legal/mit/) or [Apache-2.0](/legal/apache-2/)
+  for code.
+</Aside>
+
+The full legal text is available at
+[https://creativecommons.org/licenses/by/4.0/legalcode](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+### You are free to
+
+- **Share** — copy and redistribute the material in any medium or format for any purpose, including commercially.
+- **Adapt** — remix, transform, and build upon the material for any purpose, including commercially.
+
+### Under the following terms
+
+- **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+- **No additional restrictions** — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+### Where this applies
+
+CC BY 4.0 is used for:
+- Game textures and sprite sheets (tilesets, character art, UI elements)
+- WorldEdit schematics and map templates
+- Documentation and wiki content contributed by the community
+- Audio assets and sound effects
+
+Each asset specifies its license in an accompanying `LICENSE` file or in the
+asset's metadata. Assets without a specified license fall under the
+[EULA](/legal/eula/) by default.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-sa-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/cc-by-sa-4.mdx
@@ -1,0 +1,48 @@
+---
+title: Creative Commons Attribution-ShareAlike 4.0
+description: The CC BY-SA 4.0 License as referenced for assets and community content within the KBVE monorepo.
+sidebar:
+    label: CC BY-SA 4.0
+    order: 19
+tags:
+    - legal
+    - license
+    - creative-commons
+    - assets
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+
+<Aside type="caution" title="ShareAlike">
+  CC BY-SA 4.0 adds a copyleft-like "ShareAlike" requirement to CC BY 4.0.
+  If you remix, transform, or build upon the material, you must distribute your
+  contributions under the same CC BY-SA 4.0 license (or a compatible one).
+</Aside>
+
+The full legal text is available at
+[https://creativecommons.org/licenses/by-sa/4.0/legalcode](https://creativecommons.org/licenses/by-sa/4.0/legalcode).
+
+### You are free to
+
+- **Share** — copy and redistribute the material in any medium or format for any purpose, including commercially.
+- **Adapt** — remix, transform, and build upon the material for any purpose, including commercially.
+
+### Under the following terms
+
+- **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made.
+- **ShareAlike** — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+- **No additional restrictions** — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+### Where this applies
+
+CC BY-SA 4.0 is used for community-contributed content where modifications
+should stay open:
+- Community wiki pages and guides
+- Shared building schematics contributed by players
+- Collaborative documentation and tutorials
+- Mod configuration templates shared across the community
+
+The ShareAlike clause ensures that improvements and derivatives remain freely
+available to the community under the same terms.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/eula.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/eula.mdx
@@ -107,15 +107,35 @@ license governs solely for that component.
 The following open-source licenses may apply to components within the KBVE
 monorepo and distributed applications:
 
--   [MIT License](/legal/mit/) — permissive; allows use, modification, and redistribution with attribution.
--   [Apache License 2.0](/legal/apache-2/) — permissive with patent grant; allows use, modification, and redistribution.
--   [GNU General Public License v3.0](/legal/gpl-3/) — copyleft; derivative works must be distributed under the same license.
+**Permissive licenses** — allow use, modification, and redistribution with minimal conditions:
+
+-   [MIT License](/legal/mit/) — attribution required.
+-   [Apache License 2.0](/legal/apache-2/) — attribution + express patent grant.
+-   [BSD 2-Clause](/legal/bsd-2/) — attribution in source and binary distributions.
+-   [BSD 3-Clause](/legal/bsd-3/) — attribution + no-endorsement clause.
+-   [ISC License](/legal/isc/) — functionally equivalent to MIT, common in npm ecosystem.
+
+**Copyleft licenses** — require derivative works or modifications to carry the same license:
+
+-   [GNU General Public License v3.0](/legal/gpl-3/) — full copyleft; derivative works must be GPL-3.0.
+-   [GNU Lesser General Public License v3.0](/legal/lgpl-3/) — weak copyleft; linking exception for proprietary code.
+-   [Mozilla Public License 2.0](/legal/mpl-2/) — file-level copyleft; modified files must stay MPL-2.0.
+
+**Creative Commons licenses** — for non-code assets (textures, documentation, schematics, audio):
+
+-   [CC BY 4.0](/legal/cc-by-4/) — share and adapt with attribution.
+-   [CC BY-SA 4.0](/legal/cc-by-sa-4/) — share and adapt with attribution + ShareAlike.
+
+**Public domain dedications** — no conditions whatsoever:
+
+-   [The Unlicense / CC0](/legal/unlicense/) — waives all copyright; no attribution required.
 
 Each component's `Cargo.toml`, `package.json`, or `LICENSE` file specifies
 which license applies. Components that do not specify a license are governed
-by this EULA. Where a distributed binary incorporates a GPL-3.0 dependency,
-the relevant source code is made available as required by that license, and
-the GPL-licensed portions are excluded from the scope of this EULA.
+by this EULA. Where a distributed binary incorporates a copyleft dependency
+(GPL-3.0, LGPL-3.0, or MPL-2.0), the relevant source code is made available
+as required by that license, and the copyleft-licensed portions are excluded
+from the scope of this EULA.
 
 You may review the full text of each license on the pages linked above.
 

--- a/apps/kbve/astro-kbve/src/content/docs/legal/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/index.mdx
@@ -47,13 +47,37 @@ its `Cargo.toml`, `package.json`, or `LICENSE` file.
 
 <CardGrid>
   <LinkCard href="/legal/mit" title="MIT License" icon="open-book">
-    Permissive license allowing use, modification, and redistribution with attribution.
+    Permissive — use, modify, redistribute with attribution.
   </LinkCard>
   <LinkCard href="/legal/apache-2" title="Apache License 2.0" icon="open-book">
-    Permissive license with an express patent grant and trademark protections.
+    Permissive — patent grant + trademark protections.
+  </LinkCard>
+  <LinkCard href="/legal/bsd-2" title="BSD 2-Clause" icon="open-book">
+    Permissive — minimal conditions, attribution only.
+  </LinkCard>
+  <LinkCard href="/legal/bsd-3" title="BSD 3-Clause" icon="open-book">
+    Permissive — attribution + no-endorsement clause.
+  </LinkCard>
+  <LinkCard href="/legal/isc" title="ISC License" icon="open-book">
+    Permissive — MIT-equivalent, common in npm ecosystem.
   </LinkCard>
   <LinkCard href="/legal/gpl-3" title="GPL-3.0" icon="open-book">
-    Copyleft license requiring derivative works to carry the same license.
+    Copyleft — derivative works must carry the same license.
+  </LinkCard>
+  <LinkCard href="/legal/lgpl-3" title="LGPL-3.0" icon="open-book">
+    Weak copyleft — linking exception for proprietary code.
+  </LinkCard>
+  <LinkCard href="/legal/mpl-2" title="MPL-2.0" icon="open-book">
+    File-level copyleft — modified files stay MPL-2.0.
+  </LinkCard>
+  <LinkCard href="/legal/cc-by-4" title="CC BY 4.0" icon="open-book">
+    Creative Commons — share and adapt assets with attribution.
+  </LinkCard>
+  <LinkCard href="/legal/cc-by-sa-4" title="CC BY-SA 4.0" icon="open-book">
+    Creative Commons — attribution + ShareAlike for derivatives.
+  </LinkCard>
+  <LinkCard href="/legal/unlicense" title="Unlicense / CC0" icon="open-book">
+    Public domain — no conditions, no attribution required.
   </LinkCard>
 </CardGrid>
 

--- a/apps/kbve/astro-kbve/src/content/docs/legal/isc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/isc.mdx
@@ -1,0 +1,54 @@
+---
+title: ISC License
+description: The ISC License as referenced by dependencies within the KBVE monorepo.
+sidebar:
+    label: ISC
+    order: 15
+tags:
+    - legal
+    - license
+    - isc
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## ISC License
+
+<Aside type="note" title="Scope">
+  This page is a reference for third-party dependencies and components that use
+  the ISC License. It does not apply to KBVE-authored code unless explicitly
+  stated in a component's license file.
+</Aside>
+
+```
+ISC License
+
+Copyright (c) <year>, <copyright holder>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+```
+
+### What this means
+
+The ISC License is functionally equivalent to the MIT License but with simpler
+language. It permits use, copying, modification, and distribution with or
+without fee, requiring only that the copyright notice and permission notice
+appear in all copies.
+
+### Where this applies
+
+The ISC License is the default license for npm packages and is used extensively
+in the Node.js ecosystem. Many transitive npm dependencies in the KBVE monorepo
+carry this license (e.g., semver, glob, minimatch, and hundreds of small
+utility packages).

--- a/apps/kbve/astro-kbve/src/content/docs/legal/lgpl-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/lgpl-3.mdx
@@ -1,0 +1,47 @@
+---
+title: GNU Lesser General Public License v3.0
+description: The LGPL-3.0 License as referenced by dependencies within the KBVE monorepo.
+sidebar:
+    label: LGPL-3.0
+    order: 17
+tags:
+    - legal
+    - license
+    - lgpl
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## GNU Lesser General Public License v3.0
+
+<Aside type="caution" title="Weak Copyleft">
+  LGPL-3.0 allows proprietary software to **link** against LGPL-licensed
+  libraries without the proprietary code becoming GPL-licensed. However,
+  modifications to the LGPL library itself must be released under LGPL-3.0,
+  and users must be able to replace the LGPL library with a modified version.
+</Aside>
+
+The full text of the GNU Lesser General Public License v3.0 is available at
+[https://www.gnu.org/licenses/lgpl-3.0.en.html](https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+The LGPL-3.0 is defined as an additional set of permissions on top of the
+[GPL-3.0](/legal/gpl-3/). It inherits all GPL-3.0 terms and adds exceptions
+for linking.
+
+### What this means
+
+The LGPL-3.0 is a weak copyleft license designed for libraries. Key provisions:
+
+- **Linking exception**: Proprietary applications can link to LGPL-3.0 libraries (statically or dynamically) without the application itself becoming GPL-licensed.
+- **Library modifications**: If you modify the LGPL library's source, the modified library must be released under LGPL-3.0.
+- **User freedom**: End users must be able to replace the LGPL library with their own modified version (typically satisfied by dynamic linking or providing object files for relinking).
+- **Patent grant**: Same as GPL-3.0 — contributors grant patent rights.
+
+### Where this applies
+
+LGPL-3.0 is common in media processing libraries (FFmpeg components, audio
+codecs), GUI toolkits, and system libraries. When the KBVE monorepo links
+against an LGPL-3.0 library, the linking exception allows the surrounding
+proprietary application to remain under the [EULA](/legal/eula/), while the
+LGPL library itself retains its copyleft obligations.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/mpl-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/mpl-2.mdx
@@ -1,0 +1,45 @@
+---
+title: Mozilla Public License 2.0
+description: The MPL-2.0 License as referenced by dependencies within the KBVE monorepo.
+sidebar:
+    label: MPL-2.0
+    order: 16
+tags:
+    - legal
+    - license
+    - mpl
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Mozilla Public License Version 2.0
+
+<Aside type="caution" title="File-Level Copyleft">
+  MPL-2.0 is a weak copyleft license. Modified **files** must remain under
+  MPL-2.0, but you can combine MPL-2.0 code with proprietary or differently
+  licensed code in the same project, provided the MPL-2.0 files stay available.
+  This is weaker than GPL (which covers the entire derivative work) but stronger
+  than MIT/Apache (which have no copyleft).
+</Aside>
+
+The full text of the Mozilla Public License 2.0 is available at
+[https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/).
+
+### What this means
+
+The MPL-2.0 is a file-level copyleft license created by Mozilla. Key provisions:
+
+- **Use, modify, distribute**: You can use, modify, and distribute MPL-2.0 code freely.
+- **File-level copyleft**: If you modify an MPL-2.0 file, the modified file must remain under MPL-2.0 and its source must be made available.
+- **Larger works**: You can combine MPL-2.0 files with files under other licenses (including proprietary) in a larger work. Only the MPL-2.0 files themselves carry the copyleft obligation.
+- **Patent grant**: Contributors grant a patent license for their contributions.
+- **GPL compatibility**: MPL-2.0 code can be relicensed under GPL-2.0+, LGPL-2.1+, or AGPL-3.0+ if needed for compatibility.
+
+### Where this applies
+
+Some Rust crates in the ecosystem use MPL-2.0 (e.g., certain crypto libraries,
+configuration parsers). When the KBVE monorepo depends on an MPL-2.0 library,
+the source of any modified MPL-2.0 files is made available as required.
+Unmodified MPL-2.0 dependencies used as-is satisfy the license by pointing to
+the upstream source repository.

--- a/apps/kbve/astro-kbve/src/content/docs/legal/unlicense.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/legal/unlicense.mdx
@@ -1,0 +1,77 @@
+---
+title: The Unlicense / CC0
+description: Public domain dedications as referenced by components and assets within the KBVE monorepo.
+sidebar:
+    label: Unlicense / CC0
+    order: 20
+tags:
+    - legal
+    - license
+    - public-domain
+    - open-source
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## The Unlicense
+
+<Aside type="note" title="Scope">
+  The Unlicense and CC0 are public domain dedications — they impose no
+  conditions whatsoever. Code or assets released under these terms can be used
+  for any purpose without attribution, modification restrictions, or copyleft
+  obligations.
+</Aside>
+
+```
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>
+```
+
+---
+
+## Creative Commons Zero (CC0 1.0)
+
+CC0 is the Creative Commons equivalent for non-code works (data, documentation,
+assets). It is a public domain dedication with a fallback permissive license for
+jurisdictions that do not recognize public domain dedications.
+
+The full legal text is available at
+[https://creativecommons.org/publicdomain/zero/1.0/legalcode](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### What this means
+
+Both the Unlicense and CC0 waive all copyright interest. There are:
+- **No attribution requirements**
+- **No copyleft obligations**
+- **No restrictions on use, modification, or redistribution**
+- **No patent grants** (unlike Apache-2.0)
+
+### Where this applies
+
+Public domain dedications are used for:
+- Utility code snippets and boilerplate
+- Data files, lookup tables, and configuration templates
+- Sample code and educational examples
+- Assets explicitly donated to the public domain by contributors


### PR DESCRIPTION
## Summary
Extends the legal section with 8 additional license reference pages, bringing the total to 11 licenses documented on kbve.com. These are reference pages — they don't apply everywhere, they exist so any component can point to the canonical text when specifying its license.

## New pages

| Page | License | Type |
|------|---------|------|
| `/legal/bsd-2/` | BSD 2-Clause "Simplified" | Permissive |
| `/legal/bsd-3/` | BSD 3-Clause "New/Revised" | Permissive |
| `/legal/isc/` | ISC License | Permissive |
| `/legal/mpl-2/` | Mozilla Public License 2.0 | File-level copyleft |
| `/legal/lgpl-3/` | GNU Lesser GPL v3.0 | Weak copyleft |
| `/legal/cc-by-4/` | Creative Commons Attribution 4.0 | Assets/docs |
| `/legal/cc-by-sa-4/` | CC Attribution-ShareAlike 4.0 | Assets/docs (ShareAlike) |
| `/legal/unlicense/` | The Unlicense + CC0 | Public domain |

## Updated pages
- **EULA** — Open-Source Components section now categorizes all 11 licenses by type (permissive, copyleft, Creative Commons, public domain)
- **Legal index** — card grid expanded with all 11 license entries

## Test plan
- [x] Build passes clean
- [ ] Verify all 8 new routes render correctly
- [ ] Verify EULA shows updated categorized license list
- [ ] Verify legal index card grid shows all 11 licenses