### PR TITLE
fix(astro-kbve): origin check on worker postMessage handlers (CodeQL #220-#223)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/realtime/Realtime.worker.ts
+++ b/apps/kbve/astro-kbve/src/components/realtime/Realtime.worker.ts
@@ -330,10 +330,23 @@ function renderToCanvas(event: RealtimeEvent) {
 	}
 }
 
+// Dedicated workers receive `event.origin === ''` from their owning page;
+// reject anything else to satisfy CodeQL js/missing-origin-check.
+function isAllowedOrigin(event: MessageEvent): boolean {
+	return event.origin === '' || event.origin === self.location.origin;
+}
+
 /**
  * Handle messages from main thread
  */
 self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
+	if (!isAllowedOrigin(event)) {
+		console.warn(
+			'[Realtime Worker] Rejected message from origin:',
+			event.origin,
+		);
+		return;
+	}
 	const message = event.data;
 
 	switch (message.type) {

--- a/apps/kbve/astro-kbve/src/workers/supabase.db.simple.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.db.simple.ts
@@ -1,9 +1,23 @@
 /// <reference lib="webworker" />
 // Simplified DB worker for debugging
+export {};
 
 console.log('[DB Worker Simple] Starting...');
 
+// Dedicated workers receive `event.origin === ''` from their owning page;
+// reject anything else to satisfy CodeQL js/missing-origin-check.
+function isAllowedOrigin(event: MessageEvent): boolean {
+	return event.origin === '' || event.origin === self.location.origin;
+}
+
 self.onmessage = (e) => {
+	if (!isAllowedOrigin(e)) {
+		console.warn(
+			'[DB Worker Simple] Rejected message from origin:',
+			e.origin,
+		);
+		return;
+	}
 	console.log('[DB Worker Simple] Received:', e.data);
 
 	const { id, type } = e.data;

--- a/apps/kbve/astro-kbve/src/workers/supabase.db.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.db.ts
@@ -145,8 +145,18 @@ function createWorkerStorage(id: number) {
 // Initialize worker
 console.log('[DB Worker] Initializing...');
 
+// Dedicated workers receive `event.origin === ''` from their owning page;
+// reject anything else to satisfy CodeQL js/missing-origin-check.
+function isAllowedOrigin(event: MessageEvent): boolean {
+	return event.origin === '' || event.origin === self.location.origin;
+}
+
 // Handle incoming messages
 self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
+	if (!isAllowedOrigin(e)) {
+		console.warn('[DB Worker] Rejected message from origin:', e.origin);
+		return;
+	}
 	const msg = e.data;
 	const { id, type, payload } = msg;
 

--- a/apps/kbve/astro-kbve/src/workers/test-worker.ts
+++ b/apps/kbve/astro-kbve/src/workers/test-worker.ts
@@ -1,9 +1,20 @@
 /// <reference lib="webworker" />
 // Simple test worker to verify worker loading works
+export {};
 
 console.log('[Test Worker] Starting...');
 
+// Dedicated workers receive `event.origin === ''` from their owning page;
+// reject anything else to satisfy CodeQL js/missing-origin-check.
+function isAllowedOrigin(event: MessageEvent): boolean {
+	return event.origin === '' || event.origin === self.location.origin;
+}
+
 self.onmessage = (e) => {
+	if (!isAllowedOrigin(e)) {
+		console.warn('[Test Worker] Rejected message from origin:', e.origin);
+		return;
+	}
 	console.log('[Test Worker] Received message:', e.data);
 	self.postMessage({ type: 'pong', data: e.data });
 };


### PR DESCRIPTION
## Summary

Four CodeQL `js/missing-origin-check` warnings (medium severity) closed by adding an `isAllowedOrigin` gate to each dedicated worker's `self.onmessage` handler:

- [#220](https://github.com/KBVE/kbve/security/code-scanning/220) — [Realtime.worker.ts:336](apps/kbve/astro-kbve/src/components/realtime/Realtime.worker.ts#L336)
- [#221](https://github.com/KBVE/kbve/security/code-scanning/221) — [supabase.db.simple.ts:6](apps/kbve/astro-kbve/src/workers/supabase.db.simple.ts#L6)
- [#222](https://github.com/KBVE/kbve/security/code-scanning/222) — [test-worker.ts:6](apps/kbve/astro-kbve/src/workers/test-worker.ts#L6)
- [#223](https://github.com/KBVE/kbve/security/code-scanning/223) — [supabase.db.ts:149](apps/kbve/astro-kbve/src/workers/supabase.db.ts#L149)

## Fix

Each worker now declares:

```ts
function isAllowedOrigin(event: MessageEvent): boolean {
    return event.origin === '' || event.origin === self.location.origin;
}
```

The handler short-circuits with a `console.warn` if the origin doesn't match. `event.origin === ''` is the dedicated-worker default when its owning page postMessages it; `self.location.origin` covers explicit cross-origin messages from same-origin frames if/when those are ever wired up.

`test-worker.ts` and `supabase.db.simple.ts` lacked any top-level imports/exports, so TypeScript was treating them as scripts and merging their globals — the per-file `isAllowedOrigin` declarations would have collided. Added `export {}` to each so they compile as modules. No runtime behavior change.

## Out of scope

- [#60](https://github.com/KBVE/kbve/security/code-scanning/60) is the same class of issue but lives in [packages/npm/droid/src/lib/workers/supabase-db-worker.ts](packages/npm/droid/src/lib/workers/supabase-db-worker.ts#L88) — a separate package. Deferred to keep this PR scoped to astro-kbve.

## Verification

- `npx tsc --noEmit -p apps/kbve/astro-kbve/tsconfig.json` reports no new errors in any of the four edited files.

## Test plan

- [ ] CI green on `trunk/atom-codeql-worker-origin-check-*`
- [ ] Post-merge: confirm next JS/TS CodeQL run on `main` closes #220-#223