### PR TITLE
chore(bevy_battle): seed version.toml to 0.0.1 for first publish

### DIFF
--- a/packages/rust/bevy/bevy_battle/version.toml
+++ b/packages/rust/bevy/bevy_battle/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.0"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
## Summary
- Seed \`bevy_battle/version.toml\` to \`0.0.1\` so the ci-publish gate stops short-circuiting on the \`0.0.0\` sentinel.
- L0 deps (\`bevy_behavior\`) now live on crates.io at \`0.1.0\` — bevy_battle's \`cargo publish\` resolves cleanly (verified via \`cargo publish --dry-run\`).
- Unblocks the L1 step in the L0 → L1 → uniti chain. Uniti (L2) follows once bevy_battle lands.

## Test plan
- [ ] CI dispatches \`bevy_battle\` for first publish on merge
- [ ] Post-publish sync PR opens, bumping version.toml to \`0.1.0\`
- [ ] crates.io shows \`bevy_battle\` at \`0.1.0\`