### PR TITLE
feat(ci): auto-regen ci-dispatch-manifest in post-publish PR + manifest guard on dev PRs

### DIFF
--- a/.github/workflows/ci-manifest-guard.yml
+++ b/.github/workflows/ci-manifest-guard.yml
@@ -4,6 +4,7 @@ on:
     pull_request:
         branches:
             - main
+            - dev
         paths:
             - 'apps/kbve/astro-kbve/src/content/**'
             - 'apps/kbve/astro-kbve/src/content.config.ts'

--- a/.github/workflows/utils-update-version-toml.yml
+++ b/.github/workflows/utils-update-version-toml.yml
@@ -82,6 +82,32 @@ jobs:
                   echo "Synced $TARGET to $VERSION:"
                   grep -m1 'version' "$TARGET"
 
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - uses: pnpm/action-setup@v5
+              with:
+                  version: 10.33.0
+                  run_install: false
+
+            - id: pnpm-store
+              run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+            - uses: actions/cache@v5
+              with:
+                  path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml', 'package.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+
+            - run: pnpm install --frozen-lockfile
+
+            - name: Regenerate ci-dispatch-manifest
+              run: |
+                  npx nx run astro-kbve:build
+                  npx nx run astro-kbve:sync:ci-manifest
+
             - name: Create PR
               env:
                   GH_TOKEN: ${{ github.token }}
@@ -98,6 +124,7 @@ jobs:
                   if [ -n "${{ inputs.version_target_path }}" ] && [ -f "${{ inputs.version_target_path }}" ]; then
                     git add "${{ inputs.version_target_path }}"
                   fi
+                  git add .github/ci-dispatch-manifest.json
                   if git diff --cached --quiet; then
                     echo "::notice::version.toml already at ${VERSION} on dev — nothing to commit."
                     exit 0


### PR DESCRIPTION
## Summary

Closes the loop where MDX `version:` bumps drift from `ci-dispatch-manifest.json` and the only signal is a Manifest Guard failure days later when dev tries to merge into main.

### utils-update-version-toml.yml
After the existing version.toml + target-file (Cargo.toml/package.json) sync, the workflow now also:
- Sets up node + pnpm
- Runs `npx nx run astro-kbve:build`
- Runs `npx nx run astro-kbve:sync:ci-manifest`
- `git add .github/ci-dispatch-manifest.json` so the regen lands in the same auto-PR

So every post-publish auto-PR ships version.toml + target file + manifest as one atomic change.

### ci-manifest-guard.yml
Previously only ran on PRs to `main`. Atom PRs target `dev`, so manual `chore: preparing release vX` MDX bumps merged to dev without the guard ever firing — drift only surfaced at dev→main time. Now the guard also runs on PRs targeting `dev`, so any MDX `version:` bump gets caught at PR time.

## Test plan
- [ ] On the next post-publish auto-PR (kbve / rareicon / etc.), confirm the PR contains `.github/ci-dispatch-manifest.json` alongside `version.toml`
- [ ] Open a test PR with an MDX `version:` bump but no manifest regen → confirm Manifest Guard now blocks the dev PR (was previously silent)