### PR TITLE
fix(astro-kbve): tainted format string + WS URL allowlist (CodeQL #218, #227)

### DIFF
--- a/apps/kbve/astro-kbve/src/workers/supabase.db.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.db.ts
@@ -317,7 +317,9 @@ self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
 				});
 		}
 	} catch (err: any) {
-		console.error(`[DB Worker] Error handling ${type}:`, err);
+		// Pass the user-controlled `type` as a separate argument rather than
+		// interpolating it into the format string (CodeQL js/tainted-format-string).
+		console.error('[DB Worker] Error handling', type, ':', err);
 		respond(id, { ok: false, error: err.message || String(err) });
 	}
 };

--- a/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.websocket.ts
@@ -81,13 +81,41 @@ function sanitizeForLog(value: unknown): string {
 
 console.log('[WebSocket Worker] Initializing...');
 
-// Determine WebSocket URL
+// Determine WebSocket URL.
+// `customUrl` arrives via worker postMessage and is treated as user-controlled,
+// so it is validated against an allowlist before use (CodeQL
+// js/client-side-request-forgery): scheme must be ws/wss and host must equal
+// the worker's own origin host. Anything else falls back to the default.
 function getWebSocketUrl(customUrl?: string): string {
-	if (customUrl) return customUrl;
+	const fallback = 'ws://localhost:4321/ws';
+	if (!customUrl) return fallback;
 
-	// In dedicated worker, we don't have location, so use default
-	// The URL should be passed from main thread
-	return 'ws://localhost:4321/ws';
+	let parsed: URL;
+	try {
+		parsed = new URL(customUrl);
+	} catch {
+		console.warn('[WebSocket Worker] Rejected malformed customUrl');
+		return fallback;
+	}
+
+	if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+		console.warn(
+			'[WebSocket Worker] Rejected non-ws scheme:',
+			parsed.protocol,
+		);
+		return fallback;
+	}
+
+	const expectedHost = self.location?.host;
+	if (expectedHost && parsed.host !== expectedHost) {
+		console.warn(
+			'[WebSocket Worker] Rejected cross-origin host:',
+			parsed.host,
+		);
+		return fallback;
+	}
+
+	return parsed.toString();
 }
 
 // Connect to WebSocket


### PR DESCRIPTION
## Summary

Two CodeQL alerts in the astro-kbve workers cleaned up:

- [#218](https://github.com/KBVE/kbve/security/code-scanning/218) `js/tainted-format-string` (high warning) — [supabase.db.ts:320](apps/kbve/astro-kbve/src/workers/supabase.db.ts#L320). The handler logged its error with the user-controlled `type` interpolated into the first argument of `console.error`, which `console` treats as a printf-style format string (`%s`/`%o` substitutions). Pass `type` as a separate argument instead.
- [#227](https://github.com/KBVE/kbve/security/code-scanning/227) `js/client-side-request-forgery` (medium error) — [supabase.websocket.ts:122](apps/kbve/astro-kbve/src/workers/supabase.websocket.ts#L122). The `WebSocket(authenticatedUrl)` host derives from `wsUrl`, which arrives via worker postMessage and is therefore user-controlled. `getWebSocketUrl` now parses `customUrl`, requires `ws:`/`wss:` scheme, and requires the host to equal `self.location.host`. Rejected inputs fall back to the existing localhost default and emit a `console.warn`.

## Verification

`npx tsc --noEmit -p apps/kbve/astro-kbve/tsconfig.json` reports no new errors in either edited file (pre-existing unused-import / `await on non-promise` hints elsewhere are unchanged).

## Test plan

- [ ] CI green on `trunk/atom-codeql-ws-format-csrf-*`
- [ ] Post-merge: confirm next JS/TS CodeQL run on `main` closes #218 + #227