### PR TITLE
fix(firecracker): sbom is boolean, provenance is string in nx-tools

### DIFF
--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -42,7 +42,7 @@
 					"load": true,
 					"push": false,
 					"provenance": "false",
-					"sbom": "false"
+					"sbom": false
 				}
 			}
 		},


### PR DESCRIPTION
## Summary

Run [#25540234933](https://github.com/KBVE/kbve/actions/runs/25540234933):

\`\`\`
Property 'sbom' does not match the schema. 'false' should be a 'boolean'.
\`\`\`

\`@nx-tools/nx-container:build\`'s input schema is **asymmetric**:

- \`provenance\`: **string** — accepts \`\"false\"\` / \`\"true\"\` / \`\"max\"\` / \`\"mode=max\"\` / profile JSON, matching the underlying \`docker/build-push-action\` semantics.
- \`sbom\`: **boolean** — only \`true\` / \`false\`.

PR #10622 unified both as strings to fix the prior \`provenance\` error, which broke \`sbom\`. Use the correct type per field.

## Test plan

- [ ] After merge, \`CI - Docker / firecracker-python-net\` passes the executor schema check, builds without provenance/sbom attestations, \`--load\`s the single-arch image into the daemon, and the shared workflow pushes \`:0.1.0\` + \`:latest\`.