### PR TITLE
feat(mc): multi-server RCON + ClickHouse presence snapshots

### DIFF
--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -1,9 +1,15 @@
-// MC RCON client with DashMap-cached player data and Mojang profile enrichment.
+// MC RCON client with multi-server support, DashMap-cached player data,
+// Mojang profile enrichment, and ClickHouse snapshot publishing.
 //
-// Background task polls RCON `list` every 15s, resolves UUIDs + textures
-// via Mojang API, and stores results in a single DashMap for instant lookups.
+// Background task polls every configured RCON endpoint in parallel every
+// 15s, tags each player with the backend server they're on, resolves
+// UUIDs + textures via Mojang, and writes a snapshot row per player to
+// `mc.player_snapshots_distributed` in ClickHouse. axum-kbve serves its
+// own /api/v1/mc/players from an in-memory cache for low latency; edge
+// functions and other consumers read historical state from ClickHouse.
 
 use dashmap::DashMap;
+use futures_util::future::join_all;
 use serde::Serialize;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
@@ -20,9 +26,15 @@ use super::ensure_https;
 const REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const PLAYER_TTL: Duration = Duration::from_secs(3600); // 1h
 const RCON_TIMEOUT: Duration = Duration::from_secs(5);
+const CH_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 
 const MOJANG_API: &str = "https://api.mojang.com/users/profiles/minecraft";
 const MOJANG_SESSION: &str = "https://sessionserver.mojang.com/session/minecraft/profile";
+
+// Names we probe for multi-server env var prefixes. Add new backends
+// by listing their env var suffix here — each maps to
+// MC_RCON_<NAME>_HOST / _PORT / _PASSWORD.
+const KNOWN_SERVERS: &[&str] = &["LOBBY", "SURVIVAL"];
 
 // ---------------------------------------------------------------------------
 // Types
@@ -34,14 +46,43 @@ pub struct McPlayer {
     pub name: String,
     pub uuid: Option<String>,
     pub skin_url: Option<String>,
+    /// Backend server the player is connected to ("lobby", "survival").
+    pub server: String,
+}
+
+/// Per-server status for API clients that want a breakdown by backend.
+/// `reachable=false` means the RCON call failed this interval — the
+/// player list for that server is stale or empty in the aggregate
+/// response.
+#[derive(Clone, Debug, Serialize)]
+pub struct McServerStatus {
+    pub server: String,
+    pub online: usize,
+    pub max: usize,
+    pub reachable: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct McPlayerList {
+    /// Total online across all reachable servers.
     pub online: usize,
+    /// Sum of `max_slots` across all reachable servers.
     pub max: usize,
     pub players: Vec<McPlayer>,
+    pub servers: Vec<McServerStatus>,
     pub cached_at: u64,
+}
+
+/// One RCON endpoint. Multiple can be configured for lobby + survival +
+/// future backends.
+#[derive(Clone, Debug)]
+struct RconEndpoint {
+    /// Lowercase server name ("lobby", "survival"). Surfaced on each
+    /// McPlayer and written to ClickHouse.
+    name: String,
+    host: String,
+    port: u16,
+    password: String,
 }
 
 /// Single cache entry holding all resolved data for a Minecraft player.
@@ -64,10 +105,11 @@ impl CachedPlayer {
 }
 
 pub struct McService {
-    rcon_host: String,
-    rcon_port: u16,
-    rcon_password: String,
+    endpoints: Vec<RconEndpoint>,
     http: reqwest::Client,
+    /// Optional — writes every snapshot to ClickHouse when configured.
+    /// None means CH env vars were missing and we're in-memory only.
+    clickhouse: Option<ClickHouseWriter>,
     // Cached player list (refreshed by background task)
     player_list: Arc<tokio::sync::RwLock<Option<McPlayerList>>>,
     // Single cache for all player data (name → uuid + skin_url + texture_bytes)
@@ -85,24 +127,18 @@ pub fn get_mc_service() -> Option<&'static Arc<McService>> {
 }
 
 pub fn init_mc_service() -> bool {
-    let host = match std::env::var("MC_RCON_HOST") {
-        Ok(h) => h,
-        Err(_) => return false,
-    };
-    let port: u16 = std::env::var("MC_RCON_PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(25575);
-    let password = std::env::var("MC_RCON_PASSWORD").unwrap_or_default();
+    let endpoints = parse_rcon_endpoints();
+    if endpoints.is_empty() {
+        return false;
+    }
 
     let svc = Arc::new(McService {
-        rcon_host: host,
-        rcon_port: port,
-        rcon_password: password,
+        endpoints,
         http: reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .build()
             .unwrap_or_default(),
+        clickhouse: ClickHouseWriter::from_env(),
         player_list: Arc::new(tokio::sync::RwLock::new(None)),
         players: Arc::new(DashMap::new()),
     });
@@ -129,6 +165,48 @@ pub fn init_mc_service() -> bool {
     true
 }
 
+/// Parse RCON endpoints from env vars. Prefers the multi-server scheme
+/// (`MC_RCON_LOBBY_*`, `MC_RCON_SURVIVAL_*`). Falls back to the legacy
+/// single-server scheme (`MC_RCON_HOST`/`MC_RCON_PORT`/`MC_RCON_PASSWORD`,
+/// reported as server="default") if no prefixed vars are set.
+fn parse_rcon_endpoints() -> Vec<RconEndpoint> {
+    let mut out = Vec::new();
+
+    for name in KNOWN_SERVERS {
+        if let Ok(host) = std::env::var(format!("MC_RCON_{name}_HOST")) {
+            let port = std::env::var(format!("MC_RCON_{name}_PORT"))
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(25575);
+            let password = std::env::var(format!("MC_RCON_{name}_PASSWORD")).unwrap_or_default();
+            out.push(RconEndpoint {
+                name: name.to_lowercase(),
+                host,
+                port,
+                password,
+            });
+        }
+    }
+
+    if out.is_empty() {
+        if let Ok(host) = std::env::var("MC_RCON_HOST") {
+            let port = std::env::var("MC_RCON_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(25575);
+            let password = std::env::var("MC_RCON_PASSWORD").unwrap_or_default();
+            out.push(RconEndpoint {
+                name: "default".to_string(),
+                host,
+                port,
+                password,
+            });
+        }
+    }
+
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -143,6 +221,7 @@ impl McService {
                 online: 0,
                 max: 0,
                 players: vec![],
+                servers: vec![],
                 cached_at: now_epoch(),
             })
     }
@@ -193,31 +272,60 @@ impl McService {
 
 impl McService {
     async fn refresh_player_list(&self) {
-        let rcon_result = self.rcon_list().await;
-
-        let (names, max) = match rcon_result {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(error = %e, "RCON list failed");
-                return;
+        // Poll every configured endpoint in parallel. If one is down
+        // (e.g. Agones fleet has 0 Fabric pods), the others still land.
+        let polls = self.endpoints.iter().map(|ep| {
+            let ep = ep.clone();
+            async move {
+                let result = Self::rcon_list(&ep).await;
+                (ep.name, result)
             }
-        };
+        });
+        let results: Vec<(String, anyhow::Result<(Vec<String>, usize)>)> = join_all(polls).await;
 
-        let mut players = Vec::with_capacity(names.len());
+        let mut all_players: Vec<McPlayer> = Vec::new();
+        let mut server_statuses: Vec<McServerStatus> = Vec::new();
+        let mut total_online = 0usize;
+        let mut total_max = 0usize;
 
-        for name in &names {
-            let cached = self.resolve_player(name).await;
-            players.push(McPlayer {
-                name: name.clone(),
-                uuid: cached.as_ref().map(|c| c.uuid.clone()),
-                skin_url: cached.and_then(|c| c.skin_url),
-            });
+        for (server_name, result) in results {
+            match result {
+                Ok((names, max)) => {
+                    total_online += names.len();
+                    total_max += max;
+                    server_statuses.push(McServerStatus {
+                        server: server_name.clone(),
+                        online: names.len(),
+                        max,
+                        reachable: true,
+                    });
+                    for name in names {
+                        let cached = self.resolve_player(&name).await;
+                        all_players.push(McPlayer {
+                            name,
+                            uuid: cached.as_ref().map(|c| c.uuid.clone()),
+                            skin_url: cached.and_then(|c| c.skin_url),
+                            server: server_name.clone(),
+                        });
+                    }
+                }
+                Err(e) => {
+                    warn!(server = %server_name, error = %e, "RCON list failed");
+                    server_statuses.push(McServerStatus {
+                        server: server_name,
+                        online: 0,
+                        max: 0,
+                        reachable: false,
+                    });
+                }
+            }
         }
 
         let list = McPlayerList {
-            online: players.len(),
-            max,
-            players,
+            online: total_online,
+            max: total_max,
+            players: all_players.clone(),
+            servers: server_statuses.clone(),
             cached_at: now_epoch(),
         };
 
@@ -226,7 +334,19 @@ impl McService {
         // Evict expired entries
         self.players.retain(|_, v| !v.is_expired());
 
-        debug!("MC player list refreshed ({} players)", names.len());
+        debug!(
+            "MC refresh: {} players across {} servers",
+            all_players.len(),
+            server_statuses.len()
+        );
+
+        // ClickHouse write is best-effort — failures don't affect the
+        // in-memory cache that serves /api/v1/mc/players.
+        if let Some(ref ch) = self.clickhouse {
+            if let Err(e) = ch.write_snapshot(&server_statuses, &all_players).await {
+                warn!(error = %e, "ClickHouse snapshot write failed");
+            }
+        }
     }
 
     /// Resolve player name → full profile (UUID + skin URL) via DashMap cache
@@ -298,12 +418,14 @@ const RCON_EXEC: i32 = 2;
 
 impl McService {
     /// Connect to RCON, authenticate, run `list`, return (player_names, max_players).
-    async fn rcon_list(&self) -> anyhow::Result<(Vec<String>, usize)> {
-        let addr = format!("{}:{}", self.rcon_host, self.rcon_port);
+    /// Associated function so each endpoint can be polled in parallel without
+    /// borrowing &self across the join_all boundary.
+    async fn rcon_list(ep: &RconEndpoint) -> anyhow::Result<(Vec<String>, usize)> {
+        let addr = format!("{}:{}", ep.host, ep.port);
         let mut stream = tokio::time::timeout(RCON_TIMEOUT, TcpStream::connect(&addr)).await??;
 
         // Authenticate
-        rcon_send(&mut stream, 1, RCON_AUTH, &self.rcon_password).await?;
+        rcon_send(&mut stream, 1, RCON_AUTH, &ep.password).await?;
         let (req_id, _, _) = rcon_recv(&mut stream).await?;
         if req_id == -1 {
             anyhow::bail!("RCON authentication failed");
@@ -362,6 +484,91 @@ async fn rcon_recv(stream: &mut TcpStream) -> anyhow::Result<(i32, i32, String)>
     let body = String::from_utf8_lossy(&payload[8..body_end]).to_string();
 
     Ok((req_id, ptype, body))
+}
+
+// ---------------------------------------------------------------------------
+// ClickHouse writer — snapshot per player per poll into
+// mc.player_snapshots_distributed. Schema lives in
+// apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml.
+// ---------------------------------------------------------------------------
+
+struct ClickHouseWriter {
+    endpoint: String,
+    user: String,
+    password: String,
+    client: reqwest::Client,
+}
+
+impl ClickHouseWriter {
+    fn from_env() -> Option<Self> {
+        let endpoint = std::env::var("CLICKHOUSE_ENDPOINT").ok()?;
+        let user = std::env::var("CLICKHOUSE_USER").ok()?;
+        let password = std::env::var("CLICKHOUSE_PASSWORD").unwrap_or_default();
+        let client = reqwest::Client::builder()
+            .timeout(CH_WRITE_TIMEOUT)
+            .build()
+            .ok()?;
+        Some(Self {
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            user,
+            password,
+            client,
+        })
+    }
+
+    async fn write_snapshot(
+        &self,
+        servers: &[McServerStatus],
+        players: &[McPlayer],
+    ) -> anyhow::Result<()> {
+        // Skip empty snapshots — the schema is per-player, so there's
+        // nothing to record when every server is empty. The reachable
+        // flag + in-memory cache cover server liveness at query time.
+        if players.is_empty() {
+            return Ok(());
+        }
+
+        let timestamp = chrono::Utc::now()
+            .format("%Y-%m-%d %H:%M:%S%.3f")
+            .to_string();
+
+        let mut payload = String::with_capacity(players.len() * 128);
+        for p in players {
+            let status = servers.iter().find(|s| s.server == p.server);
+            let online = status.map(|s| s.online).unwrap_or(0);
+            let max = status.map(|s| s.max).unwrap_or(0);
+
+            let row = serde_json::json!({
+                "timestamp": timestamp,
+                "server": p.server,
+                "name": p.name,
+                "uuid": p.uuid.clone().unwrap_or_default(),
+                "online_count": online,
+                "max_slots": max,
+            });
+            payload.push_str(&row.to_string());
+            payload.push('\n');
+        }
+
+        let url = format!(
+            "{}/?query=INSERT+INTO+mc.player_snapshots_distributed+FORMAT+JSONEachRow",
+            self.endpoint
+        );
+        let resp = self
+            .client
+            .post(&url)
+            .basic_auth(&self.user, Some(&self.password))
+            .body(payload)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("ClickHouse insert failed: status={status} body={body}");
+        }
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kube/kbve/manifest/clickhouse-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/clickhouse-externalsecret.yaml
@@ -1,0 +1,56 @@
+# Cross-namespace secret sync: clickhouse-vector-credentials from the
+# vector namespace into kbve as clickhouse-credentials. axum-kbve uses
+# it to write MC presence snapshots to the mc.player_snapshots table.
+#
+# Single source of truth stays at vector/clickhouse-vector-credentials
+# (SealedSecret in apps/kube/vector/manifests/sealed-clickhouse-vector.yaml).
+# Complementary RBAC lives at
+# apps/kube/vector/manifests/kbve-ch-credentials-rbac.yaml.
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: vector-remote-secret-store
+    namespace: kbve
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: vector
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: clickhouse-credentials
+    namespace: kbve
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: vector-remote-secret-store
+        kind: SecretStore
+    target:
+        name: clickhouse-credentials
+        creationPolicy: Owner
+    data:
+        - secretKey: endpoint
+          remoteRef:
+              key: clickhouse-vector-credentials
+              property: endpoint
+        - secretKey: username
+          remoteRef:
+              key: clickhouse-vector-credentials
+              property: username
+        - secretKey: password
+          remoteRef:
+              key: clickhouse-vector-credentials
+              property: password

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -129,20 +129,50 @@ spec:
                         value: '/etc/ssl/webtransport-selfsigned/tls.key'
                       - name: CHUCKRPG_UPSTREAM_URL
                         value: 'http://rows.ows.svc.cluster.local:4322'
-                      # MC RCON — drives the /api/v1/mc/players endpoint
-                      # (kbve.com/mc/players). Service DNS resolves to the
-                      # current Agones lobby pod. Password synced from the
-                      # mc namespace via ExternalSecret — single source of
-                      # truth in mc/mc-rcon-password SealedSecret.
-                      - name: MC_RCON_HOST
+                      # MC RCON (multi-server) — drives /api/v1/mc/players.
+                      # axum-kbve polls both backends in parallel, tags each
+                      # player with the server they're on, and writes
+                      # snapshots to ClickHouse below for other consumers.
+                      # Password synced from the mc namespace via the
+                      # mc-rcon-credentials ExternalSecret — single source
+                      # of truth in mc/mc-rcon-password SealedSecret.
+                      - name: MC_RCON_LOBBY_HOST
                         value: 'mc-lobby-backend.arc-runners.svc.cluster.local'
-                      - name: MC_RCON_PORT
+                      - name: MC_RCON_LOBBY_PORT
                         value: '25575'
-                      - name: MC_RCON_PASSWORD
+                      - name: MC_RCON_LOBBY_PASSWORD
                         valueFrom:
                             secretKeyRef:
                                 name: mc-rcon-credentials
                                 key: rcon-password
+                      - name: MC_RCON_SURVIVAL_HOST
+                        value: 'mc-fabric-backend.arc-runners.svc.cluster.local'
+                      - name: MC_RCON_SURVIVAL_PORT
+                        value: '25575'
+                      - name: MC_RCON_SURVIVAL_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: mc-rcon-credentials
+                                key: rcon-password
+                      # ClickHouse — axum-kbve writes one snapshot row per
+                      # player per poll to mc.player_snapshots_distributed.
+                      # Credentials synced from the vector namespace via
+                      # the clickhouse-credentials ExternalSecret.
+                      - name: CLICKHOUSE_ENDPOINT
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: endpoint
+                      - name: CLICKHOUSE_USER
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: username
+                      - name: CLICKHOUSE_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: password
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
     - kbve-serviceaccount.yaml
     - kbve-externalsecret.yaml
     - mc-rcon-externalsecret.yaml
+    - clickhouse-externalsecret.yaml
     - forgejo-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml
@@ -17,3 +18,4 @@ resources:
     - kbve-wt-selfsigned-cronjob.yaml
     - cf-cache-purge-externalsecret.yaml
     - cf-cache-purge-postsync.yaml
+    - mc-presence-ch-setup-job.yaml

--- a/apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml
+++ b/apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml
@@ -1,0 +1,143 @@
+# Creates the mc database and mc.player_snapshots ReplicatedMergeTree
+# table in ClickHouse on every ArgoCD PostSync. Idempotent via
+# CREATE ... IF NOT EXISTS.
+#
+# axum-kbve writes one row per player per poll to this table. Other
+# consumers (edge functions, dashboard) can read from it instead of
+# hitting RCON directly. 30-day TTL is a starting value — adjust if
+# historical queries push us over storage budget.
+#
+# Mirrors apps/kube/vector/manifests/observability-ch-setup-job.yaml.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: mc-presence-ch-setup-script
+    namespace: kbve
+data:
+    setup.sh: |
+        #!/bin/sh
+        set -eu
+
+        echo "Verifying ClickHouse connectivity..."
+        curl -sf --max-time 10 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "SELECT 1" >/dev/null || {
+          echo "ERROR: Cannot connect to ClickHouse at ${CLICKHOUSE_ENDPOINT}"
+          exit 1
+        }
+        echo "ClickHouse connection OK."
+
+        echo "Creating mc database..."
+        curl -sf --max-time 10 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "CREATE DATABASE IF NOT EXISTS mc ON CLUSTER 'cluster'" >/dev/null || {
+          echo "ERROR: Failed to create mc database"
+          exit 1
+        }
+        echo "Database 'mc' ready."
+
+        echo "Creating player_snapshots table (ReplicatedMergeTree)..."
+        curl -sf --max-time 30 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "
+        CREATE TABLE IF NOT EXISTS mc.player_snapshots ON CLUSTER 'cluster'
+        (
+            timestamp     DateTime64(3, 'UTC'),
+            server        LowCardinality(String),
+            name          String,
+            uuid          String DEFAULT '',
+            online_count  UInt32,
+            max_slots     UInt32,
+            ingested_at   DateTime64(3, 'UTC') DEFAULT now64(3)
+        )
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/mc/player_snapshots', '{replica}')
+        ORDER BY (server, timestamp, name)
+        PARTITION BY toYYYYMMDD(timestamp)
+        TTL toDateTime(timestamp) + INTERVAL 30 DAY
+        " >/dev/null || {
+          echo "ERROR: Failed to create player_snapshots table"
+          exit 1
+        }
+        echo "Table 'mc.player_snapshots' ready."
+
+        echo "Creating player_snapshots_distributed table (Distributed)..."
+        curl -sf --max-time 30 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "
+        CREATE TABLE IF NOT EXISTS mc.player_snapshots_distributed ON CLUSTER 'cluster'
+        AS mc.player_snapshots
+        ENGINE = Distributed('cluster', 'mc', 'player_snapshots', rand())
+        " >/dev/null || {
+          echo "ERROR: Failed to create player_snapshots_distributed table"
+          exit 1
+        }
+        echo "Table 'mc.player_snapshots_distributed' ready."
+
+        echo ""
+        echo "MC presence schema setup complete."
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: mc-presence-ch-setup
+    namespace: kbve
+    labels:
+        app: mc-presence-ch-setup
+        app.kubernetes.io/part-of: mc
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+    ttlSecondsAfterFinished: 86400
+    backoffLimit: 3
+    template:
+        metadata:
+            labels:
+                app: mc-presence-ch-setup
+        spec:
+            restartPolicy: OnFailure
+            containers:
+                - name: setup
+                  image: curlimages/curl:8.12.1
+                  command: ['/bin/sh', '/scripts/setup.sh']
+                  env:
+                      - name: CLICKHOUSE_ENDPOINT
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: endpoint
+                      - name: CLICKHOUSE_USER
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: username
+                      - name: CLICKHOUSE_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: password
+                  volumeMounts:
+                      - name: setup-script
+                        mountPath: /scripts
+                        readOnly: true
+                  resources:
+                      requests:
+                          memory: '32Mi'
+                          cpu: '50m'
+                      limits:
+                          memory: '64Mi'
+                          cpu: '100m'
+                  securityContext:
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+            volumes:
+                - name: setup-script
+                  configMap:
+                      name: mc-presence-ch-setup-script
+                      defaultMode: 0555

--- a/apps/kube/vector/manifests/kbve-ch-credentials-rbac.yaml
+++ b/apps/kube/vector/manifests/kbve-ch-credentials-rbac.yaml
@@ -1,0 +1,34 @@
+# Allow the kbve-external-secrets ServiceAccount (in kbve namespace)
+# to read the clickhouse-vector-credentials secret from the vector
+# namespace. Used by the ExternalSecret at
+# apps/kube/kbve/manifest/clickhouse-externalsecret.yaml to sync CH
+# credentials into kbve so axum-kbve can write MC presence snapshots.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: clickhouse-credentials-reader-for-kbve
+    namespace: vector
+    labels:
+        app.kubernetes.io/part-of: observability
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'list', 'watch']
+      resourceNames: ['clickhouse-vector-credentials']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-read-clickhouse-credentials
+    namespace: vector
+    labels:
+        app.kubernetes.io/part-of: observability
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: clickhouse-credentials-reader-for-kbve
+subjects:
+    - kind: ServiceAccount
+      name: kbve-external-secrets
+      namespace: kbve


### PR DESCRIPTION
## Summary
axum-kbve now polls both MC backends (lobby + survival) in parallel, tags each player with which server they're on, and writes snapshots to ClickHouse so edge functions and other future consumers can read historical presence without hitting RCON themselves.

## Architecture
axum-kbve stays the primary RCON poller. CH becomes the shared read layer. Edge functions and future consumers SELECT from `mc.player_snapshots_distributed` for cheap reads, or still go direct to RCON when they need real-time or to run commands.

## Code changes (`apps/kbve/axum-kbve/src/db/mc.rs`)
- `McPlayer` gains a `server` field (`"lobby"`, `"survival"`)
- New `McServerStatus` + `servers: Vec<McServerStatus>` on `McPlayerList` — per-backend online/max/reachable
- `McService` holds `Vec<RconEndpoint>` instead of a single host/port/password. Polls all via `futures_util::future::join_all`
- Graceful degradation: one unreachable backend (Agones fleet with zero Fabric pods, network blip, etc.) logs a warning and marks that server `reachable: false`; the overall response still succeeds
- Env parsing: prefers `MC_RCON_LOBBY_*` / `MC_RCON_SURVIVAL_*`, falls back to the legacy single-server `MC_RCON_*` scheme for backward compat
- New `ClickHouseWriter` initialized from `CLICKHOUSE_ENDPOINT/USER/PASSWORD`. After each refresh, inserts one row per player into `mc.player_snapshots_distributed` via HTTP `JSONEachRow`. Best-effort — CH write failures log a warning and never affect the in-memory cache that serves `/api/v1/mc/players`
- All 4 existing unit tests still pass

## Infra changes
- **`apps/kube/vector/manifests/kbve-ch-credentials-rbac.yaml`** (new) — Role + RoleBinding granting the `kbve-external-secrets` SA read access to only `clickhouse-vector-credentials` in the vector namespace
- **`apps/kube/kbve/manifest/clickhouse-externalsecret.yaml`** (new) — SecretStore + ExternalSecret syncing it into kbve as `clickhouse-credentials`. Source of truth stays in the vector namespace SealedSecret (no duplication)
- **`apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml`** (new) — ArgoCD PostSync Job that creates the `mc` database and `player_snapshots` ReplicatedMergeTree + `player_snapshots_distributed` Distributed table. 30-day TTL, partitioned by day, ORDER BY `(server, timestamp, name)`. Mirrors the observability-ch-setup-job pattern
- **`kbve-deployment.yaml`** — swaps single `MC_RCON_*` for `MC_RCON_LOBBY_*` + `MC_RCON_SURVIVAL_*`, adds `CLICKHOUSE_ENDPOINT/USER/PASSWORD`
- **`kustomization.yaml`** — registers the two new files

## Schema
```sql
CREATE TABLE mc.player_snapshots (
    timestamp     DateTime64(3, 'UTC'),
    server        LowCardinality(String),    -- 'lobby', 'survival'
    name          String,
    uuid          String DEFAULT '',
    online_count  UInt32,                    -- server count at this snapshot
    max_slots     UInt32,
    ingested_at   DateTime64(3, 'UTC') DEFAULT now64(3)
)
ENGINE = ReplicatedMergeTree
ORDER BY (server, timestamp, name)
PARTITION BY toYYYYMMDD(timestamp)
TTL toDateTime(timestamp) + INTERVAL 30 DAY;
```

## Test plan
- [ ] `cargo check -p axum-kbve` clean (✓ done locally, 1m 36s)
- [ ] `cargo test -p axum-kbve --bin axum-kbve db::mc::` all pass (✓ 4/4 done locally)
- [ ] Merge + dev→main promotion
- [ ] `kubectl get externalsecret clickhouse-credentials -n kbve` → SecretSynced
- [ ] `kubectl get secret clickhouse-credentials -n kbve` has `endpoint/username/password` keys
- [ ] `mc-presence-ch-setup` Job completes successfully
- [ ] `SELECT database, name FROM system.tables WHERE database = 'mc'` shows the two tables
- [ ] `curl https://kbve.com/api/v1/mc/players` returns `servers: [...]` alongside `players: [...]` with `server` field on each player
- [ ] ClickHouse `SELECT server, count() FROM mc.player_snapshots_distributed WHERE timestamp > now() - INTERVAL 5 MINUTE GROUP BY server` shows rows flowing in

## Follow-ups (not this PR)
- Frontend `McPlayerList.tsx` — render a Lobby/Survival badge on each player card
- Edge functions — migrate simple "who's online" reads from RCON to a `SELECT FROM mc.player_snapshots_distributed WHERE timestamp > now() - INTERVAL 30 SECOND`
- If query patterns warrant it: a materialized view over `player_snapshots` that keeps only the latest snapshot per (server, name), for constant-time "current online" lookups