### PR TITLE
fix(axum-kbve): copy packages/npm/devops/ in Dockerfile astro stage

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 
 # Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
+COPY packages/npm/devops/ packages/npm/devops/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
 


### PR DESCRIPTION
## Summary

PR #10604 wired astro-kbve components (\`UsernameSetup\`, \`McPlayerList\`, \`profile-controller\`) to \`import { kbveApi } from '@kbve/devops'\`. The workspace tsconfig path-maps \`@kbve/devops\` to \`packages/npm/devops/src/index.ts\`. Local builds work because the source tree is present, but the axum-kbve Dockerfile only copies \`astro/droid/laser\` into the \`astro-builder\` stage — \`devops\` never lands in the build context, so Vite/Rollup hits \`"failed to resolve import '@kbve/devops'"\` and the container build aborts before \`/app/dist/apps/astro-kbve\` exists. The precompressor stage then trips on \`COPY --from=astro-builder /app/dist/apps/astro-kbve /static\` not found.

Repro: https://github.com/KBVE/kbve/actions/runs/25540228592

## Changes

- \`apps/kbve/axum-kbve/Dockerfile\` — add \`COPY packages/npm/devops/ packages/npm/devops/\` next to the existing workspace package copies

## Test plan

Verified astro-kbve has no other unresolved \`@kbve/*\` path aliases — \`astro\`, \`devops\`, \`droid\`, \`laser\` are the only real imports; the rest (\`khashvault\`, \`source\`, \`worker\`, \`expo-bbq\`, \`gha\`, \`nativewind\`) are MDX prose references in journal entries.

- [ ] CI - Docker / axum-kbve passes on this branch