### PR TITLE
fix(vm): drop broken aria2-proxy:test target — defer to vitest e2e

### DIFF
--- a/apps/vm/aria2-proxy/project.json
+++ b/apps/vm/aria2-proxy/project.json
@@ -58,23 +58,6 @@
 					]
 				}
 			}
-		},
-		"test": {
-			"executor": "nx:run-commands",
-			"dependsOn": ["container"],
-			"options": {
-				"commands": [
-					"echo '=== aria2-proxy image tests ==='",
-					"docker inspect ghcr.io/kbve/aria2-proxy:latest --format '{{.Config.User}}' | grep -q 1000 && echo 'PASS: non-root user 1000'",
-					"docker inspect ghcr.io/kbve/aria2-proxy:latest --format '{{.Config.WorkingDir}}' | grep -q /downloads && echo 'PASS: workdir /downloads'",
-					"docker run --rm ghcr.io/kbve/aria2-proxy:latest aria2c --version | head -1 | grep -q 'aria2 version' && echo 'PASS: aria2c available'",
-					"docker run --rm ghcr.io/kbve/aria2-proxy:latest python3 --version | grep -q 'Python 3' && echo 'PASS: python3 available'",
-					"docker run --rm ghcr.io/kbve/aria2-proxy:latest sh -c 'test -f /sbin/tini' && echo 'PASS: tini present'",
-					"docker run --rm ghcr.io/kbve/aria2-proxy:latest sh -c 'test -d /downloads && test -w /downloads' && echo 'PASS: /downloads writable by non-root'",
-					"echo '=== aria2-proxy tests passed ==='"
-				],
-				"parallel": false
-			}
 		}
 	},
 	"tags": ["scope:vm", "aria2-proxy", "infrastructure", "kubevirt"]


### PR DESCRIPTION
## Summary
Fixes the CI-Dev failure on post-merge of #10221. The `aria2-proxy:test` target inspected `ghcr.io/kbve/aria2-proxy:latest` but the `container:local` target tags the image as `kbve/aria2-proxy:latest` (no `ghcr.io/` prefix — that only gets applied in `containerx:production`). CI failed immediately with \`Error: No such object: ghcr.io/kbve/aria2-proxy:latest\`.

## Fix
Remove the redundant shell-script `test` target from `apps/vm/aria2-proxy/project.json`. Every assertion it made is already covered by the vitest suite in `apps/vm/aria2-proxy-e2e/e2e/image.spec.ts`:

| Original `test` shell check | vitest equivalent |
|---|---|
| User == 1000 | security.spec.ts — `id -u`, `id -g` |
| WorkingDir == /downloads | image.spec.ts — `docker inspect ... WorkingDir` |
| aria2c --version | image.spec.ts — `aria2c --version` |
| python3 --version | image.spec.ts — `python3 --version` |
| tini present | image.spec.ts — `test -f /sbin/tini` |
| /downloads writable | security.spec.ts — write + read probe |

The e2e suite builds its own image via `docker buildx build --load` and references `kbve/aria2-proxy:latest` directly via `IMAGE_NAME` — no tag-mismatch bug possible there.

## Why this is the right shape
Mirrors the kubectl pattern: main project (`kubectl`) has only `build`/`container` targets; the sibling `kubectl-e2e` project owns testing. Before this fix, aria2-proxy was double-testing (shell script + vitest) with subtly different image references. Keeping only the vitest suite as the source of truth removes both the duplication and the tag bug.

## Test plan
- [x] `git diff` shows only `apps/vm/aria2-proxy/project.json` (17 deletions, 0 insertions)
- [x] `npx nx show project aria2-proxy` confirms `container` + `containerx` targets only, no `test`
- [ ] CI-Dev passes `aria2-proxy` build after merge
- [ ] `aria2-proxy-e2e:e2e` still runs its 20 specs (independent, no change)