### PR TITLE
fix(argocd): custom health for KubeVirt VirtualMachine + VMI

### DIFF
--- a/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
+++ b/apps/kube/argocd/manifests/patch-argocd-cm-cert-health.yaml
@@ -137,3 +137,75 @@ data:
         end
         hs.status = "Healthy"
         return hs
+    # KubeVirt VirtualMachine: Manual/Halted runStrategy + Stopped is the
+    # steady state for builder VMs that KEDA boots on demand. Default Argo
+    # health treats any non-Running VM as Progressing forever, which leaves
+    # the angelscript app permanently STALLED. Mirror printableStatus +
+    # runStrategy so intentionally-off VMs report Healthy.
+    resource.customizations.health.kubevirt.io_VirtualMachine: |
+        hs = {}
+        local status = obj.status or {}
+        local printable = status.printableStatus or ""
+        local runStrategy = (obj.spec or {}).runStrategy or ""
+        if printable == "Running" then
+          hs.status = "Healthy"
+          hs.message = "VM running"
+          return hs
+        end
+        if printable == "Stopped" then
+          if runStrategy == "Manual" or runStrategy == "Halted" then
+            hs.status = "Healthy"
+            hs.message = "VM intentionally stopped (" .. runStrategy .. ")"
+            return hs
+          end
+          hs.status = "Degraded"
+          hs.message = "VM stopped but runStrategy=" .. runStrategy
+          return hs
+        end
+        if printable == "Paused" then
+          hs.status = "Healthy"
+          hs.message = "VM paused"
+          return hs
+        end
+        if printable == "Starting" or printable == "Stopping"
+           or printable == "Migrating" or printable == "Provisioning"
+           or printable == "WaitingForVolumeBinding" or printable == "Terminating" then
+          hs.status = "Progressing"
+          hs.message = "VM " .. string.lower(printable)
+          return hs
+        end
+        if string.find(printable, "Error") or printable == "CrashLoopBackOff"
+           or printable == "Unknown" then
+          hs.status = "Degraded"
+          hs.message = "VM " .. printable
+          return hs
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for printableStatus"
+        return hs
+    resource.customizations.health.kubevirt.io_VirtualMachineInstance: |
+        hs = {}
+        local phase = (obj.status or {}).phase or ""
+        if phase == "Running" then
+          hs.status = "Healthy"
+          hs.message = "VMI running"
+          return hs
+        end
+        if phase == "Succeeded" then
+          hs.status = "Healthy"
+          hs.message = "VMI terminated cleanly"
+          return hs
+        end
+        if phase == "Failed" or phase == "Unknown" then
+          hs.status = "Degraded"
+          hs.message = "VMI " .. phase
+          return hs
+        end
+        if phase == "Pending" or phase == "Scheduling" or phase == "Scheduled" then
+          hs.status = "Progressing"
+          hs.message = "VMI " .. phase
+          return hs
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for phase"
+        return hs


### PR DESCRIPTION
## Summary
- Default ArgoCD health probe for \`kubevirt.io/VirtualMachine\` only knows \`Running\` = Healthy. Any other \`printableStatus\` reports Progressing, so the angelscript builder VMs (\`windows-builder\`, \`macos-builder\`) parked at \`runStrategy: Manual\` sit at "STALLED 47d" indefinitely. VMIs hit the same problem when KEDA isn't actively booting one.
- Add Lua health customizations to \`argocd-cm\` that read \`printableStatus\` + \`runStrategy\` (VM) and \`phase\` (VMI):

  - **VirtualMachine**: Running → Healthy. Stopped + Manual/Halted → Healthy ("intentionally stopped"). Stopped + Always → Degraded. Paused → Healthy. Transient phases (Starting/Stopping/Migrating/Provisioning/...) → Progressing. \`*Error*\` / \`CrashLoopBackOff\` / \`Unknown\` → Degraded.
  - **VirtualMachineInstance**: Running → Healthy. Succeeded → Healthy (clean shutdown after KEDA job). Failed/Unknown → Degraded. Pending/Scheduling/Scheduled → Progressing.

- Mirrors existing pattern in this same ConfigMap for cert-manager Certificate, ExternalSecret/SecretStore, KEDA ScaledObject/ScaledJob, AutoscalingRunnerSet.

## Why this is the long-term fix
- KEDA ScaledJobs flip these VMs Stopped ↔ Running on demand. Removing the manifests would break the KEDA refs and lose git source-of-truth. Custom health checks let the manifests stay declarative while reporting the correct steady state.
- Pattern is reusable — any future KubeVirt VM (e.g. provisioned macOS) automatically inherits correct health reporting.

## Test plan
- [x] \`kubectl kustomize apps/kube/kube/argocd/manifests\` renders without error and includes both new \`resource.customizations.health.kubevirt.io_*\` keys
- [ ] After merge + ArgoCD picks up the configmap: \`angelscript\` app sync flips from STALLED → Healthy with \`windows-builder\` (Stopped+Manual) reported Healthy
- [ ] KEDA ScaledJob spins \`windows-builder\` up for a CI job → VM transitions Healthy (Starting → Progressing → Running → Healthy) → back to Healthy (Stopped) on idle shutdown without bouncing the app status
- [ ] No regression on cert-manager / external-secrets / KEDA / Service health (other Lua blocks untouched)