### PR TITLE
fix(kbve): redirect mc.kbve.com + minecraft.kbve.com to /mc/

### DIFF
--- a/apps/kube/kbve/manifest/kbve-mc-redirect-ingress.yaml
+++ b/apps/kube/kbve/manifest/kbve-mc-redirect-ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: kbve-mc-redirect
+    namespace: kbve
+    annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-http
+        nginx.ingress.kubernetes.io/permanent-redirect: https://kbve.com/mc$request_uri
+        nginx.ingress.kubernetes.io/permanent-redirect-code: '301'
+        nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+spec:
+    ingressClassName: nginx
+    tls:
+        - hosts:
+              - mc.kbve.com
+              - minecraft.kbve.com
+          secretName: kbve-mc-tls
+    rules:
+        - host: mc.kbve.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 4321
+        - host: minecraft.kbve.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: kbve-service
+                            port:
+                                number: 4321

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
     - kbve-gateway.yaml
     - kbve-ingress.yaml
     - kbve-www-redirect-ingress.yaml
+    - kbve-mc-redirect-ingress.yaml
     - kbve-wt-selfsigned-cronjob.yaml
     - cf-cache-purge-externalsecret.yaml
     - cf-cache-purge-postsync.yaml


### PR DESCRIPTION
## Summary
- Adds \`kbve-mc-redirect\` Ingress (nginx) that 301s \`mc.kbve.com\` and \`minecraft.kbve.com\` to \`https://kbve.com/mc/\`
- cert-manager mints \`kbve-mc-tls\` covering both hostnames via \`letsencrypt-http\`
- HTTPS-only — game TCP 25565 path (Velocity hostPort on dedicated-server node) is untouched

## Test plan
- [ ] ArgoCD sync the kbve app
- [ ] cert-manager mints \`kbve-mc-tls\` for both hostnames
- [ ] \`curl -sI https://minecraft.kbve.com\` returns \`HTTP/2 301\` with \`location: https://kbve.com/mc/\`
- [ ] \`curl -sI https://mc.kbve.com\` returns \`HTTP/2 301\` with \`location: https://kbve.com/mc/\`
- [ ] Subpath preserved: \`curl -sIL https://minecraft.kbve.com/players\` follows to \`https://kbve.com/mc/players\`
- [ ] Game still connects to \`mc.kbve.com:25565\` (TCP, untouched by this Ingress)
- [ ] Verify CF DNS for both hostnames proxies HTTPS to ingress-nginx LB (\`.74\`), NOT Cilium gateway (\`.71\`)