### PR TITLE
feat(astro-kbve): readable argo diff + stalled detection + Clickhouse Logs rename

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
@@ -6,6 +6,9 @@ import {
 	syncColor,
 	fetchResourceTree,
 	fetchAppEvents,
+	detectAppStall,
+	detectResourceStall,
+	formatAge,
 	type AppEvent,
 	type ArgoApplication,
 	type ResourceTree,
@@ -22,7 +25,40 @@ import {
 	ChevronDown,
 	ChevronRight,
 	Box,
+	Clock,
 } from 'lucide-react';
+
+function StallBadge({
+	reason,
+	ageMs,
+	compact,
+}: {
+	reason: string;
+	ageMs: number;
+	compact?: boolean;
+}) {
+	return (
+		<span
+			title={`${reason} for ${formatAge(ageMs)}`}
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: 3,
+				padding: compact ? '0 6px' : '2px 8px',
+				borderRadius: 4,
+				background: 'rgba(245, 158, 11, 0.12)',
+				border: '1px solid rgba(245, 158, 11, 0.35)',
+				color: '#fbbf24',
+				fontSize: compact ? '0.65rem' : '0.7rem',
+				fontWeight: 600,
+				textTransform: 'uppercase',
+				letterSpacing: '0.04em',
+			}}>
+			<Clock size={compact ? 10 : 11} />
+			Stalled {ageMs > 0 ? formatAge(ageMs) : ''}
+		</span>
+	);
+}
 
 // ---------------------------------------------------------------------------
 // Status helpers
@@ -210,6 +246,18 @@ function ResourceRow({
 					{node.namespace}/
 				</span>
 				{node.name}
+				{(() => {
+					const stall = detectResourceStall(node);
+					return stall ? (
+						<span style={{ marginLeft: 'auto' }}>
+							<StallBadge
+								reason={stall.reason}
+								ageMs={stall.ageMs}
+								compact
+							/>
+						</span>
+					) : null;
+				})()}
 			</div>
 			{selected && (
 				<ReactArgoResourceDetail
@@ -271,7 +319,11 @@ function ResourceTreePanel({
 
 	const filterMatch = (n: ResourceNode) => {
 		if (kindFilter && n.kind !== kindFilter) return false;
-		if (healthFilter && n.health?.status !== healthFilter) return false;
+		if (healthFilter === '__stalled') {
+			if (!detectResourceStall(n)) return false;
+		} else if (healthFilter && n.health?.status !== healthFilter) {
+			return false;
+		}
 		if (search) {
 			const q = search.toLowerCase();
 			if (
@@ -362,6 +414,7 @@ function ResourceTreePanel({
 				<option value="Progressing">Progressing</option>
 				<option value="Suspended">Suspended</option>
 				<option value="Missing">Missing</option>
+				<option value="__stalled">Stalled only</option>
 			</select>
 			<input
 				value={search}
@@ -778,11 +831,24 @@ function ApplicationRow({
 				</span>
 				<span
 					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 6,
 						fontWeight: 600,
 						color: 'var(--sl-color-text, #e6edf3)',
 						fontSize: '0.9rem',
 					}}>
 					{app.metadata.name}
+					{(() => {
+						const stall = detectAppStall(app);
+						return stall ? (
+							<StallBadge
+								reason={stall.reason}
+								ageMs={stall.ageMs}
+								compact
+							/>
+						) : null;
+					})()}
 				</span>
 				<span
 					style={{

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
@@ -461,6 +461,254 @@ export function EventsList({ events }: { events: AppEvent[] }) {
 // Diff
 // ---------------------------------------------------------------------------
 
+type DiffOp = 'eq' | 'add' | 'del';
+interface DiffLine {
+	op: DiffOp;
+	live?: string;
+	target?: string;
+	leftNo?: number;
+	rightNo?: number;
+}
+
+function computeUnifiedDiff(liveYaml: string, targetYaml: string): DiffLine[] {
+	const a = liveYaml ? liveYaml.split('\n') : [];
+	const b = targetYaml ? targetYaml.split('\n') : [];
+	const m = a.length;
+	const n = b.length;
+	const lcs: number[][] = Array.from({ length: m + 1 }, () =>
+		new Array(n + 1).fill(0),
+	);
+	for (let i = m - 1; i >= 0; i--) {
+		for (let j = n - 1; j >= 0; j--) {
+			lcs[i][j] =
+				a[i] === b[j]
+					? lcs[i + 1][j + 1] + 1
+					: Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+		}
+	}
+	const out: DiffLine[] = [];
+	let i = 0,
+		j = 0,
+		left = 0,
+		right = 0;
+	while (i < m && j < n) {
+		if (a[i] === b[j]) {
+			left++;
+			right++;
+			out.push({
+				op: 'eq',
+				live: a[i],
+				target: b[j],
+				leftNo: left,
+				rightNo: right,
+			});
+			i++;
+			j++;
+		} else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+			left++;
+			out.push({ op: 'del', live: a[i], leftNo: left });
+			i++;
+		} else {
+			right++;
+			out.push({ op: 'add', target: b[j], rightNo: right });
+			j++;
+		}
+	}
+	while (i < m) {
+		left++;
+		out.push({ op: 'del', live: a[i], leftNo: left });
+		i++;
+	}
+	while (j < n) {
+		right++;
+		out.push({ op: 'add', target: b[j], rightNo: right });
+		j++;
+	}
+	return out;
+}
+
+function diffSummary(lines: DiffLine[]): { added: number; removed: number } {
+	let added = 0,
+		removed = 0;
+	for (const l of lines) {
+		if (l.op === 'add') added++;
+		else if (l.op === 'del') removed++;
+	}
+	return { added, removed };
+}
+
+const DIFF_BG = {
+	add: 'rgba(34, 197, 94, 0.08)',
+	del: 'rgba(239, 68, 68, 0.08)',
+	eq: 'transparent',
+} as const;
+const DIFF_BORDER = {
+	add: '#22c55e',
+	del: '#ef4444',
+	eq: 'transparent',
+} as const;
+
+function UnifiedDiffView({ lines }: { lines: DiffLine[] }) {
+	return (
+		<div
+			style={{
+				background: 'var(--sl-color-bg-inline-code, #0d1117)',
+				borderRadius: 6,
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+				maxHeight: 480,
+				overflow: 'auto',
+				fontFamily: 'var(--sl-font-mono, monospace)',
+				fontSize: '0.72rem',
+				lineHeight: 1.4,
+			}}>
+			{lines.map((l, idx) => {
+				const text =
+					l.op === 'eq'
+						? (l.live ?? '')
+						: l.op === 'add'
+							? (l.target ?? '')
+							: (l.live ?? '');
+				const sym = l.op === 'add' ? '+' : l.op === 'del' ? '-' : ' ';
+				const color =
+					l.op === 'add'
+						? '#86efac'
+						: l.op === 'del'
+							? '#fca5a5'
+							: 'var(--sl-color-text, #e6edf3)';
+				return (
+					<div
+						key={idx}
+						style={{
+							display: 'grid',
+							gridTemplateColumns: '36px 36px 14px 1fr',
+							gap: 8,
+							padding: '0 8px',
+							background: DIFF_BG[l.op],
+							borderLeft: `2px solid ${DIFF_BORDER[l.op]}`,
+						}}>
+						<span
+							style={{
+								color: 'var(--sl-color-gray-4, #6b7280)',
+								textAlign: 'right',
+								userSelect: 'none',
+							}}>
+							{l.leftNo ?? ''}
+						</span>
+						<span
+							style={{
+								color: 'var(--sl-color-gray-4, #6b7280)',
+								textAlign: 'right',
+								userSelect: 'none',
+							}}>
+							{l.rightNo ?? ''}
+						</span>
+						<span
+							style={{
+								color,
+								fontWeight: 700,
+								userSelect: 'none',
+							}}>
+							{sym}
+						</span>
+						<span
+							style={{
+								color,
+								whiteSpace: 'pre',
+								wordBreak: 'break-all',
+							}}>
+							{text}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function SideBySideDiffView({ lines }: { lines: DiffLine[] }) {
+	return (
+		<div
+			style={{
+				background: 'var(--sl-color-bg-inline-code, #0d1117)',
+				borderRadius: 6,
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+				maxHeight: 480,
+				overflow: 'auto',
+				fontFamily: 'var(--sl-font-mono, monospace)',
+				fontSize: '0.72rem',
+				lineHeight: 1.4,
+			}}>
+			{lines.map((l, idx) => {
+				const leftBg = l.op === 'del' ? DIFF_BG.del : DIFF_BG.eq;
+				const rightBg = l.op === 'add' ? DIFF_BG.add : DIFF_BG.eq;
+				const leftColor =
+					l.op === 'del'
+						? '#fca5a5'
+						: 'var(--sl-color-text, #e6edf3)';
+				const rightColor =
+					l.op === 'add'
+						? '#86efac'
+						: 'var(--sl-color-text, #e6edf3)';
+				return (
+					<div
+						key={idx}
+						style={{
+							display: 'grid',
+							gridTemplateColumns: '36px 1fr 36px 1fr',
+							borderBottom:
+								idx < lines.length - 1
+									? '1px solid rgba(255,255,255,0.02)'
+									: 'none',
+						}}>
+						<span
+							style={{
+								color: 'var(--sl-color-gray-4, #6b7280)',
+								textAlign: 'right',
+								padding: '0 6px',
+								userSelect: 'none',
+								background: leftBg,
+							}}>
+							{l.leftNo ?? ''}
+						</span>
+						<span
+							style={{
+								color: leftColor,
+								whiteSpace: 'pre',
+								wordBreak: 'break-all',
+								padding: '0 6px',
+								background: leftBg,
+								borderRight:
+									'1px solid var(--sl-color-gray-5, #262626)',
+							}}>
+							{l.live ?? ''}
+						</span>
+						<span
+							style={{
+								color: 'var(--sl-color-gray-4, #6b7280)',
+								textAlign: 'right',
+								padding: '0 6px',
+								userSelect: 'none',
+								background: rightBg,
+							}}>
+							{l.rightNo ?? ''}
+						</span>
+						<span
+							style={{
+								color: rightColor,
+								whiteSpace: 'pre',
+								wordBreak: 'break-all',
+								padding: '0 6px',
+								background: rightBg,
+							}}>
+							{l.target ?? ''}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
 function DiffTab({
 	sel,
 	managed,
@@ -468,6 +716,9 @@ function DiffTab({
 	sel: ResourceSelector;
 	managed: ManagedResource | null;
 }) {
+	const [view, setView] = useState<'unified' | 'split'>('unified');
+	const [showEq, setShowEq] = useState<boolean>(false);
+
 	if (!managed) {
 		return (
 			<div
@@ -499,6 +750,22 @@ function DiffTab({
 		}
 	}, [managed.targetState]);
 
+	const liveYaml = useMemo(() => (live ? toYaml(live) : ''), [live]);
+	const targetYaml = useMemo(() => (target ? toYaml(target) : ''), [target]);
+
+	const allLines = useMemo(
+		() => computeUnifiedDiff(liveYaml, targetYaml),
+		[liveYaml, targetYaml],
+	);
+	const visibleLines = useMemo(
+		() => (showEq ? allLines : allLines.filter((l) => l.op !== 'eq')),
+		[allLines, showEq],
+	);
+	const summary = useMemo(() => diffSummary(allLines), [allLines]);
+
+	const onlyLive = !!live && !target;
+	const onlyTarget = !live && !!target;
+
 	if (!live && !target) {
 		return (
 			<div
@@ -512,45 +779,155 @@ function DiffTab({
 		);
 	}
 
+	if (onlyLive || onlyTarget) {
+		const yaml = onlyLive ? liveYaml : targetYaml;
+		const label = onlyLive
+			? 'Live only — no target'
+			: 'Target only — not in cluster';
+		const color = onlyLive ? '#fbbf24' : '#8b5cf6';
+		const reason = onlyLive
+			? `${sel.kind} exists in the cluster but is not in the desired state. ${
+					managed.requiresPruning
+						? 'Argo will prune on next sync.'
+						: ''
+				}`
+			: `${sel.kind} is in the desired state but missing from the cluster. Argo will create on next sync.`;
+		return (
+			<div>
+				<div
+					style={{
+						padding: '0.5rem 0.75rem',
+						borderRadius: 6,
+						background: `${color}14`,
+						border: `1px solid ${color}40`,
+						color,
+						fontSize: '0.8rem',
+						fontWeight: 600,
+						marginBottom: 8,
+					}}>
+					{label}
+				</div>
+				<div
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.75rem',
+						marginBottom: 8,
+					}}>
+					{reason}
+				</div>
+				<CodeBlock>{yaml}</CodeBlock>
+			</div>
+		);
+	}
+
+	if (summary.added === 0 && summary.removed === 0) {
+		return (
+			<div>
+				<div
+					style={{
+						padding: '0.5rem 0.75rem',
+						borderRadius: 6,
+						background: 'rgba(34, 197, 94, 0.08)',
+						border: '1px solid rgba(34, 197, 94, 0.3)',
+						color: '#22c55e',
+						fontSize: '0.8rem',
+						fontWeight: 600,
+						marginBottom: 8,
+					}}>
+					No diff — live matches target
+				</div>
+				<CodeBlock>{liveYaml}</CodeBlock>
+			</div>
+		);
+	}
+
 	return (
 		<div>
 			<div
 				style={{
-					display: 'grid',
-					gridTemplateColumns: '1fr 1fr',
-					gap: '0.5rem',
+					display: 'flex',
+					gap: 8,
+					marginBottom: 8,
+					alignItems: 'center',
+					flexWrap: 'wrap',
 				}}>
-				<div>
-					<div
-						style={{
-							fontSize: '0.7rem',
-							fontWeight: 600,
-							color: '#22c55e',
-							textTransform: 'uppercase',
-							letterSpacing: '0.05em',
-							marginBottom: 4,
-						}}>
-						Live (cluster)
-					</div>
-					<CodeBlock>{live ? toYaml(live) : '(missing)'}</CodeBlock>
+				<div
+					style={{
+						display: 'inline-flex',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						overflow: 'hidden',
+					}}>
+					{(['unified', 'split'] as const).map((m) => (
+						<button
+							key={m}
+							onClick={() => setView(m)}
+							style={{
+								background:
+									view === m
+										? 'rgba(139, 92, 246, 0.15)'
+										: 'transparent',
+								color:
+									view === m
+										? '#c4b5fd'
+										: 'var(--sl-color-gray-3, #8b949e)',
+								border: 'none',
+								padding: '4px 10px',
+								fontSize: '0.75rem',
+								fontWeight: 600,
+								cursor: 'pointer',
+								textTransform: 'capitalize',
+							}}>
+							{m === 'unified' ? 'Unified' : 'Side-by-side'}
+						</button>
+					))}
 				</div>
-				<div>
-					<div
-						style={{
-							fontSize: '0.7rem',
-							fontWeight: 600,
-							color: '#8b5cf6',
-							textTransform: 'uppercase',
-							letterSpacing: '0.05em',
-							marginBottom: 4,
-						}}>
-						Target (desired)
-					</div>
-					<CodeBlock>
-						{target ? toYaml(target) : '(missing)'}
-					</CodeBlock>
-				</div>
+				<label
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: 4,
+						fontSize: '0.75rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						cursor: 'pointer',
+					}}>
+					<input
+						type="checkbox"
+						checked={showEq}
+						onChange={(e) => setShowEq(e.target.checked)}
+					/>
+					Show unchanged
+				</label>
+				<span
+					style={{
+						fontSize: '0.7rem',
+						color: '#86efac',
+						fontWeight: 600,
+					}}>
+					+{summary.added}
+				</span>
+				<span
+					style={{
+						fontSize: '0.7rem',
+						color: '#fca5a5',
+						fontWeight: 600,
+					}}>
+					-{summary.removed}
+				</span>
+				<span
+					style={{
+						marginLeft: 'auto',
+						fontSize: '0.7rem',
+						color: 'var(--sl-color-gray-4, #6b7280)',
+					}}>
+					{visibleLines.length}/{allLines.length} lines
+				</span>
 			</div>
+			{view === 'unified' ? (
+				<UnifiedDiffView lines={visibleLines} />
+			) : (
+				<SideBySideDiffView lines={visibleLines} />
+			)}
 			{managed.requiresPruning && (
 				<div
 					style={{
@@ -1109,7 +1486,7 @@ function ContainersTab({
 						) : null}
 					</div>
 				)}
-				{lastInfo && lastInfo.reason && (
+				{lastInfo && !!lastInfo.reason && (
 					<div
 						style={{
 							marginTop: 4,
@@ -1316,7 +1693,7 @@ export default function ReactArgoResourceDetail({
 		{ id: 'events', label: 'Events' },
 		{ id: 'diff', label: 'Diff' },
 		...(isPod ? [{ id: 'logs' as TabId, label: 'Logs' }] : []),
-		{ id: 'indexed', label: 'Indexed Logs' },
+		{ id: 'indexed', label: 'Clickhouse Logs' },
 	];
 
 	useEffect(() => {

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoSummary.tsx
@@ -7,6 +7,7 @@ import {
 	Activity,
 	XCircle,
 	RefreshCw,
+	Clock,
 	AlertCircle,
 } from 'lucide-react';
 
@@ -66,6 +67,7 @@ export default function ReactArgoSummary() {
 	const syncedCount = useStore(argoService.$syncedCount);
 	const degradedCount = useStore(argoService.$degradedCount);
 	const outOfSyncCount = useStore(argoService.$outOfSyncCount);
+	const stalledCount = useStore(argoService.$stalledCount);
 
 	return (
 		<>
@@ -169,6 +171,12 @@ export default function ReactArgoSummary() {
 						label="Out of Sync"
 						value={outOfSyncCount}
 						color={outOfSyncCount > 0 ? '#f59e0b' : '#22c55e'}
+					/>
+					<StatCard
+						icon={<Clock size={16} style={{ color: '#fbbf24' }} />}
+						label="Stalled"
+						value={stalledCount}
+						color={stalledCount > 0 ? '#fbbf24' : '#22c55e'}
 					/>
 				</div>
 			)}

--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
@@ -397,6 +397,59 @@ export function syncColor(status: string): string {
 	}
 }
 
+export const STALL_THRESHOLD_MS = 5 * 60 * 1000;
+
+export interface StallReason {
+	reason: string;
+	ageMs: number;
+}
+
+export function detectAppStall(app: ArgoApplication): StallReason | null {
+	const op = app.status.operationState;
+	if (op && op.phase === 'Running' && op.startedAt) {
+		const ageMs = Date.now() - new Date(op.startedAt).getTime();
+		if (ageMs >= STALL_THRESHOLD_MS) {
+			return { reason: 'Sync running', ageMs };
+		}
+	}
+	if (app.status.health.status === 'Progressing' && app.status.reconciledAt) {
+		const ageMs = Date.now() - new Date(app.status.reconciledAt).getTime();
+		if (ageMs >= STALL_THRESHOLD_MS) {
+			return { reason: 'Progressing', ageMs };
+		}
+	}
+	if (app.status.sync.status === 'OutOfSync' && app.status.reconciledAt) {
+		const ageMs = Date.now() - new Date(app.status.reconciledAt).getTime();
+		if (ageMs >= 30 * 60 * 1000) {
+			return { reason: 'OutOfSync', ageMs };
+		}
+	}
+	return null;
+}
+
+export function detectResourceStall(node: ResourceNode): StallReason | null {
+	if (node.health?.status === 'Progressing' && node.createdAt) {
+		const ageMs = Date.now() - new Date(node.createdAt).getTime();
+		if (ageMs >= STALL_THRESHOLD_MS) {
+			return { reason: 'Progressing', ageMs };
+		}
+	}
+	if (node.health?.status === 'Degraded') {
+		return { reason: 'Degraded', ageMs: 0 };
+	}
+	if (node.health?.status === 'Missing') {
+		return { reason: 'Missing', ageMs: 0 };
+	}
+	return null;
+}
+
+export function formatAge(ageMs: number): string {
+	if (ageMs < 60 * 1000) return `${Math.floor(ageMs / 1000)}s`;
+	if (ageMs < 60 * 60 * 1000) return `${Math.floor(ageMs / 60000)}m`;
+	if (ageMs < 24 * 60 * 60 * 1000) return `${Math.floor(ageMs / 3600000)}h`;
+	return `${Math.floor(ageMs / 86400000)}d`;
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -449,6 +502,20 @@ class ArgoService {
 		[this.$applications],
 		(apps) =>
 			apps.filter((a) => a.status.sync.status === 'OutOfSync').length,
+	);
+
+	public readonly $stalledApps = computed([this.$applications], (apps) =>
+		apps
+			.map((a) => ({ app: a, stall: detectAppStall(a) }))
+			.filter(
+				(x): x is { app: ArgoApplication; stall: StallReason } =>
+					x.stall !== null,
+			),
+	);
+
+	public readonly $stalledCount = computed(
+		[this.$stalledApps],
+		(s) => s.length,
 	);
 
 	private _refreshInterval: ReturnType<typeof setInterval> | undefined;


### PR DESCRIPTION
## Summary

Three quality-of-life fixes on the argo dashboard from yesterday's drawer landing:

### 1. Diff is actually readable now

The previous diff was two YAML blocks side-by-side with no highlighting and a 1fr/1fr grid that wasted half the panel when one side was just \`(missing)\`.

- LCS-based line-level diff between live + target YAML
- Default Unified view: line-number gutters, +/- prefix, green/red rows
- Side-by-side toggle with columns lined up by op
- \`Show unchanged\` checkbox to collapse to changed-only
- \`+N/-M\` summary chip + \`visible/total lines\` counter
- **Live-only / target-only states** render a single panel with a clear reason banner instead of an empty 'missing' column
- **No-op state** ('live matches target') gets its own banner

### 2. Stalled detection

Easier to spot apps/resources stuck in long-running operations:

- \`detectAppStall\` covers: \`operationState.phase=Running > 5min\`, \`health.Progressing > 5min since reconciledAt\`, \`OutOfSync > 30min\`
- \`detectResourceStall\` covers: resource health \`Progressing > 5min\` since createdAt, plus \`Degraded\` / \`Missing\` as immediate stalls
- \`StallBadge\` pill rendered next to app name + next to each resource row
- Summary cards gain a **Stalled** count
- Resource list health filter gains \`Stalled only\` option

### 3. Rename

Drawer tab \`Indexed Logs\` → \`Clickhouse Logs\`

## Test plan

- [x] \`nx run astro-kbve:build\` clean
- [ ] Open a Synced+Healthy resource → Diff shows 'No diff — live matches target'
- [ ] Open a RoleBinding with \`(missing)\` target → Diff shows single-panel 'Live only' with reason
- [ ] Open an OutOfSync resource → Diff shows Unified view with +/- coloring; toggle to side-by-side; toggle 'Show unchanged'
- [ ] Force a Progressing resource > 5min → Stalled pill appears on resource row + summary count increments
- [ ] Filter resource list to 'Stalled only' → only stalled rows visible
- [ ] Drawer tab now reads 'Clickhouse Logs'