### PR TITLE
test(arc-runner): e2e harness + canary scale-set (Phase 1)

### DIFF
--- a/apps/kube/github/runners/application.yaml
+++ b/apps/kube/github/runners/application.yaml
@@ -16,6 +16,18 @@ spec:
               releaseName: arc-runner-set
               valueFiles:
                   - $values/apps/kube/github/runners/manifests/values.yaml
+        # Helm chart for the KBVE custom-image canary scale set.
+        # Same DinD config as arc-runner-set, but the runner container
+        # is ghcr.io/kbve/arc-runner. Workflows opt in via
+        # `runs-on: arc-runner-set-kbve`. Retires once values.yaml is
+        # flipped to the kbve image (#10329).
+        - repoURL: ghcr.io/actions/actions-runner-controller-charts
+          targetRevision: 0.9.3
+          chart: gha-runner-scale-set
+          helm:
+              releaseName: arc-runner-set-kbve
+              valueFiles:
+                  - $values/apps/kube/github/runners/manifests/values-kbve.yaml
         # Helm chart for the Unreal Engine runner scale set (Linux)
         - repoURL: ghcr.io/actions/actions-runner-controller-charts
           targetRevision: 0.9.3

--- a/apps/kube/github/runners/manifests/values-kbve.yaml
+++ b/apps/kube/github/runners/manifests/values-kbve.yaml
@@ -1,0 +1,143 @@
+# ARC Runner Scale Set — KBVE custom-image canary.
+#
+# Mirrors values.yaml but points the runner + init container at
+# ghcr.io/kbve/arc-runner (built from packages/docker/arc-runner/).
+# That image bakes in git-lfs, unzip, jq, xz-utils, gh + the sudoers
+# tweak, so workflows targeting `runs-on: arc-runner-set-kbve` skip
+# the per-job apt-get install steps.
+#
+# Phased rollout — see https://github.com/KBVE/kbve/issues/10329:
+#   1. This scale-set deploys idle alongside the upstream
+#      arc-runner-set. No workflow targets it yet.
+#   2. One workflow at a time gets flipped from
+#      `runs-on: arc-runner-set` to `runs-on: arc-runner-set-kbve`,
+#      starting with the cheapest jobs.
+#   3. Once every workflow has been validated on the new image, the
+#      main values.yaml flips its image too and this canary retires.
+#   4. apt-get install band-aids in ci-unity.yml etc. get stripped.
+
+runnerScaleSetName: 'arc-runner-set-kbve'
+githubConfigUrl: 'https://github.com/kbve'
+githubConfigSecret: github-arc-token
+
+controllerServiceAccount:
+    name: arc-controller
+    namespace: arc-systems
+
+# Canary capacity — keep low until workflows are migrated. Bump
+# in step with traffic as the upstream arc-runner-set drains.
+minRunners: 0
+maxRunners: 3
+
+template:
+    metadata:
+        annotations:
+            kbve.com/restart-trigger: '20260504-canary-bootstrap'
+    spec:
+        initContainers:
+            - name: init-dind-externals
+              image: ghcr.io/kbve/arc-runner:0.1.1
+              command:
+                  [
+                      'cp',
+                      '-r',
+                      '-v',
+                      '/home/runner/externals/.',
+                      '/home/runner/tmpDir/',
+                  ]
+              volumeMounts:
+                  - name: dind-externals
+                    mountPath: /home/runner/tmpDir
+        containers:
+            - name: runner
+              image: ghcr.io/kbve/arc-runner:0.1.1
+              # No `command:` override — the image bakes in the
+              # sudoers entry, so the upstream entrypoint
+              # (/home/runner/run.sh) Just Works.
+              env:
+                  - name: DOCKER_HOST
+                    value: tcp://localhost:2376
+                  - name: RUNNER_ALLOW_RUNASROOT
+                    value: '1'
+              resources:
+                  limits:
+                      cpu: '12'
+                      memory: 24Gi
+                  requests:
+                      # Idle runners burn ~100m. Reserve 1 CPU so the
+                      # pod schedules; bursts hit the 12 CPU limit.
+                      cpu: '1'
+                      memory: 4Gi
+              securityContext:
+                  runAsUser: 0
+                  runAsGroup: 0
+              volumeMounts:
+                  - name: work
+                    mountPath: /home/runner/_work
+                  - name: dind-sock
+                    mountPath: /var/run
+                  - name: dind-externals
+                    mountPath: /home/runner/externals
+                  - name: runner-cache
+                    mountPath: /home/runner/_cache
+            - name: dind
+              image: docker:29.3.0-dind
+              # See values.yaml dind block for the full rationale on
+              # ulimit nofile + containerd-snapshotter=false. Keeping
+              # it identical means the canary fails the same way as
+              # the upstream pool if a Docker quirk reappears.
+              command: ['sh', '-c']
+              args:
+                  - 'ulimit -n 1048576 && mkdir -p /var/lib/docker && echo "dind starting; data-root contents:" && ls -la /var/lib/docker && exec dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376 --tls=false --default-ulimit=nofile=1048576:1048576 --feature=containerd-snapshotter=false --registry-mirror=http://registry-mirror.arc-runners.svc.cluster.local:5000 --insecure-registry=registry-mirror.arc-runners.svc.cluster.local:5000'
+              securityContext:
+                  privileged: true
+              resources:
+                  limits:
+                      cpu: '12'
+                      memory: 32Gi
+                  requests:
+                      cpu: 500m
+                      memory: 2Gi
+              volumeMounts:
+                  - name: work
+                    mountPath: /home/runner/_work
+                  - name: dind-sock
+                    mountPath: /var/run
+                  - name: dind-externals
+                    mountPath: /home/runner/externals
+                  - name: runner-cache
+                    mountPath: /home/runner/_cache
+                  - name: dind-storage
+                    mountPath: /var/lib/docker
+        volumes:
+            - name: work
+              emptyDir: {}
+            - name: dind-sock
+              emptyDir: {}
+            - name: dind-externals
+              emptyDir: {}
+            - name: dind-storage
+              emptyDir:
+                  sizeLimit: 100Gi
+            - name: runner-cache
+              persistentVolumeClaim:
+                  claimName: arc-runner-cache-sdb
+
+listenerTemplate:
+    spec:
+        containers:
+            - name: listener
+              resources:
+                  limits:
+                      cpu: 250m
+                      memory: 256Mi
+                  requests:
+                      cpu: 50m
+                      memory: 64Mi
+              securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  capabilities:
+                      drop:
+                          - ALL

--- a/packages/docker/arc-runner-e2e/e2e/helpers/docker.ts
+++ b/packages/docker/arc-runner-e2e/e2e/helpers/docker.ts
@@ -1,0 +1,43 @@
+import { execSync } from 'node:child_process';
+
+export const RUNNER_CONTAINER = 'arc-runner-e2e';
+export const DIND_CONTAINER = 'arc-runner-e2e-dind';
+export const IMAGE_NAME = 'kbve/arc-runner:latest';
+
+/**
+ * Run a command inside the runner container, returning trimmed stdout.
+ * Throws on non-zero exit.
+ */
+export function dockerExec(cmd: string, container = RUNNER_CONTAINER): string {
+	return execSync(`docker exec ${container} ${cmd}`, {
+		encoding: 'utf-8',
+		timeout: 30_000,
+	}).trim();
+}
+
+/**
+ * Same as dockerExec but never throws — surfaces exit code + streams.
+ */
+export function dockerExecSafe(
+	cmd: string,
+	container = RUNNER_CONTAINER,
+): { exitCode: number; stdout: string; stderr: string } {
+	try {
+		const stdout = execSync(`docker exec ${container} ${cmd}`, {
+			encoding: 'utf-8',
+			timeout: 30_000,
+		}).trim();
+		return { exitCode: 0, stdout, stderr: '' };
+	} catch (e: unknown) {
+		const err = e as {
+			status?: number;
+			stdout?: string;
+			stderr?: string;
+		};
+		return {
+			exitCode: err.status ?? 1,
+			stdout: (err.stdout ?? '').toString().trim(),
+			stderr: (err.stderr ?? '').toString().trim(),
+		};
+	}
+}

--- a/packages/docker/arc-runner-e2e/e2e/image.spec.ts
+++ b/packages/docker/arc-runner-e2e/e2e/image.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { dockerExec, dockerExecSafe } from './helpers/docker';
+
+describe('arc-runner image — baked-in tools', () => {
+	it('git-lfs is on PATH and reports a version', () => {
+		const out = dockerExec("bash -lc 'git-lfs --version'");
+		expect(out).toMatch(/^git-lfs\//);
+	});
+
+	it('git-lfs install --system was applied at build time', () => {
+		// `git-lfs install --system` writes the smudge filter into
+		// /etc/gitconfig — confirms the Dockerfile actually ran it.
+		const out = dockerExec(
+			"bash -lc 'git config --system --get filter.lfs.smudge'",
+		);
+		expect(out).toContain('git-lfs');
+	});
+
+	it('jq runs and parses JSON', () => {
+		const out = dockerExec(
+			`bash -lc "echo '{\\"k\\":\\"v\\"}' | jq -r .k"`,
+		);
+		expect(out).toBe('v');
+	});
+
+	it('unzip is on PATH', () => {
+		const out = dockerExec("bash -lc 'unzip -v | head -1'");
+		expect(out).toMatch(/UnZip/);
+	});
+
+	it('xz is on PATH', () => {
+		const out = dockerExec("bash -lc 'xz --version | head -1'");
+		expect(out).toMatch(/xz \(XZ Utils\)/);
+	});
+
+	it('gh CLI is on PATH', () => {
+		const out = dockerExec("bash -lc 'gh --version | head -1'");
+		expect(out).toMatch(/^gh version/);
+	});
+
+	it('xz extracts a tar.xz archive end-to-end', () => {
+		// Confirms xz is functional, not just present — Unity / butler
+		// installers ship .tar.xz, so failing this means matrix legs
+		// would die mid-extract even though `xz --version` worked.
+		const out = dockerExec(
+			`bash -lc "cd /tmp && echo hello > probe.txt && tar -cJf probe.tar.xz probe.txt && rm probe.txt && tar -xJf probe.tar.xz && cat probe.txt"`,
+		);
+		expect(out).toBe('hello');
+	});
+});
+
+describe('arc-runner image — runtime layout', () => {
+	it('upstream actions-runner entrypoint is present', () => {
+		// /home/runner/run.sh is the upstream entrypoint the K8s pod
+		// command falls through to — must survive our layered RUN.
+		const result = dockerExecSafe(
+			"bash -lc 'test -x /home/runner/run.sh && echo present'",
+		);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toBe('present');
+	});
+
+	it('externals/ directory is intact for init-dind-externals copy', () => {
+		// init container does `cp -r /home/runner/externals/. /tmpDir/`
+		// — empty externals would silently no-op and break DinD net.
+		const out = dockerExec("bash -lc 'ls /home/runner/externals | wc -l'");
+		expect(Number.parseInt(out, 10)).toBeGreaterThan(0);
+	});
+
+	it('runner unix user exists with uid/gid 1001', () => {
+		const out = dockerExec("bash -lc 'id runner'");
+		expect(out).toMatch(/uid=1001/);
+		expect(out).toMatch(/gid=\d+\(docker\)|gid=1001/);
+	});
+
+	it('sudoers entry baked in lets root sudo without password', () => {
+		// We're already running as root; the test is that the line
+		// landed in /etc/sudoers, so the K8s pod can drop its
+		// `command:` override that injects the same line at runtime.
+		const out = dockerExec(
+			'bash -lc \'grep "^root ALL=(ALL) NOPASSWD:ALL" /etc/sudoers\'',
+		);
+		expect(out).toContain('NOPASSWD:ALL');
+	});
+});

--- a/packages/docker/arc-runner-e2e/e2e/integration.spec.ts
+++ b/packages/docker/arc-runner-e2e/e2e/integration.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import { DIND_CONTAINER, RUNNER_CONTAINER } from './helpers/docker';
+
+// Integration tests exercise the runner ↔ DinD wiring used in the
+// gha-runner-scale-set pod spec. Both services share the runner's
+// network namespace via compose `network_mode: service:runner`, so
+// the runner reaches dockerd at localhost:2376 (the same address the
+// DOCKER_HOST env var advertises in production).
+
+describe('arc-runner ↔ DinD shared netns', () => {
+	it('dind container is up', () => {
+		const out = execSync(
+			`docker inspect -f '{{.State.Running}}' ${DIND_CONTAINER}`,
+			{
+				encoding: 'utf-8',
+			},
+		).trim();
+		expect(out).toBe('true');
+	});
+
+	it('dockerd accepts TCP connections on localhost:2376 from inside the runner', () => {
+		// Runner's DOCKER_HOST is `tcp://localhost:2376`. If this curl
+		// fails the production runner container would also fail to
+		// talk to its sidecar.
+		const out = execSync(
+			`docker exec ${RUNNER_CONTAINER} bash -lc "curl -sf http://localhost:2376/_ping"`,
+			{ encoding: 'utf-8' },
+		).trim();
+		expect(out).toBe('OK');
+	});
+
+	it('runner can list dockerd images via DOCKER_HOST', () => {
+		// Tools the workflow runs (e.g. `docker pull`, `game-ci`) all
+		// hit dockerd through the same TCP endpoint. A successful
+		// `docker info` call is the smallest version of that flow.
+		const out = execSync(
+			`docker exec -e DOCKER_HOST=tcp://localhost:2376 ${RUNNER_CONTAINER} bash -lc "apt-get install -y --no-install-recommends docker.io-cli >/dev/null 2>&1 || true; docker --host=tcp://localhost:2376 info --format '{{.ServerVersion}}'"`,
+			{ encoding: 'utf-8' },
+		).trim();
+		// 29.x = the production sidecar pin (docker:29.3.0-dind).
+		expect(out).toMatch(/^29\./);
+	});
+});

--- a/packages/docker/arc-runner-e2e/package.json
+++ b/packages/docker/arc-runner-e2e/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "arc-runner-e2e",
+	"private": true,
+	"version": "0.0.0"
+}

--- a/packages/docker/arc-runner-e2e/project.json
+++ b/packages/docker/arc-runner-e2e/project.json
@@ -1,0 +1,31 @@
+{
+	"name": "arc-runner-e2e",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "packages/docker/arc-runner-e2e/e2e",
+	"implicitDependencies": ["arc-runner"],
+	"targets": {
+		"test": {
+			"executor": "nx:noop",
+			"cache": false
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker compose -f packages/docker/arc-runner/arc-runner-e2e-compose.yaml -p arc-runner-e2e down -v --remove-orphans 2>/dev/null || true",
+					"docker buildx build --platform linux/amd64 -f packages/docker/arc-runner/Dockerfile -t kbve/arc-runner:latest --load packages/docker/arc-runner/",
+					"docker compose -f packages/docker/arc-runner/arc-runner-e2e-compose.yaml -p arc-runner-e2e up -d",
+					"echo 'Waiting for dockerd...' && for i in $(seq 1 60); do if docker exec arc-runner-e2e bash -lc 'curl -sf http://localhost:2376/_ping >/dev/null'; then echo 'dockerd ready after '\"$i\"'s'; break; fi; if [ $i -eq 60 ]; then echo 'dockerd did not become ready'; docker logs arc-runner-e2e-dind 2>&1 | tail -30; docker compose -f packages/docker/arc-runner/arc-runner-e2e-compose.yaml -p arc-runner-e2e down -v --remove-orphans; exit 1; fi; sleep 1; done",
+					"cd packages/docker/arc-runner-e2e && npx vitest run; EC=$?; cd - >/dev/null && docker compose -f packages/docker/arc-runner/arc-runner-e2e-compose.yaml -p arc-runner-e2e down -v --remove-orphans 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false
+			},
+			"configurations": {
+				"ci": {}
+			}
+		}
+	},
+	"tags": ["scope:docker", "arc-runner", "e2e"]
+}

--- a/packages/docker/arc-runner-e2e/tsconfig.json
+++ b/packages/docker/arc-runner-e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"types": ["node", "vitest/globals"]
+	},
+	"include": ["e2e/**/*.ts", "vitest.config.ts"]
+}

--- a/packages/docker/arc-runner-e2e/vitest.config.ts
+++ b/packages/docker/arc-runner-e2e/vitest.config.ts
@@ -1,0 +1,15 @@
+export default {
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 60_000,
+		hookTimeout: 120_000,
+		fileParallelism: false,
+		pool: 'threads',
+		poolOptions: {
+			threads: {
+				minThreads: 1,
+				maxThreads: 1,
+			},
+		},
+	},
+};

--- a/packages/docker/arc-runner/arc-runner-e2e-compose.yaml
+++ b/packages/docker/arc-runner/arc-runner-e2e-compose.yaml
@@ -1,0 +1,54 @@
+# ============================================================================
+# arc-runner — e2e docker-compose stack.
+#
+# Mirrors the in-cluster ARC runner pod layout (runner + DinD sidecar
+# sharing a network namespace) so tests exercise the same wiring used
+# by the gha-runner-scale-set chart.
+#
+# Usage from repo root:
+#   docker compose -f packages/docker/arc-runner/arc-runner-e2e-compose.yaml up -d
+#   # ... run vitest assertions inside the runner container ...
+#   docker compose -f packages/docker/arc-runner/arc-runner-e2e-compose.yaml down -v
+#
+# Or via nx:
+#   ./kbve.sh -nx arc-runner-e2e:e2e
+# ============================================================================
+
+services:
+    runner:
+        image: kbve/arc-runner:latest
+        container_name: arc-runner-e2e
+        # Long-lived sleep so vitest can exec assertions against the
+        # baked-in tools without the upstream `run.sh` trying to
+        # register the runner against GitHub.
+        entrypoint: ['/bin/bash', '-c', 'sleep infinity']
+        environment:
+            DOCKER_HOST: tcp://localhost:2376
+            RUNNER_ALLOW_RUNASROOT: '1'
+        # Match the pod's runAsUser: 0 / runAsGroup: 0 securityContext
+        # so the sudoers entry baked into the image takes effect.
+        user: '0:0'
+
+    dind:
+        image: docker:29.3.0-dind
+        container_name: arc-runner-e2e-dind
+        privileged: true
+        # Share the runner's network namespace — same as the K8s pod
+        # spec, so `localhost:2376` from inside the runner reaches
+        # this dockerd. Means `network_mode` only takes effect once
+        # the runner container is already up.
+        network_mode: 'service:runner'
+        depends_on:
+            - runner
+        # Same dockerd flags as the production pod (containerd
+        # snapshotter off, larger ulimit, registry mirror dropped
+        # because the e2e host doesn't run the in-cluster mirror).
+        command:
+            - sh
+            - -c
+            - 'ulimit -n 1048576 && exec dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376 --tls=false --default-ulimit=nofile=1048576:1048576 --feature=containerd-snapshotter=false'
+        volumes:
+            - dind-storage:/var/lib/docker
+
+volumes:
+    dind-storage:


### PR DESCRIPTION
## Summary
Two related additions for the [arc-runner image rollout (#10329)](https://github.com/KBVE/kbve/issues/10329) on top of the just-published \`ghcr.io/kbve/arc-runner:0.1.1\`.

### 1. e2e harness for the image
- [\`packages/docker/arc-runner/arc-runner-e2e-compose.yaml\`](packages/docker/arc-runner/arc-runner-e2e-compose.yaml) — runner + docker:29.3.0-dind sidecar in a shared network namespace, identical layout to the gha-runner-scale-set pod spec.
- [\`packages/docker/arc-runner-e2e/\`](packages/docker/arc-runner-e2e/) — vitest project sibling of \`arc-runner\`. Two scopes:
  - \`image.spec.ts\` — git-lfs / jq / unzip / xz / gh on PATH, git-lfs --system filter applied, sudoers entry present, /home/runner/run.sh + externals/ intact, runner uid 1001.
  - \`integration.spec.ts\` — runner ↔ DinD wiring (dockerd reachable on TCP 2376, server version 29.x).

Local run: \`./kbve.sh -nx arc-runner-e2e:e2e\`.

CI plumbing for \`test_framework: typescript\` is a separate PR — the mdx flag isn't yet read by ci-docker.yml, so arc-runner's \`has_test\` stays \`false\` until that lands.

### 2. Canary scale set (Phase 1 of rollout)
- New file [\`values-kbve.yaml\`](apps/kube/github/runners/manifests/values-kbve.yaml) wired into [\`application.yaml\`](apps/kube/github/runners/application.yaml) as a second Helm release \`arc-runner-set-kbve\` next to the existing \`arc-runner-set\`.
- Pod spec mirrors the upstream pool except:
  - runner + init image → \`ghcr.io/kbve/arc-runner:0.1.1\`
  - \`runnerScaleSetName: arc-runner-set-kbve\`
  - \`maxRunners: 3\` (canary cap, vs 10 on the main pool)
  - Upstream pod's inline \`command:\` override is dropped — the image bakes the sudoers line, so \`/home/runner/run.sh\` takes over directly.

No workflow targets \`arc-runner-set-kbve\` yet, so this PR adds capacity without changing any traffic.

## Phased rollout (subsequent PRs)
1. **(this PR)** Stand up the canary alongside upstream.
2. Flip one low-risk workflow (\`ci-dbmate-validate\`) → \`runs-on: arc-runner-set-kbve\`, verify.
3. Migrate remaining workflows one at a time, \`ci-unity\` last.
4. Flip the main \`values.yaml\` to the kbve image, retire \`arc-runner-set-kbve\`.
5. Strip \`apt-get install git-lfs\` from \`ci-unity.yml\`.

## Test plan
- [x] e2e suite passes locally against the canary image
- [ ] After merge: \`kubectl -n arc-runners get pods -l app.kubernetes.io/instance=arc-runner-set-kbve\` shows the listener pod up
- [ ] Manually-dispatched test workflow targeting \`arc-runner-set-kbve\` completes without runtime apt-get installs

Refs #10329.