### PR TITLE
fix(axum-kbve): copy packages/data/openapi/ in Dockerfile astro stage

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -29,6 +29,12 @@ COPY packages/npm/laser/ packages/npm/laser/
 # Copy generated schemas used by astro-kbve content collections
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 
+# Copy on-disk OpenAPI spec consumed by astro-kbve at build time.
+# src/pages/llms.txt.ts imports packages/data/openapi/openapi.json so
+# /llms.txt is generated from the same utoipa-emitted spec the live
+# API serves at /api/openapi.json.
+COPY packages/data/openapi/ packages/data/openapi/
+
 # Crate READMEs imported by astro-kbve project pages (e.g.
 # /project/holy-crate uses `import { Content } from '...README.md'`
 # so the crate doc and the kbve.com page stay in sync from one file).


### PR DESCRIPTION
Closes #10595.

## Root cause
PR #10590 (openapi pipeline) added an import in [\`llms.txt.ts:21\`](apps/kbve/astro-kbve/src/pages/llms.txt.ts#L21) that pulls the on-disk spec at \`packages/data/openapi/openapi.json\` so \`/llms.txt\` is generated from the same utoipa-emitted spec the live API serves at \`/api/openapi.json\`. The \`astro-builder\` stage of [\`apps/kbve/axum-kbve/Dockerfile\`](apps/kbve/axum-kbve/Dockerfile) only \`COPY\`s \`packages/npm/*\` and \`packages/data/codegen/\` into the build context, so Vite's resolver fails:

\`\`\`
Could not resolve "../../../../../packages/data/openapi/openapi.json"
  from "src/pages/llms.txt.ts"
\`\`\`

Every Docker build of \`axum-kbve\` died in the astro stage, which killed the \`axum-kbve-e2e\` job under \`CI - Docker\` (run [#25528717474](https://github.com/KBVE/kbve/actions/runs/25528717474)).

## Fix
Add an explicit \`COPY packages/data/openapi/ packages/data/openapi/\` alongside the existing \`packages/data/codegen/generated/\` copy. The directory is ~36 KiB JSON + a README, so layer cost is negligible. The file is committed to git so the Docker build context always has it.

## Test plan
- [ ] Re-run \`CI - Docker / axum-kbve\` — astro builder reaches the build step without the Vite resolver error
- [ ] \`/llms.txt\` in the resulting image lists all endpoints from \`packages/data/openapi/openapi.json\`
- [ ] Existing astro-kbve docs page builds (no regression on other COPY targets)