### PR TITLE
chore(deps-dev): bump fake-indexeddb 6.0.0 -> 6.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"eslint-plugin-playwright": "^0.15.3",
 		"eslint-plugin-react": "7.35.0",
 		"eslint-plugin-react-hooks": "^7.0.1",
-		"fake-indexeddb": "^6.0.0",
+		"fake-indexeddb": "^6.2.5",
 		"grpc-tools": "^1.13.1",
 		"grpc_tools_node_protoc_ts": "^5.3.3",
 		"husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,8 +495,8 @@ importers:
                 specifier: ^7.0.1
                 version: 7.0.1(eslint@8.57.0)
             fake-indexeddb:
-                specifier: ^6.0.0
-                version: 6.0.0
+                specifier: ^6.2.5
+                version: 6.2.5
             grpc-tools:
                 specifier: ^1.13.1
                 version: 1.13.1(encoding@0.1.13)
@@ -14631,10 +14631,10 @@ packages:
             }
         engines: { '0': node >=0.6.0 }
 
-    fake-indexeddb@6.0.0:
+    fake-indexeddb@6.2.5:
         resolution:
             {
-                integrity: sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==,
+                integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==,
             }
         engines: { node: '>=18' }
 
@@ -38238,7 +38238,7 @@ snapshots:
 
     extsprintf@1.3.0: {}
 
-    fake-indexeddb@6.0.0: {}
+    fake-indexeddb@6.2.5: {}
 
     fast-content-type-parse@3.0.0: {}
 


### PR DESCRIPTION
Supersedes #10440.

The dependabot PR had bitrotted into an 80k-line indentation-churn diff because dependabot regenerates the lock with 2-space indent, while dev's lock is prettier-formatted to 4-space (per \`.prettierrc.mjs\` \`tabWidth: 4\`). Reapplying the version bump cleanly here gives a tiny diff: \`package.json\` + 10 lines of \`pnpm-lock.yaml\`.

## Changes

- \`package.json\` — pin \`fake-indexeddb\` from \`^6.0.0\` to \`^6.2.5\`
- \`pnpm-lock.yaml\` — regenerated lock entry for the new version

## Test plan

- [x] \`npx nx run-many -t test --projects=droid,khashvault\` — 106 tests pass across 11 files. \`droid\` and \`khashvault\` are the only consumers; both \`import 'fake-indexeddb/auto'\` from their vitest setup files
- [ ] Close #10440 once this lands