### PR TITLE
fix(axum-kbve): forum thread lookup by 32-char hex ID + astro error pages

### DIFF
--- a/apps/kbve/axum-kbve/src/db/forum.rs
+++ b/apps/kbve/axum-kbve/src/db/forum.rs
@@ -205,9 +205,8 @@ impl ForumService {
         space_slug: Option<&str>,
         slug_or_id: &str,
     ) -> Result<Option<(ThreadRow, SpaceRow)>, String> {
-        // Distinguish ULID (26 chars, Crockford alphabet) from a slug.
-        let looks_like_ulid =
-            slug_or_id.len() == 26 && slug_or_id.bytes().all(|b| b.is_ascii_alphanumeric());
+        let looks_like_ulid = matches!(slug_or_id.len(), 26 | 32)
+            && slug_or_id.bytes().all(|b| b.is_ascii_alphanumeric());
 
         let url = format!("{}/threads", self.client.config().rest_url());
         let headers = self.client.rpc_headers(SCHEMA)?;

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -1263,6 +1263,68 @@ async fn osrs_item_handler_trailing(Path(item): Path<String>) -> Response<Body> 
         .unwrap()
 }
 
+fn resolve_static_dir() -> String {
+    std::env::var("STATIC_DIR").unwrap_or_else(|_| {
+        for candidate in ["templates/dist", "../astro/dist", "astro/dist"] {
+            if std::path::Path::new(candidate).exists() {
+                return candidate.to_string();
+            }
+        }
+        "templates/dist".to_string()
+    })
+}
+
+async fn serve_astro_error_page(status: StatusCode) -> Response {
+    let static_dir = resolve_static_dir();
+    let html_path = match status {
+        StatusCode::BAD_GATEWAY => format!("{}/502.html", static_dir),
+        StatusCode::SERVICE_UNAVAILABLE => format!("{}/503.html", static_dir),
+        _ => format!("{}/404.html", static_dir),
+    };
+    let gz_path = format!("{}.gz", html_path);
+
+    if let Ok(content) = tokio::fs::read(&gz_path).await {
+        return Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+            .header(header::CONTENT_ENCODING, "gzip")
+            .body(Body::from(content))
+            .unwrap_or_else(|_| Response::new(Body::empty()));
+    }
+
+    if let Ok(content) = tokio::fs::read(&html_path).await {
+        return Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(Body::from(content))
+            .unwrap_or_else(|_| Response::new(Body::empty()));
+    }
+
+    let fallback_404 = format!("{}/404.html", static_dir);
+    let fallback_404_gz = format!("{}.gz", fallback_404);
+    if let Ok(content) = tokio::fs::read(&fallback_404_gz).await {
+        return Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+            .header(header::CONTENT_ENCODING, "gzip")
+            .body(Body::from(content))
+            .unwrap_or_else(|_| Response::new(Body::empty()));
+    }
+    if let Ok(content) = tokio::fs::read(&fallback_404).await {
+        return Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(Body::from(content))
+            .unwrap_or_else(|_| Response::new(Body::empty()));
+    }
+
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from(status.canonical_reason().unwrap_or("Error")))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
 /// OSRS API endpoint - returns item price data as JSON.
 /// GET /api/v1/osrs/{item_id}
 ///
@@ -2703,18 +2765,14 @@ async fn forum_thread_handler(Path(slug_or_id): Path<String>) -> Response {
                     slug_or_id,
                     e
                 );
-                return (StatusCode::BAD_GATEWAY, "forum upstream error").into_response();
+                return serve_astro_error_page(StatusCode::BAD_GATEWAY).await;
             }
         };
 
     let (thread, space) = match pair {
         Some(p) => p,
         None => {
-            return (
-                StatusCode::NOT_FOUND,
-                format!("thread {} not found", slug_or_id),
-            )
-                .into_response();
+            return serve_astro_error_page(StatusCode::NOT_FOUND).await;
         }
     };
 


### PR DESCRIPTION
## Symptom
\`https://kbve.com/forum/t/019dd0b57f73dab90e99e4a5044a93f9#c019df52d9a1cd99600ec503c19c680c6\` returned \`404 thread 019dd0b57f73dab90e99e4a5044a93f9 not found\` (plain text). Same row resolves fine via slug at \`/forum/t/welcome-to-the-new-kbve-forums\`, so the row exists and is active.

## Two bugs

### 1. ULID detection too strict
\`get_thread_by_slug_or_id\` checked \`slug_or_id.len() == 26\` (Crockford base32) to decide between ID and slug. \`gen_ulid()\` in this DB returns 32-char lowercase hex, so the ID lookup branch never fired and the query fell through to \`slug=eq.<id>\` which missed the row.

Fix: accept 26 OR 32-char alphanumeric strings as ID candidates.

### 2. Plain-text 404 / 502
Forum handler returned raw text. New \`serve_astro_error_page\` helper hands off to the astro-built \`404.html\` / \`502.html\` / \`503.html\` (gzipped if available, falls back to 404.html if a status-specific page is missing).

## DB verification
\`\`\`
id                               | title                          | slug                           | status
019dd0b57f73dab90e99e4a5044a93f9 | Welcome to the new KBVE forums | welcome-to-the-new-kbve-forums | active
\`\`\`

## Test plan
- [x] \`cargo build\` clean
- [ ] After deploy: \`/forum/t/019dd0b57f73dab90e99e4a5044a93f9\` → 200 (same thread as the slug URL)
- [ ] \`/forum/t/notathread\` → 404 with the astro splash 404 page (not raw text)
- [ ] PostgREST upstream error → 502 with the new 502.html page (uses 404.html fallback if 502.html not deployed yet)