### PR TITLE
test(astro-rareicon-e2e): cover press, multi-source merge, license footer, social UTM

### DIFF
--- a/apps/rareicon/astro-rareicon-e2e/e2e/catalog-merged.spec.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/catalog-merged.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import {
+	BRAND_ICON_ROUTES,
+	MULTI_SOURCE_ICON_ROUTES,
+	ATTRIBUTION_REQUIRED_ROUTES,
+} from './helpers/routes';
+
+/**
+ * Coverage for the codegen pipeline's merger output:
+ *   - Multi-source merged terms render the badge with a non-zero source count
+ *   - License footer renders for every generated/hand-crafted term
+ *   - Attribution-required terms render the gold "Attribution required" callout
+ *   - Brand-source terms (CC0 Simple Icons) skip the callout
+ */
+
+test.describe('Multi-source merged terms', () => {
+	for (const route of MULTI_SOURCE_ICON_ROUTES) {
+		test(`${route.label} renders multi-source badge`, async ({ page }) => {
+			await page.goto(route.path);
+			const badge = page.locator('.ri-icon-term__multi-source');
+			await expect(badge).toBeVisible();
+			await expect(badge).toContainText(/variants? merged from/i);
+		});
+
+		test(`${route.label} variant grid has 2+ entries`, async ({ page }) => {
+			await page.goto(route.path);
+			const variants = page.locator('.ri-icon-variant');
+			expect(await variants.count()).toBeGreaterThanOrEqual(2);
+		});
+	}
+});
+
+test.describe('License footer', () => {
+	for (const route of [
+		...BRAND_ICON_ROUTES,
+		...ATTRIBUTION_REQUIRED_ROUTES,
+	]) {
+		test(`${route.label} renders license footer`, async ({ page }) => {
+			await page.goto(route.path);
+			const license = page.locator('.ri-icon-term__license');
+			await expect(license).toBeVisible();
+		});
+
+		test(`${route.label} surfaces a source page link`, async ({ page }) => {
+			await page.goto(route.path);
+			const link = page.locator('.ri-icon-term__license-link');
+			await expect(link).toBeVisible();
+			const href = await link.getAttribute('href');
+			expect(href).toMatch(/^https?:\/\//);
+		});
+	}
+});
+
+test.describe('Attribution-required UI (CC BY)', () => {
+	for (const route of ATTRIBUTION_REQUIRED_ROUTES) {
+		test(`${route.label} renders gold Attribution required callout`, async ({
+			page,
+		}) => {
+			await page.goto(route.path);
+			const required = page.locator('.ri-icon-term__license--required');
+			await expect(required).toBeVisible();
+			await expect(required).toContainText(/Attribution required/i);
+		});
+	}
+});
+
+test.describe('Brand glyph terms (no attribution required)', () => {
+	for (const route of BRAND_ICON_ROUTES) {
+		test(`${route.label} omits Attribution required callout`, async ({
+			page,
+		}) => {
+			await page.goto(route.path);
+			// Footer present (CC0 still surfaces a "License" header) but
+			// not the gold attribution-required variant
+			const required = page.locator('.ri-icon-term__license--required');
+			await expect(required).toHaveCount(0);
+		});
+	}
+});

--- a/apps/rareicon/astro-rareicon-e2e/e2e/helpers/routes.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/helpers/routes.ts
@@ -7,6 +7,7 @@ export const CONTENT_ROUTES = [
 	{ path: '/game/overview/', label: 'Game overview' },
 	{ path: '/game/factions/', label: 'Factions page' },
 	{ path: '/steam/', label: 'Steam marketing landing' },
+	{ path: '/press/', label: 'Press kit landing' },
 ] as const;
 
 export const ICON_ROUTES = [
@@ -16,4 +17,48 @@ export const ICON_ROUTES = [
 	{ path: '/icons/arrow-right/', label: 'Arrow-right term page' },
 	{ path: '/icons/close/', label: 'Close term page' },
 	{ path: '/icons/terminal/', label: 'Terminal term page' },
+] as const;
+
+/**
+ * Brand / hand-crafted icon term pages — distinct from auto-generated
+ * Lucide outlines. These should each render the license footer with a
+ * source URL, plus visible attribution copy.
+ */
+export const BRAND_ICON_ROUTES = [
+	{ path: '/icons/steam/', label: 'Steam brand glyph' },
+	{ path: '/icons/itch/', label: 'itch.io brand glyph' },
+	{ path: '/icons/bluesky/', label: 'Bluesky brand glyph' },
+	{ path: '/icons/tiktok/', label: 'TikTok brand glyph' },
+] as const;
+
+/**
+ * Concept terms that pull variants from multiple FOSS icon packs after
+ * the codegen merger pass. Each should render the
+ * `.ri-icon-term__multi-source` badge advertising the variant + source
+ * counts. Pages picked from the dedup ledger to stay stable across regen.
+ */
+export const MULTI_SOURCE_ICON_ROUTES = [
+	{ path: '/icons/python/', label: 'Python multi-source term' },
+	{ path: '/icons/react/', label: 'React multi-source term' },
+	{ path: '/icons/docker/', label: 'Docker multi-source term' },
+	{ path: '/icons/rust/', label: 'Rust multi-source term' },
+	{ path: '/icons/home/', label: 'Home multi-source term' },
+	{ path: '/icons/heart/', label: 'Heart multi-source term' },
+] as const;
+
+/**
+ * Catalog terms whose source carries CC BY attribution requirements
+ * (Game Icons CC BY 3.0, Solar CC BY 4.0). License footer must render
+ * the gold "Attribution required" callout for these pages.
+ */
+export const ATTRIBUTION_REQUIRED_ROUTES = [
+	{ path: '/icons/broadsword/', label: 'Game Icons broadsword (CC BY 3.0)' },
+	{
+		path: '/icons/wizard-face/',
+		label: 'Game Icons wizard-face (CC BY 3.0)',
+	},
+	{
+		path: '/icons/dragon-head/',
+		label: 'Game Icons dragon-head (CC BY 3.0)',
+	},
 ] as const;

--- a/apps/rareicon/astro-rareicon-e2e/e2e/press.spec.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/press.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Press kit', () => {
+	test('press page loads with 200 + RareIcon-press title', async ({
+		page,
+	}) => {
+		const response = await page.goto('/press/');
+		expect(response?.status()).toBe(200);
+		await expect(page).toHaveTitle(/Press|RareIcon/);
+	});
+
+	test('fact sheet renders developer / publisher / genre rows', async ({
+		page,
+	}) => {
+		await page.goto('/press/');
+		const facts = page.locator('.ri-press__facts');
+		await expect(facts).toBeVisible();
+		await expect(facts).toContainText('Developer');
+		await expect(facts).toContainText('Publisher');
+		await expect(facts).toContainText('Genre');
+	});
+
+	test('pitch quote present', async ({ page }) => {
+		await page.goto('/press/');
+		const blockquote = page.locator('.ri-press blockquote').first();
+		await expect(blockquote).toBeVisible();
+		await expect(blockquote).toContainText(/Chip|RareIcon|bullet/i);
+	});
+
+	test('SocialBar cards rendered under Follow Along', async ({ page }) => {
+		await page.goto('/press/');
+		const socialbar = page
+			.locator('.ri-socialbar.ri-socialbar--cards')
+			.first();
+		await expect(socialbar).toBeVisible();
+		// Press kit should surface at least 3 platform cards
+		const items = socialbar.locator('.ri-socialbar__item');
+		expect(await items.count()).toBeGreaterThanOrEqual(3);
+	});
+
+	test('contact emails render in body copy', async ({ page }) => {
+		await page.goto('/press/');
+		const body = page.locator('.ri-press');
+		await expect(body).toContainText('press@kbve.com');
+		await expect(body).toContainText('creators@kbve.com');
+	});
+});
+
+test.describe('Press kit OG meta override', () => {
+	test('og:title carries Press Kit override copy', async ({ page }) => {
+		await page.goto('/press/');
+		const ogTitle = await page
+			.locator('meta[property="og:title"]')
+			.getAttribute('content');
+		expect(ogTitle).toBeTruthy();
+		expect(ogTitle).toMatch(/Press Kit|RareIcon/i);
+	});
+
+	test('og:description carries override (not raw frontmatter description)', async ({
+		page,
+	}) => {
+		await page.goto('/press/');
+		const ogDesc = await page
+			.locator('meta[property="og:description"]')
+			.getAttribute('content');
+		expect(ogDesc).toBeTruthy();
+		expect(ogDesc?.length).toBeGreaterThan(40);
+	});
+
+	test('og:image points at the public asset path', async ({ page }) => {
+		await page.goto('/press/');
+		const ogImg = await page
+			.locator('meta[property="og:image"]')
+			.getAttribute('content');
+		expect(ogImg).toMatch(
+			/^https?:\/\/.+\/(assets|branding)\/.+\.(png|jpg|svg)$/i,
+		);
+	});
+});

--- a/apps/rareicon/astro-rareicon-e2e/e2e/smoke.spec.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/smoke.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { CONTENT_ROUTES, ICON_ROUTES, SPLASH_ROUTES } from './helpers/routes';
+import {
+	ATTRIBUTION_REQUIRED_ROUTES,
+	BRAND_ICON_ROUTES,
+	CONTENT_ROUTES,
+	ICON_ROUTES,
+	MULTI_SOURCE_ICON_ROUTES,
+	SPLASH_ROUTES,
+} from './helpers/routes';
 
 test.describe('astro-rareicon smoke tests', () => {
 	test('homepage loads with 200 and has RareIcon title', async ({ page }) => {
@@ -29,6 +36,27 @@ test.describe('astro-rareicon smoke tests', () => {
 	}
 
 	for (const route of ICON_ROUTES) {
+		test(`${route.label} loads with 200`, async ({ page }) => {
+			const response = await page.goto(route.path);
+			expect(response?.status()).toBe(200);
+		});
+	}
+
+	for (const route of BRAND_ICON_ROUTES) {
+		test(`${route.label} loads with 200`, async ({ page }) => {
+			const response = await page.goto(route.path);
+			expect(response?.status()).toBe(200);
+		});
+	}
+
+	for (const route of MULTI_SOURCE_ICON_ROUTES) {
+		test(`${route.label} loads with 200`, async ({ page }) => {
+			const response = await page.goto(route.path);
+			expect(response?.status()).toBe(200);
+		});
+	}
+
+	for (const route of ATTRIBUTION_REQUIRED_ROUTES) {
 		test(`${route.label} loads with 200`, async ({ page }) => {
 			const response = await page.goto(route.path);
 			expect(response?.status()).toBe(200);

--- a/apps/rareicon/astro-rareicon-e2e/e2e/social.spec.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/social.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Coverage for the SocialBar component, footer routing, and per-page
+ * `og:title` / `og:description` overrides shipped in earlier phases.
+ */
+
+test.describe('Footer SocialBar', () => {
+	test('homepage footer renders SocialBar badges', async ({ page }) => {
+		await page.goto('/');
+		const badges = page.locator('.ri-socialbar.ri-socialbar--badges');
+		await expect(badges).toBeVisible();
+		const items = badges.locator('.ri-socialbar__item');
+		expect(await items.count()).toBeGreaterThanOrEqual(5);
+	});
+
+	test('Steam badge links to internal /steam/ (in-house SEO)', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		const steam = page
+			.locator('.ri-socialbar__item[data-platform="steam"]')
+			.first();
+		const href = await steam.getAttribute('href');
+		expect(href).toMatch(/^\/steam\/?$/);
+	});
+
+	test('Discord badge routes through kbve.com (UTM-tagged)', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		const discord = page
+			.locator('.ri-socialbar__item[data-platform="discord"]')
+			.first();
+		const href = await discord.getAttribute('href');
+		expect(href).toContain('kbve.com/discord');
+		expect(href).toContain('utm_source=rareicon');
+		expect(href).toContain('utm_campaign=footer');
+	});
+});
+
+test.describe('Steam page SocialBar', () => {
+	test('steam page renders cards-variant SocialBar excluding self', async ({
+		page,
+	}) => {
+		await page.goto('/steam/');
+		const cards = page.locator('.ri-socialbar.ri-socialbar--cards').first();
+		await expect(cards).toBeVisible();
+		// Steam excluded from this surface — own page already linked above
+		const steam = cards.locator('[data-platform="steam"]');
+		await expect(steam).toHaveCount(0);
+	});
+
+	test('steam page SocialBar tags utm_campaign=steam-page', async ({
+		page,
+	}) => {
+		await page.goto('/steam/');
+		const discord = page
+			.locator(
+				'.ri-socialbar.ri-socialbar--cards [data-platform="discord"]',
+			)
+			.first();
+		const href = await discord.getAttribute('href');
+		expect(href).toContain('utm_campaign=steam-page');
+	});
+});
+
+test.describe('Per-page og:* overrides', () => {
+	test('homepage og:title carries override copy', async ({ page }) => {
+		await page.goto('/');
+		const ogTitle = await page
+			.locator('meta[property="og:title"]')
+			.getAttribute('content');
+		expect(ogTitle).toMatch(/Bullet-Hell|RareIcon/i);
+	});
+
+	test('steam page og:title pushes wishlist copy', async ({ page }) => {
+		await page.goto('/steam/');
+		const ogTitle = await page
+			.locator('meta[property="og:title"]')
+			.getAttribute('content');
+		expect(ogTitle).toMatch(/Wishlist|Steam/i);
+	});
+
+	test('press page og:description differs from default', async ({ page }) => {
+		await page.goto('/press/');
+		const ogDesc = await page
+			.locator('meta[property="og:description"]')
+			.getAttribute('content');
+		expect(ogDesc).toMatch(/press|streamers|content creators|coverage/i);
+	});
+
+	test('twitter:image fallback to global default when no per-page override', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		const twImg = await page
+			.locator('meta[name="twitter:image"]')
+			.getAttribute('content');
+		expect(twImg).toBeTruthy();
+		expect(twImg).toMatch(/^https?:\/\//);
+	});
+
+	test('twitter:card defaults to summary_large_image', async ({ page }) => {
+		await page.goto('/');
+		const twCard = await page
+			.locator('meta[name="twitter:card"]')
+			.getAttribute('content');
+		expect(twCard).toBe('summary_large_image');
+	});
+});
+
+test.describe('Footer Kingdom nav routes through kbve.com', () => {
+	const platforms = [
+		'github',
+		'discord',
+		'youtube',
+		'twitch',
+		'twitter',
+		'bluesky',
+		'tiktok',
+		'itch',
+	];
+
+	for (const platform of platforms) {
+		test(`${platform} link routes through kbve.com`, async ({ page }) => {
+			await page.goto('/');
+			const link = page
+				.locator(`.ri-footer__col a[href*="kbve.com/${platform}"]`)
+				.first();
+			await expect(link).toBeAttached();
+		});
+	}
+});


### PR DESCRIPTION
## Summary

E2E coverage catches up to the catalog growth + new routes + new UI components added in phases 1–17. Test count grows **~25 → 95** across **4 spec files**.

## What's covered

### `press.spec.ts` — new
- `/press/` returns 200, title contains "Press" or "RareIcon"
- Fact sheet renders rows for Developer / Publisher / Genre
- Pitch blockquote present with `Chip|RareIcon|bullet` copy
- `<SocialBar variant="cards">` renders ≥3 platform cards under "Follow Along"
- Contact emails (`press@kbve.com`, `creators@kbve.com`) in body
- `og:title` / `og:description` / `og:image` overrides emit on the page

### `catalog-merged.spec.ts` — new
- Multi-source merged terms (`python`, `react`, `docker`, `rust`, `home`, `heart`) render `.ri-icon-term__multi-source` badge
- Variant grid carries 2+ entries on merged terms
- License footer present on every brand + attribution-required term
- Source page link points to an upstream URL
- Gold "Attribution required" callout shows up only on CC BY (Game Icons broadsword / wizard-face / dragon-head)
- CC0 brand pages (steam / itch / bluesky / tiktok) **omit** the attribution-required callout

### `social.spec.ts` — new
- Footer `.ri-socialbar--badges` renders ≥5 platform badges
- Internal Steam badge → `/steam/` (in-house SEO, no `kbve.com` redirect)
- Discord badge routes through `kbve.com/discord` with `utm_source=rareicon` + `utm_campaign=footer`
- Steam-page SocialBar uses `cards` variant + excludes own platform + tags `utm_campaign=steam-page`
- Per-page og overrides on homepage / steam / press
- `twitter:card=summary_large_image` global default
- Footer Kingdom nav routes for github / discord / youtube / twitch / x / bluesky / tiktok / itch all through `kbve.com`

### `smoke.spec.ts` + `helpers/routes.ts` — extended
- New route arrays: `BRAND_ICON_ROUTES`, `MULTI_SOURCE_ICON_ROUTES`, `ATTRIBUTION_REQUIRED_ROUTES`
- `/press/` added to `CONTENT_ROUTES`
- 200-status iterations across all three new route families

## Test plan

- [x] `npx playwright test --list` — 95 tests across 4 files parse cleanly under the dev project
- [ ] CI: full e2e run against the built astro-rareicon site
- [ ] CI catches any catalog regressions where:
  - merged terms lose their multi-source badge
  - license footer disappears from generated mdx
  - footer SocialBar drops the UTM tagging
  - per-page og:* override frontmatter gets stripped from new mdx