### PR TITLE
docs(agents): pipeline:docker apps — only bump mdx, never version.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,18 @@ For small, self-contained changes (docs, config, single-file fixes). Atoms use i
 
 ---
 
+# pipeline:docker apps — version bumps
+
+For any project with `pipeline: docker` in its `*.mdx` frontmatter (mc-velocity, mc-lobby, mc, etc.):
+
+- ✅ Bump only the mdx frontmatter `version: "x.y.z"` to ship a new image.
+- ❌ Never edit `apps/<app>/version.toml` — CI's post-publish PR owns it.
+- ❌ Never edit `apps/kube/.../<app>-deployment.yaml` `image:` tag — same.
+
+Dispatch compares mdx `version:` against `version.toml`; if equal, it skips the build entirely. Pre-bumping `version.toml` silently breaks the pipeline.
+
+---
+
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
 


### PR DESCRIPTION
## Summary

Adds a short `# pipeline:docker apps — version bumps` section to \`AGENTS.md\` so the rule is loaded as project context for every contributor (and every Claude session) automatically.

## Why

The publish dispatch detects "needs publish" by comparing the mdx \`version:\` against \`version.toml\`. If they're equal, dispatch skips Argo entirely — no image build, no post-publish PR, no rollout. Pre-bumping \`version.toml\` in the same PR as the mdx silently breaks the pipeline. Bit \`mc-velocity\` 1.1.2 → 1.1.4 (three back-to-back PRs that merged but never deployed; cluster stayed pinned to 1.1.1 until a single-mdx-bump recovery PR shipped).

## Test plan

- [ ] Section renders correctly when AGENTS.md is loaded as Claude/agent project context
- [ ] Wording is unambiguous about which files are off-limits