### PR TITLE
fix(cert-manager): de-dup letsencrypt-dns ClusterIssuer

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -103,27 +103,6 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-    name: letsencrypt-dns
-spec:
-    acme:
-        email: cert@kbve.com
-        server: https://acme-v02.api.letsencrypt.org/directory
-        privateKeySecretRef:
-            name: letsencrypt-dns-account-key
-        solvers:
-            - selector:
-                  dnsZones:
-                      - kbve.com
-              dns01:
-                  cloudflare:
-                      apiTokenSecretRef:
-                          name: cloudflare-api-token-secret
-                          key: api-token
-
----
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
     name: selfsigned-issuer
 spec:
     selfSigned: {}

--- a/apps/kube/cert-manager/manifests/letsencrypt-dns-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/letsencrypt-dns-issuer.yaml
@@ -7,7 +7,7 @@ spec:
         server: https://acme-v02.api.letsencrypt.org/directory
         email: cert@kbve.com
         privateKeySecretRef:
-            name: letsencrypt-dns-private-key
+            name: letsencrypt-dns-account-key
         solvers:
             - selector:
                   dnsZones:


### PR DESCRIPTION
## Summary
- PR #10537 added `letsencrypt-dns-issuer.yaml` but left the inline `letsencrypt-dns` block in `cluster-issuer.yaml` (originally added in commit 5035e78a1, Oct 2025). kustomize build emitted two ClusterIssuers named `letsencrypt-dns` → ArgoCD ComparisonError → cert-manager app sync status "Unknown" (resources stayed Healthy because in-cluster state was untouched).
- Drop the inline block. Keep the standalone file as the canonical home for DNS-01: one issuer per file, mirrors cert-manager community convention, easier to grow per-zone solvers later.
- Align the standalone file's `privateKeySecretRef` on `letsencrypt-dns-account-key` to match the ACME account cert-manager already registered with Let's Encrypt — avoids re-registration churn vs. switching to `letsencrypt-dns-private-key`.

## Test plan
- [x] `kubectl kustomize apps/kube/cert-manager/manifests` renders exactly one `ClusterIssuer/letsencrypt-dns`
- [ ] After merge: ArgoCD `cert-manager` app sync status flips from Unknown → Synced
- [ ] Existing `letsencrypt-dns` ClusterIssuer in cluster stays Ready (no ACME re-registration since secret name is unchanged)
- [ ] `www.kbve.com` cert (only consumer of `letsencrypt-dns`) still issues / renews via DNS-01