### PR TITLE
feat(rareicon): Lumbercamp + Mining Pit biome-anchored producer buildings

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/Resources/Locales/en.json
+++ b/apps/rareicon/unity-rareicon/Assets/Resources/Locales/en.json
@@ -137,6 +137,8 @@
 	"building.trade_house": "Trade House",
 	"building.merchants_guild": "Merchants Guild",
 	"building.outpost": "Outpost",
+	"building.lumbercamp": "Lumbercamp",
+	"building.mining_pit": "Mining Pit",
 	"building.unknown": "Building",
 	"item.any_food": "Any Food",
 	"item.pouch": "Pouch",

--- a/apps/rareicon/unity-rareicon/Assets/Resources/Locales/ja.json
+++ b/apps/rareicon/unity-rareicon/Assets/Resources/Locales/ja.json
@@ -113,6 +113,8 @@
 	"building.trade_house": "商館",
 	"building.merchants_guild": "商人ギルド",
 	"building.outpost": "前哨基地",
+	"building.lumbercamp": "伐採場",
+	"building.mining_pit": "採掘場",
 	"building.unknown": "建物",
 	"item.any_food": "何でも食料",
 	"item.pouch": "小袋",

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Data/BuildingDB.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Data/BuildingDB.cs
@@ -58,6 +58,9 @@ namespace RareIcon
                                                         new((ushort)ItemId.StoneBlock, 1) };
         static readonly Ingredient[] CostOutpost    = { new((ushort)ItemId.Timber,     2),
                                                         new((ushort)ItemId.StoneBlock, 2) };
+        static readonly Ingredient[] CostLumbercamp = { new((ushort)ItemId.Timber,     2),
+                                                        new((ushort)ItemId.StoneBlock, 1) };
+        static readonly Ingredient[] CostMiningPit  = { new((ushort)ItemId.Timber,     3) };
         static readonly Ingredient[] CostNone     = System.Array.Empty<Ingredient>();
 
         // -- Upgrade chain costs --
@@ -90,6 +93,8 @@ namespace RareIcon
             BuildingType.Inn        => CostInn,
             BuildingType.Market     => CostMarket,
             BuildingType.Outpost    => CostOutpost,
+            BuildingType.Lumbercamp => CostLumbercamp,
+            BuildingType.MiningPit  => CostMiningPit,
             _ => CostNone,
         };
 
@@ -118,11 +123,13 @@ namespace RareIcon
             : SingleHex;
 
         // -- Biome rules --
-        /// <summary>Returns true if `biome` can host `buildingType`. Ocean / River refuse all builds.</summary>
+        /// <summary>Returns true if `biome` can host `buildingType`. Ocean / River refuse all builds; Lumbercamp must be on Forest; Mining Pit must be on Sand.</summary>
         public static bool IsBuildable(byte buildingType, byte biome)
         {
             if (biome == BiomeGenerator.BIOME_OCEAN) return false;
             if (biome == BiomeGenerator.BIOME_RIVER) return false;
+            if (buildingType == BuildingType.Lumbercamp) return biome == BiomeGenerator.BIOME_FOREST;
+            if (buildingType == BuildingType.MiningPit)  return biome == BiomeGenerator.BIOME_SAND;
             // Per-type future rules slot here:
             //   Furnace might forbid Snow (no fuel),
             //   Wall might allow only Stone / Dirt for foundation, etc.
@@ -140,6 +147,8 @@ namespace RareIcon
             BuildingType.Inn        => "building.inn",
             BuildingType.Market     => "building.market",
             BuildingType.Outpost    => "building.outpost",
+            BuildingType.Lumbercamp => "building.lumbercamp",
+            BuildingType.MiningPit  => "building.mining_pit",
             _ => "building.unknown",
         };
 
@@ -165,6 +174,8 @@ namespace RareIcon
             BuildTarget.Inn        => BuildingType.Inn,
             BuildTarget.Market     => BuildingType.Market,
             BuildTarget.Outpost    => BuildingType.Outpost,
+            BuildTarget.Lumbercamp => BuildingType.Lumbercamp,
+            BuildTarget.MiningPit  => BuildingType.MiningPit,
             _ => BuildingType.None,
         };
 
@@ -179,6 +190,8 @@ namespace RareIcon
             BuildingType.Inn        => BuildTarget.Inn,
             BuildingType.Market     => BuildTarget.Market,
             BuildingType.Outpost    => BuildTarget.Outpost,
+            BuildingType.Lumbercamp => BuildTarget.Lumbercamp,
+            BuildingType.MiningPit  => BuildTarget.MiningPit,
             _ => BuildTarget.None,
         };
 
@@ -193,6 +206,8 @@ namespace RareIcon
             BuildingType.Inn        => 280,
             BuildingType.Market     => 140,
             BuildingType.Outpost    => 220,
+            BuildingType.Lumbercamp => 200,
+            BuildingType.MiningPit  => 220,
             _                       => 100,
         };
 
@@ -208,6 +223,8 @@ namespace RareIcon
             BuildingType.Capital,
             BuildingType.Outpost,
             BuildingType.Farm,
+            BuildingType.Lumbercamp,
+            BuildingType.MiningPit,
             BuildingType.Barracks,
             BuildingType.Furnace,
             BuildingType.GoblinCave,

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Components/BankLedgerComponents.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Components/BankLedgerComponents.cs
@@ -97,6 +97,26 @@ namespace RareIcon
         public ushort Count;
     }
 
+    /// <summary>Lumbercamp output stock (WoodLog + Branches + Leaves). Produced by LumbercampProductionSystem when a Lumberjack tends the camp; BuildingSurplusTransferSystem drains to Capital.</summary>
+    [InternalBufferCapacity(4)]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct LumbercampLedger : IBankLedger
+    {
+        public Ulid   Uid;
+        public ushort ItemId;
+        public ushort Count;
+    }
+
+    /// <summary>Mining Pit output stock (Stone, eventually ores). Produced by MiningPitProductionSystem when a Miner tends the pit; BuildingSurplusTransferSystem drains to Capital.</summary>
+    [InternalBufferCapacity(4)]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MiningPitLedger : IBankLedger
+    {
+        public Ulid   Uid;
+        public ushort ItemId;
+        public ushort Count;
+    }
+
     /// <summary>Shared algorithm helpers over any per-bank ledger. Callers Reinterpret their concrete DynamicBuffer&lt;CapitalLedger&gt;/&lt;FurnaceLedger&gt;/etc. into DynamicBuffer&lt;BankLedgerBase&gt; at the call boundary, then pass the view here. One implementation, no generics, no interface method calls — Burst compiles these as plain struct-field loops. Writes through the reinterpreted view alias the original buffer's memory so mutations stick.</summary>
     public static class BankLedgerOps
     {

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Components/BuildingComponents.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Components/BuildingComponents.cs
@@ -21,7 +21,9 @@ namespace RareIcon
         public const byte Inn        = 6;
         public const byte Market     = 7;
         public const byte Outpost    = 8;
-        // Tower, Wall, Mine, etc. land here as we add their .hlsl files.
+        public const byte Lumbercamp = 9;
+        public const byte MiningPit  = 10;
+        // Tower, Wall, etc. land here as we add their .hlsl files.
     }
 
     /// <summary>
@@ -39,6 +41,8 @@ namespace RareIcon
         public const byte Inn        = 6;
         public const byte Market     = 7;
         public const byte Outpost    = 8;
+        public const byte Lumbercamp = 9;
+        public const byte MiningPit  = 10;
     }
 
     /// <summary>Marker tag for the Capital — craft / governance systems query key.</summary>
@@ -210,6 +214,12 @@ namespace RareIcon
 
     /// <summary>Marker tag for Outpost buildings.</summary>
     public struct OutpostTag : IComponentData { }
+
+    /// <summary>Marker tag for Lumbercamp buildings — placed on Forest hexes. LumbercampProductionSystem ticks only while a Lumberjack is on the footprint or sheltered inside.</summary>
+    public struct LumbercampTag : IComponentData { }
+
+    /// <summary>Marker tag for Mining Pit buildings — placed on Sand hexes. MiningPitProductionSystem ticks only while a Miner is on the footprint or sheltered inside.</summary>
+    public struct MiningPitTag : IComponentData { }
 
     /// <summary>Per-outpost cooldown-gated arrow volley. Every CooldownSeconds the outpost fires ArrowsPerVolley projectiles in a cone of half-angle SpreadHalfAngleRad around the closest CombatDB threat within Range. Burns ArrowCost from the sibling OutpostArrowPool per firing.</summary>
     public struct OutpostVolley : IComponentData

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Logistics/Systems/LedgerMirrorSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Logistics/Systems/LedgerMirrorSystem.cs
@@ -6,7 +6,7 @@ using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Phase 6: mirrors committed CurrentAmounts back into per-entity DynamicBuffer&lt;*Ledger&gt; views (Capital/Furnace/Farm/Barracks/GoblinCave). Walks the keys in PendingDeltas (the subset that changed this frame) and pushes each value to the matching ledger buffer. Sole writer of every bank buffer now that the DB is authoritative.</summary>
+    /// <summary>Phase 6: mirrors committed CurrentAmounts back into per-entity DynamicBuffer&lt;*Ledger&gt; views (Capital/Furnace/Farm/Barracks/GoblinCave/Lumbercamp/MiningPit). Walks the keys in PendingDeltas (the subset that changed this frame) and pushes each value to the matching ledger buffer. Sole writer of every bank buffer now that the DB is authoritative.</summary>
     [UpdateInGroup(typeof(LogisticsEndGroup))]
     [UpdateAfter(typeof(PackApplySystem))]
     public partial struct LedgerMirrorSystem : ISystem
@@ -31,6 +31,8 @@ namespace RareIcon
                 FarmLookup       = SystemAPI.GetBufferLookup<FarmLedger>(false),
                 BarracksLookup   = SystemAPI.GetBufferLookup<BarracksLedger>(false),
                 GoblinCaveLookup = SystemAPI.GetBufferLookup<GoblinCaveLedger>(false),
+                LumbercampLookup = SystemAPI.GetBufferLookup<LumbercampLedger>(false),
+                MiningPitLookup  = SystemAPI.GetBufferLookup<MiningPitLedger>(false),
             }.Schedule(dep);
 
             db.PipelineHandle = state.Dependency;
@@ -48,6 +50,8 @@ namespace RareIcon
         public BufferLookup<FarmLedger>       FarmLookup;
         public BufferLookup<BarracksLedger>   BarracksLookup;
         public BufferLookup<GoblinCaveLedger> GoblinCaveLookup;
+        public BufferLookup<LumbercampLedger> LumbercampLookup;
+        public BufferLookup<MiningPitLedger>  MiningPitLookup;
 
         public void Execute()
         {
@@ -83,6 +87,16 @@ namespace RareIcon
                 else if (GoblinCaveLookup.HasBuffer(key.Bank))
                 {
                     var view = GoblinCaveLookup[key.Bank].Reinterpret<BankLedgerBase>();
+                    SetSlotCount(view, key.ItemId, amount);
+                }
+                else if (LumbercampLookup.HasBuffer(key.Bank))
+                {
+                    var view = LumbercampLookup[key.Bank].Reinterpret<BankLedgerBase>();
+                    SetSlotCount(view, key.ItemId, amount);
+                }
+                else if (MiningPitLookup.HasBuffer(key.Bank))
+                {
+                    var view = MiningPitLookup[key.Bank].Reinterpret<BankLedgerBase>();
                     SetSlotCount(view, key.ItemId, amount);
                 }
             }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Logistics/Systems/LogisticsBootstrapSeedSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Logistics/Systems/LogisticsBootstrapSeedSystem.cs
@@ -13,16 +13,20 @@ namespace RareIcon
         EntityQuery _farmQ;
         EntityQuery _barracksQ;
         EntityQuery _goblinCaveQ;
+        EntityQuery _lumbercampQ;
+        EntityQuery _miningPitQ;
 
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<LogisticsDBSingleton>();
 
-            _capitalQ    = new EntityQueryBuilder(Allocator.Temp).WithAll<CapitalLedger>().WithNone<BankSeededTag>().Build(ref state);
-            _furnaceQ    = new EntityQueryBuilder(Allocator.Temp).WithAll<FurnaceLedger>().WithNone<BankSeededTag>().Build(ref state);
-            _farmQ       = new EntityQueryBuilder(Allocator.Temp).WithAll<FarmLedger>().WithNone<BankSeededTag>().Build(ref state);
-            _barracksQ   = new EntityQueryBuilder(Allocator.Temp).WithAll<BarracksLedger>().WithNone<BankSeededTag>().Build(ref state);
-            _goblinCaveQ = new EntityQueryBuilder(Allocator.Temp).WithAll<GoblinCaveLedger>().WithNone<BankSeededTag>().Build(ref state);
+            _capitalQ     = new EntityQueryBuilder(Allocator.Temp).WithAll<CapitalLedger>().WithNone<BankSeededTag>().Build(ref state);
+            _furnaceQ     = new EntityQueryBuilder(Allocator.Temp).WithAll<FurnaceLedger>().WithNone<BankSeededTag>().Build(ref state);
+            _farmQ        = new EntityQueryBuilder(Allocator.Temp).WithAll<FarmLedger>().WithNone<BankSeededTag>().Build(ref state);
+            _barracksQ    = new EntityQueryBuilder(Allocator.Temp).WithAll<BarracksLedger>().WithNone<BankSeededTag>().Build(ref state);
+            _goblinCaveQ  = new EntityQueryBuilder(Allocator.Temp).WithAll<GoblinCaveLedger>().WithNone<BankSeededTag>().Build(ref state);
+            _lumbercampQ  = new EntityQueryBuilder(Allocator.Temp).WithAll<LumbercampLedger>().WithNone<BankSeededTag>().Build(ref state);
+            _miningPitQ   = new EntityQueryBuilder(Allocator.Temp).WithAll<MiningPitLedger>().WithNone<BankSeededTag>().Build(ref state);
         }
 
         public void OnDestroy(ref SystemState state) { }
@@ -34,7 +38,9 @@ namespace RareIcon
                 !_furnaceQ.IsEmpty ||
                 !_farmQ.IsEmpty ||
                 !_barracksQ.IsEmpty ||
-                !_goblinCaveQ.IsEmpty;
+                !_goblinCaveQ.IsEmpty ||
+                !_lumbercampQ.IsEmpty ||
+                !_miningPitQ.IsEmpty;
 
             if (!any) return;
 
@@ -48,6 +54,8 @@ namespace RareIcon
             SeedFarm(ref state, ref db);
             SeedBarracks(ref state, ref db);
             SeedGoblinCave(ref state, ref db);
+            SeedLumbercamp(ref state, ref db);
+            SeedMiningPit(ref state, ref db);
         }
 
         void SeedCapital(ref SystemState state, ref LogisticsDBSingleton db)
@@ -109,6 +117,32 @@ namespace RareIcon
             {
                 var e = entities[i];
                 var buf = state.EntityManager.GetBuffer<GoblinCaveLedger>(e).Reinterpret<BankLedgerBase>();
+                SeedOne(ref db, e, buf);
+                state.EntityManager.AddComponent<BankSeededTag>(e);
+            }
+            entities.Dispose();
+        }
+
+        void SeedLumbercamp(ref SystemState state, ref LogisticsDBSingleton db)
+        {
+            var entities = _lumbercampQ.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                var buf = state.EntityManager.GetBuffer<LumbercampLedger>(e).Reinterpret<BankLedgerBase>();
+                SeedOne(ref db, e, buf);
+                state.EntityManager.AddComponent<BankSeededTag>(e);
+            }
+            entities.Dispose();
+        }
+
+        void SeedMiningPit(ref SystemState state, ref LogisticsDBSingleton db)
+        {
+            var entities = _miningPitQ.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                var buf = state.EntityManager.GetBuffer<MiningPitLedger>(e).Reinterpret<BankLedgerBase>();
                 SeedOne(ref db, e, buf);
                 state.EntityManager.AddComponent<BankSeededTag>(e);
             }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BuildingSpawnSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BuildingSpawnSystem.cs
@@ -366,6 +366,8 @@ namespace RareIcon
             BuildingType.Inn        => "Inn",
             BuildingType.Market     => "Market",
             BuildingType.Outpost    => "Outpost",
+            BuildingType.Lumbercamp => "Lumbercamp",
+            BuildingType.MiningPit  => "Mining Pit",
             _ => "Unknown",
         };
 

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BuildingStaffingSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BuildingStaffingSystem.cs
@@ -82,11 +82,13 @@ namespace RareIcon
 
         static byte RoleForBuilding(byte buildingType) => buildingType switch
         {
-            BuildingType.Capital  => ProfessionKind.Builder,
-            BuildingType.Farm     => ProfessionKind.Farmer,
-            BuildingType.Barracks => ProfessionKind.Guard,
-            BuildingType.Furnace  => ProfessionKind.Blacksmith,
-            _                     => ProfessionKind.None,
+            BuildingType.Capital    => ProfessionKind.Builder,
+            BuildingType.Farm       => ProfessionKind.Farmer,
+            BuildingType.Barracks   => ProfessionKind.Guard,
+            BuildingType.Furnace    => ProfessionKind.Blacksmith,
+            BuildingType.Lumbercamp => ProfessionKind.Lumberjack,
+            BuildingType.MiningPit  => ProfessionKind.Miner,
+            _                       => ProfessionKind.None,
         };
     }
 

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BuildingSurplusTransferSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BuildingSurplusTransferSystem.cs
@@ -6,7 +6,7 @@ using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Drains each source building's above-floor SurplusExport items into Capital via Surplus reservations keyed on the source bank. Three serialized jobs (Farm/Furnace/Barracks) sharing the same Reservations writer.</summary>
+    /// <summary>Drains each source building's above-floor SurplusExport items into Capital via Surplus reservations keyed on the source bank. Five serialized jobs (Farm/Furnace/Barracks/Lumbercamp/MiningPit) sharing the same Reservations writer.</summary>
     [UpdateInGroup(typeof(EconomySystemGroup))]
     public partial struct BuildingSurplusTransferSystem : ISystem
     {
@@ -27,9 +27,11 @@ namespace RareIcon
             var reservations = db.Reservations.AsParallelWriter();
 
             var dep = JobHandle.CombineDependencies(state.Dependency, db.PipelineHandle);
-            dep = new FarmSurplusJob     { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
-            dep = new FurnaceSurplusJob  { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
-            dep = new BarracksSurplusJob { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
+            dep = new FarmSurplusJob       { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
+            dep = new FurnaceSurplusJob    { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
+            dep = new BarracksSurplusJob   { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
+            dep = new LumbercampSurplusJob { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
+            dep = new MiningPitSurplusJob  { Capital = capital, Tick = tick, Reservations = reservations }.ScheduleParallel(dep);
 
             db.PipelineHandle = dep;
             state.Dependency  = dep;
@@ -75,6 +77,36 @@ namespace RareIcon
         public NativeParallelMultiHashMap<LedgerKey, ReservationRecord>.ParallelWriter Reservations;
 
         void Execute(Entity entity, in DynamicBuffer<BarracksLedger> typedStorage, in DynamicBuffer<SurplusExport> exports)
+        {
+            if (entity == Capital) return;
+            SurplusTransferShared.Run(typedStorage.Reinterpret<BankLedgerBase>(), exports, Capital, entity, Tick, ref Reservations);
+        }
+    }
+
+    [BurstCompile]
+    [WithAll(typeof(LumbercampTag))]
+    public partial struct LumbercampSurplusJob : IJobEntity
+    {
+        public Entity Capital;
+        public uint   Tick;
+        public NativeParallelMultiHashMap<LedgerKey, ReservationRecord>.ParallelWriter Reservations;
+
+        void Execute(Entity entity, in DynamicBuffer<LumbercampLedger> typedStorage, in DynamicBuffer<SurplusExport> exports)
+        {
+            if (entity == Capital) return;
+            SurplusTransferShared.Run(typedStorage.Reinterpret<BankLedgerBase>(), exports, Capital, entity, Tick, ref Reservations);
+        }
+    }
+
+    [BurstCompile]
+    [WithAll(typeof(MiningPitTag))]
+    public partial struct MiningPitSurplusJob : IJobEntity
+    {
+        public Entity Capital;
+        public uint   Tick;
+        public NativeParallelMultiHashMap<LedgerKey, ReservationRecord>.ParallelWriter Reservations;
+
+        void Execute(Entity entity, in DynamicBuffer<MiningPitLedger> typedStorage, in DynamicBuffer<SurplusExport> exports)
         {
             if (entity == Capital) return;
             SurplusTransferShared.Run(typedStorage.Reinterpret<BankLedgerBase>(), exports, Capital, entity, Tick, ref Reservations);

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/ConstructionCompleteSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/ConstructionCompleteSystem.cs
@@ -105,6 +105,34 @@ namespace RareIcon
                     Ecb.AddComponent(chunkIdx, entity, new ProvidesSleep   { Capacity = 10 });
                     Ecb.AddComponent(chunkIdx, entity, new ProvidesHealing { Priority = 1 });
                     break;
+                case BuildingType.Lumbercamp:
+                    Ecb.AddComponent<LumbercampTag>(chunkIdx, entity);
+                    Ecb.AddBuffer<LumbercampLedger>(chunkIdx, entity);
+                    Ecb.AddComponent(chunkIdx, entity, new TenderMultiplier { Value = 0f });
+                    var lumberRecipes = Ecb.AddBuffer<ProductionRecipe>(chunkIdx, entity);
+                    lumberRecipes.Add(new ProductionRecipe
+                    {
+                        Output1Id = (ushort)ItemId.WoodLog, Output1Amount = 1,
+                        CycleDuration = 3f,
+                        CycleEndsAt   = 0f,
+                    });
+                    var lumberExports = Ecb.AddBuffer<SurplusExport>(chunkIdx, entity);
+                    lumberExports.Add(new SurplusExport { ItemId = (ushort)ItemId.WoodLog, Floor = 0 });
+                    break;
+                case BuildingType.MiningPit:
+                    Ecb.AddComponent<MiningPitTag>(chunkIdx, entity);
+                    Ecb.AddBuffer<MiningPitLedger>(chunkIdx, entity);
+                    Ecb.AddComponent(chunkIdx, entity, new TenderMultiplier { Value = 0f });
+                    var pitRecipes = Ecb.AddBuffer<ProductionRecipe>(chunkIdx, entity);
+                    pitRecipes.Add(new ProductionRecipe
+                    {
+                        Output1Id = (ushort)ItemId.Stone, Output1Amount = 1,
+                        CycleDuration = 3f,
+                        CycleEndsAt   = 0f,
+                    });
+                    var pitExports = Ecb.AddBuffer<SurplusExport>(chunkIdx, entity);
+                    pitExports.Add(new SurplusExport { ItemId = (ushort)ItemId.Stone, Floor = 0 });
+                    break;
             }
 
             Ecb.AddComponent<NeedsStaffing>(chunkIdx, entity);

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LumbercampTenderScanSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LumbercampTenderScanSystem.cs
@@ -1,0 +1,115 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace RareIcon
+{
+    /// <summary>Writes TenderMultiplier.Value = 1 when any Lumberjack-intent unit stands on a Lumbercamp's footprint *or* is ShelteredInside the camp (Phase B garrison path). Otherwise 0 — LumbercampProductionSystem refuses to start a cycle without a worker. Mirrors FarmTenderScanSystem's shape plus the shelter roster.</summary>
+    [BurstCompile]
+    [UpdateInGroup(typeof(BehaviorSystemGroup))]
+    [UpdateAfter(typeof(ProfessionDispatchSystem))]
+    public partial struct LumbercampTenderScanSystem : ISystem
+    {
+        [BurstCompile] public void OnCreate(ref SystemState state) { }
+        [BurstCompile] public void OnDestroy(ref SystemState state) { }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            var tendedHexes  = new NativeHashSet<int2>(16, Allocator.TempJob);
+            var tendingHosts = new NativeHashSet<Entity>(16, Allocator.TempJob);
+
+            foreach (var (intent, movement) in
+                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<UnitMovement>>().WithNone<ShelteredInside>())
+            {
+                if (intent.ValueRO.Kind != ProfessionKind.Lumberjack) continue;
+                tendedHexes.Add(movement.ValueRO.CurrentHex);
+            }
+
+            foreach (var (intent, sheltered) in
+                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<ShelteredInside>>())
+            {
+                if (intent.ValueRO.Kind != ProfessionKind.Lumberjack) continue;
+                tendingHosts.Add(sheltered.ValueRO.Host);
+            }
+
+            state.Dependency = new LumbercampTenderJob
+            {
+                TendedHexes  = tendedHexes.AsReadOnly(),
+                TendingHosts = tendingHosts.AsReadOnly(),
+            }.ScheduleParallel(state.Dependency);
+
+            state.Dependency = tendedHexes.Dispose(state.Dependency);
+            state.Dependency = tendingHosts.Dispose(state.Dependency);
+        }
+    }
+
+    [BurstCompile]
+    [WithAll(typeof(LumbercampTag))]
+    public partial struct LumbercampTenderJob : IJobEntity
+    {
+        [ReadOnly] public NativeHashSet<int2>.ReadOnly   TendedHexes;
+        [ReadOnly] public NativeHashSet<Entity>.ReadOnly TendingHosts;
+
+        void Execute(Entity entity, in Building building, ref TenderMultiplier tender)
+        {
+            bool tended = TendedHexes.Contains(building.RootHex) || TendingHosts.Contains(entity);
+            tender.Value = tended ? 1f : 0f;
+        }
+    }
+
+    /// <summary>Writes TenderMultiplier.Value = 1 when any Miner-intent unit stands on a Mining Pit's footprint *or* is ShelteredInside the pit (Phase B garrison path). Otherwise 0 — MiningPitProductionSystem refuses to start a cycle without a worker.</summary>
+    [BurstCompile]
+    [UpdateInGroup(typeof(BehaviorSystemGroup))]
+    [UpdateAfter(typeof(ProfessionDispatchSystem))]
+    public partial struct MiningPitTenderScanSystem : ISystem
+    {
+        [BurstCompile] public void OnCreate(ref SystemState state) { }
+        [BurstCompile] public void OnDestroy(ref SystemState state) { }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            var tendedHexes  = new NativeHashSet<int2>(16, Allocator.TempJob);
+            var tendingHosts = new NativeHashSet<Entity>(16, Allocator.TempJob);
+
+            foreach (var (intent, movement) in
+                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<UnitMovement>>().WithNone<ShelteredInside>())
+            {
+                if (intent.ValueRO.Kind != ProfessionKind.Miner) continue;
+                tendedHexes.Add(movement.ValueRO.CurrentHex);
+            }
+
+            foreach (var (intent, sheltered) in
+                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<ShelteredInside>>())
+            {
+                if (intent.ValueRO.Kind != ProfessionKind.Miner) continue;
+                tendingHosts.Add(sheltered.ValueRO.Host);
+            }
+
+            state.Dependency = new MiningPitTenderJob
+            {
+                TendedHexes  = tendedHexes.AsReadOnly(),
+                TendingHosts = tendingHosts.AsReadOnly(),
+            }.ScheduleParallel(state.Dependency);
+
+            state.Dependency = tendedHexes.Dispose(state.Dependency);
+            state.Dependency = tendingHosts.Dispose(state.Dependency);
+        }
+    }
+
+    [BurstCompile]
+    [WithAll(typeof(MiningPitTag))]
+    public partial struct MiningPitTenderJob : IJobEntity
+    {
+        [ReadOnly] public NativeHashSet<int2>.ReadOnly   TendedHexes;
+        [ReadOnly] public NativeHashSet<Entity>.ReadOnly TendingHosts;
+
+        void Execute(Entity entity, in Building building, ref TenderMultiplier tender)
+        {
+            bool tended = TendedHexes.Contains(building.RootHex) || TendingHosts.Contains(entity);
+            tender.Value = tended ? 1f : 0f;
+        }
+    }
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/ProductionSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/ProductionSystem.cs
@@ -319,4 +319,162 @@ namespace RareIcon
             if (r.Output3Amount > 0) res.Add(ReservationOps.Key(target, r.Output3Id), ReservationOps.Produce(target, r.Output3Amount, tick));
         }
     }
+
+    /// <summary>Lumbercamp ProductionRecipes. Hard-gated on a worker: TenderMultiplier &gt; 0 (a Lumberjack on the footprint or ShelteredInside the camp) is required to start a cycle. No inputs — the Forest hex underneath is the resource well. Outputs Produce against own LumbercampLedger.</summary>
+    [UpdateInGroup(typeof(EconomySystemGroup))]
+    public partial struct LumbercampProductionSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            var q = new EntityQueryBuilder(Allocator.Temp)
+                .WithAll<LumbercampTag, LumbercampLedger, ProductionRecipe>()
+                .Build(ref state);
+            state.RequireForUpdate(q);
+            state.RequireForUpdate<LogisticsDBSingleton>();
+        }
+
+        public void OnDestroy(ref SystemState state) { }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            if (!SystemAPI.HasSingleton<WorldClock>()) return;
+            float now  = SystemAPI.GetSingleton<WorldClock>().AbsSeconds;
+            uint  tick = (uint)(SystemAPI.Time.ElapsedTime * 1000d);
+
+            ref var db = ref SystemAPI.GetSingletonRW<LogisticsDBSingleton>().ValueRW;
+            var dep    = JobHandle.CombineDependencies(state.Dependency, db.PipelineHandle);
+
+            var handle = new LumbercampProductionJob
+            {
+                Now          = now,
+                Tick         = tick,
+                TenderLookup = SystemAPI.GetComponentLookup<TenderMultiplier>(true),
+                Reservations = db.Reservations.AsParallelWriter(),
+            }.ScheduleParallel(dep);
+
+            db.PipelineHandle = handle;
+            state.Dependency  = handle;
+        }
+    }
+
+    /// <summary>Mining Pit ProductionRecipes. Same shape as Lumbercamp but for Stone (and future ores) from the Sand hex underneath. Tender-gated on a Miner — Phase B shelter path included.</summary>
+    [UpdateInGroup(typeof(EconomySystemGroup))]
+    public partial struct MiningPitProductionSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            var q = new EntityQueryBuilder(Allocator.Temp)
+                .WithAll<MiningPitTag, MiningPitLedger, ProductionRecipe>()
+                .Build(ref state);
+            state.RequireForUpdate(q);
+            state.RequireForUpdate<LogisticsDBSingleton>();
+        }
+
+        public void OnDestroy(ref SystemState state) { }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            if (!SystemAPI.HasSingleton<WorldClock>()) return;
+            float now  = SystemAPI.GetSingleton<WorldClock>().AbsSeconds;
+            uint  tick = (uint)(SystemAPI.Time.ElapsedTime * 1000d);
+
+            ref var db = ref SystemAPI.GetSingletonRW<LogisticsDBSingleton>().ValueRW;
+            var dep    = JobHandle.CombineDependencies(state.Dependency, db.PipelineHandle);
+
+            var handle = new MiningPitProductionJob
+            {
+                Now          = now,
+                Tick         = tick,
+                TenderLookup = SystemAPI.GetComponentLookup<TenderMultiplier>(true),
+                Reservations = db.Reservations.AsParallelWriter(),
+            }.ScheduleParallel(dep);
+
+            db.PipelineHandle = handle;
+            state.Dependency  = handle;
+        }
+    }
+
+    [BurstCompile]
+    [WithAll(typeof(LumbercampTag))]
+    public partial struct LumbercampProductionJob : IJobEntity
+    {
+        public float Now;
+        public uint  Tick;
+
+        [ReadOnly] public ComponentLookup<TenderMultiplier> TenderLookup;
+
+        public NativeParallelMultiHashMap<LedgerKey, ReservationRecord>.ParallelWriter Reservations;
+
+        void Execute(Entity entity, ref DynamicBuffer<ProductionRecipe> recipes)
+        {
+            float tender = TenderLookup.HasComponent(entity) ? TenderLookup[entity].Value : 0f;
+
+            for (int i = 0; i < recipes.Length; i++)
+            {
+                var r = recipes[i];
+                if (r.CycleEndsAt > 0f)
+                {
+                    if (Now < r.CycleEndsAt) continue;
+                    EmitOutputs(ref Reservations, entity, r, Tick);
+                    r.CycleEndsAt = 0f;
+                    recipes[i] = r;
+                    continue;
+                }
+
+                if (tender <= 0f) continue;
+
+                r.CycleEndsAt = Now + math.max(0.1f, r.CycleDuration);
+                recipes[i] = r;
+            }
+        }
+
+        static void EmitOutputs(ref NativeParallelMultiHashMap<LedgerKey, ReservationRecord>.ParallelWriter res, Entity target, in ProductionRecipe r, uint tick)
+        {
+            if (r.Output1Amount > 0) res.Add(ReservationOps.Key(target, r.Output1Id), ReservationOps.Produce(target, r.Output1Amount, tick));
+            if (r.Output2Amount > 0) res.Add(ReservationOps.Key(target, r.Output2Id), ReservationOps.Produce(target, r.Output2Amount, tick));
+            if (r.Output3Amount > 0) res.Add(ReservationOps.Key(target, r.Output3Id), ReservationOps.Produce(target, r.Output3Amount, tick));
+        }
+    }
+
+    [BurstCompile]
+    [WithAll(typeof(MiningPitTag))]
+    public partial struct MiningPitProductionJob : IJobEntity
+    {
+        public float Now;
+        public uint  Tick;
+
+        [ReadOnly] public ComponentLookup<TenderMultiplier> TenderLookup;
+
+        public NativeParallelMultiHashMap<LedgerKey, ReservationRecord>.ParallelWriter Reservations;
+
+        void Execute(Entity entity, ref DynamicBuffer<ProductionRecipe> recipes)
+        {
+            float tender = TenderLookup.HasComponent(entity) ? TenderLookup[entity].Value : 0f;
+
+            for (int i = 0; i < recipes.Length; i++)
+            {
+                var r = recipes[i];
+                if (r.CycleEndsAt > 0f)
+                {
+                    if (Now < r.CycleEndsAt) continue;
+                    EmitOutputs(ref Reservations, entity, r, Tick);
+                    r.CycleEndsAt = 0f;
+                    recipes[i] = r;
+                    continue;
+                }
+
+                if (tender <= 0f) continue;
+
+                r.CycleEndsAt = Now + math.max(0.1f, r.CycleDuration);
+                recipes[i] = r;
+            }
+        }
+
+        static void EmitOutputs(ref NativeParallelMultiHashMap<LedgerKey, ReservationRecord>.ParallelWriter res, Entity target, in ProductionRecipe r, uint tick)
+        {
+            if (r.Output1Amount > 0) res.Add(ReservationOps.Key(target, r.Output1Id), ReservationOps.Produce(target, r.Output1Amount, tick));
+            if (r.Output2Amount > 0) res.Add(ReservationOps.Key(target, r.Output2Id), ReservationOps.Produce(target, r.Output2Amount, tick));
+            if (r.Output3Amount > 0) res.Add(ReservationOps.Key(target, r.Output3Id), ReservationOps.Produce(target, r.Output3Amount, tick));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Two new producer buildings shipped together as Phase A + B of the worker-safety redesign. Rather than roaming Lumberjacks/Miners who get hurt in the field and wedge the empire into relief loops, a camp sits on the resource tile and a tender either stands on its footprint (Phase A) or is `ShelteredInside` the camp (Phase B garrison) to activate production. Production is fully gated: no worker → zero output, so the player controls throughput by where workers are sent.

### Placement
- **Lumbercamp** must be placed **on** a Forest hex (`BIOME_FOREST`)
- **Mining Pit** must be placed **on** a Sand hex (`BIOME_SAND`) — gives desert biomes a viable stone source without manual Stone hexes
- `BuildingDB.IsBuildable` enforces biome at preview + spawn

### Economy
- Cost: Lumbercamp = 2 Timber + 1 Stone, Mining Pit = 3 Timber
- Max HP: 200 / 220; `RequiresInTerritory` like every non-Capital
- Cycle: 3s per 1 WoodLog / 1 Stone when tended, 0 otherwise
- Output mirrors to `LumbercampLedger` / `MiningPitLedger`, then `BuildingSurplusTransferSystem` drains `Floor = 0` to Capital each tick

### Wiring
- `BuildingType` + `BuildTarget` enums (9 + 10) + palette entry
- `LumbercampTag` + `MiningPitTag` + `LumbercampLedger` + `MiningPitLedger`
- `ConstructionCompleteSystem` attaches tags + ledger buffer + `ProductionRecipe` + `TenderMultiplier { Value = 0 }` + `SurplusExport`
- `LumbercampProductionSystem` + `MiningPitProductionSystem` (both `[BurstCompile]` ISystem) read `TenderMultiplier` and skip cycle start when `Value ≤ 0` — the literal "no production without a worker" rule
- `LumbercampTenderScanSystem` + `MiningPitTenderScanSystem` build a `NativeHashSet<int2>` of footprint-workers and a `NativeHashSet<Entity>` of `ShelteredInside` hosts, then write `TenderMultiplier.Value` per camp — matches Lumberjack on the tile OR sheltered inside the camp
- `BuildingSurplusTransferSystem` gains `LumbercampSurplusJob` + `MiningPitSurplusJob` serialized after the existing three
- `LogisticsBootstrapSeedSystem` + `LedgerMirrorSystem` both handle the two new bank types
- `BuildingStaffingSystem` auto-assigns Lumberjack / Miner on completion

### Follow-ups (not in this PR)
- `HexBuilding.shader` sprite include for the new BuildingType bytes (currently falls through to default placeholder)
- When a camp is built, clear `HexResources` on its tile so the dispatcher stops issuing manual Lumberjack/Miner harvest offers there (otherwise units dual-harvest: tend the camp + deplete the hex manually)

## Test plan

- [ ] Open build palette — Lumbercamp + Mining Pit appear in order near Farm
- [ ] Place Lumbercamp on a non-Forest tile — preview shows invalid (red)
- [ ] Place Lumbercamp on a Forest tile — preview valid, construction starts
- [ ] Place Mining Pit on a non-Sand tile — invalid
- [ ] Place Mining Pit on a Sand tile — valid
- [ ] Construction completes → Lumberjack auto-staffs the Lumbercamp → `TenderMultiplier.Value = 1` in the inspector
- [ ] Watch the Lumbercamp ledger fill with WoodLog on the 3s cycle
- [ ] Surplus flows to Capital (`CapitalLedger` WoodLog count rises)
- [ ] Remove the tender (kill the unit or force-move away) → production stalls, no new WoodLog accrues
- [ ] Same loop for Mining Pit → Stone
- [ ] Phase B garrison: shelter a Lumberjack inside the camp via the Send-In command (if wired), `TenderMultiplier.Value` stays at 1 even though nobody is on the footprint