### PR TITLE
chore(bevy_mapdb): unstick version.toml so first publish can fire

### DIFF
--- a/packages/rust/bevy/bevy_mapdb/version.toml
+++ b/packages/rust/bevy/bevy_mapdb/version.toml
@@ -1,2 +1,2 @@
-version = "0.1.0"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
\`bevy_mapdb\` has never been published to crates.io but its \`version.toml\` already reads \`0.1.0\`, matching its \`Cargo.toml\`. The \`CI - Publish\` outer gate compares the two and only proceeds when \`local_version > version_toml\`, so the crate stays unpublished even though the source is publish-ready (verified locally via \`cargo publish --dry-run\`).

Reset \`version.toml\` to the \`0.0.1\` "wants to publish" sentinel so the gate fires on the next \`workflow_dispatch\`. The post-publish auto-PR (\`utils-update-version-toml.yml\`) will set it back to the real \`0.1.0\` once the crate ships.

No code change.

## Followup

Other L0 crates that are first-publish ready and **don't** need a PR (their version.toml is already \`0.0.0\`, gate passes naturally):

- \`bevy_cam\` (0.1.0)
- \`bevy_player\` (0.1.0)
- \`bevy_quests\` (0.1.0)
- \`bevy_statemachine\` (0.1.0)

These can be dispatched directly via:

\`\`\`
gh workflow run ci-publish.yml --repo KBVE/kbve \\
  -f package_type=crates -f package_name=<crate>
\`\`\`

## Test plan

- [ ] PR merges to dev.
- [ ] \`workflow_dispatch\` of CI - Publish for \`bevy_mapdb\` reaches the publish step (no longer skipped at the outer gate).
- [ ] \`bevy_mapdb\` 0.1.0 lands on crates.io.
- [ ] Post-publish auto-PR bumps version.toml back to \`0.1.0\`.