### PR TITLE
fix(firecracker): disable provenance/sbom so buildx --load works

### DIFF
--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -41,9 +41,8 @@
 					"tags": ["ghcr.io/kbve/firecracker-python-net:latest"],
 					"load": true,
 					"push": false,
-					"cache-to": [
-						"type=registry,ref=ghcr.io/kbve/firecracker-python-net:buildcache,mode=max"
-					]
+					"provenance": false,
+					"sbom": false
 				}
 			}
 		},


### PR DESCRIPTION
## Summary

Run [#25532483124](https://github.com/KBVE/kbve/actions/runs/25532483124) reproduced the same shared-workflow failure (\"No images found matching 'kbve/firecracker-python-net'\") even after PR #10600 switched to \`load: true\`. Looking at the buildx output:

\`\`\`
#9 exporting to image
#9 exporting manifest list sha256:5c19... done
\`\`\`

Buildx emitted a **manifest list** (OCI multi-arch image index) because \`provenance\` and \`sbom\` attestations are on by default. The docker daemon's \`--load\` path cannot import manifest lists, so the image never appears in the daemon, and the shared workflow's push step has nothing to push.

The shared workflow's silent \`docker buildx build --load\` fallback (\`2>/dev/null || warning\`) hits the same manifest-list shape on the rebuild and also fails to populate the daemon.

## Fix

- \`provenance: false, sbom: false\` on the production configuration so buildx emits a single-arch image manifest that \`--load\` can import.
- Drop \`cache-to\` on this first publish. Combining a registry cache export with a daemon-loaded image produced the manifest-list shape too. The cache can be re-introduced once the publish path is green.

## Test plan

- [ ] After merge, \`CI - Docker / firecracker-python-net\` should publish \`ghcr.io/kbve/firecracker-python-net:0.1.0\` and \`:latest\`.
- [ ] \`docker.io/kbve/firecracker-python-net:0.1.0\` and \`:latest\` mirrored.
- [ ] Post-publish bumps \`version.toml\` to \`0.1.0\`.