### PR TITLE
feat(astro-kbve,edge-logs): deepen argo dashboard with ClickHouse cross-integration + container/conditions panels + tree view + filters

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
@@ -128,6 +128,101 @@ function ErrorBlock({ message }: { message: string }) {
 	);
 }
 
+type ResourceViewMode = 'kind' | 'tree';
+
+function ResourceRow({
+	node,
+	depth,
+	appName,
+	selected,
+	token,
+	onSelectResource,
+}: {
+	node: ResourceNode;
+	depth: number;
+	appName: string;
+	selected: boolean;
+	token: string;
+	onSelectResource: (sel: ResourceSelector) => void;
+}) {
+	const sel: ResourceSelector = {
+		appName,
+		kind: node.kind,
+		namespace: node.namespace ?? '',
+		name: node.name,
+		group: node.group,
+		version: node.version,
+		uid: node.uid,
+	};
+	return (
+		<>
+			<div
+				onClick={() => onSelectResource(sel)}
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					padding: '4px 8px',
+					paddingLeft: 8 + depth * 16,
+					fontSize: '0.8rem',
+					color: 'var(--sl-color-text, #e6edf3)',
+					cursor: 'pointer',
+					borderRadius: 4,
+					background: selected
+						? 'rgba(139, 92, 246, 0.12)'
+						: 'transparent',
+					transition: 'background 0.12s',
+				}}
+				onMouseEnter={(e) => {
+					if (!selected) {
+						e.currentTarget.style.background =
+							'rgba(255, 255, 255, 0.03)';
+					}
+				}}
+				onMouseLeave={(e) => {
+					if (!selected) {
+						e.currentTarget.style.background = 'transparent';
+					}
+				}}>
+				{node.health && (
+					<span
+						style={{
+							color: healthColor(node.health.status),
+						}}>
+						{healthIcon(node.health.status)}
+					</span>
+				)}
+				<span
+					style={{
+						fontSize: '0.7rem',
+						padding: '0 6px',
+						borderRadius: 3,
+						background: 'rgba(139, 92, 246, 0.1)',
+						color: '#c4b5fd',
+						fontWeight: 600,
+					}}>
+					{node.kind}
+				</span>
+				<span
+					style={{
+						color: 'var(--sl-color-gray-4, #6b7280)',
+					}}>
+					{node.namespace}/
+				</span>
+				{node.name}
+			</div>
+			{selected && (
+				<ReactArgoResourceDetail
+					token={token}
+					sel={sel}
+					healthMessage={node.health?.message}
+					onClose={() => argoService.selectResource(null)}
+				/>
+			)}
+		</>
+	);
+}
+
 function ResourceTreePanel({
 	token,
 	appName,
@@ -142,6 +237,11 @@ function ResourceTreePanel({
 	const [tree, setTree] = useState<ResourceTree | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+
+	const [viewMode, setViewMode] = useState<ResourceViewMode>('kind');
+	const [kindFilter, setKindFilter] = useState<string>('');
+	const [healthFilter, setHealthFilter] = useState<string>('');
+	const [search, setSearch] = useState<string>('');
 
 	useEffect(() => {
 		let cancelled = false;
@@ -162,6 +262,27 @@ function ResourceTreePanel({
 		};
 	}, [token, appName]);
 
+	const isSelected = (n: ResourceNode) =>
+		!!selectedResource &&
+		selectedResource.appName === appName &&
+		selectedResource.kind === n.kind &&
+		selectedResource.namespace === (n.namespace ?? '') &&
+		selectedResource.name === n.name;
+
+	const filterMatch = (n: ResourceNode) => {
+		if (kindFilter && n.kind !== kindFilter) return false;
+		if (healthFilter && n.health?.status !== healthFilter) return false;
+		if (search) {
+			const q = search.toLowerCase();
+			if (
+				!n.name.toLowerCase().includes(q) &&
+				!(n.namespace ?? '').toLowerCase().includes(q)
+			)
+				return false;
+		}
+		return true;
+	};
+
 	if (loading) return <LoadingBlock label="Loading resources..." />;
 	if (error) return <ErrorBlock message={error} />;
 	if (!tree?.nodes?.length) {
@@ -177,7 +298,167 @@ function ResourceTreePanel({
 		);
 	}
 
-	const grouped = tree.nodes.reduce(
+	const allKinds = Array.from(new Set(tree.nodes.map((n) => n.kind))).sort();
+	const filtered = tree.nodes.filter(filterMatch);
+
+	const filterControls = (
+		<div
+			style={{
+				display: 'flex',
+				gap: 8,
+				marginBottom: 8,
+				alignItems: 'center',
+				flexWrap: 'wrap',
+			}}>
+			<div
+				style={{
+					display: 'inline-flex',
+					borderRadius: 6,
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					overflow: 'hidden',
+				}}>
+				{(['kind', 'tree'] as ResourceViewMode[]).map((m) => (
+					<button
+						key={m}
+						onClick={() => setViewMode(m)}
+						style={{
+							background:
+								viewMode === m
+									? 'rgba(139, 92, 246, 0.15)'
+									: 'transparent',
+							color:
+								viewMode === m
+									? '#c4b5fd'
+									: 'var(--sl-color-gray-3, #8b949e)',
+							border: 'none',
+							padding: '4px 10px',
+							fontSize: '0.75rem',
+							fontWeight: 600,
+							cursor: 'pointer',
+							textTransform: 'capitalize',
+						}}>
+						{m === 'kind' ? 'By Kind' : 'Tree'}
+					</button>
+				))}
+			</div>
+			<select
+				value={kindFilter}
+				onChange={(e) => setKindFilter(e.target.value)}
+				style={smallSelectStyle}>
+				<option value="">All kinds</option>
+				{allKinds.map((k) => (
+					<option key={k} value={k}>
+						{k}
+					</option>
+				))}
+			</select>
+			<select
+				value={healthFilter}
+				onChange={(e) => setHealthFilter(e.target.value)}
+				style={smallSelectStyle}>
+				<option value="">All health</option>
+				<option value="Healthy">Healthy</option>
+				<option value="Degraded">Degraded</option>
+				<option value="Progressing">Progressing</option>
+				<option value="Suspended">Suspended</option>
+				<option value="Missing">Missing</option>
+			</select>
+			<input
+				value={search}
+				onChange={(e) => setSearch(e.target.value)}
+				placeholder="filter by name/namespace..."
+				style={{
+					...smallSelectStyle,
+					minWidth: 180,
+					flex: '1 1 200px',
+				}}
+			/>
+			<span
+				style={{
+					fontSize: '0.7rem',
+					color: 'var(--sl-color-gray-4, #6b7280)',
+				}}>
+				{filtered.length}/{tree.nodes.length}
+			</span>
+		</div>
+	);
+
+	if (filtered.length === 0) {
+		return (
+			<div>
+				{filterControls}
+				<div
+					style={{
+						padding: '1rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.85rem',
+					}}>
+					No resources match current filter
+				</div>
+			</div>
+		);
+	}
+
+	if (viewMode === 'tree') {
+		const byUid = new Map<string, ResourceNode>();
+		for (const n of tree.nodes) {
+			if (n.uid) byUid.set(n.uid, n);
+		}
+		const childrenByParentUid = new Map<string, ResourceNode[]>();
+		const roots: ResourceNode[] = [];
+		for (const n of tree.nodes) {
+			const parentUid = n.parentRefs?.[0]?.uid;
+			if (parentUid && byUid.has(parentUid)) {
+				const arr = childrenByParentUid.get(parentUid) ?? [];
+				arr.push(n);
+				childrenByParentUid.set(parentUid, arr);
+			} else {
+				roots.push(n);
+			}
+		}
+
+		const filteredUids = new Set(
+			filtered.map((n) => n.uid).filter(Boolean) as string[],
+		);
+		const includesFilteredDescendant = (n: ResourceNode): boolean => {
+			if (n.uid && filteredUids.has(n.uid)) return true;
+			const kids = (n.uid && childrenByParentUid.get(n.uid)) || [];
+			return kids.some(includesFilteredDescendant);
+		};
+
+		const renderNode = (
+			n: ResourceNode,
+			depth: number,
+		): React.ReactNode => {
+			if (!includesFilteredDescendant(n)) return null;
+			const kids =
+				(n.uid && childrenByParentUid.get(n.uid)) ||
+				([] as ResourceNode[]);
+			return (
+				<React.Fragment
+					key={`${n.uid ?? `${n.namespace}-${n.name}-${depth}`}`}>
+					<ResourceRow
+						node={n}
+						depth={depth}
+						appName={appName}
+						selected={isSelected(n)}
+						token={token}
+						onSelectResource={onSelectResource}
+					/>
+					{kids.map((k) => renderNode(k, depth + 1))}
+				</React.Fragment>
+			);
+		};
+
+		return (
+			<div>
+				{filterControls}
+				{roots.map((r) => renderNode(r, 0))}
+			</div>
+		);
+	}
+
+	const grouped = filtered.reduce(
 		(acc, node) => {
 			const kind = node.kind;
 			if (!acc[kind]) acc[kind] = [];
@@ -187,15 +468,9 @@ function ResourceTreePanel({
 		{} as Record<string, ResourceNode[]>,
 	);
 
-	const isSelected = (n: ResourceNode) =>
-		!!selectedResource &&
-		selectedResource.appName === appName &&
-		selectedResource.kind === n.kind &&
-		selectedResource.namespace === (n.namespace ?? '') &&
-		selectedResource.name === n.name;
-
 	return (
 		<div>
+			{filterControls}
 			{Object.entries(grouped).map(([kind, nodes]) => (
 				<div key={kind} style={{ marginBottom: '0.75rem' }}>
 					<div
@@ -209,84 +484,31 @@ function ResourceTreePanel({
 						}}>
 						{kind} ({nodes.length})
 					</div>
-					{nodes.map((node, i) => {
-						const selected = isSelected(node);
-						const sel: ResourceSelector = {
-							appName,
-							kind: node.kind,
-							namespace: node.namespace ?? '',
-							name: node.name,
-							group: node.group,
-							version: node.version,
-							uid: node.uid,
-						};
-						return (
-							<React.Fragment
-								key={`${node.namespace}-${node.name}-${i}`}>
-								<div
-									onClick={() => onSelectResource(sel)}
-									style={{
-										display: 'flex',
-										alignItems: 'center',
-										gap: 8,
-										padding: '4px 8px',
-										fontSize: '0.8rem',
-										color: 'var(--sl-color-text, #e6edf3)',
-										cursor: 'pointer',
-										borderRadius: 4,
-										background: selected
-											? 'rgba(139, 92, 246, 0.12)'
-											: 'transparent',
-										transition: 'background 0.12s',
-									}}
-									onMouseEnter={(e) => {
-										if (!selected) {
-											e.currentTarget.style.background =
-												'rgba(255, 255, 255, 0.03)';
-										}
-									}}
-									onMouseLeave={(e) => {
-										if (!selected) {
-											e.currentTarget.style.background =
-												'transparent';
-										}
-									}}>
-									{node.health && (
-										<span
-											style={{
-												color: healthColor(
-													node.health.status,
-												),
-											}}>
-											{healthIcon(node.health.status)}
-										</span>
-									)}
-									<span
-										style={{
-											color: 'var(--sl-color-gray-4, #6b7280)',
-										}}>
-										{node.namespace}/
-									</span>
-									{node.name}
-								</div>
-								{selected && (
-									<ReactArgoResourceDetail
-										token={token}
-										sel={sel}
-										healthMessage={node.health?.message}
-										onClose={() =>
-											argoService.selectResource(null)
-										}
-									/>
-								)}
-							</React.Fragment>
-						);
-					})}
+					{nodes.map((node, i) => (
+						<ResourceRow
+							key={`${node.uid ?? `${node.namespace}-${node.name}-${i}`}`}
+							node={node}
+							depth={0}
+							appName={appName}
+							selected={isSelected(node)}
+							token={token}
+							onSelectResource={onSelectResource}
+						/>
+					))}
 				</div>
 			))}
 		</div>
 	);
 }
+
+const smallSelectStyle: React.CSSProperties = {
+	background: 'var(--sl-color-bg-nav, #111)',
+	color: 'var(--sl-color-text, #e6edf3)',
+	border: '1px solid var(--sl-color-gray-5, #262626)',
+	borderRadius: 6,
+	padding: '4px 8px',
+	fontSize: '0.75rem',
+};
 
 function AppEventsPanel({
 	token,

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
@@ -9,6 +9,7 @@ import {
 	type ManagedResource,
 	type ResourceSelector,
 } from './argoService';
+import { fetchIndexedLogs, type LogRow } from './clickhouseService';
 import { Loader2, X, AlertCircle } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -70,7 +71,15 @@ function toYaml(value: unknown, indent = 0): string {
 // Tab bar
 // ---------------------------------------------------------------------------
 
-type TabId = 'summary' | 'manifest' | 'events' | 'diff' | 'logs';
+type TabId =
+	| 'summary'
+	| 'manifest'
+	| 'events'
+	| 'diff'
+	| 'logs'
+	| 'indexed'
+	| 'conditions'
+	| 'containers';
 
 function TabBar({
 	tabs,
@@ -727,9 +736,535 @@ function LogsTab({
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Main detail panel
-// ---------------------------------------------------------------------------
+function IndexedLogsTab({
+	token,
+	sel,
+	isPod,
+}: {
+	token: string;
+	sel: ResourceSelector;
+	isPod: boolean;
+}) {
+	const [rows, setRows] = useState<LogRow[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [minutes, setMinutes] = useState<number>(60);
+	const [level, setLevel] = useState<string>('');
+	const [search, setSearch] = useState<string>('');
+
+	const load = async () => {
+		try {
+			setLoading(true);
+			setError(null);
+			const data = await fetchIndexedLogs(token, {
+				namespace: sel.namespace || undefined,
+				podName: isPod ? sel.name : undefined,
+				level: level || undefined,
+				search: search || undefined,
+				minutes,
+				limit: 500,
+			});
+			setRows(data);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : 'Failed to load');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	useEffect(() => {
+		load();
+	}, [token, sel.appName, sel.namespace, sel.name, isPod, minutes, level]);
+
+	return (
+		<div>
+			<div
+				style={{
+					display: 'flex',
+					gap: 8,
+					marginBottom: 8,
+					alignItems: 'center',
+					flexWrap: 'wrap',
+				}}>
+				<span
+					style={{
+						fontSize: '0.7rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+					}}>
+					{isPod
+						? `pod=${sel.name}`
+						: `namespace=${sel.namespace || '(cluster)'}`}
+				</span>
+				<select
+					value={minutes}
+					onChange={(e) => setMinutes(Number(e.target.value))}
+					style={selectStyle}>
+					{[
+						[15, '15m'],
+						[60, '1h'],
+						[360, '6h'],
+						[1440, '24h'],
+						[10080, '7d'],
+					].map(([m, label]) => (
+						<option key={m} value={m}>
+							{label}
+						</option>
+					))}
+				</select>
+				<select
+					value={level}
+					onChange={(e) => setLevel(e.target.value)}
+					style={selectStyle}>
+					<option value="">All levels</option>
+					<option value="error">error</option>
+					<option value="warn">warn</option>
+					<option value="info">info</option>
+					<option value="debug">debug</option>
+				</select>
+				<input
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') load();
+					}}
+					placeholder="search message..."
+					style={{
+						...selectStyle,
+						minWidth: 180,
+						flex: '1 1 200px',
+					}}
+				/>
+				<button
+					onClick={load}
+					disabled={loading}
+					style={{
+						background: 'rgba(139, 92, 246, 0.12)',
+						color: '#c4b5fd',
+						border: '1px solid rgba(139, 92, 246, 0.3)',
+						borderRadius: 6,
+						padding: '4px 10px',
+						fontSize: '0.75rem',
+						cursor: loading ? 'wait' : 'pointer',
+					}}>
+					{loading ? 'Loading...' : 'Refresh'}
+				</button>
+			</div>
+			{error && (
+				<div
+					style={{
+						padding: '0.5rem 0.75rem',
+						color: '#ef4444',
+						fontSize: '0.8rem',
+						marginBottom: 8,
+					}}>
+					{error}
+				</div>
+			)}
+			{rows.length === 0 && !loading && !error ? (
+				<div
+					style={{
+						padding: '1rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.85rem',
+					}}>
+					No indexed log lines for this filter
+				</div>
+			) : (
+				<div
+					style={{
+						background: 'var(--sl-color-bg-inline-code, #0d1117)',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						maxHeight: 420,
+						overflow: 'auto',
+						fontFamily: 'var(--sl-font-mono, monospace)',
+						fontSize: '0.72rem',
+						lineHeight: 1.4,
+					}}>
+					{rows.map((r, i) => {
+						const ts = r.timestamp
+							? new Date(r.timestamp).toLocaleTimeString()
+							: '';
+						const lvl = String(r.level ?? '').toLowerCase();
+						const lvlColor =
+							lvl === 'error'
+								? '#ef4444'
+								: lvl === 'warn'
+									? '#fbbf24'
+									: lvl === 'debug'
+										? '#94a3b8'
+										: '#22c55e';
+						return (
+							<div
+								key={i}
+								style={{
+									padding: '4px 8px',
+									borderBottom:
+										i < rows.length - 1
+											? '1px solid rgba(255,255,255,0.03)'
+											: 'none',
+									display: 'grid',
+									gridTemplateColumns: '80px 60px 100px 1fr',
+									gap: 8,
+									alignItems: 'baseline',
+								}}>
+								<span
+									style={{
+										color: 'var(--sl-color-gray-4, #6b7280)',
+									}}>
+									{ts}
+								</span>
+								<span
+									style={{
+										color: lvlColor,
+										fontWeight: 600,
+										textTransform: 'uppercase',
+										fontSize: '0.65rem',
+									}}>
+									{r.level ?? ''}
+								</span>
+								<span
+									style={{
+										color: 'var(--sl-color-gray-4, #6b7280)',
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+										whiteSpace: 'nowrap',
+									}}
+									title={r.pod_name ?? ''}>
+									{r.pod_name ?? ''}
+								</span>
+								<span
+									style={{
+										color: 'var(--sl-color-text, #e6edf3)',
+										whiteSpace: 'pre-wrap',
+										wordBreak: 'break-word',
+									}}>
+									{r.message ?? ''}
+								</span>
+							</div>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}
+
+const selectStyle: React.CSSProperties = {
+	background: 'var(--sl-color-bg-nav, #111)',
+	color: 'var(--sl-color-text, #e6edf3)',
+	border: '1px solid var(--sl-color-gray-5, #262626)',
+	borderRadius: 6,
+	padding: '4px 8px',
+	fontSize: '0.8rem',
+};
+
+function ContainersTab({
+	containerStatuses,
+	initContainerStatuses,
+}: {
+	containerStatuses: Array<Record<string, unknown>>;
+	initContainerStatuses: Array<Record<string, unknown>>;
+}) {
+	const renderRow = (cs: Record<string, unknown>, isInit: boolean) => {
+		const name = cs.name as string;
+		const ready = cs.ready as boolean | undefined;
+		const started = cs.started as boolean | undefined;
+		const restartCount = cs.restartCount as number | undefined;
+		const image = cs.image as string | undefined;
+		const state = (cs.state as Record<string, unknown>) ?? {};
+		const lastState = (cs.lastState as Record<string, unknown>) ?? {};
+
+		const stateName = Object.keys(state)[0] ?? 'unknown';
+		const stateInfo = state[stateName] as
+			| Record<string, unknown>
+			| undefined;
+		const stateColor =
+			stateName === 'running'
+				? '#22c55e'
+				: stateName === 'waiting'
+					? '#fbbf24'
+					: '#ef4444';
+
+		const lastStateName = Object.keys(lastState)[0];
+		const lastInfo = lastStateName
+			? (lastState[lastStateName] as Record<string, unknown>)
+			: undefined;
+
+		return (
+			<div
+				key={`${isInit ? 'init-' : ''}${name}`}
+				style={{
+					padding: '0.6rem 0.75rem',
+					borderRadius: 6,
+					background: 'var(--sl-color-bg, #0d1117)',
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					marginBottom: 6,
+				}}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 8,
+						marginBottom: 4,
+						fontSize: '0.85rem',
+					}}>
+					{isInit && (
+						<span
+							style={{
+								fontSize: '0.65rem',
+								padding: '1px 6px',
+								borderRadius: 3,
+								background: 'rgba(148, 163, 184, 0.12)',
+								color: '#94a3b8',
+								fontWeight: 600,
+							}}>
+							INIT
+						</span>
+					)}
+					<span
+						style={{
+							fontWeight: 600,
+							color: 'var(--sl-color-text, #e6edf3)',
+						}}>
+						{name}
+					</span>
+					<span
+						style={{
+							fontSize: '0.7rem',
+							padding: '1px 8px',
+							borderRadius: 3,
+							color: stateColor,
+							background: `${stateColor}18`,
+							border: `1px solid ${stateColor}30`,
+							fontWeight: 600,
+							textTransform: 'uppercase',
+						}}>
+						{stateName}
+					</span>
+					{ready !== undefined && (
+						<span
+							style={{
+								fontSize: '0.7rem',
+								color: ready ? '#22c55e' : '#ef4444',
+							}}>
+							ready: {ready ? 'true' : 'false'}
+						</span>
+					)}
+					{started !== undefined && (
+						<span
+							style={{
+								fontSize: '0.7rem',
+								color: started ? '#22c55e' : '#fbbf24',
+							}}>
+							started: {started ? 'true' : 'false'}
+						</span>
+					)}
+					{restartCount !== undefined && restartCount > 0 && (
+						<span
+							style={{
+								marginLeft: 'auto',
+								fontSize: '0.7rem',
+								color: restartCount > 5 ? '#ef4444' : '#fbbf24',
+								fontWeight: 600,
+							}}>
+							restarts: {restartCount}
+						</span>
+					)}
+				</div>
+				{image && (
+					<div
+						style={{
+							fontSize: '0.7rem',
+							color: 'var(--sl-color-gray-4, #6b7280)',
+							fontFamily: 'var(--sl-font-mono, monospace)',
+							marginBottom: 4,
+							wordBreak: 'break-all',
+						}}>
+						{image}
+					</div>
+				)}
+				{stateInfo && Object.keys(stateInfo).length > 0 && (
+					<div
+						style={{
+							fontSize: '0.72rem',
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							marginTop: 4,
+						}}>
+						{stateInfo.reason ? (
+							<>
+								<span
+									style={{
+										color: stateColor,
+										fontWeight: 600,
+									}}>
+									{String(stateInfo.reason)}
+								</span>
+								{stateInfo.message
+									? `: ${String(stateInfo.message)}`
+									: ''}
+							</>
+						) : stateInfo.startedAt ? (
+							<>started {String(stateInfo.startedAt)}</>
+						) : null}
+					</div>
+				)}
+				{lastInfo && lastInfo.reason && (
+					<div
+						style={{
+							marginTop: 4,
+							fontSize: '0.7rem',
+							color: '#fca5a5',
+						}}>
+						last {lastStateName}: {String(lastInfo.reason)}
+						{lastInfo.exitCode !== undefined
+							? ` (exit ${String(lastInfo.exitCode)})`
+							: ''}
+						{lastInfo.message
+							? ` — ${String(lastInfo.message)}`
+							: ''}
+					</div>
+				)}
+			</div>
+		);
+	};
+
+	return (
+		<div>
+			{initContainerStatuses.length > 0 && (
+				<div style={{ marginBottom: 8 }}>
+					<div
+						style={{
+							fontSize: '0.7rem',
+							fontWeight: 600,
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							marginBottom: 4,
+							textTransform: 'uppercase',
+							letterSpacing: '0.05em',
+						}}>
+						Init Containers
+					</div>
+					{initContainerStatuses.map((c) => renderRow(c, true))}
+				</div>
+			)}
+			<div
+				style={{
+					fontSize: '0.7rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					marginBottom: 4,
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+				}}>
+				Containers
+			</div>
+			{containerStatuses.map((c) => renderRow(c, false))}
+		</div>
+	);
+}
+
+function ConditionsTab({
+	conditions,
+}: {
+	conditions: Array<Record<string, unknown>>;
+}) {
+	if (conditions.length === 0) {
+		return (
+			<div
+				style={{
+					padding: '1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+				}}>
+				No conditions reported
+			</div>
+		);
+	}
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+			{conditions.map((c, i) => {
+				const type = c.type as string;
+				const statusVal = c.status as string;
+				const reason = c.reason as string | undefined;
+				const message = c.message as string | undefined;
+				const ts = (c.lastTransitionTime ?? c.lastProbeTime) as
+					| string
+					| undefined;
+				const isTrue = statusVal === 'True';
+				const isFalse = statusVal === 'False';
+				const color = isTrue
+					? '#22c55e'
+					: isFalse
+						? '#ef4444'
+						: '#fbbf24';
+				return (
+					<div
+						key={`${type}-${i}`}
+						style={{
+							padding: '0.5rem 0.75rem',
+							borderRadius: 6,
+							background: 'var(--sl-color-bg, #0d1117)',
+							border: '1px solid var(--sl-color-gray-5, #262626)',
+						}}>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 8,
+								marginBottom: 2,
+								fontSize: '0.8rem',
+							}}>
+							<span
+								style={{
+									fontWeight: 600,
+									color: 'var(--sl-color-text, #e6edf3)',
+								}}>
+								{type}
+							</span>
+							<span
+								style={{
+									fontSize: '0.7rem',
+									padding: '1px 8px',
+									borderRadius: 3,
+									color,
+									background: `${color}18`,
+									border: `1px solid ${color}30`,
+									fontWeight: 600,
+								}}>
+								{statusVal}
+							</span>
+							{ts && (
+								<span
+									style={{
+										marginLeft: 'auto',
+										color: 'var(--sl-color-gray-4, #6b7280)',
+										fontSize: '0.7rem',
+									}}>
+									{new Date(ts).toLocaleString()}
+								</span>
+							)}
+						</div>
+						{(reason || message) && (
+							<div
+								style={{
+									fontSize: '0.75rem',
+									color: 'var(--sl-color-gray-3, #8b949e)',
+								}}>
+								{reason && (
+									<span style={{ fontWeight: 600 }}>
+										{reason}
+									</span>
+								)}
+								{reason && message ? ': ' : ''}
+								{message ?? ''}
+							</div>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
 
 export default function ReactArgoResourceDetail({
 	token,
@@ -758,13 +1293,30 @@ export default function ReactArgoResourceDetail({
 	const [managedError, setManagedError] = useState<string | null>(null);
 
 	const isPod = sel.kind === 'Pod';
+	const status = (manifest?.status as Record<string, unknown>) ?? {};
+	const conditions = Array.isArray(status.conditions)
+		? (status.conditions as Array<Record<string, unknown>>)
+		: [];
+	const containerStatuses = Array.isArray(status.containerStatuses)
+		? (status.containerStatuses as Array<Record<string, unknown>>)
+		: [];
+	const initContainerStatuses = Array.isArray(status.initContainerStatuses)
+		? (status.initContainerStatuses as Array<Record<string, unknown>>)
+		: [];
 
 	const tabs: { id: TabId; label: string }[] = [
 		{ id: 'summary', label: 'Summary' },
 		{ id: 'manifest', label: 'Manifest' },
+		...(isPod && (containerStatuses.length || initContainerStatuses.length)
+			? [{ id: 'containers' as TabId, label: 'Containers' }]
+			: []),
+		...(conditions.length
+			? [{ id: 'conditions' as TabId, label: 'Conditions' }]
+			: []),
 		{ id: 'events', label: 'Events' },
 		{ id: 'diff', label: 'Diff' },
 		...(isPod ? [{ id: 'logs' as TabId, label: 'Logs' }] : []),
+		{ id: 'indexed', label: 'Indexed Logs' },
 	];
 
 	useEffect(() => {
@@ -977,6 +1529,19 @@ export default function ReactArgoResourceDetail({
 			{tab === 'logs' && (
 				<LogsTab token={token} sel={sel} manifest={manifest} />
 			)}
+
+			{tab === 'indexed' && (
+				<IndexedLogsTab token={token} sel={sel} isPod={isPod} />
+			)}
+
+			{tab === 'containers' && (
+				<ContainersTab
+					containerStatuses={containerStatuses}
+					initContainerStatuses={initContainerStatuses}
+				/>
+			)}
+
+			{tab === 'conditions' && <ConditionsTab conditions={conditions} />}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/clickhouseService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/clickhouseService.ts
@@ -768,3 +768,46 @@ class ClickHouseService {
 }
 
 export const clickhouseService = new ClickHouseService();
+
+export interface IndexedLogQuery {
+	namespace?: string;
+	podName?: string;
+	service?: string;
+	level?: string;
+	search?: string;
+	minutes?: number;
+	limit?: number;
+}
+
+export async function fetchIndexedLogs(
+	token: string,
+	query: IndexedLogQuery,
+): Promise<LogRow[]> {
+	const body: Record<string, unknown> = {
+		command: 'query',
+		minutes: query.minutes ?? 60,
+		limit: query.limit ?? 200,
+	};
+	if (query.namespace) body.pod_namespace = query.namespace;
+	if (query.podName) body.pod_name = query.podName;
+	if (query.service) body.service = query.service;
+	if (query.level) body.level = query.level;
+	if (query.search) body.search = query.search;
+
+	const resp = await fetch(PROXY_BASE, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(body),
+		signal: AbortSignal.timeout(15000),
+	});
+
+	if (resp.status === 403)
+		throw new Error('Access restricted to indexed logs');
+	if (!resp.ok) throw new Error(`ClickHouse logs API error: ${resp.status}`);
+
+	const data: QueryData = await resp.json();
+	return Array.isArray(data?.rows) ? (data.rows as LogRow[]) : [];
+}

--- a/apps/kbve/edge/functions/logs/index.ts
+++ b/apps/kbve/edge/functions/logs/index.ts
@@ -33,6 +33,7 @@ const ch = createClient({
 
 interface QueryParams {
   pod_namespace?: string;
+  pod_name?: string;
   service?: string;
   level?: string;
   search?: string;
@@ -51,6 +52,11 @@ async function handleQuery(params: QueryParams) {
   if (params.pod_namespace) {
     conditions.push("pod_namespace = {ns:String}");
     queryParams.ns = params.pod_namespace;
+  }
+
+  if (params.pod_name) {
+    conditions.push("pod_name = {pn:String}");
+    queryParams.pn = params.pod_name;
   }
 
   if (params.service) {


### PR DESCRIPTION
## Summary

Builds on the resource detail drawer landed in #10480. Closes the remaining read-only gaps so the dashboard mirrors what ArgoCD's own UI exposes for a single application, and adds Vector→ClickHouse cross-integration so indexed logs sit beside live kubelet logs in the same drawer.

## Edge function

- ` apps/kbve/edge/functions/logs/index.ts` — accepts \`pod_name\` as a query param so callers can filter ClickHouse rows down to a single pod (was namespace+service+level+search only). Backward-compatible additive change.

## Frontend

**clickhouseService.ts** — new \`fetchIndexedLogs(token, { namespace, podName, service, level, search, minutes, limit })\` helper that POSTs \`/dashboard/clickhouse/proxy\` with the right command body.

**ReactArgoResourceDetail.tsx** — three new tabs on the per-resource drawer:

| Tab | Scope | Fields |
|-----|-------|--------|
| Indexed Logs | All kinds (Pod = filter by pod_name; non-Pod = filter by namespace) | timestamp, level, pod, message; minute/level/search controls |
| Containers | Pod-only | per-container state pill, ready/started flags, restartCount, image, current reason+message, last-state reason+exitCode; init containers grouped separately |
| Conditions | Generic | parses \`status.conditions\` (PodScheduled, Ready, ContainersReady, etc.) with status pill, reason, message, lastTransitionTime |

**ReactArgoAppTable.tsx** — resource list panel gains a filter bar (kind dropdown + health dropdown + name/namespace search + match counter) and a By Kind / Tree view toggle. Tree mode walks \`parentRefs\` to render Deployment→ReplicaSet→Pod… hierarchies with depth indentation; non-matching subtrees collapse so search still works. Each row gets a kind pill so identification stays clear in tree mode where the by-kind grouping is gone.

## Deferred (separate PRs needed)

- **Resource sync action** — \`POST /api/v1/applications/{name}/sync\` with a resources filter would need a write-side dashboard permission beyond the existing \`DASHBOARD_VIEW\` gate
- **Live log streaming** — Argo's \`follow=true\` log endpoint requires flipping the axum argo proxy to \`streaming: true\` plus a \`ReadableStream\`-aware client

## Test plan

- [x] \`nx run astro-kbve:build\` clean (5490 pages)
- [ ] Open \`/dashboard/argo/\`, expand kilobase, verify resource list filter bar (kind + health + search)
- [ ] Toggle Tree view, verify Deployment→ReplicaSet→Pod indentation
- [ ] Click a Pod, verify Containers tab shows restart count + last-state reason for any restarted container
- [ ] Verify Conditions tab parses \`status.conditions\`
- [ ] Verify Indexed Logs tab returns ClickHouse rows for the pod (Pod kind) and for the namespace (non-Pod kinds)
- [ ] Verify level/search filters on Indexed Logs work