### PR TITLE
fix(firecracker): copy apk signing keys into /rootfs

### DIFF
--- a/packages/docker/firecracker/python/net/Dockerfile
+++ b/packages/docker/firecracker/python/net/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --no-cache e2fsprogs
 
 RUN mkdir -p /rootfs/etc/apk && \
     cp /etc/apk/repositories /rootfs/etc/apk/repositories && \
+    cp -a /etc/apk/keys /rootfs/etc/apk/ && \
     apk add --root /rootfs --initdb --no-cache \
         alpine-baselayout \
         busybox \


### PR DESCRIPTION
## Summary

PR #10554 fixed the empty repositories problem but the next CI run surfaced the next layer:

\`\`\`
WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.21/main: UNTRUSTED signature
WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.21/community: UNTRUSTED signature
ERROR: unable to select packages:
  alpine-baselayout (no such package):
  busybox (no such package):
  ...
\`\`\`

apk fetched the indexes successfully but rejected them as unsigned because `/rootfs/etc/apk/keys/` was empty — the alpine signing keys live on the host (`/etc/apk/keys/`) but `--initdb` doesn't copy them into the new root.

## Fix

Add `cp -a /etc/apk/keys /rootfs/etc/apk/` next to the `repositories` copy so the solver inside `--root /rootfs` has both the URLs and the trust material to verify signatures.

## Test plan

- [ ] Validation step in the next dev→main release PR builds `firecracker-python-net:containerx` cleanly (no UNTRUSTED signature warnings).
- [ ] `ghcr.io/kbve/firecracker-python-net:0.1.0` published once it lands on main.