### PR TITLE
feat(astro-kbve): drop splash template for /dashboard pages

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroArgoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroArgoDashboard.astro
@@ -7,7 +7,7 @@ import ReactArgoAppTable from './ReactArgoAppTable';
 
 <section
 	id="argo-dashboard-wrapper"
-	class="argo-dashboard-wrapper"
+	class="argo-dashboard-wrapper kbve-dashboard-page"
 	aria-label="ArgoCD deployment dashboard">
 	<div id="dashboard-content" class="dashboard-content">
 		<ReactArgoAuth client:only="react">
@@ -36,8 +36,7 @@ import ReactArgoAppTable from './ReactArgoAppTable';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.dashboard-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
@@ -10,7 +10,7 @@ import ReactCHQueryTabs from './ReactCHQueryTabs';
 
 <section
 	id="clickhouse-dashboard-wrapper"
-	class="clickhouse-dashboard-wrapper"
+	class="clickhouse-dashboard-wrapper kbve-dashboard-page"
 	aria-label="ClickHouse logs dashboard">
 	<div id="dashboard-content" class="dashboard-content">
 		<ReactCHAuth client:only="react">
@@ -57,8 +57,7 @@ import ReactCHQueryTabs from './ReactCHQueryTabs';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.dashboard-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroDashboardHome.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroDashboardHome.astro
@@ -6,7 +6,7 @@ import ReactHomeServiceCards from './ReactHomeServiceCards';
 
 <section
 	id="dashboard-home-wrapper"
-	class="relative min-h-screen w-screen bg-transparent ml-[calc(-50vw+50%)]"
+	class="kbve-dashboard-page relative min-h-screen w-full bg-transparent"
 	aria-label="Dashboard home">
 	<div
 		id="dashboard-home-content"

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroEdgeDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroEdgeDashboard.astro
@@ -6,7 +6,7 @@ import ReactEdgeStatusGrid from './ReactEdgeStatusGrid';
 
 <section
 	id="edge-dashboard-wrapper"
-	class="edge-dashboard-wrapper"
+	class="edge-dashboard-wrapper kbve-dashboard-page"
 	aria-label="Edge function health dashboard">
 	<div id="dashboard-content" class="dashboard-content">
 		<div class="not-content edge-dashboard">
@@ -33,8 +33,7 @@ import ReactEdgeStatusGrid from './ReactEdgeStatusGrid';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.dashboard-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -9,7 +9,7 @@ import ReactForgejoUserGrid from './ReactForgejoUserGrid';
 
 <section
 	id="forgejo-dashboard-wrapper"
-	class="forgejo-dashboard-wrapper"
+	class="forgejo-dashboard-wrapper kbve-dashboard-page"
 	aria-label="Forgejo repository dashboard">
 	<div id="dashboard-content" class="dashboard-content">
 		<ReactForgejoAuth client:only="react">
@@ -48,8 +48,7 @@ import ReactForgejoUserGrid from './ReactForgejoUserGrid';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.dashboard-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
@@ -8,7 +8,7 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 
 <section
 	id="grafana-dashboard-wrapper"
-	class="grafana-dashboard-wrapper"
+	class="grafana-dashboard-wrapper kbve-dashboard-page"
 	aria-label="Grafana monitoring dashboard">
 	<div id="dashboard-content" class="dashboard-content">
 		<ReactGrafanaAuth client:only="react">
@@ -44,8 +44,7 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.dashboard-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroIDEDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroIDEDashboard.astro
@@ -5,7 +5,7 @@ import ReactCodeIDE from './ReactCodeIDE';
 
 <section
 	id="ide-dashboard-wrapper"
-	class="ide-dashboard-wrapper"
+	class="ide-dashboard-wrapper kbve-dashboard-page"
 	aria-label="Firecracker IDE dashboard">
 	<div id="dashboard-content" class="dashboard-content">
 		<ReactVMAuth client:only="react">
@@ -21,8 +21,7 @@ import ReactCodeIDE from './ReactCodeIDE';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.dashboard-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKasmDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKasmDashboard.astro
@@ -5,7 +5,7 @@ import ReactKasmViewer from './ReactKasmViewer';
 
 <section
 	id="kasm-dashboard-wrapper"
-	class="kasm-dashboard-wrapper"
+	class="kasm-dashboard-wrapper kbve-dashboard-page"
 	aria-label="KASM Workspace Viewer">
 	<div id="kasm-content" class="kasm-content">
 		<ReactVMAuth client:only="react">
@@ -21,8 +21,7 @@ import ReactKasmViewer from './ReactKasmViewer';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.kasm-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroRowsDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroRowsDashboard.astro
@@ -5,7 +5,7 @@ import ReactRowsDashboard from './ReactRowsDashboard';
 
 <section
 	id="rows-dashboard-wrapper"
-	class="rows-dashboard-wrapper"
+	class="rows-dashboard-wrapper kbve-dashboard-page"
 	aria-label="ROWS Game Operations Dashboard">
 	<div id="rows-dashboard-content" class="rows-dashboard-content">
 		<ReactHomeAuth client:only="react">
@@ -21,8 +21,7 @@ import ReactRowsDashboard from './ReactRowsDashboard';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.rows-dashboard-content {

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroVMDashboard.astro
@@ -10,7 +10,7 @@ import ReactFirecrackerCards from './ReactFirecrackerCards';
 
 <section
 	id="vm-dashboard-wrapper"
-	class="vm-dashboard-wrapper"
+	class="vm-dashboard-wrapper kbve-dashboard-page"
 	aria-label="Virtual Machine dashboard">
 	<div id="dashboard-content" class="dashboard-content">
 		<ReactVMAuth client:only="react">
@@ -47,8 +47,7 @@ import ReactFirecrackerCards from './ReactFirecrackerCards';
 		background: transparent;
 		min-height: 100vh;
 		position: relative;
-		width: 100vw;
-		margin-left: calc(-50vw + 50%);
+		width: 100%;
 	}
 
 	.dashboard-content {

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/argo/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/argo/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: ArgoCD Dashboard
 description: KBVE Cluster Deployment Dashboard
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/clickhouse/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/clickhouse/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: ClickHouse Logs
 description: KBVE Cluster Log Aggregation Dashboard
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/edge/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/edge/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Edge Functions
 description: KBVE Edge Function Health Dashboard
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/forgejo/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/forgejo/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Forgejo Dashboard
 description: KBVE Forgejo Repository Dashboard
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/grafana/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/grafana/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Grafana Dashboard
 description: KBVE Cluster Monitoring Dashboard
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/ide/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/ide/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Firecracker IDE
 description: Browser-based Python IDE running in Firecracker microVMs
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Dashboard
 description: KBVE Dashboard
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/rows/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/rows/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: ROWS Dashboard
 description: ChuckRPG Game Server Operations Dashboard
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: VM Dashboard
 description: KubeVirt Virtual Machine Control Panel
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/kasm/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/kasm/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: KASM Workspace
 description: KASM Workspace Viewer
-template: splash
 tableOfContents: false
 graph:
     visible: false

--- a/apps/kbve/astro-kbve/src/styles/global.css
+++ b/apps/kbve/astro-kbve/src/styles/global.css
@@ -670,3 +670,18 @@ html[data-nav-dir='back']::view-transition-new(root) {
 	--sg-osrs-fill: #b8860b;
 	--sg-osrs-stroke: #6b4a05;
 }
+
+/* ── Dashboard pages: expand the Starlight content column ──
+   Dashboards render data-dense cards / charts and shouldn't be constrained
+   by the default ~50rem content width. Any page rendering a dashboard
+   component marks its top-level wrapper with .kbve-dashboard-page; the
+   :has() selector here applies the wide layout only on those pages. The
+   left sidebar and right TOC stay where they are — only the content area
+   between them widens. */
+body:has(.kbve-dashboard-page)
+	:is(.sl-markdown-content, main.main-pane, .content-panel article.content) {
+	max-width: 100% !important;
+}
+body:has(.kbve-dashboard-page) {
+	--sl-content-width: 100%;
+}


### PR DESCRIPTION
## Summary
Switches the staff dashboard surface to Starlight's default docs template instead of the marketing splash. Sidebar + breadcrumb come back, content column expands to full width on dashboard pages only.

## Why
\`splash\` is meant for marketing landings — full-bleed hero, no sidebar, no breadcrumb. The dashboards are data-dense and heavily multi-page (\`/dashboard\` + Grafana / Argo / ClickHouse / VM / Forgejo / Edge / IDE / Rows / KASM). Without a sidebar you have to memorize URLs to hop between them, which broke the "everything one click away" goal that motivated all the recent observability work.

Each dashboard page now gets:
- **Left sidebar** — free dashboard-to-dashboard navigation (the \`sidebar.order\` values already grouped them under one header).
- **Breadcrumb** at the top of every page so you always know where you are inside the dashboard tree.
- Auth-gated visibility from the existing \`data-auth-visibility\` attributes works as before.

## Wide-content override
To keep the data-dense layout (cards, charts, log tables) we override Starlight's default ~50rem content column width on dashboard pages **only**:
- Each \`Astro*Dashboard\` component adds a marker class \`kbve-dashboard-page\` to its outermost wrapper.
- A single \`body:has(.kbve-dashboard-page)\` rule in [\`global.css\`](apps/kbve/astro-kbve/src/styles/global.css) drops the content-area \`max-width\` and the \`--sl-content-width\` variable to 100%.
- The left sidebar and right TOC stay where they are — only the content column between them widens.

## Cleanup
Drops the \`width: 100vw; margin-left: calc(-50vw + 50%);\` escape hatch from each \`Astro*Dashboard.astro\`. That hack was needed under \`splash\` to break out of the centered marketing column. Under the default template the content column is already the available horizontal area (between sidebar + TOC), so a plain \`width: 100%\` fills it without overlapping the sidebar.

\`AstroDashboardHome.astro\` had the same hack expressed in Tailwind (\`w-screen ml-[calc(-50vw+50%)]\`) — same drop, same \`kbve-dashboard-page\` class added.

## Pages migrated
- \`/dashboard\` (overview)
- \`/dashboard/grafana\`
- \`/dashboard/argo\`
- \`/dashboard/clickhouse\`
- \`/dashboard/vm\`
- \`/dashboard/vm/kasm\`
- \`/dashboard/forgejo\`
- \`/dashboard/edge\`
- \`/dashboard/ide\`
- \`/dashboard/rows\`

## Out of scope
- \`AstroSettings.astro\` and \`AstroKanbanDashboard.astro\` keep their existing wrappers — Settings isn't currently mounted on any dashboard mdx (scaffold for future), and Kanban already used the default template (no splash to remove). Both can pick up the marker class in a follow-up if they migrate to the new layout.

## Test plan
- [x] No new TS errors introduced (\`nx run astro-kbve:check\` baseline unchanged at 73 pre-existing proto errors).
- [ ] All 10 dashboard pages render with sidebar + breadcrumb + wide content area; cards/charts use full available width without overlapping the sidebar.
- [ ] Non-dashboard pages (docs / project / icons) keep the default ~50rem content column — wide override doesn't leak.
- [ ] Auth-gated sidebar links still hide/show correctly under \`data-auth-tone="anon"\` / \`auth\` / \`staff\`.
- [ ] No regression on view-transition cross-fades between dashboard pages.