### PR TITLE
feat(kasm): per-container hardening + Reloader + dedicated SA

### DIFF
--- a/apps/kube/kasm/README.md
+++ b/apps/kube/kasm/README.md
@@ -1,0 +1,84 @@
+# kasm — Kubernetes Deployment
+
+Browser-based Discord workspace running inside a [KASM](https://kasmweb.com) container. All egress from the workspace exits through a [Gluetun](https://github.com/qdm12/gluetun) WireGuard tunnel — the workspace shares Gluetun's network namespace, so it has no direct internet path. If Gluetun drops, traffic stops instead of leaking through the cluster's public IP.
+
+## Manifests
+
+| File                                 | Purpose                                                                                                             |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `application.yaml`                   | ArgoCD `Application` pointing at `apps/kube/kasm/manifest`; ignores `spec.replicas` so manual scale-ups don't drift |
+| `manifest/namespace.yaml`            | `kasm` namespace                                                                                                    |
+| `manifest/serviceaccount.yaml`       | `kasm-sa` (used by the pod)                                                                                         |
+| `manifest/deployment.yaml`           | `kasm-vpn` Deployment (gluetun + workspace + init) and `kasm-vpn-service`                                           |
+| `manifest/pvc.yaml`                  | 5Gi Longhorn PVC for `/home/kasm-user` (Discord browser profile)                                                    |
+| `manifest/sealed-vpn-wireguard.yaml` | SealedSecret holding the WireGuard provider, type, and keys                                                         |
+| `manifest/network-policy.yaml`       | CiliumNetworkPolicy locking egress to the VPN tunnel                                                                |
+
+## Topology
+
+| Container       | Image                                  | Role                                                  |
+| --------------- | -------------------------------------- | ----------------------------------------------------- |
+| `fix-pvc-perms` | `busybox:1.37` (init)                  | `chown -R 1000:1000 /home/kasm-user`                  |
+| `gluetun`       | `ghcr.io/qdm12/gluetun:v3.41.1`        | WireGuard tunnel + kill-switch + HTTP proxy on `8000` |
+| `workspace`     | `kasmweb/discord:1.18.0-rolling-daily` | KASM browser desktop on `6901` (shares gluetun netns) |
+
+`replicas: 0` by default. Scale to `1` manually when the workspace is needed; ArgoCD's `ignoreDifferences` on `/spec/replicas` keeps the manual scale-up from reverting.
+
+## Hardening
+
+The Deployment runs under per-container security profiles tuned for the role of each container:
+
+### Pod-level
+
+- `fsGroup: 1000` — PVC files end up group-writable for `kasm-user`
+- `seccompProfile: RuntimeDefault` — applied to every container in the pod
+- Pod-level `runAsNonRoot` is intentionally **not** set, because the init container needs to chown the PVC as root. Per-container UIDs are pinned individually instead.
+
+### `fix-pvc-perms` (init)
+
+- `runAsUser: 0` (must be root for `chown -R`); `runAsNonRoot: false`
+- `allowPrivilegeEscalation: false`
+- `readOnlyRootFilesystem: true` (busybox `chown` doesn't write to `/`)
+- Capabilities: drop `ALL`; add only `CHOWN`, `DAC_OVERRIDE`, `FOWNER`
+
+### `gluetun`
+
+- Runs as the image default (root) — gluetun manages the network namespace shared with the workspace, so pinning `runAsNonRoot` would break the WireGuard handshake
+- `allowPrivilegeEscalation: false`
+- Capabilities: drop `ALL`; add only `NET_ADMIN` (required for the tun device + iptables kill-switch)
+
+### `workspace`
+
+- `runAsNonRoot: true`, UID/GID `1000` (matches the `kasm-user` account baked into KASM workspace images)
+- `allowPrivilegeEscalation: false`
+- Capabilities: drop `ALL`
+- `readOnlyRootFilesystem` is **deliberately not set** — the upstream image writes to `/tmp`, `/var`, and `/home/kasm-user/.cache` during boot. Flipping it on without staging the matched `emptyDir` mounts would crash-loop the pod. Tracked as a follow-up.
+
+### Service account
+
+- Dedicated `kasm-sa` with `automountServiceAccountToken: false` at both the SA and pod level. The pod does not call the kube API.
+
+## Reloader integration
+
+The Deployment carries `reloader.stakater.com/auto: "true"`. When the `vpn-wireguard` SealedSecret rotates (re-keying the WireGuard tunnel), Reloader rolls the Deployment automatically. If the manual scale is at `0` the annotation has no effect, by design.
+
+## Known follow-ups
+
+- **`VNC_PW` is plaintext** in `deployment.yaml` (`workspace.env.VNC_PW: changeme`). Move to a SealedSecret named `kasm-vnc-secret` with `kubeseal` and switch the env to `valueFrom.secretKeyRef` before scaling this Deployment > `0` for any non-throwaway use. Tracked here so anyone wiring up the workspace remembers to seal a real password first.
+- **`readOnlyRootFilesystem` on the `workspace` container** — needs `emptyDir` mounts for `/tmp`, `/var/cache`, and the relevant subpaths under `/home/kasm-user`, plus a live-test cycle.
+- **Gluetun non-root** — the upstream image supports `PUID`/`PGID` env vars; investigating whether running gluetun as a non-zero UID with `NET_ADMIN` still completes the WireGuard handshake under the cluster's CNI is worth a follow-up.
+
+## Egress lockdown
+
+The cluster's CiliumNetworkPolicy in `network-policy.yaml` restricts egress from any pod with `app: kasm-vpn` to:
+
+- kube-dns (UDP/TCP 53)
+- in-cluster RFC1918 ranges (so the pod can reach the gluetun-managed tunnel itself)
+
+External traffic only leaves the cluster through the WireGuard tunnel inside Gluetun. If the tunnel drops, gluetun's iptables kill-switch and Cilium policy together stop traffic instead of falling back to the node's IP.
+
+## ArgoCD
+
+- App: `kasm` (source: `apps/kube/kasm/manifest`)
+- Sync: automated with prune + selfHeal; `spec.replicas` ignored so manual scale-ups don't drift
+- Managed by `kube-root` app-of-apps

--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -11,6 +11,11 @@ metadata:
         app: kasm-vpn
         app.kubernetes.io/part-of: kasm
         app.kubernetes.io/component: workspace
+    annotations:
+        # Reloader rolls this Deployment whenever the vpn-wireguard
+        # SealedSecret rotates — re-keying the WireGuard tunnel takes
+        # effect on the next pod start without a manual rollout.
+        reloader.stakater.com/auto: 'true'
 spec:
     replicas: 0 # Manual scale — set to 1 when needed
     selector:
@@ -23,21 +28,56 @@ spec:
                 app.kubernetes.io/part-of: kasm
                 app.kubernetes.io/component: workspace
         spec:
-            # kasm-user is uid 1000 — fsGroup makes the PVC group-writable.
+            serviceAccountName: kasm-sa
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            # Pod-level only sets fsGroup + seccomp. Per-container UIDs
+            # are pinned individually because the init container must
+            # run as root to chown the PVC, while the workspace and
+            # gluetun containers run with their image defaults.
             securityContext:
                 fsGroup: 1000
+                seccompProfile:
+                    type: RuntimeDefault
             initContainers:
                 - name: fix-pvc-perms
                   image: busybox:1.37
                   command: ['sh', '-c', 'chown -R 1000:1000 /home/kasm-user']
+                  # Init must run as root to chown an existing PVC
+                  # (fsGroup only sets the volume root, not files
+                  # written by previous runs as different UIDs).
+                  # Caps are minimised to just what chown needs.
+                  securityContext:
+                      runAsUser: 0
+                      runAsGroup: 0
+                      runAsNonRoot: false
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                          add:
+                              - CHOWN
+                              - DAC_OVERRIDE
+                              - FOWNER
                   volumeMounts:
                       - name: discord-profile
                         mountPath: /home/kasm-user
             containers:
                 - name: gluetun
                   image: ghcr.io/qdm12/gluetun:v3.41.1
+                  # Gluetun needs NET_ADMIN to set up the tun device
+                  # and write iptables rules for the kill-switch. All
+                  # other caps are dropped. The image runs as its
+                  # default user (root) because it manages the network
+                  # namespace shared with the workspace container;
+                  # pinning runAsNonRoot here would break the
+                  # WireGuard handshake.
                   securityContext:
+                      allowPrivilegeEscalation: false
                       capabilities:
+                          drop:
+                              - ALL
                           add:
                               - NET_ADMIN
                   ports:
@@ -99,7 +139,29 @@ spec:
 
                 - name: workspace
                   image: kasmweb/discord:1.18.0-rolling-daily
+                  # KASM workspace images bake `kasm-user` at UID 1000.
+                  # Pin runAsNonRoot + the matching UID/GID; drop every
+                  # Linux capability — the desktop session does not
+                  # need any of them. Privilege escalation is off so a
+                  # process inside the workspace cannot setuid.
+                  # readOnlyRootFilesystem is intentionally NOT set
+                  # because the upstream image writes to /tmp, /var,
+                  # /home/kasm-user/.cache during boot; flipping it on
+                  # without staging the matched emptyDir mounts would
+                  # crash-loop the pod. Tracked as a follow-up.
+                  securityContext:
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      runAsGroup: 1000
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
                   env:
+                      # FIXME(kasm): VNC_PW is plaintext here. Move to
+                      # a SealedSecret (kasm-vnc-secret) with kubeseal
+                      # before scaling this Deployment > 0. Tracked in
+                      # apps/kube/kasm/README.md.
                       - name: VNC_PW
                         value: 'changeme'
                       - name: KASM_PORT

--- a/apps/kube/kasm/manifest/serviceaccount.yaml
+++ b/apps/kube/kasm/manifest/serviceaccount.yaml
@@ -1,0 +1,10 @@
+# ServiceAccount used by the kasm-vpn Deployment pod. The pod does
+# not call the kube API, so the projected token is unused weight —
+# disable it here at the SA level. The pod spec re-states the field
+# so any future template binding the SA inherits the safe default.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: kasm-sa
+    namespace: kasm
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

The kasm-vpn Deployment runs three containers with very different role needs (root chown init, root-but-NET_ADMIN-only VPN sidecar, non-root desktop workspace), so hardening is applied per-container rather than via a single pod-level profile. Pod-level only sets `fsGroup: 1000` and `seccompProfile: RuntimeDefault`; the rest is per-container.

A dedicated `kasm-sa` ServiceAccount is added with `automountServiceAccountToken: false` at both the SA and pod level — the pod does not call the kube API.

`reloader.stakater.com/auto: "true"` on the Deployment ties the `vpn-wireguard` SealedSecret rotation to an automatic roll. The `replicas: 0` default and ArgoCD's existing `ignoreDifferences` on `/spec/replicas` keep the manual scale-up flow intact.

## Per-container security profile

| Container         | runAsNonRoot | UID  | readOnly rootfs | allowPrivEsc | caps                                               |
| ----------------- | ------------ | ---- | --------------- | ------------ | -------------------------------------------------- |
| `fix-pvc-perms`   | `false`      | `0`  | yes             | `false`      | drop ALL, add CHOWN + DAC_OVERRIDE + FOWNER        |
| `gluetun`         | image dflt   | root | no (writes /)   | `false`      | drop ALL, add NET_ADMIN                            |
| `workspace`       | `true`       | 1000 | deferred        | `false`      | drop ALL                                           |

### Why pod-level `runAsNonRoot` is not set

The init container needs to run as root to `chown -R 1000:1000 /home/kasm-user` (`fsGroup` only chowns the volume mount root, not files written by previous runs as different UIDs). A pod-level `runAsNonRoot: true` is admission-enforced — it cannot be overridden per-container — so we pin UIDs individually instead.

### Why `gluetun` is left as root

Gluetun manages the network namespace shared with the workspace container and runs the WireGuard handshake. Pinning `runAsNonRoot` here breaks the tunnel. The image's `PUID`/`PGID` env path that allows non-root operation is worth a separate investigation against the cluster's CNI; tracking it as a follow-up rather than risking a broken pod here.

### Why `readOnlyRootFilesystem` on the workspace container is deferred

The upstream `kasmweb/discord` image writes to `/tmp`, `/var`, and `/home/kasm-user/.cache` during boot. Flipping the flag on without staging matched `emptyDir` mounts crash-loops the pod. Tracked as a follow-up that needs a live test cycle.

## Known follow-ups (in `apps/kube/kasm/README.md`)

- **`VNC_PW` is plaintext** in `deployment.yaml` (`workspace.env.VNC_PW: changeme`). Move to a `kasm-vnc-secret` SealedSecret with `kubeseal` and switch the env to `valueFrom.secretKeyRef` before scaling this Deployment > `0` for any non-throwaway use.
- **`readOnlyRootFilesystem` on the workspace container** — needs `emptyDir` mounts plus a live-test cycle.
- **Gluetun non-root** — investigate `PUID`/`PGID` operation under the cluster's CNI.

## Hardening pattern by namespace so far

| ns           | manifest type     | Reloader | non-root          | readOnly rootfs | caps drop | SA token off |
| ------------ | ----------------- | -------- | ----------------- | --------------- | --------- | ------------ |
| chuckrpg     | raw               | yes      | UID 10001         | yes + /tmp ED   | yes       | yes          |
| redis        | Bitnami chart     | yes      | chart             | chart           | chart     | chart        |
| n8n          | raw               | yes      | UID 1000          | deferred        | yes       | yes          |
| discordsh    | raw               | yes      | UID 10001         | yes + /tmp ED   | yes       | yes          |
| herbmail     | raw               | yes      | UID 10001         | yes + /tmp ED   | yes       | yes          |
| cryptothrone | raw               | yes      | UID 10001         | yes + /tmp ED   | yes       | yes          |
| memes        | raw               | yes      | UID 10001         | yes + /tmp ED   | yes       | yes          |
| rentearth    | raw               | yes      | UID 10001         | yes + /tmp ED   | yes       | yes          |
| cityvote     | raw               | n/a      | UID 10001         | yes + /tmp ED   | yes       | yes          |
| valkey       | valkey-io chart   | yes      | chart             | chart           | chart     | chart        |
| kasm         | raw, multi-ctr    | yes      | per-container     | per-container   | per-ctr   | yes          |

## Test plan

- [ ] ArgoCD `kasm` Application syncs cleanly after dev → main promotion. Diff is limited to the new `kasm-sa` ServiceAccount, the Deployment's `metadata.annotations.reloader.stakater.com/auto`, the `securityContext` blocks, and `serviceAccountName: kasm-sa`.
- [ ] `kubectl -n kasm get sa kasm-sa -o jsonpath='{.automountServiceAccountToken}'` returns `false`.
- [ ] `kubectl -n kasm get deploy kasm-vpn -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}'` returns `"true"`.
- [ ] `kubectl -n kasm scale deploy kasm-vpn --replicas=1` brings the pod up cleanly: init runs and exits 0, gluetun reaches `Healthy`, workspace becomes `Ready`.
- [ ] Workspace VNC connects and Discord loads through the gluetun proxy.
- [ ] **Before scaling > 0** for any real use, replace the `VNC_PW: changeme` env with a `secretKeyRef` to a `kasm-vnc-secret` SealedSecret.
- [ ] After confirming the workspace is healthy, return `replicas` to `0` (ArgoCD's `ignoreDifferences` keeps it pinned at whatever value is set in the cluster).