### PR TITLE
fix(jedi, axum-kbve, kube): wire ClickHouse direct route end-to-end

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/502.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/502.mdx
@@ -1,0 +1,12 @@
+---
+title: '502'
+template: splash
+editUrl: false
+hero:
+  title: '502'
+  tagline: Bad Gateway. An upstream service didn't return a valid response.
+---
+
+import NotFound404Search from '../../components/search/NotFound404Search.astro';
+
+<NotFound404Search />

--- a/apps/kbve/astro-kbve/src/content/docs/503.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/503.mdx
@@ -1,0 +1,12 @@
+---
+title: '503'
+template: splash
+editUrl: false
+hero:
+  title: '503'
+  tagline: Service Unavailable. A backend route is misconfigured or temporarily down.
+---
+
+import NotFound404Search from '../../components/search/NotFound404Search.astro';
+
+<NotFound404Search />

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -593,19 +593,23 @@ use jedi::state::sidecar::ClickHouseConfig;
 static CLICKHOUSE_DIRECT: OnceLock<ClickHouseConfig> = OnceLock::new();
 
 pub fn init_clickhouse_direct() -> bool {
-    // ClickHouseConfig::from_env defaults host=localhost / port=8123 if
-    // CLICKHOUSE_HOST / CLICKHOUSE_PORT aren't set, so a misconfigured pod
-    // would silently target localhost. Require at least one of the two to
-    // be present to consider the proxy "configured".
-    let has_env = std::env::var("CLICKHOUSE_HOST").is_ok()
-        || std::env::var("CLICKHOUSE_PORT").is_ok()
-        || std::env::var("CLICKHOUSE_USER").is_ok()
-        || std::env::var("CLICKHOUSE_DATABASE").is_ok();
-    if !has_env {
+    let (config, url_explicit) = ClickHouseConfig::from_env_resolved();
+
+    if !url_explicit {
+        warn!(
+            "ClickHouse direct route refused — set CLICKHOUSE_ENDPOINT (preferred) or \
+             CLICKHOUSE_HOST/PORT in the deployment env."
+        );
         return false;
     }
 
-    let config = ClickHouseConfig::from_env();
+    if config.database == "default" && std::env::var("CLICKHOUSE_DATABASE").is_err() {
+        warn!(
+            "ClickHouse direct route initialized with database=default — set \
+             CLICKHOUSE_DATABASE (e.g. observability) so queries hit the right schema."
+        );
+    }
+
     CLICKHOUSE_DIRECT.set(config).is_ok()
 }
 

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -173,6 +173,8 @@ spec:
                             secretKeyRef:
                                 name: clickhouse-credentials
                                 key: password
+                      - name: CLICKHOUSE_DATABASE
+                        value: 'observability'
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd

--- a/packages/rust/jedi/src/state/sidecar.rs
+++ b/packages/rust/jedi/src/state/sidecar.rs
@@ -1,295 +1,333 @@
+use crate::error::JediError;
+use chrono::Utc;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::borrow::Cow;
 use std::env;
-use chrono::Utc;
-use serde::{ Deserialize, Serialize, de::DeserializeOwned };
-use crate::error::JediError;
-use std::sync::Arc;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::fs;
 
 pub fn get_env(key: &str, default: &str) -> String {
-  let file_key = format!("{}_FILE", key);
-  if let Ok(path) = env::var(&file_key) {
-    std::fs
-      ::read_to_string(path)
-      .map(|s| s.trim().to_string())
-      .unwrap_or_else(|_| default.to_string())
-  } else {
-    env::var(key).unwrap_or_else(|_| default.to_string())
-  }
+    let file_key = format!("{}_FILE", key);
+    if let Ok(path) = env::var(&file_key) {
+        std::fs::read_to_string(path)
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|_| default.to_string())
+    } else {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
 }
 
 pub async fn get_env_async(key: &str, default: &str) -> String {
-  let file_key = format!("{}_FILE", key);
-  if let Ok(path) = env::var(&file_key) {
-    tokio::fs
-      ::read_to_string(path).await
-      .map(|s| s.trim().to_string())
-      .unwrap_or_else(|_| default.to_string())
-  } else {
-    env::var(key).unwrap_or_else(|_| default.to_string())
-  }
+    let file_key = format!("{}_FILE", key);
+    if let Ok(path) = env::var(&file_key) {
+        tokio::fs::read_to_string(path)
+            .await
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|_| default.to_string())
+    } else {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct FileTokenStorage<T> {
-  pub(crate) path: Arc<PathBuf>,
-  _phantom: std::marker::PhantomData<T>,
+    pub(crate) path: Arc<PathBuf>,
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T> FileTokenStorage<T> where T: Serialize + DeserializeOwned + Send + Sync + 'static {
-  pub fn new<P: Into<PathBuf>>(path: P) -> Self {
-    Self {
-      path: Arc::new(path.into()),
-      _phantom: std::marker::PhantomData,
-    }
-  }
-
-  pub async fn load(&self) -> Option<T> {
-    match fs::read_to_string(&*self.path).await {
-      Ok(contents) => {
-        match serde_json::from_str::<T>(&contents) {
-          Ok(token) => Some(token),
-          Err(e) => {
-            tracing::warn!("Failed to parse token JSON: {}", e);
-            None
-          }
+impl<T> FileTokenStorage<T>
+where
+    T: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
+        Self {
+            path: Arc::new(path.into()),
+            _phantom: std::marker::PhantomData,
         }
-      }
-      Err(e) => {
-        tracing::warn!("Failed to read token file: {}", e);
-        None
-      }
     }
-  }
 
-  pub async fn save(&self, value: &T) {
-    if let Ok(json) = serde_json::to_string_pretty(value) {
-      if let Err(e) = fs::write(&*self.path, json).await {
-        tracing::error!("Failed to write token file: {}", e);
-      } else {
-        tracing::debug!("Token saved at {:?}", self.path);
-      }
+    pub async fn load(&self) -> Option<T> {
+        match fs::read_to_string(&*self.path).await {
+            Ok(contents) => match serde_json::from_str::<T>(&contents) {
+                Ok(token) => Some(token),
+                Err(e) => {
+                    tracing::warn!("Failed to parse token JSON: {}", e);
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!("Failed to read token file: {}", e);
+                None
+            }
+        }
     }
-  }
+
+    pub async fn save(&self, value: &T) {
+        if let Ok(json) = serde_json::to_string_pretty(value) {
+            if let Err(e) = fs::write(&*self.path, json).await {
+                tracing::error!("Failed to write token file: {}", e);
+            } else {
+                tracing::debug!("Token saved at {:?}", self.path);
+            }
+        }
+    }
 
     pub async fn try_load(&self) -> Result<T, JediError> {
-      let contents = fs::read_to_string(&*self.path).await?;
-      let token = serde_json::from_str::<T>(&contents)
-        .map_err(|e| JediError::Internal(Cow::Owned(format!("Parse error: {e}"))))?;
-      Ok(token)
+        let contents = fs::read_to_string(&*self.path).await?;
+        let token = serde_json::from_str::<T>(&contents)
+            .map_err(|e| JediError::Internal(Cow::Owned(format!("Parse error: {e}"))))?;
+        Ok(token)
     }
-  
+
     pub async fn try_save(&self, value: &T) -> Result<(), JediError> {
-      let json = serde_json::to_string_pretty(value)
-        .map_err(|e| JediError::Internal(Cow::Owned(format!("Serialize error: {e}"))))?;
-      fs::write(&*self.path, json).await?;
-      Ok(())
+        let json = serde_json::to_string_pretty(value)
+            .map_err(|e| JediError::Internal(Cow::Owned(format!("Serialize error: {e}"))))?;
+        fs::write(&*self.path, json).await?;
+        Ok(())
     }
 }
 
 pub struct RedisConfig {
-  pub url: String,
+    pub url: String,
 }
 
 impl RedisConfig {
-  pub fn from_env() -> Self {
-    let host = get_env("REDIS_HOST", "localhost");
-    let port = get_env("REDIS_PORT", "6379");
-    let password = get_env("REDIS_PASSWORD", "");
+    pub fn from_env() -> Self {
+        let host = get_env("REDIS_HOST", "localhost");
+        let port = get_env("REDIS_PORT", "6379");
+        let password = get_env("REDIS_PASSWORD", "");
 
-    let url = if password.is_empty() {
-      format!("redis://{}:{}", host, port)
-    } else {
-      format!("redis://:{}@{}:{}", password, host, port)
-    };
+        let url = if password.is_empty() {
+            format!("redis://{}:{}", host, port)
+        } else {
+            format!("redis://:{}@{}:{}", password, host, port)
+        };
 
-    Self { url }
-  }
+        Self { url }
+    }
 }
 
 #[cfg(feature = "clickhouse")]
 pub struct ClickHouseConfig {
-  pub url: String,
-  pub user: String,
-  pub password: String,
-  pub database: String,
+    pub url: String,
+    pub user: String,
+    pub password: String,
+    pub database: String,
 }
 
 #[cfg(feature = "clickhouse")]
 impl ClickHouseConfig {
-  pub fn from_env() -> Self {
-    let host = get_env("CLICKHOUSE_HOST", "localhost");
-    let port = get_env("CLICKHOUSE_PORT", "8123");
-    let user = get_env("CLICKHOUSE_USER", "default");
-    let password = get_env("CLICKHOUSE_PASSWORD", "");
-    let database = get_env("CLICKHOUSE_DATABASE", "default");
-
-    let url = format!("http://{}:{}", host, port);
-
-    Self { url, user, password, database }
-  }
-
-  pub fn build_client(&self) -> clickhouse::Client {
-    let mut client = clickhouse::Client::default()
-      .with_url(&self.url)
-      .with_user(&self.user)
-      .with_database(&self.database);
-
-    if !self.password.is_empty() {
-      client = client.with_password(&self.password);
+    pub fn from_env() -> Self {
+        Self::from_env_resolved().0
     }
 
-    client
-  }
+    /// Returns `(config, url_explicit)` — `url_explicit` is `false` when
+    /// the URL fell back to localhost so callers can fail loud.
+    pub fn from_env_resolved() -> (Self, bool) {
+        let endpoint = env::var("CLICKHOUSE_ENDPOINT")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+        let host_set = env::var("CLICKHOUSE_HOST").is_ok() || env::var("CLICKHOUSE_PORT").is_ok();
 
-  pub async fn execute_select(&self, query: &str) -> Result<Vec<serde_json::Value>, JediError> {
-    let http = reqwest::Client::new();
-    let full_query = format!("{} FORMAT JSONEachRow", query);
+        let (url, url_explicit) = if let Some(ep) = endpoint {
+            (ep.trim_end_matches('/').to_string(), true)
+        } else {
+            let host = get_env("CLICKHOUSE_HOST", "localhost");
+            let port = get_env("CLICKHOUSE_PORT", "8123");
+            (format!("http://{}:{}", host, port), host_set)
+        };
 
-    let mut req = http
-      .post(&self.url)
-      .query(&[("database", &self.database)])
-      .body(full_query);
+        let user = env::var("CLICKHOUSE_USER")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                env::var("CLICKHOUSE_USERNAME")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+            })
+            .unwrap_or_else(|| "default".to_string());
+        let password = get_env("CLICKHOUSE_PASSWORD", "");
+        let database = get_env("CLICKHOUSE_DATABASE", "default");
 
-    if !self.user.is_empty() {
-      req = req.header("X-ClickHouse-User", &self.user);
-    }
-    if !self.password.is_empty() {
-      req = req.header("X-ClickHouse-Key", &self.password);
-    }
-
-    let resp = req
-      .send()
-      .await
-      .map_err(|e| JediError::Database(Cow::Owned(format!("ClickHouse HTTP error: {}", e))))?;
-
-    if !resp.status().is_success() {
-      let body = resp.text().await.unwrap_or_default();
-      return Err(JediError::Database(Cow::Owned(format!("ClickHouse query failed: {}", body))));
-    }
-
-    let text = resp
-      .text()
-      .await
-      .map_err(|e| JediError::Database(Cow::Owned(format!("ClickHouse response error: {}", e))))?;
-
-    let rows: Vec<serde_json::Value> = text
-      .lines()
-      .filter(|l| !l.is_empty())
-      .map(|l| serde_json::from_str(l))
-      .collect::<Result<_, _>>()
-      .map_err(|e| JediError::Parse(format!("ClickHouse JSON parse error: {}", e)))?;
-
-    Ok(rows)
-  }
-
-  pub async fn execute_insert(&self, table: &str, rows: &[serde_json::Value]) -> Result<(), JediError> {
-    if rows.is_empty() {
-      return Ok(());
+        (
+            Self {
+                url,
+                user,
+                password,
+                database,
+            },
+            url_explicit,
+        )
     }
 
-    let body = rows
-      .iter()
-      .map(|r| serde_json::to_string(r))
-      .collect::<Result<Vec<_>, _>>()
-      .map_err(|e| JediError::Parse(format!("ClickHouse JSON serialize error: {}", e)))?
-      .join("\n");
+    pub fn build_client(&self) -> clickhouse::Client {
+        let mut client = clickhouse::Client::default()
+            .with_url(&self.url)
+            .with_user(&self.user)
+            .with_database(&self.database);
 
-    let insert_query = format!("INSERT INTO {} FORMAT JSONEachRow", table);
-    let http = reqwest::Client::new();
+        if !self.password.is_empty() {
+            client = client.with_password(&self.password);
+        }
 
-    let mut req = http
-      .post(&self.url)
-      .query(&[("database", &self.database), ("query", &insert_query)])
-      .body(body);
-
-    if !self.user.is_empty() {
-      req = req.header("X-ClickHouse-User", &self.user);
-    }
-    if !self.password.is_empty() {
-      req = req.header("X-ClickHouse-Key", &self.password);
+        client
     }
 
-    let resp = req
-      .send()
-      .await
-      .map_err(|e| JediError::Database(Cow::Owned(format!("ClickHouse HTTP error: {}", e))))?;
+    pub async fn execute_select(&self, query: &str) -> Result<Vec<serde_json::Value>, JediError> {
+        let http = reqwest::Client::new();
+        let full_query = format!("{} FORMAT JSONEachRow", query);
 
-    if !resp.status().is_success() {
-      let err_body = resp.text().await.unwrap_or_default();
-      return Err(JediError::Database(Cow::Owned(format!("ClickHouse insert failed: {}", err_body))));
+        let mut req = http
+            .post(&self.url)
+            .query(&[("database", &self.database)])
+            .body(full_query);
+
+        if !self.user.is_empty() {
+            req = req.header("X-ClickHouse-User", &self.user);
+        }
+        if !self.password.is_empty() {
+            req = req.header("X-ClickHouse-Key", &self.password);
+        }
+
+        let resp = req.send().await.map_err(|e| {
+            JediError::Database(Cow::Owned(format!("ClickHouse HTTP error: {}", e)))
+        })?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(JediError::Database(Cow::Owned(format!(
+                "ClickHouse query failed: {}",
+                body
+            ))));
+        }
+
+        let text = resp.text().await.map_err(|e| {
+            JediError::Database(Cow::Owned(format!("ClickHouse response error: {}", e)))
+        })?;
+
+        let rows: Vec<serde_json::Value> = text
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l))
+            .collect::<Result<_, _>>()
+            .map_err(|e| JediError::Parse(format!("ClickHouse JSON parse error: {}", e)))?;
+
+        Ok(rows)
     }
 
-    Ok(())
-  }
+    pub async fn execute_insert(
+        &self,
+        table: &str,
+        rows: &[serde_json::Value],
+    ) -> Result<(), JediError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let body = rows
+            .iter()
+            .map(|r| serde_json::to_string(r))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| JediError::Parse(format!("ClickHouse JSON serialize error: {}", e)))?
+            .join("\n");
+
+        let insert_query = format!("INSERT INTO {} FORMAT JSONEachRow", table);
+        let http = reqwest::Client::new();
+
+        let mut req = http
+            .post(&self.url)
+            .query(&[("database", &self.database), ("query", &insert_query)])
+            .body(body);
+
+        if !self.user.is_empty() {
+            req = req.header("X-ClickHouse-User", &self.user);
+        }
+        if !self.password.is_empty() {
+            req = req.header("X-ClickHouse-Key", &self.password);
+        }
+
+        let resp = req.send().await.map_err(|e| {
+            JediError::Database(Cow::Owned(format!("ClickHouse HTTP error: {}", e)))
+        })?;
+
+        if !resp.status().is_success() {
+            let err_body = resp.text().await.unwrap_or_default();
+            return Err(JediError::Database(Cow::Owned(format!(
+                "ClickHouse insert failed: {}",
+                err_body
+            ))));
+        }
+
+        Ok(())
+    }
 }
 
 pub struct TwitchAuth {
-  pub client_id: String,
-  pub client_secret: String,
-  pub token_path: String,
+    pub client_id: String,
+    pub client_secret: String,
+    pub token_path: String,
 }
 
 impl TwitchAuth {
-  pub fn from_env() -> Self {
-    let client_id = get_env("TWITCH_CLIENT_ID", "");
-    let client_secret = get_env("TWITCH_CLIENT_SECRET", "");
-    let token_path = get_env("TWITCH_TOKEN_PATH", "twitch_tokens.json");
+    pub fn from_env() -> Self {
+        let client_id = get_env("TWITCH_CLIENT_ID", "");
+        let client_secret = get_env("TWITCH_CLIENT_SECRET", "");
+        let token_path = get_env("TWITCH_TOKEN_PATH", "twitch_tokens.json");
 
-    if client_id.is_empty() || client_secret.is_empty() {
-      panic!("Missing TWITCH_CLIENT_ID or TWITCH_CLIENT_SECRET");
+        if client_id.is_empty() || client_secret.is_empty() {
+            panic!("Missing TWITCH_CLIENT_ID or TWITCH_CLIENT_SECRET");
+        }
+
+        Self {
+            client_id,
+            client_secret,
+            token_path,
+        }
     }
-
-    Self { client_id, client_secret, token_path }
-  }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 struct EnvTwitchToken {
-  access_token: String,
-  refresh_token: String,
-  expires_in: i64,
-  token_type: String,
-  #[serde(default)]
-  scope: Vec<String>,
+    access_token: String,
+    refresh_token: String,
+    expires_in: i64,
+    token_type: String,
+    #[serde(default)]
+    scope: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 struct TwitchFileToken {
-  access_token: String,
-  refresh_token: String,
-  expires_in: i64,
-  created_at: String,
+    access_token: String,
+    refresh_token: String,
+    expires_in: i64,
+    created_at: String,
 }
 
 pub fn save_twitch_json_from_env(env_key: &str, file_path: &str) -> Result<(), JediError> {
-  let raw = std::env
-    ::var(env_key)
-    .map_err(|e| JediError::Internal(Cow::Owned(format!("env: {}", e))))?;
-  let parsed: EnvTwitchToken = serde_json
-    ::from_str(&raw)
-    .map_err(|e| JediError::Internal(Cow::Owned(format!("json: {}", e))))?;
+    let raw = std::env::var(env_key)
+        .map_err(|e| JediError::Internal(Cow::Owned(format!("env: {}", e))))?;
+    let parsed: EnvTwitchToken = serde_json::from_str(&raw)
+        .map_err(|e| JediError::Internal(Cow::Owned(format!("json: {}", e))))?;
 
-  let token = TwitchFileToken {
-    access_token: parsed.access_token,
-    refresh_token: parsed.refresh_token,
-    expires_in: parsed.expires_in,
-    created_at: Utc::now().to_rfc3339(),
-  };
+    let token = TwitchFileToken {
+        access_token: parsed.access_token,
+        refresh_token: parsed.refresh_token,
+        expires_in: parsed.expires_in,
+        created_at: Utc::now().to_rfc3339(),
+    };
 
-  let json = serde_json
-    ::to_string_pretty(&token)
-    .map_err(|e| JediError::Internal(Cow::Owned(format!("serde: {}", e))))?;
-  std::fs
-    ::write(file_path, json)
-    .map_err(|e| JediError::Internal(Cow::Owned(format!("fs: {}", e))))?;
+    let json = serde_json::to_string_pretty(&token)
+        .map_err(|e| JediError::Internal(Cow::Owned(format!("serde: {}", e))))?;
+    std::fs::write(file_path, json)
+        .map_err(|e| JediError::Internal(Cow::Owned(format!("fs: {}", e))))?;
 
-  tracing::debug!(
-      env_key = %env_key,
-      file_path = %file_path,
-      "[Twitch] Token saved from environment to file"
-  );
+    tracing::debug!(
+        env_key = %env_key,
+        file_path = %file_path,
+        "[Twitch] Token saved from environment to file"
+    );
 
-  Ok(())
+    Ok(())
 }


### PR DESCRIPTION
## Symptom
\`/dashboard/clickhouse/proxy\` returns 502, pod log shows:
\`\`\`
ClickHouse HTTP error: error sending request for url (http://localhost:8123/?database=default)
\`\`\`
since the direct-route landed (#10646). Boot logged \`ClickHouse direct route initialized\` but every query hit localhost.

## Three layered bugs

### 1. Env var name mismatch
Deployment env wires \`CLICKHOUSE_ENDPOINT\` (full URL from the \`clickhouse-credentials\` ESO secret) + \`CLICKHOUSE_USER\` / \`CLICKHOUSE_PASSWORD\`. \`jedi::ClickHouseConfig::from_env\` only knew \`CLICKHOUSE_HOST\` + \`CLICKHOUSE_PORT\`, so it fell back to \`localhost:8123\` silently.

### 2. No database wired
Real schema is \`observability\` (\`logs_distributed\` lives there). jedi defaulted to \`default\`, so every query landed on the wrong schema.

### 3. Init guard too permissive
\`init_clickhouse_direct\` accepted any of \`CLICKHOUSE_HOST\` / \`PORT\` / \`USER\` / \`DATABASE\` being set as "configured" and logged success even while the URL silently fell back to localhost.

## Fixes

### [\`jedi/src/state/sidecar.rs\`](packages/rust/jedi/src/state/sidecar.rs)
- \`from_env_resolved()\` returns \`(config, url_explicit)\`. Reads \`CLICKHOUSE_ENDPOINT\` first, falls back to \`CLICKHOUSE_HOST/PORT\`, and only flags \`url_explicit=true\` when one of those was actually set.
- Accepts \`CLICKHOUSE_USERNAME\` as alias for \`CLICKHOUSE_USER\` so the secret key shape (\`username\` / \`password\` / \`endpoint\`) maps cleanly.
- \`from_env()\` keeps the old signature, delegates to the resolved variant.

### [\`axum-kbve/src/transport/proxy.rs\`](apps/kbve/axum-kbve/src/transport/proxy.rs)
- \`init_clickhouse_direct\` refuses init when \`url_explicit\` is false and warns instead of pretending to be configured.
- Separately warns when database falls back to \`default\` without \`CLICKHOUSE_DATABASE\` set.

### [\`kbve-deployment.yaml\`](apps/kube/kbve/manifest/kbve-deployment.yaml)
- Adds \`CLICKHOUSE_DATABASE=observability\`.

### [\`502.mdx\`](apps/kbve/astro-kbve/src/content/docs/502.mdx) + [\`503.mdx\`](apps/kbve/astro-kbve/src/content/docs/503.mdx) (new)
- Splash error pages mirroring \`404.mdx\` so 502 / 503 responses surface a styled page instead of a raw axum body.

## RBAC (verified, no change needed)
\`clickhouse-credentials\` ESO secret synced from \`vector\` namespace to \`kbve\` via \`ClusterSecretStore\`. RoleBinding \`kbve-read-clickhouse-credentials\` in \`vector\` ns grants the kbve SA read access. Already working.

## Test plan
- [x] \`cargo build --features clickhouse\` (jedi) clean
- [x] \`cargo build\` (axum-kbve) clean
- [ ] Deploy → pod log shows no \`error sending request for url (http://localhost:8123/...)\` lines
- [ ] \`/dashboard/clickhouse/proxy\` returns rows from \`observability.logs_distributed\` (curl + dashboard UI)
- [ ] Misconfigured env on a future deploy → init refuses + dashboard hits 503 path instead of timing out per-query