### PR TITLE
ci(utils-ci-lint-test): nx reset + NX_DAEMON=false before affected lint/test

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -110,8 +110,24 @@ jobs:
                   mkdir -p ~/.pgrx
                   printf '[configs]\npg17 = "/usr/lib/postgresql/17/bin/pg_config"\n' > ~/.pgrx/config.toml
 
+            # Force a fresh nx project graph before affected lint/test runs.
+            # Without this, the @nx/dependency-checks ESLint rule has a known
+            # race when a dep + its first import land in back-to-back PRs:
+            # the daemon's cached graph sees the dep in package.json but
+            # not yet the import in src/, so it falsely flags the package
+            # as unused (see #10607). `nx reset` rebuilds graph + cache and
+            # NX_DAEMON=false stops a stale daemon from being reused.
+            - name: Reset nx graph
+              run: pnpm nx reset
+              env:
+                  NX_DAEMON: 'false'
+
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud
+              env:
+                  NX_DAEMON: 'false'
 
             - name: Test affected projects
               run: pnpm nx affected --target=test --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud
+              env:
+                  NX_DAEMON: 'false'

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -115,19 +115,15 @@ jobs:
             # race when a dep + its first import land in back-to-back PRs:
             # the daemon's cached graph sees the dep in package.json but
             # not yet the import in src/, so it falsely flags the package
-            # as unused (see #10607). `nx reset` rebuilds graph + cache and
-            # NX_DAEMON=false stops a stale daemon from being reused.
+            # as unused (see #10607). `nx reset` clears the cache and stops
+            # any stale daemon — the next nx invocation spawns a fresh daemon
+            # and rebuilds the graph from disk, so daemon caching still helps
+            # the rest of the run.
             - name: Reset nx graph
               run: pnpm nx reset
-              env:
-                  NX_DAEMON: 'false'
 
             - name: Lint affected projects
               run: pnpm nx affected --target=lint --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud
-              env:
-                  NX_DAEMON: 'false'
 
             - name: Test affected projects
               run: pnpm nx affected --target=test --base=${{ inputs.base-ref }} --head=${{ inputs.head-ref }} --no-cloud
-              env:
-                  NX_DAEMON: 'false'


### PR DESCRIPTION
Hardens the dev→main validation workflow against transient \`@nx/dependency-checks\` flakes like the one #10607 just walked us through.

## Root cause of #10607
PR #10604 added \`openapi-fetch\` to \`packages/npm/devops/package.json\` **and** the first source files importing it (\`src/lib/client/kbve/*.ts\`) in the same commit. PR #10604 merged at \`01:57:30Z\`. The Validate Dev→Main PR run for #10593 kicked off at \`01:58:17Z\` — about 30 seconds later. The nx project graph the daemon hydrated in CI saw the new \`package.json\` entry but had cached an older view of the source tree, so the \`@nx/dependency-checks\` ESLint rule scanned a graph that didn't yet contain the new imports and flagged the package as unused:

\`\`\`
42:3  error  The "openapi-fetch" package is not used by "devops" project  @nx/dependency-checks
\`\`\`

Six failed runs later, run [#25534261267](https://github.com/KBVE/kbve/actions/runs/25534261267) hydrated a fresh graph and lint passed — issue auto-closed without any code change. Six failed runs on a flake also burned six issue retriggers via \`utils-ci-failure-tracker.yml\`.

Local \`nx run devops:lint\` against \`origin/dev\` passes cleanly: zero errors. Confirmed there's no real lint regression to chase — only the race.

## Fix
- New \`Reset nx graph\` step before \`Lint affected projects\` runs \`pnpm nx reset\` to clear cache + stop any reused daemon.
- Pin \`NX_DAEMON: 'false'\` on the lint and test steps so each invocation walks the project graph from disk. Eliminates the daemon as a state carrier between invocations.

Costs ~10–30s of graph rebuild per CI run. Cheap insurance vs. absorbing N retriggers + a manual eyeball every time a dep + its first import ship back-to-back.

## Test plan
- [ ] Next \`Validate Dev→Main PR\` run completes without \`@nx/dependency-checks\` false positive on \`devops:lint\`.
- [ ] No regression on existing affected lint/test behavior — same projects considered affected as before.
- [ ] CI step duration delta within ~30s envelope.