### PR TITLE
chore(deps-dev): bump eslint-plugin-import 2.31.0 -> 2.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"esbuild": "0.25.0",
 		"eslint": "8.57.0",
 		"eslint-config-prettier": "10.1.2",
-		"eslint-plugin-import": "2.31.0",
+		"eslint-plugin-import": "2.32.0",
 		"eslint-plugin-jsx-a11y": "6.10.2",
 		"eslint-plugin-playwright": "^0.15.3",
 		"eslint-plugin-react": "7.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,8 +480,8 @@ importers:
                 specifier: 10.1.2
                 version: 10.1.2(eslint@8.57.0)
             eslint-plugin-import:
-                specifier: 2.31.0
-                version: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)
+                specifier: 2.32.0
+                version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)
             eslint-plugin-jsx-a11y:
                 specifier: 6.10.2
                 version: 6.10.2(eslint@8.57.0)
@@ -10682,6 +10682,13 @@ packages:
             }
         engines: { node: '>= 0.4' }
 
+    array-includes@3.1.9:
+        resolution:
+            {
+                integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==,
+            }
+        engines: { node: '>= 0.4' }
+
     array-iterate@2.0.1:
         resolution:
             {
@@ -10709,10 +10716,10 @@ packages:
             }
         engines: { node: '>= 0.4' }
 
-    array.prototype.findlastindex@1.2.5:
+    array.prototype.findlastindex@1.2.6:
         resolution:
             {
-                integrity: sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==,
+                integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==,
             }
         engines: { node: '>= 0.4' }
 
@@ -10723,10 +10730,10 @@ packages:
             }
         engines: { node: '>= 0.4' }
 
-    array.prototype.flatmap@1.3.2:
+    array.prototype.flat@1.3.3:
         resolution:
             {
-                integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==,
+                integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==,
             }
         engines: { node: '>= 0.4' }
 
@@ -13980,6 +13987,13 @@ packages:
             }
         engines: { node: '>= 0.4' }
 
+    es-abstract@1.24.2:
+        resolution:
+            {
+                integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==,
+            }
+        engines: { node: '>= 0.4' }
+
     es-define-property@1.0.1:
         resolution:
             {
@@ -14159,10 +14173,10 @@ packages:
                 integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==,
             }
 
-    eslint-module-utils@2.12.0:
+    eslint-module-utils@2.12.1:
         resolution:
             {
-                integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==,
+                integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==,
             }
         engines: { node: '>=4' }
         peerDependencies:
@@ -14183,10 +14197,10 @@ packages:
             eslint-import-resolver-webpack:
                 optional: true
 
-    eslint-plugin-import@2.31.0:
+    eslint-plugin-import@2.32.0:
         resolution:
             {
-                integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==,
+                integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==,
             }
         engines: { node: '>=4' }
         peerDependencies:
@@ -20019,13 +20033,6 @@ packages:
             }
         engines: { node: '>= 0.4' }
 
-    object.values@1.2.0:
-        resolution:
-            {
-                integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==,
-            }
-        engines: { node: '>= 0.4' }
-
     object.values@1.2.1:
         resolution:
             {
@@ -23542,6 +23549,13 @@ packages:
                 integrity: sha512-EEHMVYHNXFHfGtgjNITnka0aHhiAlo93F7z2/Pwd+g0teG9CnM3JIINM7hVVB5/rhw9voufD7Wukwgtw2uqh6w==,
             }
 
+    stop-iteration-iterator@1.1.0:
+        resolution:
+            {
+                integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==,
+            }
+        engines: { node: '>= 0.4' }
+
     stream-buffers@2.2.0:
         resolution:
             {
@@ -23662,12 +23676,6 @@ packages:
                 integrity: sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==,
             }
         engines: { node: '>= 0.4' }
-
-    string.prototype.trimend@1.0.8:
-        resolution:
-            {
-                integrity: sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==,
-            }
 
     string.prototype.trimend@1.0.9:
         resolution:
@@ -27250,7 +27258,7 @@ snapshots:
             '@babel/helper-plugin-utils': 7.28.6
             debug: 4.4.3
             lodash.debounce: 4.0.8
-            resolve: 1.22.11
+            resolve: 1.22.12
         transitivePeerDependencies:
             - supports-color
         optional: true
@@ -27262,7 +27270,7 @@ snapshots:
             '@babel/helper-plugin-utils': 7.28.6
             debug: 4.4.3
             lodash.debounce: 4.0.8
-            resolve: 1.22.11
+            resolve: 1.22.12
         transitivePeerDependencies:
             - supports-color
 
@@ -30308,7 +30316,7 @@ snapshots:
             '@microsoft/tsdoc': 0.15.1
             ajv: 8.12.0
             jju: 1.4.0
-            resolve: 1.22.11
+            resolve: 1.22.12
 
     '@microsoft/tsdoc@0.15.1': {}
 
@@ -33125,14 +33133,14 @@ snapshots:
             fs-extra: 11.3.0
             import-lazy: 4.0.0
             jju: 1.4.0
-            resolve: 1.22.11
+            resolve: 1.22.12
             semver: 7.5.4
         optionalDependencies:
             '@types/node': 18.19.17
 
     '@rushstack/rig-package@0.5.3':
         dependencies:
-            resolve: 1.22.11
+            resolve: 1.22.12
             strip-json-comments: 3.1.1
 
     '@rushstack/terminal@0.15.1(@types/node@18.19.17)':
@@ -35252,6 +35260,17 @@ snapshots:
             get-intrinsic: 1.2.4
             is-string: 1.0.7
 
+    array-includes@3.1.9:
+        dependencies:
+            call-bind: 1.0.8
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-object-atoms: 1.1.1
+            get-intrinsic: 1.3.0
+            is-string: 1.1.1
+            math-intrinsics: 1.1.0
+
     array-iterate@2.0.1: {}
 
     array-shuffle@1.0.1: {}
@@ -35267,14 +35286,15 @@ snapshots:
             es-object-atoms: 1.1.1
             es-shim-unscopables: 1.1.0
 
-    array.prototype.findlastindex@1.2.5:
+    array.prototype.findlastindex@1.2.6:
         dependencies:
-            call-bind: 1.0.7
+            call-bind: 1.0.8
+            call-bound: 1.0.4
             define-properties: 1.2.1
-            es-abstract: 1.23.3
+            es-abstract: 1.23.9
             es-errors: 1.3.0
-            es-object-atoms: 1.0.0
-            es-shim-unscopables: 1.0.2
+            es-object-atoms: 1.1.1
+            es-shim-unscopables: 1.1.0
 
     array.prototype.flat@1.3.2:
         dependencies:
@@ -35283,12 +35303,12 @@ snapshots:
             es-abstract: 1.23.3
             es-shim-unscopables: 1.0.2
 
-    array.prototype.flatmap@1.3.2:
+    array.prototype.flat@1.3.3:
         dependencies:
-            call-bind: 1.0.7
+            call-bind: 1.0.8
             define-properties: 1.2.1
-            es-abstract: 1.23.3
-            es-shim-unscopables: 1.0.2
+            es-abstract: 1.23.9
+            es-shim-unscopables: 1.1.0
 
     array.prototype.flatmap@1.3.3:
         dependencies:
@@ -37525,7 +37545,7 @@ snapshots:
             has-property-descriptors: 1.0.2
             has-proto: 1.0.3
             has-symbols: 1.1.0
-            hasown: 2.0.2
+            hasown: 2.0.3
             internal-slot: 1.0.7
             is-array-buffer: 3.0.4
             is-callable: 1.2.7
@@ -37543,7 +37563,7 @@ snapshots:
             safe-array-concat: 1.1.2
             safe-regex-test: 1.1.0
             string.prototype.trim: 1.2.9
-            string.prototype.trimend: 1.0.8
+            string.prototype.trimend: 1.0.9
             string.prototype.trimstart: 1.0.8
             typed-array-buffer: 1.0.2
             typed-array-byte-length: 1.0.1
@@ -37576,7 +37596,7 @@ snapshots:
             has-property-descriptors: 1.0.2
             has-proto: 1.2.0
             has-symbols: 1.1.0
-            hasown: 2.0.2
+            hasown: 2.0.3
             internal-slot: 1.1.0
             is-array-buffer: 3.0.5
             is-callable: 1.2.7
@@ -37596,6 +37616,63 @@ snapshots:
             safe-push-apply: 1.0.0
             safe-regex-test: 1.1.0
             set-proto: 1.0.0
+            string.prototype.trim: 1.2.10
+            string.prototype.trimend: 1.0.9
+            string.prototype.trimstart: 1.0.8
+            typed-array-buffer: 1.0.3
+            typed-array-byte-length: 1.0.3
+            typed-array-byte-offset: 1.0.4
+            typed-array-length: 1.0.7
+            unbox-primitive: 1.1.0
+            which-typed-array: 1.1.19
+
+    es-abstract@1.24.2:
+        dependencies:
+            array-buffer-byte-length: 1.0.2
+            arraybuffer.prototype.slice: 1.0.4
+            available-typed-arrays: 1.0.7
+            call-bind: 1.0.8
+            call-bound: 1.0.4
+            data-view-buffer: 1.0.2
+            data-view-byte-length: 1.0.2
+            data-view-byte-offset: 1.0.1
+            es-define-property: 1.0.1
+            es-errors: 1.3.0
+            es-object-atoms: 1.1.1
+            es-set-tostringtag: 2.1.0
+            es-to-primitive: 1.3.0
+            function.prototype.name: 1.1.8
+            get-intrinsic: 1.3.0
+            get-proto: 1.0.1
+            get-symbol-description: 1.1.0
+            globalthis: 1.0.4
+            gopd: 1.2.0
+            has-property-descriptors: 1.0.2
+            has-proto: 1.2.0
+            has-symbols: 1.1.0
+            hasown: 2.0.3
+            internal-slot: 1.1.0
+            is-array-buffer: 3.0.5
+            is-callable: 1.2.7
+            is-data-view: 1.0.2
+            is-negative-zero: 2.0.3
+            is-regex: 1.2.1
+            is-set: 2.0.3
+            is-shared-array-buffer: 1.0.4
+            is-string: 1.1.1
+            is-typed-array: 1.1.15
+            is-weakref: 1.1.1
+            math-intrinsics: 1.1.0
+            object-inspect: 1.13.4
+            object-keys: 1.1.1
+            object.assign: 4.1.7
+            own-keys: 1.0.1
+            regexp.prototype.flags: 1.5.4
+            safe-array-concat: 1.1.3
+            safe-push-apply: 1.0.0
+            safe-regex-test: 1.1.0
+            set-proto: 1.0.0
+            stop-iteration-iterator: 1.1.0
             string.prototype.trim: 1.2.10
             string.prototype.trimend: 1.0.9
             string.prototype.trimstart: 1.0.8
@@ -37646,15 +37723,15 @@ snapshots:
             es-errors: 1.3.0
             get-intrinsic: 1.3.0
             has-tostringtag: 1.0.2
-            hasown: 2.0.2
+            hasown: 2.0.3
 
     es-shim-unscopables@1.0.2:
         dependencies:
-            hasown: 2.0.2
+            hasown: 2.0.3
 
     es-shim-unscopables@1.1.0:
         dependencies:
-            hasown: 2.0.2
+            hasown: 2.0.3
 
     es-to-primitive@1.2.1:
         dependencies:
@@ -37768,12 +37845,12 @@ snapshots:
     eslint-import-resolver-node@0.3.9:
         dependencies:
             debug: 3.2.7
-            is-core-module: 2.15.1
-            resolve: 1.22.10
+            is-core-module: 2.16.2
+            resolve: 1.22.12
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
         dependencies:
             debug: 3.2.7
         optionalDependencies:
@@ -37783,27 +37860,27 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0):
+    eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0):
         dependencies:
             '@rtsao/scc': 1.1.0
-            array-includes: 3.1.8
-            array.prototype.findlastindex: 1.2.5
-            array.prototype.flat: 1.3.2
-            array.prototype.flatmap: 1.3.2
+            array-includes: 3.1.9
+            array.prototype.findlastindex: 1.2.6
+            array.prototype.flat: 1.3.3
+            array.prototype.flatmap: 1.3.3
             debug: 3.2.7
             doctrine: 2.1.0
             eslint: 8.57.0
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
-            hasown: 2.0.2
-            is-core-module: 2.15.1
+            eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+            hasown: 2.0.3
+            is-core-module: 2.16.2
             is-glob: 4.0.3
             minimatch: 3.1.4
             object.fromentries: 2.0.8
             object.groupby: 1.0.3
-            object.values: 1.2.0
+            object.values: 1.2.1
             semver: 6.3.1
-            string.prototype.trimend: 1.0.8
+            string.prototype.trimend: 1.0.9
             tsconfig-paths: 3.15.0
         optionalDependencies:
             '@typescript-eslint/parser': 7.18.0(eslint@8.57.0)(typescript@5.9.3)
@@ -38507,7 +38584,7 @@ snapshots:
             asynckit: 0.4.0
             combined-stream: 1.0.8
             es-set-tostringtag: 2.1.0
-            hasown: 2.0.2
+            hasown: 2.0.3
             mime-types: 2.1.35
 
     forwarded@0.2.0: {}
@@ -38581,7 +38658,7 @@ snapshots:
             call-bound: 1.0.4
             define-properties: 1.2.1
             functions-have-names: 1.2.3
-            hasown: 2.0.2
+            hasown: 2.0.3
             is-callable: 1.2.7
 
     functions-have-names@1.2.3: {}
@@ -38602,7 +38679,7 @@ snapshots:
             function-bind: 1.1.2
             has-proto: 1.0.3
             has-symbols: 1.1.0
-            hasown: 2.0.2
+            hasown: 2.0.3
 
     get-intrinsic@1.3.0:
         dependencies:
@@ -38614,7 +38691,7 @@ snapshots:
             get-proto: 1.0.1
             gopd: 1.2.0
             has-symbols: 1.1.0
-            hasown: 2.0.2
+            hasown: 2.0.3
             math-intrinsics: 1.1.0
 
     get-nonce@1.0.1: {}
@@ -38977,7 +39054,6 @@ snapshots:
     hasown@2.0.3:
         dependencies:
             function-bind: 1.1.2
-        optional: true
 
     hast-util-embedded@3.0.0:
         dependencies:
@@ -39512,13 +39588,13 @@ snapshots:
     internal-slot@1.0.7:
         dependencies:
             es-errors: 1.3.0
-            hasown: 2.0.2
+            hasown: 2.0.3
             side-channel: 1.1.0
 
     internal-slot@1.1.0:
         dependencies:
             es-errors: 1.3.0
-            hasown: 2.0.2
+            hasown: 2.0.3
             side-channel: 1.1.0
 
     internmap@1.0.1: {}
@@ -39598,16 +39674,15 @@ snapshots:
 
     is-core-module@2.15.1:
         dependencies:
-            hasown: 2.0.2
+            hasown: 2.0.3
 
     is-core-module@2.16.1:
         dependencies:
-            hasown: 2.0.2
+            hasown: 2.0.3
 
     is-core-module@2.16.2:
         dependencies:
             hasown: 2.0.3
-        optional: true
 
     is-data-view@1.0.1:
         dependencies:
@@ -39734,7 +39809,7 @@ snapshots:
             call-bound: 1.0.4
             gopd: 1.2.0
             has-tostringtag: 1.0.2
-            hasown: 2.0.2
+            hasown: 2.0.3
 
     is-regexp@1.0.0: {}
 
@@ -42339,22 +42414,16 @@ snapshots:
 
     object.fromentries@2.0.8:
         dependencies:
-            call-bind: 1.0.7
+            call-bind: 1.0.8
             define-properties: 1.2.1
-            es-abstract: 1.23.3
-            es-object-atoms: 1.0.0
+            es-abstract: 1.23.9
+            es-object-atoms: 1.1.1
 
     object.groupby@1.0.3:
         dependencies:
-            call-bind: 1.0.7
+            call-bind: 1.0.8
             define-properties: 1.2.1
-            es-abstract: 1.23.3
-
-    object.values@1.2.0:
-        dependencies:
-            call-bind: 1.0.7
-            define-properties: 1.2.1
-            es-object-atoms: 1.0.0
+            es-abstract: 1.23.9
 
     object.values@1.2.1:
         dependencies:
@@ -44126,13 +44195,13 @@ snapshots:
 
     resolve@1.22.10:
         dependencies:
-            is-core-module: 2.16.1
+            is-core-module: 2.16.2
             path-parse: 1.0.7
             supports-preserve-symlinks-flag: 1.0.0
 
     resolve@1.22.11:
         dependencies:
-            is-core-module: 2.16.1
+            is-core-module: 2.16.2
             path-parse: 1.0.7
             supports-preserve-symlinks-flag: 1.0.0
 
@@ -44142,7 +44211,6 @@ snapshots:
             is-core-module: 2.16.2
             path-parse: 1.0.7
             supports-preserve-symlinks-flag: 1.0.0
-        optional: true
 
     resolve@1.22.8:
         dependencies:
@@ -44917,6 +44985,11 @@ snapshots:
         dependencies:
             graceful-fs: 4.2.11
 
+    stop-iteration-iterator@1.1.0:
+        dependencies:
+            es-errors: 1.3.0
+            internal-slot: 1.1.0
+
     stream-buffers@2.2.0:
         optional: true
 
@@ -45017,12 +45090,6 @@ snapshots:
             define-properties: 1.2.1
             es-abstract: 1.23.9
             es-object-atoms: 1.1.1
-
-    string.prototype.trimend@1.0.8:
-        dependencies:
-            call-bind: 1.0.7
-            define-properties: 1.2.1
-            es-object-atoms: 1.0.0
 
     string.prototype.trimend@1.0.9:
         dependencies:


### PR DESCRIPTION
Supersedes #10075. Stale dependabot PR was unmergeable — reapplied cleanly against current dev.

## Changes

- \`package.json\` — pin \`eslint-plugin-import\` from \`2.31.0\` to \`2.32.0\`
- \`pnpm-lock.yaml\` — version entry + transitive shifts (~150 lines)

## Test plan

- [x] \`npx nx run-many -t lint --projects=devops,droid,khashvault,laser\` — clean (only pre-existing \`no-unused-vars\` warnings)
- [ ] Close #10075 once this lands