### PR TITLE
fix(docker): copy bevy_tasker source into discordsh-bot foundation + builder

### DIFF
--- a/apps/discordsh/discordsh-bot/Dockerfile
+++ b/apps/discordsh/discordsh-bot/Dockerfile
@@ -98,6 +98,11 @@ COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 COPY packages/rust/bevy/bevy_mapdb packages/rust/bevy/bevy_mapdb
 COPY packages/rust/bevy/bevy_pathfinder packages/rust/bevy/bevy_pathfinder
 COPY packages/rust/bevy/bevy_db packages/rust/bevy/bevy_db
+# bevy_db carries an optional path dep on bevy_tasker behind the
+# "bevy-plugin" feature; cargo reads the dep manifest even when the
+# feature is off, so the source must exist on disk in this stage too
+# (planner stage already copies it — see #10668).
+COPY packages/rust/bevy/bevy_tasker packages/rust/bevy/bevy_tasker
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -129,6 +134,8 @@ COPY packages/rust/bevy/bevy_chat packages/rust/bevy/bevy_chat
 COPY packages/rust/bevy/bevy_mapdb packages/rust/bevy/bevy_mapdb
 COPY packages/rust/bevy/bevy_pathfinder packages/rust/bevy/bevy_pathfinder
 COPY packages/rust/bevy/bevy_db packages/rust/bevy/bevy_db
+# bevy_db -> bevy_tasker (optional path dep, gated on bevy-plugin feature)
+COPY packages/rust/bevy/bevy_tasker packages/rust/bevy/bevy_tasker
 
 # Application source (most frequently changing — placed last for cache)
 COPY apps/discordsh/discordsh-bot apps/discordsh/discordsh-bot


### PR DESCRIPTION
Closes #10676.

## Root cause
#10668 added the \`bevy_tasker\` \`Cargo.toml\` to the **planner** stage so \`cargo chef prepare\` could resolve the optional path dep \`bevy_db -> bevy_tasker\` (gated behind the \`bevy-plugin\` feature). The follow-up \`cargo build --release\` in the **foundation** stage (and the application build in the **builder** stage) read the dep manifest even when the feature is off, so the source needs to be on disk in those stages too — only the planner stage was patched.

Production failure (\`#56 [foundation 23/23]\`):

\`\`\`
error: failed to load manifest for workspace member \`/app/apps/discordsh/discordsh-bot\`
referenced by workspace at \`/app/Cargo.toml\`

Caused by:
  failed to load manifest for dependency \`bevy_db\`
Caused by:
  failed to load manifest for dependency \`bevy_tasker\`
Caused by:
  failed to read \`/app/packages/rust/bevy/bevy_tasker/Cargo.toml\`
  No such file or directory (os error 2)
\`\`\`

## Fix
Add \`COPY packages/rust/bevy/bevy_tasker\` to both the **foundation** and **builder** stages to mirror the planner. The \`bevy-plugin\` feature stays disabled here — \`bevy_tasker\` only needs to *exist* so cargo's manifest read succeeds.

## Test plan
- [ ] \`CI - Docker / discordsh-bot\` succeeds end-to-end on next dispatch.
- [ ] \`docker build -f apps/discordsh/discordsh-bot/Dockerfile .\` completes locally.
- [ ] No regression on existing image — \`discordsh-bot\` runtime size unchanged (only Cargo.toml + sources reach the foundation/builder, none of it lands in the runtime stage).