### PR TITLE
chore(kasm,firecracker): bump gluetun + align firecracker-ctl + trim chatty comments

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -29,9 +29,6 @@ spec:
             nodeSelector:
                 kvm: 'true'
             automountServiceAccountToken: false
-            # Wait for the rootfs init job (PostSync hook) to populate
-            # vmlinux + rootfs images before the main container starts.
-            # Matches the firecracker-ctl deployment pattern.
             initContainers:
                 - name: wait-rootfs
                   image: busybox:1.37
@@ -62,21 +59,16 @@ spec:
                           cpu: 100m
                           memory: 32Mi
             containers:
-                # ── Gluetun VPN sidecar ──
-                # Establishes WireGuard tunnel. firecracker-ctl shares this
-                # network namespace, so all VM traffic routes through the VPN.
                 - name: gluetun
-                  image: ghcr.io/qdm12/gluetun:v3.40.0
+                  image: ghcr.io/qdm12/gluetun:v3.41.1
                   securityContext:
                       capabilities:
                           add:
                               - NET_ADMIN
                   ports:
-                      # Expose firecracker-ctl API through Gluetun's network stack
                       - name: api
                         containerPort: 9001
                         protocol: TCP
-                      # Gluetun health/control API
                       - name: gluetun-http
                         containerPort: 9999
                         protocol: TCP
@@ -88,18 +80,15 @@ spec:
                         value: '24h'
                       - name: TZ
                         value: 'UTC'
-                      # Firewall — allow firecracker-ctl API port + health
                       - name: FIREWALL_INPUT_PORTS
                         value: '9001,9999'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
-                      # Disable DNS-over-TLS (port 853 blocked through tunnel,
-                      # same issue as KASM — causes health check failures)
+                      # DoT off — port 853 blocked through tunnel.
                       - name: DOT
                         value: 'off'
                       - name: DNS_ADDRESS
                         value: '1.1.1.1'
-                      # Give tunnel time to stabilize before health check
                       - name: HEALTH_VPN_DURATION_INITIAL
                         value: '30s'
                       - name: HEALTH_SERVER_ADDRESS
@@ -127,9 +116,8 @@ spec:
                           cpu: 500m
                           memory: 384Mi
 
-                # ── firecracker-ctl (shares Gluetun's network namespace) ──
                 - name: firecracker-ctl
-                  image: ghcr.io/kbve/firecracker-ctl:0.1.27
+                  image: ghcr.io/kbve/firecracker-ctl:0.1.28
                   resources:
                       requests:
                           cpu: 250m
@@ -146,12 +134,8 @@ spec:
                         value: '10001'
                       - name: FC_JAILER_GID
                         value: '10001'
-                      # Different port? No — Gluetun already firewalls 9001
-                      # and this container doesn't own its own net namespace.
-                      # Listen on 9001 (same as default) through Gluetun.
                   securityContext:
-                      # Same seccomp exception as the non-network deployment
-                      # (jailer pivot_root requirement — see firecracker-deployment.yaml)
+                      # jailer pivot_root requires Unconfined seccomp.
                       seccompProfile:
                           type: Unconfined
                       readOnlyRootFilesystem: true
@@ -177,10 +161,7 @@ spec:
                         mountPath: /var/lib/firecracker/scratch
                       - name: tmp
                         mountPath: /tmp
-                  # No liveness/readiness probes on this container —
-                  # the probe port 9001 is owned by Gluetun (shared netns)
-                  # and we can't distinguish which container responds.
-                  # Gluetun's own health check covers the pod.
+                  # No probes — port 9001 is owned by Gluetun (shared netns).
             volumes:
                 - name: rootfs-cache
                   persistentVolumeClaim:

--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -23,8 +23,7 @@ spec:
                 app.kubernetes.io/part-of: kasm
                 app.kubernetes.io/component: workspace
         spec:
-            # KASM workspace runs as uid 1000 (kasm-user).
-            # fsGroup ensures the PVC is group-writable.
+            # kasm-user is uid 1000 — fsGroup makes the PVC group-writable.
             securityContext:
                 fsGroup: 1000
             initContainers:
@@ -35,20 +34,16 @@ spec:
                       - name: discord-profile
                         mountPath: /home/kasm-user
             containers:
-                # ── Gluetun VPN sidecar ──
-                # Establishes WireGuard tunnel. KASM container routes through it.
                 - name: gluetun
-                  image: ghcr.io/qdm12/gluetun:v3.40.0
+                  image: ghcr.io/qdm12/gluetun:v3.41.1
                   securityContext:
                       capabilities:
                           add:
                               - NET_ADMIN
                   ports:
-                      # KASM web port exposed through Gluetun's network stack
                       - name: kasm-web
                         containerPort: 6901
                         protocol: TCP
-                      # Gluetun health/control API
                       - name: gluetun-http
                         containerPort: 8000
                         protocol: TCP
@@ -56,34 +51,27 @@ spec:
                       - secretRef:
                             name: vpn-wireguard
                   env:
-                      # Gluetun-specific settings
                       - name: UPDATER_PERIOD
                         value: '24h'
                       - name: TZ
                         value: 'UTC'
-                      # HTTP proxy for containers sharing the network
                       - name: HTTPPROXY
                         value: 'on'
                       - name: HTTPPROXY_LOG
                         value: 'off'
-                      # Firewall — allow KASM port + health check port + DNS
                       - name: FIREWALL_INPUT_PORTS
                         value: '6901,9999'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
-                      # Disable DNS-over-TLS — port 853 is blocked
-                      # through the WireGuard tunnel, causing gluetun's
-                      # internal healthcheck to fail every 6s.
+                      # DoT off — port 853 is blocked through the tunnel
+                      # and gluetun's internal healthcheck fails every 6s
+                      # if it tries to use it.
                       - name: DOT
                         value: 'off'
-                      # Use plaintext DNS through the tunnel instead
                       - name: DNS_ADDRESS
                         value: '1.1.1.1'
-                      # Give VPN tunnel time to stabilize before
-                      # gluetun's internal healthcheck starts checking
                       - name: HEALTH_VPN_DURATION_INITIAL
                         value: '30s'
-                      # Health check server
                       - name: HEALTH_SERVER_ADDRESS
                         value: '0.0.0.0:9999'
                   livenessProbe:
@@ -109,9 +97,6 @@ spec:
                           memory: '384Mi'
                           cpu: '500m'
 
-                # ── KASM Discord workspace ──
-                # Uses Gluetun's network namespace — all traffic exits via VPN.
-                # Browser profile persisted via PVC so Discord session survives restarts.
                 - name: workspace
                   image: kasmweb/discord:1.18.0-rolling-daily
                   env:
@@ -122,7 +107,6 @@ spec:
                   volumeMounts:
                       - name: discord-profile
                         mountPath: /home/kasm-user
-                  # Network shared with gluetun — no ports needed here
                   resources:
                       requests:
                           memory: '1Gi'


### PR DESCRIPTION
## Summary
Image pins:
- \`ghcr.io/qdm12/gluetun\` v3.40.0 → **v3.41.1** (kasm + firecracker-net)
- \`ghcr.io/kbve/firecracker-ctl\` 0.1.27 → **0.1.28** in firecracker-net-deployment (was a patch behind firecracker-deployment)

\`busybox:1.37\` and \`kasmweb/discord:1.18.0-rolling-daily\` left as-is — \`1.37\` is current stable, \`rolling-daily\` is intentional for daily security updates.

Also trims a batch of inline yaml comments that just restated what the keys already say (port descriptions, "section divider" headers, \"firewall — allow X port\" comments). Kept the comments that capture *why* — DoT off, jailer pivot_root seccomp, no probes on the shared netns container.

## Effect after merge
ArgoCD syncs:
- \`kasm\` app rolls \`kasm-vpn\` Deployment with new gluetun
- \`firecracker-ctl\` app rolls \`firecracker-ctl-net\` Deployment with new gluetun + aligned firecracker-ctl
- \`firecracker-ctl\` (no-network) is unchanged

## Test plan
- [x] \`kubectl apply --dry-run=server\` accepts both manifests
- [ ] After merge: pod images report v3.41.1 + 0.1.28
- [ ] Gluetun health server stays green on the rolled pods