### PR TITLE
fix(mc-uplink): port to 1.21.11 yarn ServerCommandSource API

### DIFF
--- a/apps/mc/uplink/src/main/java/com/kbve/mcuplink/KbveMcUplink.java
+++ b/apps/mc/uplink/src/main/java/com/kbve/mcuplink/KbveMcUplink.java
@@ -99,14 +99,12 @@ public final class KbveMcUplink implements ModInitializer {
         server.execute(() -> {
             CapturingOutput out = new CapturingOutput();
             ServerCommandSource source = server.getCommandSource()
-                    .withOutput(out, 4, true)
+                    .withOutput(out)
                     .withSilent();
-            int result;
             boolean ok;
             try {
-                result = server.getCommandManager().executeWithPrefix(source, req.command());
-                // executeWithPrefix returns the raw command result code (0 = fail).
-                ok = result > 0 || !out.captured().isEmpty();
+                server.getCommandManager().parseAndExecute(source, req.command());
+                ok = !out.captured().isEmpty();
             } catch (Throwable t) {
                 LOGGER.warn("[{}] dispatch threw for '{}': {}", MOD_ID, req.command(), t.getMessage());
                 out.appendLine("Error: " + (t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName()));


### PR DESCRIPTION
## Summary
\`Test Docker / Test mc Docker App\` failing on dev — \`apps/mc/uplink\` mod doesn't compile against 1.21.11 yarn:

\`\`\`
KbveMcUplink.java:102: error: method withOutput in class ServerCommandSource cannot be applied to given types;
KbveMcUplink.java:107: error: cannot find symbol
\`\`\`

Yarn 1.21.11 API:
- \`ServerCommandSource.withOutput(CommandOutput)\` is single-arg now (no \`(out, level, broadcast)\` overload).
- \`CommandManager.executeWithPrefix\` is gone — replaced by \`parseAndExecute(ServerCommandSource, String)\` which returns void.

## Changes
- Drop the level + broadcast args from \`withOutput\`.
- Switch to \`parseAndExecute\`. Drop the \`result > 0\` success heuristic; success is now \`!out.captured().isEmpty()\` plus the existing exception-path append of \`"Error: ..."\`.

## Test plan
- [ ] CI \`Test Docker / Test mc Docker App\` passes on this PR
- [ ] After merge: Discord \`>cmd\` relay still routes commands and surfaces output