### PR TITLE
feat(discordsh): drop /dungeon start args, add class-picker for fresh players

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/bot.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/bot.rs
@@ -130,6 +130,8 @@ async fn event_handler(
                 components::handle_status_component(component, ctx, data)
                     .await
                     .map(|_| ())
+            } else if custom_id.starts_with("dngclass|") {
+                components::class_picker::handle_class_pick(component, ctx, data).await
             } else if custom_id.starts_with("dng|") {
                 super::game::router::handle_game_component(component, ctx, data).await
             } else if custom_id.starts_with("gh|") {

--- a/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-use std::time::Instant;
-
 use poise::serenity_prelude as serenity;
 
 use kbve::MemberStatus;
 
 use crate::discord::bot::{Context, Error};
-use crate::discord::game::{self, card, content, pathfinding, persistence, render, types::*};
+use crate::discord::components::class_picker;
+use crate::discord::game::{card, content, launch, pathfinding, persistence, render, types::*};
 
 /// Dungeon crawler game — stress-test embeds, buttons, and select menus.
 #[poise::command(
@@ -17,18 +15,15 @@ pub async fn dungeon(_ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
 }
 
-/// Start a new dungeon session.
+/// Start a Party-mode dungeon session. First-time players pick a class.
 #[poise::command(slash_command)]
-async fn start(
-    ctx: Context<'_>,
-    #[description = "Session mode"] mode: Option<String>,
-    #[description = "Choose your class (warrior/rogue/cleric)"] class: Option<String>,
-) -> Result<(), Error> {
+async fn start(ctx: Context<'_>) -> Result<(), Error> {
     let user = ctx.author().id;
     let channel = ctx.channel_id();
+    let app = &ctx.data().app;
 
-    // Check for existing session in this channel
-    if let Some(existing) = ctx.data().app.sessions.find_by_channel(channel) {
+    // Bail if a session already exists in this channel.
+    if let Some(existing) = app.sessions.find_by_channel(channel) {
         ctx.send(
             poise::CreateReply::default()
                 .content(format!(
@@ -41,167 +36,74 @@ async fn start(
         return Ok(());
     }
 
-    let session_mode = match mode.as_deref() {
-        Some("party") => SessionMode::Party,
-        _ => SessionMode::Solo,
+    // Resolve the player's class from their saved profile, or send an
+    // ephemeral class picker if they don't have one yet. The picker's
+    // button handler resumes this same launch flow.
+    let saved_profile = app.profiles.load(user.get()).await;
+    let resolved_class = saved_profile
+        .as_ref()
+        .and_then(persistence::class_from_profile);
+    let Some(player_class) = resolved_class else {
+        let embed = class_picker::picker_embed();
+        let components = class_picker::picker_components();
+        ctx.send(
+            poise::CreateReply::default()
+                .content("You don't have a character yet — pick a class to begin.")
+                .embed(embed)
+                .components(components)
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
     };
 
-    let player_class = match class.as_deref() {
-        Some("rogue") => ClassType::Rogue,
-        Some("cleric") => ClassType::Cleric,
-        _ => ClassType::Warrior,
-    };
+    let user_display_name = ctx.author().name.clone();
+    let launched =
+        match launch::prepare_launch(app, user, &user_display_name, channel, player_class).await {
+            Ok(l) => l,
+            Err(reason) => {
+                ctx.send(
+                    poise::CreateReply::default()
+                        .content(format!("Cannot start dungeon: {}", reason))
+                        .ephemeral(true),
+                )
+                .await?;
+                return Ok(());
+            }
+        };
 
-    let (id, short_id) = game::new_short_sid();
-
-    // Claim the play mode lock — prevents the same player from being in
-    // both Discord dungeon AND isometric game at the same time (data race
-    // on profile saves). Returns a RAII guard that releases on drop unless
-    // we explicitly commit() after the session is fully created.
-    // Gracefully degrades to a no-op guard if Supabase is down.
-    let mode_guard = match ctx
-        .data()
-        .app
-        .profiles
-        .claim_mode(user.get(), &short_id, false)
-        .await
-    {
-        Ok(g) => g,
-        Err(reason) => {
-            ctx.send(
-                poise::CreateReply::default()
-                    .content(format!("Cannot start dungeon: {}", reason))
-                    .ephemeral(true),
-            )
-            .await?;
-            return Ok(());
-        }
-    };
-
-    let map = content::generate_initial_map(&id);
-    let room = content::room_from_tile(map.tiles.get(&map.position).unwrap());
-    let phase = GamePhase::City;
-    let enemies = Vec::new();
-
-    // Membership lookup (cached, gracefully degrades to Guest)
-    let member_status_raw = ctx.data().app.members.lookup(user.get()).await;
-    let (player_name, member_tag) = match &member_status_raw {
-        MemberStatus::Member(profile) => (
-            profile
-                .discord_username
-                .clone()
-                .unwrap_or_else(|| ctx.author().name.clone()),
-            MemberStatusTag::Member {
-                username: profile
-                    .discord_username
-                    .clone()
-                    .unwrap_or_else(|| ctx.author().name.clone()),
-            },
-        ),
-        MemberStatus::Guest { .. } => (ctx.author().name.clone(), MemberStatusTag::Guest),
-    };
-
-    let (class_hp, class_armor, class_dmg, class_crit, class_gold) =
-        content::class_starting_stats(&player_class);
-
-    let mut player = PlayerState {
-        name: player_name,
-        inventory: content::starting_inventory(),
-        member_status: member_tag,
-        class: player_class,
-        max_hp: class_hp,
-        hp: class_hp,
-        armor: class_armor,
-        gold: class_gold,
-        base_damage_bonus: class_dmg,
-        crit_chance: class_crit,
-        ..PlayerState::default()
-    };
-
-    // Load persisted profile and apply to player
-    let mut quest_journal = QuestJournal::default();
-    let saved_profile = ctx.data().app.profiles.load(user.get()).await;
-    if let Some(ref profile) = saved_profile {
-        persistence::apply_profile_to_player(profile, &mut player, &mut quest_journal);
-        player.saved_snapshot = Some(profile.clone());
-    }
-
-    // We need to send the message first to get the MessageId
-    let session_state = SessionState {
-        id,
-        short_id: short_id.clone(),
-        owner: user,
-        party: Vec::new(),
-        mode: session_mode.clone(),
-        phase,
-        channel_id: channel,
-        message_id: serenity::MessageId::new(1), // placeholder, updated below
-        created_at: Instant::now(),
-        last_action_at: Instant::now(),
-        turn: 0,
-        players: HashMap::from([(user, player)]),
-        enemies,
-        room,
-        log: vec![
-            "You arrive at the Underground City. Prepare your party before venturing out..."
-                .to_owned(),
-        ],
-        show_items: false,
-        pending_actions: HashMap::new(),
-        map,
-        show_map: true,
-        show_inventory: false,
-        pending_destination: None,
-        enemies_had_first_strike: false,
-        quest_journal,
-        active_dialogue: None,
-    };
-
-    let components = render::render_components(&session_state);
-
-    // Render game card PNG (CPU-bound, runs on blocking thread)
-    let fontdb = ctx.data().app.fontdb.clone();
-    let card_png = card::render_game_card(&session_state, fontdb).await;
-    if let Err(ref e) = card_png {
-        tracing::warn!(error = %e, "Failed to render game card for /dungeon start");
-    }
-    let has_card = card_png.is_ok();
-    let embed = render::render_embed(&session_state, has_card);
-
-    let mode_label = match session_mode {
-        SessionMode::Solo => "Solo",
-        SessionMode::Party => "Party",
-    };
+    let launch::Launched {
+        session_state,
+        mode_guard,
+        embed,
+        components,
+        card_png,
+        member_status,
+        short_id,
+        ..
+    } = launched;
 
     let mut create_reply = poise::CreateReply::default()
         .content(format!(
-            "**Embed Dungeon** started! ({} mode, session `{}`)",
-            mode_label, short_id
+            "**Embed Dungeon** started! (Party mode, session `{}`)",
+            short_id
         ))
         .embed(embed)
         .components(components);
 
-    if let Ok(png) = card_png {
+    if let Some(png) = card_png {
         create_reply =
             create_reply.attachment(serenity::CreateAttachment::bytes(png, "game_card.png"));
     }
 
     let reply = ctx.send(create_reply).await?;
-
-    // Get the message ID from the reply
     let msg = reply.message().await?;
-    let mut final_state = session_state;
-    final_state.message_id = msg.id;
+    let message_id = msg.id;
 
-    ctx.data().app.sessions.create(final_state);
+    let member_status_for_notice = member_status;
+    launch::commit_launch(app, session_state, mode_guard, message_id);
 
-    // Session is fully registered — release the lock from the guard's
-    // ownership. Future release will happen via save_all_players when
-    // the session ends naturally.
-    mode_guard.commit();
-
-    // One-time guest notice
-    if let MemberStatus::Guest { notified } = &member_status_raw
+    if let MemberStatus::Guest { notified } = &member_status_for_notice
         && !notified
     {
         ctx.send(
@@ -213,7 +115,7 @@ async fn start(
                 .ephemeral(true),
         )
         .await?;
-        ctx.data().app.members.mark_notified(user.get());
+        app.members.mark_notified(user.get());
     }
 
     Ok(())

--- a/apps/discordsh/discordsh-bot/src/discord/components/class_picker.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/class_picker.rs
@@ -1,0 +1,233 @@
+//! Class-picker component — shown to a player who runs `/dungeon
+//! start` without a saved profile (their first run, or a future
+//! permadeath wipe). Three buttons, one per class. Clicking a button
+//! launches a dungeon session with the chosen class and edits the
+//! ephemeral picker into a confirmation.
+//!
+//! Custom ID format: `dngclass|<class>` where `<class>` is one of
+//! `warrior` / `rogue` / `cleric`.
+
+use poise::serenity_prelude as serenity;
+use tracing::{error, warn};
+
+use kbve::MemberStatus;
+
+use crate::discord::bot::{Data, Error};
+use crate::discord::game::launch;
+use crate::discord::game::types::ClassType;
+
+// ── Custom IDs ──────────────────────────────────────────────────────
+
+const ID_WARRIOR: &str = "dngclass|warrior";
+const ID_ROGUE: &str = "dngclass|rogue";
+const ID_CLERIC: &str = "dngclass|cleric";
+
+// ── Picker UI ───────────────────────────────────────────────────────
+
+/// Embed describing each class and its starting kit. Shown in the
+/// ephemeral message that accompanies the picker buttons.
+pub fn picker_embed() -> serenity::CreateEmbed {
+    serenity::CreateEmbed::new()
+        .title("Choose your character")
+        .description(
+            "You only get one. Pick the class you want to play; this \
+             choice persists across runs until your character dies.",
+        )
+        .field(
+            "\u{2694} Warrior",
+            "High HP, heavy armor, reliable damage. Starts with a \
+             worn longsword and battered chainmail.",
+            true,
+        )
+        .field(
+            "\u{1F5E1} Rogue",
+            "Low HP, high crit, ambush bonus and flee chance. Starts \
+             with a tarnished dagger and leather scraps.",
+            true,
+        )
+        .field(
+            "\u{2728} Cleric",
+            "Balanced HP, healing access, faction perks. Starts with \
+             a cracked mace and woven robes.",
+            true,
+        )
+        .color(0x5865F2)
+}
+
+/// Three-button row: Warrior / Rogue / Cleric.
+pub fn picker_components() -> Vec<serenity::CreateActionRow> {
+    vec![serenity::CreateActionRow::Buttons(vec![
+        serenity::CreateButton::new(ID_WARRIOR)
+            .label("Warrior")
+            .style(serenity::ButtonStyle::Primary)
+            .emoji(serenity::ReactionType::Unicode("\u{2694}".to_owned())),
+        serenity::CreateButton::new(ID_ROGUE)
+            .label("Rogue")
+            .style(serenity::ButtonStyle::Secondary)
+            .emoji(serenity::ReactionType::Unicode("\u{1F5E1}".to_owned())),
+        serenity::CreateButton::new(ID_CLERIC)
+            .label("Cleric")
+            .style(serenity::ButtonStyle::Success)
+            .emoji(serenity::ReactionType::Unicode("\u{2728}".to_owned())),
+    ])]
+}
+
+/// Parse a `dngclass|<class>` custom id into the picked class.
+fn class_from_custom_id(custom_id: &str) -> Option<ClassType> {
+    match custom_id {
+        ID_WARRIOR => Some(ClassType::Warrior),
+        ID_ROGUE => Some(ClassType::Rogue),
+        ID_CLERIC => Some(ClassType::Cleric),
+        _ => None,
+    }
+}
+
+// ── Handler ─────────────────────────────────────────────────────────
+
+/// Handle a click on a class-picker button. Builds the dungeon
+/// session, posts the public dungeon message in the same channel,
+/// then edits the ephemeral picker into a confirmation.
+pub async fn handle_class_pick(
+    interaction: &serenity::ComponentInteraction,
+    ctx: &serenity::Context,
+    data: &Data,
+) -> Result<(), Error> {
+    let custom_id = interaction.data.custom_id.as_str();
+    let Some(picked_class) = class_from_custom_id(custom_id) else {
+        return Ok(());
+    };
+
+    let user = interaction.user.id;
+    let channel = interaction.channel_id;
+    let app = &data.app;
+
+    // Bail if a session has been started in this channel since the
+    // picker was sent (race with another player or an end/start cycle).
+    if let Some(existing) = app.sessions.find_by_channel(channel) {
+        let _ = interaction
+            .create_response(
+                &ctx.http,
+                serenity::CreateInteractionResponse::UpdateMessage(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content(format!(
+                            "A session ({}) is already running in this channel — end it first.",
+                            existing
+                        ))
+                        .embeds(Vec::new())
+                        .components(Vec::new()),
+                ),
+            )
+            .await;
+        return Ok(());
+    }
+
+    let user_display_name = interaction.user.name.clone();
+    let launched =
+        match launch::prepare_launch(app, user, &user_display_name, channel, picked_class).await {
+            Ok(l) => l,
+            Err(reason) => {
+                let _ = interaction
+                    .create_response(
+                        &ctx.http,
+                        serenity::CreateInteractionResponse::UpdateMessage(
+                            serenity::CreateInteractionResponseMessage::new()
+                                .content(format!("Cannot start dungeon: {}", reason))
+                                .embeds(Vec::new())
+                                .components(Vec::new()),
+                        ),
+                    )
+                    .await;
+                return Ok(());
+            }
+        };
+
+    let launch::Launched {
+        session_state,
+        mode_guard,
+        embed,
+        components,
+        card_png,
+        member_status,
+        short_id,
+        ..
+    } = launched;
+
+    // Acknowledge the button click first by rewriting the ephemeral
+    // picker into a confirmation. Failing to ack within ~3s leaves the
+    // user with a "interaction failed" toast, so do this before the
+    // public dungeon message goes out.
+    if let Err(e) = interaction
+        .create_response(
+            &ctx.http,
+            serenity::CreateInteractionResponse::UpdateMessage(
+                serenity::CreateInteractionResponseMessage::new()
+                    .content(format!(
+                        "Character created — **{}**. Dungeon starting below.",
+                        class_label(picked_class)
+                    ))
+                    .embeds(Vec::new())
+                    .components(Vec::new()),
+            ),
+        )
+        .await
+    {
+        warn!(error = %e, "Failed to update class-picker ephemeral");
+    }
+
+    // Send the public dungeon message in the same channel. This is
+    // what `/dungeon join` and the action buttons attach to.
+    let mut create_message = serenity::CreateMessage::new()
+        .content(format!(
+            "**Embed Dungeon** started! (Party mode, session `{}`)",
+            short_id
+        ))
+        .embed(embed)
+        .components(components);
+    if let Some(png) = card_png {
+        create_message =
+            create_message.add_file(serenity::CreateAttachment::bytes(png, "game_card.png"));
+    }
+
+    let posted = match channel.send_message(&ctx.http, create_message).await {
+        Ok(msg) => msg,
+        Err(e) => {
+            error!(
+                error = %e,
+                "Failed to post dungeon message after class pick — releasing mode lock"
+            );
+            // mode_guard's Drop releases the play-mode lock so the
+            // user isn't stuck if the message send fails.
+            drop(mode_guard);
+            return Ok(());
+        }
+    };
+
+    launch::commit_launch(app, session_state, mode_guard, posted.id);
+
+    if let MemberStatus::Guest { notified } = &member_status
+        && !notified
+    {
+        let _ = interaction
+            .create_followup(
+                &ctx.http,
+                serenity::CreateInteractionResponseFollowup::new()
+                    .content(
+                        "You're playing as a **Guest**. Link your Discord account at \
+                             <https://kbve.com> to unlock Member perks!",
+                    )
+                    .ephemeral(true),
+            )
+            .await;
+        app.members.mark_notified(user.get());
+    }
+
+    Ok(())
+}
+
+fn class_label(class: ClassType) -> &'static str {
+    match class {
+        ClassType::Warrior => "Warrior",
+        ClassType::Rogue => "Rogue",
+        ClassType::Cleric => "Cleric",
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/discord/components/class_picker.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/class_picker.rs
@@ -13,6 +13,7 @@ use tracing::{error, warn};
 use kbve::MemberStatus;
 
 use crate::discord::bot::{Data, Error};
+use crate::discord::game::content;
 use crate::discord::game::launch;
 use crate::discord::game::types::ClassType;
 
@@ -24,34 +25,59 @@ const ID_CLERIC: &str = "dngclass|cleric";
 
 // ── Picker UI ───────────────────────────────────────────────────────
 
-/// Embed describing each class and its starting kit. Shown in the
-/// ephemeral message that accompanies the picker buttons.
+/// Embed describing each class — stats, signature perk, and the
+/// shared starter kit. Stat numbers come straight from
+/// [`content::class_starting_stats`] so the embed stays in sync with
+/// gameplay tuning.
 pub fn picker_embed() -> serenity::CreateEmbed {
+    let starter_kit = "Potion \u{00D7}2 \u{2022} Bandage \u{00D7}1 \u{2022} Bomb \u{00D7}1";
+
     serenity::CreateEmbed::new()
         .title("Choose your character")
         .description(
             "You only get one. Pick the class you want to play; this \
              choice persists across runs until your character dies.",
         )
+        .field("\u{2694} Warrior", class_field(&ClassType::Warrior), true)
+        .field("\u{1F5E1} Rogue", class_field(&ClassType::Rogue), true)
+        .field("\u{2728} Cleric", class_field(&ClassType::Cleric), true)
         .field(
-            "\u{2694} Warrior",
-            "High HP, heavy armor, reliable damage. Starts with a \
-             worn longsword and battered chainmail.",
-            true,
+            "Starter kit (all classes)",
+            format!("{starter_kit}\nGear is earned in-run."),
+            false,
         )
-        .field(
-            "\u{1F5E1} Rogue",
-            "Low HP, high crit, ambush bonus and flee chance. Starts \
-             with a tarnished dagger and leather scraps.",
-            true,
-        )
-        .field(
-            "\u{2728} Cleric",
-            "Balanced HP, healing access, faction perks. Starts with \
-             a cracked mace and woven robes.",
-            true,
-        )
+        .footer(serenity::CreateEmbedFooter::new(
+            "Stats can grow with level + gear; class is permanent.",
+        ))
         .color(0x5865F2)
+}
+
+/// Format the per-class field body — stats line, signature perk,
+/// flavor blurb. Multi-line so each class section reads as a card.
+fn class_field(class: &ClassType) -> String {
+    let (hp, armor, dmg, crit, gold) = content::class_starting_stats(class);
+    let crit_pct = (crit * 100.0).round() as i32;
+    let stats = format!(
+        "**HP** {hp} \u{2022} **Armor** {armor} \u{2022} **Dmg** +{dmg}\n\
+         **Crit** {crit_pct}% \u{2022} **Gold** {gold}",
+    );
+    let (perk, flavor) = match class {
+        ClassType::Warrior => (
+            "**Charge** \u{2014} 50% chance to strike first each combat.",
+            "Front-line bruiser. Soaks hits, swings hard.",
+        ),
+        ClassType::Rogue => (
+            "**Ambush** \u{2014} 50% chance to deny enemy first strikes.\n\
+             **Slippery** \u{2014} bonus flee chance.",
+            "Hit fast, slip away. Crit-leaning.",
+        ),
+        ClassType::Cleric => (
+            "**Faith** \u{2014} stronger heal output.\n\
+             **Standing** \u{2014} faction reputation perks.",
+            "Sustain caster. Slower kills, longer runs.",
+        ),
+    };
+    format!("{stats}\n\n{perk}\n\n_{flavor}_")
 }
 
 /// Three-button row: Warrior / Rogue / Cleric.

--- a/apps/discordsh/discordsh-bot/src/discord/components/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod chart_buttons;
+pub mod class_picker;
 pub mod github_components;
 mod status_buttons;
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/launch.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/launch.rs
@@ -1,0 +1,169 @@
+//! Shared dungeon-session launch path.
+//!
+//! Both `/dungeon start` (slash command) and the class-picker button
+//! handler need to build the same initial session state and assets.
+//! This module owns the build step — claim the play-mode lock, generate
+//! the initial map, hydrate the player from any persisted profile, and
+//! pre-render the embed/components/card. Callers handle the
+//! context-specific message I/O (poise reply vs. component followup)
+//! and finish up by calling [`commit_launch`] once the message has
+//! been delivered.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use poise::serenity_prelude as serenity;
+
+use kbve::MemberStatus;
+
+use crate::discord::game::{card, content, persistence, render, types::*};
+use crate::state::AppState;
+
+/// Pre-built session payload returned by [`prepare_launch`]. The caller
+/// sends `embed` + `components` (+ `card_png` if `Some`) to its
+/// channel, then calls [`commit_launch`] with the resulting message id.
+pub struct Launched {
+    /// Fully populated session, except for `message_id` which the
+    /// caller fills in once the public dungeon message has been sent.
+    pub session_state: SessionState,
+    /// RAII guard for the play-mode lock. `commit_launch` consumes it
+    /// once the session is registered.
+    pub mode_guard: persistence::ModeLockGuard,
+    pub embed: serenity::CreateEmbed,
+    pub components: Vec<serenity::CreateActionRow>,
+    pub card_png: Option<Vec<u8>>,
+    pub member_status: MemberStatus,
+    pub short_id: ShortSid,
+    pub user_id: serenity::UserId,
+}
+
+/// Build a fresh dungeon session for `user` in `channel` using `class`.
+///
+/// Returns `Err(reason)` when the play-mode lock can't be claimed —
+/// the caller should surface `reason` as an ephemeral error.
+pub async fn prepare_launch(
+    app: &Arc<AppState>,
+    user: serenity::UserId,
+    user_display_name: &str,
+    channel: serenity::ChannelId,
+    class: ClassType,
+) -> Result<Launched, String> {
+    let (id, short_id) = super::new_short_sid();
+
+    let mode_guard = app
+        .profiles
+        .claim_mode(user.get(), &short_id, false)
+        .await?;
+
+    let map = content::generate_initial_map(&id);
+    let room = content::room_from_tile(map.tiles.get(&map.position).unwrap());
+    let phase = GamePhase::City;
+
+    let member_status = app.members.lookup(user.get()).await;
+    let (player_name, member_tag) = match &member_status {
+        MemberStatus::Member(profile) => {
+            let username = profile
+                .discord_username
+                .clone()
+                .unwrap_or_else(|| user_display_name.to_owned());
+            (username.clone(), MemberStatusTag::Member { username })
+        }
+        MemberStatus::Guest { .. } => (user_display_name.to_owned(), MemberStatusTag::Guest),
+    };
+
+    let (class_hp, class_armor, class_dmg, class_crit, class_gold) =
+        content::class_starting_stats(&class);
+
+    let mut player = PlayerState {
+        name: player_name,
+        inventory: content::starting_inventory(),
+        member_status: member_tag,
+        class,
+        max_hp: class_hp,
+        hp: class_hp,
+        armor: class_armor,
+        gold: class_gold,
+        base_damage_bonus: class_dmg,
+        crit_chance: class_crit,
+        ..PlayerState::default()
+    };
+
+    let mut quest_journal = QuestJournal::default();
+    let saved_profile = app.profiles.load(user.get()).await;
+    if let Some(ref profile) = saved_profile {
+        persistence::apply_profile_to_player(profile, &mut player, &mut quest_journal);
+        player.saved_snapshot = Some(profile.clone());
+    }
+
+    let session_state = SessionState {
+        id,
+        short_id: short_id.clone(),
+        owner: user,
+        party: Vec::new(),
+        // Phase 1 of the redesign always launches into Party so the
+        // dungeon embed exposes the join button. Solo mode stays in the
+        // enum for any internal callers that still need it.
+        mode: SessionMode::Party,
+        phase,
+        channel_id: channel,
+        message_id: serenity::MessageId::new(1), // placeholder, filled by caller
+        created_at: Instant::now(),
+        last_action_at: Instant::now(),
+        turn: 0,
+        players: HashMap::from([(user, player)]),
+        enemies: Vec::new(),
+        room,
+        log: vec![
+            "You arrive at the Underground City. Prepare your party before venturing out..."
+                .to_owned(),
+        ],
+        show_items: false,
+        pending_actions: HashMap::new(),
+        map,
+        show_map: true,
+        show_inventory: false,
+        pending_destination: None,
+        enemies_had_first_strike: false,
+        quest_journal,
+        active_dialogue: None,
+    };
+
+    let components = render::render_components(&session_state);
+
+    let fontdb = app.fontdb.clone();
+    let card_png = match card::render_game_card(&session_state, fontdb).await {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to render game card for dungeon start");
+            None
+        }
+    };
+    let embed = render::render_embed(&session_state, card_png.is_some());
+
+    Ok(Launched {
+        session_state,
+        mode_guard,
+        embed,
+        components,
+        card_png,
+        member_status,
+        short_id,
+        user_id: user,
+    })
+}
+
+/// Finalise a launch after the dungeon message has been delivered.
+/// Sets the message id on the session, registers it with the session
+/// store, and commits the play-mode lock so it isn't released by the
+/// guard's `Drop`.
+pub fn commit_launch(
+    app: &Arc<AppState>,
+    mut session_state: SessionState,
+    mode_guard: persistence::ModeLockGuard,
+    message_id: serenity::MessageId,
+) {
+    session_state.message_id = message_id;
+    app.sessions.create(session_state);
+    mode_guard.commit();
+}

--- a/apps/discordsh/discordsh-bot/src/discord/game/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/mod.rs
@@ -3,6 +3,7 @@ pub mod card;
 pub mod content;
 pub mod github_cards;
 pub mod irc_events;
+pub mod launch;
 pub mod logic;
 pub mod pathfinding;
 pub mod persistence;

--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -785,6 +785,19 @@ fn class_to_id(class: &ClassType) -> i16 {
     }
 }
 
+/// Resolve a class from a persisted profile. Returns `None` when the
+/// profile has no character set (`class_id == 0`) — used by the
+/// `/dungeon start` flow to decide whether to launch directly or send
+/// the class picker. Existing profiles always carry a valid class id;
+/// the `0` sentinel is reserved for the future permadeath path that
+/// clears a character without deleting the row.
+pub fn class_from_profile(profile: &DungeonProfile) -> Option<ClassType> {
+    if profile.class_id == 0 {
+        return None;
+    }
+    Some(class_from_id(profile.class_id))
+}
+
 fn reason_to_outcome(reason: &GameOverReason) -> i16 {
     match reason {
         GameOverReason::Victory => 1,


### PR DESCRIPTION
PR 1 of 2 in the discordsh roguelite redesign. The followup PR adds the **Downed** state, 30-turn / 24-hour death timer, and full profile delete on permadeath; landing this first gives that PR a stable entry path to attach to.

## Behavior change
- \`/dungeon start\` no longer takes \`mode\` or \`class\` arguments. Sessions are always **Party** now (the Solo flow had no real reason to exist as a separate UX); the \`SessionMode\` enum stays in case any internal callers still want to distinguish.
- A first-time player who runs \`/dungeon start\` gets an ephemeral picker — one Warrior / Rogue / Cleric button each plus a flavor embed describing the starting kit — and only proceeds to the dungeon after picking. Repeat players skip the picker and load with their saved class as before.

## Code
- New \`discord/game/launch.rs\` extracts the session-build pipeline (claim play-mode lock → generate map → hydrate player from profile → render embed/components/card) so the slash command and the picker handler share one path. \`prepare_launch\` returns a \`Launched\` payload; \`commit_launch\` finalises after the public message goes out.
- New \`discord/components/class_picker.rs\` owns the picker UI and the \`dngclass|<class>\` button handler. On click it acks the ephemeral picker with a confirmation, posts the public dungeon message in the same channel, and registers the session via \`commit_launch\`. If the message send fails the play-mode lock is released via the guard's \`Drop\` so the user isn't locked out.
- \`persistence::class_from_profile(&DungeonProfile)\` is the new hook for the routing decision. It reserves \`class_id == 0\` as the **no character** sentinel for the upcoming permadeath path; existing profiles always carry a real class id, so the new branch never fires for current players.
- \`bot.rs\` router learns the \`dngclass|\` prefix.

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy --no-deps\` clean on edited files
- [x] \`cargo test --bin discordsh-bot\` — 705/705 pass
- [ ] Docker build green in CI
- [ ] Smoke in staging:
  - existing player runs \`/dungeon start\` → straight into dungeon with saved class
  - new player runs \`/dungeon start\` → ephemeral picker → click Warrior → public dungeon message + ephemeral confirms

## Followup PR (queued)
- \`/dungeon start\` redesign part 2: Downed state on 0HP, 30-turn / 24-hour rescue timer, party escort to inn/hospital, full profile delete on permadeath, picker re-shown after death.