### PR TITLE
fix(forgejo): wire sealed-kbve-ci + grant arc-runners RBAC

### DIFF
--- a/apps/kube/forgejo/manifest/kustomization.yaml
+++ b/apps/kube/forgejo/manifest/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
     - rbac.yaml
     - forgejo-externalsecret.yaml
     - sealed-deploy-keys.yaml
+    - sealed-kbve-ci.yaml
     # Future: actions-runner.yaml

--- a/apps/kube/forgejo/manifest/rbac.yaml
+++ b/apps/kube/forgejo/manifest/rbac.yaml
@@ -53,7 +53,7 @@ subjects:
       name: forgejo-external-secrets
       namespace: forgejo
 ---
-# Role: Allow ARC runners to read forgejo-deploy-keys secret
+# Role: Allow ARC runners to read forgejo-deploy-keys + forgejo-kbve-ci secrets
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -62,7 +62,7 @@ metadata:
 rules:
     - apiGroups: ['']
       resources: ['secrets']
-      resourceNames: ['forgejo-deploy-keys']
+      resourceNames: ['forgejo-deploy-keys', 'forgejo-kbve-ci']
       verbs: ['get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
The \`arc-runners\` ArgoCD app has been Degraded since 2026-04-29 because its \`forgejo-kbve-ci\` ExternalSecret can't pull the source from the \`forgejo\` namespace:

\`\`\`
could not get secret data from provider:
secrets "forgejo-kbve-ci" is forbidden:
User "system:serviceaccount:arc-runners:arc-runners-external-secrets"
cannot get resource "secrets" in API group "" in the namespace "forgejo"
\`\`\`

## Root cause
Two missing pieces, both in [apps/kube/forgejo/manifest/](apps/kube/forgejo/manifest/):

1. \`sealed-kbve-ci.yaml\` exists on disk but was never added to \`kustomization.yaml\`, so Argo never applied it — the sealed secret literally doesn't exist in-cluster (only \`forgejo-admin\`, \`forgejo-deploy-keys\`, \`forgejo-lfs-jwt\` are present).

2. The \`arc-runners-forgejo-access\` Role's \`resourceNames\` only whitelists \`forgejo-deploy-keys\`. Even after the secret is created, the cross-namespace ExternalSecret read would still be denied.

## Change
- Add \`sealed-kbve-ci.yaml\` to the kustomization resources list.
- Extend \`arc-runners-forgejo-access\` Role to include \`forgejo-kbve-ci\` in \`resourceNames\`.

## Effect after merge
1. Argo syncs forgejo app → \`forgejo/forgejo-kbve-ci\` Secret materialises (sealed-secrets controller decrypts the existing yaml).
2. arc-runners Role allows the SA to read it.
3. The arc-runners ExternalSecret refreshes on its 1h interval and projects \`forgejo-kbve-ci\` into arc-runners.
4. arc-runners Argo app turns Healthy.

## Test plan
- [x] kustomize build accepts the manifest
- [ ] After merge: \`kubectl -n forgejo get sealedsecret\` shows \`forgejo-kbve-ci\`
- [ ] \`kubectl -n forgejo get secret forgejo-kbve-ci\` returns the unsealed Secret
- [ ] \`kubectl -n arc-runners get externalsecret forgejo-kbve-ci\` reports \`STATUS: True / READY: True\`
- [ ] \`kubectl -n argocd get app arc-runners\` reports Healthy