### PR TITLE
feat(astro-kbve): Grafana Alerts island on /dashboard/grafana

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
@@ -3,6 +3,7 @@ import ReactGrafanaAuth from './ReactGrafanaAuth';
 import ReactGrafanaHeader from './ReactGrafanaHeader';
 import ReactGrafanaNodes from './ReactGrafanaNodes';
 import ReactGrafanaK8s from './ReactGrafanaK8s';
+import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 ---
 
 <section
@@ -15,6 +16,13 @@ import ReactGrafanaK8s from './ReactGrafanaK8s';
 				<!-- Island: Header (title, cache badge, time range, refresh) -->
 				<div id="grafana-header">
 					<ReactGrafanaHeader client:only="react" />
+				</div>
+
+				<!-- Island: Alerts (firing PrometheusRules from Grafana
+				     unified alerting). Anchor target for the firing-count
+				     chip in the header. -->
+				<div id="grafana-alerts">
+					<ReactGrafanaAlerts client:only="react" />
 				</div>
 
 				<!-- Island: Node section (stat cards, drill-downs, charts) -->

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaAlerts.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaAlerts.tsx
@@ -1,0 +1,423 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	AlertCircle,
+	AlertTriangle,
+	BellOff,
+	BellRing,
+	ChevronDown,
+	ChevronUp,
+	Loader2,
+	RefreshCw,
+} from 'lucide-react';
+import { fetchAlerts, grafanaService, type Alert } from './grafanaService';
+
+const SEVERITY_COLORS: Record<string, string> = {
+	critical: '#ef4444',
+	high: '#f97316',
+	warning: '#eab308',
+	medium: '#eab308',
+	info: '#06b6d4',
+	low: '#06b6d4',
+};
+
+function severityColor(sev: string | undefined): string {
+	const key = (sev ?? '').toLowerCase();
+	return SEVERITY_COLORS[key] ?? '#8b949e';
+}
+
+function relativeTime(iso: string | null): string {
+	if (!iso) return 'just now';
+	const t = Date.parse(iso);
+	if (Number.isNaN(t)) return 'recently';
+	const seconds = Math.floor((Date.now() - t) / 1000);
+	if (seconds < 60) return `${seconds}s ago`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return `${days}d ago`;
+}
+
+function summarizeLabels(a: Alert): string {
+	const parts: string[] = [];
+	const ns = a.labels.namespace ?? a.labels.kubernetes_namespace;
+	const pod = a.labels.pod ?? a.labels.kubernetes_pod_name;
+	const svc = a.labels.service ?? a.labels.job;
+	if (ns) parts.push(`ns=${ns}`);
+	if (pod) parts.push(`pod=${pod}`);
+	if (!pod && svc) parts.push(`svc=${svc}`);
+	return parts.join(' · ');
+}
+
+function AlertRow({ alert }: { alert: Alert }) {
+	const sev = (alert.labels.severity ?? '').toLowerCase() || 'unknown';
+	const color = severityColor(sev);
+	const name = alert.labels.alertname ?? '(unnamed alert)';
+	const summary =
+		alert.annotations.summary ??
+		alert.annotations.description ??
+		alert.annotations.message ??
+		'';
+	const isFiring = alert.state === 'firing';
+	const labelLine = summarizeLabels(alert);
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'flex-start',
+				gap: '0.75rem',
+				padding: '0.6rem 0.75rem',
+				borderRadius: 8,
+				border: `1px solid ${isFiring ? color + '55' : 'var(--sl-color-gray-5, #262626)'}`,
+				background: isFiring
+					? `${color}10`
+					: 'var(--sl-color-bg-nav, #111)',
+			}}>
+			<div
+				style={{
+					width: 4,
+					alignSelf: 'stretch',
+					borderRadius: 2,
+					background: color,
+					flexShrink: 0,
+				}}
+			/>
+			<div style={{ flex: 1, minWidth: 0 }}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.5rem',
+						flexWrap: 'wrap',
+					}}>
+					<span
+						style={{
+							color: 'var(--sl-color-text, #e6edf3)',
+							fontWeight: 600,
+							fontSize: '0.85rem',
+						}}>
+						{name}
+					</span>
+					<span
+						style={{
+							padding: '1px 6px',
+							borderRadius: 3,
+							background: `${color}20`,
+							color,
+							fontSize: '0.65rem',
+							fontWeight: 700,
+							textTransform: 'uppercase',
+							letterSpacing: '0.05em',
+						}}>
+						{sev}
+					</span>
+					<span
+						style={{
+							padding: '1px 6px',
+							borderRadius: 3,
+							background:
+								alert.state === 'firing'
+									? 'rgba(239,68,68,0.15)'
+									: 'rgba(234,179,8,0.15)',
+							color:
+								alert.state === 'firing'
+									? '#fca5a5'
+									: '#fde68a',
+							fontSize: '0.65rem',
+							fontWeight: 600,
+							textTransform: 'uppercase',
+						}}>
+						{alert.state}
+					</span>
+					<span
+						style={{
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.7rem',
+							marginLeft: 'auto',
+						}}>
+						{relativeTime(alert.activeAt)}
+					</span>
+				</div>
+				{summary && (
+					<div
+						style={{
+							color: 'var(--sl-color-gray-2, #b3b9c4)',
+							fontSize: '0.78rem',
+							marginTop: '0.25rem',
+							lineHeight: 1.4,
+						}}>
+						{summary}
+					</div>
+				)}
+				{labelLine && (
+					<div
+						style={{
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.7rem',
+							marginTop: '0.25rem',
+							fontFamily:
+								'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+						}}>
+						{labelLine}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export default function ReactGrafanaAlerts() {
+	const accessToken = useStore(grafanaService.$accessToken);
+	const userId = useStore(grafanaService.$userId);
+	const alerts = useStore(grafanaService.$alerts);
+	const firing = useStore(grafanaService.$alertsFiring);
+	const pending = useStore(grafanaService.$alertsPending);
+	const loaded = useStore(grafanaService.$alertsLoaded);
+	const error = useStore(grafanaService.$alertsError);
+
+	const [loading, setLoading] = useState(false);
+	const [expanded, setExpanded] = useState(false);
+	const [fromCache, setFromCache] = useState(false);
+
+	const refresh = useCallback(
+		async (skipCache: boolean) => {
+			if (!accessToken || !userId) return;
+			setLoading(true);
+			grafanaService.$alertsError.set(null);
+			try {
+				const snap = await fetchAlerts(accessToken, userId, skipCache);
+				if (!snap) {
+					grafanaService.$alertsError.set(
+						'Could not fetch alerts from Grafana',
+					);
+					return;
+				}
+				grafanaService.$alerts.set(snap.alerts);
+				grafanaService.$alertsFiring.set(snap.firingCount);
+				grafanaService.$alertsPending.set(snap.pendingCount);
+				grafanaService.$alertsLoaded.set(true);
+				setFromCache(snap.fromCache);
+			} catch (e: unknown) {
+				grafanaService.$alertsError.set(
+					e instanceof Error ? e.message : 'Failed to load alerts',
+				);
+			} finally {
+				setLoading(false);
+			}
+		},
+		[accessToken, userId],
+	);
+
+	useEffect(() => {
+		if (accessToken && userId && !loaded) {
+			refresh(false);
+		}
+	}, [accessToken, userId, loaded, refresh]);
+
+	if (!accessToken || !userId) return null;
+
+	const hasIssues = firing > 0 || pending > 0;
+	const headerColor =
+		firing > 0 ? '#ef4444' : pending > 0 ? '#eab308' : '#22c55e';
+	const HeaderIcon =
+		firing > 0 ? BellRing : pending > 0 ? AlertTriangle : BellOff;
+
+	return (
+		<section
+			style={{
+				borderRadius: 12,
+				border: `1px solid ${hasIssues ? headerColor + '55' : 'var(--sl-color-gray-5, #262626)'}`,
+				background: hasIssues
+					? `${headerColor}08`
+					: 'var(--sl-color-bg-nav, #111)',
+				overflow: 'hidden',
+			}}>
+			<button
+				onClick={() => setExpanded((v) => !v)}
+				style={{
+					width: '100%',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.6rem',
+					padding: '0.75rem 1rem',
+					background: 'transparent',
+					border: 'none',
+					cursor: 'pointer',
+					color: 'var(--sl-color-text, #e6edf3)',
+				}}>
+				<HeaderIcon size={18} style={{ color: headerColor }} />
+				<span style={{ fontSize: '1rem', fontWeight: 600 }}>
+					Alerts
+				</span>
+				<div
+					style={{
+						display: 'flex',
+						gap: '0.4rem',
+						marginLeft: '0.25rem',
+					}}>
+					{firing > 0 && (
+						<span
+							style={{
+								padding: '1px 8px',
+								borderRadius: 3,
+								background: 'rgba(239,68,68,0.15)',
+								color: '#fca5a5',
+								fontSize: '0.7rem',
+								fontWeight: 700,
+								textTransform: 'uppercase',
+							}}>
+							{firing} firing
+						</span>
+					)}
+					{pending > 0 && (
+						<span
+							style={{
+								padding: '1px 8px',
+								borderRadius: 3,
+								background: 'rgba(234,179,8,0.15)',
+								color: '#fde68a',
+								fontSize: '0.7rem',
+								fontWeight: 700,
+								textTransform: 'uppercase',
+							}}>
+							{pending} pending
+						</span>
+					)}
+					{!hasIssues && loaded && (
+						<span
+							style={{
+								padding: '1px 8px',
+								borderRadius: 3,
+								background: 'rgba(34,197,94,0.15)',
+								color: '#86efac',
+								fontSize: '0.7rem',
+								fontWeight: 700,
+								textTransform: 'uppercase',
+							}}>
+							all clear
+						</span>
+					)}
+				</div>
+				{fromCache && (
+					<span
+						style={{
+							padding: '1px 6px',
+							borderRadius: 3,
+							background: 'var(--sl-color-gray-6, #1c1c1c)',
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.65rem',
+							textTransform: 'uppercase',
+							letterSpacing: '0.05em',
+						}}>
+						cached
+					</span>
+				)}
+				<button
+					onClick={(e) => {
+						e.stopPropagation();
+						refresh(true);
+					}}
+					disabled={loading}
+					title="Refresh alerts"
+					style={{
+						marginLeft: 'auto',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						width: 28,
+						height: 28,
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						background: 'var(--sl-color-bg-nav, #111)',
+						color: 'var(--sl-color-text, #e6edf3)',
+						cursor: loading ? 'wait' : 'pointer',
+					}}>
+					<RefreshCw
+						size={13}
+						style={
+							loading
+								? { animation: 'spin 1s linear infinite' }
+								: undefined
+						}
+					/>
+				</button>
+				{expanded ? (
+					<ChevronUp
+						size={16}
+						style={{ color: 'var(--sl-color-gray-3, #8b949e)' }}
+					/>
+				) : (
+					<ChevronDown
+						size={16}
+						style={{ color: 'var(--sl-color-gray-3, #8b949e)' }}
+					/>
+				)}
+			</button>
+
+			{expanded && (
+				<div
+					style={{
+						padding: '0.5rem 0.75rem 0.85rem',
+						display: 'flex',
+						flexDirection: 'column',
+						gap: '0.5rem',
+						borderTop: '1px solid var(--sl-color-gray-5, #262626)',
+					}}>
+					{loading && alerts.length === 0 && (
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 8,
+								padding: '0.75rem 0.25rem',
+								color: 'var(--sl-color-gray-3, #8b949e)',
+								fontSize: '0.85rem',
+							}}>
+							<Loader2
+								size={14}
+								style={{ animation: 'spin 1s linear infinite' }}
+							/>
+							Loading alerts...
+						</div>
+					)}
+					{error && (
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 6,
+								padding: '0.5rem 0.6rem',
+								borderRadius: 6,
+								background: 'rgba(239,68,68,0.1)',
+								border: '1px solid rgba(239,68,68,0.3)',
+								color: '#fca5a5',
+								fontSize: '0.8rem',
+							}}>
+							<AlertCircle size={14} />
+							{error}
+						</div>
+					)}
+					{!loading && !error && alerts.length === 0 && loaded && (
+						<div
+							style={{
+								padding: '0.65rem 0.5rem',
+								color: 'var(--sl-color-gray-3, #8b949e)',
+								fontSize: '0.85rem',
+							}}>
+							No alerts firing or pending — cluster is clean.
+						</div>
+					)}
+					{alerts.map((a, i) => (
+						<AlertRow
+							key={`${a.labels.alertname ?? 'alert'}-${i}`}
+							alert={a}
+						/>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaHeader.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaHeader.tsx
@@ -4,13 +4,15 @@ import {
 	TIME_RANGE_KEYS,
 	type TimeRangeKey,
 } from './grafanaService';
-import { RefreshCw, AlertCircle } from 'lucide-react';
+import { RefreshCw, AlertCircle, BellRing } from 'lucide-react';
 
 export default function ReactGrafanaHeader() {
 	const fromCache = useStore(grafanaService.$fromCache);
 	const refreshing = useStore(grafanaService.$refreshing);
 	const error = useStore(grafanaService.$error);
 	const timeRange = useStore(grafanaService.$timeRange);
+	const alertsFiring = useStore(grafanaService.$alertsFiring);
+	const alertsPending = useStore(grafanaService.$alertsPending);
 
 	return (
 		<>
@@ -48,6 +50,51 @@ export default function ReactGrafanaHeader() {
 							}}>
 							cached
 						</span>
+					)}
+					{alertsFiring > 0 && (
+						<a
+							href="#grafana-alerts"
+							title="Firing alerts"
+							style={{
+								marginLeft: '0.5rem',
+								display: 'inline-flex',
+								alignItems: 'center',
+								gap: 4,
+								padding: '2px 8px',
+								borderRadius: '4px',
+								background: 'rgba(239,68,68,0.15)',
+								color: '#fca5a5',
+								fontSize: '0.7rem',
+								fontWeight: 700,
+								textTransform: 'uppercase' as const,
+								letterSpacing: '0.05em',
+								textDecoration: 'none',
+							}}>
+							<BellRing size={11} />
+							{alertsFiring} firing
+						</a>
+					)}
+					{alertsPending > 0 && alertsFiring === 0 && (
+						<a
+							href="#grafana-alerts"
+							title="Pending alerts"
+							style={{
+								marginLeft: '0.5rem',
+								display: 'inline-flex',
+								alignItems: 'center',
+								gap: 4,
+								padding: '2px 8px',
+								borderRadius: '4px',
+								background: 'rgba(234,179,8,0.15)',
+								color: '#fde68a',
+								fontSize: '0.7rem',
+								fontWeight: 700,
+								textTransform: 'uppercase' as const,
+								letterSpacing: '0.05em',
+								textDecoration: 'none',
+							}}>
+							{alertsPending} pending
+						</a>
 					)}
 				</div>
 				<div

--- a/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
@@ -454,6 +454,15 @@ class GrafanaService {
 	public readonly $namespacePods = atom<NamespacePodCount[]>([]);
 	public readonly $drillDownLoading = atom<boolean>(false);
 
+	// Alerts (populated by ReactGrafanaAlerts island; exposed here so the
+	// header island can subscribe to firing-count + state without a second
+	// fetch).
+	public readonly $alerts = atom<Alert[]>([]);
+	public readonly $alertsFiring = atom<number>(0);
+	public readonly $alertsPending = atom<number>(0);
+	public readonly $alertsLoaded = atom<boolean>(false);
+	public readonly $alertsError = atom<string | null>(null);
+
 	// --- Init ---
 
 	private _loadTimeRange(): TimeRangeKey {
@@ -1128,4 +1137,122 @@ export async function fetchPodMetrics(
 
 	setCachedPodMetrics(uid, ns, pod, tr, metrics);
 	return metrics;
+}
+
+// ---------------------------------------------------------------------------
+// Alerts — surfaces firing PrometheusRules through Grafana's unified
+// alerting Prometheus-compatible API. One endpoint, no datasource lookup,
+// matches the same proxy auth path the rest of the dashboard uses.
+//
+// Endpoint: GET /api/prometheus/grafana/api/v1/alerts (proxied)
+// Response: { status: "success", data: { alerts: Alert[] } }
+//
+// Cached per-user (no time-range key — alert state is "now") with a 60s
+// TTL so the alerts panel stays close to live without hammering Grafana.
+// ---------------------------------------------------------------------------
+
+export interface Alert {
+	labels: Record<string, string>;
+	annotations: Record<string, string>;
+	state: 'firing' | 'pending' | 'inactive' | string;
+	activeAt: string | null;
+	value: string | null;
+}
+
+export interface AlertsSnapshot {
+	alerts: Alert[];
+	firingCount: number;
+	pendingCount: number;
+	fetchedAt: number;
+	fromCache: boolean;
+}
+
+interface CachedAlerts {
+	snapshot: AlertsSnapshot;
+	user_id: string;
+}
+
+const ALERTS_CACHE_KEY = 'cache:grafana:alerts';
+const ALERTS_CACHE_TTL_MS = 60 * 1000;
+
+function getCachedAlerts(uid: string): AlertsSnapshot | null {
+	try {
+		const raw = localStorage.getItem(ALERTS_CACHE_KEY);
+		if (!raw) return null;
+		const cached: CachedAlerts = JSON.parse(raw);
+		if (cached.user_id !== uid) {
+			localStorage.removeItem(ALERTS_CACHE_KEY);
+			return null;
+		}
+		if (Date.now() - cached.snapshot.fetchedAt > ALERTS_CACHE_TTL_MS) {
+			return null;
+		}
+		return { ...cached.snapshot, fromCache: true };
+	} catch {
+		return null;
+	}
+}
+
+function setCachedAlerts(uid: string, snapshot: AlertsSnapshot): void {
+	try {
+		const payload: CachedAlerts = {
+			snapshot: { ...snapshot, fromCache: false },
+			user_id: uid,
+		};
+		localStorage.setItem(ALERTS_CACHE_KEY, JSON.stringify(payload));
+	} catch {
+		/* quota exceeded */
+	}
+}
+
+function rankAlert(a: Alert): number {
+	const sev = (a.labels.severity ?? '').toLowerCase();
+	if (sev === 'critical') return 0;
+	if (sev === 'high') return 1;
+	if (sev === 'warning' || sev === 'medium') return 2;
+	if (sev === 'info' || sev === 'low') return 3;
+	return 4;
+}
+
+export async function fetchAlerts(
+	token: string,
+	uid: string,
+	skipCache = false,
+): Promise<AlertsSnapshot | null> {
+	if (!skipCache) {
+		const cached = getCachedAlerts(uid);
+		if (cached) return cached;
+	}
+
+	const resp = await fetch(
+		`${PROXY_BASE}/api/prometheus/grafana/api/v1/alerts`,
+		{ headers: { Authorization: `Bearer ${token}` } },
+	);
+
+	if (resp.status === 403) {
+		throw new AccessRestrictedError();
+	}
+	if (!resp.ok) return null;
+
+	const body: { data?: { alerts?: Alert[] } } = await resp.json();
+	const raw = body?.data?.alerts ?? [];
+
+	const sorted = [...raw].sort((a, b) => {
+		const sevDiff = rankAlert(a) - rankAlert(b);
+		if (sevDiff !== 0) return sevDiff;
+		return (a.labels.alertname ?? '').localeCompare(
+			b.labels.alertname ?? '',
+		);
+	});
+
+	const snapshot: AlertsSnapshot = {
+		alerts: sorted,
+		firingCount: sorted.filter((a) => a.state === 'firing').length,
+		pendingCount: sorted.filter((a) => a.state === 'pending').length,
+		fetchedAt: Date.now(),
+		fromCache: false,
+	};
+
+	setCachedAlerts(uid, snapshot);
+	return snapshot;
 }


### PR DESCRIPTION
Closes the original "we need a better way to see alerts" goal that started this observability arc — promised follow-up from #10596.

## Summary
Surfaces firing PrometheusRules through Grafana's unified alerting Prometheus-compatible API at \`/api/prometheus/grafana/api/v1/alerts\`. Proxied through the existing \`/dashboard/grafana/proxy\` auth path — no additional secret or service endpoint to wire up.

## Why
Until now, the only way to see firing alerts was to bounce out of the dashboard into Grafana's UI. That broke the same context-switch flow the Argo Grafana tab fixed for pod metrics.

## Changes

### [\`grafanaService.ts\`](apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts)
- New \`Alert\` / \`AlertsSnapshot\` types.
- \`fetchAlerts(token, uid, skipCache)\` — sorts by severity rank (\`critical → high → warning → info → unknown\`) then alertname.
- Per-user \`localStorage\` cache, **60s TTL** (alert state is "now", so shorter than the 5min cluster-snapshot cache).
- Five new atoms on \`grafanaService\`: \`$alerts\`, \`$alertsFiring\`, \`$alertsPending\`, \`$alertsLoaded\`, \`$alertsError\`. Header island subscribes to firing/pending counts without a second fetch.

### [\`ReactGrafanaAlerts.tsx\`](apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaAlerts.tsx) (new)
- Collapsible panel below the header. Auto-loads on mount, manual refresh button, "cached" badge.
- Empty state ("all clear") when nothing firing or pending.
- Per-row severity stripe colored by \`labels.severity\`, alertname + severity badge + state badge + relative \`activeAt\`, summary from \`annotations.summary\`/\`description\`/\`message\`, label hint line (\`ns=… pod=… svc=…\`).

### [\`ReactGrafanaHeader.tsx\`](apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaHeader.tsx)
- Adds a firing-count chip next to "cached" when \`$alertsFiring > 0\`, pending-count chip when only pending. Anchors to \`#grafana-alerts\` so clicking the chip jumps straight to the panel.

### [\`AstroGrafanaDashboard.astro\`](apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro)
- Mounts the new island between the header and the Nodes section. \`id="grafana-alerts"\` is the chip anchor target.

## Load discipline
- Lazy-loaded via the island's own \`useEffect\`, not coupled to \`fetchMetrics\`.
- 60s cache absorbs repeat visits / panel toggles.
- 403 from the proxy throws \`AccessRestrictedError\` so non-staff hit the same forbidden state already wired up in \`ReactGrafanaAuth\`.

## Follow-up (separate PR)
Scoped alerts inside the Argo resource-detail Grafana tab — filter the alert list by \`labels.namespace\` + \`labels.pod\`/\`labels.kubernetes_pod_name\` so each pod's drawer shows only the alerts that mention it.

## Test plan
- [x] No new TS errors introduced (\`nx run astro-kbve:check\` baseline unchanged at 73 pre-existing proto errors).
- [ ] Open \`/dashboard/grafana\` → "Alerts" panel renders below the header. Clicking expands the panel, shows rows when alerts firing.
- [ ] Header chip (\`N firing\`) shows up when there are firing alerts; clicking jumps to the panel.
- [ ] Manual refresh fetches without spamming the proxy (60s cache between auto-loads).
- [ ] Non-staff user → existing 403 path triggers \`forbidden\` state, no alert panel renders.
- [ ] Empty state ("all clear") renders cleanly when zero alerts.