### PR TITLE
fix(axum-kbve): mirror profile-forum styles into askama template

### DIFF
--- a/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
@@ -1,6 +1,5 @@
 ---
 import Adsense from '@/components/astropad/adsense/Adsense.astro';
-import AstroFooter from '@/components/footer/AstroFooter.astro';
 // AskamaProfileProvider - Mirrors the Askama profile.html template
 // This component renders the user profile page that Axum serves for /@username routes
 // Askama variables: {{ username }}, {{ username_first_char }}, {{ unsplash_banner_id }}, {{ bio }}, {{ status }}, {{ primary_avatar_url }}, {{ discord_username }}, {{ discord_avatar }}, {{ discord_is_guild_member }}, {{ discord_id }}, {{ discord_guild_nickname }}, {{ discord_joined_at }}, {{ discord_is_boosting }}, {{ discord_role_count }}, {{ discord_role_names }}, {{ github_username }}, {{ github_avatar }}, {{ twitch_username }}, {{ twitch_avatar }}, {{ twitch_is_live }}, {{ rentearth_characters }}, {{ rentearth_total_playtime_hours }}, {{ rentearth_last_activity }}
@@ -837,11 +836,6 @@ const forumProfileSection = `{% if forum_present %}
 		<div class="adsense-container">
 			<Adsense />
 		</div>
-
-		<!-- Site footer — Starlight's splash template doesn't render
-			 the global footer slot, so we mount it manually here so
-			 /@username pages keep parity with /forum/, /, etc. -->
-		<AstroFooter />
 	</div>
 </div>
 

--- a/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
@@ -2981,7 +2981,12 @@ const forumProfileSection = `{% if forum_present %}
 		display: grid;
 		gap: 0.4rem;
 	}
-	.profile-forum :global(.profile-forum__row) {
+	/* Wrap the WHOLE selector in :global() — using `.profile-forum :global(...)`
+	 * makes Astro auto-scope the parent `.profile-forum` to `[data-astro-cid-XXX]`,
+	 * but the parent <article> is injected via `Fragment set:html` so it has no
+	 * scope attr and the rule never matches. Wrapping the whole selector in
+	 * :global() keeps both halves unscoped so they apply to the injected markup. */
+	:global(.profile-forum .profile-forum__row) {
 		display: grid;
 		gap: 0.2rem;
 		padding: 0.6rem 0.85rem;
@@ -2994,11 +2999,11 @@ const forumProfileSection = `{% if forum_present %}
 			border-color 0.15s ease,
 			background 0.15s ease;
 	}
-	.profile-forum :global(.profile-forum__row:hover) {
+	:global(.profile-forum .profile-forum__row:hover) {
 		border-color: rgba(139, 92, 246, 0.5);
 		background: rgba(139, 92, 246, 0.08);
 	}
-	.profile-forum :global(.profile-forum__row-title) {
+	:global(.profile-forum .profile-forum__row-title) {
 		font-size: 0.875rem;
 		font-weight: 600;
 		display: -webkit-box;
@@ -3006,14 +3011,14 @@ const forumProfileSection = `{% if forum_present %}
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 	}
-	.profile-forum :global(.profile-forum__row-meta) {
+	:global(.profile-forum .profile-forum__row-meta) {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.3rem;
 		font-size: 0.75rem;
 		color: rgba(148, 163, 184, 0.85);
 	}
-	.profile-forum :global(.profile-forum__pin) {
+	:global(.profile-forum .profile-forum__pin) {
 		margin-right: 0.25rem;
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
@@ -2981,11 +2981,6 @@ const forumProfileSection = `{% if forum_present %}
 		display: grid;
 		gap: 0.4rem;
 	}
-	/* Wrap the WHOLE selector in :global() — using `.profile-forum :global(...)`
-	 * makes Astro auto-scope the parent `.profile-forum` to `[data-astro-cid-XXX]`,
-	 * but the parent <article> is injected via `Fragment set:html` so it has no
-	 * scope attr and the rule never matches. Wrapping the whole selector in
-	 * :global() keeps both halves unscoped so they apply to the injected markup. */
 	:global(.profile-forum .profile-forum__row) {
 		display: grid;
 		gap: 0.2rem;

--- a/apps/kbve/astro-kbve/src/content/docs/askama/profile.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/askama/profile.mdx
@@ -102,6 +102,7 @@ sidebar:
 ---
 
 import AskamaProfileProvider from '@/components/providers/AskamaProfileProvider.astro';
+import AstroFooter from '@/components/footer/AstroFooter.astro';
 
 {/* JSON-LD Structured Data for Person/Profile */}
 <script type="application/ld+json" set:html={`{
@@ -121,3 +122,5 @@ import AskamaProfileProvider from '@/components/providers/AskamaProfileProvider.
 }`} />
 
 <AskamaProfileProvider />
+
+<AstroFooter />

--- a/apps/kbve/axum-kbve/templates/askama/profile/index.html
+++ b/apps/kbve/axum-kbve/templates/askama/profile/index.html
@@ -724,6 +724,193 @@
             white-space: nowrap;
             border: 0;
         }
+
+        /* ── Forum activity card ─────────────────────────────────── */
+        .profile-forum {
+            background: linear-gradient(
+                145deg,
+                rgba(30, 41, 59, 0.9) 0%,
+                rgba(15, 23, 42, 0.95) 100%
+            );
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 20px;
+            padding: 1.75rem 2rem;
+            box-shadow:
+                0 25px 50px -12px rgba(0, 0, 0, 0.5),
+                0 0 0 1px rgba(255, 255, 255, 0.05),
+                inset 0 1px 0 rgba(255, 255, 255, 0.05),
+                inset 0 -2px 4px rgba(0, 0, 0, 0.2);
+            display: grid;
+            gap: 1.5rem;
+            color: #fafafa;
+            transition:
+                transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                box-shadow 0.4s ease;
+        }
+        .profile-forum:hover {
+            transform: translateY(-4px);
+            box-shadow:
+                0 30px 60px -12px rgba(0, 0, 0, 0.55),
+                0 0 0 1px rgba(255, 255, 255, 0.08),
+                inset 0 1px 0 rgba(255, 255, 255, 0.05),
+                inset 0 -2px 4px rgba(0, 0, 0, 0.2);
+        }
+        @media (max-width: 640px) {
+            .profile-forum {
+                padding: 1.5rem 1.5rem;
+            }
+        }
+        .profile-forum__header {
+            display: grid;
+            gap: 0.6rem;
+        }
+        .profile-forum__header-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+        .profile-forum__eyebrow {
+            margin: 0 0 0.2rem;
+            font-size: 0.6875rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: #8b5cf6;
+        }
+        .profile-forum__title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            margin: 0;
+            letter-spacing: -0.01em;
+        }
+        .profile-forum__cta {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.5rem 1rem;
+            background: rgba(139, 92, 246, 0.15);
+            border: 1px solid rgba(139, 92, 246, 0.4);
+            border-radius: 8px;
+            color: #c4b5fd;
+            font-size: 0.8125rem;
+            font-weight: 600;
+            text-decoration: none;
+            transition:
+                background 0.15s ease,
+                border-color 0.15s ease;
+        }
+        .profile-forum__cta:hover {
+            background: rgba(139, 92, 246, 0.25);
+            border-color: rgba(139, 92, 246, 0.6);
+        }
+        .profile-forum__signature {
+            font-size: 0.875rem;
+            color: rgba(226, 232, 240, 0.75);
+            margin: 0;
+            padding: 0.6rem 0.85rem;
+            border-left: 3px solid rgba(139, 92, 246, 0.5);
+            background: rgba(139, 92, 246, 0.06);
+            border-radius: 0 8px 8px 0;
+            font-style: italic;
+        }
+        .profile-forum__stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+            gap: 0.5rem;
+            padding: 0.75rem;
+            background: rgba(15, 23, 42, 0.6);
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.1);
+            margin: 0;
+        }
+        .profile-forum__stat {
+            display: grid;
+            gap: 0.1rem;
+            margin: 0;
+            text-align: center;
+        }
+        .profile-forum__stat dt {
+            font-size: 0.6875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: rgba(148, 163, 184, 0.85);
+        }
+        .profile-forum__stat dd {
+            margin: 0;
+            font-size: 1rem;
+            font-weight: 700;
+            color: #fafafa;
+        }
+        .profile-forum__columns {
+            display: grid;
+            gap: 1rem;
+            grid-template-columns: minmax(0, 1fr);
+        }
+        @media (min-width: 720px) {
+            .profile-forum__columns {
+                grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+            }
+        }
+        .profile-forum__col {
+            display: grid;
+            gap: 0.5rem;
+        }
+        .profile-forum__col-title {
+            font-size: 0.75rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: rgba(226, 232, 240, 0.7);
+            margin: 0;
+        }
+        .profile-forum__empty {
+            font-size: 0.875rem;
+            color: rgba(148, 163, 184, 0.7);
+            margin: 0;
+            padding: 0.75rem 0;
+        }
+        .profile-forum__list {
+            display: grid;
+            gap: 0.4rem;
+        }
+        .profile-forum .profile-forum__row {
+            display: grid;
+            gap: 0.2rem;
+            padding: 0.6rem 0.85rem;
+            background: rgba(15, 23, 42, 0.5);
+            border: 1px solid rgba(148, 163, 184, 0.08);
+            border-radius: 10px;
+            text-decoration: none;
+            color: #fafafa;
+            transition:
+                border-color 0.15s ease,
+                background 0.15s ease;
+        }
+        .profile-forum .profile-forum__row:hover {
+            border-color: rgba(139, 92, 246, 0.5);
+            background: rgba(139, 92, 246, 0.08);
+        }
+        .profile-forum .profile-forum__row-title {
+            font-size: 0.875rem;
+            font-weight: 600;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+        .profile-forum .profile-forum__row-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.3rem;
+            font-size: 0.75rem;
+            color: rgba(148, 163, 184, 0.85);
+        }
+        .profile-forum .profile-forum__pin {
+            margin-right: 0.25rem;
+        }
     </style>
 </head>
 <body>

--- a/apps/kbve/axum-kbve/templates/askama/profile/index.html
+++ b/apps/kbve/axum-kbve/templates/askama/profile/index.html
@@ -1,3 +1,4 @@
+<!-- Source: apps/kbve/astro-kbve/src/content/docs/askama/profile.mdx -->
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- /@username (axum + askama) was rendering the forum activity card with zero CSS — raw HTML, default link styling, unstyled stats grid
- Astro provider AskamaProfileProvider.astro carries the .profile-forum* rules wrapped in :global() for SSG /profile, but askama template was missing them
- Both files are intentional mirrors (provider line 4 comment); this commit restores parity by copying the rules into the askama <style> block

## Verification
- Stripped-whitespace diff between Astro provider's :global()-wrapped rules and the new askama rules: zero content drift
- Descendant selectors preserved (`.profile-forum .profile-forum__row` etc) to match Astro's auto-scoped pattern

## Follow-up (out of scope)
- Templates are hand-mirrored. Future option: codegen the askama template from the Astro provider so this can't drift again.

## Test plan
- [ ] Hit https://kbve.com/@h0lybyte after deploy → forum activity card renders with card chrome, stats grid, themed CTA, styled row links
- [ ] Confirm /profile (SSG) still renders correctly — no regression