### PR TITLE
feat(memes): harden Deployment + Reloader-driven secret rotation

### DIFF
--- a/apps/kube/memes/README.md
+++ b/apps/kube/memes/README.md
@@ -1,0 +1,40 @@
+# memes — Kubernetes Deployment
+
+Single-Deployment axum service for the meme content surface. Routes through both the Cilium `kbve-gateway` (HTTPRoute) and the legacy nginx Ingress for `letsencrypt-http` cert minting.
+
+## Manifests
+
+| File                                 | Purpose                                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `application.yaml`                   | ArgoCD `Application` pointing at `apps/kube/memes/manifest`                                      |
+| `manifest/kustomization.yaml`        | Kustomize index                                                                                  |
+| `manifest/memes-serviceaccount.yaml` | `memes-external-secrets` (used by ExternalSecrets) + `memes-sa` (used by the pod)                |
+| `manifest/memes-externalsecret.yaml` | SecretStore + ExternalSecret rendering `supabase-shared` from kilobase                           |
+| `manifest/memes-deployment.yaml`     | `memes-deployment` (axum) + `memes-service` (ClusterIP)                                          |
+| `manifest/httproute.yaml`            | HTTPRoute attaching the service to `kbve-gateway`                                                |
+| `manifest/nginx-ingress.yaml`        | Legacy nginx Ingress — kept active because cert-manager's ingress-shim mints `memes-tls` from it |
+
+## Hardening
+
+The Deployment runs under a restricted PodSecurity profile:
+
+- `runAsNonRoot: true`, UID/GID `10001` (matches the binary owner set by `--chown=10001:10001` in `apps/memes/axum-memes/Dockerfile`)
+- `readOnlyRootFilesystem: true` with a 64Mi `emptyDir` mounted at `/tmp` for scratch
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- Dedicated `memes-sa` ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod level. The pod no longer rides on the `default` SA. The existing `memes-external-secrets` SA is unchanged — it is the credential ExternalSecrets uses to read source secrets out of `kilobase` and is not the pod SA.
+- CPU/memory `requests` and `limits` set so the kubelet enforces a cgroup; bursts cap at `2 CPU / 1 GiB`.
+
+## Reloader integration
+
+The Deployment carries `reloader.stakater.com/auto: "true"`. Stakater Reloader rolls the workload whenever `supabase-shared` rotates — the ExternalSecret refreshes that Secret hourly from the kilobase JWT/db source. The pod template also keeps a static `rollout-restart` annotation so a manual rollout can still be forced by bumping the timestamp if Reloader ever misses an event.
+
+## TLS
+
+cert-manager mints `memes-tls` via the active `nginx-ingress.yaml` (annotated with `cert-manager.io/cluster-issuer: letsencrypt-http`); the Ingress is in the kustomization so the ingress-shim sees it and creates the `Certificate` automatically. No explicit `Certificate` resource is required for this namespace today, unlike chuckrpg / herbmail / cryptothrone where the Ingress was checked in but never listed in kustomization.
+
+## ArgoCD
+
+- App: `memes` (source: `apps/kube/memes/manifest`)
+- Sync: automated with prune + selfHeal
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/memes/manifest/memes-deployment.yaml
+++ b/apps/kube/memes/manifest/memes-deployment.yaml
@@ -5,6 +5,12 @@ metadata:
     namespace: memes
     labels:
         app: memes
+    annotations:
+        # Reloader rolls this Deployment whenever supabase-shared
+        # rotates (rendered hourly by memes-supabase-secrets
+        # ExternalSecret) — Supabase JWT/key rotations propagate
+        # without a manual kubectl rollout restart.
+        reloader.stakater.com/auto: 'true'
 spec:
     replicas: 1
     selector:
@@ -13,11 +19,24 @@ spec:
     template:
         metadata:
             annotations:
+                # Manual rollout-restart trigger preserved as a fallback
+                # if Reloader misses a Secret rotation — bump the value
+                # to force the Deployment controller to roll the pods.
                 rollout-restart: '2026-04-03T22:25:16Z'
             labels:
                 app: memes
                 version: '0.1.8'
         spec:
+            serviceAccountName: memes-sa
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                fsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: memes
                   image: ghcr.io/kbve/memes:0.1.8
@@ -47,6 +66,21 @@ spec:
                       limits:
                           memory: '1024Mi'
                           cpu: '2000m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+            volumes:
+                # Writable scratch for the axum binary while the
+                # rootfs itself stays read-only.
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 64Mi
 ---
 apiVersion: v1
 kind: Service

--- a/apps/kube/memes/manifest/memes-serviceaccount.yaml
+++ b/apps/kube/memes/manifest/memes-serviceaccount.yaml
@@ -1,5 +1,19 @@
+# ServiceAccount used by ExternalSecrets to read source secrets out of
+# the kilobase namespace via the kilobase-remote-secret-store
+# SecretStore. Bound by Roles in apps/kube/kilobase manifests.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: memes-external-secrets
-  namespace: memes
+    name: memes-external-secrets
+    namespace: memes
+---
+# ServiceAccount used by the memes Deployment pod. The pod does not
+# call the kube API, so the projected token is unused weight — disable
+# it here at the SA level. The pod spec re-states the field so any
+# future template binding the SA inherits the safe default.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: memes-sa
+    namespace: memes
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

- `memes-deployment` now runs under a restricted PSA profile mirroring chuckrpg (#10547), discordsh (#10568), herbmail (#10582), and cryptothrone (#10597): `runAsNonRoot: true` UID/GID `10001` (matches `--chown=10001:10001` in `apps/memes/axum-memes/Dockerfile`; same `chisel-ubuntu-axum` runtime base), `readOnlyRootFilesystem: true` with a 64Mi `/tmp` emptyDir, `allowPrivilegeEscalation: false`, all Linux capabilities dropped, `seccompProfile: RuntimeDefault`.
- New dedicated `memes-sa` ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod level. The pod no longer rides on the `default` SA. The existing `memes-external-secrets` SA is unchanged — it is the credential ExternalSecrets uses against kilobase, not the pod SA.
- Adds `reloader.stakater.com/auto: "true"` so the hourly `supabase-shared` rotation rolls the pod automatically. The existing `rollout-restart` pod-template annotation is preserved as a manual fallback (belt-and-suspenders alongside Reloader).
- New `apps/kube/memes/README.md` documents topology, hardening posture, and the Reloader / cert flows.

## TLS — left alone on purpose

cert-manager's ingress-shim is actively minting `memes-tls` from the in-kustomization `nginx-ingress.yaml` (Certificate `Ready`, not stranded). Unlike chuckrpg / herbmail / cryptothrone where the Ingress was checked in but never listed in kustomization (which caused the orphan-Secret failure mode), memes' cert flow has been working continuously. Migrating to the explicit `Certificate` + `ReferenceGrant` pair would be churn for no benefit — leaving it as-is.

## Hardening pattern by namespace so far

| ns           | manifest type | Reloader | non-root  | readOnly rootfs | caps drop | SA token off |
| ------------ | ------------- | -------- | --------- | --------------- | --------- | ------------ |
| chuckrpg     | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| redis        | Bitnami chart | yes      | chart     | chart           | chart     | chart        |
| n8n          | raw           | yes      | UID 1000  | deferred        | yes       | yes          |
| discordsh    | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| herbmail     | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| cryptothrone | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| memes        | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |

## Test plan

- [ ] ArgoCD `memes` Application syncs cleanly after dev → main promotion.
- [ ] `kubectl -n memes get pod -l app=memes` shows the pod `Running` under SA `memes-sa`, `runAsUser: 10001`, `readOnlyRootFilesystem: true`.
- [ ] `kubectl -n memes get deploy memes-deployment -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}'` returns `"true"`.
- [ ] `kubectl -n memes get certificate memes-tls -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` keeps returning `True` (no regression in the existing cert flow).
- [ ] The memes hostname keeps responding 200 through the gateway during and after rollout.
- [ ] Trigger a no-op rotation on `supabase-shared` (or wait for the hourly ExternalSecret refresh) and observe Reloader rolling the Deployment.