### PR TITLE
fix(firecracker): force load=false in production so buildx pushes

### DIFF
--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -40,13 +40,11 @@
 				},
 				"production": {
 					"tags": ["ghcr.io/kbve/firecracker-python-net:latest"],
+					"load": false,
 					"push": true,
 					"metadata": {
 						"images": ["ghcr.io/kbve/firecracker-python-net"]
 					},
-					"cache-from": [
-						"type=registry,ref=ghcr.io/kbve/firecracker-python-net:buildcache"
-					],
 					"cache-to": [
 						"type=registry,ref=ghcr.io/kbve/firecracker-python-net:buildcache,mode=max"
 					]


### PR DESCRIPTION
## Summary

The first publish run reached cache-to export but never pushed \`ghcr.io/kbve/firecracker-python-net:latest\`, so the follow-up \`imagetools create\` step failed with:

\`\`\`
ERROR: ghcr.io/kbve/firecracker-python-net:latest: not found
\`\`\`

\`@nx-tools/nx-container:build\` merges the production configuration on top of the base options. The base options had \`load: true, push: false\` (for local dev). Production added \`push: true\` but did not reset \`load\`, leaving both truthy — buildx then ran the build, exported cache-to, and never pushed the image.

This was the same shape as chisel, so the bug is latent there too — chisel just hasn't tripped it because its image already exists in the registry.

## Fix

- Explicitly set \`load: false\` next to \`push: true\` in the production configuration so buildx actually pushes \`:latest\`.
- Drop \`cache-from\` on this first publish — the referenced \`:buildcache\` tag does not exist yet and the importer logs a noisy \`ERROR\`. \`cache-to\` still creates the cache; subsequent publishes can re-introduce \`cache-from\` once it lands in the registry.

## Test plan

- [ ] After merge, \`CI - Docker / firecracker-python-net\` should push \`ghcr.io/kbve/firecracker-python-net:latest\`.
- [ ] \`imagetools create\` then tags \`:0.1.0\` from \`:latest\` and the workflow succeeds.