### PR TITLE
fix(ci): run external_publish modrinth inside :gradle pre-warmed image

### DIFF
--- a/.github/workflows/utils-external-publish.yml
+++ b/.github/workflows/utils-external-publish.yml
@@ -43,18 +43,24 @@ jobs:
             fromJson(inputs.external_publish).modrinth_mod_id != '' ||
             fromJson(inputs.external_publish).modrinth_pack_id != ''
         runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/kbve/mc:gradle
+            env:
+                GRADLE_USER_HOME: /home/gradle/.gradle
         timeout-minutes: 25
         permissions:
             contents: read
         steps:
+            - name: Install runtime dependencies (curl, jq, zip)
+              run: |
+                  set -euo pipefail
+                  if ! command -v jq >/dev/null 2>&1 || ! command -v zip >/dev/null 2>&1; then
+                    apt-get update -qq
+                    apt-get install -y --no-install-recommends curl jq zip
+                  fi
+
             - name: Checkout
               uses: actions/checkout@v6
-
-            - name: Set up JDK 21
-              uses: actions/setup-java@v5
-              with:
-                  distribution: temurin
-                  java-version: '21'
 
             - name: Resolve external_publish fields
               id: ep
@@ -86,7 +92,7 @@ jobs:
             - name: Build Fabric mod JAR
               run: |
                   cd "${{ inputs.source_path }}/behavior_statetree/java"
-                  ./gradlew build --no-daemon
+                  gradle build --no-daemon
 
             - name: Locate built JAR
               id: jar


### PR DESCRIPTION
## Summary
\`utils-external-publish.yml\` modrinth job moves from bare \`ubuntu-latest\` + fresh JDK to \`ghcr.io/kbve/mc:gradle\` (the same pre-warmed Loom image \`ci-mc-gradle-cache.yml\` already publishes). All Fabric Loom transitive deps — Minecraft jars, Yarn mappings, Fabric API/Loader, Mercury, cadixdev — live in \`/home/gradle/.gradle/caches\` inside the image, so the build is offline-friendly and survives Maven Central 403s.

## Changes
- \`container.image: ghcr.io/kbve/mc:gradle\`
- \`container.env.GRADLE_USER_HOME: /home/gradle/.gradle\` (root user → warm cache)
- Drop \`actions/setup-java@v5\` (JDK 21 in image)
- \`apt-get install -y curl jq zip\` at job start (\`gradle:jdk21\` base lacks them; needed for Modrinth API + \`build-mrpack.sh\`)
- \`gradle build --no-daemon\` instead of \`./gradlew build --no-daemon\` so the version matches the cache

## Test plan
- [ ] Trigger next mc Docker publish (or workflow_dispatch ci-docker app=mc)
- [ ] modrinth job logs show \`Container: ghcr.io/kbve/mc:gradle\`
- [ ] Build Fabric mod JAR step finishes in seconds, no Maven Central network calls
- [ ] No regression: jar uploads + mrpack rolling slot replacement both succeed