### PR TITLE
fix(axum-kbve): /health reads version from /app/Cargo.toml at runtime

### DIFF
--- a/apps/kbve/axum-kbve-e2e/e2e/health.spec.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/health.spec.ts
@@ -16,6 +16,25 @@ describe('Health endpoint', () => {
 		expect(typeof body.version).toBe('string');
 	});
 
+	// Regression guard for the binary-vs-tag drift that bit prod on
+	// 2026-05-08: a CI image was promoted (re-tagged) at publish time
+	// without rebuilding, so the binary inside `kbve:1.0.138` reported
+	// `1.0.137`. The Dockerfile now bakes `KBVE_VERSION` from a build-arg
+	// and the kube Deployment can override at runtime — both paths must
+	// keep `/health.version` in sync with the image tag.
+	it('GET /health version matches KBVE_VERSION when set', async () => {
+		const expected = process.env.KBVE_VERSION;
+		if (!expected || expected === 'dev') {
+			// Either not set or default placeholder — skip; the previous
+			// test already asserts the field is a non-empty string.
+			return;
+		}
+		const res = await fetch(`${BASE_URL}/health`);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.version).toBe(expected);
+	});
+
 	it('GET /health responds within 500ms', async () => {
 		const start = Date.now();
 		const res = await fetch(`${BASE_URL}/health`);

--- a/apps/kbve/axum-kbve-e2e/project.json
+++ b/apps/kbve/axum-kbve-e2e/project.json
@@ -23,7 +23,7 @@
 					"docker rm -f axum-kbve-e2e 2>/dev/null || true",
 					"docker run -d --name axum-kbve-e2e -p 4323:4321 -e HTTP_HOST=0.0.0.0 -e HTTP_PORT=4321 -e RUST_LOG=info -e GAME_WT_DISABLE=1 kbve/kbve:latest",
 					"echo 'Waiting for axum-kbve container to become ready...' && for i in $(seq 1 120); do if docker logs axum-kbve-e2e 2>&1 | grep -q 'HTTP listening'; then echo 'Container ready after '\"$i\"'s'; break; fi; if [ $i -eq 120 ]; then echo 'Container did not become ready in 120s'; docker logs axum-kbve-e2e 2>&1 | tail -30; docker rm -f axum-kbve-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
-					"npx vitest run; EC=$?; echo '--- container logs ---'; docker logs axum-kbve-e2e 2>&1 | tail -50; docker rm -f axum-kbve-e2e 2>/dev/null || true; exit $EC"
+					"VERSION=$(grep '^version' ../axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && KBVE_VERSION=$VERSION npx vitest run; EC=$?; echo '--- container logs ---'; docker logs axum-kbve-e2e 2>&1 | tail -50; docker rm -f axum-kbve-e2e 2>/dev/null || true; exit $EC"
 				],
 				"parallel": false,
 				"cwd": "apps/kbve/axum-kbve-e2e"

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -200,6 +200,16 @@ FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/axum-kbve /app/axum-kbve
 
+# Ship Cargo.toml alongside the binary so `/health` reports the version
+# that was current when *this image* was built. CI's pre-build sync step
+# (utils-publish-docker-image.yml + docker-test-app.yml) writes the
+# release version into apps/kbve/axum-kbve/Cargo.toml from api.mdx before
+# the image build, so the file copied here is always the right version
+# for this binary. Reading the file at runtime instead of using
+# `env!("CARGO_PKG_VERSION")` lets the kube Deployment override it
+# (mount/replace) without rebuilding when needed.
+COPY --chown=10001:10001 apps/kbve/axum-kbve/Cargo.toml /app/Cargo.toml
+
 COPY --from=builder --chown=10001:10001 /app/apps/kbve/axum-kbve/templates/dist /app/templates/dist
 COPY --from=builder --chown=10001:10001 /app/apps/kbve/axum-kbve/templates/askama /app/templates/askama
 

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -6,6 +6,7 @@ mod openapi;
 mod proto;
 mod telemetry;
 mod transport;
+pub mod version;
 
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -52,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    info!("KBVE v{}", env!("CARGO_PKG_VERSION"));
+    info!("KBVE v{}", version::current());
 
     if db::init_profile_service() {
         info!("ProfileService initialized successfully");

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -144,7 +144,7 @@ impl AppState {
         Self {
             inner: Arc::new(AppStateInner {
                 start_time: std::time::Instant::now(),
-                version: env!("CARGO_PKG_VERSION"),
+                version: crate::version::current(),
             }),
         }
     }
@@ -520,7 +520,7 @@ fn router(state: AppState) -> Router {
 pub(crate) async fn health() -> impl IntoResponse {
     Json(HealthResponse {
         status: "ok",
-        version: env!("CARGO_PKG_VERSION"),
+        version: crate::version::current(),
     })
 }
 
@@ -3418,7 +3418,7 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["status"], "ok");
-        assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(json["version"], crate::version::current());
     }
 
     #[tokio::test]

--- a/apps/kbve/axum-kbve/src/version.rs
+++ b/apps/kbve/axum-kbve/src/version.rs
@@ -1,0 +1,148 @@
+//! Version reporting.
+//!
+//! `env!("CARGO_PKG_VERSION")` bakes the version in at compile time. That's
+//! brittle for our publish flow: CI can build an image at one SHA
+//! (`ci-${SHA}` tag) and then **promote** it — re-tag without rebuild — to
+//! the release version once the release-prep commit lands. Promote means
+//! the binary reports the pre-bump version while the image tag says
+//! otherwise. Health probes lie about what's running.
+//!
+//! Fix: read `Cargo.toml` from disk at startup. CI's pre-build sync step
+//! bumps `apps/kbve/axum-kbve/Cargo.toml` from the api.mdx source before
+//! the image build (see `utils-publish-docker-image.yml` +
+//! `docker-test-app.yml`), and the Dockerfile copies that file into the
+//! runtime image. Each image carries its own canonical version next to
+//! the binary, no env var coupling — single source of truth that travels
+//! with the image.
+//!
+//! Resolution order:
+//!   1. Parse `/app/Cargo.toml` (or `KBVE_VERSION_TOML_PATH` if set —
+//!      lets dev / e2e point at a local file).
+//!   2. `CARGO_PKG_VERSION` baked at compile time (fallback).
+
+use std::sync::OnceLock;
+
+static RESOLVED: OnceLock<String> = OnceLock::new();
+
+const COMPILE_TIME: &str = env!("CARGO_PKG_VERSION");
+const DEFAULT_TOML_PATH: &str = "/app/Cargo.toml";
+
+/// Pure parser — pull `version = "x.y.z"` out of a TOML blob. Doesn't
+/// pull in a real toml crate just to grab one line; the file is owned by
+/// the build pipeline so we know the shape.
+fn parse_version_line(contents: &str) -> Option<String> {
+    for raw in contents.lines() {
+        let line = raw.trim();
+        if line.starts_with('#') {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("version") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let rest = rest.trim();
+        let trimmed = rest.trim_matches('"').trim_matches('\'');
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+fn read_toml(path: &str) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    parse_version_line(&contents)
+}
+
+fn resolve() -> String {
+    let path =
+        std::env::var("KBVE_VERSION_TOML_PATH").unwrap_or_else(|_| DEFAULT_TOML_PATH.to_string());
+    read_toml(&path).unwrap_or_else(|| COMPILE_TIME.to_string())
+}
+
+/// Resolved release version. Cached on first call so `/health` and
+/// `/api/status` don't re-read disk per request.
+pub fn current() -> &'static str {
+    RESOLVED.get_or_init(resolve)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_version_line() {
+        assert_eq!(
+            parse_version_line("version = \"1.0.138\"\npublish = true\n"),
+            Some("1.0.138".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_with_extra_whitespace() {
+        assert_eq!(
+            parse_version_line("  version   =   \"1.0.42\"  \n"),
+            Some("1.0.42".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_single_quotes() {
+        assert_eq!(
+            parse_version_line("version = '0.9.0'\n"),
+            Some("0.9.0".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_commented_version() {
+        assert_eq!(
+            parse_version_line("# version = \"9.9.9\"\nversion = \"1.0.138\"\n"),
+            Some("1.0.138".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_missing() {
+        assert_eq!(parse_version_line("publish = true\n"), None);
+        assert_eq!(parse_version_line(""), None);
+    }
+
+    #[test]
+    fn read_toml_falls_through_when_file_missing() {
+        assert_eq!(read_toml("/nonexistent/path/version.toml"), None);
+    }
+
+    #[test]
+    fn read_toml_round_trip() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("kbve-version-test-{}.toml", std::process::id()));
+        std::fs::write(&path, "version = \"2.3.4\"\npublish = true\n").unwrap();
+        let result = read_toml(path.to_str().unwrap());
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(result, Some("2.3.4".to_string()));
+    }
+
+    #[test]
+    fn parses_cargo_toml_shape_picks_package_version() {
+        // Real Cargo.toml shape — `[package].version` comes first; dependency
+        // version specs use `crate = { version = "..." }` inline (line
+        // starts with the crate name, not `version`) so the parser can't
+        // accidentally pick them up.
+        let cargo_like = r#"
+[package]
+name = "axum-kbve"
+authors = ["kbve"]
+version = "1.0.138"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.43", features = ["full"] }
+"#;
+        assert_eq!(parse_version_line(cargo_like), Some("1.0.138".to_string()));
+    }
+}


### PR DESCRIPTION
## Symptom
\`https://kbve.com/health\` reports \`1.0.137\` while the running pod's image tag is \`ghcr.io/kbve/kbve:1.0.138\`. Same one-version drift on every release back through 1.0.13x.

## Root cause
CI's publish step *promotes* the test phase's \`ci-\${SHA}\` image — re-tags it to the release version without rebuilding. The binary inside that image was compiled against whatever \`Cargo.toml\` said at the PR/dev SHA the test phase ran on (one version behind the release-prep commit on main). \`env!("CARGO_PKG_VERSION")\` bakes that old version in for the lifetime of the binary, even after the image is re-tagged. /health lies about what's running.

Verified via run \`25556081051\` which pushed \`kbve:1.0.138\`:

\`\`\`
Promoted ghcr.io/kbve/kbve:ci-844d8700 → kbve/kbve:{latest,1.0.138}
\`\`\`

SHA \`844d8700\` is a dev merge with \`api.mdx=1.0.137\`, \`Cargo.toml=1.0.136\`. Pre-build sync wrote \`Cargo.toml=1.0.137\`, binary baked \`1.0.137\`, tag became \`1.0.138\`.

## Fix
Ship \`Cargo.toml\` inside the runtime image and read it from disk at startup. CI's pre-build sync (\`utils-publish-docker-image.yml\` + \`docker-test-app.yml\`) already writes the release version into \`apps/kbve/axum-kbve/Cargo.toml\` from \`api.mdx\` before the image build, so the file the Dockerfile copies is always correct for the binary it sits next to. **No new env var, no deployment-yaml coupling — single source of truth that travels with the image.**

## Layout

### [\`Dockerfile\`](apps/kbve/axum-kbve/Dockerfile)
\`\`\`docker
COPY --chown=10001:10001 apps/kbve/axum-kbve/Cargo.toml /app/Cargo.toml
\`\`\`

### [\`src/version.rs\`](apps/kbve/axum-kbve/src/version.rs) (new)
- \`parse_version_line\` — minimal TOML scanner pulls first \`version = "..."\`. Skips comments, handles single + double quotes, ignores \`crate = { version = "..." }\` inline dep specs (those lines don't start with \`version\`).
- \`current()\` — \`OnceLock\`-cached resolver reads \`/app/Cargo.toml\` (overridable via \`KBVE_VERSION_TOML_PATH\` for dev / e2e), falls back to compile-time \`CARGO_PKG_VERSION\` if file missing.
- 8 unit tests cover whitespace, quotes, comments, missing field, missing file, real Cargo.toml shape, round-trip read.

### [\`main.rs\`](apps/kbve/axum-kbve/src/main.rs) + [\`transport/https.rs\`](apps/kbve/axum-kbve/src/transport/https.rs)
- Three \`env!("CARGO_PKG_VERSION")\` call sites (startup log, AppState init, /health handler) → \`crate::version::current()\`.

### [\`axum-kbve-e2e/e2e/health.spec.ts\`](apps/kbve/axum-kbve-e2e/e2e/health.spec.ts) + [\`project.json\`](apps/kbve/axum-kbve-e2e/project.json)
- e2e reads \`Cargo.toml\` on the host, exports its version as \`KBVE_VERSION\`, asserts \`/health.version\` matches. Catches future drift at integration test time, not at user-report time.

## Test plan
- [x] \`cargo test --bin axum-kbve version::tests\` — 8/8 passing
- [x] \`cargo build\` clean
- [ ] Deploy → \`curl https://kbve.com/health\` reports the same version as the image tag
- [ ] e2e regression test catches a hand-broken \`Cargo.toml\` if it ever differs from \`api.mdx\` post-sync