### PR TITLE
chore: drop dead locals + redundant kbve import (CodeQL #90-#93, #101, #102, #439, #440, #483)

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/scene_objects.rs
@@ -537,7 +537,7 @@ fn update_hovered_snapshot(
 /// On left-click, if a hovered entity has Interactable, write its data to the snapshot.
 /// React polls this snapshot to open a modal with object-specific content.
 fn detect_click_selection(
-    mut commands: Commands,
+    mut _commands: Commands,
     mouse: Res<ButtonInput<MouseButton>>,
     hovered_query: Query<
         (
@@ -556,7 +556,7 @@ fn detect_click_selection(
         return;
     }
 
-    let Some((entity, gt, interactable, flower, rock, mushroom, tile_coord)) =
+    let Some((entity, gt, interactable, flower, rock, mushroom, _tile_coord)) =
         hovered_query.iter().next()
     else {
         return;

--- a/apps/pydesk/templates/home.html
+++ b/apps/pydesk/templates/home.html
@@ -1484,7 +1484,6 @@
 
 				// Load and render accounts
 				loadAccounts() {
-					const accounts = this.getStoredAccounts();
 					this.renderAccounts();
 					this.updateStats();
 				},
@@ -1957,7 +1956,7 @@
 							return;
 						}
 
-						const { data, error } = await window.supabase.auth.signUp({
+						const { error } = await window.supabase.auth.signUp({
 							email: email,
 							password: password,
 							options: {
@@ -1974,7 +1973,7 @@
 							document.getElementById('authForm').reset();
 						}, 2000);
 					} else {
-						const { data, error } = await window.supabase.auth.signInWithPassword({
+						const { error } = await window.supabase.auth.signInWithPassword({
 							email: email,
 							password: password
 						});
@@ -2010,7 +2009,7 @@
 				try {
 					updateAuthStatus('Redirecting to ' + provider + '...', 'info');
 					
-					const { data, error } = await window.supabase.auth.signInWithOAuth({
+					const { error } = await window.supabase.auth.signInWithOAuth({
 						provider: provider,
 						options: {
 							redirectTo: window.location.origin + window.location.pathname
@@ -2206,12 +2205,10 @@
 
 			async function loadUserBalanceProfile(user) {
 				try {
-					// Determine identifier and check if wallet user
-					let identifier = user.email;
+					// Check if wallet user
 					let isWalletUser = false;
-					
+
 					if (user.app_metadata?.provider === 'wallet' || user.wallet_address) {
-						identifier = user.wallet_address || user.id;
 						isWalletUser = true;
 					}
 					

--- a/packages/python/fudster/fudster/cli.py
+++ b/packages/python/fudster/fudster/cli.py
@@ -79,9 +79,9 @@ def main() -> None:
 def version() -> None:
     """Show fudster and kbve versions."""
     import fudster as _fudster
-    import kbve as _kbve
+    from kbve import __version__ as _kbve_version
     click.echo(f"fudster {_fudster.__version__}")
-    click.echo(f"kbve    {_kbve.__version__}")
+    click.echo(f"kbve    {_kbve_version}")
 
 
 # ── info ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes nine CodeQL note alerts across three packages — all real, all mechanical:

| Alert | File | Fix |
|---|---|---|
| [#439](https://github.com/KBVE/kbve/security/code-scanning/439) | [scene_objects.rs:565](apps/kbve/isometric/src-tauri/src/game/scene_objects.rs#L565) | rename `tile_coord` to `_tile_coord` in destructure |
| [#440](https://github.com/KBVE/kbve/security/code-scanning/440) | [scene_objects.rs:540](apps/kbve/isometric/src-tauri/src/game/scene_objects.rs#L540) | rename `mut commands` to `mut _commands` (Bevy system param, never read in body) |
| [#90](https://github.com/KBVE/kbve/security/code-scanning/90) | [home.html:1487](apps/pydesk/templates/home.html#L1487) | drop unused `const accounts = this.getStoredAccounts()` — `renderAccounts()` calls it itself |
| [#91](https://github.com/KBVE/kbve/security/code-scanning/91) | [home.html:1960](apps/pydesk/templates/home.html#L1960) | destructure `{ error }` only from `signUp` |
| [#92](https://github.com/KBVE/kbve/security/code-scanning/92) | [home.html:1977](apps/pydesk/templates/home.html#L1977) | destructure `{ error }` only from `signInWithPassword` |
| [#93](https://github.com/KBVE/kbve/security/code-scanning/93) | [home.html:2013](apps/pydesk/templates/home.html#L2013) | destructure `{ error }` only from `signInWithOAuth` |
| [#101](https://github.com/KBVE/kbve/security/code-scanning/101) | [home.html:2210](apps/pydesk/templates/home.html#L2210) | drop unused `let identifier = user.email` |
| [#102](https://github.com/KBVE/kbve/security/code-scanning/102) | [home.html:2214](apps/pydesk/templates/home.html#L2214) | drop unused `identifier = user.wallet_address \|\| user.id` (kept the `isWalletUser = true` write since downstream code uses it) |
| [#483](https://github.com/KBVE/kbve/security/code-scanning/483) | [cli.py:82](packages/python/fudster/fudster/cli.py#L82) | swap `import kbve as _kbve` for `from kbve import __version__ as _kbve_version` so the module is no longer imported with both styles in the same file |

The Rust renames are pattern-binding cosmetic (`_x` is semantically identical to `x` in a destructure, the prefix only suppresses the unused warning). The pydesk `data` removals don't change behavior — `data` was never read in any of the three handlers. The fudster import swap keeps the same `version` output (`fudster X` / `kbve Y`).

## Out of scope

- [#124](https://github.com/KBVE/kbve/security/code-scanning/124) (`transparency_value` in `packages/rust/q/src/manager/gui_manager.rs`) is a CodeQL false positive — the param IS used, but only inside `#[cfg(target_os = "macos")]`. Renaming to `_transparency_value` breaks the macos build; should be dismissed in the UI.
- [#88](https://github.com/KBVE/kbve/security/code-scanning/88), [#482](https://github.com/KBVE/kbve/security/code-scanning/482), [#488](https://github.com/KBVE/kbve/security/code-scanning/488) are stale — the flagged variables / imports have already been refactored on `main` and will auto-close on the next JS/TS scan.

## Verification

- `python3 -m py_compile packages/python/fudster/fudster/cli.py` — passes.
- The Rust changes are purely the leading-underscore convention; rustc / clippy treat `_var` and `var` identically in a binding pattern, no compile-side effect.
- `home.html` is a Jinja template; the JS fragments parse identically since only unused destructured names + a single `const`/`let` line were removed.

## Test plan

- [ ] CI green on `trunk/atom-codeql-mixed-unused-*`
- [ ] Post-merge: confirm next CodeQL runs close #90-#93, #101, #102, #439, #440, #483