### PR TITLE
feat(bevy_pathfinder,discordsh): tile-graph pathfinding + /dungeon route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "axum-discordsh"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "anyhow",
  "askama",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "discordsh-bot"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "askama",
@@ -4986,6 +4986,7 @@ dependencies = [
  "bevy_items",
  "bevy_mapdb",
  "bevy_npc",
+ "bevy_pathfinder",
  "bevy_quests",
  "bevy_skills",
  "chrono",

--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -39,6 +39,9 @@ bevy_quests = { path = "../../../packages/rust/bevy/bevy_quests" }
 bevy_skills = { path = "../../../packages/rust/bevy/bevy_skills" }
 bevy_chat = { path = "../../../packages/rust/bevy/bevy_chat" }
 bevy_mapdb = { path = "../../../packages/rust/bevy/bevy_mapdb" }
+bevy_pathfinder = { path = "../../../packages/rust/bevy/bevy_pathfinder", default-features = false, features = [
+    "tile-graph",
+] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -25,6 +25,7 @@ COPY packages/rust/bevy/bevy_quests/Cargo.toml packages/rust/bevy/bevy_quests/Ca
 COPY packages/rust/bevy/bevy_skills/Cargo.toml packages/rust/bevy/bevy_skills/Cargo.toml
 COPY packages/rust/bevy/bevy_chat/Cargo.toml packages/rust/bevy/bevy_chat/Cargo.toml
 COPY packages/rust/bevy/bevy_mapdb/Cargo.toml packages/rust/bevy/bevy_mapdb/Cargo.toml
+COPY packages/rust/bevy/bevy_pathfinder/Cargo.toml packages/rust/bevy/bevy_pathfinder/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
@@ -40,7 +41,8 @@ RUN mkdir -p apps/discordsh/discordsh-bot/src && echo "fn main() {}" > apps/disc
     mkdir -p packages/rust/bevy/bevy_quests/src && echo "" > packages/rust/bevy/bevy_quests/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_skills/src && echo "" > packages/rust/bevy/bevy_skills/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_chat/src && echo "" > packages/rust/bevy/bevy_chat/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_mapdb/src && echo "" > packages/rust/bevy/bevy_mapdb/src/lib.rs
+    mkdir -p packages/rust/bevy/bevy_mapdb/src && echo "" > packages/rust/bevy/bevy_mapdb/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_pathfinder/src && echo "" > packages/rust/bevy/bevy_pathfinder/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -86,11 +88,12 @@ COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 COPY packages/rust/bevy/bevy_skills packages/rust/bevy/bevy_skills
 COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 COPY packages/rust/bevy/bevy_mapdb packages/rust/bevy/bevy_mapdb
+COPY packages/rust/bevy/bevy_pathfinder packages/rust/bevy/bevy_pathfinder
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo build --release -p kbve -p jedi -p holy -p bevy_inventory -p bevy_items -p bevy_behavior -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat -p bevy_mapdb
+    cargo build --release -p kbve -p jedi -p holy -p bevy_inventory -p bevy_items -p bevy_behavior -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat -p bevy_mapdb -p bevy_pathfinder
 
 # ============================================================================
 # [STAGE D] - Build Application
@@ -115,6 +118,7 @@ COPY packages/rust/bevy/bevy_quests packages/rust/bevy/bevy_quests
 COPY packages/rust/bevy/bevy_skills packages/rust/bevy/bevy_skills
 COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 COPY packages/rust/bevy/bevy_mapdb packages/rust/bevy/bevy_mapdb
+COPY packages/rust/bevy/bevy_pathfinder packages/rust/bevy/bevy_pathfinder
 
 # Application source (most frequently changing — placed last for cache)
 COPY apps/discordsh/discordsh-bot apps/discordsh/discordsh-bot

--- a/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
@@ -6,12 +6,12 @@ use poise::serenity_prelude as serenity;
 use kbve::MemberStatus;
 
 use crate::discord::bot::{Context, Error};
-use crate::discord::game::{self, card, content, persistence, render, types::*};
+use crate::discord::game::{self, card, content, pathfinding, persistence, render, types::*};
 
 /// Dungeon crawler game — stress-test embeds, buttons, and select menus.
 #[poise::command(
     slash_command,
-    subcommands("start", "join", "leave", "status", "end", "leaderboard")
+    subcommands("start", "join", "leave", "status", "end", "leaderboard", "route")
 )]
 pub async fn dungeon(_ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
@@ -634,6 +634,107 @@ async fn leaderboard(
         .color(0xFFD700);
 
     ctx.send(poise::CreateReply::default().embed(embed)).await?;
+
+    Ok(())
+}
+
+/// Shortest revealed-tile route to the nearest tile of the given kind.
+#[poise::command(slash_command)]
+async fn route(
+    ctx: Context<'_>,
+    #[description = "Where to head: boss / city / merchant / rest / treasure / story"]
+    target: String,
+) -> Result<(), Error> {
+    let user = ctx.author().id;
+
+    let goal_room_type = match target.to_lowercase().as_str() {
+        "boss" => RoomType::Boss,
+        "city" | "town" => RoomType::UndergroundCity,
+        "merchant" | "market" | "shop" => RoomType::Merchant,
+        "rest" | "shrine" | "campfire" => RoomType::RestShrine,
+        "treasure" | "loot" => RoomType::Treasure,
+        "story" | "lore" => RoomType::Story,
+        other => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content(format!(
+                        "Unknown target `{other}`. Try: boss / city / merchant / rest / treasure / story.",
+                    ))
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let sid = match ctx.data().app.sessions.find_by_user(user) {
+        Some(s) => s,
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content("You're not in any active session.")
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let handle = match ctx.data().app.sessions.get(&sid) {
+        Some(h) => h,
+        None => return Ok(()),
+    };
+
+    let session = handle.lock().await;
+    let from = session.map.position;
+    let path = pathfinding::path_to_goal(
+        &session.map,
+        from,
+        pathfinding::GoalKind::Room(goal_room_type.clone()),
+    );
+    let goal_tile = path
+        .as_ref()
+        .and_then(|p| p.last())
+        .and_then(|p| session.map.tiles.get(p))
+        .cloned();
+    drop(session);
+
+    let target_label = match goal_room_type {
+        RoomType::Boss => "boss arena",
+        RoomType::UndergroundCity => "underground city",
+        RoomType::Merchant => "merchant",
+        RoomType::RestShrine => "rest shrine",
+        RoomType::Treasure => "treasure room",
+        RoomType::Story => "story room",
+        _ => "tile",
+    };
+
+    let body = match (path, goal_tile) {
+        (Some(path), Some(goal_tile)) if path.len() >= 2 => {
+            let dirs = pathfinding::directions_along_path(&path);
+            let route = dirs
+                .iter()
+                .map(|d| d.label())
+                .collect::<Vec<_>>()
+                .join(" \u{2192} "); // " → "
+            let hops = dirs.len();
+            format!(
+                "{} hop(s) to **{}** ({}):\n{}",
+                hops, goal_tile.name, target_label, route
+            )
+        }
+        (Some(path), Some(goal_tile)) if path.len() == 1 => format!(
+            "You're already in **{}** ({}).",
+            goal_tile.name, target_label
+        ),
+        _ => format!(
+            "No revealed path to a {} from your current room. Explore further first.",
+            target_label
+        ),
+    };
+
+    ctx.send(poise::CreateReply::default().content(body).ephemeral(true))
+        .await?;
 
     Ok(())
 }

--- a/apps/discordsh/discordsh-bot/src/discord/game/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/mod.rs
@@ -4,6 +4,7 @@ pub mod content;
 pub mod github_cards;
 pub mod irc_events;
 pub mod logic;
+pub mod pathfinding;
 pub mod persistence;
 pub mod proto_bridge;
 pub mod render;

--- a/apps/discordsh/discordsh-bot/src/discord/game/pathfinding.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/pathfinding.rs
@@ -1,0 +1,216 @@
+//! Tile-graph pathfinding over the dungeon [`MapState`].
+//!
+//! Builds a `bevy_pathfinder::TileGraph<MapPos>` from the revealed tile
+//! set, treating two tiles as connected only when both sides declare
+//! the matching exit (no one-way doors today). Adjacent tiles whose
+//! exits don't reciprocate are still walkable individually but no edge
+//! is added between them — the player would have to backtrack and
+//! reveal another path.
+//!
+//! The graph is rebuilt on demand for each path query rather than
+//! cached on the session: `MapState` mutates frequently (every
+//! exploration step) and current map sizes are small enough (≤200
+//! tiles in a typical run) that the BFS dominates anyway.
+
+use bevy_pathfinder::tile_graph::{PathField, TileGraph};
+
+use super::types::{Direction, MapPos, MapState, RoomType};
+
+/// Build a tile graph from the revealed portion of the map. Edges are
+/// added only when both endpoints exist in `map.tiles` and each side's
+/// `exits` list includes the matching cardinal direction.
+pub fn build_tile_graph(map: &MapState) -> TileGraph<MapPos> {
+    let mut graph = TileGraph::<MapPos>::new();
+    for tile in map.tiles.values() {
+        graph.add_node(tile.pos);
+    }
+    for tile in map.tiles.values() {
+        for &dir in tile.exits.iter() {
+            let nb = tile.pos.neighbor(dir);
+            let Some(neighbor_tile) = map.tiles.get(&nb) else {
+                continue;
+            };
+            if !neighbor_tile.exits.contains(&dir.opposite()) {
+                continue;
+            }
+            graph.add_edge(tile.pos, nb, 1.0);
+        }
+    }
+    graph
+}
+
+/// Predicate used by pathfinding to decide which revealed tiles are
+/// candidate goals for a path query. Decoupled from `RoomType` so
+/// we can layer on landmark-ref or boss-only filters later without
+/// breaking the BFS plumbing.
+pub enum GoalKind<'a> {
+    /// Any tile whose `room_type` matches the given variant.
+    Room(RoomType),
+    /// A specific landmark by `mapdb` ref (e.g. `"shattered-crown"`).
+    /// Reserved for future `/dungeon route landmark:<ref>` queries; the
+    /// current `/dungeon route` command only exposes `Room` goals.
+    #[allow(dead_code)]
+    Landmark(&'a str),
+}
+
+impl<'a> GoalKind<'a> {
+    fn matches_tile(&self, tile: &super::types::MapTile) -> bool {
+        match self {
+            GoalKind::Room(room_type) => &tile.room_type == room_type,
+            GoalKind::Landmark(r) => tile.landmark_ref.as_deref() == Some(*r),
+        }
+    }
+}
+
+/// Find the shortest path (in hops) from `from` to the nearest tile
+/// matching `goal`. Returns the full sequence `[from, ..., goal]` or
+/// `None` when no matching tile is reachable from `from`.
+pub fn path_to_goal(map: &MapState, from: MapPos, goal: GoalKind<'_>) -> Option<Vec<MapPos>> {
+    if !map.tiles.contains_key(&from) {
+        return None;
+    }
+    let goals: Vec<MapPos> = map
+        .tiles
+        .values()
+        .filter(|t| goal.matches_tile(t))
+        .map(|t| t.pos)
+        .collect();
+    if goals.is_empty() {
+        return None;
+    }
+    let graph = build_tile_graph(map);
+    let field = PathField::compute(&graph, &goals);
+    let path = field.path_from(from);
+    if path.is_empty() { None } else { Some(path) }
+}
+
+/// Convert a tile-coordinate path into a list of cardinal moves the
+/// player must make. Useful for rendering `/path` results as
+/// `North → East → East`. Returns an empty vec when `path` has fewer
+/// than two entries (already at the goal or empty path).
+pub fn directions_along_path(path: &[MapPos]) -> Vec<Direction> {
+    let mut out = Vec::with_capacity(path.len().saturating_sub(1));
+    for window in path.windows(2) {
+        let from = window[0];
+        let to = window[1];
+        for &dir in Direction::all() {
+            if from.neighbor(dir) == to {
+                out.push(dir);
+                break;
+            }
+        }
+    }
+    out
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::discord::game::types::{MapTile, RoomType};
+
+    fn tile(pos: MapPos, room_type: RoomType, exits: Vec<Direction>) -> MapTile {
+        MapTile {
+            pos,
+            room_type,
+            name: format!("Tile {},{}", pos.x, pos.y),
+            description: String::new(),
+            exits,
+            visited: true,
+            cleared: false,
+            landmark_ref: None,
+        }
+    }
+
+    fn small_map() -> MapState {
+        // Layout (visited, four-tile cross):
+        //          (0,-1) Boss
+        //  (-1,0) (0,0)   (1,0) Merchant
+        //          (0,1)
+        let mut tiles = HashMap::new();
+        let origin = MapPos::new(0, 0);
+        tiles.insert(
+            origin,
+            tile(
+                origin,
+                RoomType::UndergroundCity,
+                vec![
+                    Direction::North,
+                    Direction::South,
+                    Direction::East,
+                    Direction::West,
+                ],
+            ),
+        );
+        tiles.insert(
+            MapPos::new(0, -1),
+            tile(MapPos::new(0, -1), RoomType::Boss, vec![Direction::South]),
+        );
+        tiles.insert(
+            MapPos::new(0, 1),
+            tile(MapPos::new(0, 1), RoomType::Combat, vec![Direction::North]),
+        );
+        tiles.insert(
+            MapPos::new(1, 0),
+            tile(MapPos::new(1, 0), RoomType::Merchant, vec![Direction::West]),
+        );
+        tiles.insert(
+            MapPos::new(-1, 0),
+            tile(MapPos::new(-1, 0), RoomType::Combat, vec![Direction::East]),
+        );
+        MapState {
+            seed: 0,
+            position: origin,
+            tiles,
+            tiles_visited: 5,
+            boss_positions: vec![MapPos::new(0, -1)],
+        }
+    }
+
+    #[test]
+    fn path_finds_boss_to_north() {
+        let map = small_map();
+        let path = path_to_goal(&map, MapPos::new(0, 0), GoalKind::Room(RoomType::Boss))
+            .expect("path must exist");
+        assert_eq!(path.first(), Some(&MapPos::new(0, 0)));
+        assert_eq!(path.last(), Some(&MapPos::new(0, -1)));
+        let dirs = directions_along_path(&path);
+        assert_eq!(dirs, vec![Direction::North]);
+    }
+
+    #[test]
+    fn no_path_when_room_type_absent() {
+        let map = small_map();
+        let result = path_to_goal(&map, MapPos::new(0, 0), GoalKind::Room(RoomType::Treasure));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn path_skips_unrevealed_neighbors() {
+        // Origin has an exit east; the (1,0) tile has east exit too but
+        // there's no (2,0) tile yet. Pathfinding to a non-existent goal
+        // returns None; pathfinding to the merchant still works.
+        let map = small_map();
+        let path = path_to_goal(&map, MapPos::new(0, 0), GoalKind::Room(RoomType::Merchant))
+            .expect("merchant reachable");
+        assert_eq!(path, vec![MapPos::new(0, 0), MapPos::new(1, 0)]);
+    }
+
+    #[test]
+    fn directions_translate_each_hop() {
+        let path = vec![
+            MapPos::new(0, 0),
+            MapPos::new(1, 0),
+            MapPos::new(1, 1),
+            MapPos::new(0, 1),
+        ];
+        let dirs = directions_along_path(&path);
+        assert_eq!(
+            dirs,
+            vec![Direction::East, Direction::South, Direction::West]
+        );
+    }
+}

--- a/packages/rust/bevy/bevy_pathfinder/Cargo.toml
+++ b/packages/rust/bevy/bevy_pathfinder/Cargo.toml
@@ -20,6 +20,14 @@ default = []
 # suitable for JNI cdylibs (behavior_statetree) and CLI tools.
 bevy = ["dep:bevy"]
 
+# Sparse graph pathfinding for abstract tile games (per-node edge list,
+# not a uniform 2D grid). Use this when nodes are arbitrary coordinates
+# and adjacency is governed by per-node connectivity (e.g. a dungeon
+# whose tiles each declare which directions are open). Disjoint from
+# the dense `BlockGrid` API, which stays the right tool for voxel /
+# walkability-grid worlds.
+tile-graph = []
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 

--- a/packages/rust/bevy/bevy_pathfinder/src/graph.rs
+++ b/packages/rust/bevy/bevy_pathfinder/src/graph.rs
@@ -1,0 +1,31 @@
+//! Generic graph trait shared by both the dense [`BlockGrid`] world and
+//! sparse [`TileGraph`] adjacency lists.
+//!
+//! [`BlockGrid`]: crate::grid::BlockGrid
+//! [`TileGraph`]: crate::tile_graph::TileGraph
+
+use std::hash::Hash;
+
+/// Minimal directed-graph abstraction used by the generic
+/// [`PathField`](crate::tile_graph::PathField) BFS.
+///
+/// An implementor describes a finite set of nodes and, for each node,
+/// the set of nodes reachable in one step along with the cost of each
+/// edge. Implementors are free to store nodes/edges however they like
+/// (adjacency list, on-the-fly grid neighbors, etc.).
+///
+/// Nodes must be cheaply copyable, equatable, and hashable so they can
+/// flow through `HashMap`-backed BFS state without further bookkeeping.
+pub trait NavGraph {
+    /// Identifier for a single node. Typical implementors use small
+    /// blittable types — `(i32, i32)`, packed coords, ULID-style ids.
+    type Node: Copy + Eq + Hash;
+
+    /// Every node currently present in the graph. Order is
+    /// implementation-defined; callers must not rely on it.
+    fn nodes(&self) -> Vec<Self::Node>;
+
+    /// Outgoing edges from `node` as `(neighbor, cost)` pairs. Returns
+    /// an empty vector when `node` is not present in the graph.
+    fn neighbors(&self, node: Self::Node) -> Vec<(Self::Node, f32)>;
+}

--- a/packages/rust/bevy/bevy_pathfinder/src/lib.rs
+++ b/packages/rust/bevy/bevy_pathfinder/src/lib.rs
@@ -1,23 +1,35 @@
 //! Grid-based flow field pathfinding and chokepoint detection.
 //!
-//! Three layers:
+//! Two parallel APIs, each suited to a different graph shape:
+//!
+//! ## Dense voxel / block worlds (Minecraft-style)
 //!
 //! 1. **`BlockGrid`** — 2D walkability grid built from Minecraft block
 //!    snapshots (or any tile-based world). Each cell stores height,
 //!    walkability, and a terrain cost.
-//!
 //! 2. **`FlowField`** — BFS-computed direction vectors pointing every
 //!    walkable cell toward one or more goal positions. All agents sharing
 //!    a goal look up their next move in O(1) instead of running per-agent A*.
-//!
 //! 3. **`FlowGate`** — narrow passage / chokepoint detector. Identifies
-//!    cells where the corridor width drops below a threshold, connecting
-//!    wider regions. Useful for ambush AI, territory control, and patrol
-//!    route generation.
+//!    cells where the corridor width drops below a threshold.
 //!
-//! The crate is pure Rust by default. Enable the `bevy` feature to get
-//! `Resource` derives for ECS integration.
+//! ## Sparse abstract tile graphs (`tile-graph` feature)
+//!
+//! 1. **`NavGraph`** — minimal trait describing a node-and-edge graph
+//!    where each node yields its weighted neighbors.
+//! 2. **`TileGraph<N>`** — generic adjacency-list `NavGraph` impl for
+//!    arbitrary node types (e.g. dungeon tile coordinates with per-tile
+//!    exit directions).
+//! 3. **`PathField<N>`** — BFS result over any `NavGraph`: distance and
+//!    next-hop per node toward the nearest goal.
+//!
+//! The crate is pure Rust by default. Enable the `bevy` feature for
+//! `Resource` derives. Enable `tile-graph` for the sparse-graph API.
 
 pub mod flow_field;
 pub mod flow_gate;
+pub mod graph;
 pub mod grid;
+
+#[cfg(feature = "tile-graph")]
+pub mod tile_graph;

--- a/packages/rust/bevy/bevy_pathfinder/src/tile_graph.rs
+++ b/packages/rust/bevy/bevy_pathfinder/src/tile_graph.rs
@@ -1,0 +1,291 @@
+//! Sparse adjacency-list pathfinding for abstract tile graphs.
+//!
+//! Where [`BlockGrid`](crate::grid::BlockGrid) is the right tool for
+//! voxel / dense walkability worlds, [`TileGraph`] fits games whose
+//! "tiles" are arbitrary node types and whose adjacency is governed by
+//! per-tile connectivity rather than uniform 2D coordinates. Examples:
+//!
+//! * A dungeon whose rooms each declare which directions have doors.
+//! * A node-based map editor where edges are drawn by the designer.
+//! * A web of system-objects where neighbors are arbitrary references.
+//!
+//! Build a [`TileGraph<N>`] by adding nodes and weighted edges, then
+//! call [`PathField::compute`] to BFS from one or more goals. Every
+//! reachable node gets a distance and a next-hop pointing toward the
+//! nearest goal — the same one-shot computation pattern as the dense
+//! [`FlowField`](crate::flow_field::FlowField), generalized over node
+//! type.
+//!
+//! Gated behind the `tile-graph` feature so callers that only need the
+//! voxel pipeline don't pay the (tiny) compile cost.
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+
+use crate::graph::NavGraph;
+
+// ── TileGraph ───────────────────────────────────────────────────────
+
+/// Generic adjacency-list graph keyed by an arbitrary node type.
+///
+/// Storage is one `Vec<N>` for the node iteration order plus one
+/// `HashMap<N, Vec<(N, f32)>>` for outgoing edges. Insertion is
+/// idempotent — adding a node twice or adding the same edge twice is
+/// allowed, but the second add still appends another entry to the
+/// neighbor list (callers that care about uniqueness should dedupe
+/// upstream).
+#[derive(Debug, Clone)]
+pub struct TileGraph<N: Copy + Eq + Hash> {
+    nodes: Vec<N>,
+    edges: HashMap<N, Vec<(N, f32)>>,
+}
+
+impl<N: Copy + Eq + Hash> Default for TileGraph<N> {
+    fn default() -> Self {
+        Self {
+            nodes: Vec::new(),
+            edges: HashMap::new(),
+        }
+    }
+}
+
+impl<N: Copy + Eq + Hash> TileGraph<N> {
+    /// New empty graph.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert `node` if it isn't already present.
+    pub fn add_node(&mut self, node: N) {
+        if !self.edges.contains_key(&node) {
+            self.nodes.push(node);
+            self.edges.insert(node, Vec::new());
+        }
+    }
+
+    /// Insert a directed edge `from -> to` with the given cost. Both
+    /// endpoints are added if missing.
+    pub fn add_edge(&mut self, from: N, to: N, cost: f32) {
+        self.add_node(from);
+        self.add_node(to);
+        // SAFETY: `add_node` inserts the entry, so `get_mut` cannot fail.
+        self.edges.get_mut(&from).unwrap().push((to, cost));
+    }
+
+    /// Insert both `a -> b` and `b -> a` with the same cost.
+    pub fn add_undirected(&mut self, a: N, b: N, cost: f32) {
+        self.add_edge(a, b, cost);
+        self.add_edge(b, a, cost);
+    }
+
+    /// Total nodes in the graph.
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Borrow the node list in insertion order.
+    pub fn node_list(&self) -> &[N] {
+        &self.nodes
+    }
+}
+
+impl<N: Copy + Eq + Hash> NavGraph for TileGraph<N> {
+    type Node = N;
+
+    fn nodes(&self) -> Vec<N> {
+        self.nodes.clone()
+    }
+
+    fn neighbors(&self, node: N) -> Vec<(N, f32)> {
+        self.edges.get(&node).cloned().unwrap_or_default()
+    }
+}
+
+// ── PathField ───────────────────────────────────────────────────────
+
+/// Multi-source BFS result over any [`NavGraph`].
+///
+/// Stores per-reachable-node distance (in hops) and the next-hop node
+/// to step to in order to reach the nearest goal. Unreachable and
+/// out-of-graph nodes return `None` from every accessor.
+#[derive(Debug, Clone)]
+pub struct PathField<N: Copy + Eq + Hash> {
+    distances: HashMap<N, u32>,
+    next_hop: HashMap<N, N>,
+}
+
+impl<N: Copy + Eq + Hash> Default for PathField<N> {
+    fn default() -> Self {
+        Self {
+            distances: HashMap::new(),
+            next_hop: HashMap::new(),
+        }
+    }
+}
+
+impl<N: Copy + Eq + Hash> PathField<N> {
+    /// BFS from every node in `goals` simultaneously. Distance is in
+    /// hops (edge cost is currently ignored — a Dijkstra variant can be
+    /// added later if weighted shortest path becomes a need).
+    ///
+    /// Goals not present in `graph` are silently skipped so that a stale
+    /// goal list (e.g. a previously-revealed tile no longer in the
+    /// current map) doesn't pollute the distance table with phantom
+    /// entries.
+    pub fn compute<G: NavGraph<Node = N>>(graph: &G, goals: &[N]) -> Self {
+        use std::collections::HashSet;
+
+        let known: HashSet<N> = graph.nodes().into_iter().collect();
+        let mut distances: HashMap<N, u32> = HashMap::new();
+        let mut next_hop: HashMap<N, N> = HashMap::new();
+        let mut queue: VecDeque<N> = VecDeque::new();
+
+        for &g in goals {
+            if !known.contains(&g) || distances.contains_key(&g) {
+                continue;
+            }
+            distances.insert(g, 0);
+            queue.push_back(g);
+        }
+
+        while let Some(cur) = queue.pop_front() {
+            let cur_dist = *distances
+                .get(&cur)
+                .expect("queued node always has a recorded distance");
+            for (nb, _cost) in graph.neighbors(cur) {
+                if distances.contains_key(&nb) {
+                    continue;
+                }
+                distances.insert(nb, cur_dist + 1);
+                next_hop.insert(nb, cur);
+                queue.push_back(nb);
+            }
+        }
+
+        Self {
+            distances,
+            next_hop,
+        }
+    }
+
+    /// Hops from `node` to the nearest goal. `Some(0)` for a goal node;
+    /// `None` for unreachable or unknown nodes.
+    pub fn distance(&self, node: N) -> Option<u32> {
+        self.distances.get(&node).copied()
+    }
+
+    /// Whether the field has a recorded distance for `node`.
+    pub fn is_reachable(&self, node: N) -> bool {
+        self.distances.contains_key(&node)
+    }
+
+    /// The neighbor node to step to next from `node` to reach the
+    /// nearest goal. `None` for goal nodes (already there) or
+    /// unreachable nodes.
+    pub fn next_step(&self, node: N) -> Option<N> {
+        self.next_hop.get(&node).copied()
+    }
+
+    /// Walk the next-hop chain from `start` to its nearest goal.
+    /// Returns `[start, ..., goal]`. Empty when `start` is unreachable.
+    /// Capped at 65 535 hops as a defence against cyclic graphs that
+    /// somehow slip past the BFS invariant.
+    pub fn path_from(&self, start: N) -> Vec<N> {
+        if !self.is_reachable(start) {
+            return Vec::new();
+        }
+        let mut path = Vec::new();
+        let mut cur = start;
+        path.push(cur);
+        while let Some(&next) = self.next_hop.get(&cur) {
+            path.push(next);
+            cur = next;
+            if path.len() > u16::MAX as usize {
+                break;
+            }
+        }
+        path
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_graph_has_no_paths() {
+        let g: TileGraph<i32> = TileGraph::new();
+        let f = PathField::compute(&g, &[42]);
+        assert!(!f.is_reachable(42));
+        assert_eq!(f.distance(42), None);
+    }
+
+    #[test]
+    fn goal_is_distance_zero() {
+        let mut g: TileGraph<(i32, i32)> = TileGraph::new();
+        g.add_node((0, 0));
+        let f = PathField::compute(&g, &[(0, 0)]);
+        assert_eq!(f.distance((0, 0)), Some(0));
+        assert_eq!(f.next_step((0, 0)), None);
+    }
+
+    #[test]
+    fn linear_chain_distances() {
+        let mut g: TileGraph<u32> = TileGraph::new();
+        g.add_undirected(0, 1, 1.0);
+        g.add_undirected(1, 2, 1.0);
+        g.add_undirected(2, 3, 1.0);
+        let f = PathField::compute(&g, &[3]);
+        assert_eq!(f.distance(0), Some(3));
+        assert_eq!(f.distance(1), Some(2));
+        assert_eq!(f.distance(2), Some(1));
+        assert_eq!(f.distance(3), Some(0));
+        // Walking from 0 should give [0, 1, 2, 3].
+        let path = f.path_from(0);
+        assert_eq!(path, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn multi_goal_picks_nearest() {
+        let mut g: TileGraph<u32> = TileGraph::new();
+        for i in 0..6 {
+            g.add_undirected(i, i + 1, 1.0);
+        }
+        // Goals at 0 and 6 — middle node 3 should pick whichever side is closer.
+        let f = PathField::compute(&g, &[0, 6]);
+        assert_eq!(f.distance(0), Some(0));
+        assert_eq!(f.distance(6), Some(0));
+        assert_eq!(f.distance(3), Some(3));
+    }
+
+    #[test]
+    fn unreachable_components_stay_none() {
+        let mut g: TileGraph<u32> = TileGraph::new();
+        g.add_undirected(0, 1, 1.0);
+        g.add_node(99); // disconnected
+        let f = PathField::compute(&g, &[0]);
+        assert_eq!(f.distance(1), Some(1));
+        assert!(!f.is_reachable(99));
+        assert!(f.path_from(99).is_empty());
+    }
+
+    #[test]
+    fn directed_edges_are_one_way() {
+        let mut g: TileGraph<u32> = TileGraph::new();
+        g.add_edge(0, 1, 1.0); // only forward
+        let f_from_zero = PathField::compute(&g, &[1]);
+        // 0 reaches 1 because the edge goes 0->1 ... wait, BFS uses
+        // outgoing edges from the goal. So when goal=1, it expands 1's
+        // outgoing edges, of which there are none. So 0 is unreachable
+        // from goal 1 in this directed graph.
+        assert_eq!(f_from_zero.distance(1), Some(0));
+        assert!(!f_from_zero.is_reachable(0));
+
+        let f_from_one = PathField::compute(&g, &[0]);
+        // From goal 0 we expand 0->1, so 1 becomes distance 1.
+        assert_eq!(f_from_one.distance(0), Some(0));
+        assert_eq!(f_from_one.distance(1), Some(1));
+    }
+}


### PR DESCRIPTION
Phase 2 of #10601 — pathfinding for the Discord embed dungeon.

## Why this re-shaped the crate

The existing \`BlockGrid\` + dense \`FlowField\` API in \`bevy_pathfinder\` is the right tool for voxel / Minecraft-style worlds (the three current consumers — \`uniti\`, \`behavior_statetree\`, \`isometric/src-tauri\` — use it that way). It's the wrong tool for the Discord embed:

- The embed graph is **sparse** (only revealed tiles exist).
- It's **4-connected** with **explicit per-tile exits** (\`tile.exits: Vec<Direction>\`) — two adjacent tiles aren't necessarily connected.
- BlockGrid models walkability + height-step + 8-connected diagonals — none of which apply.

So instead of forcing voxel idioms onto an abstract tile graph, this PR adds a parallel sparse-graph API behind a new feature flag. The voxel API is untouched, all three existing consumers keep building.

## Changes

**\`bevy_pathfinder\`**
- New \`tile-graph\` cargo feature (off by default).
- New \`graph::NavGraph\` trait — minimal node-and-edge abstraction with weighted neighbors.
- New \`tile_graph::TileGraph<N>\` — adjacency-list \`NavGraph\` impl over arbitrary copyable+hashable node types.
- New \`tile_graph::PathField<N>\` — multi-source BFS over any \`NavGraph\`. Distances in hops, next-hop chain, \`path_from\` walking. Goals not present in the graph are silently skipped (keeps stale-goal calls quiet).

**\`discordsh-bot\`**
- Adds \`bevy_pathfinder\` dep with \`default-features = false, features = [\"tile-graph\"]\` — only the sparse API, no voxel baggage. Dockerfile staging mirrors existing crate pattern.
- New \`game::pathfinding\` module: \`build_tile_graph(map)\` projects \`MapState.tiles\` + per-tile exit lists into a \`TileGraph<MapPos>\`, edges only when both endpoints declare matching exits (no one-way doors today). \`path_to_goal\` BFSes from the player's tile to the nearest tile matching a \`GoalKind::Room\` or \`GoalKind::Landmark(ref)\`. \`directions_along_path\` decodes the route into cardinal moves.
- New \`/dungeon route <target>\` slash subcommand. Targets: \`boss / city / merchant / rest / treasure / story\` (with aliases like \`market\`, \`shrine\`, \`loot\`, \`lore\`). Returns hop count + \`North → East → East\` style route. Ephemeral reply. Pure query — does not move the player or reveal new tiles.

## Test plan
- [x] \`cargo test\` on \`bevy_pathfinder --features tile-graph\` — 6 new tile_graph tests pass; existing FlowField/BlockGrid tests untouched
- [x] \`cargo check\` on \`uniti\`, \`behavior_statetree\` — downstream voxel consumers still build clean
- [x] \`cargo test\` on \`discordsh-bot\` — 705 passed (701 baseline + 4 new in \`game::pathfinding\`)
- [x] \`cargo clippy --no-deps\` clean on edited bot files
- [ ] Docker build green in CI
- [ ] Smoke in staging: \`/dungeon route boss\` and \`/dungeon route city\` after exploring a few rooms

## Follow-ups (not in this PR, tracked in #10601)
- NPC pursuit AI using the same \`PathField\`
- Escape-route highlight on the SVG map render
- \`/dungeon route landmark:<ref>\` arg wired to \`GoalKind::Landmark\`