### PR TITLE
fix(lint): clippy cleanups in axum-kbve + bevy_pathfinding (partial unblock of #10216)

### DIFF
--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -73,6 +73,10 @@ pub struct McPlayerList {
     pub cached_at: u64,
 }
 
+/// `(server_name, rcon_list_result)` returned by each parallel RCON
+/// poll. Factored out to silence the `type_complexity` clippy lint.
+type RconPollResult = (String, anyhow::Result<(Vec<String>, usize)>);
+
 /// One RCON endpoint. Multiple can be configured for lobby + survival +
 /// future backends.
 #[derive(Clone, Debug)]
@@ -281,7 +285,7 @@ impl McService {
                 (ep.name, result)
             }
         });
-        let results: Vec<(String, anyhow::Result<(Vec<String>, usize)>)> = join_all(polls).await;
+        let results: Vec<RconPollResult> = join_all(polls).await;
 
         let mut all_players: Vec<McPlayer> = Vec::new();
         let mut server_statuses: Vec<McServerStatus> = Vec::new();
@@ -470,7 +474,7 @@ async fn rcon_recv(stream: &mut TcpStream) -> anyhow::Result<(i32, i32, String)>
     stream.read_exact(&mut len_buf).await?;
     let length = i32::from_le_bytes(len_buf) as usize;
 
-    if length < 10 || length > 4096 {
+    if !(10..=4096).contains(&length) {
         anyhow::bail!("RCON packet length out of range: {length}");
     }
 
@@ -614,11 +618,9 @@ fn parse_list_response(response: &str) -> anyhow::Result<(Vec<String>, usize)> {
 /// The `properties` array contains a base64-encoded JSON with texture URLs.
 fn extract_skin_url(profile: &serde_json::Value) -> Option<String> {
     let properties = profile.get("properties")?.as_array()?;
-    let textures_prop = properties.iter().find(|p| {
-        p.get("name")
-            .and_then(|n| n.as_str())
-            .map_or(false, |n| n == "textures")
-    })?;
+    let textures_prop = properties
+        .iter()
+        .find(|p| p.get("name").and_then(|n| n.as_str()) == Some("textures"))?;
     let b64 = textures_prop.get("value")?.as_str()?;
 
     let decoded = base64_decode(b64)?;

--- a/packages/rust/bevy/bevy_pathfinding/src/flow_field.rs
+++ b/packages/rust/bevy/bevy_pathfinding/src/flow_field.rs
@@ -103,11 +103,11 @@ impl FlowField {
             if !grid.in_bounds(gx, gz) || !grid.is_walkable(gx, gz) {
                 continue;
             }
-            if let Some(i) = Self::idx(gx, gz, grid.origin_x, grid.origin_z, w, d) {
-                if cost[i] == UNREACHABLE {
-                    cost[i] = 0;
-                    queue.push_back((gx, gz));
-                }
+            if let Some(i) = Self::idx(gx, gz, grid.origin_x, grid.origin_z, w, d)
+                && cost[i] == UNREACHABLE
+            {
+                cost[i] = 0;
+                queue.push_back((gx, gz));
             }
         }
 

--- a/packages/rust/bevy/bevy_pathfinding/src/flow_gate.rs
+++ b/packages/rust/bevy/bevy_pathfinding/src/flow_gate.rs
@@ -225,10 +225,10 @@ pub fn detect_gates(grid: &BlockGrid) -> Vec<FlowGate> {
 
             let avg_clearance: f32 = cluster
                 .iter()
-                .filter_map(|&(x, z)| {
+                .map(|&(x, z)| {
                     let lx = (x - grid.origin_x) as u32;
                     let lz = (z - grid.origin_z) as u32;
-                    Some(clearance[(lz * w + lx) as usize] as f32)
+                    clearance[(lz * w + lx) as usize] as f32
                 })
                 .sum::<f32>()
                 / cluster.len() as f32;


### PR DESCRIPTION
## Summary
Fixes the axum-kbve and bevy_pathfinding halves of the lint failure reported in #10216. A **separate PR** handles the `uniti` `unsafe_op_in_unsafe_fn` sweep so the two reviews don't block each other — but **both PRs are needed** for the Dev→Main lint job to go green.

## axum-kbve/src/db/mc.rs (3 fixes)
| Lint | Before | After |
|------|--------|-------|
| `type_complexity` | inline `Vec<(String, anyhow::Result<(Vec<String>, usize)>)>` | `type RconPollResult = ...` alias |
| `manual_range_contains` | `length < 10 \|\| length > 4096` | `!(10..=4096).contains(&length)` |
| `unnecessary_map_or` | `.and_then(\|n\| n.as_str()).map_or(false, \|n\| n == "textures")` | `.and_then(\|n\| n.as_str()) == Some("textures")` |

## bevy_pathfinding (2 fixes)
| Lint | File | Change |
|------|------|--------|
| `collapsible_if` | `flow_field.rs` | Merge two nested `if`s into `&&` |
| `unnecessary_filter_map` | `flow_gate.rs` | `.filter_map` → `.map` (always returned `Some`) |

## Verification
- `cargo clippy --bin axum-kbve -p axum-kbve -- -D warnings` → clean
- `cargo clippy -p uniti -- -D warnings` → still fails on `unsafe_op_in_unsafe_fn` (tracked in follow-up PR)
- `cargo test -p axum-kbve --bin axum-kbve db::mc::` → 4/4 pass