### PR TITLE
fix(e2e): unblock rows + firecracker-ctl-e2e Docker builds

### DIFF
--- a/apps/ows/rows/Dockerfile
+++ b/apps/ows/rows/Dockerfile
@@ -9,6 +9,7 @@
 
 # ── Stage 1: Plan — generate dependency recipe ──────────────
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
+ENV CARGO_INCREMENTAL=0
 
 # Create workspace
 RUN printf '[workspace]\nmembers = ["apps/ows/rows", "packages/rust/jedi", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml

--- a/apps/vm/firecracker-ctl-e2e/project.json
+++ b/apps/vm/firecracker-ctl-e2e/project.json
@@ -15,7 +15,7 @@
 			"options": {
 				"commands": [
 					"docker rm -f firecracker-ctl-e2e 2>/dev/null || true",
-					"docker buildx build --platform linux/amd64 -f apps/vm/firecracker-ctl-e2e/mock/Dockerfile.mock -t kbve/firecracker-ctl:mock --load .",
+					"docker buildx build --platform linux/amd64 -f apps/vm/firecracker-ctl-e2e/mock/Dockerfile.mock -t kbve/firecracker-ctl:mock --load ../../..",
 					"docker run -d --name firecracker-ctl-e2e -p 19001:9001 -e FC_USE_JAILER=false -e RUST_LOG=info -e FC_MAX_CONCURRENT_VMS=5 -e FC_VM_TTL_SECS=60 kbve/firecracker-ctl:mock",
 					"echo 'Waiting for firecracker-ctl container to become ready...' && for i in $(seq 1 60); do if curl -sf http://127.0.0.1:19001/health >/dev/null 2>&1; then echo 'Container ready after '\"$i\"'s'; break; fi; if [ $i -eq 60 ]; then echo 'Container did not become ready in 60s'; docker logs firecracker-ctl-e2e 2>&1 | tail -30; docker rm -f firecracker-ctl-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
 					"npx vitest run; EC=$?; echo '--- container logs ---'; docker logs firecracker-ctl-e2e 2>&1 | tail -50; docker rm -f firecracker-ctl-e2e 2>/dev/null || true; exit $EC"


### PR DESCRIPTION
## Summary
- `rows` planner Dockerfile stage was missing `ENV CARGO_INCREMENTAL=0`. `cargo chef prepare` shells out to `cargo metadata`, which invokes the sccache-wrapped rustc; sccache aborts with `incremental compilation is prohibited`. Cook stage already had the env — added it to the planner so they match.
- `firecracker-ctl-e2e` Nx target sets `cwd: apps/vm/firecracker-ctl-e2e` but the buildx command used `.` as the build context, so `COPY apps/...` in `Dockerfile.mock` failed with `lstat apps: no such file or directory`. Pointed the context at the repo root (`../../..`).

Both issues showed up in the weekly E2E run (`CI - E2E / main`, run 24981037892).

## Test plan
- [ ] Re-run `CI - E2E` on this branch (manual `workflow_dispatch`)
- [ ] Confirm `E2E - rows-e2e` passes (planner stage no longer dies on `cargo chef prepare`)
- [ ] Confirm `E2E - firecracker-ctl-e2e` passes (mock image builds with repo-root context)