### PR TITLE
ci(unity): serialize CI - Unity dispatches via concurrency group

### DIFF
--- a/.github/workflows/ci-unity.yml
+++ b/.github/workflows/ci-unity.yml
@@ -83,6 +83,10 @@ on:
 
 permissions: {}
 
+concurrency:
+    group: ci-unity
+    cancel-in-progress: false
+
 jobs:
     queue_guard:
         name: Queue Guard


### PR DESCRIPTION
## Summary
- Add workflow-level \`concurrency: { group: ci-unity, cancel-in-progress: false }\` to \`CI - Unity\`. Newer dispatches now queue behind the running one instead of running in parallel.
- Unity personal license caps at 2 active seats globally; one dispatch already burns both via \`max-parallel: 2\` in the build matrix, so a second concurrent dispatch had three activations fighting for two seats. Queueing avoids license starvation and removes the cross-run interference that was hammering the shared Library cache.

## Refs
- Concurrent runs that motivated this: [25407885824](https://github.com/KBVE/kbve/actions/runs/25407885824) + [25408941794](https://github.com/KBVE/kbve/actions/runs/25408941794).

## Test plan
- [ ] Trigger two \`workflow_dispatch\` runs of \`CI - Unity / rareicon\` back-to-back; second should sit in \`queued\` until the first finishes
- [ ] Confirm no run is auto-cancelled (\`cancel-in-progress: false\`)
- [ ] After merging, future Unity dispatches across all apps share the single \`ci-unity\` queue