### PR TITLE
feat(valkey): bump chart 0.9.3 -> 0.9.4 + Reloader-driven password rotation

### DIFF
--- a/apps/kube/valkey/README.md
+++ b/apps/kube/valkey/README.md
@@ -1,0 +1,37 @@
+# valkey — Kubernetes Deployment
+
+Secondary key-value store alongside Redis. Backed by the official `valkey-io/valkey-helm` chart (not Bitnami), in `standalone` shape (one master, no replicas) with persistence on Longhorn.
+
+## Manifests
+
+| File                                      | Purpose                                                                                         |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `application.yaml`                        | ArgoCD `Application` — multi-source: chart + `values.yaml` + sealed-secret manifest dir         |
+| `manifests/values.yaml`                   | Helm values overlay: auth, persistence, metrics, Reloader annotation                            |
+| `manifests/valkey-auth-sealedsecret.yaml` | SealedSecret holding the auth password, referenced by `auth.usersExistingSecret`                |
+| `manifests/kustomization.yaml`            | Lists the SealedSecret as a kustomize resource so ArgoCD picks it up alongside the chart render |
+
+## Hardening
+
+The valkey-helm chart at `0.9.4` ships hardened pod defaults — none of these are overridden in our values.yaml, they flow from the chart:
+
+- `runAsNonRoot: true`, UID/GID `1000`, `fsGroup: 1000`
+- `readOnlyRootFilesystem: true`
+- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- `seccompProfile: RuntimeDefault` (added in chart 0.9.4)
+- `automountServiceAccountToken: false` on the rendered pod spec
+- CPU/memory `requests` and `limits` set on the master container so the kubelet enforces a cgroup; bursts cap at `500m / 512Mi`
+
+## Reloader integration
+
+`workloadAnnotations.reloader.stakater.com/auto: "true"` lands the annotation on the rendered Deployment metadata — the surface Stakater Reloader watches by default. When `valkey-auth` rotates, the master pod rolls automatically. Verified via `helm template` against chart 0.9.4 that the annotation appears under `Deployment.metadata.annotations`, not just the pod template.
+
+## Chart version policy
+
+Pinned to `0.9.4` (Valkey app `9.0.2`). Bumped from `0.9.3` to pick up the new `workloadAnnotations` field plus the `seccompProfile` and `allowPrivilegeEscalation` defaults. Selector labels are identical between 0.9.3 and 0.9.4 (verified via `helm template` diff), so no immutability conflict on upgrade.
+
+## ArgoCD
+
+- App: `valkey` (multi-source — chart + this repo's `values.yaml` + manifest dir)
+- Sync: automated with prune + selfHeal
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/valkey/application.yaml
+++ b/apps/kube/valkey/application.yaml
@@ -7,7 +7,14 @@ spec:
     project: default
     sources:
         - repoURL: https://valkey-io.github.io/valkey-helm/
-          targetRevision: 0.9.3
+          # Bumped 0.9.3 -> 0.9.4 (Valkey app 9.0.1 -> 9.0.2, patch only)
+          # to pick up the new `workloadAnnotations` value (annotates the
+          # Deployment metadata directly — cleaner Reloader wiring than
+          # podAnnotations) plus chart-default seccompProfile RuntimeDefault
+          # and allowPrivilegeEscalation: false. Selector labels are
+          # identical between 0.9.3 and 0.9.4 (verified via helm template
+          # diff), so no immutability conflict on upgrade.
+          targetRevision: 0.9.4
           chart: valkey
           helm:
               releaseName: valkey

--- a/apps/kube/valkey/manifests/values.yaml
+++ b/apps/kube/valkey/manifests/values.yaml
@@ -1,6 +1,15 @@
 # Valkey configuration — secondary key-value store alongside Redis
 # Official valkey-io/valkey-helm chart (not Bitnami)
 
+# Stakater Reloader watches workloads with this annotation and rolls
+# the pod when any referenced ConfigMap/Secret changes. valkey-helm
+# 0.9.4 added `workloadAnnotations` which lands the annotation on the
+# Deployment metadata itself — that is the surface Reloader watches by
+# default, so a rotation of the valkey-auth SealedSecret triggers an
+# automatic roll of the master pod.
+workloadAnnotations:
+    reloader.stakater.com/auto: 'true'
+
 auth:
     enabled: true
     aclUsers:


### PR DESCRIPTION
## Summary

Two coordinated edits to the valkey ArgoCD Application.

### 1. Chart bump `0.9.3` -> `0.9.4` (Valkey app `9.0.1` -> `9.0.2`, patch only)

The 0.9.4 chart adds three things this PR wants:

- A new `workloadAnnotations` value that lands annotations directly on the rendered Deployment metadata — the surface Stakater Reloader watches by default, instead of relying on the pod-template annotation fallback path.
- `seccompProfile.type: RuntimeDefault` baked into the default `podSecurityContext`.
- `allowPrivilegeEscalation: false` baked into the default container `securityContext`.

Selector labels are identical between 0.9.3 and 0.9.4 (verified via `helm template` diff), so there is no immutability conflict on upgrade. The chart renders a `Deployment` (not a `StatefulSet`), but the same upgrade-safety check still applies.

### 2. `workloadAnnotations.reloader.stakater.com/auto: "true"`

Wires Stakater Reloader so a rotation of the `valkey-auth` SealedSecret rolls the master pod automatically. Verified via `helm template` against the new chart that the annotation lands on the `Deployment.metadata.annotations` block, not just the pod template.

This mirrors the redis hardening pattern (#10556) on the valkey-helm chart's terms.

## Hardening posture (chart-driven, no overrides needed)

The valkey-helm chart at `0.9.4` ships hardened pod defaults — none of these are overridden in `values.yaml`, they flow from the chart:

- `runAsNonRoot: true`, UID/GID `1000`, `fsGroup: 1000`
- `readOnlyRootFilesystem: true`
- `allowPrivilegeEscalation: false`, all Linux capabilities dropped
- `seccompProfile: RuntimeDefault` (added in chart 0.9.4)
- `automountServiceAccountToken: false` on the rendered pod spec
- CPU/memory `requests` and `limits` set on the master container so the kubelet enforces a cgroup; bursts cap at `500m / 512Mi`

## Hardening pattern by namespace so far

| ns           | manifest type     | Reloader | non-root  | readOnly rootfs | caps drop | SA token off |
| ------------ | ----------------- | -------- | --------- | --------------- | --------- | ------------ |
| chuckrpg     | raw               | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| redis        | Bitnami chart     | yes      | chart     | chart           | chart     | chart        |
| n8n          | raw               | yes      | UID 1000  | deferred        | yes       | yes          |
| discordsh    | raw               | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| herbmail     | raw               | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| cryptothrone | raw               | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| memes        | raw               | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| rentearth    | raw               | yes      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| cityvote     | raw               | n/a      | UID 10001 | yes + /tmp ED   | yes       | yes          |
| valkey       | valkey-io chart   | yes      | chart     | chart           | chart     | chart        |

## Test plan

- [ ] ArgoCD `valkey` Application reconciles cleanly to `0.9.4` after dev → main promotion.
- [ ] `kubectl -n valkey get deploy valkey -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}'` returns `"true"`.
- [ ] `kubectl -n valkey get pod -l app.kubernetes.io/name=valkey` shows the pod `Running` under UID `1000`, `readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`.
- [ ] The 8Gi `valkey-data` Longhorn PVC binds and the master accepts auth using the existing `valkey-auth` SealedSecret password.
- [ ] Trigger a no-op re-seal of `valkey-auth` (or a dummy label change) and observe Reloader rolling the master pod within ~30s.