### PR TITLE
fix(multus): bump memory limits to survive Talos reboot CNI burst

### DIFF
--- a/apps/kube/multus/manifests/multus-daemonset.yaml
+++ b/apps/kube/multus/manifests/multus-daemonset.yaml
@@ -162,10 +162,10 @@ spec:
                   resources:
                       requests:
                           cpu: '200m'
-                          memory: '100Mi'
+                          memory: '256Mi'
                       limits:
                           cpu: '300m'
-                          memory: '150Mi'
+                          memory: '512Mi'
                   securityContext:
                       privileged: true
                   terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## Summary
Default multus memory `100Mi req / 150Mi limit` was too small for the concurrent CNI request burst when ~150 pods come up in parallel after a Talos node reboot. During the 1.12.5 → 1.13.0 upgrade kube-multus was OOMKilled (exit 137) and took everything with it.

Bumps to `256Mi req / 512Mi limit` to cover the burst with headroom.

## Cascade observed during the incident
- multus OOMKilled → no pod sandbox networking
- CoreDNS stuck \`ContainerCreating\` → no in-cluster DNS
- longhorn-manager couldn't reach \`longhorn-conversion-webhook.longhorn-system.svc\` (UDP 10.96.0.10:53 \`operation not permitted\`) → CrashLoopBackOff
- Longhorn CSI plugins / attacher / provisioner stuck → all PVC mounts stalled
- ArgoCD pods stuck on PVC bind → couldn't reconcile to repair anything

The 'operation not permitted' error looked like a Cilium policy block but was really 'kube-dns Service has no healthy backing pods because CoreDNS sandbox creation failed because multus is dead'.

## Test plan
- [x] Manually patched the running DaemonSet on \`talos-4bn-whr\` to confirm the higher limits unblock the cascade
- [ ] ArgoCD picks up the manifest change after merge → DaemonSet reconciles to the new values
- [ ] Future Talos node upgrades complete without the OOM cascade