### PR TITLE
feat(irc-gateway): add /minechat JSON WebSocket route for game clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7880,6 +7880,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.9",
  "axum-extra",
+ "bevy_chat",
  "dotenvy",
  "futures-util",
  "http-body-util",

--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -28,6 +28,11 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 jedi = { path = "../../../packages/rust/jedi" }
 kbve = { path = "../../../packages/rust/kbve" }
 
+# Shared chat message schema — ChatMessage + MessageKind +
+# to_irc_privmsg/from_irc_privmsg. Default features only; we don't
+# need the plugin or ffi features here.
+bevy_chat = { path = "../../../packages/rust/bevy/bevy_chat" }
+
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }
 

--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -1,0 +1,314 @@
+//! `/minechat` — JSON-framed WebSocket endpoint for Minecraft/Unity clients.
+//!
+//! ## Why this exists
+//!
+//! The existing `/ws` endpoint proxies raw IRC protocol frames so browser
+//! IRC clients can talk to ergo as if they spoke IRC directly. That's great
+//! for people running an IRC client in the browser, but it makes every new
+//! game client re-implement an IRC parser just to say "hello".
+//!
+//! `/minechat` terminates the IRC protocol on the server side. Clients send
+//! and receive structured [`ChatMessage`] JSON frames and never see a PRIVMSG
+//! in their lives. The gateway translates JSON ↔ IRC internally, auto-joins
+//! the game channel on connect, and enforces a channel + kind whitelist so a
+//! malicious client can't send arbitrary raw IRC.
+//!
+//! ## Wire format (both directions)
+//!
+//! ```json
+//! { "kind": "chat", "sender": "mc-abcd1234", "platform": "minecraft",
+//!   "channel": "#world-events", "content": "hello", "payload": null }
+//! ```
+//!
+//! ## Auth
+//!
+//! Reuses the JWT flow from [`/ws`]. The client nick is deterministically
+//! derived from the JWT subject so a player can't impersonate another
+//! player on the wire: `mc-<first 8 alnum chars of sub>`.
+//!
+//! ## Safety rails
+//!
+//! - **Channel whitelist** — clients can only publish to channels in
+//!   [`ALLOWED_CHANNELS`]. Attempts on other channels are silently dropped
+//!   (logged at debug).
+//! - **Server-side platform tag** — the client's `platform` field is
+//!   overwritten with the authenticated session's platform ("minecraft"
+//!   for now). Prevents a client from claiming to be someone else's
+//!   platform.
+//! - **Server-side sender tag** — same treatment as `platform`; the server
+//!   pins it to the authenticated nick.
+//! - **No raw IRC passthrough** — there is no escape hatch to send arbitrary
+//!   IRC commands from this endpoint. If you want raw IRC, use `/ws`.
+
+use axum::{
+    extract::Request,
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use bevy_chat::{ChatMessage, MessageKind};
+use futures_util::{SinkExt, StreamExt};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
+
+use crate::auth::jwt;
+
+/// Handle to the ergo writer, shared between the two session tasks so
+/// either one can emit a line (PONG replies, publishes, etc.) without
+/// fighting over ownership of the TCP socket.
+type ErgoWriter = Arc<Mutex<tokio::net::tcp::OwnedWriteHalf>>;
+
+/// Channels a `/minechat` client is allowed to publish to.
+///
+/// Kept static and tiny on purpose — expanding this set is a deliberate
+/// decision, not something clients can negotiate. If a channel isn't in
+/// this list, publishes are dropped.
+const ALLOWED_CHANNELS: &[&str] = &["#world-events", "#mc-global"];
+
+/// Platform tag stamped onto every message leaving this endpoint.
+const PLATFORM: &str = "minecraft";
+
+/// Upgrade the HTTP request to a WebSocket, authenticate, and hand off to
+/// the session loop.
+pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse {
+    let token = match jwt::extract_token(&req) {
+        Some(t) => t,
+        None => return StatusCode::UNAUTHORIZED.into_response(),
+    };
+
+    let claims = match jwt::validate_token(&token) {
+        Ok(c) => c,
+        Err(status) => return status.into_response(),
+    };
+
+    // Derive the game nick from the JWT subject. We keep it short and
+    // prefixed so it's obvious in channel activity which identities are
+    // game clients vs. browser-IRC clients.
+    let nick = format!("mc-{}", sanitize_sub(&claims.sub, 8));
+
+    info!(user = %nick, "minechat upgrade accepted");
+    ws.on_upgrade(move |socket| session(socket, nick))
+        .into_response()
+}
+
+/// Per-connection state machine. Runs until the WebSocket closes or ergo
+/// drops the IRC connection. Two independent futures fan JSON↔IRC in each
+/// direction; either one returning ends the session via `tokio::select!`.
+async fn session(client_ws: WebSocket, nick: String) {
+    let ergo_host = std::env::var("ERGO_IRC_HOST")
+        .unwrap_or_else(|_| "ergo-irc-service.irc.svc.cluster.local".into());
+    let ergo_port: u16 = std::env::var("ERGO_IRC_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6667);
+
+    let ergo = match TcpStream::connect(format!("{ergo_host}:{ergo_port}")).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!(user = %nick, "failed to connect to ergo: {e}");
+            return;
+        }
+    };
+
+    let (ergo_r, ergo_w_raw) = ergo.into_split();
+    let mut ergo_reader = BufReader::new(ergo_r);
+    let ergo_w: ErgoWriter = Arc::new(Mutex::new(ergo_w_raw));
+
+    // Register with ergo: NICK + USER + auto-join each allowed channel.
+    // We send these before splitting into tasks so the client sees a
+    // ready session once JOIN replies arrive.
+    if let Err(e) = write_irc_line(&ergo_w, &format!("NICK {nick}")).await {
+        error!(user = %nick, "NICK write failed: {e}");
+        return;
+    }
+    if let Err(e) = write_irc_line(&ergo_w, &format!("USER {nick} 0 * :minechat gateway")).await {
+        error!(user = %nick, "USER write failed: {e}");
+        return;
+    }
+    for ch in ALLOWED_CHANNELS {
+        if let Err(e) = write_irc_line(&ergo_w, &format!("JOIN {ch}")).await {
+            warn!(user = %nick, channel = ch, "JOIN write failed: {e}");
+        }
+    }
+
+    let (mut client_tx, mut client_rx) = client_ws.split();
+
+    // client JSON → ergo IRC (filtered + stamped)
+    let nick_c2i = nick.clone();
+    let ergo_w_c2i = Arc::clone(&ergo_w);
+    let c2i = async move {
+        while let Some(Ok(msg)) = client_rx.next().await {
+            let text = match msg {
+                Message::Text(t) => t.to_string(),
+                Message::Close(_) => break,
+                Message::Ping(_) | Message::Pong(_) => continue,
+                Message::Binary(_) => {
+                    debug!(user = %nick_c2i, "ignoring binary frame");
+                    continue;
+                }
+            };
+
+            let mut parsed = match serde_json::from_str::<ChatMessage>(&text) {
+                Ok(m) => m,
+                Err(e) => {
+                    debug!(user = %nick_c2i, "dropping malformed JSON frame: {e}");
+                    continue;
+                }
+            };
+
+            // Channel whitelist — silently drop anything unexpected.
+            if !ALLOWED_CHANNELS.iter().any(|c| *c == parsed.channel) {
+                debug!(user = %nick_c2i, channel = %parsed.channel, "channel not allowed");
+                continue;
+            }
+
+            // Keep the Custom kind tag tight so it can't smuggle control
+            // characters through the IRC wire format.
+            if let MessageKind::Custom(ref s) = parsed.kind {
+                if s.is_empty()
+                    || s.len() > 32
+                    || !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                {
+                    debug!(user = %nick_c2i, "dropping malformed custom kind");
+                    continue;
+                }
+            }
+
+            // Pin sender + platform server-side so clients can't spoof.
+            parsed.sender = nick_c2i.clone();
+            parsed.platform = PLATFORM.to_string();
+
+            let line = parsed.to_irc_privmsg();
+            if let Err(e) = write_irc_line(&ergo_w_c2i, &line).await {
+                warn!(user = %nick_c2i, "ergo write failed: {e}");
+                break;
+            }
+        }
+    };
+
+    // ergo IRC → client JSON (parse PRIVMSGs, answer PINGs, drop the rest)
+    let nick_i2c = nick.clone();
+    let ergo_w_i2c = Arc::clone(&ergo_w);
+    let i2c = async move {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let read = ergo_reader.read_line(&mut line).await;
+            let n = match read {
+                Ok(0) => break, // ergo closed
+                Ok(n) => n,
+                Err(e) => {
+                    warn!(user = %nick_i2c, "ergo read failed: {e}");
+                    break;
+                }
+            };
+            let raw = line[..n].trim_end_matches(['\r', '\n']).to_string();
+
+            // Answer PINGs so ergo keeps the session alive.
+            if let Some(rest) = raw.strip_prefix("PING ") {
+                let pong = format!("PONG {rest}");
+                if let Err(e) = write_irc_line(&ergo_w_i2c, &pong).await {
+                    warn!(user = %nick_i2c, "PONG write failed: {e}");
+                    break;
+                }
+                continue;
+            }
+
+            // Only PRIVMSG lines get surfaced to the client. JOINs, numerics,
+            // MODE, etc. stay hidden — clients speak the JSON abstraction.
+            if let Some((channel, payload)) = parse_privmsg(&raw) {
+                if let Some(mut msg) = ChatMessage::from_irc_privmsg(&channel, &payload) {
+                    if msg.platform.is_empty() {
+                        msg.platform = "irc".into();
+                    }
+                    if send_json(&mut client_tx, &msg).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = c2i => {},
+        _ = i2c => {},
+    }
+
+    info!(user = %nick, "minechat session ended");
+}
+
+/// Write a single IRC command to ergo, terminated with CRLF. Acquires
+/// the writer mutex briefly — both session tasks share the same TCP
+/// writer half, so this is how they cooperate.
+async fn write_irc_line(w: &ErgoWriter, line: &str) -> std::io::Result<()> {
+    let mut guard = w.lock().await;
+    guard.write_all(line.as_bytes()).await?;
+    guard.write_all(b"\r\n").await?;
+    guard.flush().await
+}
+
+/// Serialise a [`ChatMessage`] and push it to the WebSocket client.
+async fn send_json(
+    tx: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    msg: &ChatMessage,
+) -> Result<(), ()> {
+    let text = serde_json::to_string(msg).map_err(|_| ())?;
+    tx.send(Message::Text(text.into())).await.map_err(|_| ())
+}
+
+/// Parse `:nick!user@host PRIVMSG #channel :payload` → `(channel, payload)`.
+/// Returns `None` for any other IRC line (JOIN, PING, numerics, etc.).
+fn parse_privmsg(line: &str) -> Option<(String, String)> {
+    // Strip leading `:prefix ` if present.
+    let rest = if let Some(rest) = line.strip_prefix(':') {
+        rest.split_once(' ').map(|(_p, r)| r)?
+    } else {
+        line
+    };
+    let mut parts = rest.splitn(3, ' ');
+    let cmd = parts.next()?;
+    if cmd != "PRIVMSG" {
+        return None;
+    }
+    let channel = parts.next()?.to_string();
+    let trailing = parts.next()?;
+    let payload = trailing.strip_prefix(':').unwrap_or(trailing).to_string();
+    Some((channel, payload))
+}
+
+/// Keep only ASCII alphanumerics from a JWT sub and truncate.
+fn sanitize_sub(sub: &str, max_len: usize) -> String {
+    sub.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(max_len)
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_privmsg() {
+        let line = ":alice!a@host PRIVMSG #world-events :[CHAT] alice@minecraft: hello";
+        let (ch, payload) = parse_privmsg(line).unwrap();
+        assert_eq!(ch, "#world-events");
+        assert_eq!(payload, "[CHAT] alice@minecraft: hello");
+    }
+
+    #[test]
+    fn ignores_non_privmsg() {
+        assert!(parse_privmsg("PING :server").is_none());
+        assert!(parse_privmsg(":bob JOIN #foo").is_none());
+    }
+
+    #[test]
+    fn sanitizes_sub() {
+        assert_eq!(sanitize_sub("abc-123|XYZ", 8), "abc123xy");
+        assert_eq!(sanitize_sub("A", 8), "a");
+    }
+}

--- a/apps/irc/irc-gateway/src/gateway/mod.rs
+++ b/apps/irc/irc-gateway/src/gateway/mod.rs
@@ -1,3 +1,4 @@
 pub mod irc;
+pub mod minechat;
 pub mod rest;
 pub mod websocket;

--- a/apps/irc/irc-gateway/src/transport/https.rs
+++ b/apps/irc/irc-gateway/src/transport/https.rs
@@ -86,6 +86,10 @@ fn router(static_config: &crate::astro::StaticConfig) -> Router {
         .route("/health", get(health))
         .route("/ws", get(crate::gateway::websocket::ws_handler))
         .route("/webirc", get(crate::gateway::websocket::ws_handler))
+        // JSON-framed WebSocket for game clients (Minecraft, Unity, etc.).
+        // Terminates the IRC protocol server-side; clients only see
+        // ChatMessage JSON. See gateway::minechat for the full contract.
+        .route("/minechat", get(crate::gateway::minechat::ws_handler))
         .nest("/api/v1", crate::gateway::rest::api_router());
 
     static_router.merge(api_router).layer(middleware)


### PR DESCRIPTION
## Summary

Adds a second WebSocket endpoint to the existing irc-gateway, `/minechat`, that speaks `bevy_chat::ChatMessage` JSON instead of raw IRC protocol.

| | `/ws` (existing) | `/minechat` (this PR) |
|---|---|---|
| Client speaks | Raw IRC frames | `ChatMessage` JSON |
| Who's it for | Browser IRC clients | Minecraft / Unity / etc. |
| Auto-joins | Nothing — client sends `JOIN` | `#world-events`, `#mc-global` |
| Nick format | Sanitized email | `mc-<first8-of-sub>` |
| Raw IRC commands | Passes through | Blocked |

## Why

Per conversation on #10194 gap 6 — game clients shouldn't need to parse IRC just to say "hello". `/minechat` terminates the IRC protocol server-side and exposes a stable JSON contract.

## Safety rails

Client → IRC direction:
- **Channel whitelist** (`ALLOWED_CHANNELS = ["#world-events", "#mc-global"]`) — everything else is silently dropped.
- **Server-side sender + platform pin** — client can't spoof identity or claim a different platform tag.
- **Custom kind validation** — alphanumeric/underscore, ≤32 chars, so no control-character smuggling through the IRC wire format.
- **No raw IRC escape hatch** — if a consumer wants raw IRC, that's what `/ws` is for.

IRC → client direction:
- Only `PRIVMSG` lines are surfaced; JOINs, numerics, MODEs, etc. stay hidden.
- Gateway answers ergo `PING`s internally so clients don't need to.

## Session internals

- Shared `Arc<Mutex<OwnedWriteHalf>>` around the ergo TCP writer so both the inbound (PONG reply) and outbound (publish) tasks can safely reach it.
- Fresh TCP connection to `ergo-irc-service.irc.svc.cluster.local:6667` per upgrade — no WebSocket double-tunnel.
- NICK/USER/JOIN(×N) sent synchronously before the relay loop starts.

## Compile + tests

- `cargo check -p irc-gateway` clean
- 3 new unit tests (PRIVMSG parse, non-PRIVMSG ignore, sub sanitizer) all pass

## Next steps (deferred)

- Fabric client mod that speaks this protocol — depends on #10201 being shipped first so we have the server-side emit side working end-to-end before we wire the client
- Supabase JWT claim carrying MC UUID so nicks can be verified server-side instead of derived from the sub
- Per-identity rate limiting