### PR TITLE
fix(firecracker): install e2fsprogs-extra for resize2fs

### DIFF
--- a/packages/docker/firecracker/python/net/Dockerfile
+++ b/packages/docker/firecracker/python/net/Dockerfile
@@ -20,7 +20,7 @@
 
 FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
 
-RUN apk add --no-cache e2fsprogs
+RUN apk add --no-cache e2fsprogs e2fsprogs-extra
 
 RUN mkdir -p /rootfs/etc/apk && \
     cp /etc/apk/repositories /rootfs/etc/apk/repositories && \


### PR DESCRIPTION
## Summary

After PR #10555 (apk keys) merged, the next CI run got past the package install step but failed at the very last command in the rootfs RUN block:

\`\`\`
#7 3.440 /bin/sh: resize2fs: not found
exit code: 127
\`\`\`

Cause: in Alpine 3.21, \`resize2fs\` is **not** part of \`e2fsprogs\` — it lives in \`e2fsprogs-extra\`. The host build stage installed only \`e2fsprogs\`, so \`mkfs.ext4\` worked but the resize call right after it could not find the binary.

## Fix

Add \`e2fsprogs-extra\` to the first \`apk add\` line so \`resize2fs\` is on PATH when the rootfs ext4 is finalized. (The existing \`alpine-python\` rootfs has the same latent bug; not fixing it here since it builds via a different path that may have it pre-baked.)

## Test plan

- [ ] Validation step in the next dev→main release PR builds \`firecracker-python-net:containerx\` past the resize2fs call.
- [ ] \`ghcr.io/kbve/firecracker-python-net:0.1.0\` published once it lands on main.