### PR TITLE
feat(mc): airship crosshair-aim steering — drops A/D turn keys

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -67,8 +67,23 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         super.updateRenderState(entity, state, tickDelta);
         String name = entity.getModelName();
         state.modelName = (name == null || name.isEmpty()) ? DEFAULT_MODEL : name;
-        state.heading = entity.getLerpedYaw(tickDelta);
+        float lerped = entity.getLerpedYaw(tickDelta);
+        float yawDelta = wrapDegrees(lerped - state.heading);
+        state.targetRoll = clamp(-yawDelta * 4.0f, -35f, 35f);
+        state.renderRoll += (state.targetRoll - state.renderRoll) * 0.15f;
+        state.heading = lerped;
         state.animationTime = (entity.age + tickDelta) * 0.05f;
+    }
+
+    private static float wrapDegrees(float a) {
+        a = a % 360f;
+        if (a >= 180f) a -= 360f;
+        if (a < -180f) a += 360f;
+        return a;
+    }
+
+    private static float clamp(float v, float lo, float hi) {
+        return Math.max(lo, Math.min(hi, v));
     }
 
     // -- Render -------------------------------------------------------------
@@ -94,9 +109,10 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         // Scale from Blockbench units to world units
         matrices.scale(MODEL_SCALE, MODEL_SCALE, MODEL_SCALE);
 
-        // Ship heading rotation (Y-axis)
         matrices.multiply(new Quaternionf().rotateY(
                 (float) Math.toRadians(-state.heading)));
+        matrices.multiply(new Quaternionf().rotateZ(
+                (float) Math.toRadians(state.renderRoll)));
 
         // Walk the model tree — submit render commands per face
         int light = 0xF000F0; // full bright (airships fly in sky)

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -14,7 +14,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.Perspective;
 import net.minecraft.entity.Entity;
 import net.minecraft.resource.ResourceType;
-import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,19 +62,17 @@ public class ShipClientMod implements ClientModInitializer {
 
         boolean n = client.options.forwardKey.isPressed();
         boolean s = client.options.backKey.isPressed();
-
-        long handle = client.getWindow().getHandle();
-        boolean rise = client.options.jumpKey.isPressed();
-        boolean lower = GLFW.glfwGetKey(handle, GLFW.GLFW_KEY_TAB) == GLFW.GLFW_PRESS;
         boolean boost = client.options.sprintKey.isPressed();
 
         float forward = n ? 1.0f : (s ? -1.0f : 0f);
-        float vertical = rise ? 1.0f : (lower ? -1.0f : 0f);
         float targetYaw = client.player.getYaw();
+        float targetPitch = client.player.getPitch();
 
+        boolean rise = targetPitch < -8f;
+        boolean lower = targetPitch > 8f;
         hud.setInputState(n, s, false, false, rise, lower, boost);
 
-        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, vertical, boost, targetYaw));
+        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, boost, targetYaw, targetPitch));
     }
 
     public void setActiveHelm(String shipId, String shipName) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -63,8 +63,6 @@ public class ShipClientMod implements ClientModInitializer {
 
         boolean n = client.options.forwardKey.isPressed();
         boolean s = client.options.backKey.isPressed();
-        boolean w = client.options.leftKey.isPressed();
-        boolean e = client.options.rightKey.isPressed();
 
         long handle = client.getWindow().getHandle();
         boolean rise = client.options.jumpKey.isPressed();
@@ -72,12 +70,12 @@ public class ShipClientMod implements ClientModInitializer {
         boolean boost = client.options.sprintKey.isPressed();
 
         float forward = n ? 1.0f : (s ? -1.0f : 0f);
-        float sideways = w ? 1.0f : (e ? -1.0f : 0f);
         float vertical = rise ? 1.0f : (lower ? -1.0f : 0f);
+        float targetYaw = client.player.getYaw();
 
-        hud.setInputState(n, s, e, w, rise, lower, boost);
+        hud.setInputState(n, s, false, false, rise, lower, boost);
 
-        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, sideways, vertical, boost));
+        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, vertical, boost, targetYaw));
     }
 
     public void setActiveHelm(String shipId, String shipName) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -44,9 +44,9 @@ public class ShipClientMod implements ClientModInitializer {
 
         Entity vehicle = client.player.getVehicle();
         if (vehicle instanceof ShipEntity shipEntity) {
-            if (activeHelmShipId == null) {
-                java.util.UUID shipId = shipEntity.getShipId();
-                String idStr = shipId != null ? shipId.toString() : "";
+            java.util.UUID shipId = shipEntity.getShipId();
+            String idStr = shipId != null ? shipId.toString() : "";
+            if (!idStr.isEmpty() && !idStr.equals(activeHelmShipId)) {
                 LOGGER.info("[Ship Client] Mounted ShipEntity (id={}, name={})",
                         idStr, shipEntity.getShipName());
                 setActiveHelm(idStr, shipEntity.getShipName());
@@ -58,7 +58,7 @@ public class ShipClientMod implements ClientModInitializer {
             clearActiveHelm();
         }
 
-        if (activeHelmShipId == null) return;
+        if (activeHelmShipId == null || activeHelmShipId.isEmpty()) return;
 
         boolean n = client.options.forwardKey.isPressed();
         boolean s = client.options.backKey.isPressed();

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -145,7 +145,7 @@ public class ShipHud implements HudRenderCallback {
                     (screenWidth - bw) / 2, screenHeight - 90, 0xFFFFAA00, true);
         }
 
-        String controls = "WASD Move  Space Up  Tab Down  Ctrl Boost  Shift Dismount";
+        String controls = "Mouse Aim  W Throttle  Space Up  Tab Down  Ctrl Boost  Shift Dismount";
         int controlsWidth = client.textRenderer.getWidth(controls);
         context.drawText(client.textRenderer, Text.of("§7" + controls),
                 screenWidth - controlsWidth - 10, screenHeight - 15, 0x999999, true);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -145,7 +145,7 @@ public class ShipHud implements HudRenderCallback {
                     (screenWidth - bw) / 2, screenHeight - 90, 0xFFFFAA00, true);
         }
 
-        String controls = "Mouse Aim  W Throttle  Space Up  Tab Down  Ctrl Boost  Shift Dismount";
+        String controls = "Mouse Aim/Pitch  W Throttle  Ctrl Boost  Shift Dismount";
         int controlsWidth = client.textRenderer.getWidth(controls);
         context.drawText(client.textRenderer, Text.of("§7" + controls),
                 screenWidth - controlsWidth - 10, screenHeight - 15, 0x999999, true);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipRenderState.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipRenderState.java
@@ -20,4 +20,10 @@ public class ShipRenderState extends EntityRenderState {
 
     /** Animation time in ticks (continuous counter for propellers, sails). */
     public float animationTime = 0.0f;
+
+    /** Auto-roll target derived from yaw rate (degrees, clamped). */
+    public float targetRoll = 0.0f;
+
+    /** Smoothed render roll, lerped toward targetRoll each frame. */
+    public float renderRoll = 0.0f;
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -18,22 +18,22 @@ public final class ShipNetworking {
 
     public static final Identifier HELM_INPUT_ID = Identifier.of("behavior_statetree", "helm_input");
 
-    /** Helm steering input. forward/sideways = WASD; vertical = Space/Tab; boost = sprint. */
+    /** Helm steering input. forward = W throttle; vertical = Space/Tab; boost = sprint; target_yaw = camera-driven heading the ship should turn toward. */
     public record HelmInputPayload(
             String shipId,
             float forward,
-            float sideways,
             float vertical,
-            boolean boost
+            boolean boost,
+            float targetYaw
     ) implements CustomPayload {
         public static final CustomPayload.Id<HelmInputPayload> ID = new CustomPayload.Id<>(HELM_INPUT_ID);
         public static final PacketCodec<RegistryByteBuf, HelmInputPayload> CODEC =
                 PacketCodec.tuple(
                         PacketCodecs.STRING, HelmInputPayload::shipId,
                         PacketCodecs.FLOAT, HelmInputPayload::forward,
-                        PacketCodecs.FLOAT, HelmInputPayload::sideways,
                         PacketCodecs.FLOAT, HelmInputPayload::vertical,
                         PacketCodecs.BOOLEAN, HelmInputPayload::boost,
+                        PacketCodecs.FLOAT, HelmInputPayload::targetYaw,
                         HelmInputPayload::new
                 );
 
@@ -70,8 +70,15 @@ public final class ShipNetworking {
                 } else {
                     ship.setTargetSpeed(Math.max(currentSpeed - 0.1f, 0f));
                 }
-                if (payload.sideways() > 0) ship.setHeading(ship.getHeading() - 1.0f);
-                if (payload.sideways() < 0) ship.setHeading(ship.getHeading() + 1.0f);
+
+                float current = ship.getHeading();
+                float diff = ((payload.targetYaw() - current) % 360f + 540f) % 360f - 180f;
+                float deadZoneDeg = 5f;
+                if (Math.abs(diff) < deadZoneDeg) diff = 0f;
+                float maxDeltaPerTick = 2.0f;
+                float step = Math.max(-maxDeltaPerTick, Math.min(maxDeltaPerTick, diff * 0.15f));
+                if (step != 0f) ship.setHeading(current + step);
+
                 ship.setVerticalIntent(payload.vertical());
             });
         });

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -18,22 +18,22 @@ public final class ShipNetworking {
 
     public static final Identifier HELM_INPUT_ID = Identifier.of("behavior_statetree", "helm_input");
 
-    /** Helm steering input. forward = W throttle; vertical = Space/Tab; boost = sprint; target_yaw = camera-driven heading the ship should turn toward. */
+    /** Helm steering input. forward = W throttle; boost = sprint; target_yaw / target_pitch = camera-driven heading + altitude direction. */
     public record HelmInputPayload(
             String shipId,
             float forward,
-            float vertical,
             boolean boost,
-            float targetYaw
+            float targetYaw,
+            float targetPitch
     ) implements CustomPayload {
         public static final CustomPayload.Id<HelmInputPayload> ID = new CustomPayload.Id<>(HELM_INPUT_ID);
         public static final PacketCodec<RegistryByteBuf, HelmInputPayload> CODEC =
                 PacketCodec.tuple(
                         PacketCodecs.STRING, HelmInputPayload::shipId,
                         PacketCodecs.FLOAT, HelmInputPayload::forward,
-                        PacketCodecs.FLOAT, HelmInputPayload::vertical,
                         PacketCodecs.BOOLEAN, HelmInputPayload::boost,
                         PacketCodecs.FLOAT, HelmInputPayload::targetYaw,
+                        PacketCodecs.FLOAT, HelmInputPayload::targetPitch,
                         HelmInputPayload::new
                 );
 
@@ -79,7 +79,15 @@ public final class ShipNetworking {
                 float step = Math.max(-maxDeltaPerTick, Math.min(maxDeltaPerTick, diff * 0.15f));
                 if (step != 0f) ship.setHeading(current + step);
 
-                ship.setVerticalIntent(payload.vertical());
+                float pitchDeadZone = 8f;
+                float pitch = payload.targetPitch();
+                float verticalIntent;
+                if (Math.abs(pitch) < pitchDeadZone) {
+                    verticalIntent = 0f;
+                } else {
+                    verticalIntent = (float) -Math.sin(Math.toRadians(pitch));
+                }
+                ship.setVerticalIntent(verticalIntent);
             });
         });
     }

--- a/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/advancement/take_to_the_skies.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/advancement/take_to_the_skies.json
@@ -1,0 +1,35 @@
+{
+	"parent": "minecraft:adventure/root",
+	"display": {
+		"icon": {
+			"id": "minecraft:elytra"
+		},
+		"title": {
+			"text": "Take to the Skies"
+		},
+		"description": {
+			"text": "Board your first KBVE airship"
+		},
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"criteria": {
+		"board_ship": {
+			"trigger": "minecraft:player_interacted_with_entity",
+			"conditions": {
+				"entity": [
+					{
+						"condition": "minecraft:entity_properties",
+						"entity": "this",
+						"predicate": {
+							"type": "behavior_statetree:ship"
+						}
+					}
+				]
+			}
+		}
+	},
+	"requirements": [["board_ship"]]
+}


### PR DESCRIPTION
## Summary
Phase 1 of arcade-flight steering. Mouse + camera now drive ship heading; A/D do nothing.

\`HelmInputPayload.sideways\` → \`targetYaw\` (float, degrees). Client sends \`client.player.getYaw()\` every tick. Server lerps current heading toward the target with proportional gain + dead zone + max rate cap:

\`\`\`
diff = wrap(targetYaw - heading, -180, 180)
if |diff| < 5°    → no-op
step = clamp(diff * 0.15, -2°, +2°)  per tick
heading += step
\`\`\`

Result: ship "pulls" toward where you look — fast on big angle errors, settles gently. 2°/tick cap (~40°/sec) prevents teleport on a 180° flick.

## Controls now
| Key | Action |
|---|---|
| Mouse | Aim (ship turns toward camera) |
| W | Throttle |
| S | Decelerate |
| Space | Rise |
| Tab | Descend |
| Ctrl | Boost |
| Shift | Dismount |

## Phase 2 (separate PR)
- Pitch from camera vertical for ascend/descend (replaces Space/Tab)
- Auto-roll banking on horizontal offset
- Per-ship-type tunable rates + dead zone

## Test plan
- [ ] Wait for next mc Docker publish + new mrpack
- [ ] \`/spawnship airship\` + \`/boardship\` → look around with mouse, ship rotates smoothly toward camera
- [ ] Snap mouse 180° → ship turns at ~40°/sec, no teleport
- [ ] Tiny mouse jitter near current heading → no wobble (dead zone)