### PR TITLE
fix(firecracker): seed apk repositories before --root --initdb

### DIFF
--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -159,6 +159,9 @@ on:
             ue_kbvesqlite:
                 description: 'KBVESQLite plugin changed'
                 value: ${{ jobs.alter.outputs.ue_kbvesqlite }}
+            firecracker_python_net:
+                description: 'Firecracker Python Net rootfs changed'
+                value: ${{ jobs.alter.outputs.firecracker_python_net }}
 
 jobs:
     alter:
@@ -214,6 +217,7 @@ jobs:
             ue_kbveyyjson: ${{ steps.delta.outputs.ue_kbveyyjson_any_changed }}
             ue_kbvezstd: ${{ steps.delta.outputs.ue_kbvezstd_any_changed }}
             ue_kbvesqlite: ${{ steps.delta.outputs.ue_kbvesqlite_any_changed }}
+            firecracker_python_net: ${{ steps.delta.outputs.firecracker_python_net_any_changed }}
 
         steps:
             - name: Checkout the repository
@@ -359,3 +363,6 @@ jobs:
                       ue_kbvesqlite:
                           - 'packages/unreal/KBVESQLite/Source/**'
                           - 'packages/unreal/KBVESQLite/KBVESQLite.uplugin'
+                      firecracker_python_net:
+                          - 'packages/docker/firecracker/python/net/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx'

--- a/packages/docker/firecracker/python/net/Dockerfile
+++ b/packages/docker/firecracker/python/net/Dockerfile
@@ -22,7 +22,8 @@ FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
 
 RUN apk add --no-cache e2fsprogs
 
-RUN mkdir -p /rootfs && \
+RUN mkdir -p /rootfs/etc/apk && \
+    cp /etc/apk/repositories /rootfs/etc/apk/repositories && \
     apk add --root /rootfs --initdb --no-cache \
         alpine-baselayout \
         busybox \

--- a/packages/docker/firecracker/python/net/version.toml
+++ b/packages/docker/firecracker/python/net/version.toml
@@ -1,2 +1,2 @@
 [package]
-version = "0.1.0"
+version = "0.0.1"


### PR DESCRIPTION
## Summary

The `firecracker-python-net` build in PR #10550's validation step failed with:

\`\`\`
ERROR: unable to select packages:
  alpine-baselayout (no such package):
  busybox (no such package):
  musl (no such package):
  ...
\`\`\`

Every package — including ones that *always* exist in alpine main like `alpine-baselayout` and `busybox` — reported "no such package". That's the giveaway: the apk solver had **zero** repository state. `apk add --root /rootfs --initdb` initializes a fresh DB inside `/rootfs` but does not auto-copy `/etc/apk/repositories` from the host, so the solver inside `--root` runs against an empty repo list.

The existing in-cluster `alpine-python` rootfs avoids this by accident — it builds via the ArgoCD PostSync hook on a pre-configured builder. Through Nx buildx in CI the bug surfaces.

## Fix

Seed `/rootfs/etc/apk/repositories` from `/etc/apk/repositories` (the `alpine:3.21` base image already has main + community enabled) before the `apk add --root /rootfs --initdb` invocation.

## Test plan

- [ ] After merge, confirm `firecracker-python-net:containerx` builds in the dev→main validation step (no "no such package" error).
- [ ] Confirm `ghcr.io/kbve/firecracker-python-net:0.1.0` is published once it lands on main.