### PR TITLE
fix(discordsh): add bevy_behavior to Docker build context

### DIFF
--- a/apps/discordsh/discordsh-bot/Cargo.workspace.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.workspace.toml
@@ -6,6 +6,7 @@ members = [
     "packages/rust/kbve",
     "packages/rust/bevy/bevy_inventory",
     "packages/rust/bevy/bevy_items",
+    "packages/rust/bevy/bevy_behavior",
     "packages/rust/bevy/bevy_battle",
     "packages/rust/bevy/bevy_npc",
     "packages/rust/bevy/bevy_quests",

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -17,6 +17,7 @@ COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 COPY packages/rust/bevy/bevy_inventory/Cargo.toml packages/rust/bevy/bevy_inventory/Cargo.toml
 COPY packages/rust/bevy/bevy_items/Cargo.toml packages/rust/bevy/bevy_items/Cargo.toml
+COPY packages/rust/bevy/bevy_behavior/Cargo.toml packages/rust/bevy/bevy_behavior/Cargo.toml
 COPY packages/rust/bevy/bevy_battle/Cargo.toml packages/rust/bevy/bevy_battle/Cargo.toml
 COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
 COPY packages/rust/bevy/bevy_quests/Cargo.toml packages/rust/bevy/bevy_quests/Cargo.toml
@@ -30,6 +31,7 @@ RUN mkdir -p apps/discordsh/discordsh-bot/src && echo "fn main() {}" > apps/disc
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_inventory/src && echo "" > packages/rust/bevy/bevy_inventory/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_items/src && echo "" > packages/rust/bevy/bevy_items/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_behavior/src && echo "" > packages/rust/bevy/bevy_behavior/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_battle/src && echo "" > packages/rust/bevy/bevy_battle/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_quests/src && echo "" > packages/rust/bevy/bevy_quests/src/lib.rs && \
@@ -72,6 +74,7 @@ COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
+COPY packages/rust/bevy/bevy_behavior packages/rust/bevy/bevy_behavior
 COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
 COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
@@ -81,7 +84,7 @@ COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat
+    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_behavior -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat
 
 # ============================================================================
 # [STAGE D] - Build Application
@@ -98,6 +101,7 @@ COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
+COPY packages/rust/bevy/bevy_behavior packages/rust/bevy/bevy_behavior
 COPY packages/rust/bevy/bevy_battle packages/rust/bevy/bevy_battle
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
 COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests


### PR DESCRIPTION
Closes #10227

## Problem
CI - Docker / discordsh-bot failed with:

```
#23 0.154 Error: Failed to compute recipe
#23 0.154     1: \`cargo metadata\` execution failed
#23 0.154     2: \`cargo metadata\` exited with an error: error: failed to load manifest for workspace member \`/app/apps/discordsh/discordsh-bot\`
#23 0.154          failed to load manifest for dependency \`bevy_battle\`
#23 0.154          failed to load manifest for dependency \`bevy_behavior\`
#23 0.154          failed to read \`/app/packages/rust/bevy/bevy_behavior/Cargo.toml\`
#23 0.154          No such file or directory (os error 2)
```

## Root cause
`bevy_battle/Cargo.toml` took a path dependency on `bevy_behavior` (line 25: `bevy_behavior = { path = "../bevy_behavior" }`), but the `discordsh-bot/Dockerfile` was never updated to copy `bevy_behavior` into the build context. The cargo-chef planner stage couldn't resolve the transitive path dependency and failed on `cargo metadata`.

## Fix
Mirror the existing pattern used for every other `bevy_*` crate in the Dockerfile:

1. **Planner stage** — add `COPY packages/rust/bevy/bevy_behavior/Cargo.toml`
2. **Planner stage stubs** — add `mkdir -p packages/rust/bevy/bevy_behavior/src && echo "" > .../lib.rs`
3. **Foundation stage** — add `COPY packages/rust/bevy/bevy_behavior` + `-p bevy_behavior` to the cargo build invocation
4. **Builder stage** — add `COPY packages/rust/bevy/bevy_behavior`
5. **Cargo.workspace.toml** — add `packages/rust/bevy/bevy_behavior` to `workspace.members` so `-p bevy_behavior` resolves

Pattern matches: `bevy_inventory`, `bevy_items`, `bevy_battle`, `bevy_npc`, `bevy_quests`, `bevy_skills`, `bevy_chat`.

## Test plan
- [ ] CI — `Test Docker / Test discordsh-bot-e2e Docker App` step passes
- [ ] Post-merge — closes #10227 automatically