### PR TITLE
feat(mc): wire axum-kbve to MC lobby RCON for /api/v1/mc/players

### DIFF
--- a/apps/kube/agones/mc/kbve-rcon-rbac.yaml
+++ b/apps/kube/agones/mc/kbve-rcon-rbac.yaml
@@ -1,0 +1,36 @@
+# Allow the kbve-external-secrets ServiceAccount (in kbve namespace)
+# to read mc-rcon-password from the mc namespace. Used by the
+# ExternalSecret in apps/kube/kbve/manifest/mc-rcon-externalsecret.yaml
+# to sync RCON credentials into the kbve namespace at runtime so
+# axum-kbve can drive the /api/v1/mc/players endpoint.
+#
+# Single source of truth remains the mc/mc-rcon-password SealedSecret.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: mc-rcon-reader-for-kbve
+    namespace: mc
+    labels:
+        app.kubernetes.io/part-of: mc
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'list', 'watch']
+      resourceNames: ['mc-rcon-password']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-read-mc-rcon
+    namespace: mc
+    labels:
+        app.kubernetes.io/part-of: mc
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: mc-rcon-reader-for-kbve
+subjects:
+    - kind: ServiceAccount
+      name: kbve-external-secrets
+      namespace: kbve

--- a/apps/kube/agones/mc/rcon-networkpolicy.yaml
+++ b/apps/kube/agones/mc/rcon-networkpolicy.yaml
@@ -43,6 +43,18 @@ spec:
           ports:
               - port: 25575
                 protocol: TCP
+        # axum-kbve (kbve namespace) → RCON for the /api/v1/mc/players
+        # endpoint on kbve.com/mc/players.
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: kbve
+                podSelector:
+                    matchLabels:
+                        app: kbve
+          ports:
+              - port: 25575
+                protocol: TCP
         # MC pods talking to each other → RCON
         - from:
               - podSelector:

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -129,6 +129,20 @@ spec:
                         value: '/etc/ssl/webtransport-selfsigned/tls.key'
                       - name: CHUCKRPG_UPSTREAM_URL
                         value: 'http://rows.ows.svc.cluster.local:4322'
+                      # MC RCON — drives the /api/v1/mc/players endpoint
+                      # (kbve.com/mc/players). Service DNS resolves to the
+                      # current Agones lobby pod. Password synced from the
+                      # mc namespace via ExternalSecret — single source of
+                      # truth in mc/mc-rcon-password SealedSecret.
+                      - name: MC_RCON_HOST
+                        value: 'mc-lobby-backend.arc-runners.svc.cluster.local'
+                      - name: MC_RCON_PORT
+                        value: '25575'
+                      - name: MC_RCON_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: mc-rcon-credentials
+                                key: rcon-password
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: kbve
 resources:
     - kbve-serviceaccount.yaml
     - kbve-externalsecret.yaml
+    - mc-rcon-externalsecret.yaml
     - forgejo-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml

--- a/apps/kube/kbve/manifest/mc-rcon-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/mc-rcon-externalsecret.yaml
@@ -1,0 +1,45 @@
+# Cross-namespace secret sync: mc-rcon-password from mc namespace
+# into kbve namespace for the axum-kbve RCON player list endpoint.
+#
+# Follows the same pattern as kbve-externalsecret.yaml (kilobase→kbve)
+# and functions/mc-rcon-externalsecret.yaml (mc→kilobase).
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: mc-remote-secret-store
+    namespace: kbve
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: mc
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: mc-rcon-credentials
+    namespace: kbve
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: mc-remote-secret-store
+        kind: SecretStore
+    target:
+        name: mc-rcon-credentials
+        creationPolicy: Owner
+    data:
+        - secretKey: rcon-password
+          remoteRef:
+              key: mc-rcon-password
+              property: rcon-password


### PR DESCRIPTION
## Summary
Fixes "MC server not connected" on https://kbve.com/mc/players/.

The axum-kbve backend's `init_mc_service()` bails when `MC_RCON_HOST` env var is missing, so `/api/v1/mc/players` returns HTTP 503 → frontend shows "MC server not connected". The kbve-deployment simply had no RCON config at all.

## Chain wired in this PR (single source of truth)
The RCON password stays in one place — `mc/mc-rcon-password` SealedSecret. No duplication:

1. **`apps/kube/agones/mc/kbve-rcon-rbac.yaml`** (new) — Role + RoleBinding in the `mc` namespace granting only `get/list/watch` on the single `mc-rcon-password` secret to the `kbve-external-secrets` ServiceAccount
2. **`apps/kube/kbve/manifest/mc-rcon-externalsecret.yaml`** (new) — SecretStore pointing at `mc` namespace + ExternalSecret syncing into `kbve/mc-rcon-credentials`. Mirrors the existing `functions/mc-rcon-externalsecret.yaml` pattern for `kilobase`
3. **`apps/kube/kbve/manifest/kbve-deployment.yaml`** — adds `MC_RCON_HOST` (`mc-lobby-backend.arc-runners.svc.cluster.local`), `MC_RCON_PORT` (25575), `MC_RCON_PASSWORD` (from the synced secret)
4. **`apps/kube/agones/mc/rcon-networkpolicy.yaml`** — extends RCON ingress to allow the `kbve` namespace pods alongside the existing `kilobase/functions` rule
5. **`apps/kube/kbve/manifest/kustomization.yaml`** — registers the new ExternalSecret file

## Scope
Lobby-only. `mc.rs` currently supports one RCON endpoint. The next PR extends it to a multi-server client (lobby + survival Fabric fleet) and adds a `server` field to `McPlayer` so the frontend can show which backend each player is on.

## Test plan
- [ ] Merge + dev→main promotion
- [ ] `kubectl get externalsecret -n kbve mc-rcon-credentials` → `SecretSynced`
- [ ] `kubectl get secret -n kbve mc-rcon-credentials` exists with `rcon-password` key
- [ ] `kbve-deployment` pod has `MC_RCON_*` env vars set
- [ ] `curl https://kbve.com/api/v1/mc/players` → 200 with player list JSON (not 503)
- [ ] Frontend at `/mc/players/` shows players instead of "MC server not connected"