### PR TITLE
feat(axum-kbve, jedi): direct ClickHouse logs route via jedi[clickhouse]

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -77,7 +77,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 webpki-roots = "0.26"
 
 # Workspace path dependencies
-jedi = { path = "../../../packages/rust/jedi" }
+jedi = { path = "../../../packages/rust/jedi", features = ["clickhouse"] }
 kbve = { path = "../../../packages/rust/kbve" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -121,10 +121,14 @@ async fn main() -> anyhow::Result<()> {
         warn!("ArgoCD proxy not configured (ARGOCD_UPSTREAM_URL not set)");
     }
 
-    if transport::proxy::init_clickhouse_logs_proxy() {
-        info!("ClickHouse logs proxy initialized - /dashboard/clickhouse/proxy enabled");
+    if transport::proxy::init_clickhouse_direct() {
+        info!(
+            "ClickHouse direct route initialized - /dashboard/clickhouse/proxy now talks straight to ClickHouse via jedi"
+        );
     } else {
-        warn!("ClickHouse logs proxy not configured (CLICKHOUSE_LOGS_UPSTREAM_URL not set)");
+        warn!(
+            "ClickHouse direct route not configured (CLICKHOUSE_HOST / CLICKHOUSE_PORT / CLICKHOUSE_USER / CLICKHOUSE_DATABASE not set)"
+        );
     }
 
     if transport::proxy::init_forgejo_proxy() {

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -573,50 +573,133 @@ pub async fn argo_proxy_handler(path: Option<Path<String>>, req: Request<Body>) 
 // ClickHouse logs proxy singleton
 // ---------------------------------------------------------------------------
 
-static CLICKHOUSE_LOGS: OnceLock<ServiceProxy> = OnceLock::new();
+// ---------------------------------------------------------------------------
+// ClickHouse Logs — direct path
+//
+// Replaces the previous /functions/v1/logs supabase edge function fronting.
+// axum-kbve now talks straight to the ClickHouse cluster via jedi's
+// ClickHouseConfig, so a CDN outage on esm.sh (which 500'd the edge fn boot
+// graph and produced the "0 / 0 / 0 logs" outage on 2026-05-08) cannot kill
+// the dashboard logs view again.
+//
+// Auth: same DASHBOARD_VIEW gate every other dashboard proxy uses. Query
+// surface is locked down inside jedi (clamped minutes/limit/search, escaped
+// label values).
+// ---------------------------------------------------------------------------
 
-pub fn init_clickhouse_logs_proxy() -> bool {
-    let supabase_url = match std::env::var("SUPABASE_URL") {
-        Ok(u) => u.trim_end_matches('/').to_string(),
-        Err(_) => return false,
-    };
-    let upstream = format!("{supabase_url}/functions/v1/logs");
+use jedi::entity::pipe_clickhouse::logs as ch_logs;
+use jedi::state::sidecar::ClickHouseConfig;
 
-    let service_role_key = match std::env::var("SUPABASE_SERVICE_ROLE_KEY") {
-        Ok(k) => k,
-        Err(_) => return false,
-    };
+static CLICKHOUSE_DIRECT: OnceLock<ClickHouseConfig> = OnceLock::new();
 
-    let client = Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(Duration::from_secs(5))
-        .timeout(Duration::from_secs(30))
-        .build()
-        .expect("failed to build reqwest client for clickhouse logs proxy");
+pub fn init_clickhouse_direct() -> bool {
+    // ClickHouseConfig::from_env defaults host=localhost / port=8123 if
+    // CLICKHOUSE_HOST / CLICKHOUSE_PORT aren't set, so a misconfigured pod
+    // would silently target localhost. Require at least one of the two to
+    // be present to consider the proxy "configured".
+    let has_env = std::env::var("CLICKHOUSE_HOST").is_ok()
+        || std::env::var("CLICKHOUSE_PORT").is_ok()
+        || std::env::var("CLICKHOUSE_USER").is_ok()
+        || std::env::var("CLICKHOUSE_DATABASE").is_ok();
+    if !has_env {
+        return false;
+    }
 
-    CLICKHOUSE_LOGS
-        .set(ServiceProxy {
-            name: "ClickHouse Logs",
-            client,
-            upstream,
-            upstream_token: Some(service_role_key),
-            iframe_safe: false,
-            streaming: false,
-        })
-        .is_ok()
+    let config = ClickHouseConfig::from_env();
+    CLICKHOUSE_DIRECT.set(config).is_ok()
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+struct ClickHouseRequest {
+    command: String,
+    #[serde(default)]
+    pod_namespace: Option<String>,
+    #[serde(default)]
+    pod_name: Option<String>,
+    #[serde(default)]
+    service: Option<String>,
+    #[serde(default)]
+    level: Option<String>,
+    #[serde(default)]
+    search: Option<String>,
+    #[serde(default)]
+    minutes: Option<u32>,
+    #[serde(default)]
+    limit: Option<u32>,
 }
 
 pub async fn clickhouse_logs_proxy_handler(
-    path: Option<Path<String>>,
-    req: Request<Body>,
+    _path: Option<Path<String>>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Response {
-    match CLICKHOUSE_LOGS.get() {
-        Some(proxy) => proxy.handle(path, req).await,
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(json!({"error": "ClickHouse logs proxy not configured"})),
-        )
-            .into_response(),
+    if let Err(resp) = require_dashboard_view(&headers, "ClickHouse Logs").await {
+        return resp;
+    }
+
+    let config = match CLICKHOUSE_DIRECT.get() {
+        Some(c) => c,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({"error": "ClickHouse direct route not configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    let req: ClickHouseRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({"error": format!("invalid JSON body: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let result = match req.command.as_str() {
+        "query" => {
+            let params = ch_logs::LogsQueryParams {
+                pod_namespace: req.pod_namespace,
+                pod_name: req.pod_name,
+                service: req.service,
+                level: req.level,
+                search: req.search,
+                minutes: req.minutes,
+                limit: req.limit,
+            };
+            ch_logs::run_query(config, &params).await
+        }
+        "stats" => {
+            let params = ch_logs::LogsStatsParams {
+                minutes: req.minutes,
+            };
+            ch_logs::run_stats(config, &params).await
+        }
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(
+                    json!({"error": format!("unknown command '{other}', expected 'query' or 'stats'")}),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    match result {
+        Ok(out) => axum::Json(out).into_response(),
+        Err(e) => {
+            warn!("ClickHouse logs query failed: {e}");
+            (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(json!({"error": format!("ClickHouse query failed: {e}")})),
+            )
+                .into_response()
+        }
     }
 }
 

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
@@ -1,0 +1,229 @@
+// Typed query builders for the observability.logs_distributed table.
+//
+// These mirror what the supabase edge function at apps/kbve/edge/functions/logs
+// used to do — `query` (filtered SELECT) and `stats` (GROUP BY) — but build the
+// SQL inside Rust so axum-kbve can hit ClickHouse directly via
+// ClickHouseConfig::execute_select. The edge function is no longer in the
+// critical path for the dashboard logs view.
+//
+// Bounds match the edge function exactly so callers cannot expand the query
+// surface (defense-in-depth in case the auth gate ever loosens):
+//   - minutes:        1..=10080 (7 days)
+//   - limit:          1..=500
+//   - search length:  <=100 chars
+//
+// All user-supplied strings go through `escape_clickhouse_string` to neutralize
+// `\` and `'` before being inlined into the SQL. ClickHouse parameterized
+// queries (`{name:Type}`) only work over the native protocol, not over the
+// HTTP+JSONEachRow path ClickHouseConfig::execute_select uses, so escape +
+// inline is the simpler approach.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::super::error::JediError;
+use super::super::super::state::sidecar::ClickHouseConfig;
+
+pub const MAX_MINUTES: u32 = 10_080; // 7 days
+pub const DEFAULT_MINUTES: u32 = 60;
+pub const MAX_LIMIT: u32 = 500;
+pub const DEFAULT_LIMIT: u32 = 100;
+pub const MAX_SEARCH_LENGTH: usize = 100;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LogsQueryParams {
+    #[serde(default)]
+    pub pod_namespace: Option<String>,
+    #[serde(default)]
+    pub pod_name: Option<String>,
+    #[serde(default)]
+    pub service: Option<String>,
+    #[serde(default)]
+    pub level: Option<String>,
+    #[serde(default)]
+    pub search: Option<String>,
+    #[serde(default)]
+    pub minutes: Option<u32>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LogsStatsParams {
+    #[serde(default)]
+    pub minutes: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogsResult {
+    pub rows: Vec<serde_json::Value>,
+    pub count: usize,
+}
+
+fn escape_clickhouse_string(input: &str) -> String {
+    let mut out = String::with_capacity(input.len() + 2);
+    for ch in input.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\'' => out.push_str("\\'"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn clamped_minutes(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_MINUTES).clamp(1, MAX_MINUTES)
+}
+
+fn clamped_limit(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT)
+}
+
+fn clamped_search(raw: &str) -> String {
+    let trimmed: String = raw.chars().take(MAX_SEARCH_LENGTH).collect();
+    escape_clickhouse_string(&trimmed)
+}
+
+/// Build the `query` SQL — filtered SELECT against logs_distributed,
+/// ordered by timestamp DESC.
+pub fn build_query_sql(params: &LogsQueryParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let limit = clamped_limit(params.limit);
+
+    let mut conditions: Vec<String> =
+        vec![format!("timestamp > now() - INTERVAL {} MINUTE", minutes)];
+
+    if let Some(ns) = params.pod_namespace.as_deref().filter(|s| !s.is_empty()) {
+        conditions.push(format!(
+            "pod_namespace = '{}'",
+            escape_clickhouse_string(ns)
+        ));
+    }
+    if let Some(pn) = params.pod_name.as_deref().filter(|s| !s.is_empty()) {
+        conditions.push(format!("pod_name = '{}'", escape_clickhouse_string(pn)));
+    }
+    if let Some(svc) = params.service.as_deref().filter(|s| !s.is_empty()) {
+        conditions.push(format!("service = '{}'", escape_clickhouse_string(svc)));
+    }
+    if let Some(lvl) = params.level.as_deref().filter(|s| !s.is_empty()) {
+        conditions.push(format!(
+            "level = '{}'",
+            escape_clickhouse_string(&lvl.to_lowercase())
+        ));
+    }
+    if let Some(search) = params.search.as_deref().filter(|s| !s.is_empty()) {
+        conditions.push(format!("message ILIKE '%{}%'", clamped_search(search)));
+    }
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+
+    format!(
+        "SELECT timestamp, pod_namespace, service, level, message, pod_name, metadata \
+		 FROM logs_distributed \
+		 {} \
+		 ORDER BY timestamp DESC \
+		 LIMIT {}",
+        where_clause, limit
+    )
+}
+
+/// Build the `stats` SQL — GROUP BY namespace+service+level for the last
+/// `minutes` minutes.
+pub fn build_stats_sql(params: &LogsStatsParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    format!(
+        "SELECT pod_namespace, service, level, count() AS cnt \
+		 FROM logs_distributed \
+		 WHERE timestamp > now() - INTERVAL {} MINUTE \
+		 GROUP BY pod_namespace, service, level \
+		 ORDER BY cnt DESC \
+		 LIMIT 200",
+        minutes
+    )
+}
+
+pub async fn run_query(
+    config: &ClickHouseConfig,
+    params: &LogsQueryParams,
+) -> Result<LogsResult, JediError> {
+    let sql = build_query_sql(params);
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
+pub async fn run_stats(
+    config: &ClickHouseConfig,
+    params: &LogsStatsParams,
+) -> Result<LogsResult, JediError> {
+    let sql = build_stats_sql(params);
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_quotes_and_backslashes() {
+        assert_eq!(escape_clickhouse_string("he'llo"), "he\\'llo");
+        assert_eq!(escape_clickhouse_string("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn clamps_minutes_and_limit() {
+        assert_eq!(clamped_minutes(None), DEFAULT_MINUTES);
+        assert_eq!(clamped_minutes(Some(0)), 1);
+        assert_eq!(clamped_minutes(Some(99_999)), MAX_MINUTES);
+        assert_eq!(clamped_limit(Some(0)), 1);
+        assert_eq!(clamped_limit(Some(9_999)), MAX_LIMIT);
+    }
+
+    #[test]
+    fn build_query_sql_with_filters() {
+        let params = LogsQueryParams {
+            pod_namespace: Some("kbve".into()),
+            service: Some("axum".into()),
+            level: Some("ERROR".into()),
+            search: Some("panic".into()),
+            minutes: Some(15),
+            limit: Some(50),
+            ..Default::default()
+        };
+        let sql = build_query_sql(&params);
+        assert!(sql.contains("INTERVAL 15 MINUTE"));
+        assert!(sql.contains("pod_namespace = 'kbve'"));
+        assert!(sql.contains("service = 'axum'"));
+        assert!(sql.contains("level = 'error'"));
+        assert!(sql.contains("message ILIKE '%panic%'"));
+        assert!(sql.contains("LIMIT 50"));
+    }
+
+    #[test]
+    fn build_stats_sql_default_minutes() {
+        let sql = build_stats_sql(&LogsStatsParams::default());
+        assert!(sql.contains(&format!("INTERVAL {} MINUTE", DEFAULT_MINUTES)));
+        assert!(sql.contains("GROUP BY pod_namespace, service, level"));
+    }
+
+    #[test]
+    fn build_query_sql_neutralizes_injection() {
+        let params = LogsQueryParams {
+            pod_namespace: Some("kbve' OR 1=1 --".into()),
+            ..Default::default()
+        };
+        let sql = build_query_sql(&params);
+        // Escaped single quote keeps the injection inside the literal.
+        assert!(sql.contains("pod_namespace = 'kbve\\' OR 1=1 --'"));
+    }
+}

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/mod.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/mod.rs
@@ -1,5 +1,7 @@
-pub mod core;
 pub mod clickhouse_types;
+pub mod core;
+pub mod logs;
 
-pub use core::*;
 pub use clickhouse_types::*;
+pub use core::*;
+pub use logs::{LogsQueryParams, LogsResult, LogsStatsParams, run_query, run_stats};


### PR DESCRIPTION
Long-term **Option C** from #10640 — replaces the supabase edge function fronting at \`/functions/v1/logs\` with a direct path: **axum-kbve → jedi::entity::pipe_clickhouse::logs → ClickHouse HTTP**. The edge function is no longer in the critical path for the dashboard logs view, so a CDN outage on \`esm.sh\` (which 500'd the edge function boot graph and produced the "0 / 0 / 0 logs" outage on 2026-05-08) cannot kill the view again.

PR #10640 already swapped \`esm.sh\` for \`npm:\` to unstick the immediate incident. This PR removes the edge function from the read path entirely.

## Layout

### \`packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs\` (new)
- \`LogsQueryParams\` + \`LogsStatsParams\` + \`LogsResult\` types
- \`build_query_sql\` / \`build_stats_sql\` — parameter-clamped, single-quote and backslash escaped (SELECT-only, no DDL/INSERT surface here)
- \`run_query\` / \`run_stats\` — execute via existing \`ClickHouseConfig\`
- Bounds match what the edge function used to enforce:
    - \`minutes\`: \`1..=10080\` (7 days)
    - \`limit\`:   \`1..=500\`
    - \`search\`:  \`<= 100\` chars
- 5 unit tests cover clamps, escape semantics, full SQL render, and a single-quote injection attempt.

### \`apps/kbve/axum-kbve/Cargo.toml\`
- \`jedi\` enabled with the \`clickhouse\` feature.

### \`apps/kbve/axum-kbve/src/transport/proxy.rs\`
- Drops \`init_clickhouse_logs_proxy\` + the \`ServiceProxy\` fronting the edge function.
- Adds \`init_clickhouse_direct\` + a rewritten \`clickhouse_logs_proxy_handler\` that decodes \`{ command, ...params }\`, dispatches to jedi \`run_query\` / \`run_stats\`, returns JSON. Auth gate is the same \`DASHBOARD_VIEW\` check every other dashboard proxy uses — staff-only access is unchanged from the edge fn (which required \`service_role\`).
- Init guard requires at least one \`CLICKHOUSE_HOST\` / \`CLICKHOUSE_PORT\` / \`CLICKHOUSE_USER\` / \`CLICKHOUSE_DATABASE\` env var so a misconfigured pod doesn't silently target localhost.

### \`apps/kbve/axum-kbve/src/main.rs\`
- \`init_clickhouse_logs_proxy()\` → \`init_clickhouse_direct()\`.
- Updated startup log line to reflect the new path.

## Compatibility
- Route path \`/dashboard/clickhouse/proxy\` is unchanged — dashboard JS in \`ReactClickHouseDashboard\` / \`clickhouseService\` keeps working with no client changes.
- Body schema \`{ command, pod_namespace, pod_name, service, level, search, minutes, limit }\` is identical to the edge fn.

## Follow-up (separate PR)
Delete \`apps/kbve/edge/functions/logs\` once the direct route is verified in prod. Keep until then so we have a known-good fallback if jedi's HTTP path hits anything unexpected against ClickHouse 0.14 over 8123.

## Test plan
- [x] \`cargo test --manifest-path packages/rust/jedi/Cargo.toml --features clickhouse logs\` — 5 / 5 passing locally
- [x] \`cargo build --manifest-path apps/kbve/axum-kbve/Cargo.toml\` — clean
- [x] \`cargo clippy --manifest-path apps/kbve/axum-kbve/Cargo.toml --no-deps\` — no new errors
- [ ] Deploy → \`/dashboard\` ClickHouse logs view shows non-zero counts again, sourced direct (Network tab confirms response from axum, not the edge fn 502)
- [ ] \`curl -X POST $KBVE_URL/dashboard/clickhouse/proxy -H "Authorization: Bearer $STAFF_JWT" -H "Content-Type: application/json" -d '{"command":"stats","minutes":15}'\` returns rows
- [ ] Filter combinations (level, namespace, search) all return expected rows
- [ ] Injection probe (\`pod_namespace = "kbve' OR 1=1 --"\`) returns no extra rows — escape works at the boundary