### PR TITLE
test(droid,irc-gateway): expand coverage for gateway, schemas, jwt

### DIFF
--- a/apps/irc/irc-gateway/src/auth/jwt.rs
+++ b/apps/irc/irc-gateway/src/auth/jwt.rs
@@ -1,10 +1,10 @@
 use axum::{
     extract::Request,
-    http::{header, StatusCode},
-    response::IntoResponse,
+    http::{StatusCode, header},
     middleware::Next,
+    response::IntoResponse,
 };
-use jsonwebtoken::{decode, DecodingKey, Validation, Algorithm};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,22 +28,22 @@ pub fn extract_token(req: &Request) -> Option<String> {
         .map(String::from)
         .or_else(|| {
             // Try ?token= query param (for WebSocket upgrades)
-            req.uri()
-                .query()
-                .and_then(|q| {
-                    q.split('&')
-                        .find_map(|pair| {
-                            let (key, value) = pair.split_once('=')?;
-                            if key == "token" { Some(value.to_string()) } else { None }
-                        })
+            req.uri().query().and_then(|q| {
+                q.split('&').find_map(|pair| {
+                    let (key, value) = pair.split_once('=')?;
+                    if key == "token" {
+                        Some(value.to_string())
+                    } else {
+                        None
+                    }
                 })
+            })
         })
 }
 
 /// Validate JWT and return claims
 pub fn validate_token(token: &str) -> Result<Claims, StatusCode> {
-    let secret = std::env::var("JWT_SECRET")
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let secret = std::env::var("JWT_SECRET").map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut validation = Validation::new(Algorithm::HS256);
     validation.set_required_spec_claims(&["sub", "exp", "iat"]);
@@ -58,10 +58,7 @@ pub fn validate_token(token: &str) -> Result<Claims, StatusCode> {
 }
 
 /// Axum middleware that requires valid JWT
-pub async fn require_auth(
-    req: Request,
-    next: Next,
-) -> impl IntoResponse {
+pub async fn require_auth(req: Request, next: Next) -> impl IntoResponse {
     let token = match extract_token(&req) {
         Some(t) => t,
         None => return StatusCode::UNAUTHORIZED.into_response(),
@@ -70,5 +67,154 @@ pub async fn require_auth(
     match validate_token(&token) {
         Ok(_claims) => next.run(req).await.into_response(),
         Err(status) => status.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use serial_test::serial;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const TEST_SECRET: &str = "kbve-jwt-secret-for-tests";
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_secs()
+    }
+
+    fn issue(secret: &str, sub: &str, exp_offset: i64) -> String {
+        let iat = now_secs();
+        let exp = (iat as i64 + exp_offset) as u64;
+        let claims = Claims {
+            sub: sub.to_string(),
+            email: Some(format!("{sub}@example.com")),
+            role: Some("authenticated".to_string()),
+            exp,
+            iat,
+        };
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("encode test jwt")
+    }
+
+    fn req_with_query(query: &str) -> Request {
+        Request::builder()
+            .uri(format!("https://chat.kbve.com/ws?{query}"))
+            .body(Body::empty())
+            .expect("build request")
+    }
+
+    fn req_with_bearer(token: &str) -> Request {
+        Request::builder()
+            .uri("https://chat.kbve.com/ws")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .expect("build request")
+    }
+
+    #[test]
+    fn extract_token_from_authorization_header() {
+        let req = req_with_bearer("abc.def.ghi");
+        assert_eq!(extract_token(&req).as_deref(), Some("abc.def.ghi"));
+    }
+
+    #[test]
+    fn extract_token_falls_back_to_query_param() {
+        let req = req_with_query("token=qry.tok.val&other=1");
+        assert_eq!(extract_token(&req).as_deref(), Some("qry.tok.val"));
+    }
+
+    #[test]
+    fn extract_token_prefers_authorization_over_query() {
+        let req = Request::builder()
+            .uri("https://chat.kbve.com/ws?token=fromquery")
+            .header(header::AUTHORIZATION, "Bearer fromheader")
+            .body(Body::empty())
+            .expect("build request");
+        assert_eq!(extract_token(&req).as_deref(), Some("fromheader"));
+    }
+
+    #[test]
+    fn extract_token_ignores_other_query_keys() {
+        let req = req_with_query("foo=bar&token=tok.123");
+        assert_eq!(extract_token(&req).as_deref(), Some("tok.123"));
+    }
+
+    #[test]
+    fn extract_token_returns_none_when_absent() {
+        let req = Request::builder()
+            .uri("https://chat.kbve.com/ws")
+            .body(Body::empty())
+            .expect("build request");
+        assert!(extract_token(&req).is_none());
+    }
+
+    #[test]
+    fn extract_token_ignores_bearer_without_space() {
+        let req = Request::builder()
+            .uri("https://chat.kbve.com/ws")
+            .header(header::AUTHORIZATION, "Bearer")
+            .body(Body::empty())
+            .expect("build request");
+        assert!(extract_token(&req).is_none());
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_accepts_valid_token() {
+        std::env::set_var("JWT_SECRET", TEST_SECRET);
+        let token = issue(TEST_SECRET, "user-123", 3600);
+        let claims = validate_token(&token).expect("token should validate");
+        assert_eq!(claims.sub, "user-123");
+        assert_eq!(claims.email.as_deref(), Some("user-123@example.com"));
+        std::env::remove_var("JWT_SECRET");
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_rejects_wrong_secret() {
+        std::env::set_var("JWT_SECRET", TEST_SECRET);
+        let token = issue("different-secret", "user-456", 3600);
+        let result = validate_token(&token);
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+        std::env::remove_var("JWT_SECRET");
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_rejects_expired_token() {
+        std::env::set_var("JWT_SECRET", TEST_SECRET);
+        let token = issue(TEST_SECRET, "user-789", -120);
+        let result = validate_token(&token);
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+        std::env::remove_var("JWT_SECRET");
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_returns_500_when_secret_unset() {
+        std::env::remove_var("JWT_SECRET");
+        let result = validate_token("anything.at.all");
+        assert_eq!(result.unwrap_err(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_rejects_garbage_input() {
+        std::env::set_var("JWT_SECRET", TEST_SECRET);
+        assert_eq!(
+            validate_token("not-a-jwt").unwrap_err(),
+            StatusCode::UNAUTHORIZED,
+        );
+        assert_eq!(validate_token("").unwrap_err(), StatusCode::UNAUTHORIZED,);
+        std::env::remove_var("JWT_SECRET");
     }
 }

--- a/packages/npm/droid/src/lib/gateway/capabilities.spec.ts
+++ b/packages/npm/droid/src/lib/gateway/capabilities.spec.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	detectCapabilities,
+	getStrategyDescription,
+	logCapabilities,
+	selectStrategy,
+} from './capabilities';
+
+const realUA = navigator.userAgent;
+
+afterEach(() => {
+	Object.defineProperty(navigator, 'userAgent', {
+		value: realUA,
+		configurable: true,
+	});
+	vi.restoreAllMocks();
+});
+
+function setUA(ua: string) {
+	Object.defineProperty(navigator, 'userAgent', {
+		value: ua,
+		configurable: true,
+	});
+}
+
+describe('detectCapabilities', () => {
+	it('flags Safari when Safari is in UA but Chrome is not', () => {
+		setUA(
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+		);
+		const caps = detectCapabilities();
+		expect(caps.isSafari).toBe(true);
+		expect(caps.isAndroid).toBe(false);
+	});
+
+	it('does not flag Safari for Chrome on macOS', () => {
+		setUA(
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36',
+		);
+		const caps = detectCapabilities();
+		expect(caps.isSafari).toBe(false);
+	});
+
+	it('flags Android UA', () => {
+		setUA(
+			'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Mobile Safari/537.36',
+		);
+		const caps = detectCapabilities();
+		expect(caps.isAndroid).toBe(true);
+	});
+});
+
+describe('selectStrategy', () => {
+	it('picks shared-worker on capable desktop', () => {
+		expect(
+			selectStrategy({
+				hasSharedWorker: true,
+				hasWorker: true,
+				hasBroadcastChannel: true,
+				isAndroid: false,
+				isSafari: false,
+			}),
+		).toBe('shared-worker');
+	});
+
+	it('falls back to web-worker on Android even with SharedWorker support', () => {
+		expect(
+			selectStrategy({
+				hasSharedWorker: true,
+				hasWorker: true,
+				hasBroadcastChannel: true,
+				isAndroid: true,
+				isSafari: false,
+			}),
+		).toBe('web-worker');
+	});
+
+	it('falls back to web-worker without SharedWorker', () => {
+		expect(
+			selectStrategy({
+				hasSharedWorker: false,
+				hasWorker: true,
+				hasBroadcastChannel: true,
+				isAndroid: false,
+				isSafari: true,
+			}),
+		).toBe('web-worker');
+	});
+
+	it('falls back to direct without BroadcastChannel', () => {
+		expect(
+			selectStrategy({
+				hasSharedWorker: true,
+				hasWorker: true,
+				hasBroadcastChannel: false,
+				isAndroid: false,
+				isSafari: false,
+			}),
+		).toBe('direct');
+	});
+
+	it('returns direct when Worker is unavailable', () => {
+		expect(
+			selectStrategy({
+				hasSharedWorker: false,
+				hasWorker: false,
+				hasBroadcastChannel: false,
+				isAndroid: false,
+				isSafari: false,
+			}),
+		).toBe('direct');
+	});
+});
+
+describe('getStrategyDescription', () => {
+	it('returns a description for every strategy variant', () => {
+		expect(getStrategyDescription('shared-worker')).toMatch(/SharedWorker/);
+		expect(getStrategyDescription('web-worker')).toMatch(/WebSocket/);
+		expect(getStrategyDescription('direct')).toMatch(/Direct/);
+	});
+});
+
+describe('logCapabilities', () => {
+	it('writes a single console.log with the capability snapshot', () => {
+		const spy = vi
+			.spyOn(console, 'log')
+			.mockImplementation(() => undefined);
+		logCapabilities({
+			hasSharedWorker: true,
+			hasWorker: true,
+			hasBroadcastChannel: true,
+			isAndroid: false,
+			isSafari: false,
+		});
+		expect(spy).toHaveBeenCalledTimes(1);
+		const [, payload] = spy.mock.calls[0];
+		expect(payload).toMatchObject({
+			SharedWorker: 'yes',
+			Worker: 'yes',
+			BroadcastChannel: 'yes',
+			Platform: 'Desktop',
+		});
+	});
+});

--- a/packages/npm/droid/src/lib/state/welcome-toast.spec.ts
+++ b/packages/npm/droid/src/lib/state/welcome-toast.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { showWelcomeToast } from './welcome-toast';
+import { $auth, AuthPresets, resetAuth, setAuth } from './auth';
+import { $toasts } from './toasts';
+
+const SHOWN_KEY = 'kbve:welcome-shown';
+
+beforeEach(() => {
+	sessionStorage.clear();
+	$toasts.set({});
+	$auth.set({
+		tone: 'loading',
+		flags: AuthPresets.LOADING,
+		name: '',
+		username: undefined,
+		avatar: undefined,
+		id: '',
+		error: undefined,
+	});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('showWelcomeToast', () => {
+	it('emits a "Welcome back, <name>" success toast for an authed user', () => {
+		setAuth({ tone: 'auth', name: 'Alice' });
+		showWelcomeToast();
+		const toasts = Object.values($toasts.get());
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0]).toMatchObject({
+			message: 'Welcome back, Alice',
+			severity: 'success',
+		});
+		expect(sessionStorage.getItem(SHOWN_KEY)).toBe('1');
+	});
+
+	it('emits a generic info toast for an anon visitor', () => {
+		setAuth({ tone: 'anon' });
+		showWelcomeToast();
+		const toasts = Object.values($toasts.get());
+		expect(toasts[0]).toMatchObject({
+			message: 'Welcome!',
+			severity: 'info',
+		});
+	});
+
+	it('does not emit twice in the same session', () => {
+		setAuth({ tone: 'anon' });
+		showWelcomeToast();
+		showWelcomeToast();
+		expect(Object.values($toasts.get())).toHaveLength(1);
+	});
+
+	it('emits when auth resolves after a delay (subscription path)', () => {
+		showWelcomeToast();
+		expect(Object.values($toasts.get())).toHaveLength(0);
+
+		setAuth({ tone: 'auth', name: 'Bob' });
+		const toasts = Object.values($toasts.get());
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0]).toMatchObject({ message: 'Welcome back, Bob' });
+	});
+
+	it('falls back to a generic toast after the 10s timeout when auth never resolves', () => {
+		vi.useFakeTimers();
+		showWelcomeToast();
+		expect(Object.values($toasts.get())).toHaveLength(0);
+
+		vi.advanceTimersByTime(10_000);
+		const toasts = Object.values($toasts.get());
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0]).toMatchObject({
+			message: 'Welcome!',
+			severity: 'info',
+		});
+	});
+
+	it('marks shown without emitting when tone is error', () => {
+		setAuth({ tone: 'error', error: 'boom' });
+		showWelcomeToast();
+		expect(Object.values($toasts.get())).toHaveLength(0);
+		expect(sessionStorage.getItem(SHOWN_KEY)).toBe('1');
+	});
+
+	it('treats sessionStorage failures as not-shown without throwing', () => {
+		const original = Storage.prototype.getItem;
+		Storage.prototype.getItem = () => {
+			throw new Error('private mode');
+		};
+		try {
+			expect(() => {
+				resetAuth();
+				showWelcomeToast();
+			}).not.toThrow();
+		} finally {
+			Storage.prototype.getItem = original;
+		}
+	});
+});

--- a/packages/npm/droid/src/lib/types/event-schemas.spec.ts
+++ b/packages/npm/droid/src/lib/types/event-schemas.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DroidEventSchemas,
+	DroidFirstConnectSchema,
+	DroidReadySchema,
+	AuthReadySchema,
+	AuthErrorSchema,
+	WorkerErrorSchema,
+	PageLifecycleSchema,
+	PanelEventSchema,
+	DroidDownscaleSchema,
+	DroidUpscaleSchema,
+	DroidModReadySchema,
+} from './event-types';
+
+describe('DroidEventSchemas — happy path round-trips', () => {
+	it.each([
+		['droid-ready', DroidReadySchema, { timestamp: 1 }],
+		[
+			'droid-first-connect',
+			DroidFirstConnectSchema,
+			{ timestamp: 1, workersFirst: { db: true, ws: false } },
+		],
+		[
+			'droid-mod-ready',
+			DroidModReadySchema,
+			{ meta: { id: 'x', name: 'X', version: '1.0.0' }, timestamp: 1 },
+		],
+		[
+			'droid-downscale',
+			DroidDownscaleSchema,
+			{ timestamp: 1, level: 'minimal' },
+		],
+		['droid-upscale', DroidUpscaleSchema, { timestamp: 1, level: 'full' }],
+		[
+			'panel-open',
+			PanelEventSchema,
+			{ id: 'right', payload: { foo: 'bar' } },
+		],
+		['panel-close', PanelEventSchema, { id: 'top' }],
+		[
+			'auth-ready',
+			AuthReadySchema,
+			{ timestamp: 1, tone: 'auth' as const, name: 'Alice' },
+		],
+		[
+			'auth-error',
+			AuthErrorSchema,
+			{ timestamp: 1, message: 'invalid grant' },
+		],
+		[
+			'worker-error',
+			WorkerErrorSchema,
+			{
+				timestamp: 1,
+				worker: 'ws' as const,
+				operation: 'connect',
+				message: 'closed',
+			},
+		],
+		[
+			'page-mount',
+			PageLifecycleSchema,
+			{ timestamp: 1, url: '/foo', source: 'initial' as const },
+		],
+	])('%s accepts a valid payload', (_name, schema, payload) => {
+		expect(schema.safeParse(payload).success).toBe(true);
+	});
+});
+
+describe('DroidEventSchemas — rejection cases', () => {
+	it('rejects droid-first-connect without workersFirst', () => {
+		expect(
+			DroidFirstConnectSchema.safeParse({ timestamp: 1 }).success,
+		).toBe(false);
+	});
+
+	it('rejects auth-ready with an unknown tone', () => {
+		expect(
+			AuthReadySchema.safeParse({ timestamp: 1, tone: 'staff' }).success,
+		).toBe(false);
+	});
+
+	it('rejects worker-error with an unknown worker name', () => {
+		expect(
+			WorkerErrorSchema.safeParse({
+				timestamp: 1,
+				worker: 'gateway',
+				operation: 'x',
+				message: 'y',
+			}).success,
+		).toBe(false);
+	});
+
+	it('rejects page-lifecycle with an unknown source', () => {
+		expect(
+			PageLifecycleSchema.safeParse({
+				timestamp: 1,
+				url: '/x',
+				source: 'turbolinks',
+			}).success,
+		).toBe(false);
+	});
+
+	it('rejects schemas missing the timestamp field', () => {
+		expect(DroidReadySchema.safeParse({}).success).toBe(false);
+		expect(AuthErrorSchema.safeParse({ message: 'x' }).success).toBe(false);
+	});
+});
+
+describe('DroidEventSchemas — registry contract', () => {
+	it('every key resolves to a schema with safeParse', () => {
+		for (const [key, schema] of Object.entries(DroidEventSchemas)) {
+			expect(typeof (schema as { safeParse?: unknown }).safeParse).toBe(
+				'function',
+			);
+			expect(key).toMatch(/^[a-z]+(-[a-z]+)+$/);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
+34 droid vitest cases + 11 irc-gateway cargo tests aimed at the modules most likely to silently rot.

### \`@kbve/droid\` (vitest 72 → 106)
- **\`gateway/capabilities.spec.ts\`** — UA detection (Safari vs Chrome vs Android), \`selectStrategy\` fallback ladder (shared-worker → web-worker → direct), description coverage, \`logCapabilities\` payload.
- **\`state/welcome-toast.spec.ts\`** — auth / anon / error tone variants, session-storage de-dupe, late-arrival auth subscription, 10 s timeout fallback (fake timers), sessionStorage-throws path.
- **\`types/event-schemas.spec.ts\`** — happy-path round-trips for every payload in \`DroidEventSchemas\` + targeted rejections (unknown auth tone, unknown worker, missing timestamp, unknown lifecycle source) + registry contract that every key resolves to a Zod schema.

### \`irc-gateway\` (new \`#[cfg(test)] mod\`)
- **\`auth/jwt.rs\`** — \`extract_token\` over Bearer header, \`?token=\` query, header-preference, malformed bearer, absent; \`validate_token\` over happy path, wrong secret, expired \`exp\`, missing \`JWT_SECRET\` (500), garbage/empty input. \`serial_test\` gates env mutation so \`JWT_SECRET\` writes don't leak across parallel threads.

## Test plan
- [x] \`nx run droid:test\` — 106/106
- [x] \`cargo test\` (irc-gateway) — 11/11 jwt cases pass
- [x] No production code changed; all additions are \`*.spec.ts\` / \`#[cfg(test)]\`