### PR TITLE
feat(firecracker): wire firecracker-python-net rootfs into PVC + dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
@@ -342,13 +342,21 @@ class IDEService {
 		this.$result.set(null);
 		this.$error.set(null);
 
+		// Network (VPN) Python presets boot the firecracker-python-net rootfs
+		// (resolv.conf + iproute2 + py3-requests/httpx baked in). All other
+		// preset/network combinations keep the preset's declared rootfs.
+		const rootfs =
+			useNetwork && preset.language === 'python'
+				? 'firecracker-python-net'
+				: preset.rootfs;
+
 		try {
 			const createResp = await fcFetch<{ vm_id: string; status: string }>(
 				token,
 				'/vm/create',
 				'POST',
 				{
-					rootfs: preset.rootfs,
+					rootfs,
 					vcpu_count: preset.vcpu_count,
 					mem_size_mib: preset.mem_size_mib,
 					timeout_ms: preset.timeout_ms,

--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v7
+    name: firecracker-rootfs-init-v8
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -31,7 +31,7 @@ spec:
 
                           echo "=== Firecracker rootfs init ==="
 
-                          apk add --no-cache curl e2fsprogs
+                          apk add --no-cache curl e2fsprogs skopeo jq
 
                           # --- vmlinux kernel ---
                           if [ ! -f "${OUTPUT}/vmlinux" ]; then
@@ -88,21 +88,70 @@ spec:
                           }
 
                           # --- alpine-minimal ---
-                          echo "[2/4] alpine-minimal..."
+                          echo "[2/6] alpine-minimal..."
                           build_rootfs "alpine-minimal" 32
 
                           # --- alpine-python ---
-                          echo "[3/4] alpine-python..."
+                          echo "[3/6] alpine-python..."
                           build_rootfs "alpine-python" 128 python3
 
                           # --- alpine-node ---
-                          echo "[4/5] alpine-node..."
+                          echo "[4/6] alpine-node..."
                           build_rootfs "alpine-node" 128 nodejs
+
+                          # --- firecracker-python-net (pulled from GHCR) ---
+                          # Network-capable Alpine + Python rootfs published as
+                          # ghcr.io/kbve/firecracker-python-net:<version>. The
+                          # image is a scratch image carrying /rootfs.ext4
+                          # (built by packages/docker/firecracker/python/net).
+                          # Selected at deploy time when the dashboard's
+                          # Network (VPN) checkbox is set.
+                          echo "[5/6] firecracker-python-net (from GHCR)..."
+                          NET_TARGET="${OUTPUT}/firecracker-python-net.ext4"
+                          NET_IMAGE="docker://ghcr.io/kbve/firecracker-python-net:0.1.0"
+                          if [ ! -f "${NET_TARGET}" ]; then
+                              echo "  Pulling ${NET_IMAGE}..."
+                              IMG_DIR=$(mktemp -d)
+                              skopeo copy --src-tls-verify=true \
+                                  "${NET_IMAGE}" "dir:${IMG_DIR}"
+
+                              # The single-arch image has one tar layer
+                              # containing /rootfs.ext4. Iterate through layer
+                              # blobs (named by digest) and extract the file.
+                              FOUND=0
+                              for layer in ${IMG_DIR}/*; do
+                                  case "$(file -b "$layer" 2>/dev/null || true)" in
+                                      *gzip*|*"tar archive"*)
+                                          tar -xf "$layer" -C "${IMG_DIR}" rootfs.ext4 2>/dev/null && \
+                                              { FOUND=1; break; } || true
+                                          ;;
+                                  esac
+                              done
+
+                              if [ "$FOUND" != "1" ]; then
+                                  # Fallback: try every blob without filtering
+                                  for layer in ${IMG_DIR}/*; do
+                                      [ -f "$layer" ] || continue
+                                      tar -xf "$layer" -C "${IMG_DIR}" rootfs.ext4 2>/dev/null && \
+                                          { FOUND=1; break; } || true
+                                  done
+                              fi
+
+                              if [ "$FOUND" = "1" ]; then
+                                  cp "${IMG_DIR}/rootfs.ext4" "${NET_TARGET}"
+                                  echo "  firecracker-python-net.ext4: $(du -h ${NET_TARGET} | cut -f1)"
+                              else
+                                  echo "  ERROR: rootfs.ext4 not found in any layer of ${NET_IMAGE}"
+                              fi
+                              rm -rf "${IMG_DIR}"
+                          else
+                              echo "  firecracker-python-net.ext4 already exists, skipping"
+                          fi
 
                           # --- pip package cache ---
                           # Reads package list from ConfigMap (firecracker-pip-packages).
-                          # Rebuild triggered when init job name is bumped (v6 → v7).
-                          echo "[5/5] pip-cache..."
+                          # Rebuild triggered when init job name is bumped (v7 → v8).
+                          echo "[6/6] pip-cache..."
                           if [ ! -f "${OUTPUT}/pip-cache.ext4" ]; then
                               apk add --no-cache python3 py3-pip
                               PIPCACHE=$(mktemp -d)


### PR DESCRIPTION
## Summary

Path C from the design discussion: stage the published GHCR image into the firecracker rootfs PVC and route the dashboard's **Network (VPN)** Python presets to it.

## Init job (\`apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml\`)

- Bumped Job name \`firecracker-rootfs-init-v7\` → \`firecracker-rootfs-init-v8\` so ArgoCD reruns the PostSync hook and re-stages the rootfs PVC.
- Added \`skopeo\` + \`jq\` to the apk install line.
- New \"[5/6] firecracker-python-net\" step:
    1. \`skopeo copy docker://ghcr.io/kbve/firecracker-python-net:0.1.0 dir:\${IMG_DIR}\`
    2. Iterate the dumped layer blobs, extract \`/rootfs.ext4\` from whichever one carries it.
    3. Copy to \`/var/lib/firecracker/rootfs/firecracker-python-net.ext4\` on the shared PVC (mounted by both \`firecracker-ctl\` and \`firecracker-ctl-net\` deployments).
- Renumbered existing log lines (\`[2/4]\` → \`[2/6]\`, …) to match the new step count.

## Dashboard service (\`apps/kbve/astro-kbve/.../ideService.ts\`)

- When the **Network (VPN)** checkbox is set on a Python preset, swap the rootfs from \`alpine-python\` → \`firecracker-python-net\` before \`/vm/create\`. All other preset / network combinations keep their declared rootfs.
- Single inline derivation, no preset duplication.

## Why this fixes the smoke-test failure

The previous \`Network (VPN)\` test ran:
\`\`\`
import requests
ModuleNotFoundError: No module named 'requests'
```

That booted the \`alpine-python\` rootfs (only \`python3\` baked, no \`/etc/resolv.conf\`, no eth0 bring-up). The new \`firecracker-python-net\` rootfs ships with:

- \`py3-requests\`, \`py3-httpx\`, \`py3-urllib3\`, \`py3-certifi\`, \`py3-pip\`
- \`/etc/resolv.conf\` with \`1.1.1.1\` + \`8.8.8.8\`
- \`/init\` that mounts \`/proc /sys /dev\`, brings up \`lo\` + \`eth0\`, then exec's the entrypoint

## Test plan

- [ ] After merge, ArgoCD reconciles the firecracker app, the new init Job runs, and \`firecracker-python-net.ext4\` lands on the rootfs PVC.
- [ ] Dashboard IDE: select Python Quick + check Network (VPN), run the PoetryDB smoke script, see a poem print + exit 0.
- [ ] Dashboard IDE: select Python Quick without Network (VPN), confirm \`alpine-python\` is still used (no behavior change).