### PR TITLE
test(laser): flush deferred-destroy macrotask in PhaserGame unmount specs

### DIFF
--- a/packages/npm/laser/src/lib/phaser/PhaserGame.spec.tsx
+++ b/packages/npm/laser/src/lib/phaser/PhaserGame.spec.tsx
@@ -69,9 +69,12 @@ describe('PhaserGame', () => {
 		expect(MockGame).toHaveBeenCalledTimes(1);
 	});
 
-	it('should destroy Phaser.Game on unmount', () => {
+	it('should destroy Phaser.Game on unmount', async () => {
 		const { unmount } = render(<PhaserGame config={minimalConfig} />);
 		unmount();
+		// PhaserGame defers destroy via setTimeout(0) to survive
+		// React StrictMode's mount→cleanup→mount; flush macrotasks.
+		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(mockDestroy).toHaveBeenCalledWith(true);
 	});
 
@@ -85,12 +88,14 @@ describe('PhaserGame', () => {
 		});
 	});
 
-	it('should call onDestroy on unmount', () => {
+	it('should call onDestroy on unmount', async () => {
 		const onDestroy = vi.fn();
 		const { unmount } = render(
 			<PhaserGame config={minimalConfig} onDestroy={onDestroy} />,
 		);
 		unmount();
+		// Deferred destroy — flush the setTimeout(0) in PhaserGame.
+		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(onDestroy).toHaveBeenCalledTimes(1);
 	});
 


### PR DESCRIPTION
## Summary

\`PhaserGame\` defers its \`Phaser.Game\` tear-down via \`setTimeout(0)\` so the component survives React StrictMode's mount → cleanup → mount cycle (see \`PhaserGame.tsx\` \`scheduleCleanup\`). The two unmount specs predate that change and asserted \`destroy\` synchronously right after \`unmount()\`, so CI failed:

\`\`\`
AssertionError: expected "vi.fn()" to be called with arguments: [ true ]
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
\`\`\`

## Changes

\`packages/npm/laser/src/lib/phaser/PhaserGame.spec.tsx\`:

- \`should destroy Phaser.Game on unmount\` and \`should call onDestroy on unmount\` are now \`async\` and \`await new Promise((r) => setTimeout(r, 0))\` after \`unmount()\` to flush the same macrotask \`PhaserGame\`'s \`scheduleCleanup\` schedules.

Matches the production lifecycle — no source changes.

## Test plan

- [x] \`npx nx run laser:test\` — 57/57 pass (was 55/57)
- Repro CI: https://github.com/KBVE/kbve/actions/runs/25583081902