### PR TITLE
chore(kyverno): bump chart 3.4.4 -> 3.8.0 to drop bitnami/kubectl

### DIFF
--- a/apps/kube/kyverno/application.yaml
+++ b/apps/kube/kyverno/application.yaml
@@ -10,7 +10,19 @@ spec:
     source:
         repoURL: https://kyverno.github.io/kyverno
         chart: kyverno
-        targetRevision: 3.4.4
+        # Bumped from 3.4.4 (Kyverno v1.14) to 3.8.0 (Kyverno v1.18) to
+        # drop the chart's dependency on `bitnami/kubectl:1.32.3`. That
+        # image was deleted from docker.io's public tier when Bitnami
+        # moved its catalog to the authenticated `bitnamisecure` repo
+        # in August 2025, and the helm-hook cleanup Jobs were stuck in
+        # ImagePullBackOff. Chart 3.8.0 replaces every bitnami/kubectl
+        # reference with `ghcr.io/kyverno/readiness-checker` and
+        # `reg.kyverno.io/kyverno/kyverno-cli`, both pulling from
+        # registries Kyverno itself controls. ClusterPolicy CRD still
+        # serves v1, v2, and v1beta1 in 3.8.0, so the existing
+        # apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml
+        # (kyverno.io/v1) keeps working without changes.
+        targetRevision: 3.8.0
         helm:
             values: |
                 fullnameOverride: kyverno


### PR DESCRIPTION
## Summary

- Bumps `apps/kube/kyverno/application.yaml` `targetRevision` from `3.4.4` (Kyverno v1.14) to `3.8.0` (Kyverno v1.18).
- The bump's primary motivation is to drop the chart's dependency on `bitnami/kubectl:1.32.3`. That image was deleted from `docker.io`'s public tier when Bitnami moved its catalog to the authenticated `bitnamisecure` repo in August 2025; the chart's helm-hook cleanup Jobs have been stuck in `ImagePullBackOff` ever since (the `kyverno-clean-reports` Job in production was 13h into the back-off when this work started).

## Why a bump and not an image override

Three of the chart's 3.4.4 helm-hook Jobs reference `bitnami/kubectl:1.32.3`: `kyverno-clean-reports`, `kyverno-remove-configmap`, `kyverno-scale-to-zero`. We could override `policyReportsCleanup.image` and `webhooksCleanup.image` in our values overlay, but that leaves us hand-pinning a version of an image we don't control while every newer chart release has already removed the dependency upstream. The bump is the durable fix.

## Image deltas

| Job                          | 3.4.4                            | 3.8.0                                            |
| ---------------------------- | -------------------------------- | ------------------------------------------------ |
| `kyverno-clean-reports`      | `bitnami/kubectl:1.32.3`         | _removed — handled inside controllers_           |
| `kyverno-remove-configmap`   | `bitnami/kubectl:1.32.3`         | _removed_                                        |
| `kyverno-scale-to-zero`      | `bitnami/kubectl:1.32.3`         | `ghcr.io/kyverno/readiness-checker:v1.18.0`      |
| `kyverno-rm-webhooks` (new)  | _n/a_                            | `ghcr.io/kyverno/readiness-checker:v1.18.0`      |
| `kyverno-migrate-resources`  | `kyverno-cli:v1.14.4`            | `kyverno-cli:v1.18.0` (handles CRD migration)    |

`grep -c "bitnami/" rendered-3.8.0-manifests.yaml` returns `0`.

## Compatibility checks performed

- `helm template kyverno kyverno/kyverno --version 3.8.0 -f <our-values>` rendered cleanly — no unknown-key warnings.
- All overlay keys still recognised: `fullnameOverride`, `admissionController.replicas`, `backgroundController.replicas`, `cleanupController.replicas`, `reportsController.replicas`, `config.excludeKyvernoNamespace`, `config.resourceFilters`.
- Rendered `kyverno-admission-controller` Deployment shows `replicas: 2`, confirming the overlay is applied.
- `clusterpolicies.kyverno.io` CRD still serves `v1`, `v2`, and `v1beta1` in 3.8.0, so the existing `apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml` (`apiVersion: kyverno.io/v1`) keeps working without changes.
- `spec.validationFailureAction` at the top level is now flagged **Deprecated** in favour of `spec.rules[].validate.validationFailureAction`, but the deprecated path is still served. Moving the field on the dbmate policy is a follow-up, not a blocker.
- Resource kinds rendered are identical between 3.4.4 and 3.8.0 (`ClusterRole`, `ClusterRoleBinding`, `ConfigMap`, `CustomResourceDefinition`, `Deployment`, `Job`, `PodDisruptionBudget`, `Role`, `RoleBinding`, `Service`, `ServiceAccount`).

## Risks and rollout notes

- Chart 3.8.0 ships a Helm `pre-upgrade` hook (`kyverno-migrate-resources`) that runs the kyverno-cli migration before the controllers come up. ArgoCD translates `helm.sh/hook: pre-upgrade` to `argocd.argoproj.io/hook: PreSync`; with `ServerSideApply=true` already set on this Application this should run cleanly. Worth eyeballing the migration Job's logs on first sync.
- App version jumps four minors (`v1.14` → `v1.18`). Behavior changes within Kyverno itself are mostly additive (new policy types, performance work) — none of our existing policies use features the upgrade removed.
- The currently stuck `kyverno-clean-reports` Job is a Helm hook that will be GC'd when the chart syncs to the new revision (it doesn't exist in 3.8.0). No manual cleanup required, but `kubectl -n kyverno delete job kyverno-clean-reports kyverno-remove-configmap` is a safe pre-emptive step if Argo doesn't prune helm-hook Jobs.

## Test plan

- [ ] ArgoCD `kyverno` Application reconciles to `3.8.0` without sync errors.
- [ ] `kubectl -n kyverno get job` no longer lists `kyverno-clean-reports` / `kyverno-remove-configmap`; `kyverno-scale-to-zero` and `kyverno-rm-webhooks` (if present) reach `Completed`.
- [ ] `kubectl -n kyverno get pod` shows admission, background, cleanup, and reports controllers all `Running` on `v1.18.0` images.
- [ ] `kubectl -n kyverno logs job/kyverno-migrate-resources` shows a clean exit (no migration errors).
- [ ] `kubectl get clusterpolicy kilobase-jobs-restricted -o jsonpath='{.status.conditions}'` reports `Ready: True` against the new controllers.
- [ ] Smoke-test the dbmate-runner policy by attempting to create a Job in `kilobase` that violates the rule — Kyverno should still reject it.