### PR TITLE
feat(n8n): harden Deployments + Reloader-driven secret rotation

### DIFF
--- a/apps/kube/n8n/README.md
+++ b/apps/kube/n8n/README.md
@@ -1,0 +1,56 @@
+# n8n — Kubernetes Deployment
+
+Workflow automation platform running in queue-based execution mode: a main `n8n` Deployment serves the UI / webhooks and produces jobs, and an `n8n-worker` Deployment consumes them. Both reuse the cluster Redis (`redis-master.redis.svc.cluster.local`) as the BullMQ queue and the shared Supabase Postgres (`supabase-cluster-rw.kilobase.svc.cluster.local`, `n8n` schema) for persistence.
+
+## Manifests
+
+| File                                  | Purpose                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `application.yaml`                    | ArgoCD `Application` pointing at `apps/kube/n8n/manifest`                                         |
+| `manifest/n8n-deployment.yaml`        | Main `n8n` Deployment — UI + webhook receiver + task-runner sidecar                               |
+| `manifest/n8n-worker-deployment.yaml` | `n8n-worker` Deployment — pulls queue jobs from Redis + task-runner sidecar                       |
+| `manifest/n8n-service.yaml`           | ClusterIP Service exposing 5678 / metrics                                                         |
+| `manifest/n8n-ingress.yaml`           | Ingress for `n8n.kbve.com`                                                                        |
+| `manifest/httproute.yaml`             | Gateway API HTTPRoute (alternative path)                                                          |
+| `manifest/rbac.yaml`                  | `n8n-sa` ServiceAccount + cross-namespace Roles/Bindings + Redis-side NetworkPolicy               |
+| `manifest/n8n-pdb.yaml`               | PodDisruptionBudgets for `n8n` and `n8n-worker` (both `minAvailable: 1`)                          |
+| `manifest/n8n-keda.yaml`              | KEDA scaler for the worker Deployment based on Redis queue depth                                  |
+| `manifest/n8n-servicemonitor.yaml`    | Prometheus ServiceMonitor                                                                         |
+| `manifest/n8n-*-sealedsecret.yaml`    | SealedSecrets: `n8n-encryption-secret`, `n8n-license-secret`, `n8n-runner-auth`, `n8n-basic-auth` |
+| `manifest/n8n-externalsecret.yaml`    | ExternalSecret pulling `redis-auth` and `supabase-postgres` into the namespace                    |
+
+## Hardening
+
+Both Deployments and the task-runner sidecars now run under a restricted PodSecurity profile:
+
+- `runAsNonRoot: true`, UID/GID `1000` (matches the `node` user baked into the upstream `n8nio/n8n` and `n8nio/runners` images)
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- `n8n-sa` ServiceAccount carries `automountServiceAccountToken: false`; both pod specs re-state the same so any future template binding `n8n-sa` inherits the safe default
+- CPU/memory `requests` and `limits` set on every container so the kubelet enforces a cgroup; main container limits at `8Gi / 4 CPU`, worker at `4Gi / 2 CPU`, runners at `1Gi / 1 CPU`
+
+`readOnlyRootFilesystem` is **deliberately not set** in this iteration. The upstream n8n image writes to `/home/node/.n8n` at boot (license file, default settings) and `/tmp` (binary data staging) even when the database lives externally; flipping this on without first staging matched `emptyDir` mounts would crash-loop the Deployment. Tracked as a follow-up.
+
+## Reloader integration
+
+Both Deployments carry `reloader.stakater.com/auto: "true"`. Stakater Reloader watches the workload-level annotation and rolls the Deployment when any referenced Secret or ConfigMap changes. The covered surface includes:
+
+- `n8n-redis-secret` (envFrom)
+- `n8n-supabase-shared` (DB password via `secretKeyRef`)
+- `n8n-encryption-secret` (n8n's at-rest encryption key)
+- `n8n-license-secret` (license activation key)
+- `n8n-runner-auth` (broker auth between n8n and the task runner)
+
+Before this annotation, rotating any of these required a manual `kubectl rollout restart`.
+
+## Out of scope (intentionally deferred)
+
+- **`readOnlyRootFilesystem`** — needs `emptyDir` for `/home/node/.n8n` and `/tmp` plus a live test cycle to confirm n8n still boots and the runner sidecar can launch isolated processes.
+- **PDB tuning** — both PDBs are `minAvailable: 1` against `replicas: 1`, which makes node drain block forever. Worth fixing alongside replica scale-out (worker is already KEDA-scaled, so the worker PDB should follow KEDA's min-replicas).
+- **CiliumNetworkPolicy** — current cross-namespace policy is the legacy `networking.k8s.io/v1` `NetworkPolicy` in `rbac.yaml`. Migrating to CNP belongs with the wider Cilium Phase 2 work, not bundled here.
+
+## ArgoCD
+
+- App: `n8n` (source: `apps/kube/n8n/manifest`)
+- Sync: automated with prune + selfHeal
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -5,6 +5,12 @@ metadata:
     namespace: n8n
     labels:
         app: n8n
+    annotations:
+        # Reloader rolls this Deployment whenever any referenced Secret
+        # or ConfigMap changes — n8n-redis-secret, n8n-supabase-shared,
+        # n8n-encryption-secret, n8n-license-secret, n8n-runner-auth all
+        # qualify, so post-rotation drift is no longer manual.
+        reloader.stakater.com/auto: 'true'
 spec:
     replicas: 1
     selector:
@@ -16,6 +22,14 @@ spec:
                 app: n8n
         spec:
             serviceAccountName: n8n-sa
+            automountServiceAccountToken: false
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                    type: RuntimeDefault
             affinity:
                 podAntiAffinity:
                     preferredDuringSchedulingIgnoredDuringExecution:
@@ -144,6 +158,11 @@ spec:
                       limits:
                           memory: '8Gi'
                           cpu: '4000m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
                   livenessProbe:
                       httpGet:
                           path: /healthz
@@ -185,6 +204,11 @@ spec:
                       limits:
                           memory: '1Gi'
                           cpu: '1000m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
                   livenessProbe:
                       httpGet:
                           path: /healthz

--- a/apps/kube/n8n/manifest/n8n-worker-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-worker-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
     namespace: n8n
     labels:
         app: n8n-worker
+    annotations:
+        # Reloader rolls this Deployment whenever any referenced Secret
+        # or ConfigMap changes — same secret set as the main n8n pod.
+        reloader.stakater.com/auto: 'true'
 spec:
     replicas: 1
     selector:
@@ -16,6 +20,14 @@ spec:
                 app: n8n-worker
         spec:
             serviceAccountName: n8n-sa
+            automountServiceAccountToken: false
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                    type: RuntimeDefault
             affinity:
                 podAntiAffinity:
                     preferredDuringSchedulingIgnoredDuringExecution:
@@ -141,6 +153,11 @@ spec:
                       limits:
                           memory: '4Gi'
                           cpu: '2000m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
                   livenessProbe:
                       httpGet:
                           path: /healthz
@@ -182,6 +199,11 @@ spec:
                       limits:
                           memory: '1Gi'
                           cpu: '1000m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
                   livenessProbe:
                       httpGet:
                           path: /healthz

--- a/apps/kube/n8n/manifest/rbac.yaml
+++ b/apps/kube/n8n/manifest/rbac.yaml
@@ -1,9 +1,14 @@
-# ServiceAccount used by the n8n Deployment pod
+# ServiceAccount used by the n8n Deployment pod.
+# The pod does not call the kube API — token mount is disabled here at
+# the SA level; the Deployment specs also set the field at the pod
+# level so any future template that re-binds this SA still inherits the
+# safe default.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
     name: n8n-sa
     namespace: n8n
+automountServiceAccountToken: false
 ---
 # Role: Allow n8n ExternalSecrets SA to read redis-auth secret
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

- Both `n8n` and `n8n-worker` Deployments (plus their `n8n-runner` task-runner sidecars) now run under a restricted PSA profile: `runAsNonRoot: true`, UID/GID `1000` (matches the `node` user baked into the upstream `n8nio/n8n` and `n8nio/runners` images), `allowPrivilegeEscalation: false`, all Linux capabilities dropped, `seccompProfile: RuntimeDefault`.
- `n8n-sa` now carries `automountServiceAccountToken: false` at the SA level; both pod specs re-state it so any future template binding the SA inherits the safe default. The pod does not call the kube API, so the projected token is unused weight.
- Adds `reloader.stakater.com/auto: "true"` on both Deployments — Reloader rolls the workload when any referenced Secret changes (`n8n-redis-secret`, `n8n-supabase-shared`, `n8n-encryption-secret`, `n8n-license-secret`, `n8n-runner-auth`). Before this, rotation drift required a manual `kubectl rollout restart`.
- Adds `apps/kube/n8n/README.md` documenting the hardening posture, Reloader integration, and the work intentionally deferred to follow-ups.

## Why this matters

This is the third namespace landing the same Reloader + non-root + cap-drop pattern we used on chuckrpg (#10547) and redis (#10556). n8n carries the largest secret surface of the three — five distinct SealedSecret/ExternalSecret references across two Deployments — so the manual-restart-after-rotation problem hit hardest here.

## Out of scope (intentionally deferred)

- **`readOnlyRootFilesystem`** — the upstream n8n image writes to `/home/node/.n8n` (license file, default settings) and `/tmp` (binary data staging) at boot even with the database configured externally. Flipping the flag on without first staging matched `emptyDir` mounts would crash-loop the Deployment. Tracked as a follow-up that needs a live boot test.
- **PDB tuning** — `n8n-pdb` and `n8n-worker-pdb` are both `minAvailable: 1` against `replicas: 1`, which makes node drain block forever. Worth fixing alongside replica scale-out (the worker is already KEDA-scaled, so its PDB should follow KEDA's min-replicas).
- **CiliumNetworkPolicy** — the cross-namespace ingress policy in `rbac.yaml` is still legacy `networking.k8s.io/v1` `NetworkPolicy`. Migrating to CNP belongs with the wider Cilium Phase 2 work, not bundled here.

## Test plan

- [ ] ArgoCD `n8n` Application syncs cleanly after dev → main promotion.
- [ ] `kubectl -n n8n get deploy n8n -o jsonpath='{.spec.template.spec.securityContext}'` shows `runAsNonRoot: true`, `runAsUser: 1000`, `seccompProfile: {type: RuntimeDefault}`.
- [ ] `kubectl -n n8n get deploy n8n -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}'` returns `"true"` (same for `n8n-worker`).
- [ ] `n8n.kbve.com/healthz` returns 200 after rollout — main pod still serves UI/webhooks; worker still pulls jobs from Redis (queue depth visible in metrics).
- [ ] Trigger a no-op re-seal on `n8n-encryption-secret` (or another referenced SealedSecret) and observe Reloader rolling both Deployments within ~30s.
- [ ] `kubectl -n n8n exec deploy/n8n -- ls /var/run/secrets/kubernetes.io 2>/dev/null` returns no path (token mount disabled).