### PR TITLE
fix(mc): airship scale 1.0 + hull HP + iron repair + texture path + clearAll orphans

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBTexture.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/bbmodel/BBTexture.java
@@ -38,10 +38,14 @@ public class BBTexture {
         this.uvWidth = BBModelUtils.getIntElement(element, "uv_width", 16);
         this.uvHeight = BBModelUtils.getIntElement(element, "uv_height", 16);
 
+        String pathName = this.name.endsWith(".png") ? this.name : this.name + ".png";
         if (this.name.contains(":")) {
             this.location = Identifier.of(this.name);
         } else {
-            this.location = Identifier.of(identifier.getNamespace(), "textures/entity/" + this.name);
+            String modelPath = identifier.getPath();
+            int lastSlash = modelPath.lastIndexOf('/');
+            String folder = lastSlash >= 0 ? modelPath.substring(0, lastSlash + 1) : "";
+            this.location = Identifier.of(identifier.getNamespace(), "textures/entity/" + folder + pathName);
         }
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -48,11 +48,11 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
     private static final java.util.Set<String> MISSING_MODELS_LOGGED =
             java.util.concurrent.ConcurrentHashMap.newKeySet();
 
-    private static final float MODEL_SCALE = 1.0f / 4.0f;
+    private static final float MODEL_SCALE = 1.0f;
 
     public BBModelShipRenderer(EntityRendererFactory.Context ctx) {
         super(ctx);
-        this.shadowRadius = 2.0f;
+        this.shadowRadius = 4.0f;
     }
 
     // -- State lifecycle ----------------------------------------------------

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -53,6 +53,7 @@ public class ShipClientMod implements ClientModInitializer {
                 setActiveHelm(idStr, shipEntity.getShipName());
             }
             hud.setTelemetry(shipEntity.getTargetSpeed(), shipEntity.getYaw(), (int) Math.floor(shipEntity.getY()));
+            hud.setHealth(shipEntity.getShipHealth(), ShipEntity.MAX_HEALTH);
         } else if (activeHelmShipId != null) {
             LOGGER.info("[Ship Client] Dismounted — clearing helm");
             clearActiveHelm();

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -17,6 +17,8 @@ public class ShipHud implements HudRenderCallback {
     private float speed = 0f;
     private float heading = 0f;
     private int altitude = 0;
+    private float health = 100f;
+    private float maxHealth = 100f;
 
     public void setActive(String shipName) {
         this.active = true;
@@ -48,6 +50,11 @@ public class ShipHud implements HudRenderCallback {
         this.speed = speed;
         this.heading = heading;
         this.altitude = altitude;
+    }
+
+    public void setHealth(float health, float maxHealth) {
+        this.health = health;
+        this.maxHealth = maxHealth;
     }
 
     public boolean isActive() {
@@ -106,6 +113,21 @@ public class ShipHud implements HudRenderCallback {
         int telWidth = client.textRenderer.getWidth(telemetry);
         context.drawText(client.textRenderer, Text.of("§e" + telemetry),
                 (screenWidth - telWidth) / 2, screenHeight - 78, 0xFFFFFFFF, true);
+
+        int barW = 120;
+        int barH = 6;
+        int barX = (screenWidth - barW) / 2;
+        int barY = screenHeight - 66;
+        float ratio = maxHealth > 0 ? Math.max(0f, Math.min(1f, health / maxHealth)) : 0f;
+        int fillW = (int) (barW * ratio);
+        int hpColor = ratio > 0.5f ? 0xFF44CC44 : (ratio > 0.25f ? 0xFFCCAA22 : 0xFFCC2222);
+        context.fill(barX - 1, barY - 1, barX + barW + 1, barY + barH + 1, 0xFF000000);
+        context.fill(barX, barY, barX + barW, barY + barH, 0xFF333333);
+        if (fillW > 0) context.fill(barX, barY, barX + fillW, barY + barH, hpColor);
+        String hpText = String.format("HULL %.0f / %.0f", health, maxHealth);
+        int hpW = client.textRenderer.getWidth(hpText);
+        context.drawText(client.textRenderer, Text.of("§f" + hpText),
+                (screenWidth - hpW) / 2, barY - 10, 0xFFFFFFFF, true);
 
         if (inputBoost && speed > 0) {
             String boostTag = "§6§lBOOST";

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -38,6 +38,10 @@ public class ShipEntity extends Entity {
             DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
     private static final TrackedData<String> SHIP_ID =
             DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
+    private static final TrackedData<Float> SHIP_HEALTH =
+            DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.FLOAT);
+
+    public static final float MAX_HEALTH = 100.0f;
 
     private String ownerUuidStr = "";
     private float heading = 0.0f;
@@ -90,11 +94,26 @@ public class ShipEntity extends Entity {
     public float getVerticalIntent() { return verticalIntent; }
     public void setVerticalIntent(float v) { this.verticalIntent = Math.max(-1f, Math.min(1f, v)); }
 
+    public float getShipHealth() { return this.dataTracker.get(SHIP_HEALTH); }
+    public void setShipHealth(float hp) {
+        this.dataTracker.set(SHIP_HEALTH, Math.max(0f, Math.min(MAX_HEALTH, hp)));
+    }
+
     @Override
     public boolean damage(net.minecraft.server.world.ServerWorld world,
                           net.minecraft.entity.damage.DamageSource source,
                           float amount) {
-        return false;
+        if (this.isRemoved()) return false;
+        if (source.isIn(net.minecraft.registry.tag.DamageTypeTags.IS_FIRE)) return false;
+        if (source.isIn(net.minecraft.registry.tag.DamageTypeTags.IS_FALL)) return false;
+
+        float newHp = getShipHealth() - amount;
+        setShipHealth(newHp);
+        if (newHp <= 0f) {
+            this.removeAllPassengers();
+            this.discard();
+        }
+        return true;
     }
 
     @Override
@@ -110,6 +129,21 @@ public class ShipEntity extends Entity {
     @Override
     public ActionResult interact(PlayerEntity player, Hand hand) {
         if (player.isSneaking()) return ActionResult.PASS;
+
+        net.minecraft.item.ItemStack stack = player.getStackInHand(hand);
+        if (stack.isOf(net.minecraft.item.Items.IRON_INGOT) && getShipHealth() < MAX_HEALTH) {
+            float before = getShipHealth();
+            setShipHealth(before + 25.0f);
+            if (!player.getAbilities().creativeMode) {
+                stack.decrement(1);
+            }
+            if (!this.getEntityWorld().isClient()) {
+                player.sendMessage(net.minecraft.text.Text.of(
+                        String.format("Ship repaired: %.0f → %.0f / %.0f",
+                                before, getShipHealth(), MAX_HEALTH)), true);
+            }
+            return ActionResult.SUCCESS;
+        }
 
         if (player instanceof ServerPlayerEntity && !this.hasPassengers()) {
             player.startRiding(this);
@@ -171,6 +205,7 @@ public class ShipEntity extends Entity {
         builder.add(MODEL_NAME, "immersive_aircraft/airship");
         builder.add(SHIP_NAME, "");
         builder.add(SHIP_ID, "");
+        builder.add(SHIP_HEALTH, MAX_HEALTH);
     }
 
     @Override
@@ -181,6 +216,7 @@ public class ShipEntity extends Entity {
         setShipName(view.getString("ShipName", ""));
         this.heading = view.getFloat("Heading", 0.0f);
         this.targetSpeed = view.getFloat("TargetSpeed", 0.0f);
+        setShipHealth(view.getFloat("ShipHealth", MAX_HEALTH));
     }
 
     @Override
@@ -191,5 +227,6 @@ public class ShipEntity extends Entity {
         view.putString("ShipName", getShipName());
         view.putFloat("Heading", heading);
         view.putFloat("TargetSpeed", targetSpeed);
+        view.putFloat("ShipHealth", getShipHealth());
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
@@ -45,6 +45,7 @@ public final class ShipManager {
         entity.setShipId(shipId);
         entity.setOwnerUuid(ownerUuid);
         entity.setModelName(modelName);
+        entity.setShipHealth(ShipEntity.MAX_HEALTH);
         entity.refreshPositionAndAngles(
                 nearPos.getX() + 0.5,
                 nearPos.getY() + SPAWN_HEIGHT_OFFSET,
@@ -113,13 +114,22 @@ public final class ShipManager {
      * Remove all active ships (dev tool).
      */
     public void clearAll(ServerWorld world) {
+        int tracked = activeShips.size();
         for (var entry : activeShips.entrySet()) {
             entry.getValue().removeAllPassengers();
             entry.getValue().discard();
         }
-        int count = activeShips.size();
         activeShips.clear();
-        LOGGER.info("[Ship] Cleared all {} ships", count);
+
+        int orphans = 0;
+        for (var entity : world.iterateEntities()) {
+            if (entity instanceof ShipEntity ship && ship.isAlive()) {
+                ship.removeAllPassengers();
+                ship.discard();
+                orphans++;
+            }
+        }
+        LOGGER.info("[Ship] Cleared {} tracked + {} orphan ships", tracked, orphans);
     }
 
     /**


### PR DESCRIPTION
## Summary
Follow-up to #10459, merged before these landed. Bundled into one PR.

- **Scale 1.0** — \`MODEL_SCALE = 1.0f\`, shadow radius 4.0. The 1/4 from #10457 still rendered too small per playtest.
- **BBModel texture path fix** — pink/black missing-texture cause: \`BBTexture\` built identifier as \`textures/entity/airship\` (no \`.png\`, no parent folder). Now appends \`.png\` and mirrors the model's parent dir, so \`objects/immersive_aircraft/airship.bbmodel\` resolves to \`textures/entity/immersive_aircraft/airship.png\`.
- **Hull HP system.** \`SHIP_HEALTH\` TrackedData (default + cap = 100). \`damage()\` subtracts (skipping fire/fall) and discards on 0. NBT save/load + spawn-init.
- **Repair via iron ingot.** Right-click ship with iron ingot → +25 HP, consumes 1 ingot (creative skipped). Mount path falls through when full HP / no iron.
- **HUD hull bar** — green/yellow/red ramp with \`HULL n / 100\` readout above compass.
- **\`/clearallships\` orphans** — now also iterates \`world.iterateEntities()\` and discards every \`ShipEntity\`, not just tracking-map entries. Old persistent ships from a previous boot get swept.

## Test plan
- [ ] Wait for next mc Docker publish + new mrpack
- [ ] \`/spawnship airship\` — correct colors (no pink/black), full-scale (~1:1)
- [ ] HUD shows green hull bar
- [ ] Sword-hit a ship → bar drops, color shifts yellow/red
- [ ] Right-click iron ingot → bar climbs +25, ingot consumed
- [ ] \`/clearallships\` removes orphan ships from prior session