### PR TITLE
feat(axum-kbve): utoipa annotations for ClickHouse logs route

### DIFF
--- a/apps/kbve/axum-kbve/src/openapi.rs
+++ b/apps/kbve/axum-kbve/src/openapi.rs
@@ -25,6 +25,7 @@ use crate::transport::https::{
     CreateCommentBody, CreateThreadBody, EditCommentBody, HealthResponse, SetUsernameRequest,
     StatusResponse,
 };
+use crate::transport::proxy::{ClickHouseLogsRequest, ClickHouseLogsResponse};
 
 /// Adds the `bearerAuth` security scheme so `#[utoipa::path(security(...))]`
 /// references resolve. JWT goes in the `Authorization: Bearer ...` header.
@@ -66,7 +67,8 @@ impl Modify for SecurityAddon {
         (name = "forum", description = "Public forum threads, comments, spaces, and tags."),
         (name = "osrs", description = "Old School RuneScape item lookups."),
         (name = "mc", description = "Minecraft RCON-backed live data: player list, head textures."),
-        (name = "telemetry", description = "Client-side error reporting from WASM/JS.")
+        (name = "telemetry", description = "Client-side error reporting from WASM/JS."),
+        (name = "dashboard", description = "Staff-only routes powering kbve.com/dashboard. Gated on DASHBOARD_VIEW.")
     ),
     paths(
         // system
@@ -95,6 +97,8 @@ impl Modify for SecurityAddon {
         crate::transport::https::api_edit_comment,
         crate::transport::https::api_remove_comment,
         crate::transport::https::api_staff_edit_comment,
+        // dashboard
+        crate::transport::proxy::clickhouse_logs_proxy_handler,
     ),
     components(
         schemas(
@@ -118,6 +122,8 @@ impl Modify for SecurityAddon {
             CreateThreadBody,
             CreateCommentBody,
             EditCommentBody,
+            ClickHouseLogsRequest,
+            ClickHouseLogsResponse,
         )
     ),
     modifiers(&SecurityAddon)

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -609,31 +609,72 @@ pub fn init_clickhouse_direct() -> bool {
     CLICKHOUSE_DIRECT.set(config).is_ok()
 }
 
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-struct ClickHouseRequest {
-    command: String,
+/// Body schema for `POST /dashboard/clickhouse/proxy`. Mirrors the legacy
+/// supabase edge function at `/functions/v1/logs` so the dashboard JS in
+/// `clickhouseService.ts` doesn't have to change. Bounds are enforced inside
+/// jedi (`pipe_clickhouse::logs`):
+/// - `minutes` clamped to `1..=10080`
+/// - `limit` clamped to `1..=500`
+/// - `search` truncated to 100 chars
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+pub struct ClickHouseLogsRequest {
+    /// Either `"query"` (filtered SELECT) or `"stats"` (GROUP BY).
+    pub command: String,
+    /// Filter by Kubernetes namespace (e.g. `"kbve"`, `"kilobase"`).
     #[serde(default)]
-    pod_namespace: Option<String>,
+    pub pod_namespace: Option<String>,
+    /// Filter by exact pod name.
     #[serde(default)]
-    pod_name: Option<String>,
+    pub pod_name: Option<String>,
+    /// Filter by `service` label as emitted by Vector (e.g. `"axum-kbve"`).
     #[serde(default)]
-    service: Option<String>,
+    pub service: Option<String>,
+    /// Filter by log level (`"error"`, `"warn"`, `"info"`, ...). Lowercased
+    /// before matching.
     #[serde(default)]
-    level: Option<String>,
+    pub level: Option<String>,
+    /// `ILIKE %search%` against the message body.
     #[serde(default)]
-    search: Option<String>,
+    pub search: Option<String>,
+    /// Lookback window in minutes. Defaults to 60, clamped 1..=10080.
     #[serde(default)]
-    minutes: Option<u32>,
+    pub minutes: Option<u32>,
+    /// Max rows returned. Defaults to 100, clamped 1..=500. Stats responses
+    /// always return up to 200 rows regardless of this value.
     #[serde(default)]
-    limit: Option<u32>,
+    pub limit: Option<u32>,
 }
 
-pub async fn clickhouse_logs_proxy_handler(
-    _path: Option<Path<String>>,
-    headers: HeaderMap,
-    body: Bytes,
-) -> Response {
+/// Response shape for the ClickHouse logs route. `rows` is the raw
+/// `JSONEachRow` output from ClickHouse — one object per record with keys
+/// matching `observability.logs_distributed` columns for `"query"`, or
+/// `{ pod_namespace, service, level, cnt }` for `"stats"`.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+pub struct ClickHouseLogsResponse {
+    /// One JSON object per row. Shape depends on `command`:
+    /// - `"query"` → `{ timestamp, pod_namespace, service, level, message, pod_name, metadata }`
+    /// - `"stats"` → `{ pod_namespace, service, level, cnt }`
+    #[schema(value_type = Vec<serde_json::Value>)]
+    pub rows: Vec<serde_json::Value>,
+    pub count: usize,
+}
+
+#[utoipa::path(
+    post,
+    path = "/dashboard/clickhouse/proxy",
+    tag = "dashboard",
+    request_body = ClickHouseLogsRequest,
+    security(("bearerAuth" = [])),
+    responses(
+        (status = 200, description = "Rows from observability.logs_distributed (query) or aggregated counts (stats)", body = ClickHouseLogsResponse),
+        (status = 400, description = "Malformed JSON body or unknown `command`"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 403, description = "Token lacks DASHBOARD_VIEW staff permission"),
+        (status = 502, description = "ClickHouse cluster returned an error or was unreachable"),
+        (status = 503, description = "ClickHouse direct route not configured (CLICKHOUSE_* env vars unset)")
+    )
+)]
+pub async fn clickhouse_logs_proxy_handler(headers: HeaderMap, body: Bytes) -> Response {
     if let Err(resp) = require_dashboard_view(&headers, "ClickHouse Logs").await {
         return resp;
     }
@@ -649,7 +690,7 @@ pub async fn clickhouse_logs_proxy_handler(
         }
     };
 
-    let req: ClickHouseRequest = match serde_json::from_slice(&body) {
+    let req: ClickHouseLogsRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
             return (
@@ -691,7 +732,11 @@ pub async fn clickhouse_logs_proxy_handler(
     };
 
     match result {
-        Ok(out) => axum::Json(out).into_response(),
+        Ok(out) => axum::Json(ClickHouseLogsResponse {
+            rows: out.rows,
+            count: out.count,
+        })
+        .into_response(),
         Err(e) => {
             warn!("ClickHouse logs query failed: {e}");
             (

--- a/packages/data/openapi/openapi.json
+++ b/packages/data/openapi/openapi.json
@@ -11,7 +11,7 @@
 		"license": {
 			"name": "MIT"
 		},
-		"version": "1.0.135"
+		"version": "1.0.136"
 	},
 	"servers": [
 		{
@@ -678,6 +678,54 @@
 				}
 			}
 		},
+		"/dashboard/clickhouse/proxy": {
+			"post": {
+				"tags": ["dashboard"],
+				"operationId": "clickhouse_logs_proxy_handler",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/ClickHouseLogsRequest"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Rows from observability.logs_distributed (query) or aggregated counts (stats)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ClickHouseLogsResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Malformed JSON body or unknown `command`"
+					},
+					"401": {
+						"description": "Missing or invalid Bearer token"
+					},
+					"403": {
+						"description": "Token lacks DASHBOARD_VIEW staff permission"
+					},
+					"502": {
+						"description": "ClickHouse cluster returned an error or was unreachable"
+					},
+					"503": {
+						"description": "ClickHouse direct route not configured (CLICKHOUSE_* env vars unset)"
+					}
+				},
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				]
+			}
+		},
 		"/health": {
 			"get": {
 				"tags": ["system"],
@@ -699,6 +747,65 @@
 	},
 	"components": {
 		"schemas": {
+			"ClickHouseLogsRequest": {
+				"type": "object",
+				"description": "Body schema for `POST /dashboard/clickhouse/proxy`. Mirrors the legacy\nsupabase edge function at `/functions/v1/logs` so the dashboard JS in\n`clickhouseService.ts` doesn't have to change. Bounds are enforced inside\njedi (`pipe_clickhouse::logs`):\n- `minutes` clamped to `1..=10080`\n- `limit` clamped to `1..=500`\n- `search` truncated to 100 chars",
+				"required": ["command"],
+				"properties": {
+					"command": {
+						"type": "string",
+						"description": "Either `\"query\"` (filtered SELECT) or `\"stats\"` (GROUP BY)."
+					},
+					"level": {
+						"type": ["string", "null"],
+						"description": "Filter by log level (`\"error\"`, `\"warn\"`, `\"info\"`, ...). Lowercased\nbefore matching."
+					},
+					"limit": {
+						"type": ["integer", "null"],
+						"format": "int32",
+						"description": "Max rows returned. Defaults to 100, clamped 1..=500. Stats responses\nalways return up to 200 rows regardless of this value.",
+						"minimum": 0
+					},
+					"minutes": {
+						"type": ["integer", "null"],
+						"format": "int32",
+						"description": "Lookback window in minutes. Defaults to 60, clamped 1..=10080.",
+						"minimum": 0
+					},
+					"pod_name": {
+						"type": ["string", "null"],
+						"description": "Filter by exact pod name."
+					},
+					"pod_namespace": {
+						"type": ["string", "null"],
+						"description": "Filter by Kubernetes namespace (e.g. `\"kbve\"`, `\"kilobase\"`)."
+					},
+					"search": {
+						"type": ["string", "null"],
+						"description": "`ILIKE %search%` against the message body."
+					},
+					"service": {
+						"type": ["string", "null"],
+						"description": "Filter by `service` label as emitted by Vector (e.g. `\"axum-kbve\"`)."
+					}
+				}
+			},
+			"ClickHouseLogsResponse": {
+				"type": "object",
+				"description": "Response shape for the ClickHouse logs route. `rows` is the raw\n`JSONEachRow` output from ClickHouse — one object per record with keys\nmatching `observability.logs_distributed` columns for `\"query\"`, or\n`{ pod_namespace, service, level, cnt }` for `\"stats\"`.",
+				"required": ["rows", "count"],
+				"properties": {
+					"count": {
+						"type": "integer",
+						"minimum": 0
+					},
+					"rows": {
+						"type": "array",
+						"items": {},
+						"description": "One JSON object per row. Shape depends on `command`:\n- `\"query\"` → `{ timestamp, pod_namespace, service, level, message, pod_name, metadata }`\n- `\"stats\"` → `{ pod_namespace, service, level, cnt }`"
+					}
+				}
+			},
 			"ClientEvent": {
 				"type": "object",
 				"required": ["level", "message"],
@@ -1672,6 +1779,10 @@
 		{
 			"name": "telemetry",
 			"description": "Client-side error reporting from WASM/JS."
+		},
+		{
+			"name": "dashboard",
+			"description": "Staff-only routes powering kbve.com/dashboard. Gated on DASHBOARD_VIEW."
 		}
 	]
 }


### PR DESCRIPTION
Follow-up to #10646 (Option C — direct ClickHouse path). Wires the new route into the OpenAPI surface so it shows up in \`/api/openapi.json\`, the Scalar viewer at \`/dashboard/api\`, and the build-time \`/llms.txt\` rollup. Spec-level confirmation of the staff-only auth gate (handler annotated with \`bearerAuth\` security + 401 / 403 / 502 / 503 responses).

## Changes

### \`apps/kbve/axum-kbve/src/transport/proxy.rs\`
- Renamed local request struct to \`ClickHouseLogsRequest\` and added \`ClickHouseLogsResponse\` — both \`pub\` with \`serde::{Deserialize, Serialize}\` + \`utoipa::ToSchema\`. Field-level docs explain the bounds enforced inside jedi (clamped \`minutes\` / \`limit\` / \`search\`) and the row shape that varies by \`command\`.
- \`#[utoipa::path]\` on \`clickhouse_logs_proxy_handler\`: \`POST\`, \`/dashboard/clickhouse/proxy\`, tag \`dashboard\`, \`bearerAuth\` security, six response codes (200 / 400 / 401 / 403 / 502 / 503).
- Dropped the \`Option<Path<String>>\` extractor from the handler — \`utoipa\` panics on it (\`internal error: Cannot get here\`) and the path segment was unused. Both \`/dashboard/clickhouse/proxy\` and \`/dashboard/clickhouse/proxy/{*path}\` still wire to the same handler; axum just discards the captured path.
- Wrapped the \`Ok\`-branch response in \`ClickHouseLogsResponse\` so the emitted spec matches what the handler actually returns over the wire.

### \`apps/kbve/axum-kbve/src/openapi.rs\`
- Added \`dashboard\` tag (covers future staff-only routes too).
- Registered both new schemas in \`components(schemas(...))\` and the handler in \`paths(...)\`.

### \`packages/data/openapi/openapi.json\`
- Regenerated so the spec served at \`/api/openapi.json\` + consumed by \`/llms.txt\` at build time matches.

## Edge function status
Edge fn at \`apps/kbve/edge/functions/logs\` is **kept in place** as the emergency fallback path + a hook for future integrations. Not in the critical \`/dashboard\` read path anymore (axum-kbve serves directly), but the worker still boots and the route at \`/functions/v1/logs\` still answers — useful if the direct path ever needs to be cut over again, and reusable as a building block for other observability tooling.

## Test plan
- [x] \`cargo build --manifest-path apps/kbve/axum-kbve/Cargo.toml\` clean
- [x] \`cargo run -- --emit-openapi\` produces a spec with \`/dashboard/clickhouse/proxy\` POST entry and \`ClickHouseLogsRequest\` / \`ClickHouseLogsResponse\` schemas under \`components\`
- [ ] \`/dashboard/api\` Scalar viewer renders the new route under the \`dashboard\` tag with a Try-It-Out box bound to the schema
- [ ] \`/llms.txt\` build pulls the route into the API surface section
- [ ] No regression on the runtime route — dashboard logs view still loads (no client change required)