### PR TITLE
fix(mc): retry Modrinth mod downloads on transient HTTP/2 errors

### DIFF
--- a/apps/mc/Dockerfile
+++ b/apps/mc/Dockerfile
@@ -302,7 +302,13 @@ declare -A MODS=(
 
 for name in "${!MODS[@]}"; do
   read -r sha1 url <<< "${MODS[$name]}"
-  curl -fsSL -o "/mods/$name" "$url"
+  # Modrinth's CDN occasionally throws HTTP/2 stream errors (curl exit 92)
+  # on a fresh CI runner. Retry with backoff so transient flakes don't
+  # fail the whole image build. --retry-all-errors covers the HTTP/2
+  # framing-layer failures that --retry alone skips.
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 30 --max-time 120 \
+    -o "/mods/$name" "$url"
   echo "$sha1  /mods/$name" | sha1sum -c -
 done
 MODS


### PR DESCRIPTION
## Summary

- CI mc Docker build has been failing because `curl -fsSL` exits 92 (HTTP/2 stream framing error) when Modrinth's CDN intermittently drops a connection mid-transfer
- The download loop in `apps/mc/Dockerfile` runs ~50 curls back-to-back with no retry — a single flake aborts the whole image build
- Add `curl --retry 5 --retry-delay 2 --retry-all-errors` plus `--connect-timeout 30 --max-time 120`. `--retry-all-errors` is required because curl's default `--retry` only handles transient HTTP status codes; HTTP/2 framing errors fall outside that set

Closes #10575

## Test plan

- [ ] Re-run the failing workflow on this branch to confirm CI passes
- [ ] No expected behavior change for green builds — retries only fire on transient errors