### PR TITLE
chore(mc): strip narration // comments from ship + client + mixin

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/BBModelShipRenderer.java
@@ -50,8 +50,6 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
 
     private static final float MODEL_SCALE = 1.0f;
 
-    // Per-render scratch — engine power gates propeller animation speed.
-    // Stored as a field instead of plumbed through every renderObject call.
     private float currentEnginePower = 0.0f;
     private float currentBankRoll = 0.0f;
     private float currentPitch = 0.0f;
@@ -61,8 +59,6 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         super(ctx);
         this.shadowRadius = 4.0f;
     }
-
-    // -- State lifecycle ----------------------------------------------------
 
     @Override
     public ShipRenderState createRenderState() {
@@ -76,17 +72,13 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         state.modelName = (name == null || name.isEmpty()) ? DEFAULT_MODEL : name;
         float lerped = entity.getLerpedYaw(tickDelta);
 
-        // Server-side bankRoll already smoothed; clamp + lerp on the client
-        // for a final settle so render stays smooth across tick boundaries.
         state.targetRoll = clamp(entity.getBankRoll(), -35f, 35f);
         state.renderRoll += (state.targetRoll - state.renderRoll) * 0.15f;
         state.heading = lerped;
 
         state.enginePower = entity.getEnginePower();
-        // Propeller spin accumulates each frame at engine-scaled rate.
         state.propellerSpin = (state.propellerSpin + state.enginePower * 30.0f) % 360f;
         state.animationTime = (entity.age + tickDelta) * 0.05f;
-        // Pitch + ground state for control surface deflection / landing gear.
         state.pitchDeg = entity.getPitch();
         state.onGround = entity.isOnGround();
     }
@@ -101,8 +93,6 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
     private static float clamp(float v, float lo, float hi) {
         return Math.max(lo, Math.min(hi, v));
     }
-
-    // -- Render -------------------------------------------------------------
 
     @Override
     public void render(ShipRenderState state, MatrixStack matrices,
@@ -122,7 +112,6 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
 
         matrices.push();
 
-        // Scale from Blockbench units to world units
         matrices.scale(MODEL_SCALE, MODEL_SCALE, MODEL_SCALE);
 
         matrices.multiply(new Quaternionf().rotateY(
@@ -130,18 +119,11 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         matrices.multiply(new Quaternionf().rotateZ(
                 (float) Math.toRadians(state.renderRoll)));
 
-        // Stash engine power for propeller-name-keyed time scaling.
         currentEnginePower = state.enginePower;
         currentBankRoll = state.renderRoll;
         currentPitch = state.pitchDeg;
         currentOnGround = state.onGround;
 
-        // Drive ImmersiveAircraft-style bbmodel keyframe expressions.
-        // The .bbmodel files reference variable.engine_rotation,
-        // variable.pressing_interpolated_x/y/z, etc. Without these set
-        // every frame the propeller, rudder, and elevator animators
-        // evaluate to 0 and stay frozen. Globals are fine because
-        // rendering is single-threaded.
         com.kbve.statetree.bbmodel.BBAnimationVariables.set(
                 "time", state.animationTime);
         com.kbve.statetree.bbmodel.BBAnimationVariables.set(
@@ -162,8 +144,7 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         com.kbve.statetree.bbmodel.BBAnimationVariables.set(
                 "roll", state.renderRoll);
 
-        // Walk the model tree — submit render commands per face
-        int light = 0xF000F0; // full bright (airships fly in sky)
+        int light = 0xF000F0;
         for (BBObject obj : model.root) {
             renderObject(model, obj, matrices, queue, light, state.animationTime);
         }
@@ -171,20 +152,12 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         matrices.pop();
     }
 
-    // -- Tree traversal -----------------------------------------------------
-
     private void renderObject(BBModel model, BBObject object, MatrixStack matrices,
                               OrderedRenderCommandQueue queue, int light, float time) {
         matrices.push();
 
-        // Apply object origin
         matrices.translate(object.origin.x(), object.origin.y(), object.origin.z());
 
-        // Apply keyframe animation. Most IA-style bbmodels reference
-        // BBAnimationVariables (engine_rotation, pressing_interpolated_*)
-        // — those are now set per-frame in render() so propeller spin,
-        // rudder yaw, and elevator pitch all come from the bbmodel's
-        // own animator without extra code.
         boolean hasAnimator = false;
         if (!model.animations.isEmpty()) {
             BBAnimation animation = model.animations.get(0);
@@ -203,13 +176,8 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
             }
         }
 
-        // Apply object rotation
         matrices.multiply(BBModelUtils.fromXYZ(object.rotation));
 
-        // Code-driven control surface fallback — only fires when the
-        // bbmodel doesn't already have an animator for this object.
-        // Lets bbmodels without IA-style variable expressions still get
-        // visible rudder/elevator/gear deflection.
         if (!hasAnimator && object.name != null) {
             String lname = object.name.toLowerCase();
             if (lname.contains("rudder") || lname.contains("aileron")) {
@@ -226,7 +194,6 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         }
 
         if (object instanceof BBBone bone) {
-            // Bones pivot around their origin — translate back before recursing
             matrices.translate(-object.origin.x(), -object.origin.y(), -object.origin.z());
 
             if (bone.visibility) {
@@ -241,8 +208,6 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
         matrices.pop();
     }
 
-    // -- Face submission ----------------------------------------------------
-
     private void submitFaces(BBFaceContainer container, MatrixStack matrices,
                              OrderedRenderCommandQueue queue, int light) {
         for (BBFace face : container.getFaces()) {
@@ -250,7 +215,6 @@ public class BBModelShipRenderer extends EntityRenderer<ShipEntity, ShipRenderSt
                     ? RenderLayers.entityCutout(face.texture.location)
                     : RenderLayers.entityCutoutNoCull(face.texture.location);
 
-            // submitCustom captures current matrix state in the entry
             queue.submitCustom(matrices, layer, (entry, vc) -> {
                 for (int i = 0; i < 4; i++) {
                     BBFace.BBVertex v = face.vertices[i];

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -71,8 +71,6 @@ public class ShipClientMod implements ClientModInitializer {
             }
             hud.setTelemetry(shipEntity.getTargetSpeed(), shipEntity.getYaw(), (int) Math.floor(shipEntity.getY()));
             hud.setClimbRate((float) shipEntity.getVelocity().y);
-            // Radar altitude — distance above the highest motion-blocking
-            // surface beneath the ship. -1 means 'no terrain below' (void).
             int floorY = shipEntity.getEntityWorld().getTopY(
                     net.minecraft.world.Heightmap.Type.MOTION_BLOCKING,
                     (int) Math.floor(shipEntity.getX()),
@@ -80,7 +78,6 @@ public class ShipClientMod implements ClientModInitializer {
             int aglM = Math.max(0, (int) (shipEntity.getY() - floorY));
             hud.setAgl(aglM);
 
-            // Flight mode classification — drives the [MODE] tag next to ship name.
             float vy = (float) shipEntity.getVelocity().y;
             float ep = shipEntity.getEnginePower();
             float ts = shipEntity.getTargetSpeed();
@@ -104,9 +101,6 @@ public class ShipClientMod implements ClientModInitializer {
             hud.setCautions(shipEntity.getCautionBits());
             hud.setBoostReserve(shipEntity.getBoostReserve());
 
-            // Mirror the server-side wind formula in ShipEntity.tick:
-            //   nx = cos(age/20/mass) * stats.wind * weatherMul
-            //   nz = cos(age/21/mass) * stats.wind * weatherMul
             float mass = Math.max(0.5f, shipEntity.getStats().mass());
             float wRaw = shipEntity.getStats().wind();
             net.minecraft.world.World wWorld = shipEntity.getEntityWorld();
@@ -133,8 +127,6 @@ public class ShipClientMod implements ClientModInitializer {
         float forward = n ? 1.0f : (s ? -1.0f : 0f);
         float targetYaw = client.player.getYaw();
         float targetPitch = client.player.getPitch();
-        // Keyboard Y axis: jump = ascend, custom descend key = down.
-        // Sneak intentionally untouched — stays bound to vanilla dismount.
         float keyVertical = jump ? 1.0f : (descend ? -1.0f : 0.0f);
 
         boolean rise = jump || (!descend && targetPitch < -20f);
@@ -144,13 +136,8 @@ public class ShipClientMod implements ClientModInitializer {
         ClientPlayNetworking.send(new HelmInputPayload(
                 activeHelmShipId, forward, boost, targetYaw, targetPitch, keyVertical));
 
-        // Fire weapons on attack key press (mouse left). Server enforces
-        // per-slot cooldown so spamming the key doesn't desync.
         if (client.options.attackKey.isPressed()) {
             ClientPlayNetworking.send(new WeaponFirePayload(activeHelmShipId, targetYaw, targetPitch));
-            // Visual recoil — small upward camera kick read by GameRendererMixin.
-            // Server cooldown prevents abuse; if the shot didn't actually fire
-            // the kick is harmless visual.
             com.kbve.statetree.mixin.client.GameRendererMixin.weaponRecoil = 4.0f;
         }
     }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipHud.java
@@ -69,7 +69,6 @@ public class ShipHud implements HudRenderCallback {
     }
 
     public void setClimbRate(float verticalVelocity) {
-        // Convert blocks/tick to blocks/sec for a more familiar readout.
         this.climbRate = verticalVelocity * 20f;
     }
 
@@ -128,8 +127,6 @@ public class ShipHud implements HudRenderCallback {
         int screenWidth = client.getWindow().getScaledWidth();
         int screenHeight = client.getWindow().getScaledHeight();
 
-        // STALL vignette — pulsing red border around the screen edges so
-        // the pilot can't miss imminent loss-of-control.
         if ("STALL".equals(flightMode)) {
             int alpha = (int) (((Math.sin(System.currentTimeMillis() / 120.0) + 1) * 0.5) * 80) + 40;
             int color = (alpha << 24) | 0xCC2222;
@@ -195,9 +192,7 @@ public class ShipHud implements HudRenderCallback {
         String climbStr = climbRate >= 0
                 ? String.format("§a▲%.1f", climbRate)
                 : String.format("§c▼%.1f", -climbRate);
-        // Speed color: green cruise → yellow sprint → red boost.
         String spdColor = speed > 1.2f ? "§c" : (speed > 0.7f ? "§e" : "§a");
-        // AGL color — red if low (< 8), yellow if borderline (< 16), white otherwise.
         String aglColor = aglMeters < 8 ? "§c" : (aglMeters < 16 ? "§e" : "§f");
         String telemetry = String.format(
                 "%sSPD %.1f§r  §7ALT§f %d  %sAGL %d§r  §7HDG§f %03d°  %s",
@@ -223,20 +218,17 @@ public class ShipHud implements HudRenderCallback {
         context.drawText(client.textRenderer, Text.of("§f" + hpText),
                 (screenWidth - hpW) / 2, barY - 10, 0xFFFFFFFF, true);
 
-        // Engine power gauge — orange bar above hull.
         int engY = barY - 20;
         int engFillW = (int) (barW * Math.max(0f, Math.min(1f, enginePower)));
         context.fill(barX - 1, engY - 1, barX + barW + 1, engY + barH + 1, 0xFF000000);
         context.fill(barX, engY, barX + barW, engY + barH, 0xFF333333);
         if (engFillW > 0) context.fill(barX, engY, barX + engFillW, engY + barH, 0xFFFF8822);
 
-        // Boost reservoir — narrow strip on top of engine bar (purple).
         int boostFillW = (int) (barW * Math.max(0f, Math.min(1f, boostReserve)));
         int boostColor = boostReserve <= 0.05f ? 0xFFCC2222 : 0xFFAA22DD;
         context.fill(barX, engY - 4, barX + barW, engY - 1, 0xFF111111);
         if (boostFillW > 0) context.fill(barX, engY - 4, barX + boostFillW, engY - 1, boostColor);
 
-        // Fuel gauge — yellow bar above engine. Flashes red when low.
         int fuelY = engY - 14;
         float fuelRatio = maxFuel > 0 ? Math.max(0f, Math.min(1f, fuel / maxFuel)) : 0f;
         int fuelFillW = (int) (barW * fuelRatio);
@@ -256,7 +248,6 @@ public class ShipHud implements HudRenderCallback {
         context.drawText(client.textRenderer, Text.of((fuelLow ? "§c" : "§f") + fuelText),
                 (screenWidth - fuelTextW) / 2, fuelY - 10, 0xFFFFFFFF, true);
 
-        // Low-fuel + empty warnings centered up top.
         if (fuel <= 0f) {
             String warn = "§c§lOUT OF FUEL — REFUEL WITH COAL OR LAVA BUCKET";
             int ww = client.textRenderer.getWidth(warn);
@@ -281,13 +272,10 @@ public class ShipHud implements HudRenderCallback {
         context.drawText(client.textRenderer, Text.of("§7" + controls),
                 screenWidth - controlsWidth - 10, screenHeight - 15, 0x999999, true);
 
-        // Upgrade slots indicator (top-left).
         String upgText = String.format("§bUPGRADES %d/%d", upgradeCount, maxUpgradeSlots);
         context.drawText(client.textRenderer, Text.of(upgText),
                 10, 10, 0xFFFFFFFF, true);
 
-        // Wind indicator (top-left under upgrades). Arrow rotates by
-        // windAngleDeg, color fades from gray (calm) → cyan (gusty).
         if (windStrength > 0.001f) {
             String[] arrows = {"↑", "↗", "→", "↘", "↓", "↙", "←", "↖"};
             int idx = (int) (((windAngleDeg % 360 + 360) % 360) / 45f) % 8;
@@ -298,34 +286,30 @@ public class ShipHud implements HudRenderCallback {
                     10, 22, wColor, true);
         }
 
-        // Cautions stack (just above the controls hint, right side).
-        // Mirrors IA's PULL_UP / VOID / DAMAGED indicators; LOW_FUEL is
-        // already shown via the fuel bar, but it's mirrored here as a
-        // pulsing red word for parity at a glance.
         boolean blink = (System.currentTimeMillis() / 300) % 2 == 0;
         int row = 0;
-        if ((cautionBits & 0x1) != 0) { // PULL_UP
+        if ((cautionBits & 0x1) != 0) {
             String t = "§4§lPULL UP";
             context.drawText(client.textRenderer, Text.of(t),
                     screenWidth - client.textRenderer.getWidth(t) - 10,
                     30 + row * 12, blink ? 0xFFFF3333 : 0xFFAA0000, true);
             row++;
         }
-        if ((cautionBits & 0x2) != 0) { // VOID
+        if ((cautionBits & 0x2) != 0) {
             String t = "§4§lVOID";
             context.drawText(client.textRenderer, Text.of(t),
                     screenWidth - client.textRenderer.getWidth(t) - 10,
                     30 + row * 12, blink ? 0xFFFF3333 : 0xFFAA0000, true);
             row++;
         }
-        if ((cautionBits & 0x4) != 0) { // DAMAGED
+        if ((cautionBits & 0x4) != 0) {
             String t = "§c§lDAMAGED";
             context.drawText(client.textRenderer, Text.of(t),
                     screenWidth - client.textRenderer.getWidth(t) - 10,
                     30 + row * 12, blink ? 0xFFFF6666 : 0xFFCC2222, true);
             row++;
         }
-        if ((cautionBits & 0x8) != 0 && fuel > 0f) { // LOW_FUEL (out-of-fuel handled elsewhere)
+        if ((cautionBits & 0x8) != 0 && fuel > 0f) {
             String t = "§e§lLOW FUEL";
             context.drawText(client.textRenderer, Text.of(t),
                     screenWidth - client.textRenderer.getWidth(t) - 10,

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipScreen.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipScreen.java
@@ -22,28 +22,24 @@ import net.minecraft.text.Text;
  */
 public class ShipScreen extends HandledScreen<ShipScreenHandler> {
 
-    // Panel chrome.
     private static final int PANEL_FILL    = 0xFF1B2128;
     private static final int PANEL_HILIGHT = 0xFF3A4452;
     private static final int PANEL_SHADOW  = 0xFF0A0E12;
     private static final int PANEL_BORDER  = 0xFF44505E;
 
-    // Accent strip behind a slot section header.
     private static final int ACCENT_FILL   = 0xFF252D38;
 
-    // Slot frame.
     private static final int SLOT_BG       = 0xFF0E1116;
     private static final int SLOT_BORDER   = 0xFF3F4954;
     private static final int SLOT_HILIGHT  = 0x40FFFFFF;
     private static final int SLOT_SHADOW   = 0x60000000;
 
-    // Section accents (subtle inset tint per section).
-    private static final int TINT_UPGRADE  = 0x602A4A88;   // blue
-    private static final int TINT_BANNER   = 0x60883078;   // magenta
-    private static final int TINT_FUEL     = 0x60AA6020;   // orange
-    private static final int TINT_WEAPON   = 0x60882828;   // red
-    private static final int TINT_CARGO    = 0x402F3742;   // neutral
-    private static final int TINT_PLAYER   = 0x301F242C;   // muted
+    private static final int TINT_UPGRADE  = 0x602A4A88;
+    private static final int TINT_BANNER   = 0x60883078;
+    private static final int TINT_FUEL     = 0x60AA6020;
+    private static final int TINT_WEAPON   = 0x60882828;
+    private static final int TINT_CARGO    = 0x402F3742;
+    private static final int TINT_PLAYER   = 0x301F242C;
 
     private static final int LABEL_COLOR   = 0xFFEACE76;
     private static final int LABEL_DIM     = 0xFF8A95A0;
@@ -64,40 +60,30 @@ public class ShipScreen extends HandledScreen<ShipScreenHandler> {
 
         beveledPanel(ctx, x, y, w, h);
 
-        // Top-row accent strip (covers the gear-section).
         ctx.fill(x + 4, y + 14, x + w - 4, y + 38, ACCENT_FILL);
 
-        // Cargo accent strip.
         ctx.fill(x + 58, y + 40, x + 134, y + 116, ACCENT_FILL);
 
-        // Player inventory accent strip.
         ctx.fill(x + 4, y + 122, x + w - 4, y + 200, ACCENT_FILL);
 
-        // Section divider above player inventory.
         ctx.fill(x + 6, y + 119, x + w - 6, y + 121, PANEL_BORDER);
 
         int sy = y + 18;
-        // Upgrades
         for (int i = 0; i < ShipInventory.UPGRADE_COUNT; i++) {
             slotFrame(ctx, x + 8 + i * 18, sy, TINT_UPGRADE);
         }
-        // Banner
         slotFrame(ctx, x + 88, sy, TINT_BANNER);
-        // Fuel
         slotFrame(ctx, x + 108, sy, TINT_FUEL);
-        // Weapons
         for (int i = 0; i < ShipInventory.WEAPON_COUNT; i++) {
             slotFrame(ctx, x + 128 + i * 18, sy, TINT_WEAPON);
         }
 
-        // Storage 4x4
         for (int row = 0; row < 4; row++) {
             for (int col = 0; col < 4; col++) {
                 slotFrame(ctx, x + 62 + col * 18, y + 44 + row * 18, TINT_CARGO);
             }
         }
 
-        // Player inventory 3x9 + hotbar
         int py0 = y + 126;
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 9; col++) {
@@ -132,16 +118,11 @@ public class ShipScreen extends HandledScreen<ShipScreenHandler> {
 
     /** 1-pixel beveled outer panel: highlight top/left, shadow bottom/right. */
     private static void beveledPanel(DrawContext ctx, int x, int y, int w, int h) {
-        // Drop shadow (1px)
         ctx.fill(x + 1, y + 1, x + w + 1, y + h + 1, PANEL_SHADOW);
-        // Outer border
         ctx.fill(x - 1, y - 1, x + w + 1, y + h + 1, PANEL_BORDER);
-        // Body fill
         ctx.fill(x, y, x + w, y + h, PANEL_FILL);
-        // Top + left highlight
         ctx.fill(x, y, x + w, y + 1, PANEL_HILIGHT);
         ctx.fill(x, y, x + 1, y + h, PANEL_HILIGHT);
-        // Bottom + right shadow
         ctx.fill(x, y + h - 1, x + w, y + h, PANEL_SHADOW);
         ctx.fill(x + w - 1, y, x + w, y + h, PANEL_SHADOW);
     }
@@ -152,13 +133,9 @@ public class ShipScreen extends HandledScreen<ShipScreenHandler> {
      * own item rendering lines up.
      */
     private static void slotFrame(DrawContext ctx, int x, int y, int tint) {
-        // Outer 18x18 frame
         ctx.fill(x - 1, y - 1, x + 17, y + 17, SLOT_BORDER);
-        // Inner fill
         ctx.fill(x, y, x + 16, y + 16, SLOT_BG);
-        // Section tint overlay
         ctx.fill(x, y, x + 16, y + 16, tint);
-        // Inset bevel: highlight top/left, shadow bottom/right
         ctx.fill(x - 1, y - 1, x + 17, y, SLOT_HILIGHT);
         ctx.fill(x - 1, y - 1, x, y + 17, SLOT_HILIGHT);
         ctx.fill(x - 1, y + 16, x + 17, y + 17, SLOT_SHADOW);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/client/GameRendererMixin.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/client/GameRendererMixin.java
@@ -35,12 +35,9 @@ public abstract class GameRendererMixin {
         if (client.player == null) return;
         if (!(client.player.getVehicle() instanceof ShipEntity ship)) return;
 
-        // Apply ship's bank roll around forward axis. Halved so the cockpit
-        // tilt feels suggestive rather than disorienting.
         matrices.multiply(new Quaternionf().rotateZ(
                 (float) Math.toRadians(ship.getBankRoll() * 0.5f)));
 
-        // Weapon recoil — quick X-axis kick that decays each frame.
         if (weaponRecoil > 0.01f) {
             matrices.multiply(new Quaternionf().rotateX(
                     (float) Math.toRadians(-weaponRecoil)));

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipCommands.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipCommands.java
@@ -107,9 +107,6 @@ public final class ShipCommands {
                     return 1;
                 }));
 
-        // /listships — print every active ship's id, model, and distance
-        // from the executing player. Helpful for finding a parked ship
-        // after dismounting and wandering off.
         dispatcher.register(CommandManager.literal("listships")
                 .requires(ServerCommandSource::isExecutedByPlayer)
                 .executes(ctx -> {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntity.java
@@ -30,7 +30,6 @@ import java.util.UUID;
  */
 public class ShipEntity extends Entity {
 
-    // Tracked data syncs to clients via vanilla entity tracking.
     private static final TrackedData<String> MODEL_NAME =
             DataTracker.registerData(ShipEntity.class, TrackedDataHandlerRegistry.STRING);
     private static final TrackedData<String> SHIP_NAME =
@@ -78,7 +77,6 @@ public class ShipEntity extends Entity {
 
     private String ownerUuidStr = "";
 
-    // Smoothed flight state — runs identically server + client off synced inputs.
     private final InterpolatedFloat enginePower = new InterpolatedFloat(50.0f);
     private final InterpolatedFloat verticalDrive = new InterpolatedFloat(20.0f);
     private float lastHeading = 0.0f;
@@ -91,20 +89,15 @@ public class ShipEntity extends Entity {
     private boolean lastOnGroundForDust = true;
     private int autoParkHoverTicks = 0;
 
-    // Cached stats — refreshed when model changes or upgrades change.
     private FlightStats statsCache = FlightStats.DEFAULT;
     private String statsCacheKey = "";
     private int upgradesHashCache = 0;
 
-    // Backing inventory: 4 upgrade + 1 banner + 4 weapon + 16 storage slots.
     private final ShipInventory inventory = new ShipInventory(this);
-    // Per-weapon-slot cooldown (ticks remaining).
     private final int[] weaponCooldowns = new int[ShipInventory.WEAPON_COUNT];
 
     public ShipEntity(EntityType<?> type, World world) {
         super(type, world);
-        // Engine-modulated gravity is applied manually in tick(); disable
-        // vanilla pull so a hovering airship doesn't sink at idle.
         this.setNoGravity(true);
     }
 
@@ -135,7 +128,6 @@ public class ShipEntity extends Entity {
             return;
         }
 
-        // Drop everything in the inventory (player gathers + re-stuffs after redeploy).
         for (int i = 0; i < inventory.size(); i++) {
             net.minecraft.item.ItemStack s = inventory.getStack(i);
             if (!s.isEmpty()) this.dropStack(world, s);
@@ -169,7 +161,6 @@ public class ShipEntity extends Entity {
         if (this.getEntityWorld().isClient()) return;
         ServerWorld sw = (ServerWorld) this.getEntityWorld();
 
-        // Aim direction from pilot's view (so weapons follow the camera).
         double yawRad = Math.toRadians(aimYaw);
         double pitchRad = Math.toRadians(aimPitch);
         double dx = -Math.sin(yawRad) * Math.cos(pitchRad);
@@ -177,8 +168,6 @@ public class ShipEntity extends Entity {
         double dz = Math.cos(yawRad) * Math.cos(pitchRad);
         Vec3d aim = new Vec3d(dx, dy, dz).normalize();
 
-        // Mount positions from per-aircraft JSON (ship-local). Falls back to a
-        // single hardcoded forward mount if the model has none configured.
         java.util.List<Vec3d> localMounts = FlightStatsRegistry.getMounts(getModelName());
 
         double shipYawRad = Math.toRadians(this.getYaw());
@@ -193,14 +182,12 @@ public class ShipEntity extends Entity {
             ShipWeapons.Weapon weapon = ShipWeapons.weaponFor(stack.getItem());
             if (weapon == null) continue;
 
-            // Resolve mount: pick i-th JSON mount if available, else cycle.
             Vec3d local;
             if (!localMounts.isEmpty()) {
                 local = localMounts.get(i % localMounts.size());
             } else {
                 local = new Vec3d(0.0, 0.6, 1.5);
             }
-            // Rotate ship-local mount around Y by ship yaw.
             double wx = this.getX() + local.x * cosY - local.z * sinY;
             double wy = this.getY() + local.y;
             double wz = this.getZ() + local.x * sinY + local.z * cosY;
@@ -217,8 +204,6 @@ public class ShipEntity extends Entity {
         String n = getShipName();
         return n.isEmpty() ? "Ship" : n;
     }
-
-    // -- Accessors ----------------------------------------------------------
 
     public UUID getShipId() {
         String id = this.dataTracker.get(SHIP_ID);
@@ -327,7 +312,7 @@ public class ShipEntity extends Entity {
 
     /** Called by ShipInventory.markDirty after any slot change. */
     public void onInventoryChanged() {
-        upgradesHashCache = -1; // force getStats() recompute
+        upgradesHashCache = -1;
         if (!this.getEntityWorld().isClient()) {
             syncUpgradesCsv();
             syncBannerId();
@@ -357,8 +342,6 @@ public class ShipEntity extends Entity {
         this.dataTracker.set(UPGRADES_CSV, packed.toString());
     }
 
-    // -- Damage / interact --------------------------------------------------
-
     @Override
     public boolean damage(ServerWorld world,
                           net.minecraft.entity.damage.DamageSource source,
@@ -376,15 +359,12 @@ public class ShipEntity extends Entity {
     }
 
     private void destroyAndExplode(ServerWorld world) {
-        // Tally TNT in cargo before clearing — boosts explosion radius so
-        // hauling TNT around becomes a calculated risk (mirrors IA behaviour).
         int tntCount = 0;
         for (int i = 0; i < inventory.size(); i++) {
             net.minecraft.item.ItemStack s = inventory.getStack(i);
             if (s.isOf(net.minecraft.item.Items.TNT)) tntCount += s.getCount();
         }
 
-        // Drop entire inventory (upgrades + banner + weapons + cargo) for salvage.
         for (int i = 0; i < inventory.size(); i++) {
             net.minecraft.item.ItemStack s = inventory.getStack(i);
             if (!s.isEmpty()) this.dropStack(world, s);
@@ -395,7 +375,6 @@ public class ShipEntity extends Entity {
             world.createExplosion(this, this.getX(), this.getY(), this.getZ(),
                     power, World.ExplosionSourceType.MOB);
         }
-        // Detach any towed mobs so leads survive the ship's destruction.
         for (net.minecraft.entity.mob.MobEntity mob : world
                 .getEntitiesByClass(net.minecraft.entity.mob.MobEntity.class,
                         this.getBoundingBox().expand(20.0),
@@ -433,7 +412,6 @@ public class ShipEntity extends Entity {
         float myMass = getStats().mass();
         float theirMass = peer.getStats().mass();
         float massSum = Math.max(0.5f, myMass + theirMass);
-        // Heavier ship bullies lighter one — push scales inversely with own mass.
         double myShare = theirMass / massSum;
         double theirShare = myMass / massSum;
 
@@ -485,7 +463,6 @@ public class ShipEntity extends Entity {
     public ActionResult interact(PlayerEntity player, Hand hand) {
         net.minecraft.item.ItemStack stack = player.getStackInHand(hand);
 
-        // Sneak + empty hand → open ship inventory GUI.
         if (player.isSneaking() && stack.isEmpty()) {
             if (player instanceof ServerPlayerEntity sp) {
                 sp.openHandledScreen(new net.minecraft.screen.SimpleNamedScreenHandlerFactory(
@@ -495,7 +472,6 @@ public class ShipEntity extends Entity {
             }
             return ActionResult.SUCCESS;
         }
-        // Sneak + upgrade item → quick-install into first free upgrade slot.
         if (player.isSneaking() && ShipUpgrades.isUpgrade(stack.getItem())) {
             for (int i = 0; i < ShipInventory.UPGRADE_COUNT; i++) {
                 int idx = ShipInventory.UPGRADE_START + i;
@@ -511,7 +487,6 @@ public class ShipEntity extends Entity {
             }
             return ActionResult.PASS;
         }
-        // Sneak + weapon item → quick-install into first free weapon slot.
         if (player.isSneaking() && ShipWeapons.isWeapon(stack.getItem())) {
             for (int i = 0; i < ShipInventory.WEAPON_COUNT; i++) {
                 int idx = ShipInventory.WEAPON_START + i;
@@ -527,11 +502,6 @@ public class ShipEntity extends Entity {
             return ActionResult.PASS;
         }
 
-        // Repair: any iron-tier material works.
-        //   IRON_INGOT      +25 HP
-        //   IRON_BLOCK      +50 HP (denser slab patches more hull)
-        //   COPPER_INGOT    +15 HP (cheaper but weaker)
-        //   NETHERITE_INGOT +60 HP (premium full-stack patch)
         if (getShipHealth() < MAX_HEALTH) {
             float repairAmt = 0f;
             if (stack.isOf(net.minecraft.item.Items.IRON_INGOT))            repairAmt = 25f;
@@ -551,7 +521,6 @@ public class ShipEntity extends Entity {
             }
         }
 
-        // Refuel: coal → +200 fuel; lava bucket → +2000 fuel (consumes bucket).
         if (getFuelLevel() < MAX_FUEL) {
             float before = getFuelLevel();
             float added = 0f;
@@ -579,14 +548,6 @@ public class ShipEntity extends Entity {
             }
         }
 
-        // Tow rope — right-click ship while holding LEAD transfers any
-        // mob currently leashed to the player onto the ship as the new
-        // leash holder. Vanilla MobEntity tickLeash then keeps the
-        // mob within range as the ship moves.
-        // Pickup — sneak + shears packs the ship back into an item with
-        // its core state preserved (name, HP, fuel). Cargo + weapons +
-        // upgrades drop at the pickup site so the player can re-stuff
-        // when they redeploy. Only owner / op may pack up.
         if (player.isSneaking() && stack.isOf(net.minecraft.item.Items.SHEARS)) {
             if (!ownerOrOpCanModify(player)) {
                 if (!this.getEntityWorld().isClient()) {
@@ -649,13 +610,10 @@ public class ShipEntity extends Entity {
         return this.getPassengerList().size() < seatCapacity() && passenger instanceof PlayerEntity;
     }
 
-    // -- Multi-passenger seating -------------------------------------------
-
     @Override
     protected Vec3d getPassengerAttachmentPos(Entity passenger,
                                               EntityDimensions dimensions,
                                               float scaleFactor) {
-        // Find seat for this passenger from stats.seats[count-1][index].
         List<Entity> riders = this.getPassengerList();
         List<List<Vec3d>> seatRows = FlightStatsRegistry.getSeats(getModelName());
         int count = riders.size();
@@ -670,8 +628,6 @@ public class ShipEntity extends Entity {
         return row.get(idx);
     }
 
-    // -- Tick ---------------------------------------------------------------
-
     @Override
     public void tick() {
         super.tick();
@@ -683,23 +639,13 @@ public class ShipEntity extends Entity {
         boolean ridden = hasPassengers();
         boolean fueled = getFuelLevel() > 0f;
 
-        // Auto-cut throttle when out of fuel OR fully submerged. IA shuts
-        // the engine off the instant the cabin dunks because flooded
-        // intakes can't burn fuel; we mirror that gating here.
         boolean submerged = this.isSubmergedInWater();
         if (!fueled || submerged) ts = 0f;
 
-        // Cargo weight — heavier load throttles down max engine output
-        // and slows the engine ramp. 0.0 = empty cargo, 1.0 = every
-        // storage slot stacked. Caps the penalty at 50 % of max thrust.
         float cargoLoad = computeCargoLoad();
         float loadPenalty = Math.min(0.5f, cargoLoad * 0.5f);
         float effectiveTarget = ts * (1.0f - loadPenalty);
 
-        // Boost reservoir — clamps the requested throttle to 1.0 once the
-        // pilot has burned through their 5-second boost budget. Drains
-        // 1/100 per tick (5s full burn) while ts > 1.0; regens 1/200 per
-        // tick (10s recovery) otherwise. Server-side only.
         if (!this.getEntityWorld().isClient()) {
             float reserve = getBoostReserve();
             if (effectiveTarget > 1.0f) {
@@ -718,12 +664,10 @@ public class ShipEntity extends Entity {
         enginePower.update(ridden && fueled && !submerged ? effectiveTarget : 0.0f);
         verticalDrive.update(ridden ? vi : 0.0f);
 
-        // Bank roll from yaw delta — smoothed, used by renderer + camera.
         float headingDelta = ((heading - lastHeading + 540f) % 360f) - 180f;
         bankRoll = bankRoll * 0.85f + headingDelta * stats.rollFactor() * 0.15f;
         lastHeading = heading;
 
-        // Track whether we're touching water for dampening.
         if (this.isTouchingWater()) {
             inWaterLevel = Math.min(1.0f, inWaterLevel + 0.05f);
         } else {
@@ -732,7 +676,6 @@ public class ShipEntity extends Entity {
 
         if (this.getEntityWorld().isClient()) return;
 
-        // Decrement weapon cooldowns each tick.
         for (int i = 0; i < weaponCooldowns.length; i++) {
             if (weaponCooldowns[i] > 0) weaponCooldowns[i]--;
         }
@@ -740,15 +683,11 @@ public class ShipEntity extends Entity {
         float power = enginePower.getSmooth();
         float vert = verticalDrive.getSmooth();
 
-        // Burn fuel proportional to engine output. Idle = no consumption.
         if (power > 0.01f && fueled) {
             float burn = power * stats.engineSpeed() * 2.0f;
             setFuelLevel(getFuelLevel() - burn);
         }
 
-        // Cargo auto-repair — scan storage slots for iron-tier materials
-        // and consume one item per tick when hull is below max. Lets a
-        // pilot stockpile patch material in cargo and limp home.
         if (getShipHealth() < MAX_HEALTH && this.age % 20 == 0) {
             for (int i = 0; i < ShipInventory.STORAGE_COUNT; i++) {
                 int slot = ShipInventory.STORAGE_START + i;
@@ -768,8 +707,6 @@ public class ShipEntity extends Entity {
             }
         }
 
-        // Boiler feed — top off fuel from the dedicated feed slot when low.
-        // Consumes one item per top-off; lava buckets leave an empty bucket.
         if (getFuelLevel() < MAX_FUEL - COAL_FUEL) {
             net.minecraft.item.ItemStack feed = inventory.getStack(ShipInventory.FUEL_SLOT);
             if (!feed.isEmpty()) {
@@ -796,22 +733,16 @@ public class ShipEntity extends Entity {
             }
         }
 
-        // Forward direction in horizontal plane (rotorcraft style).
         double rad = Math.toRadians(heading);
         double fx = -Math.sin(rad);
         double fz = Math.cos(rad);
 
         Vec3d vel = this.getVelocity();
 
-        // Forward thrust scaled by engineSpeed. No quintic curve — linear power.
         double thrustScale = power * stats.engineSpeed() * (1.0f - inWaterLevel * 0.5f);
         vel = vel.add(fx * thrustScale, 0.0, fz * thrustScale);
 
-        // Vertical thrust (rotorcraft) — pitchSpeed > 0 means plane (uses pitch instead).
         if (stats.pitchSpeed() <= 0.0f) {
-            // Takeoff assist — bonus climb thrust when within 5 blocks of
-            // the ground while ascending. Helps a stalled / heavy ship
-            // unstick from terrain instead of bouncing helplessly.
             float verticalBonus = 1.0f;
             if (vert > 0.1f && this.getEntityWorld() instanceof ServerWorld swT) {
                 int floorY = swT.getTopY(net.minecraft.world.Heightmap.Type.MOTION_BLOCKING,
@@ -823,16 +754,11 @@ public class ShipEntity extends Entity {
             }
             vel = vel.add(0.0, vert * power * stats.verticalSpeed() * verticalBonus, 0.0);
         } else {
-            // Plane — input drives pitch; pitch + forward velocity yields lift.
             float pitch = this.getPitch();
             pitch += stats.pitchSpeed() * vert;
             pitch *= (1.0f - stats.stabilizer());
-            // Clamp at ±75° instead of ±90° so a plane can't quite go
-            // vertical — leaves room for the camera to read direction
-            // and prevents the model from inverting.
             this.setPitch(MathHelper.clamp(pitch, -75.0f, 75.0f));
 
-            // Glide: forward thrust on descent.
             if (stats.glideFactor() > 0.0f) {
                 double dy = lastY - this.getY();
                 if (lastY != 0.0 && dy != 0.0) {
@@ -843,7 +769,6 @@ public class ShipEntity extends Entity {
         }
         lastY = this.getY();
 
-        // Drag/lift — lerp horizontal velocity toward heading.
         Vec3d horiz = new Vec3d(vel.x, 0, vel.z);
         double speed = horiz.length();
         if (speed > 1.0e-4) {
@@ -874,7 +799,6 @@ public class ShipEntity extends Entity {
         }
         vel = vel.add(0.0, gravity, 0.0);
 
-        // Wind perturbation — cosNoise-style ambient drift.
         if (stats.wind() > 0.0f && !this.isOnGround() && inWaterLevel < 0.5f) {
             ServerWorld sw = (ServerWorld) this.getEntityWorld();
             float windStrength = stats.wind()
@@ -885,15 +809,12 @@ public class ShipEntity extends Entity {
             vel = vel.add(nx * 0.005, 0.0, nz * 0.005);
         }
 
-        // Ground-pitch settle (planes only).
         if (this.isOnGround() && stats.pitchSpeed() > 0.0f) {
             float p = this.getPitch();
             this.setPitch((p + stats.groundPitch()) * 0.9f - stats.groundPitch());
-            // Ground friction.
             vel = vel.multiply(stats.groundFriction(), 1.0, stats.groundFriction());
         }
 
-        // Crash explosion — impact when hard-landing with significant downward velocity.
         if (stats.canExplodeOnCrash() && this.isOnGround()) {
             double impact = -vel.y;
             if (impact > 1.5) {
@@ -902,28 +823,20 @@ public class ShipEntity extends Entity {
             }
         }
 
-        // Caution flags — refreshed every tick, synced via TrackedData byte.
         int caution = 0;
         ServerWorld sworld = (ServerWorld) this.getEntityWorld();
-        // PULL_UP: descending fast and within 6 blocks of the next solid block below.
         if (vel.y < -0.15) {
             int floorY = sworld.getTopY(net.minecraft.world.Heightmap.Type.MOTION_BLOCKING,
                     (int) Math.floor(this.getX()), (int) Math.floor(this.getZ()));
             if (this.getY() - floorY < 6.0) caution |= CAUTION_PULL_UP;
         }
-        // VOID: under the world bottom.
         if (this.getY() < sworld.getBottomY() + 4) caution |= CAUTION_VOID;
-        // DAMAGED: hp below 25%.
         if (getShipHealth() < MAX_HEALTH * 0.25f) caution |= CAUTION_DAMAGED;
-        // LOW_FUEL: fuel below threshold.
         if (isFuelLow()) caution |= CAUTION_LOW_FUEL;
         if (caution != getCautionBits()) {
             this.dataTracker.set(CAUTION_BITS, (byte) caution);
         }
 
-        // Audio warnings — one-shot when a caution flag flips ON. Volume kept
-        // tame so the cockpit isn't a constant siren when the pilot is
-        // already grazing terrain.
         int newCautions = caution & ~lastCautionBitsForSound;
         if ((newCautions & CAUTION_PULL_UP) != 0) {
             sworld.playSound(null, this.getX(), this.getY(), this.getZ(),
@@ -940,7 +853,6 @@ public class ShipEntity extends Entity {
                     net.minecraft.sound.SoundEvents.BLOCK_NOTE_BLOCK_HAT.value(),
                     net.minecraft.sound.SoundCategory.NEUTRAL, 0.5f, 1.4f);
         }
-        // PULL_UP keeps beeping while held — fire every 8 ticks for urgency.
         if ((caution & CAUTION_PULL_UP) != 0 && this.age % 8 == 0
                 && (newCautions & CAUTION_PULL_UP) == 0) {
             sworld.playSound(null, this.getX(), this.getY(), this.getZ(),
@@ -954,14 +866,10 @@ public class ShipEntity extends Entity {
             this.move(MovementType.SELF, vel);
         }
 
-        // Particle trail — per-aircraft visual style.
         if (power > 0.3f && this.getEntityWorld() instanceof ServerWorld sw) {
             spawnTrailParticles(sw, power);
         }
 
-        // Boost speed-lines — perpendicular cloud streaks while throttle
-        // exceeds normal max (sprint key bumps maxThrottle to 1.5). Mirrors
-        // IA's high-speed visual flourish.
         if (power > 1.0f && this.getEntityWorld() instanceof ServerWorld swBoost
                 && this.age % 2 == 0) {
             double radB = Math.toRadians(this.getYaw());
@@ -977,22 +885,16 @@ public class ShipEntity extends Entity {
             }
         }
 
-        // Banner color plume — independent of throttle so a parked ship
-        // still flies its colors.
         if (this.getEntityWorld() instanceof ServerWorld sw3) {
             spawnBannerParticles(sw3);
         }
 
-        // Takeoff dust — burst of cloud particles on the tick the ship
-        // leaves the ground (or lands), suggesting backwash kicking up
-        // dirt. Mirrors IA's takeoff plume.
         boolean nowOnGround = this.isOnGround();
         if (nowOnGround != lastOnGroundForDust
                 && this.getEntityWorld() instanceof ServerWorld swDust) {
             swDust.spawnParticles(net.minecraft.particle.ParticleTypes.CLOUD,
                     this.getX(), this.getY() + 0.1, this.getZ(),
                     14, 1.2, 0.05, 1.2, 0.05);
-            // Quieter thump for landings, no sound on takeoff (engine sound covers it).
             if (nowOnGround) {
                 swDust.playSound(null, this.getX(), this.getY(), this.getZ(),
                         net.minecraft.sound.SoundEvents.ENTITY_HORSE_LAND,
@@ -1001,8 +903,6 @@ public class ShipEntity extends Entity {
         }
         lastOnGroundForDust = nowOnGround;
 
-        // Damage smoke — leak black smoke when hull is critical so other
-        // pilots can spot a wounded ship at a distance.
         if (getShipHealth() < MAX_HEALTH * 0.25f && this.age % 3 == 0
                 && this.getEntityWorld() instanceof ServerWorld swDmg) {
             swDmg.spawnParticles(net.minecraft.particle.ParticleTypes.LARGE_SMOKE,
@@ -1010,11 +910,8 @@ public class ShipEntity extends Entity {
                     1, 0.2, 0.1, 0.2, 0.02);
         }
 
-        // Engine sound — pitch scales with throttle. Cadence speeds up as
-        // power rises so the audio gets more frantic at full thrust.
         if (this.getEntityWorld() instanceof ServerWorld sw2) {
             net.minecraft.sound.SoundEvent loopSound = resolveEngineSound(stats.engineSound());
-            // Engine spinup — distinct one-shot + visible smoke burst.
             if (lastEnginePowerForSound < 0.05f && power >= 0.05f) {
                 sw2.playSound(null, this.getX(), this.getY(), this.getZ(),
                         net.minecraft.sound.SoundEvents.ITEM_FLINTANDSTEEL_USE,
@@ -1024,16 +921,12 @@ public class ShipEntity extends Entity {
                         this.getX(), this.getY() + 0.6, this.getZ(),
                         12, 0.5, 0.2, 0.5, 0.04);
             }
-            // Engine shutdown — soft puff when throttle drops to zero.
             if (lastEnginePowerForSound >= 0.05f && power < 0.05f) {
                 sw2.playSound(null, this.getX(), this.getY(), this.getZ(),
                         net.minecraft.sound.SoundEvents.BLOCK_FIRE_EXTINGUISH,
                         net.minecraft.sound.SoundCategory.NEUTRAL,
                         0.4f, 1.0f);
             }
-            // Engine loop — periodic rumble while running, sound from stats.
-            // propellerCount > 1 makes a multi-engine plane sound beefier
-            // (faster cadence + slightly louder) without changing the sample.
             if (power > 0.05f && loopSound != null) {
                 int props = Math.max(1, stats.propellerCount());
                 int cadence = Math.max(1, (int) ((12 - 8 * power) / Math.sqrt(props)));
@@ -1079,7 +972,6 @@ public class ShipEntity extends Entity {
         if (color < 0) return;
         net.minecraft.particle.DustParticleEffect dust =
                 new net.minecraft.particle.DustParticleEffect(color, 1.4f);
-        // Two puffs offset along ship roll axis to suggest a flag waving.
         double rad = Math.toRadians(this.getYaw());
         double sx = Math.cos(rad) * 0.4;
         double sz = Math.sin(rad) * 0.4;
@@ -1141,7 +1033,6 @@ public class ShipEntity extends Entity {
             return;
         }
 
-        // Legacy fallback for models with no trailOffsets configured.
         double rad = Math.toRadians(this.getYaw());
         if (model.contains("biplane")) {
             if (this.age % 2 == 0) {
@@ -1210,11 +1101,8 @@ public class ShipEntity extends Entity {
         }
     }
 
-    // -- Dismount safety ---------------------------------------------------
-
     @Override
     public Vec3d updatePassengerForDismount(net.minecraft.entity.LivingEntity passenger) {
-        // Try a few horizontal offsets at ship height; default to ship pos.
         double radius = Math.max(getStats().boundingWidth(), 1.5);
         double yawRad = Math.toRadians(this.getYaw());
         Vec3d[] candidates = new Vec3d[]{
@@ -1235,8 +1123,6 @@ public class ShipEntity extends Entity {
         }
         return super.updatePassengerForDismount(passenger);
     }
-
-    // -- DataTracker / NBT --------------------------------------------------
 
     @Override
     protected void initDataTracker(net.minecraft.entity.data.DataTracker.Builder builder) {
@@ -1267,8 +1153,6 @@ public class ShipEntity extends Entity {
         setShipHealth(view.getFloat("ShipHealth", MAX_HEALTH));
         setFuelLevel(view.getFloat("FuelLevel", MAX_FUEL));
 
-        // Inventory: full ItemStack codec preserves components (enchantments,
-        // banner patterns, custom names, durability) across world reload.
         for (int i = 0; i < inventory.size(); i++) inventory.setStack(i, net.minecraft.item.ItemStack.EMPTY);
         view.read("Inventory",
                 com.mojang.serialization.Codec.list(net.minecraft.item.ItemStack.OPTIONAL_CODEC))

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntityTypes.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipEntityTypes.java
@@ -15,10 +15,6 @@ public final class ShipEntityTypes {
 
     private static final Identifier SHIP_ID = Identifier.of("behavior_statetree", "ship");
 
-    // 5x2 hitbox — covers a small airship deck. The BBModel visual may
-    // extend further (sails, masts, propellers) but this is the solid
-    // footprint players collide with and can stand on. Per-model
-    // dimension overrides can come later.
     public static final EntityType<ShipEntity> SHIP = Registry.register(
             Registries.ENTITY_TYPE,
             SHIP_ID,
@@ -31,7 +27,6 @@ public final class ShipEntityTypes {
 
     /** Call from mod init to force static initialization. */
     public static void register() {
-        // Static init handles registration
     }
 
     private ShipEntityTypes() {}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipInventory.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipInventory.java
@@ -15,14 +15,14 @@ public class ShipInventory extends SimpleInventory {
 
     public static final int UPGRADE_START = 0;
     public static final int UPGRADE_COUNT = ShipUpgrades.MAX_SLOTS;
-    public static final int BANNER_SLOT = UPGRADE_START + UPGRADE_COUNT;        // 4
-    public static final int WEAPON_START = BANNER_SLOT + 1;                     // 5
+    public static final int BANNER_SLOT = UPGRADE_START + UPGRADE_COUNT;
+    public static final int WEAPON_START = BANNER_SLOT + 1;
     public static final int WEAPON_COUNT = 4;
-    public static final int STORAGE_START = WEAPON_START + WEAPON_COUNT;        // 9
+    public static final int STORAGE_START = WEAPON_START + WEAPON_COUNT;
     public static final int STORAGE_COUNT = 16;
     /** Boiler-style fuel feed slot (auto-consumes coal / lava buckets when fuel low). */
-    public static final int FUEL_SLOT = STORAGE_START + STORAGE_COUNT;          // 25
-    public static final int TOTAL_SLOTS = FUEL_SLOT + 1;                        // 26
+    public static final int FUEL_SLOT = STORAGE_START + STORAGE_COUNT;
+    public static final int TOTAL_SLOTS = FUEL_SLOT + 1;
 
     private final ShipEntity ship;
 
@@ -39,9 +39,6 @@ public class ShipInventory extends SimpleInventory {
     @Override
     public void markDirty() {
         super.markDirty();
-        // Ship cached stats depend on upgrade slots; invalidate so getStats()
-        // recomposes on next access. Banner/weapon slots also notify the
-        // entity so rendering and weapon-system caches refresh.
         ship.onInventoryChanged();
     }
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipItem.java
@@ -52,9 +52,6 @@ public class ShipItem extends Item {
             entity.setModelName(modelName);
             entity.refreshPositionAndAngles(pos.x, pos.y + 1.0, pos.z, user.getYaw(), 0);
 
-            // Restore packed state from CUSTOM_DATA component if present —
-            // pickup mechanic stores the ship's name/HP/fuel here so a
-            // packed ship redeploys with whatever shape it was packed in.
             float restoredHealth = ShipEntity.MAX_HEALTH;
             float restoredFuel = ShipEntity.MAX_FUEL * 0.5f;
             net.minecraft.component.type.NbtComponent comp =

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipManager.java
@@ -52,7 +52,6 @@ public final class ShipManager {
         entity.setOwnerName(ownerName);
         entity.setModelName(modelName);
         entity.setShipHealth(ShipEntity.MAX_HEALTH);
-        // Spawn with half-tank — players can refuel via coal / lava bucket interact.
         entity.setFuelLevel(ShipEntity.MAX_FUEL * 0.5f);
         entity.refreshPositionAndAngles(
                 nearPos.getX() + 0.5,
@@ -66,10 +65,6 @@ public final class ShipManager {
         }
 
         activeShips.put(shipId, entity);
-
-        // Vanilla entity tracking handles spawn/despawn sync to clients —
-        // world.spawnEntity() above already sent the spawn packet, and
-        // entity.discard() handles despawn below.
 
         LOGGER.info("[Ship] Spawned '{}' (id={}) at [{}, {}, {}] for owner {}",
                 modelName, shipId,
@@ -142,7 +137,6 @@ public final class ShipManager {
      * Server tick — no-op for entity-based ships (entity.tick() handles movement).
      */
     public void tick(ServerWorld world) {
-        // Evict dead/discarded entities
         activeShips.entrySet().removeIf(e -> !e.getValue().isAlive());
     }
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipNetworking.java
@@ -71,8 +71,6 @@ public final class ShipNetworking {
         public Id<? extends CustomPayload> getId() { return ID; }
     }
 
-    // -- Registration -------------------------------------------------------
-
     public static void registerPayloads() {
         PayloadTypeRegistry.playC2S().register(HelmInputPayload.ID, HelmInputPayload.CODEC);
         PayloadTypeRegistry.playC2S().register(WeaponFirePayload.ID, WeaponFirePayload.CODEC);
@@ -94,10 +92,6 @@ public final class ShipNetworking {
                 ShipEntity ship = manager.getShip(shipId);
                 if (ship == null) return;
 
-                // Throttle is normalized [0..maxThrottle]; physics layer scales by stats.engineSpeed.
-                // Ramp slowed (0.05 / 0.04 -> 0.025 / 0.03) so the W key feels
-                // analog instead of binary; boost ceiling trimmed 1.5 -> 1.3 so
-                // sprinting adds 30 % over cruise instead of doubling speed.
                 float maxThrottle = payload.boost() ? 1.3f : 1.0f;
                 float currentSpeed = ship.getTargetSpeed();
                 if (payload.forward() > 0) {
@@ -110,15 +104,10 @@ public final class ShipNetworking {
                 float diff = ((payload.targetYaw() - current) % 360f + 540f) % 360f - 180f;
                 float deadZoneDeg = 5f;
                 if (Math.abs(diff) < deadZoneDeg) diff = 0f;
-                // Scale yaw rate with the model's yawSpeed stat for consistent feel.
                 float maxDeltaPerTick = ship.getStats().yawSpeed();
                 float step = Math.max(-maxDeltaPerTick, Math.min(maxDeltaPerTick, diff * 0.15f));
                 if (step != 0f) ship.setHeading(current + step);
 
-                // Keyboard Y axis (jump / sneak) wins over camera pitch when
-                // pressed — matches IA's pressingInterpolatedY semantics. Mouse
-                // pitch only contributes if the keyboard is idle, and even
-                // then only past a wide dead-zone so cruise flight feels stable.
                 float verticalIntent;
                 if (Math.abs(payload.keyVertical()) > 0.01f) {
                     verticalIntent = Math.max(-1f, Math.min(1f, payload.keyVertical()));

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipScreenHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipScreenHandler.java
@@ -47,7 +47,6 @@ public class ShipScreenHandler extends ScreenHandler {
     }
 
     private void layoutSlots(PlayerInventory playerInv) {
-        // Top row: 4 upgrades, 1 banner, 4 weapons.
         int y0 = 18;
         for (int i = 0; i < ShipInventory.UPGRADE_COUNT; i++) {
             final int idx = ShipInventory.UPGRADE_START + i;
@@ -84,7 +83,6 @@ public class ShipScreenHandler extends ScreenHandler {
             });
         }
 
-        // Storage 4x4 below.
         int sX0 = 62;
         int sY0 = 44;
         for (int row = 0; row < 4; row++) {
@@ -95,7 +93,6 @@ public class ShipScreenHandler extends ScreenHandler {
             }
         }
 
-        // Player inventory 3x9.
         int pY0 = 126;
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 9; col++) {
@@ -103,7 +100,6 @@ public class ShipScreenHandler extends ScreenHandler {
                         8 + col * 18, pY0 + row * 18));
             }
         }
-        // Hotbar.
         for (int col = 0; col < 9; col++) {
             addSlot(new Slot(playerInv, col, 8 + col * 18, pY0 + 58));
         }
@@ -118,10 +114,8 @@ public class ShipScreenHandler extends ScreenHandler {
         ItemStack moved = original.copy();
 
         if (slotIndex < INV_SLOTS) {
-            // Ship → player inventory.
             if (!insertItem(original, INV_SLOTS, slots.size(), true)) return ItemStack.EMPTY;
         } else {
-            // Player → ship; route by item type to the right slot range.
             if (ShipUpgrades.isUpgrade(original.getItem())) {
                 if (!insertItem(original,
                         ShipInventory.UPGRADE_START,

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipScreenHandlerTypes.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipScreenHandlerTypes.java
@@ -22,6 +22,5 @@ public final class ShipScreenHandlerTypes {
     private ShipScreenHandlerTypes() {}
 
     public static void register() {
-        // Static init handles registration.
     }
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipUpgrades.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipUpgrades.java
@@ -40,28 +40,20 @@ public final class ShipUpgrades {
     private static final Map<Item, Mod> REGISTRY = new HashMap<>();
 
     static {
-        // Diamond — faster engine.
         REGISTRY.put(Items.DIAMOND, new Mod(
                 1.30f, 1f, 1f, 1f, 1f, 1f, 1f, 0f, 1f, 1f));
-        // Redstone block — stronger vertical thrust.
         REGISTRY.put(Items.REDSTONE_BLOCK, new Mod(
                 1f, 1.50f, 1f, 1f, 1f, 1f, 1f, 0f, 1f, 1f));
-        // Gold block — tighter heading lock.
         REGISTRY.put(Items.GOLD_BLOCK, new Mod(
                 1f, 1f, 1.30f, 1f, 1f, 1f, 1f, 0f, 1f, 1f));
-        // Copper block — better cruise (less drag perpendicular to heading).
         REGISTRY.put(Items.COPPER_BLOCK, new Mod(
                 1f, 1f, 1f, 1.03f, 1.03f, 1f, 1f, 0f, 1f, 1f));
-        // Lantern — less wind sensitivity.
         REGISTRY.put(Items.LANTERN, new Mod(
                 1f, 1f, 1f, 1f, 1f, 0.70f, 1f, 0f, 1f, 1f));
-        // Feather — adds glide (forward thrust on descent).
         REGISTRY.put(Items.FEATHER, new Mod(
                 1f, 1f, 1f, 1f, 1f, 1f, 1f, 0.05f, 1f, 1f));
-        // Packed ice — stronger pitch stabilizer.
         REGISTRY.put(Items.PACKED_ICE, new Mod(
                 1f, 1f, 1f, 1f, 1f, 1f, 1.50f, 0f, 1f, 1f));
-        // Ender pearl — sharper turning + roll.
         REGISTRY.put(Items.ENDER_PEARL, new Mod(
                 1f, 1f, 1f, 1f, 1f, 1f, 1f, 0f, 1.30f, 1.20f));
     }
@@ -108,7 +100,6 @@ public final class ShipUpgrades {
             roll *= m.rollFactorMul();
         }
 
-        // Clamp decay below 1 so velocity always settles.
         hDec = Math.min(0.999f, hDec);
         vDec = Math.min(0.999f, vDec);
         lift = Math.min(0.95f, lift);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipWeapons.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/ship/ShipWeapons.java
@@ -69,7 +69,6 @@ public final class ShipWeapons {
                                         Entity projectile, Vec3d origin, Vec3d dir,
                                         float speed) {
         projectile.setPosition(origin.x, origin.y, origin.z);
-        // Inherit ship velocity so projectile relative speed matches the cabin.
         Vec3d shipVel = ship.getVelocity();
         projectile.setVelocity(dir.x * speed + shipVel.x,
                 dir.y * speed + shipVel.y,


### PR DESCRIPTION
## Summary

Pure comment-strip pass on the ship system. Per [`feedback_no_inline_comments`](https://github.com/KBVE/kbve/blob/main/...) — keep terse Javadoc on members, drop \`//\` narration inside method bodies, section dividers, and trailing inline annotations.

- 16 files touched
- −272 lines, +17 lines (replacement blank lines collapsed)
- Behaviour unchanged
- Build verified via \`./gradlew compileJava\` in \`apps/mc/behavior_statetree/java\`

Sweep applied to:
- \`ship/*.java\` (12 files)
- \`client/*.java\` (4 files)
- \`mixin/client/GameRendererMixin.java\`

Sweep skipped (next round):
- \`bbmodel/*.java\` (Blockbench loader, larger inline-doc surface)
- \`chat/*\`, root-level \`BehaviorStateTreeMod.java\`

## Test plan

- [ ] PR CI green
- [ ] After deploy, ship behaviour identical to pre-sweep build