### PR TITLE
fix(ci-unity,rareicon): kill test Library cache, atomic build cache, defer Steam plugin gate

### DIFF
--- a/.github/workflows/ci-unity.yml
+++ b/.github/workflows/ci-unity.yml
@@ -182,18 +182,6 @@ jobs:
                   git lfs install --local
                   git lfs pull --include="${{ inputs.project_path }}/**" --exclude=""
 
-            - name: Seed Unity Library from PVC
-              run: |
-                  CACHE_DIR="/home/runner/_cache/unity-library/${{ inputs.app_name }}-test"
-                  LIB_DIR="${{ inputs.project_path }}/Library"
-                  mkdir -p "$CACHE_DIR" "$LIB_DIR"
-                  if command -v rsync >/dev/null 2>&1; then
-                      rsync -a --delete "$CACHE_DIR"/ "$LIB_DIR"/
-                  else
-                      apt-get update -qq && apt-get install -y -qq --no-install-recommends rsync
-                      rsync -a --delete "$CACHE_DIR"/ "$LIB_DIR"/
-                  fi
-
             - name: Run Unity EditMode tests
               uses: game-ci/unity-test-runner@v4
               env:
@@ -215,17 +203,6 @@ jobs:
                   name: ${{ inputs.app_name }}-test-results
                   path: ${{ inputs.project_path }}/test-results
                   retention-days: 3
-
-            - name: Save Unity Library to PVC
-              if: always()
-              run: |
-                  CACHE_DIR="/home/runner/_cache/unity-library/${{ inputs.app_name }}-test"
-                  LIB_DIR="${{ inputs.project_path }}/Library"
-                  if [ ! -d "$LIB_DIR" ]; then
-                      exit 0
-                  fi
-                  mkdir -p "$CACHE_DIR"
-                  rsync -a --delete "$LIB_DIR"/ "$CACHE_DIR"/
 
             - name: Wipe Forgejo netrc
               if: always()
@@ -288,14 +265,18 @@ jobs:
               run: |
                   CACHE_DIR="/home/runner/_cache/unity-library/${{ inputs.app_name }}-${{ matrix.target }}"
                   LIB_DIR="${{ inputs.project_path }}/Library"
-                  mkdir -p "$CACHE_DIR" "$LIB_DIR"
-                  if command -v rsync >/dev/null 2>&1; then
-                      rsync -a --delete "$CACHE_DIR"/ "$LIB_DIR"/
-                  else
+                  MARKER="$CACHE_DIR/.cache-valid"
+                  mkdir -p "$LIB_DIR"
+                  if ! command -v rsync >/dev/null 2>&1; then
                       apt-get update -qq && apt-get install -y -qq --no-install-recommends rsync
-                      rsync -a --delete "$CACHE_DIR"/ "$LIB_DIR"/
                   fi
-                  echo "Seeded Library from $CACHE_DIR ($(du -sh "$LIB_DIR" 2>/dev/null | cut -f1))"
+                  if [ -f "$MARKER" ]; then
+                      rsync -a --delete "$CACHE_DIR"/ "$LIB_DIR"/
+                      echo "Seeded Library from $CACHE_DIR ($(du -sh "$LIB_DIR" 2>/dev/null | cut -f1))"
+                  else
+                      echo "Cache marker missing at $MARKER — starting cold."
+                      mkdir -p "$CACHE_DIR"
+                  fi
 
             - name: Build with Unity
               uses: game-ci/unity-builder@v4
@@ -311,16 +292,22 @@ jobs:
                   buildName: ${{ inputs.app_name }}
 
             - name: Save Unity Library to PVC
-              if: always()
+              if: success()
               run: |
                   CACHE_DIR="/home/runner/_cache/unity-library/${{ inputs.app_name }}-${{ matrix.target }}"
+                  STAGE_DIR="${CACHE_DIR}.tmp.$$"
                   LIB_DIR="${{ inputs.project_path }}/Library"
                   if [ ! -d "$LIB_DIR" ]; then
                       echo "No Library/ to save (build may have failed before generation)"
                       exit 0
                   fi
-                  mkdir -p "$CACHE_DIR"
-                  rsync -a --delete "$LIB_DIR"/ "$CACHE_DIR"/
+                  mkdir -p "$(dirname "$CACHE_DIR")"
+                  rm -rf "$STAGE_DIR"
+                  mkdir -p "$STAGE_DIR"
+                  rsync -a --delete "$LIB_DIR"/ "$STAGE_DIR"/
+                  touch "$STAGE_DIR/.cache-valid"
+                  rm -rf "$CACHE_DIR"
+                  mv "$STAGE_DIR" "$CACHE_DIR"
                   echo "Saved Library to $CACHE_DIR ($(du -sh "$CACHE_DIR" 2>/dev/null | cut -f1))"
 
             # Strip Unity's ship-blocked debug folders before zipping so

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Editor/SteamPluginPlatformGate.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Editor/SteamPluginPlatformGate.cs
@@ -24,11 +24,18 @@ namespace RareIcon.EditorTools
 
         static SteamPluginPlatformGate()
         {
-            ApplyMobileLockdown();
+            EditorApplication.delayCall += DeferredApplyMobileLockdown;
         }
 
         [MenuItem("Tools/RareIcon/Re-apply Steam mobile plugin lockdown")]
         private static void ApplyMobileLockdownMenu() => ApplyMobileLockdown();
+
+        private static void DeferredApplyMobileLockdown()
+        {
+            EditorApplication.delayCall -= DeferredApplyMobileLockdown;
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating) return;
+            ApplyMobileLockdown();
+        }
 
         private static void ApplyMobileLockdown()
         {


### PR DESCRIPTION
## Summary
- EditMode test job no longer seeds/saves the shared Longhorn RWX Library cache. A hung run that wrote half-baked Library state via \`if: always()\` was poisoning every later run until the cache was nuked by hand. Tests cold-start in 3-5 min — cache wasn't pulling weight there.
- Build job's Library save is now success-gated and atomic: rsync into a sibling \`.tmp.$$\` dir, drop a \`.cache-valid\` marker, then \`mv\` into place. Seed step refuses to trust a cache without the marker so a pod that died mid-rsync can't ship a half-baked Library to the next pod.
- \`SteamPluginPlatformGate\`'s \`[InitializeOnLoad]\` cctor used to call \`PluginImporter.SaveAndReimport()\` synchronously inside the static ctor, which can deadlock the AssetDatabase during the second Unity launch that \`game-ci/unity-test-runner\` does for EditMode runs. Defer onto \`EditorApplication.delayCall\` (matching \`AddressablesBootstrap\`) so asset mutation happens after the domain is fully initialized.

## Failure trace
[run 25339516848](https://github.com/KBVE/kbve/actions/runs/25339516848) — Unity EditMode Tests sat silent for 43 min after the \`Testing in editmode\` header before being cancelled at the 60 min job timeout. The diff vs the prior successful run (\`691cc2a\`) was \`packages/docker/arc-runner/version.toml\` only, so code was identical — points at infra: cache state on the shared NFS PVC.

## Test plan
- [ ] Re-trigger \`CI - Unity / rareicon\`, confirm EditMode tests finish in <15 min on the first run after cache nuke
- [ ] Confirm \`Seeded Library from\` log line is replaced by \`Cache marker missing — starting cold.\` on the first build run after merge
- [ ] After one successful build, second run logs \`Seeded Library from …\` again (marker present)
- [ ] Cancelled/failed build leaves the prior cache untouched (marker still present, no half-baked overwrite)
- [ ] No \`[SteamPluginGate]\` log noise on EditMode test launches