### PR TITLE
fix(arc-runner): skip Playwright e2e — base image has no UI to test

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -23,7 +23,7 @@
 			"source_path": "packages/docker/arc-runner",
 			"runner": "ubuntu-latest",
 			"image": "kbve/arc-runner",
-			"has_test": true
+			"has_test": false
 		},
 		{
 			"key": "aria2_proxy",

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -17,7 +17,7 @@ source_path: packages/docker/arc-runner
 version_toml: packages/docker/arc-runner/version.toml
 runner: ubuntu-latest
 image: kbve/arc-runner
-has_test: true
+has_test: false
 author: h0lybyte
 license: KBVE
 status: active


### PR DESCRIPTION
## Summary
Resolves #10402.

\`ci-docker.yml\`'s test job dispatches \`docker-test-app.yml\` whenever the manifest entry has \`has_test: true\`, which spins up Playwright on ubuntu-latest. The arc-runner image is a base GitHub Actions Runner — there's no UI to exercise, and the ubuntu-latest host is missing the libraries Playwright wants:

\`\`\`
Host system is missing dependencies to run browsers.
Missing libraries:
    libgtk-4.so.1
    libgraphene-1.0.so.0
    libevent-2.1.so.7
    libopus.so.0
    ...
\`\`\`

Run: [#25261573591](https://github.com/KBVE/kbve/actions/runs/25261573591).

## Change
- mdx \`has_test: true\` → \`has_test: false\` (matches chisel-ubuntu-axum / steamcmd-ubuntu — both base images, neither runs e2e).
- Manifest regenerated (mostly prettier whitespace reflow + the \`arc_runner.has_test\` flip).

The image still has its own smoke test in [packages/docker/arc-runner/project.json](packages/docker/arc-runner/project.json) — boots the container and asserts \`git-lfs\`, \`jq\`, \`unzip\`, \`xz\`, \`gh\` are on PATH. Devs run \`./kbve.sh -nx arc-runner:test\` locally; CI publishes the image without an e2e gate.

## Effect after merge
- ci-main re-dispatches arc-runner → ci-docker skips the failing test step → publish succeeds → \`ghcr.io/kbve/arc-runner:0.1.1\` lands on ghcr.

Refs #10329.