### PR TITLE
fix(kbve): redirect www.kbve.com to apex via ingress-nginx

### DIFF
--- a/apps/kube/kbve/manifest/kbve-www-redirect-ingress.yaml
+++ b/apps/kube/kbve/manifest/kbve-www-redirect-ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: kbve-www-redirect
+    namespace: kbve
+    annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-http
+        nginx.ingress.kubernetes.io/permanent-redirect: https://kbve.com$request_uri
+        nginx.ingress.kubernetes.io/permanent-redirect-code: '301'
+        nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+spec:
+    ingressClassName: nginx
+    tls:
+        - hosts:
+              - www.kbve.com
+          secretName: kbve-www-tls
+    rules:
+        - host: www.kbve.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 4321

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
     - kbve-deployment.yaml
     - kbve-gateway.yaml
     - kbve-ingress.yaml
+    - kbve-www-redirect-ingress.yaml
     - kbve-wt-selfsigned-cronjob.yaml
     - cf-cache-purge-externalsecret.yaml
     - cf-cache-purge-postsync.yaml


### PR DESCRIPTION
## Summary
- `https://www.kbve.com` returns Cloudflare **526 Invalid SSL Certificate**; apex `https://kbve.com` returns 200
- Origin cert is fine (Google Trust Services, SAN `kbve.com` + `*.kbve.com`, valid through Jul 26 2026)
- Real cause: neither `kbve-ingress.yaml` nor `kbve-gateway.yaml` declares a `www.kbve.com` hostname, so CF reaches the origin with `Host: www.kbve.com` and falls through to the nginx default — mismatched cert → 526
- Adds a dedicated nginx Ingress for `www.kbve.com` with a cert-manager-minted TLS cert that 301-redirects every request to `https://kbve.com\$request_uri`

## Test plan
- [ ] ArgoCD sync the kbve app
- [ ] cert-manager mints `kbve-www-tls` for `www.kbve.com` (letsencrypt-http)
- [ ] \`curl -sI https://www.kbve.com\` returns \`HTTP/2 301\` with \`location: https://kbve.com/\`
- [ ] \`curl -sIL https://www.kbve.com/some/path\` follows to \`https://kbve.com/some/path\` and ends in 200
- [ ] Verify CF DNS for \`www.kbve.com\` is proxied (orange cloud) and points at the ingress-nginx LB IP (\`.74\`), NOT the Cilium gateway (\`.71\`)