### PR TITLE
fix(mc): airship scale + smoother helm controls

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -48,8 +48,7 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
     private static final java.util.Set<String> MISSING_MODELS_LOGGED =
             java.util.concurrent.ConcurrentHashMap.newKeySet();
 
-    /** Blockbench units → world blocks (1/16). */
-    private static final float MODEL_SCALE = 1.0f / 16.0f;
+    private static final float MODEL_SCALE = 1.0f / 4.0f;
 
     public BBModelShipRenderer(EntityRendererFactory.Context ctx) {
         super(ctx);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -83,9 +83,7 @@ public class ShipClientMod implements ClientModInitializer {
         float forward = n ? 1.0f : (s ? -1.0f : 0f);
         float sideways = w ? 1.0f : (e ? -1.0f : 0f);
 
-        if (forward != 0 || sideways != 0) {
-            ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, sideways));
-        }
+        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, sideways));
     }
 
     public void setActiveHelm(String shipId, String shipName) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -69,11 +69,14 @@ public final class ShipNetworking {
                 ShipEntity ship = manager.getShip(shipId);
                 if (ship == null) return;
 
-                // Entity-based ships: helm input drives speed + heading.
-                // Movement happens in ShipEntity.tick() based on those fields.
-                ship.setTargetSpeed(payload.forward() > 0 ? 2.0f : 0f);
-                if (payload.sideways() > 0) ship.setHeading(ship.getHeading() - 2.0f);
-                if (payload.sideways() < 0) ship.setHeading(ship.getHeading() + 2.0f);
+                float currentSpeed = ship.getTargetSpeed();
+                if (payload.forward() > 0) {
+                    ship.setTargetSpeed(Math.min(currentSpeed + 0.15f, 3.0f));
+                } else {
+                    ship.setTargetSpeed(Math.max(currentSpeed - 0.1f, 0f));
+                }
+                if (payload.sideways() > 0) ship.setHeading(ship.getHeading() - 1.5f);
+                if (payload.sideways() < 0) ship.setHeading(ship.getHeading() + 1.5f);
             });
         });
     }


### PR DESCRIPTION
## Summary
Playtest report: airships rendered tiny, helm input was binary on/off, A/D snapped too hard.

- \`BBModelShipRenderer.MODEL_SCALE\`: \`1/16 → 1/4\`. Player-scale ride.
- \`ShipNetworking\` helm input ramps speed gradually (+0.15/tick W held, -0.1/tick on release, capped 0–3.0). No reverse.
- Turn rate \`2.0°/tick → 1.5°/tick\` (~30°/sec).
- \`ShipClientMod\` sends helm payload every tick while helm active so the server's coast-down branch fires when keys release.

## Test plan
- [ ] Wait for next mc Docker publish + mrpack update
- [ ] \`/spawnship airship\` — visibly larger model
- [ ] \`/boardship <id>\` — W ramps up smoothly, release coasts down, A/D rotate without snapping