### PR TITLE
fix(mc): parrot/archer cooldowns, water-spawn check, helm crosshair, smoother turn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.131"
+version = "1.0.132"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
@@ -304,8 +304,12 @@ public class AiCreatureManager {
         // in rivers, oceans, or any waterlogged surface.
         BlockState surfaceState = world.getBlockState(surface);
         BlockState belowState = world.getBlockState(surface.down());
+        BlockState aboveState = world.getBlockState(surface.up());
+        BlockState above2State = world.getBlockState(surface.up().up());
         if (surfaceState.getFluidState().isIn(FluidTags.WATER)
-                || belowState.getFluidState().isIn(FluidTags.WATER)) {
+                || belowState.getFluidState().isIn(FluidTags.WATER)
+                || aboveState.getFluidState().isIn(FluidTags.WATER)
+                || above2State.getFluidState().isIn(FluidTags.WATER)) {
             return false;
         }
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -71,6 +71,15 @@ public class ShipHud implements HudRenderCallback {
         int screenWidth = client.getWindow().getScaledWidth();
         int screenHeight = client.getWindow().getScaledHeight();
 
+        int cx = screenWidth / 2;
+        int cy = screenHeight / 2;
+        int crossColor = 0xFFFFFFFF;
+        context.fill(cx - 6, cy, cx - 1, cy + 1, crossColor);
+        context.fill(cx + 2, cy, cx + 7, cy + 1, crossColor);
+        context.fill(cx, cy - 6, cx + 1, cy - 1, crossColor);
+        context.fill(cx, cy + 2, cx + 1, cy + 7, crossColor);
+        context.fill(cx - 1, cy - 1, cx + 2, cy + 2, 0x80000000);
+
         if (!shipName.isEmpty()) {
             String nameText = "§l" + shipName;
             int nameWidth = client.textRenderer.getWidth(nameText);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -70,8 +70,8 @@ public final class ShipNetworking {
                 } else {
                     ship.setTargetSpeed(Math.max(currentSpeed - 0.1f, 0f));
                 }
-                if (payload.sideways() > 0) ship.setHeading(ship.getHeading() - 1.5f);
-                if (payload.sideways() < 0) ship.setHeading(ship.getHeading() + 1.5f);
+                if (payload.sideways() > 0) ship.setHeading(ship.getHeading() - 1.0f);
+                if (payload.sideways() < 0) ship.setHeading(ship.getHeading() + 1.0f);
                 ship.setVerticalIntent(payload.vertical());
             });
         });

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -106,7 +106,7 @@ impl Default for ArrowCooldown {
     fn default() -> Self {
         Self {
             last_shot_tick: 0,
-            cooldown_ticks: 20, // 2s at 100ms ECS ticks
+            cooldown_ticks: 30,
         }
     }
 }
@@ -382,8 +382,7 @@ impl Default for PetParrotPopulationConfig {
             // Same rationale as the dog — keep the return trigger tight
             // so the parrot flies back before vanilla's teleport fires.
             follow_distance: 6.0,
-            // ECS ticks = 100ms each, so 15 ticks ≈ 1.5s between poops.
-            poop_cooldown_ticks: 15,
+            poop_cooldown_ticks: 100,
             // 20 TPS → 80 ticks = 4s of poison ticks (one damage tick/second).
             poison_duration_ticks: 80,
             poison_amplifier: 0,

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -400,6 +400,7 @@ pub fn plan_behavior(
             &NearbyEntities,
             &mut CallCooldown,
             Option<&SkeletonArchetype>,
+            Option<&mut ArrowCooldown>,
         ),
         With<AiManaged>,
     >,
@@ -413,7 +414,7 @@ pub fn plan_behavior(
 ) {
     let current_tick = server_tick.0;
 
-    for (mc_id, pos, health, epoch, nearby, mut cooldown, archetype) in &mut query {
+    for (mc_id, pos, health, epoch, nearby, mut cooldown, archetype, mut arrow_cd) in &mut query {
         let flow_hint = build_flow_hint(
             pos,
             grid_res.as_ref(),
@@ -469,10 +470,31 @@ pub fn plan_behavior(
         };
         let (_status, commands) = tree.evaluate(&observation, &mut ctx);
 
+        let filtered: Vec<NpcCommand> = if let Some(ref mut acd) = arrow_cd {
+            let elapsed = current_tick.saturating_sub(acd.last_shot_tick);
+            let mut out = Vec::with_capacity(commands.len());
+            let mut shot_consumed = false;
+            for cmd in commands {
+                match cmd {
+                    NpcCommand::ShootArrow { .. } => {
+                        if !shot_consumed && elapsed >= acd.cooldown_ticks {
+                            shot_consumed = true;
+                            acd.last_shot_tick = current_tick;
+                            out.push(cmd);
+                        }
+                    }
+                    other => out.push(other),
+                }
+            }
+            out
+        } else {
+            commands
+        };
+
         intent_buffer.ready.push(IntentReady {
             entity_id: mc_id.0,
             epoch: epoch.value,
-            commands,
+            commands: filtered,
         });
     }
 }


### PR DESCRIPTION
## Summary
Playtest pass. Five fixes:

1. **Parrot poop cooldown** 15 → 100 ECS ticks (1.5s → 10s). Was already hostile-only but spam-felt in combat.
2. **Archer arrow rate limit.** `ShootAtTarget` was emitting a ShootArrow command every tick; the existing `ArrowCooldown` component was registered but never read. `plan_behavior` now post-filters emitted commands so at most one ShootArrow per cooldown window. Default 20 → 30 ticks (~3s). This was the source of the server-crash spam.
3. **Underwater spawn check** expanded. Java was checking only the heightmap surface block + below; in oceans `MOTION_BLOCKING_NO_LEAVES` returns the seafloor, so the surface block isn't water but the column above is. Now also rejects when surface.up or surface.up.up is water — skeletons stop spawning at sea-floor depth.
4. **Airship turn rate** 1.5° → 1.0° per tick (~20°/sec). Less twitchy.
5. **Helm crosshair.** Small white + at screen center while mounted, matching vanilla aim feel.

Out of scope (separate PR): texture color (some BBModel faces still pink — reference `airship_color.png` which isn't in resources), parrot shoulder-perch idle behavior.

## Test plan
- [ ] Wait for next mc Docker publish + new mrpack
- [ ] Spawn a hostile near pet parrot — fires poop every ~10s, not every 1.5s
- [ ] Engage skeleton archer at range — single arrow ~3s apart, server log no longer spammed with ShootArrow
- [ ] Roam ocean biome — no skeletons spawn in water column
- [ ] `/spawnship airship` + `/boardship` — turn rate slower, crosshair visible at center