### PR TITLE
fix(docker): pin CARGO_INCREMENTAL=0 in all Rust builder stages + discordsh-bot bevy_tasker manifest

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -61,6 +61,10 @@ RUN find . -type f \( \
 # ============================================================================
 FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# Cargo-chef's first probe is `sccache rustc -vV`, which trips this guard.
+ENV CARGO_INCREMENTAL=0
+
 WORKDIR /app
 
 COPY apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml Cargo.toml
@@ -116,6 +120,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
 # ============================================================================
 FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# The builder image now sets this by default, but keep an explicit override
+# here so this stage is correct even when rebuilt against an older builder.
+ENV CARGO_INCREMENTAL=0
 
 WORKDIR /app
 

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -89,6 +89,10 @@ RUN find . -type f \( \
 # [STAGE C] - Cargo Chef Planner
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# Cargo-chef's first probe is `sccache rustc -vV`, which trips this guard.
+ENV CARGO_INCREMENTAL=0
+
 COPY apps/kbve/axum-kbve/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -61,6 +61,10 @@ RUN find . -type f \( \
 # ============================================================================
 FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# Cargo-chef's first probe is `sccache rustc -vV`, which trips this guard.
+ENV CARGO_INCREMENTAL=0
+
 WORKDIR /app
 
 COPY apps/rareicon/axum-rareicon/Cargo.workspace.toml Cargo.toml


### PR DESCRIPTION
Follow-up to #10653.

## sccache CARGO_INCREMENTAL gap (axum-chuckrpg / kbve / rareicon)

After #10653 merged, axum-chuckrpg's CI - Docker still panicked — same sccache 0.14.0 abort, just one stage later (\`foundation\`):

\`\`\`
error: process didn't exit successfully:
  /usr/local/cargo/bin/sccache .../rustc -vV (exit status: 1)
sccache: incremental compilation is prohibited:
         Unset CARGO_INCREMENTAL to continue.
process \"/bin/sh -c cargo build --release -p kbve -p jedi -p holy ...\" did not complete successfully: exit code: 101
\`\`\`

\`ENV\` is **per-stage** in Dockerfiles. #10653 added the override only to the \`builder-deps\` stage of axum-chuckrpg — \`planner\` and \`foundation\` re-derive from the builder image without inheriting it. The chisel-ubuntu-axum builder fix in the same PR will make this global once the new image republishes, but per-stage overrides remain a useful belt-and-suspenders against rebuilds against an older builder tag.

| Dockerfile | Stages with \`ENV CARGO_INCREMENTAL=0\` before | After this PR |
| --- | --- | --- |
| axum-chuckrpg | builder-deps | planner + builder-deps + foundation |
| axum-kbve | builder-deps + foundation | planner + builder-deps + foundation |
| axum-rareicon | builder-deps + foundation | planner + builder-deps + foundation |
| firecracker-ctl | planner + builder-deps + builder | unchanged (already complete) |

## Separate fix: discordsh-bot missing bevy_tasker manifest

CI - Docker / discordsh-bot fails earlier with a different error:

\`\`\`
Caused by: failed to load manifest for dependency \`bevy_tasker\`
  failed to read \`/app/packages/rust/bevy/bevy_tasker/Cargo.toml\`
  No such file or directory (os error 2)
\`\`\`

\`bevy_db\` carries an optional path dep on \`bevy_tasker\` behind the \`bevy-plugin\` feature. \`cargo chef prepare\` reads every workspace member manifest fully — including optional path deps — so \`bevy_tasker/Cargo.toml\` must exist on disk during the planner stage even though discordsh-bot never enables the feature. Mirror the same workaround already used in axum-chuckrpg / axum-kbve: copy the manifest and create an empty \`src/lib.rs\` stub.

## Test plan

- [ ] CI - Docker / axum-chuckrpg passes (the test that exposed the per-stage gap).
- [ ] CI - Docker / discordsh-bot passes (the bevy_tasker manifest fix).
- [ ] CI - Docker / axum-kbve and axum-rareicon don't regress (they were green except for the test-timeout exit-130 issue, which is unrelated).
- [ ] firecracker-ctl unchanged.