### PR TITLE
fix(arc-runner,dind): drop subPath — overlay2 fails on subPath bind mount

### DIFF
--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -31,7 +31,7 @@ maxRunners: 10
 template:
     metadata:
         annotations:
-            kbve.com/restart-trigger: '20260502-dind-subpath-fix'
+            kbve.com/restart-trigger: '20260502-dind-no-subpath'
     spec:
         # Init container to copy externals for DinD
         initContainers:
@@ -120,7 +120,6 @@ template:
                     mountPath: /home/runner/_cache
                   - name: dind-storage
                     mountPath: /var/lib/docker
-                    subPath: docker
         volumes:
             - name: work
               emptyDir: {}


### PR DESCRIPTION
## Summary

Unblocks ci-unity. After the previous subPath fix landed, runner pods rolled onto the new dind config but dockerd now fails to start with:

```
failed to mount overlay: invalid argument  storage-driver=overlay2
failed to start daemon: error initializing graphdriver: driver not supported: overlay2
```

The `subPath` addition turns the volume mount into a kubelet-managed bind mount, and overlay2's overlayfs syscall returns `-EINVAL` when the lower/upper/work dirs sit on that bind mount in this Talos + Longhorn iSCSI + ext4 combination.

UE runner ([values-ue.yaml](apps/kube/github/runners/manifests/values-ue.yaml)) has been running the same dind pattern without subPath for months and works fine. Match that pattern.

Keeps the explicit `--data-root`, `--storage-driver=overlay2`, and the pre-exec mkdir/ls diagnostics — those proved load-bearing for triaging this exact failure and stay cheap.

## Test plan

- [ ] Argo reconciles new RESTART_TRIGGER `20260502-dind-no-subpath`
- [ ] Helm release rolls runner pods onto new claim layout
- [ ] `kubectl logs -n arc-runners <newest-pod> -c dind --tail=20` shows clean dockerd boot (no overlay2 error, API listen on /var/run/docker.sock + tcp://0.0.0.0:2376)
- [ ] Re-run ci-unity workflow → all 5 matrix jobs reach Build with Unity step + complete