### PR TITLE
fix(astro): tighten sitegraph types so package build passes

### DIFF
--- a/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
+++ b/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
@@ -14,6 +14,7 @@ import {
 	forceCollide,
 	forceX,
 	forceY,
+	type Simulation,
 	type SimulationNodeDatum,
 	type SimulationLinkDatum,
 } from 'd3-force';
@@ -189,9 +190,7 @@ export function SiteGraph({
 	const tooltipRef = useRef<HTMLDivElement>(null);
 	const [graphData, setGraphData] = useState<SiteGraphData | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const simulationRef = useRef<ReturnType<typeof forceSimulation> | null>(
-		null,
-	);
+	const simulationRef = useRef<Simulation<GraphNode, GraphLink> | null>(null);
 
 	const [hoveredId, setHoveredId] = useState<string | null>(null);
 	const [depth, setDepth] = useState(depthProp);

--- a/packages/npm/astro/src/sitegraph/react/SiteGraphLoader.tsx
+++ b/packages/npm/astro/src/sitegraph/react/SiteGraphLoader.tsx
@@ -71,22 +71,22 @@ export function SiteGraphLoader({
 			setHasLoaded(true);
 		}
 
-		const offOpen = DroidEvents.on('panel-open', (payload: any) => {
+		const handleOpen = (payload: any) => {
 			if (payload?.id === panelId) {
 				setVisible(true);
 				setHasLoaded(true);
 			}
-		});
+		};
+		const handleClose = (payload: any) => {
+			if (payload?.id === panelId) setVisible(false);
+		};
 
-		const offClose = DroidEvents.on('panel-close', (payload: any) => {
-			if (payload?.id === panelId) {
-				setVisible(false);
-			}
-		});
+		DroidEvents.on('panel-open', handleOpen);
+		DroidEvents.on('panel-close', handleClose);
 
 		return () => {
-			offOpen();
-			offClose();
+			DroidEvents.off('panel-open', handleOpen);
+			DroidEvents.off('panel-close', handleClose);
 		};
 	}, [collapsedAttribute, panelId, wideEnough]);
 


### PR DESCRIPTION
## Summary
Follow-up to #10328. Two type errors surfaced when running \`nx run astro:build\`:
- \`simulationRef\` typed as \`ReturnType<typeof forceSimulation>\` collapses to \`Simulation<SimulationNodeDatum, ...>\` and rejects \`Simulation<GraphNode, GraphLink>\` on assignment. Now parameterized with the imported \`Simulation\` generic.
- \`SiteGraphLoader\` treated \`DroidEvents.on\` as if it returned an unsubscribe fn (carried over from the pre-extraction code) but the bus returns \`void\`. Switched to named handlers + \`DroidEvents.off\` in the cleanup.

Both passed silently before because vitest doesn't run tsc and the in-app version was never type-checked through the package boundary.

## Test plan
- [x] \`nx run astro:test\` — 20/20
- [x] \`vite build\` for droid + astro — clean
- [x] \`nx run astro-kbve:build\` — 5457 pages built