### PR TITLE
feat(rareicon-icons): multi-format SVG copy + featured terms row

### DIFF
--- a/apps/rareicon/astro-rareicon/src/components/icons/IconVariantCard.astro
+++ b/apps/rareicon/astro-rareicon/src/components/icons/IconVariantCard.astro
@@ -66,13 +66,35 @@ const tags = variant.tags ?? [];
 			)
 		}
 
-		<button
-			type="button"
-			class="ri-icon-variant__copy"
-			data-copy-svg={variant.svg_body ?? ''}
-			aria-label={`Copy ${label} SVG`}>
-			Copy SVG
-		</button>
+		<div
+			class="ri-icon-variant__copy-row"
+			role="group"
+			aria-label="Copy formats">
+			<button
+				type="button"
+				class="ri-icon-variant__copy"
+				data-copy-format="svg"
+				data-copy-svg={variant.svg_body ?? ''}
+				aria-label={`Copy ${label} as SVG`}>
+				SVG
+			</button>
+			<button
+				type="button"
+				class="ri-icon-variant__copy"
+				data-copy-format="jsx"
+				data-copy-svg={variant.svg_body ?? ''}
+				aria-label={`Copy ${label} as JSX`}>
+				JSX
+			</button>
+			<button
+				type="button"
+				class="ri-icon-variant__copy"
+				data-copy-format="data-uri"
+				data-copy-svg={variant.svg_body ?? ''}
+				aria-label={`Copy ${label} as data URI`}>
+				URI
+			</button>
+		</div>
 	</figcaption>
 </figure>
 
@@ -179,11 +201,20 @@ const tags = variant.tags ?? [];
 		color: var(--ri-text-disabled);
 	}
 
-	.ri-icon-variant__copy {
+	.ri-icon-variant__copy-row {
 		margin-top: auto;
-		padding: 0.4rem 0.75rem;
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 0.25rem;
+	}
+
+	.ri-icon-variant__copy {
+		padding: 0.4rem 0.5rem;
 		font-family: inherit;
 		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
 		border: 1px solid var(--ri-border);
 		border-radius: 6px;
 		background: transparent;
@@ -206,15 +237,55 @@ const tags = variant.tags ?? [];
 </style>
 
 <script>
+	/**
+	 * Translate raw SVG markup to each copy-format variant.
+	 *   - svg: raw markup as emitted in the catalog
+	 *   - jsx: SVG with React-friendly attribute names + camelCase props
+	 *     (className, strokeWidth, etc.) so devs can paste straight into
+	 *     a React component
+	 *   - data-uri: base64-encoded data URL ready for `<img src="...">`
+	 *     or CSS `url(...)`
+	 */
+	function toJSX(svg: string): string {
+		return svg
+			.replace(/\bclass=/g, 'className=')
+			.replace(/\bstroke-width=/g, 'strokeWidth=')
+			.replace(/\bstroke-linecap=/g, 'strokeLinecap=')
+			.replace(/\bstroke-linejoin=/g, 'strokeLinejoin=')
+			.replace(/\bstroke-dasharray=/g, 'strokeDasharray=')
+			.replace(/\bfill-rule=/g, 'fillRule=')
+			.replace(/\bclip-rule=/g, 'clipRule=')
+			.replace(/\bclip-path=/g, 'clipPath=')
+			.replace(/\baria-hidden=/g, 'ariaHidden=')
+			.replace(/\bxmlns:xlink=/g, 'xmlnsXlink=')
+			.replace(/\btext-anchor=/g, 'textAnchor=')
+			.replace(/\bfont-family=/g, 'fontFamily=')
+			.replace(/\bfont-size=/g, 'fontSize=')
+			.replace(/\bfont-weight=/g, 'fontWeight=');
+	}
+
+	function toDataUri(svg: string): string {
+		// Strip leading/trailing whitespace + collapse interior whitespace
+		// for a more compact data URI.
+		const compact = svg.replace(/\s+/g, ' ').trim();
+		const encoded = btoa(unescape(encodeURIComponent(compact)));
+		return `data:image/svg+xml;base64,${encoded}`;
+	}
+
 	document.addEventListener('click', (e) => {
 		const target = e.target as HTMLElement;
 		const btn = target.closest<HTMLButtonElement>('.ri-icon-variant__copy');
 		if (!btn) return;
 		const svg = btn.getAttribute('data-copy-svg') ?? '';
 		if (!svg) return;
+		const format = btn.getAttribute('data-copy-format') ?? 'svg';
 
-		const originalText = btn.textContent ?? 'Copy SVG';
-		navigator.clipboard.writeText(svg).then(
+		let payload = svg;
+		if (format === 'jsx') payload = toJSX(svg);
+		else if (format === 'data-uri') payload = toDataUri(svg);
+
+		const originalText = btn.textContent ?? 'COPY';
+		navigator.clipboard.writeText(payload).then(
 			() => {
 				btn.setAttribute('data-copied', 'true');
 				btn.textContent = 'Copied';
@@ -224,7 +295,7 @@ const tags = variant.tags ?? [];
 				}, 1500);
 			},
 			() => {
-				btn.textContent = 'Copy failed';
+				btn.textContent = 'Failed';
 				setTimeout(() => {
 					btn.textContent = originalText;
 				}, 1500);

--- a/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.astro
+++ b/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.astro
@@ -149,6 +149,36 @@ const synonyms = buildSynonymMap();
 		gap: 0.75rem;
 	}
 
+	.ri-icons-browser__featured {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+		padding: 1rem;
+		border-radius: 12px;
+		background: color-mix(in srgb, var(--ri-accent) 6%, transparent);
+		border: 1px solid color-mix(in srgb, var(--ri-accent) 25%, transparent);
+	}
+
+	.ri-icons-browser__featured-header {
+		display: flex;
+		align-items: baseline;
+		gap: 0.65rem;
+		flex-wrap: wrap;
+	}
+
+	.ri-icons-browser__featured-label {
+		font-size: 0.6875rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		font-weight: 700;
+		color: var(--ri-accent);
+	}
+
+	.ri-icons-browser__featured-hint {
+		font-size: 0.75rem;
+		color: var(--ri-text-disabled);
+	}
+
 	.ri-icons-browser__item {
 		margin: 0;
 	}

--- a/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.tsx
+++ b/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.tsx
@@ -53,6 +53,20 @@ export default function IconsBrowser({
 	const [multiSourceOnly, setMultiSourceOnly] = useState(false);
 	const [attributionOnly, setAttributionOnly] = useState(false);
 
+	const hasActiveFilter =
+		!!query.trim() ||
+		activeCategory !== null ||
+		activeStyle !== null ||
+		activeTheme !== null ||
+		activeSource !== null ||
+		multiSourceOnly ||
+		attributionOnly;
+
+	const featuredTerms = useMemo(
+		() => terms.filter((t) => t.featured).slice(0, 12),
+		[terms],
+	);
+
 	const filtered = useMemo(() => {
 		const q = query.trim().toLowerCase();
 		const synonymHits = refsMatchingSynonym(q, synonyms);
@@ -168,6 +182,48 @@ export default function IconsBrowser({
 					Attribution required (CC BY)
 				</button>
 			</div>
+
+			{!hasActiveFilter && featuredTerms.length > 0 && (
+				<section
+					className="ri-icons-browser__featured"
+					aria-label="Featured icons">
+					<header className="ri-icons-browser__featured-header">
+						<span className="ri-icons-browser__featured-label">
+							Featured
+						</span>
+						<span className="ri-icons-browser__featured-hint">
+							Hand-picked terms across the catalog
+						</span>
+					</header>
+					<ul className="ri-icons-browser__grid">
+						{featuredTerms.map((t) => (
+							<li key={t.ref} className="ri-icons-browser__item">
+								<a
+									href={`${basePath}/${t.ref}/`}
+									className="ri-icons-browser__card">
+									<div
+										className="ri-icons-browser__thumb"
+										dangerouslySetInnerHTML={{
+											__html: t.previewSvg ?? '',
+										}}
+									/>
+									<div className="ri-icons-browser__meta">
+										<span className="ri-icons-browser__name">
+											{t.name}
+										</span>
+										<span className="ri-icons-browser__count-pill">
+											{t.variantCount}
+											{t.variantCount === 1
+												? ' variant'
+												: ' variants'}
+										</span>
+									</div>
+								</a>
+							</li>
+						))}
+					</ul>
+				</section>
+			)}
 
 			{filtered.length === 0 ? (
 				<div className="ri-icons-browser__empty">

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/bluesky.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/bluesky.mdx
@@ -3,6 +3,7 @@ ref: bluesky
 name: Bluesky
 title: Bluesky Icon
 description: Bluesky butterfly glyph from the Simple Icons library (CC0), 1 variant — filled brand glyph, recolor via currentColor.
+featured: true
 primary_category: ui
 categories: [ui, library, social]
 tags: [simple-icons, brand, social, atproto]

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/crown.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/crown.mdx
@@ -3,6 +3,7 @@ ref: crown
 name: Crown
 title: Crown Icon
 description: Crown glyph with 5 variants from multiple FOSS icon libraries — recolor via currentColor.
+featured: true
 primary_category: ui
 categories:
   - ui

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/discord.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/discord.mdx
@@ -3,6 +3,7 @@ ref: discord
 name: Discord
 title: Discord Icon
 description: Discord glyph from the logos icon library, 1 variant — recolor via currentColor.
+featured: true
 primary_category: tech
 categories: [tech, library]
 tags: [logos-generated, logos]

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/docker.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/docker.mdx
@@ -3,6 +3,7 @@ ref: docker
 name: Docker
 title: Docker Icon
 description: Docker glyph with 4 variants from multiple FOSS icon libraries — recolor via currentColor.
+featured: true
 primary_category: tech
 categories:
   - tech

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/github.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/github.mdx
@@ -3,6 +3,7 @@ ref: github
 name: Github
 title: Github Icon
 description: Github glyph with 2 variants from multiple FOSS icon libraries — recolor via currentColor.
+featured: true
 primary_category: ui
 categories:
   - ui

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/itch.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/itch.mdx
@@ -3,6 +3,7 @@ ref: itch
 name: Itch
 title: Itch.io Icon
 description: Itch.io glyph from the Simple Icons library (CC0), 1 variant — filled brand glyph, recolor via currentColor.
+featured: true
 primary_category: ui
 categories: [ui, library, gaming]
 tags: [simple-icons, brand, gaming, indie, platform]

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/python.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/python.mdx
@@ -3,6 +3,7 @@ ref: python
 name: Python
 title: Python Icon
 description: Python glyph with 3 variants from multiple FOSS icon libraries — recolor via currentColor.
+featured: true
 primary_category: tech
 categories:
   - tech

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/react.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/react.mdx
@@ -3,6 +3,7 @@ ref: react
 name: React
 title: React Icon
 description: React glyph with 3 variants from multiple FOSS icon libraries — recolor via currentColor.
+featured: true
 primary_category: tech
 categories:
   - tech

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/rust.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/rust.mdx
@@ -3,6 +3,7 @@ ref: rust
 name: Rust
 title: Rust Icon
 description: Rust glyph with 3 variants from multiple FOSS icon libraries — recolor via currentColor.
+featured: true
 primary_category: tech
 categories:
   - tech

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/steam.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/steam.mdx
@@ -3,6 +3,7 @@ ref: steam
 name: Steam
 title: Steam Icon
 description: Steam glyph from the Simple Icons library (CC0), 1 variant — filled brand glyph, recolor via currentColor.
+featured: true
 primary_category: ui
 categories: [ui, library, gaming]
 tags: [simple-icons, brand, gaming, platform]


### PR DESCRIPTION
## Summary

- **Multi-format copy** on every variant card — replaces single "Copy SVG" button with **SVG / JSX / URI** trio
- **Featured terms row** on `/icons/` landing — highlights flagship hand-picked terms above the main grid

## Multi-format copy

Per-button `data-copy-format` switches behavior in the click-delegation script:

| Format | Output | Use case |
|--------|--------|----------|
| **SVG** | raw markup as emitted in the catalog | drop into HTML, paste into Figma |
| **JSX** | React-friendly attribute names (`className`, `strokeWidth`, `strokeLinecap`, `fillRule`, `clipPath`, …) | paste straight into a React component |
| **URI** | base64-encoded `data:image/svg+xml;base64,…` | `<img src="…">` or CSS `url(…)` |

Visible "Copied" / "Failed" feedback persists 1.5s, same UX, per-format.

## Featured terms row

`IconsBrowser.tsx` renders the first 12 terms with `featured: true` in a gold-accented panel pinned above the main grid. **Auto-hides** as soon as the user types a query or toggles any filter chip — keeps the surface clean during browse, disappears during search.

10 flagship hand-crafted refs flagged `featured: true`:
- **Brand:** steam, itch, github, discord, bluesky
- **Gamedev:** crown (sword + shield already featured)
- **Tech:** rust, python, react, docker

## Test plan

- [x] `astro build` — 1266 pages emitted, pagefind index intact
- [x] Featured row toggles correctly (visible idle, hidden when chip / search active)
- [ ] CI: e2e regression suite (PR #10623) catches any browser UI regressions
- [ ] Manual: copy a variant in each format — verify clipboard contents match
- [ ] Manual: featured row renders gold-accented panel + 12 flagship cards