### PR TITLE
fix(forum): mount AstroFooter on all forum mdx pages

### DIFF
--- a/apps/kbve/astro-kbve/src/components/footer/AstroDroidFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroDroidFooter.astro
@@ -1,0 +1,7 @@
+---
+import { DroidOverlays } from '@/components/providers/DroidOverlays';
+---
+
+<div data-island="toast-mount" hidden>
+	<DroidOverlays client:only="react" />
+</div>

--- a/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
@@ -1,6 +1,6 @@
 ---
 import FooterQuickLinks from './FooterQuickLinks.astro';
-import { DroidOverlays } from '@/components/providers/DroidOverlays';
+import AstroDroidFooter from './AstroDroidFooter.astro';
 import SocialTooltip from '@kbve/astro/components/tooltip/social/SocialTooltip.astro';
 
 const legalLinks = [
@@ -223,9 +223,7 @@ const currentYear = new Date().getFullYear();
 	</div>
 
 	<FooterQuickLinks />
-	<div data-island="toast-mount" hidden>
-		<DroidOverlays client:only="react" />
-	</div>
+	<AstroDroidFooter />
 </footer>
 
 <style>

--- a/apps/kbve/astro-kbve/src/content/docs/askama/forum/compose.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/askama/forum/compose.mdx
@@ -22,5 +22,8 @@ sidebar:
 ---
 
 import AskamaForumComposeProvider from '@/components/providers/AskamaForumComposeProvider.astro';
+import AstroFooter from '@/components/footer/AstroFooter.astro';
 
 <AskamaForumComposeProvider />
+
+<AstroFooter />

--- a/apps/kbve/astro-kbve/src/content/docs/askama/forum/feed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/askama/forum/feed.mdx
@@ -34,5 +34,8 @@ sidebar:
 ---
 
 import AskamaForumFeedProvider from '@/components/providers/AskamaForumFeedProvider.astro';
+import AstroFooter from '@/components/footer/AstroFooter.astro';
 
 <AskamaForumFeedProvider />
+
+<AstroFooter />

--- a/apps/kbve/astro-kbve/src/content/docs/askama/forum/space_not_found.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/askama/forum/space_not_found.mdx
@@ -22,5 +22,8 @@ sidebar:
 ---
 
 import AskamaForumSpaceNotFoundProvider from '@/components/providers/AskamaForumSpaceNotFoundProvider.astro';
+import AstroFooter from '@/components/footer/AstroFooter.astro';
 
 <AskamaForumSpaceNotFoundProvider />
+
+<AstroFooter />

--- a/apps/kbve/astro-kbve/src/content/docs/askama/forum/tags.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/askama/forum/tags.mdx
@@ -22,5 +22,8 @@ sidebar:
 ---
 
 import AskamaForumTagsProvider from '@/components/providers/AskamaForumTagsProvider.astro';
+import AstroFooter from '@/components/footer/AstroFooter.astro';
 
 <AskamaForumTagsProvider />
+
+<AstroFooter />

--- a/apps/kbve/astro-kbve/src/content/docs/askama/forum/thread.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/askama/forum/thread.mdx
@@ -46,5 +46,8 @@ sidebar:
 ---
 
 import AskamaForumThreadProvider from '@/components/providers/AskamaForumThreadProvider.astro';
+import AstroFooter from '@/components/footer/AstroFooter.astro';
 
 <AskamaForumThreadProvider />
+
+<AstroFooter />

--- a/apps/kbve/astro-kbve/src/content/docs/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/index.mdx
@@ -20,6 +20,7 @@ import RingHero from '@kbve/astro/components/hero/ring/RingHero.astro';
 import RingShipGrid from '@kbve/astro/components/hero/ring/RingShipGrid.astro';
 import RingShipCard from '@kbve/astro/components/hero/ring/RingShipCard.astro';
 import ScrollRing from '@kbve/astro/components/hero/observer/ScrollRing.astro';
+import AstroDroidFooter from '@/components/footer/AstroDroidFooter.astro';
 
 <RingHero
     title="KiloByte Virtual Enterprise"
@@ -105,3 +106,5 @@ The page chain loops — scroll past the bottom to enter the ring, scroll past t
 </div>
 
 <ScrollRing prev="/projects/" next="/service/" prevLabel="Projects" nextLabel="Services" />
+
+<AstroDroidFooter />


### PR DESCRIPTION
## Summary
- Forum pages (compose, feed, thread, tags, space_not_found) all use `template: splash`, which suppresses Starlight's Footer slot
- Adds explicit `<AstroFooter />` import + render at the bottom of each MDX page so the KBVE footer shows up on every forum view
- Same pattern as profile page fix in #10498

## Test plan
- [ ] After deploy, hit /forum/, /forum/new, /forum/t/{slug}, /forum/tags, /forum/s/{nonexistent} — footer renders on all five
- [ ] Confirm no double footer (none of the 5 providers had AstroFooter previously)

## Note
- User reported missing footer on /forum/new alongside an auth-gate misfire ("Sign in to start a thread" while signed in). Auth-gate issue is separate — likely supa.ts init timeout / stale service worker. This PR addresses the footer parity only.