### PR TITLE
feat(chuckrpg): harden deployment + Reloader scaffolding

### DIFF
--- a/apps/kube/chuckrpg/README.md
+++ b/apps/kube/chuckrpg/README.md
@@ -33,13 +33,49 @@ The isometric game client uses WebTransport (QUIC/UDP) on `wt.kbve.com:5001`. Th
 
 ## Manifests
 
-| File                   | Resources                                                        |
-| ---------------------- | ---------------------------------------------------------------- |
-| `namespace.yaml`       | `chuckrpg` namespace                                             |
-| `deployment.yaml`      | `chuckrpg-deployment` (axum-chuckrpg)                            |
-| `httproute.yaml`       | HTTPRoutes for `chuckrpg.com` and `api.chuckrpg.com`             |
-| `certificate.yaml`     | TLS certs for `chuckrpg.com` and `api.chuckrpg.com`              |
-| `reference-grant.yaml` | Allows `kbve-gateway` to reference certs in `chuckrpg` namespace |
+| File                   | Resources                                                                               |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `namespace.yaml`       | `chuckrpg` namespace                                                                    |
+| `serviceaccount.yaml`  | `chuckrpg` ServiceAccount (no token automount — pod does not call the kube API)         |
+| `configmap.yaml`       | `chuckrpg-config` — runtime env (HTTP_HOST/PORT/RUST_LOG) plus future integration stubs |
+| `deployment.yaml`      | `chuckrpg-deployment` (axum-chuckrpg) and `chuckrpg-service` (ClusterIP)                |
+| `httproute.yaml`       | HTTPRoutes for `chuckrpg.com` and `api.chuckrpg.com`                                    |
+| `certificate.yaml`     | TLS certs for `chuckrpg.com` and `api.chuckrpg.com`                                     |
+| `reference-grant.yaml` | Allows `kbve-gateway` to reference certs in `chuckrpg` namespace                        |
+
+## Hardening
+
+The Deployment runs under a restricted PodSecurity profile:
+
+- `runAsNonRoot: true`, UID/GID `10001` (matches the binary owner set in the Dockerfile)
+- `readOnlyRootFilesystem: true` with a 64Mi `emptyDir` mounted at `/tmp` for scratch
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- Dedicated ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod spec — the axum binary does not need to talk to the kube API
+- CPU/memory `requests` and `limits` set on the container so the kubelet enforces a cgroup; bursts cap at 500m / 256Mi
+
+## Runtime configuration & secret rotation
+
+Runtime env lives in `chuckrpg-config` (ConfigMap) — never in the Deployment spec. CI/CD only bumps the image tag; config edits are a separate flow that does not touch the image.
+
+The Deployment carries `reloader.stakater.com/auto: "true"`, so any change to `chuckrpg-config` (or the optional `chuckrpg-secrets` once it exists) triggers a rolling restart automatically. `chuckrpg-secrets` is referenced with `optional: true` so the pod boots fine before any SealedSecret is added.
+
+### Adding the secret store later
+
+1. Generate a SealedSecret named `chuckrpg-secrets` in the `chuckrpg` namespace (use the bitnami sealed-secrets controller; see `apps/kube/redis/manifests/redis-auth-sealedsecret.yaml` for the structure).
+2. Commit it to `apps/kube/chuckrpg/manifest/`.
+3. ArgoCD syncs it; Reloader detects the new Secret reference and rolls the Deployment.
+
+### Future integrations (kube-DNS targets)
+
+In-cluster service URLs are pre-wired as commented entries in `configmap.yaml`. Uncomment + populate when each upstream is ready:
+
+- `POSTGREST_URL` — `http://supabase-postgrest.kilobase.svc.cluster.local:3000`
+- `SUPABASE_FUNCTIONS_URL` — `http://supabase-edge-functions.kilobase.svc.cluster.local:9000`
+- `DATABASE_HOST` — `supabase-cluster-rw.kilobase.svc.cluster.local`
+- Discord webhook URL/token belong in the SealedSecret, not the ConfigMap
+
+A CiliumNetworkPolicy permitting egress from `chuckrpg` to `kilobase` should land alongside the first integration that actually needs cross-namespace traffic.
 
 ## ArgoCD
 

--- a/apps/kube/chuckrpg/manifest/configmap.yaml
+++ b/apps/kube/chuckrpg/manifest/configmap.yaml
@@ -1,0 +1,33 @@
+# Runtime configuration for the chuckrpg axum service.
+#
+# Edits to this ConfigMap trigger a rolling restart of the Deployment
+# via the `reloader.stakater.com/auto: "true"` annotation. CI/CD only
+# bumps the image tag in deployment.yaml — runtime env lives here so
+# config and image cycles stay decoupled.
+#
+# Future integration slots are commented out below. Uncomment + populate
+# when the corresponding upstream service is reachable.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: chuckrpg-config
+    namespace: chuckrpg
+    labels:
+        app: chuckrpg
+data:
+    HTTP_HOST: '0.0.0.0'
+    HTTP_PORT: '4322'
+    RUST_LOG: 'info'
+    # --- Future integration env (uncomment when wired) -----------------
+    # PostgREST in the kilobase namespace, in-cluster DNS only.
+    # POSTGREST_URL: 'http://supabase-postgrest.kilobase.svc.cluster.local:3000'
+    #
+    # Supabase Edge Functions (Deno runtime) in kilobase.
+    # SUPABASE_FUNCTIONS_URL: 'http://supabase-edge-functions.kilobase.svc.cluster.local:9000'
+    #
+    # Postgres direct (read-write primary, CloudNativePG service).
+    # DATABASE_HOST: 'supabase-cluster-rw.kilobase.svc.cluster.local'
+    # DATABASE_PORT: '5432'
+    #
+    # Discord webhook channel name (URL/token live in the Secret).
+    # DISCORD_WEBHOOK_NAME: 'chuckrpg-events'

--- a/apps/kube/chuckrpg/manifest/deployment.yaml
+++ b/apps/kube/chuckrpg/manifest/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
     namespace: chuckrpg
     labels:
         app: chuckrpg
+    annotations:
+        # Stakater Reloader watches every ConfigMap/Secret referenced by
+        # this Deployment (envFrom, env.valueFrom, volumes) and triggers a
+        # rolling restart on change. Currently only chuckrpg-config exists;
+        # chuckrpg-secrets is optional until SealedSecret is added.
+        reloader.stakater.com/auto: 'true'
 spec:
     replicas: 1
     strategy:
@@ -20,6 +26,16 @@ spec:
             labels:
                 app: chuckrpg
         spec:
+            serviceAccountName: chuckrpg
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                fsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: chuckrpg
                   image: ghcr.io/kbve/chuckrpg:0.1.7
@@ -44,13 +60,15 @@ spec:
                       periodSeconds: 5
                       timeoutSeconds: 3
                       failureThreshold: 3
-                  env:
-                      - name: HTTP_HOST
-                        value: '0.0.0.0'
-                      - name: HTTP_PORT
-                        value: '4322'
-                      - name: RUST_LOG
-                        value: 'info'
+                  envFrom:
+                      - configMapRef:
+                            name: chuckrpg-config
+                      # Optional so the pod still boots before the
+                      # SealedSecret lands. Once chuckrpg-secrets exists
+                      # Reloader will roll the Deployment automatically.
+                      - secretRef:
+                            name: chuckrpg-secrets
+                            optional: true
                   resources:
                       requests:
                           memory: '128Mi'
@@ -58,6 +76,22 @@ spec:
                       limits:
                           memory: '256Mi'
                           cpu: '500m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+            volumes:
+                # Writable scratch for the axum binary while the rootfs
+                # itself stays read-only. Sized small — chuckrpg does not
+                # cache anything significant at runtime.
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 64Mi
 ---
 apiVersion: v1
 kind: Service

--- a/apps/kube/chuckrpg/manifest/serviceaccount.yaml
+++ b/apps/kube/chuckrpg/manifest/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: chuckrpg
+    namespace: chuckrpg
+    labels:
+        app: chuckrpg
+# Pod does not call the kube API. Token mount disabled here and at the
+# pod spec to remove an unused credential from the container.
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

- Hardens the `chuckrpg-deployment` pod spec: non-root UID 10001 (matches the binary owner from the Dockerfile), read-only rootfs with a 64Mi `/tmp` emptyDir, all caps dropped, `seccompProfile: RuntimeDefault`, dedicated ServiceAccount with `automountServiceAccountToken: false` at both SA and pod spec.
- Moves runtime env (`HTTP_HOST`, `HTTP_PORT`, `RUST_LOG`) out of the Deployment into a new `chuckrpg-config` ConfigMap so CI/CD only owns the image tag.
- Wires `reloader.stakater.com/auto: "true"` so ConfigMap/Secret edits trigger a rolling restart automatically. `chuckrpg-secrets` is referenced with `optional: true`, so the pod still boots before any SealedSecret lands.
- Pre-wires (commented) kube-DNS targets in the ConfigMap for the planned PostgREST, Supabase Edge Functions, Postgres, and Discord webhook integrations — future env adds become a one-line uncomment, not a manifest rewrite.

## CI/CD impact

Zero. The image-tag bump path in [`apps/kube/chuckrpg/manifest/deployment.yaml`](apps/kube/chuckrpg/manifest/deployment.yaml) still touches only the `image:` line. ArgoCD reads the manifest directory, so the new `serviceaccount.yaml` and `configmap.yaml` are picked up automatically without any kustomization changes.

## Out of scope (intentionally deferred)

- **CiliumNetworkPolicy** — best added alongside the first cross-namespace integration that actually exercises egress to `kilobase`, so the gateway/pod selectors can be verified against live traffic instead of guessed.
- **PodDisruptionBudget** — `replicas: 1` makes a `minAvailable: 1` PDB a node-drain footgun. Revisit when chuckrpg scales out.
- **SealedSecret stub** — no credentials yet; `optional: true` on the `secretRef` keeps the pod healthy until one lands.

## Test plan

- [ ] ArgoCD syncs the `chuckrpg` Application without diff churn after merge to `dev`.
- [ ] `kubectl -n chuckrpg get pod -l app=chuckrpg -o yaml` shows the pod running as UID 10001 with `readOnlyRootFilesystem: true`.
- [ ] `kubectl -n chuckrpg auth can-i --as=system:serviceaccount:chuckrpg:chuckrpg get pods` returns `no` (SA has no RoleBindings).
- [ ] Editing `chuckrpg-config` (e.g. flipping `RUST_LOG` to `debug`) triggers a Reloader-driven rollout within ~30s.
- [ ] `chuckrpg.com` and `api.chuckrpg.com` keep responding 200 on `/health` through the gateway during and after rollout.