### PR TITLE
ci(firecracker): wire firecracker-python-net into dispatch pipeline

### DIFF
--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -159,6 +159,9 @@ on:
             ue_kbvesqlite:
                 description: 'KBVESQLite plugin changed'
                 value: ${{ jobs.alter.outputs.ue_kbvesqlite }}
+            firecracker_python_net:
+                description: 'Firecracker Python Net rootfs changed'
+                value: ${{ jobs.alter.outputs.firecracker_python_net }}
 
 jobs:
     alter:
@@ -214,6 +217,7 @@ jobs:
             ue_kbveyyjson: ${{ steps.delta.outputs.ue_kbveyyjson_any_changed }}
             ue_kbvezstd: ${{ steps.delta.outputs.ue_kbvezstd_any_changed }}
             ue_kbvesqlite: ${{ steps.delta.outputs.ue_kbvesqlite_any_changed }}
+            firecracker_python_net: ${{ steps.delta.outputs.firecracker_python_net_any_changed }}
 
         steps:
             - name: Checkout the repository
@@ -359,3 +363,6 @@ jobs:
                       ue_kbvesqlite:
                           - 'packages/unreal/KBVESQLite/Source/**'
                           - 'packages/unreal/KBVESQLite/KBVESQLite.uplugin'
+                      firecracker_python_net:
+                          - 'packages/docker/firecracker/python/net/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx'

--- a/packages/docker/firecracker/python/net/version.toml
+++ b/packages/docker/firecracker/python/net/version.toml
@@ -1,2 +1,2 @@
 [package]
-version = "0.1.0"
+version = "0.0.1"


### PR DESCRIPTION
## Summary

Two gaps kept the new ` firecracker-python-net` image out of CI after #10544 merged:

1. **File alterations had no entry.** [utils-file-alterations.yml](.github/workflows/utils-file-alterations.yml) maps changed paths → registry keys. Without an entry, `is_altered()` returned `false` for `firecracker_python_net` and the manifest dispatch step skipped it (only `axum-kbve` dispatched in the post-merge run).
2. **Version gate self-blocked.** Both the MDX `version: "0.1.0"` and `version.toml` `version = "0.1.0"` matched, so `is_newer` and `version_gate` both returned `should_publish=false` ("version published, skipping"). `version.toml` is meant to be the *last-published* version — for the first publish it should be lower than the source.

## Changes

- Add `firecracker_python_net` to `utils-file-alterations.yml`:
    - output declaration in `outputs:` and `jobs.alter.outputs:`
    - filter pattern `packages/docker/firecracker/python/net/**` and the MDX page
- Drop `packages/docker/firecracker/python/net/version.toml` from `0.1.0` → `0.0.1` so the first dispatch fires (CI bumps it back to `0.1.0` after the publish succeeds).

## Test plan

- [ ] After merge to `main`, confirm `Manifest Dispatch` shows `firecracker-python-net — files changed, dispatching`.
- [ ] Confirm `ci-docker.yml` runs build + push for `ghcr.io/kbve/firecracker-python-net:0.1.0`.
- [ ] Confirm `version.toml` is auto-bumped to `0.1.0` after publish succeeds (subsequent push gates correctly).