### PR TITLE
chore(astro-kbve): drop dead locals + imports flagged by CodeQL

### DIFF
--- a/apps/kbve/astro-kbve/src/components/discord/ReactDiscordProfile.tsx
+++ b/apps/kbve/astro-kbve/src/components/discord/ReactDiscordProfile.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 export interface ReactDiscordProfileProps {
 	username: string;
 	avatarUrl?: string;

--- a/apps/kbve/astro-kbve/src/components/jay/ReactJayYuki.tsx
+++ b/apps/kbve/astro-kbve/src/components/jay/ReactJayYuki.tsx
@@ -1,11 +1,4 @@
-import {
-	useRef,
-	useState,
-	Suspense,
-	useCallback,
-	useEffect,
-	useMemo,
-} from 'react';
+import { useRef, useState, Suspense, useCallback, useEffect } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { useGLTF, Html, OrbitControls, useAnimations } from '@react-three/drei';
 import * as THREE from 'three';

--- a/apps/kbve/astro-kbve/src/components/realtime/ReactSupaRealtime.tsx
+++ b/apps/kbve/astro-kbve/src/components/realtime/ReactSupaRealtime.tsx
@@ -4,9 +4,9 @@
  * Uses the Supa SharedWorker for actual connections, Web Worker for data processing
  */
 
-import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import type { FC } from 'react';
-import { useSupa, useSession } from '@/components/providers/SupaProvider';
+import { useSession } from '@/components/providers/SupaProvider';
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from '@/lib/supa';
 import { WorkerMessageType } from './typeRealtime';
 import type {
@@ -16,7 +16,6 @@ import type {
 	ChannelSubscription,
 	WorkerInboundMessage,
 	WorkerOutboundMessage,
-	RealtimeConnectionState,
 	SubscriptionCallback,
 } from './typeRealtime';
 
@@ -35,8 +34,7 @@ export const ReactSupaRealtime: FC<RealtimeContainerProps> = ({
 	reconnectDelay = 5000,
 }) => {
 	// Supa context
-	const supa = useSupa();
-	const { session, ready: sessionReady } = useSession();
+	const { session } = useSession();
 
 	// Worker ref
 	const workerRef = useRef<Worker | null>(null);
@@ -55,19 +53,6 @@ export const ReactSupaRealtime: FC<RealtimeContainerProps> = ({
 
 	// Subscription callbacks
 	const callbacksRef = useRef<Map<string, SubscriptionCallback>>(new Map());
-
-	/**
-	 * Connection state
-	 */
-	const connectionState: RealtimeConnectionState = useMemo(
-		() => ({
-			status,
-			error: error || undefined,
-			subscriptionCount: subscriptions.size,
-			lastConnected: lastConnected || undefined,
-		}),
-		[status, error, subscriptions.size, lastConnected],
-	);
 
 	/**
 	 * Handle worker messages
@@ -266,35 +251,6 @@ export const ReactSupaRealtime: FC<RealtimeContainerProps> = ({
 			setSubscriptions((prev) => new Map(prev).set(id, fullSubscription));
 
 			return id;
-		},
-		[],
-	);
-
-	/**
-	 * Unsubscribe from a channel
-	 */
-	const unsubscribe = useCallback(
-		async (subscriptionId: string): Promise<void> => {
-			if (!workerRef.current) {
-				throw new Error('Worker not initialized');
-			}
-
-			// Send unsubscribe message to worker
-			const message: WorkerInboundMessage = {
-				type: WorkerMessageType.UNSUBSCRIBE,
-				payload: { id: subscriptionId },
-			};
-			workerRef.current.postMessage(message);
-
-			// Remove callback
-			callbacksRef.current.delete(subscriptionId);
-
-			// Update local state
-			setSubscriptions((prev) => {
-				const next = new Map(prev);
-				next.delete(subscriptionId);
-				return next;
-			});
 		},
 		[],
 	);

--- a/apps/kbve/astro-kbve/src/components/realtime/Realtime.worker.ts
+++ b/apps/kbve/astro-kbve/src/components/realtime/Realtime.worker.ts
@@ -286,7 +286,7 @@ function renderToCanvas(event: RealtimeEvent) {
 		const radius = 5;
 
 		// Color based on event type
-		let color = '#ffffff';
+		let color: string;
 		switch (event.type) {
 			case 'INSERT' as RealtimeEventType:
 				color = '#4CAF50'; // Green


### PR DESCRIPTION
## Summary

Cleans up seven CodeQL note-level alerts in `apps/kbve/astro-kbve`:

| Alert | File | Removed |
|---|---|---|
| [#236](https://github.com/KBVE/kbve/security/code-scanning/236) | [ReactDiscordProfile.tsx](apps/kbve/astro-kbve/src/components/discord/ReactDiscordProfile.tsx) | unused `useEffect` / `useState` imports |
| [#237](https://github.com/KBVE/kbve/security/code-scanning/237) | [ReactJayYuki.tsx](apps/kbve/astro-kbve/src/components/jay/ReactJayYuki.tsx) | unused `useMemo` import |
| [#238](https://github.com/KBVE/kbve/security/code-scanning/238) | [ReactSupaRealtime.tsx:38](apps/kbve/astro-kbve/src/components/realtime/ReactSupaRealtime.tsx#L38) | `const supa = useSupa()` |
| [#239](https://github.com/KBVE/kbve/security/code-scanning/239) | [ReactSupaRealtime.tsx:39](apps/kbve/astro-kbve/src/components/realtime/ReactSupaRealtime.tsx#L39) | `ready: sessionReady` alias |
| [#240](https://github.com/KBVE/kbve/security/code-scanning/240) | [ReactSupaRealtime.tsx:62](apps/kbve/astro-kbve/src/components/realtime/ReactSupaRealtime.tsx#L62) | `connectionState` useMemo block |
| [#241](https://github.com/KBVE/kbve/security/code-scanning/241) | [ReactSupaRealtime.tsx:276](apps/kbve/astro-kbve/src/components/realtime/ReactSupaRealtime.tsx#L276) | `unsubscribe` useCallback block |
| [#228](https://github.com/KBVE/kbve/security/code-scanning/228) | [Realtime.worker.ts:289](apps/kbve/astro-kbve/src/components/realtime/Realtime.worker.ts#L289) | useless `let color = '#ffffff'` initial value (every switch arm including `default` writes before read) |

Removing the four `ReactSupaRealtime` declarations cascades the `useSupa` named import, the `useMemo` named import, and the `RealtimeConnectionState` type import out as well — none had any other consumer in the file.

## Notes on stale alerts in this category

- [#248](https://github.com/KBVE/kbve/security/code-scanning/248) (`statusMessages` in `ReactUserProfile.tsx`) — file no longer exists.
- [#485](https://github.com/KBVE/kbve/security/code-scanning/485) (`auth` in `astro-memes/ReactMemeContent.tsx`) — already refactored on `main` (the `const auth = ...` binding is gone).

Both should auto-close on the next JS/TS CodeQL run.

## Verification

`npx tsc --noEmit -p apps/kbve/astro-kbve/tsconfig.json` — no new errors in any of the four edited files.

## Test plan

- [ ] CI green on `trunk/atom-codeql-unused-locals-*`
- [ ] Post-merge: confirm next JS/TS CodeQL run on `main` closes #228, #236-#241