### PR TITLE
chore(arc-runner-set): bump actions-runner 2.333.0 → 2.334.0

### DIFF
--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -31,12 +31,12 @@ maxRunners: 10
 template:
     metadata:
         annotations:
-            kbve.com/restart-trigger: '20260502-dind-subpath-fix'
+            kbve.com/restart-trigger: '20260502-runner-2.334.0'
     spec:
         # Init container to copy externals for DinD
         initContainers:
             - name: init-dind-externals
-              image: ghcr.io/actions/actions-runner:2.333.0
+              image: ghcr.io/actions/actions-runner:2.334.0
               command:
                   [
                       'cp',
@@ -50,7 +50,7 @@ template:
                     mountPath: /home/runner/tmpDir
         containers:
             - name: runner
-              image: ghcr.io/actions/actions-runner:2.333.0
+              image: ghcr.io/actions/actions-runner:2.334.0
               # Fix sudoers for root before starting runner (Unity builder uses sudo)
               command:
                   [


### PR DESCRIPTION
## Summary
Pulls the latest [GitHub-published self-hosted runner release](https://github.com/actions/runner/releases/tag/v2.334.0). Both the runner container and the \`init-dind-externals\` initContainer use the same pin so the externals copied at init time match what the runner expects.

Bumps \`kbve.com/restart-trigger\` so ArgoCD rolls the runner pods after sync.

## Effect after merge
1. ArgoCD syncs \`arc-runners\` app → values.yaml updates the gha-runner-scale-set
2. The annotation change forces existing runner pods to roll
3. New pods come up on \`actions-runner:2.334.0\`

## Test plan
- [x] kubectl apply --dry-run=client locally accepts the manifest
- [ ] Post-merge: \`kubectl -n arc-runners get pods -o jsonpath='{.items[*].spec.containers[?(@.name=="runner")].image}'\` returns \`ghcr.io/actions/actions-runner:2.334.0\`
- [ ] Next CI workflow on \`arc-runner-set\` runs cleanly on the new image