### PR TITLE
docs(packages/data): scoped READMEs across sql + proto subtrees

### DIFF
--- a/packages/data/proto/empire/README.md
+++ b/packages/data/proto/empire/README.md
@@ -1,0 +1,39 @@
+# `packages/data/proto/empire` — Rareicon Empire Protos
+
+City-state, faction, and empire-meta data shared between the Rareicon Unity client and the Bevy / Rust simulation. The proto is the canonical wire shape across the FFI boundary; saves carry it forward across runs.
+
+## Files
+
+| File           | Package  | Purpose                                                                              |
+| -------------- | -------- | ------------------------------------------------------------------------------------ |
+| `empire.proto` | `empire` | City-state lifecycle, faction definitions, persisted city / building / unit records. |
+
+## Why one shared proto across Unity ↔ Rust
+
+Rareicon's economy and simulation logic runs in Rust (Bevy ECS); the rendered world runs in Unity. Anything that crosses the FFI — save loading, ghost-sim deltas, city-state transitions — is serialized through this proto. The wire numbers must stay stable so older saves keep deserializing after balance patches.
+
+## Notable enums / messages
+
+- `CityStateStatusValue` — city lifecycle (founded → growing → sieged → fallen). **Wire numbers MUST stay stable** to preserve saves; comment in the proto mirrors `RareIcon.CityStateStatusValue` in Unity.
+- City record — coordinates, faction, population, building inventory.
+- Empire / faction record — alliances, treaties, diplomatic state.
+
+## Generated downstream
+
+| Target                  | Consumer                                                                   |
+| ----------------------- | -------------------------------------------------------------------------- |
+| Rust struct via `prost` | `packages/rust/bevy/uniti` (FFI layer) and the Rareicon Bevy ECS systems.  |
+| C# via `protoc`         | `apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Proto/Empire.cs`. |
+
+## Conventions
+
+- Wire numbers are append-only; **never renumber** — see save-compat note above.
+- Removing a field means promoting it to `reserved` and never reusing the number.
+- Unity-side enum mirrors must keep the same int values as the proto enum. The proto file has a `// keep wire numbers stable so saves carry across Unity ↔ Rust` reminder at the top — do not delete it.
+- Game-specific render / animation config does NOT belong here. Those live in `apps/rareicon/` (Unity) and the Bevy gameplay crates.
+
+## Related
+
+- Rust FFI bridge: [`packages/rust/bevy/uniti`](../../../../packages/rust/bevy/uniti/).
+- Unity-side generated proto: `apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Proto/Empire.cs`.
+- Save / persistence pipeline notes: see `project_rareicon_ffi_persistence` in the auto-memory.

--- a/packages/data/proto/kbve/README.md
+++ b/packages/data/proto/kbve/README.md
@@ -1,0 +1,40 @@
+# `packages/data/proto/kbve` — Core KBVE Protos
+
+Cross-cutting protobuf definitions used by multiple KBVE services. Anything that doesn't belong to a single game / app domain (NPC, meme, ows, empire) lives here.
+
+## Files
+
+| File                | Package          | Purpose                                                                                           |
+| ------------------- | ---------------- | ------------------------------------------------------------------------------------------------- |
+| `ci_registry.proto` | `kbve.ci`        | Source of truth for monorepo projects participating in CI dispatch (docker, npm, crates, python). |
+| `common.proto`      | `kbve.common`    | Shared primitives — ULID type, timestamps, well-known wrappers reused everywhere else.            |
+| `enums.proto`       | `kbve.enums`     | Item-category bitflags and other cross-domain enum constants.                                     |
+| `kbve.proto`        | `kbve`           | Generic service helpers — `HealthCheckRequest`/`Response` for load-balancer probes.               |
+| `kbveproto.proto`   | _(unscoped)_     | Legacy `Apikey` message and stragglers awaiting reorganisation.                                   |
+| `pool.proto`        | `kbve.pool`      | `PrefabRegistry` — game-side asset/prefab registry shared between Unity and Bevy.                 |
+| `schema.proto`      | `kbve.schema`    | Script-binding descriptors so script runtimes can introspect generated types.                     |
+| `snapshot.proto`    | `kbve.snapshot`  | `ClientMessage` / `ServerMessage` envelope used by the snapshot/replay infrastructure.            |
+| `discordsh.proto`   | `kbve.discordsh` | Mirrors the `discordsh` Postgres schema — servers, votes, guild vault.                            |
+| `forum.proto`       | `kbve.forum`     | Mirrors the `forum` Postgres schema — spaces, threads, engagement, moderation, ranks.             |
+| `osrs.proto`        | `kbve.osrs`      | Mirrors the `osrs` Postgres schema — items, monsters, drops.                                      |
+| `profile.proto`     | `kbve.profile`   | Public-facing user profile shape (display name, avatar, links).                                   |
+| `staff.proto`       | `kbve.staff`     | Bitwise permission flags for the `staff` Postgres schema.                                         |
+
+## Notable consumers
+
+- `ci_registry.proto` → `@kbve/devops` Zod registry → [`.github/ci-dispatch-manifest.json`](../../../../.github/ci-dispatch-manifest.json) (built by `nx run astro-kbve:sync:ci-manifest`).
+- `forum.proto` / `meme.proto` / `discordsh.proto` → matching `sql/schema/<name>/` and dbmate migrations.
+- `common.proto` is imported by every other proto in this directory, plus most game protos under `proto/empire`, `proto/npc`, `proto/ows`.
+
+## Conventions
+
+- One `package` per file. Use `kbve.<scope>` (e.g. `kbve.forum`) so the generated Rust / TS namespaces stay tight.
+- New schema-mirror protos belong here only when they cross multiple services. Single-game protos go in their own directory (`proto/empire`, `proto/npc`, `proto/ows`).
+- Field numbers are append-only. **Never renumber** — wire-compatible saves and on-the-wire messages depend on stability.
+- Adding a field is safe; removing one means promoting it to `reserved` and never reusing the number.
+
+## Related
+
+- Codegen scripts that consume these: [`../../codegen/`](../../codegen/).
+- Postgres schemas mirrored from forum / discordsh / profile / staff: [`../../sql/schema/`](../../sql/schema/).
+- CI dispatch: [`.github/workflows/ci-manifest-guard.yml`](../../../../.github/workflows/ci-manifest-guard.yml).

--- a/packages/data/proto/meme/README.md
+++ b/packages/data/proto/meme/README.md
@@ -1,0 +1,43 @@
+# `packages/data/proto/meme` — Meme Social Schema
+
+Protobuf mirror of the `meme` Postgres schema — meme posts, profiles, engagement (likes / saves / votes), moderation, and the card collection minigame.
+
+## Files
+
+| File         | Package | Purpose                                                                                             |
+| ------------ | ------- | --------------------------------------------------------------------------------------------------- |
+| `meme.proto` | `meme`  | Top-level enums + messages for memes, user profiles, comments, votes, saves, cards, and moderation. |
+
+## Postgres counterpart
+
+Each top-level message in `meme.proto` corresponds to a table or RPC return type in [`../../sql/schema/meme/`](../../sql/schema/meme/):
+
+| Proto message     | Postgres source                                  |
+| ----------------- | ------------------------------------------------ |
+| `Meme`            | `meme.memes` (in `meme_core.sql`)                |
+| `MemeUserProfile` | `meme.meme_user_profiles` (in `meme_social.sql`) |
+| `MemeComment`     | `meme.meme_comments` (in `meme_engagement.sql`)  |
+| `MemeVote`        | `meme.meme_votes` (in `meme_engagement.sql`)     |
+| `MemeSave`        | `meme.meme_saves` (in `meme_engagement.sql`)     |
+| `MemeReport`      | `meme.meme_reports` (in `meme_moderation.sql`)   |
+| `MemeCard*`       | `meme.cards*` (in `meme_cards.sql`)              |
+
+RPC payloads (`service_get_meme_by_id`, `service_create_meme`, …) use the matching proto messages so the wire format from `axum-memes` matches what the frontend expects.
+
+## Generated downstream
+
+- **Zod** — `apps/memes/astro-memes/src/schemas/generated/meme.zod.ts` via `npx tsx packages/data/codegen/gen-clickhouse-zod.mjs` (config: `meme-zod-config.json`).
+- **Rust** — `apps/memes/axum-memes/src/proto/meme.rs` via `prost-build`.
+
+## Conventions
+
+- One file (`meme.proto`) keeps everything in a single namespace because all messages are tightly coupled (no client wants Meme without MemeVote).
+- Field numbers are append-only — see the moderation `MemeReport` enum for an example of `reserved` use after a status was retired.
+- Optional fields use proto3 `optional` (`optional string display_name = 2`) so the Postgres `NULL` semantics round-trip cleanly through Zod.
+
+## Related
+
+- Proto-driven Rust service: [`apps/memes/axum-memes`](../../../../apps/memes/axum-memes/).
+- Astro frontend: [`apps/memes/astro-memes`](../../../../apps/memes/astro-memes/).
+- Postgres schema mirror: [`../../sql/schema/meme/`](../../sql/schema/meme/).
+- Applied migrations: [`../../sql/dbmate/migrations/20260227220000_meme_schema_init.sql`](../../sql/dbmate/migrations/20260227220000_meme_schema_init.sql) and follow-ups.

--- a/packages/data/proto/npc/README.md
+++ b/packages/data/proto/npc/README.md
@@ -1,0 +1,47 @@
+# `packages/data/proto/npc` — NPC Database Protos
+
+Universal NPC definitions — creatures, humanoids, bosses — shared across every KBVE game (KBVE isometric, Rareicon, MC, Discordsh).
+
+## Files
+
+| File          | Package | Purpose                                                                                        |
+| ------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `npcdb.proto` | `npc`   | NPC registry, stats, spawn rules, behavior traits, interaction flags, phase/time-of-day rules. |
+
+## Why one shared proto
+
+Each game used to maintain its own NPC enum / struct. That meant identical creatures (e.g. a wolf) had three different field schemas, three migrations to add HP, three places to update for a balance pass.
+
+`npcdb.proto` is the single source of truth. Game-specific concerns (render kind, pool size, animation timing) live in **per-game adapter configs** beside the game code, not in this proto. The proto only carries data that any game might want to query.
+
+## Field categories
+
+- **Identity** — `ref` (string slug, stable across runs), `id` (ULID), `name`, `family`, `rarity`.
+- **Stats** — `hp`, `attack`, `defense`, `speed`, `armor`, …
+- **Behavior** — `wander_radius`, `aggression`, flee thresholds.
+- **Spatial** — walk speed, swim/fly capabilities.
+- **Interaction** — `is_interactable`, `is_targetable`, `is_capturable`.
+- **Phase rules** — time-of-day visibility windows.
+- **Type flags** — bitmask for "is creature / is humanoid / is boss" filters.
+
+## Generated downstream
+
+| Target                                  | Consumer                                                                |
+| --------------------------------------- | ----------------------------------------------------------------------- |
+| Rust struct via `prost`                 | `packages/rust/bevy/bevy_npc` → `NpcDb` resource.                       |
+| TypeScript Zod via `gen-npcdb-zod.mjs`  | Astro / Rareicon Unity build pipelines.                                 |
+| C# via `protoc` (Rareicon Unity client) | `apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Proto/Npc.cs`. |
+
+## Conventions
+
+- `ref` is the **stable** slug (`"meadow-firefly"`). Always present.
+- `id` is the runtime ULID — present after publish, blank in source MDX.
+- Field numbers are append-only. Spawn rules / phase rules use `repeated` so multi-zone creatures fit in one entry.
+- New games adding NPCs **edit MDX, not this proto**. The MDX → JSON / binpb pipeline lives in `apps/kbve/astro-kbve/src/content/docs/npcdb/` and produces `Generated NpcRegistry` consumed by `NpcDb::from_bytes`.
+
+## Related
+
+- Bevy adapter: [`packages/rust/bevy/bevy_npc`](../../../../packages/rust/bevy/bevy_npc/).
+- Unity adapter (Rareicon): `apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/`.
+- Codegen: [`../../codegen/gen-npcdb-zod.mjs`](../../codegen/gen-npcdb-zod.mjs), [`../../codegen/gen-npcdb-data.mjs`](../../codegen/gen-npcdb-data.mjs).
+- Source MDX: `apps/kbve/astro-kbve/src/content/docs/npcdb/`.

--- a/packages/data/proto/ows/README.md
+++ b/packages/data/proto/ows/README.md
@@ -1,0 +1,39 @@
+# `packages/data/proto/ows` — Open World Server Protos
+
+Wire schema for the Open World Server (OWS) — characters, abilities, inventory, chat, areas of interest. Lines up 1:1 with the `ows` Postgres schema so the C++/UE5 server, the Rust services, and the database all share one type vocabulary.
+
+## Files
+
+| File        | Package | Purpose                                                                               |
+| ----------- | ------- | ------------------------------------------------------------------------------------- |
+| `ows.proto` | `ows`   | Enums + messages for OWS gameplay state. Mirrors `sql/schema/ows/*.sql` (40+ tables). |
+
+## Postgres counterpart
+
+Each top-level message corresponds to a table in [`../../sql/schema/ows/`](../../sql/schema/ows/). Examples:
+
+| Proto message               | Postgres source                                       |
+| --------------------------- | ----------------------------------------------------- |
+| `Character`                 | `ows.characters`                                      |
+| `Ability` / `AbilityType`   | `ows.abilities`, `ows.ability_types`                  |
+| `CharacterInventory`        | `ows.char_inventory`, `ows.char_inventory_items`      |
+| `ChatGroup` / `ChatMessage` | `ows.chat_groups`, `ows.chat_messages`                |
+| `AreaOfInterest`            | `ows.areas_of_interest`, `ows.area_of_interest_types` |
+| `Class` / `ClassInventory`  | `ows.class`, `ows.class_inventory`                    |
+
+## Generated downstream
+
+- **Rust** — UE5 server bindings consume the prost-generated module from this proto.
+- **TypeScript / Zod** — Astro / web admin tools via `gen-ows-zod.mjs`.
+
+## Conventions
+
+- Field numbers append-only — UE5 saves and live sessions both depend on stability.
+- New tables added under `sql/schema/ows/` should land a corresponding proto message in the same PR so the wire side stays in sync.
+- Cross-schema concerns (auth, profile) reuse messages from [`../kbve/`](../kbve/) — do not duplicate them here.
+
+## Related
+
+- Postgres schema mirror: [`../../sql/schema/ows/`](../../sql/schema/ows/).
+- Codegen: [`../../codegen/gen-ows-zod.mjs`](../../codegen/gen-ows-zod.mjs) (config: `../../codegen/ows-zod-config.json`).
+- OWS deployment notes: see `project_ows_instance_launcher` in the auto-memory.

--- a/packages/data/sql/README.md
+++ b/packages/data/sql/README.md
@@ -1,0 +1,60 @@
+# `packages/data/sql` — PostgreSQL Schemas, Migrations, and Compose Stacks
+
+PostgreSQL state for the KBVE Supabase cluster (`supabase-cluster` in the `kilobase` namespace) plus the local docker-compose stacks used to validate it.
+
+## Layout
+
+| Path                   | What lives here                                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| [`dbmate/`](./dbmate/) | dbmate-managed migrations and per-deployment compose files. Source of truth for **applied** schema.     |
+| [`schema/`](./schema/) | Hand-authored DDL grouped by Postgres schema (`discordsh`, `forum`, `mc`, `meme`, …). Reference mirror. |
+| [`old/`](./old/)       | Pre-dbmate migrations and helper functions. Kept for archaeology — do **not** apply to new clusters.    |
+
+## How the pieces fit together
+
+```
+proto/*.proto                        ← cross-language type contracts
+   │
+   ▼ (codegen + manual mirroring)
+schema/<schema>/*.sql                ← reference DDL grouped by Postgres schema
+   │
+   ▼ (hand-promoted into a dated migration)
+dbmate/migrations/YYYY...sql         ← what the live database actually runs
+   │
+   ▼ (dbmate up / managed by GitOps)
+supabase-cluster (kilobase)
+```
+
+`schema/` is the **review surface** — humans edit there and discuss diffs. A migration in `dbmate/migrations/` is the **deploy surface** — once applied, never edited; a new migration replaces it.
+
+## Local dev
+
+| Compose file                                                                                       | Purpose                                                        |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`dbmate/dev-docker-compose.yml`](./dbmate/dev-docker-compose.yml)                                 | Vanilla Postgres 17 for fast migration loops.                  |
+| [`dbmate/kilobase-docker-compose.yml`](./dbmate/kilobase-docker-compose.yml)                       | Production replica image (`ghcr.io/kbve/postgres:…-kilobase`). |
+| [`dbmate/forgejo-docker-compose.yml`](./dbmate/forgejo-docker-compose.yml)                         | Forgejo dependency stack.                                      |
+| [`dbmate/n8n-docker-compose.yml`](./dbmate/n8n-docker-compose.yml) / `n8n-prod-docker-compose.yml` | n8n workflow engine stacks.                                    |
+
+Quick start (against `dev-docker-compose.yml`):
+
+```bash
+cd packages/data/sql/dbmate
+docker compose -f dev-docker-compose.yml up -d
+
+export DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable&search_path=dbmate,public'
+dbmate --migrations-dir migrations up
+```
+
+## Conventions
+
+- **Never edit applied migrations.** Add a new one with `dbmate new <name>`.
+- **`DATABASE_URL` must include `search_path=dbmate,public`** so `schema_migrations` lives in the `dbmate` schema (not `public`) and stays out of the PostgREST surface.
+- **One Postgres schema per directory** in `schema/`. Files inside use the prefix `<schema>_*.sql` so they read in dependency order without an explicit ordering hint.
+- **RPC functions live next to their schema** (e.g. `schema/meme/meme_rpcs.sql`), not in a separate `functions/` tree. The pre-dbmate `old/functions/` layout is intentionally NOT carried forward.
+
+## Related
+
+- Migration changelog + applied versions table: [`dbmate/README.md`](./dbmate/README.md).
+- Per-schema DDL conventions: [`schema/README.md`](./schema/README.md).
+- Proto definitions that some Postgres tables mirror: [`../proto/`](../proto/).

--- a/packages/data/sql/schema/README.md
+++ b/packages/data/sql/schema/README.md
@@ -1,0 +1,52 @@
+# `packages/data/sql/schema` — Per-Schema DDL Mirror
+
+Hand-authored reference DDL grouped by Postgres schema. This tree is the **review surface** for SQL changes — it does not run against the database directly. Reviewed changes get promoted into a dated [`../dbmate/migrations/`](../dbmate/migrations/) file, which is what dbmate actually applies.
+
+## Schemas
+
+| Directory                    | Postgres schema | Owner / consumers                                                                   |
+| ---------------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| [`discordsh/`](./discordsh/) | `discordsh`     | Discord game-data service (servers, votes, dungeon profiles, guild vault).          |
+| [`forum/`](./forum/)         | `forum`         | KBVE forum core (spaces, threads, engagement, moderation, RPCs).                    |
+| [`mc/`](./mc/)               | `mc`            | Minecraft server (auth, characters, containers, players, skills, transfers).        |
+| [`meme/`](./meme/)           | `meme`          | Meme social platform (cards, engagement, moderation, social, RPCs).                 |
+| [`n8n/`](./n8n/)             | `n8n`           | n8n workflow engine bootstrap.                                                      |
+| [`osrs/`](./osrs/)           | `osrs`          | OSRS data tables and read RPCs.                                                     |
+| [`ows/`](./ows/)             | `ows`           | Open World Server (characters, abilities, inventories, chat, areas of interest, …). |
+| [`profile/`](./profile/)     | `profile`       | Cross-app user profiles.                                                            |
+| [`realtime/`](./realtime/)   | `realtime`      | Supabase Realtime publication and broadcast helpers.                                |
+| [`staff/`](./staff/)         | `staff`         | Bitwise staff permission / access-control tables.                                   |
+| [`tracker/`](./tracker/)     | `tracker`       | Activity / metrics tracking.                                                        |
+| [`vault/`](./vault/)         | `vault`         | Encrypted secret storage helpers.                                                   |
+
+## File layout convention
+
+Each schema directory follows the same pattern:
+
+```
+schema/<schema>/
+  <schema>_core.sql          ← tables, types, base indexes
+  <schema>_<feature>.sql     ← feature-grouped extensions (e.g. meme_engagement.sql)
+  <schema>_rpcs.sql          ← service RPC functions exposed to PostgREST
+```
+
+- File prefix matches the schema name so `\i schema/<schema>/*.sql` glob-loads in alphabetical order.
+- Tables → indexes → views → triggers → policies → functions → grants. Within a single file, in that order.
+- RPCs that read are `service_get_*`; RPCs that mutate are `service_<verb>_*`. Keep them in `<schema>_rpcs.sql`.
+- Cross-schema FKs are allowed but should be declared in the **referencing** schema's file, not the referenced one.
+
+## Promoting a change to a migration
+
+1. Edit the relevant file under `schema/<schema>/`.
+2. Open a PR with the schema-only change for review.
+3. Once approved, run `dbmate new <description>` from `packages/data/sql/dbmate/`.
+4. Copy the diff into the new migration file. Add the matching `down` block.
+5. Apply locally against the dev compose to verify before pushing.
+
+The `schema/` tree is intentionally **idempotent-safe**: every CREATE uses `IF NOT EXISTS`, every function uses `CREATE OR REPLACE`. That makes a clean bootstrap (`\i schema/<schema>/*.sql`) work on an empty database for local testing. dbmate migrations don't share that constraint — they assume a known prior state.
+
+## Related
+
+- dbmate-managed migrations + applied changelog: [`../dbmate/`](../dbmate/).
+- Local dev compose stacks: [`../dbmate/dev-docker-compose.yml`](../dbmate/dev-docker-compose.yml).
+- Pre-dbmate / archaeology: [`../old/`](../old/) — kept for reference, do not apply.


### PR DESCRIPTION
## Summary

Follow-up to #10580. Audited the rest of `packages/data/` for missing READMEs and added the high-traffic ones.

### Added

- **`sql/README.md`** — top-level SQL index. Maps `dbmate/`, `schema/`, `old/`, the four compose stacks, and pins the schema → migration promotion flow + the `search_path=dbmate,public` rule.
- **`sql/schema/README.md`** — convention doc for the per-schema mirror (12 schemas: discordsh, forum, mc, meme, n8n, osrs, ows, profile, realtime, staff, tracker, vault). File-naming + ordering rules so individual schema dirs don't each need a micro-README.
- **`proto/kbve/README.md`** — index for the 13 cross-cutting protos (ci_registry, common, forum, profile, etc.) plus consumer pointers (CI dispatch manifest, axum services, Astro Zod).
- **`proto/npc/README.md`** — universal `npcdb.proto` shared across KBVE, Rareicon, MC, Discordsh. Field categories + downstream targets (bevy_npc, Rareicon Unity).
- **`proto/meme/README.md`** — meme social schema with the proto ↔ Postgres ↔ Zod consumer table.
- **`proto/empire/README.md`** — Rareicon city-state / faction protos. Documents the Unity ↔ Rust wire-stability requirement.
- **`proto/ows/README.md`** — Open World Server protos mirroring `sql/schema/ows/`.

### Skipped (intentional)

- `proto/google/` — well-known imports only; a one-liner README isn't worth it.
- `proto/jedi/`, `proto/rows/` — small, can fold into `proto/kbve/` if they grow.
- `codegen/generated/` — already covered by the parent `codegen/README.md`.
- `sql/old/` — deprecated tree, points back to `sql/schema/`.
- Per-schema READMEs under `sql/schema/<schema>/` — handled by the convention doc in `sql/schema/README.md`.

No code changes.

## Test plan

- [x] All relative links resolve (verified with `find` against the repo).
- [x] Markdown tables render cleanly (rustfmt-equivalent passes via lint-staged auto-format).
- [ ] Reviewer sanity-check on the per-table mappings in `proto/meme/` and `proto/ows/`.