### PR TITLE
fix(cert-manager): add rareicon.com solver to letsencrypt-http issuer

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -84,6 +84,21 @@ spec:
                             namespace: kbve
                             kind: Gateway
                             sectionName: http
+
+            # --- Solver 7: RAREICON.COM domains ---
+            # Stays on the nginx solver until the Cilium gateway VIP (.71)
+            # is reachable from Let's Encrypt; until then nginx-on-.74 is
+            # the only path that completes HTTP-01.
+            - selector:
+                  dnsZones:
+                      - rareicon.com
+              http01:
+                  ingress:
+                      ingressClassName: nginx
+                      ingressTemplate:
+                          metadata:
+                              annotations:
+                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer


### PR DESCRIPTION
## Summary
The \`letsencrypt-http\` ClusterIssuer's solver list didn't include \`rareicon.com\`, so the \`rareicon-tls\` and \`rareicon-api-tls\` Certificates have been stuck since the day they were created:

\`\`\`
Failed to determine a valid solver configuration for the set of domains on the Order:
no configured challenge solvers can be used for this challenge
\`\`\`

That stuck order is what's keeping the rareicon Argo app Degraded (transition timestamp: 2026-04-25T16:00:11Z, matches the cert creation date).

## Change
Adds a Solver 7 that mirrors the existing nginx solvers (kbve.com / discord.sh / herbmail.com / meme.sh / cryptothrone.com). Uses ingress-nginx on .74 instead of the Cilium gateway because the Cilium VIP (.71) is still asymmetrically unreachable from Let's Encrypt — see [project_kbve_lb_split.md](memory/project_kbve_lb_split.md).

## Effect after merge
1. Argo syncs cert-manager app → ClusterIssuer picks up the new selector
2. Existing pending rareicon Orders re-evaluate, find a matching solver, and create Challenge resources
3. cert-manager spins up an http-solver Ingress on nginx .74, LE validates HTTP-01
4. \`rareicon-tls\` and \`rareicon-api-tls\` flip to Ready=True
5. rareicon Argo app turns Healthy

## Test plan
- [x] kubectl apply --dry-run=client locally accepts the YAML
- [ ] After merge: \`kubectl describe order -n rareicon\` shows challenges spawning
- [ ] \`kubectl get challenges -A\` shows rareicon-tls / rareicon-api-tls challenges presenting and being self-checked
- [ ] \`kubectl get certificate -n rareicon\` shows READY=True for both certs
- [ ] \`kubectl -n argocd get app rareicon\` reports Healthy