### PR TITLE
fix(firecracker): provenance/sbom must be strings in nx-tools schema

### DIFF
--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -41,8 +41,8 @@
 					"tags": ["ghcr.io/kbve/firecracker-python-net:latest"],
 					"load": true,
 					"push": false,
-					"provenance": false,
-					"sbom": false
+					"provenance": "false",
+					"sbom": "false"
 				}
 			}
 		},


### PR DESCRIPTION
## Summary

Run [#25534454344](https://github.com/KBVE/kbve/actions/runs/25534454344) failed before the build even started:

\`\`\`
Property 'provenance' does not match the schema. 'false' should be a 'string'.
\`\`\`

\`@nx-tools/nx-container:build\` mirrors \`docker/build-push-action\`'s semantics — both \`provenance\` and \`sbom\` accept the literal **string** \`\"false\"\` (or \`\"true\"\` / \`\"min\"\` / \`\"max\"\` / a profile JSON), not a JSON boolean. PR #10609 set them as raw booleans, which the executor's input schema rejected.

## Fix

Quote both values so the schema accepts the input.

## Test plan

- [ ] After merge, the next \`CI - Docker / firecracker-python-net\` run should reach the buildx phase, emit a single-arch image manifest (no provenance/sbom attestations), \`--load\` it into the daemon, and let the shared workflow push \`:0.1.0\` + \`:latest\`.