### PR TITLE
fix(astro-kbve): sanitize WS payloads before logging (CodeQL #225, #226)

### DIFF
--- a/apps/kbve/astro-kbve/src/workers/supabase.shared.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.shared.ts
@@ -146,6 +146,22 @@ const storage = new IDBStorage();
 // ---- Shared communication layer ----
 const comm = getWorkerCommunication();
 
+// Strip CR/LF/control chars before logging untrusted server payloads so a
+// hostile message can't forge log lines (CodeQL js/log-injection).
+function sanitizeForLog(value: unknown): string {
+	const raw =
+		typeof value === 'string'
+			? value
+			: (() => {
+					try {
+						return JSON.stringify(value);
+					} catch {
+						return String(value);
+					}
+				})();
+	return raw.replace(/[\r\n\0-\x1F\x7F]/g, ' ').slice(0, 1024);
+}
+
 const subscriptions = new Map<
 	string,
 	{ unsubscribe: () => Promise<void> | void }
@@ -250,7 +266,7 @@ async function connectWebSocket(wsUrl?: string) {
 				const message = JSON.parse(event.data);
 				console.log(
 					'[SharedWorker] WebSocket message:',
-					JSON.stringify(message),
+					sanitizeForLog(message),
 				);
 
 				// Handle pong response

--- a/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
@@ -63,6 +63,22 @@ const subscriptions = new Map<
 // Shared communication layer
 const comm = getWorkerCommunication();
 
+// Strip CR/LF/control chars before logging untrusted server payloads so a
+// hostile message can't forge log lines (CodeQL js/log-injection).
+function sanitizeForLog(value: unknown): string {
+	const raw =
+		typeof value === 'string'
+			? value
+			: (() => {
+					try {
+						return JSON.stringify(value);
+					} catch {
+						return String(value);
+					}
+				})();
+	return raw.replace(/[\r\n\0-\x1F\x7F]/g, ' ').slice(0, 1024);
+}
+
 console.log('[WebSocket Worker] Initializing...');
 
 // Determine WebSocket URL
@@ -137,7 +153,10 @@ async function connectWebSocket(wsUrl?: string) {
 					return;
 				}
 
-				console.log('[WebSocket Worker] Message:', message);
+				console.log(
+					'[WebSocket Worker] Message:',
+					sanitizeForLog(message),
+				);
 
 				// Broadcast to all workers via BroadcastChannel
 				comm.broadcast({


### PR DESCRIPTION
## Summary

Two CodeQL `js/log-injection` errors (medium severity) addressed in the astro-kbve worker pool:

- [#225](https://github.com/KBVE/kbve/security/code-scanning/225) — [supabase.websocket.ts:140](apps/kbve/astro-kbve/src/workers/supabase.websocket.ts#L140) `console.log('[WebSocket Worker] Message:', message)`
- [#226](https://github.com/KBVE/kbve/security/code-scanning/226) — [supabase.shared.ts:251](apps/kbve/astro-kbve/src/workers/supabase.shared.ts#L251) `console.log('[SharedWorker] WebSocket message:', JSON.stringify(message))`

Both sites logged the JSON-parsed server payload verbatim. A hostile message could embed CR/LF inside a string field and forge entries when devtools / log-forwarders consume the line.

## Fix

Each worker now declares a small `sanitizeForLog(value)` helper that:

1. JSON-stringifies non-string values (with `try/catch` for cycles).
2. Strips CR/LF + ASCII control range `0x00-0x1F` + `0x7F` via `.replace(/[\r\n\0-\x1F\x7F]/g, ' ')`.
3. Truncates to 1024 chars to keep noisy payloads bounded.

The two flagged log calls route through `sanitizeForLog`. Other log sites in these files already log trusted local values (status strings, error objects from the runtime, etc.).

## Verification

- `npx tsc --noEmit -p apps/kbve/astro-kbve/tsconfig.json` produces no new errors in either worker file (pre-existing errors in unrelated files remain — verbatim-module-syntax in `packages/npm/devops`, missing `openapi-fetch` types, etc., unchanged by this PR).
- Inline helper kept per-file rather than shared util to keep the diff small and the workers self-contained.

## Test plan

- [ ] CI green on `trunk/atom-codeql-log-injection-*`
- [ ] Post-merge: confirm next JS/TS CodeQL run on `main` closes #225 + #226