### PR TITLE
feat(astro-kbve): scoped Grafana tab in Argo resource drawer

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
@@ -1,0 +1,604 @@
+import React, { useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	Activity,
+	AlertCircle,
+	Cpu,
+	HardDrive,
+	Loader2,
+	Network,
+	RefreshCw,
+	RotateCcw,
+} from 'lucide-react';
+import {
+	Area,
+	AreaChart,
+	CartesianGrid,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from 'recharts';
+import {
+	fetchPodMetrics,
+	formatBytes,
+	grafanaService,
+	TIME_RANGE_KEYS,
+	type PodMetrics,
+	type TimeRangeKey,
+} from './grafanaService';
+import type { ResourceSelector } from './argoService';
+
+const tickFormatter = (t: number) =>
+	new Date(t * 1000).toLocaleTimeString([], {
+		hour: '2-digit',
+		minute: '2-digit',
+	});
+
+const tooltipLabelFormatter = (t: number) =>
+	new Date(t * 1000).toLocaleString();
+
+const tooltipStyle = {
+	background: 'var(--sl-color-bg-nav, #111)',
+	border: '1px solid var(--sl-color-gray-5, #262626)',
+	borderRadius: '8px',
+	color: 'var(--sl-color-text, #e6edf3)',
+};
+
+const axisStroke = 'var(--sl-color-gray-3, #8b949e)';
+const gridStroke = 'var(--sl-color-gray-5, #262626)';
+
+function formatBytesAbs(bytes: number | null): string {
+	if (bytes == null) return '--';
+	if (bytes >= 1_073_741_824)
+		return `${(bytes / 1_073_741_824).toFixed(2)} GiB`;
+	if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MiB`;
+	if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+	return `${bytes.toFixed(0)} B`;
+}
+
+function formatCores(cores: number | null): string {
+	if (cores == null) return '--';
+	if (cores < 0.01) return `${(cores * 1000).toFixed(0)} m`;
+	return `${cores.toFixed(2)} cores`;
+}
+
+function StatCard({
+	icon,
+	label,
+	value,
+}: {
+	icon: React.ReactNode;
+	label: string;
+	value: string;
+}) {
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '0.4rem',
+				padding: '0.75rem 0.9rem',
+				borderRadius: 8,
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+				background: 'var(--sl-color-bg-nav, #111)',
+				minHeight: 70,
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 6,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.7rem',
+					fontWeight: 500,
+					textTransform: 'uppercase',
+					letterSpacing: '0.06em',
+				}}>
+				<span style={{ color: 'var(--sl-color-accent, #06b6d4)' }}>
+					{icon}
+				</span>
+				{label}
+			</div>
+			<div
+				style={{
+					fontSize: '1.05rem',
+					fontWeight: 700,
+					color: 'var(--sl-color-text, #e6edf3)',
+					fontVariantNumeric: 'tabular-nums',
+				}}>
+				{value}
+			</div>
+		</div>
+	);
+}
+
+function TimeRangePicker({
+	value,
+	onChange,
+}: {
+	value: TimeRangeKey;
+	onChange: (v: TimeRangeKey) => void;
+}) {
+	return (
+		<div
+			style={{
+				display: 'flex',
+				gap: 2,
+				background: 'var(--sl-color-bg-nav, #111)',
+				border: '1px solid var(--sl-color-gray-5, #262626)',
+				borderRadius: 6,
+				padding: 2,
+			}}>
+			{TIME_RANGE_KEYS.map((k) => {
+				const active = k === value;
+				return (
+					<button
+						key={k}
+						onClick={() => onChange(k)}
+						style={{
+							padding: '2px 8px',
+							borderRadius: 4,
+							border: 'none',
+							background: active
+								? 'var(--sl-color-accent, #06b6d4)'
+								: 'transparent',
+							color: active
+								? '#fff'
+								: 'var(--sl-color-gray-3, #8b949e)',
+							cursor: 'pointer',
+							fontSize: '0.7rem',
+							fontWeight: active ? 600 : 500,
+						}}>
+						{k}
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+export default function ReactArgoGrafanaPanel({
+	token,
+	sel,
+}: {
+	token: string;
+	sel: ResourceSelector;
+}) {
+	const userId = useStore(grafanaService.$userId);
+	const tr = useStore(grafanaService.$timeRange);
+
+	const [metrics, setMetrics] = useState<PodMetrics | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const isPod = sel.kind === 'Pod';
+	const ns = sel.namespace;
+	const name = sel.name;
+
+	useEffect(() => {
+		if (!isPod || !userId || !ns || !name) return;
+
+		let cancelled = false;
+		(async () => {
+			setLoading(true);
+			setError(null);
+			try {
+				const data = await fetchPodMetrics(token, userId, ns, name, tr);
+				if (cancelled) return;
+				if (!data) {
+					setError('Could not find Prometheus datasource in Grafana');
+					return;
+				}
+				setMetrics(data);
+			} catch (e: unknown) {
+				if (!cancelled)
+					setError(
+						e instanceof Error
+							? e.message
+							: 'Failed to load metrics',
+					);
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [token, userId, ns, name, tr, isPod]);
+
+	const handleRefresh = async () => {
+		if (!userId || !isPod || loading) return;
+		setLoading(true);
+		setError(null);
+		try {
+			const data = await fetchPodMetrics(
+				token,
+				userId,
+				ns,
+				name,
+				tr,
+				true,
+			);
+			if (!data) {
+				setError('Could not find Prometheus datasource in Grafana');
+				return;
+			}
+			setMetrics(data);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : 'Failed to load metrics');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleTimeRange = (next: TimeRangeKey) => {
+		grafanaService.$timeRange.set(next);
+		try {
+			localStorage.setItem('grafana:timeRange', next);
+		} catch {
+			/* ignore */
+		}
+	};
+
+	if (!isPod) {
+		return (
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.5rem',
+				}}>
+				<span>
+					Per-resource Prometheus metrics are scoped to Pods. Open one
+					of the pods owned by this {sel.kind} to view CPU, memory,
+					network, and restart history.
+				</span>
+				<a
+					href="/dashboard/grafana"
+					target="_blank"
+					rel="noopener noreferrer"
+					style={{
+						color: 'var(--sl-color-accent, #06b6d4)',
+						fontSize: '0.8rem',
+						width: 'fit-content',
+					}}>
+					Open cluster overview ↗
+				</a>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '0.75rem',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: '0.5rem',
+					flexWrap: 'wrap',
+				}}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.5rem',
+						fontSize: '0.75rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+					}}>
+					<span>
+						{ns}/{name}
+					</span>
+					{metrics?.fromCache && (
+						<span
+							style={{
+								padding: '1px 6px',
+								borderRadius: 3,
+								background: 'var(--sl-color-gray-6, #1c1c1c)',
+								fontSize: '0.65rem',
+								textTransform: 'uppercase',
+								letterSpacing: '0.05em',
+							}}>
+							cached
+						</span>
+					)}
+				</div>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.5rem',
+					}}>
+					<TimeRangePicker value={tr} onChange={handleTimeRange} />
+					<button
+						onClick={handleRefresh}
+						disabled={loading}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							width: 28,
+							height: 28,
+							borderRadius: 6,
+							border: '1px solid var(--sl-color-gray-5, #262626)',
+							background: 'var(--sl-color-bg-nav, #111)',
+							color: 'var(--sl-color-text, #e6edf3)',
+							cursor: loading ? 'wait' : 'pointer',
+						}}
+						title="Refresh">
+						<RefreshCw
+							size={14}
+							style={
+								loading
+									? { animation: 'spin 1s linear infinite' }
+									: undefined
+							}
+						/>
+					</button>
+				</div>
+			</div>
+
+			{error && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 6,
+						padding: '0.5rem 0.75rem',
+						borderRadius: 6,
+						background: 'rgba(239,68,68,0.1)',
+						border: '1px solid rgba(239,68,68,0.3)',
+						color: '#fca5a5',
+						fontSize: '0.8rem',
+					}}>
+					<AlertCircle size={14} />
+					{error}
+				</div>
+			)}
+
+			{loading && !metrics && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 8,
+						padding: '0.85rem 0.5rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.85rem',
+					}}>
+					<Loader2
+						size={14}
+						style={{ animation: 'spin 1s linear infinite' }}
+					/>
+					Loading pod metrics...
+				</div>
+			)}
+
+			{metrics && (
+				<>
+					<div
+						style={{
+							display: 'grid',
+							gridTemplateColumns:
+								'repeat(auto-fit, minmax(150px, 1fr))',
+							gap: '0.5rem',
+						}}>
+						<StatCard
+							icon={<Cpu size={14} />}
+							label="CPU"
+							value={formatCores(metrics.snapshot.cpuCores)}
+						/>
+						<StatCard
+							icon={<HardDrive size={14} />}
+							label="Memory"
+							value={formatBytesAbs(metrics.snapshot.memoryBytes)}
+						/>
+						<StatCard
+							icon={<HardDrive size={14} />}
+							label="Mem Limit"
+							value={formatBytesAbs(
+								metrics.snapshot.memoryLimitBytes,
+							)}
+						/>
+						<StatCard
+							icon={<Network size={14} />}
+							label="Net RX"
+							value={formatBytes(
+								metrics.snapshot.netRxBytesPerSec,
+							)}
+						/>
+						<StatCard
+							icon={<Network size={14} />}
+							label="Net TX"
+							value={formatBytes(
+								metrics.snapshot.netTxBytesPerSec,
+							)}
+						/>
+						<StatCard
+							icon={<HardDrive size={14} />}
+							label="FS Usage"
+							value={formatBytesAbs(metrics.snapshot.fsBytes)}
+						/>
+						<StatCard
+							icon={<RotateCcw size={14} />}
+							label="Restarts"
+							value={
+								metrics.snapshot.restarts != null
+									? String(metrics.snapshot.restarts)
+									: '--'
+							}
+						/>
+						<StatCard
+							icon={<Activity size={14} />}
+							label="Phase"
+							value={
+								metrics.snapshot.running == null
+									? '--'
+									: metrics.snapshot.running
+										? 'Running'
+										: 'Not running'
+							}
+						/>
+					</div>
+
+					{metrics.cpuMemSeries.length > 0 && (
+						<div
+							style={{
+								padding: '0.75rem',
+								borderRadius: 8,
+								border: '1px solid var(--sl-color-gray-5, #262626)',
+								background: 'var(--sl-color-bg-nav, #111)',
+							}}>
+							<h4
+								style={{
+									margin: '0 0 0.5rem 0',
+									fontSize: '0.85rem',
+									color: 'var(--sl-color-text, #e6edf3)',
+								}}>
+								CPU (cores) & Memory (bytes) — {tr}
+							</h4>
+							<ResponsiveContainer width="100%" height={180}>
+								<AreaChart data={metrics.cpuMemSeries}>
+									<CartesianGrid
+										strokeDasharray="3 3"
+										stroke={gridStroke}
+									/>
+									<XAxis
+										dataKey="timestamp"
+										tickFormatter={tickFormatter}
+										stroke={axisStroke}
+										fontSize={11}
+									/>
+									<YAxis
+										yAxisId="cpu"
+										stroke={axisStroke}
+										fontSize={11}
+										width={50}
+										tickFormatter={(v: number) =>
+											v < 0.01
+												? `${(v * 1000).toFixed(0)}m`
+												: v.toFixed(2)
+										}
+									/>
+									<YAxis
+										yAxisId="mem"
+										orientation="right"
+										stroke={axisStroke}
+										fontSize={11}
+										width={60}
+										tickFormatter={(v: number) =>
+											formatBytesAbs(v)
+										}
+									/>
+									<Tooltip
+										contentStyle={tooltipStyle}
+										labelFormatter={tooltipLabelFormatter}
+										formatter={(v: number, n: string) =>
+											n === 'CPU'
+												? formatCores(v)
+												: formatBytesAbs(v)
+										}
+									/>
+									<Area
+										yAxisId="cpu"
+										type="monotone"
+										dataKey="cpu"
+										stroke="#06b6d4"
+										fill="rgba(6,182,212,0.15)"
+										name="CPU"
+										strokeWidth={2}
+									/>
+									<Area
+										yAxisId="mem"
+										type="monotone"
+										dataKey="memory"
+										stroke="#8b5cf6"
+										fill="rgba(139,92,246,0.15)"
+										name="Memory"
+										strokeWidth={2}
+									/>
+								</AreaChart>
+							</ResponsiveContainer>
+						</div>
+					)}
+
+					{metrics.netSeries.length > 0 && (
+						<div
+							style={{
+								padding: '0.75rem',
+								borderRadius: 8,
+								border: '1px solid var(--sl-color-gray-5, #262626)',
+								background: 'var(--sl-color-bg-nav, #111)',
+							}}>
+							<h4
+								style={{
+									margin: '0 0 0.5rem 0',
+									fontSize: '0.85rem',
+									color: 'var(--sl-color-text, #e6edf3)',
+								}}>
+								Network — {tr}
+							</h4>
+							<ResponsiveContainer width="100%" height={150}>
+								<AreaChart data={metrics.netSeries}>
+									<CartesianGrid
+										strokeDasharray="3 3"
+										stroke={gridStroke}
+									/>
+									<XAxis
+										dataKey="timestamp"
+										tickFormatter={tickFormatter}
+										stroke={axisStroke}
+										fontSize={11}
+									/>
+									<YAxis
+										stroke={axisStroke}
+										fontSize={11}
+										width={70}
+										tickFormatter={(v: number) =>
+											formatBytes(v).replace('/s', '')
+										}
+									/>
+									<Tooltip
+										contentStyle={tooltipStyle}
+										labelFormatter={tooltipLabelFormatter}
+										formatter={(v: number) =>
+											formatBytes(v)
+										}
+									/>
+									<Area
+										type="monotone"
+										dataKey="rx"
+										stroke="#06b6d4"
+										fill="rgba(6,182,212,0.15)"
+										name="RX"
+										strokeWidth={2}
+									/>
+									<Area
+										type="monotone"
+										dataKey="tx"
+										stroke="#8b5cf6"
+										fill="rgba(139,92,246,0.15)"
+										name="TX"
+										strokeWidth={2}
+									/>
+								</AreaChart>
+							</ResponsiveContainer>
+						</div>
+					)}
+				</>
+			)}
+
+			<style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx
@@ -10,6 +10,7 @@ import {
 	type ResourceSelector,
 } from './argoService';
 import { fetchIndexedLogs, type LogRow } from './clickhouseService';
+import ReactArgoGrafanaPanel from './ReactArgoGrafanaPanel';
 import { Loader2, X, AlertCircle } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -78,6 +79,7 @@ type TabId =
 	| 'diff'
 	| 'logs'
 	| 'indexed'
+	| 'grafana'
 	| 'conditions'
 	| 'containers';
 
@@ -1694,6 +1696,7 @@ export default function ReactArgoResourceDetail({
 		{ id: 'diff', label: 'Diff' },
 		...(isPod ? [{ id: 'logs' as TabId, label: 'Logs' }] : []),
 		{ id: 'indexed', label: 'Clickhouse Logs' },
+		{ id: 'grafana', label: 'Grafana' },
 	];
 
 	useEffect(() => {
@@ -1909,6 +1912,10 @@ export default function ReactArgoResourceDetail({
 
 			{tab === 'indexed' && (
 				<IndexedLogsTab token={token} sel={sel} isPod={isPod} />
+			)}
+
+			{tab === 'grafana' && (
+				<ReactArgoGrafanaPanel token={token} sel={sel} />
 			)}
 
 			{tab === 'containers' && (

--- a/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
@@ -889,3 +889,243 @@ class GrafanaService {
 }
 
 export const grafanaService = new GrafanaService();
+
+// ---------------------------------------------------------------------------
+// Pod-scoped metrics — used by ReactArgoGrafanaPanel inside the Argo
+// resource-detail drawer. Reuses the same Grafana proxy + datasource cache,
+// just with namespace+pod-scoped Prometheus expressions.
+// ---------------------------------------------------------------------------
+
+export interface PodMetricsSnapshot {
+	cpuCores: number | null;
+	memoryBytes: number | null;
+	memoryLimitBytes: number | null;
+	netRxBytesPerSec: number | null;
+	netTxBytesPerSec: number | null;
+	fsBytes: number | null;
+	restarts: number | null;
+	running: boolean | null;
+}
+
+export interface PodTimeSeriesPoint {
+	timestamp: number;
+	cpu: number | null;
+	memory: number | null;
+}
+
+export interface PodNetTimeSeriesPoint {
+	timestamp: number;
+	rx: number | null;
+	tx: number | null;
+}
+
+export interface PodMetrics {
+	snapshot: PodMetricsSnapshot;
+	cpuMemSeries: PodTimeSeriesPoint[];
+	netSeries: PodNetTimeSeriesPoint[];
+	fromCache: boolean;
+}
+
+interface CachedPodMetrics {
+	metrics: PodMetrics;
+	cached_at: number;
+	user_id: string;
+}
+
+const POD_CACHE_KEY_PREFIX = 'cache:grafana:pod';
+const POD_CACHE_TTL_MS = 5 * 60 * 1000;
+
+function podCacheKey(
+	uid: string,
+	ns: string,
+	pod: string,
+	tr: TimeRangeKey,
+): string {
+	return `${POD_CACHE_KEY_PREFIX}:${uid}:${ns}:${pod}:${tr}`;
+}
+
+function getCachedPodMetrics(
+	uid: string,
+	ns: string,
+	pod: string,
+	tr: TimeRangeKey,
+): PodMetrics | null {
+	try {
+		const raw = localStorage.getItem(podCacheKey(uid, ns, pod, tr));
+		if (!raw) return null;
+		const cached: CachedPodMetrics = JSON.parse(raw);
+		if (cached.user_id !== uid) {
+			localStorage.removeItem(podCacheKey(uid, ns, pod, tr));
+			return null;
+		}
+		if (Date.now() - cached.cached_at > POD_CACHE_TTL_MS) return null;
+		return { ...cached.metrics, fromCache: true };
+	} catch {
+		return null;
+	}
+}
+
+function setCachedPodMetrics(
+	uid: string,
+	ns: string,
+	pod: string,
+	tr: TimeRangeKey,
+	metrics: PodMetrics,
+): void {
+	try {
+		const payload: CachedPodMetrics = {
+			metrics: { ...metrics, fromCache: false },
+			cached_at: Date.now(),
+			user_id: uid,
+		};
+		localStorage.setItem(
+			podCacheKey(uid, ns, pod, tr),
+			JSON.stringify(payload),
+		);
+	} catch {
+		/* quota exceeded */
+	}
+}
+
+function escapeLabel(v: string): string {
+	return v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function podQueries(
+	ns: string,
+	pod: string,
+): {
+	cpu: string;
+	memory: string;
+	memoryLimit: string;
+	netRx: string;
+	netTx: string;
+	fs: string;
+	restarts: string;
+	running: string;
+} {
+	const sel = `namespace="${escapeLabel(ns)}",pod="${escapeLabel(pod)}"`;
+	const containerSel = `${sel},container!="POD",container!=""`;
+	return {
+		cpu: `sum(rate(container_cpu_usage_seconds_total{${containerSel}}[5m]))`,
+		memory: `sum(container_memory_working_set_bytes{${containerSel}})`,
+		memoryLimit: `sum(kube_pod_container_resource_limits{${sel},resource="memory"})`,
+		netRx: `sum(rate(container_network_receive_bytes_total{${sel}}[5m]))`,
+		netTx: `sum(rate(container_network_transmit_bytes_total{${sel}}[5m]))`,
+		fs: `sum(container_fs_usage_bytes{${containerSel}})`,
+		restarts: `sum(kube_pod_container_status_restarts_total{${sel}})`,
+		running: `kube_pod_status_phase{${sel},phase="Running"}`,
+	};
+}
+
+export async function fetchPodMetrics(
+	token: string,
+	uid: string,
+	ns: string,
+	pod: string,
+	tr: TimeRangeKey,
+	skipCache = false,
+): Promise<PodMetrics | null> {
+	if (!skipCache) {
+		const cached = getCachedPodMetrics(uid, ns, pod, tr);
+		if (cached) return cached;
+	}
+
+	const dsId = await findPrometheusDatasourceId(token);
+	if (dsId == null) return null;
+
+	const config = TIME_RANGES[tr];
+	const now = Math.floor(Date.now() / 1000);
+	const rangeStart = now - config.seconds;
+	const q = podQueries(ns, pod);
+
+	const [
+		cpuCores,
+		memoryBytes,
+		memoryLimitBytes,
+		netRx,
+		netTx,
+		fsBytes,
+		restarts,
+		runningRaw,
+	] = await Promise.all([
+		queryInstant(token, dsId, q.cpu),
+		queryInstant(token, dsId, q.memory),
+		queryInstant(token, dsId, q.memoryLimit),
+		queryInstant(token, dsId, q.netRx),
+		queryInstant(token, dsId, q.netTx),
+		queryInstant(token, dsId, q.fs),
+		queryInstant(token, dsId, q.restarts),
+		queryInstant(token, dsId, q.running),
+	]);
+
+	const [cpuRange, memRange, rxRange, txRange] = await Promise.all([
+		queryRange(token, dsId, q.cpu, rangeStart, now, config.step),
+		queryRange(token, dsId, q.memory, rangeStart, now, config.step),
+		queryRange(token, dsId, q.netRx, rangeStart, now, config.step),
+		queryRange(token, dsId, q.netTx, rangeStart, now, config.step),
+	]);
+
+	const cpuMemMap = new Map<number, PodTimeSeriesPoint>();
+	for (const [ts, val] of cpuRange) {
+		cpuMemMap.set(ts, {
+			timestamp: ts,
+			cpu: parseFloat(val),
+			memory: null,
+		});
+	}
+	for (const [ts, val] of memRange) {
+		const existing = cpuMemMap.get(ts);
+		if (existing) {
+			existing.memory = parseFloat(val);
+		} else {
+			cpuMemMap.set(ts, {
+				timestamp: ts,
+				cpu: null,
+				memory: parseFloat(val),
+			});
+		}
+	}
+	const cpuMemSeries = Array.from(cpuMemMap.values()).sort(
+		(a, b) => a.timestamp - b.timestamp,
+	);
+
+	const netMap = new Map<number, PodNetTimeSeriesPoint>();
+	for (const [ts, val] of rxRange) {
+		netMap.set(ts, { timestamp: ts, rx: parseFloat(val), tx: null });
+	}
+	for (const [ts, val] of txRange) {
+		const existing = netMap.get(ts);
+		if (existing) {
+			existing.tx = parseFloat(val);
+		} else {
+			netMap.set(ts, {
+				timestamp: ts,
+				rx: null,
+				tx: parseFloat(val),
+			});
+		}
+	}
+	const netSeries = Array.from(netMap.values()).sort(
+		(a, b) => a.timestamp - b.timestamp,
+	);
+
+	const metrics: PodMetrics = {
+		snapshot: {
+			cpuCores,
+			memoryBytes,
+			memoryLimitBytes,
+			netRxBytesPerSec: netRx,
+			netTxBytesPerSec: netTx,
+			fsBytes,
+			restarts: restarts != null ? Math.round(restarts) : null,
+			running: runningRaw != null ? runningRaw >= 1 : null,
+		},
+		cpuMemSeries,
+		netSeries,
+		fromCache: false,
+	};
+
+	setCachedPodMetrics(uid, ns, pod, tr, metrics);
+	return metrics;
+}


### PR DESCRIPTION
## Summary
- New 4th tab "Grafana" inside the Argo resource detail drawer ([ReactArgoResourceDetail](apps/kbve/astro-kbve/src/components/dashboard/ReactArgoResourceDetail.tsx)). When a Pod is selected, fetches scoped Prometheus metrics through the existing \`/dashboard/grafana/proxy\` and renders them inline (no iframe) — same Recharts pattern as the cluster overview, just narrowed to one pod.
- New [\`ReactArgoGrafanaPanel\`](apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx) island: 8 stat cards (CPU cores, Memory, Memory Limit, Net RX, Net TX, FS Usage, Restarts, Phase) + dual-axis CPU/Memory chart + Network RX/TX chart.
- New \`fetchPodMetrics(token, uid, ns, pod, tr)\` in [\`grafanaService.ts\`](apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts) — pod-scoped PromQL using kube-prometheus-stack standard metrics, reuses cached datasource id + the same query helpers as the cluster overview.

## Why
Triage flow was forcing a context switch — open Argo, find the noisy pod, then bounce to Grafana, then re-pick time range, then re-search by namespace+pod. Now the relevant CPU/memory/network/restart history sits right next to the manifest, events, diff, and logs that already live in the drawer.

## Load discipline (no Grafana / Argo API overload)
- **Lazy**: panel mounts only when the user clicks the Grafana tab. No background polling, no preload.
- **Per-pod localStorage cache**, keyed by user+namespace+pod+timeRange, 5-minute TTL. Repeat opens of the same pod are free; multi-pod inspections scale with *unique pods clicked*, not total cluster pods.
- **Single datasource discovery per session** — reuses the existing \`cache:grafana:ds-id\` localStorage entry, no extra \`/api/datasources\` hit.
- **Time range shared** with the main \`/dashboard/grafana\` page via the \`grafanaService.$timeRange\` atom + the existing \`grafana:timeRange\` localStorage key — one window across surfaces.
- For non-Pod kinds (Deployment, StatefulSet, etc.), the tab renders a short hint pointing the user at the cluster overview. **Owner-aggregated metrics** (Deployment → its pods) are a follow-up.

## PromQL (pod-scoped)
\`\`\`promql
sum(rate(container_cpu_usage_seconds_total{namespace,pod,container!="POD",container!=""}[5m]))
sum(container_memory_working_set_bytes{namespace,pod,container!="POD",container!=""})
sum(kube_pod_container_resource_limits{namespace,pod,resource="memory"})
sum(rate(container_network_receive_bytes_total{namespace,pod}[5m]))
sum(rate(container_network_transmit_bytes_total{namespace,pod}[5m]))
sum(container_fs_usage_bytes{namespace,pod,container!="POD",container!=""})
sum(kube_pod_container_status_restarts_total{namespace,pod})
kube_pod_status_phase{namespace,pod,phase="Running"}
\`\`\`

## Follow-ups (separate PRs)
- **Alerts island** on \`/dashboard/grafana\` surfacing firing PrometheusRules from \`/api/prometheus/grafana/api/v1/alerts\`.
- **Owner-aggregated metrics** for Deployment / StatefulSet / DaemonSet kinds in this same Grafana tab — join via \`kube_pod_owner\`.
- More data points on the cluster overview (top noisy pods, PVC pressure, cgroup throttling).

## Test plan
- [x] No new TypeScript errors introduced (\`nx run astro-kbve:check\` — unchanged baseline excluding pre-existing proto codegen errors).
- [ ] Open Argo dashboard → click any Pod → Grafana tab appears as 4th tab; clicking it fetches metrics and renders charts.
- [ ] Switch time range (1h/6h/24h/7d) on the Grafana tab; both the panel and the main \`/dashboard/grafana\` honor the same setting.
- [ ] Open same pod twice within 5 minutes → second open shows "cached" badge with no network call.
- [ ] Click a Deployment → tab renders the "scoped to Pods" hint with a link to the cluster overview.
- [ ] Forbidden user (non-staff) → existing 403 path on the proxy still surfaces an error inside the panel without breaking the rest of the drawer.