### PR TITLE
fix(mc): copy bevy_chat crate into Docker rust-builder stage

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -32,17 +32,17 @@ COPY packages/rust/bevy/bevy_npc/ bevy_npc/
 COPY packages/rust/bevy/bevy_supa/ bevy_supa/
 COPY packages/rust/bevy/bevy_pathfinding/ bevy_pathfinding/
 COPY packages/rust/bevy/bevy_behavior/ bevy_behavior/
+COPY packages/rust/bevy/bevy_chat/ bevy_chat/
 
 # Rewrite package path refs for the flattened Docker context.
-# - behavior_statetree ← ../../../packages/rust/bevy/bevy_npc
-# - behavior_statetree ← ../../../packages/rust/bevy/bevy_pathfinding
-# - behavior_statetree ← ../../../packages/rust/bevy/bevy_behavior
-# - mc_auth             ← ../../../packages/rust/bevy/bevy_supa
+# Every bevy_* path dep in behavior_statetree/mc_auth must be rewritten
+# from ../../../packages/rust/bevy/<crate> to ../<crate>.
 RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_npc"|path = "../bevy_npc"|' behavior_statetree/Cargo.toml
 RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_pathfinding"|path = "../bevy_pathfinding"|' behavior_statetree/Cargo.toml
 RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_behavior"|path = "../bevy_behavior"|' behavior_statetree/Cargo.toml
+RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_chat"|path = "../bevy_chat"|' behavior_statetree/Cargo.toml
 RUN sed -i 's|path = "../../../packages/rust/bevy/bevy_supa"|path = "../bevy_supa"|' mc_auth/Cargo.toml
-RUN printf '[workspace]\nresolver = "2"\nmembers = ["behavior_statetree", "mc_auth", "bevy_npc", "bevy_supa", "bevy_pathfinding", "bevy_behavior"]\n' > Cargo.toml
+RUN printf '[workspace]\nresolver = "2"\nmembers = ["behavior_statetree", "mc_auth", "bevy_npc", "bevy_supa", "bevy_pathfinding", "bevy_behavior", "bevy_chat"]\n' > Cargo.toml
 
 RUN cargo build -p behavior_statetree -p mc_auth --release
 # Outputs:


### PR DESCRIPTION
## Summary
`behavior_statetree` depends on `bevy_chat` (with `ffi` feature) but the Dockerfile didn't copy it. Build was failing with:
```
failed to read `/packages/rust/bevy/bevy_chat/Cargo.toml`
```

## Changes
- `COPY packages/rust/bevy/bevy_chat/ bevy_chat/` into rust-builder stage
- `sed` rewrite for `bevy_chat` path (../../../packages/rust/bevy/bevy_chat → ../bevy_chat)
- `bevy_chat` added to synthesized workspace members list

Verified no transitive path deps on other uncopied bevy crates:
```
for crate in bevy_npc bevy_pathfinding bevy_behavior bevy_chat bevy_supa; do
  grep -E 'path = "\.\./(bevy_|[a-z])' packages/rust/bevy/$crate/Cargo.toml
done
# (no output — all crates are flat, no inter-crate paths)
```

## Test plan
- [ ] Docker build succeeds (cargo build -p behavior_statetree -p mc_auth)
- [ ] e2e tests pass