### PR TITLE
fix(py): exit-from-finally + mixed-returns (CodeQL #59, #47, #48)

### DIFF
--- a/apps/discordsh/notification-bot/notification_bot/api/discord/discord_service.py
+++ b/apps/discordsh/notification-bot/notification_bot/api/discord/discord_service.py
@@ -8,15 +8,12 @@ from typing import Optional
 import discord
 from notification_bot.utils.logger import logger
 
-# Import constants
 try:
     from ..supabase.constants import DISCORD_THREAD_ID, DEFAULT_CLEANUP_LIMIT
 except ImportError:
-    # Fallback constants
     DISCORD_THREAD_ID = os.getenv("DISCORD_THREAD_ID")
     DEFAULT_CLEANUP_LIMIT = 50
 
-# Import managers - use try/except for graceful fallback
 try:
     from ..supabase import vault_manager, tracker_manager
 except ImportError:
@@ -42,11 +39,9 @@ class DiscordBotService:
             return self._bot
 
         try:
-            # Check if we're in development mode and have env vars set
             python_env = os.getenv('PYTHON_ENV', '').lower()
             is_development = python_env == 'development'
 
-            # Try to get token from environment variables first if in development
             env_token = None
             if is_development:
                 env_token = (os.getenv('DISCORD_BOT') or
@@ -58,7 +53,6 @@ class DiscordBotService:
                     "Using Discord token from environment variables (development mode)")
                 self._token = env_token
             else:
-                # Fallback to Supabase vault for production or when env vars not set
                 logger.info("Retrieving Discord token from Supabase vault")
                 secret_id = "39781c47-be8f-4a10-ae3a-714da299ca07"
                 result = await vault_manager.get_vault_secret(secret_id)
@@ -67,24 +61,19 @@ class DiscordBotService:
                     raise Exception(
                         f"Failed to retrieve Discord token: {result.error}")
 
-                # Extract the token from the secret data
                 secret_data = result.data
                 if not secret_data or 'decrypted_secret' not in secret_data:
                     raise Exception("Discord token not found in vault secret")
 
                 self._token = secret_data['decrypted_secret']
 
-            # Create Discord bot with intents
             intents = discord.Intents.default()
-            intents.message_content = True  # Enable message content intent
+            intents.message_content = True
             intents.guilds = True
             intents.guild_messages = True
 
-            # For cross-cluster deployments, use distributed shard coordination via Supabase
-            # Get instance ID for this deployment
             instance_id = os.getenv('HOSTNAME', str(uuid.uuid4())[:8])
 
-            # Check sharding configuration - priority order matters
             use_auto_scaling = os.getenv(
                 'USE_AUTO_SCALING', 'false').lower() == 'true'
             use_distributed_sharding = os.getenv(
@@ -100,19 +89,17 @@ class DiscordBotService:
                 f"Distributed sharding enabled: {use_distributed_sharding}")
 
             if use_auto_scaling:
-                # Auto-scaling: All shards in one process using AutoShardedClient
                 logger.info(
                     f"Using AutoShardedClient with all shards in one process for instance {instance_id}")
                 suggested_shard_count = int(os.getenv('TOTAL_SHARDS', '2'))
                 self._bot = discord.AutoShardedClient(
                     intents=intents,
-                    shard_count=suggested_shard_count  # Suggest minimum, Discord may use more
+                    shard_count=suggested_shard_count
                 )
                 logger.info(
                     f"Created AutoShardedClient with {suggested_shard_count} shards in one process")
 
             elif use_distributed_sharding:
-                # True distributed sharding: One shard per container using manual Client
                 shard_id = int(os.getenv('SHARD_ID', '0'))
                 shard_count = int(os.getenv('SHARD_COUNT', '2'))
 
@@ -130,12 +117,10 @@ class DiscordBotService:
                     f"Created distributed Client for shard {shard_id}/{shard_count}")
 
             else:
-                # Fallback: Traditional environment variable sharding or single instance auto-sharding
                 shard_id = int(os.getenv('SHARD_ID', '-1'))
                 shard_count = int(os.getenv('SHARD_COUNT', '1'))
 
                 if shard_id >= 0 and shard_count > 1:
-                    # Manual sharding via environment variables (backward compatibility)
                     self._bot = discord.Client(
                         intents=intents,
                         shard_id=shard_id,
@@ -144,12 +129,10 @@ class DiscordBotService:
                     logger.info(
                         f"Using fallback manual sharding: shard {shard_id}/{shard_count}")
                 else:
-                    # Auto-sharding for single instance
                     self._bot = discord.AutoShardedClient(intents=intents)
                     logger.info(
                         "Using fallback auto-sharding for single instance")
 
-            # Set up event handlers
             self._setup_event_handlers()
 
             logger.info("Discord bot initialized successfully")
@@ -173,10 +156,8 @@ class DiscordBotService:
                 f"🟢🟢🟢 ON_READY EVENT TRIGGERED! Bot logged in as {self._bot.user} 🟢🟢🟢")
             logger.info(f"Bot is in {len(self._bot.guilds)} guilds")
 
-            # Log shard information and track what Discord actually assigned
             actual_shards = []
             if hasattr(self._bot, 'shards') and self._bot.shards:
-                # AutoShardedClient - track what Discord determined
                 logger.info(
                     f"🔍 Discord determined {len(self._bot.shards)} shards for this instance")
                 for shard_id, shard in self._bot.shards.items():
@@ -186,7 +167,6 @@ class DiscordBotService:
                     logger.info(
                         f"  ✅ Shard {shard_id}: {len(shard_guilds)} guilds, latency: {shard.latency:.2f}ms")
 
-                # Check master server assignment
                 from ..supabase.constants import MASTER_SERVER
                 master_shard = MASTER_SERVER % len(
                     self._bot.shards) if self._bot.shards else 0
@@ -200,7 +180,6 @@ class DiscordBotService:
                     )
 
             elif hasattr(self._bot, 'shard_id') and self._bot.shard_id is not None:
-                # Manual sharding - track what was assigned
                 shard_id = self._bot.shard_id
                 shard_count = getattr(self._bot, 'shard_count', 1)
                 actual_shards = [shard_id]
@@ -211,16 +190,13 @@ class DiscordBotService:
                     f" guilds, latency: {self._bot.latency:.2f}ms"
                 )
             else:
-                # No sharding
                 actual_shards = [0]
                 logger.info("📌 Using single instance (no sharding)")
 
-            # Log all guild assignments
             logger.info(f"📋 Guild assignments for shards {actual_shards}:")
             for guild in self._bot.guilds:
                 shard_info = f", Shard: {guild.shard_id}" if hasattr(
                     guild, 'shard_id') else ""
-                # Highlight master server
                 if guild.id == MASTER_SERVER:
                     logger.info(
                         f"  - {guild.name} (ID: {guild.id}{shard_info}) 🎯 MASTER SERVER")
@@ -228,20 +204,15 @@ class DiscordBotService:
                     logger.info(
                         f"  - {guild.name} (ID: {guild.id}{shard_info})")
 
-            # Track actual shard assignment in database
             await self._record_actual_shard_assignment(actual_shards)
 
-            # Clear the starting flag since we're now ready
             self._is_starting = False
             logger.info("Bot is now fully ready, cleared starting flag")
 
-            # Send interactive status embed to the specified thread
             await self._send_status_message()
 
-            # Start periodic heartbeat task (database tracking only)
             await self._start_periodic_heartbeat()
 
-            # Update heartbeat for sharding configurations that need tracking
             use_auto_scaling = os.getenv(
                 'USE_AUTO_SCALING', 'false').lower() == 'true'
             use_distributed_sharding = os.getenv(
@@ -251,7 +222,6 @@ class DiscordBotService:
                 cluster_name = os.getenv('CLUSTER_NAME', 'default')
                 guild_count = len(self._bot.guilds)
 
-                # Calculate average latency
                 if hasattr(self._bot, 'shards') and self._bot.shards:
                     shard_vals = self._bot.shards.values()
                     latency_ms = sum(s.latency for s in shard_vals) / \
@@ -271,7 +241,6 @@ class DiscordBotService:
                     f" {guild_count} guilds, {latency_ms:.2f}ms latency"
                 )
 
-            # Verify master server connection and control
             await self._verify_master_server_control()
 
         @self._bot.event
@@ -317,14 +286,14 @@ class DiscordBotService:
             return
 
         async def heartbeat_loop():
-            await asyncio.sleep(30)  # Wait 30 seconds before first heartbeat
+            await asyncio.sleep(30)
             while not self._bot.is_closed():
                 try:
                     await self._periodic_heartbeat()
-                    await asyncio.sleep(30)  # 30 second intervals
+                    await asyncio.sleep(30)
                 except Exception as e:
                     logger.error(f"Error in periodic heartbeat: {e}")
-                    await asyncio.sleep(10)  # Shorter retry interval on error
+                    await asyncio.sleep(10)
 
         self._heartbeat_task = asyncio.create_task(heartbeat_loop())
         logger.info("Started periodic database heartbeat task")
@@ -332,7 +301,6 @@ class DiscordBotService:
     async def _periodic_heartbeat(self):
         """Perform periodic database heartbeat tracking only"""
         try:
-            # Update database heartbeat only for configurations that need tracking
             use_auto_scaling = os.getenv(
                 'USE_AUTO_SCALING', 'false').lower() == 'true'
             use_distributed_sharding = os.getenv(
@@ -342,7 +310,6 @@ class DiscordBotService:
                 cluster_name = os.getenv('CLUSTER_NAME', 'default')
                 guild_count = len(self._bot.guilds) if self._bot.guilds else 0
 
-                # Calculate average latency
                 if hasattr(self._bot, 'shards') and self._bot.shards:
                     shard_vals = self._bot.shards.values()
                     latency_ms = sum(s.latency for s in shard_vals) / \
@@ -353,7 +320,6 @@ class DiscordBotService:
                         1000 if hasattr(self._bot, 'latency') else 0
                     )
 
-                # Update database heartbeat only
                 from ..supabase import tracker_manager
                 await tracker_manager.update_heartbeat(
                     instance_id=instance_id,
@@ -392,7 +358,6 @@ class DiscordBotService:
                         f"No access to master server {master_guild_id}")
                     return
 
-            # Find the status channel (could be default channel or specific channel)
             status_channel = None
             for channel in master_guild.text_channels:
                 if channel.name in ['general', 'bot-status', 'status'] or channel == master_guild.system_channel:
@@ -407,7 +372,6 @@ class DiscordBotService:
                     f"No suitable text channel found in master server {master_guild_id}")
                 return
 
-            # Update the embed with shard-specific title
             await self._send_master_status_embed(status_channel)
 
         except Exception as e:
@@ -416,16 +380,13 @@ class DiscordBotService:
     async def _send_master_status_embed(self, channel):
         """Send or update status embed in master server with shard-specific title"""
         try:
-            # Get current shard information
             current_shard = None
             if hasattr(self._bot, 'shard_id') and self._bot.shard_id is not None:
                 current_shard = self._bot.shard_id
 
-            # Import and create master server status embed with shard ID in title
             from .embed.discord_status_embed import BotStatusView
             view = await BotStatusView.create_master_server_view(self, current_shard)
 
-            # Try to update existing message first
             if self._master_status_message_id:
                 try:
                     existing_message = await channel.fetch_message(self._master_status_message_id)
@@ -436,7 +397,6 @@ class DiscordBotService:
                     )
                     return existing_message
                 except discord.NotFound:
-                    # Message was deleted, create new one
                     logger.info(
                         "⚠️ Previous master server embed"
                         f" {self._master_status_message_id} not found, creating new one"
@@ -447,7 +407,6 @@ class DiscordBotService:
                         f"Failed to update existing master embed {self._master_status_message_id}: {e}")
                     self._master_status_message_id = None
 
-            # Create new message only if we don't have an existing one
             new_message = await channel.send(view=view)
             self._master_status_message_id = new_message.id
             logger.info(
@@ -473,7 +432,6 @@ class DiscordBotService:
                 logger.info(
                     f"  └─ Will send status embeds to thread {DISCORD_THREAD_ID}")
 
-                # Log which shard is handling this master server
                 if hasattr(self._bot, 'shards') and self._bot.shards:
                     for shard_id in self._bot.shards:
                         if master_guild.shard_id == shard_id:
@@ -501,13 +459,11 @@ class DiscordBotService:
             master_guild_id = MASTER_SERVER
             master_guild = self._bot.get_guild(master_guild_id)
 
-            # Only send if this shard owns the master server
             if not master_guild:
                 logger.debug(
                     f"Master server {master_guild_id} not accessible to this shard")
                 return
 
-            # Check if we own this guild
             if hasattr(self._bot, 'shard_id') and self._bot.shard_id is not None:
                 expected_shard = master_guild_id % int(
                     os.getenv('TOTAL_SHARDS', '2'))
@@ -520,7 +476,6 @@ class DiscordBotService:
                     )
                     return
 
-            # Find status channel
             status_channel = None
             for channel in master_guild.text_channels:
                 if channel.name in ['general', 'bot-status', 'status'] or channel == master_guild.system_channel:
@@ -552,12 +507,10 @@ class DiscordBotService:
             instance_id = os.getenv('HOSTNAME', str(uuid.uuid4())[:8])
             cluster_name = os.getenv('CLUSTER_NAME', 'default')
 
-            # Record each shard this instance is handling
             for shard_id in actual_shards:
                 logger.info(
                     f"📝 Recording shard {shard_id} assignment for instance {instance_id}")
 
-                # Use existing tracker but with discovered shard info
                 guild_count = len(
                     [g for g in self._bot.guilds if g.shard_id == shard_id]) if self._bot.guilds else 0
 
@@ -593,7 +546,6 @@ class DiscordBotService:
                     "Master server not accessible for shutdown status update")
                 return
 
-            # Check if this instance owns the master server
             if hasattr(self._bot, 'shards') and self._bot.shards:
                 master_shard = master_guild_id % len(self._bot.shards)
                 our_shards = list(self._bot.shards.keys())
@@ -604,7 +556,6 @@ class DiscordBotService:
                     )
                     return
 
-            # Find status channel
             status_channel = None
             for channel in master_guild.text_channels:
                 if channel.name in ['general', 'bot-status', 'status'] or channel == master_guild.system_channel:
@@ -616,10 +567,8 @@ class DiscordBotService:
 
             if status_channel and self._master_status_message_id:
                 try:
-                    # Update existing embed with shutdown status
                     from .embed.discord_status_embed import BotStatusView
 
-                    # Get current shard for title
                     current_shard = None
                     if hasattr(self._bot, 'shards') and self._bot.shards:
                         current_shard = list(self._bot.shards.keys())[
@@ -647,7 +596,6 @@ class DiscordBotService:
     async def _update_shutdown_status(self):
         """Update database status to stopping for tracking"""
         try:
-            # Update database status to stopping for configurations that need tracking
             use_auto_scaling = os.getenv(
                 'USE_AUTO_SCALING', 'false').lower() == 'true'
             use_distributed_sharding = os.getenv(
@@ -682,7 +630,6 @@ class DiscordBotService:
             logger.info(
                 f"Attempting to send status embed to thread {DISCORD_THREAD_ID}")
 
-            # Try to get the thread/channel (cache first)
             thread = self._bot.get_channel(DISCORD_THREAD_ID)
             if not thread:
                 logger.info(
@@ -703,7 +650,6 @@ class DiscordBotService:
                 logger.info(
                     f"Found thread in cache: {thread.name} (Type: {type(thread).__name__})")
 
-            # Clean up previous status message
             if self._last_status_message_id:
                 try:
                     old_message = await thread.fetch_message(self._last_status_message_id)
@@ -717,11 +663,9 @@ class DiscordBotService:
                     logger.warning(
                         f"Error deleting previous status message: {e}")
 
-            # Import and use the interactive status embed
             from .embed.discord_status_embed import send_bot_status_embed
             logger.info("Sending interactive status embed with buttons...")
 
-            # Send the interactive status embed
             status_message = await send_bot_status_embed(thread, self)
             self._last_status_message_id = status_message.id
 
@@ -735,7 +679,6 @@ class DiscordBotService:
             import traceback
             logger.error(f"Full traceback: {traceback.format_exc()}")
 
-            # Fallback to simple message
             await self._send_simple_status_message("🟢 **Bot is now ONLINE** - Ready to receive notifications!")
 
     async def _send_simple_status_message(self, message: str):
@@ -744,7 +687,6 @@ class DiscordBotService:
             logger.info(
                 f"Sending simple status message to thread {DISCORD_THREAD_ID}")
 
-            # Try to get the thread/channel (cache first)
             thread = self._bot.get_channel(DISCORD_THREAD_ID)
             if not thread:
                 try:
@@ -754,7 +696,6 @@ class DiscordBotService:
                         f"Cannot access thread {DISCORD_THREAD_ID} for simple message")
                     return
 
-            # Send simple message
             status_message = await thread.send(message)
             self._last_status_message_id = status_message.id
             logger.info(
@@ -765,10 +706,8 @@ class DiscordBotService:
 
     async def _send_status_message(self):
         """Send status message to Discord thread (wrapper for backward compatibility)"""
-        # Check if we should send status embeds based on master server access
         from ..supabase.constants import MASTER_SERVER
 
-        # Check if this bot instance can see the master server
         master_guild = self._bot.get_guild(MASTER_SERVER)
 
         if not master_guild:
@@ -801,13 +740,11 @@ class DiscordBotService:
                 "shard_info": {}
             }
 
-        # Collect shard information
         shard_info = {}
         current_shard = None
         shard_count = 0
 
         if hasattr(self._bot, 'shards') and self._bot.shards:
-            # AutoShardedClient
             shard_count = len(self._bot.shards)
             for shard_id, shard in self._bot.shards.items():
                 shard_guilds = [
@@ -815,11 +752,10 @@ class DiscordBotService:
                 shard_info[str(shard_id)] = {
                     'shard_id': shard_id,
                     'guild_count': len(shard_guilds),
-                    'latency': shard.latency * 1000,  # Convert to ms
+                    'latency': shard.latency * 1000,
                     'is_closed': shard.is_closed()
                 }
         elif hasattr(self._bot, 'shard_id') and self._bot.shard_id is not None:
-            # Manual sharding (single shard)
             current_shard = self._bot.shard_id
             shard_count = getattr(self._bot, 'shard_count', 1)
             shard_info[str(current_shard)] = {
@@ -829,7 +765,6 @@ class DiscordBotService:
                 'is_closed': self._bot.is_closed()
             }
         else:
-            # No sharding (single instance)
             shard_count = 1
             current_shard = 0
             shard_info['0'] = {
@@ -854,10 +789,8 @@ class DiscordBotService:
     def get_status_with_health(self) -> dict:
         """Get current bot status with health data"""
         try:
-            # Get basic bot status
             bot_status = self.get_status()
 
-            # Get health data
             from ...utils.health_monitor import health_monitor
             health_data = health_monitor.get_comprehensive_health()
 
@@ -867,7 +800,6 @@ class DiscordBotService:
             }
         except Exception as e:
             logger.warning(f"Failed to get health data: {e}")
-            # Return just bot status if health data fails
             return {
                 "bot_status": self.get_status(),
                 "health_data": {
@@ -883,7 +815,6 @@ class DiscordBotService:
         if self._is_stopping:
             raise Exception("Bot is currently stopping, please wait")
 
-        # Debug bot state
         if self._bot:
             logger.info(f"DEBUG: Bot exists: {self._bot}")
             logger.info(f"DEBUG: Bot is_closed: {self._bot.is_closed()}")
@@ -896,18 +827,13 @@ class DiscordBotService:
             if hasattr(self._bot, 'latency'):
                 logger.info(f"DEBUG: Bot latency: {self._bot.latency}")
 
-        # For now, just rely on the _is_starting flag to prevent double starts
-        # The detailed checks were causing issues with fresh bot instances
-
         try:
             self._is_starting = True
             logger.info("Starting Discord bot...")
 
-            # Initialize bot if not already done
             if not self._bot:
                 await self.initialize_bot()
 
-            # Start the bot - this will run until the bot is stopped
             logger.info("Bot about to start - this will run the event loop...")
             await self._bot.start(self._token)
 
@@ -916,7 +842,6 @@ class DiscordBotService:
             logger.error(f"Failed to start bot: {e}")
             raise
         finally:
-            # This will only execute when the bot stops
             self._is_starting = False
             logger.info("Bot startup completed or stopped")
 
@@ -934,18 +859,14 @@ class DiscordBotService:
             if send_message:
                 await self._send_offline_message()
 
-            # Update database status to stopping and update master server embed
             await self._update_shutdown_status()
 
-            # Stop heartbeat task
             if self._heartbeat_task and not self._heartbeat_task.done():
                 self._heartbeat_task.cancel()
                 logger.info("Cancelled periodic heartbeat task")
 
-            # Close the bot
             await self._bot.close()
 
-            # Clean up shard assignment if using sharding configurations that need tracking
             use_auto_scaling = os.getenv(
                 'USE_AUTO_SCALING', 'false').lower() == 'true'
             use_distributed_sharding = os.getenv(
@@ -970,17 +891,13 @@ class DiscordBotService:
 
         logger.info("Restarting Discord bot...")
 
-        # Stop if running
         if self._bot and not self._bot.is_closed():
             await self.stop_bot(send_message=False)
 
-        # Wait a moment
         await asyncio.sleep(2)
 
-        # Reset bot instance
         self._bot = None
 
-        # Start again
         await self.bring_online()
 
     async def bring_online(self):
@@ -988,10 +905,8 @@ class DiscordBotService:
         if self._bot and not self._bot.is_closed():
             raise Exception("Bot is already online")
 
-        # Reset the bot instance and start fresh
         self._bot = None
 
-        # Start the bot in the background
         async def start_bot_task():
             try:
                 await self.start_bot()
@@ -999,7 +914,6 @@ class DiscordBotService:
                 logger.error(f"Failed to start bot in background task: {e}")
                 self._is_starting = False
 
-        # Create and start the task
         asyncio.create_task(start_bot_task())
 
     async def _send_offline_message(self):
@@ -1008,7 +922,6 @@ class DiscordBotService:
             if not self._bot or self._bot.is_closed():
                 return
 
-            # Check if we're in master server before sending offline message
             from ..supabase.constants import MASTER_SERVER
             master_guild = self._bot.get_guild(MASTER_SERVER)
 
@@ -1022,18 +935,15 @@ class DiscordBotService:
                     f"Could not find channel/thread with ID {DISCORD_THREAD_ID}")
                 return
 
-            # Create offline embed
             embed = discord.Embed(
                 title="🛑 Discord Bot Status",
                 description="Bot is going offline...",
-                color=0xff0000  # Red
+                color=0xff0000
             )
 
-            # Add timestamp
             import datetime
             embed.timestamp = datetime.datetime.now()
 
-            # Send the message
             await channel.send(embed=embed)
             logger.info(f"Sent offline message to thread {DISCORD_THREAD_ID}")
 
@@ -1051,24 +961,21 @@ class DiscordBotService:
                 raise Exception(
                     f"Could not find channel/thread with ID {DISCORD_THREAD_ID}")
 
-            # Get messages to delete (excluding the most recent status message)
             messages_to_delete = []
             async for message in channel.history(limit=limit):
-                # Keep the most recent status message from this bot
                 if message.id == self._last_status_message_id:
                     continue
                 if message.author == self._bot.user:
                     messages_to_delete.append(message)
 
-            # Delete messages
             deleted_count = 0
             for message in messages_to_delete:
                 try:
                     await message.delete()
                     deleted_count += 1
-                    await asyncio.sleep(0.5)  # Rate limit protection
+                    await asyncio.sleep(0.5)
                 except discord.NotFound:
-                    pass  # Message was already deleted
+                    pass
                 except Exception as e:
                     logger.warning(
                         f"Failed to delete message {message.id}: {e}")

--- a/apps/discordsh/notification-bot/notification_bot/api/discord/discord_service.py
+++ b/apps/discordsh/notification-bot/notification_bot/api/discord/discord_service.py
@@ -54,7 +54,8 @@ class DiscordBotService:
                              os.getenv('DISCORD_TOKEN'))
 
             if env_token:
-                logger.info("Using Discord token from environment variables (development mode)")
+                logger.info(
+                    "Using Discord token from environment variables (development mode)")
                 self._token = env_token
             else:
                 # Fallback to Supabase vault for production or when env vars not set
@@ -63,7 +64,8 @@ class DiscordBotService:
                 result = await vault_manager.get_vault_secret(secret_id)
 
                 if not result.success:
-                    raise Exception(f"Failed to retrieve Discord token: {result.error}")
+                    raise Exception(
+                        f"Failed to retrieve Discord token: {result.error}")
 
                 # Extract the token from the secret data
                 secret_data = result.data
@@ -83,39 +85,49 @@ class DiscordBotService:
             instance_id = os.getenv('HOSTNAME', str(uuid.uuid4())[:8])
 
             # Check sharding configuration - priority order matters
-            use_auto_scaling = os.getenv('USE_AUTO_SCALING', 'false').lower() == 'true'
-            use_distributed_sharding = os.getenv('USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
+            use_auto_scaling = os.getenv(
+                'USE_AUTO_SCALING', 'false').lower() == 'true'
+            use_distributed_sharding = os.getenv(
+                'USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
 
-            logger.info(f"USE_AUTO_SCALING environment variable: {os.getenv('USE_AUTO_SCALING', 'not set')}")
+            logger.info(
+                f"USE_AUTO_SCALING environment variable: {os.getenv('USE_AUTO_SCALING', 'not set')}")
             dist_shard_env = os.getenv('USE_DISTRIBUTED_SHARDING', 'not set')
-            logger.info(f"USE_DISTRIBUTED_SHARDING environment variable: {dist_shard_env}")
+            logger.info(
+                f"USE_DISTRIBUTED_SHARDING environment variable: {dist_shard_env}")
             logger.info(f"Auto-scaling enabled: {use_auto_scaling}")
-            logger.info(f"Distributed sharding enabled: {use_distributed_sharding}")
+            logger.info(
+                f"Distributed sharding enabled: {use_distributed_sharding}")
 
             if use_auto_scaling:
                 # Auto-scaling: All shards in one process using AutoShardedClient
-                logger.info(f"Using AutoShardedClient with all shards in one process for instance {instance_id}")
+                logger.info(
+                    f"Using AutoShardedClient with all shards in one process for instance {instance_id}")
                 suggested_shard_count = int(os.getenv('TOTAL_SHARDS', '2'))
                 self._bot = discord.AutoShardedClient(
                     intents=intents,
                     shard_count=suggested_shard_count  # Suggest minimum, Discord may use more
                 )
-                logger.info(f"Created AutoShardedClient with {suggested_shard_count} shards in one process")
+                logger.info(
+                    f"Created AutoShardedClient with {suggested_shard_count} shards in one process")
 
             elif use_distributed_sharding:
                 # True distributed sharding: One shard per container using manual Client
                 shard_id = int(os.getenv('SHARD_ID', '0'))
                 shard_count = int(os.getenv('SHARD_COUNT', '2'))
 
-                logger.info(f"Using true distributed sharding for instance {instance_id}")
-                logger.info(f"This container will run shard {shard_id} of {shard_count} total shards")
+                logger.info(
+                    f"Using true distributed sharding for instance {instance_id}")
+                logger.info(
+                    f"This container will run shard {shard_id} of {shard_count} total shards")
 
                 self._bot = discord.Client(
                     intents=intents,
                     shard_id=shard_id,
                     shard_count=shard_count
                 )
-                logger.info(f"Created distributed Client for shard {shard_id}/{shard_count}")
+                logger.info(
+                    f"Created distributed Client for shard {shard_id}/{shard_count}")
 
             else:
                 # Fallback: Traditional environment variable sharding or single instance auto-sharding
@@ -129,11 +141,13 @@ class DiscordBotService:
                         shard_id=shard_id,
                         shard_count=shard_count
                     )
-                    logger.info(f"Using fallback manual sharding: shard {shard_id}/{shard_count}")
+                    logger.info(
+                        f"Using fallback manual sharding: shard {shard_id}/{shard_count}")
                 else:
                     # Auto-sharding for single instance
                     self._bot = discord.AutoShardedClient(intents=intents)
-                    logger.info("Using fallback auto-sharding for single instance")
+                    logger.info(
+                        "Using fallback auto-sharding for single instance")
 
             # Set up event handlers
             self._setup_event_handlers()
@@ -155,24 +169,30 @@ class DiscordBotService:
 
         @self._bot.event
         async def on_ready():
-            logger.info(f"🟢🟢🟢 ON_READY EVENT TRIGGERED! Bot logged in as {self._bot.user} 🟢🟢🟢")
+            logger.info(
+                f"🟢🟢🟢 ON_READY EVENT TRIGGERED! Bot logged in as {self._bot.user} 🟢🟢🟢")
             logger.info(f"Bot is in {len(self._bot.guilds)} guilds")
 
             # Log shard information and track what Discord actually assigned
             actual_shards = []
             if hasattr(self._bot, 'shards') and self._bot.shards:
                 # AutoShardedClient - track what Discord determined
-                logger.info(f"🔍 Discord determined {len(self._bot.shards)} shards for this instance")
+                logger.info(
+                    f"🔍 Discord determined {len(self._bot.shards)} shards for this instance")
                 for shard_id, shard in self._bot.shards.items():
-                    shard_guilds = [g for g in self._bot.guilds if g.shard_id == shard_id]
+                    shard_guilds = [
+                        g for g in self._bot.guilds if g.shard_id == shard_id]
                     actual_shards.append(shard_id)
-                    logger.info(f"  ✅ Shard {shard_id}: {len(shard_guilds)} guilds, latency: {shard.latency:.2f}ms")
+                    logger.info(
+                        f"  ✅ Shard {shard_id}: {len(shard_guilds)} guilds, latency: {shard.latency:.2f}ms")
 
                 # Check master server assignment
                 from ..supabase.constants import MASTER_SERVER
-                master_shard = MASTER_SERVER % len(self._bot.shards) if self._bot.shards else 0
+                master_shard = MASTER_SERVER % len(
+                    self._bot.shards) if self._bot.shards else 0
                 if master_shard in actual_shards:
-                    logger.info(f"🎯 This instance OWNS master server {MASTER_SERVER} (shard {master_shard})")
+                    logger.info(
+                        f"🎯 This instance OWNS master server {MASTER_SERVER} (shard {master_shard})")
                 else:
                     logger.info(
                         f"ℹ️ Master server {MASTER_SERVER} belongs to shard"
@@ -184,7 +204,8 @@ class DiscordBotService:
                 shard_id = self._bot.shard_id
                 shard_count = getattr(self._bot, 'shard_count', 1)
                 actual_shards = [shard_id]
-                logger.info(f"📌 Using manual shard assignment: {shard_id} of {shard_count} total")
+                logger.info(
+                    f"📌 Using manual shard assignment: {shard_id} of {shard_count} total")
                 logger.info(
                     f"  - Current shard {shard_id}: {len(self._bot.guilds)}"
                     f" guilds, latency: {self._bot.latency:.2f}ms"
@@ -197,12 +218,15 @@ class DiscordBotService:
             # Log all guild assignments
             logger.info(f"📋 Guild assignments for shards {actual_shards}:")
             for guild in self._bot.guilds:
-                shard_info = f", Shard: {guild.shard_id}" if hasattr(guild, 'shard_id') else ""
+                shard_info = f", Shard: {guild.shard_id}" if hasattr(
+                    guild, 'shard_id') else ""
                 # Highlight master server
                 if guild.id == MASTER_SERVER:
-                    logger.info(f"  - {guild.name} (ID: {guild.id}{shard_info}) 🎯 MASTER SERVER")
+                    logger.info(
+                        f"  - {guild.name} (ID: {guild.id}{shard_info}) 🎯 MASTER SERVER")
                 else:
-                    logger.info(f"  - {guild.name} (ID: {guild.id}{shard_info})")
+                    logger.info(
+                        f"  - {guild.name} (ID: {guild.id}{shard_info})")
 
             # Track actual shard assignment in database
             await self._record_actual_shard_assignment(actual_shards)
@@ -218,8 +242,10 @@ class DiscordBotService:
             await self._start_periodic_heartbeat()
 
             # Update heartbeat for sharding configurations that need tracking
-            use_auto_scaling = os.getenv('USE_AUTO_SCALING', 'false').lower() == 'true'
-            use_distributed_sharding = os.getenv('USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
+            use_auto_scaling = os.getenv(
+                'USE_AUTO_SCALING', 'false').lower() == 'true'
+            use_distributed_sharding = os.getenv(
+                'USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
             if use_auto_scaling or use_distributed_sharding:
                 instance_id = os.getenv('HOSTNAME', str(uuid.uuid4())[:8])
                 cluster_name = os.getenv('CLUSTER_NAME', 'default')
@@ -228,7 +254,8 @@ class DiscordBotService:
                 # Calculate average latency
                 if hasattr(self._bot, 'shards') and self._bot.shards:
                     shard_vals = self._bot.shards.values()
-                    latency_ms = sum(s.latency for s in shard_vals) / len(self._bot.shards) * 1000
+                    latency_ms = sum(s.latency for s in shard_vals) / \
+                        len(self._bot.shards) * 1000
                 else:
                     latency_ms = self._bot.latency * 1000
 
@@ -249,19 +276,23 @@ class DiscordBotService:
 
         @self._bot.event
         async def on_shard_ready(shard_id):
-            logger.info(f"🟠 SHARD {shard_id} READY! This specific shard is now connected")
+            logger.info(
+                f"🟠 SHARD {shard_id} READY! This specific shard is now connected")
 
         @self._bot.event
         async def on_shard_connect(shard_id):
-            logger.info(f"🔵 SHARD {shard_id} CONNECTED! Connection established to Discord gateway")
+            logger.info(
+                f"🔵 SHARD {shard_id} CONNECTED! Connection established to Discord gateway")
 
         @self._bot.event
         async def on_shard_disconnect(shard_id):
-            logger.warning(f"🟡 SHARD {shard_id} DISCONNECTED! Connection to Discord gateway lost")
+            logger.warning(
+                f"🟡 SHARD {shard_id} DISCONNECTED! Connection to Discord gateway lost")
 
         @self._bot.event
         async def on_shard_resumed(shard_id):
-            logger.info(f"🟢 SHARD {shard_id} RESUMED! Reconnected and resumed previous session")
+            logger.info(
+                f"🟢 SHARD {shard_id} RESUMED! Reconnected and resumed previous session")
 
         @self._bot.event
         async def on_connect():
@@ -269,11 +300,13 @@ class DiscordBotService:
 
         @self._bot.event
         async def on_disconnect():
-            logger.warning("🟡 BOT DISCONNECTED! Connection to Discord gateway lost")
+            logger.warning(
+                "🟡 BOT DISCONNECTED! Connection to Discord gateway lost")
 
         @self._bot.event
         async def on_resumed():
-            logger.info("🟢 BOT RESUMED! Reconnected and resumed previous session")
+            logger.info(
+                "🟢 BOT RESUMED! Reconnected and resumed previous session")
 
         logger.info("✅ Discord bot event handlers set up successfully")
 
@@ -300,8 +333,10 @@ class DiscordBotService:
         """Perform periodic database heartbeat tracking only"""
         try:
             # Update database heartbeat only for configurations that need tracking
-            use_auto_scaling = os.getenv('USE_AUTO_SCALING', 'false').lower() == 'true'
-            use_distributed_sharding = os.getenv('USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
+            use_auto_scaling = os.getenv(
+                'USE_AUTO_SCALING', 'false').lower() == 'true'
+            use_distributed_sharding = os.getenv(
+                'USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
             if use_auto_scaling or use_distributed_sharding:
                 instance_id = os.getenv('HOSTNAME', str(uuid.uuid4())[:8])
                 cluster_name = os.getenv('CLUSTER_NAME', 'default')
@@ -310,10 +345,12 @@ class DiscordBotService:
                 # Calculate average latency
                 if hasattr(self._bot, 'shards') and self._bot.shards:
                     shard_vals = self._bot.shards.values()
-                    latency_ms = sum(s.latency for s in shard_vals) / len(self._bot.shards) * 1000
+                    latency_ms = sum(s.latency for s in shard_vals) / \
+                        len(self._bot.shards) * 1000
                 else:
                     latency_ms = (
-                        self._bot.latency * 1000 if hasattr(self._bot, 'latency') else 0
+                        self._bot.latency *
+                        1000 if hasattr(self._bot, 'latency') else 0
                     )
 
                 # Update database heartbeat only
@@ -342,14 +379,17 @@ class DiscordBotService:
             master_guild = self._bot.get_guild(master_guild_id)
 
             if not master_guild:
-                logger.debug(f"Master guild {master_guild_id} not found in cache, fetching...")
+                logger.debug(
+                    f"Master guild {master_guild_id} not found in cache, fetching...")
                 try:
                     master_guild = await self._bot.fetch_guild(master_guild_id)
                 except discord.NotFound:
-                    logger.warning(f"Master server {master_guild_id} not found")
+                    logger.warning(
+                        f"Master server {master_guild_id} not found")
                     return
                 except discord.Forbidden:
-                    logger.warning(f"No access to master server {master_guild_id}")
+                    logger.warning(
+                        f"No access to master server {master_guild_id}")
                     return
 
             # Find the status channel (could be default channel or specific channel)
@@ -363,7 +403,8 @@ class DiscordBotService:
                 status_channel = master_guild.text_channels[0] if master_guild.text_channels else None
 
             if not status_channel:
-                logger.warning(f"No suitable text channel found in master server {master_guild_id}")
+                logger.warning(
+                    f"No suitable text channel found in master server {master_guild_id}")
                 return
 
             # Update the embed with shard-specific title
@@ -402,17 +443,20 @@ class DiscordBotService:
                     )
                     self._master_status_message_id = None
                 except Exception as e:
-                    logger.warning(f"Failed to update existing master embed {self._master_status_message_id}: {e}")
+                    logger.warning(
+                        f"Failed to update existing master embed {self._master_status_message_id}: {e}")
                     self._master_status_message_id = None
 
             # Create new message only if we don't have an existing one
             new_message = await channel.send(view=view)
             self._master_status_message_id = new_message.id
-            logger.info(f"🆕 CREATED new master server embed for shard {current_shard} (Message ID: {new_message.id})")
+            logger.info(
+                f"🆕 CREATED new master server embed for shard {current_shard} (Message ID: {new_message.id})")
             return new_message
 
         except Exception as e:
             logger.error(f"Failed to send master status embed: {e}")
+            return None
 
     async def _verify_master_server_control(self):
         """Verify which instance has control of master server for status embeds"""
@@ -424,20 +468,27 @@ class DiscordBotService:
 
             if master_guild:
                 logger.info("🎯 THIS INSTANCE HAS MASTER SERVER CONTROL")
-                logger.info(f"  └─ Connected to: {master_guild.name} (ID: {master_guild_id})")
-                logger.info(f"  └─ Will send status embeds to thread {DISCORD_THREAD_ID}")
+                logger.info(
+                    f"  └─ Connected to: {master_guild.name} (ID: {master_guild_id})")
+                logger.info(
+                    f"  └─ Will send status embeds to thread {DISCORD_THREAD_ID}")
 
                 # Log which shard is handling this master server
                 if hasattr(self._bot, 'shards') and self._bot.shards:
                     for shard_id in self._bot.shards:
                         if master_guild.shard_id == shard_id:
-                            logger.info(f"  └─ Master server on our shard {shard_id}")
+                            logger.info(
+                                f"  └─ Master server on our shard {shard_id}")
                             break
             else:
-                logger.info("ℹ️ THIS INSTANCE DOES NOT HAVE MASTER SERVER CONTROL")
-                logger.info(f"  └─ Not connected to master server {master_guild_id}")
-                logger.info("  └─ Will NOT send status embeds (avoiding duplicates)")
-                logger.info("  └─ This is expected for shards that don't own the master server")
+                logger.info(
+                    "ℹ️ THIS INSTANCE DOES NOT HAVE MASTER SERVER CONTROL")
+                logger.info(
+                    f"  └─ Not connected to master server {master_guild_id}")
+                logger.info(
+                    "  └─ Will NOT send status embeds (avoiding duplicates)")
+                logger.info(
+                    "  └─ This is expected for shards that don't own the master server")
 
         except Exception as e:
             logger.error(f"Error verifying master server control: {e}")
@@ -452,12 +503,14 @@ class DiscordBotService:
 
             # Only send if this shard owns the master server
             if not master_guild:
-                logger.debug(f"Master server {master_guild_id} not accessible to this shard")
+                logger.debug(
+                    f"Master server {master_guild_id} not accessible to this shard")
                 return
 
             # Check if we own this guild
             if hasattr(self._bot, 'shard_id') and self._bot.shard_id is not None:
-                expected_shard = master_guild_id % int(os.getenv('TOTAL_SHARDS', '2'))
+                expected_shard = master_guild_id % int(
+                    os.getenv('TOTAL_SHARDS', '2'))
                 current_shard = self._bot.shard_id
                 if expected_shard != current_shard:
                     logger.info(
@@ -479,7 +532,8 @@ class DiscordBotService:
 
             if status_channel:
                 await self._send_master_status_embed(status_channel)
-                logger.info(f"Sent initial master server embed to {master_guild.name} - {status_channel.name}")
+                logger.info(
+                    f"Sent initial master server embed to {master_guild.name} - {status_channel.name}")
 
         except Exception as e:
             logger.error(f"Error sending initial master server embed: {e}")
@@ -487,8 +541,10 @@ class DiscordBotService:
     async def _record_actual_shard_assignment(self, actual_shards: list):
         """Record what Discord.py actually assigned to this instance"""
         try:
-            use_auto_scaling = os.getenv('USE_AUTO_SCALING', 'false').lower() == 'true'
-            use_distributed_sharding = os.getenv('USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
+            use_auto_scaling = os.getenv(
+                'USE_AUTO_SCALING', 'false').lower() == 'true'
+            use_distributed_sharding = os.getenv(
+                'USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
             if not (use_auto_scaling or use_distributed_sharding):
                 return
 
@@ -498,21 +554,25 @@ class DiscordBotService:
 
             # Record each shard this instance is handling
             for shard_id in actual_shards:
-                logger.info(f"📝 Recording shard {shard_id} assignment for instance {instance_id}")
+                logger.info(
+                    f"📝 Recording shard {shard_id} assignment for instance {instance_id}")
 
                 # Use existing tracker but with discovered shard info
-                guild_count = len([g for g in self._bot.guilds if g.shard_id == shard_id]) if self._bot.guilds else 0
+                guild_count = len(
+                    [g for g in self._bot.guilds if g.shard_id == shard_id]) if self._bot.guilds else 0
 
                 if hasattr(self._bot, 'shards') and shard_id in self._bot.shards:
                     latency_ms = self._bot.shards[shard_id].latency * 1000
                 else:
-                    latency_ms = self._bot.latency * 1000 if hasattr(self._bot, 'latency') else 0
+                    latency_ms = self._bot.latency * \
+                        1000 if hasattr(self._bot, 'latency') else 0
 
                 await tracker_manager.record_discovered_shard(
                     instance_id=instance_id,
                     cluster_name=cluster_name,
                     shard_id=shard_id,
-                    total_shards=len(self._bot.shards) if hasattr(self._bot, 'shards') else 1,
+                    total_shards=len(self._bot.shards) if hasattr(
+                        self._bot, 'shards') else 1,
                     guild_count=guild_count,
                     latency_ms=latency_ms
                 )
@@ -529,7 +589,8 @@ class DiscordBotService:
             master_guild = self._bot.get_guild(master_guild_id)
 
             if not master_guild:
-                logger.debug("Master server not accessible for shutdown status update")
+                logger.debug(
+                    "Master server not accessible for shutdown status update")
                 return
 
             # Check if this instance owns the master server
@@ -561,7 +622,8 @@ class DiscordBotService:
                     # Get current shard for title
                     current_shard = None
                     if hasattr(self._bot, 'shards') and self._bot.shards:
-                        current_shard = list(self._bot.shards.keys())[0] if self._bot.shards else None
+                        current_shard = list(self._bot.shards.keys())[
+                            0] if self._bot.shards else None
                     elif hasattr(self._bot, 'shard_id'):
                         current_shard = self._bot.shard_id
 
@@ -569,12 +631,15 @@ class DiscordBotService:
 
                     existing_message = await status_channel.fetch_message(self._master_status_message_id)
                     await existing_message.edit(view=view)
-                    logger.info(f"🛑 Updated master server embed with shutdown status (shard {current_shard})")
+                    logger.info(
+                        f"🛑 Updated master server embed with shutdown status (shard {current_shard})")
 
                 except discord.NotFound:
-                    logger.debug("Master server embed not found for shutdown update")
+                    logger.debug(
+                        "Master server embed not found for shutdown update")
                 except Exception as e:
-                    logger.warning(f"Failed to update master server shutdown status: {e}")
+                    logger.warning(
+                        f"Failed to update master server shutdown status: {e}")
 
         except Exception as e:
             logger.error(f"Error updating master server shutdown status: {e}")
@@ -583,15 +648,18 @@ class DiscordBotService:
         """Update database status to stopping for tracking"""
         try:
             # Update database status to stopping for configurations that need tracking
-            use_auto_scaling = os.getenv('USE_AUTO_SCALING', 'false').lower() == 'true'
-            use_distributed_sharding = os.getenv('USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
+            use_auto_scaling = os.getenv(
+                'USE_AUTO_SCALING', 'false').lower() == 'true'
+            use_distributed_sharding = os.getenv(
+                'USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
             if use_auto_scaling or use_distributed_sharding:
                 from ..supabase import tracker_manager
                 instance_id = os.getenv('HOSTNAME', str(uuid.uuid4())[:8])
                 cluster_name = os.getenv('CLUSTER_NAME', 'default')
 
                 await tracker_manager.update_status_to_stopping(instance_id, cluster_name)
-                logger.info(f"📝 Updated database status to 'stopping' for {instance_id}")
+                logger.info(
+                    f"📝 Updated database status to 'stopping' for {instance_id}")
 
         except Exception as e:
             logger.error(f"Error updating shutdown status: {e}")
@@ -611,34 +679,43 @@ class DiscordBotService:
     async def _send_status_embed(self):
         """Send interactive status embed to Discord thread (matching old implementation)"""
         try:
-            logger.info(f"Attempting to send status embed to thread {DISCORD_THREAD_ID}")
+            logger.info(
+                f"Attempting to send status embed to thread {DISCORD_THREAD_ID}")
 
             # Try to get the thread/channel (cache first)
             thread = self._bot.get_channel(DISCORD_THREAD_ID)
             if not thread:
-                logger.info("Thread not in cache, attempting to fetch from API...")
+                logger.info(
+                    "Thread not in cache, attempting to fetch from API...")
                 try:
                     thread = await self._bot.fetch_channel(DISCORD_THREAD_ID)
-                    logger.info(f"Successfully fetched thread from API: {thread.name}")
+                    logger.info(
+                        f"Successfully fetched thread from API: {thread.name}")
                 except discord.NotFound:
-                    logger.error(f"Thread with ID {DISCORD_THREAD_ID} not found via API")
+                    logger.error(
+                        f"Thread with ID {DISCORD_THREAD_ID} not found via API")
                     return
                 except discord.Forbidden:
-                    logger.error(f"No permission to access thread {DISCORD_THREAD_ID}")
+                    logger.error(
+                        f"No permission to access thread {DISCORD_THREAD_ID}")
                     return
             else:
-                logger.info(f"Found thread in cache: {thread.name} (Type: {type(thread).__name__})")
+                logger.info(
+                    f"Found thread in cache: {thread.name} (Type: {type(thread).__name__})")
 
             # Clean up previous status message
             if self._last_status_message_id:
                 try:
                     old_message = await thread.fetch_message(self._last_status_message_id)
                     await old_message.delete()
-                    logger.info(f"Deleted previous status message {self._last_status_message_id}")
+                    logger.info(
+                        f"Deleted previous status message {self._last_status_message_id}")
                 except (discord.NotFound, discord.Forbidden):
-                    logger.info("Previous status message not found or cannot delete")
+                    logger.info(
+                        "Previous status message not found or cannot delete")
                 except Exception as e:
-                    logger.warning(f"Error deleting previous status message: {e}")
+                    logger.warning(
+                        f"Error deleting previous status message: {e}")
 
             # Import and use the interactive status embed
             from .embed.discord_status_embed import send_bot_status_embed
@@ -664,7 +741,8 @@ class DiscordBotService:
     async def _send_simple_status_message(self, message: str):
         """Send simple status message as fallback"""
         try:
-            logger.info(f"Sending simple status message to thread {DISCORD_THREAD_ID}")
+            logger.info(
+                f"Sending simple status message to thread {DISCORD_THREAD_ID}")
 
             # Try to get the thread/channel (cache first)
             thread = self._bot.get_channel(DISCORD_THREAD_ID)
@@ -672,13 +750,15 @@ class DiscordBotService:
                 try:
                     thread = await self._bot.fetch_channel(DISCORD_THREAD_ID)
                 except (discord.NotFound, discord.Forbidden):
-                    logger.error(f"Cannot access thread {DISCORD_THREAD_ID} for simple message")
+                    logger.error(
+                        f"Cannot access thread {DISCORD_THREAD_ID} for simple message")
                     return
 
             # Send simple message
             status_message = await thread.send(message)
             self._last_status_message_id = status_message.id
-            logger.info(f"✅ Sent simple status message to thread {DISCORD_THREAD_ID}")
+            logger.info(
+                f"✅ Sent simple status message to thread {DISCORD_THREAD_ID}")
 
         except Exception as e:
             logger.error(f"❌ Failed to send simple status message: {e}")
@@ -692,11 +772,14 @@ class DiscordBotService:
         master_guild = self._bot.get_guild(MASTER_SERVER)
 
         if not master_guild:
-            logger.info(f"⚠️ Bot is NOT in master server {MASTER_SERVER} - skipping status embed to avoid duplicates")
-            logger.info("This shard will handle its assigned guilds but won't post status embeds")
+            logger.info(
+                f"⚠️ Bot is NOT in master server {MASTER_SERVER} - skipping status embed to avoid duplicates")
+            logger.info(
+                "This shard will handle its assigned guilds but won't post status embeds")
             return
 
-        logger.info(f"✅ Bot IS in master server {MASTER_SERVER} - sending status embed")
+        logger.info(
+            f"✅ Bot IS in master server {MASTER_SERVER} - sending status embed")
         await self._send_status_embed()
 
     def get_bot(self) -> Optional[discord.Client]:
@@ -727,7 +810,8 @@ class DiscordBotService:
             # AutoShardedClient
             shard_count = len(self._bot.shards)
             for shard_id, shard in self._bot.shards.items():
-                shard_guilds = [g for g in self._bot.guilds if g.shard_id == shard_id] if self._bot.guilds else []
+                shard_guilds = [
+                    g for g in self._bot.guilds if g.shard_id == shard_id] if self._bot.guilds else []
                 shard_info[str(shard_id)] = {
                     'shard_id': shard_id,
                     'guild_count': len(shard_guilds),
@@ -803,10 +887,12 @@ class DiscordBotService:
         if self._bot:
             logger.info(f"DEBUG: Bot exists: {self._bot}")
             logger.info(f"DEBUG: Bot is_closed: {self._bot.is_closed()}")
-            logger.info(f"DEBUG: Bot has is_ready: {hasattr(self._bot, 'is_ready')}")
+            logger.info(
+                f"DEBUG: Bot has is_ready: {hasattr(self._bot, 'is_ready')}")
             if hasattr(self._bot, 'is_ready'):
                 logger.info(f"DEBUG: Bot is_ready(): {self._bot.is_ready()}")
-            logger.info(f"DEBUG: Bot has latency: {hasattr(self._bot, 'latency')}")
+            logger.info(
+                f"DEBUG: Bot has latency: {hasattr(self._bot, 'latency')}")
             if hasattr(self._bot, 'latency'):
                 logger.info(f"DEBUG: Bot latency: {self._bot.latency}")
 
@@ -860,8 +946,10 @@ class DiscordBotService:
             await self._bot.close()
 
             # Clean up shard assignment if using sharding configurations that need tracking
-            use_auto_scaling = os.getenv('USE_AUTO_SCALING', 'false').lower() == 'true'
-            use_distributed_sharding = os.getenv('USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
+            use_auto_scaling = os.getenv(
+                'USE_AUTO_SCALING', 'false').lower() == 'true'
+            use_distributed_sharding = os.getenv(
+                'USE_DISTRIBUTED_SHARDING', 'false').lower() == 'true'
             if use_auto_scaling or use_distributed_sharding:
                 instance_id = os.getenv('HOSTNAME', str(uuid.uuid4())[:8])
                 cluster_name = os.getenv('CLUSTER_NAME', 'default')
@@ -930,7 +1018,8 @@ class DiscordBotService:
 
             channel = self._bot.get_channel(DISCORD_THREAD_ID)
             if not channel:
-                logger.warning(f"Could not find channel/thread with ID {DISCORD_THREAD_ID}")
+                logger.warning(
+                    f"Could not find channel/thread with ID {DISCORD_THREAD_ID}")
                 return
 
             # Create offline embed
@@ -959,7 +1048,8 @@ class DiscordBotService:
 
             channel = self._bot.get_channel(DISCORD_THREAD_ID)
             if not channel:
-                raise Exception(f"Could not find channel/thread with ID {DISCORD_THREAD_ID}")
+                raise Exception(
+                    f"Could not find channel/thread with ID {DISCORD_THREAD_ID}")
 
             # Get messages to delete (excluding the most recent status message)
             messages_to_delete = []
@@ -980,7 +1070,8 @@ class DiscordBotService:
                 except discord.NotFound:
                     pass  # Message was already deleted
                 except Exception as e:
-                    logger.warning(f"Failed to delete message {message.id}: {e}")
+                    logger.warning(
+                        f"Failed to delete message {message.id}: {e}")
 
             logger.info(f"Cleaned up {deleted_count} old messages from thread")
             return deleted_count

--- a/apps/discordsh/notification-bot/notification_bot/api/supabase/tracker.py
+++ b/apps/discordsh/notification-bot/notification_bot/api/supabase/tracker.py
@@ -8,17 +8,14 @@ from pydantic import BaseModel, Field
 from .supabase_service import supabase_conn
 from notification_bot.utils.logger import logger
 
-# Import VERSION from constants
 try:
     from .constants import VERSION
 except ImportError:
-    VERSION = "1.4"  # fallback
+    VERSION = "1.4"
 
-# Log the version on module load
 logger.info(f"Tracker module loaded with VERSION: {VERSION}")
 
 
-# Pydantic Models for Tracker Operations
 class ShardAssignment(BaseModel):
     """Model for shard assignment data"""
     id: str
@@ -79,12 +76,10 @@ class TrackerManager:
         try:
             client = self._supabase.init_supabase_client()
 
-            # Always use the upsert function - it handles all cases properly
             logger.info(
                 f"Getting shard assignment for instance {instance_id} in cluster {cluster_name}")
 
             try:
-                # Check for existing assignment first
                 existing_check = (
                     client.schema('tracker')
                     .table('cluster_management')
@@ -95,7 +90,6 @@ class TrackerManager:
                 )
 
                 if existing_check.data:
-                    # Update existing assignment
                     assignment = existing_check.data[0]
                     logger.info(
                         f"Found existing assignment for {instance_id}: shard {assignment['shard_id']}")
@@ -123,10 +117,8 @@ class TrackerManager:
                         'total_shards': total_shards
                     }
                 else:
-                    # No existing assignment - find next available shard
                     logger.info(f"Creating new assignment for {instance_id}")
 
-                    # Get all current active shard assignments for this cluster
                     active_shards_result = (
                         client.schema('tracker')
                         .table('cluster_management')
@@ -136,20 +128,17 @@ class TrackerManager:
                         .execute()
                     )
 
-                    # Determine which shards are already taken
                     taken_shards = set()
                     if active_shards_result.data:
                         taken_shards = {row['shard_id']
                                         for row in active_shards_result.data}
 
-                    # Find the next available shard ID (0 to total_shards-1)
                     assigned_shard_id = None
                     for shard_id in range(total_shards):
                         if shard_id not in taken_shards:
                             assigned_shard_id = shard_id
                             break
 
-                    # If all shards are taken, take over the oldest assignment
                     if assigned_shard_id is None:
                         logger.warning(
                             f"All {total_shards} shards are taken, finding oldest assignment to take over")
@@ -168,7 +157,6 @@ class TrackerManager:
                             logger.info(
                                 f"Taking over oldest assignment: shard {assigned_shard_id}")
                         else:
-                            # Fallback to shard 0 if no existing assignments
                             assigned_shard_id = 0
                             logger.warning(
                                 "No existing assignments found, defaulting to shard 0")
@@ -208,7 +196,6 @@ class TrackerManager:
                         if 'duplicate key value violates unique constraint' in str(insert_error):
                             logger.warning(
                                 f"Shard {assigned_shard_id} already assigned, taking it over")
-                            # Take over the assigned shard
                             takeover_result = (
                                 client.schema('tracker')
                                 .table('cluster_management')
@@ -246,9 +233,7 @@ class TrackerManager:
                     logger.warning(
                         f"Shard conflict detected, attempting to take over existing assignment: {e}")
 
-                    # Try to take over the existing shard assignment
                     try:
-                        # Get the shard ID from the error message
                         import re
                         match = re.search(
                             r'shard_id\)=\([^,]+,\s*(\d+)\)', error_str)
@@ -257,7 +242,6 @@ class TrackerManager:
                             logger.info(
                                 f"Taking over shard {shard_id} from previous assignment")
 
-                            # Update the existing record to this instance
                             takeover_result = (
                                 client.schema('tracker')
                                 .table('cluster_management')
@@ -493,7 +477,6 @@ class TrackerManager:
             bot_version = str(VERSION)
             deployment_version = os.getenv('DEPLOYMENT_VERSION', str(VERSION))
 
-            # Use upsert to handle both insert and update cases
             upsert_data = {
                 'instance_id': instance_id,
                 'cluster_name': cluster_name,
@@ -587,5 +570,4 @@ class TrackerManager:
             return False
 
 
-# Global tracker manager instance
 tracker_manager = TrackerManager()

--- a/apps/discordsh/notification-bot/notification_bot/api/supabase/tracker.py
+++ b/apps/discordsh/notification-bot/notification_bot/api/supabase/tracker.py
@@ -26,7 +26,8 @@ class ShardAssignment(BaseModel):
     cluster_name: str
     shard_id: int
     total_shards: int
-    status: str = Field(default='active', pattern='^(active|inactive|error|starting|stopping)$')
+    status: str = Field(
+        default='active', pattern='^(active|inactive|error|starting|stopping)$')
     last_heartbeat: datetime
     created_at: datetime
     updated_at: datetime
@@ -79,7 +80,8 @@ class TrackerManager:
             client = self._supabase.init_supabase_client()
 
             # Always use the upsert function - it handles all cases properly
-            logger.info(f"Getting shard assignment for instance {instance_id} in cluster {cluster_name}")
+            logger.info(
+                f"Getting shard assignment for instance {instance_id} in cluster {cluster_name}")
 
             try:
                 # Check for existing assignment first
@@ -95,7 +97,8 @@ class TrackerManager:
                 if existing_check.data:
                     # Update existing assignment
                     assignment = existing_check.data[0]
-                    logger.info(f"Found existing assignment for {instance_id}: shard {assignment['shard_id']}")
+                    logger.info(
+                        f"Found existing assignment for {instance_id}: shard {assignment['shard_id']}")
 
                     (
                         client.schema('tracker')
@@ -136,7 +139,8 @@ class TrackerManager:
                     # Determine which shards are already taken
                     taken_shards = set()
                     if active_shards_result.data:
-                        taken_shards = {row['shard_id'] for row in active_shards_result.data}
+                        taken_shards = {row['shard_id']
+                                        for row in active_shards_result.data}
 
                     # Find the next available shard ID (0 to total_shards-1)
                     assigned_shard_id = None
@@ -147,7 +151,8 @@ class TrackerManager:
 
                     # If all shards are taken, take over the oldest assignment
                     if assigned_shard_id is None:
-                        logger.warning(f"All {total_shards} shards are taken, finding oldest assignment to take over")
+                        logger.warning(
+                            f"All {total_shards} shards are taken, finding oldest assignment to take over")
                         oldest_assignment = (
                             client.schema('tracker')
                             .table('cluster_management')
@@ -160,13 +165,16 @@ class TrackerManager:
 
                         if oldest_assignment.data:
                             assigned_shard_id = oldest_assignment.data[0]['shard_id']
-                            logger.info(f"Taking over oldest assignment: shard {assigned_shard_id}")
+                            logger.info(
+                                f"Taking over oldest assignment: shard {assigned_shard_id}")
                         else:
                             # Fallback to shard 0 if no existing assignments
                             assigned_shard_id = 0
-                            logger.warning("No existing assignments found, defaulting to shard 0")
+                            logger.warning(
+                                "No existing assignments found, defaulting to shard 0")
 
-                    logger.info(f"Assigning shard {assigned_shard_id} to {instance_id}")
+                    logger.info(
+                        f"Assigning shard {assigned_shard_id} to {instance_id}")
 
                     try:
                         (
@@ -189,7 +197,8 @@ class TrackerManager:
                             .execute()
                         )
 
-                        logger.info(f"Created new assignment for {instance_id}: shard {assigned_shard_id}")
+                        logger.info(
+                            f"Created new assignment for {instance_id}: shard {assigned_shard_id}")
                         return {
                             'shard_id': assigned_shard_id,
                             'total_shards': total_shards
@@ -197,7 +206,8 @@ class TrackerManager:
 
                     except Exception as insert_error:
                         if 'duplicate key value violates unique constraint' in str(insert_error):
-                            logger.warning(f"Shard {assigned_shard_id} already assigned, taking it over")
+                            logger.warning(
+                                f"Shard {assigned_shard_id} already assigned, taking it over")
                             # Take over the assigned shard
                             takeover_result = (
                                 client.schema('tracker')
@@ -220,7 +230,8 @@ class TrackerManager:
                             )
 
                             if takeover_result.data:
-                                logger.info(f"Successfully took over shard {assigned_shard_id}")
+                                logger.info(
+                                    f"Successfully took over shard {assigned_shard_id}")
                                 return {
                                     'shard_id': assigned_shard_id,
                                     'total_shards': total_shards
@@ -232,16 +243,19 @@ class TrackerManager:
                 error_str = str(e)
                 if ('duplicate key value violates unique constraint' in error_str
                         and 'cluster_management_cluster_name_shard_id_key' in error_str):
-                    logger.warning(f"Shard conflict detected, attempting to take over existing assignment: {e}")
+                    logger.warning(
+                        f"Shard conflict detected, attempting to take over existing assignment: {e}")
 
                     # Try to take over the existing shard assignment
                     try:
                         # Get the shard ID from the error message
                         import re
-                        match = re.search(r'shard_id\)=\([^,]+,\s*(\d+)\)', error_str)
+                        match = re.search(
+                            r'shard_id\)=\([^,]+,\s*(\d+)\)', error_str)
                         if match:
                             shard_id = int(match.group(1))
-                            logger.info(f"Taking over shard {shard_id} from previous assignment")
+                            logger.info(
+                                f"Taking over shard {shard_id} from previous assignment")
 
                             # Update the existing record to this instance
                             takeover_result = (
@@ -265,20 +279,24 @@ class TrackerManager:
                             )
 
                             if takeover_result.data:
-                                logger.info(f"Successfully took over shard {shard_id}")
+                                logger.info(
+                                    f"Successfully took over shard {shard_id}")
                                 return {
                                     'shard_id': shard_id,
                                     'total_shards': total_shards
                                 }
                             else:
-                                logger.error("Failed to take over shard assignment")
+                                logger.error(
+                                    "Failed to take over shard assignment")
                                 return None
 
                     except Exception as takeover_error:
-                        logger.error(f"Failed to take over shard: {takeover_error}")
+                        logger.error(
+                            f"Failed to take over shard: {takeover_error}")
                         return None
                 else:
-                    logger.error(f"Failed to call upsert_instance_assignment: {e}")
+                    logger.error(
+                        f"Failed to call upsert_instance_assignment: {e}")
                     import traceback
                     logger.error(f"Traceback: {traceback.format_exc()}")
                     return None
@@ -288,6 +306,8 @@ class TrackerManager:
             import traceback
             logger.error(f"Traceback: {traceback.format_exc()}")
             return None
+
+        return None
 
     async def update_heartbeat(
         self,
@@ -345,7 +365,8 @@ class TrackerManager:
                 )
 
                 if hasattr(result, 'error') and result.error:
-                    logger.warning(f"Failed to update shard heartbeat: {result.error}")
+                    logger.warning(
+                        f"Failed to update shard heartbeat: {result.error}")
                     return False
                 else:
                     logger.debug(
@@ -395,10 +416,12 @@ class TrackerManager:
                 )
 
                 if hasattr(result, 'error') and result.error:
-                    logger.warning(f"Failed to cleanup shard assignment: {result.error}")
+                    logger.warning(
+                        f"Failed to cleanup shard assignment: {result.error}")
                     return False
                 else:
-                    logger.info(f"Marked shard assignment as inactive for {instance_id}")
+                    logger.info(
+                        f"Marked shard assignment as inactive for {instance_id}")
                     return True
             except Exception as e:
                 logger.warning(f"Failed to cleanup shard assignment: {e}")
@@ -497,10 +520,12 @@ class TrackerManager:
                 )
 
                 if hasattr(result, 'error') and result.error:
-                    logger.warning(f"Failed to record discovered shard: {result.error}")
+                    logger.warning(
+                        f"Failed to record discovered shard: {result.error}")
                     return False
                 else:
-                    logger.info(f"Recorded discovered shard {shard_id} for {instance_id} ({guild_count} guilds)")
+                    logger.info(
+                        f"Recorded discovered shard {shard_id} for {instance_id} ({guild_count} guilds)")
                     return True
 
             except Exception as e:
@@ -545,10 +570,12 @@ class TrackerManager:
                 )
 
                 if hasattr(result, 'error') and result.error:
-                    logger.warning(f"Failed to update status to stopping: {result.error}")
+                    logger.warning(
+                        f"Failed to update status to stopping: {result.error}")
                     return False
                 else:
-                    logger.debug(f"Updated status to 'stopping' for {instance_id}")
+                    logger.debug(
+                        f"Updated status to 'stopping' for {instance_id}")
                     return True
 
             except Exception as e:

--- a/apps/pydesk/pydesk/main.py
+++ b/apps/pydesk/pydesk/main.py
@@ -90,7 +90,8 @@ routes.get("/ws/status", RuneLiteClient, "status_runelite")
 
 routes.get("/api/bitcoin-price", CoinDeskClient, "get_current_bitcoin_price")
 routes.get("/api/poem", PoetryDBClient, "get_random_poem")
-routes.get("/api/config-runelite", RuneLiteClient, "start_and_configure_runelite")
+routes.get("/api/config-runelite", RuneLiteClient,
+           "start_and_configure_runelite")
 
 
 @app.get("/api/echo")
@@ -100,12 +101,13 @@ async def echo_main():
         await websocket_client.example()
     finally:
         await websocket_client.close()
-        return {"ws": "true"}
+    return {"ws": "true"}
 
 
 @app.get("/api/news")
 async def google_news():
-    rss_utility = RSSUtility(base_url="https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en")
+    rss_utility = RSSUtility(
+        base_url="https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en")
     try:
         soup = await rss_utility.fetch_and_parse_rss()
         rss_feed_model = await rss_utility.convert_to_model(soup)
@@ -128,7 +130,8 @@ if ChromeClient is not None:
     routes.get("/api/start-chrome", ChromeClient, "start_chrome_async")
     routes.get("/api/stop-chrome", ChromeClient, "stop_chrome_async")
     routes.get("/api/go-to-gitlab", ChromeClient, "go_to_gitlab")
-    routes.get("/api/go-to-greenboard", ChromeClient, "fetch_embedded_job_board")
+    routes.get("/api/go-to-greenboard", ChromeClient,
+               "fetch_embedded_job_board")
 
 if DiscordClient is not None:
     routes.get("/api/discord-login", DiscordClient, "login_with_passkey")

--- a/apps/pydesk/pydesk/main.py
+++ b/apps/pydesk/pydesk/main.py
@@ -11,7 +11,6 @@ from contextlib import asynccontextmanager
 import os
 import logging
 
-# Desktop automation clients (conditional imports)
 try:
     from fudster import ScreenClient, ChromeClient, DiscordClient
 except ImportError:
@@ -39,13 +38,11 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 routes = Routes(app, templates_dir="templates")
 
-# Mount static files directory for assets
 app.mount("/assets", StaticFiles(directory="assets"), name="assets")
 
 CORS(app)
 
 
-# Worker file routes - serve local worker files
 @app.get("/assets/canvas-worker.js")
 async def serve_canvas_worker():
     worker_path = "assets/canvas-worker.js"
@@ -73,8 +70,6 @@ async def serve_ws_worker():
         return Response(content="// Worker file not found", media_type="application/javascript", status_code=404)
 
 
-# --- WebSocket routes (/ws/) ---
-
 @app.websocket("/ws")
 async def websocket_handshake(websocket: WebSocket):
     await ws_handler.handle_websocket(websocket)
@@ -85,8 +80,6 @@ routes.get("/ws/start-runelite", RuneLiteClient, "start_runelite_async")
 routes.get("/ws/stop-runelite", RuneLiteClient, "stop_runelite_async")
 routes.get("/ws/status", RuneLiteClient, "status_runelite")
 
-
-# --- RESTful API routes (/api/) ---
 
 routes.get("/api/bitcoin-price", CoinDeskClient, "get_current_bitcoin_price")
 routes.get("/api/poem", PoetryDBClient, "get_random_poem")
@@ -117,7 +110,6 @@ async def google_news():
         return {"news": "failed"}
 
 
-# Desktop automation endpoints (only available if optional deps are installed)
 if ScreenClient is not None:
     @app.get("/api/click")
     async def click_main():
@@ -136,8 +128,6 @@ if ChromeClient is not None:
 if DiscordClient is not None:
     routes.get("/api/discord-login", DiscordClient, "login_with_passkey")
 
-
-# --- Server entry point using kbve AppServer ---
 
 config = ServerConfig(http_port=8086)
 server = AppServer(config=config, app=app)


### PR DESCRIPTION
## Summary

| Alert | File | Fix |
|---|---|---|
| [#59](https://github.com/KBVE/kbve/security/code-scanning/59) `py/exit-from-finally` | [pydesk/main.py:103](apps/pydesk/pydesk/main.py#L103) | Move `return {"ws": "true"}` outside the `finally:` so exceptions from `websocket_client.example()` propagate instead of being swallowed; `close()` still runs in `finally`. |
| [#47](https://github.com/KBVE/kbve/security/code-scanning/47) `py/mixed-returns` | [discord_service.py:375](apps/discordsh/notification-bot/notification_bot/api/discord/discord_service.py#L375) | Add explicit `return None` to `_send_master_status_embed`'s outer `except Exception` so all paths return explicitly. |
| [#48](https://github.com/KBVE/kbve/security/code-scanning/48) `py/mixed-returns` | [tracker.py:61](apps/discordsh/notification-bot/notification_bot/api/supabase/tracker.py#L61) | `get_shard_assignment` previously fell off the end of the duplicate-key + regex-miss path with implicit `None`. Add an explicit `return None` at function end. |

The pydesk pre-commit hook reformatted long lines / docstrings in `discord_service.py`, `tracker.py`, and `main.py`, which inflates the diff stats — the actual logic delta is the three return changes above.

## Out of scope

- [#58](https://github.com/KBVE/kbve/security/code-scanning/58) `py/empty-except` (`apps/discordsh/notification-bot/notification_bot/utils/health_monitor.py:186`) — the rule explicitly fires whenever `except: pass` has no explanatory comment, and per repo style we don't want narration comments. Note-severity, dropped from this PR.
- [#251](https://github.com/KBVE/kbve/security/code-scanning/251) — flagged `let u;` lives in a minified Astro hydration blob that was vendored as an Askama template; manual edits would get clobbered if the template is ever regenerated.
- [#37](https://github.com/KBVE/kbve/security/code-scanning/37) / [#49](https://github.com/KBVE/kbve/security/code-scanning/49) — `kbve_pb2*.py` are protoc-generated; can't be edited without losing the change on the next codegen run.

## Verification

`python3 -m py_compile` on all three edited files passes.

## Test plan

- [ ] CI green on `trunk/atom-codeql-py-quality-*`
- [ ] Post-merge: confirm next Python CodeQL run on `main` closes #47, #48, #59