### PR TITLE
docs(packages/data): scoped READMEs for data + ch

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,0 +1,41 @@
+# `packages/data` — Data, Schemas, and Codegen
+
+Single tree for every cross-language data definition in the monorepo. Apps and services compile against artifacts produced here so the same shape moves through proto, Postgres, ClickHouse, and TypeScript without drift.
+
+## Layout
+
+| Directory                | What lives here                                                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| [`proto/`](./proto/)     | Protobuf `.proto` files — source of truth for cross-service data structures.                                       |
+| [`codegen/`](./codegen/) | Generators that read proto descriptors + JSON config and emit typed Zod / TS schemas into app trees.               |
+| [`sql/`](./sql/)         | PostgreSQL schemas, dbmate migrations, and supporting docker-compose stacks for the Supabase cluster.              |
+| [`ch/`](./ch/)           | ClickHouse DDL — Logflare OTEL templates, observability log/trace pipelines, and firecracker microVM event tables. |
+
+## Pipeline
+
+```
+proto/*.proto
+   │  prost / buf / protoc
+   ▼
+codegen/descriptors/*.binpb
+   │  gen-*-zod.mjs
+   ▼
+apps/<service>/src/schemas/generated/*.ts   ← Zod + TS
+sql/schema/<schema>/*.sql                   ← hand-authored Postgres schema mirror
+sql/dbmate/migrations/*.sql                 ← applied migrations (dbmate)
+ch/schemas/*.sql                            ← hand-authored ClickHouse DDL
+```
+
+The proto file is authoritative for **structure**. Postgres migrations and ClickHouse DDL are authoritative for **deployed schema state** in their respective stores.
+
+## Conventions
+
+- Edit proto, regenerate Zod via `npx tsx packages/data/codegen/gen-*-zod.mjs`.
+- Never hand-edit `codegen/generated/` or `codegen/descriptors/` — they are build artifacts.
+- Never hand-edit applied dbmate migrations. Add a new one with `dbmate new <name>`.
+- Match Postgres + ClickHouse table names to the proto message names where practical so traces line up across stores.
+
+## Related
+
+- Memory pipeline pattern: itemdb / npcdb / mapdb / questdb sync via `astro-kbve` scripts (`nx run astro-kbve:sync:{itemdb,npcdb,mapdb}`). MDX is the source of truth for those pools.
+- CI registry proto: [`proto/kbve/ci_registry.proto`](./proto/kbve/ci_registry.proto) → Zod → `@kbve/devops` registry → `.github/ci-dispatch-manifest.json`.

--- a/packages/data/ch/README.md
+++ b/packages/data/ch/README.md
@@ -1,0 +1,91 @@
+# `packages/data/ch` — ClickHouse Schemas
+
+ClickHouse DDL for the KBVE observability stack. Two flavors live side by side:
+
+1. **Logflare-compatible templates** (`logs.sql`, `metrics.sql`, `traces.sql`) — extracted from Logflare's `QueryTemplates.ex`, used as reference when Logflare provisions per-source tables (`otel_logs_<token>`, etc.).
+2. **First-party direct-write tables** (`observability.sql`, `firecracker.sql`) — populated by Vector → ClickHouse without Logflare in the path. Production deploys use `ReplicatedMergeTree` + `Distributed` across a 2 shard × 2 replica cluster.
+
+## Files
+
+| File                     | Purpose                                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `database.sql`           | Creates the `logflare` database. Run before any `logflare.*` template.                                                             |
+| `logs.sql`               | Logflare OTEL log templates (JSON attribute columns + map-typed variants).                                                         |
+| `metrics.sql`            | Logflare OTEL metric templates.                                                                                                    |
+| `traces.sql`             | Logflare OTEL trace templates.                                                                                                     |
+| `observability.sql`      | `observability.logs_raw` (replicated) + `logs_distributed` — direct Vector → ClickHouse log pipeline. Day-partitioned, 45-day TTL. |
+| `firecracker.sql`        | `firecracker.vm_events` — microVM lifecycle telemetry from `firecracker-ctl`. 90-day TTL for capacity planning.                    |
+| `dev-docker-compose.yml` | Single-node ClickHouse for local DDL validation (no Logflare, no Postgres). Mounted on `tmpfs` for cheap teardown.                 |
+
+## Engines and retention
+
+| Table                            | Engine                | Partition      | TTL     |
+| -------------------------------- | --------------------- | -------------- | ------- |
+| `logflare.otel_logs_template`    | MergeTree (templated) | daily          | 45 days |
+| `logflare.otel_metrics_template` | MergeTree (templated) | daily          | 45 days |
+| `logflare.otel_traces_template`  | MergeTree (templated) | daily          | 45 days |
+| `observability.logs_raw`         | ReplicatedMergeTree   | `toYYYYMMDD`   | 45 days |
+| `observability.logs_distributed` | Distributed           | (fan-out only) | n/a     |
+| `firecracker.vm_events`          | MergeTree             | `toYYYYMMDD`   | 90 days |
+
+Production overrides Logflare's default engine via:
+
+```elixir
+config :logflare, :clickhouse_backend_adaptor, engine: "ReplicatedMergeTree"
+```
+
+## Local DDL validation
+
+```bash
+cd packages/data/ch
+cp dev-docker-compose.yml docker-compose.yml
+docker compose up -d
+
+# Apply schemas (skip the ON CLUSTER clauses — single node has no cluster).
+docker compose exec -T clickhouse clickhouse-client \
+  --user logflare --password logflare \
+  --multiquery < schemas/database.sql
+for f in schemas/logs.sql schemas/metrics.sql schemas/traces.sql; do
+  docker compose exec -T clickhouse clickhouse-client \
+    --user logflare --password logflare -d logflare \
+    --multiquery < "$f"
+done
+
+# Inspect:
+docker compose exec clickhouse clickhouse-client \
+  --user logflare --password logflare -d logflare -q "SHOW TABLES"
+
+docker compose down -v
+```
+
+`observability.sql` and `firecracker.sql` use `ON CLUSTER 'cluster'` and `ReplicatedMergeTree('/clickhouse/tables/{shard}/...', '{replica}')` — they only apply cleanly against a real clustered cluster. For local validation, strip the `ON CLUSTER` clauses and switch the engine to plain `MergeTree`.
+
+## Pipeline
+
+```
+service stdout / OTEL exporter
+       │
+       ▼
+   Vector agent ───┐
+                   │
+      writes to    ▼
+        observability.logs_raw  (per-shard local table)
+                   │
+  reads through    ▼
+        observability.logs_distributed  (cluster-wide view)
+                   │
+                   ▼
+              dashboards / queries
+```
+
+For Logflare-managed sources the same shape applies, but Logflare provisions one `otel_logs_<token>` table per source instead of a single `logs_raw`.
+
+## Future work
+
+OpenTelemetry trace ingestion (Vector 0.54 experimental) is queued behind the log pipeline stabilisation — see [`project_otel_tracing.md`](../../../../.claude/projects/-Users-alappatel-Documents-GitHub-kbve/memory/project_otel_tracing.md) in the auto-memory.
+
+## Related
+
+- Vector pipelines: `apps/kube/observability/manifests/`
+- Postgres-side audit log: [`../sql/`](../sql/)
+- KBVE log routing service: `apps/kbve/axum-kbve/src/observability/`


### PR DESCRIPTION
## Summary

Adds two scoped READMEs to `packages/data/` to match the docs already present in `proto/`, `codegen/`, and `sql/dbmate/`:

- **`packages/data/README.md`** — top-level index. Maps the four subtrees (`proto`, `codegen`, `sql`, `ch`), shows the proto → codegen → language-specific schema pipeline, and pins the conventions (no hand-edits to generated artifacts, no edits to applied dbmate migrations).
- **`packages/data/ch/README.md`** — covers ClickHouse DDL: Logflare-compatible OTEL templates vs. first-party direct-write tables (`observability.logs_raw`, `firecracker.vm_events`), engine + retention table, local DDL validation via the dev compose, and a Vector → ClickHouse pipeline diagram.

No code changes, just docs.

## Test plan

- [x] Markdown renders cleanly on GitHub (tables align, code fences close).
- [x] All relative links target real paths (`./proto/`, `./codegen/`, `./sql/`, `./ch/`, `../sql/`).
- [ ] Reviewer sanity check on the engine / TTL table (`observability.logs_raw` ReplicatedMergeTree, 45-day TTL; `firecracker.vm_events` MergeTree, 90-day TTL).