### PR TITLE
fix(docker): add missing bevy_tasker manifest to discordsh-bot planner

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -61,6 +61,10 @@ RUN find . -type f \( \
 # ============================================================================
 FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# Cargo-chef's first probe is `sccache rustc -vV`, which trips this guard.
+ENV CARGO_INCREMENTAL=0
+
 WORKDIR /app
 
 COPY apps/chuckrpg/axum-chuckrpg/Cargo.workspace.toml Cargo.toml
@@ -116,6 +120,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
 # ============================================================================
 FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# The builder image now sets this by default, but keep an explicit override
+# here so this stage is correct even when rebuilt against an older builder.
+ENV CARGO_INCREMENTAL=0
 
 WORKDIR /app
 

--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -27,6 +27,11 @@ COPY packages/rust/bevy/bevy_chat/Cargo.toml packages/rust/bevy/bevy_chat/Cargo.
 COPY packages/rust/bevy/bevy_mapdb/Cargo.toml packages/rust/bevy/bevy_mapdb/Cargo.toml
 COPY packages/rust/bevy/bevy_pathfinder/Cargo.toml packages/rust/bevy/bevy_pathfinder/Cargo.toml
 COPY packages/rust/bevy/bevy_db/Cargo.toml packages/rust/bevy/bevy_db/Cargo.toml
+# bevy_db carries an optional path dep on bevy_tasker behind the
+# "bevy-plugin" feature. cargo chef prepare reads every member manifest
+# fully — including optional path deps — so the bevy_tasker manifest
+# must exist on disk even though we never enable the feature here.
+COPY packages/rust/bevy/bevy_tasker/Cargo.toml packages/rust/bevy/bevy_tasker/Cargo.toml
 
 COPY packages/data/proto packages/data/proto
 
@@ -44,7 +49,8 @@ RUN mkdir -p apps/discordsh/discordsh-bot/src && echo "fn main() {}" > apps/disc
     mkdir -p packages/rust/bevy/bevy_chat/src && echo "" > packages/rust/bevy/bevy_chat/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_mapdb/src && echo "" > packages/rust/bevy/bevy_mapdb/src/lib.rs && \
     mkdir -p packages/rust/bevy/bevy_pathfinder/src && echo "" > packages/rust/bevy/bevy_pathfinder/src/lib.rs && \
-    mkdir -p packages/rust/bevy/bevy_db/src && echo "" > packages/rust/bevy/bevy_db/src/lib.rs
+    mkdir -p packages/rust/bevy/bevy_db/src && echo "" > packages/rust/bevy/bevy_db/src/lib.rs && \
+    mkdir -p packages/rust/bevy/bevy_tasker/src && echo "" > packages/rust/bevy/bevy_tasker/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -89,6 +89,10 @@ RUN find . -type f \( \
 # [STAGE C] - Cargo Chef Planner
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# Cargo-chef's first probe is `sccache rustc -vV`, which trips this guard.
+ENV CARGO_INCREMENTAL=0
+
 COPY apps/kbve/axum-kbve/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -61,6 +61,10 @@ RUN find . -type f \( \
 # ============================================================================
 FROM ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
 
+# sccache 0.14.0 refuses to wrap rustc unless CARGO_INCREMENTAL is explicitly 0.
+# Cargo-chef's first probe is `sccache rustc -vV`, which trips this guard.
+ENV CARGO_INCREMENTAL=0
+
 WORKDIR /app
 
 COPY apps/rareicon/axum-rareicon/Cargo.workspace.toml Cargo.toml


### PR DESCRIPTION
CI - Docker / discordsh-bot fails:

\`\`\`
Caused by: failed to load manifest for dependency \`bevy_tasker\`
  failed to read \`/app/packages/rust/bevy/bevy_tasker/Cargo.toml\`
  No such file or directory (os error 2)
\`\`\`

\`bevy_db\` carries an optional path dep on \`bevy_tasker\` behind the \`bevy-plugin\` feature. \`cargo chef prepare\` reads every workspace member manifest fully — including optional path deps — so \`bevy_tasker/Cargo.toml\` must be on disk during the planner stage even though discordsh-bot never enables the feature.

Mirror the same workaround already in \`axum-chuckrpg\` / \`axum-kbve\`: copy \`packages/rust/bevy/bevy_tasker/Cargo.toml\` into the planner image and create an empty \`src/lib.rs\` stub. Comment block matches the existing one in chuckrpg so the rationale is documented in both places.

This is unrelated to the sccache CARGO_INCREMENTAL fix in #10663 — that one was about the cargo chef cook stage panicking; this one is about chef prepare failing because a manifest is missing.

## Test plan

- [ ] CI - Docker / discordsh-bot passes after this lands.