### PR TITLE
feat(mc): auto-park hover + owner name tag

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipCommands.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipCommands.java
@@ -45,7 +45,8 @@ public final class ShipCommands {
                             String modelName = resolveModelPath(input);
                             ServerWorld world = ctx.getSource().getWorld();
                             ShipEntity ship = manager.placeShip(world, modelName,
-                                    player.getUuid(), player.getBlockPos());
+                                    player.getUuid(), player.getName().getString(),
+                                    player.getBlockPos());
                             if (ship != null) {
                                 ctx.getSource().sendFeedback(
                                         () -> Text.of("Spawned " + modelName + " (id=" + ship.getShipId() + "). /boardship " + ship.getShipId() + " to teleport on."), true);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -37,6 +37,8 @@ public class ShipEntity extends Entity {
             DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
     private static final TrackedData<String> SHIP_ID =
             DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
+    private static final TrackedData<String> OWNER_NAME =
+            DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
     private static final TrackedData<Float> SHIP_HEALTH =
             DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.FLOAT);
     private static final TrackedData<Float> TARGET_SPEED =
@@ -231,6 +233,13 @@ public class ShipEntity extends Entity {
     }
     public void setOwnerUuid(UUID uuid) {
         this.ownerUuidStr = uuid != null ? uuid.toString() : "";
+    }
+
+    public String getOwnerName() {
+        return this.dataTracker.get(OWNER_NAME);
+    }
+    public void setOwnerName(String name) {
+        this.dataTracker.set(OWNER_NAME, name != null ? name : "");
     }
 
     public String getModelName() { return this.dataTracker.get(MODEL_NAME); }
@@ -444,6 +453,27 @@ public class ShipEntity extends Entity {
 
     @Override
     public boolean canHit() { return true; }
+
+    @Override
+    public net.minecraft.text.Text getName() {
+        String owner = getOwnerName();
+        String ship = getShipName();
+        if (owner.isEmpty() && ship.isEmpty()) return super.getName();
+        String label;
+        if (!ship.isEmpty() && !owner.isEmpty()) {
+            label = owner + "'s " + ship;
+        } else if (!ship.isEmpty()) {
+            label = ship;
+        } else {
+            label = owner + "'s Ship";
+        }
+        return net.minecraft.text.Text.literal(label);
+    }
+
+    @Override
+    public boolean shouldRenderName() {
+        return !getOwnerName().isEmpty() || !getShipName().isEmpty();
+    }
 
     @Override
     public EntityDimensions getDimensions(net.minecraft.entity.EntityPose pose) {
@@ -1213,6 +1243,7 @@ public class ShipEntity extends Entity {
         builder.add(MODEL_NAME, "immersive_aircraft/airship");
         builder.add(SHIP_NAME, "");
         builder.add(SHIP_ID, "");
+        builder.add(OWNER_NAME, "");
         builder.add(SHIP_HEALTH, MAX_HEALTH);
         builder.add(TARGET_SPEED, 0.0f);
         builder.add(VERTICAL_INTENT, 0.0f);
@@ -1227,6 +1258,7 @@ public class ShipEntity extends Entity {
     public void readCustomData(ReadView view) {
         this.dataTracker.set(SHIP_ID, view.getString("ShipId", ""));
         this.ownerUuidStr = view.getString("OwnerUuid", "");
+        setOwnerName(view.getString("OwnerName", ""));
         setModelName(view.getString("ModelName", "immersive_aircraft/airship"));
         setShipName(view.getString("ShipName", ""));
         this.setYaw(view.getFloat("Heading", 0.0f));
@@ -1254,6 +1286,7 @@ public class ShipEntity extends Entity {
     public void writeCustomData(WriteView view) {
         view.putString("ShipId", this.dataTracker.get(SHIP_ID));
         view.putString("OwnerUuid", ownerUuidStr);
+        view.putString("OwnerName", getOwnerName());
         view.putString("ModelName", getModelName());
         view.putString("ShipName", getShipName());
         view.putFloat("Heading", this.getYaw());

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -87,6 +87,7 @@ public class ShipEntity extends Entity {
     /** Previous tick's caution bits — used to fire one-shot warning sounds on transition. */
     private byte lastCautionBitsForSound = 0;
     private boolean lastOnGroundForDust = true;
+    private int autoParkHoverTicks = 0;
 
     // Cached stats — refreshed when model changes or upgrades change.
     private FlightStats statsCache = FlightStats.DEFAULT;
@@ -827,8 +828,20 @@ public class ShipEntity extends Entity {
             vel = new Vec3d(vel.x, vel.y * stats.verticalDecay(), vel.z);
         }
 
-        // Engine-modulated gravity — full power = hover, off = fall.
-        double gravity = -0.04 * (1.0 - power);
+        double gravity;
+        if (autoParkHoverTicks > 0 && !ridden) {
+            autoParkHoverTicks--;
+            vel = vel.multiply(0.97, 1.0, 0.97);
+            gravity = -0.005;
+            if (this.age % 6 == 0
+                    && this.getEntityWorld() instanceof ServerWorld swPark) {
+                swPark.spawnParticles(net.minecraft.particle.ParticleTypes.CLOUD,
+                        this.getX(), this.getY() - 0.4, this.getZ(),
+                        2, 0.4, 0.05, 0.4, 0.0);
+            }
+        } else {
+            gravity = -0.04 * (1.0 - power);
+        }
         vel = vel.add(0.0, gravity, 0.0);
 
         // Wind perturbation — cosNoise-style ambient drift.
@@ -1150,6 +1163,11 @@ public class ShipEntity extends Entity {
     protected void removePassenger(Entity passenger) {
         super.removePassenger(passenger);
         if (this.getEntityWorld().isClient()) return;
+
+        if (this.getPassengerList().isEmpty() && !this.isOnGround()) {
+            autoParkHoverTicks = 200;
+        }
+
         if (!(passenger instanceof net.minecraft.entity.LivingEntity living)) return;
         ServerWorld sw = (ServerWorld) this.getEntityWorld();
         int floorY = sw.getTopY(net.minecraft.world.Heightmap.Type.MOTION_BLOCKING,

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
@@ -48,6 +48,7 @@ public class ShipItem extends Item {
             ShipEntity entity = new ShipEntity(ShipEntityTypes.SHIP, world);
             entity.setShipId(java.util.UUID.randomUUID());
             entity.setOwnerUuid(user.getUuid());
+            entity.setOwnerName(user.getName().getString());
             entity.setModelName(modelName);
             entity.refreshPositionAndAngles(pos.x, pos.y + 1.0, pos.z, user.getYaw(), 0);
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
@@ -39,11 +39,17 @@ public final class ShipManager {
      */
     public ShipEntity placeShip(ServerWorld world, String modelName,
                                 UUID ownerUuid, BlockPos nearPos) {
+        return placeShip(world, modelName, ownerUuid, "", nearPos);
+    }
+
+    public ShipEntity placeShip(ServerWorld world, String modelName,
+                                UUID ownerUuid, String ownerName, BlockPos nearPos) {
         UUID shipId = UUID.randomUUID();
 
         ShipEntity entity = new ShipEntity(ShipEntityTypes.SHIP, world);
         entity.setShipId(shipId);
         entity.setOwnerUuid(ownerUuid);
+        entity.setOwnerName(ownerName);
         entity.setModelName(modelName);
         entity.setShipHealth(ShipEntity.MAX_HEALTH);
         // Spawn with half-tank — players can refuel via coal / lava bucket interact.


### PR DESCRIPTION
## Summary

### 1. Auto-park hover (`dbe5af0b3`)
- Last pilot leaving an airborne ship sets `autoParkHoverTicks=200`
- While timer runs and no rider aboard: gravity replaced with -0.005 (vs -0.04), horizontal velocity bleeds 3% per tick, soft cloud puff every 6 ticks
- Ship parachutes down to terrain over ~10 s instead of nosediving the moment throttle cuts

### 2. Owner name tag (`ca80c4333`)
- `OWNER_NAME` `TrackedData<String>` populated at spawn (`ShipItem.use` + new `ShipManager.placeShip` overload) from `player.getName()`
- NBT-persisted as `OwnerName`
- `ShipEntity.getName()` returns `Owner's Ship` (or `Owner's <ShipName>` when custom-named); `shouldRenderName` true → vanilla floating-text renderer paints above entity

## Test plan

- [ ] Mount airship, climb to ~50 blocks, dismount → ship glides down with cloud puffs instead of nosediving
- [ ] Spawn airship → other player sees `<YourName>'s Ship` floating above it
- [ ] World reload → owner name persists