### PR TITLE
feat(mc): airship vertical control + boost + telemetry HUD + smoke trail

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -14,34 +14,23 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.Perspective;
 import net.minecraft.entity.Entity;
 import net.minecraft.resource.ResourceType;
+import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Client-side mod entrypoint for the ship system.
- *
- * <p>Vanilla entity tracking handles position, heading, and tracked data
- * (modelName, shipName) sync automatically. The only client→server payload
- * is {@code HelmInputPayload} for WASD steering.
- */
 public class ShipClientMod implements ClientModInitializer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
 
     private final ShipHud hud = new ShipHud();
 
-    /** Ship the local player is currently steering (null if not at helm). */
     private String activeHelmShipId = null;
-
-    /** Saved camera perspective to restore on dismount. */
     private Perspective savedPerspective = null;
 
     @Override
     public void onInitializeClient() {
-        // Register BBModel renderer for ShipEntity
         EntityRendererRegistry.register(ShipEntityTypes.SHIP, BBModelShipRenderer::new);
 
-        // Load .bbmodel files from client resources
         ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES)
                 .registerReloadListener(new BBModelLoader());
 
@@ -50,8 +39,6 @@ public class ShipClientMod implements ClientModInitializer {
 
         LOGGER.info("[Ship Client] Initialized — BBModel renderer + HUD + helm ready");
     }
-
-    // -- Helm WASD input + camera -------------------------------------------
 
     private void onClientTick(MinecraftClient client) {
         if (client.player == null) return;
@@ -65,6 +52,7 @@ public class ShipClientMod implements ClientModInitializer {
                         idStr, shipEntity.getShipName());
                 setActiveHelm(idStr, shipEntity.getShipName());
             }
+            hud.setTelemetry(shipEntity.getTargetSpeed(), shipEntity.getYaw(), (int) Math.floor(shipEntity.getY()));
         } else if (activeHelmShipId != null) {
             LOGGER.info("[Ship Client] Dismounted — clearing helm");
             clearActiveHelm();
@@ -72,18 +60,23 @@ public class ShipClientMod implements ClientModInitializer {
 
         if (activeHelmShipId == null) return;
 
-        // Read WASD input (cardinal directions — airship-style)
         boolean n = client.options.forwardKey.isPressed();
         boolean s = client.options.backKey.isPressed();
         boolean w = client.options.leftKey.isPressed();
         boolean e = client.options.rightKey.isPressed();
 
-        hud.setInputState(n, s, e, w);
+        long handle = client.getWindow().getHandle();
+        boolean rise = client.options.jumpKey.isPressed();
+        boolean lower = GLFW.glfwGetKey(handle, GLFW.GLFW_KEY_TAB) == GLFW.GLFW_PRESS;
+        boolean boost = client.options.sprintKey.isPressed();
 
         float forward = n ? 1.0f : (s ? -1.0f : 0f);
         float sideways = w ? 1.0f : (e ? -1.0f : 0f);
+        float vertical = rise ? 1.0f : (lower ? -1.0f : 0f);
 
-        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, sideways));
+        hud.setInputState(n, s, e, w, rise, lower, boost);
+
+        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, sideways, vertical, boost));
     }
 
     public void setActiveHelm(String shipId, String shipName) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -6,27 +6,17 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.text.Text;
 
-/**
- * Client-side HUD overlay for airship piloting.
- *
- * <p>Shows:
- * <ul>
- *   <li>Ship name (top center)</li>
- *   <li>Directional compass — N/W/H/E/S layout (bottom center)</li>
- *   <li>Controls hint (bottom right)</li>
- * </ul>
- *
- * <p>The hull integrity bar was removed when ships transitioned from
- * block-based to entity-based rendering — there are no blocks left to
- * damage or count.
- */
 public class ShipHud implements HudRenderCallback {
 
     private boolean active = false;
     private String shipName = "";
 
-    // Current input state — set by ShipClientMod.setInputState() each tick.
     private boolean inputN = false, inputS = false, inputE = false, inputW = false;
+    private boolean inputRise = false, inputLower = false, inputBoost = false;
+
+    private float speed = 0f;
+    private float heading = 0f;
+    private int altitude = 0;
 
     public void setActive(String shipName) {
         this.active = true;
@@ -37,14 +27,27 @@ public class ShipHud implements HudRenderCallback {
         this.active = false;
         this.shipName = "";
         inputN = inputS = inputE = inputW = false;
+        inputRise = inputLower = inputBoost = false;
+        speed = 0f;
+        heading = 0f;
+        altitude = 0;
     }
 
-    /** Update input state from ShipClientMod each client tick. */
-    public void setInputState(boolean n, boolean s, boolean e, boolean w) {
+    public void setInputState(boolean n, boolean s, boolean e, boolean w,
+                              boolean rise, boolean lower, boolean boost) {
         this.inputN = n;
         this.inputS = s;
         this.inputE = e;
         this.inputW = w;
+        this.inputRise = rise;
+        this.inputLower = lower;
+        this.inputBoost = boost;
+    }
+
+    public void setTelemetry(float speed, float heading, int altitude) {
+        this.speed = speed;
+        this.heading = heading;
+        this.altitude = altitude;
     }
 
     public boolean isActive() {
@@ -61,27 +64,22 @@ public class ShipHud implements HudRenderCallback {
         int screenWidth = client.getWindow().getScaledWidth();
         int screenHeight = client.getWindow().getScaledHeight();
 
-        // -- Ship name (top center) --
         if (!shipName.isEmpty()) {
-            String nameText = "\u00A7l" + shipName;
+            String nameText = "§l" + shipName;
             int nameWidth = client.textRenderer.getWidth(nameText);
             context.drawText(client.textRenderer, Text.of(nameText),
                     (screenWidth - nameWidth) / 2, 10, 0xFFFFFF, true);
         }
 
-        // -- Directional compass (bottom center) --
-        //         N
-        //     W   H   E
-        //         S
         int compassCenterX = screenWidth / 2;
-        int compassCenterY = screenHeight - 40;
+        int compassCenterY = screenHeight - 50;
         int spacing = 14;
 
-        context.fill(compassCenterX - 24, compassCenterY - 18,
-                compassCenterX + 24, compassCenterY + 18, 0x80000000);
+        context.fill(compassCenterX - 28, compassCenterY - 22,
+                compassCenterX + 28, compassCenterY + 22, 0x80000000);
 
-        int activeColor = 0xFFFFCC00;   // gold when pressed
-        int inactiveColor = 0xFF888888; // gray when not
+        int activeColor = 0xFFFFCC00;
+        int inactiveColor = 0xFF888888;
         int hoverColor = (!inputN && !inputS && !inputE && !inputW) ? 0xFF00CCFF : inactiveColor;
 
         drawCenteredChar(context, client, "N", compassCenterX, compassCenterY - spacing,
@@ -94,16 +92,37 @@ public class ShipHud implements HudRenderCallback {
                 inputE ? activeColor : inactiveColor);
         drawCenteredChar(context, client, "H", compassCenterX, compassCenterY - 4, hoverColor);
 
-        // -- Controls hint (bottom right) --
-        String controls = "WASD: Move  Space: Up  Shift: Dismount";
+        int vertX = compassCenterX + 50;
+        context.fill(vertX - 12, compassCenterY - 22, vertX + 12, compassCenterY + 22, 0x80000000);
+        drawCenteredChar(context, client, "▲", vertX, compassCenterY - spacing,
+                inputRise ? activeColor : inactiveColor);
+        drawCenteredChar(context, client, "Y", vertX, compassCenterY - 4,
+                inputBoost ? 0xFFFF6633 : inactiveColor);
+        drawCenteredChar(context, client, "▼", vertX, compassCenterY + spacing - 8,
+                inputLower ? activeColor : inactiveColor);
+
+        String telemetry = String.format("SPD %.1f  ALT %d  HDG %03d°",
+                speed, altitude, ((int) ((heading % 360) + 360)) % 360);
+        int telWidth = client.textRenderer.getWidth(telemetry);
+        context.drawText(client.textRenderer, Text.of("§e" + telemetry),
+                (screenWidth - telWidth) / 2, screenHeight - 78, 0xFFFFFFFF, true);
+
+        if (inputBoost && speed > 0) {
+            String boostTag = "§6§lBOOST";
+            int bw = client.textRenderer.getWidth(boostTag);
+            context.drawText(client.textRenderer, Text.of(boostTag),
+                    (screenWidth - bw) / 2, screenHeight - 90, 0xFFFFAA00, true);
+        }
+
+        String controls = "WASD Move  Space Up  Tab Down  Ctrl Boost  Shift Dismount";
         int controlsWidth = client.textRenderer.getWidth(controls);
-        context.drawText(client.textRenderer, Text.of("\u00A77" + controls),
+        context.drawText(client.textRenderer, Text.of("§7" + controls),
                 screenWidth - controlsWidth - 10, screenHeight - 15, 0x999999, true);
     }
 
     private static void drawCenteredChar(DrawContext context, MinecraftClient client,
                                          String ch, int x, int y, int color) {
         int w = client.textRenderer.getWidth(ch);
-        context.drawText(client.textRenderer, Text.of("\u00A7l" + ch), x - w / 2, y, color, true);
+        context.drawText(client.textRenderer, Text.of("§l" + ch), x - w / 2, y, color, true);
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -42,6 +42,7 @@ public class ShipEntity extends Entity {
     private String ownerUuidStr = "";
     private float heading = 0.0f;
     private float targetSpeed = 0.0f;
+    private float verticalIntent = 0.0f;
 
     public ShipEntity(EntityType<?> type, World world) {
         super(type, world);
@@ -80,14 +81,14 @@ public class ShipEntity extends Entity {
     public float getHeading() { return heading; }
     public void setHeading(float heading) {
         this.heading = heading % 360;
-        // Mirror to vanilla yaw so entity tracking syncs rotation to clients.
         this.setYaw(this.heading);
     }
 
     public float getTargetSpeed() { return targetSpeed; }
     public void setTargetSpeed(float speed) { this.targetSpeed = Math.max(0, speed); }
 
-    // -- Damage (abstract in 1.21.11) -----------------------------------------
+    public float getVerticalIntent() { return verticalIntent; }
+    public void setVerticalIntent(float v) { this.verticalIntent = Math.max(-1f, Math.min(1f, v)); }
 
     @Override
     public boolean damage(net.minecraft.server.world.ServerWorld world,
@@ -95,13 +96,6 @@ public class ShipEntity extends Entity {
                           float amount) {
         return false;
     }
-
-    // -- Collision ----------------------------------------------------------
-    //
-    // Ships are solid — other entities collide with the hitbox and players
-    // can stand on the deck. The entity dimensions (set in ShipEntityTypes)
-    // define the AABB; BBModel visuals may extend beyond it, but the
-    // collision box is the simplified solid footprint.
 
     @Override
     public boolean isCollidable(Entity other) {
@@ -112,8 +106,6 @@ public class ShipEntity extends Entity {
     public boolean canHit() {
         return true;
     }
-
-    // -- Interaction --------------------------------------------------------
 
     @Override
     public ActionResult interact(PlayerEntity player, Hand hand) {
@@ -131,17 +123,12 @@ public class ShipEntity extends Entity {
         return !this.hasPassengers() && passenger instanceof PlayerEntity;
     }
 
-    // -- Movement -----------------------------------------------------------
-
     @Override
     public void tick() {
         super.tick();
 
-        // Keep vanilla yaw in sync with our heading (important for clients
-        // that only see the entity via standard tracking — they use getYaw()).
         this.setYaw(heading);
 
-        if (targetSpeed <= 0.0f) return;
         if (!this.hasPassengers()) return;
         Entity rider = this.getFirstPassenger();
         if (!(rider instanceof ServerPlayerEntity)) return;
@@ -149,8 +136,19 @@ public class ShipEntity extends Entity {
         double rad = Math.toRadians(heading);
         double dx = -Math.sin(rad) * targetSpeed * 0.05;
         double dz = Math.cos(rad) * targetSpeed * 0.05;
+        double dy = verticalIntent * 0.15;
 
-        this.move(MovementType.SELF, new Vec3d(dx, 0, dz));
+        if (dx == 0 && dy == 0 && dz == 0) return;
+
+        this.move(MovementType.SELF, new Vec3d(dx, dy, dz));
+
+        if (targetSpeed > 0.5f && this.getEntityWorld() instanceof net.minecraft.server.world.ServerWorld sw) {
+            if (this.age % 4 == 0) {
+                sw.spawnParticles(net.minecraft.particle.ParticleTypes.CAMPFIRE_COSY_SMOKE,
+                        this.getX(), this.getY() + 1.0, this.getZ(),
+                        1, 0.1, 0.05, 0.1, 0.01);
+            }
+        }
     }
 
     public void steerFromRider(PlayerEntity rider) {
@@ -167,8 +165,6 @@ public class ShipEntity extends Entity {
             heading += sideways > 0 ? -2.0f : 2.0f;
         }
     }
-
-    // -- Serialization (1.21.11 WriteView / ReadView API) -------------------
 
     @Override
     protected void initDataTracker(net.minecraft.entity.data.DataTracker.Builder builder) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -11,28 +11,20 @@ import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Network packets for the ship system.
- *
- * <p>Only {@link HelmInputPayload} remains. Position, heading, modelName,
- * and shipName all sync through vanilla entity tracking (position via
- * entity motion, heading via {@code yaw}, the others via DataTracker).
- * Previously there were ShipSpawn/Despawn/Move/Status payloads for the
- * block-based ship system — those were deleted when ships became entities.
- */
+/** Network packets for the ship system. Only HelmInputPayload remains; everything else syncs via vanilla entity tracking. */
 public final class ShipNetworking {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("behavior_statetree");
 
     public static final Identifier HELM_INPUT_ID = Identifier.of("behavior_statetree", "helm_input");
 
-    // -- Client → Server payloads -------------------------------------------
-
-    /** WASD helm steering input. */
+    /** Helm steering input. forward/sideways = WASD; vertical = Space/Tab; boost = sprint. */
     public record HelmInputPayload(
             String shipId,
             float forward,
-            float sideways
+            float sideways,
+            float vertical,
+            boolean boost
     ) implements CustomPayload {
         public static final CustomPayload.Id<HelmInputPayload> ID = new CustomPayload.Id<>(HELM_INPUT_ID);
         public static final PacketCodec<RegistryByteBuf, HelmInputPayload> CODEC =
@@ -40,6 +32,8 @@ public final class ShipNetworking {
                         PacketCodecs.STRING, HelmInputPayload::shipId,
                         PacketCodecs.FLOAT, HelmInputPayload::forward,
                         PacketCodecs.FLOAT, HelmInputPayload::sideways,
+                        PacketCodecs.FLOAT, HelmInputPayload::vertical,
+                        PacketCodecs.BOOLEAN, HelmInputPayload::boost,
                         HelmInputPayload::new
                 );
 
@@ -69,14 +63,16 @@ public final class ShipNetworking {
                 ShipEntity ship = manager.getShip(shipId);
                 if (ship == null) return;
 
+                float maxSpeed = payload.boost() ? 4.5f : 3.0f;
                 float currentSpeed = ship.getTargetSpeed();
                 if (payload.forward() > 0) {
-                    ship.setTargetSpeed(Math.min(currentSpeed + 0.15f, 3.0f));
+                    ship.setTargetSpeed(Math.min(currentSpeed + 0.15f, maxSpeed));
                 } else {
                     ship.setTargetSpeed(Math.max(currentSpeed - 0.1f, 0f));
                 }
                 if (payload.sideways() > 0) ship.setHeading(ship.getHeading() - 1.5f);
                 if (payload.sideways() < 0) ship.setHeading(ship.getHeading() + 1.5f);
+                ship.setVerticalIntent(payload.vertical());
             });
         });
     }

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -120,6 +120,9 @@ impl Default for ArrowCooldown {
 #[derive(Component, Debug)]
 pub struct AiPetDog;
 
+#[derive(Component, Debug, Clone, Copy)]
+pub struct LastObservedTick(pub u64);
+
 /// Marker for AI Pet Parrot entities. A pet parrot is a tamed parrot
 /// spawned alongside a player that flies nearby and drops a ranged
 /// "poop" poison attack on hostiles. Like pet dogs, parrots skip the

--- a/apps/mc/behavior_statetree/src/ecs/mod.rs
+++ b/apps/mc/behavior_statetree/src/ecs/mod.rs
@@ -25,7 +25,7 @@ use events::{
 use systems::{
     ingest_map_data, ingest_observations, ingest_player_snapshots, manage_pet_dog_population,
     manage_pet_parrot_population, manage_skeleton_population, plan_behavior, plan_pet_dog_behavior,
-    plan_pet_parrot_behavior, rebuild_flow_fields,
+    plan_pet_parrot_behavior, prune_stale_pets, rebuild_flow_fields,
 };
 
 /// Plugin that registers all AI ECS components, resources, and systems.
@@ -59,6 +59,7 @@ impl Plugin for AiBehaviorPlugin {
                     ingest_player_snapshots,
                     ingest_observations,
                     ingest_map_data,
+                    prune_stale_pets,
                     rebuild_flow_fields,
                     plan_behavior,
                     plan_pet_dog_behavior,

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -32,15 +32,15 @@ pub fn ingest_observations(
         &mut McHealth,
         &mut AiEpoch,
         &mut NearbyEntities,
+        Option<&mut LastObservedTick>,
     )>,
     mut server_tick: ResMut<ServerTick>,
 ) {
     for obs in obs_buffer.pending.drain(..) {
         server_tick.0 = obs.tick;
 
-        // Try to find existing entity
         let mut found = false;
-        for (mc_id, mut pos, mut health, mut epoch, mut nearby) in &mut query {
+        for (mc_id, mut pos, mut health, mut epoch, mut nearby, mut last_obs) in &mut query {
             if mc_id.0 == obs.entity_id {
                 pos.x = obs.position[0];
                 pos.y = obs.position[1];
@@ -58,6 +58,9 @@ pub fn ingest_observations(
                         is_hostile: e.is_hostile,
                     })
                     .collect();
+                if let Some(ref mut lt) = last_obs {
+                    lt.0 = obs.tick;
+                }
                 found = true;
                 break;
             }
@@ -104,6 +107,7 @@ pub fn ingest_observations(
                         position,
                         health,
                         AiEpoch { value: 1 },
+                        LastObservedTick(obs.tick),
                         nearby,
                     ));
                 }
@@ -121,6 +125,7 @@ pub fn ingest_observations(
                         position,
                         health,
                         AiEpoch { value: 1 },
+                        LastObservedTick(obs.tick),
                         PoopCooldown::default(),
                         nearby,
                     ));
@@ -1138,4 +1143,24 @@ pub fn rebuild_flow_fields(
 
     // Detect chokepoints
     gates.0 = flow_gate::detect_gates(grid);
+}
+
+pub fn prune_stale_pets(
+    mut commands: Commands,
+    server_tick: Res<ServerTick>,
+    pets: Query<(Entity, &McEntityId, &LastObservedTick), Or<(With<AiPetDog>, With<AiPetParrot>)>>,
+) {
+    const STALE_AFTER_TICKS: u64 = 200;
+
+    for (ecs_entity, mc_id, last_obs) in &pets {
+        let age = server_tick.0.saturating_sub(last_obs.0);
+        if age > STALE_AFTER_TICKS {
+            tracing::info!(
+                "[ECS] Pruning stale pet ECS entity (mc_id={}, age={} ticks)",
+                mc_id.0,
+                age,
+            );
+            commands.entity(ecs_entity).despawn();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Builds on top of #10457. Three pilot-feel improvements:

- **Vertical control.** Space rises, Tab descends. New \`vertical\` float on \`HelmInputPayload\`; ShipEntity tick applies Y delta = \`verticalIntent * 0.15\`.
- **Sprint boost.** Ctrl raises speed cap 3.0 → 4.5. New \`boost\` bool on payload.
- **Telemetry HUD.** \`SPD x.x  ALT n  HDG nnn°\` line + vertical-input column (▲/Y/▼) + BOOST badge while sprint engaged. Controls hint refreshed.
- **Smoke trail.** Server spawns CAMPFIRE_COSY_SMOKE particles every 4 ticks while \`targetSpeed > 0.5\`.

## Controls
| Key | Action |
|---|---|
| W | Throttle (ramps up) |
| A / D | Turn left / right |
| Space | Rise |
| Tab | Descend |
| Ctrl | Boost (cap 3.0 → 4.5) |
| Shift | Dismount |

## Test plan
- [ ] Wait for next mc Docker publish + new mrpack
- [ ] \`/spawnship airship\` + \`/boardship\`
- [ ] W ramps speed, smoke trail appears
- [ ] Space rises, Tab descends, both visible on HUD
- [ ] Hold Ctrl+W → BOOST badge, faster top speed
- [ ] HUD telemetry updates live (SPD/ALT/HDG)