### PR TITLE
chore(bevy_db): bump redb 2.6.3 → 4.1 + adopt ReadableDatabase trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "axum-rareicon"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "askama",
@@ -12711,9 +12711,9 @@ checksum = "a0d463f2884048e7153449a55166f91028d5b0ea53c79377099ce4e8cf0cf9bb"
 
 [[package]]
 name = "redb"
-version = "2.6.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]

--- a/packages/rust/bevy/bevy_db/Cargo.toml
+++ b/packages/rust/bevy/bevy_db/Cargo.toml
@@ -33,7 +33,7 @@ bevy_tasker = { version = "0.1", path = "../bevy_tasker", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-redb = "2"
+redb = "4"
 dirs = "6"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/packages/rust/bevy/bevy_db/src/backend/native.rs
+++ b/packages/rust/bevy/bevy_db/src/backend/native.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use redb::{Database, TableDefinition};
+use redb::{Database, ReadableDatabase, TableDefinition};
 
 use crate::error::DbError;
 use crate::store::DbStore;

--- a/packages/rust/bevy/bevy_db/src/native.rs
+++ b/packages/rust/bevy/bevy_db/src/native.rs
@@ -21,7 +21,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use redb::{Database, TableDefinition};
+use redb::{Database, ReadableDatabase, TableDefinition};
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::error::DbError;


### PR DESCRIPTION
Supersedes #10074.

## What
Bump \`redb\` from 2.6.3 to 4.1 in \`packages/rust/bevy/bevy_db\` and add the small API adaptation needed for the new major version.

## Why
The dependabot PR (#10074) was a clean Cargo.toml bump but doesn't compile against redb 4 — \`Database::begin_read\` moved into a new \`ReadableDatabase\` trait in 4.0, so callers have to bring the trait into scope. Without that import the existing \`backend::native::NativeStore\` and the new public \`native::NativeStore\` (added in #10649) both fail with 28 \`E0599: no method named begin_read\` errors.

## Code change
Three lines:
- \`Cargo.toml\`: \`redb = \"2\"\` → \`redb = \"4\"\`.
- Two \`use\` lines: \`use redb::{Database, TableDefinition};\` → \`use redb::{Database, ReadableDatabase, TableDefinition};\`.

\`begin_write\` stayed inherent on \`Database\`, so nothing else in our wrappers needed to change.

## File format compatibility
redb 3.0 dropped support for the on-disk v2 format. Concretely:
- **discordsh-bot**: clean slate. \`DB_PATH\` only landed in #10649; the production bot hasn't redeployed since, so there are no v2 redb files anywhere.
- **isometric (Tauri)**: a developer who ran the desktop game with the previous bevy_db plugin may have a local \`~/.local/share/kbve_db.redb\` in v2 format. After this bump \`Database::create(...)\` will reject it. Mitigation: wipe the file before first run. At the project's current alpha stage this is acceptable; if it becomes a problem later we can land a 2.6 → 3.x → 4.x upgrade pass.

## Test plan
- [x] \`cargo test --no-default-features\` on \`bevy_db\` — 4/4 \`native::tests\` pass
- [x] \`cargo check\` on \`isometric\` (default features, Bevy plugin path) — clean
- [x] \`cargo test --bin discordsh-bot\` — 705/705 pass
- [ ] CI green
- [ ] Verify \`#10074\` can be closed once this lands

## Follow-up
Close dependabot's #10074 after merge.