### PR TITLE
fix(chat): resolve DataCloneError by routing ws events via BroadcastChannel

### DIFF
--- a/apps/irc/astro-irc/src/components/chat/service.ts
+++ b/apps/irc/astro-irc/src/components/chat/service.ts
@@ -91,6 +91,62 @@ function systemMessage(channel: string, content: string): void {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
+// ---------------------------------------------------------------------------
+// Worker → UI bridge
+//
+// The ws-worker posts status + message events on the `kbve_ws_events`
+// BroadcastChannel. We subscribe here instead of calling kbve.ws.onMessage
+// / kbve.ws.onStatus through Comlink — Comlink forwards method args via
+// postMessage, and functions aren't structured-cloneable, so passing raw
+// callbacks across the SharedWorker boundary raised DataCloneError and
+// killed the connection handshake before it completed.
+//
+// Keeping the subscription at module scope means reconnects reuse the same
+// channel instead of stacking subscriptions on every connect() call.
+// ---------------------------------------------------------------------------
+let eventsChannel: BroadcastChannel | null = null;
+
+function ensureEventsSubscription(): void {
+	if (eventsChannel) return;
+	if (typeof BroadcastChannel === 'undefined') {
+		console.warn(
+			'[chat] BroadcastChannel unavailable — ws events will not reach the UI',
+		);
+		return;
+	}
+
+	eventsChannel = new BroadcastChannel('kbve_ws_events');
+	eventsChannel.onmessage = (e: MessageEvent) => {
+		const evt = e.data;
+		if (!evt || typeof evt !== 'object') return;
+
+		if (evt.type === 'status') {
+			const status = evt.status as string;
+			if (status === 'connected') {
+				$connectionStatus.set('connected');
+				systemMessage($activeChannel.get(), 'Connected to IRC');
+			} else if (status === 'disconnected' || status === 'error') {
+				$connectionStatus.set(status as ConnectionStatus);
+			}
+			return;
+		}
+
+		if (evt.type === 'message') {
+			const data = evt.data;
+			const text =
+				typeof data === 'string'
+					? data
+					: decoder.decode(
+							data instanceof ArrayBuffer
+								? new Uint8Array(data)
+								: data,
+						);
+			handleIncoming(text);
+			return;
+		}
+	};
+}
+
 export async function connect(wsUrl: string, token?: string): Promise<void> {
 	if ($connectionStatus.get() === 'connected') return;
 
@@ -107,28 +163,11 @@ export async function connect(wsUrl: string, token?: string): Promise<void> {
 			? `${wsUrl}${wsUrl.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`
 			: wsUrl;
 
+		// Subscribe BEFORE connect so we don't miss the initial 'connected'
+		// status event from the worker.
+		ensureEventsSubscription();
+
 		await kbve.ws.connect(url);
-
-		kbve.ws.onStatus((status: string) => {
-			if (status === 'connected') {
-				$connectionStatus.set('connected');
-				systemMessage($activeChannel.get(), 'Connected to IRC');
-			} else if (status === 'disconnected' || status === 'error') {
-				$connectionStatus.set(status as ConnectionStatus);
-			}
-		});
-
-		kbve.ws.onMessage((data: ArrayBuffer | Uint8Array | string) => {
-			const text =
-				typeof data === 'string'
-					? data
-					: decoder.decode(
-							data instanceof ArrayBuffer
-								? new Uint8Array(data)
-								: data,
-						);
-			handleIncoming(text);
-		});
 	} catch (err: any) {
 		$connectionStatus.set('error');
 		$error.set(err.message ?? 'Connection failed');

--- a/packages/npm/droid/src/lib/workers/ws-worker.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.ts
@@ -6,15 +6,39 @@ interface SharedWorkerGlobalScope extends Worker {
 declare const self: SharedWorkerGlobalScope;
 
 let ws: WebSocket | null = null;
-let onMessageCallback: ((data: string | ArrayBuffer) => void) | null = null;
-let onStatusCallback: ((status: string) => void) | null = null;
 
-// BroadcastChannel for direct ws-worker → db-worker communication.
-// The db-worker listens on this channel and writes to IndexedDB,
-// keeping the main thread out of the data pipeline entirely.
+// ---------------------------------------------------------------------------
+// Transport channels
+//
+// `kbve_ws_data`   — raw WebSocket payloads for the db-worker to persist.
+//                    Payload: { type: 'ws.store', format, data, ts }
+//
+// `kbve_ws_events` — status + message events for UI consumers (chat service,
+//                    presence, overlays, etc.).
+//                    Payload:
+//                      { type: 'status',  status: string }
+//                      { type: 'message', format: 'text',   data: string }
+//                      { type: 'message', format: 'binary', data: Uint8Array }
+//
+// Keeping persistence and UI on separate channels means each consumer only
+// sees what it cares about, and a new subscriber (e.g. cross-tab presence)
+// drops in without filtering db-bound payloads.
+//
+// Historical note: an earlier design exposed onMessage(cb) / onStatus(cb)
+// through Comlink. That failed with DataCloneError because Comlink forwards
+// method args via postMessage, and functions are not structured-cloneable.
+// If a future strategy wants a different transport (SharedArrayBuffer,
+// MessagePort, proxied-Comlink callbacks), add it alongside — don't remove
+// the BroadcastChannel path, it's the fallback that works everywhere.
+// ---------------------------------------------------------------------------
 const dbChannel =
 	typeof BroadcastChannel !== 'undefined'
 		? new BroadcastChannel('kbve_ws_data')
+		: null;
+
+const eventsChannel =
+	typeof BroadcastChannel !== 'undefined'
+		? new BroadcastChannel('kbve_ws_events')
 		: null;
 
 // Heartbeat
@@ -62,7 +86,7 @@ function stopHeartbeat() {
 }
 
 function broadcastStatus(status: string) {
-	onStatusCallback?.(status);
+	eventsChannel?.postMessage({ type: 'status', status });
 }
 
 function attemptReconnect() {
@@ -87,7 +111,14 @@ function attemptReconnect() {
 	}, RECONNECT_DELAY_MS);
 }
 
-// --- WebSocket API ---
+// ---------------------------------------------------------------------------
+// WebSocket API exposed via Comlink
+//
+// Only commands that carry structured-cloneable data cross this bridge
+// (strings, typed arrays). Event subscription is deliberately NOT here —
+// it lives on the BroadcastChannel side to avoid DataCloneError when a
+// caller passes a raw function.
+// ---------------------------------------------------------------------------
 const wsInstanceAPI = {
 	async connect(url: string) {
 		if (ws && ws.readyState === WebSocket.OPEN) return;
@@ -126,12 +157,9 @@ const wsInstanceAPI = {
 					}
 				}
 
-				// Forward to main thread callback (UI rendering)
-				onMessageCallback?.(e.data);
-
-				// Forward to db-worker for storage (off main thread).
-				// BroadcastChannel requires structured-cloneable data,
-				// so we send text as-is and binary as a Uint8Array copy.
+				// Fan out to db-worker (persistence pipeline).
+				// Structured-cloneable payloads only — strings and
+				// Uint8Array are both safe across BroadcastChannel.
 				if (dbChannel) {
 					if (typeof e.data === 'string') {
 						dbChannel.postMessage({
@@ -146,6 +174,24 @@ const wsInstanceAPI = {
 							format: 'binary',
 							data: new Uint8Array(e.data),
 							ts: Date.now(),
+						});
+					}
+				}
+
+				// Fan out to UI consumers (chat service, presence, etc.).
+				// Same structured-cloneable constraint applies.
+				if (eventsChannel) {
+					if (typeof e.data === 'string') {
+						eventsChannel.postMessage({
+							type: 'message',
+							format: 'text',
+							data: e.data,
+						});
+					} else if (e.data instanceof ArrayBuffer) {
+						eventsChannel.postMessage({
+							type: 'message',
+							format: 'binary',
+							data: new Uint8Array(e.data),
 						});
 					}
 				}
@@ -174,7 +220,13 @@ const wsInstanceAPI = {
 
 	async send(payload: Uint8Array) {
 		if (ws?.readyState === WebSocket.OPEN) {
-			ws.send(payload);
+			// Cast narrows Uint8Array<ArrayBufferLike> to BufferSource for
+			// WebSocket.send. Newer TS DOM lib parameterizes Uint8Array over
+			// ArrayBuffer | SharedArrayBuffer, but send() only accepts
+			// ArrayBuffer-backed views. Every caller here posts a freshly
+			// encoded payload (Uint8Array from TextEncoder or similar), so
+			// the backing buffer is always a plain ArrayBuffer.
+			ws.send(payload as BufferSource);
 		} else {
 			console.warn('[WS] Tried to send while disconnected');
 		}
@@ -191,14 +243,6 @@ const wsInstanceAPI = {
 		ws?.close(1000, 'Client request');
 		ws = null;
 		broadcastStatus('disconnected');
-	},
-
-	onMessage(callback: (data: string | ArrayBuffer) => void) {
-		onMessageCallback = callback;
-	},
-
-	onStatus(callback: (status: string) => void) {
-		onStatusCallback = callback;
 	},
 
 	async getStatus(): Promise<string> {


### PR DESCRIPTION
## Problem
chat.kbve.com fails to connect with:
```
Unhandled Promise Rejection: DataCloneError: The object can not be cloned.
```

## Root cause
The droid `ws-worker` (`packages/npm/droid/src/lib/workers/ws-worker.ts`) exposed `onMessage(cb)` and `onStatus(cb)` through Comlink. Comlink forwards method arguments via `postMessage` under the hood — and **functions are not structured-cloneable** per the HTML spec. The moment `service.ts` called `kbve.ws.onMessage((data) => {...})` with a raw arrow function, the SharedWorker bridge threw DataCloneError and killed the handshake before the UI ever observed a `'connected'` status.

Not a SharedArrayBuffer / COOP-COEP issue — those are separate problems. Functions stay non-cloneable even with full cross-origin isolation.

## Fix
Drop the callback API on the worker. Route status and message events through a dedicated `kbve_ws_events` BroadcastChannel. The existing `kbve_ws_data` channel (ws-worker → db-worker persistence) is untouched.

### Worker → UI channels (after)
```
WebSocket onmessage
  ├─→ BroadcastChannel(kbve_ws_data)   → db-worker persistence
  └─→ BroadcastChannel(kbve_ws_events) → chat service / presence / UI
```

### Comlink surface (data-in only)
`connect(url)`, `send(Uint8Array)`, `close()`, `getStatus()` — all carry structured-cloneable payloads, no DataCloneError risk.

## Changes
- **`packages/npm/droid/src/lib/workers/ws-worker.ts`**
  - Removed `onMessageCallback`, `onStatusCallback`, `onMessage()`, `onStatus()` from the Comlink API
  - Added `kbve_ws_events` BroadcastChannel
  - Status changes (connect/error/disconnect/reconnecting/failed) post to `kbve_ws_events`
  - Incoming WS messages fan out to both channels in parallel
  - Fixed unrelated TS diagnostic on `ws.send(Uint8Array)` (newer DOM lib parameterizes over `ArrayBufferLike`)
- **`apps/irc/astro-irc/src/components/chat/service.ts`**
  - New `ensureEventsSubscription()` opens the `kbve_ws_events` BroadcastChannel at module scope
  - Subscription runs before `kbve.ws.connect()` so the initial status event isn't missed
  - Removed the two `kbve.ws.onStatus(...)` / `kbve.ws.onMessage(...)` Comlink callback calls

## Forward compatibility
The BroadcastChannel transport is intentionally kept as the default fallback — future strategies (proxied Comlink callbacks via `Comlink.proxy()`, SharedArrayBuffer ring buffer, dedicated MessagePort relay) can be added alongside behind a user-selectable setting. Nothing about this PR closes that door.

## Test plan
- [x] `nx run droid:test` — 72/72 pass
- [x] `nx run astro-irc:build` — 8 pages built clean
- [ ] Manual: load chat.kbve.com, confirm no DataCloneError in console
- [ ] Manual: observe `'connected'` status propagates to UI
- [ ] Manual: observe IRC PRIVMSG round-trip works
- [ ] If still not connecting post-merge: separate investigation on the gateway / ingress side (JWT validation, Ergo reachability, ingress WebSocket timeouts) — those are independent of this fix