### PR TITLE
feat(mc): craftable airship/biplane/gyrodyne items + recipes

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
@@ -3,6 +3,7 @@ package com.kbve.statetree;
 import com.kbve.statetree.chat.McChatEvents;
 import com.kbve.statetree.ship.ShipCommands;
 import com.kbve.statetree.ship.ShipEntityTypes;
+import com.kbve.statetree.ship.ShipItems;
 import com.kbve.statetree.ship.ShipManager;
 import com.kbve.statetree.ship.ShipNetworking;
 import net.fabricmc.api.ModInitializer;
@@ -27,8 +28,9 @@ public class BehaviorStateTreeMod implements ModInitializer {
 
     @Override
     public void onInitialize() {
-        // Register ship entity type
+        // Register ship entity type + spawn items
         ShipEntityTypes.register();
+        ShipItems.register();
 
         // Register network payloads + server-side helm input receiver
         ShipNetworking.registerPayloads();

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
@@ -1,0 +1,61 @@
+package com.kbve.statetree.ship;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.RaycastContext;
+import net.minecraft.world.World;
+
+public class ShipItem extends Item {
+
+    private final String modelName;
+
+    public ShipItem(Settings settings, String modelName) {
+        super(settings);
+        this.modelName = modelName;
+    }
+
+    @Override
+    public ActionResult use(World world, PlayerEntity user, Hand hand) {
+        ItemStack stack = user.getStackInHand(hand);
+
+        Vec3d eye = user.getEyePos();
+        Vec3d look = user.getRotationVec(1.0f);
+        Vec3d end = eye.add(look.x * 5.0, look.y * 5.0, look.z * 5.0);
+        BlockHitResult hit = world.raycast(new RaycastContext(
+                eye, end,
+                RaycastContext.ShapeType.OUTLINE,
+                RaycastContext.FluidHandling.NONE,
+                user));
+
+        if (hit.getType() != HitResult.Type.BLOCK) {
+            return ActionResult.PASS;
+        }
+
+        if (world instanceof ServerWorld serverWorld) {
+            Vec3d pos = hit.getPos();
+            ShipEntity entity = new ShipEntity(ShipEntityTypes.SHIP, world);
+            entity.setShipId(java.util.UUID.randomUUID());
+            entity.setOwnerUuid(user.getUuid());
+            entity.setModelName(modelName);
+            entity.setShipHealth(ShipEntity.MAX_HEALTH);
+            entity.refreshPositionAndAngles(pos.x, pos.y + 1.0, pos.z, user.getYaw(), 0);
+
+            if (!serverWorld.spawnEntity(entity)) {
+                return ActionResult.FAIL;
+            }
+
+            if (!user.getAbilities().creativeMode) {
+                stack.decrement(1);
+            }
+        }
+
+        return ActionResult.SUCCESS;
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItems.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItems.java
@@ -1,0 +1,37 @@
+package com.kbve.statetree.ship;
+
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+
+public final class ShipItems {
+
+    public static final Item AIRSHIP = register("airship", "immersive_aircraft/airship");
+    public static final Item BIPLANE = register("biplane", "immersive_aircraft/biplane");
+    public static final Item GYRODYNE = register("gyrodyne", "immersive_aircraft/gyrodyne");
+
+    private static final RegistryKey<ItemGroup> TOOLS_GROUP =
+            RegistryKey.of(RegistryKeys.ITEM_GROUP, Identifier.ofVanilla("tools"));
+
+    private static Item register(String name, String modelName) {
+        Identifier id = Identifier.of("behavior_statetree", name);
+        RegistryKey<Item> key = RegistryKey.of(RegistryKeys.ITEM, id);
+        return Registry.register(Registries.ITEM, id,
+                new ShipItem(new Item.Settings().registryKey(key).maxCount(1), modelName));
+    }
+
+    public static void register() {
+        ItemGroupEvents.modifyEntriesEvent(TOOLS_GROUP).register(content -> {
+            content.add(AIRSHIP);
+            content.add(BIPLANE);
+            content.add(GYRODYNE);
+        });
+    }
+
+    private ShipItems() {}
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/items/airship.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/items/airship.json
@@ -1,0 +1,6 @@
+{
+	"model": {
+		"type": "minecraft:model",
+		"model": "behavior_statetree:item/airship"
+	}
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/items/biplane.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/items/biplane.json
@@ -1,0 +1,6 @@
+{
+	"model": {
+		"type": "minecraft:model",
+		"model": "behavior_statetree:item/biplane"
+	}
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/items/gyrodyne.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/items/gyrodyne.json
@@ -1,0 +1,6 @@
+{
+	"model": {
+		"type": "minecraft:model",
+		"model": "behavior_statetree:item/gyrodyne"
+	}
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/lang/en_us.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+	"item.behavior_statetree.airship": "KBVE Airship",
+	"item.behavior_statetree.biplane": "KBVE Biplane",
+	"item.behavior_statetree.gyrodyne": "KBVE Gyrodyne"
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/models/item/airship.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/models/item/airship.json
@@ -1,0 +1,6 @@
+{
+	"parent": "minecraft:item/generated",
+	"textures": {
+		"layer0": "minecraft:item/elytra"
+	}
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/models/item/biplane.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/models/item/biplane.json
@@ -1,0 +1,6 @@
+{
+	"parent": "minecraft:item/generated",
+	"textures": {
+		"layer0": "minecraft:item/elytra"
+	}
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/models/item/gyrodyne.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/assets/behavior_statetree/models/item/gyrodyne.json
@@ -1,0 +1,6 @@
+{
+	"parent": "minecraft:item/generated",
+	"textures": {
+		"layer0": "minecraft:item/elytra"
+	}
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/recipe/airship.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/recipe/airship.json
@@ -1,0 +1,14 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": ["WWW", "WIW", "PPP"],
+	"key": {
+		"W": "minecraft:white_wool",
+		"I": "minecraft:iron_block",
+		"P": "minecraft:oak_planks"
+	},
+	"result": {
+		"id": "behavior_statetree:airship",
+		"count": 1
+	},
+	"category": "misc"
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/recipe/biplane.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/recipe/biplane.json
@@ -1,0 +1,15 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": ["WIW", "IFI", "PPP"],
+	"key": {
+		"W": "minecraft:white_wool",
+		"I": "minecraft:iron_ingot",
+		"F": "minecraft:furnace",
+		"P": "minecraft:oak_planks"
+	},
+	"result": {
+		"id": "behavior_statetree:biplane",
+		"count": 1
+	},
+	"category": "misc"
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/recipe/gyrodyne.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/recipe/gyrodyne.json
@@ -1,0 +1,14 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": [" I ", "WPW", " P "],
+	"key": {
+		"I": "minecraft:iron_ingot",
+		"W": "minecraft:white_wool",
+		"P": "minecraft:oak_planks"
+	},
+	"result": {
+		"id": "behavior_statetree:gyrodyne",
+		"count": 1
+	},
+	"category": "misc"
+}


### PR DESCRIPTION
## Summary
Right-click-to-spawn ship items + crafting recipes. Mirrors the [ImmersiveAircraft](https://github.com/Luke100000/ImmersiveAircraft) \`VehicleItem\` pattern, ported to 1.21.11 yarn.

## Files
- \`ShipItem.java\` — raycast 5 blocks, place fresh \`ShipEntity\` at hit, set modelName/owner/HP, consume 1 from stack (creative skips).
- \`ShipItems.java\` — registers airship/biplane/gyrodyne items (maxCount=1), adds to vanilla \`tools\` creative tab.
- \`data/behavior_statetree/recipe/{airship,biplane,gyrodyne}.json\` — vanilla-only ingredients.
- \`assets/behavior_statetree/items/*.json\` — 1.21.11 item definitions.
- \`assets/behavior_statetree/models/item/*.json\` — placeholder elytra texture.
- \`assets/behavior_statetree/lang/en_us.json\` — display names.
- \`BehaviorStateTreeMod\` calls \`ShipItems.register()\`.

## Recipes
| Ship | Pattern |
|---|---|
| Airship | wool wool wool / wool iron-block wool / planks planks planks |
| Biplane | wool iron wool / iron furnace iron / planks planks planks |
| Gyrodyne | _ iron _ / wool planks wool / _ planks _ |

## Out of scope (future)
- Custom item textures (currently elytra placeholder)
- More ship types
- NBT-driven model variant on a single item

## Test plan
- [ ] Wait for next mc Docker publish + new mrpack
- [ ] Craft airship via recipe → item shows in inventory
- [ ] Right-click ground → ship spawns at aim point, item consumed
- [ ] Take to the Skies advancement triggers on first board (existing)