### PR TITLE
fix(irc-gateway): wire bevy_chat into Docker build graph (closes #10231)

### DIFF
--- a/apps/irc/irc-gateway/Cargo.workspace.toml
+++ b/apps/irc/irc-gateway/Cargo.workspace.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "apps/irc/irc-gateway",
+    "packages/rust/bevy/bevy_chat",
     "packages/rust/jedi",
     "packages/rust/kbve",
 ]

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -68,12 +68,14 @@ COPY Cargo.lock ./
 COPY apps/irc/irc-gateway/Cargo.toml apps/irc/irc-gateway/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+COPY packages/rust/bevy/bevy_chat/Cargo.toml packages/rust/bevy/bevy_chat/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
 RUN mkdir -p apps/irc/irc-gateway/src && echo "fn main() {}" > apps/irc/irc-gateway/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
-    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_chat/src && echo "" > packages/rust/bevy/bevy_chat/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -102,8 +104,14 @@ COPY --from=planner /app/Cargo.toml ./
 COPY Cargo.lock ./
 
 COPY apps/irc/irc-gateway/Cargo.toml apps/irc/irc-gateway/Cargo.toml
+# bevy_chat is a workspace member and a path dep of irc-gateway; cargo
+# evaluates the full graph even for -p kbve -p jedi, so we stub it here
+# to keep this stage untouched by chat-side changes.
+COPY packages/rust/bevy/bevy_chat/Cargo.toml packages/rust/bevy/bevy_chat/Cargo.toml
 RUN mkdir -p apps/irc/irc-gateway/src && \
-    echo "fn main() {}" > apps/irc/irc-gateway/src/main.rs
+    echo "fn main() {}" > apps/irc/irc-gateway/src/main.rs && \
+    mkdir -p packages/rust/bevy/bevy_chat/src && \
+    echo "" > packages/rust/bevy/bevy_chat/src/lib.rs
 
 COPY packages/data/proto packages/data/proto
 
@@ -129,6 +137,8 @@ COPY --from=astro-precompressor /static /app/apps/irc/irc-gateway/templates/dist
 COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
+# Shared ChatMessage schema used by /minechat — path dep of irc-gateway.
+COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 
 COPY apps/irc/irc-gateway apps/irc/irc-gateway
 


### PR DESCRIPTION
## Summary

PR #10209 added \`bevy_chat\` as a path dep of \`irc-gateway\` without updating the Dockerfile, which broke the CI docker build (#10231):

\`\`\`
failed to read \`/app/packages/rust/bevy/bevy_chat/Cargo.toml\`
No such file or directory (os error 2)
\`\`\`

## Changes

1. **\`Cargo.workspace.toml\`** — adds \`packages/rust/bevy/bevy_chat\` to the trimmed workspace \`members\` list.

2. **Dockerfile Stage C (planner)** — copies \`bevy_chat/Cargo.toml\` and stubs \`src/lib.rs\`, matching the existing \`jedi\`/\`kbve\` pattern so \`cargo chef prepare\` can extract the full dependency graph.

3. **Dockerfile Stage E (foundation)** — copies the same stub so \`cargo build -p kbve -p jedi\` sees a complete workspace graph (cargo evaluates it even when only two members are built).

4. **Dockerfile Stage F (builder)** — copies the real \`bevy_chat\` source so \`cargo build -p irc-gateway\` can compile it.

## Verification

Reproduced the planner stage locally (copied the same files the Dockerfile would, then ran \`cargo metadata --no-deps\`). Result:
- \`workspace_members\` includes \`bevy_chat\`
- \`irc-gateway\`'s \`bevy_chat\` path dep resolves to the workspace member
- No missing-manifest errors

Closes #10231.