### PR TITLE
fix(ci): supply data field on Modrinth addfilestoversion POST

### DIFF
--- a/.github/workflows/utils-external-publish.yml
+++ b/.github/workflows/utils-external-publish.yml
@@ -145,9 +145,11 @@ jobs:
                       "https://api.modrinth.com/v2/version/$EXISTING" \
                       | jq -r '.files[].hashes.sha1')
 
+                    printf '{"file_parts":["jar"]}' > /tmp/jar-add-data.json
                     HTTP_CODE=$(curl -sSL -o /tmp/jar-add.json -w '%{http_code}' \
                       -X POST "https://api.modrinth.com/v2/version/$EXISTING/file" \
                       -H "Authorization: $MODRINTH_TOKEN" \
+                      -F "data=@/tmp/jar-add-data.json;type=application/json" \
                       -F "jar=@$JAR_PATH;type=application/java-archive")
                     if [ "$HTTP_CODE" != "204" ] && [ "$HTTP_CODE" != "200" ]; then
                       echo "::error::Modrinth JAR add-to-version failed (HTTP $HTTP_CODE)"
@@ -267,9 +269,11 @@ jobs:
                       "https://api.modrinth.com/v2/version/$EXISTING" \
                       | jq -r '.files[].hashes.sha1')
 
+                    printf '{"file_parts":["mrpack"]}' > /tmp/mrpack-add-data.json
                     HTTP_CODE=$(curl -sSL -o /tmp/mrpack-add.json -w '%{http_code}' \
                       -X POST "https://api.modrinth.com/v2/version/$EXISTING/file" \
                       -H "Authorization: $MODRINTH_TOKEN" \
+                      -F "data=@/tmp/mrpack-add-data.json;type=application/json" \
                       -F "mrpack=@$MRPACK_PATH;type=application/x-modrinth-modpack+zip")
                     if [ "$HTTP_CODE" != "204" ] && [ "$HTTP_CODE" != "200" ]; then
                       echo "::error::Modrinth mrpack add-to-version failed (HTTP $HTTP_CODE)"


### PR DESCRIPTION
## Summary
Modrinth's \`POST /v2/version/{id}/file\` requires a \`data\` JSON multipart part **before** the file part. Without it the API returns:

\`\`\`
HTTP 400 invalid_input
Error with multipart data: \`data\` field must come before file fields
\`\`\`

Both the JAR and mrpack rolling-mode replace paths in \`utils-external-publish.yml\` now write a small \`file_parts\` JSON to \`/tmp\` and include it as \`-F "data=@..."\` ahead of the file part.

- JAR: \`{"file_parts":["jar"]}\`
- mrpack: \`{"file_parts":["mrpack"]}\`

Same shape as the existing per-version create POST on \`/v2/version\`.

This was committed to the previous PR's branch after merge (orphaned commit on \`trunk/mc-gradle-image-*\`), now cleanly cherry-picked onto a fresh branch.

## Test plan
- [ ] Trigger next mc Docker publish
- [ ] modrinth job completes Rolling JAR mode replace step (no HTTP 400)
- [ ] Rolling mrpack mode replace step also passes
- [ ] PATCH version_number to current semver succeeds, rolling slot displayed as e.g. v1.0.32