### PR TITLE
chore(crates,bevy): seed L0 version.toml to bootstrap first publish

### DIFF
--- a/packages/rust/bevy/bevy_behavior/version.toml
+++ b/packages/rust/bevy/bevy_behavior/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.0"
+version = "0.0.1"
 publish = true

--- a/packages/rust/bevy/bevy_inventory/version.toml
+++ b/packages/rust/bevy/bevy_inventory/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.0"
+version = "0.0.1"
 publish = true

--- a/packages/rust/bevy/bevy_skills/version.toml
+++ b/packages/rust/bevy/bevy_skills/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.0"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
## Summary
- Seed \`version.toml\` to \`0.0.1\` for three L0 leaf crates (\`bevy_inventory\`, \`bevy_skills\`, \`bevy_behavior\`) so the ci-publish version gate stops short-circuiting on the \`0.0.0\` sentinel.
- Cargo.toml is already at \`0.1.0\` for each → gate sees \`local > published\` → first publish dispatches → post-publish sync writes the real version back.
- Unblocks the L0 → L1 → uniti publish chain. L1 (\`bevy_battle\`) and L2 (\`uniti\`) follow once L0 lands on crates.io.

Verified each crate with \`cargo publish --dry-run\` — all package + upload cleanly.

## Test plan
- [ ] CI dispatches \`bevy_inventory\`, \`bevy_skills\`, \`bevy_behavior\` for first publish on merge
- [ ] Post-publish sync PR opens for each, bumping \`version.toml\` to \`0.1.0\`
- [ ] crates.io shows all three at \`0.1.0\`