### PR TITLE
feat(kilobase): seed mc-chat-jwt SealedSecret to unblock agones-mc

### DIFF
--- a/apps/kube/kilobase/manifests/sealed-mc-chat-jwt.yaml
+++ b/apps/kube/kilobase/manifests/sealed-mc-chat-jwt.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: mc-chat-jwt
+    namespace: kilobase
+spec:
+    encryptedData:
+        signing-key: AgBLJW9pGOw+AFXPU5gL179YRzavn+mmKujOOhZeqltHv71ZRtt0TERr0Mqt3MNZ1+qhxZLe85PGoS5nkowtHU7RJ3ylIYCxMiRg2iKD+kCbMnbHodPWkTOY48Xi8K5SX9v+6Jq1UM7GcQhoabDTYPv9mbMsCAuLUcQYyq8GgYAyClBHLwItsjwUvzXgI1Mi/XwUhMeIpogpW+X1oAPw83fgjSntArc/sgmJIpTtKoVL+SPabjzmidi7w86CijAGHTTDu++SN+9C2BZisRc3rg9dq/E+OQzfuDF5dvP3cUGQoeCc9JBJZbOjjWW0MqWihYTo/HTqMYi0GwSd/xUJ+I4hKa0rKPejl+DOx+hmDVJiZzywWZfEIIS74vE9nA4fuuLtRfD/SQfqvMDRcjsgg2PDmTvW4CvQFblFACTLb/ZSTc4CixvZ+6GF2Gc/A7dOZ8MZy//ko8tDQz5elbzu84rdYgqduKmSxzzxjrrLGb/fCVUhFu4hZb1xd3BztF2bWcM15gGHq9yu8O52/2iem7qn0D740gAKfKQyNx+q5dc0UT0k8JHyLeocmWtMkkoZDT9NY0Hi3rKc8em5egfITzm4M/g5iusLbg+5Gjzio61l1P3WQ5NldHmSCuBU4rYm+Zctlml8Jx8T9uXkQV+Rc9exc7hXa/xk+ulkjMsEW1lkIN0kE1NvpzxIlFaS54Xw8GOUCG5PgCHwkSrHtxjt/+hjShF8Qw8QttO0e6kxIQMJB0zXWLDJe/Q2IV7MFgPcgz/ORiUyrqmTM4rqCRqcEi5mO67SxiMDWfNP0ERceq4pA7m7xO11S6nm
+    template:
+        metadata:
+            name: mc-chat-jwt
+            namespace: kilobase


### PR DESCRIPTION
## Summary
The agones-mc ArgoCD app has been Degraded since 2026-04-20 because the ExternalSecret \`arc-runners/mc-chat-jwt-signing-key\` was unable to read its source \`kilobase/mc-chat-jwt\` — the source secret is documented as the canonical signing key in [chat-jwt-external-secret.yaml](apps/kube/agones/mc/chat-jwt-external-secret.yaml) but had never actually been created in the cluster.

\`\`\`
error retrieving secret at .data[0], key: mc-chat-jwt, err: secrets "mc-chat-jwt" not found
\`\`\`

## Change
Seeds \`kilobase/mc-chat-jwt\` with a fresh 64-byte base64 signing key, sealed via kubeseal against the in-cluster controller. Field name \`signing-key\` matches what the cross-namespace ExternalSecret + the \`mc_auth\` Rust crate expect.

## Effect after merge
1. Argo syncs \`kilobase\` app → SealedSecrets controller decrypts → \`kilobase/mc-chat-jwt\` exists.
2. \`arc-runners/mc-chat-jwt-signing-key\` ExternalSecret refreshes on its 15m interval and projects \`signing-key\` into the arc-runners Secret.
3. agones-mc Argo app turns Healthy.
4. Future fleet pod restarts pick up the env var \`MC_CHAT_JWT_SIGNING_KEY\` from the projected Secret.

## Test plan
- [x] kubeseal handshake against \`kube-system/sealed-secrets-controller\` succeeded
- [ ] After merge: \`kubectl -n kilobase get secret mc-chat-jwt\` returns the unsealed Secret
- [ ] \`kubectl -n arc-runners get externalsecret mc-chat-jwt-signing-key\` reports \`STATUS: True / READY: True\`
- [ ] \`kubectl -n argocd get app agones-mc\` reports Healthy