### PR TITLE
feat(discordsh): harden StatefulSets + Reloader-driven secret rotation

### DIFF
--- a/apps/kube/discordsh/README.md
+++ b/apps/kube/discordsh/README.md
@@ -1,0 +1,50 @@
+# discordsh — Kubernetes Deployment
+
+Discord-side surface for the KBVE world. Two StatefulSets run side by side:
+
+- `discordsh` — the axum web service (`ghcr.io/kbve/discordsh`) that serves the Astro frontend on port 4321.
+- `discordsh-bot` — the Rust Discord bot (`ghcr.io/kbve/discordsh-bot`) that listens on port 4322 for health and pulls its `DISCORD_TOKEN` at runtime from Supabase Vault using the namespace-scoped service-role key.
+
+Both share the same `discordsh-config` ConfigMap, `discordsh-redis-secret`, and `discordsh-supabase-shared` Secret, and reach Redis (`redis-master.redis.svc.cluster.local:6379`), the IRC bridge (`ergo-irc-service.irc.svc.cluster.local:6667`), and Supabase Kong (`kong.kilobase.svc.cluster.local:8000`) over in-cluster DNS.
+
+## Manifests
+
+| File                                     | Purpose                                                                                                                 |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `application.yaml`                       | ArgoCD `Application` pointing at `apps/kube/discordsh/manifest`                                                         |
+| `manifest/namespace.yaml`                | `discordsh` namespace                                                                                                   |
+| `manifest/configmap.yaml`                | `discordsh-config` runtime configuration                                                                                |
+| `manifest/discordsh-externalsecret.yaml` | ExternalSecret pulling Redis / Supabase credentials into the namespace                                                  |
+| `manifest/deployment.yaml`               | `discordsh` StatefulSet (axum web) + headless Service                                                                   |
+| `manifest/discordsh-bot-deployment.yaml` | `discordsh-bot` StatefulSet (Rust bot) + headless Service                                                               |
+| `manifest/discordsh-service.yaml`        | ClusterIP Service for the axum web                                                                                      |
+| `manifest/httproute.yaml`                | Gateway API HTTPRoute                                                                                                   |
+| `manifest/ingress.yaml`                  | Ingress for the public hostname                                                                                         |
+| `manifest/rbac.yaml`                     | `discordsh-sa` (pod SA) + cross-namespace Roles/Bindings for `discordsh-external-secrets` SA + Redis-side NetworkPolicy |
+
+## Hardening
+
+Both StatefulSets and their containers now run under a restricted PodSecurity profile:
+
+- `runAsNonRoot: true`, UID/GID `10001` (matches the binary owner set by `--chown=10001:10001` in `apps/discordsh/axum-discordsh/Dockerfile` and `apps/discordsh/discordsh-bot/Dockerfile`)
+- `readOnlyRootFilesystem: true` with a 64Mi `emptyDir` mounted at `/tmp` for scratch (the axum binary and the bot's image-rendering paths both stage to `/tmp`)
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- `discordsh-sa` ServiceAccount carries `automountServiceAccountToken: false`; both pod specs re-state the same so any future template binding the SA inherits the safe default (the pods do not call the kube API)
+- CPU/memory `requests` and `limits` set on every container so the kubelet enforces a cgroup; bursts cap at `500m / 512Mi`
+
+## Reloader integration
+
+Both StatefulSets carry `reloader.stakater.com/auto: "true"`. Stakater Reloader watches the workload-level annotation and rolls the StatefulSet whenever any referenced ConfigMap or Secret changes. The covered surface includes:
+
+- `discordsh-config` (envFrom on both)
+- `discordsh-redis-secret` (envFrom on both)
+- `discordsh-supabase-shared` (envFrom + `secretKeyRef` on both for the Supabase service-role key)
+
+The bot resolves `DISCORD_TOKEN` at runtime from Supabase Vault, so it does not need a Secret reference for that token specifically — but a rotation of the service-role key (which authenticates the Vault read) still rolls the bot, which is the desired behavior.
+
+## ArgoCD
+
+- App: `discordsh` (source: `apps/kube/discordsh/manifest`)
+- Sync: automated with prune + selfHeal
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/discordsh/manifest/deployment.yaml
+++ b/apps/kube/discordsh/manifest/deployment.yaml
@@ -23,6 +23,12 @@ metadata:
     labels:
         app: discordsh
         tier: frontend
+    annotations:
+        # Reloader rolls this StatefulSet whenever any referenced
+        # Secret or ConfigMap changes — discordsh-config (envFrom),
+        # discordsh-redis-secret (envFrom), and
+        # discordsh-supabase-shared (env.valueFrom) all qualify.
+        reloader.stakater.com/auto: 'true'
 spec:
     serviceName: discordsh-headless
     replicas: 1
@@ -36,6 +42,15 @@ spec:
                 tier: frontend
         spec:
             serviceAccountName: discordsh-sa
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                fsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: discordsh
                   image: ghcr.io/kbve/discordsh:0.1.43
@@ -78,6 +93,15 @@ spec:
                       limits:
                           memory: '512Mi'
                           cpu: '500m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
                   livenessProbe:
                       httpGet:
                           path: /health
@@ -94,3 +118,9 @@ spec:
                       periodSeconds: 5
                       timeoutSeconds: 3
                       failureThreshold: 3
+            volumes:
+                # Writable scratch for the axum binary while the
+                # rootfs itself stays read-only. Sized small.
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 64Mi

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -21,6 +21,13 @@ metadata:
     namespace: discordsh
     labels:
         app: discordsh-bot
+    annotations:
+        # Reloader rolls the StatefulSet on Secret/ConfigMap rotation.
+        # The bot resolves DISCORD_TOKEN at runtime from Supabase
+        # Vault, so it does not need a Secret reference for that, but
+        # discordsh-config, discordsh-redis-secret, and
+        # discordsh-supabase-shared still benefit from auto-rolls.
+        reloader.stakater.com/auto: 'true'
 spec:
     serviceName: discordsh-bot-headless
     replicas: 1
@@ -33,6 +40,15 @@ spec:
                 app: discordsh-bot
         spec:
             serviceAccountName: discordsh-sa
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                fsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: discordsh-bot
                   image: ghcr.io/kbve/discordsh-bot:0.1.10
@@ -74,6 +90,15 @@ spec:
                   ports:
                       - name: health
                         containerPort: 4322
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
                   livenessProbe:
                       httpGet:
                           path: /health
@@ -86,3 +111,9 @@ spec:
                           port: 4322
                       initialDelaySeconds: 10
                       periodSeconds: 10
+            volumes:
+                # Writable scratch for image rendering and any temp
+                # files the bot needs while the rootfs stays read-only.
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 64Mi

--- a/apps/kube/discordsh/manifest/rbac.yaml
+++ b/apps/kube/discordsh/manifest/rbac.yaml
@@ -1,8 +1,14 @@
+# ServiceAccount used by the discordsh and discordsh-bot StatefulSets.
+# Neither pod calls the kube API, so the projected token is unused
+# weight — disable token mount here at the SA level. The pod specs
+# also re-state the field so any future template binding this SA
+# inherits the safe default.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
     name: discordsh-sa
     namespace: discordsh
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
## Summary

- Both the `discordsh` axum web StatefulSet and the `discordsh-bot` Rust StatefulSet now run under a restricted PSA profile: `runAsNonRoot: true`, UID/GID `10001` (matches the binary owner set by `--chown=10001:10001` in both Dockerfiles — they share the same `chisel-ubuntu-axum` runtime base used by chuckrpg), `readOnlyRootFilesystem: true` with a 64Mi `/tmp` emptyDir for scratch, `allowPrivilegeEscalation: false`, all Linux capabilities dropped, `seccompProfile: RuntimeDefault`.
- `discordsh-sa` ServiceAccount now carries `automountServiceAccountToken: false`; both pod specs re-state the field so any future template binding the SA inherits the safe default. Neither pod calls the kube API, so the projected token is unused weight.
- Adds `reloader.stakater.com/auto: "true"` on both StatefulSets — Reloader rolls the workload whenever any referenced Secret or ConfigMap changes (`discordsh-config`, `discordsh-redis-secret`, `discordsh-supabase-shared`). The bot resolves `DISCORD_TOKEN` at runtime from Supabase Vault, so it does not need a Secret reference for that token specifically; a rotation of the Supabase service-role key still rolls the bot, which is the desired behavior.
- Adds `apps/kube/discordsh/README.md` documenting the topology, hardening posture, and Reloader integration.

## Why this matters

Continuing the small-namespace hardening rollout after chuckrpg (#10547), redis (#10556), and n8n (#10558). discordsh is the next-smallest namespace with real Secret rotation surface — three referenced secrets across two workloads — and shares the exact same image-build pattern as chuckrpg, so the hardening recipe transplanted 1:1.

## Hardening pattern by namespace so far

| ns        | manifest type | Reloader | non-root  | readOnly rootfs | caps drop | SA token off |
| --------- | ------------- | -------- | --------- | --------------- | --------- | ------------ |
| chuckrpg  | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| redis     | Bitnami chart | yes      | chart     | chart           | chart     | chart        |
| n8n       | raw           | yes      | UID 1000  | deferred        | yes       | yes          |
| discordsh | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |

## Test plan

- [ ] ArgoCD `discordsh` Application syncs cleanly after dev → main promotion.
- [ ] `kubectl -n discordsh get sts discordsh -o jsonpath='{.spec.template.spec.securityContext}'` shows `runAsNonRoot: true`, `runAsUser: 10001`, `seccompProfile: {type: RuntimeDefault}` (same for `discordsh-bot`).
- [ ] `kubectl -n discordsh get sts discordsh -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}'` returns `"true"` (same for `discordsh-bot`).
- [ ] `kubectl -n discordsh get pod -l app=discordsh -o jsonpath='{.items[0].status.containerStatuses[0].ready}'` returns `true`; `/health` on port 4321 returns 200.
- [ ] `kubectl -n discordsh get pod -l app=discordsh-bot -o jsonpath='{.items[0].status.containerStatuses[0].ready}'` returns `true`; `/health` on port 4322 returns 200.
- [ ] Trigger a no-op rotation on `discordsh-redis-secret` (or another referenced Secret) and observe Reloader rolling both StatefulSets within ~30s.