### PR TITLE
fix(ci): rebuild isometric WASM on shared bevy_* crate changes

### DIFF
--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -344,6 +344,21 @@ jobs:
                           - 'apps/kbve/isometric/src-tauri/tauri.conf.json'
                           - 'apps/kbve/isometric/package.json'
                           - 'apps/kbve/isometric/vite.config.ts'
+                          # Shared Rust crates (path = ... in src-tauri/Cargo.toml).
+                          # Any change here MUST rebuild the WASM client otherwise
+                          # the lightyear ProtocolPlugin registry hashes drift
+                          # from the gameserver and the protocol-check observer
+                          # panics on connect ("the message protocol doesn't match").
+                          - 'packages/rust/bevy/bevy_behavior/**'
+                          - 'packages/rust/bevy/bevy_cam/**'
+                          - 'packages/rust/bevy/bevy_chat/**'
+                          - 'packages/rust/bevy/bevy_db/**'
+                          - 'packages/rust/bevy/bevy_inventory/**'
+                          - 'packages/rust/bevy/bevy_items/**'
+                          - 'packages/rust/bevy/bevy_kbve_net/**'
+                          - 'packages/rust/bevy/bevy_npc/**'
+                          - 'packages/rust/bevy/bevy_pathfinder/**'
+                          - 'packages/rust/bevy/bevy_skills/**'
                           - 'packages/rust/bevy/bevy_tasker/**'
                       ue_devops:
                           - 'packages/unreal/UEDevOps/Source/**'

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -1,3 +1,10 @@
+# NOTE: every shared `bevy_*` path-dep below is mirrored in
+# `.github/workflows/utils-file-alterations.yml` under the `isometric:` glob.
+# When you add a new path-dep here, add the matching path filter there or the
+# WASM client will skip rebuilds on shared-crate changes — the lightyear
+# ProtocolPlugin registry will drift between client and server and the
+# protocol-check observer will panic on connect ("the message protocol doesn't match").
+
 [package]
 name = "isometric-game"
 version = "0.1.0"


### PR DESCRIPTION
## Symptom

Live https://kbve.com/isometric/ panics on connect:

```
panicked at bevy_ecs/src/error/handler.rs:125:
Encountered an error in observer
`lightyear::protocol::ProtocolCheckPlugin::receive_verify_protocol`:
the message protocol doesn't match
```

## Root cause

The `isometric:` path filter in `utils-file-alterations.yml` only watched `apps/kbve/isometric/**` plus `bevy_tasker/**`. When #10559 added `CreatureCapturedBatch` to `bevy_kbve_net::protocol::ProtocolPlugin`:

- `astro_kbve` triggered → `axum-kbve` gameserver was rebuilt and redeployed → **server protocol registry has the new message**.
- `isometric:` did **NOT** trigger → WASM was not rebuilt → **client still ships the pre-#10559 protocol registry**.

`ProtocolCheckPlugin` hashes the registered messages / channels on both sides and panics when the hashes diverge — which is what the user saw on the live build.

## Fix

1. Add every shared `bevy_*` path-dep referenced from `apps/kbve/isometric/src-tauri/Cargo.toml` to the `isometric:` glob:
   - `bevy_behavior`, `bevy_cam`, `bevy_chat`, `bevy_db`, `bevy_inventory`, `bevy_items`, `bevy_kbve_net`, `bevy_npc`, `bevy_pathfinder`, `bevy_skills` (`bevy_tasker` was already there).
2. Add a header comment at the top of `src-tauri/Cargo.toml` reminding future contributors to mirror new path-deps in the workflow filter. The comment also forces this PR to trip the (newly-extended) `isometric:` filter so the WASM redeploys with a fresh protocol registry matching the currently-deployed gameserver.

## Test plan

- [ ] CI - Bevy fires on this PR (path filter sees the `Cargo.toml` edit).
- [ ] WASM build artifact is produced and the deploy PR opens automatically.
- [ ] Once the deploy PR merges, https://kbve.com/isometric/ connects without the protocol-mismatch panic.
- [ ] Future change to any of the listed shared crates triggers the bevy workflow (regression guard).