### PR TITLE
polish(mc): IA feature parity pass — cautions, sounds, anims, tooltips

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -53,6 +53,9 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
     // Per-render scratch — engine power gates propeller animation speed.
     // Stored as a field instead of plumbed through every renderObject call.
     private float currentEnginePower = 0.0f;
+    private float currentBankRoll = 0.0f;
+    private float currentPitch = 0.0f;
+    private boolean currentOnGround = true;
 
     public BBModelShipRenderer(EntityRendererFactory.Context ctx) {
         super(ctx);
@@ -83,6 +86,9 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         // Propeller spin accumulates each frame at engine-scaled rate.
         state.propellerSpin = (state.propellerSpin + state.enginePower * 30.0f) % 360f;
         state.animationTime = (entity.age + tickDelta) * 0.05f;
+        // Pitch + ground state for control surface deflection / landing gear.
+        state.pitchDeg = entity.getPitch();
+        state.onGround = entity.isOnGround();
     }
 
     private static float wrapDegrees(float a) {
@@ -126,6 +132,9 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
 
         // Stash engine power for propeller-name-keyed time scaling.
         currentEnginePower = state.enginePower;
+        currentBankRoll = state.renderRoll;
+        currentPitch = state.pitchDeg;
+        currentOnGround = state.onGround;
 
         // Walk the model tree — submit render commands per face
         int light = 0xF000F0; // full bright (airships fly in sky)
@@ -174,6 +183,25 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
 
         // Apply object rotation
         matrices.multiply(BBModelUtils.fromXYZ(object.rotation));
+
+        // Control surface deflection — bbmodel objects can opt in by name.
+        //   rudder/aileron  → Y rotation tracks bank roll (yaw rate)
+        //   elevator        → X rotation tracks pitch deflection (planes)
+        //   gear            → Y rotation snaps 0°/90° based on ground state
+        if (object.name != null) {
+            String lname = object.name.toLowerCase();
+            if (lname.contains("rudder") || lname.contains("aileron")) {
+                float def = clamp(-currentBankRoll * 0.6f, -25f, 25f);
+                matrices.multiply(new Quaternionf().rotateY((float) Math.toRadians(def)));
+            } else if (lname.contains("elevator")) {
+                float def = clamp(currentPitch * 0.4f, -20f, 20f);
+                matrices.multiply(new Quaternionf().rotateX((float) Math.toRadians(def)));
+            } else if (lname.contains("gear") || lname.contains("landing")) {
+                if (!currentOnGround) {
+                    matrices.multiply(new Quaternionf().rotateZ((float) Math.toRadians(85.0)));
+                }
+            }
+        }
 
         if (object instanceof BBBone bone) {
             // Bones pivot around their origin — translate back before recursing

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -62,6 +62,7 @@ public class ShipClientMod implements ClientModInitializer {
             hud.setEnginePower(shipEntity.getEnginePower());
             hud.setUpgrades(shipEntity.getUpgradeCount(),
                     com.kbve.statetree.ship.ShipUpgrades.MAX_SLOTS);
+            hud.setCautions(shipEntity.getCautionBits());
         } else if (activeHelmShipId != null) {
             LOGGER.info("[Ship Client] Dismounted — clearing helm");
             clearActiveHelm();

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -25,6 +25,7 @@ public class ShipHud implements HudRenderCallback {
     private boolean fuelLow = false;
     private int upgradeCount = 0;
     private int maxUpgradeSlots = 4;
+    private byte cautionBits = 0;
 
     public void setActive(String shipName) {
         this.active = true;
@@ -79,6 +80,10 @@ public class ShipHud implements HudRenderCallback {
     public void setUpgrades(int count, int maxSlots) {
         this.upgradeCount = count;
         this.maxUpgradeSlots = maxSlots;
+    }
+
+    public void setCautions(byte bits) {
+        this.cautionBits = bits;
     }
 
     public boolean isActive() {
@@ -218,6 +223,40 @@ public class ShipHud implements HudRenderCallback {
         String upgText = String.format("§bUPGRADES %d/%d", upgradeCount, maxUpgradeSlots);
         context.drawText(client.textRenderer, Text.of(upgText),
                 10, 10, 0xFFFFFFFF, true);
+
+        // Cautions stack (just above the controls hint, right side).
+        // Mirrors IA's PULL_UP / VOID / DAMAGED indicators; LOW_FUEL is
+        // already shown via the fuel bar, but it's mirrored here as a
+        // pulsing red word for parity at a glance.
+        boolean blink = (System.currentTimeMillis() / 300) % 2 == 0;
+        int row = 0;
+        if ((cautionBits & 0x1) != 0) { // PULL_UP
+            String t = "§4§lPULL UP";
+            context.drawText(client.textRenderer, Text.of(t),
+                    screenWidth - client.textRenderer.getWidth(t) - 10,
+                    30 + row * 12, blink ? 0xFFFF3333 : 0xFFAA0000, true);
+            row++;
+        }
+        if ((cautionBits & 0x2) != 0) { // VOID
+            String t = "§4§lVOID";
+            context.drawText(client.textRenderer, Text.of(t),
+                    screenWidth - client.textRenderer.getWidth(t) - 10,
+                    30 + row * 12, blink ? 0xFFFF3333 : 0xFFAA0000, true);
+            row++;
+        }
+        if ((cautionBits & 0x4) != 0) { // DAMAGED
+            String t = "§c§lDAMAGED";
+            context.drawText(client.textRenderer, Text.of(t),
+                    screenWidth - client.textRenderer.getWidth(t) - 10,
+                    30 + row * 12, blink ? 0xFFFF6666 : 0xFFCC2222, true);
+            row++;
+        }
+        if ((cautionBits & 0x8) != 0 && fuel > 0f) { // LOW_FUEL (out-of-fuel handled elsewhere)
+            String t = "§e§lLOW FUEL";
+            context.drawText(client.textRenderer, Text.of(t),
+                    screenWidth - client.textRenderer.getWidth(t) - 10,
+                    30 + row * 12, blink ? 0xFFFFCC22 : 0xFFAA8800, true);
+        }
     }
 
     private static void drawCenteredChar(DrawContext context, MinecraftClient client,

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipRenderState.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipRenderState.java
@@ -32,4 +32,11 @@ public class ShipRenderState extends EntityRenderState {
 
     /** Continuously-accumulated propeller rotation (degrees), engine-power scaled. */
     public float propellerSpin = 0.0f;
+
+    /** Pitch in degrees — used for elevator deflection on planes. */
+    public float pitchDeg = 0.0f;
+
+    /** True when the ship is on/near the ground — drives landing-gear visibility. */
+    public boolean onGround = false;
 }
+

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/FlightStats.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/FlightStats.java
@@ -26,6 +26,11 @@ package com.kbve.statetree.ship;
  * @param boundingHeight   Entity bounding box height (blocks).
  * @param cameraZoom       Third-person camera distance while riding.
  * @param canExplodeOnCrash Whether a hard impact triggers an explosion.
+ * @param trailParticle    Vanilla particle ID for the engine trail. Empty
+ *                         falls back to the legacy model-name-keyed dispatch
+ *                         in {@code ShipEntity.spawnTrailParticles}.
+ * @param engineSound      Vanilla SoundEvent ID for the engine loop.
+ *                         Empty falls back to {@code minecraft:entity.minecart.riding}.
  */
 public record FlightStats(
         float yawSpeed,
@@ -47,7 +52,9 @@ public record FlightStats(
         float boundingWidth,
         float boundingHeight,
         float cameraZoom,
-        boolean canExplodeOnCrash
+        boolean canExplodeOnCrash,
+        String trailParticle,
+        String engineSound
 ) {
     /** Default fallback when no JSON is found — tuned for an airship. */
     public static final FlightStats DEFAULT = new FlightStats(
@@ -55,6 +62,7 @@ public record FlightStats(
             0.0f, 0.1f, 0.97f, 0.925f,
             5.0f, 0.1f, 0.05f, 3.0f,
             0.5f, 0.0f, 50.0f, 20.0f,
-            5.0f, 2.0f, 6.0f, false
+            5.0f, 2.0f, 6.0f, false,
+            "", ""
     );
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/FlightStatsRegistry.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/FlightStatsRegistry.java
@@ -150,11 +150,17 @@ public final class FlightStatsRegistry {
                 f(p, "boundingWidth", d.boundingWidth()),
                 f(p, "boundingHeight", d.boundingHeight()),
                 f(p, "cameraZoom", d.cameraZoom()),
-                p.has("canExplodeOnCrash") && p.get("canExplodeOnCrash").getAsBoolean()
+                p.has("canExplodeOnCrash") && p.get("canExplodeOnCrash").getAsBoolean(),
+                s(p, "trailParticle", d.trailParticle()),
+                s(p, "engineSound", d.engineSound())
         );
     }
 
     private static float f(JsonObject p, String key, float def) {
         return p.has(key) ? p.get(key).getAsFloat() : def;
+    }
+
+    private static String s(JsonObject p, String key, String def) {
+        return p.has(key) ? p.get(key).getAsString() : def;
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -51,6 +51,19 @@ public class ShipEntity extends Entity {
     /** Banner item ID (e.g. "minecraft:red_banner") for client-side rendering. */
     private static final TrackedData<String> BANNER_ITEM_ID =
             DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
+    /**
+     * Bit-packed caution flags — bit 0 PULL_UP (low altitude near ground),
+     * bit 1 VOID (below world bottom), bit 2 DAMAGED (hp under 25%),
+     * bit 3 LOW_FUEL (already exposed via getFuelLevel but mirrored here
+     * for HUD-side parity with IA's Cautions enum).
+     */
+    private static final TrackedData<Byte> CAUTION_BITS =
+            DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.BYTE);
+
+    public static final int CAUTION_PULL_UP   = 1 << 0;
+    public static final int CAUTION_VOID      = 1 << 1;
+    public static final int CAUTION_DAMAGED   = 1 << 2;
+    public static final int CAUTION_LOW_FUEL  = 1 << 3;
 
     public static final float MAX_HEALTH = 100.0f;
     public static final float MAX_FUEL = 1000.0f;
@@ -200,6 +213,10 @@ public class ShipEntity extends Entity {
     public float getEnginePower() { return enginePower.getSmooth(); }
     public float getBankRoll() { return bankRoll; }
     public float getCameraZoom() { return getStats().cameraZoom(); }
+
+    /** Bit-packed caution flags — see CAUTION_* constants. Read by HUD. */
+    public byte getCautionBits() { return this.dataTracker.get(CAUTION_BITS); }
+    public boolean hasCaution(int mask) { return (getCautionBits() & mask) != 0; }
 
     public FlightStats getStats() {
         String key = getModelName();
@@ -594,6 +611,25 @@ public class ShipEntity extends Entity {
             }
         }
 
+        // Caution flags — refreshed every tick, synced via TrackedData byte.
+        int caution = 0;
+        ServerWorld sworld = (ServerWorld) this.getEntityWorld();
+        // PULL_UP: descending fast and within 6 blocks of the next solid block below.
+        if (vel.y < -0.15) {
+            int floorY = sworld.getTopY(net.minecraft.world.Heightmap.Type.MOTION_BLOCKING,
+                    (int) Math.floor(this.getX()), (int) Math.floor(this.getZ()));
+            if (this.getY() - floorY < 6.0) caution |= CAUTION_PULL_UP;
+        }
+        // VOID: under the world bottom.
+        if (this.getY() < sworld.getBottomY() + 4) caution |= CAUTION_VOID;
+        // DAMAGED: hp below 25%.
+        if (getShipHealth() < MAX_HEALTH * 0.25f) caution |= CAUTION_DAMAGED;
+        // LOW_FUEL: fuel below threshold.
+        if (isFuelLow()) caution |= CAUTION_LOW_FUEL;
+        if (caution != getCautionBits()) {
+            this.dataTracker.set(CAUTION_BITS, (byte) caution);
+        }
+
         this.setVelocity(vel);
         if (vel.lengthSquared() > 1.0e-6) {
             this.move(MovementType.SELF, vel);
@@ -613,12 +649,16 @@ public class ShipEntity extends Entity {
         // Engine sound — pitch scales with throttle. Cadence speeds up as
         // power rises so the audio gets more frantic at full thrust.
         if (this.getEntityWorld() instanceof ServerWorld sw2) {
-            // Engine spinup — distinct one-shot when throttle first kicks in.
+            net.minecraft.sound.SoundEvent loopSound = resolveEngineSound(stats.engineSound());
+            // Engine spinup — distinct one-shot + visible smoke burst.
             if (lastEnginePowerForSound < 0.05f && power >= 0.05f) {
                 sw2.playSound(null, this.getX(), this.getY(), this.getZ(),
                         net.minecraft.sound.SoundEvents.ITEM_FLINTANDSTEEL_USE,
                         net.minecraft.sound.SoundCategory.NEUTRAL,
                         0.6f, 0.8f);
+                sw2.spawnParticles(net.minecraft.particle.ParticleTypes.LARGE_SMOKE,
+                        this.getX(), this.getY() + 0.6, this.getZ(),
+                        12, 0.5, 0.2, 0.5, 0.04);
             }
             // Engine shutdown — soft puff when throttle drops to zero.
             if (lastEnginePowerForSound >= 0.05f && power < 0.05f) {
@@ -627,19 +667,30 @@ public class ShipEntity extends Entity {
                         net.minecraft.sound.SoundCategory.NEUTRAL,
                         0.4f, 1.0f);
             }
-            // Engine loop — periodic minecart-rumble while running.
-            if (power > 0.05f) {
+            // Engine loop — periodic rumble while running, sound from stats.
+            if (power > 0.05f && loopSound != null) {
                 int cadence = Math.max(2, (int) (12 - 8 * power));
                 if (this.age % cadence == 0) {
                     float pitch = 0.5f + 0.7f * power;
                     sw2.playSound(null, this.getX(), this.getY(), this.getZ(),
-                            net.minecraft.sound.SoundEvents.ENTITY_MINECART_RIDING,
+                            loopSound,
                             net.minecraft.sound.SoundCategory.NEUTRAL,
                             0.35f + 0.3f * power, pitch);
                 }
             }
             lastEnginePowerForSound = power;
         }
+    }
+
+    /** Resolve a SoundEvent by registry ID. Falls back to minecart riding. */
+    private static net.minecraft.sound.SoundEvent resolveEngineSound(String id) {
+        if (id == null || id.isEmpty()) {
+            return net.minecraft.sound.SoundEvents.ENTITY_MINECART_RIDING;
+        }
+        net.minecraft.util.Identifier soundId = net.minecraft.util.Identifier.tryParse(id);
+        if (soundId == null) return net.minecraft.sound.SoundEvents.ENTITY_MINECART_RIDING;
+        net.minecraft.sound.SoundEvent ev = net.minecraft.registry.Registries.SOUND_EVENT.get(soundId);
+        return ev != null ? ev : net.minecraft.sound.SoundEvents.ENTITY_MINECART_RIDING;
     }
 
     private static Vec3d lerp(Vec3d a, Vec3d b, double t) {
@@ -695,40 +746,78 @@ public class ShipEntity extends Entity {
         };
     }
 
-    /** Per-aircraft trail effect (server-side spawn so all clients see it). */
+    /**
+     * Per-aircraft trail effect (server-side spawn so all clients see it).
+     * Particle type comes from stats.trailParticle when set; spawn position
+     * is still chosen per-model (wing-tip / rotor wash / aft exhaust)
+     * since IA's TrailDescriptor JSON shape isn't ported.
+     */
     private void spawnTrailParticles(ServerWorld sw, float power) {
         String model = getModelName();
-        double rad = Math.toRadians(this.getYaw());
-        // Behind-the-aircraft offset (negative forward direction).
-        double behindX = this.getX() - (-Math.sin(rad)) * 1.2;
-        double behindZ = this.getZ() - Math.cos(rad) * 1.2;
+        FlightStats stats = getStats();
+        net.minecraft.particle.ParticleEffect particle = resolveTrailParticle(stats.trailParticle(), model);
+        if (particle == null) return;
 
+        double rad = Math.toRadians(this.getYaw());
         if (model.contains("biplane")) {
-            // Wing-tip vapor — two cloud puffs offset perpendicular to heading.
             if (this.age % 2 == 0) {
                 double wx = Math.cos(rad) * 1.4;
                 double wz = Math.sin(rad) * 1.4;
-                sw.spawnParticles(net.minecraft.particle.ParticleTypes.CLOUD,
+                sw.spawnParticles(particle,
                         this.getX() + wx, this.getY() + 0.3, this.getZ() + wz,
                         1, 0.0, 0.0, 0.0, 0.0);
-                sw.spawnParticles(net.minecraft.particle.ParticleTypes.CLOUD,
+                sw.spawnParticles(particle,
                         this.getX() - wx, this.getY() + 0.3, this.getZ() - wz,
                         1, 0.0, 0.0, 0.0, 0.0);
             }
         } else if (model.contains("gyrodyne")) {
-            // Rotor wash — small white smoke beneath the aircraft.
             if (this.age % 3 == 0) {
-                sw.spawnParticles(net.minecraft.particle.ParticleTypes.SMOKE,
+                sw.spawnParticles(particle,
                         this.getX(), this.getY() - 0.3, this.getZ(),
                         2, 0.4, 0.1, 0.4, 0.02);
             }
         } else {
-            // Airship default — exhaust smoke trailing aft.
             if (this.age % 4 == 0) {
-                sw.spawnParticles(net.minecraft.particle.ParticleTypes.CAMPFIRE_COSY_SMOKE,
+                double behindX = this.getX() - (-Math.sin(rad)) * 1.2;
+                double behindZ = this.getZ() - Math.cos(rad) * 1.2;
+                sw.spawnParticles(particle,
                         behindX, this.getY() + 0.5, behindZ,
                         1, 0.1, 0.05, 0.1, 0.01);
             }
+        }
+    }
+
+    private static net.minecraft.particle.ParticleEffect resolveTrailParticle(String id, String model) {
+        if (id != null && !id.isEmpty()) {
+            net.minecraft.util.Identifier pid = net.minecraft.util.Identifier.tryParse(id);
+            if (pid != null) {
+                net.minecraft.particle.ParticleType<?> pt =
+                        net.minecraft.registry.Registries.PARTICLE_TYPE.get(pid);
+                if (pt instanceof net.minecraft.particle.ParticleEffect pe) return pe;
+            }
+        }
+        if (model.contains("biplane")) return net.minecraft.particle.ParticleTypes.CLOUD;
+        if (model.contains("gyrodyne")) return net.minecraft.particle.ParticleTypes.SMOKE;
+        return net.minecraft.particle.ParticleTypes.CAMPFIRE_COSY_SMOKE;
+    }
+
+    /**
+     * Granted to riders dismounting at altitude so they don't take fall
+     * damage from a long drop. Mirrors the courtesy IA's vehicles extend.
+     */
+    @Override
+    protected void removePassenger(Entity passenger) {
+        super.removePassenger(passenger);
+        if (this.getEntityWorld().isClient()) return;
+        if (!(passenger instanceof net.minecraft.entity.LivingEntity living)) return;
+        ServerWorld sw = (ServerWorld) this.getEntityWorld();
+        int floorY = sw.getTopY(net.minecraft.world.Heightmap.Type.MOTION_BLOCKING,
+                (int) Math.floor(living.getX()), (int) Math.floor(living.getZ()));
+        double altitude = living.getY() - floorY;
+        if (altitude > 5.0) {
+            living.addStatusEffect(new net.minecraft.entity.effect.StatusEffectInstance(
+                    net.minecraft.entity.effect.StatusEffects.SLOW_FALLING,
+                    200, 0, false, false, true));
         }
     }
 
@@ -771,6 +860,7 @@ public class ShipEntity extends Entity {
         builder.add(FUEL_LEVEL, MAX_FUEL);
         builder.add(UPGRADES_CSV, "");
         builder.add(BANNER_ITEM_ID, "");
+        builder.add(CAUTION_BITS, (byte) 0);
     }
 
     @Override

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
@@ -1,9 +1,12 @@
 package com.kbve.statetree.ship;
 
+import net.minecraft.component.type.TooltipDisplayComponent;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -11,6 +14,8 @@ import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
+
+import java.util.function.Consumer;
 
 public class ShipItem extends Item {
 
@@ -57,5 +62,31 @@ public class ShipItem extends Item {
         }
 
         return ActionResult.SUCCESS;
+    }
+
+    @Override
+    public void appendTooltip(ItemStack stack, TooltipContext ctx,
+                              TooltipDisplayComponent display,
+                              Consumer<Text> tooltip,
+                              TooltipType type) {
+        super.appendTooltip(stack, ctx, display, tooltip, type);
+        FlightStats s = FlightStatsRegistry.get(modelName);
+        boolean isPlane = s.pitchSpeed() > 0f;
+        tooltip.accept(Text.literal(isPlane ? "§7Type: §fPlane" : "§7Type: §fRotorcraft"));
+        tooltip.accept(Text.literal(String.format("§7Engine: §a%.2f §7m/tick", s.engineSpeed())));
+        if (isPlane) {
+            tooltip.accept(Text.literal(String.format("§7Pitch: §a%.1f° §7Glide: §a%.2f",
+                    s.pitchSpeed(), s.glideFactor())));
+        } else {
+            tooltip.accept(Text.literal(String.format("§7Vertical: §a%.2f §7m/tick", s.verticalSpeed())));
+        }
+        tooltip.accept(Text.literal(String.format("§7Yaw: §a%.1f°/tick §7Lift: §a%.2f",
+                s.yawSpeed(), s.lift())));
+        tooltip.accept(Text.literal(String.format("§7Bbox: §a%.1f×%.1f §7Wind: §a%.2f",
+                s.boundingWidth(), s.boundingHeight(), s.wind())));
+        if (s.canExplodeOnCrash()) {
+            tooltip.accept(Text.literal("§c⚠ Explodes on hard impact"));
+        }
+        tooltip.accept(Text.literal("§8Sneak + right-click ship to open inventory"));
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipUpgrades.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipUpgrades.java
@@ -119,7 +119,8 @@ public final class ShipUpgrades {
                 base.groundFriction(), base.groundPitch(),
                 base.engineReaction(), base.verticalReaction(),
                 base.boundingWidth(), base.boundingHeight(),
-                base.cameraZoom(), base.canExplodeOnCrash()
+                base.cameraZoom(), base.canExplodeOnCrash(),
+                base.trailParticle(), base.engineSound()
         );
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/aircraft/immersive_aircraft/airship.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/aircraft/immersive_aircraft/airship.json
@@ -19,7 +19,9 @@
 		"boundingWidth": 5.0,
 		"boundingHeight": 2.0,
 		"cameraZoom": 6.0,
-		"canExplodeOnCrash": false
+		"canExplodeOnCrash": false,
+		"trailParticle": "minecraft:campfire_cosy_smoke",
+		"engineSound": "minecraft:entity.minecart.riding"
 	},
 	"passengerPositions": [[{ "x": 0.0, "y": 0.6, "z": 0.0 }]],
 	"weaponMounts": [

--- a/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/aircraft/immersive_aircraft/biplane.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/aircraft/immersive_aircraft/biplane.json
@@ -19,7 +19,9 @@
 		"boundingWidth": 1.75,
 		"boundingHeight": 0.85,
 		"cameraZoom": 5.0,
-		"canExplodeOnCrash": true
+		"canExplodeOnCrash": true,
+		"trailParticle": "minecraft:cloud",
+		"engineSound": "minecraft:entity.minecart.riding"
 	},
 	"passengerPositions": [[{ "x": 0.0, "y": 0.3, "z": 0.0 }]],
 	"weaponMounts": [

--- a/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/aircraft/immersive_aircraft/gyrodyne.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/data/behavior_statetree/aircraft/immersive_aircraft/gyrodyne.json
@@ -19,7 +19,9 @@
 		"boundingWidth": 1.3,
 		"boundingHeight": 0.6,
 		"cameraZoom": 2.0,
-		"canExplodeOnCrash": true
+		"canExplodeOnCrash": true,
+		"trailParticle": "minecraft:smoke",
+		"engineSound": "minecraft:entity.minecart.inside.underwater"
 	},
 	"passengerPositions": [[{ "x": 0.0, "y": 0.2, "z": 0.0 }]],
 	"weaponMounts": [


### PR DESCRIPTION
## Summary

Closes the remaining gap between our ship system and ImmersiveAircraft's non-asset-dependent feature surface. **No new .ogg / .png assets required** — everything reuses vanilla particle / sound / item infra.

## What's in

### FlightStats / JSON
- Two new optional fields: \`trailParticle\` + \`engineSound\` (registry IDs). Empty string falls back to legacy per-model defaults
- airship → \`campfire_cosy_smoke\` + \`entity.minecart.riding\`
- biplane → \`cloud\` + \`entity.minecart.riding\`
- gyrodyne → \`smoke\` + \`entity.minecart.inside.underwater\` (deeper rotor thrum)
- \`ShipUpgrades.apply\` forwards both through

### Cautions HUD
Mirrors IA's \`Cautions\` enum, bit-packed into \`TrackedData<Byte>\`:
- \`PULL_UP\` — descending > 0.15 m/tick within 6 blocks of ground
- \`VOID\` — below world bottom + 4
- \`DAMAGED\` — HP < 25%
- \`LOW_FUEL\` — mirrored from fuel level

HUD draws blinking red warnings stacked top-right.

### Engine spinup visual
\`LARGE_SMOKE\` puff (12 particles) on power transition past 0.05 — visible burst that pairs with the existing flint-and-steel sound.

### Dismount-in-air slow-fall
\`removePassenger\` override grants 10s of SLOW_FALLING when the rider exits >5 blocks above ground. No more fall-damage punishment for bailing out at altitude.

### Animation state binding
\`BBModelShipRenderer\` applies extra transforms by object name:
- \`rudder\` / \`aileron\` → Y rotation tracks bank roll, ±25°
- \`elevator\` → X rotation tracks pitch, ±20°
- \`gear\` / \`landing\` → Z 85° when airborne (retracts)

bbmodels opt in by naming their objects accordingly; existing models unaffected.

### Item tooltips
Hovering airship/biplane/gyrodyne previews stats:
- Type (Plane / Rotorcraft)
- Engine speed
- Pitch + glide (planes) or Vertical (rotorcraft)
- Yaw + lift
- Bbox + wind
- ⚠ Explodes on hard impact (when applicable)
- Sneak-interact hint

## Test plan

- [ ] PR CI green
- [ ] After deploy: dive toward terrain → \`PULL UP\` blinks
- [ ] HP < 25 → \`DAMAGED\` blinks
- [ ] Engine start emits visible smoke burst
- [ ] Dismount at altitude → no fall damage
- [ ] Hover ship item in inventory → stat preview shows