### PR TITLE
fix(kbve): static mc.kbve.com redirect, unblock ArgoCD sync wave

### DIFF
--- a/apps/kube/kbve/manifest/kbve-mc-redirect-ingress.yaml
+++ b/apps/kube/kbve/manifest/kbve-mc-redirect-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
     namespace: kbve
     annotations:
         cert-manager.io/cluster-issuer: letsencrypt-http
-        nginx.ingress.kubernetes.io/permanent-redirect: https://kbve.com/mc$request_uri
+        nginx.ingress.kubernetes.io/permanent-redirect: https://kbve.com/mc
         nginx.ingress.kubernetes.io/permanent-redirect-code: '301'
         nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
@@ -13,20 +13,9 @@ spec:
     tls:
         - hosts:
               - mc.kbve.com
-              - minecraft.kbve.com
           secretName: kbve-mc-tls
     rules:
         - host: mc.kbve.com
-          http:
-              paths:
-                  - path: /
-                    pathType: Prefix
-                    backend:
-                        service:
-                            name: kbve-service
-                            port:
-                                number: 4321
-        - host: minecraft.kbve.com
           http:
               paths:
                   - path: /


### PR DESCRIPTION
## Summary

- ingress-nginx rejects `permanent-redirect` annotations containing `$variables` at the default High risk-level — silently drops the rule, never publishes `loadBalancer.ingress` to ingress status
- Empty Address blocked Argo health gate on `kbve-mc-redirect` + `kbve-www-redirect` for ~10h, freezing the kbve sync wave at 1.0.134 (manifest already pinned 1.0.135)
- Fix mc.kbve.com cluster-side with a static target (`https://kbve.com/mc`) — path preservation unnecessary for a landing-page redirect
- Drop `minecraft.kbve.com` from the ingress + TLS SANs (now handled by Cloudflare Redirect Rules at the edge — already CF-proxied)

## Why static + not CF-proxied for mc.kbve.com
Minecraft TCP 25565 needs the apex A record direct to the cluster IP — CF free tier can't proxy TCP. Cluster handles the HTTPS redirect; CF handles the rest.

`www.kbve.com` separately migrated to CF Redirect Rules (out of band).

## Test plan
- [ ] After merge + Argo sync: `kubectl -n kbve get ingress kbve-mc-redirect` shows Address `142.132.206.74`
- [ ] `curl -sI https://mc.kbve.com/test` → `301`, `location: https://kbve.com/mc`
- [ ] `kubectl -n kbve get deploy kbve-deployment -o jsonpath='{.spec.template.spec.containers[*].image}'` → `ghcr.io/kbve/kbve:1.0.135`
- [ ] `curl -s https://kbve.com/health` → `{"status":"ok","version":"1.0.135"}`