### PR TITLE
feat(astro-kbve): expand argo dashboard with per-resource detail drawer + app tabs

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
@@ -5,9 +5,14 @@ import {
 	healthColor,
 	syncColor,
 	fetchResourceTree,
+	fetchAppEvents,
+	type AppEvent,
 	type ArgoApplication,
 	type ResourceTree,
+	type ResourceNode,
+	type ResourceSelector,
 } from './argoService';
+import ReactArgoResourceDetail, { EventsList } from './ReactArgoResourceDetail';
 import {
 	CheckCircle2,
 	XCircle,
@@ -86,12 +91,53 @@ function StatusBadge({
 // Resource Tree Panel
 // ---------------------------------------------------------------------------
 
+function LoadingBlock({ label }: { label: string }) {
+	return (
+		<div
+			style={{
+				padding: '1rem',
+				color: 'var(--sl-color-gray-3, #8b949e)',
+				display: 'flex',
+				alignItems: 'center',
+				gap: 8,
+				fontSize: '0.85rem',
+			}}>
+			<Loader2
+				size={14}
+				style={{ animation: 'spin 1s linear infinite' }}
+			/>
+			{label}
+		</div>
+	);
+}
+
+function ErrorBlock({ message }: { message: string }) {
+	return (
+		<div
+			style={{
+				padding: '1rem',
+				color: '#ef4444',
+				fontSize: '0.85rem',
+				display: 'flex',
+				alignItems: 'center',
+				gap: 8,
+			}}>
+			<AlertCircle size={14} />
+			{message}
+		</div>
+	);
+}
+
 function ResourceTreePanel({
 	token,
 	appName,
+	selectedResource,
+	onSelectResource,
 }: {
 	token: string;
 	appName: string;
+	selectedResource: ResourceSelector | null;
+	onSelectResource: (sel: ResourceSelector) => void;
 }) {
 	const [tree, setTree] = useState<ResourceTree | null>(null);
 	const [loading, setLoading] = useState(true);
@@ -116,38 +162,8 @@ function ResourceTreePanel({
 		};
 	}, [token, appName]);
 
-	if (loading) {
-		return (
-			<div
-				style={{
-					padding: '1rem',
-					color: 'var(--sl-color-gray-3, #8b949e)',
-					display: 'flex',
-					alignItems: 'center',
-					gap: 8,
-				}}>
-				<Loader2
-					size={14}
-					style={{ animation: 'spin 1s linear infinite' }}
-				/>
-				Loading resources...
-			</div>
-		);
-	}
-
-	if (error) {
-		return (
-			<div
-				style={{
-					padding: '1rem',
-					color: '#ef4444',
-					fontSize: '0.85rem',
-				}}>
-				{error}
-			</div>
-		);
-	}
-
+	if (loading) return <LoadingBlock label="Loading resources..." />;
+	if (error) return <ErrorBlock message={error} />;
 	if (!tree?.nodes?.length) {
 		return (
 			<div
@@ -168,15 +184,18 @@ function ResourceTreePanel({
 			acc[kind].push(node);
 			return acc;
 		},
-		{} as Record<string, typeof tree.nodes>,
+		{} as Record<string, ResourceNode[]>,
 	);
 
+	const isSelected = (n: ResourceNode) =>
+		!!selectedResource &&
+		selectedResource.appName === appName &&
+		selectedResource.kind === n.kind &&
+		selectedResource.namespace === (n.namespace ?? '') &&
+		selectedResource.name === n.name;
+
 	return (
-		<div
-			style={{
-				padding: '0.75rem 1rem',
-				borderTop: '1px solid var(--sl-color-gray-5, #262626)',
-			}}>
+		<div>
 			{Object.entries(grouped).map(([kind, nodes]) => (
 				<div key={kind} style={{ marginBottom: '0.75rem' }}>
 					<div
@@ -190,36 +209,290 @@ function ResourceTreePanel({
 						}}>
 						{kind} ({nodes.length})
 					</div>
-					{nodes.map((node, i) => (
-						<div
-							key={`${node.namespace}-${node.name}-${i}`}
-							style={{
-								display: 'flex',
-								alignItems: 'center',
-								gap: 8,
-								padding: '4px 0',
-								fontSize: '0.8rem',
-								color: 'var(--sl-color-text, #e6edf3)',
-							}}>
-							{node.health && (
-								<span
+					{nodes.map((node, i) => {
+						const selected = isSelected(node);
+						const sel: ResourceSelector = {
+							appName,
+							kind: node.kind,
+							namespace: node.namespace ?? '',
+							name: node.name,
+							group: node.group,
+							version: node.version,
+							uid: node.uid,
+						};
+						return (
+							<React.Fragment
+								key={`${node.namespace}-${node.name}-${i}`}>
+								<div
+									onClick={() => onSelectResource(sel)}
 									style={{
-										color: healthColor(node.health.status),
+										display: 'flex',
+										alignItems: 'center',
+										gap: 8,
+										padding: '4px 8px',
+										fontSize: '0.8rem',
+										color: 'var(--sl-color-text, #e6edf3)',
+										cursor: 'pointer',
+										borderRadius: 4,
+										background: selected
+											? 'rgba(139, 92, 246, 0.12)'
+											: 'transparent',
+										transition: 'background 0.12s',
+									}}
+									onMouseEnter={(e) => {
+										if (!selected) {
+											e.currentTarget.style.background =
+												'rgba(255, 255, 255, 0.03)';
+										}
+									}}
+									onMouseLeave={(e) => {
+										if (!selected) {
+											e.currentTarget.style.background =
+												'transparent';
+										}
 									}}>
-									{healthIcon(node.health.status)}
-								</span>
-							)}
-							<span
-								style={{
-									color: 'var(--sl-color-gray-4, #6b7280)',
-								}}>
-								{node.namespace}/
-							</span>
-							{node.name}
-						</div>
-					))}
+									{node.health && (
+										<span
+											style={{
+												color: healthColor(
+													node.health.status,
+												),
+											}}>
+											{healthIcon(node.health.status)}
+										</span>
+									)}
+									<span
+										style={{
+											color: 'var(--sl-color-gray-4, #6b7280)',
+										}}>
+										{node.namespace}/
+									</span>
+									{node.name}
+								</div>
+								{selected && (
+									<ReactArgoResourceDetail
+										token={token}
+										sel={sel}
+										healthMessage={node.health?.message}
+										onClose={() =>
+											argoService.selectResource(null)
+										}
+									/>
+								)}
+							</React.Fragment>
+						);
+					})}
 				</div>
 			))}
+		</div>
+	);
+}
+
+function AppEventsPanel({
+	token,
+	appName,
+}: {
+	token: string;
+	appName: string;
+}) {
+	const [events, setEvents] = useState<AppEvent[] | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				setLoading(true);
+				const data = await fetchAppEvents(token, appName);
+				if (!cancelled) setEvents(data);
+			} catch (e: unknown) {
+				if (!cancelled)
+					setError(e instanceof Error ? e.message : 'Failed to load');
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [token, appName]);
+
+	if (loading) return <LoadingBlock label="Loading events..." />;
+	if (error) return <ErrorBlock message={error} />;
+	return <EventsList events={events ?? []} />;
+}
+
+function AppHistoryPanel({ app }: { app: ArgoApplication }) {
+	const history = (app.status as Record<string, unknown>)?.history as
+		| Array<Record<string, unknown>>
+		| undefined;
+	if (!history || history.length === 0) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+				}}>
+				No sync history recorded
+			</div>
+		);
+	}
+	const sorted = [...history].sort((a, b) => {
+		const ai = (a.id as number) ?? 0;
+		const bi = (b.id as number) ?? 0;
+		return bi - ai;
+	});
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+			{sorted.map((h, i) => {
+				const deployedAt = h.deployedAt as string | undefined;
+				const revision = h.revision as string | undefined;
+				const source = h.source as
+					| {
+							repoURL?: string;
+							path?: string;
+							targetRevision?: string;
+					  }
+					| undefined;
+				const id = h.id as number | undefined;
+				return (
+					<div
+						key={`${id ?? i}`}
+						style={{
+							padding: '0.5rem 0.75rem',
+							borderRadius: 6,
+							background: 'var(--sl-color-bg, #0d1117)',
+							border: '1px solid var(--sl-color-gray-5, #262626)',
+							fontSize: '0.8rem',
+						}}>
+						<div
+							style={{
+								display: 'flex',
+								gap: 8,
+								alignItems: 'center',
+								marginBottom: 4,
+							}}>
+							<span
+								style={{
+									color: '#c4b5fd',
+									fontWeight: 600,
+									fontSize: '0.75rem',
+								}}>
+								#{id ?? '?'}
+							</span>
+							<span
+								style={{
+									color: 'var(--sl-color-text, #e6edf3)',
+									fontFamily:
+										'var(--sl-font-mono, monospace)',
+									fontSize: '0.75rem',
+								}}>
+								{revision
+									? revision.slice(0, 12)
+									: '(no revision)'}
+							</span>
+							<span
+								style={{
+									marginLeft: 'auto',
+									color: 'var(--sl-color-gray-4, #6b7280)',
+									fontSize: '0.7rem',
+								}}>
+								{deployedAt
+									? new Date(deployedAt).toLocaleString()
+									: ''}
+							</span>
+						</div>
+						{source && (
+							<div
+								style={{
+									color: 'var(--sl-color-gray-4, #6b7280)',
+									fontSize: '0.7rem',
+								}}>
+								{source.repoURL ?? ''}
+								{source.path ? ` @ ${source.path}` : ''}
+								{source.targetRevision
+									? ` (${source.targetRevision})`
+									: ''}
+							</div>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function AppExpandedPanel({
+	app,
+	token,
+	tab,
+	onTabChange,
+	selectedResource,
+	onSelectResource,
+}: {
+	app: ArgoApplication;
+	token: string;
+	tab: 'resources' | 'events' | 'history';
+	onTabChange: (t: 'resources' | 'events' | 'history') => void;
+	selectedResource: ResourceSelector | null;
+	onSelectResource: (sel: ResourceSelector) => void;
+}) {
+	const tabs: { id: 'resources' | 'events' | 'history'; label: string }[] = [
+		{ id: 'resources', label: 'Resources' },
+		{ id: 'events', label: 'Events' },
+		{ id: 'history', label: 'Sync History' },
+	];
+	return (
+		<div
+			style={{
+				padding: '0.75rem 1rem',
+				borderTop: '1px solid var(--sl-color-gray-5, #262626)',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					gap: 0,
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					marginBottom: '0.75rem',
+				}}>
+				{tabs.map((t) => {
+					const isActive = t.id === tab;
+					return (
+						<button
+							key={t.id}
+							onClick={() => onTabChange(t.id)}
+							style={{
+								background: 'transparent',
+								border: 'none',
+								borderBottom: `2px solid ${isActive ? '#8b5cf6' : 'transparent'}`,
+								color: isActive
+									? 'var(--sl-color-text, #e6edf3)'
+									: 'var(--sl-color-gray-3, #8b949e)',
+								padding: '0.4rem 0.75rem',
+								fontSize: '0.8rem',
+								fontWeight: isActive ? 600 : 500,
+								cursor: 'pointer',
+								marginBottom: '-1px',
+							}}>
+							{t.label}
+						</button>
+					);
+				})}
+			</div>
+			{tab === 'resources' && (
+				<ResourceTreePanel
+					token={token}
+					appName={app.metadata.name}
+					selectedResource={selectedResource}
+					onSelectResource={onSelectResource}
+				/>
+			)}
+			{tab === 'events' && (
+				<AppEventsPanel token={token} appName={app.metadata.name} />
+			)}
+			{tab === 'history' && <AppHistoryPanel app={app} />}
 		</div>
 	);
 }
@@ -233,11 +506,19 @@ function ApplicationRow({
 	token,
 	expanded,
 	onToggle,
+	tab,
+	onTabChange,
+	selectedResource,
+	onSelectResource,
 }: {
 	app: ArgoApplication;
 	token: string;
 	expanded: boolean;
 	onToggle: () => void;
+	tab: 'resources' | 'events' | 'history';
+	onTabChange: (t: 'resources' | 'events' | 'history') => void;
+	selectedResource: ResourceSelector | null;
+	onSelectResource: (sel: ResourceSelector) => void;
 }) {
 	const lastSync = app.status.operationState?.finishedAt
 		? new Date(app.status.operationState.finishedAt).toLocaleString()
@@ -307,7 +588,14 @@ function ApplicationRow({
 				</span>
 			</div>
 			{expanded && (
-				<ResourceTreePanel token={token} appName={app.metadata.name} />
+				<AppExpandedPanel
+					app={app}
+					token={token}
+					tab={tab}
+					onTabChange={onTabChange}
+					selectedResource={selectedResource}
+					onSelectResource={onSelectResource}
+				/>
 			)}
 		</div>
 	);
@@ -323,6 +611,8 @@ export default function ReactArgoAppTable() {
 	const error = useStore(argoService.$error);
 	const accessToken = useStore(argoService.$accessToken);
 	const expandedApp = useStore(argoService.$expandedApp);
+	const selectedResource = useStore(argoService.$selectedResource);
+	const appTab = useStore(argoService.$appTab);
 
 	if (!applications.length) {
 		if (!loading && !error) {
@@ -405,6 +695,10 @@ export default function ReactArgoAppTable() {
 					onToggle={() =>
 						argoService.toggleExpandedApp(app.metadata.name)
 					}
+					tab={appTab}
+					onTabChange={(t) => argoService.setAppTab(t)}
+					selectedResource={selectedResource}
+					onSelectResource={(sel) => argoService.selectResource(sel)}
 				/>
 			))}
 		</>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
@@ -1,0 +1,982 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+	fetchAppEvents,
+	fetchLiveResource,
+	fetchManagedResources,
+	fetchPodLogs,
+	type AppEvent,
+	type LogLine,
+	type ManagedResource,
+	type ResourceSelector,
+} from './argoService';
+import { Loader2, X, AlertCircle } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Inline YAML emitter (read-only, kubectl-ish)
+// ---------------------------------------------------------------------------
+
+function toYaml(value: unknown, indent = 0): string {
+	const pad = '  '.repeat(indent);
+	if (value === null || value === undefined) return 'null';
+	if (typeof value === 'string') {
+		if (value === '' || /[:#&*!|>'"%@`\n]|^\s|\s$/.test(value)) {
+			return JSON.stringify(value);
+		}
+		return value;
+	}
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+	if (Array.isArray(value)) {
+		if (value.length === 0) return '[]';
+		return value
+			.map((item) => {
+				const rendered = toYaml(item, indent + 1);
+				if (typeof item === 'object' && item !== null) {
+					const lines = rendered.split('\n');
+					const first = lines[0]?.replace(/^ {2}/, '');
+					const rest = lines.slice(1).join('\n');
+					return `${pad}- ${first}${rest ? `\n${rest}` : ''}`;
+				}
+				return `${pad}- ${rendered}`;
+			})
+			.join('\n');
+	}
+	if (typeof value === 'object') {
+		const entries = Object.entries(value as Record<string, unknown>);
+		if (entries.length === 0) return '{}';
+		return entries
+			.map(([k, v]) => {
+				if (v === null || v === undefined) return `${pad}${k}: null`;
+				if (typeof v === 'object') {
+					const rendered = toYaml(v, indent + 1);
+					if (Array.isArray(v) && v.length === 0)
+						return `${pad}${k}: []`;
+					if (
+						!Array.isArray(v) &&
+						Object.keys(v as object).length === 0
+					)
+						return `${pad}${k}: {}`;
+					return `${pad}${k}:\n${rendered}`;
+				}
+				return `${pad}${k}: ${toYaml(v, indent + 1)}`;
+			})
+			.join('\n');
+	}
+	return String(value);
+}
+
+// ---------------------------------------------------------------------------
+// Tab bar
+// ---------------------------------------------------------------------------
+
+type TabId = 'summary' | 'manifest' | 'events' | 'diff' | 'logs';
+
+function TabBar({
+	tabs,
+	active,
+	onSelect,
+}: {
+	tabs: { id: TabId; label: string }[];
+	active: TabId;
+	onSelect: (t: TabId) => void;
+}) {
+	return (
+		<div
+			style={{
+				display: 'flex',
+				gap: 0,
+				borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+				marginBottom: '0.75rem',
+			}}>
+			{tabs.map((t) => {
+				const isActive = t.id === active;
+				return (
+					<button
+						key={t.id}
+						onClick={() => onSelect(t.id)}
+						style={{
+							background: 'transparent',
+							border: 'none',
+							borderBottom: `2px solid ${isActive ? '#8b5cf6' : 'transparent'}`,
+							color: isActive
+								? 'var(--sl-color-text, #e6edf3)'
+								: 'var(--sl-color-gray-3, #8b949e)',
+							padding: '0.5rem 0.75rem',
+							fontSize: '0.8rem',
+							fontWeight: isActive ? 600 : 500,
+							cursor: 'pointer',
+							marginBottom: '-1px',
+						}}>
+						{t.label}
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Container helpers
+// ---------------------------------------------------------------------------
+
+function FetchState({
+	loading,
+	error,
+	empty,
+}: {
+	loading: boolean;
+	error: string | null;
+	empty?: string;
+}) {
+	if (loading) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					fontSize: '0.85rem',
+				}}>
+				<Loader2
+					size={14}
+					style={{ animation: 'spin 1s linear infinite' }}
+				/>
+				Loading...
+			</div>
+		);
+	}
+	if (error) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: '#ef4444',
+					fontSize: '0.85rem',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+				}}>
+				<AlertCircle size={14} />
+				{error}
+			</div>
+		);
+	}
+	if (empty) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+				}}>
+				{empty}
+			</div>
+		);
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+function SummaryTab({
+	sel,
+	manifest,
+	healthMessage,
+}: {
+	sel: ResourceSelector;
+	manifest: Record<string, unknown> | null;
+	healthMessage?: string;
+}) {
+	const meta = (manifest?.metadata as Record<string, unknown>) ?? {};
+	const status = (manifest?.status as Record<string, unknown>) ?? {};
+	const labels = (meta?.labels as Record<string, string>) ?? {};
+	const annotations = (meta?.annotations as Record<string, string>) ?? {};
+	const created = meta?.creationTimestamp as string | undefined;
+
+	const rows: [string, React.ReactNode][] = [
+		['Kind', sel.kind],
+		['API Group', sel.group || 'core'],
+		['Version', sel.version || 'v1'],
+		['Namespace', sel.namespace || '(cluster)'],
+		['Name', sel.name],
+		['UID', (meta.uid as string) || sel.uid || '--'],
+		['Created', created ? new Date(created).toLocaleString() : '--'],
+		['Resource Version', (meta.resourceVersion as string) || '--'],
+	];
+
+	if (typeof status.phase === 'string') {
+		rows.push(['Phase', status.phase as string]);
+	}
+
+	return (
+		<div style={{ fontSize: '0.85rem' }}>
+			{healthMessage && (
+				<div
+					style={{
+						padding: '0.75rem',
+						marginBottom: '0.75rem',
+						borderRadius: 6,
+						background: 'rgba(239, 68, 68, 0.08)',
+						border: '1px solid rgba(239, 68, 68, 0.3)',
+						color: '#fca5a5',
+						fontSize: '0.8rem',
+					}}>
+					{healthMessage}
+				</div>
+			)}
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns: '160px 1fr',
+					gap: '0.4rem 1rem',
+					marginBottom: '1rem',
+				}}>
+				{rows.map(([k, v]) => (
+					<React.Fragment key={k}>
+						<div
+							style={{
+								color: 'var(--sl-color-gray-3, #8b949e)',
+								fontSize: '0.75rem',
+								textTransform: 'uppercase',
+								letterSpacing: '0.05em',
+							}}>
+							{k}
+						</div>
+						<div
+							style={{
+								color: 'var(--sl-color-text, #e6edf3)',
+								wordBreak: 'break-all',
+							}}>
+							{v}
+						</div>
+					</React.Fragment>
+				))}
+			</div>
+
+			{Object.keys(labels).length > 0 && (
+				<KVBlock title="Labels" data={labels} />
+			)}
+			{Object.keys(annotations).length > 0 && (
+				<KVBlock title="Annotations" data={annotations} truncate />
+			)}
+		</div>
+	);
+}
+
+function KVBlock({
+	title,
+	data,
+	truncate = false,
+}: {
+	title: string;
+	data: Record<string, string>;
+	truncate?: boolean;
+}) {
+	return (
+		<div style={{ marginBottom: '1rem' }}>
+			<div
+				style={{
+					fontSize: '0.7rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					marginBottom: 4,
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+				}}>
+				{title}
+			</div>
+			<div
+				style={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: 6,
+				}}>
+				{Object.entries(data).map(([k, v]) => {
+					const value =
+						truncate && v.length > 80 ? v.slice(0, 77) + '...' : v;
+					return (
+						<span
+							key={k}
+							title={`${k}=${v}`}
+							style={{
+								fontSize: '0.7rem',
+								padding: '2px 8px',
+								borderRadius: 4,
+								background: 'rgba(139, 92, 246, 0.08)',
+								border: '1px solid rgba(139, 92, 246, 0.2)',
+								color: 'var(--sl-color-text, #e6edf3)',
+								fontFamily: 'var(--sl-font-mono, monospace)',
+							}}>
+							{k}={value}
+						</span>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Manifest viewer
+// ---------------------------------------------------------------------------
+
+function CodeBlock({ children }: { children: string }) {
+	return (
+		<pre
+			style={{
+				background: 'var(--sl-color-bg-inline-code, #0d1117)',
+				color: 'var(--sl-color-text, #e6edf3)',
+				padding: '0.75rem',
+				borderRadius: 6,
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+				fontSize: '0.75rem',
+				fontFamily: 'var(--sl-font-mono, monospace)',
+				maxHeight: '420px',
+				overflow: 'auto',
+				whiteSpace: 'pre',
+				margin: 0,
+			}}>
+			{children}
+		</pre>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Events tab
+// ---------------------------------------------------------------------------
+
+export function EventsList({ events }: { events: AppEvent[] }) {
+	if (events.length === 0) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+				}}>
+				No events recorded for this resource
+			</div>
+		);
+	}
+	const sorted = [...events].sort((a, b) => {
+		const ta = new Date(
+			a.lastTimestamp ?? a.eventTime ?? a.firstTimestamp ?? 0,
+		).getTime();
+		const tb = new Date(
+			b.lastTimestamp ?? b.eventTime ?? b.firstTimestamp ?? 0,
+		).getTime();
+		return tb - ta;
+	});
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+			{sorted.map((e, i) => {
+				const ts =
+					e.lastTimestamp ?? e.eventTime ?? e.firstTimestamp ?? '';
+				const isWarn = e.type === 'Warning';
+				return (
+					<div
+						key={`${e.metadata?.uid ?? i}`}
+						style={{
+							padding: '0.5rem 0.75rem',
+							borderRadius: 6,
+							background: isWarn
+								? 'rgba(245, 158, 11, 0.06)'
+								: 'rgba(34, 197, 94, 0.04)',
+							border: `1px solid ${isWarn ? 'rgba(245, 158, 11, 0.25)' : 'rgba(34, 197, 94, 0.18)'}`,
+						}}>
+						<div
+							style={{
+								display: 'flex',
+								gap: 8,
+								alignItems: 'center',
+								marginBottom: 2,
+								fontSize: '0.75rem',
+							}}>
+							<span
+								style={{
+									color: isWarn ? '#fbbf24' : '#22c55e',
+									fontWeight: 600,
+								}}>
+								{e.reason ?? '(no reason)'}
+							</span>
+							{e.count && e.count > 1 && (
+								<span
+									style={{
+										color: 'var(--sl-color-gray-4, #6b7280)',
+										fontSize: '0.7rem',
+									}}>
+									×{e.count}
+								</span>
+							)}
+							<span
+								style={{
+									marginLeft: 'auto',
+									color: 'var(--sl-color-gray-4, #6b7280)',
+									fontSize: '0.7rem',
+								}}>
+								{ts ? new Date(ts).toLocaleString() : ''}
+							</span>
+						</div>
+						<div
+							style={{
+								color: 'var(--sl-color-text, #e6edf3)',
+								fontSize: '0.8rem',
+								wordBreak: 'break-word',
+							}}>
+							{e.message ?? ''}
+						</div>
+						{e.source?.component && (
+							<div
+								style={{
+									color: 'var(--sl-color-gray-4, #6b7280)',
+									fontSize: '0.7rem',
+									marginTop: 2,
+								}}>
+								source: {e.source.component}
+								{e.source.host ? ` (${e.source.host})` : ''}
+							</div>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Diff
+// ---------------------------------------------------------------------------
+
+function DiffTab({
+	sel,
+	managed,
+}: {
+	sel: ResourceSelector;
+	managed: ManagedResource | null;
+}) {
+	if (!managed) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+				}}>
+				Resource not managed by Argo (no diff available)
+			</div>
+		);
+	}
+
+	const live = useMemo(() => {
+		if (!managed.liveState) return null;
+		try {
+			return JSON.parse(managed.liveState);
+		} catch {
+			return null;
+		}
+	}, [managed.liveState]);
+
+	const target = useMemo(() => {
+		if (!managed.targetState) return null;
+		try {
+			return JSON.parse(managed.targetState);
+		} catch {
+			return null;
+		}
+	}, [managed.targetState]);
+
+	if (!live && !target) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+				}}>
+				No live or target state available
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns: '1fr 1fr',
+					gap: '0.5rem',
+				}}>
+				<div>
+					<div
+						style={{
+							fontSize: '0.7rem',
+							fontWeight: 600,
+							color: '#22c55e',
+							textTransform: 'uppercase',
+							letterSpacing: '0.05em',
+							marginBottom: 4,
+						}}>
+						Live (cluster)
+					</div>
+					<CodeBlock>{live ? toYaml(live) : '(missing)'}</CodeBlock>
+				</div>
+				<div>
+					<div
+						style={{
+							fontSize: '0.7rem',
+							fontWeight: 600,
+							color: '#8b5cf6',
+							textTransform: 'uppercase',
+							letterSpacing: '0.05em',
+							marginBottom: 4,
+						}}>
+						Target (desired)
+					</div>
+					<CodeBlock>
+						{target ? toYaml(target) : '(missing)'}
+					</CodeBlock>
+				</div>
+			</div>
+			{managed.requiresPruning && (
+				<div
+					style={{
+						marginTop: '0.5rem',
+						padding: '0.5rem 0.75rem',
+						borderRadius: 6,
+						background: 'rgba(245, 158, 11, 0.08)',
+						border: '1px solid rgba(245, 158, 11, 0.3)',
+						color: '#fbbf24',
+						fontSize: '0.75rem',
+					}}>
+					Pruning required — this {sel.kind} exists in the cluster but
+					is no longer in the desired state
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Logs (Pod kind only)
+// ---------------------------------------------------------------------------
+
+function LogsTab({
+	token,
+	sel,
+	manifest,
+}: {
+	token: string;
+	sel: ResourceSelector;
+	manifest: Record<string, unknown> | null;
+}) {
+	const containers = useMemo(() => {
+		const spec = (manifest?.spec as Record<string, unknown>) ?? {};
+		const list = (spec.containers as Array<{ name: string }>) ?? [];
+		const init = (spec.initContainers as Array<{ name: string }>) ?? [];
+		return [...list.map((c) => c.name), ...init.map((c) => c.name)];
+	}, [manifest]);
+
+	const [container, setContainer] = useState<string>('');
+	const [tailLines, setTailLines] = useState<number>(200);
+	const [logs, setLogs] = useState<LogLine[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (containers.length > 0 && !container) {
+			setContainer(containers[0]);
+		}
+	}, [containers, container]);
+
+	const load = async () => {
+		try {
+			setLoading(true);
+			setError(null);
+			const result = await fetchPodLogs(token, sel.appName, sel.name, {
+				namespace: sel.namespace,
+				container: container || undefined,
+				tailLines,
+			});
+			setLogs(result);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : 'Failed to load logs');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	useEffect(() => {
+		if (container) load();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [container, tailLines]);
+
+	return (
+		<div>
+			<div
+				style={{
+					display: 'flex',
+					gap: 8,
+					marginBottom: 8,
+					alignItems: 'center',
+					flexWrap: 'wrap',
+				}}>
+				{containers.length > 0 && (
+					<select
+						value={container}
+						onChange={(e) => setContainer(e.target.value)}
+						style={{
+							background: 'var(--sl-color-bg-nav, #111)',
+							color: 'var(--sl-color-text, #e6edf3)',
+							border: '1px solid var(--sl-color-gray-5, #262626)',
+							borderRadius: 6,
+							padding: '4px 8px',
+							fontSize: '0.8rem',
+						}}>
+						{containers.map((c) => (
+							<option key={c} value={c}>
+								{c}
+							</option>
+						))}
+					</select>
+				)}
+				<select
+					value={tailLines}
+					onChange={(e) => setTailLines(Number(e.target.value))}
+					style={{
+						background: 'var(--sl-color-bg-nav, #111)',
+						color: 'var(--sl-color-text, #e6edf3)',
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						borderRadius: 6,
+						padding: '4px 8px',
+						fontSize: '0.8rem',
+					}}>
+					{[100, 200, 500, 1000].map((n) => (
+						<option key={n} value={n}>
+							Last {n} lines
+						</option>
+					))}
+				</select>
+				<button
+					onClick={load}
+					disabled={loading}
+					style={{
+						background: 'rgba(139, 92, 246, 0.12)',
+						color: '#c4b5fd',
+						border: '1px solid rgba(139, 92, 246, 0.3)',
+						borderRadius: 6,
+						padding: '4px 10px',
+						fontSize: '0.75rem',
+						cursor: loading ? 'wait' : 'pointer',
+					}}>
+					{loading ? 'Loading...' : 'Refresh'}
+				</button>
+			</div>
+			{error && (
+				<div
+					style={{
+						padding: '0.5rem 0.75rem',
+						color: '#ef4444',
+						fontSize: '0.8rem',
+						marginBottom: 8,
+					}}>
+					{error}
+				</div>
+			)}
+			{logs.length === 0 && !loading && !error ? (
+				<div
+					style={{
+						padding: '1rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.85rem',
+					}}>
+					No log lines
+				</div>
+			) : (
+				<pre
+					style={{
+						background: 'var(--sl-color-bg-inline-code, #0d1117)',
+						color: 'var(--sl-color-text, #e6edf3)',
+						padding: '0.75rem',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						fontSize: '0.72rem',
+						fontFamily: 'var(--sl-font-mono, monospace)',
+						maxHeight: '420px',
+						overflow: 'auto',
+						whiteSpace: 'pre-wrap',
+						wordBreak: 'break-all',
+						margin: 0,
+						lineHeight: 1.4,
+					}}>
+					{logs
+						.map((l) => {
+							const ts = l.timeStamp
+								? new Date(l.timeStamp).toLocaleTimeString()
+								: '';
+							return ts ? `[${ts}] ${l.content}` : l.content;
+						})
+						.join('\n')}
+				</pre>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Main detail panel
+// ---------------------------------------------------------------------------
+
+export default function ReactArgoResourceDetail({
+	token,
+	sel,
+	healthMessage,
+	onClose,
+}: {
+	token: string;
+	sel: ResourceSelector;
+	healthMessage?: string;
+	onClose: () => void;
+}) {
+	const [tab, setTab] = useState<TabId>('summary');
+	const [manifest, setManifest] = useState<Record<string, unknown> | null>(
+		null,
+	);
+	const [manifestLoading, setManifestLoading] = useState(true);
+	const [manifestError, setManifestError] = useState<string | null>(null);
+
+	const [events, setEvents] = useState<AppEvent[] | null>(null);
+	const [eventsLoading, setEventsLoading] = useState(false);
+	const [eventsError, setEventsError] = useState<string | null>(null);
+
+	const [managed, setManaged] = useState<ManagedResource | null>(null);
+	const [managedLoading, setManagedLoading] = useState(false);
+	const [managedError, setManagedError] = useState<string | null>(null);
+
+	const isPod = sel.kind === 'Pod';
+
+	const tabs: { id: TabId; label: string }[] = [
+		{ id: 'summary', label: 'Summary' },
+		{ id: 'manifest', label: 'Manifest' },
+		{ id: 'events', label: 'Events' },
+		{ id: 'diff', label: 'Diff' },
+		...(isPod ? [{ id: 'logs' as TabId, label: 'Logs' }] : []),
+	];
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				setManifestLoading(true);
+				setManifestError(null);
+				const data = await fetchLiveResource(token, sel);
+				if (!cancelled) setManifest(data);
+			} catch (e: unknown) {
+				if (!cancelled)
+					setManifestError(
+						e instanceof Error ? e.message : 'Failed to load',
+					);
+			} finally {
+				if (!cancelled) setManifestLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [token, sel.appName, sel.kind, sel.namespace, sel.name, sel.group]);
+
+	useEffect(() => {
+		if (tab !== 'events' || events !== null) return;
+		let cancelled = false;
+		(async () => {
+			try {
+				setEventsLoading(true);
+				setEventsError(null);
+				const data = await fetchAppEvents(token, sel.appName, {
+					uid:
+						sel.uid ??
+						((manifest?.metadata as Record<string, unknown>)
+							?.uid as string | undefined),
+					namespace: sel.namespace,
+					name: sel.name,
+					kind: sel.kind,
+				});
+				if (!cancelled) setEvents(data);
+			} catch (e: unknown) {
+				if (!cancelled)
+					setEventsError(
+						e instanceof Error ? e.message : 'Failed to load',
+					);
+			} finally {
+				if (!cancelled) setEventsLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		tab,
+		token,
+		sel.appName,
+		sel.uid,
+		sel.namespace,
+		sel.name,
+		sel.kind,
+		manifest,
+		events,
+	]);
+
+	useEffect(() => {
+		if (tab !== 'diff' || managed !== null || managedError !== null) return;
+		let cancelled = false;
+		(async () => {
+			try {
+				setManagedLoading(true);
+				setManagedError(null);
+				const all = await fetchManagedResources(token, sel.appName);
+				const match =
+					all.find(
+						(m) =>
+							m.kind === sel.kind &&
+							m.name === sel.name &&
+							(m.namespace ?? '') === sel.namespace,
+					) ?? null;
+				if (!cancelled) setManaged(match);
+			} catch (e: unknown) {
+				if (!cancelled)
+					setManagedError(
+						e instanceof Error ? e.message : 'Failed to load',
+					);
+			} finally {
+				if (!cancelled) setManagedLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		tab,
+		token,
+		sel.appName,
+		sel.kind,
+		sel.namespace,
+		sel.name,
+		managed,
+		managedError,
+	]);
+
+	return (
+		<div
+			style={{
+				margin: '0.5rem 0 0.75rem',
+				padding: '0.75rem',
+				borderRadius: 8,
+				background: 'var(--sl-color-bg, #0d1117)',
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					marginBottom: '0.5rem',
+				}}>
+				<span
+					style={{
+						fontSize: '0.75rem',
+						padding: '2px 8px',
+						borderRadius: 4,
+						background: 'rgba(139, 92, 246, 0.12)',
+						color: '#c4b5fd',
+						fontWeight: 600,
+					}}>
+					{sel.kind}
+				</span>
+				<span
+					style={{
+						color: 'var(--sl-color-text, #e6edf3)',
+						fontSize: '0.85rem',
+						fontWeight: 600,
+					}}>
+					{sel.namespace ? `${sel.namespace}/` : ''}
+					{sel.name}
+				</span>
+				<button
+					onClick={onClose}
+					style={{
+						marginLeft: 'auto',
+						background: 'transparent',
+						border: 'none',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						cursor: 'pointer',
+						padding: 4,
+						display: 'flex',
+						alignItems: 'center',
+					}}
+					title="Close">
+					<X size={14} />
+				</button>
+			</div>
+
+			<TabBar tabs={tabs} active={tab} onSelect={setTab} />
+
+			{tab === 'summary' &&
+				(manifestLoading ? (
+					<FetchState loading error={null} />
+				) : manifestError ? (
+					<SummaryTab
+						sel={sel}
+						manifest={null}
+						healthMessage={healthMessage ?? manifestError}
+					/>
+				) : (
+					<SummaryTab
+						sel={sel}
+						manifest={manifest}
+						healthMessage={healthMessage}
+					/>
+				))}
+
+			{tab === 'manifest' &&
+				(manifestLoading ? (
+					<FetchState loading error={null} />
+				) : manifestError ? (
+					<FetchState loading={false} error={manifestError} />
+				) : manifest ? (
+					<CodeBlock>{toYaml(manifest)}</CodeBlock>
+				) : (
+					<FetchState
+						loading={false}
+						error={null}
+						empty="No manifest"
+					/>
+				))}
+
+			{tab === 'events' &&
+				(eventsLoading || events === null ? (
+					<FetchState loading={eventsLoading} error={eventsError} />
+				) : eventsError ? (
+					<FetchState loading={false} error={eventsError} />
+				) : (
+					<EventsList events={events} />
+				))}
+
+			{tab === 'diff' &&
+				(managedLoading ? (
+					<FetchState loading error={null} />
+				) : managedError ? (
+					<FetchState loading={false} error={managedError} />
+				) : (
+					<DiffTab sel={sel} managed={managed} />
+				))}
+
+			{tab === 'logs' && (
+				<LogsTab token={token} sel={sel} manifest={manifest} />
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
@@ -54,6 +54,17 @@ export interface ResourceNode {
 	kind: string;
 	namespace: string;
 	name: string;
+	uid?: string;
+	parentRefs?: Array<{
+		group?: string;
+		kind: string;
+		namespace?: string;
+		name: string;
+		uid?: string;
+	}>;
+	info?: Array<{ name: string; value: string }>;
+	createdAt?: string;
+	resourceVersion?: string;
 	health?: {
 		status: string;
 		message?: string;
@@ -62,6 +73,56 @@ export interface ResourceNode {
 
 export interface ResourceTree {
 	nodes: ResourceNode[];
+}
+
+export interface AppEvent {
+	type?: string;
+	reason?: string;
+	message?: string;
+	count?: number;
+	firstTimestamp?: string;
+	lastTimestamp?: string;
+	eventTime?: string;
+	source?: { component?: string; host?: string };
+	involvedObject?: {
+		kind?: string;
+		namespace?: string;
+		name?: string;
+		uid?: string;
+	};
+	metadata?: { uid?: string; name?: string; namespace?: string };
+}
+
+export interface ManagedResource {
+	group?: string;
+	version?: string;
+	kind: string;
+	namespace?: string;
+	name: string;
+	hook?: boolean;
+	requiresPruning?: boolean;
+	liveState?: string;
+	targetState?: string;
+	diff?: string;
+	normalizedLiveState?: string;
+	predictedLiveState?: string;
+}
+
+export interface LogLine {
+	content: string;
+	timeStamp?: string;
+	podName?: string;
+	last?: boolean;
+}
+
+export interface ResourceSelector {
+	appName: string;
+	kind: string;
+	namespace: string;
+	name: string;
+	group?: string;
+	version?: string;
+	uid?: string;
 }
 
 interface CachedData {
@@ -147,6 +208,138 @@ export async function fetchResourceTree(
 	return await resp.json();
 }
 
+export async function fetchLiveResource(
+	token: string,
+	sel: ResourceSelector,
+): Promise<Record<string, unknown>> {
+	const params = new URLSearchParams({
+		namespace: sel.namespace,
+		resourceName: sel.name,
+		kind: sel.kind,
+		version: sel.version ?? 'v1',
+		group: sel.group ?? '',
+	});
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/applications/${encodeURIComponent(sel.appName)}/resource?${params}`,
+		{
+			headers: { Authorization: `Bearer ${token}` },
+			signal: AbortSignal.timeout(15000),
+		},
+	);
+
+	if (resp.status === 403) throw new AccessRestrictedError();
+	if (resp.status === 404)
+		throw new Error('Resource not found in cluster (may be Missing)');
+	if (!resp.ok) throw new Error(`ArgoCD API error: ${resp.status}`);
+
+	const body = await resp.json();
+	const raw = body?.manifest;
+	if (typeof raw !== 'string')
+		throw new Error('Unexpected response: missing manifest');
+	try {
+		return JSON.parse(raw) as Record<string, unknown>;
+	} catch {
+		throw new Error('Failed to parse manifest JSON');
+	}
+}
+
+export async function fetchAppEvents(
+	token: string,
+	appName: string,
+	resourceFilter?: {
+		uid?: string;
+		namespace?: string;
+		name?: string;
+		kind?: string;
+	},
+): Promise<AppEvent[]> {
+	const params = new URLSearchParams();
+	if (resourceFilter?.uid) params.set('resourceUID', resourceFilter.uid);
+	if (resourceFilter?.namespace)
+		params.set('resourceNamespace', resourceFilter.namespace);
+	if (resourceFilter?.name) params.set('resourceName', resourceFilter.name);
+	const qs = params.toString();
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/applications/${encodeURIComponent(appName)}/events${qs ? `?${qs}` : ''}`,
+		{
+			headers: { Authorization: `Bearer ${token}` },
+			signal: AbortSignal.timeout(10000),
+		},
+	);
+
+	if (resp.status === 403) throw new AccessRestrictedError();
+	if (!resp.ok) throw new Error(`ArgoCD API error: ${resp.status}`);
+
+	const body = await resp.json();
+	return Array.isArray(body?.items) ? (body.items as AppEvent[]) : [];
+}
+
+export async function fetchManagedResources(
+	token: string,
+	appName: string,
+): Promise<ManagedResource[]> {
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/applications/${encodeURIComponent(appName)}/managed-resources`,
+		{
+			headers: { Authorization: `Bearer ${token}` },
+			signal: AbortSignal.timeout(15000),
+		},
+	);
+
+	if (resp.status === 403) throw new AccessRestrictedError();
+	if (!resp.ok) throw new Error(`ArgoCD API error: ${resp.status}`);
+
+	const body = await resp.json();
+	return Array.isArray(body?.items) ? (body.items as ManagedResource[]) : [];
+}
+
+export async function fetchPodLogs(
+	token: string,
+	appName: string,
+	podName: string,
+	opts: {
+		namespace: string;
+		container?: string;
+		tailLines?: number;
+		sinceSeconds?: number;
+	},
+): Promise<LogLine[]> {
+	const params = new URLSearchParams({
+		namespace: opts.namespace,
+		podName: podName,
+		tailLines: String(opts.tailLines ?? 200),
+		follow: 'false',
+	});
+	if (opts.container) params.set('container', opts.container);
+	if (opts.sinceSeconds)
+		params.set('sinceSeconds', String(opts.sinceSeconds));
+
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/applications/${encodeURIComponent(appName)}/pods/${encodeURIComponent(podName)}/logs?${params}`,
+		{
+			headers: { Authorization: `Bearer ${token}` },
+			signal: AbortSignal.timeout(20000),
+		},
+	);
+
+	if (resp.status === 403) throw new AccessRestrictedError();
+	if (resp.status === 404) throw new Error('Pod not found');
+	if (!resp.ok) throw new Error(`ArgoCD API error: ${resp.status}`);
+
+	const text = await resp.text();
+	const lines: LogLine[] = [];
+	for (const raw of text.split('\n')) {
+		if (!raw.trim()) continue;
+		try {
+			const parsed = JSON.parse(raw);
+			if (parsed?.result) lines.push(parsed.result as LogLine);
+		} catch {
+			lines.push({ content: raw });
+		}
+	}
+	return lines;
+}
+
 // ---------------------------------------------------------------------------
 // Cache helpers
 // ---------------------------------------------------------------------------
@@ -220,6 +413,10 @@ class ArgoService {
 	public readonly $errorReason = atom<string | null>(null);
 	public readonly $lastUpdated = atom<Date | null>(null);
 	public readonly $expandedApp = atom<string | null>(null);
+	public readonly $selectedResource = atom<ResourceSelector | null>(null);
+	public readonly $appTab = atom<'resources' | 'events' | 'history'>(
+		'resources',
+	);
 
 	// Computed
 	public readonly $totalApps = computed(
@@ -332,9 +529,32 @@ class ArgoService {
 	public toggleExpandedApp(name: string): void {
 		if (this.$expandedApp.get() === name) {
 			this.$expandedApp.set(null);
+			this.$selectedResource.set(null);
 		} else {
 			this.$expandedApp.set(name);
+			this.$appTab.set('resources');
+			this.$selectedResource.set(null);
 		}
+	}
+
+	public selectResource(sel: ResourceSelector | null): void {
+		const cur = this.$selectedResource.get();
+		if (
+			sel &&
+			cur &&
+			cur.appName === sel.appName &&
+			cur.kind === sel.kind &&
+			cur.namespace === sel.namespace &&
+			cur.name === sel.name
+		) {
+			this.$selectedResource.set(null);
+		} else {
+			this.$selectedResource.set(sel);
+		}
+	}
+
+	public setAppTab(tab: 'resources' | 'events' | 'history'): void {
+		this.$appTab.set(tab);
 	}
 
 	private _startAutoRefresh(): void {


### PR DESCRIPTION
## Summary

The argo dashboard previously stopped at the resource-tree list (kind, namespace/name, health icon). To dig deeper you had to switch to ArgoCD's own UI. This brings the inspection surface inline so the dashboard is closer to a 1:1 of what ArgoCD shows for a single app.

Frontend-only — the existing axum proxy at `/dashboard/argo/proxy` is fully transparent (JWT + DASHBOARD_VIEW gate, no path whitelist), so the new endpoints flow through unchanged. No backend or RBAC changes.

## What's new

**App-level expansion** now has three tabs:
- **Resources** — grouped child resource list (existing behavior)
- **Events** — application-wide kubernetes events
- **Sync History** — entries from `app.status.history` (revision, source, deployedAt)

**Each resource row** in the Resources tab is now clickable and opens an inline detail drawer with up to five tabs:
- **Summary** — kind / api group / namespace / uid / labels / annotations + `health.message` highlighted as a banner
- **Manifest** — live cluster state rendered as YAML (inline emitter, no new dep)
- **Events** — events filtered by `resourceUID + namespace + name`
- **Diff** — live vs target side-by-side, plus pruning warning when `requiresPruning`
- **Logs** — Pod kind only; container picker, tailLines selector (100/200/500/1000), refresh

## Argo endpoints used

- ` GET /api/v1/applications/{name}/resource?namespace=&resourceName=&kind=&group=&version=`
- ` GET /api/v1/applications/{name}/events?resourceUID=&resourceNamespace=&resourceName=`
- ` GET /api/v1/applications/{name}/managed-resources`
- ` GET /api/v1/applications/{name}/pods/{pod}/logs?namespace=&container=&tailLines=&follow=false`

## Files

- ` apps/kbve/astro-kbve/src/components/dashboard/argoService.ts` — extended types (\`ResourceNode.uid\`/parentRefs, \`AppEvent\`, \`ManagedResource\`, \`LogLine\`, \`ResourceSelector\`); new fetchers; new \`\$selectedResource\` + \`\$appTab\` atoms with toggle helpers
- ` apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx` (new) — drawer + inline YAML emitter + Summary/Manifest/Events/Diff/Logs tabs
- ` apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx` — resource rows clickable, app expansion gets the tab bar, Sync History pulled from \`app.status.history\`

## Test plan

- [x] \`nx run astro-kbve:build\` clean (5490 pages)
- [ ] Open \`/dashboard/argo/\`, expand kilobase, verify Resources tab matches old behavior
- [ ] Click a Pod, verify Summary loads, switch to Manifest, Events, Diff, Logs
- [ ] Click a non-Pod (Secret/ConfigMap), verify Logs tab is hidden
- [ ] Verify Diff tab gracefully reports "Resource not managed by Argo" for live-only resources
- [ ] Switch to app-level Events / Sync History tabs