### PR TITLE
feat(bevy_db,discordsh): redb L2 profile cache + tokio-friendly NativeStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,6 +1933,7 @@ dependencies = [
  "redb",
  "rexie",
  "serde",
+ "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4982,6 +4983,7 @@ dependencies = [
  "bevy_battle",
  "bevy_behavior",
  "bevy_chat",
+ "bevy_db",
  "bevy_inventory",
  "bevy_items",
  "bevy_mapdb",

--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -42,6 +42,7 @@ bevy_mapdb = { path = "../../../packages/rust/bevy/bevy_mapdb" }
 bevy_pathfinder = { path = "../../../packages/rust/bevy/bevy_pathfinder", default-features = false, features = [
     "tile-graph",
 ] }
+bevy_db = { path = "../../../packages/rust/bevy/bevy_db", default-features = false }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -26,6 +26,7 @@ COPY packages/rust/bevy/bevy_skills/Cargo.toml packages/rust/bevy/bevy_skills/Ca
 COPY packages/rust/bevy/bevy_chat/Cargo.toml packages/rust/bevy/bevy_chat/Cargo.toml
 COPY packages/rust/bevy/bevy_mapdb/Cargo.toml packages/rust/bevy/bevy_mapdb/Cargo.toml
 COPY packages/rust/bevy/bevy_pathfinder/Cargo.toml packages/rust/bevy/bevy_pathfinder/Cargo.toml
+COPY packages/rust/bevy/bevy_db/Cargo.toml packages/rust/bevy/bevy_db/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
@@ -42,7 +43,8 @@ RUN mkdir -p apps/discordsh/discordsh-bot/src && echo "fn main() {}" > apps/disc
     mkdir -p packages/rust/bevy/bevy_skills/src && echo "" > packages/rust/bevy/bevy_skills/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_chat/src && echo "" > packages/rust/bevy/bevy_chat/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_mapdb/src && echo "" > packages/rust/bevy/bevy_mapdb/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_pathfinder/src && echo "" > packages/rust/bevy/bevy_pathfinder/src/lib.rs
+    mkdir -p packages/rust/bevy/bevy_pathfinder/src && echo "" > packages/rust/bevy/bevy_pathfinder/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_db/src && echo "" > packages/rust/bevy/bevy_db/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -89,11 +91,12 @@ COPY packages/rust/bevy/bevy_skills packages/rust/bevy/bevy_skills
 COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 COPY packages/rust/bevy/bevy_mapdb packages/rust/bevy/bevy_mapdb
 COPY packages/rust/bevy/bevy_pathfinder packages/rust/bevy/bevy_pathfinder
+COPY packages/rust/bevy/bevy_db packages/rust/bevy/bevy_db
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo build --release -p kbve -p jedi -p holy -p bevy_inventory -p bevy_items -p bevy_behavior -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat -p bevy_mapdb -p bevy_pathfinder
+    cargo build --release -p kbve -p jedi -p holy -p bevy_inventory -p bevy_items -p bevy_behavior -p bevy_battle -p bevy_npc -p bevy_quests -p bevy_skills -p bevy_chat -p bevy_mapdb -p bevy_pathfinder -p bevy_db
 
 # ============================================================================
 # [STAGE D] - Build Application
@@ -119,6 +122,7 @@ COPY packages/rust/bevy/bevy_skills packages/rust/bevy/bevy_skills
 COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 COPY packages/rust/bevy/bevy_mapdb packages/rust/bevy/bevy_mapdb
 COPY packages/rust/bevy/bevy_pathfinder packages/rust/bevy/bevy_pathfinder
+COPY packages/rust/bevy/bevy_db packages/rust/bevy/bevy_db
 
 # Application source (most frequently changing — placed last for cache)
 COPY apps/discordsh/discordsh-bot apps/discordsh/discordsh-bot

--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -1,11 +1,15 @@
 //! Dungeon player persistence — Supabase-backed profile storage.
 //!
-//! Follows the `MemberCache` pattern: LRU cache + Supabase RPC + graceful
-//! degradation (if Supabase is unavailable, games still work in-memory).
+//! Cache hierarchy: in-mem LRU → optional redb L2 (bevy_db) → Supabase RPC.
+//! All layers degrade gracefully — when Supabase is offline the bot can
+//! still serve cached profiles from redb across pod restarts; when redb
+//! isn't configured the bot falls back to LRU + Supabase as before.
 
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use bevy_db::NativeStore;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::{debug, error, warn};
@@ -20,6 +24,8 @@ use super::types::{
 const SCHEMA: &str = "discordsh";
 const CACHE_CAP: usize = 512;
 const CACHE_TTL: Duration = Duration::from_secs(300);
+/// redb table name for the persistent profile L2 cache.
+const REDB_PROFILE_TABLE: &str = "discordsh:profiles";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -96,30 +102,87 @@ pub struct ProfileStore {
     client: Option<SupabaseClient>,
     cache: Mutex<lru::LruCache<u64, CachedProfile>>,
     ttl: Duration,
+    /// Optional persistent L2 cache (redb). Survives pod restarts and
+    /// covers Supabase outages. `None` when `DB_PATH` is unset.
+    local_db: Option<Arc<NativeStore>>,
 }
 
 impl ProfileStore {
-    /// Build from environment. Returns a no-op store if Supabase is unavailable.
+    /// Build from environment without an L2 cache. Kept for tests and
+    /// callers that don't need redb-backed persistence.
+    #[cfg(test)]
     pub fn from_env() -> Self {
+        Self::from_env_with_local(None)
+    }
+
+    /// Build from environment, optionally backing the LRU with a redb L2
+    /// cache. Returns a no-op store when Supabase is unavailable; the L2
+    /// cache still works in that case (last known profile per player).
+    pub fn from_env_with_local(local_db: Option<Arc<NativeStore>>) -> Self {
         Self {
             client: SupabaseClient::from_env(),
             cache: Mutex::new(lru::LruCache::new(NonZeroUsize::new(CACHE_CAP).unwrap())),
             ttl: CACHE_TTL,
+            local_db,
         }
     }
 
-    /// Load a profile, checking cache first then Supabase RPC.
+    /// Hydrate the LRU + return a profile from the L2 redb cache, if
+    /// any. Errors and missing keys both yield `None` so the caller
+    /// transparently falls through to Supabase.
+    async fn read_local(&self, discord_id: u64) -> Option<DungeonProfile> {
+        let db = self.local_db.as_ref()?;
+        let key = discord_id.to_string();
+        match db.get::<DungeonProfile>(REDB_PROFILE_TABLE, &key).await {
+            Ok(Some(profile)) => {
+                let mut cache = self.cache.lock().await;
+                cache.put(
+                    discord_id,
+                    CachedProfile {
+                        profile: profile.clone(),
+                        fetched_at: Instant::now(),
+                    },
+                );
+                Some(profile)
+            }
+            Ok(None) => None,
+            Err(e) => {
+                warn!(error = %e, discord_id, "L2 redb read failed");
+                None
+            }
+        }
+    }
+
+    /// Best-effort write to the redb L2 cache. Failures are logged and
+    /// swallowed — the in-mem LRU + Supabase remain authoritative.
+    async fn write_local(&self, discord_id: u64, profile: &DungeonProfile) {
+        let Some(db) = self.local_db.as_ref() else {
+            return;
+        };
+        let key = discord_id.to_string();
+        if let Err(e) = db.put(REDB_PROFILE_TABLE, &key, profile).await {
+            warn!(error = %e, discord_id, "L2 redb write failed");
+        }
+    }
+
+    /// Load a profile. Path: in-mem LRU → redb L2 → Supabase RPC.
     pub async fn load(&self, discord_id: u64) -> Option<DungeonProfile> {
-        // Check cache
+        // L0: in-mem LRU
         {
             let mut cache = self.cache.lock().await;
-            if let Some(entry) = cache.get(&discord_id) {
-                if entry.fetched_at.elapsed() < self.ttl {
-                    return Some(entry.profile.clone());
-                }
+            if let Some(entry) = cache.get(&discord_id)
+                && entry.fetched_at.elapsed() < self.ttl
+            {
+                return Some(entry.profile.clone());
             }
         }
 
+        // L1: redb (also re-hydrates the LRU on hit)
+        if let Some(profile) = self.read_local(discord_id).await {
+            return Some(profile);
+        }
+
+        // L2: Supabase RPC
         let client = self.client.as_ref()?;
         let params = serde_json::json!({ "p_discord_id": discord_id as i64 });
 
@@ -139,14 +202,17 @@ impl ProfileStore {
                 match resp.json::<Vec<DungeonProfile>>().await {
                     Ok(rows) if !rows.is_empty() => {
                         let profile = rows.into_iter().next().unwrap();
-                        let mut cache = self.cache.lock().await;
-                        cache.put(
-                            discord_id,
-                            CachedProfile {
-                                profile: profile.clone(),
-                                fetched_at: Instant::now(),
-                            },
-                        );
+                        {
+                            let mut cache = self.cache.lock().await;
+                            cache.put(
+                                discord_id,
+                                CachedProfile {
+                                    profile: profile.clone(),
+                                    fetched_at: Instant::now(),
+                                },
+                            );
+                        }
+                        self.write_local(discord_id, &profile).await;
                         Some(profile)
                     }
                     Ok(_) => None,
@@ -164,7 +230,20 @@ impl ProfileStore {
     }
 
     /// Save a profile + run summary (fire-and-forget via tokio::spawn).
+    /// Writes the profile to the redb L2 cache synchronously before
+    /// dispatching to Supabase so a pod restart between RPC failure and
+    /// next load still serves the latest snapshot.
     pub fn save_async(&self, profile: DungeonProfile, run: RunSummary) {
+        if let Some(db) = self.local_db.clone() {
+            let profile_for_local = profile.clone();
+            tokio::spawn(async move {
+                let key = profile_for_local.discord_id.to_string();
+                if let Err(e) = db.put(REDB_PROFILE_TABLE, &key, &profile_for_local).await {
+                    warn!(error = %e, discord_id = profile_for_local.discord_id, "L2 redb mirror write failed");
+                }
+            });
+        }
+
         let Some(client) = self.client.clone() else {
             return;
         };

--- a/apps/discordsh/discordsh-bot/src/state.rs
+++ b/apps/discordsh/discordsh-bot/src/state.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
@@ -5,6 +6,7 @@ use std::time::Instant;
 use poise::serenity_prelude as serenity;
 use tokio::sync::{Notify, RwLock};
 
+use bevy_db::NativeStore;
 use kbve::{FontDb, MemberCache};
 
 use bevy_chat::ChatClient;
@@ -71,6 +73,42 @@ pub struct AppState {
     /// Optional IRC client for cross-platform chat and world events.
     /// `None` if IRC is unavailable or not configured.
     pub irc: Option<ChatClient>,
+
+    /// Optional persistent KV store (redb). Opened from `DB_PATH` env var
+    /// at startup. `None` when the variable is unset or the file fails to
+    /// open — callers must treat persistence as best-effort. Used today
+    /// as an L2 cache for [`ProfileStore`]; reserved for future
+    /// `SessionStore` snapshot persistence.
+    #[allow(dead_code)]
+    pub local_db: Option<Arc<NativeStore>>,
+}
+
+/// Resolve the local KV store path from `DB_PATH`. Returns `None` when
+/// the variable is unset; logs and returns `None` if the file fails to
+/// open so the bot can still run with Supabase-only persistence.
+fn open_local_db() -> Option<Arc<NativeStore>> {
+    let raw = std::env::var("DB_PATH").ok()?;
+    if raw.trim().is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(&raw);
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        tracing::warn!(error = %e, parent = %parent.display(), "Failed to create local DB parent dir");
+        return None;
+    }
+    match NativeStore::open(path.clone()) {
+        Ok(store) => {
+            tracing::info!(path = %path.display(), "Local KV store opened (redb)");
+            Some(Arc::new(store))
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "Failed to open local KV store; running Supabase-only");
+            None
+        }
+    }
 }
 
 /// Resolve the default GitHub repo from env vars (checked once at startup).
@@ -132,6 +170,9 @@ impl AppState {
             None
         };
 
+        let local_db = open_local_db();
+        let profiles = Arc::new(ProfileStore::from_env_with_local(local_db.clone()));
+
         Self {
             health_monitor,
             tracker,
@@ -142,13 +183,14 @@ impl AppState {
             bot_http: RwLock::new(None),
             sessions: Arc::new(SessionStore::new()),
             members: Arc::new(MemberCache::from_env()),
-            profiles: Arc::new(ProfileStore::from_env()),
+            profiles,
             fontdb,
             default_repo: resolve_default_repo(),
             github_repo_policy: jedi::entity::github::RepoPolicy::from_env(),
             github_guard: GitHubCommandGuard::from_env(),
             github_cache: GitHubCache::new(),
             irc,
+            local_db,
         }
     }
 }

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -80,6 +80,11 @@ spec:
                             secretKeyRef:
                                 name: discordsh-supabase-shared
                                 key: service-role-key
+                      # Local KV cache (redb) — DungeonProfile L2 cache
+                      # backed by a Longhorn PVC. Survives pod restarts so
+                      # profiles stay warm during Supabase outages.
+                      - name: DB_PATH
+                        value: '/data/discordsh.redb'
                   resources:
                       requests:
                           memory: '256Mi'
@@ -99,6 +104,8 @@ spec:
                   volumeMounts:
                       - name: tmp
                         mountPath: /tmp
+                      - name: data
+                        mountPath: /data
                   livenessProbe:
                       httpGet:
                           path: /health
@@ -117,3 +124,13 @@ spec:
                 - name: tmp
                   emptyDir:
                       sizeLimit: 64Mi
+    volumeClaimTemplates:
+        - metadata:
+              name: data
+          spec:
+              accessModes:
+                  - ReadWriteOnce
+              storageClassName: longhorn
+              resources:
+                  requests:
+                      storage: 1Gi

--- a/packages/rust/bevy/bevy_db/Cargo.toml
+++ b/packages/rust/bevy/bevy_db/Cargo.toml
@@ -12,12 +12,25 @@ keywords = ["bevy", "persistence", "wasm", "database", "gamedev"]
 categories = ["game-development", "database"]
 readme = "README.md"
 
+[features]
+default = ["bevy-plugin"]
+
+# Bevy ECS plugin layer — `Db` resource, `DbRequest<T>` poller, `WriteBatch`
+# builder. Without this feature the crate exposes only the platform-native
+# async store directly (suitable for tokio-based services like
+# discordsh-bot that don't run a Bevy `App`).
+bevy-plugin = ["dep:bevy", "dep:bevy_tasker", "dep:crossbeam-channel"]
+
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
-bevy_tasker = { version = "0.1", path = "../bevy_tasker" }
-crossbeam-channel = "0.5"
 serde = { version = "1", features = ["derive"] }
 bincode = { version = "2", features = ["serde"] }
+
+# Bevy plumbing — only when the `bevy-plugin` feature is on.
+bevy = { version = "0.18", default-features = false, features = [
+    "bevy_state",
+], optional = true }
+bevy_tasker = { version = "0.1", path = "../bevy_tasker", optional = true }
+crossbeam-channel = { version = "0.5", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 redb = "2"
@@ -29,6 +42,9 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 once_cell = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/rust/bevy/bevy_db/src/lib.rs
+++ b/packages/rust/bevy/bevy_db/src/lib.rs
@@ -1,9 +1,10 @@
-//! `bevy_db` — Cross-platform async key-value persistence for Bevy.
+//! `bevy_db` — Cross-platform async key-value persistence.
 //!
 //! Uses `redb` (pure Rust B+tree) on native and `rexie` (IndexedDB) on WASM.
-//! All I/O is dispatched off the game thread via `bevy_tasker`.
 //!
-//! # Usage
+//! Two consumer-facing shapes, picked by feature flag:
+//!
+//! ## `bevy-plugin` (default) — Bevy ECS plugin
 //!
 //! ```rust,ignore
 //! app.add_plugins(BevyDbPlugin::default());
@@ -16,58 +17,90 @@
 //!     if pending.is_none() {
 //!         *pending = Some(db.get("players", "hero"));
 //!     }
-//!     if let Some(ref req) = *pending {
-//!         if let Some(result) = req.try_recv() {
-//!             // Use result
-//!             *pending = None;
-//!         }
+//!     if let Some(ref req) = *pending
+//!         && let Some(result) = req.try_recv()
+//!     {
+//!         *pending = None;
 //!     }
 //! }
 //! ```
+//!
+//! ## `default-features = false` — direct async store
+//!
+//! For tokio-based services (Discord bots, axum apps, CLIs) that don't
+//! run a Bevy `App`. Use [`native::NativeStore`] directly:
+//!
+//! ```rust,ignore
+//! let store = NativeStore::open("/data/app.redb".into())?;
+//! store.put("sessions", "abc123", &session).await?;
+//! let loaded: Option<Session> = store.get("sessions", "abc123").await?;
+//! ```
 
 pub mod backend;
-pub mod batch;
 pub mod error;
-pub mod handle;
 pub(crate) mod store;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod native;
+
+#[cfg(feature = "bevy-plugin")]
+pub mod batch;
+#[cfg(feature = "bevy-plugin")]
+pub mod handle;
+#[cfg(feature = "bevy-plugin")]
 pub(crate) mod task;
 
 pub use error::DbError;
+
+#[cfg(feature = "bevy-plugin")]
 pub use handle::{Db, DbRequest};
 
-use bevy::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::NativeStore;
 
-/// Plugin that initializes the database backend and inserts the `Db` resource.
-pub struct BevyDbPlugin {
-    /// Database name. On native this becomes the filename; on WASM the IndexedDB name.
-    pub db_name: String,
-}
+#[cfg(feature = "bevy-plugin")]
+mod plugin {
+    use bevy::prelude::*;
 
-impl Default for BevyDbPlugin {
-    fn default() -> Self {
-        Self {
-            db_name: "kbve_db".into(),
+    use crate::backend;
+    use crate::handle::Db;
+
+    /// Plugin that initializes the database backend and inserts the `Db` resource.
+    pub struct BevyDbPlugin {
+        /// Database name. On native this becomes the filename; on WASM the IndexedDB name.
+        pub db_name: String,
+    }
+
+    impl Default for BevyDbPlugin {
+        fn default() -> Self {
+            Self {
+                db_name: "kbve_db".into(),
+            }
+        }
+    }
+
+    impl Plugin for BevyDbPlugin {
+        fn build(&self, app: &mut App) {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let path = dirs::data_local_dir()
+                    .unwrap_or_else(|| std::path::PathBuf::from("."))
+                    .join(&self.db_name)
+                    .with_extension("redb");
+
+                let store =
+                    backend::BackendStore::open(path).expect("failed to open bevy_db database");
+                app.insert_resource(Db::new(store));
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                let store = backend::BackendStore::new(self.db_name.clone());
+                app.insert_resource(Db::new(store));
+            }
         }
     }
 }
 
-impl Plugin for BevyDbPlugin {
-    fn build(&self, app: &mut App) {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let path = dirs::data_local_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join(&self.db_name)
-                .with_extension("redb");
-
-            let store = backend::BackendStore::open(path).expect("failed to open bevy_db database");
-            app.insert_resource(Db::new(store));
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            let store = backend::BackendStore::new(self.db_name.clone());
-            app.insert_resource(Db::new(store));
-        }
-    }
-}
+#[cfg(feature = "bevy-plugin")]
+pub use plugin::BevyDbPlugin;

--- a/packages/rust/bevy/bevy_db/src/native.rs
+++ b/packages/rust/bevy/bevy_db/src/native.rs
@@ -1,0 +1,262 @@
+//! Tokio-friendly redb store — public counterpart of the internal
+//! `backend::native::NativeStore` used by the Bevy plugin.
+//!
+//! This is the surface non-Bevy services (axum apps, Discord bots,
+//! CLIs) consume when they enable `default-features = false`. It hides
+//! the internal `DbStore` trait and presents a small typed API:
+//! bincode in, bincode out.
+//!
+//! Cheap to clone — internally an `Arc<redb::Database>` — so a single
+//! `NativeStore` handle can be threaded through application state and
+//! cloned per request without re-opening the file.
+//!
+//! # Caveats
+//!
+//! redb's transaction API is synchronous. Calls execute on whatever
+//! tokio worker thread awaits them; long-running batch writes can
+//! block that worker. For typical session-state writes (single small
+//! JSON blob, ≤ a few ms per commit) this is fine. If you need to
+//! shield the runtime, wrap calls in [`tokio::task::spawn_blocking`].
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use redb::{Database, TableDefinition};
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::error::DbError;
+
+/// Composite key format mirrors the Bevy plugin's internal layout so a
+/// single redb file can be shared between both APIs (e.g. a tool reads
+/// what a Bevy app wrote, or vice versa).
+fn composite_key(table: &str, key: &str) -> String {
+    format!("{table}\0{key}")
+}
+
+fn extract_key(composite: &str, table: &str) -> Option<String> {
+    let prefix = format!("{table}\0");
+    composite.strip_prefix(&prefix).map(|s| s.to_owned())
+}
+
+const DATA_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("data");
+
+/// Pure-redb async key-value store, suitable for tokio runtimes.
+///
+/// Cloning is cheap (`Arc<Database>`); pass a clone per worker / request.
+#[derive(Clone)]
+pub struct NativeStore {
+    db: Arc<Database>,
+}
+
+impl NativeStore {
+    /// Open or create the redb file at the given path. The parent
+    /// directory must already exist.
+    pub fn open(path: PathBuf) -> Result<Self, DbError> {
+        let db = Database::create(path).map_err(|e| DbError::Backend(format!("redb open: {e}")))?;
+        Ok(Self { db: Arc::new(db) })
+    }
+
+    /// Read a bincode-encoded value at `(table, key)`. Returns
+    /// `Ok(None)` for a missing key (or a not-yet-created table) and
+    /// `Err(DbError::Serialization(_))` if the bytes can't be decoded
+    /// as `T`.
+    pub async fn get<T: DeserializeOwned>(
+        &self,
+        table: &str,
+        key: &str,
+    ) -> Result<Option<T>, DbError> {
+        let bytes = self.get_bytes(table, key).await?;
+        match bytes {
+            None => Ok(None),
+            Some(b) => {
+                let (val, _) = bincode::serde::decode_from_slice(&b, bincode::config::standard())
+                    .map_err(|e| DbError::Serialization(e.to_string()))?;
+                Ok(Some(val))
+            }
+        }
+    }
+
+    /// Write a bincode-encoded value at `(table, key)`. Overwrites any
+    /// existing entry.
+    pub async fn put<T: Serialize>(
+        &self,
+        table: &str,
+        key: &str,
+        value: &T,
+    ) -> Result<(), DbError> {
+        let bytes = bincode::serde::encode_to_vec(value, bincode::config::standard())
+            .map_err(|e| DbError::Serialization(e.to_string()))?;
+        self.put_bytes(table, key, bytes).await
+    }
+
+    /// Remove `(table, key)`. No-op if the key is absent.
+    pub async fn delete(&self, table: &str, key: &str) -> Result<(), DbError> {
+        let ck = composite_key(table, key);
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        {
+            let mut tbl = match write_txn.open_table(DATA_TABLE) {
+                Ok(t) => t,
+                Err(redb::TableError::TableDoesNotExist(_)) => return Ok(()),
+                Err(e) => return Err(DbError::Backend(e.to_string())),
+            };
+            tbl.remove(ck.as_str())
+                .map_err(|e| DbError::Backend(e.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        Ok(())
+    }
+
+    /// All keys in `table` whose ref starts with `prefix`. Empty if the
+    /// table doesn't exist yet.
+    pub async fn list_keys(&self, table: &str, prefix: &str) -> Result<Vec<String>, DbError> {
+        let scan_prefix = format!("{table}\0{prefix}");
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+
+        let tbl = match read_txn.open_table(DATA_TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+            Err(e) => return Err(DbError::Backend(e.to_string())),
+        };
+
+        let mut keys = Vec::new();
+        let range = tbl
+            .range(scan_prefix.as_str()..)
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+
+        for entry in range {
+            let (k, _) = entry.map_err(|e| DbError::Backend(e.to_string()))?;
+            let composite = k.value().to_string();
+            if !composite.starts_with(&scan_prefix) {
+                break;
+            }
+            if let Some(key) = extract_key(&composite, table) {
+                keys.push(key);
+            }
+        }
+
+        Ok(keys)
+    }
+
+    // ── Internal byte-level helpers ────────────────────────────────
+
+    async fn get_bytes(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, DbError> {
+        let ck = composite_key(table, key);
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+
+        let tbl = match read_txn.open_table(DATA_TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(DbError::Backend(e.to_string())),
+        };
+
+        match tbl.get(ck.as_str()) {
+            Ok(Some(val)) => Ok(Some(val.value().to_vec())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(DbError::Backend(e.to_string())),
+        }
+    }
+
+    async fn put_bytes(&self, table: &str, key: &str, value: Vec<u8>) -> Result<(), DbError> {
+        let ck = composite_key(table, key);
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        {
+            let mut tbl = write_txn
+                .open_table(DATA_TABLE)
+                .map_err(|e| DbError::Backend(e.to_string()))?;
+            tbl.insert(ck.as_str(), value.as_slice())
+                .map_err(|e| DbError::Backend(e.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| DbError::Backend(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Sample {
+        name: String,
+        score: u32,
+    }
+
+    fn temp_db() -> NativeStore {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!("bevy_db_test_{}_{}.redb", std::process::id(), id));
+        let _ = std::fs::remove_file(&path);
+        NativeStore::open(path).expect("open redb")
+    }
+
+    #[tokio::test]
+    async fn round_trip_typed_value() {
+        let db = temp_db();
+        let v = Sample {
+            name: "alice".into(),
+            score: 42,
+        };
+        db.put("samples", "a", &v).await.unwrap();
+        let got: Option<Sample> = db.get("samples", "a").await.unwrap();
+        assert_eq!(got, Some(v));
+    }
+
+    #[tokio::test]
+    async fn missing_key_returns_none() {
+        let db = temp_db();
+        let got: Option<Sample> = db.get("samples", "missing").await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_entry() {
+        let db = temp_db();
+        let v = Sample {
+            name: "bob".into(),
+            score: 1,
+        };
+        db.put("samples", "b", &v).await.unwrap();
+        db.delete("samples", "b").await.unwrap();
+        let got: Option<Sample> = db.get("samples", "b").await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_keys_filters_by_prefix() {
+        let db = temp_db();
+        for k in ["alpha", "alfa", "beta"] {
+            db.put(
+                "samples",
+                k,
+                &Sample {
+                    name: k.into(),
+                    score: 0,
+                },
+            )
+            .await
+            .unwrap();
+        }
+        let mut keys = db.list_keys("samples", "al").await.unwrap();
+        keys.sort();
+        assert_eq!(keys, vec!["alfa".to_string(), "alpha".to_string()]);
+    }
+}


### PR DESCRIPTION
Phase 3 of #10601 — bevy_db integration. Same restructure pattern as Phase 2 (#10627): the existing public shape was Bevy-only (\`Db\` resource, \`DbRequest<T>\` polled per frame), which doesn't fit a tokio-based service like discordsh-bot. So gate Bevy behind a feature flag and expose a tokio-native sibling API.

## bevy_db
- Cargo: \`default = [\"bevy-plugin\"]\`. \`bevy\`, \`bevy_tasker\`, and \`crossbeam-channel\` are now optional, pulled in only by the \`bevy-plugin\` feature. The existing isometric (Tauri) consumer picks up default features and is unaffected.
- New public \`bevy_db::native::NativeStore\` (re-exported as \`bevy_db::NativeStore\`) — pure-redb async store with typed bincode \`get<T>\` / \`put<T>\` / \`delete\` / \`list_keys\`. Cheap to clone (\`Arc<redb::Database>\`).
- The Bevy plugin (\`BevyDbPlugin\`, \`Db\`, \`DbRequest\`, \`WriteBatch\`) is unchanged in behavior; only modules and re-exports moved behind the new feature gate.

## discordsh-bot
- Adds \`bevy_db\` with \`default-features = false\` so the binary pulls only redb, not Bevy. Dockerfile staged the same way as the other bevy_* crates.
- New \`AppState.local_db: Option<Arc<NativeStore>>\` opened from \`DB_PATH\` at startup. Missing env var, missing parent dir, or redb open failure all log a warning and degrade to \`None\` so the bot keeps running with Supabase-only persistence.
- \`ProfileStore\` gains an L2 redb cache between the in-mem LRU and Supabase. \`load()\` checks LRU → redb → Supabase and re-hydrates upper layers on hit. \`save_async\` now mirrors the latest profile to redb in addition to firing the Supabase RPC, so a pod that restarts after a Supabase outage still serves the most recent snapshot.

## K8s manifest
- StatefulSet gets a \`volumeClaimTemplates\` entry (\`data\`, 1Gi, longhorn, RWO) mounted at \`/data\`. \`DB_PATH=/data/discordsh.redb\` added to the env block.

## Test plan
- [x] \`cargo test\` on \`bevy_db\` (both default + \`--no-default-features\`) — 4 new \`native::tests\` pass
- [x] \`cargo check\` on \`isometric\` (Tauri default-features consumer) — clean
- [x] \`cargo test --bin discordsh-bot\` — 705 passed (no regression)
- [x] \`cargo clippy --no-deps\` clean on edited bot files
- [ ] Docker build green in CI
- [ ] Smoke test in staging: pod restart between profile saves preserves latest snapshot

## Follow-ups (tracked in #10601)
- Full \`SessionState\` resume across pod restart — blocked on adding \`Deserialize\` to the type and its \`serenity::*Id\` / \`Instant\` fields. Separate PR.