### PR TITLE
fix(mc): align pet creature tags so pet_dog/pet_parrot spawn intents resolve

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentDecoder.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/command/IntentDecoder.java
@@ -31,8 +31,8 @@ public final class IntentDecoder {
     /** Legacy wire key → (creatureTag, tamed). */
     private static final Map<String, LegacySpawn> LEGACY_SPAWNS = Map.of(
             "SpawnSkeleton", new LegacySpawn("skeleton", false),
-            "SpawnPetDog", new LegacySpawn("pet_dog", true),
-            "SpawnPetParrot", new LegacySpawn("pet_parrot", true),
+            "SpawnPetDog", new LegacySpawn("dog", true),
+            "SpawnPetParrot", new LegacySpawn("parrot", true),
             "SpawnSkeletonMelee", new LegacySpawn("skeleton_melee", false),
             "SpawnSkeletonMage", new LegacySpawn("skeleton_mage", false),
             "SpawnSkeletonArcher", new LegacySpawn("skeleton_archer", false)


### PR DESCRIPTION
## Summary
Live server log was emitting once per population-manager tick (~2s):

\`\`\`
[AI] Unknown creature tag 'pet_dog' in SpawnCreature
[AI] Unknown creature tag 'pet_parrot' in SpawnCreature
\`\`\`

Pet population manager fires \`SpawnPetDog\` / \`SpawnPetParrot\` whenever an online player has no dog/parrot in the ECS dogs/parrots query. Java side accepted the intents but rejected the lookup because the registry key didn't match.

## Cause
\`IntentDecoder.LEGACY_SPAWNS\` mapped:
- \`SpawnPetDog\` → \`SpawnCreature{tag:"pet_dog", tamed:true}\`
- \`SpawnPetParrot\` → \`SpawnCreature{tag:"pet_parrot", tamed:true}\`

But \`PetDogCreatureKind.tag()\` returns \`"dog"\` and \`PetParrotCreatureKind.tag()\` returns \`"parrot"\`. \`WorldCommandApplier.creatureRegistry\` is keyed by \`kind.tag()\`, so lookups for \`"pet_dog"\` / \`"pet_parrot"\` always returned null.

## Fix
Align the decoder strings with the actual tag values: \`pet_dog → dog\`, \`pet_parrot → parrot\`. One-line each.

## Test plan
- [ ] Wait for next mc Docker publish + restart
- [ ] Server log no longer spams \`Unknown creature tag\`
- [ ] Within 4s of joining a fresh world, pet wolf + parrot spawn beside the player
- [ ] After \`/kill\`-ing them, they respawn on the next pop-manager pass