### PR TITLE
fix(uniti): drop unnecessary i32 casts in ffi_concurrency test

### DIFF
--- a/packages/rust/bevy/uniti/tests/ffi_concurrency.rs
+++ b/packages/rust/bevy/uniti/tests/ffi_concurrency.rs
@@ -17,8 +17,8 @@ fn concurrent_chunk_touch_no_corruption() {
         handles.push(thread::spawn(move || {
             let h = world_addr as *mut std::ffi::c_void;
             for i in 0..50 {
-                let cx = (t * 100 + i) as i32;
-                let ok = unsafe { uniti_world_chunk_touch(h, cx, t as i32, 1, 0, 0) };
+                let cx = t * 100 + i;
+                let ok = unsafe { uniti_world_chunk_touch(h, cx, t, 1, 0, 0) };
                 if ok == 1 {
                     s.fetch_add(1, Ordering::Relaxed);
                 }


### PR DESCRIPTION
## Summary
- Rust 1.95 (CI) clippy flags `i32 as i32` as `unnecessary_cast` under `-D warnings`
- Local toolchain (1.94) didn't flag it, so it slipped through
- Fixes the [verify job failure](https://github.com/KBVE/kbve/actions/runs/25200044446/job/73888916150)

## Test plan
- [x] `cargo clippy --manifest-path packages/rust/bevy/uniti/Cargo.toml --all-targets -- -D warnings` clean locally