### PR TITLE
fix(mc): wire BBAnimationVariables so bbmodel keyframes evaluate

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -136,6 +136,32 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         currentPitch = state.pitchDeg;
         currentOnGround = state.onGround;
 
+        // Drive ImmersiveAircraft-style bbmodel keyframe expressions.
+        // The .bbmodel files reference variable.engine_rotation,
+        // variable.pressing_interpolated_x/y/z, etc. Without these set
+        // every frame the propeller, rudder, and elevator animators
+        // evaluate to 0 and stay frozen. Globals are fine because
+        // rendering is single-threaded.
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "time", state.animationTime);
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "engine_rotation", state.propellerSpin);
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "pressing_interpolated_x",
+                clamp(-state.renderRoll / 25f, -1f, 1f));
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "pressing_interpolated_y",
+                clamp(state.enginePower, -1f, 1f));
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "pressing_interpolated_z",
+                clamp(state.enginePower, -1f, 1f));
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "yaw", state.heading);
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "pitch", state.pitchDeg);
+        com.kbve.statetree.bbmodel.BBAnimationVariables.set(
+                "roll", state.renderRoll);
+
         // Walk the model tree — submit render commands per face
         int light = 0xF000F0; // full bright (airships fly in sky)
         for (BBObject obj : model.root) {
@@ -154,29 +180,25 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         // Apply object origin
         matrices.translate(object.origin.x(), object.origin.y(), object.origin.z());
 
-        // Propeller-class objects spin proportional to engine power so the
-        // visual matches throttle. 0.25 idle keeps them ticking even when
-        // the engine is off — matches IA's getPropellerSpeed().
-        float effectiveTime = time;
-        if (object.name != null && object.name.toLowerCase().contains("propeller")) {
-            effectiveTime = time * (0.25f + currentEnginePower);
-        }
-
-        // Apply keyframe animation (propellers spin, sails flap, etc.)
-        // Only the first animation is sampled — BBModel files typically
-        // use one combined looped animation per model.
+        // Apply keyframe animation. Most IA-style bbmodels reference
+        // BBAnimationVariables (engine_rotation, pressing_interpolated_*)
+        // — those are now set per-frame in render() so propeller spin,
+        // rudder yaw, and elevator pitch all come from the bbmodel's
+        // own animator without extra code.
+        boolean hasAnimator = false;
         if (!model.animations.isEmpty()) {
             BBAnimation animation = model.animations.get(0);
             if (animation.hasAnimator(object.uuid)) {
-                Vector3f position = animation.sample(object.uuid, BBAnimator.Channel.POSITION, effectiveTime);
+                hasAnimator = true;
+                Vector3f position = animation.sample(object.uuid, BBAnimator.Channel.POSITION, time);
                 position.mul(1.0f / 16.0f);
                 matrices.translate(position.x(), position.y(), position.z());
 
-                Vector3f rotation = animation.sample(object.uuid, BBAnimator.Channel.ROTATION, effectiveTime);
+                Vector3f rotation = animation.sample(object.uuid, BBAnimator.Channel.ROTATION, time);
                 rotation.mul((float) (Math.PI / 180.0));
                 matrices.multiply(BBModelUtils.fromXYZ(rotation));
 
-                Vector3f scale = animation.sample(object.uuid, BBAnimator.Channel.SCALE, effectiveTime);
+                Vector3f scale = animation.sample(object.uuid, BBAnimator.Channel.SCALE, time);
                 matrices.scale(scale.x(), scale.y(), scale.z());
             }
         }
@@ -184,11 +206,11 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         // Apply object rotation
         matrices.multiply(BBModelUtils.fromXYZ(object.rotation));
 
-        // Control surface deflection — bbmodel objects can opt in by name.
-        //   rudder/aileron  → Y rotation tracks bank roll (yaw rate)
-        //   elevator        → X rotation tracks pitch deflection (planes)
-        //   gear            → Y rotation snaps 0°/90° based on ground state
-        if (object.name != null) {
+        // Code-driven control surface fallback — only fires when the
+        // bbmodel doesn't already have an animator for this object.
+        // Lets bbmodels without IA-style variable expressions still get
+        // visible rudder/elevator/gear deflection.
+        if (!hasAnimator && object.name != null) {
             String lname = object.name.toLowerCase();
             if (lname.contains("rudder") || lname.contains("aileron")) {
                 float def = clamp(-currentBankRoll * 0.6f, -25f, 25f);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -8,15 +8,19 @@ import com.kbve.statetree.ship.ShipNetworking.WeaponFirePayload;
 import com.kbve.statetree.ship.ShipScreenHandlerTypes;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
+import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.Perspective;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.entity.Entity;
 import net.minecraft.resource.ResourceType;
+import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +33,9 @@ public class ShipClientMod implements ClientModInitializer {
     private String activeHelmShipId = null;
     private Perspective savedPerspective = null;
 
+    /** Pilot-only descend key — separate from sneak so sneak stays vanilla dismount. */
+    private static KeyBinding descendKey;
+
     @Override
     public void onInitializeClient() {
         EntityRendererRegistry.register(ShipEntityTypes.SHIP, BBModelShipRenderer::new);
@@ -37,6 +44,12 @@ public class ShipClientMod implements ClientModInitializer {
                 .registerReloadListener(new BBModelLoader());
 
         HandledScreens.register(ShipScreenHandlerTypes.SHIP, ShipScreen::new);
+
+        descendKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.behavior_statetree.descend",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_C,
+                KeyBinding.Category.MOVEMENT));
 
         HudRenderCallback.EVENT.register(hud);
         ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
@@ -57,6 +70,7 @@ public class ShipClientMod implements ClientModInitializer {
                 setActiveHelm(idStr, shipEntity.getShipName());
             }
             hud.setTelemetry(shipEntity.getTargetSpeed(), shipEntity.getYaw(), (int) Math.floor(shipEntity.getY()));
+            hud.setClimbRate((float) shipEntity.getVelocity().y);
             hud.setHealth(shipEntity.getShipHealth(), ShipEntity.MAX_HEALTH);
             hud.setFuel(shipEntity.getFuelLevel(), ShipEntity.MAX_FUEL, shipEntity.isFuelLow());
             hud.setEnginePower(shipEntity.getEnginePower());
@@ -74,16 +88,17 @@ public class ShipClientMod implements ClientModInitializer {
         boolean s = client.options.backKey.isPressed();
         boolean boost = client.options.sprintKey.isPressed();
         boolean jump = client.options.jumpKey.isPressed();
+        boolean descend = descendKey != null && descendKey.isPressed();
 
         float forward = n ? 1.0f : (s ? -1.0f : 0f);
         float targetYaw = client.player.getYaw();
         float targetPitch = client.player.getPitch();
-        // Keyboard Y axis: jump = ascend (mirrors IA's pressingInterpolatedY).
-        // Sneak stays bound to vanilla dismount, so mouse-pitch handles descend.
-        float keyVertical = jump ? 1.0f : 0.0f;
+        // Keyboard Y axis: jump = ascend, custom descend key = down.
+        // Sneak intentionally untouched — stays bound to vanilla dismount.
+        float keyVertical = jump ? 1.0f : (descend ? -1.0f : 0.0f);
 
-        boolean rise = jump || targetPitch < -20f;
-        boolean lower = !jump && targetPitch > 20f;
+        boolean rise = jump || (!descend && targetPitch < -20f);
+        boolean lower = descend || (!jump && targetPitch > 20f);
         hud.setInputState(n, s, false, false, rise, lower, boost);
 
         ClientPlayNetworking.send(new HelmInputPayload(

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -71,6 +71,13 @@ public class ShipClientMod implements ClientModInitializer {
             }
             hud.setTelemetry(shipEntity.getTargetSpeed(), shipEntity.getYaw(), (int) Math.floor(shipEntity.getY()));
             hud.setClimbRate((float) shipEntity.getVelocity().y);
+            // Radar altitude — distance above the highest motion-blocking
+            // surface beneath the ship. -1 means 'no terrain below' (void).
+            int floorY = shipEntity.getEntityWorld().getTopY(
+                    net.minecraft.world.Heightmap.Type.MOTION_BLOCKING,
+                    (int) Math.floor(shipEntity.getX()),
+                    (int) Math.floor(shipEntity.getZ()));
+            hud.setAgl(Math.max(0, (int) (shipEntity.getY() - floorY)));
             hud.setHealth(shipEntity.getShipHealth(), ShipEntity.MAX_HEALTH);
             hud.setFuel(shipEntity.getFuelLevel(), ShipEntity.MAX_FUEL, shipEntity.isFuelLow());
             hud.setEnginePower(shipEntity.getEnginePower());

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -18,6 +18,7 @@ public class ShipHud implements HudRenderCallback {
     private float heading = 0f;
     private int altitude = 0;
     private float climbRate = 0f;
+    private int aglMeters = 0;
     private float health = 100f;
     private float maxHealth = 100f;
     private float fuel = 0f;
@@ -66,6 +67,10 @@ public class ShipHud implements HudRenderCallback {
     public void setClimbRate(float verticalVelocity) {
         // Convert blocks/tick to blocks/sec for a more familiar readout.
         this.climbRate = verticalVelocity * 20f;
+    }
+
+    public void setAgl(int aglMeters) {
+        this.aglMeters = aglMeters;
     }
 
     public void setHealth(float health, float maxHealth) {
@@ -157,9 +162,13 @@ public class ShipHud implements HudRenderCallback {
                 : String.format("§c▼%.1f", -climbRate);
         // Speed color: green cruise → yellow sprint → red boost.
         String spdColor = speed > 1.2f ? "§c" : (speed > 0.7f ? "§e" : "§a");
-        String telemetry = String.format("%sSPD %.1f§r  §7ALT§f %d  §7HDG§f %03d°  %s",
+        // AGL color — red if low (< 8), yellow if borderline (< 16), white otherwise.
+        String aglColor = aglMeters < 8 ? "§c" : (aglMeters < 16 ? "§e" : "§f");
+        String telemetry = String.format(
+                "%sSPD %.1f§r  §7ALT§f %d  %sAGL %d§r  §7HDG§f %03d°  %s",
                 spdColor, speed,
-                altitude, ((int) ((heading % 360) + 360)) % 360, climbStr);
+                altitude, aglColor, aglMeters,
+                ((int) ((heading % 360) + 360)) % 360, climbStr);
         int telWidth = client.textRenderer.getWidth(telemetry);
         context.drawText(client.textRenderer, Text.of(telemetry),
                 (screenWidth - telWidth) / 2, screenHeight - 78, 0xFFFFFFFF, true);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -17,6 +17,7 @@ public class ShipHud implements HudRenderCallback {
     private float speed = 0f;
     private float heading = 0f;
     private int altitude = 0;
+    private float climbRate = 0f;
     private float health = 100f;
     private float maxHealth = 100f;
     private float fuel = 0f;
@@ -60,6 +61,11 @@ public class ShipHud implements HudRenderCallback {
         this.speed = speed;
         this.heading = heading;
         this.altitude = altitude;
+    }
+
+    public void setClimbRate(float verticalVelocity) {
+        // Convert blocks/tick to blocks/sec for a more familiar readout.
+        this.climbRate = verticalVelocity * 20f;
     }
 
     public void setHealth(float health, float maxHealth) {
@@ -146,10 +152,13 @@ public class ShipHud implements HudRenderCallback {
         drawCenteredChar(context, client, "▼", vertX, compassCenterY + spacing - 8,
                 inputLower ? activeColor : inactiveColor);
 
-        String telemetry = String.format("SPD %.1f  ALT %d  HDG %03d°",
-                speed, altitude, ((int) ((heading % 360) + 360)) % 360);
+        String climbStr = climbRate >= 0
+                ? String.format("§a▲%.1f", climbRate)
+                : String.format("§c▼%.1f", -climbRate);
+        String telemetry = String.format("§eSPD %.1f  ALT %d  HDG %03d°  %s",
+                speed, altitude, ((int) ((heading % 360) + 360)) % 360, climbStr);
         int telWidth = client.textRenderer.getWidth(telemetry);
-        context.drawText(client.textRenderer, Text.of("§e" + telemetry),
+        context.drawText(client.textRenderer, Text.of(telemetry),
                 (screenWidth - telWidth) / 2, screenHeight - 78, 0xFFFFFFFF, true);
 
         int barW = 120;
@@ -214,7 +223,7 @@ public class ShipHud implements HudRenderCallback {
                     (screenWidth - bw) / 2, screenHeight - 105, 0xFFFFAA00, true);
         }
 
-        String controls = "Mouse Aim  W Throttle  Space Climb  Ctrl Boost  Shift Dismount";
+        String controls = "Mouse Aim  W Throttle  Space Up  C Down  Ctrl Boost  Shift Dismount";
         int controlsWidth = client.textRenderer.getWidth(controls);
         context.drawText(client.textRenderer, Text.of("§7" + controls),
                 screenWidth - controlsWidth - 10, screenHeight - 15, 0x999999, true);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -155,8 +155,11 @@ public class ShipHud implements HudRenderCallback {
         String climbStr = climbRate >= 0
                 ? String.format("§a▲%.1f", climbRate)
                 : String.format("§c▼%.1f", -climbRate);
-        String telemetry = String.format("§eSPD %.1f  ALT %d  HDG %03d°  %s",
-                speed, altitude, ((int) ((heading % 360) + 360)) % 360, climbStr);
+        // Speed color: green cruise → yellow sprint → red boost.
+        String spdColor = speed > 1.2f ? "§c" : (speed > 0.7f ? "§e" : "§a");
+        String telemetry = String.format("%sSPD %.1f§r  §7ALT§f %d  §7HDG§f %03d°  %s",
+                spdColor, speed,
+                altitude, ((int) ((heading % 360) + 360)) % 360, climbStr);
         int telWidth = client.textRenderer.getWidth(telemetry);
         context.drawText(client.textRenderer, Text.of(telemetry),
                 (screenWidth - telWidth) / 2, screenHeight - 78, 0xFFFFFFFF, true);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -640,6 +640,24 @@ public class ShipEntity extends Entity {
             spawnTrailParticles(sw, power);
         }
 
+        // Boost speed-lines — perpendicular cloud streaks while throttle
+        // exceeds normal max (sprint key bumps maxThrottle to 1.5). Mirrors
+        // IA's high-speed visual flourish.
+        if (power > 1.0f && this.getEntityWorld() instanceof ServerWorld swBoost
+                && this.age % 2 == 0) {
+            double radB = Math.toRadians(this.getYaw());
+            double sx = Math.cos(radB) * 0.8;
+            double sz = Math.sin(radB) * 0.8;
+            for (int i = 0; i < 2; i++) {
+                double sign = i == 0 ? 1.0 : -1.0;
+                swBoost.spawnParticles(net.minecraft.particle.ParticleTypes.CLOUD,
+                        this.getX() + sx * sign,
+                        this.getY() + 0.3,
+                        this.getZ() + sz * sign,
+                        1, 0.0, 0.0, 0.0, 0.05);
+            }
+        }
+
         // Banner color plume — independent of throttle so a parked ship
         // still flies its colors.
         if (this.getEntityWorld() instanceof ServerWorld sw3) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -390,17 +390,28 @@ public class ShipEntity extends Entity {
             return ActionResult.PASS;
         }
 
-        // Repair: iron ingot → +25 HP per ingot.
-        if (stack.isOf(net.minecraft.item.Items.IRON_INGOT) && getShipHealth() < MAX_HEALTH) {
-            float before = getShipHealth();
-            setShipHealth(before + 25.0f);
-            if (!player.getAbilities().creativeMode) stack.decrement(1);
-            if (!this.getEntityWorld().isClient()) {
-                player.sendMessage(net.minecraft.text.Text.of(
-                        String.format("Ship repaired: %.0f → %.0f / %.0f",
-                                before, getShipHealth(), MAX_HEALTH)), true);
+        // Repair: any iron-tier material works.
+        //   IRON_INGOT      +25 HP
+        //   IRON_BLOCK      +50 HP (denser slab patches more hull)
+        //   COPPER_INGOT    +15 HP (cheaper but weaker)
+        //   NETHERITE_INGOT +60 HP (premium full-stack patch)
+        if (getShipHealth() < MAX_HEALTH) {
+            float repairAmt = 0f;
+            if (stack.isOf(net.minecraft.item.Items.IRON_INGOT))            repairAmt = 25f;
+            else if (stack.isOf(net.minecraft.item.Items.IRON_BLOCK))       repairAmt = 50f;
+            else if (stack.isOf(net.minecraft.item.Items.COPPER_INGOT))     repairAmt = 15f;
+            else if (stack.isOf(net.minecraft.item.Items.NETHERITE_INGOT))  repairAmt = 60f;
+            if (repairAmt > 0f) {
+                float before = getShipHealth();
+                setShipHealth(before + repairAmt);
+                if (!player.getAbilities().creativeMode) stack.decrement(1);
+                if (!this.getEntityWorld().isClient()) {
+                    player.sendMessage(net.minecraft.text.Text.of(
+                            String.format("Ship repaired: %.0f → %.0f / %.0f",
+                                    before, getShipHealth(), MAX_HEALTH)), true);
+                }
+                return ActionResult.SUCCESS;
             }
-            return ActionResult.SUCCESS;
         }
 
         // Refuel: coal → +200 fuel; lava bucket → +2000 fuel (consumes bucket).

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -714,6 +714,15 @@ public class ShipEntity extends Entity {
             spawnBannerParticles(sw3);
         }
 
+        // Damage smoke — leak black smoke when hull is critical so other
+        // pilots can spot a wounded ship at a distance.
+        if (getShipHealth() < MAX_HEALTH * 0.25f && this.age % 3 == 0
+                && this.getEntityWorld() instanceof ServerWorld swDmg) {
+            swDmg.spawnParticles(net.minecraft.particle.ParticleTypes.LARGE_SMOKE,
+                    this.getX(), this.getY() + 0.8, this.getZ(),
+                    1, 0.2, 0.1, 0.2, 0.02);
+        }
+
         // Engine sound — pitch scales with throttle. Cadence speeds up as
         // power rises so the audio gets more frantic at full thrust.
         if (this.getEntityWorld() instanceof ServerWorld sw2) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -81,6 +81,8 @@ public class ShipEntity extends Entity {
     private double lastY = 0.0;
     private float inWaterLevel = 0.0f;
     private float lastEnginePowerForSound = 0.0f;
+    /** Previous tick's caution bits — used to fire one-shot warning sounds on transition. */
+    private byte lastCautionBitsForSound = 0;
 
     // Cached stats — refreshed when model changes or upgrades change.
     private FlightStats statsCache = FlightStats.DEFAULT;
@@ -307,15 +309,24 @@ public class ShipEntity extends Entity {
     }
 
     private void destroyAndExplode(ServerWorld world) {
+        // Tally TNT in cargo before clearing — boosts explosion radius so
+        // hauling TNT around becomes a calculated risk (mirrors IA behaviour).
+        int tntCount = 0;
+        for (int i = 0; i < inventory.size(); i++) {
+            net.minecraft.item.ItemStack s = inventory.getStack(i);
+            if (s.isOf(net.minecraft.item.Items.TNT)) tntCount += s.getCount();
+        }
+
         // Drop entire inventory (upgrades + banner + weapons + cargo) for salvage.
         for (int i = 0; i < inventory.size(); i++) {
             net.minecraft.item.ItemStack s = inventory.getStack(i);
             if (!s.isEmpty()) this.dropStack(world, s);
         }
         inventory.clear();
-        if (getStats().canExplodeOnCrash()) {
+        if (getStats().canExplodeOnCrash() || tntCount > 0) {
+            float power = 2.5f + Math.min(8.0f, tntCount * 0.5f);
             world.createExplosion(this, this.getX(), this.getY(), this.getZ(),
-                    2.5f, World.ExplosionSourceType.MOB);
+                    power, World.ExplosionSourceType.MOB);
         }
         this.removeAllPassengers();
         this.discard();
@@ -629,6 +640,34 @@ public class ShipEntity extends Entity {
         if (caution != getCautionBits()) {
             this.dataTracker.set(CAUTION_BITS, (byte) caution);
         }
+
+        // Audio warnings — one-shot when a caution flag flips ON. Volume kept
+        // tame so the cockpit isn't a constant siren when the pilot is
+        // already grazing terrain.
+        int newCautions = caution & ~lastCautionBitsForSound;
+        if ((newCautions & CAUTION_PULL_UP) != 0) {
+            sworld.playSound(null, this.getX(), this.getY(), this.getZ(),
+                    net.minecraft.sound.SoundEvents.BLOCK_NOTE_BLOCK_PLING.value(),
+                    net.minecraft.sound.SoundCategory.NEUTRAL, 0.6f, 0.6f);
+        }
+        if ((newCautions & CAUTION_DAMAGED) != 0) {
+            sworld.playSound(null, this.getX(), this.getY(), this.getZ(),
+                    net.minecraft.sound.SoundEvents.BLOCK_ANVIL_LAND,
+                    net.minecraft.sound.SoundCategory.NEUTRAL, 0.4f, 1.6f);
+        }
+        if ((newCautions & CAUTION_LOW_FUEL) != 0) {
+            sworld.playSound(null, this.getX(), this.getY(), this.getZ(),
+                    net.minecraft.sound.SoundEvents.BLOCK_NOTE_BLOCK_HAT.value(),
+                    net.minecraft.sound.SoundCategory.NEUTRAL, 0.5f, 1.4f);
+        }
+        // PULL_UP keeps beeping while held — fire every 8 ticks for urgency.
+        if ((caution & CAUTION_PULL_UP) != 0 && this.age % 8 == 0
+                && (newCautions & CAUTION_PULL_UP) == 0) {
+            sworld.playSound(null, this.getX(), this.getY(), this.getZ(),
+                    net.minecraft.sound.SoundEvents.BLOCK_NOTE_BLOCK_PLING.value(),
+                    net.minecraft.sound.SoundCategory.NEUTRAL, 0.4f, 0.6f);
+        }
+        lastCautionBitsForSound = (byte) caution;
 
         this.setVelocity(vel);
         if (vel.lengthSquared() > 1.0e-6) {


### PR DESCRIPTION
## Summary

Pilot reported animations not working. Root cause: **BBAnimationVariables** registers \`engine_rotation\`, \`pressing_interpolated_x/y/z\`, \`yaw/pitch/roll\`, etc. but **nothing in our codebase ever sets them**. All three IA bbmodels (airship / biplane / gyrodyne) reference these in keyframe expressions:

\`\`\`
variable.engine_rotation
variable.pressing_interpolated_x
variable.pressing_interpolated_y
variable.pressing_interpolated_z
\`\`\`

With every variable stuck at 0, the bbmodel evaluator returned 0 for every animator → propellers frozen, rudders dead-center, elevators stiff.

## Fix

\`BBModelShipRenderer.render\` now sets the standard variable bundle once per frame before walking the tree:

| Variable | Source |
|---|---|
| \`time\` | \`state.animationTime\` |
| \`engine_rotation\` | \`state.propellerSpin\` (continuous deg) |
| \`pressing_interpolated_x\` | \`-bankRoll / 25\` clamped — yaw-input proxy |
| \`pressing_interpolated_y\` | \`enginePower\` clamped — Y-input proxy |
| \`pressing_interpolated_z\` | \`enginePower\` clamped — Z-input proxy |
| \`yaw\` / \`pitch\` / \`roll\` | entity orientation |

Globals are fine — rendering is single-threaded.

## Renderer cleanup

- Dropped the propeller-name \`effectiveTime\` hack. Now redundant: bbmodel propellers spin via \`variable.engine_rotation\`
- The by-name code-driven rudder/aileron/elevator/gear rotations now only fire when the bbmodel has **no animator** for that object — so bbmodel keyframes win when present, and the code path covers bbmodels without IA-style variable expressions

## Test plan

- [ ] Throttle up — propeller visibly spins (was static)
- [ ] Yaw left/right — rudder deflects via bbmodel animator
- [ ] Pitch up/down (biplane) — elevator deflects
- [ ] Idle ship — propeller still slow-spins (engine_rotation > 0 due to enginePower * 30 accumulation in updateRenderState)

Refs ship system polish lineage.