### PR TITLE
fix(mc): add cloth-config to mrpack so AppleSkin loads

### DIFF
--- a/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
+++ b/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
@@ -338,6 +338,18 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
       "env": { "client": "optional", "server": "optional" }
     },
     {
+      "path": "mods/cloth-config-21.11.153-fabric.jar",
+      "hashes": {
+        "sha1": "4c224606a963bce223db5b27edb4959ecf40d4ee",
+        "sha512": "8f455489d4b71069e998568cf4e1450116f4360a4eb481cd89117f629c6883164886cf63ca08ac4fc929dd13d1112152755a6216d4a1498ee6406ef102093e51"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/xuX40TN5/cloth-config-21.11.153-fabric.jar"
+      ],
+      "fileSize": 1148427,
+      "env": { "client": "required", "server": "unsupported" }
+    },
+    {
       "path": "mods/travelersbackpack-fabric-1.21.11-10.11.9.jar",
       "hashes": {
         "sha1": "fb2d5a2fd919ee127d9a170e3e85f798edb852a5",


### PR DESCRIPTION
## Summary
- AppleSkin's ModMenu integration calls cloth-config to render its config screen. Without it, client init throws `RuntimeException: cloth-config not loaded`. Adds `cloth-config-21.11.153-fabric.jar` (client-required, server-unsupported) alongside the AppleSkin entry in `build-mrpack.sh`.
- Also resolves the DataTracker `IndexOutOfBoundsException: Index 8 out of bounds for length 8` on connect — the published dist was `kbve-mc-client-1.0.23.mrpack` (pre-#10224 ShipEntity tracked fields), while the deployed server is now v1.0.24 with the polished ShipEntity schema. Rebuilding from current `version.toml=1.0.24` produces a matching client jar.

## Test plan
- [ ] Rebuild jar: `cd apps/mc/behavior_statetree/java && ./gradlew build --no-daemon`
- [ ] Build mrpack: `./mrpack/build-mrpack.sh` → `dist/kbve-mc-client-1.0.24.mrpack`
- [ ] Import `.mrpack` in Prism / Modrinth Launcher
- [ ] Confirm no `cloth-config not loaded` in client log
- [ ] Connect to server — no DataTracker IOOBE disconnect