### PR TITLE
feat(bevy): Phase 3 — Discord personality trees + Isometric pathfinding + shared-tree stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7959,6 +7959,7 @@ dependencies = [
  "bevy_inventory",
  "bevy_items",
  "bevy_kbve_net",
+ "bevy_pathfinding",
  "bevy_skills",
  "bevy_tasker",
  "console_error_panic_hook",

--- a/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
@@ -16,7 +16,7 @@ use bevy_battle::{
     FirstStrikeFired, FleeIntent, Health, Intent, Messages, MinimalPlugins, PlayerClass, PlayerTag,
     TickEffectsRequest, UseItemIntent,
 };
-use bevy_behavior::{BehaviorContext, BehaviorNode, Healthed, NodeStatus, Sequence};
+use bevy_behavior::{BehaviorContext, BehaviorNode, Healthed, NodeStatus, Selector};
 use bevy_inventory::Inventory;
 
 use super::content;
@@ -279,7 +279,7 @@ impl CombatWorld {
                     CombatIndex(es.index),
                     Combatant,
                     EnemyTag,
-                    BehaviorPolicy(build_enemy_tree()),
+                    BehaviorPolicy(build_enemy_tree(es.personality)),
                 ))
                 .id();
             enemies.push((es.index, entity));
@@ -837,26 +837,30 @@ pub fn run_enemy_turns_only(
     }
 }
 
-// ── Enemy behavior tree ────────────────────────────────────────────
+// ── Enemy behavior trees (per personality) ────────────────────────
 //
-// When an enemy drops below 30% HP and isn't enraged (berserk enemies
-// don't retreat), prefer HealSelf. Otherwise the tree returns no
-// action and bevy_battle's enemy_turn_system falls back to the
-// existing random roll table. Keeps current combat variety while
-// adding one bit of conditional intelligence — the foundation for
-// personality-driven trees in future PRs.
+// Each personality tree is a Selector — children evaluated top to
+// bottom, first successful one wins. Any child returning Failure
+// bubbles up and lets bevy_battle's `roll_new_intent()` pick from
+// the random table, preserving combat variety.
+//
+// The leaves below live in this file rather than bevy_behavior
+// because they emit bevy_battle's `Intent` enum directly. Migrating
+// them to closure-driven `bevy_behavior::AttackNearest<F>` etc. is
+// a follow-up once we have a full combat-observation layer.
 
-struct LowHpHeal {
+struct HealSelfIfLowHp {
     threshold_fraction: f32,
     heal_amount: i32,
 }
 
-impl BehaviorNode<CombatObservation, Intent> for LowHpHeal {
+impl BehaviorNode<CombatObservation, Intent> for HealSelfIfLowHp {
     fn evaluate(
         &self,
         observation: &CombatObservation,
         _ctx: &mut BehaviorContext<'_>,
     ) -> (NodeStatus, Vec<Intent>) {
+        // Enraged = berserk, won't stop to heal.
         if observation.enraged || observation.health_fraction() >= self.threshold_fraction {
             return (NodeStatus::Failure, vec![]);
         }
@@ -869,13 +873,140 @@ impl BehaviorNode<CombatObservation, Intent> for LowHpHeal {
     }
 }
 
-fn build_enemy_tree() -> Box<dyn BehaviorNode<CombatObservation, Intent>> {
-    Box::new(Sequence {
-        children: vec![Box::new(LowHpHeal {
-            threshold_fraction: 0.3,
-            heal_amount: 10,
-        })],
-    })
+/// Always attack — no conditional. For Aggressive / Feral personalities
+/// that should never retreat. Damage scales with level.
+struct AlwaysAttack;
+
+impl BehaviorNode<CombatObservation, Intent> for AlwaysAttack {
+    fn evaluate(
+        &self,
+        observation: &CombatObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<Intent>) {
+        let mut dmg = 5 + observation.level as i32;
+        if observation.enraged {
+            dmg = (dmg as f32 * 1.5) as i32;
+        }
+        (NodeStatus::Success, vec![Intent::Attack { dmg }])
+    }
+}
+
+/// Flee when HP dips — Cowardly / Fearful break early. Returns Flee
+/// at higher HP thresholds than the default tree would.
+struct FleeIfLowHp {
+    threshold_fraction: f32,
+}
+
+impl BehaviorNode<CombatObservation, Intent> for FleeIfLowHp {
+    fn evaluate(
+        &self,
+        observation: &CombatObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<Intent>) {
+        if observation.health_fraction() >= self.threshold_fraction {
+            return (NodeStatus::Failure, vec![]);
+        }
+        (NodeStatus::Success, vec![Intent::Flee])
+    }
+}
+
+/// AoE burst at low HP — Ancient personalities go out swinging.
+/// Damage scales with level.
+struct DesperateAoe {
+    threshold_fraction: f32,
+}
+
+impl BehaviorNode<CombatObservation, Intent> for DesperateAoe {
+    fn evaluate(
+        &self,
+        observation: &CombatObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<Intent>) {
+        if observation.health_fraction() >= self.threshold_fraction {
+            return (NodeStatus::Failure, vec![]);
+        }
+        let dmg = 6 + observation.level as i32;
+        (NodeStatus::Success, vec![Intent::AoeAttack { dmg }])
+    }
+}
+
+/// Apply a debuff if the target isn't already weakened — for Cunning
+/// personalities that prefer to set up before swinging. Defaults to
+/// Weakened stacks since there's no target-observation yet; later PRs
+/// can feed player-effect snapshots through CombatObservation.
+struct ApplyWeakened;
+
+impl BehaviorNode<CombatObservation, Intent> for ApplyWeakened {
+    fn evaluate(
+        &self,
+        observation: &CombatObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<Intent>) {
+        // Cunning enemies debuff only when not already damaged themselves.
+        if observation.health_fraction() < 0.5 {
+            return (NodeStatus::Failure, vec![]);
+        }
+        (
+            NodeStatus::Success,
+            vec![Intent::Debuff {
+                effect: EffectKind::Weakened,
+                stacks: 1,
+                turns: 3,
+            }],
+        )
+    }
+}
+
+fn build_enemy_tree(personality: Personality) -> Box<dyn BehaviorNode<CombatObservation, Intent>> {
+    match personality {
+        // Aggressive / Feral — never retreat, always swing hard.
+        Personality::Aggressive | Personality::Feral => Box::new(Selector {
+            children: vec![Box::new(AlwaysAttack)],
+        }),
+        // Cowardly / Fearful — flee early, heal when low, then fall
+        // through to random rolls for the middle-HP band.
+        Personality::Cowardly | Personality::Fearful => Box::new(Selector {
+            children: vec![
+                Box::new(FleeIfLowHp {
+                    threshold_fraction: 0.5,
+                }),
+                Box::new(HealSelfIfLowHp {
+                    threshold_fraction: 0.7,
+                    heal_amount: 8,
+                }),
+            ],
+        }),
+        // Ancient — AoE burst at low HP, otherwise let the random
+        // table handle it (preserves boss flavor variety).
+        Personality::Ancient => Box::new(Selector {
+            children: vec![Box::new(DesperateAoe {
+                threshold_fraction: 0.35,
+            })],
+        }),
+        // Cunning — open with a debuff if healthy, otherwise random.
+        Personality::Cunning => Box::new(Selector {
+            children: vec![Box::new(ApplyWeakened)],
+        }),
+        // Noble / Stoic — emergency heal only. Retains most of the
+        // random table for tactical variety.
+        Personality::Noble | Personality::Stoic => Box::new(Selector {
+            children: vec![Box::new(HealSelfIfLowHp {
+                threshold_fraction: 0.25,
+                heal_amount: 12,
+            })],
+        }),
+        // Cheerful / Mysterious / Passive — fall back to the original
+        // "heal at 30%" logic from the foundation PR. These don't have
+        // a strong combat bias yet.
+        Personality::Cheerful | Personality::Mysterious | Personality::Passive => {
+            Box::new(Selector {
+                children: vec![Box::new(HealSelfIfLowHp {
+                    threshold_fraction: 0.3,
+                    heal_amount: 10,
+                })],
+            })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ bevy_items = { path = "../../../../packages/rust/bevy/bevy_items", features = ["
 bevy_cam = { path = "../../../../packages/rust/bevy/bevy_cam" }
 bevy_kbve_net = { path = "../../../../packages/rust/bevy/bevy_kbve_net", features = ["npcdb", "client", "creatures"] }
 bevy_behavior = { path = "../../../../packages/rust/bevy/bevy_behavior" }
+bevy_pathfinding = { path = "../../../../packages/rust/bevy/bevy_pathfinding" }
 bevy_skills = { path = "../../../../packages/rust/bevy/bevy_skills" }
 bevy_db = { path = "../../../../packages/rust/bevy/bevy_db" }
 bevy_chat = { path = "../../../../packages/rust/bevy/bevy_chat", features = ["plugin"] }

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/mod.rs
@@ -4,6 +4,8 @@ pub mod creature;
 mod firefly;
 pub mod generic;
 pub mod observation;
+pub mod pathfinding;
+pub mod shared_tree;
 pub mod sprite_material;
 
 use bevy::prelude::*;

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/pathfinding.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/pathfinding.rs
@@ -1,0 +1,64 @@
+//! Pathfinding adapter for Isometric creatures — foundation layer.
+//!
+//! `bevy_pathfinding` operates on a 2D grid (`BlockGrid`) with BFS-computed
+//! `FlowField`s. Isometric is a 3D game with continuous positions, so
+//! using it requires a mapping:
+//!
+//! ```text
+//!   world Vec3 (x, y, z)  →  grid (col, row) = (x / cell_size, z / cell_size)
+//! ```
+//!
+//! This module defines the cell size + helper conversions. A later PR will
+//! build a per-frame `FlowField` from the walkable terrain mesh and have
+//! creature `BehaviorNode` leaves query it for navigation — matching the
+//! pattern MC already uses in `behavior_statetree::tree::flow_nodes`.
+//!
+//! Keeping this module as a stub lets the crate land + compile; the actual
+//! grid construction and flow-field dispatch is wired in the follow-up PR
+//! that migrates Isometric's BehaviorNode enum to `bevy_behavior` trees.
+
+use bevy::prelude::Vec3;
+
+/// Grid cell edge length in world units. Picked to match the isometric tile
+/// pitch so one grid cell corresponds to one visual tile.
+pub const CELL_SIZE: f32 = 1.0;
+
+/// Convert a world-space position to a `(col, row)` grid cell index.
+///
+/// The y-axis (height) is discarded — pathfinding is 2D. Creatures spawn
+/// and move on the surface mesh, so vertical position is irrelevant for
+/// the flow-field layer.
+pub fn world_to_grid(pos: Vec3) -> (i32, i32) {
+    (
+        (pos.x / CELL_SIZE).floor() as i32,
+        (pos.z / CELL_SIZE).floor() as i32,
+    )
+}
+
+/// Convert a grid cell index back to a world-space position (cell center).
+///
+/// `y` is supplied by the caller since pathfinding doesn't track height.
+pub fn grid_to_world(col: i32, row: i32, y: f32) -> Vec3 {
+    Vec3::new(
+        (col as f32 + 0.5) * CELL_SIZE,
+        y,
+        (row as f32 + 0.5) * CELL_SIZE,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn world_grid_roundtrip() {
+        let pos = Vec3::new(3.5, 2.0, -1.5);
+        let (col, row) = world_to_grid(pos);
+        assert_eq!((col, row), (3, -2));
+        let back = grid_to_world(col, row, pos.y);
+        // Cell center is offset by 0.5 from the origin corner, so the
+        // roundtrip lands within one cell of the input.
+        assert!((back.x - 3.5).abs() <= CELL_SIZE);
+        assert!((back.z - (-1.5)).abs() <= CELL_SIZE);
+    }
+}

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/shared_tree.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/shared_tree.rs
@@ -1,0 +1,95 @@
+//! Opt-in `bevy_behavior` trees for Isometric creatures.
+//!
+//! Foundation layer — defines a `SharedBehaviorTree` component and a
+//! demo tree for the wraith creature type. The existing enum-based
+//! `BehaviorNode` in `generic/behavior.rs` continues running for every
+//! other creature; this module gives future PRs a concrete shape to
+//! migrate into without rewriting the full dispatch loop today.
+//!
+//! Next PR: extend `brain.rs` dispatch so that when an entity has
+//! `SharedBehaviorTree`, its observation is built via
+//! [`super::observation::CreatureObservation`] and evaluated against
+//! the shared tree instead of the local enum walker.
+
+use bevy::prelude::Component;
+use bevy_behavior::{BehaviorContext, BehaviorNode, NodeStatus, Selector};
+
+use super::generic::behavior::CreatureIntent;
+use super::observation::CreatureObservation;
+
+/// Attach this component to a creature entity to evaluate its decisions
+/// through the shared `bevy_behavior` engine. Without it, the creature
+/// keeps using the existing `BehaviorProfile` / local `BehaviorNode`
+/// enum walker in `generic/behavior.rs`.
+#[derive(Component)]
+pub struct SharedBehaviorTree(pub Box<dyn BehaviorNode<CreatureObservation, CreatureIntent>>);
+
+/// Flee from the player when they're within `trigger_distance`.
+///
+/// Uses `nearby_entities` from the observation's `Aware` impl — the
+/// dispatch layer (future PR) will populate this with hostile player
+/// snapshots captured on the main thread.
+struct FleeWhenPlayerClose {
+    trigger_distance: f64,
+    speed: f32,
+    anim: &'static str,
+}
+
+impl BehaviorNode<CreatureObservation, CreatureIntent> for FleeWhenPlayerClose {
+    fn evaluate(
+        &self,
+        observation: &CreatureObservation,
+        _ctx: &mut BehaviorContext<'_>,
+    ) -> (NodeStatus, Vec<CreatureIntent>) {
+        use bevy_behavior::{Aware, Positioned, observation::dist_sq};
+
+        let self_pos = observation.position();
+        let nearest = observation
+            .nearby_entities()
+            .iter()
+            .filter(|e| e.is_hostile)
+            .min_by(|a, b| {
+                dist_sq(&self_pos, &a.position)
+                    .partial_cmp(&dist_sq(&self_pos, &b.position))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        let Some(threat) = nearest else {
+            return (NodeStatus::Failure, vec![]);
+        };
+        let dist = dist_sq(&self_pos, &threat.position).sqrt();
+        if dist > self.trigger_distance {
+            return (NodeStatus::Failure, vec![]);
+        }
+
+        // Unit vector away from the threat (y discarded — Isometric
+        // creatures move on the surface plane).
+        let dx = self_pos[0] - threat.position[0];
+        let dz = self_pos[2] - threat.position[2];
+        let norm = (dx * dx + dz * dz).sqrt().max(1e-3);
+        let direction = bevy::prelude::Vec3::new((dx / norm) as f32, 0.0, (dz / norm) as f32);
+
+        (
+            NodeStatus::Success,
+            vec![CreatureIntent::Flee {
+                direction,
+                speed: self.speed,
+                anim_name: self.anim,
+            }],
+        )
+    }
+}
+
+/// Demo tree for the wraith — the Isometric equivalent of MC's
+/// "spooky but non-combat" archetype. Flees when any hostile closes
+/// within 4 blocks; otherwise returns no intent (the existing enum
+/// tree produces the normal wander-and-emote behavior).
+pub fn build_wraith_tree() -> Box<dyn BehaviorNode<CreatureObservation, CreatureIntent>> {
+    Box::new(Selector {
+        children: vec![Box::new(FleeWhenPlayerClose {
+            trigger_distance: 4.0,
+            speed: 2.5,
+            anim: "wraith_flee",
+        })],
+    })
+}


### PR DESCRIPTION
## Summary

Three integrations landed together — tightens the unified skeleton AI loop across Discord, Isometric, and the shared crates. Follows Phase 1 (#10197) and Phase 2 (#10214).

### 1. Discord personality trees (real gameplay change)

`bevy_battle::Personality` has existed since the start but was never consulted in combat decisions. This PR wires it in: `build_enemy_tree(personality)` returns a different `Selector` tree per enum variant.

| Personality | Tree |
|---|---|
| Aggressive / Feral | `AlwaysAttack` — never retreat |
| Cowardly / Fearful | `FleeIfLowHp(50%)` → `HealSelfIfLowHp(70%)` |
| Ancient | `DesperateAoe(35%)` — AoE burst when cornered |
| Cunning | `ApplyWeakened` while still healthy |
| Noble / Stoic | Emergency heal only at 25% HP |
| Cheerful / Mysterious / Passive | Original heal-at-30% baseline from Phase 2 |

Any `NodeStatus::Failure` bubbles through to `bevy_battle`'s existing random roll table, so combat variety is preserved. Only the conditional overrides are new.

### 2. Isometric bevy_pathfinding foundation

- New dep in `isometric-game/Cargo.toml`.
- New module `creatures/pathfinding.rs` with `world_to_grid` / `grid_to_world` helpers. `CELL_SIZE = 1.0` matches the isometric tile pitch.
- No runtime wiring yet — actual `FlowField` construction and integration with creature movement is the follow-up.

### 3. Isometric `SharedBehaviorTree` opt-in

- New module `creatures/shared_tree.rs` with a `SharedBehaviorTree` component holding `Box<dyn BehaviorNode<CreatureObservation, CreatureIntent>>`.
- Demo `build_wraith_tree()` that emits `Flee` intents when a hostile closes within 4 blocks.
- The existing enum-based `BehaviorNode` in `generic/behavior.rs` keeps running for every creature. This PR ships the component shape so the follow-up can extend `brain.rs` dispatch to check for the component and evaluate via `bevy_behavior` — mirroring how `BehaviorPolicy` was added to `bevy_battle` in Phase 2.

## Test plan

- [x] `cargo check -p discordsh-bot` — no new warnings
- [x] `cargo check -p isometric-game` — no new warnings
- [x] `cargo check -p bevy_battle` — unchanged, passes
- [ ] Manual smoke test: Cowardly dungeon enemy flees earlier than an Aggressive one at the same HP
- [ ] Wraith tree: confirm `SharedBehaviorTree` component compiles when attached (runtime dispatch is the follow-up)

## Roadmap after this PR

| Phase | Status |
|---|---|
| 1. `bevy_behavior` into `behavior_statetree` | ✅ #10197 |
| 2. `bevy_behavior` into `bevy_battle` + Isometric observation adapter | ✅ #10214 |
| **3. Personality trees + pathfinding/shared-tree stubs** | **this PR** |
| 4. Isometric `BehaviorNode` enum → shared trees (full migration of boar/wolf/stag/frog/badger/wraith) | next |
| 5. MC ↔ Discord bridge via `bevy_statemachine` | later |