### PR TITLE
feat(firecracker): stage rootfs via dedicated Job + reuse post-publish sed

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.136",
+			"version": "1.0.138",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -82,7 +82,7 @@
 		{
 			"key": "discordsh",
 			"app_name": "discordsh",
-			"version": "0.1.43",
+			"version": "0.1.44",
 			"version_toml": "apps/discordsh/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh.mdx",
 			"version_target": "apps/discordsh/axum-discordsh/Cargo.toml",
@@ -96,7 +96,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.10",
+			"version": "0.1.11",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -110,7 +110,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.29",
+			"version": "0.1.31",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -137,12 +137,15 @@
 		{
 			"key": "firecracker_python_net",
 			"app_name": "firecracker-python-net",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "packages/docker/firecracker/python/net/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx",
 			"source_path": "packages/docker/firecracker/python/net",
 			"runner": "ubuntu-latest",
 			"image": "kbve/firecracker-python-net",
+			"deployment_yamls": [
+				"apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml"
+			],
 			"has_test": false
 		},
 		{
@@ -211,7 +214,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.41",
+			"version": "1.0.43",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",
@@ -272,7 +275,7 @@
 		{
 			"key": "rareicon",
 			"app_name": "axum-rareicon",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"version_toml": "apps/rareicon/axum-rareicon/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rareicon.mdx",
 			"version_target": "apps/rareicon/axum-rareicon/Cargo.toml",
@@ -426,7 +429,7 @@
 		{
 			"key": "bevy_pathfinder_crate",
 			"package_name": "bevy_pathfinder",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "packages/rust/bevy/bevy_pathfinder/version.toml",
 			"version_source": "packages/rust/bevy/bevy_pathfinder/Cargo.toml",
 			"version_target": "packages/rust/bevy/bevy_pathfinder/Cargo.toml"

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
@@ -13,11 +13,13 @@ tags:
 key: firecracker_python_net
 pipeline: docker
 app_name: firecracker-python-net
-version: "0.1.0"
+version: "0.1.1"
 version_toml: packages/docker/firecracker/python/net/version.toml
 source_path: packages/docker/firecracker/python/net
 runner: ubuntu-latest
 image: kbve/firecracker-python-net
+deployment_yamls:
+    - apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml
 has_test: false
 author: h0lybyte
 license: KBVE
@@ -26,7 +28,7 @@ status: active
 
 ## Overview
 
-Network-capable Python rootfs image used by the **staff-side** Firecracker deployment (`firecracker-ctl-net`). Built as a multi-stage Docker image whose final scratch layer carries a single `/rootfs.ext4` artifact.
+Network-capable Python rootfs image used by the **staff-side** Firecracker deployment (`firecracker-ctl-net`). Built as a multi-stage Docker image whose final layer (alpine 3.21 + `/rootfs.ext4`) ships a `cp` entrypoint so the in-cluster stage Job can run the image directly and copy `/rootfs.ext4` onto the firecracker rootfs PVC.
 
 This image is **not** for the public sandbox quick-mode VMs. Those keep the no-network `alpine-python` rootfs from [apps/vm/firecracker-ctl/rootfs/Dockerfile.alpine-python](apps/vm/firecracker-ctl/rootfs/Dockerfile.alpine-python) — sandboxing without internet egress is the safety property.
 

--- a/apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml
@@ -1,0 +1,60 @@
+# ---------------------------------------------------------------------------
+# firecracker-net-rootfs-stage
+#
+# Stages /var/lib/firecracker/rootfs/firecracker-python-net.ext4 onto the
+# shared `firecracker-rootfs` PVC by running the published
+# ghcr.io/kbve/firecracker-python-net image directly. The image's ENTRYPOINT
+# is `cp` and CMD is the args below — copies /rootfs.ext4 from the image's
+# own filesystem to /dest on the PVC.
+#
+# The image: line below is bumped automatically by utils-post-publish.yml
+# whenever a new version of firecracker-python-net is published. The MDX
+# entry at apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-
+# net.mdx wires this manifest into the dispatch manifest via
+# `deployment_yamls`.
+#
+# Sync hook: hook-delete-policy `BeforeHookCreation` removes the previous
+# Job before each ArgoCD sync so a new image tag re-runs cleanly.
+# ---------------------------------------------------------------------------
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: firecracker-net-rootfs-stage
+    namespace: firecracker
+    labels:
+        app: firecracker-rootfs-init
+    annotations:
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 3600
+    template:
+        metadata:
+            labels:
+                app: firecracker-rootfs-init
+        spec:
+            restartPolicy: OnFailure
+            containers:
+                - name: stage
+                  image: ghcr.io/kbve/firecracker-python-net:0.1.1
+                  imagePullPolicy: IfNotPresent
+                  args:
+                      - /rootfs.ext4
+                      - /dest/firecracker-python-net.ext4
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 128Mi
+                      limits:
+                          cpu: 500m
+                          memory: 512Mi
+                  volumeMounts:
+                      - name: rootfs
+                        mountPath: /dest
+                  securityContext:
+                      runAsUser: 0
+            volumes:
+                - name: rootfs
+                  persistentVolumeClaim:
+                      claimName: firecracker-rootfs

--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v8
+    name: firecracker-rootfs-init-v9
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -31,7 +31,7 @@ spec:
 
                           echo "=== Firecracker rootfs init ==="
 
-                          apk add --no-cache curl e2fsprogs skopeo jq
+                          apk add --no-cache curl e2fsprogs
 
                           # --- vmlinux kernel ---
                           if [ ! -f "${OUTPUT}/vmlinux" ]; then
@@ -88,70 +88,24 @@ spec:
                           }
 
                           # --- alpine-minimal ---
-                          echo "[2/6] alpine-minimal..."
+                          echo "[2/4] alpine-minimal..."
                           build_rootfs "alpine-minimal" 32
 
                           # --- alpine-python ---
-                          echo "[3/6] alpine-python..."
+                          echo "[3/4] alpine-python..."
                           build_rootfs "alpine-python" 128 python3
 
                           # --- alpine-node ---
-                          echo "[4/6] alpine-node..."
+                          echo "[4/5] alpine-node..."
                           build_rootfs "alpine-node" 128 nodejs
-
-                          # --- firecracker-python-net (pulled from GHCR) ---
-                          # Network-capable Alpine + Python rootfs published as
-                          # ghcr.io/kbve/firecracker-python-net:<version>. The
-                          # image is a scratch image carrying /rootfs.ext4
-                          # (built by packages/docker/firecracker/python/net).
-                          # Selected at deploy time when the dashboard's
-                          # Network (VPN) checkbox is set.
-                          echo "[5/6] firecracker-python-net (from GHCR)..."
-                          NET_TARGET="${OUTPUT}/firecracker-python-net.ext4"
-                          NET_IMAGE="docker://ghcr.io/kbve/firecracker-python-net:0.1.0"
-                          if [ ! -f "${NET_TARGET}" ]; then
-                              echo "  Pulling ${NET_IMAGE}..."
-                              IMG_DIR=$(mktemp -d)
-                              skopeo copy --src-tls-verify=true \
-                                  "${NET_IMAGE}" "dir:${IMG_DIR}"
-
-                              # The single-arch image has one tar layer
-                              # containing /rootfs.ext4. Iterate through layer
-                              # blobs (named by digest) and extract the file.
-                              FOUND=0
-                              for layer in ${IMG_DIR}/*; do
-                                  case "$(file -b "$layer" 2>/dev/null || true)" in
-                                      *gzip*|*"tar archive"*)
-                                          tar -xf "$layer" -C "${IMG_DIR}" rootfs.ext4 2>/dev/null && \
-                                              { FOUND=1; break; } || true
-                                          ;;
-                                  esac
-                              done
-
-                              if [ "$FOUND" != "1" ]; then
-                                  # Fallback: try every blob without filtering
-                                  for layer in ${IMG_DIR}/*; do
-                                      [ -f "$layer" ] || continue
-                                      tar -xf "$layer" -C "${IMG_DIR}" rootfs.ext4 2>/dev/null && \
-                                          { FOUND=1; break; } || true
-                                  done
-                              fi
-
-                              if [ "$FOUND" = "1" ]; then
-                                  cp "${IMG_DIR}/rootfs.ext4" "${NET_TARGET}"
-                                  echo "  firecracker-python-net.ext4: $(du -h ${NET_TARGET} | cut -f1)"
-                              else
-                                  echo "  ERROR: rootfs.ext4 not found in any layer of ${NET_IMAGE}"
-                              fi
-                              rm -rf "${IMG_DIR}"
-                          else
-                              echo "  firecracker-python-net.ext4 already exists, skipping"
-                          fi
 
                           # --- pip package cache ---
                           # Reads package list from ConfigMap (firecracker-pip-packages).
-                          # Rebuild triggered when init job name is bumped (v7 → v8).
-                          echo "[6/6] pip-cache..."
+                          # Rebuild triggered when init job name is bumped (v8 → v9).
+                          # NOTE: firecracker-python-net.ext4 is staged by a
+                          # dedicated Job (firecracker-net-rootfs-stage.yaml)
+                          # that runs the published GHCR image directly.
+                          echo "[5/5] pip-cache..."
                           if [ ! -f "${OUTPUT}/pip-cache.ext4" ]; then
                               apk add --no-cache python3 py3-pip
                               PIPCACHE=$(mktemp -d)

--- a/apps/kube/firecracker/manifests/kustomization.yaml
+++ b/apps/kube/firecracker/manifests/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
     - firecracker-pip-packages.yaml
     - firecracker-vm-init.yaml
     - firecracker-rootfs-init.yaml
+    - firecracker-net-rootfs-stage.yaml
     - firecracker-pip-cache-cronjob.yaml
     - firecracker-deployment.yaml
     - firecracker-service.yaml

--- a/packages/docker/firecracker/python/net/Dockerfile
+++ b/packages/docker/firecracker/python/net/Dockerfile
@@ -13,9 +13,11 @@
 # Pairs with: firecracker-ctl-net (FC_PERSISTENT_ENDPOINTS_ENABLED=true).
 # Sandbox quick-mode VMs use the no-network alpine-python image.
 #
-# Usage:
-#   docker build -f Dockerfile -t fc-python-net .
-#   docker run --rm fc-python-net cat /rootfs.ext4 > python-net.ext4
+# Final image is a tiny alpine layer with /rootfs.ext4 + a `cp` entrypoint so
+# the in-cluster stage Job (apps/kube/firecracker/manifests/firecracker-net-
+# rootfs-stage.yaml) can run the image directly:
+#   image: ghcr.io/kbve/firecracker-python-net:<version>
+#   args:  ["/rootfs.ext4", "/dest/firecracker-python-net.ext4"]
 # ============================================================================
 
 FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
@@ -56,5 +58,7 @@ fi\n' > /rootfs/init && \
     mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \
     resize2fs -M /rootfs.ext4
 
-FROM scratch
+FROM --platform=linux/amd64 alpine:3.21
 COPY --from=rootfs-builder /rootfs.ext4 /rootfs.ext4
+ENTRYPOINT ["/bin/cp"]
+CMD ["/rootfs.ext4", "/dest/firecracker-python-net.ext4"]


### PR DESCRIPTION
## Summary

Replaces the failed v8 skopeo block with a dedicated Job that runs the published GHCR image directly. The image now ships with an alpine final stage + `cp` ENTRYPOINT, so the Job's `image:` line is a real `image: ghcr.io/kbve/firecracker-python-net:<tag>` entry that `utils-post-publish.yml`'s sed pattern can auto-bump on every publish (via `deployment_yamls`).

## Background

After PR #10667 merged, the v8 init Job failed with `BackoffLimitExceeded` because:
- Init Job hardcoded `:0.1.0` via skopeo.
- GHCR only had `:0.0.1` published (the previous publish ran when `version.toml` was the `0.0.1` sentinel; the post-publish hook then bumped `version.toml` → `0.1.0` but no fresh publish ran since MDX matched).
- Result: `manifest unknown` from skopeo → 3 retries → backoff exceeded → `firecracker-python-net.ext4` never staged → dashboard test still hit `ModuleNotFoundError: No module named 'requests'`.

The deeper issue is that the skopeo invocation lived inside a shell-string, which `utils-post-publish.yml`'s sed (`image: <name>:<tag>`) cannot patch. So even if we'd hardcoded the right version, it would need a manual bump every release.

## Changes

| File | Change |
|------|--------|
| `packages/docker/firecracker/python/net/Dockerfile` | Final stage `scratch` → `alpine:3.21` + `ENTRYPOINT [\"/bin/cp\"]` + `CMD [\"/rootfs.ext4\", \"/dest/firecracker-python-net.ext4\"]`. ~5 MB extra; image stays under ~50 MB. |
| `apps/kbve/astro-kbve/.../firecracker-python-net.mdx` | `version: \"0.1.0\"` → `\"0.1.1\"` + `deployment_yamls: [apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml]`. |
| `apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml` | **New** Job. `image: ghcr.io/kbve/firecracker-python-net:0.1.1` (the line `utils-post-publish.yml` patches); `hook-delete-policy: BeforeHookCreation` so each ArgoCD sync recreates the Job and picks up the latest tag. |
| `apps/kube/firecracker/manifests/kustomization.yaml` | Adds the new manifest. |
| `apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml` | Reverts the v8 skopeo block + apk additions. Bumped name `v8 → v9` so ArgoCD reruns the clean baseline. firecracker-python-net.ext4 staging is now the new Job's responsibility. |
| `.github/ci-dispatch-manifest.json` | Regenerated via `npx nx run astro-kbve:sync:ci-manifest`. |

## Auto-flow after merge

1. CI Docker publishes `:0.1.1` (MDX > version.toml triggers).
2. `utils-post-publish.yml` sed-bumps the stage Job's `image: ghcr.io/.../firecracker-python-net:0.1.0` → `:0.1.1` and `version.toml` to match.
3. ArgoCD reconciles → recreates stage Job (`BeforeHookCreation`) → pulls `:0.1.1` → `cp /rootfs.ext4 /dest/firecracker-python-net.ext4` onto the firecracker-rootfs PVC.
4. Subsequent publishes auto-bump in lockstep without touching this PR's machinery.

## Test plan

- [ ] After merge, `CI - Docker / firecracker-python-net` publishes `ghcr.io/kbve/firecracker-python-net:0.1.1` + `:latest`.
- [ ] `utils-post-publish.yml` opens an atom PR bumping `version.toml` to `0.1.1` and the stage Job's `image:` line.
- [ ] After atom PR merges + ArgoCD reconciles, `kubectl get jobs -n firecracker firecracker-net-rootfs-stage` shows `Complete`.
- [ ] `kubectl exec -n firecracker firecracker-ctl-net-... -- ls -lh /var/lib/firecracker/rootfs/` shows `firecracker-python-net.ext4` present.
- [ ] Dashboard IDE Python Quick + Network (VPN) + PoetryDB smoke script returns a poem with exit 0.