### PR TITLE
fix(astro): refresh expired session in AuthBridge.getSession

### DIFF
--- a/packages/npm/astro/src/auth/AuthBridge.ts
+++ b/packages/npm/astro/src/auth/AuthBridge.ts
@@ -81,10 +81,24 @@ export class AuthBridge {
 		this.client = null;
 	}
 
-	async getSession() {
+	async getSession(refreshBufferSec = 30) {
 		const client = this.ensureClient();
 		const { data, error } = await client.auth.getSession();
 		if (error) throw error;
-		return data.session;
+
+		const session = data.session;
+		if (!session) return null;
+
+		const nowSec = Math.floor(Date.now() / 1000);
+		const expiresAt = session.expires_at ?? 0;
+		const isStale = expiresAt > 0 && expiresAt - nowSec <= refreshBufferSec;
+		if (!isStale) return session;
+
+		const { data: refreshed, error: refreshError } =
+			await client.auth.refreshSession();
+		if (refreshError || !refreshed.session) return null;
+
+		setSharedToken(refreshed.session.access_token);
+		return refreshed.session;
 	}
 }


### PR DESCRIPTION
## Summary
ReactChatRoom calls \`authBridge.getSession()\` and pipes the access token straight into \`connect(wsUrl, token)\`. Supabase's \`getSession()\` returns the cached session even after the access token has expired, so once the 1h Supabase JWT lifetime is up the IRC WebSocket handshake at \`chat.kbve.com/ws\` 401s with no visible reason in the UI.

\`AuthBridge.getSession\` now:
- checks \`expires_at\` against \`Math.floor(Date.now() / 1000)\` with a 30s buffer
- falls through to \`client.auth.refreshSession()\` when stale
- returns \`null\` on refresh failure (caller already treats null as anon)
- rewrites the shared \`*.kbve.com\` cookie via \`setSharedToken\` on a successful refresh so other subdomains see the new token

\`bootAuth\` already handled this for the gateway path; the bridge's direct path was the gap.

## Test plan
- [x] vitest 29/29
- [x] vite build clean (droid + astro)
- [ ] Manual: open chat tab with a fresh session → connects (regression check)
- [ ] Manual: open chat tab with a session past \`expires_at\` (e.g. set system clock forward, or wait 1h) → bridge refreshes silently, WebSocket connects
- [ ] Manual: revoke / sign out from another tab → \`getSession\` returns null, UI flips to anon login