### PR TITLE
feat(mc_auth): mint /minechat JWTs + ExternalSecret plumbing (Scope A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
  "futures-util",
  "http-body-util",
  "jedi",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "kbve",
  "lightyear",
  "lightyear_avian3d",
@@ -1452,7 +1452,7 @@ dependencies = [
  "dotenvy",
  "http-body-util",
  "jedi",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "kbve",
  "num_cpus",
  "reqwest 0.12.28",
@@ -7887,7 +7887,7 @@ dependencies = [
  "futures-util",
  "http-body-util",
  "jedi",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "kbve",
  "num_cpus",
  "serde",
@@ -8259,6 +8259,19 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "ring",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
@@ -8308,7 +8321,7 @@ dependencies = [
  "diesel",
  "dotenvy",
  "jedi",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "lru",
  "num-bigint",
  "once_cell",
@@ -9539,6 +9552,7 @@ dependencies = [
  "bevy_supa",
  "crossbeam-channel",
  "jni 0.21.1",
+ "jsonwebtoken 9.3.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -12808,7 +12822,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-util",
  "jedi",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "k8s-openapi",
  "kbve",
  "kube",

--- a/apps/kube/agones/mc/chat-jwt-external-secret.yaml
+++ b/apps/kube/agones/mc/chat-jwt-external-secret.yaml
@@ -1,0 +1,112 @@
+# Project the kilobase-owned MC chat JWT signing key into arc-runners
+# so the `mc_auth` native library inside each Agones fleet pod can mint
+# short-lived HS256 tokens for players to authenticate with the
+# irc-gateway `/minechat` endpoint.
+#
+# Single source of truth: the raw signing key lives exactly once, in
+# `kilobase/mc-chat-jwt` (field: `signing-key`). The irc-gateway side
+# (Scope B) will read the same source in its own namespace via a
+# mirrored ExternalSecret, so MC and the gateway share identical key
+# material without anyone having to copy bytes between systems.
+#
+# Cross-namespace wiring follows the same pattern as
+# supabase-external-secret.yaml:
+#   - Role + RoleBinding in kilobase whitelist the `mc-chat-jwt`
+#     secret for the existing `agones-mc-external-secrets` SA in
+#     arc-runners.
+#   - The existing `kilobase-supabase-jwt-store` SecretStore is NOT
+#     reused here because its `remoteNamespace` is fine but tying two
+#     unrelated ExternalSecrets to the same SecretStore makes it
+#     harder to audit which SA is pulling which field. A dedicated
+#     SecretStore with the same auth binding keeps grants explicit.
+#   - ExternalSecret in arc-runners reads the `signing-key` field and
+#     projects it into `arc-runners/mc-chat-jwt-signing-key`.
+#
+# Fleet rotation: ExternalSecret refreshes every 15m. New pods pick up
+# rotated keys on next startup; existing pods hold their old key in
+# env until they restart. Tokens are short-lived (5m) so a rotation
+# fully propagates within ~20m worst case.
+
+---
+# RBAC: allow the arc-runners ExternalSecrets ServiceAccount to read
+# ONLY the mc-chat-jwt secret from kilobase.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: mc-chat-jwt-reader-for-agones
+    namespace: kilobase
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['mc-chat-jwt']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: agones-read-mc-chat-jwt
+    namespace: kilobase
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: mc-chat-jwt-reader-for-agones
+subjects:
+    # Reuses the ServiceAccount already declared in gameserver-secrets.yaml —
+    # same SA holds cross-namespace reads for rcon + supabase, now also the
+    # chat JWT. One SA, three distinct RoleBindings scoping it to three
+    # specific secrets.
+    - kind: ServiceAccount
+      name: agones-mc-external-secrets
+      namespace: arc-runners
+---
+# SecretStore pointing at the kilobase namespace. Kept separate from the
+# Supabase store so revoking one grant (e.g. after a Supabase rotation
+# audit) doesn't implicitly move scope on the other.
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-mc-chat-jwt-store
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: agones-mc-external-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+# ExternalSecret: reads kilobase/mc-chat-jwt.signing-key and projects
+# it into arc-runners/mc-chat-jwt-signing-key.signing-key.
+# Fleet pods mount this via envFrom as `MC_CHAT_JWT_SIGNING_KEY`.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: mc-chat-jwt-signing-key
+    namespace: arc-runners
+spec:
+    refreshInterval: 15m
+    secretStoreRef:
+        name: kilobase-mc-chat-jwt-store
+        kind: SecretStore
+    target:
+        name: mc-chat-jwt-signing-key
+        creationPolicy: Owner
+        template:
+            # Rename the field to the env var the Fleet container will
+            # read, so fleet.yaml can use a clean envFrom secretRef
+            # without per-field mapping.
+            data:
+                MC_CHAT_JWT_SIGNING_KEY: '{{ .signingKey }}'
+    data:
+        - secretKey: signingKey
+          remoteRef:
+              key: mc-chat-jwt
+              property: signing-key

--- a/apps/kube/agones/mc/fleet.yaml
+++ b/apps/kube/agones/mc/fleet.yaml
@@ -169,6 +169,21 @@ spec:
                                 value: 'mc-server'
                               - name: IRC_CHANNELS
                                 value: '#world-events'
+                              # HS256 signing key for short-lived player JWTs
+                              # used against the irc-gateway /minechat endpoint.
+                              # Synced into this namespace by the
+                              # mc-chat-jwt-signing-key ExternalSecret from the
+                              # canonical kilobase/mc-chat-jwt source. Marked
+                              # optional so pods still boot cleanly before the
+                              # key has propagated; the Rust minter then
+                              # returns an error that bubbles up as "token
+                              # minting unavailable" in /chat-token output.
+                              - name: MC_CHAT_JWT_SIGNING_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: mc-chat-jwt-signing-key
+                                        key: MC_CHAT_JWT_SIGNING_KEY
+                                        optional: true
                           resources:
                               requests:
                                   memory: 2Gi

--- a/apps/mc/mc_auth/Cargo.toml
+++ b/apps/mc/mc_auth/Cargo.toml
@@ -48,3 +48,8 @@ reqwest = { version = "0.12", default-features = false, features = [
 # stays alive in the Agones Fleet. Without these pings the pod is recycled
 # every ~5 minutes by Agones' health controller.
 agones = "1.57"
+
+# HS256 JWT minter for short-lived player tokens against the irc-gateway
+# `/minechat` endpoint. Rustls / default-features kept off because mc_auth
+# already uses rustls-tls via reqwest; no need to pull ring in twice.
+jsonwebtoken = { version = "9", default-features = false }

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/ChatTokenCommand.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/ChatTokenCommand.java
@@ -1,0 +1,113 @@
+package com.kbve.mcauth;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registers the {@code /chat-token} command.
+ *
+ * <p>Players run this in-game to receive a short-lived HS256 JWT they can
+ * present to the irc-gateway {@code /minechat} WebSocket endpoint. The
+ * token is minted locally by {@link NativeRuntime#mintChatToken} — no
+ * network I/O — and includes claims for the player's UUID and username
+ * so the gateway can set the IRC nick without re-running Mojang auth.
+ *
+ * <p>Output is sent only to the requesting player (never broadcast) and
+ * only via {@code sendMessage(..., false)} — not the overlay — so the
+ * token doesn't end up flashed on other nearby clients' screens.
+ *
+ * <p>The token is a raw string, not hyperlinked. Future work: wire a
+ * custom plugin-message channel so a companion client mod can pick it
+ * up automatically without the player copy-pasting.
+ */
+public final class ChatTokenCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(McAuthMod.MOD_ID);
+
+    private ChatTokenCommand() {}
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(
+                CommandManager.literal("chat-token")
+                        .requires(source -> source.isExecutedByPlayer())
+                        .executes(ctx -> {
+                            ServerPlayerEntity player = ctx.getSource().getPlayer();
+                            if (player == null) {
+                                return 0;
+                            }
+                            return execute(player);
+                        }));
+    }
+
+    private static int execute(ServerPlayerEntity player) {
+        if (!NativeRuntime.isLoaded()) {
+            player.sendMessage(
+                    Text.literal("[KBVE] Chat service is not available right now.")
+                            .formatted(Formatting.RED),
+                    false);
+            return 0;
+        }
+
+        String uuid = player.getUuidAsString();
+        String username = player.getNameForScoreboard();
+
+        String json;
+        try {
+            json = NativeRuntime.mintChatToken(uuid, username);
+        } catch (Throwable t) {
+            LOGGER.warn("[{}] mintChatToken() threw: {}", McAuthMod.MOD_ID, t.getMessage());
+            player.sendMessage(
+                    Text.literal("[KBVE] Couldn't mint chat token. Try again in a moment.")
+                            .formatted(Formatting.RED),
+                    false);
+            return 0;
+        }
+
+        // Parse the JSON response by hand. We avoid pulling in a full JSON
+        // library for what is essentially {"token":"..."} or {"error":"..."}.
+        // If the shape ever grows beyond this, switch to a real parser.
+        String token = extractField(json, "token");
+        if (token != null) {
+            player.sendMessage(
+                    Text.literal("[KBVE] Chat token (valid ~5 minutes, copy quickly):")
+                            .formatted(Formatting.GRAY),
+                    false);
+            player.sendMessage(
+                    Text.literal(token).formatted(Formatting.WHITE),
+                    false);
+            return 1;
+        }
+
+        String error = extractField(json, "error");
+        String msg = error != null ? error : "unknown error";
+        LOGGER.info("[{}] chat token mint failed for {}: {}", McAuthMod.MOD_ID, username, msg);
+        player.sendMessage(
+                Text.literal("[KBVE] Chat token unavailable: " + msg)
+                        .formatted(Formatting.RED),
+                false);
+        return 0;
+    }
+
+    /**
+     * Pull a string value out of a trivially-shaped JSON object. Handles
+     * the two shapes this command produces: {@code {"token":"..."}} and
+     * {@code {"error":"..."}}. Does NOT handle escape sequences beyond
+     * what the Rust side emits (no backslash in tokens, so this is fine).
+     */
+    private static String extractField(String json, String key) {
+        if (json == null) return null;
+        String needle = "\"" + key + "\":\"";
+        int start = json.indexOf(needle);
+        if (start < 0) return null;
+        start += needle.length();
+        int end = json.indexOf('"', start);
+        if (end < 0) return null;
+        return json.substring(start, end);
+    }
+}

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
@@ -52,6 +52,7 @@ public class McAuthMod implements ModInitializer {
 
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
             LinkCommand.register(dispatcher);
+            ChatTokenCommand.register(dispatcher);
         });
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/NativeRuntime.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/NativeRuntime.java
@@ -100,6 +100,23 @@ public final class NativeRuntime {
     /** Shutdown the Tokio runtime. Call during mod shutdown. */
     public static native void shutdown();
 
+    /**
+     * Mint a short-lived HS256 JWT for the irc-gateway {@code /minechat}
+     * endpoint. Synchronous — returns immediately with either a token
+     * payload or an error payload, never blocks on I/O.
+     *
+     * <p>Returns a JSON object:
+     * <ul>
+     *   <li>Success: {@code {"token":"eyJ...","expires_in":300}}</li>
+     *   <li>Failure: {@code {"error":"chat signing key is not configured on this server"}}</li>
+     * </ul>
+     *
+     * @param uuid     canonical Minecraft UUID (with dashes) — used as the {@code sub} claim
+     * @param username current in-game username — used as the {@code mc_username} claim
+     * @return JSON string (see above)
+     */
+    public static native String mintChatToken(String uuid, String username);
+
     /** Check if the native library loaded successfully. */
     public static boolean isLoaded() {
         return loaded;

--- a/apps/mc/mc_auth/src/chat_jwt.rs
+++ b/apps/mc/mc_auth/src/chat_jwt.rs
@@ -1,0 +1,172 @@
+//! Short-lived HS256 JWT minting for the `/minechat` gateway endpoint.
+//!
+//! Trust model:
+//!
+//! 1. The MC server is the only component that can prove a session is
+//!    Mojang-authenticated (Velocity forwards the verified session; the
+//!    backend Fabric server runs offline-mode and trusts that forward).
+//! 2. `mc_auth` owns the linking ceremony that writes rows into
+//!    `mc.auth_links`. Once the ceremony has run, the (mc_uuid,
+//!    mc_username) pair is the ground truth for that player's identity on
+//!    our network.
+//! 3. This module hands out signed tokens stating "player X is allowed to
+//!    speak as `mc_uuid` with `mc_username` until `exp`". The irc-gateway
+//!    verifies with the same shared secret and uses the claims to set the
+//!    IRC nick without re-running Mojang auth.
+//!
+//! The signing key is mounted as an env var from a Kubernetes Secret that
+//! is itself synced from the canonical `kilobase/mc-chat-jwt` source via
+//! ExternalSecrets. Rotating the kilobase secret rotates here on the next
+//! Fleet pod restart.
+
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Env var that holds the HS256 signing key bytes (raw UTF-8, treated as
+/// opaque bytes by `jsonwebtoken::EncodingKey::from_secret`).
+const SIGNING_KEY_ENV: &str = "MC_CHAT_JWT_SIGNING_KEY";
+
+/// Token lifetime. Short enough that a revoked link propagates quickly;
+/// long enough that players don't need to re-request on every reconnect.
+const TOKEN_TTL_SECS: u64 = 5 * 60;
+
+/// Issuer claim — identifies the MC server as the originator.
+const ISSUER: &str = "mc-auth";
+
+/// Audience claim — consumed by the irc-gateway `/minechat` route. The
+/// gateway rejects tokens that were issued for a different audience so a
+/// leaked minechat token can't be replayed against an unrelated service.
+const AUDIENCE: &str = "minechat";
+
+/// Errors surfaced to the Java caller (and ultimately the player) when a
+/// token can't be produced.
+#[derive(Debug)]
+pub enum MintError {
+    /// `MC_CHAT_JWT_SIGNING_KEY` isn't set or is empty. Typical right
+    /// after a deploy while the ExternalSecret is still propagating.
+    KeyMissing,
+    /// The underlying JWT encoder failed. Treated as an internal error.
+    Signing(jsonwebtoken::errors::Error),
+    /// The system clock is before the UNIX epoch. Something is very
+    /// wrong with the node, but we don't want to panic inside a JNI call.
+    Clock,
+}
+
+impl std::fmt::Display for MintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KeyMissing => f.write_str("chat signing key is not configured on this server"),
+            Self::Signing(e) => write!(f, "failed to sign chat token: {e}"),
+            Self::Clock => f.write_str("system clock is before UNIX epoch"),
+        }
+    }
+}
+
+impl std::error::Error for MintError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Signing(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<jsonwebtoken::errors::Error> for MintError {
+    fn from(e: jsonwebtoken::errors::Error) -> Self {
+        Self::Signing(e)
+    }
+}
+
+/// Claims payload. Field order mirrors a typical Supabase JWT so the
+/// gateway-side validator can share logic if we ever consolidate.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChatClaims {
+    /// JWT subject — the player's Mojang UUID in canonical hyphenated form.
+    pub sub: String,
+    /// MC username at the time of mint. Informational — the gateway binds
+    /// the session nick to this value.
+    pub mc_username: String,
+    /// Fixed issuer string so the gateway can disambiguate between
+    /// MC-minted and (future) bot-minted tokens.
+    pub iss: String,
+    /// Fixed audience. Rejected if it doesn't match on the gateway side.
+    pub aud: String,
+    /// Issued-at, seconds since UNIX epoch.
+    pub iat: u64,
+    /// Expiry, seconds since UNIX epoch.
+    pub exp: u64,
+}
+
+/// Mint a fresh HS256 token for a linked player. Returns the compact JWT
+/// string ready to be whispered back to the player.
+pub fn mint(mc_uuid: &str, mc_username: &str) -> Result<String, MintError> {
+    let key = match std::env::var(SIGNING_KEY_ENV) {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => return Err(MintError::KeyMissing),
+    };
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| MintError::Clock)?
+        .as_secs();
+
+    let claims = ChatClaims {
+        sub: mc_uuid.to_string(),
+        mc_username: mc_username.to_string(),
+        iss: ISSUER.to_string(),
+        aud: AUDIENCE.to_string(),
+        iat: now,
+        exp: now + TOKEN_TTL_SECS,
+    };
+
+    let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256);
+    let encoding_key = jsonwebtoken::EncodingKey::from_secret(key.as_bytes());
+    let token = jsonwebtoken::encode(&header, &claims, &encoding_key)?;
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests set a process-global env var, so they can race with any
+    // other test that reads or writes the same env. There aren't any
+    // today, and cargo's single-threaded `--test-threads=1` keeps it
+    // deterministic if there ever are.
+
+    #[test]
+    fn mint_fails_without_key() {
+        unsafe {
+            std::env::remove_var(SIGNING_KEY_ENV);
+        }
+        let err = mint("00000000-0000-0000-0000-000000000001", "alice").unwrap_err();
+        assert!(matches!(err, MintError::KeyMissing));
+    }
+
+    #[test]
+    fn mint_produces_decodable_token() {
+        const KEY: &str = "test-only-do-not-use-in-prod-0123456789abcdef";
+        unsafe {
+            std::env::set_var(SIGNING_KEY_ENV, KEY);
+        }
+        let token = mint("00000000-0000-0000-0000-000000000002", "bob").unwrap();
+        assert_eq!(token.matches('.').count(), 2, "JWT should have 3 parts");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
+        validation.set_audience(&["minechat"]);
+        validation.set_issuer(&["mc-auth"]);
+        let decoded = jsonwebtoken::decode::<ChatClaims>(
+            &token,
+            &jsonwebtoken::DecodingKey::from_secret(KEY.as_bytes()),
+            &validation,
+        )
+        .unwrap();
+        assert_eq!(decoded.claims.sub, "00000000-0000-0000-0000-000000000002");
+        assert_eq!(decoded.claims.mc_username, "bob");
+        assert!(decoded.claims.exp > decoded.claims.iat);
+
+        unsafe {
+            std::env::remove_var(SIGNING_KEY_ENV);
+        }
+    }
+}

--- a/apps/mc/mc_auth/src/lib.rs
+++ b/apps/mc/mc_auth/src/lib.rs
@@ -18,6 +18,7 @@
 //! downgraded to a graceful `Unlinked` event so players are never kicked.
 
 pub mod agones;
+pub mod chat_jwt;
 pub mod runtime;
 pub mod supabase;
 pub mod types;
@@ -136,6 +137,43 @@ pub extern "system" fn Java_com_kbve_mcauth_NativeRuntime_shutdown(
     }
 }
 
+/// Mint a short-lived HS256 JWT for the `/minechat` gateway.
+///
+/// Returns a JSON object — either `{"token":"<jwt>","expires_in":300}`
+/// on success or `{"error":"<reason>"}` on any failure. Java consumes
+/// this as-is (no async queue involved; minting is local and fast).
+///
+/// Why JSON and not just the raw token: the Java side surfaces errors
+/// to the player directly, so we need a stable shape that distinguishes
+/// "signing key not configured" (retry later) from "mint succeeded"
+/// without relying on out-of-band error codes.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_mcauth_NativeRuntime_mintChatToken<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    uuid: JString<'local>,
+    username: JString<'local>,
+) -> jstring {
+    let mc_uuid: String = match env.get_string(&uuid) {
+        Ok(s) => s.into(),
+        Err(_) => {
+            return make_chat_jstring(&mut env, ChatMintResult::err("invalid uuid string"));
+        }
+    };
+    let mc_username: String = match env.get_string(&username) {
+        Ok(s) => s.into(),
+        Err(_) => {
+            return make_chat_jstring(&mut env, ChatMintResult::err("invalid username string"));
+        }
+    };
+
+    let response = match chat_jwt::mint(&mc_uuid, &mc_username) {
+        Ok(token) => ChatMintResult::ok(token),
+        Err(e) => ChatMintResult::err(e.to_string()),
+    };
+    make_chat_jstring(&mut env, response)
+}
+
 // -----------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------
@@ -145,5 +183,44 @@ fn make_jstring(env: &mut JNIEnv, response: &AuthResponse) -> jstring {
         serde_json::to_string(response).unwrap_or_else(|_| "{\"status\":\"error\"}".to_string());
     env.new_string(&json)
         .expect("failed to create auth response JSON string")
+        .into_raw()
+}
+
+/// Minimal result shape for `mintChatToken`. Kept out of `types.rs`
+/// because it doesn't participate in the AuthJob / PlayerEvent pipeline —
+/// minting is strictly synchronous and local to the JNI call.
+#[derive(serde::Serialize)]
+struct ChatMintResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token: Option<String>,
+    /// Seconds until the minted token expires. Present on success only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_in: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl ChatMintResult {
+    fn ok(token: String) -> Self {
+        Self {
+            token: Some(token),
+            expires_in: Some(300),
+            error: None,
+        }
+    }
+    fn err(msg: impl Into<String>) -> Self {
+        Self {
+            token: None,
+            expires_in: None,
+            error: Some(msg.into()),
+        }
+    }
+}
+
+fn make_chat_jstring(env: &mut JNIEnv, response: ChatMintResult) -> jstring {
+    let json = serde_json::to_string(&response)
+        .unwrap_or_else(|_| "{\"error\":\"serialize\"}".to_string());
+    env.new_string(&json)
+        .expect("failed to create chat mint response JSON string")
         .into_raw()
 }


### PR DESCRIPTION
## Summary

Scope A of the MC ↔ chat-gateway auth story. The MC server now mints its own short-lived HS256 JWTs for players, which the irc-gateway \`/minechat\` endpoint will verify (Scope B, next worktree).

## Trust chain

- \`mc_auth\` owns the linking ceremony that writes verified \`(mc_uuid, mc_username)\` rows. Once that row exists, those values are ground truth — Mojang auth was already proven by Velocity forwarding the session.
- Tokens carry \`sub=mc_uuid\`, \`mc_username\`, \`iss=mc-auth\`, \`aud=minechat\`, 5-minute \`exp\`. HS256 symmetric, shared secret with the gateway.

## Signing-key plumbing

- **Canonical source**: \`kilobase/mc-chat-jwt\` with field \`signing-key\` (to be populated once before deploy — the worktree assumes it exists).
- **ExternalSecret** in \`arc-runners\` projects it into \`mc-chat-jwt-signing-key.MC_CHAT_JWT_SIGNING_KEY\`.
- **RBAC**: dedicated Role in \`kilobase\` scopes the existing \`agones-mc-external-secrets\` SA to *only* the \`mc-chat-jwt\` secret. Same pattern as \`supabase-external-secret.yaml\`.
- **SecretStore**: new \`kilobase-mc-chat-jwt-store\`, not a reuse of the supabase one, so revoking either grant stays audit-clean.
- **Fleet**: env var mounted \`optional: true\` so pods boot cleanly before the key has propagated; \`/chat-token\` returns a user-facing "not configured" error until the secret syncs.

## Runtime

- \`apps/mc/mc_auth/src/chat_jwt.rs\` — \`mint(mc_uuid, mc_username) -> String\`. Two unit tests (missing key, roundtrip decode).
- JNI entry point \`Java_...NativeRuntime_mintChatToken\` returns JSON: \`{"token":"...","expires_in":300}\` on success or \`{"error":"..."}\` on failure.
- \`NativeRuntime.mintChatToken\` method declaration + \`ChatTokenCommand\` registering \`/chat-token\` that whispers the token back to the requesting player (no broadcast, no overlay).

## Verification

- \`cargo check -p mc_auth\` clean.
- \`cargo test -p mc_auth --lib chat_jwt\` — 2/2 passing.
- \`./gradlew compileJava\` in \`apps/mc/mc_auth/java\` clean.

## Deferred (Scope B, next worktree)

- Mirror the ExternalSecret into the \`irc\` namespace.
- Add an HS256 verifier path on irc-gateway \`/minechat\` that accepts \`iss=mc-auth, aud=minechat\` tokens and uses \`mc_username\` as the IRC nick (replacing today's \`mc-<sub-prefix>\` derivation).
- Optional: plugin-message channel so a companion client mod can pick up the token automatically instead of the player copy-pasting.

## Secret provisioning checklist (manual, one-time before deploy)

- [ ] Create \`kilobase/mc-chat-jwt\` Secret with field \`signing-key\` (64 random bytes, base64 or raw).
- [ ] Confirm ExternalSecret \`mc-chat-jwt-signing-key\` in \`arc-runners\` reaches \`Ready\` status.
- [ ] Restart Fleet pods so the new env var lands.