### PR TITLE
feat(bevy): wire bevy_behavior into bevy_battle + Isometric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ name = "bevy_battle"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_behavior",
  "getrandom 0.4.2",
  "rand 0.10.0",
  "serde",
@@ -4880,6 +4881,7 @@ dependencies = [
  "askama",
  "axum 0.8.9",
  "bevy_battle",
+ "bevy_behavior",
  "bevy_chat",
  "bevy_inventory",
  "bevy_items",
@@ -7949,6 +7951,7 @@ dependencies = [
  "avian3d",
  "base64 0.22.1",
  "bevy",
+ "bevy_behavior",
  "bevy_cam",
  "bevy_chat",
  "bevy_db",

--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -33,6 +33,7 @@ kbve = { path = "../../../packages/rust/kbve", features = ["supabase", "image-ge
 bevy_items = { path = "../../../packages/rust/bevy/bevy_items", features = ["inventory"] }
 bevy_inventory = { path = "../../../packages/rust/bevy/bevy_inventory", default-features = false }
 bevy_battle = { path = "../../../packages/rust/bevy/bevy_battle" }
+bevy_behavior = { path = "../../../packages/rust/bevy/bevy_behavior" }
 bevy_npc = { path = "../../../packages/rust/bevy/bevy_npc" }
 bevy_quests = { path = "../../../packages/rust/bevy/bevy_quests" }
 bevy_skills = { path = "../../../packages/rust/bevy/bevy_skills" }

--- a/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
@@ -10,11 +10,13 @@ use std::collections::HashMap;
 use poise::serenity_prelude as serenity;
 
 use bevy_battle::{
-    ActiveEffects, App, Armor, AttackIntent, BevyBattlePlugin, CombatIndex, CombatModifiers,
-    CombatName, CombatOutcome, CombatStats, Combatant, CurrentIntent, DefendIntent, EnemyAI,
-    EnemyTag, EnemyTurnRequest, Entity, EquippedGear, FirstStrikeFired, FleeIntent, Health,
-    Messages, MinimalPlugins, PlayerClass, PlayerTag, TickEffectsRequest, UseItemIntent,
+    ActiveEffects, App, Armor, AttackIntent, BehaviorPolicy, BevyBattlePlugin, CombatIndex,
+    CombatModifiers, CombatName, CombatObservation, CombatOutcome, CombatStats, Combatant,
+    CurrentIntent, DefendIntent, EnemyAI, EnemyTag, EnemyTurnRequest, Entity, EquippedGear,
+    FirstStrikeFired, FleeIntent, Health, Intent, Messages, MinimalPlugins, PlayerClass, PlayerTag,
+    TickEffectsRequest, UseItemIntent,
 };
+use bevy_behavior::{BehaviorContext, BehaviorNode, Healthed, NodeStatus, Sequence};
 use bevy_inventory::Inventory;
 
 use super::content;
@@ -277,6 +279,7 @@ impl CombatWorld {
                     CombatIndex(es.index),
                     Combatant,
                     EnemyTag,
+                    BehaviorPolicy(build_enemy_tree()),
                 ))
                 .id();
             enemies.push((es.index, entity));
@@ -832,6 +835,47 @@ pub fn run_enemy_turns_only(
         outcomes,
         snapshot,
     }
+}
+
+// ── Enemy behavior tree ────────────────────────────────────────────
+//
+// When an enemy drops below 30% HP and isn't enraged (berserk enemies
+// don't retreat), prefer HealSelf. Otherwise the tree returns no
+// action and bevy_battle's enemy_turn_system falls back to the
+// existing random roll table. Keeps current combat variety while
+// adding one bit of conditional intelligence — the foundation for
+// personality-driven trees in future PRs.
+
+struct LowHpHeal {
+    threshold_fraction: f32,
+    heal_amount: i32,
+}
+
+impl BehaviorNode<CombatObservation, Intent> for LowHpHeal {
+    fn evaluate(
+        &self,
+        observation: &CombatObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<Intent>) {
+        if observation.enraged || observation.health_fraction() >= self.threshold_fraction {
+            return (NodeStatus::Failure, vec![]);
+        }
+        (
+            NodeStatus::Success,
+            vec![Intent::HealSelf {
+                amount: self.heal_amount,
+            }],
+        )
+    }
+}
+
+fn build_enemy_tree() -> Box<dyn BehaviorNode<CombatObservation, Intent>> {
+    Box::new(Sequence {
+        children: vec![Box::new(LowHpHeal {
+            threshold_fraction: 0.3,
+            heal_amount: 10,
+        })],
+    })
 }
 
 #[cfg(test)]

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ bevy_inventory = { path = "../../../../packages/rust/bevy/bevy_inventory" }
 bevy_items = { path = "../../../../packages/rust/bevy/bevy_items", features = ["inventory"] }
 bevy_cam = { path = "../../../../packages/rust/bevy/bevy_cam" }
 bevy_kbve_net = { path = "../../../../packages/rust/bevy/bevy_kbve_net", features = ["npcdb", "client", "creatures"] }
+bevy_behavior = { path = "../../../../packages/rust/bevy/bevy_behavior" }
 bevy_skills = { path = "../../../../packages/rust/bevy/bevy_skills" }
 bevy_db = { path = "../../../../packages/rust/bevy/bevy_db" }
 bevy_chat = { path = "../../../../packages/rust/bevy/bevy_chat", features = ["plugin"] }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -3,6 +3,7 @@ pub mod common;
 pub mod creature;
 mod firefly;
 pub mod generic;
+pub mod observation;
 pub mod sprite_material;
 
 use bevy::prelude::*;

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/observation.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/observation.rs
@@ -1,0 +1,54 @@
+//! Behavior tree observation adapter for Isometric creatures.
+//!
+//! Snapshots the creature state the shared `bevy_behavior` built-in leaves
+//! need (position, health, nearby entities, tick) into a struct that
+//! implements the `Positioned` / `Healthed` / `Aware` / `Ticked` traits.
+//!
+//! This is the foundation layer — later PRs will build Isometric-specific
+//! trees on top and dispatch them alongside (or replacing) the existing
+//! `BehaviorNode` enum in `creatures/generic/behavior.rs`.
+
+use bevy::prelude::Vec3;
+use bevy_behavior::{Aware, EntitySnapshot, Healthed, Positioned, Ticked};
+
+/// Creature observation snapshot — assembled from `Creature`, `CreatureVitals`,
+/// and world queries at decision time. Short-lived (one tree eval per entity
+/// per decision tick); do not store.
+pub struct CreatureObservation {
+    pub position: Vec3,
+    pub health: f32,
+    pub max_health: f32,
+    pub tick: u64,
+    pub nearby: Vec<EntitySnapshot>,
+}
+
+impl Positioned for CreatureObservation {
+    fn position(&self) -> [f64; 3] {
+        [
+            self.position.x as f64,
+            self.position.y as f64,
+            self.position.z as f64,
+        ]
+    }
+}
+
+impl Healthed for CreatureObservation {
+    fn current_health(&self) -> f32 {
+        self.health
+    }
+    fn max_health(&self) -> f32 {
+        self.max_health
+    }
+}
+
+impl Aware for CreatureObservation {
+    fn nearby_entities(&self) -> &[EntitySnapshot] {
+        &self.nearby
+    }
+}
+
+impl Ticked for CreatureObservation {
+    fn tick(&self) -> u64 {
+        self.tick
+    }
+}

--- a/packages/rust/bevy/bevy_battle/Cargo.toml
+++ b/packages/rust/bevy/bevy_battle/Cargo.toml
@@ -19,6 +19,11 @@ bevy = { version = "0.18", default-features = false, features = [
 serde = { version = "1", features = ["derive"] }
 rand = "0.10"
 
+# Shared behavior tree engine — enables the optional BehaviorPolicy
+# component that lets consumers override the random enemy_turn roll
+# with a conditional tree. No tree attached = unchanged random behavior.
+bevy_behavior = { path = "../bevy_behavior" }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }
 

--- a/packages/rust/bevy/bevy_battle/src/component.rs
+++ b/packages/rust/bevy/bevy_battle/src/component.rs
@@ -140,3 +140,49 @@ pub struct EnemyTag;
 /// Marker: entity has died. Added on death, used for filtering.
 #[derive(Component, Debug, Clone, Copy)]
 pub struct Dead;
+
+// ── Behavior tree override ─────────────────────────────────────────
+
+/// Snapshot an enemy turn system passes to an attached [`BehaviorPolicy`]
+/// tree. Implements `bevy_behavior::Healthed` so generic leaves like
+/// `IsHealthLow` work without knowing about bevy_battle's internals.
+#[derive(Debug, Clone)]
+pub struct CombatObservation {
+    pub hp: f32,
+    pub max_hp: f32,
+    pub level: u8,
+    pub enraged: bool,
+    pub charged: bool,
+    pub weakened: bool,
+    pub personality: Personality,
+}
+
+impl bevy_behavior::Healthed for CombatObservation {
+    fn current_health(&self) -> f32 {
+        self.hp
+    }
+    fn max_health(&self) -> f32 {
+        self.max_hp
+    }
+}
+
+/// Optional behavior tree attached to an enemy. When present on an
+/// entity, the `enemy_turn_system` evaluates the tree first — only
+/// falling back to `roll_new_intent()`'s random table when the tree
+/// returns an empty action list.
+///
+/// Consumers build the tree using `bevy_behavior` primitives. Example:
+///
+/// ```ignore
+/// use bevy_battle::{BehaviorPolicy, CombatObservation, Intent};
+/// use bevy_behavior::{Sequence, IsHealthLow};
+///
+/// let tree = Sequence { children: vec![
+///     Box::new(IsHealthLow { threshold: 10.0 }),
+///     // closure-driven leaf emitting a HealSelf intent
+///     // ...
+/// ]};
+/// BehaviorPolicy(Box::new(tree))
+/// ```
+#[derive(Component)]
+pub struct BehaviorPolicy(pub Box<dyn bevy_behavior::BehaviorNode<CombatObservation, Intent>>);

--- a/packages/rust/bevy/bevy_battle/src/system/enemy_turn.rs
+++ b/packages/rust/bevy/bevy_battle/src/system/enemy_turn.rs
@@ -37,6 +37,7 @@ pub fn enemy_turn_system(
         ),
         (With<PlayerTag>, Without<Dead>, Without<EnemyTag>),
     >,
+    policies: Query<&BehaviorPolicy, With<EnemyTag>>,
     modifiers: Res<CombatModifiers>,
     mut rng: ResMut<BattleRng>,
 ) {
@@ -242,9 +243,39 @@ pub fn enemy_turn_system(
             }
         }
 
-        // Roll new intent
-        if let Ok((_, _, _, _, _, mut ai, mut intent)) = enemies.get_mut(*enemy_entity) {
-            roll_and_set_intent(&mut ai, &mut intent, &mut rng.0);
+        // Roll new intent — check for an optional BehaviorPolicy tree
+        // first; fall back to the random table if no tree is attached or
+        // the tree returns no action.
+        if let Ok((_, _, hp, _, effects, mut ai, mut intent)) = enemies.get_mut(*enemy_entity) {
+            let tree_intent = policies.get(*enemy_entity).ok().and_then(|policy| {
+                let observation = CombatObservation {
+                    hp: hp.current as f32,
+                    max_hp: hp.max as f32,
+                    level: ai.level,
+                    enraged: ai.enraged,
+                    charged: ai.charged,
+                    weakened: effects.has(&EffectKind::Weakened),
+                    personality: ai.personality,
+                };
+                // Minimal context — cooldowns are unused for combat decisions
+                // right now but the trait requires a valid context. A future
+                // PR can wire per-enemy ability cooldowns through here.
+                let mut per_npc = bevy_behavior::TickCooldown::new(0);
+                let mut global = bevy_behavior::TickCooldown::new(0);
+                let mut ctx = bevy_behavior::BehaviorContext {
+                    current_tick: 0,
+                    per_npc: &mut per_npc,
+                    global: &mut global,
+                };
+                let (_, mut intents) = policy.0.evaluate(&observation, &mut ctx);
+                intents.pop()
+            });
+
+            if let Some(chosen) = tree_intent {
+                intent.0 = chosen;
+            } else {
+                roll_and_set_intent(&mut ai, &mut intent, &mut rng.0);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the unified skeleton AI roadmap ([#10194](https://github.com/KBVE/kbve/issues/10194)). Both halves of the ask land together:

- **Discord MUD** — real functional change: enemies now use a behavior tree to prefer `HealSelf` when HP drops under 30%.
- **Isometric** — foundation layer: observation trait adapter ready for a follow-up PR to migrate the existing `BehaviorNode` enum trees to the shared engine.

### `bevy_battle` (the hook)

The enemy AI decision lives in `bevy_battle::enemy_turn_system`, so the integration point has to be there. Added:

- **`BehaviorPolicy`** component — holds `Box<dyn BehaviorNode<CombatObservation, Intent>>`. Optional — enemies without one get the existing random-roll behavior unchanged.
- **`CombatObservation`** struct — implements `bevy_behavior::Healthed`. Snapshots HP, level, enraged/charged/weakened flags, personality. Passed to the tree each turn.
- **`enemy_turn_system`** — now queries for an attached policy. If present and the tree returns an intent, use it. If no policy or empty result, fall through to `roll_new_intent` (unchanged).

Backward compatible — every existing call site still works identically because the behavior is gated on a new optional component.

### `discordsh-bot`

Attaches a **`LowHpHeal`** tree to every enemy spawned in `battle_bridge.rs`. Single leaf:
- Fires `HealSelf { amount: 10 }` when `health_fraction() < 0.3` and the enemy isn't enraged (berserk enemies don't retreat).
- Returns `NodeStatus::Failure` otherwise, so `bevy_battle`'s random table takes over.

This is the minimum viable tree that proves the integration works end-to-end. Future PRs can build personality-specific trees (Cowardly flees earlier, Ancient casts AoE at low HP, etc.) using the same hook.

### `isometric-game`

Minimal foundation only — adds `creatures/observation.rs` with a `CreatureObservation` struct implementing all four traits (`Positioned`, `Healthed`, `Aware`, `Ticked`). The existing `BehaviorNode` enum trees in `creatures/generic/behavior.rs` continue running unchanged.

Purpose: unblock a follow-up PR that migrates those hardcoded trees (boar, wolf, stag, wraith, etc.) to `bevy_behavior::Selector`/`Sequence` without needing to also define the observation contract in that same PR.

## Test plan

- [x] `cargo check -p bevy_battle` — compiles clean
- [x] `cargo check -p discordsh-bot` — compiles clean (42 pre-existing warnings, none new)
- [x] `cargo check -p isometric-game` — compiles clean (32 pre-existing warnings, none new)
- [ ] Manual smoke test: Discord dungeon enemy at low HP should heal itself instead of random-rolling
- [ ] Existing enemy behavior for high-HP enemies unchanged (tree returns `Failure`, random roll runs)