### PR TITLE
fix(ci): add holy crate stub to discordsh-bot/rows/chuckrpg Dockerfiles

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -68,6 +68,7 @@ COPY Cargo.lock ./
 
 COPY apps/chuckrpg/axum-chuckrpg/Cargo.toml apps/chuckrpg/axum-chuckrpg/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 COPY packages/rust/bevy/bevy_kbve_net/Cargo.toml packages/rust/bevy/bevy_kbve_net/Cargo.toml
 COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
@@ -76,6 +77,7 @@ COPY packages/data/proto packages/data/proto
 
 RUN mkdir -p apps/chuckrpg/axum-chuckrpg/src && echo "fn main() {}" > apps/chuckrpg/axum-chuckrpg/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/holy/src && echo "" > packages/rust/holy/src/lib.rs && \
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_kbve_net/src && echo "" > packages/rust/bevy/bevy_kbve_net/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs
@@ -118,13 +120,14 @@ RUN mkdir -p apps/chuckrpg/axum-chuckrpg/src && \
 COPY packages/data/proto packages/data/proto
 
 COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_kbve_net packages/rust/bevy/bevy_kbve_net
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release -p kbve -p jedi -p bevy_kbve_net -p bevy_npc
+    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc
 
 # ============================================================================
 # [STAGE F] - Build Application
@@ -137,6 +140,7 @@ COPY --from=astro-precompressor /static /app/apps/chuckrpg/axum-chuckrpg/templat
 # Foundation crate source (cargo needs source to verify fingerprints)
 COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_kbve_net packages/rust/bevy/bevy_kbve_net
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -14,6 +14,7 @@ COPY Cargo.lock ./
 
 COPY apps/discordsh/discordsh-bot/Cargo.toml apps/discordsh/discordsh-bot/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 COPY packages/rust/bevy/bevy_inventory/Cargo.toml packages/rust/bevy/bevy_inventory/Cargo.toml
 COPY packages/rust/bevy/bevy_items/Cargo.toml packages/rust/bevy/bevy_items/Cargo.toml
@@ -28,6 +29,7 @@ COPY packages/data/proto packages/data/proto
 
 RUN mkdir -p apps/discordsh/discordsh-bot/src && echo "fn main() {}" > apps/discordsh/discordsh-bot/src/main.rs && \
     mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/holy/src && echo "" > packages/rust/holy/src/lib.rs && \
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_inventory/src && echo "" > packages/rust/bevy/bevy_inventory/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_items/src && echo "" > packages/rust/bevy/bevy_items/src/lib.rs && \
@@ -71,6 +73,7 @@ RUN mkdir -p apps/discordsh/discordsh-bot/src && \
 COPY packages/data/proto packages/data/proto
 
 COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items
@@ -84,7 +87,7 @@ COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo build --release -p kbve -p jedi -p bevy_inventory -p bevy_items -p bevy_behavior -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat
+    cargo build --release -p kbve -p jedi -p holy -p bevy_inventory -p bevy_items -p bevy_behavior -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat
 
 # ============================================================================
 # [STAGE D] - Build Application
@@ -98,6 +101,7 @@ RUN dpkg -s make >/dev/null 2>&1 || \
 # Foundation crate source (cargo needs source to verify fingerprints)
 COPY packages/data/proto packages/data/proto
 COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_inventory packages/rust/bevy/bevy_inventory
 COPY packages/rust/bevy/bevy_items packages/rust/bevy/bevy_items

--- a/apps/ows/rows/Dockerfile
+++ b/apps/ows/rows/Dockerfile
@@ -12,16 +12,18 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS pla
 ENV CARGO_INCREMENTAL=0
 
 # Create workspace
-RUN printf '[workspace]\nmembers = ["apps/ows/rows", "packages/rust/jedi", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+RUN printf '[workspace]\nmembers = ["apps/ows/rows", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
 
 # Copy all manifests + source for recipe generation
 COPY apps/ows/rows/Cargo.toml apps/ows/rows/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 COPY packages/data/proto/ packages/data/proto/
 COPY apps/ows/rows/build.rs apps/ows/rows/build.rs
 COPY apps/ows/rows/src/ apps/ows/rows/src/
 COPY packages/rust/jedi/src/ packages/rust/jedi/src/
+COPY packages/rust/holy/src/ packages/rust/holy/src/
 COPY packages/rust/kbve/src/ packages/rust/kbve/src/
 
 RUN cargo chef prepare --recipe-path recipe.json
@@ -31,11 +33,12 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS coo
 ENV CARGO_INCREMENTAL=0
 
 # Create workspace
-RUN printf '[workspace]\nmembers = ["apps/ows/rows", "packages/rust/jedi", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+RUN printf '[workspace]\nmembers = ["apps/ows/rows", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
 
 # Copy manifests + build.rs (needed for proc macros / build scripts)
 COPY apps/ows/rows/Cargo.toml apps/ows/rows/Cargo.toml
 COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 COPY packages/data/proto/ packages/data/proto/
 COPY apps/ows/rows/build.rs apps/ows/rows/build.rs
@@ -54,6 +57,7 @@ RUN dpkg -s make >/dev/null 2>&1 || \
     (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
 
 COPY packages/rust/jedi/ packages/rust/jedi/
+COPY packages/rust/holy/ packages/rust/holy/
 COPY packages/rust/kbve/ packages/rust/kbve/
 COPY apps/ows/rows/src/ apps/ows/rows/src/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
Closes #10574

## Summary
- Three Dockerfiles fail \`cargo chef prepare\` with \`failed to load manifest for dependency holy\` because \`kbve\` started depending on \`../holy\` (commit 6ffd206c0) but the Docker stages weren't updated.
- Affected: \`apps/discordsh/discordsh-bot\` (the one in #10574), \`apps/ows/rows\`, \`apps/chuckrpg/axum-chuckrpg\`. The other 7 Rust Dockerfiles already stage \`holy\`.

## Change
For each affected Dockerfile, mirror the existing pattern used by \`axum-kbve\`:
- Planner stage: \`COPY packages/rust/holy/Cargo.toml\` + stub \`src/lib.rs\` (or real \`src/\` for rows).
- Foundation/builder stages: \`COPY packages/rust/holy packages/rust/holy\`.
- \`cargo build\` \`-p\` lists include \`-p holy\`.
- \`rows\` workspace inline: add \`packages/rust/holy\` to members.

## Test plan
- [ ] CI green on \`Test Docker / discordsh-bot-e2e\`
- [ ] CI green on \`rows\` and \`axum-chuckrpg\` Docker builds
- [ ] No regression on \`axum-kbve\` / other already-working Dockerfiles