### PR TITLE
fix(firecracker): match shared publish workflow contract (load to daemon)

### DIFF
--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -17,8 +17,7 @@
 				"local": {},
 				"production": {
 					"commands": [
-						"npx nx run firecracker-python-net:containerx:production",
-						"VERSION=$(grep -m1 'version' packages/docker/firecracker/python/net/version.toml | sed 's/.*\"\\(.*\\)\\\"/\\1/') && docker buildx imagetools create --tag ghcr.io/kbve/firecracker-python-net:${VERSION} ghcr.io/kbve/firecracker-python-net:latest && echo \"Published ghcr.io/kbve/firecracker-python-net:${VERSION}\""
+						"npx nx run firecracker-python-net:containerx:production"
 					]
 				}
 			}
@@ -40,8 +39,8 @@
 				},
 				"production": {
 					"tags": ["ghcr.io/kbve/firecracker-python-net:latest"],
-					"load": false,
-					"push": true,
+					"load": true,
+					"push": false,
 					"cache-to": [
 						"type=registry,ref=ghcr.io/kbve/firecracker-python-net:buildcache,mode=max"
 					]


### PR DESCRIPTION
## Summary

Run [#25528718646](https://github.com/KBVE/kbve/actions/runs/25528718646) actually pushed \`:latest\` and \`:0.0.1\` to GHCR via the explicit imagetools step. But then the shared \`utils-publish-docker-image.yml\`'s **Push Docker Images** step failed with:

\`\`\`
##[error]No images found matching 'kbve/firecracker-python-net'. Listing all images:
REPOSITORY          TAG               IMAGE ID       CREATED        SIZE
moby/buildkit       buildx-stable-1   e03746490b61   5 weeks ago    241MB
tonistiigi/binfmt   latest            fb4f8f43716f   2 months ago   85.1MB
\`\`\`

The shared workflow expects the build to populate the **local docker daemon** (\`load=true\` semantics), then it \`docker tag\` + \`docker push\` to both GHCR and Docker Hub. Our production config used \`push=true\`, so the image went straight to the registry and the daemon stayed empty — the shared step had nothing to push.

This is the same model \`chisel-ubuntu-axum\` uses: load to daemon, let the shared workflow handle the registry push and the version bump.

## Fix

- Set \`load: true, push: false\` on the production configuration so the daemon gets the image.
- Drop the explicit \`imagetools create\` step from the container target's production chain. The shared workflow already pushes both \`:version\` and \`:latest\` to GHCR + Docker Hub from the daemon image.

### Side benefit

The dropped \`imagetools\` step was reading the version from \`version.toml\` (sentinel \`0.0.1\`) and would have tagged \`:0.0.1\` instead of \`:0.1.0\`. The shared workflow uses \`version_check\`'s output, which reads from the MDX (\`version: \"0.1.0\"\`), so the published version comes out correct after this change.

## Test plan

- [ ] After merge, \`CI - Docker / firecracker-python-net\` should publish both \`ghcr.io/kbve/firecracker-python-net:0.1.0\` and \`:latest\`.
- [ ] Mirror to \`docker.io/kbve/firecracker-python-net:0.1.0\` + \`:latest\`.
- [ ] Post-publish bumps \`version.toml\` from \`0.0.1\` → \`0.1.0\`.