### PR TITLE
feat(mc): flip Modrinth release channel to release

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -198,7 +198,7 @@
 			"external_publish": {
 				"modrinth_mod_id": "QoFCg0tO",
 				"modrinth_pack_id": "86Wqkiak",
-				"modrinth_version_type": "alpha",
+				"modrinth_version_type": "release",
 				"modrinth_game_versions": "[\"1.21.11\"]",
 				"modrinth_loaders": "[\"fabric\"]"
 			}

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -23,7 +23,7 @@ e2e_name: mc
 external_publish:
     modrinth_mod_id: QoFCg0tO
     modrinth_pack_id: 86Wqkiak
-    modrinth_version_type: alpha
+    modrinth_version_type: release
     modrinth_loaders: '["fabric"]'
     modrinth_game_versions: '["1.21.11"]'
 ---


### PR DESCRIPTION
## Summary
Modrinth's project landing page filters Alpha versions out by default. mc.mdx had \`modrinth_version_type: alpha\`, so newer mrpacks (1.0.24, 1.0.26, 1.0.27) were hidden behind the Alpha toggle while v1.0.23 (last release-channel publish) kept showing as Primary.

Flip to \`release\` so future JAR + mrpack uploads land on the default channel and the project page reflects the actual latest server version.

Existing alpha versions stay alpha (Modrinth does not auto-recategorize).

Did NOT manually bump version.toml — CI/CD handles via post_publish on next mc Docker publish (per repo convention).

## Test plan
- [ ] Wait for next mc Docker publish (or workflow_dispatch ci-docker)
- [ ] external_publish job logs show \`VERSION_TYPE: release\`
- [ ] New mrpack lands as Primary on https://modrinth.com/modpack/kbve without needing Alpha filter