### PR TITLE
fix(firecracker): drop metadata field so explicit :latest tag survives

### DIFF
--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -42,9 +42,6 @@
 					"tags": ["ghcr.io/kbve/firecracker-python-net:latest"],
 					"load": false,
 					"push": true,
-					"metadata": {
-						"images": ["ghcr.io/kbve/firecracker-python-net"]
-					},
 					"cache-to": [
 						"type=registry,ref=ghcr.io/kbve/firecracker-python-net:buildcache,mode=max"
 					]


### PR DESCRIPTION
## Summary

Run [#25525404648](https://github.com/KBVE/kbve/actions/runs/25525404648) reached the build step cleanly but the publish chain still failed:

\`\`\`
ERROR: ghcr.io/kbve/firecracker-python-net:latest: not found
\`\`\`

Looking at the executor's input dump in the run log:

\`\`\`
##[group]Docker tags
ghcr.io/kbve/firecracker-python-net:main
\`\`\`

The \`@nx-tools/nx-container:build\` executor pre-runs \`docker/metadata-action\` whenever \`metadata.images\` is set on the configuration. The metadata-action then **overrides** our explicit \`tags: [":latest"]\` with auto-derived tags from the default rule set:

\`\`\`
type=ref,event=branch  →  ghcr.io/kbve/firecracker-python-net:main
\`\`\`

So the build pushed \`:main\` (correctly!) but never \`:latest\`, and the follow-up \`docker buildx imagetools create --tag :0.1.0 :latest\` failed with \"not found\".

## Fix

Drop the \`metadata.images\` field on the production configuration so the executor uses the explicit \`tags\` array directly. The rest of the publish chain already handles version tagging by hand (\`imagetools create --tag :\${VERSION} :latest\`), so we do not need the metadata-action's auto-derivation here.

This image's \`container\` target's production command chain remains:

1. \`containerx:production\` builds and pushes \`:latest\`.
2. \`docker buildx imagetools create --tag :\${VERSION} :latest\` fans out the version tag from \`:latest\`.

## Test plan

- [ ] After merge, \`CI - Docker / firecracker-python-net\` should push \`ghcr.io/kbve/firecracker-python-net:latest\`.
- [ ] \`imagetools create\` then succeeds and \`:0.1.0\` lands in the registry.