### PR TITLE
fix(docker): pin CARGO_INCREMENTAL=0 for sccache 0.14.0 in builder image

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -95,6 +95,12 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ============================================================================
 FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
 
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# The builder image now sets this by default, but keep an explicit override
+# here so this Dockerfile is correct even if rebuilt against an older builder
+# tag that predates the upstream fix.
+ENV CARGO_INCREMENTAL=0
+
 WORKDIR /app
 
 COPY --from=planner /app/recipe.json recipe.json

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -51,10 +51,16 @@ RUN rustup target add x86_64-unknown-linux-gnu && \
 
 # sccache wraps rustc to cache compilation artifacts across builds.
 # Consumers mount --mount=type=cache,target=/usr/local/sccache for persistence.
-# NOTE: sccache is incompatible with incremental compilation — do NOT set
-# CARGO_INCREMENTAL=1 when RUSTC_WRAPPER=sccache.
+#
+# sccache 0.14.0 hard-aborts with
+#   "incremental compilation is prohibited: Unset CARGO_INCREMENTAL to continue"
+# whenever CARGO_INCREMENTAL is unset (defaults to 1 for cargo dev profile)
+# OR set to anything other than 0. Pin it to 0 here so every consumer of
+# this builder image inherits the correct value automatically — otherwise
+# `cargo chef cook` panics in `recipe.rs:224` on its first `rustc -vV` probe.
 ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
 ENV SCCACHE_DIR=/usr/local/sccache
+ENV CARGO_INCREMENTAL=0
 
 # ── Node.js + pnpm (for Astro frontend builds) ──────────────────────
 ARG NODE_VERSION=24


### PR DESCRIPTION
## Symptom

Every \`cargo chef cook\` Docker build against \`ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder\` is panicking:

\`\`\`
thread 'main' panicked at cargo-chef-0.1.77/src/recipe.rs:224:27:
Exited with status code: 101
\`\`\`

Triggered the sweep of CI - Docker failures across \`axum-chuckrpg\`, \`axum-rareicon\`, \`axum-kbve\`, \`firecracker-python-net\` since #10581 (chisel 1.4.1 bump) republished the builder image.

## Root cause

Reproduced locally inside the builder image:

\`\`\`
$ sccache /usr/local/rustup/toolchains/*/bin/rustc -vV
sccache: incremental compilation is prohibited:
         Unset CARGO_INCREMENTAL to continue.
EXIT=1
\`\`\`

The republished builder ships sccache **0.14.0**, which hard-aborts when \`CARGO_INCREMENTAL\` is unset (cargo's dev-profile default is 1) or is set to anything other than 0. cargo-chef invokes \`sccache rustc -vV\` as its first probe to read the toolchain version — sccache crashes before any actual compilation, and cargo-chef panics in \`recipe.rs:224\` reporting the wrapper exit.

\`axum-kbve\`, \`axum-rareicon\`, \`firecracker-ctl\` set \`ENV CARGO_INCREMENTAL=0\` in their own Dockerfiles, so they survive (\`axum-kbve\` and \`axum-rareicon\` exit 130 = test timeout, separate issue). \`axum-chuckrpg\` is the only consumer that doesn't, which is why it's the one with the recipe.rs panic.

## Fix

1. **\`packages/docker/chisel-ubuntu-axum/Dockerfile\`** — pin \`ENV CARGO_INCREMENTAL=0\` next to the existing \`ENV RUSTC_WRAPPER=…/sccache\` so every consumer of the builder image inherits the correct value. Long-term fix.
2. **\`apps/chuckrpg/axum-chuckrpg/Dockerfile\`** — add the same \`ENV\` to the \`builder-deps\` stage explicitly. Immediate unblock without waiting for the builder image to rebuild and republish; matches what the other Rust apps already do.

## Verification

\`\`\`
$ docker build --platform=linux/amd64 --target builder -t chisel-ubuntu-axum:test packages/docker/chisel-ubuntu-axum/
$ docker run --rm --platform=linux/amd64 chisel-ubuntu-axum:test sh -c \"echo CARGO_INCREMENTAL=\\\$CARGO_INCREMENTAL; sccache /usr/local/rustup/toolchains/*/bin/rustc -vV; echo EXIT=\\\$?\"
CARGO_INCREMENTAL=0
rustc 1.94.1 (e408947bf 2026-03-25)
…
EXIT=0
\`\`\`

## Test plan

- [ ] CI - Docker / axum-chuckrpg passes once this lands.
- [ ] After the builder image republishes (post-merge), CI - Docker / axum-kbve / axum-rareicon / firecracker-python-net rebuilds reach the test phase cleanly. Any remaining exit-130 cases are downstream test issues, not this regression.