### PR TITLE
feat(kube): register kyverno application in app-of-apps kustomization

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
     # after a cluster CA rotation. Read-only CronJob, emits JSON to Vector.
     - ca-staleness-monitor/application.yaml
     - keda/application.yaml
+    - kyverno/application.yaml
     - crossplane/application.yaml
     - crossplane/providers-application.yaml
     - external-secrets/application.yaml


### PR DESCRIPTION
## Summary
- Add \`- kyverno/application.yaml\` to \`apps/kube/kustomization.yaml\`. The Kyverno ArgoCD Application manifest has been sitting committed but unregistered, so the chart never installed. One-line registration turns it into a live deployment on the next root sync.

## Why
Kyverno gives us declarative \`ClusterCleanupPolicy\` resources, which is the cleanest way to GC stuck \`Failed\` ephemeralrunners in \`arc-runners\` (last incident: 20h-old failed CR blocked the listener from scaling, queueing every Unity job until manual cleanup).

## Out of scope
The actual \`ClusterCleanupPolicy\` for failed ephemeralrunners ships in a follow-up PR once Kyverno is healthy in cluster.

## Test plan
- [ ] Merge → ArgoCD root sync creates \`kyverno\` Application
- [ ] \`kubectl -n argocd get application kyverno\` is \`Synced\` and \`Healthy\`
- [ ] \`kubectl -n kyverno get pods\` shows admission (2x), background, cleanup, reports controllers Running
- [ ] \`kubectl get crds | grep kyverno\` lists ClusterCleanupPolicy / Policy / ClusterPolicy CRDs
- [ ] No collateral webhook breakage: confirm a write to a regular namespace still succeeds (e.g. \`kubectl -n default annotate cm kube-root-ca.crt smoke=test\`)