### PR TITLE
fix(ci): force bash shell on external_publish modrinth container job

### DIFF
--- a/.github/workflows/utils-external-publish.yml
+++ b/.github/workflows/utils-external-publish.yml
@@ -50,6 +50,9 @@ jobs:
         timeout-minutes: 25
         permissions:
             contents: read
+        defaults:
+            run:
+                shell: bash
         steps:
             - name: Install runtime dependencies (curl, jq, zip)
               run: |


### PR DESCRIPTION
## Summary
\`ghcr.io/kbve/mc:gradle\` (debian-based \`gradle:jdk21\`) defaults \`/bin/sh\` to dash. GitHub Actions falls back to \`shell: sh -e {0}\` for steps inside container jobs without an explicit shell, and dash rejects \`set -o pipefail\`:

\`\`\`
/__w/_temp/...sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2.
\`\`\`

Every \`run:\` block in this job opens with \`set -euo pipefail\`, so they all crash on the first line.

Fix: \`defaults.run.shell: bash\` on the modrinth job. \`bash\` is already in the image, just selects the right interpreter.

## Test plan
- [ ] Trigger next mc Docker publish (or re-run failed run 25278900175)
- [ ] Install runtime dependencies step doesn't error on \`set -o pipefail\`
- [ ] Job proceeds to gradle build + Modrinth API calls