### PR TITLE
fix(pydesk): build droid command status via DOM API (CodeQL #11)

### DIFF
--- a/apps/pydesk/templates/home.html
+++ b/apps/pydesk/templates/home.html
@@ -2343,13 +2343,23 @@
 					
 					try {
 						if (window.kbve && window.kbve !== null) {
-							// Use the KBVE system
-							outputDiv.innerHTML = `
-								<div class="text-blue-600">Command: ${command}</div>
-								<div class="text-gray-600">Executing via KBVE system...</div>
-								<div class="text-xs text-gray-500">User: ${window.AuthStateManager.getCurrentUser()?.email}</div>
-								<div class="text-xs text-gray-500">Timestamp: ${new Date().toISOString()}</div>
-							`;
+							// Use the KBVE system. Build the status block via the DOM
+							// API so user-controlled `command` and `email` go through
+							// `textContent` rather than `innerHTML` (CodeQL js/xss-through-dom).
+							outputDiv.replaceChildren();
+							const cmdLine = document.createElement('div');
+							cmdLine.className = 'text-blue-600';
+							cmdLine.textContent = `Command: ${command}`;
+							const execLine = document.createElement('div');
+							execLine.className = 'text-gray-600';
+							execLine.textContent = 'Executing via KBVE system...';
+							const userLine = document.createElement('div');
+							userLine.className = 'text-xs text-gray-500';
+							userLine.textContent = `User: ${window.AuthStateManager.getCurrentUser()?.email ?? ''}`;
+							const tsLine = document.createElement('div');
+							tsLine.className = 'text-xs text-gray-500';
+							tsLine.textContent = `Timestamp: ${new Date().toISOString()}`;
+							outputDiv.append(cmdLine, execLine, userLine, tsLine);
 							
 							// Clear the input
 							commandInput.value = '';


### PR DESCRIPTION
## Summary

CodeQL [#11](https://github.com/KBVE/kbve/security/code-scanning/11) `js/xss-through-dom` (high) — [home.html:2347](apps/pydesk/templates/home.html#L2347).

`executeDroidCommand` interpolated the user-controlled `command` value (and the current user's `email`) into a template literal that was then assigned to `outputDiv.innerHTML`. A command like `<img src=x onerror=alert(1)>` would execute on submit.

## Fix

Rebuild the status block with `document.createElement` and assign every user-controlled value via `textContent`. The static "Executing via KBVE system…" line keeps its identical text; the same four `<div>` elements with the same Tailwind classes are appended in order.

## Out of scope

This template has many other `innerHTML` writes (status panels, balance info, etc.). None are flagged by CodeQL because they're built from server-rendered or hard-coded values; leaving them alone keeps this PR scoped to the actual XSS source.

## Test plan

- [ ] CI green on `trunk/atom-codeql-pydesk-xss-*`
- [ ] Manual: enter a droid command containing `<b>foo</b>` — output should display the literal text, not bold.
- [ ] Post-merge: confirm next JS/TS CodeQL run on `main` closes #11