### PR TITLE
feat(firecracker): add firecracker-python-net rootfs image

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -135,6 +135,17 @@
 			"has_test": false
 		},
 		{
+			"key": "firecracker_python_net",
+			"app_name": "firecracker-python-net",
+			"version": "0.1.0",
+			"version_toml": "packages/docker/firecracker/python/net/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx",
+			"source_path": "packages/docker/firecracker/python/net",
+			"runner": "ubuntu-latest",
+			"image": "kbve/firecracker-python-net",
+			"has_test": false
+		},
+		{
 			"key": "herbmail",
 			"app_name": "herbmail",
 			"version": "0.1.1",
@@ -650,7 +661,7 @@
 	"unreal_game": [],
 	"bevy_game": [],
 	"summary": {
-		"docker": 22,
+		"docker": 23,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -660,6 +671,6 @@
 		"godot": 0,
 		"unreal_game": 0,
 		"bevy_game": 0,
-		"total": 61
+		"total": 62
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
@@ -1,0 +1,63 @@
+---
+title: Firecracker Python Net
+description: |
+    Network-capable Alpine + Python rootfs for the staff-side firecracker-ctl-net deployment. Bakes requests, httpx, urllib3, certifi, ca-certificates, and a resolv.conf with public DNS.
+sidebar:
+    label: FC Python Net
+    order: 55
+tags:
+    - docker
+    - firecracker
+    - python
+    - base-image
+key: firecracker_python_net
+pipeline: docker
+app_name: firecracker-python-net
+version: "0.1.0"
+version_toml: packages/docker/firecracker/python/net/version.toml
+source_path: packages/docker/firecracker/python/net
+runner: ubuntu-latest
+image: kbve/firecracker-python-net
+has_test: false
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+Network-capable Python rootfs image used by the **staff-side** Firecracker deployment (`firecracker-ctl-net`). Built as a multi-stage Docker image whose final scratch layer carries a single `/rootfs.ext4` artifact.
+
+This image is **not** for the public sandbox quick-mode VMs. Those keep the no-network `alpine-python` rootfs from [apps/vm/firecracker-ctl/rootfs/Dockerfile.alpine-python](apps/vm/firecracker-ctl/rootfs/Dockerfile.alpine-python) — sandboxing without internet egress is the safety property.
+
+## What's baked in
+
+- Alpine 3.21 + Python 3.12
+- `py3-pip`, `py3-requests`, `py3-httpx`, `py3-urllib3`, `py3-certifi`
+- `ca-certificates-bundle`, `ca-certificates`, `iproute2`
+- `/etc/resolv.conf` with `1.1.1.1` and `8.8.8.8`
+- `/init` mounts `/proc`, `/sys`, `/dev`, brings up `lo` + `eth0`, then `exec /entrypoint`
+
+## Two ecosystems
+
+| Image | Deployment | Network | DNS | requests baked |
+|-------|-----------|---------|-----|----------------|
+| `alpine-python` (existing) | `firecracker-ctl` (public quick) | none | no | no |
+| `firecracker-python-net` (this) | `firecracker-ctl-net` (staff persistent) | TAP via Gluetun/WireGuard | yes | yes |
+
+## Build
+
+```bash
+npx nx run firecracker-python-net:container
+npx nx run firecracker-python-net:extract
+```
+
+Output: `packages/docker/firecracker/python/net/dist/python-net.ext4`.
+
+## Publish
+
+```bash
+npx nx run firecracker-python-net:container:production
+```
+
+Pushes `ghcr.io/kbve/firecracker-python-net:latest` and `:<version>`.

--- a/packages/docker/firecracker/python/net/Dockerfile
+++ b/packages/docker/firecracker/python/net/Dockerfile
@@ -1,0 +1,58 @@
+# ============================================================================
+# firecracker-python-net — network-capable Python rootfs for Firecracker
+#
+# Alpine 3.21 + Python 3.12 + py3-requests/httpx/urllib3/certifi + ca-certs.
+# Output: /rootfs.ext4 (~50 MB) for the firecracker-ctl-net deployment.
+#
+# Bakes:
+#   - python3, py3-pip, py3-requests, py3-httpx, py3-urllib3, py3-certifi
+#   - ca-certificates-bundle
+#   - /etc/resolv.conf with 1.1.1.1 + 8.8.8.8
+#   - init that mounts proc/sys/dev, brings up lo + eth0, then exec /entrypoint
+#
+# Pairs with: firecracker-ctl-net (FC_PERSISTENT_ENDPOINTS_ENABLED=true).
+# Sandbox quick-mode VMs use the no-network alpine-python image.
+#
+# Usage:
+#   docker build -f Dockerfile -t fc-python-net .
+#   docker run --rm fc-python-net cat /rootfs.ext4 > python-net.ext4
+# ============================================================================
+
+FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
+
+RUN apk add --no-cache e2fsprogs
+
+RUN mkdir -p /rootfs && \
+    apk add --root /rootfs --initdb --no-cache \
+        alpine-baselayout \
+        busybox \
+        musl \
+        ca-certificates-bundle \
+        ca-certificates \
+        iproute2 \
+        python3 \
+        py3-pip \
+        py3-requests \
+        py3-httpx \
+        py3-urllib3 \
+        py3-certifi && \
+    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log,etc} && \
+    printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /rootfs/etc/resolv.conf && \
+    printf '#!/bin/sh\n\
+mount -t proc proc /proc\n\
+mount -t sysfs sys /sys\n\
+mount -t devtmpfs dev /dev\n\
+ip link set lo up 2>/dev/null\n\
+ip link set eth0 up 2>/dev/null\n\
+if [ -x /entrypoint ]; then\n\
+  exec /entrypoint\n\
+else\n\
+  exec /bin/sh\n\
+fi\n' > /rootfs/init && \
+    chmod +x /rootfs/init && \
+    dd if=/dev/zero of=/rootfs.ext4 bs=1M count=0 seek=192 && \
+    mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \
+    resize2fs -M /rootfs.ext4
+
+FROM scratch
+COPY --from=rootfs-builder /rootfs.ext4 /rootfs.ext4

--- a/packages/docker/firecracker/python/net/README.md
+++ b/packages/docker/firecracker/python/net/README.md
@@ -1,0 +1,37 @@
+# firecracker-python-net
+
+Network-capable Python rootfs for Firecracker microVMs.
+
+## What's baked
+
+- Alpine 3.21 + Python 3.12
+- `py3-pip`, `py3-requests`, `py3-httpx`, `py3-urllib3`, `py3-certifi`
+- `ca-certificates-bundle`, `ca-certificates`, `iproute2`
+- `/etc/resolv.conf` with `1.1.1.1` and `8.8.8.8`
+- `/init` that mounts `/proc`, `/sys`, `/dev`, brings up `lo` + `eth0`, then `exec /entrypoint`
+
+## When to use
+
+This image pairs with the **net deployment** (`firecracker-ctl-net`, `FC_PERSISTENT_ENDPOINTS_ENABLED=true`). It is intended for staff-deployed persistent endpoints that need outbound HTTP.
+
+For sandbox quick-mode VMs (no network, public exec), keep using the no-network `alpine-python` rootfs in [apps/vm/firecracker-ctl/rootfs/Dockerfile.alpine-python](../../../../../apps/vm/firecracker-ctl/rootfs/Dockerfile.alpine-python).
+
+## Output
+
+- Container image: `ghcr.io/kbve/firecracker-python-net:<version>` (scratch image carrying `/rootfs.ext4`)
+- Extracted ext4 (via `nx run firecracker-python-net:extract`): `dist/python-net.ext4`
+
+## Build
+
+```bash
+npx nx run firecracker-python-net:container
+npx nx run firecracker-python-net:extract
+```
+
+## Publish (CI)
+
+```bash
+npx nx run firecracker-python-net:container:production
+```
+
+Pushes `ghcr.io/kbve/firecracker-python-net:latest` and `:<version>`.

--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -1,0 +1,86 @@
+{
+	"name": "firecracker-python-net",
+	"$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/docker/firecracker/python/net",
+	"targets": {
+		"container": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"npx nx run firecracker-python-net:containerx",
+					"VERSION=$(grep -m1 'version' packages/docker/firecracker/python/net/version.toml | sed 's/.*\"\\(.*\\)\\\"/\\1/') && docker tag ghcr.io/kbve/firecracker-python-net:latest ghcr.io/kbve/firecracker-python-net:${VERSION} && echo \"Tagged ghcr.io/kbve/firecracker-python-net:${VERSION}\""
+				],
+				"parallel": false
+			},
+			"configurations": {
+				"local": {},
+				"production": {
+					"commands": [
+						"npx nx run firecracker-python-net:containerx:production",
+						"VERSION=$(grep -m1 'version' packages/docker/firecracker/python/net/version.toml | sed 's/.*\"\\(.*\\)\\\"/\\1/') && docker buildx imagetools create --tag ghcr.io/kbve/firecracker-python-net:${VERSION} ghcr.io/kbve/firecracker-python-net:latest && echo \"Published ghcr.io/kbve/firecracker-python-net:${VERSION}\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"options": {
+				"engine": "docker",
+				"context": "packages/docker/firecracker/python/net",
+				"file": "packages/docker/firecracker/python/net/Dockerfile",
+				"platforms": ["linux/amd64"],
+				"load": true,
+				"push": false,
+				"tags": ["ghcr.io/kbve/firecracker-python-net:latest"]
+			},
+			"configurations": {
+				"local": {
+					"tags": ["ghcr.io/kbve/firecracker-python-net:latest"]
+				},
+				"production": {
+					"tags": ["ghcr.io/kbve/firecracker-python-net:latest"],
+					"push": true,
+					"metadata": {
+						"images": ["ghcr.io/kbve/firecracker-python-net"]
+					},
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/firecracker-python-net:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/firecracker-python-net:buildcache,mode=max"
+					]
+				}
+			}
+		},
+		"extract": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container"],
+			"options": {
+				"commands": [
+					"mkdir -p packages/docker/firecracker/python/net/dist",
+					"docker create --name fc-python-net-extract ghcr.io/kbve/firecracker-python-net:latest true > /dev/null 2>&1 || true",
+					"docker cp fc-python-net-extract:/rootfs.ext4 packages/docker/firecracker/python/net/dist/python-net.ext4",
+					"docker rm fc-python-net-extract > /dev/null 2>&1 || true",
+					"echo 'Extracted: packages/docker/firecracker/python/net/dist/python-net.ext4'"
+				],
+				"parallel": false
+			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container"],
+			"options": {
+				"commands": [
+					"echo '=== firecracker-python-net rootfs tests ==='",
+					"docker create --name fc-python-net-test ghcr.io/kbve/firecracker-python-net:latest true > /dev/null 2>&1",
+					"docker export fc-python-net-test | tar -t | grep -q '^rootfs.ext4$' && echo 'PASS: rootfs.ext4 present'",
+					"docker rm fc-python-net-test > /dev/null 2>&1",
+					"echo '=== All firecracker-python-net tests passed ==='"
+				],
+				"parallel": false
+			}
+		}
+	},
+	"tags": ["docker", "base-image", "firecracker", "python", "net"]
+}

--- a/packages/docker/firecracker/python/net/version.toml
+++ b/packages/docker/firecracker/python/net/version.toml
@@ -1,0 +1,2 @@
+[package]
+version = "0.1.0"

--- a/packages/npm/devops/src/lib/ci/registry.ts
+++ b/packages/npm/devops/src/lib/ci/registry.ts
@@ -289,6 +289,22 @@ export const CI_PROJECTS: CiProject[] = ProjectArraySchema.parse([
 		status: 'active',
 		tags: ['docker', 'base-image', 'chisel'],
 	},
+	{
+		key: 'firecracker_python_net',
+		name: 'Firecracker Python Net',
+		pipeline: 'docker',
+		app_name: 'firecracker-python-net',
+		description:
+			'Network-capable Alpine + Python rootfs (requests/httpx baked) for the staff-side firecracker-ctl-net deployment',
+		source_path: 'packages/docker/firecracker/python/net',
+		version_toml: 'packages/docker/firecracker/python/net/version.toml',
+		runner: 'ubuntu-latest',
+		image: 'kbve/firecracker-python-net',
+		author: 'h0lybyte',
+		license: 'KBVE',
+		status: 'active',
+		tags: ['docker', 'base-image', 'firecracker', 'python'],
+	},
 
 	// ── NPM Packages ───────────────────────────────────────────
 	{


### PR DESCRIPTION
## Summary

- New base image `packages/docker/firecracker/python/net/` produces a network-capable Alpine + Python ext4 rootfs for the staff-side `firecracker-ctl-net` deployment.
- Bakes `py3-requests`, `py3-httpx`, `py3-urllib3`, `py3-certifi`, `ca-certificates`, `iproute2`, `/etc/resolv.conf` (1.1.1.1 + 8.8.8.8), and an `/init` that brings up `lo` + `eth0` before exec'ing `/entrypoint`.
- Registered as `firecracker_python_net` in the CI registry (MDX + Zod) and the dispatch manifest was regenerated end-to-end (`docker: 22 → 23`).

## Why two images

The existing `alpine-python` rootfs stays no-network for the public quick-mode sandbox — sandboxing without internet egress is the safety property. The new image is only consumed by the staff/persistent path where outbound HTTP routes through Gluetun/WireGuard.

| Image | Deployment | Network | DNS | requests baked |
|-------|-----------|---------|-----|----------------|
| `alpine-python` (existing) | `firecracker-ctl` (public quick) | none | no | no |
| `firecracker-python-net` (new) | `firecracker-ctl-net` (staff persistent) | TAP via Gluetun | yes | yes |

## Test plan

- [ ] `npx nx run firecracker-python-net:container` builds locally on `linux/amd64`.
- [ ] `npx nx run firecracker-python-net:extract` produces `dist/python-net.ext4` (~50 MB).
- [ ] Boot the ext4 inside `firecracker-ctl-net` with a Python entrypoint that calls `requests.get(...)` and confirm DNS resolves + HTTPS succeeds.
- [ ] Confirm `.github/ci-dispatch-manifest.json` picks up the new entry under `docker[]` with `key=firecracker_python_net`.
- [ ] CI publish workflow tags `ghcr.io/kbve/firecracker-python-net:0.1.0` on first release.