### PR TITLE
ci(manifest-guard): allow version-only drift

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.135",
+			"version": "1.0.136",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -211,7 +211,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.40",
+			"version": "1.0.41",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",
@@ -272,7 +272,7 @@
 		{
 			"key": "rareicon",
 			"app_name": "axum-rareicon",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"version_toml": "apps/rareicon/axum-rareicon/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rareicon.mdx",
 			"version_target": "apps/rareicon/axum-rareicon/Cargo.toml",

--- a/.github/workflows/ci-manifest-guard.yml
+++ b/.github/workflows/ci-manifest-guard.yml
@@ -57,10 +57,34 @@ jobs:
 
             - name: Diff manifest
               run: |
-                  if ! git diff --exit-code -- .github/ci-dispatch-manifest.json; then
-                      echo "::error::ci-dispatch-manifest.json is out of sync with the MDX sources."
+                  # Block only on STRUCTURAL drift. Version-field drift is
+                  # expected: MDX prep commits bump the source version, and the
+                  # post-publish workflow (utils-update-version-toml.yml)
+                  # regenerates the manifest in a follow-up auto-PR. Failing
+                  # the guard on that gap blocks unrelated PRs without value.
+                  if git diff --exit-code -- .github/ci-dispatch-manifest.json > /dev/null; then
+                      echo "Manifest is in sync."
+                      exit 0
+                  fi
+
+                  # Filter the patch down to changed lines that AREN'T `version`
+                  # fields. `git diff -U0` keeps only +/- lines (no context).
+                  # Strip file headers, then drop any line that is purely a
+                  # `"version": "..."` change. Anything left = real drift.
+                  STRUCTURAL_DIFF=$(git diff -U0 -- .github/ci-dispatch-manifest.json \
+                      | grep -E '^[+-]' \
+                      | grep -vE '^(\+\+\+|---) ' \
+                      | grep -vE '^[+-][[:space:]]*"version":[[:space:]]*"[^"]*",?[[:space:]]*$' \
+                      || true)
+
+                  if [ -n "$STRUCTURAL_DIFF" ]; then
+                      echo "::error::ci-dispatch-manifest.json has structural drift from the MDX sources."
                       echo "::error::Run 'npx nx run astro-kbve:build && npx nx run astro-kbve:sync:ci-manifest' locally and commit the regenerated manifest."
+                      echo "Structural diff:"
+                      echo "$STRUCTURAL_DIFF"
                       git diff --stat -- .github/ci-dispatch-manifest.json
                       exit 1
                   fi
-                  echo "Manifest is in sync."
+
+                  echo "::notice::Only version-field drift detected — allowed (post-publish auto-PR will sync)."
+                  git diff --stat -- .github/ci-dispatch-manifest.json


### PR DESCRIPTION
## Summary

The CI - Manifest Guard was blocking unrelated PRs whenever the dev branch had MDX version bumps that hadn't yet been reflected in `.github/ci-dispatch-manifest.json`. The version field is regenerated by the post-publish auto-PR (`utils-update-version-toml.yml`), so the drift is expected and short-lived — but every PR opened during that gap inherited the diff and failed the guard for no actionable reason. Saw this on the merge of #10559 — [run 25504952219](https://github.com/KBVE/kbve/actions/runs/25504952219/job/74847992191).

The diff step is now selective:

1. If the manifest is fully in sync → pass.
2. If there is drift, filter the patch to lines that are NOT pure `\"version\": \"X.Y.Z\"` field changes.
3. Any remaining `+/-` lines = structural drift → fail with the same error as before.
4. If the only drift is in `version` fields → log a notice and pass. The post-publish auto-PR will close the gap on its next run.

Also regenerates the manifest in-place to clear the current drift (axum-kbve 1.0.135 → 1.0.136, mc 1.0.40 → 1.0.41, rareicon 0.1.1 → 0.1.2) so the new behavior has a clean baseline.

## Test plan

- [x] Local positive test: drift filter returns empty (only version fields changed) → exits 0.
- [x] Local negative test: injected an `app_name` change → filter retains it → exits 1.
- [ ] Confirm CI passes on this PR (the manifest is regenerated; the diff step should report \"Manifest is in sync.\").
- [ ] Confirm no other workflows broke (only `ci-manifest-guard.yml` and the manifest JSON were touched).