### PR TITLE
feat(discordsh): render highlighted map on /dungeon route

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/dungeon.rs
@@ -645,6 +645,10 @@ async fn route(
         .and_then(|p| p.last())
         .and_then(|p| session.map.tiles.get(p))
         .cloned();
+    let session_for_render = path
+        .as_ref()
+        .filter(|p| p.len() >= 2)
+        .map(|_| session.clone());
     drop(session);
 
     let target_label: String = match &goal {
@@ -663,39 +667,65 @@ async fn route(
             .unwrap_or_else(|| format!("landmark `{slug}`")),
     };
 
-    let body = match (path, goal_tile) {
-        (Some(path), Some(goal_tile)) if path.len() >= 2 => {
-            let dirs = pathfinding::directions_along_path(&path);
+    let (body, render_path) = match (path.as_ref(), goal_tile) {
+        (Some(p), Some(goal_tile)) if p.len() >= 2 => {
+            let dirs = pathfinding::directions_along_path(p);
             let route = dirs
                 .iter()
                 .map(|d| d.label())
                 .collect::<Vec<_>>()
-                .join(" \u{2192} "); // " → "
+                .join(" \u{2192} ");
             let hops = dirs.len();
-            format!(
-                "{} hop(s) to **{}** ({}):\n{}",
-                hops, goal_tile.name, target_label, route
+            (
+                format!(
+                    "{} hop(s) to **{}** ({}):\n{}",
+                    hops, goal_tile.name, target_label, route
+                ),
+                Some(p.clone()),
             )
         }
-        (Some(path), Some(goal_tile)) if path.len() == 1 => format!(
-            "You're already in **{}** ({}).",
-            goal_tile.name, target_label
+        (Some(p), Some(goal_tile)) if p.len() == 1 => (
+            format!(
+                "You're already in **{}** ({}).",
+                goal_tile.name, target_label
+            ),
+            None,
         ),
-        _ => match &goal {
-            ResolvedGoal::Landmark(slug) => format!(
-                "No revealed path to landmark `{slug}` from your current room. \
-                 Either it isn't on the map yet, or you haven't explored \
-                 close enough to reveal a route."
-            ),
-            ResolvedGoal::Room(_) => format!(
-                "No revealed path to a {} from your current room. Explore further first.",
-                target_label
-            ),
-        },
+        _ => (
+            match &goal {
+                ResolvedGoal::Landmark(slug) => format!(
+                    "No revealed path to landmark `{slug}` from your current room. \
+                     Either it isn't on the map yet, or you haven't explored \
+                     close enough to reveal a route."
+                ),
+                ResolvedGoal::Room(_) => format!(
+                    "No revealed path to a {} from your current room. Explore further first.",
+                    target_label
+                ),
+            },
+            None,
+        ),
     };
 
-    ctx.send(poise::CreateReply::default().content(body).ephemeral(true))
-        .await?;
+    let route_png = match (render_path, session_for_render) {
+        (Some(route_pos), Some(snapshot)) => {
+            let fontdb = ctx.data().app.fontdb.clone();
+            match card::render_map_card_with_route(&snapshot, &route_pos, fontdb).await {
+                Ok(bytes) => Some(bytes),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to render route map for /dungeon route");
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
+
+    let mut reply = poise::CreateReply::default().content(body).ephemeral(true);
+    if let Some(png) = route_png {
+        reply = reply.attachment(serenity::CreateAttachment::bytes(png, "route_map.png"));
+    }
+    ctx.send(reply).await?;
 
     Ok(())
 }

--- a/apps/discordsh/discordsh-bot/src/discord/game/card.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/card.rs
@@ -762,6 +762,12 @@ pub struct MapTileDisplay {
     pub has_exit_e: bool,
     pub has_exit_w: bool,
     pub cleared: bool,
+    /// True when this tile sits on a `/dungeon route` highlight overlay.
+    /// Drives the cyan ring stroke in the map SVG template.
+    pub is_on_route: bool,
+    /// True for the last tile of a highlighted route — the destination.
+    /// Gets a thicker stroke than intermediate route tiles.
+    pub is_route_goal: bool,
 }
 
 /// Askama SVG template for the dungeon map card.
@@ -805,15 +811,28 @@ fn room_type_icon_id(room_type: &RoomType) -> &'static str {
     }
 }
 
-/// Build a `MapCardTemplate` from the current session state.
-///
-/// Creates a 7x7 grid centred on the player's current position.
-/// Only tiles that are visited or adjacent to a visited tile (discovered)
-/// are included; everything else is left blank (dark background).
+/// Build a `MapCardTemplate` from the current session state — no route
+/// overlay. Thin wrapper over the route-aware builder.
 pub fn build_map_card(session: &SessionState) -> MapCardTemplate {
+    build_map_card_with_route(session, &[])
+}
+
+/// Build a `MapCardTemplate` with an optional `/dungeon route` overlay.
+///
+/// Tiles in `route` are flagged `is_on_route`; the last entry is also
+/// `is_route_goal`. Pass an empty slice to render an unannotated map.
+///
+/// The 7×7 grid is centred on the player's current position. Only
+/// visited or discovered tiles are emitted; everything else is left
+/// blank (dark background). Route tiles outside the visible window
+/// are silently skipped.
+pub fn build_map_card_with_route(session: &SessionState, route: &[MapPos]) -> MapCardTemplate {
     let pos = &session.map.position;
     let half = 3i16; // 7x7 grid, center at index 3
     let mut tiles = Vec::new();
+
+    let route_set: std::collections::HashSet<MapPos> = route.iter().copied().collect();
+    let route_goal: Option<MapPos> = route.last().copied();
 
     for gy in 0..7i16 {
         for gx in 0..7i16 {
@@ -865,6 +884,9 @@ pub fn build_map_card(session: &SessionState) -> MapCardTemplate {
                 let tx = 20 + gxi * 52;
                 let ty = 44 + gyi * 52;
 
+                let is_on_route = route_set.contains(&world_pos);
+                let is_route_goal = route_goal == Some(world_pos);
+
                 tiles.push(MapTileDisplay {
                     tx,
                     ty,
@@ -881,6 +903,8 @@ pub fn build_map_card(session: &SessionState) -> MapCardTemplate {
                     has_exit_e: tile.exits.contains(&Direction::East),
                     has_exit_w: tile.exits.contains(&Direction::West),
                     cleared: tile.cleared,
+                    is_on_route,
+                    is_route_goal,
                 });
             }
         }
@@ -916,6 +940,37 @@ pub async fn render_map_card(session: &SessionState, fontdb: FontDb) -> Result<V
     tokio::task::spawn_blocking(move || render_map_card_blocking(&session_clone, &fontdb))
         .await
         .map_err(|e| format!("Map render task panicked: {e}"))?
+}
+
+/// Render the map card with a `/dungeon route` overlay as PNG bytes.
+/// Tiles in `route` get a cyan ring; the last entry gets a thicker
+/// stroke marking it as the goal. CPU-bound.
+pub fn render_map_card_with_route_blocking(
+    session: &SessionState,
+    route: &[MapPos],
+    fontdb: &FontDb,
+) -> Result<Vec<u8>, String> {
+    let template = build_map_card_with_route(session, route);
+    let svg_string = template
+        .render()
+        .map_err(|e| format!("Map SVG template error: {e}"))?;
+
+    render_svg_to_png(&svg_string, fontdb).map_err(|e| format!("Map SVG render error: {e}"))
+}
+
+/// Async wrapper for [`render_map_card_with_route_blocking`].
+pub async fn render_map_card_with_route(
+    session: &SessionState,
+    route: &[MapPos],
+    fontdb: FontDb,
+) -> Result<Vec<u8>, String> {
+    let session_clone = session.clone();
+    let route_clone = route.to_vec();
+    tokio::task::spawn_blocking(move || {
+        render_map_card_with_route_blocking(&session_clone, &route_clone, &fontdb)
+    })
+    .await
+    .map_err(|e| format!("Map render task panicked: {e}"))?
 }
 
 // ── Public render function ──────────────────────────────────────────

--- a/apps/discordsh/discordsh-bot/templates/game/map.svg
+++ b/apps/discordsh/discordsh-bot/templates/game/map.svg
@@ -25,8 +25,13 @@
     fill="{{ tile.fill_color }}"
     {% if !tile.is_visited %}opacity="0.35"{% else %}opacity="0.8"{% endif %}/>
 
+  {% if tile.is_on_route %}
+  <rect x="{{ tile.tx - 1 }}" y="{{ tile.ty - 1 }}" width="50" height="50" rx="7"
+    fill="none" stroke="#22d3ee" stroke-width="{% if tile.is_route_goal %}3{% else %}2{% endif %}"
+    stroke-dasharray="{% if tile.is_route_goal %}0{% else %}3,2{% endif %}"/>
+  {% endif %}
+
   {% if tile.is_current %}
-  <!-- Current position highlight -->
   <rect x="{{ tile.tx - 2 }}" y="{{ tile.ty - 2 }}" width="52" height="52" rx="8"
     fill="none" stroke="#ffd700" stroke-width="2.5"/>
   {% endif %}


### PR DESCRIPTION
Phase 2 followup from #10601 — escape-route highlight on the SVG map. Closes the third Phase 2 followup that was deferred at #10627 ship time.

## Behavior
\`/dungeon route\` now attaches a route-annotated map PNG to the ephemeral reply when a path is found. Tiles on the path get a cyan dashed ring; the destination tile gets a thicker solid ring. The current room's gold ring still wins visually if it sits on the path.

Maps render only when the BFS path has at least two tiles — otherwise the player is already at the goal or no route exists, in which case the existing text reply is unchanged.

## Code
- \`MapTileDisplay\` gains \`is_on_route\` / \`is_route_goal\`. The route ring SVG is layered before the \`is_current\` highlight so the gold ring stays on top.
- New \`build_map_card_with_route(session, &[MapPos])\` reuses the same 7×7 viewport logic as \`build_map_card\`; the no-route helper becomes a one-line wrapper.
- New \`render_map_card_with_route(_blocking)\` mirrors the existing map renderers and dispatches via \`tokio::task::spawn_blocking\`.
- \`/dungeon route\` clones the session under the lock, drops the lock, then renders the map. Render failures log a warning and degrade to text-only — no fallback to the unannotated map.

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy --no-deps\` clean on edited regions
- [x] \`cargo test --bin discordsh-bot\` — 705/705 pass
- [ ] Smoke in staging: \`/dungeon route target:boss\` after exploring a few tiles → ephemeral reply has hop count + route map PNG with dashed cyan ring on path tiles, solid ring on the boss tile
- [ ] \`/dungeon route landmark:made-up-slug\` → text-only reply (no PNG), error copy

## What's not in this PR (still on the #10601 board)
- NPC pursuit AI using the same \`PathField\`