### PR TITLE
fix(astro-rareicon): drop Adsense import from press.mdx (closes #10577)

### DIFF
--- a/apps/rareicon/astro-rareicon/src/content/docs/press.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/press.mdx
@@ -11,7 +11,6 @@ editUrl: false
 lastUpdated: false
 ---
 
-import Adsense from '@/components/astropad/adsense/Adsense.astro';
 import SocialBar from '@/components/social/SocialBar.astro';
 
 <div class="ri-press not-content">
@@ -122,8 +121,6 @@ appreciated but not required.
 />
 
 </div>
-
-<Adsense />
 
 <style is:global>{`
   .ri-press {


### PR DESCRIPTION
## Root cause

\`apps/rareicon/astro-rareicon/src/content/docs/press.mdx\` imports
\`@/components/astropad/adsense/Adsense.astro\` — that component lives in **astro-kbve**, not astro-rareicon. The \`@/\` alias in this project resolves to \`apps/rareicon/astro-rareicon/src/\`, so Rollup couldn't locate the component and Vite bailed:

\`\`\`
[vite]: Rollup failed to resolve import "@/components/astropad/adsense/Adsense.astro"
  from "/app/apps/rareicon/astro-rareicon/src/content/docs/press.mdx"
\`\`\`

The build failure cascaded into the **axum-rareicon Docker test** (which copies the \`dist/\` output of astro-rareicon as a build stage), surfacing as repeated CI failures on the \`Nx e2e axum-rareicon-e2e\` step since **2026-05-07 22:29 UTC** (every run since the press kit landed).

Issue tracker had stacked up:
- 25525407504 → 25525849956 → 25528720712 → 25528770661 → 25532484061 → 25534457294, all the same way.

## Fix

Drop the unused Adsense import + closing tag from press.mdx. The component slot wasn't load-bearing — rareicon doesn't run AdSense; the import was scaffolded by mistake when copying the splash-page pattern from astro-kbve.

## Verification

\`\`\`
cd apps/rareicon/astro-rareicon && npx astro build
[build] 1266 page(s) built in 33.16s
[build] Complete!
\`\`\`

## Test plan
- [x] \`astro build\` from worktree: 1266 pages built clean
- [x] Build cascade (axum-rareicon Dockerfile depends on astro-rareicon \`dist/\`) should now pass
- [ ] CI re-runs the previously-failing \`axum-rareicon-e2e\` step and lands green
- [ ] Issue #10577 auto-closes on merge via the \`closes #10577\` trailer