### PR TITLE
fix(mc): smooth airship yaw via getLerpedYaw — kills 'snap back' jitter

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -67,9 +67,7 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         super.updateRenderState(entity, state, tickDelta);
         String name = entity.getModelName();
         state.modelName = (name == null || name.isEmpty()) ? DEFAULT_MODEL : name;
-        // Read yaw (synced via vanilla entity tracking) — not the custom
-        // heading field which only exists server-side.
-        state.heading = entity.getYaw();
+        state.heading = entity.getLerpedYaw(tickDelta);
         state.animationTime = (entity.age + tickDelta) * 0.05f;
     }
 


### PR DESCRIPTION
## Summary
Airship turning still felt like the model "tries to shift then snaps back". Cause: \`BBModelShipRenderer.updateRenderState\` was reading \`entity.getYaw()\` raw, so the rendered yaw stayed flat between server tracking snapshots and jumped at each new packet.

Fix: use \`entity.getLerpedYaw(tickDelta)\` — vanilla helper that interpolates \`lastYaw → getYaw()\` per partial tick and handles 359° → 0° wraparound. Server-side unchanged.

## Test plan
- [ ] Wait for next mc Docker publish + new mrpack
- [ ] \`/spawnship airship\` + \`/boardship\`, hold A/D — model rotates smoothly without snap-back
- [ ] Cross 0°/360° boundary — no full-circle spin