### PR TITLE
feat(bevy_chat): add ffi feature for JNI/C# consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ version = "1.0.16"
 dependencies = [
  "bevy",
  "bevy_behavior",
+ "bevy_chat",
  "bevy_npc",
  "bevy_pathfinding",
  "crossbeam-channel",

--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -147,6 +147,28 @@ spec:
                               # pick up a seed change.
                               - name: SEED
                                 value: '-4470905440626961808'
+                              # IRC / chat bridge (bevy_chat via JNI). The
+                              # behavior_statetree mod reads these at server
+                              # start and emits world events (player death,
+                              # boss kill, etc.) to #world-events. Unset
+                              # IRC_HOST disables the bridge entirely — the
+                              # mod degrades to a no-op and MC continues to
+                              # work normally. IRC_PASSWORD is intentionally
+                              # omitted for now; ergo's force-nick-equals-account
+                              # lets us reserve the "mc-server" nick on first
+                              # connect, and a sealed secret can be layered in
+                              # later once service-account provisioning is
+                              # formalised.
+                              - name: IRC_HOST
+                                value: 'ergo-irc-service.irc.svc.cluster.local'
+                              - name: IRC_PORT
+                                value: '6667'
+                              - name: IRC_TLS
+                                value: 'false'
+                              - name: IRC_NICK
+                                value: 'mc-server'
+                              - name: IRC_CHANNELS
+                                value: '#world-events'
                           resources:
                               requests:
                                   memory: 2Gi

--- a/apps/mc/behavior_statetree/Cargo.toml
+++ b/apps/mc/behavior_statetree/Cargo.toml
@@ -47,3 +47,8 @@ bevy_pathfinding = { path = "../../../packages/rust/bevy/bevy_pathfinding" }
 # (archetype, flow field) stay local; the generic engine is shared.
 bevy_behavior = { path = "../../../packages/rust/bevy/bevy_behavior" }
 
+# Chat bridge — IRC client exposed via C-FFI so JNI can drive it
+# (kbve_chat_connect / send / poll / disconnect). Pulls in the ffi
+# feature which activates extern "C" entry points.
+bevy_chat = { path = "../../../packages/rust/bevy/bevy_chat", features = ["ffi"] }
+

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
@@ -1,5 +1,6 @@
 package com.kbve.statetree;
 
+import com.kbve.statetree.chat.McChatEvents;
 import com.kbve.statetree.ship.ShipCommands;
 import com.kbve.statetree.ship.ShipEntityTypes;
 import com.kbve.statetree.ship.ShipManager;
@@ -74,6 +75,12 @@ public class BehaviorStateTreeMod implements ModInitializer {
         });
 
         LOGGER.info("[{}] Ship system registered (entity-based, BBModel rendered)", MOD_ID);
+
+        // MC ↔ IRC chat bridge. Safe to call before checking
+        // NativeRuntime.isLoaded — ChatBridge degrades to a no-op handle
+        // when IRC_HOST is unset or the connect call fails.
+        McChatEvents.register();
+        LOGGER.info("[{}] Chat bridge wired (env-gated)", MOD_ID);
 
         if (!NativeRuntime.isLoaded()) {
             LOGGER.error("[{}] Native library not loaded — NPC AI disabled (ships still work)", MOD_ID);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ChatBridge.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ChatBridge.java
@@ -1,0 +1,94 @@
+package com.kbve.statetree;
+
+/**
+ * JNI bridge to the Rust {@code bevy_chat} IRC client, wrapped via the
+ * {@code ffi} feature of the shared {@code bevy_chat} crate.
+ *
+ * <p>The native library that hosts these symbols is the same
+ * {@code behavior_statetree} cdylib loaded by {@link NativeRuntime}. Its
+ * static initializer runs first (by class-loading order) and takes care of
+ * extracting and {@code System.load()}-ing the shared library, so this
+ * class only needs to reference it to guarantee load order. We do NOT
+ * call {@code System.load} a second time — the JVM only needs one handle.
+ *
+ * <p>This class is thread-safe. The opaque handle is just a native pointer
+ * (cast to {@code long}); all the locking is done in Rust.
+ *
+ * <h2>Lifecycle</h2>
+ * <pre>
+ *   long h = ChatBridge.connect("ergo-irc-service.irc.svc.cluster.local",
+ *                               6667, false, "mc-server",
+ *                               System.getenv("IRC_PASSWORD"),
+ *                               "#world-events");
+ *   if (h == 0) throw new RuntimeException("IRC connect failed");
+ *
+ *   ChatBridge.send(h, "kill", "Steve", "minecraft", "#world-events",
+ *                   "Steve slew the Ender Dragon", "{\"boss\":\"Ender Dragon\"}");
+ *
+ *   // ... later, on server stop:
+ *   ChatBridge.disconnect(h);
+ * </pre>
+ */
+public final class ChatBridge {
+
+    // Force-load NativeRuntime so the shared library is available before
+    // any of these natives are linked. The JVM resolves native methods
+    // lazily on first call, so this just guarantees load order.
+    static {
+        @SuppressWarnings("unused")
+        Class<?> _init = NativeRuntime.class;
+    }
+
+    private ChatBridge() {}
+
+    /**
+     * Connect to an IRC server and return an opaque handle.
+     *
+     * @param host IRC server hostname or IP
+     * @param port typically 6667 (plain) or 6697 (TLS)
+     * @param tls if true, use TLS
+     * @param nick registered nickname (must match account if ergo enforces
+     *             {@code force-nick-equals-account})
+     * @param password server password (PASS), or null/empty for none
+     * @param channels comma-separated channel list, e.g. "#world-events,#global"
+     * @return opaque handle (nonzero) on success, {@code 0} on failure
+     */
+    public static native long connect(String host, int port, boolean tls,
+                                       String nick, String password, String channels);
+
+    /**
+     * Send a structured chat message.
+     *
+     * @param handle handle from {@link #connect}
+     * @param kind one of "chat", "system", "kill", "rare_drop", "capture",
+     *             "quest_complete", "area_unlocked", "death", "craft", or any
+     *             custom string (emitted as {@code EVENT:<UPPER>})
+     * @param sender display name (player, NPC, or "System")
+     * @param platform source platform, e.g. "minecraft"
+     * @param channel IRC channel, e.g. "#world-events"
+     * @param content human-readable message
+     * @param payloadJson optional JSON object as a string, or null
+     * @return true on success; false on bad args or transport error
+     */
+    public static native boolean send(long handle, String kind, String sender,
+                                       String platform, String channel,
+                                       String content, String payloadJson);
+
+    /**
+     * Drain pending incoming messages as a JSON array.
+     *
+     * <p>Returns {@code "[]"} when the queue is empty, or null on error.
+     * Each element is a {@code ChatMessage} object:
+     * <pre>
+     *   { "kind": "chat", "sender": "...", "platform": "...",
+     *     "channel": "#global", "content": "...", "payload": {...}? }
+     * </pre>
+     */
+    public static native String poll(long handle);
+
+    /** Returns true if the underlying IRC connection is active. */
+    public static native boolean isConnected(long handle);
+
+    /** Close the connection and free the handle. Safe to call on a zero handle. */
+    public static native void disconnect(long handle);
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/chat/McChatEvents.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/chat/McChatEvents.java
@@ -1,0 +1,206 @@
+package com.kbve.statetree.chat;
+
+import com.kbve.statetree.ChatBridge;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.boss.WitherEntity;
+import net.minecraft.entity.boss.dragon.EnderDragonEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Wires MC server events to the {@link ChatBridge} IRC client.
+ *
+ * <p>All outbound events fire on {@code #world-events} with platform
+ * {@code "minecraft"}. The bridge is optional — if {@code IRC_HOST} is
+ * not set at boot, the handle stays at zero and every event becomes a
+ * no-op. This keeps MC startup independent of ergo availability.
+ *
+ * <h2>Environment variables</h2>
+ * <ul>
+ *   <li>{@code IRC_HOST} — ergo hostname, e.g.
+ *       {@code ergo-irc-service.irc.svc.cluster.local}. Unset → bridge disabled.</li>
+ *   <li>{@code IRC_PORT} — default {@code 6667}</li>
+ *   <li>{@code IRC_TLS} — {@code "true"} / {@code "1"} to enable TLS</li>
+ *   <li>{@code IRC_NICK} — default {@code mc-server}</li>
+ *   <li>{@code IRC_PASSWORD} — ergo PASS, or unset for no auth</li>
+ *   <li>{@code IRC_CHANNELS} — default {@code #world-events}</li>
+ * </ul>
+ *
+ * <h2>Emitted events</h2>
+ * <ul>
+ *   <li>{@code kill} — boss entity killed by a player</li>
+ *   <li>{@code death} — player death</li>
+ *   <li>{@code chat} (optional, future) — in-game chat relay</li>
+ * </ul>
+ */
+public final class McChatEvents {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
+    private static final String PLATFORM = "minecraft";
+    private static final String CHANNEL = "#world-events";
+
+    /** Opaque native handle. Zero means the bridge is disabled. */
+    private static final AtomicLong HANDLE = new AtomicLong(0);
+
+    private McChatEvents() {}
+
+    /**
+     * Register Fabric event listeners and (lazily) establish the IRC
+     * connection on server start. Call once from {@code onInitialize}.
+     */
+    public static void register() {
+        // Open the IRC connection when the server starts, not at class
+        // load time, so failures don't block mod boot and env vars are
+        // evaluated with the container's final environment.
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> openConnection());
+        ServerLifecycleEvents.SERVER_STOPPING.register(server -> closeConnection());
+
+        // Player death — emit on final death tick.
+        ServerLivingEntityEvents.AFTER_DEATH.register((entity, damageSource) -> {
+            if (!(entity instanceof ServerPlayerEntity player)) return;
+            String cause = damageSource.getName();
+            String name = player.getNameForScoreboard();
+            emit("death", name, name + " died to " + cause,
+                    jsonObject("cause", jsonString(cause)));
+        });
+
+        // Boss kill — Wither and Ender Dragon, attributed to the killing player.
+        ServerLivingEntityEvents.AFTER_DEATH.register((entity, damageSource) -> {
+            boolean isBoss = entity instanceof EnderDragonEntity || entity instanceof WitherEntity;
+            if (!isBoss) return;
+            if (!(damageSource.getAttacker() instanceof PlayerEntity killer)) return;
+            String killerName = killer.getNameForScoreboard();
+            String bossName = entityLabel(entity);
+            emit("kill", killerName,
+                    killerName + " slew the " + bossName,
+                    jsonObject("boss", jsonString(bossName)));
+        });
+
+        // Player join — optional welcome ping on #world-events.
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+            ServerPlayerEntity player = handler.getPlayer();
+            if (player == null) return;
+            String name = player.getNameForScoreboard();
+            emit("system", name, name + " joined Minecraft", null);
+        });
+    }
+
+    // ── Connection lifecycle ─────────────────────────────────────────
+
+    private static void openConnection() {
+        String host = System.getenv("IRC_HOST");
+        if (host == null || host.isBlank()) {
+            LOGGER.info("[chat] IRC_HOST unset — chat bridge disabled");
+            return;
+        }
+        int port = parseIntEnv("IRC_PORT", 6667);
+        boolean tls = parseBoolEnv("IRC_TLS", false);
+        String nick = envOrDefault("IRC_NICK", "mc-server");
+        String password = System.getenv("IRC_PASSWORD"); // null is fine
+        String channels = envOrDefault("IRC_CHANNELS", CHANNEL);
+
+        long handle = ChatBridge.connect(host, port, tls, nick, password, channels);
+        if (handle == 0L) {
+            LOGGER.warn("[chat] IRC connect failed (host={}:{}, nick={}) — chat bridge disabled",
+                    host, port, nick);
+            return;
+        }
+        HANDLE.set(handle);
+        LOGGER.info("[chat] Connected to IRC {}:{} as {} ({})", host, port, nick, channels);
+    }
+
+    private static void closeConnection() {
+        long h = HANDLE.getAndSet(0L);
+        if (h != 0L) {
+            ChatBridge.disconnect(h);
+            LOGGER.info("[chat] IRC disconnected");
+        }
+    }
+
+    // ── Emit helper ──────────────────────────────────────────────────
+
+    /**
+     * Send an event to IRC if the bridge is active. Failures are logged
+     * at debug level — IRC problems must not disrupt gameplay.
+     */
+    private static void emit(String kind, String sender, String content, String payloadJson) {
+        long h = HANDLE.get();
+        if (h == 0L) return;
+        try {
+            boolean ok = ChatBridge.send(h, kind, sender, PLATFORM, CHANNEL, content, payloadJson);
+            if (!ok) {
+                LOGGER.debug("[chat] send returned false (kind={}, sender={})", kind, sender);
+            }
+        } catch (Throwable t) {
+            LOGGER.debug("[chat] send threw (kind={}, sender={}): {}", kind, sender, t.getMessage());
+        }
+    }
+
+    // ── Env helpers ──────────────────────────────────────────────────
+
+    private static String envOrDefault(String key, String fallback) {
+        String v = System.getenv(key);
+        return (v == null || v.isBlank()) ? fallback : v;
+    }
+
+    private static int parseIntEnv(String key, int fallback) {
+        String v = System.getenv(key);
+        if (v == null || v.isBlank()) return fallback;
+        try {
+            return Integer.parseInt(v.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private static boolean parseBoolEnv(String key, boolean fallback) {
+        String v = System.getenv(key);
+        if (v == null) return fallback;
+        String lower = v.trim().toLowerCase();
+        return lower.equals("true") || lower.equals("1") || lower.equals("yes");
+    }
+
+    // ── Tiny JSON helpers (no dependency on a JSON lib) ──────────────
+
+    private static String jsonString(String s) {
+        if (s == null) return "null";
+        StringBuilder sb = new StringBuilder(s.length() + 2);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    /** Build a tiny single-key JSON object. Good enough for our fixed-shape payloads. */
+    private static String jsonObject(String key, String valueJson) {
+        return "{" + jsonString(key) + ":" + valueJson + "}";
+    }
+
+    private static String entityLabel(LivingEntity entity) {
+        if (entity instanceof EnderDragonEntity) return "Ender Dragon";
+        if (entity instanceof WitherEntity) return "Wither";
+        return entity.getType().getName().getString();
+    }
+}

--- a/apps/mc/behavior_statetree/src/lib.rs
+++ b/apps/mc/behavior_statetree/src/lib.rs
@@ -280,3 +280,207 @@ pub extern "system" fn Java_com_kbve_statetree_NativeRuntime_shutdown(
     // OnceLock doesn't support take(), so we let it live until JVM shutdown.
     // The channels will be dropped, causing the consumer loop to exit.
 }
+
+// ── ChatBridge JNI entry points ───────────────────────────────────────
+//
+// Thin JNI shim over `bevy_chat::ffi::kbve_chat_*`. The Java side holds
+// the opaque handle as a `long` (native pointer) and passes it back on
+// every call. Handles are per-connection — typically one per MC server
+// at mod init.
+
+use bevy_chat::ffi::{
+    ChatHandle, kbve_chat_connect, kbve_chat_disconnect, kbve_chat_is_connected, kbve_chat_poll,
+    kbve_chat_send,
+};
+use jni::sys::jlong;
+use std::ffi::CString;
+
+/// Helper: convert a Java string to a C string. Returns None on invalid UTF-8 or
+/// null reference, which the caller translates into a failure return code.
+fn jstring_to_cstring(env: &mut JNIEnv, s: &JString) -> Option<CString> {
+    if s.is_null() {
+        return None;
+    }
+    let rust_str: String = env.get_string(s).ok()?.into();
+    CString::new(rust_str).ok()
+}
+
+/// Connect to an IRC server. Returns an opaque handle encoded as a `jlong`,
+/// or `0` on failure. The handle must be freed via `disconnect`.
+///
+/// `password` and `channels` can be null / empty strings for defaults.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_statetree_ChatBridge_connect(
+    mut env: JNIEnv,
+    _class: JClass,
+    host: JString,
+    port: jni::sys::jint,
+    tls: jni::sys::jboolean,
+    nick: JString,
+    password: JString,
+    channels: JString,
+) -> jlong {
+    let host_c = match jstring_to_cstring(&mut env, &host) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let nick_c = match jstring_to_cstring(&mut env, &nick) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let channels_c = match jstring_to_cstring(&mut env, &channels) {
+        Some(c) => c,
+        None => return 0,
+    };
+    // Password is optional — empty or null both mean "no PASS".
+    let password_c = jstring_to_cstring(&mut env, &password);
+    let password_ptr = password_c
+        .as_ref()
+        .map(|c| c.as_ptr())
+        .unwrap_or(std::ptr::null());
+
+    let mut handle: *mut ChatHandle = std::ptr::null_mut();
+    let rc = unsafe {
+        kbve_chat_connect(
+            host_c.as_ptr(),
+            port as u16,
+            if tls == 0 { 0 } else { 1 },
+            nick_c.as_ptr(),
+            password_ptr,
+            channels_c.as_ptr(),
+            &mut handle,
+        )
+    };
+    if rc == 0 { handle as jlong } else { 0 }
+}
+
+/// Send a structured chat message. Returns `true` on success.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_statetree_ChatBridge_send(
+    mut env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    kind: JString,
+    sender: JString,
+    platform: JString,
+    channel: JString,
+    content: JString,
+    payload_json: JString,
+) -> jboolean {
+    if handle == 0 {
+        return 0;
+    }
+    let kind_c = match jstring_to_cstring(&mut env, &kind) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let sender_c = match jstring_to_cstring(&mut env, &sender) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let platform_c = match jstring_to_cstring(&mut env, &platform) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let channel_c = match jstring_to_cstring(&mut env, &channel) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let content_c = match jstring_to_cstring(&mut env, &content) {
+        Some(c) => c,
+        None => return 0,
+    };
+    // Payload is optional — null Java string → null C pointer.
+    let payload_c = jstring_to_cstring(&mut env, &payload_json);
+    let payload_ptr = payload_c
+        .as_ref()
+        .map(|c| c.as_ptr())
+        .unwrap_or(std::ptr::null());
+
+    let rc = unsafe {
+        kbve_chat_send(
+            handle as *mut ChatHandle,
+            kind_c.as_ptr(),
+            sender_c.as_ptr(),
+            platform_c.as_ptr(),
+            channel_c.as_ptr(),
+            content_c.as_ptr(),
+            payload_ptr,
+        )
+    };
+    if rc == 0 { 1 } else { 0 }
+}
+
+/// Drain pending incoming messages as a JSON array string. Returns null on
+/// error; returns `"[]"` if the queue is empty. Buffer sizes up adaptively.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_statetree_ChatBridge_poll(
+    env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) -> jstring {
+    if handle == 0 {
+        return std::ptr::null_mut();
+    }
+    // Grow the buffer on each ERR_BUF_TOO_SMALL until it fits. Starting at
+    // 4KiB covers typical batches; ceiling at 1MiB guards against runaway
+    // payloads on misbehaving senders.
+    let mut cap: usize = 4096;
+    let ceiling: usize = 1 << 20;
+    loop {
+        let mut buf = vec![0i8; cap];
+        let rc = unsafe {
+            kbve_chat_poll(
+                handle as *mut ChatHandle,
+                buf.as_mut_ptr() as *mut std::ffi::c_char,
+                cap,
+            )
+        };
+        if rc >= 0 {
+            let len = rc as usize;
+            let json = match std::str::from_utf8(unsafe {
+                std::slice::from_raw_parts(buf.as_ptr() as *const u8, len)
+            }) {
+                Ok(s) => s,
+                Err(_) => return std::ptr::null_mut(),
+            };
+            return match env.new_string(json) {
+                Ok(js) => js.into_raw(),
+                Err(_) => std::ptr::null_mut(),
+            };
+        }
+        if rc == -2 && cap < ceiling {
+            cap = (cap * 2).min(ceiling);
+            continue;
+        }
+        // Any other error, or buffer grew past ceiling — give up.
+        return std::ptr::null_mut();
+    }
+}
+
+/// Returns `true` if the handle is currently connected to IRC.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_statetree_ChatBridge_isConnected(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) -> jboolean {
+    if handle == 0 {
+        return 0;
+    }
+    let rc = unsafe { kbve_chat_is_connected(handle as *mut ChatHandle) };
+    if rc == 1 { 1 } else { 0 }
+}
+
+/// Close the connection and free the handle. Safe to call on a `0` handle.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_statetree_ChatBridge_disconnect(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) {
+    if handle == 0 {
+        return;
+    }
+    unsafe { kbve_chat_disconnect(handle as *mut ChatHandle) };
+}

--- a/packages/rust/bevy/bevy_chat/Cargo.toml
+++ b/packages/rust/bevy/bevy_chat/Cargo.toml
@@ -23,7 +23,7 @@ crossbeam-channel = { version = "0.5", optional = true }
 
 # Native (tokio TCP) — used by Discord bot and lightyear server
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["net", "io-util", "sync", "time", "rt"] }
+tokio = { version = "1", features = ["net", "io-util", "sync", "time", "rt", "rt-multi-thread"] }
 
 # WASM (web_sys WebSocket) — used by isometric game in browser
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -36,3 +36,7 @@ default = []
 ## Enables the Bevy plugin (`ChatPlugin`) that bridges IRC messages into ECS events.
 ## Use this in the isometric game; omit for the Discord bot (which uses `ChatClient` directly).
 plugin = ["dep:bevy", "dep:crossbeam-channel"]
+## Enables the C-FFI surface (`chat_ffi` module) for non-Rust consumers.
+## Exposes opaque-handle extern "C" functions usable from JNI (MC Fabric)
+## and csbindgen (Unity). Native-only — not available on WASM.
+ffi = []

--- a/packages/rust/bevy/bevy_chat/src/ffi.rs
+++ b/packages/rust/bevy/bevy_chat/src/ffi.rs
@@ -1,0 +1,404 @@
+//! C-FFI surface for non-Rust consumers (JNI, csbindgen, etc.).
+//!
+//! This module exposes an opaque-handle API over [`ChatClient`] that works
+//! from Java (via JNI), C# (via csbindgen), and any other language with a
+//! C calling convention.
+//!
+//! ## Design
+//!
+//! - **Opaque handle**: [`ChatHandle`] is returned as `*mut ChatHandle` and
+//!   must be freed via [`kbve_chat_disconnect`]. The caller never dereferences
+//!   it directly.
+//! - **Owned runtime**: each handle owns a multi-threaded tokio runtime so
+//!   non-async callers (Java server thread, Unity main thread) can drive it
+//!   via blocking FFI calls without needing their own async reactor.
+//! - **String contract**: all `*const c_char` inputs must be null-terminated
+//!   UTF-8. Invalid UTF-8 or null pointers return an error code, never panic.
+//! - **Message polling**: [`kbve_chat_poll`] fills a caller-provided buffer
+//!   with a JSON array of pending [`ChatMessage`]s. Caller allocates the
+//!   buffer; callee fills and null-terminates. Truncation is indicated by
+//!   a return value of `-2`.
+//! - **Thread safety**: all functions are safe to call from any thread. The
+//!   underlying [`ChatClient`] is `Send + Sync` (native only).
+//!
+//! ## Error codes
+//!
+//! | Return | Meaning |
+//! |--------|---------|
+//! |  `0`   | Success |
+//! | `-1`   | Invalid argument (null pointer, bad UTF-8, bad handle) |
+//! | `-2`   | Buffer too small (poll only) |
+//! | `-3`   | Send/connect failed (transport error) |
+//! | `-4`   | Runtime error (tokio could not be started) |
+
+use crate::{ChatClient, ChatMessage, IrcConfig, MessageKind};
+use std::ffi::{CStr, c_char};
+use std::sync::Arc;
+use std::sync::mpsc;
+use tokio::runtime::Runtime;
+use tokio::sync::broadcast;
+
+const OK: i32 = 0;
+const ERR_INVALID: i32 = -1;
+const ERR_BUF_TOO_SMALL: i32 = -2;
+const ERR_TRANSPORT: i32 = -3;
+const ERR_RUNTIME: i32 = -4;
+
+/// Opaque handle returned by [`kbve_chat_connect`].
+///
+/// Must be freed via [`kbve_chat_disconnect`]. Do not access fields
+/// directly — the layout is not stable.
+pub struct ChatHandle {
+    rt: Runtime,
+    client: ChatClient,
+    /// Drained into the poll buffer on each [`kbve_chat_poll`] call.
+    pending: Arc<std::sync::Mutex<Vec<ChatMessage>>>,
+    /// Background task that forwards broadcast messages into `pending`.
+    /// Kept alive for the handle's lifetime; dropped on disconnect.
+    _pump: tokio::task::JoinHandle<()>,
+}
+
+/// Read a null-terminated UTF-8 C string into a Rust `&str`.
+/// Returns `None` on null pointer or invalid UTF-8.
+unsafe fn cstr_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
+    if ptr.is_null() {
+        return None;
+    }
+    unsafe { CStr::from_ptr(ptr) }.to_str().ok()
+}
+
+/// Connect to an IRC server and return an opaque handle.
+///
+/// # Parameters
+///
+/// - `host` — IRC server hostname (null-terminated UTF-8)
+/// - `port` — IRC server port (typically 6667 for plain, 6697 for TLS)
+/// - `tls` — `1` to use TLS, `0` for plain TCP
+/// - `nick` — IRC nickname (null-terminated UTF-8)
+/// - `password` — IRC server password, or null to skip PASS registration
+/// - `channels` — comma-separated channel list (e.g. `"#global,#world-events"`)
+/// - `out_handle` — receives the handle pointer on success
+///
+/// # Returns
+///
+/// - [`OK`] on success (handle written to `out_handle`)
+/// - [`ERR_INVALID`] if any required pointer is null or not UTF-8
+/// - [`ERR_RUNTIME`] if the tokio runtime failed to start
+/// - [`ERR_TRANSPORT`] if the connection/registration failed
+///
+/// # Safety
+///
+/// Caller must ensure all `*const c_char` arguments are null-terminated and
+/// remain valid for the duration of the call. `out_handle` must be a valid
+/// writable pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kbve_chat_connect(
+    host: *const c_char,
+    port: u16,
+    tls: i32,
+    nick: *const c_char,
+    password: *const c_char,
+    channels: *const c_char,
+    out_handle: *mut *mut ChatHandle,
+) -> i32 {
+    if out_handle.is_null() {
+        return ERR_INVALID;
+    }
+    unsafe { *out_handle = std::ptr::null_mut() };
+
+    let host = match unsafe { cstr_to_str(host) } {
+        Some(s) => s.to_owned(),
+        None => return ERR_INVALID,
+    };
+    let nick = match unsafe { cstr_to_str(nick) } {
+        Some(s) => s.to_owned(),
+        None => return ERR_INVALID,
+    };
+    let channels = match unsafe { cstr_to_str(channels) } {
+        Some(s) => s
+            .split(',')
+            .map(|c| c.trim().to_owned())
+            .filter(|c| !c.is_empty())
+            .collect::<Vec<_>>(),
+        None => return ERR_INVALID,
+    };
+    // password is optional — null means no PASS registration
+    let password = if password.is_null() {
+        None
+    } else {
+        match unsafe { cstr_to_str(password) } {
+            Some(s) => Some(s.to_owned()),
+            None => return ERR_INVALID,
+        }
+    };
+
+    let config = IrcConfig {
+        host,
+        port,
+        tls: tls != 0,
+        nick,
+        password,
+        channels,
+        reconnect_delay_secs: 5,
+    };
+
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .thread_name("bevy-chat-ffi")
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(_) => return ERR_RUNTIME,
+    };
+
+    // Build + connect the client on the runtime.
+    let mut client = ChatClient::new(config);
+    if let Err(_) = rt.block_on(client.connect()) {
+        return ERR_TRANSPORT;
+    }
+
+    // Pump broadcast subscribers into a lock-guarded Vec that poll() drains.
+    let pending = Arc::new(std::sync::Mutex::new(Vec::<ChatMessage>::new()));
+    let pending_for_pump = Arc::clone(&pending);
+    let mut rx: broadcast::Receiver<ChatMessage> = client.subscribe();
+
+    let pump = rt.spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    if let Ok(mut guard) = pending_for_pump.lock() {
+                        guard.push(msg);
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    // Slow consumer — drop missed messages and continue.
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
+    let handle = Box::new(ChatHandle {
+        rt,
+        client,
+        pending,
+        _pump: pump,
+    });
+
+    unsafe { *out_handle = Box::into_raw(handle) };
+    OK
+}
+
+/// Send a structured chat message.
+///
+/// # Parameters
+///
+/// - `handle` — a valid handle from [`kbve_chat_connect`]
+/// - `kind` — one of: `"chat"`, `"system"`, `"kill"`, `"rare_drop"`,
+///   `"capture"`, `"quest_complete"`, `"area_unlocked"`, `"death"`,
+///   `"craft"`, or any custom string (treated as [`MessageKind::Custom`])
+/// - `sender` — display name
+/// - `platform` — source platform (e.g. `"minecraft"`, `"unity"`, `"discord"`)
+/// - `channel` — IRC channel (e.g. `"#world-events"`)
+/// - `content` — human-readable message text
+/// - `payload_json` — optional null-terminated JSON string, or null
+///
+/// # Returns
+///
+/// - [`OK`] on success
+/// - [`ERR_INVALID`] on bad inputs or handle
+/// - [`ERR_TRANSPORT`] if the send failed (not connected, network error)
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`kbve_chat_connect`] and
+/// not yet freed. All string pointers must be null-terminated UTF-8.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kbve_chat_send(
+    handle: *mut ChatHandle,
+    kind: *const c_char,
+    sender: *const c_char,
+    platform: *const c_char,
+    channel: *const c_char,
+    content: *const c_char,
+    payload_json: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        return ERR_INVALID;
+    }
+    let h = unsafe { &*handle };
+
+    let kind_str = match unsafe { cstr_to_str(kind) } {
+        Some(s) => s,
+        None => return ERR_INVALID,
+    };
+    let sender = match unsafe { cstr_to_str(sender) } {
+        Some(s) => s,
+        None => return ERR_INVALID,
+    };
+    let platform = match unsafe { cstr_to_str(platform) } {
+        Some(s) => s,
+        None => return ERR_INVALID,
+    };
+    let channel = match unsafe { cstr_to_str(channel) } {
+        Some(s) => s,
+        None => return ERR_INVALID,
+    };
+    let content = match unsafe { cstr_to_str(content) } {
+        Some(s) => s,
+        None => return ERR_INVALID,
+    };
+
+    let kind = match kind_str {
+        "chat" => MessageKind::Chat,
+        "system" => MessageKind::System,
+        "kill" => MessageKind::Kill,
+        "rare_drop" => MessageKind::RareDrop,
+        "capture" => MessageKind::Capture,
+        "quest_complete" => MessageKind::QuestComplete,
+        "area_unlocked" => MessageKind::AreaUnlocked,
+        "death" => MessageKind::Death,
+        "craft" => MessageKind::Craft,
+        other => MessageKind::Custom(other.to_owned()),
+    };
+
+    let payload = if payload_json.is_null() {
+        None
+    } else {
+        match unsafe { cstr_to_str(payload_json) } {
+            Some(s) => serde_json::from_str::<serde_json::Value>(s).ok(),
+            None => return ERR_INVALID,
+        }
+    };
+
+    let msg = ChatMessage::event(kind, sender, platform, channel, content, payload);
+
+    // Use a oneshot to ferry the result out of the async block.
+    let (tx, rx) = mpsc::channel();
+    let client = h.client.clone();
+    h.rt.spawn(async move {
+        let _ = tx.send(client.send(&msg).await);
+    });
+
+    match rx.recv() {
+        Ok(Ok(())) => OK,
+        _ => ERR_TRANSPORT,
+    }
+}
+
+/// Drain pending incoming messages into a caller-provided buffer.
+///
+/// Messages are serialized as a JSON array: `[{...}, {...}]`. If there are
+/// no pending messages, the buffer is filled with `"[]"`.
+///
+/// # Parameters
+///
+/// - `handle` — a valid handle from [`kbve_chat_connect`]
+/// - `out_buf` — caller-allocated buffer
+/// - `buf_len` — capacity of `out_buf` in bytes (including space for null terminator)
+///
+/// # Returns
+///
+/// - number of bytes written (not including null terminator) on success
+/// - [`ERR_INVALID`] on bad inputs
+/// - [`ERR_BUF_TOO_SMALL`] if the serialized JSON would exceed `buf_len`
+///   (messages remain in the pending queue and can be retried with a larger buffer)
+///
+/// # Safety
+///
+/// `out_buf` must be valid and writable for `buf_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kbve_chat_poll(
+    handle: *mut ChatHandle,
+    out_buf: *mut c_char,
+    buf_len: usize,
+) -> i32 {
+    if handle.is_null() || out_buf.is_null() || buf_len == 0 {
+        return ERR_INVALID;
+    }
+    let h = unsafe { &*handle };
+
+    let messages = {
+        let mut guard = match h.pending.lock() {
+            Ok(g) => g,
+            Err(_) => return ERR_INVALID,
+        };
+        std::mem::take(&mut *guard)
+    };
+
+    let json = match serde_json::to_string(&messages) {
+        Ok(s) => s,
+        Err(_) => {
+            // Re-queue on serialization failure (shouldn't happen in practice).
+            if let Ok(mut guard) = h.pending.lock() {
+                guard.extend(messages);
+            }
+            return ERR_INVALID;
+        }
+    };
+
+    let bytes = json.as_bytes();
+    if bytes.len() + 1 > buf_len {
+        // Re-queue so caller can retry with a bigger buffer.
+        if let Ok(mut guard) = h.pending.lock() {
+            guard.extend(messages);
+        }
+        return ERR_BUF_TOO_SMALL;
+    }
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr() as *const c_char, out_buf, bytes.len());
+        *out_buf.add(bytes.len()) = 0;
+    }
+
+    bytes.len() as i32
+}
+
+/// Check whether the client is currently connected.
+///
+/// # Returns
+///
+/// - `1` if connected
+/// - `0` if disconnected
+/// - [`ERR_INVALID`] if handle is null
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kbve_chat_is_connected(handle: *mut ChatHandle) -> i32 {
+    if handle.is_null() {
+        return ERR_INVALID;
+    }
+    let h = unsafe { &*handle };
+    if h.rt.block_on(h.client.is_connected()) {
+        1
+    } else {
+        0
+    }
+}
+
+/// Disconnect and free the handle.
+///
+/// After this call, the handle pointer must not be used again.
+/// Passing a null pointer is a no-op.
+///
+/// # Safety
+///
+/// `handle` must be a pointer previously returned by [`kbve_chat_connect`],
+/// or null. Calling this twice on the same pointer is undefined behavior.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kbve_chat_disconnect(handle: *mut ChatHandle) {
+    if handle.is_null() {
+        return;
+    }
+    let boxed = unsafe { Box::from_raw(handle) };
+    let ChatHandle {
+        rt,
+        client,
+        pending: _,
+        _pump,
+    } = *boxed;
+    // Gracefully close the IRC connection before tearing down the runtime.
+    rt.block_on(client.disconnect());
+    // Dropping the runtime aborts the pump task.
+    drop(rt);
+}

--- a/packages/rust/bevy/bevy_chat/src/lib.rs
+++ b/packages/rust/bevy/bevy_chat/src/lib.rs
@@ -57,3 +57,12 @@ pub use client_wasm::ChatClient;
 mod plugin;
 #[cfg(feature = "plugin")]
 pub use plugin::{ChatInbox, ChatOutbox, ChatPlugin, IncomingChatEvent};
+
+// ── Optional C-FFI surface (native only) ──────────────────────────────
+//
+// Exposes `extern "C"` functions usable from JNI (MC Fabric) and
+// csbindgen (Unity). Native-only — WASM consumers use `ChatClient`
+// directly via wasm-bindgen.
+
+#[cfg(all(feature = "ffi", not(target_arch = "wasm32")))]
+pub mod ffi;


### PR DESCRIPTION
## Summary

Full MC-side pipeline for the chat bridge, layered on top of the new `bevy_chat` `ffi` feature (first commit in this PR).

### 1. bevy_chat `ffi` feature (first commit)
- Opaque `ChatHandle` returned from `kbve_chat_connect`, freed by `kbve_chat_disconnect`
- Each handle owns a multi-threaded tokio runtime so non-async callers (JNI, Unity) can drive it via blocking calls
- All strings are null-terminated UTF-8 `*const c_char`; null and invalid UTF-8 return error codes, never panic
- Incoming messages are pumped from the broadcast subscriber into a lock-guarded `Vec` drained by `kbve_chat_poll` as a JSON array
- Buffer-too-small on poll re-queues messages so the caller can retry with a bigger buffer
- Feature is off by default — discordsh-bot and WASM browser client are untouched

### 2. Rust JNI entry points (`behavior_statetree/src/lib.rs`)
Five thin wrappers mirroring the `ffi` surface:
- `Java_com_kbve_statetree_ChatBridge_connect` → returns opaque `jlong` (0 on failure)
- `Java_com_kbve_statetree_ChatBridge_send` → `jboolean`
- `Java_com_kbve_statetree_ChatBridge_poll` → `jstring` JSON array, grows buffer up to 1 MiB on ERR_BUF_TOO_SMALL
- `Java_com_kbve_statetree_ChatBridge_isConnected` → `jboolean`
- `Java_com_kbve_statetree_ChatBridge_disconnect`

### 3. Java bridge
- `ChatBridge.java` — `native` method declarations, relies on `NativeRuntime`'s static initializer for library load ordering
- `McChatEvents.java` — owns the handle, reads env vars, wires Fabric events:
  - `ServerLivingEntityEvents.AFTER_DEATH` → player death → `kind=death`
  - Same event → wither/ender dragon killed by a player → `kind=kill`
  - `ServerPlayConnectionEvents.JOIN` → `kind=system` welcome
- `BehaviorStateTreeMod.onInitialize` calls `McChatEvents.register()` before the `NativeRuntime.isLoaded` gate — chat bridge works even if the AI native lib fails

### 4. Fleet env vars (`apps/kube/agones/mc/fleet.yaml`)
```
IRC_HOST=ergo-irc-service.irc.svc.cluster.local
IRC_PORT=6667
IRC_TLS=false
IRC_NICK=mc-server
IRC_CHANNELS=#world-events
```
`IRC_PASSWORD` intentionally unset — relies on ergo's `force-nick-equals-account` to reserve the nick on first connect. Sealed-secret wiring can layer in later once we formalise service-account provisioning.

## Intentionally deferred (tracked separately)

- **Ergo ingress NetworkPolicy** — no existing policy restricts ergo; adding one requires a full audit of consumers (discordsh-bot, irc-gateway, MC, WASM isometric) to avoid silent breakage
- **MC egress CiliumNetworkPolicy** — `arc-runners` has no default-deny egress today, connection works without one. Revisit when cluster posture tightens
- **ergo service-account seed** — `/REGISTER mc-server <pw>` needs to be run once via admin client or a one-shot Job; deferred until we decide between manual registration vs automated Job

## Verified locally

- `cargo check -p bevy_chat --features ffi` ✓
- `cargo check -p behavior_statetree` ✓
- `./gradlew compileJava` (behavior_statetree Java mod) ✓

## Test plan

- [ ] Docker build of `kbve/mc` image succeeds via CI
- [ ] On deploy, MC logs show `[chat] Connected to IRC ... as mc-server (#world-events)`
- [ ] Trigger a Wither kill in-game → `#world-events` shows `[EVENT:KILL] Steve@minecraft: Steve slew the Wither {"boss":"Wither"}`
- [ ] Kill a player → `[EVENT:DEATH] Steve@minecraft: Steve died to ...`
- [ ] `docker logs discordsh-bot` shows no new errors (bot should ignore MC-emitted events)

Closes gap #6 of #10194.