### PR TITLE
feat(redis): annotate chart for Reloader-driven password rotation

### DIFF
--- a/apps/kube/redis/README.md
+++ b/apps/kube/redis/README.md
@@ -1,0 +1,39 @@
+# Redis — Kubernetes Deployment
+
+Cluster-wide Redis for internal services (rate limiting, ephemeral state, queue brokering). Deployed via the Bitnami `redis` Helm chart in `standalone` architecture (one master, no replicas) with persistence on Longhorn.
+
+## Manifests
+
+| File                                     | Purpose                                                                                         |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `application.yaml`                       | ArgoCD `Application` — multi-source: Bitnami chart + `values.yaml` + sealed-secret manifest dir |
+| `manifests/values.yaml`                  | Helm values overlay: architecture, auth, persistence, network policy, hardening annotations     |
+| `manifests/redis-auth-sealedsecret.yaml` | SealedSecret holding the auth password, referenced by `auth.existingSecret`                     |
+| `manifests/kustomization.yaml`           | Lists the SealedSecret as a kustomize resource so ArgoCD picks it up alongside the chart render |
+
+## Hardening
+
+The Bitnami chart already renders a hardened pod spec by default — this is intentional baseline, not custom configuration:
+
+- `runAsNonRoot: true`, UID/GID `1001` (Bitnami convention)
+- `readOnlyRootFilesystem: true` with chart-managed `emptyDir` mounts for scratch
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- `automountServiceAccountToken: false` (chart default at every level: SA, master pod, replica pod, metrics)
+- CPU/memory `requests` and `limits` set on the master container so the kubelet enforces a cgroup; bursts cap at 500m / 512Mi
+
+The chart-rendered NetworkPolicy (`networkPolicy.enabled: true`) restricts ingress to pods matching the chart's auth selector — combined with `allowExternal: true`, any pod in the cluster can reach Redis on 6379, but the namespace boundary is still enforced by the policy.
+
+## Reloader integration
+
+`commonAnnotations.reloader.stakater.com/auto: "true"` propagates to every chart resource, including the master StatefulSet itself. Stakater Reloader watches workload-level annotations (not just pod template), so this is the correct surface to ensure the controller sees changes. When `redis-auth` rotates, the master pod rolls automatically.
+
+## Chart version policy
+
+Pinned to `21.2.13` (Redis 8.0.3). Newer chart majors (22.x → 25.x) ship newer Redis app versions and have evolved alongside Bitnami's image-licensing changes; bumping past 21.x belongs in its own PR with image-pull and consumer-compatibility verification, not bundled with hardening.
+
+## ArgoCD
+
+- App: `redis` (multi-source — Bitnami chart + this repo's `values.yaml` + manifest dir)
+- Sync: automated with prune + selfHeal
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/redis/manifests/values.yaml
+++ b/apps/kube/redis/manifests/values.yaml
@@ -1,37 +1,48 @@
 # Redis configuration for cluster-wide usage
 architecture: standalone
 
+# Stakater Reloader watches every workload that carries this annotation
+# (StatefulSet here, since master.kind defaults to StatefulSet) and rolls
+# the pod when the referenced Secret/ConfigMap changes. Wiring it via
+# commonAnnotations propagates to all chart-rendered resources, so the
+# StatefulSet itself is annotated — not just the pod template — which is
+# the surface Reloader actually watches. Today this means redis-auth
+# rotations roll the master automatically; before this annotation the
+# master kept the old password in memory until manual restart.
+commonAnnotations:
+    reloader.stakater.com/auto: 'true'
+
 auth:
-  enabled: true
-  existingSecret: redis-auth
-  existingSecretPasswordKey: redis-password
+    enabled: true
+    existingSecret: redis-auth
+    existingSecretPasswordKey: redis-password
 
 master:
-  service:
-    type: ClusterIP
-    ports:
-      redis: 6379
-  persistence:
-    enabled: true
-    size: 8Gi
-    storageClass: "longhorn"
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "100m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
+    service:
+        type: ClusterIP
+        ports:
+            redis: 6379
+    persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: 'longhorn'
+    resources:
+        requests:
+            memory: '256Mi'
+            cpu: '100m'
+        limits:
+            memory: '512Mi'
+            cpu: '500m'
 
 metrics:
-  enabled: true
-  serviceMonitor:
     enabled: true
-    namespace: redis
+    serviceMonitor:
+        enabled: true
+        namespace: redis
 
 # Network policy to allow cluster-wide access
 networkPolicy:
-  enabled: true
-  allowExternal: true
-  ingressNSMatchLabels: {}
-  ingressNSPodMatchLabels: {}
+    enabled: true
+    allowExternal: true
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}


### PR DESCRIPTION
## Summary

- Adds `commonAnnotations.reloader.stakater.com/auto: "true"` to the Bitnami redis chart values overlay so Stakater Reloader watches the master StatefulSet (and every other chart-rendered resource).
- Verified via `helm template` against chart `21.2.13` that the annotation lands on the StatefulSet metadata — the workload-level surface Reloader actually consults — not just the pod template.
- Adds an `apps/kube/redis/README.md` documenting the hardening posture, Reloader integration, and chart-version policy.

## Why this matters

Before this change, rotating `redis-auth` (the SealedSecret) would update the Secret in the cluster but the master pod kept the old password in memory until someone restarted it manually. With the annotation in place, Reloader sees the Secret change and rolls the StatefulSet automatically.

This is the redis arm of the same Reloader scaffolding pattern landed on chuckrpg in #10547. Continuing the small-namespace-first rollout — redis is single-replica, internal-only, already has a SealedSecret in flight, so it's the lowest-risk place to validate password-rotation-driven rollout end to end before applying the same pattern to larger namespaces.

## Hardening posture (no manifest changes needed)

Bitnami chart `21.2.13` already ships hardened defaults — they are inherited, not overridden:

- `runAsNonRoot: true`, UID/GID `1001`
- `readOnlyRootFilesystem: true` with chart-managed `emptyDir` scratch
- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
- `seccompProfile: RuntimeDefault`
- `automountServiceAccountToken: false` at every level (SA, master pod, replica pod, metrics)
- CPU/memory `requests` and `limits` set so the kubelet enforces a cgroup; bursts cap at `500m / 512Mi`

The chart-rendered NetworkPolicy (`networkPolicy.enabled: true`) is left intact for cluster-wide ingress on `6379`.

## Chart version policy

Pinned to `21.2.13` (Redis app `8.0.3`). Newer chart majors (22.x → 25.x) introduce newer Redis app versions and have evolved alongside Bitnami's August 2025 image-licensing changes; bumping past 21.x belongs in a separate PR with image-pull and consumer-compatibility verification, not bundled with hardening.

## Out of scope (intentionally deferred)

- **Chart bump past 21.x** — separate PR with rollout plan covering Bitnami image pull (post-licensing), StatefulSet selector immutability, and Redis 8.0 → 8.x consumer compatibility.
- **PodDisruptionBudget** — `architecture: standalone` means a single master pod; a `minAvailable: 1` PDB is a node-drain footgun. Revisit if/when a replica is added.

## Test plan

- [ ] ArgoCD `redis` Application syncs cleanly after merge — diff is limited to the new annotation propagating across StatefulSet, Service, ServiceAccount, and rendered metadata.
- [ ] `kubectl -n redis get statefulset redis-master -o jsonpath='{.metadata.annotations}'` includes `reloader.stakater.com/auto: "true"`.
- [ ] Trigger a no-op SealedSecret re-seal of `redis-auth` (or a dummy label change) and observe Reloader rolling the master pod within ~30s.
- [ ] After the roll, downstream consumers reconnect cleanly and authenticate against the new (or unchanged) password.