### PR TITLE
fix(herbmail): restore rollout-restart pod-template annotation

### DIFF
--- a/apps/kube/herbmail/manifest/herbmail-deployment.yaml
+++ b/apps/kube/herbmail/manifest/herbmail-deployment.yaml
@@ -18,6 +18,11 @@ spec:
             app: herbmail
     template:
         metadata:
+            annotations:
+                # Manual rollout-restart trigger preserved as a fallback
+                # if Reloader misses a Secret rotation — bump the value
+                # to force the Deployment controller to roll the pods.
+                rollout-restart: '2026-04-03T22:24:57Z'
             labels:
                 app: herbmail
                 version: '0.1.1'


### PR DESCRIPTION
## Summary

Re-adds the `rollout-restart: '2026-04-03T22:24:57Z'` annotation under `spec.template.metadata.annotations` on `herbmail-deployment` that was inadvertently dropped during the hardening refactor in #10582.

The annotation is a manual escape hatch — bumping the timestamp forces the Deployment controller to roll the pods without touching Reloader or the image tag. Belt-and-suspenders alongside the `reloader.stakater.com/auto` annotation already in place: Reloader handles automatic rolls on Secret rotation; the static annotation keeps the manual fallback available if Reloader is down or misses an event.

## Audit of other hardening PRs

Confirmed via `git show` that the other namespaces in the same hardening rollout did not carry a `rollout-restart` annotation in their original manifests, so no parallel fix is needed:

- chuckrpg (#10547) — no annotation
- discordsh (#10568) — no annotation on either StatefulSet
- cryptothrone (#10597) — no annotation
- n8n (#10558) — no annotation on main or worker

This fix is herbmail-specific.

## Test plan

- [ ] ArgoCD `herbmail` Application syncs cleanly after dev → main promotion.
- [ ] `kubectl -n herbmail get deploy herbmail-deployment -o jsonpath='{.spec.template.metadata.annotations.rollout-restart}'` returns `2026-04-03T22:24:57Z`.
- [ ] Bumping the value (e.g. via `kubectl patch`) triggers a normal rolling restart of the pod.