### PR TITLE
fix(ci): use fabric loader for mrpack POST, not 'mrpack'

### DIFF
--- a/.github/workflows/utils-external-publish.yml
+++ b/.github/workflows/utils-external-publish.yml
@@ -176,6 +176,7 @@ jobs:
                   PACK_PROJECT_ID: ${{ steps.ep.outputs.pack_id }}
                   VERSION: ${{ inputs.version }}
                   VERSION_TYPE: ${{ steps.ep.outputs.version_type }}
+                  LOADERS: ${{ steps.ep.outputs.loaders }}
                   GAME_VERSIONS: ${{ steps.ep.outputs.game_versions }}
                   MRPACK_PATH: ${{ steps.mrpack.outputs.path }}
               run: |
@@ -201,7 +202,7 @@ jobs:
                     "version_number": "$VERSION",
                     "version_type": "$VERSION_TYPE",
                     "project_id": "$PACK_PROJECT_ID",
-                    "loaders": ["mrpack"],
+                    "loaders": $LOADERS,
                     "game_versions": $GAME_VERSIONS,
                     "featured": true,
                     "dependencies": [],


### PR DESCRIPTION
## Summary
Modrinth's modpack project type validates the \`loaders\` field against the supported game loader set (fabric/forge/neoforge/quilt). Posting \`\"loaders\": [\"mrpack\"]\` returns:

\`\`\`
HTTP 400 invalid_input
Error with multipart data: Provided value 'mrpack' is not a valid variant for mrpack_loaders
\`\`\`

The JAR step already uses \`\$LOADERS\` from \`external_publish.modrinth_loaders\` (\`[\"fabric\"]\` for mc). Reuse the same value for the mrpack POST.

Same bug exists in \`apps/kube/agones/mc/modrinth-publish-job.yaml\` (line 286) — that's why the in-cluster path stopped landing mrpack uploads at v1.0.23. Cluster job will be retired in the follow-up cleanup PR.

## Test plan
- [ ] Trigger mc Docker publish (or workflow_dispatch on ci-docker)
- [ ] external_publish modrinth job logs successful mrpack POST
- [ ] Verify v1.0.26 (or current) modpack appears at https://modrinth.com/modpack/86Wqkiak