### PR TITLE
fix(axum-kbve): ensure_https returns typed reqwest::Url (CodeQL #434-#438)

### DIFF
--- a/apps/kbve/axum-kbve/src/db/mod.rs
+++ b/apps/kbve/axum-kbve/src/db/mod.rs
@@ -10,16 +10,19 @@ mod rentearth;
 mod supabase;
 mod twitch;
 
-/// Validate that a URL uses HTTPS before transmitting sensitive data.
-/// Returns `Err` if the URL does not start with `https://`.
-pub(crate) fn ensure_https(url: &str) -> Result<&str, String> {
-    if url.starts_with("https://") {
-        Ok(url)
-    } else {
-        Err(format!(
+/// Parse a URL and require an `https` scheme before transmitting sensitive
+/// data. Returns a typed `reqwest::Url` so callers pass it straight to
+/// `Client::get` — this also makes the scheme check visible to CodeQL's
+/// `rust/cleartext-transmission` query (a string `starts_with` check on a
+/// `&str` is not recognized as a sanitizer).
+pub(crate) fn ensure_https(url: &str) -> Result<reqwest::Url, String> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("invalid URL: {e}"))?;
+    if parsed.scheme() != "https" {
+        return Err(format!(
             "refusing to transmit sensitive data over non-HTTPS URL: {url}"
-        ))
+        ));
     }
+    Ok(parsed)
 }
 
 pub use cache::{get_profile_cache, init_profile_cache};


### PR DESCRIPTION
## Summary

Five CodeQL `rust/cleartext-transmission` warnings (high security severity) in axum-kbve closed by tightening `ensure_https`:

- [#434](https://github.com/KBVE/kbve/security/code-scanning/434) — [mc.rs:282](apps/kbve/axum-kbve/src/db/mc.rs#L282) (`uuid` source, fetch_skin_url)
- [#435](https://github.com/KBVE/kbve/security/code-scanning/435) — [discord.rs:219](apps/kbve/axum-kbve/src/db/discord.rs#L219) (`user_id`, get_member)
- [#436](https://github.com/KBVE/kbve/security/code-scanning/436) — [discord.rs:260](apps/kbve/axum-kbve/src/db/discord.rs#L260) (`user_id`, get_user)
- [#437](https://github.com/KBVE/kbve/security/code-scanning/437) — [twitch.rs:225](apps/kbve/axum-kbve/src/db/twitch.rs#L225) (`user_id`, /users)
- [#438](https://github.com/KBVE/kbve/security/code-scanning/438) — [twitch.rs:270](apps/kbve/axum-kbve/src/db/twitch.rs#L270) (`user_id`, /streams)

All five sites already routed their URL through `ensure_https`, but the prior implementation only did `&str.starts_with("https://")` — CodeQL doesn't treat that as a sanitizer barrier.

## Fix

`ensure_https` now parses the URL via `reqwest::Url::parse` and asserts `scheme() == "https"`, returning the typed `reqwest::Url`. Callers' bindings (`let url = ensure_https(&url)?;`) keep the same name and `Client::get(url)` keeps working via `IntoUrl`. No call-site edits needed; only the local type changes from `&str` to `reqwest::Url`. Scheme check on a parsed `Url` is the recognised CodeQL sanitizer pattern.

## Verification

`cargo check --manifest-path apps/kbve/axum-kbve/Cargo.toml --bin axum-kbve` — clean (only pre-existing manifest-key warnings unrelated to this change).

## Test plan

- [ ] CI green on `trunk/atom-codeql-rust-cleartext-tx-*`
- [ ] Post-merge: confirm next Rust CodeQL run on `main` closes #434-#438