### PR TITLE
perf(rareicon): tile pixel grid 16 → 32 (preserved visuals)

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexTile.shader
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexTile.shader
@@ -15,7 +15,7 @@ Shader "RareIcon/HexTile"
 
         // Procedural pixel trees — composited inside the tile, no extra geometry.
         _TreeDensity   ("Tree Density (0=none, 1=every tile)", Range(0,1)) = 0.0
-        _TreePixelGrid ("Tree Pixel Grid (resolution per tile)", Float)    = 16.0
+        _TreePixelGrid ("Tree Pixel Grid (resolution per tile)", Float)    = 32.0
         _TrunkColor    ("Trunk Color", Color)        = (0.25, 0.16, 0.10, 1)
         _CanopyDark    ("Canopy Dark", Color)        = (0.10, 0.30, 0.10, 1)
         _CanopyMid     ("Canopy Mid", Color)         = (0.18, 0.45, 0.18, 1)

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexBerryBush.hlsl
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexBerryBush.hlsl
@@ -15,17 +15,23 @@
 float3 ApplyBerryBush(float3 ground, float2 px, float grid, float seed, float amount)
 {
     int berryCap = clamp((int)ceil(amount * 5.0), 1, 5);
-    float2 bc = float2(grid * 0.45, grid * 0.40) + float2(
-        floor((hash21(float2(seed, 61.0)) - 0.5) * 4.0),
-        floor((hash21(float2(seed, 62.0)) - 0.5) * 2.0));
 
-    float lobeL = circleMask(px, bc,                       2.4);
-    float lobeR = circleMask(px, bc + float2( 2.5, 0.0),   2.0);
-    float crown = circleMask(px, bc + float2( 1.0, 1.6),   1.8);
+    // Pixel-space scale (1.0 at legacy 16-grid, 2.0 at 32-grid bump).
+    // Lobe radii, berry-pip sizes, and shadow offsets all multiply by s so
+    // the bush stays the same apparent size after a density bump.
+    float s = grid * 0.0625;
+
+    float2 bc = float2(grid * 0.45, grid * 0.40) + float2(
+        floor((hash21(float2(seed, 61.0)) - 0.5) * 4.0 * s),
+        floor((hash21(float2(seed, 62.0)) - 0.5) * 2.0 * s));
+
+    float lobeL = circleMask(px, bc,                              2.4 * s);
+    float lobeR = circleMask(px, bc + float2( 2.5, 0.0) * s,      2.0 * s);
+    float crown = circleMask(px, bc + float2( 1.0, 1.6) * s,      1.8 * s);
     float bush  = max(lobeL, max(lobeR, crown));
 
     float3 result = lerp(ground, _BerryBushColor.rgb, bush);
-    float bottomRim = bush * step(px.y, bc.y - 1.5);
+    float bottomRim = bush * step(px.y, bc.y - 1.5 * s);
     result = lerp(result, _BerryBushColor.rgb * 0.65, bottomRim);
 
     [unroll]
@@ -36,16 +42,16 @@ float3 ApplyBerryBush(float3 ground, float2 px, float grid, float seed, float am
         if (hash21(float2(bs, 63.0)) < 0.40) continue;
 
         float2 bd = float2(
-            floor((hash21(float2(bs, 64.0)) - 0.5) * 3.5),
-            floor( hash21(float2(bs, 65.0)) * 2.0 + 1.0));
-        float2 berryC = bc + float2(1.0, 1.0) + bd;
+            floor((hash21(float2(bs, 64.0)) - 0.5) * 3.5 * s),
+            floor( hash21(float2(bs, 65.0)) * 2.0 * s + 1.0 * s));
+        float2 berryC = bc + float2(1.0, 1.0) * s + bd;
 
         float onBush = step(min(min(length(px - bc),
-                                    length(px - (bc + float2(2.5, 0.0)))),
-                                length(px - (bc + float2(1.0, 1.6)))), 2.5);
+                                    length(px - (bc + float2(2.5, 0.0) * s))),
+                                length(px - (bc + float2(1.0, 1.6) * s))), 2.5 * s);
 
-        float berryPx  = step(length(px - berryC), 0.7);
-        float shadowPx = step(length(px - (berryC + float2(0, -1))), 0.7);
+        float berryPx  = step(length(px - berryC), 0.7 * s);
+        float shadowPx = step(length(px - (berryC + float2(0, -1) * s)), 0.7 * s);
         result = lerp(result, _BerryColor.rgb,        berryPx  * onBush);
         result = lerp(result, _BerryColor.rgb * 0.55, shadowPx * onBush * (1.0 - berryPx));
     }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexBoulder.hlsl
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexBoulder.hlsl
@@ -21,50 +21,55 @@ float3 ApplyBoulder(float3 ground, float2 px, float grid, float seed, float amou
     float3 lit   = saturate(_StoneColor.rgb * (1.0 + colorJit));
     float3 shade = saturate(_StoneShade.rgb * (1.0 + colorJit));
 
+    // Pixel-space scale. 1.0 at legacy 16-grid, 2.0 at the 32-grid bump.
+    // Raw pixel radii / offsets multiply by s so the boulder silhouette
+    // stays the same on-screen size; grid-relative coords auto-track.
+    float s = grid * 0.0625;
+
     // === Main boulder ===
     float2 c1 = float2(grid * 0.5, grid * 0.4) + float2(
-        floor((hash21(float2(seed, 71.0)) - 0.5) * 4.0),
-        floor((hash21(float2(seed, 72.0)) - 0.5) * 3.0));
+        floor((hash21(float2(seed, 71.0)) - 0.5) * 4.0 * s),
+        floor((hash21(float2(seed, 72.0)) - 0.5) * 3.0 * s));
 
     // Main mass radius varies 2.4–3.4 — small pebble vs chunky boulder.
-    float r1 = 2.4 + hash21(float2(seed, 73.0)) * 1.0;
+    float r1 = (2.4 + hash21(float2(seed, 73.0)) * 1.0) * s;
     float boulder = circleMask(px, c1, r1);
 
     // Lump 1 (always present) — adds asymmetry.
     float2 lo1 = float2(
-        (hash21(float2(seed, 74.0)) - 0.5) * 4.0,
-        (hash21(float2(seed, 75.0)) - 0.5) * 3.0);
+        (hash21(float2(seed, 74.0)) - 0.5) * 4.0 * s,
+        (hash21(float2(seed, 75.0)) - 0.5) * 3.0 * s);
     boulder = max(boulder,
-        circleMask(px, c1 + lo1, 1.5 + hash21(float2(seed, 76.0)) * 0.9));
+        circleMask(px, c1 + lo1, (1.5 + hash21(float2(seed, 76.0)) * 0.9) * s));
 
     // Lump 2 (~70% chance).
     if (hash21(float2(seed, 77.0)) > 0.30)
     {
         float2 lo2 = float2(
-            (hash21(float2(seed, 78.0)) - 0.5) * 4.5,
-            (hash21(float2(seed, 79.0)) - 0.5) * 2.5);
+            (hash21(float2(seed, 78.0)) - 0.5) * 4.5 * s,
+            (hash21(float2(seed, 79.0)) - 0.5) * 2.5 * s);
         boulder = max(boulder,
-            circleMask(px, c1 + lo2, 1.3 + hash21(float2(seed, 80.0)) * 0.8));
+            circleMask(px, c1 + lo2, (1.3 + hash21(float2(seed, 80.0)) * 0.8) * s));
     }
 
     // Lump 3 (~50% chance, biased downward → "rests on the ground" feel).
     if (hash21(float2(seed, 81.0)) > 0.50)
     {
         float2 lo3 = float2(
-            (hash21(float2(seed, 82.0)) - 0.5) * 4.0,
-            (hash21(float2(seed, 83.0)) - 0.5) * 2.0 - 0.5);
+            (hash21(float2(seed, 82.0)) - 0.5) * 4.0 * s,
+            (hash21(float2(seed, 83.0)) - 0.5) * 2.0 * s - 0.5 * s);
         boulder = max(boulder,
-            circleMask(px, c1 + lo3, 1.4 + hash21(float2(seed, 84.0)) * 0.7));
+            circleMask(px, c1 + lo3, (1.4 + hash21(float2(seed, 84.0)) * 0.7) * s));
     }
 
     // Top-half lit / bottom-half shaded — keeps the volume read.
-    float3 stoneCol = (px.y > c1.y - 0.5) ? lit : shade;
+    float3 stoneCol = (px.y > c1.y - 0.5 * s) ? lit : shade;
     float3 result = lerp(ground, stoneCol, boulder);
 
     // Single highlight pixel on the upper lit side — reads as a sun catch.
-    float2 hp = c1 + float2(0.0, r1 - 1.0)
-                   + float2(floor((hash21(float2(seed, 85.0)) - 0.5) * 2.0), 0.0);
-    float highlight = step(length(px - hp), 0.6) * boulder;
+    float2 hp = c1 + float2(0.0, r1 - 1.0 * s)
+                   + float2(floor((hash21(float2(seed, 85.0)) - 0.5) * 2.0 * s), 0.0);
+    float highlight = step(length(px - hp), 0.6 * s) * boulder;
     result = lerp(result, lit * 1.25, highlight);
 
     // === Companion pebble (~40% chance, gated on full-stone hexes) ===
@@ -72,21 +77,21 @@ float3 ApplyBoulder(float3 ground, float2 px, float grid, float seed, float amou
     {
         float side = (hash21(float2(seed, 90.0)) > 0.5) ? 1.0 : -1.0;
         float2 c2 = c1 + float2(
-            side * (r1 + 1.5 + hash21(float2(seed, 91.0)) * 1.5),
-            (hash21(float2(seed, 92.0)) - 0.5) * 2.0 - 0.5);
+            side * (r1 + 1.5 * s + hash21(float2(seed, 91.0)) * 1.5 * s),
+            (hash21(float2(seed, 92.0)) - 0.5) * 2.0 * s - 0.5 * s);
 
-        float pebble = circleMask(px, c2, 1.0 + hash21(float2(seed, 93.0)) * 0.9);
+        float pebble = circleMask(px, c2, (1.0 + hash21(float2(seed, 93.0)) * 0.9) * s);
 
         // Optional small lump on the pebble itself.
         if (hash21(float2(seed, 94.0)) > 0.5)
         {
             float2 plo = c2 + float2(
-                (hash21(float2(seed, 95.0)) - 0.5) * 2.0,
-                (hash21(float2(seed, 96.0)) - 0.5) * 1.5);
-            pebble = max(pebble, circleMask(px, plo, 1.0));
+                (hash21(float2(seed, 95.0)) - 0.5) * 2.0 * s,
+                (hash21(float2(seed, 96.0)) - 0.5) * 1.5 * s);
+            pebble = max(pebble, circleMask(px, plo, 1.0 * s));
         }
 
-        float3 pebbleCol = (px.y > c2.y - 0.5) ? lit : shade;
+        float3 pebbleCol = (px.y > c2.y - 0.5 * s) ? lit : shade;
         result = lerp(result, pebbleCol, pebble);
     }
 

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexCactus.hlsl
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexCactus.hlsl
@@ -31,6 +31,10 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
     bool showSidePads = amount > 0.5;
     float3 result = ground;
 
+    // Pixel-space scale (1.0 at legacy 16-grid, 2.0 at 32-grid bump).
+    // `ps` to avoid shadowing the loop index `int s` below.
+    float ps = grid * 0.0625;
+
     // Per-plant hue / brightness drift so neighbours don't clone.
     float bright = 0.94 + hash21(float2(seed, 71.0)) * 0.14;
     float warm   = (hash21(float2(seed, 72.0)) - 0.5) * 0.06;
@@ -52,16 +56,16 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
             floor((hash21(float2(seed, 13.0)) - 0.5) * grid * 0.18));
 
         // Base pad: ~3 wide × 4 tall rounded rectangle.
-        float basePad = circleMask(px, c,                        2.6);
+        float basePad = circleMask(px, c,                                    2.6 * ps);
         // Side pads (two optional, slightly higher, offset left/right).
-        float pad2 = circleMask(px, c + float2(-2.5, 1.2),       1.8);
-        float pad3 = circleMask(px, c + float2( 2.5, 1.4),       1.8);
+        float pad2 = circleMask(px, c + float2(-2.5, 1.2) * ps,              1.8 * ps);
+        float pad3 = circleMask(px, c + float2( 2.5, 1.4) * ps,              1.8 * ps);
         // Side / crown pads are gated on amount so a near-foraged
         // plant reads as just the base pad.
         float pad2Gate = showSidePads ? step(0.25, hash21(float2(seed, 14.0))) : 0.0;
         float pad3Gate = showSidePads ? step(0.35, hash21(float2(seed, 15.0))) : 0.0;
         // Crown pad (smaller, centred above base).
-        float crown = circleMask(px, c + float2(0.0, 2.4),       1.5);
+        float crown = circleMask(px, c + float2(0.0, 2.4) * ps,              1.5 * ps);
         float crownGate = showSidePads ? step(0.20, hash21(float2(seed, 16.0))) : 0.0;
 
         float silhouette = max(basePad,
@@ -70,7 +74,7 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
 
         // Shaded rim on the lower row of each pad — gives the ovoid shape
         // a hint of 3D lighting without a full gradient.
-        float rim = silhouette * step(px.y, c.y - 1.0);
+        float rim = silhouette * step(px.y, c.y - 1.0 * ps);
         result = lerp(result, body,     silhouette);
         result = lerp(result, bodyDark, rim);
 
@@ -81,10 +85,10 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
             float ss = seed + (float)s * 5.0;
             if (hash21(float2(ss, 17.0)) < 0.55) continue;
             float2 sp = c + float2(
-                floor((hash21(float2(ss, 18.0)) - 0.5) * 6.0),
-                floor((hash21(float2(ss, 19.0)) - 0.5) * 5.0));
-            float onBody = step(length(sp - c), 3.0);
-            float spinePx = step(length(px - sp), 0.6) * onBody;
+                floor((hash21(float2(ss, 18.0)) - 0.5) * 6.0 * ps),
+                floor((hash21(float2(ss, 19.0)) - 0.5) * 5.0 * ps));
+            float onBody = step(length(sp - c), 3.0 * ps);
+            float spinePx = step(length(px - sp), 0.6 * ps) * onBody;
             result = lerp(result, spine, spinePx * silhouette);
         }
 
@@ -98,10 +102,10 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
             float fs = seed + (float)f * 7.0;
             if (hash21(float2(fs, 21.0)) < 0.45) continue;
             float2 fp = c + float2(
-                floor((hash21(float2(fs, 22.0)) - 0.5) * 5.0),
-                floor(hash21(float2(fs, 23.0)) * 2.0 + 1.5));
-            float onBody = step(length(fp - c), 3.2);
-            float fruit  = step(length(px - fp), 0.8) * onBody;
+                floor((hash21(float2(fs, 22.0)) - 0.5) * 5.0 * ps),
+                floor(hash21(float2(fs, 23.0)) * 2.0 * ps + 1.5 * ps));
+            float onBody = step(length(fp - c), 3.2 * ps);
+            float fruit  = step(length(px - fp), 0.8 * ps) * onBody;
             result = lerp(result, flower, fruit);
         }
     }
@@ -113,26 +117,26 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
             0.0);
 
         // Trunk: 2 wide × ~6 tall column with rounded top.
-        float trunkH = 5.0 + floor(hash21(float2(seed, 32.0)) * 3.0); // 5–7
-        float trunk  = rectMask(px, c + float2(-1, 0), float2(2, trunkH));
-        float trunkTop = circleMask(px, c + float2(0.0, trunkH - 0.5), 1.3);
+        float trunkH = (5.0 + floor(hash21(float2(seed, 32.0)) * 3.0)) * ps; // 5–7 at legacy
+        float trunk  = rectMask(px, c + float2(-1 * ps, 0), float2(2 * ps, trunkH));
+        float trunkTop = circleMask(px, c + float2(0.0, trunkH - 0.5 * ps), 1.3 * ps);
 
         // Optional bent arm — low-gated so ~40% of plants have one.
         // Suppressed entirely on heavily-foraged plants so the column
         // looks weathered rather than ornamental.
         float armGate  = showSidePads ? step(0.60, hash21(float2(seed, 33.0))) : 0.0;
         float armSide  = step(0.50, hash21(float2(seed, 34.0))); // 0 left, 1 right
-        float armDx    = lerp(-2.0, 2.0, armSide);
+        float armDx    = lerp(-2.0 * ps, 2.0 * ps, armSide);
         float2 armBase = c + float2(armDx, trunkH * 0.45);
-        float arm      = rectMask(px, armBase + float2(-0.5, 0.0), float2(1, 2));
-        float armTip   = circleMask(px, armBase + float2(armDx * 0.5, 2.0), 1.2);
+        float arm      = rectMask(px, armBase + float2(-0.5 * ps, 0.0), float2(1 * ps, 2 * ps));
+        float armTip   = circleMask(px, armBase + float2(armDx * 0.5, 2.0 * ps), 1.2 * ps);
         float armShape = max(arm, armTip) * armGate;
 
         float silhouette = max(trunk, max(trunkTop, armShape));
 
         // Central shade column on the right half of the trunk — cheap rib
         // effect since the trunk is only 2 px wide.
-        float ribCol  = rectMask(px, c + float2(0, 0), float2(1, trunkH));
+        float ribCol  = rectMask(px, c + float2(0, 0), float2(1 * ps, trunkH));
         result = lerp(result, body,     silhouette);
         result = lerp(result, bodyDark, ribCol * trunk);
 
@@ -140,10 +144,10 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
         [unroll]
         for (int s = 0; s < 4; s++)
         {
-            float spy = c.y + 0.5 + (float)s * 1.5;
+            float spy = c.y + 0.5 * ps + (float)s * 1.5 * ps;
             float2 sp = float2(c.x, floor(spy));
-            float onTrunk = step(px.y, c.y + trunkH - 1.0) * step(c.y, px.y);
-            float spinePx = step(length(px - sp), 0.55) * onTrunk;
+            float onTrunk = step(px.y, c.y + trunkH - 1.0 * ps) * step(c.y, px.y);
+            float spinePx = step(length(px - sp), 0.55 * ps) * onTrunk;
             result = lerp(result, spine, spinePx * silhouette);
         }
 
@@ -159,11 +163,11 @@ float3 ApplyCactus(float3 ground, float2 px, float grid, float seed, float isDra
             float fs = seed + (float)f * 9.0;
             if (f > 0 && hash21(float2(fs, 41.0)) < 0.55) continue;
             float fy = c.y + trunkH * 0.6
-                     + floor(hash21(float2(fs, 42.0)) * 2.0);
-            float fx = c.x + (hash21(float2(fs, 43.0)) < 0.5 ? -1.5 : 1.5);
+                     + floor(hash21(float2(fs, 42.0)) * 2.0 * ps);
+            float fx = c.x + (hash21(float2(fs, 43.0)) < 0.5 ? -1.5 * ps : 1.5 * ps);
             float2 fp = float2(floor(fx), floor(fy));
-            float fruit = step(length(px - fp) * float2(1.1, 0.8).y, 1.1);
-            float bract = step(length(px - (fp + float2(0, 1))), 0.7);
+            float fruit = step(length(px - fp) * float2(1.1, 0.8).y, 1.1 * ps);
+            float bract = step(length(px - (fp + float2(0, 1 * ps))), 0.7 * ps);
             result = lerp(result, dragonCol, fruit);
             result = lerp(result, body,      bract);
         }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexHerbs.hlsl
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexHerbs.hlsl
@@ -14,6 +14,12 @@ float3 ApplyHerbs(float3 ground, float2 px, float grid, float seed, float amount
     float3 result = ground;
     int tuftCap = clamp((int)ceil(amount * 5.0), 1, 5);
 
+    // Pixel-space scale. 1.0 at legacy 16-grid, 2.0 at current 32-grid.
+    // Raw pixel radii / offsets multiply by s so silhouettes stay the same
+    // on-screen size when the grid density is bumped. Grid-relative coords
+    // (e.g. `grid * 0.4`) already track automatically and stay untouched.
+    float s = grid * 0.0625;
+
     [unroll]
     for (int h = 0; h < 5; h++)
     {
@@ -25,7 +31,7 @@ float3 ApplyHerbs(float3 ground, float2 px, float grid, float seed, float amount
             floor((hash21(float2(hs, 52.0)) - 0.5) * (grid * 0.55)),
             floor((hash21(float2(hs, 53.0)) - 0.5) * (grid * 0.35)));
 
-        float tuft = step(length(px - hc), 0.9);
+        float tuft = step(length(px - hc), 0.9 * s);
         result = lerp(result, _HerbColor.rgb, tuft);
     }
     return result;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexMushroom.hlsl
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexMushroom.hlsl
@@ -28,6 +28,10 @@ float3 ApplyMushrooms(float3 ground, float2 px, float grid, float seed, float am
     float3 spotCol = float3(0.96, 0.93, 0.85);
     int mushroomCap = clamp((int)ceil(amount * 3.0), 1, 3);
 
+    // Pixel-space scale (1.0 at legacy 16-grid, 2.0 at 32-grid bump).
+    // Named `ps` to avoid shadowing the inner loop's `int s`.
+    float ps = grid * 0.0625;
+
     [unroll]
     for (int m = 0; m < 3; m++)
     {
@@ -55,41 +59,41 @@ float3 ApplyMushrooms(float3 ground, float2 px, float grid, float seed, float am
         float3 capGills = capBase * 0.55;
         float3 capHL    = saturate(capBase * 1.22 + 0.04);
 
-        // Integer-aligned centre.
+        // Integer-aligned centre. Grid-relative, auto-tracks density.
         float2 c = float2(floor(grid * 0.5), floor(grid * 0.42)) + float2(
             floor((hash21(float2(ms, 82.0)) - 0.5) * grid * 0.40),
             floor((hash21(float2(ms, 83.0)) - 0.5) * grid * 0.25));
 
         // Stem height by kind — chanterelle squat, fly agaric tallest.
-        float stemH = 3.0;
-        if (kind == 1) stemH = 1.0;
-        if (kind == 2) stemH = 4.0;
-        float stemBottomY = c.y - stemH + 1.0;
+        float stemH = 3.0 * ps;
+        if (kind == 1) stemH = 1.0 * ps;
+        if (kind == 2) stemH = 4.0 * ps;
+        float stemBottomY = c.y - stemH + 1.0 * ps;
 
         // Ground shadow — single pixel one row below stem bottom.
         float shadowMask = rectMask(px,
-            float2(c.x, stemBottomY - 1.0), float2(1, 1));
+            float2(c.x, stemBottomY - 1.0 * ps), float2(1, 1) * ps);
         result = lerp(result, ground * 0.68, shadowMask * 0.55);
 
-        // Stem — 1 pixel wide.
+        // Stem — 1 pixel wide at legacy, scales with density.
         float stem = rectMask(px,
-            float2(c.x, stemBottomY), float2(1, stemH));
+            float2(c.x, stemBottomY), float2(1.0 * ps, stemH));
         result = lerp(result, _MushroomStem.rgb, stem);
 
         // Cap — compact dome, chanterelle slightly wider.
-        float capR = 1.5 + hash21(float2(ms, 84.0)) * 0.6;   // 1.5–2.1
-        if (kind == 1) capR += 0.4;                           // 1.9–2.5
-        float2 capCenter = c + float2(0, 0.5);
+        float capR = (1.5 + hash21(float2(ms, 84.0)) * 0.6) * ps;   // 1.5–2.1
+        if (kind == 1) capR += 0.4 * ps;                             // 1.9–2.5
+        float2 capCenter = c + float2(0, 0.5 * ps);
         float capDist = length(px - capCenter);
         float cap = step(capDist, capR) * step(c.y, px.y);
         result = lerp(result, capBase, cap);
 
         // Gill line on the bottom row of the dome.
-        float gillMask = cap * step(px.y, c.y + 0.5);
+        float gillMask = cap * step(px.y, c.y + 0.5 * ps);
         result = lerp(result, capGills, gillMask);
 
         // Top highlight (rows c.y + 2 and up).
-        float topMask = cap * step(c.y + 2.0, px.y);
+        float topMask = cap * step(c.y + 2.0 * ps, px.y);
         result = lerp(result, capHL, topMask);
 
         // Spots — fly agaric only, 1-2 single-pixel dots on the upper cap.
@@ -100,9 +104,9 @@ float3 ApplyMushrooms(float3 ground, float2 px, float grid, float seed, float am
             float ss = ms + (float)s * 3.0;
             if (s > 0 && hash21(float2(ss, 87.0)) < 0.55) continue;
             float2 spotPos = c + float2(
-                floor(hash21(float2(ss, 89.0)) * 3.0) - 1.0,
-                1.0 + floor(hash21(float2(ss, 90.0)) * 2.0));
-            float spot = step(length(px - spotPos), 0.75) * cap * spotGate;
+                floor(hash21(float2(ss, 89.0)) * 3.0 * ps) - 1.0 * ps,
+                1.0 * ps + floor(hash21(float2(ss, 90.0)) * 2.0 * ps));
+            float spot = step(length(px - spotPos), 0.75 * ps) * cap * spotGate;
             result = lerp(result, spotCol, spot);
         }
     }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexTree.hlsl
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexTree.hlsl
@@ -33,6 +33,11 @@ float3 ApplyPixelTree(float3 ground, float2 px, float grid, float seed, float am
     int amountCap   = clamp((int)ceil(amount * 3.0), 1, 3);
     int treeCount   = min(rolledCount, amountCap);
 
+    // Pixel-space scale (1.0 at legacy 16-grid, 2.0 at 32-grid bump).
+    // Every raw pixel offset / size / radius multiplies by s; grid-relative
+    // coords (e.g. `grid * 0.5`) already track density automatically.
+    float s = grid * 0.0625;
+
     float trunkMask = 0.0;
     float trunkLightMask = 0.0;
     float trunkShadeMask = 0.0;
@@ -40,7 +45,7 @@ float3 ApplyPixelTree(float3 ground, float2 px, float grid, float seed, float am
     float canopySunMask = 0.0;
     float minDist = 1e6;
     float2 nearestCenter = 0.0;
-    float nearestRadius = 1.0;
+    float nearestRadius = 1.0 * s;
 
     [unroll]
     for (int t = 0; t < 3; t++)
@@ -54,28 +59,28 @@ float3 ApplyPixelTree(float3 ground, float2 px, float grid, float seed, float am
             floor((hash21(float2(ts, 22.0)) - 0.5) * grid * 0.25));
 
         // Trunk core: 3 wide × 5 tall column.
-        float trunkCore = rectMask(px, c + float2(-1, -5), float2(3, 5));
+        float trunkCore = rectMask(px, c + float2(-1, -5) * s, float2(3, 5) * s);
 
         // Root flare: 60% of trees spread to 5 px on the bottom row.
         float flared = step(0.40, hash21(float2(ts, 77.0)));
-        float rootOx = lerp(-1.0, -2.0, flared);
-        float rootW  = lerp( 3.0,  5.0, flared);
-        float trunkRoot = rectMask(px, c + float2(rootOx, -5),
-                                   float2(rootW, 1));
+        float rootOx = lerp(-1.0, -2.0, flared) * s;
+        float rootW  = lerp( 3.0,  5.0, flared) * s;
+        float trunkRoot = rectMask(px, c + float2(rootOx, -5 * s),
+                                   float2(rootW, 1 * s));
 
         // Buttress knuckles one pixel out from the trunk on row c.y-4.
         // Gate with step() so the loop stays unroll-friendly.
         float buttressGate = step(0.55, hash21(float2(ts, 88.0)));
-        float buttressL = rectMask(px, c + float2(-2, -4), float2(1, 1));
-        float buttressR = rectMask(px, c + float2( 2, -4), float2(1, 1));
+        float buttressL = rectMask(px, c + float2(-2, -4) * s, float2(1, 1) * s);
+        float buttressR = rectMask(px, c + float2( 2, -4) * s, float2(1, 1) * s);
         float buttress = max(buttressL, buttressR) * buttressGate;
 
         trunkMask = max(trunkMask,
             max(trunkCore, max(trunkRoot, buttress)));
         trunkLightMask = max(trunkLightMask,
-            rectMask(px, c + float2(-1, -4), float2(1, 4)));
+            rectMask(px, c + float2(-1, -4) * s, float2(1, 4) * s));
         trunkShadeMask = max(trunkShadeMask,
-            rectMask(px, c + float2( 1, -4), float2(1, 4)));
+            rectMask(px, c + float2( 1, -4) * s, float2(1, 4) * s));
 
         // Canopy: up to 6 blobs, first two guaranteed.
         [unroll]
@@ -86,9 +91,9 @@ float3 ApplyPixelTree(float3 ground, float2 px, float grid, float seed, float am
             if (!present) continue;
 
             float2 bo = float2(
-                (hash21(float2(bs, 44.0)) - 0.5) * 7.0,
-                hash21(float2(bs, 55.0)) * 3.8 + 0.8);
-            float br = 2.5 + hash21(float2(bs, 66.0)) * 2.5;
+                (hash21(float2(bs, 44.0)) - 0.5) * 7.0 * s,
+                hash21(float2(bs, 55.0)) * 3.8 * s + 0.8 * s);
+            float br = (2.5 + hash21(float2(bs, 66.0)) * 2.5) * s;
             float2 bc = c + bo;
             canopyMask = max(canopyMask, circleMask(px, bc, br));
 
@@ -104,9 +109,9 @@ float3 ApplyPixelTree(float3 ground, float2 px, float grid, float seed, float am
             // canopyMask later so it never paints outside the silhouette.
             if (b == 0)
             {
-                float sunR = max(br - 2.8, 1.0);
+                float sunR = max(br - 2.8 * s, 1.0 * s);
                 canopySunMask = max(canopySunMask,
-                    circleMask(px, bc + float2(-1.5, 1.5), sunR));
+                    circleMask(px, bc + float2(-1.5, 1.5) * s, sunR));
             }
         }
     }


### PR DESCRIPTION
## Summary
Doubles the addressable per-tile pixel budget for biome decorations, trees, and cactus — unlocks finer detail for future art passes (farm redraw, richer mushrooms / herbs / trees, denser silhouettes) without any visible change to current tiles.

## How it stays visually identical

Every include's `Apply*` function computes a scale factor:

```hlsl
float s = grid * 0.0625;   // 1.0 at legacy 16-grid, 2.0 at 32-grid
```

Raw pixel literals (offsets, radii, sizes fed to `rectMask` / `circleMask` / `step(length(...), R)`) all multiply by `s`. Grid-relative coords like `grid * 0.5` auto-track density and stay untouched. Net result at the new 32-grid: every existing shape occupies the same fraction of the tile — just discretised over 4× the pixel area.

## Files touched

| File | Change |
|---|---|
| `HexTile.shader` | `_TreePixelGrid 16.0 → 32.0` |
| `HexBoulder.hlsl` | `s` scale + wrap pixel literals |
| `HexBerryBush.hlsl` | `s` scale + wrap pixel literals |
| `HexMushroom.hlsl` | `ps` scale (avoids `int s` loop shadow) + wrap pixel literals |
| `HexHerbs.hlsl` | `s` scale + tuft radius wrap |
| `HexCactus.hlsl` | `ps` scale (avoids `int s` loop shadow) + wrap pixel literals |
| `HexTree.hlsl` | `s` scale + wrap pixel literals |
| `HexTerritoryEdge.hlsl` | **unchanged** — operates in world-space hex SDF (`-d`), not pixels |

## Out of scope (follow-up PRs)

- `_UnitPixelGrid` (creatures, weapons) — still 16. Separate bump lets that PR stay focused on a consistent unit-art redraw.
- `_BuildingPixelGrid` — already at 48, no change needed.
- `_ProjectilePixelGrid` — fine at 16 (projectiles are tiny by design).
- Farm composition redraw — unblocked by this PR, separate work.

## Test plan
- [ ] Open Unity → reimport `HexTile.shader` if the material doesn't auto-refresh
- [ ] Existing biome tiles (grass / forest / stone / sand / dirt) render visually identical to pre-merge dev
- [ ] Forest tiles: tree silhouettes, canopies, trunks look the same as before
- [ ] Sand tiles: prickly-pear and dragonfruit cactus look the same
- [ ] Grass tiles: berries / mushrooms / herbs / stone boulders unchanged
- [ ] Territory border (after placing Capital) still draws correctly (SDF-driven, density-independent)
- [ ] Frame time at camera default zoom unchanged (the bump only raises the pixel-discretisation resolution, doesn't add fill cost)