### PR TITLE
fix(arc-runners): per-project LRU for unity-library cache

### DIFF
--- a/apps/kube/github/runners/manifests/cache-cleanup-cronjob.yaml
+++ b/apps/kube/github/runners/manifests/cache-cleanup-cronjob.yaml
@@ -6,9 +6,17 @@
 #   3. Heavy  (every 3d)  — Phase 1 + 2 + 3: capacity gate (>80% → LRU prune largest)
 #
 # Per-cache policy via CACHE_POLICIES (space-separated NAME:MODE:CAP_GB):
-#   - mode=age: age out files older than AGE_DAYS, then enforce CAP_GB
-#   - mode=cap: NEVER age out (active build artifacts like Unity Library);
-#               only LRU-prune when directory exceeds CAP_GB
+#   - mode=age:          age out files older than AGE_DAYS, then file-level LRU
+#   - mode=cap:          NEVER age out; file-level LRU when over CAP_GB
+#                        (use only for caches WITHOUT internal manifests)
+#   - mode=cap-project:  NEVER age out; per-subdir LRU when over CAP_GB —
+#                        evicts whole project subdirs (safe for Unity Library
+#                        which has ArtifactDB/SourceAssetDB integrity)
+#
+# Unity Library structure: /cache/unity-library/<project-platform>/{ArtifactDB,
+# SourceAssetDB, Artifacts/, ShaderCache/, ...}. File-level LRU on the inner
+# Artifacts/ would orphan ArtifactDB entries → corruption on next import.
+# cap-project drops whole platform dirs; Unity reimports that platform once.
 #
 # Uses mtime (not atime) because Longhorn/NFS may mount with noatime.
 # All three share the same PVC mount at /cache.
@@ -28,7 +36,7 @@ data:
         CAPACITY_PCT="${CAPACITY_PCT:-80}"
         # Per-cache policy: NAME:MODE:CAP_GB (space-separated)
         # NEVER age unity-library — Unity rebuilds the entire Library on cache miss (~30min)
-        CACHE_POLICIES="${CACHE_POLICIES:-cargo:age:20 lfs:age:5 unity-library:cap:50}"
+        CACHE_POLICIES="${CACHE_POLICIES:-cargo:age:20 lfs:age:5 unity-library:cap-project:80}"
 
         echo "=== ${TIER} cleanup starting ==="
         echo "  age=${AGE_DAYS}d  policies='${CACHE_POLICIES}'"
@@ -82,6 +90,54 @@ data:
             echo "  $(basename "$DIR"): now $(( NEW_KB / 1024 ))Mi (cap-prune ${ELAPSED}s)"
         }
 
+        # Per-subdir LRU: when DIR exceeds cap, drop whole oldest subdirs
+        # (one nesting level). Used for caches with internal manifests where
+        # file-level deletion would corrupt state (e.g., Unity Library).
+        # Subdir freshness tracked via the most-recently-touched file inside.
+        cap_project_prune() {
+            DIR="$1"
+            CAP_GB="$2"
+            [ -d "$DIR" ] || return 0
+            CAP_KB=$(( CAP_GB * 1024 * 1024 ))
+            DIR_KB=$(du -sk "$DIR" 2>/dev/null | cut -f1)
+            [ -z "${DIR_KB}" ] && return 0
+            if [ "${DIR_KB}" -le "${CAP_KB}" ]; then
+                echo "  $(basename "$DIR"): $(( DIR_KB / 1024 ))Mi under ${CAP_GB}Gi cap (project-LRU)"
+                return 0
+            fi
+            OVER_KB=$(( DIR_KB - CAP_KB ))
+            HEADROOM_KB=$(( CAP_KB / 10 ))
+            TARGET_PRUNE_KB=$(( OVER_KB + HEADROOM_KB ))
+            echo "  $(basename "$DIR"): $(( DIR_KB / 1024 ))Mi over by $(( OVER_KB / 1024 ))Mi — evicting oldest projects"
+            START=$(date +%s)
+            # awk picks subdirs to evict via cumulative size; while executes rm.
+            # Freshness via -maxdepth 2 (Unity touches ArtifactDB/SourceAssetDB
+            # on every import — captures activity without walking 350K artifacts).
+            for SUB in "$DIR"/*/; do
+                [ -d "$SUB" ] || continue
+                NEWEST=$(find "$SUB" -maxdepth 2 -type f -exec stat -c '%Y' {} + 2>/dev/null \
+                    | sort -rn | head -1)
+                [ -z "${NEWEST}" ] && NEWEST=$(stat -c '%Y' "$SUB" 2>/dev/null || echo 0)
+                SUB_KB=$(du -sk "$SUB" 2>/dev/null | cut -f1)
+                [ -z "${SUB_KB}" ] && SUB_KB=0
+                printf '%s\t%s\t%s\n' "${NEWEST}" "${SUB_KB}" "$SUB"
+            done | sort -n | awk -v target="${TARGET_PRUNE_KB}" -F'\t' '
+                {
+                    cum += $2
+                    print $3
+                    if (cum >= target) exit
+                }
+              ' | while IFS= read -r EVICT_PATH; do
+                [ -d "$EVICT_PATH" ] || continue
+                EVICT_KB=$(du -sk "$EVICT_PATH" 2>/dev/null | cut -f1)
+                echo "  evict $(basename "$EVICT_PATH") ($(( EVICT_KB / 1024 ))Mi)"
+                rm -rf "$EVICT_PATH"
+            done
+            ELAPSED=$(( $(date +%s) - START ))
+            NEW_KB=$(du -sk "$DIR" 2>/dev/null | cut -f1)
+            echo "  $(basename "$DIR"): now $(( NEW_KB / 1024 ))Mi (project-LRU ${ELAPSED}s)"
+        }
+
         # Phase 1: per-cache age prune (parallel; only for mode=age)
         echo "Phase 1: age prune (parallel)"
         for ENTRY in ${CACHE_POLICIES}; do
@@ -99,8 +155,19 @@ data:
             echo "Phase 2: cap enforcement"
             for ENTRY in ${CACHE_POLICIES}; do
                 NAME=$(echo "${ENTRY}" | cut -d: -f1)
+                MODE=$(echo "${ENTRY}" | cut -d: -f2)
                 CAP=$(echo "${ENTRY}" | cut -d: -f3)
-                cap_prune "${CACHE}/${NAME}" "${CAP}"
+                case "${MODE}" in
+                    age|cap)
+                        cap_prune "${CACHE}/${NAME}" "${CAP}"
+                        ;;
+                    cap-project)
+                        cap_project_prune "${CACHE}/${NAME}" "${CAP}"
+                        ;;
+                    *)
+                        echo "  $(basename "${CACHE}/${NAME}"): unknown mode '${MODE}' — skipping"
+                        ;;
+                esac
             done
             echo ""
         fi


### PR DESCRIPTION
## Summary

File-level LRU on Unity Library was unsafe. Unity stores `ArtifactDB` and `SourceAssetDB` at the top of each project Library — these manifests index every entry under `Artifacts/` by hash. Deleting bytes inside `Artifacts/` without updating `ArtifactDB` leaves stale refs and triggers corruption / reimport on next build.

## Live cache layout (verified via inspector pod)

```
/cache/unity-library/
├── rareicon-Android/         20.4G  (newest after iOS)
├── rareicon-iOS/              6.1G
├── rareicon-StandaloneLinux64/ 4.4G
├── rareicon-StandaloneOSX/    4.4G
├── rareicon-StandaloneWindows64/ 4.0G
└── rareicon-test/             3.5G  (oldest, 2026-05-04)
   total: ~44G  (cap was 50G → tight)
```

Each subdir contains `ArtifactDB`, `SourceAssetDB`, `Artifacts/`, `ShaderCache/`, `PackageCache/`, etc.

## Changes

- **New `cap-project` mode** in `cleanup.sh`. LRU at the project-subdir level — drops whole oldest project dirs until under cap. Unity reimports that platform once on next build (one-time ~5–15 min for Android, no manifest corruption).
- **Policy bump**: `unity-library:cap:50` → `unity-library:cap-project:80`. 80Gi covers all 6 platforms with ~40% headroom; 50 was below the existing 44G total.
- **Subdir freshness via `find -maxdepth 2 + stat`**: Unity touches `ArtifactDB`/`SourceAssetDB` at the top level on every import — captures activity in tens of stat calls instead of walking 350K `Artifacts/` files.
- **awk picks targets, while/rm executes**: avoids subshell-state issues when reading from a pipe in `sh`.

## Dry-run validation (against live PVC)

Forced eviction with target=20Gi, no actual deletes:

```
=== Subdir listing (mtime, size_kb, path) ===
1777924848  3668124   rareicon-test/                   ← oldest
1778106518  4215576   rareicon-StandaloneWindows64/
1778106541  4585912   rareicon-StandaloneLinux64/
1778107508  4595580   rareicon-StandaloneOSX/
1778107802  21350956  rareicon-Android/
1778108278  6420556   rareicon-iOS/                    ← newest

=== Eviction order ===
WOULD evict rareicon-test (3582Mi)
WOULD evict rareicon-StandaloneWindows64 (4116Mi)
WOULD evict rareicon-StandaloneLinux64 (4478Mi)
WOULD evict rareicon-StandaloneOSX (4487Mi)
WOULD evict rareicon-Android (20850Mi)
[stops — iOS preserved]
```

Sort order correct, cumulative target enforced, newest project survives.

## Test plan

- [ ] ArgoCD syncs ConfigMap update (no CronJob spec changes — only script body)
- [ ] Manual run: `kubectl create job --from=cronjob/arc-cache-cleanup-medium arc-cache-cleanup-medium-test -n arc-runners`
- [ ] Logs show `under 80Gi cap (project-LRU)` for unity-library at current 44G
- [ ] Verify `rareicon-Android/ArtifactDB` and `SourceAssetDB` files untouched after run
- [ ] Confirm next Unity build for any platform completes without `[Library/ArtifactDB error]` in editor log