### PR TITLE
fix(chuckrpg): restore nginx Ingress for chuckrpg.com — hotfix to main

### DIFF
--- a/apps/kube/chuckrpg/manifest/chuckrpg-ingress.yaml
+++ b/apps/kube/chuckrpg/manifest/chuckrpg-ingress.yaml
@@ -1,0 +1,34 @@
+# Ingress: chuckrpg.com routing via ingress-nginx
+#
+# Mirrors the chuckrpg-routes HTTPRoute (httproute.yaml) so traffic
+# reaches chuckrpg-service whether DNS points at the nginx LoadBalancer
+# or the Cilium Gateway. Until DNS is cut over to the Cilium gateway,
+# this Ingress is the path that actually serves chuckrpg.com.
+#
+# Cloudflare proxies chuckrpg.com to the ingress-nginx LoadBalancer.
+# cert-manager mints the origin cert via letsencrypt-http (secret: chuckrpg-tls).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: chuckrpg-ingress
+    namespace: chuckrpg
+    annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-http
+        nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+spec:
+    ingressClassName: nginx
+    tls:
+        - hosts:
+              - chuckrpg.com
+          secretName: chuckrpg-tls
+    rules:
+        - host: chuckrpg.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: chuckrpg-service
+                            port:
+                                number: 4322


### PR DESCRIPTION
## Summary
- Hotfix cherry-pick of 67f52368f (merged to \`dev\` via #10204) directly to \`main\` so chuckrpg.com stops 404'ing without waiting on release PR #10196.
- Single-file add: \`apps/kube/chuckrpg/manifest/chuckrpg-ingress.yaml\`. Mirrors the existing HTTPRoute via nginx Ingress because Cloudflare DNS still proxies chuckrpg.com to the ingress-nginx LoadBalancer, not the Cilium gateway.
- Same pattern h0ly used for the kbve.com 404 in 0b51773a1 (#10096).

## Test plan
- [ ] Argo syncs the new Ingress into the \`chuckrpg\` namespace.
- [ ] \`kubectl -n chuckrpg get ingress chuckrpg-ingress\` shows an ADDRESS.
- [ ] \`curl -I https://chuckrpg.com/\` returns non-404.
- [ ] TLS cert (\`chuckrpg-tls\`) still valid.