### PR TITLE
feat(cityvote): harden Deployment with non-root + read-only rootfs

### DIFF
--- a/apps/kube/cityvote/README.md
+++ b/apps/kube/cityvote/README.md
@@ -1,0 +1,39 @@
+# cityvote — Kubernetes Deployment
+
+Single-Deployment service. No backend secrets — no ExternalSecret, no SealedSecret, no Reloader integration. Public traffic flows in via both the Cilium `kbve-gateway` (HTTPRoute) and the legacy nginx Ingress (kept active so cert-manager's ingress-shim mints the TLS Secret).
+
+## Manifests
+
+| File                                    | Purpose                                                                                             |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `application.yaml`                      | ArgoCD `Application` pointing at `apps/kube/cityvote/manifest`                                      |
+| `manifest/kustomization.yaml`           | Kustomize index                                                                                     |
+| `manifest/cityvote-serviceaccount.yaml` | `cityvote-sa` (used by the pod)                                                                     |
+| `manifest/cityvote-deployment.yaml`     | `cityvote-deployment` + `cityvote-service` (ClusterIP)                                              |
+| `manifest/httproute.yaml`               | HTTPRoute attaching the service to `kbve-gateway`                                                   |
+| `manifest/nginx-ingress.yaml`           | Legacy nginx Ingress — kept active because cert-manager's ingress-shim mints the TLS Secret from it |
+
+## Hardening
+
+The Deployment runs under a restricted PodSecurity profile:
+
+- `runAsNonRoot: true`, UID/GID `10001`. Verified locally that `ghcr.io/kbve/cityvote:1.0.3` starts cleanly under `--user 10001:10001 --read-only --tmpfs /tmp:size=64M` (process logs `HTTP/WS listening on http://0.0.0.0:4321`).
+- `readOnlyRootFilesystem: true` with a 64Mi `emptyDir` mounted at `/tmp` for scratch
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- Dedicated `cityvote-sa` ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod level. The pod no longer rides on the `default` SA. The pod does not call the kube API, so the projected token is unused weight.
+- CPU/memory `requests` and `limits` set so the kubelet enforces a cgroup; bursts cap at `200m / 256Mi`.
+
+## Reloader integration
+
+Not applicable — the Deployment has no Secret or ConfigMap references, so there is nothing for Reloader to watch. The pod template keeps a static `rollout-restart` annotation so a manual rollout can still be forced by bumping the timestamp if a redeploy is needed without changing the image tag.
+
+## TLS
+
+cert-manager mints the TLS Secret via the active `nginx-ingress.yaml` (annotated with `cert-manager.io/cluster-issuer: letsencrypt-http`); the Ingress is in the kustomization so the ingress-shim sees it and creates the `Certificate` automatically. No explicit `Certificate` resource is required for this namespace today.
+
+## ArgoCD
+
+- App: `cityvote` (source: `apps/kube/cityvote/manifest`)
+- Sync: automated with prune + selfHeal
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/cityvote/manifest/cityvote-deployment.yaml
+++ b/apps/kube/cityvote/manifest/cityvote-deployment.yaml
@@ -1,53 +1,83 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cityvote-deployment
-  namespace: cityvote
-  labels:
-    app: cityvote
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: cityvote
-  template:
-    metadata:
-      annotations:
-        rollout-restart: "2025-11-20T23:30:00Z"
-      labels:
+    name: cityvote-deployment
+    namespace: cityvote
+    labels:
         app: cityvote
-        version: "1.0.3"
-    spec:
-      containers:
-      - name: cityvote
-        image: ghcr.io/kbve/cityvote:1.0.3
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 4321
-          protocol: TCP
-        env:
-        - name: PORT
-          value: "4321"
-        resources:
-          requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            cpu: "200m"
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: cityvote
+    template:
+        metadata:
+            annotations:
+                # Manual rollout-restart trigger preserved as a fallback
+                # if a redeploy is needed without bumping the image tag.
+                rollout-restart: '2025-11-20T23:30:00Z'
+            labels:
+                app: cityvote
+                version: '1.0.3'
+        spec:
+            serviceAccountName: cityvote-sa
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                fsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: cityvote
+                  image: ghcr.io/kbve/cityvote:1.0.3
+                  imagePullPolicy: Always
+                  ports:
+                      - containerPort: 4321
+                        protocol: TCP
+                  env:
+                      - name: PORT
+                        value: '4321'
+                  resources:
+                      requests:
+                          memory: '128Mi'
+                          cpu: '100m'
+                      limits:
+                          memory: '256Mi'
+                          cpu: '200m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+            volumes:
+                # Writable scratch for the binary while the rootfs
+                # itself stays read-only. Verified locally that the
+                # ghcr.io/kbve/cityvote:1.0.3 image starts cleanly
+                # under runAsUser:10001 + read-only rootfs + tmpfs /tmp
+                # (HTTP listening on 0.0.0.0:4321).
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 64Mi
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: cityvote-service
-  namespace: cityvote
-  labels:
-    app: cityvote
+    name: cityvote-service
+    namespace: cityvote
+    labels:
+        app: cityvote
 spec:
-  type: ClusterIP
-  selector:
-    app: cityvote
-  ports:
-  - port: 4321
-    targetPort: 4321
-    protocol: TCP
+    type: ClusterIP
+    selector:
+        app: cityvote
+    ports:
+        - port: 4321
+          targetPort: 4321
+          protocol: TCP

--- a/apps/kube/cityvote/manifest/cityvote-serviceaccount.yaml
+++ b/apps/kube/cityvote/manifest/cityvote-serviceaccount.yaml
@@ -1,0 +1,10 @@
+# ServiceAccount used by the cityvote Deployment pod. The pod does not
+# call the kube API, so the projected token is unused weight — disable
+# it here at the SA level. The pod spec re-states the field so any
+# future template binding the SA inherits the safe default.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: cityvote-sa
+    namespace: cityvote
+automountServiceAccountToken: false

--- a/apps/kube/cityvote/manifest/kustomization.yaml
+++ b/apps/kube/cityvote/manifest/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: cityvote
 
 resources:
+    - cityvote-serviceaccount.yaml
     - cityvote-deployment.yaml
     - httproute.yaml
     - nginx-ingress.yaml


### PR DESCRIPTION
## Summary

Continues the small-namespace hardening rollout — cityvote is the smallest remaining target (single Deployment, no Secret refs, no ExternalSecret, no SealedSecret).

- `cityvote-deployment` now runs under a restricted PSA profile mirroring the rest of the rollout: `runAsNonRoot: true` UID/GID `10001`, `readOnlyRootFilesystem: true` with a 64Mi `/tmp` emptyDir, `allowPrivilegeEscalation: false`, all Linux capabilities dropped, `seccompProfile: RuntimeDefault`.
- Verified locally that `ghcr.io/kbve/cityvote:1.0.3` starts cleanly under `--user 10001:10001 --read-only --tmpfs /tmp:size=64M` (process logs `HTTP/WS listening on http://0.0.0.0:4321`).
- New dedicated `cityvote-sa` ServiceAccount with `automountServiceAccountToken: false` at both the SA and pod level. The pod no longer rides on the `default` SA. The pod does not call the kube API.
- The existing `rollout-restart` pod-template annotation is preserved as a manual fallback.
- New `apps/kube/cityvote/README.md` documents the topology and hardening posture.

## Reloader — explicitly omitted

The Deployment has no Secret or ConfigMap references, so there is nothing for Reloader to watch. Adding the `reloader.stakater.com/auto` annotation would be a no-op weight. Documented in the README so the omission is intentional, not an oversight.

## Hardening pattern by namespace so far

| ns           | manifest type | Reloader | non-root  | readOnly rootfs | caps drop | SA token off |
| ------------ | ------------- | -------- | --------- | --------------- | --------- | ------------ |
| chuckrpg     | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| redis        | Bitnami chart | yes      | chart     | chart           | chart     | chart        |
| n8n          | raw           | yes      | UID 1000  | deferred        | yes       | yes          |
| discordsh    | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| herbmail     | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| cryptothrone | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| memes        | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| rentearth    | raw           | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| cityvote     | raw           | n/a      | UID 10001 | yes + /tmp ED   | yes       | yes          |

## Test plan

- [ ] ArgoCD `cityvote` Application syncs cleanly after dev → main promotion.
- [ ] `kubectl -n cityvote get pod -l app=cityvote` shows the pod `Running` under SA `cityvote-sa`, `runAsUser: 10001`, `readOnlyRootFilesystem: true`.
- [ ] cityvote public hostname keeps responding through the gateway during and after rollout.
- [ ] Bumping the `rollout-restart` annotation on the Deployment triggers a manual rolling restart.