### PR TITLE
feat(mc): account-link UI on /mc/ + Mojang lookup edge module

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mc/mc-auth/AstroMcAuthLink.astro
+++ b/apps/kbve/astro-kbve/src/components/mc/mc-auth/AstroMcAuthLink.astro
@@ -1,0 +1,8 @@
+---
+import { SupaProvider } from '@/components/providers/SupaProvider';
+import { ReactMcAuthLink } from './ReactMcAuthLink';
+---
+
+<SupaProvider client:only="react">
+	<ReactMcAuthLink client:only="react" />
+</SupaProvider>

--- a/apps/kbve/astro-kbve/src/components/mc/mc-auth/ReactMcAuthLink.tsx
+++ b/apps/kbve/astro-kbve/src/components/mc/mc-auth/ReactMcAuthLink.tsx
@@ -1,0 +1,438 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useSession } from '@/components/providers/SupaProvider';
+import {
+	getLinkStatus,
+	mojangLookup,
+	requestLink,
+	unlink,
+	type LinkStatus,
+	type MojangProfile,
+} from './mcAuthService';
+
+type Phase =
+	| 'init'
+	| 'anon'
+	| 'unlinked'
+	| 'lookup'
+	| 'confirm'
+	| 'requesting'
+	| 'pending'
+	| 'verified'
+	| 'unlinking';
+
+const POLL_INTERVAL_MS = 5_000;
+const CODE_TTL_MS = 10 * 60 * 1000;
+
+const styles = {
+	container: {
+		borderRadius: '0.5rem',
+		border: '1px solid var(--sl-color-gray-5)',
+		background: 'var(--sl-color-bg-nav)',
+		padding: '1rem 1.25rem',
+		marginBottom: '1.5rem',
+	} as React.CSSProperties,
+	header: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		marginBottom: '0.75rem',
+		paddingBottom: '0.5rem',
+		borderBottom: '1px solid var(--sl-color-gray-6)',
+	} as React.CSSProperties,
+	title: {
+		margin: 0,
+		fontSize: '1rem',
+		fontWeight: 600,
+		color: 'var(--sl-color-white)',
+	} as React.CSSProperties,
+	badge: {
+		fontSize: '0.75rem',
+		padding: '0.125rem 0.5rem',
+		borderRadius: '9999px',
+		fontWeight: 600,
+	} as React.CSSProperties,
+	badgeLinked: {
+		background: 'rgba(34, 197, 94, 0.15)',
+		color: 'rgb(34, 197, 94)',
+	} as React.CSSProperties,
+	badgePending: {
+		background: 'rgba(234, 179, 8, 0.15)',
+		color: 'rgb(234, 179, 8)',
+	} as React.CSSProperties,
+	badgeUnlinked: {
+		background: 'rgba(156, 163, 175, 0.15)',
+		color: 'var(--sl-color-gray-3)',
+	} as React.CSSProperties,
+	row: {
+		display: 'flex',
+		gap: '0.5rem',
+		alignItems: 'center',
+		flexWrap: 'wrap',
+	} as React.CSSProperties,
+	input: {
+		flex: 1,
+		minWidth: '180px',
+		padding: '0.5rem 0.75rem',
+		borderRadius: '0.375rem',
+		border: '1px solid var(--sl-color-gray-5)',
+		background: 'var(--sl-color-bg)',
+		color: 'var(--sl-color-white)',
+		fontSize: '0.9rem',
+	} as React.CSSProperties,
+	button: {
+		padding: '0.5rem 1rem',
+		borderRadius: '0.375rem',
+		border: '1px solid var(--sl-color-accent)',
+		background: 'var(--sl-color-accent)',
+		color: 'var(--sl-color-white)',
+		fontSize: '0.9rem',
+		fontWeight: 600,
+		cursor: 'pointer',
+	} as React.CSSProperties,
+	buttonGhost: {
+		padding: '0.5rem 1rem',
+		borderRadius: '0.375rem',
+		border: '1px solid var(--sl-color-gray-5)',
+		background: 'transparent',
+		color: 'var(--sl-color-white)',
+		fontSize: '0.9rem',
+		cursor: 'pointer',
+	} as React.CSSProperties,
+	code: {
+		display: 'inline-block',
+		fontFamily:
+			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+		fontSize: '1.75rem',
+		fontWeight: 700,
+		letterSpacing: '0.25em',
+		color: 'var(--sl-color-accent-high)',
+		padding: '0.5rem 1rem',
+		background: 'var(--sl-color-bg)',
+		border: '1px dashed var(--sl-color-accent)',
+		borderRadius: '0.375rem',
+	} as React.CSSProperties,
+	error: {
+		color: 'rgb(248, 113, 113)',
+		fontSize: '0.85rem',
+		marginTop: '0.5rem',
+	} as React.CSSProperties,
+	muted: {
+		color: 'var(--sl-color-gray-3)',
+		fontSize: '0.85rem',
+		marginTop: '0.5rem',
+	} as React.CSSProperties,
+	stack: {
+		display: 'flex',
+		flexDirection: 'column',
+		gap: '0.5rem',
+	} as React.CSSProperties,
+};
+
+function badgeStyle(phase: Phase) {
+	if (phase === 'verified') {
+		return { ...styles.badge, ...styles.badgeLinked };
+	}
+	if (phase === 'pending') {
+		return { ...styles.badge, ...styles.badgePending };
+	}
+	return { ...styles.badge, ...styles.badgeUnlinked };
+}
+
+function badgeLabel(phase: Phase) {
+	if (phase === 'verified') return 'Linked';
+	if (phase === 'pending') return 'Pending';
+	if (phase === 'anon') return 'Sign in';
+	return 'Not linked';
+}
+
+function formatRemaining(ms: number) {
+	if (ms <= 0) return 'expired';
+	const total = Math.floor(ms / 1000);
+	const m = Math.floor(total / 60);
+	const s = total % 60;
+	return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function statusToPhase(status: LinkStatus | null): Phase {
+	if (!status) return 'unlinked';
+	if (status.is_verified) return 'verified';
+	if (status.is_pending) return 'pending';
+	return 'unlinked';
+}
+
+export function ReactMcAuthLink() {
+	const { session, ready } = useSession();
+	const [phase, setPhase] = useState<Phase>('init');
+	const [error, setError] = useState<string | null>(null);
+	const [profile, setProfile] = useState<MojangProfile | null>(null);
+	const [code, setCode] = useState<number | null>(null);
+	const [codeExpiresAt, setCodeExpiresAt] = useState<number | null>(null);
+	const [now, setNow] = useState(() => Date.now());
+	const [link, setLink] = useState<LinkStatus | null>(null);
+	const [usernameInput, setUsernameInput] = useState('');
+	const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+	const accessToken = (session?.access_token as string | undefined) ?? null;
+
+	const refreshStatus = useCallback(async (token: string) => {
+		try {
+			const status = await getLinkStatus(token);
+			setLink(status);
+			const next = statusToPhase(status);
+			setPhase((prev) => {
+				// Don't overwrite an in-flight UI state with the polled one
+				if (
+					prev === 'lookup' ||
+					prev === 'confirm' ||
+					prev === 'requesting' ||
+					prev === 'unlinking'
+				) {
+					return prev;
+				}
+				return next;
+			});
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : 'status failed';
+			setError(message);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (!ready) return;
+		if (!session) {
+			setPhase('anon');
+			return;
+		}
+		if (!accessToken) return;
+		void refreshStatus(accessToken);
+	}, [ready, session, accessToken, refreshStatus]);
+
+	useEffect(() => {
+		if (phase !== 'pending' || !accessToken) {
+			if (pollRef.current) {
+				clearInterval(pollRef.current);
+				pollRef.current = null;
+			}
+			return;
+		}
+		pollRef.current = setInterval(() => {
+			void refreshStatus(accessToken);
+		}, POLL_INTERVAL_MS);
+		return () => {
+			if (pollRef.current) {
+				clearInterval(pollRef.current);
+				pollRef.current = null;
+			}
+		};
+	}, [phase, accessToken, refreshStatus]);
+
+	useEffect(() => {
+		if (!codeExpiresAt) return;
+		const id = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(id);
+	}, [codeExpiresAt]);
+
+	const onLookup = useCallback(async () => {
+		if (!accessToken) return;
+		setError(null);
+		setPhase('lookup');
+		try {
+			const found = await mojangLookup(usernameInput.trim(), accessToken);
+			if (!found) {
+				setError(
+					`No Minecraft account found for "${usernameInput.trim()}". Check spelling.`,
+				);
+				setPhase('unlinked');
+				return;
+			}
+			setProfile(found);
+			setPhase('confirm');
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : 'lookup failed';
+			setError(message);
+			setPhase('unlinked');
+		}
+	}, [accessToken, usernameInput]);
+
+	const onRequestCode = useCallback(async () => {
+		if (!accessToken || !profile) return;
+		setError(null);
+		setPhase('requesting');
+		try {
+			const v = await requestLink(profile.mc_uuid, accessToken);
+			setCode(v);
+			setCodeExpiresAt(Date.now() + CODE_TTL_MS);
+			setPhase('pending');
+			void refreshStatus(accessToken);
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : 'request failed';
+			setError(message);
+			setPhase('confirm');
+		}
+	}, [accessToken, profile, refreshStatus]);
+
+	const onUnlink = useCallback(async () => {
+		if (!accessToken) return;
+		setError(null);
+		setPhase('unlinking');
+		try {
+			await unlink(accessToken);
+			setProfile(null);
+			setCode(null);
+			setCodeExpiresAt(null);
+			setLink(null);
+			setUsernameInput('');
+			setPhase('unlinked');
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : 'unlink failed';
+			setError(message);
+			setPhase('verified');
+		}
+	}, [accessToken]);
+
+	if (phase === 'init') {
+		return (
+			<div style={styles.container}>
+				<div style={styles.header}>
+					<h3 style={styles.title}>Link your Minecraft account</h3>
+				</div>
+				<div style={styles.muted}>Loading…</div>
+			</div>
+		);
+	}
+
+	return (
+		<div style={styles.container}>
+			<div style={styles.header}>
+				<h3 style={styles.title}>Link your Minecraft account</h3>
+				<span style={badgeStyle(phase)}>{badgeLabel(phase)}</span>
+			</div>
+
+			{phase === 'anon' && (
+				<div style={styles.stack}>
+					<div style={styles.muted}>
+						Sign in with your KBVE account to link a Minecraft
+						profile.
+					</div>
+					<div>
+						<a href="/login" style={styles.button}>
+							Sign in
+						</a>
+					</div>
+				</div>
+			)}
+
+			{(phase === 'unlinked' || phase === 'lookup') && (
+				<div style={styles.stack}>
+					<div style={styles.muted}>
+						Enter your Minecraft username — we'll look up your UUID
+						via Mojang.
+					</div>
+					<div style={styles.row}>
+						<input
+							type="text"
+							placeholder="Notch"
+							value={usernameInput}
+							onChange={(e) => setUsernameInput(e.target.value)}
+							style={styles.input}
+							maxLength={16}
+							disabled={phase === 'lookup'}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' && usernameInput.trim()) {
+									void onLookup();
+								}
+							}}
+						/>
+						<button
+							type="button"
+							onClick={onLookup}
+							disabled={
+								phase === 'lookup' || !usernameInput.trim()
+							}
+							style={styles.button}>
+							{phase === 'lookup' ? 'Looking up…' : 'Look up'}
+						</button>
+					</div>
+				</div>
+			)}
+
+			{(phase === 'confirm' || phase === 'requesting') && profile && (
+				<div style={styles.stack}>
+					<div style={styles.muted}>
+						Found <strong>{profile.username}</strong> — UUID{' '}
+						<code>{profile.mc_uuid}</code>. Confirm to generate a
+						code.
+					</div>
+					<div style={styles.row}>
+						<button
+							type="button"
+							onClick={onRequestCode}
+							disabled={phase === 'requesting'}
+							style={styles.button}>
+							{phase === 'requesting'
+								? 'Generating…'
+								: 'Generate code'}
+						</button>
+						<button
+							type="button"
+							onClick={() => {
+								setProfile(null);
+								setPhase('unlinked');
+							}}
+							disabled={phase === 'requesting'}
+							style={styles.buttonGhost}>
+							Cancel
+						</button>
+					</div>
+				</div>
+			)}
+
+			{phase === 'pending' && code !== null && (
+				<div style={styles.stack}>
+					<div style={styles.muted}>
+						Join <strong>mc.kbve.com</strong> and run this in chat:
+					</div>
+					<div style={styles.row}>
+						<span style={styles.code}>
+							/link {code.toString().padStart(6, '0')}
+						</span>
+					</div>
+					<div style={styles.muted}>
+						Code expires in{' '}
+						<strong>
+							{codeExpiresAt
+								? formatRemaining(codeExpiresAt - now)
+								: 'unknown'}
+						</strong>
+						. We'll detect the link automatically.
+					</div>
+				</div>
+			)}
+
+			{(phase === 'verified' || phase === 'unlinking') && link && (
+				<div style={styles.stack}>
+					<div style={styles.muted}>
+						Linked to MC UUID <code>{link.mc_uuid}</code>.
+					</div>
+					<div style={styles.row}>
+						<button
+							type="button"
+							onClick={onUnlink}
+							disabled={phase === 'unlinking'}
+							style={styles.buttonGhost}>
+							{phase === 'unlinking' ? 'Unlinking…' : 'Unlink'}
+						</button>
+					</div>
+				</div>
+			)}
+
+			{error && <div style={styles.error}>{error}</div>}
+		</div>
+	);
+}
+
+export default ReactMcAuthLink;

--- a/apps/kbve/astro-kbve/src/components/mc/mc-auth/index.ts
+++ b/apps/kbve/astro-kbve/src/components/mc/mc-auth/index.ts
@@ -1,0 +1,9 @@
+export { ReactMcAuthLink } from './ReactMcAuthLink';
+export {
+	getLinkStatus,
+	mojangLookup,
+	requestLink,
+	unlink,
+	type LinkStatus,
+	type MojangProfile,
+} from './mcAuthService';

--- a/apps/kbve/astro-kbve/src/components/mc/mc-auth/mcAuthService.ts
+++ b/apps/kbve/astro-kbve/src/components/mc/mc-auth/mcAuthService.ts
@@ -1,0 +1,87 @@
+import { SUPABASE_URL } from '@/lib/supa';
+
+const MC_ENDPOINT = `${SUPABASE_URL}/functions/v1/mc`;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface MojangProfile {
+	mc_uuid: string;
+	username: string;
+}
+
+export interface LinkStatus {
+	mc_uuid: string;
+	status: number;
+	is_verified: boolean;
+	is_pending: boolean;
+	created_at: string;
+	updated_at: string;
+}
+
+async function postMc<T>(
+	command: string,
+	body: Record<string, unknown>,
+	accessToken: string,
+): Promise<T> {
+	const resp = await fetch(MC_ENDPOINT, {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			authorization: `Bearer ${accessToken}`,
+		},
+		body: JSON.stringify({ command, ...body }),
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+	});
+
+	const json = await resp.json().catch(() => ({}));
+	if (!resp.ok) {
+		const reason =
+			(json as { error?: string }).error ?? `HTTP ${resp.status}`;
+		throw new Error(reason);
+	}
+	return json as T;
+}
+
+export async function mojangLookup(
+	username: string,
+	accessToken: string,
+): Promise<MojangProfile | null> {
+	const data = await postMc<{ found: boolean } & MojangProfile>(
+		'mojang.lookup',
+		{ username },
+		accessToken,
+	);
+	if (!data.found) return null;
+	return { mc_uuid: data.mc_uuid, username: data.username };
+}
+
+export async function requestLink(
+	mc_uuid: string,
+	accessToken: string,
+): Promise<number> {
+	const data = await postMc<{ success: boolean; verification_code: number }>(
+		'auth.request_link',
+		{ mc_uuid },
+		accessToken,
+	);
+	return data.verification_code;
+}
+
+export async function getLinkStatus(
+	accessToken: string,
+): Promise<LinkStatus | null> {
+	const data = await postMc<{ found: boolean; link?: LinkStatus }>(
+		'auth.status',
+		{},
+		accessToken,
+	);
+	return data.found && data.link ? data.link : null;
+}
+
+export async function unlink(accessToken: string): Promise<boolean> {
+	const data = await postMc<{ success: boolean; was_linked: boolean }>(
+		'auth.unlink',
+		{},
+		accessToken,
+	);
+	return data.was_linked;
+}

--- a/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/index.mdx
@@ -10,17 +10,20 @@ tags:
 ---
 
 import { Card, CardGrid, Aside, LinkCard } from '@astrojs/starlight/components';
+import AstroMcAuthLink from '@/components/mc/mc-auth/AstroMcAuthLink.astro';
 
 The KBVE Minecraft server is a public, community-run Fabric 1.21.11 world
 with performance mods, old-combat mechanics, and a custom Rust-powered AI
 layer for NPCs and mobs.
 
-## How to join
+## Link your account
 
-<Aside title="Server address" type="tip">
-  Coming soon. Connection details, whitelist policy, and Discord-linked
-  onboarding will land here as the server opens its public slots.
-</Aside>
+<AstroMcAuthLink />
+
+Join **mc.kbve.com** with your Minecraft client. If your Supabase account
+isn't linked yet, you'll see a chat prompt in-game — generate a code
+above and run `/link <code>`. The bridge auto-verifies and flips the
+badge to **Linked**.
 
 ## What to expect
 

--- a/apps/kbve/edge/functions/mc/index.ts
+++ b/apps/kbve/edge/functions/mc/index.ts
@@ -9,6 +9,7 @@ import { handleTransfer, TRANSFER_ACTIONS } from "./transfer.ts";
 import { CHARACTER_ACTIONS, handleCharacter } from "./character.ts";
 import { handleSkill, SKILL_ACTIONS } from "./skill.ts";
 import { ADMIN_ACTIONS, handleAdmin } from "./admin.ts";
+import { handleMojang, MOJANG_ACTIONS } from "./mojang.ts";
 
 // ---------------------------------------------------------------------------
 // MC Edge Function — Unified Router
@@ -21,6 +22,7 @@ import { ADMIN_ACTIONS, handleAdmin } from "./admin.ts";
 //   character: save, load, add_xp
 //   skill:     save, load, add_xp
 //   admin:     execute, give, teleport, broadcast
+//   mojang:    lookup
 // ---------------------------------------------------------------------------
 
 const MODULES: Record<
@@ -37,6 +39,7 @@ const MODULES: Record<
   character: { handler: handleCharacter, actions: CHARACTER_ACTIONS },
   skill: { handler: handleSkill, actions: SKILL_ACTIONS },
   admin: { handler: handleAdmin, actions: ADMIN_ACTIONS },
+  mojang: { handler: handleMojang, actions: MOJANG_ACTIONS },
 };
 
 function buildHelpText(): string {

--- a/apps/kbve/edge/functions/mc/mojang.ts
+++ b/apps/kbve/edge/functions/mc/mojang.ts
@@ -1,0 +1,101 @@
+import { jsonResponse, type McRequest } from "./_shared.ts";
+
+const MOJANG_API = "https://api.mojang.com/users/profiles/minecraft";
+const LOOKUP_TIMEOUT_MS = 5000;
+const USERNAME_RE = /^[A-Za-z0-9_]{2,16}$/;
+
+type Handler = (mcReq: McRequest) => Promise<Response>;
+
+const cache = new Map<string, { data: { mc_uuid: string; username: string }; expires: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function cacheGet(key: string) {
+  const hit = cache.get(key);
+  if (!hit) return null;
+  if (Date.now() > hit.expires) {
+    cache.delete(key);
+    return null;
+  }
+  return hit.data;
+}
+
+function cacheSet(key: string, data: { mc_uuid: string; username: string }) {
+  cache.set(key, { data, expires: Date.now() + CACHE_TTL_MS });
+}
+
+const handlers: Record<string, Handler> = {
+  async lookup({ body }) {
+    const { username } = body;
+    if (typeof username !== "string" || !USERNAME_RE.test(username)) {
+      return jsonResponse(
+        { error: "username must be 2-16 chars of [A-Za-z0-9_]" },
+        400,
+      );
+    }
+
+    const cacheKey = username.toLowerCase();
+    const cached = cacheGet(cacheKey);
+    if (cached) {
+      return jsonResponse({ found: true, ...cached, cached: true });
+    }
+
+    let resp: Response;
+    try {
+      resp = await fetch(`${MOJANG_API}/${encodeURIComponent(username)}`, {
+        signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+        headers: { accept: "application/json" },
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "fetch failed";
+      return jsonResponse(
+        { error: `Mojang lookup failed: ${reason}` },
+        502,
+      );
+    }
+
+    if (resp.status === 404 || resp.status === 204) {
+      return jsonResponse({ found: false });
+    }
+    if (!resp.ok) {
+      return jsonResponse(
+        { error: `Mojang lookup returned ${resp.status}` },
+        502,
+      );
+    }
+
+    const data = await resp.json().catch(() => null);
+    if (!data || typeof data.id !== "string" || typeof data.name !== "string") {
+      return jsonResponse(
+        { error: "Mojang returned unexpected payload" },
+        502,
+      );
+    }
+
+    const mc_uuid = data.id.toLowerCase();
+    if (!/^[a-f0-9]{32}$/.test(mc_uuid)) {
+      return jsonResponse(
+        { error: "Mojang returned malformed UUID" },
+        502,
+      );
+    }
+
+    const result = { mc_uuid, username: data.name };
+    cacheSet(cacheKey, result);
+    return jsonResponse({ found: true, ...result });
+  },
+};
+
+export const MOJANG_ACTIONS = Object.keys(handlers);
+
+export async function handleMojang(mcReq: McRequest): Promise<Response> {
+  const handler = handlers[mcReq.action];
+  if (!handler) {
+    return jsonResponse(
+      {
+        error: `Unknown mojang action: ${mcReq.action}. Use: ${MOJANG_ACTIONS.join(", ")}`,
+      },
+      400,
+    );
+  }
+  return handler(mcReq);
+}


### PR DESCRIPTION
## Summary

- Wires the missing front-end half of the existing `mc_auth` bridge. The DB schema (`mc.auth`), edge function (`auth.request_link` / `auth.verify` / `auth.status` / `auth.unlink`), and in-game Fabric mod (`/link <code>` slash command + on-join nag prompt) were already shipped — but the in-game prompt sends players to `https://kbve.com/mc` and that page only said "Coming soon", so nobody could actually generate a code.
- New edge module `mc/mojang.ts` proxies `https://api.mojang.com/users/profiles/minecraft/<name>` (belt + suspenders for browser CORS, plus a 5-min in-process cache to stay under Mojang's per-IP rate limit). Wired into the `mc/index.ts` router as `mojang.lookup`.
- New React island under `components/mc/mc-auth/` (mounted on `/mc/index.mdx` via an Astro shell that wraps it in `<SupaProvider client:only="react">`). Phase machine: `anon → unlinked → lookup → confirm → pending → verified`. Polls `auth.status` every 5 s while pending, runs a 10-min countdown on the displayed code, rolls back gracefully on errors, and offers an Unlink button once verified.

## Defers

- **Offline-mode allowlist proxy** is intentionally deferred. The original goal was a parallel Velocity listener on a second port for cracked clients, but the offline-vs-online UUID divergence makes that unsafe until real users have a verified link. Account linking lands first; offline allowlist comes once we can map an offline username to an existing online UUID.

## Test plan

- [ ] Visit `https://kbve.com/mc/` while signed out — badge says "Sign in"; CTA links to `/login`.
- [ ] Sign in, enter a real Minecraft username — `mojang.lookup` resolves the UUID; confirm view shows username + UUID.
- [ ] Click "Generate code" — code appears, badge flips to "Pending", countdown ticks down from 10:00.
- [ ] Join `mc.kbve.com`, run `/link <code>` in chat — server replies "Account linked — thanks!"; web UI flips to "Linked" within 5 s of next poll.
- [ ] Click "Unlink" — badge returns to "Not linked"; refreshing the page keeps it that way.
- [ ] Wait past 10 min without running `/link` — code expires server-side; re-requesting issues a fresh code.
- [ ] Enter an invalid Mojang username — UI shows "No Minecraft account found for ..." and returns to the input.