### PR TITLE
fix(kubevirt-download-proxy): never-firing cron with valid desiredReplicas

### DIFF
--- a/apps/kube/kubevirt/download-proxy/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/download-proxy/keda-scaledobject.yaml
@@ -25,11 +25,15 @@ spec:
     minReplicaCount: 0
     maxReplicaCount: 1
     triggers:
-        # Placeholder cron trigger — keeps KEDA managing the ScaledObject.
-        # CI workflows scale up via kubectl before staging downloads.
+        # Placeholder cron trigger — keeps KEDA managing the ScaledObject so
+        # cooldown-to-zero still applies after CI workflows scale up.
+        # `desiredReplicas` must be > 0 to pass KEDA's cron validator
+        # (`'0'` is rejected with `error parsing cron metadata: no
+        # desiredReplicas specified`), so set it to '1' but pick a window
+        # that never fires — Feb 30 doesn't exist on any calendar.
         - type: cron
           metadata:
               timezone: UTC
-              start: '0 6 * * 1-5'
-              end: '0 7 * * 1-5'
-              desiredReplicas: '0'
+              start: '0 0 30 2 *'
+              end: '5 0 30 2 *'
+              desiredReplicas: '1'


### PR DESCRIPTION
## Summary
The \`kubevirt-download-proxy\` ArgoCD app has been Degraded since 2026-04-01 because the \`download-proxy-scaler\` ScaledObject can't create its HPA:

\`\`\`
ScaledObjectCheckFailed: failed to ensure HPA is correctly created for ScaledObject:
error parsing cron metadata: no desiredReplicas specified
\`\`\`

KEDA's cron trigger validator rejects \`desiredReplicas: '0'\` even though the field is technically present — the parser treats \`'0'\` as unset.

## Change
- Cron window switched to \`30 2 *\` (Feb 30 — a date that doesn't exist on any calendar) so the trigger never fires.
- \`desiredReplicas\` bumped to \`'1'\` to satisfy KEDA's >0 validation.
- Comment updated to capture why the value can't simply be \`'0'\`.

Behavior is unchanged: KEDA still manages cooldown-to-zero, CI workflows still scale up via \`kubectl scale\`, the cron trigger is a no-op placeholder.

## Effect after merge
1. Argo syncs → ScaledObject re-reconciles
2. HPA gets created → ScaledObject reports \`READY=True\`
3. \`kubevirt-download-proxy\` Argo app turns Healthy

## Out of scope (follow-up)
The Deployment still uses \`alpine:3.21\` + \`python:3.12-alpine\` with a startup-time \`apk add aria2\`. The \`ghcr.io/kbve/aria2-proxy\` image was added to the repo to replace this pattern but isn't published yet (\`NAME_UNKNOWN\` from ghcr — ci-docker dispatch never ran for it). Image swap is a separate PR after the first publish.

## Test plan
- [x] \`kubectl apply --dry-run=server\` accepts the manifest
- [ ] After merge: \`kubectl -n angelscript get scaledobject download-proxy-scaler\` reports \`READY=True\`
- [ ] \`kubectl -n argocd get app kubevirt-download-proxy\` reports Healthy