### PR TITLE
fix(rareicon,mp): gate PlayerPeerDisplayBuildSystem to Steamworks platforms

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Multiplayer/PlayerPeerDisplayBuildSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Multiplayer/PlayerPeerDisplayBuildSystem.cs
@@ -1,3 +1,5 @@
+#if (UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX) && !DISABLESTEAMWORKS
+
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
@@ -55,3 +57,5 @@ namespace RareIcon
         }
     }
 }
+
+#endif


### PR DESCRIPTION
## Summary

Android + iOS builds in [run 25419292844](https://github.com/KBVE/kbve/actions/runs/25419292844) failed with:

```
Assets/_RareIcon/Scripts/ECS/DB/Multiplayer/PlayerPeerDisplayBuildSystem.cs(10,25): error CS0246:
The type or namespace name 'PlayerPeerMirrorSystem' could not be found
```

`PlayerPeerMirrorSystem` is gated to desktop Steamworks platforms via
`#if (UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX) && !DISABLESTEAMWORKS`.

`PlayerPeerDisplayBuildSystem` references it via `[UpdateAfter(typeof(PlayerPeerMirrorSystem))]` and was missing the same gate, so on Android/iOS the type-name lookup is unresolved.

## Fix

Wrap [`PlayerPeerDisplayBuildSystem.cs`](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Multiplayer/PlayerPeerDisplayBuildSystem.cs) with the same `#if`/`#endif` pair. The system is Burst Display compose for the lobby roster, which is desktop-Steam-only anyway — coordinator, `PlayerPeer` entities, and `LobbyMemberDisplayBridge` are all already gated to the same platform set, so the system has nothing to drive on mobile builds.

## Test plan

- [ ] Android build pipeline turns green.
- [ ] iOS build pipeline turns green.
- [ ] Desktop Win/Linux/OSX builds remain green (untouched gate boundary).
- [ ] Lobby UI continues to populate correctly on a Steam desktop run (no behavior regression).