### PR TITLE
fix(security): py uninit-var sentinel + pydesk stack-trace exposure (#7, #38)

### DIFF
--- a/apps/discordsh/notification-bot/notification_bot/api/discord/embed/discord_status_embed.py
+++ b/apps/discordsh/notification-bot/notification_bot/api/discord/embed/discord_status_embed.py
@@ -47,7 +47,8 @@ class BotStatusView(ui.View):
         except Exception as e:
             # Fallback to basic status without health data if health collection fails
             import logging
-            logging.warning(f"Health data collection failed, using basic status: {e}")
+            logging.warning(
+                f"Health data collection failed, using basic status: {e}")
             status_dict = self.__bot_instance.get_status()
             return BotStatusModel.from_status_dict(status_dict)
 
@@ -254,16 +255,19 @@ class BotStatusView(ui.View):
 
         # Get Discord ID and lookup user profile
         discord_id = str(interaction.user.id)
-        logger.info(f"🔄 Refresh button clicked by {interaction.user} (Discord ID: {discord_id})")
+        logger.info(
+            f"🔄 Refresh button clicked by {interaction.user} (Discord ID: {discord_id})")
 
         # Try to lookup user in Supabase
         try:
             from ....api.supabase import user_manager
             user_profile = await user_manager.find_user_by_discord_id(discord_id)
             if user_profile:
-                logger.info(f"   └─ Supabase user found: {user_profile.user_id} ({user_profile.email})")
+                logger.info(
+                    f"   └─ Supabase user found: {user_profile.user_id} ({user_profile.email})")
             else:
-                logger.info(f"   └─ No Supabase user profile found for Discord ID: {discord_id}")
+                logger.info(
+                    f"   └─ No Supabase user profile found for Discord ID: {discord_id}")
         except Exception as e:
             logger.warning(f"   └─ Failed to lookup Supabase user: {e}")
 
@@ -318,16 +322,19 @@ class BotStatusView(ui.View):
 
         # Get Discord ID and lookup user profile
         discord_id = str(interaction.user.id)
-        logger.info(f"🧹 Cleanup button clicked by {interaction.user} (Discord ID: {discord_id})")
+        logger.info(
+            f"🧹 Cleanup button clicked by {interaction.user} (Discord ID: {discord_id})")
 
         # Try to lookup user in Supabase
         try:
             from ....api.supabase import user_manager
             user_profile = await user_manager.find_user_by_discord_id(discord_id)
             if user_profile:
-                logger.info(f"   └─ Supabase user found: {user_profile.user_id} ({user_profile.email})")
+                logger.info(
+                    f"   └─ Supabase user found: {user_profile.user_id} ({user_profile.email})")
             else:
-                logger.info(f"   └─ No Supabase user profile found for Discord ID: {discord_id}")
+                logger.info(
+                    f"   └─ No Supabase user profile found for Discord ID: {discord_id}")
         except Exception as e:
             logger.warning(f"   └─ Failed to lookup Supabase user: {e}")
 
@@ -338,7 +345,8 @@ class BotStatusView(ui.View):
             # Clean up old messages
             logger.info("Starting thread cleanup...")
             deleted_count = await self.__bot_instance.cleanup_thread_messages()
-            logger.info(f"Thread cleanup completed, deleted {deleted_count} messages")
+            logger.info(
+                f"Thread cleanup completed, deleted {deleted_count} messages")
 
             await interaction.followup.send(
                 f"🧹 Cleaned up {deleted_count} old messages from thread",
@@ -362,30 +370,36 @@ class BotStatusView(ui.View):
 
         # Get Discord ID and lookup user profile
         discord_id = str(interaction.user.id)
-        logger.info(f"🔄 Restart button clicked by {interaction.user} (Discord ID: {discord_id})")
+        logger.info(
+            f"🔄 Restart button clicked by {interaction.user} (Discord ID: {discord_id})")
 
         # Try to lookup user in Supabase
         try:
             from ....api.supabase import user_manager
             user_profile = await user_manager.find_user_by_discord_id(discord_id)
             if user_profile:
-                logger.info(f"   └─ Supabase user found: {user_profile.user_id} ({user_profile.email})")
+                logger.info(
+                    f"   └─ Supabase user found: {user_profile.user_id} ({user_profile.email})")
             else:
-                logger.info(f"   └─ No Supabase user profile found for Discord ID: {discord_id}")
+                logger.info(
+                    f"   └─ No Supabase user profile found for Discord ID: {discord_id}")
         except Exception as e:
             logger.warning(f"   └─ Failed to lookup Supabase user: {e}")
 
+        old_text: Optional[str] = None
         try:
             # Check if user has permission to restart
             if not self._has_restart_permission(interaction.user, interaction.guild):
-                logger.info(f"User {interaction.user} denied restart permission")
+                logger.info(
+                    f"User {interaction.user} denied restart permission")
                 await interaction.response.send_message(
                     "❌ You don't have permission to restart the bot. Admin role required.",
                     ephemeral=True
                 )
                 return
 
-            logger.info(f"User {interaction.user} has restart permission, proceeding...")
+            logger.info(
+                f"User {interaction.user} has restart permission, proceeding...")
             await interaction.response.defer()
 
             # Update status to show pending restart
@@ -411,7 +425,7 @@ class BotStatusView(ui.View):
 
         except Exception as e:
             # Restore original text if error
-            if 'old_text' in locals():
+            if old_text is not None:
                 self.status_text = old_text
                 embed = self.create_status_embed()
                 await interaction.followup.edit_message(

--- a/packages/python/fudster/fudster/apps/screen_client.py
+++ b/packages/python/fudster/fudster/apps/screen_client.py
@@ -28,13 +28,15 @@ class ScreenClient:
 
     def get_vnc_display_size(self):
         if pyautogui is None:
-            raise ImportError("pyautogui is required. Install with: pip install fudster[automation]")
+            raise ImportError(
+                "pyautogui is required. Install with: pip install fudster[automation]")
         screen_size = pyautogui.size()
         return screen_size
 
     async def find_and_click_image(self, button='left'):
         if pyautogui is None or cv2 is None:
-            raise ImportError("automation dependencies required. Install with: pip install fudster[automation]")
+            raise ImportError(
+                "automation dependencies required. Install with: pip install fudster[automation]")
 
         os.environ['DISPLAY'] = ':1'
 
@@ -79,20 +81,21 @@ class ScreenClient:
                 error_msg = "Image not found with sufficient confidence."
                 logger.error(error_msg)
                 return error_msg
-        except Exception as e:
-            error_msg = f"Failed to click image: {e}"
-            logger.error(error_msg)
-            return error_msg
+        except Exception:
+            logger.exception("Failed to click image")
+            return "Failed to click image; see server logs for details."
 
     def debug_mouse_move_and_click(self, coordinates, button='left', move_duration=1.0):
         if pyautogui is None:
-            raise ImportError("pyautogui is required. Install with: pip install fudster[automation]")
+            raise ImportError(
+                "pyautogui is required. Install with: pip install fudster[automation]")
 
         os.environ['DISPLAY'] = ':1'
 
         try:
             screen_width, screen_height = self.get_vnc_display_size()
-            logger.info(f"VNC Display size: width={screen_width}, height={screen_height}")
+            logger.info(
+                f"VNC Display size: width={screen_width}, height={screen_height}")
 
             for coord in coordinates:
                 x, y = coord
@@ -100,7 +103,8 @@ class ScreenClient:
                 x = min(max(x, 0), screen_width - 1)
                 y = min(max(y, 0), screen_height - 1)
 
-                logger.info(f"Moving to: ({x}, {y}) and clicking with {button} button")
+                logger.info(
+                    f"Moving to: ({x}, {y}) and clicking with {button} button")
 
                 pyautogui.sleep(0.5)
                 pyautogui.moveTo(x, y, duration=move_duration)
@@ -116,7 +120,8 @@ class ScreenClient:
 
     def take_screenshot(self):
         if pyautogui is None:
-            raise ImportError("pyautogui is required. Install with: pip install fudster[automation]")
+            raise ImportError(
+                "pyautogui is required. Install with: pip install fudster[automation]")
 
         os.environ['DISPLAY'] = ':1'
 


### PR DESCRIPTION
## Summary

Two CodeQL Python alerts addressed:

- [#38](https://github.com/KBVE/kbve/security/code-scanning/38) `py/uninitialized-local-variable` in [discord_status_embed.py](apps/discordsh/notification-bot/notification_bot/api/discord/embed/discord_status_embed.py) — pre-init `old_text: Optional[str] = None` before the restart try block; the except branch now checks the sentinel instead of the `'old_text' in locals()` runtime trick CodeQL can't reason about.
- [#7](https://github.com/KBVE/kbve/security/code-scanning/7) `py/stack-trace-exposure` in [screen_client.py](packages/python/fudster/fudster/apps/screen_client.py) — `find_and_click_image` no longer returns the formatted exception text. The HTTP handler at [main.py:124](apps/pydesk/pydesk/main.py#L124) propagates this string verbatim, so the prior `f"Failed to click image: {e}"` exposed inner stack-trace info to API callers. Use `logger.exception` for ops + return a generic message.

## Notes on sibling alerts (deliberately out of scope)

[#39, #40, #41, #42, #43](https://github.com/KBVE/kbve/security/code-scanning/39) all flag `Local variable 'self' may be used before it is initialized` inside `BotStatusView`. These are CodeQL Python false positives — the parser loses the bound-method context for `@ui.button(...)` callbacks and for the `create_status_embed` method that follows two `@classmethod async def` siblings. No code change can correctly remove the `self` reference. Recommend dismissing in the UI as `false positive` once this PR merges.

## Verification

- `python3 -m py_compile` passes on both modified files.
- Restart-button error path: when an exception fires before line 392 (`old_text = self.status_text`), the sentinel stays `None` and the restore branch is skipped — same behaviour as the prior `'old_text' in locals()` guard.
- `find_and_click_image`: caller still receives a string return, just without exception details.

## Test plan

- [ ] CI green on `trunk/atom-codeql-py-uninit-trace-*`
- [ ] Post-merge: confirm next Python CodeQL run on `main` closes #7 + #38
- [ ] Decide on dismissing #39-43 as false positive