### PR TITLE
fix(astro-kbve): supa init timeout drops user to Guest with no recovery

### DIFF
--- a/apps/kbve/astro-kbve/src/lib/supa.ts
+++ b/apps/kbve/astro-kbve/src/lib/supa.ts
@@ -15,8 +15,9 @@ export const SUPABASE_URL = 'https://supabase.kbve.com';
 export const SUPABASE_ANON_KEY =
 	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzU1NDAzMjAwLCJleHAiOjE5MTMxNjk2MDB9.oietJI22ZytbghFywvdYMSJp7rcsBdBYbcciJxeGWrg';
 
-const INIT_TIMEOUT_MS = 3_000;
-const AUTO_RECOVER_FLAG = 'kbve_supa_auto_recovered';
+const INIT_TIMEOUT_MS = 10_000;
+const AUTO_RECOVER_STAMP = 'kbve_supa_auto_recovered_at';
+const AUTO_RECOVER_COOLDOWN_MS = 60_000;
 
 function ensureClient(): SupabaseGateway {
 	if (typeof window === 'undefined') {
@@ -33,25 +34,27 @@ function ensureClient(): SupabaseGateway {
 	return _gateway;
 }
 
-/**
- * One-shot recovery for the "previous deploy left a stale worker /
- * cached chunk pointing at hashed URLs that no longer exist on the
- * CDN" scenario. We see this most often as a 30s
- * `Worker N request init timed out` from droid's WorkerPool — the
- * page bundle was loaded from cache but its embedded worker URL no
- * longer resolves.
- *
- * Guarded by a sessionStorage flag so a genuinely-broken upstream
- * (Supabase down, network down) can't loop the user.
- */
 async function autoRecoverStaleClient(): Promise<void> {
 	if (typeof window === 'undefined') return;
-	if (sessionStorage.getItem(AUTO_RECOVER_FLAG) === '1') return;
-	sessionStorage.setItem(AUTO_RECOVER_FLAG, '1');
 
-	console.warn(
-		'[Supabase] init timed out — clearing caches + reloading once.',
-	);
+	const now = Date.now();
+	let last = 0;
+	try {
+		const raw = localStorage.getItem(AUTO_RECOVER_STAMP);
+		if (raw) last = Number.parseInt(raw, 10) || 0;
+	} catch {}
+
+	if (now - last < AUTO_RECOVER_COOLDOWN_MS) {
+		console.warn('[Supabase] init timed out, recovery throttled.');
+		return;
+	}
+
+	console.warn('[Supabase] init timed out — clearing caches + reloading.');
+
+	try {
+		localStorage.setItem(AUTO_RECOVER_STAMP, String(now));
+	} catch {}
+
 	try {
 		if ('caches' in window) {
 			const keys = await caches.keys();
@@ -79,7 +82,6 @@ export function initSupa(options?: Record<string, unknown>): Promise<void> {
 		const init = (async () => {
 			await gateway.init(SUPABASE_URL, SUPABASE_ANON_KEY, options);
 			await bootAuth(gateway);
-			await resolveStaffFlag(gateway, SUPABASE_URL, SUPABASE_ANON_KEY);
 		})();
 
 		const timeout = new Promise<never>((_, reject) =>
@@ -96,11 +98,7 @@ export function initSupa(options?: Record<string, unknown>): Promise<void> {
 			throw err;
 		}
 
-		if (typeof window !== 'undefined') {
-			try {
-				sessionStorage.removeItem(AUTO_RECOVER_FLAG);
-			} catch {}
-		}
+		void resolveStaffFlag(gateway, SUPABASE_URL, SUPABASE_ANON_KEY);
 	})()
 		.then(() => {})
 		.catch((e) => {


### PR DESCRIPTION
## Summary

Signed-in users on \`kbve.com\` randomly drop to "Guest" and see \`init timeout\` when they click Sign in, and have to close Safari to recover. Three coupled bugs:

1. **\`INIT_TIMEOUT_MS\` was 3s.** Safari cold-starts the SharedWorker, opens IDB, migrates auth storage, and round-trips \`supabase.kbve.com\` for the initial session — a dormant tab waking up on cellular routinely overshoots 3s. Bumped to 10s (\`profile-controller\`'s matching init already uses 8s, so the gateway gets a small headroom over its consumer).

2. **\`resolveStaffFlag\` ran inside the timed init path.** It depends on a network round-trip to \`/rest/v1/rpc/staff_permissions\`, which can't be allowed to gate the gateway being declared usable. Moved it after the \`Promise.race\` so a slow RPC stops dropping the user back to anon. Staff flag is an enhancement (unlocks staff UI) — non-critical, fire-and-forget.

3. **\`autoRecoverStaleClient\` was guarded by a sessionStorage flag** set to \`"1"\` on first attempt and never cleared until a successful init in the same tab. A single transient timeout permanently disabled recovery for the rest of the tab's lifetime — user sees \`init timeout\` forever and can only escape by closing Safari. Switched to a localStorage timestamp + 60s cool-down: throttled enough that a genuinely-broken upstream can't reload-loop the user, but a one-off failure no longer locks them out.

## Changes

\`apps/kbve/astro-kbve/src/lib/supa.ts\`:

- \`INIT_TIMEOUT_MS\`: \`3_000\` → \`10_000\`
- New \`AUTO_RECOVER_STAMP\` (localStorage) + \`AUTO_RECOVER_COOLDOWN_MS = 60_000\`; old \`AUTO_RECOVER_FLAG\` (sessionStorage) removed.
- \`resolveStaffFlag\` moved out of the timed \`Promise.race\` and called as fire-and-forget after init succeeds.

## Test plan

- [x] \`npx astro build\` — clean
- [ ] On Safari with the prior bundle: clicking Sign in after wake-from-sleep no longer throws \`init timeout\` permanently; either the gateway initializes within 10s, or recovery fires once and a subsequent retry can fire again 60s later instead of being silently no-op'd.
- [ ] Staff users still see staff UI after page load (resolveStaffFlag now resolves a tick after init returns instead of inside it).