### PR TITLE
fix(edge/logs): swap @clickhouse/client-web from esm.sh to Deno npm:

### DIFF
--- a/apps/kbve/edge/deno.json
+++ b/apps/kbve/edge/deno.json
@@ -7,7 +7,8 @@
     "strict": true
   },
   "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2",
+    "@clickhouse/client-web": "npm:@clickhouse/client-web@1.8.1"
   },
   "fmt": {
     "useTabs": false,

--- a/apps/kbve/edge/functions/logs/index.ts
+++ b/apps/kbve/edge/functions/logs/index.ts
@@ -1,5 +1,11 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@clickhouse/client-web@1.8.1";
+// Resolves through Deno's `npm:` specifier (mapped in apps/kbve/edge/deno.json
+// imports) instead of esm.sh. esm.sh started returning 500 on
+// @clickhouse/client-web@1.8.1/dist/index.d.ts (2026-05-08), which crashed
+// every worker boot of this function and surfaced as 0/0/0 logs on /dashboard.
+// `npm:` resolves through Deno's own npm cache, no third-party CDN in the
+// boot path.
+import { createClient } from "@clickhouse/client-web";
 import { corsHeaders } from "../_shared/cors.ts";
 import {
   extractToken,


### PR DESCRIPTION
## Summary
Production edge worker for the \`/dashboard\` ClickHouse logs view has been hard-failing to boot since 2026-05-08:

\`\`\`
worker boot error: failed to bootstrap runtime: failed to create the graph:
Import 'https://esm.sh/@clickhouse/client-web@1.8.1/dist/index.d.ts'
failed: 500 Internal Server Error
\`\`\`

esm.sh started 500-ing on the type-defs sidecar for that exact package. Every isolate spawn for the \`logs\` function dies on the import graph build, so the axum proxy at \`/dashboard/clickhouse/proxy\` gets a 502 back and the dashboard renders **"0 total logs / 0 errors / 0 warnings"**.

The ClickHouse cluster itself is fine — \`observability.logs_distributed\` has 1.18B rows and the most recent ingest is from \`2026-05-08 08:50:05 UTC\`. Verified via \`kubectl exec -n clickhouse chi-clickhouse-cluster-cluster-0-0-0 -c clickhouse -- clickhouse-client\`.

## Fix
- Switch [\`apps/kbve/edge/functions/logs/index.ts\`](apps/kbve/edge/functions/logs/index.ts) to import \`@clickhouse/client-web\` via the Deno \`npm:\` specifier mapped in [\`apps/kbve/edge/deno.json\`](apps/kbve/edge/deno.json).
- \`npm:\` resolves through Deno's own npm cache — no third-party CDN in the boot path. A future esm.sh outage can't kill this function again.
- Pinning the version (\`1.8.1\`) in the imports map keeps a single source of truth.

## Follow-up (separate PR — Option C)
Move the SELECT path off the SDK entirely. Two paths:
1. Direct HTTPS POST to ClickHouse from this edge function (~30 lines of helper code, no SDK at all).
2. Relocate the proxy into \`axum-kbve\` so the edge function isn't in the critical read path. Native \`reqwest\` against ClickHouse HTTP, no Deno isolate boot, no esm.sh / npm cache.

Option 2 is the long-term win — keeps observability tooling on the same fast Rust path as the rest of the dashboard proxies.

## Test plan
- [ ] Deploy edge bundle → \`kubectl logs -n kilobase functions-* --tail=80\` no longer shows the \`InvalidWorkerCreation\` boot loop on the \`logs\` function.
- [ ] Hit \`/dashboard\` → ClickHouse logs view shows non-zero counts again.
- [ ] Direct call: \`curl -X POST $SUPABASE_URL/functions/v1/logs -H "Authorization: Bearer $SERVICE_ROLE" -H "Content-Type: application/json" -d '{"command":"stats","minutes":15}'\` returns rows.
- [ ] No regression on other edge functions (no shared imports changed).