### PR TITLE
feat(mc): wire BBModel rendering to 1.21.11 OrderedRenderCommandQueue

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -31,15 +31,18 @@ COPY apps/mc/mc_auth/ mc_auth/
 COPY packages/rust/bevy/bevy_npc/ bevy_npc/
 COPY packages/rust/bevy/bevy_supa/ bevy_supa/
 COPY packages/rust/bevy/bevy_pathfinding/ bevy_pathfinding/
+COPY packages/rust/bevy/bevy_behavior/ bevy_behavior/
 
 # Rewrite package path refs for the flattened Docker context.
 # - behavior_statetree ← ../../../packages/rust/bevy/bevy_npc
 # - behavior_statetree ← ../../../packages/rust/bevy/bevy_pathfinding
+# - behavior_statetree ← ../../../packages/rust/bevy/bevy_behavior
 # - mc_auth             ← ../../../packages/rust/bevy/bevy_supa
 RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_npc"|path = "../bevy_npc"|' behavior_statetree/Cargo.toml
 RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_pathfinding"|path = "../bevy_pathfinding"|' behavior_statetree/Cargo.toml
+RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_behavior"|path = "../bevy_behavior"|' behavior_statetree/Cargo.toml
 RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_supa"|path = "../bevy_supa"|' mc_auth/Cargo.toml
-RUN printf '[workspace]\nresolver = "2"\nmembers = ["behavior_statetree", "mc_auth", "bevy_npc", "bevy_supa", "bevy_pathfinding"]\n' > Cargo.toml
+RUN printf '[workspace]\nresolver = "2"\nmembers = ["behavior_statetree", "mc_auth", "bevy_npc", "bevy_supa", "bevy_pathfinding", "bevy_behavior"]\n' > Cargo.toml
 
 RUN cargo build -p behavior_statetree -p mc_auth --release
 # Outputs:

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -1,33 +1,150 @@
 package com.kbve.statetree.client;
 
+import com.kbve.statetree.bbmodel.BBBone;
+import com.kbve.statetree.bbmodel.BBFace;
+import com.kbve.statetree.bbmodel.BBFaceContainer;
+import com.kbve.statetree.bbmodel.BBModel;
+import com.kbve.statetree.bbmodel.BBModelLoader;
+import com.kbve.statetree.bbmodel.BBModelUtils;
+import com.kbve.statetree.bbmodel.BBObject;
 import com.kbve.statetree.ship.ShipEntity;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderLayers;
+import net.minecraft.client.render.command.OrderedRenderCommandQueue;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
-import net.minecraft.client.render.entity.state.EntityRenderState;
+import net.minecraft.client.render.state.CameraRenderState;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Identifier;
+import org.joml.Quaternionf;
 
 /**
- * Entity renderer for {@link ShipEntity}. Currently renders the entity
- * as visible (not invisible) so the bounding box and name tag display.
+ * Entity renderer for {@link ShipEntity} that draws a BBModel. Walks the
+ * model tree and submits one custom render command per face, bundling
+ * matrix state into each submission so the command queue can batch
+ * vertices by render layer.
  *
- * <p>TODO: Wire BBModelRenderer to the 1.21.11 render pipeline
- * (OrderedRenderCommandQueue). The BBModel .bbmodel files (airship,
- * biplane, gyrodyne) are loaded by BBModelLoader but the renderer
- * needs adaptation from the old VertexConsumerProvider API to the new
- * ordered render command queue system.
+ * <p>Pipeline:
+ * <pre>
+ *   render(state, matrices, queue)
+ *     → apply ship-level rotation
+ *     → recursiveRender(root BBObjects)
+ *       ├─ BBBone  → push transform, recurse into children
+ *       └─ BBCube / BBMesh → submitCustom(matrices, layer, face-emitter)
+ * </pre>
  *
- * <p>The entity architecture (modelName field, ShipManager spawn,
- * WASD controls) is fully wired — only the visual model rendering
- * remains as a follow-up.
+ * <p>Adapted from the old ImmersiveAircraft-derived {@code BBModelRenderer}
+ * (which used {@code VertexConsumerProvider}) to the 1.21.11
+ * {@link OrderedRenderCommandQueue} pipeline.
  */
-public class BBModelShipRenderer extends EntityRenderer<ShipEntity, EntityRenderState> {
+public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderState> {
+
+    /** Fallback if the entity's modelName is empty or unregistered. */
+    private static final String DEFAULT_MODEL = "immersive_aircraft/airship";
+
+    /** Blockbench units → world blocks (1/16). */
+    private static final float MODEL_SCALE = 1.0f / 16.0f;
 
     public BBModelShipRenderer(EntityRendererFactory.Context ctx) {
         super(ctx);
         this.shadowRadius = 2.0f;
     }
 
+    // -- State lifecycle ----------------------------------------------------
+
     @Override
-    public EntityRenderState createRenderState() {
-        return new EntityRenderState();
+    public ShipRenderState createRenderState() {
+        return new ShipRenderState();
+    }
+
+    @Override
+    public void updateRenderState(ShipEntity entity, ShipRenderState state, float tickDelta) {
+        super.updateRenderState(entity, state, tickDelta);
+        String name = entity.getModelName();
+        state.modelName = (name == null || name.isEmpty()) ? DEFAULT_MODEL : name;
+        // Read yaw (synced via vanilla entity tracking) — not the custom
+        // heading field which only exists server-side.
+        state.heading = entity.getYaw();
+        state.animationTime = (entity.age + tickDelta) * 0.05f;
+    }
+
+    // -- Render -------------------------------------------------------------
+
+    @Override
+    public void render(ShipRenderState state, MatrixStack matrices,
+                       OrderedRenderCommandQueue queue, CameraRenderState cameraState) {
+        super.render(state, matrices, queue, cameraState);
+
+        BBModel model = BBModelLoader.MODELS.get(
+                Identifier.of("behavior_statetree", state.modelName));
+        if (model == null) return;
+
+        matrices.push();
+
+        // Scale from Blockbench units to world units
+        matrices.scale(MODEL_SCALE, MODEL_SCALE, MODEL_SCALE);
+
+        // Ship heading rotation (Y-axis)
+        matrices.multiply(new Quaternionf().rotateY(
+                (float) Math.toRadians(-state.heading)));
+
+        // Walk the model tree — submit render commands per face
+        int light = 0xF000F0; // full bright (airships fly in sky)
+        for (BBObject obj : model.root) {
+            renderObject(obj, matrices, queue, light);
+        }
+
+        matrices.pop();
+    }
+
+    // -- Tree traversal -----------------------------------------------------
+
+    private void renderObject(BBObject object, MatrixStack matrices,
+                              OrderedRenderCommandQueue queue, int light) {
+        matrices.push();
+
+        // Apply object origin + rotation
+        matrices.translate(object.origin.x(), object.origin.y(), object.origin.z());
+        matrices.multiply(BBModelUtils.fromXYZ(object.rotation));
+
+        if (object instanceof BBBone bone) {
+            // Bones pivot around their origin — translate back before recursing
+            matrices.translate(-object.origin.x(), -object.origin.y(), -object.origin.z());
+
+            if (bone.visibility) {
+                for (BBObject child : bone.children) {
+                    renderObject(child, matrices, queue, light);
+                }
+            }
+        } else if (object instanceof BBFaceContainer container) {
+            submitFaces(container, matrices, queue, light);
+        }
+
+        matrices.pop();
+    }
+
+    // -- Face submission ----------------------------------------------------
+
+    private void submitFaces(BBFaceContainer container, MatrixStack matrices,
+                             OrderedRenderCommandQueue queue, int light) {
+        for (BBFace face : container.getFaces()) {
+            RenderLayer layer = container.enableCulling()
+                    ? RenderLayers.entityCutout(face.texture.location)
+                    : RenderLayers.entityCutoutNoCull(face.texture.location);
+
+            // submitCustom captures current matrix state in the entry
+            queue.submitCustom(matrices, layer, (entry, vc) -> {
+                for (int i = 0; i < 4; i++) {
+                    BBFace.BBVertex v = face.vertices[i];
+                    vc.vertex(entry.getPositionMatrix(), v.x, v.y, v.z)
+                            .color(1.0f, 1.0f, 1.0f, 1.0f)
+                            .texture(v.u, v.v)
+                            .overlay(OverlayTexture.DEFAULT_UV)
+                            .light(light)
+                            .normal(entry, v.nx, v.ny, v.nz);
+                }
+            });
+        }
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipRenderState.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipRenderState.java
@@ -1,0 +1,23 @@
+package com.kbve.statetree.client;
+
+import net.minecraft.client.render.entity.state.EntityRenderState;
+
+/**
+ * Render state snapshot for {@link com.kbve.statetree.ship.ShipEntity}.
+ *
+ * <p>In 1.21.11, {@code EntityRenderer.render()} takes a render state
+ * object instead of the entity directly. This class carries the ship
+ * fields the renderer needs — heading for rotation, modelName for
+ * model lookup, age for animation time.
+ */
+public class ShipRenderState extends EntityRenderState {
+
+    /** BBModel identifier path (e.g. "immersive_aircraft/airship"). */
+    public String modelName = "";
+
+    /** Yaw rotation in degrees (0-360). */
+    public float heading = 0.0f;
+
+    /** Animation time in ticks (continuous counter for propellers, sails). */
+    public float animationTime = 0.0f;
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -3,6 +3,9 @@ package com.kbve.statetree.ship;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.MovementType;
+import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.data.TrackedDataHandlerRegistry;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.storage.ReadView;
@@ -27,9 +30,13 @@ import java.util.UUID;
  */
 public class ShipEntity extends Entity {
 
+    // modelName is tracked so it auto-syncs to clients via vanilla entity
+    // tracking — the renderer reads it in updateRenderState().
+    private static final TrackedData<String> MODEL_NAME =
+            DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
+
     private String shipIdStr = "";
     private String ownerUuidStr = "";
-    private String modelName = "immersive_aircraft/airship";
     private float heading = 0.0f;
     private float targetSpeed = 0.0f;
 
@@ -56,11 +63,17 @@ public class ShipEntity extends Entity {
         this.ownerUuidStr = uuid != null ? uuid.toString() : "";
     }
 
-    public String getModelName() { return modelName; }
-    public void setModelName(String name) { this.modelName = name != null ? name : ""; }
+    public String getModelName() { return this.dataTracker.get(MODEL_NAME); }
+    public void setModelName(String name) {
+        this.dataTracker.set(MODEL_NAME, name != null ? name : "");
+    }
 
     public float getHeading() { return heading; }
-    public void setHeading(float heading) { this.heading = heading % 360; }
+    public void setHeading(float heading) {
+        this.heading = heading % 360;
+        // Mirror to vanilla yaw so entity tracking syncs rotation to clients.
+        this.setYaw(this.heading);
+    }
 
     public float getTargetSpeed() { return targetSpeed; }
     public void setTargetSpeed(float speed) { this.targetSpeed = Math.max(0, speed); }
@@ -98,6 +111,10 @@ public class ShipEntity extends Entity {
     public void tick() {
         super.tick();
 
+        // Keep vanilla yaw in sync with our heading (important for clients
+        // that only see the entity via standard tracking — they use getYaw()).
+        this.setYaw(heading);
+
         if (targetSpeed <= 0.0f) return;
         if (!this.hasPassengers()) return;
         Entity rider = this.getFirstPassenger();
@@ -129,13 +146,14 @@ public class ShipEntity extends Entity {
 
     @Override
     protected void initDataTracker(net.minecraft.entity.data.DataTracker.Builder builder) {
+        builder.add(MODEL_NAME, "immersive_aircraft/airship");
     }
 
     @Override
     public void readCustomData(ReadView view) {
         this.shipIdStr = view.getString("ShipId", "");
         this.ownerUuidStr = view.getString("OwnerUuid", "");
-        this.modelName = view.getString("ModelName", "immersive_aircraft/airship");
+        setModelName(view.getString("ModelName", "immersive_aircraft/airship"));
         this.heading = view.getFloat("Heading", 0.0f);
         this.targetSpeed = view.getFloat("TargetSpeed", 0.0f);
     }
@@ -144,7 +162,7 @@ public class ShipEntity extends Entity {
     public void writeCustomData(WriteView view) {
         view.putString("ShipId", shipIdStr);
         view.putString("OwnerUuid", ownerUuidStr);
-        view.putString("ModelName", modelName);
+        view.putString("ModelName", getModelName());
         view.putFloat("Heading", heading);
         view.putFloat("TargetSpeed", targetSpeed);
     }


### PR DESCRIPTION
## Summary

Second phase of the BBModel airship work. Adapts BBModel rendering from the old `VertexConsumerProvider` API to the 1.21.11 `OrderedRenderCommandQueue` pipeline. Also fixes a Dockerfile bug that broke the Rust build.

### BBModel rendering wiring
- **`ShipRenderState`** — new render state carrying `modelName`, `heading`, `animationTime` snapshots. 1.21.11 renderers work against state objects, not entities directly.
- **`BBModelShipRenderer.render()`** rewritten to walk the BBModel tree:
  - Scale matrix from Blockbench units → world units (1/16)
  - Apply heading rotation
  - For each `BBObject`: bones push transform + recurse, cubes/meshes submit one `queue.submitCustom()` per face with captured matrix state
  - Each face lambda emits 4 vertices with UV, normal, light, color
- **Entity sync**:
  - `ShipEntity.modelName` now lives in `DataTracker` → auto-synced to clients
  - `ShipEntity.heading` mirrors to vanilla `yaw` → entity tracking replicates rotation without a custom payload
  - Renderer reads `entity.getYaw()` instead of `getHeading()` (yaw is auto-synced)

### Dockerfile fix
`behavior_statetree` depends on `bevy_behavior` but the Dockerfile only copied `bevy_npc`, `bevy_supa`, `bevy_pathfinding`. Docker build was failing with:
```
failed to read `/packages/rust/bevy/bevy_behavior/Cargo.toml`
```
Added the COPY line, sed path rewrite, and workspace member entry.

## Test plan
- [ ] `gradlew build` passes (verified)
- [ ] Docker build succeeds (`cargo build -p behavior_statetree` compiles)
- [ ] `/spawnship immersive_aircraft/airship` — visible airship model renders in-world
- [ ] Ship rotation reflects heading changes (WASD turn)
- [ ] Model syncs to multiple clients watching the same entity