### PR TITLE
feat(discordsh): /dungeon route accepts landmark slug

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
@@ -540,32 +540,78 @@ async fn leaderboard(
     Ok(())
 }
 
-/// Shortest revealed-tile route to the nearest tile of the given kind.
+/// Shortest revealed-tile route to a room kind or named landmark.
 #[poise::command(slash_command)]
 async fn route(
     ctx: Context<'_>,
-    #[description = "Where to head: boss / city / merchant / rest / treasure / story"]
-    target: String,
+    #[description = "Room kind: boss / city / merchant / rest / treasure / story"] target: Option<
+        String,
+    >,
+    #[description = "Landmark slug (e.g. shattered-crown, goblin-cave)"] landmark: Option<String>,
 ) -> Result<(), Error> {
     let user = ctx.author().id;
 
-    let goal_room_type = match target.to_lowercase().as_str() {
-        "boss" => RoomType::Boss,
-        "city" | "town" => RoomType::UndergroundCity,
-        "merchant" | "market" | "shop" => RoomType::Merchant,
-        "rest" | "shrine" | "campfire" => RoomType::RestShrine,
-        "treasure" | "loot" => RoomType::Treasure,
-        "story" | "lore" => RoomType::Story,
-        other => {
+    enum ResolvedGoal {
+        Room(RoomType),
+        Landmark(String),
+    }
+
+    let goal = match (target.as_deref(), landmark.as_deref()) {
+        (Some(_), Some(_)) => {
             ctx.send(
                 poise::CreateReply::default()
-                    .content(format!(
-                        "Unknown target `{other}`. Try: boss / city / merchant / rest / treasure / story.",
-                    ))
+                    .content("Pick one of `target` or `landmark`, not both.")
                     .ephemeral(true),
             )
             .await?;
             return Ok(());
+        }
+        (None, None) => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content(
+                        "Pass either a `target` (boss / city / merchant / rest / treasure / story) \
+                         or a `landmark` slug.",
+                    )
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+        (Some(t), None) => {
+            let room_type = match t.to_lowercase().as_str() {
+                "boss" => RoomType::Boss,
+                "city" | "town" => RoomType::UndergroundCity,
+                "merchant" | "market" | "shop" => RoomType::Merchant,
+                "rest" | "shrine" | "campfire" => RoomType::RestShrine,
+                "treasure" | "loot" => RoomType::Treasure,
+                "story" | "lore" => RoomType::Story,
+                other => {
+                    ctx.send(
+                        poise::CreateReply::default()
+                            .content(format!(
+                                "Unknown target `{other}`. Try: boss / city / merchant / rest / treasure / story.",
+                            ))
+                            .ephemeral(true),
+                    )
+                    .await?;
+                    return Ok(());
+                }
+            };
+            ResolvedGoal::Room(room_type)
+        }
+        (None, Some(slug)) => {
+            let slug = slug.trim().to_lowercase();
+            if slug.is_empty() {
+                ctx.send(
+                    poise::CreateReply::default()
+                        .content("Landmark slug is empty.")
+                        .ephemeral(true),
+                )
+                .await?;
+                return Ok(());
+            }
+            ResolvedGoal::Landmark(slug)
         }
     };
 
@@ -589,11 +635,11 @@ async fn route(
 
     let session = handle.lock().await;
     let from = session.map.position;
-    let path = pathfinding::path_to_goal(
-        &session.map,
-        from,
-        pathfinding::GoalKind::Room(goal_room_type.clone()),
-    );
+    let goal_kind = match &goal {
+        ResolvedGoal::Room(rt) => pathfinding::GoalKind::Room(rt.clone()),
+        ResolvedGoal::Landmark(slug) => pathfinding::GoalKind::Landmark(slug),
+    };
+    let path = pathfinding::path_to_goal(&session.map, from, goal_kind);
     let goal_tile = path
         .as_ref()
         .and_then(|p| p.last())
@@ -601,14 +647,20 @@ async fn route(
         .cloned();
     drop(session);
 
-    let target_label = match goal_room_type {
-        RoomType::Boss => "boss arena",
-        RoomType::UndergroundCity => "underground city",
-        RoomType::Merchant => "merchant",
-        RoomType::RestShrine => "rest shrine",
-        RoomType::Treasure => "treasure room",
-        RoomType::Story => "story room",
-        _ => "tile",
+    let target_label: String = match &goal {
+        ResolvedGoal::Room(rt) => match rt {
+            RoomType::Boss => "boss arena",
+            RoomType::UndergroundCity => "underground city",
+            RoomType::Merchant => "merchant",
+            RoomType::RestShrine => "rest shrine",
+            RoomType::Treasure => "treasure room",
+            RoomType::Story => "story room",
+            _ => "tile",
+        }
+        .to_owned(),
+        ResolvedGoal::Landmark(slug) => crate::discord::game::proto_bridge::landmark_name(slug)
+            .map(|n| format!("landmark `{n}`"))
+            .unwrap_or_else(|| format!("landmark `{slug}`")),
     };
 
     let body = match (path, goal_tile) {
@@ -629,10 +681,17 @@ async fn route(
             "You're already in **{}** ({}).",
             goal_tile.name, target_label
         ),
-        _ => format!(
-            "No revealed path to a {} from your current room. Explore further first.",
-            target_label
-        ),
+        _ => match &goal {
+            ResolvedGoal::Landmark(slug) => format!(
+                "No revealed path to landmark `{slug}` from your current room. \
+                 Either it isn't on the map yet, or you haven't explored \
+                 close enough to reveal a route."
+            ),
+            ResolvedGoal::Room(_) => format!(
+                "No revealed path to a {} from your current room. Explore further first.",
+                target_label
+            ),
+        },
     };
 
     ctx.send(poise::CreateReply::default().content(body).ephemeral(true))

--- a/apps/discordsh/discordsh-bot/src/discord/game/pathfinding.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/pathfinding.rs
@@ -47,9 +47,8 @@ pub enum GoalKind<'a> {
     /// Any tile whose `room_type` matches the given variant.
     Room(RoomType),
     /// A specific landmark by `mapdb` ref (e.g. `"shattered-crown"`).
-    /// Reserved for future `/dungeon route landmark:<ref>` queries; the
-    /// current `/dungeon route` command only exposes `Room` goals.
-    #[allow(dead_code)]
+    /// Used by `/dungeon route landmark:<slug>` to navigate to a known
+    /// curated room.
     Landmark(&'a str),
 }
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/proto_bridge.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/proto_bridge.rs
@@ -163,9 +163,8 @@ pub fn pick_landmark_for_room_type<R: Rng + ?Sized>(
     Some(bucket[idx].clone())
 }
 
-/// Look up a landmark's display name by ref. Used by card rendering to
-/// surface the curated mapdb name when a tile has a `landmark_ref`.
-#[allow(dead_code)]
+/// Look up a landmark's display name by ref. Used by `/dungeon route
+/// landmark:<slug>` to surface the curated mapdb name in the result.
 pub fn landmark_name(r#ref: &str) -> Option<&'static str> {
     MAP_DB
         .get_object_def_by_ref(r#ref)


### PR DESCRIPTION
Closes a Phase 2 followup from #10601.

## What
\`/dungeon route\` learns a second arg, \`landmark\`, that takes a curated mapdb slug (e.g. \`shattered-crown\`, \`goblin-cave\`) and BFSes the revealed tile graph for the matching tile.

## Why
The pathfinding module already shipped \`GoalKind::Landmark(&str)\` in #10627 (gated behind \`#[allow(dead_code)]\`) and \`proto_bridge::landmark_name\` was reachable but never called. Slot was empty waiting for a slash arg. Tiny PR to close the loop and remove the dead-code markers.

## Behavior
- \`/dungeon route\` now takes either \`target\` (room kind: \`boss\` / \`city\` / \`merchant\` / \`rest\` / \`treasure\` / \`story\`) or \`landmark\` (slug). Both args are \`Option<String>\` — passing both, or neither, returns an ephemeral validation error.
- Landmark goals reuse the existing tile-graph BFS over revealed-only tiles, but match on \`tile.landmark_ref == Some(slug)\` instead of \`room_type\`.
- Result line surfaces the curated mapdb name when available — "Path to landmark \`The Shattered Crown\`" — falling back to the slug for typos / drafted entries.
- Failure copy is landmark-specific so the player knows whether the slug is invalid vs the route hasn't been revealed yet.

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy --no-deps\` clean on edited regions
- [x] \`cargo test --bin discordsh-bot\` — 705/705 pass
- [ ] Smoke in staging:
  - \`/dungeon route target:boss\` → unchanged behavior
  - \`/dungeon route landmark:shattered-crown\` after revealing tiles around it → returns hop count + cardinal route
  - \`/dungeon route landmark:made-up-slug\` → "no revealed path" + slug-specific copy
  - \`/dungeon route\` with both / neither → validation error