### PR TITLE
fix(astro-kbve): emit ci-dispatch-manifest with tab indent (match prettier)

### DIFF
--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -98,7 +98,7 @@
 		"sync:ci-manifest": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "node -e \"const fs=require('fs');const src='dist/apps/astro-kbve/api/ci-registry.json';const dst='.github/ci-dispatch-manifest.json';if(!fs.existsSync(src)){console.error('Build output not found — run astro-kbve:build first');process.exit(1);}const data=JSON.parse(fs.readFileSync(src,'utf8'));const{index,...manifest}=data;fs.writeFileSync(dst,JSON.stringify(manifest,null,2)+'\\n');console.log('Wrote',dst,'—',manifest.summary.total,'tracked items');\"",
+				"command": "node -e \"const fs=require('fs');const src='dist/apps/astro-kbve/api/ci-registry.json';const dst='.github/ci-dispatch-manifest.json';if(!fs.existsSync(src)){console.error('Build output not found — run astro-kbve:build first');process.exit(1);}const data=JSON.parse(fs.readFileSync(src,'utf8'));const{index,...manifest}=data;fs.writeFileSync(dst,JSON.stringify(manifest,null,'\\t')+'\\n');console.log('Wrote',dst,'—',manifest.summary.total,'tracked items');\"",
 				"cwd": "{workspaceRoot}"
 			}
 		},


### PR DESCRIPTION
## Summary
- One-char change to \`apps/kbve/astro-kbve/project.json\` — \`JSON.stringify(manifest, null, 2)\` → \`JSON.stringify(manifest, null, '\\t')\`. The script now emits tab-indented JSON, matching the repo's prettier config (\`useTabs: true\`).

## Why
The on-disk manifest is tab-indented because husky's pre-commit hook runs prettier over staged files. \`sync:ci-manifest\` was writing 2-space output, so every regen produced a 1326-line whitespace-only diff against what prettier had normalised — which the new \`CI - Manifest Guard\` correctly flagged as drift on the dev → main release PR (\`run 25412747333\`).

## Test plan
- [ ] Locally: \`npx nx run astro-kbve:build && npx nx run astro-kbve:sync:ci-manifest\`, confirm \`git diff --exit-code .github/ci-dispatch-manifest.json\` is clean
- [ ] Re-run the pending dev → main PR — \`Verify ci-dispatch-manifest is up to date\` should pass