### PR TITLE
fix(chuckrpg): stub bevy_tasker; feat(rentearth): harden Deployment

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -72,6 +72,11 @@ COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
 COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
 COPY packages/rust/bevy/bevy_kbve_net/Cargo.toml packages/rust/bevy/bevy_kbve_net/Cargo.toml
 COPY packages/rust/bevy/bevy_npc/Cargo.toml packages/rust/bevy/bevy_npc/Cargo.toml
+# bevy_kbve_net carries an optional path dep on bevy_tasker behind the
+# "creatures" feature. cargo chef prepare reads every member manifest
+# fully — including optional path deps — so the bevy_tasker manifest
+# must exist on disk even though we never enable the feature here.
+COPY packages/rust/bevy/bevy_tasker/Cargo.toml packages/rust/bevy/bevy_tasker/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
@@ -80,7 +85,8 @@ RUN mkdir -p apps/chuckrpg/axum-chuckrpg/src && echo "fn main() {}" > apps/chuck
     mkdir -p packages/rust/holy/src && echo "" > packages/rust/holy/src/lib.rs && \
     mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_kbve_net/src && echo "" > packages/rust/bevy/bevy_kbve_net/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs
+    mkdir -p packages/rust/bevy/bevy_npc/src && echo "" > packages/rust/bevy/bevy_npc/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_tasker/src && echo "" > packages/rust/bevy/bevy_tasker/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -124,6 +130,12 @@ COPY packages/rust/holy packages/rust/holy
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_kbve_net packages/rust/bevy/bevy_kbve_net
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
+# bevy_kbve_net's optional bevy_tasker path dep — cargo resolves the
+# manifest even when the feature is off, so the source must exist on
+# disk. Copying the real crate is safer than a stub here because the
+# cached target/ inherited from chef cook references the same on-disk
+# fingerprint.
+COPY packages/rust/bevy/bevy_tasker packages/rust/bevy/bevy_tasker
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -144,6 +156,7 @@ COPY packages/rust/holy packages/rust/holy
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/bevy/bevy_kbve_net packages/rust/bevy/bevy_kbve_net
 COPY packages/rust/bevy/bevy_npc packages/rust/bevy/bevy_npc
+COPY packages/rust/bevy/bevy_tasker packages/rust/bevy/bevy_tasker
 
 # Application source (most frequently changing — placed last for cache)
 COPY apps/chuckrpg/axum-chuckrpg apps/chuckrpg/axum-chuckrpg

--- a/apps/kube/rentearth/README.md
+++ b/apps/kube/rentearth/README.md
@@ -1,0 +1,40 @@
+# rentearth — Kubernetes Deployment
+
+Single-Deployment service serving `rentearth.com`. Bridges the Astro frontend, Supabase backend, and the in-cluster Ergo IRC service. Routes through both the Cilium `kbve-gateway` (HTTPRoute) and the legacy nginx Ingress for `letsencrypt-http` cert minting.
+
+## Manifests
+
+| File                                     | Purpose                                                                                             |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `application.yaml`                       | ArgoCD `Application` pointing at `apps/kube/rentearth/manifest`                                     |
+| `manifest/kustomization.yaml`            | Kustomize index                                                                                     |
+| `manifest/rentearth-serviceaccount.yaml` | `rentearth-external-secrets` (used by ExternalSecrets) + `rentearth-sa` (used by the pod)           |
+| `manifest/rentearth-externalsecret.yaml` | SecretStore + ExternalSecret rendering `supabase-shared` from kilobase                              |
+| `manifest/rentearth-deployment.yaml`     | `rentearth-deployment` + `rentearth-service` (ClusterIP)                                            |
+| `manifest/httproute.yaml`                | HTTPRoute attaching the service to `kbve-gateway`                                                   |
+| `manifest/nginx-ingress.yaml`            | Legacy nginx Ingress — kept active because cert-manager's ingress-shim mints the TLS Secret from it |
+
+## Hardening
+
+The Deployment runs under a restricted PodSecurity profile:
+
+- `runAsNonRoot: true`, UID/GID `10001`. The upstream `ghcr.io/kbve/rentearth:1.0.18` image was built without an explicit `USER` directive (binary owned by root), but the binary itself is world-executable and self-contained, so an arbitrary non-root UID works. Verified locally that the image starts cleanly under `--user 10001:10001 --read-only --tmpfs /tmp:size=64M` (it parses env and proceeds to runtime — only fails on missing required Supabase env, which is post-startup).
+- `readOnlyRootFilesystem: true` with a 64Mi `emptyDir` mounted at `/tmp` for scratch
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- Dedicated `rentearth-sa` ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod level. The pod no longer rides on the `default` SA. The existing `rentearth-external-secrets` SA is unchanged — it is the credential ExternalSecrets uses to read source secrets out of `kilobase` and is not the pod SA.
+- CPU/memory `requests` and `limits` set so the kubelet enforces a cgroup; bursts cap at `2 CPU / 1 GiB`.
+
+## Reloader integration
+
+The Deployment carries `reloader.stakater.com/auto: "true"`. Stakater Reloader rolls the workload whenever `supabase-shared` rotates — the ExternalSecret refreshes that Secret hourly from the kilobase JWT/db source. The pod template also keeps a static `rollout-restart` annotation so a manual rollout can still be forced by bumping the timestamp if Reloader ever misses an event.
+
+## TLS
+
+cert-manager mints the TLS Secret via the active `nginx-ingress.yaml` (annotated with `cert-manager.io/cluster-issuer: letsencrypt-http`); the Ingress is in the kustomization so the ingress-shim sees it and creates the `Certificate` automatically. No explicit `Certificate` resource is required for this namespace today.
+
+## ArgoCD
+
+- App: `rentearth` (source: `apps/kube/rentearth/manifest`)
+- Sync: automated with prune + selfHeal
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/rentearth/manifest/rentearth-deployment.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-deployment.yaml
@@ -5,6 +5,12 @@ metadata:
     namespace: rentearth
     labels:
         app: rentearth
+    annotations:
+        # Reloader rolls this Deployment whenever supabase-shared
+        # rotates (rendered hourly by rentearth-supabase-secrets
+        # ExternalSecret) — Supabase JWT/key rotations propagate
+        # without a manual kubectl rollout restart.
+        reloader.stakater.com/auto: 'true'
 spec:
     replicas: 1
     selector:
@@ -13,11 +19,24 @@ spec:
     template:
         metadata:
             annotations:
+                # Manual rollout-restart trigger preserved as a fallback
+                # if Reloader misses a Secret rotation — bump the value
+                # to force the Deployment controller to roll the pods.
                 rollout-restart: '2026-01-12T02:11:58Z'
             labels:
                 app: rentearth
                 version: '1.0.18'
         spec:
+            serviceAccountName: rentearth-sa
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                fsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: rentearth
                   image: ghcr.io/kbve/rentearth:1.0.18
@@ -56,6 +75,23 @@ spec:
                       limits:
                           memory: '1024Mi'
                           cpu: '2000m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+            volumes:
+                # Writable scratch for the binary while the rootfs
+                # itself stays read-only. Verified locally that the
+                # ghcr.io/kbve/rentearth:1.0.18 image starts cleanly
+                # under runAsUser:10001 + read-only rootfs + tmpfs /tmp.
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 64Mi
 ---
 apiVersion: v1
 kind: Service

--- a/apps/kube/rentearth/manifest/rentearth-serviceaccount.yaml
+++ b/apps/kube/rentearth/manifest/rentearth-serviceaccount.yaml
@@ -1,5 +1,19 @@
+# ServiceAccount used by ExternalSecrets to read source secrets out of
+# the kilobase namespace via the kilobase-remote-secret-store
+# SecretStore. Bound by Roles in apps/kube/kilobase manifests.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
     name: rentearth-external-secrets
     namespace: rentearth
+---
+# ServiceAccount used by the rentearth Deployment pod. The pod does not
+# call the kube API, so the projected token is unused weight — disable
+# it here at the SA level. The pod spec re-states the field so any
+# future template binding the SA inherits the safe default.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: rentearth-sa
+    namespace: rentearth
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

Two coordinated changes.

### 1. `fix(chuckrpg)` — stub `bevy_tasker` in `axum-chuckrpg` Dockerfile

Resolves #10594. The chuckrpg Docker build has been failing on `main` with:

```
failed to read `/app/packages/rust/bevy/bevy_tasker/Cargo.toml`
Caused by: No such file or directory (os error 2)
ERROR: failed to build: failed to solve: process "/bin/sh -c cargo chef prepare --recipe-path recipe.json" did not complete successfully: exit code: 1
```

#### Root cause

`packages/rust/bevy/bevy_kbve_net/Cargo.toml` carries an optional path dep on `bevy_tasker` behind the `creatures` feature:

```toml
creatures = ["npcdb", "dep:bevy_tasker", "dep:crossbeam-channel", "dep:dashmap"]
bevy_tasker = { version = "0.1", path = "../bevy_tasker", optional = true }
```

`cargo chef prepare` parses every workspace member's manifest **fully**, including optional path deps — so `bevy_tasker`'s `Cargo.toml` must exist on disk in the build context even though the `creatures` feature is disabled. The chuckrpg Dockerfile previously copied `bevy_npc` and `bevy_kbve_net` but not `bevy_tasker`, which is why `cargo chef prepare` errored.

#### Fix

- Stage C (planner): add `COPY packages/rust/bevy/bevy_tasker/Cargo.toml ...` plus a stub `src/lib.rs` so the manifest resolves.
- Stage E (foundation) and Stage F (builder): `COPY packages/rust/bevy/bevy_tasker packages/rust/bevy/bevy_tasker` so cargo's manifest resolution during `cargo build` finds the path.

Verified locally with `docker build --target planner -f apps/chuckrpg/axum-chuckrpg/Dockerfile .` — `cargo chef prepare` now exits `0`.

This is a stub-side fix only; the `creatures` feature remains disabled and `bevy_tasker` is not built.

### 2. `feat(rentearth)` — harden Deployment + Reloader-driven secret rotation

Continues the small-namespace hardening rollout after chuckrpg (#10547), redis (#10556), n8n (#10558), discordsh (#10568), herbmail (#10582), cryptothrone (#10597), and memes (#10606).

- `rentearth-deployment` now runs under a restricted PSA profile: `runAsNonRoot: true` UID/GID `10001`, `readOnlyRootFilesystem: true` with a 64Mi `/tmp` emptyDir, `allowPrivilegeEscalation: false`, all Linux capabilities dropped, `seccompProfile: RuntimeDefault`.
- The upstream `ghcr.io/kbve/rentearth:1.0.18` image was built without an explicit `USER` directive (binary owned by root), but the binary itself is world-executable and self-contained. Verified locally that the image starts cleanly under `--user 10001:10001 --read-only --tmpfs /tmp:size=64M` (panics on missing required `SUPABASE_ANON_KEY` env, which is post-startup — proves the hardening doesn't block init).
- New dedicated `rentearth-sa` ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod level. The pod no longer rides on the `default` SA. The existing `rentearth-external-secrets` SA is unchanged — it is the credential ExternalSecrets uses against kilobase, not the pod SA.
- Adds `reloader.stakater.com/auto: "true"` so the hourly `supabase-shared` rotation rolls the pod automatically. The existing `rollout-restart` pod-template annotation is preserved as a manual fallback (belt-and-suspenders alongside Reloader).
- New `apps/kube/rentearth/README.md` documents topology, hardening posture, and the Reloader / cert flows.

## Hardening pattern by namespace so far

| ns           | manifest type | Reloader | non-root  | readOnly rootfs | caps drop | SA token off |
| ------------ | ------------- | -------- | --------- | --------------- | --------- | ------------ |
| chuckrpg     | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| redis        | Bitnami chart | yes      | chart     | chart           | chart     | chart        |
| n8n          | raw           | yes      | UID 1000  | deferred        | yes       | yes          |
| discordsh    | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| herbmail     | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| cryptothrone | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| memes        | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| rentearth    | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |

## Test plan

- [ ] `axum-chuckrpg-e2e` Docker job (the one tracked by #10594) passes again on the next CI run.
- [ ] ArgoCD `rentearth` Application syncs cleanly after dev → main promotion.
- [ ] `kubectl -n rentearth get pod -l app=rentearth` shows the pod `Running` under SA `rentearth-sa`, `runAsUser: 10001`, `readOnlyRootFilesystem: true`.
- [ ] `kubectl -n rentearth get deploy rentearth-deployment -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}'` returns `"true"`.
- [ ] The rentearth public hostname keeps responding through the gateway during and after rollout.
- [ ] Trigger a no-op rotation on `supabase-shared` (or wait for the hourly ExternalSecret refresh) and observe Reloader rolling the Deployment.

Closes #10594.