### PR TITLE
chore(arc-runner): bump mdx 0.1.1 → 0.1.2 to publish kubectl/dbmate tools

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.130",
+			"version": "1.0.131",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -17,7 +17,7 @@
 		{
 			"key": "arc_runner",
 			"app_name": "arc-runner",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"version_toml": "packages/docker/arc-runner/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx",
 			"source_path": "packages/docker/arc-runner",
@@ -197,7 +197,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.33",
+			"version": "1.0.35",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",
@@ -412,7 +412,7 @@
 		{
 			"key": "bevy_pathfinder_crate",
 			"package_name": "bevy_pathfinder",
-			"version": "0.0.0",
+			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_pathfinder/version.toml",
 			"version_source": "packages/rust/bevy/bevy_pathfinder/Cargo.toml",
 			"version_target": "packages/rust/bevy/bevy_pathfinder/Cargo.toml"

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -12,7 +12,7 @@ tags:
 key: arc_runner
 pipeline: docker
 app_name: arc-runner
-version: "0.1.1"
+version: "0.1.2"
 source_path: packages/docker/arc-runner
 version_toml: packages/docker/arc-runner/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary
[7beeef678](https://github.com/KBVE/kbve/commit/7beeef678) baked \`kubectl\`, \`dbmate\`, \`envsubst\`, and \`postgresql-client\` into the arc-runner Dockerfile but didn't bump the mdx version. ci-docker.yml's version_gate compares mdx vs version.toml and skips publish when they're equal, so the new layers never landed on \`ghcr.io/kbve/arc-runner\` — \`:0.1.1\` still ships the original tool set.

Bumping the mdx \`version:\` to \`0.1.2\` clears the gate. After merge:
1. ci-main → manifest dispatch fires ci-docker for arc-runner
2. version_gate sees mdx 0.1.2 > version.toml 0.1.1 → publishes
3. \`ghcr.io/kbve/arc-runner:0.1.2\` lands with the full tool set

Manifest regenerated to match.

## Follow-up
- Once \`:0.1.2\` is published, bump the canary scale-set's \`values-kbve.yaml\` image pin to use it (separate PR — gives us a clean rollback to \`:0.1.1\` if the new tools surface a regression).
- Then proceed with Phase 2 of the rollout (#10329) — opt one workflow into \`runs-on: arc-runner-set-kbve\`.

Refs #10329.