### PR TITLE
chore(q): unstick version.toml so 0.1.1 publish can fire

### DIFF
--- a/packages/rust/q/version.toml
+++ b/packages/rust/q/version.toml
@@ -1,2 +1,2 @@
-version = "0.1.1"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
Same pattern as #10702. q is published at 0.1.0 on crates.io. The MDX source, \`Cargo.toml\`, and \`version.toml\` all read 0.1.1 — the bump was prepared but the publish never shipped. The \`CI - Publish\` outer gate (\`local_version > version_toml\`) sees them as equal and skips the publish job, so 0.1.1 stays unshipped indefinitely.

Reset \`version.toml\` to the \`0.0.1\` "wants to publish" sentinel so the gate fires on the next \`workflow_dispatch\`. Post-publish auto-PR will set \`version.toml\` back to \`0.1.1\` once the crate ships.

## Test plan

- [ ] PR merges to dev.
- [ ] \`workflow_dispatch\` of CI - Publish for \`q\` reaches the publish step (no longer skipped at the outer gate).
- [ ] q 0.1.1 lands on crates.io.
- [ ] Post-publish auto-PR bumps \`version.toml\` back to 0.1.1.