### PR TITLE
fix(cert-manager): mint www.kbve.com via DNS-01 ClusterIssuer

### DIFF
--- a/apps/kube/cert-manager/manifests/kustomization.yaml
+++ b/apps/kube/cert-manager/manifests/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
     - sealed-cloudflare-secrets.yaml
     - https://github.com/cert-manager/cert-manager/releases/download/v1.19.0/cert-manager.yaml
     - cluster-issuer.yaml
+    - letsencrypt-dns-issuer.yaml
     - kbve-cloudflare-rbac.yaml
 
 patches:

--- a/apps/kube/cert-manager/manifests/letsencrypt-dns-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/letsencrypt-dns-issuer.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+    name: letsencrypt-dns
+spec:
+    acme:
+        server: https://acme-v02.api.letsencrypt.org/directory
+        email: cert@kbve.com
+        privateKeySecretRef:
+            name: letsencrypt-dns-private-key
+        solvers:
+            - selector:
+                  dnsZones:
+                      - kbve.com
+              dns01:
+                  cloudflare:
+                      apiTokenSecretRef:
+                          name: cloudflare-api-token-secret
+                          key: api-token

--- a/apps/kube/kbve/manifest/kbve-www-redirect-ingress.yaml
+++ b/apps/kube/kbve/manifest/kbve-www-redirect-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
     name: kbve-www-redirect
     namespace: kbve
     annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-http
+        cert-manager.io/cluster-issuer: letsencrypt-dns
         nginx.ingress.kubernetes.io/permanent-redirect: https://kbve.com$request_uri
         nginx.ingress.kubernetes.io/permanent-redirect-code: '301'
         nginx.ingress.kubernetes.io/ssl-redirect: 'true'


### PR DESCRIPTION
## Summary
- New \`letsencrypt-dns\` ClusterIssuer using Cloudflare DNS-01 with the existing \`cloudflare-api-token-secret\`
- \`kbve-www-redirect-ingress\` annotation flipped from \`letsencrypt-http\` → \`letsencrypt-dns\` so only \`www.kbve.com\` mints via DNS-01
- Default \`letsencrypt-http\` issuer untouched; every other \`*.kbve.com\` cert keeps renewing the way it does today

## Why not edit the existing issuer
HTTP-01 can't complete for new \`*.kbve.com\` hostnames while CF runs in Full(strict): LE follows CF's HTTPS redirect to the origin, CF rejects the origin handshake (nginx serves Acme Co fake cert until a real one mints), challenge never lands → 526 forever. Replacing Solver 1 outright would re-mint every existing \`*.kbve.com\` cert via DNS-01 at next renewal, putting apex / chat / future certs on a path we haven't proven yet.

This PR isolates DNS-01 to the one broken hostname. If it works, follow-up PRs migrate other certs one at a time.

## Test plan
- [ ] ArgoCD sync the cert-manager + kbve apps
- [ ] \`kubectl get clusterissuer letsencrypt-dns -o yaml\` shows \`Ready=True\`
- [ ] \`kubectl describe certificate -n kbve kbve-www-tls\` shows the order moved to the new issuer
- [ ] cert-manager logs a DNS-01 TXT propagation, then \`Issuing\` → \`Ready\`
- [ ] May need to delete a stuck failed Certificate/CertificateRequest manually:
      \`kubectl delete certificate -n kbve kbve-www-tls\`
      \`kubectl delete certificaterequest -n kbve -l cert-manager.io/certificate-name=kbve-www-tls\`
- [ ] \`echo | openssl s_client -servername www.kbve.com -connect 142.132.206.74:443 2>/dev/null | openssl x509 -noout -issuer\` shows Let's Encrypt, not Acme Co
- [ ] \`curl -sI https://www.kbve.com\` returns \`HTTP/2 301\` with \`location: https://kbve.com/\`