### PR TITLE
fix(security): non-https URL gate + droid worker origin check (CodeQL #264, #60)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.136"
+version = "1.0.137"
 dependencies = [
  "anyhow",
  "askama",

--- a/packages/npm/droid/src/lib/workers/supabase-db-worker.ts
+++ b/packages/npm/droid/src/lib/workers/supabase-db-worker.ts
@@ -85,7 +85,17 @@ const memoryStorage = {
 
 console.log('[DB Worker] Initializing...');
 
+// Dedicated workers receive `event.origin === ''` from their owning page;
+// reject anything else to satisfy CodeQL js/missing-origin-check.
+function isAllowedOrigin(event: MessageEvent): boolean {
+	return event.origin === '' || event.origin === self.location.origin;
+}
+
 self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
+	if (!isAllowedOrigin(e)) {
+		console.warn('[DB Worker] Rejected message from origin:', e.origin);
+		return;
+	}
 	const msg = e.data;
 	const { id, type, payload } = msg;
 

--- a/packages/rust/kbve/src/sys/system_diagnostics.rs
+++ b/packages/rust/kbve/src/sys/system_diagnostics.rs
@@ -94,19 +94,24 @@ pub async fn call_n8n_service() -> impl IntoResponse {
     let client = reqwest::Client::new();
 
     // Use env var for internal n8n URL (defaults to public HTTPS endpoint)
-    let n8n_url = std::env::var("N8N_WORKFLOWS_URL")
+    let n8n_url_raw = std::env::var("N8N_WORKFLOWS_URL")
         .unwrap_or_else(|_| "https://automation.kbve.com/workflows".to_string());
 
-    // Enforce HTTPS to prevent cleartext transmission (CodeQL CWE-319)
-    if !n8n_url.starts_with("https://") {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "N8N_WORKFLOWS_URL must use HTTPS"})),
-        );
-    }
+    // Parse and require https. Returning a typed `reqwest::Url` keeps the
+    // scheme check visible to CodeQL `rust/non-https-url` (a `&str.starts_with`
+    // gate is not recognised as a sanitizer).
+    let n8n_url = match reqwest::Url::parse(&n8n_url_raw) {
+        Ok(url) if url.scheme() == "https" => url,
+        _ => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "N8N_WORKFLOWS_URL must use HTTPS"})),
+            );
+        }
+    };
 
     // Attempt to call the primary service
-    if let Ok(resp) = client.get(&n8n_url).send().await {
+    if let Ok(resp) = client.get(n8n_url).send().await {
         if let Ok(json) = resp.json::<Value>().await {
             return (StatusCode::OK, Json(json));
         }


### PR DESCRIPTION
## Summary

Two CodeQL alerts in different packages, both shaped after fixes already landed:

- [#264](https://github.com/KBVE/kbve/security/code-scanning/264) `rust/non-https-url` (high warning) — [system_diagnostics.rs:97](packages/rust/kbve/src/sys/system_diagnostics.rs#L97). `call_n8n_service` resolved `N8N_WORKFLOWS_URL` from env and gated it with `&str.starts_with("https://")`, which the CodeQL Rust query does not recognise as a sanitizer. Parse with `reqwest::Url::parse`, require `scheme() == "https"`, and pass the typed `Url` to `client.get`. Same pattern that closed #434-#438.
- [#60](https://github.com/KBVE/kbve/security/code-scanning/60) `js/missing-origin-check` (medium warning) — [supabase-db-worker.ts:88](packages/npm/droid/src/lib/workers/supabase-db-worker.ts#L88). Add an `isAllowedOrigin` gate on `self.onmessage` — accept only `event.origin === ''` (dedicated-worker default) or an exact match against `self.location.origin`. Same shape that closed #220-#223.

## Notes

- [#256](https://github.com/KBVE/kbve/security/code-scanning/256) (`rust/cleartext-logging` in `apps/mc/plugins/kbve-mc-plugin/src/lib.rs`) is now stale — the file was deleted from the repo. It will auto-close on the next Rust scan.
- Cargo.lock picks up the existing axum-kbve 1.0.137 sync that landed on main between the worktree's branch point and now.

## Verification

- `cargo check --manifest-path packages/rust/kbve/Cargo.toml` — clean (only pre-existing manifest-key warnings).
- `npx nx run droid:lint` reports no lint findings on the edited worker file (the 47 droid lint errors are pre-existing in unrelated files).

## Test plan

- [ ] CI green on `trunk/atom-codeql-non-https-origin-*`
- [ ] Post-merge: confirm next CodeQL runs close #264 + #60