### PR TITLE
fix(mc): add keyboard climb axis to ship helm input

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -72,16 +72,21 @@ public class ShipClientMod implements ClientModInitializer {
         boolean n = client.options.forwardKey.isPressed();
         boolean s = client.options.backKey.isPressed();
         boolean boost = client.options.sprintKey.isPressed();
+        boolean jump = client.options.jumpKey.isPressed();
 
         float forward = n ? 1.0f : (s ? -1.0f : 0f);
         float targetYaw = client.player.getYaw();
         float targetPitch = client.player.getPitch();
+        // Keyboard Y axis: jump = ascend (mirrors IA's pressingInterpolatedY).
+        // Sneak stays bound to vanilla dismount, so mouse-pitch handles descend.
+        float keyVertical = jump ? 1.0f : 0.0f;
 
-        boolean rise = targetPitch < -8f;
-        boolean lower = targetPitch > 8f;
+        boolean rise = jump || targetPitch < -20f;
+        boolean lower = !jump && targetPitch > 20f;
         hud.setInputState(n, s, false, false, rise, lower, boost);
 
-        ClientPlayNetworking.send(new HelmInputPayload(activeHelmShipId, forward, boost, targetYaw, targetPitch));
+        ClientPlayNetworking.send(new HelmInputPayload(
+                activeHelmShipId, forward, boost, targetYaw, targetPitch, keyVertical));
 
         // Fire weapons on attack key press (mouse left). Server enforces
         // per-slot cooldown so spamming the key doesn't desync.

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -209,7 +209,7 @@ public class ShipHud implements HudRenderCallback {
                     (screenWidth - bw) / 2, screenHeight - 105, 0xFFFFAA00, true);
         }
 
-        String controls = "Mouse Aim/Pitch  W Throttle  Ctrl Boost  Shift Dismount";
+        String controls = "Mouse Aim  W Throttle  Space Climb  Ctrl Boost  Shift Dismount";
         int controlsWidth = client.textRenderer.getWidth(controls);
         context.drawText(client.textRenderer, Text.of("§7" + controls),
                 screenWidth - controlsWidth - 10, screenHeight - 15, 0x999999, true);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -19,13 +19,26 @@ public final class ShipNetworking {
     public static final Identifier HELM_INPUT_ID = Identifier.of("behavior_statetree", "helm_input");
     public static final Identifier WEAPON_FIRE_ID = Identifier.of("behavior_statetree", "weapon_fire");
 
-    /** Helm steering input. forward = W throttle; boost = sprint; target_yaw / target_pitch = camera-driven heading + altitude direction. */
+    /**
+     * Helm steering input.
+     *  - forward      W throttle (1) / S brake (-1) / 0 idle
+     *  - boost        sprint key
+     *  - targetYaw    camera-driven heading
+     *  - targetPitch  camera pitch (mouse), kept as a fallback signal so a
+     *                 player without an Y-axis keybind still has some way
+     *                 to descend by looking down
+     *  - keyVertical  keyboard Y axis: jump (+1) ascend, sneak (-1) descend.
+     *                 Mirrors ImmersiveAircraft's pressingInterpolatedY axis
+     *                 — keyboard Y wins over camera-pitch when nonzero so
+     *                 the pilot can climb without aiming the camera up.
+     */
     public record HelmInputPayload(
             String shipId,
             float forward,
             boolean boost,
             float targetYaw,
-            float targetPitch
+            float targetPitch,
+            float keyVertical
     ) implements CustomPayload {
         public static final CustomPayload.Id<HelmInputPayload> ID = new CustomPayload.Id<>(HELM_INPUT_ID);
         public static final PacketCodec<RegistryByteBuf, HelmInputPayload> CODEC =
@@ -35,6 +48,7 @@ public final class ShipNetworking {
                         PacketCodecs.BOOLEAN, HelmInputPayload::boost,
                         PacketCodecs.FLOAT, HelmInputPayload::targetYaw,
                         PacketCodecs.FLOAT, HelmInputPayload::targetPitch,
+                        PacketCodecs.FLOAT, HelmInputPayload::keyVertical,
                         HelmInputPayload::new
                 );
 
@@ -98,13 +112,21 @@ public final class ShipNetworking {
                 float step = Math.max(-maxDeltaPerTick, Math.min(maxDeltaPerTick, diff * 0.15f));
                 if (step != 0f) ship.setHeading(current + step);
 
-                float pitchDeadZone = 8f;
-                float pitch = payload.targetPitch();
+                // Keyboard Y axis (jump / sneak) wins over camera pitch when
+                // pressed — matches IA's pressingInterpolatedY semantics. Mouse
+                // pitch only contributes if the keyboard is idle, and even
+                // then only past a wide dead-zone so cruise flight feels stable.
                 float verticalIntent;
-                if (Math.abs(pitch) < pitchDeadZone) {
-                    verticalIntent = 0f;
+                if (Math.abs(payload.keyVertical()) > 0.01f) {
+                    verticalIntent = Math.max(-1f, Math.min(1f, payload.keyVertical()));
                 } else {
-                    verticalIntent = (float) -Math.sin(Math.toRadians(pitch));
+                    float pitch = payload.targetPitch();
+                    float pitchDeadZone = 20f;
+                    if (Math.abs(pitch) < pitchDeadZone) {
+                        verticalIntent = 0f;
+                    } else {
+                        verticalIntent = (float) -Math.sin(Math.toRadians(pitch)) * 0.5f;
+                    }
                 }
                 ship.setVerticalIntent(verticalIntent);
             });


### PR DESCRIPTION
## Summary

Pilot reported vertical controls feeling rough — small mouse-pitch jitter mid-flight wobbles altitude, and climbing requires aiming the camera up off the heading.

Root cause: \`verticalIntent\` was 100% mouse-pitch derived (\`-sin(cameraPitch)\`). ImmersiveAircraft splits this — \`pressingInterpolatedY\` (jump / sneak keys) drives vertical thrust, camera is purely yaw/heading.

## Changes

- \`HelmInputPayload\` gains a \`keyVertical\` float field (jump = +1, sneak unused for now since vanilla dismount still binds it)
- \`ShipClientMod\` sends \`keyVertical = 1.0\` when \`jumpKey.isPressed()\`
- \`ShipNetworking\` server handler:
  - keyboard wins when \`|keyVertical| > 0.01\`
  - mouse-pitch fallback widens dead-zone 8° → 20° and halves output, so cruising while looking around no longer ladders the ship up/down
- HUD controls hint adds \`Space Climb\`

## Test plan

- [ ] PR CI green
- [ ] After deploy: hold \`W\` + \`Space\` to climb forward without aiming up
- [ ] Mouse pitch within ±20° leaves altitude flat
- [ ] Look down past 20° still descends as fallback

Refs ship system polish from #10589 / #10603 lineage.