### PR TITLE
fix(isometric/wasm): export __heap_base for wasm-bindgen threading

### DIFF
--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -344,6 +344,21 @@ jobs:
                           - 'apps/kbve/isometric/src-tauri/tauri.conf.json'
                           - 'apps/kbve/isometric/package.json'
                           - 'apps/kbve/isometric/vite.config.ts'
+                          # Shared Rust crates (path = ... in src-tauri/Cargo.toml).
+                          # Any change here MUST rebuild the WASM client otherwise
+                          # the lightyear ProtocolPlugin registry hashes drift
+                          # from the gameserver and the protocol-check observer
+                          # panics on connect ("the message protocol doesn't match").
+                          - 'packages/rust/bevy/bevy_behavior/**'
+                          - 'packages/rust/bevy/bevy_cam/**'
+                          - 'packages/rust/bevy/bevy_chat/**'
+                          - 'packages/rust/bevy/bevy_db/**'
+                          - 'packages/rust/bevy/bevy_inventory/**'
+                          - 'packages/rust/bevy/bevy_items/**'
+                          - 'packages/rust/bevy/bevy_kbve_net/**'
+                          - 'packages/rust/bevy/bevy_npc/**'
+                          - 'packages/rust/bevy/bevy_pathfinder/**'
+                          - 'packages/rust/bevy/bevy_skills/**'
                           - 'packages/rust/bevy/bevy_tasker/**'
                       ue_devops:
                           - 'packages/unreal/UEDevOps/Source/**'

--- a/apps/kbve/isometric/src-tauri/.cargo/config.toml
+++ b/apps/kbve/isometric/src-tauri/.cargo/config.toml
@@ -5,6 +5,12 @@ rustflags = [
     "-C", "link-arg=--import-memory",
     "-C", "link-arg=--shared-memory",
     "-C", "link-arg=--max-memory=4294967296",
+    # Threading exports — wasm-bindgen needs every one of these to inject the
+    # per-worker thread-id glue. Recent nightly rustc no longer emits
+    # __heap_base by default, so wasm-bindgen-cli fails with
+    #   "failed to prepare module for threading … failed to find __heap_base"
+    # if it is omitted. Keep the full set.
+    "-C", "link-arg=--export=__heap_base",
     "-C", "link-arg=--export=__wasm_init_tls",
     "-C", "link-arg=--export=__tls_size",
     "-C", "link-arg=--export=__tls_align",

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -1,3 +1,10 @@
+# NOTE: every shared `bevy_*` path-dep below is mirrored in
+# `.github/workflows/utils-file-alterations.yml` under the `isometric:` glob.
+# When you add a new path-dep here, add the matching path filter there or the
+# WASM client will skip rebuilds on shared-crate changes — the lightyear
+# ProtocolPlugin registry will drift between client and server and the
+# protocol-check observer will panic on connect ("the message protocol doesn't match").
+
 [package]
 name = "isometric-game"
 version = "0.1.0"


### PR DESCRIPTION
Follow-up to #10608. The path-filter fix landed correctly — CI - Bevy now triggers on shared bevy crate changes — but the WASM build itself failed in [run 25540246022](https://github.com/KBVE/kbve/actions/runs/25540246022):

\`\`\`
error: failed to prepare module for threading
Caused by:
    failed to find \`__heap_base\` for injecting thread id
\`\`\`

Recent rustc nightly no longer emits \`__heap_base\` from the wasm linker by default. wasm-bindgen-cli's threading glue needs that symbol to inject per-worker thread ids. The cargo config already explicitly exports \`__wasm_init_tls\` and the \`__tls_*\` symbols — add \`__heap_base\` to the same set.

Single-line change:

\`\`\`toml
"-C", "link-arg=--export=__heap_base",
\`\`\`

## Test plan

- [ ] CI - Bevy build_wasm succeeds.
- [ ] Generated WASM still loads in the browser (live deploy, kbve.com/isometric/ no longer panics on connect).