### PR TITLE
feat(astro-rareicon): flesh out /game/* with world, loop, combat, units pages + fix stale footer links

### DIFF
--- a/apps/rareicon/astro-rareicon/src/components/starlight/Footer.astro
+++ b/apps/rareicon/astro-rareicon/src/components/starlight/Footer.astro
@@ -27,8 +27,8 @@ const currentYear = new Date().getFullYear();
 
 		<nav class="ri-footer__col">
 			<h3 class="ri-footer__title">Adventure</h3>
-			<a href="/guides/getting-started/">Getting Started</a>
-			<a href="/game/">Game</a>
+			<a href="/guides/introduction/">Getting Started</a>
+			<a href="/game/overview/">Game</a>
 			<a href="/steam/">Steam</a>
 			<a href="/press/">Press Kit</a>
 		</nav>

--- a/apps/rareicon/astro-rareicon/src/content/docs/game/combat.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/game/combat.mdx
@@ -1,0 +1,45 @@
+---
+title: Combat Loop
+description: Bullet-hell mechanics in RareIcon — twin-stick movement, stolen icons, parallel event pipeline, and the systems that keep 60 FPS at high entity counts.
+sidebar:
+  label: Combat
+  order: 5
+---
+
+Bullet-hell first. Hundreds of enemies, no framerate excuses. Built on Unity DOTS / ECS so the simulation stays at 60 FPS even when the screen is full of projectiles.
+
+## Inputs
+
+- **Move** — WASD
+- **Aim** — mouse cursor
+- **Shoot** — left mouse, held for sustained fire
+- **Cast** — right mouse + 1–4 for ability slot
+- **Dash** — space, short i-frames + cooldown
+- **Auto-aim assist** — toggle in [Controls](/guides/controls/)
+
+## What you can do moment-to-moment
+
+- **Sustained fire** — direct twin-stick aim, falls off at long range
+- **Stolen icons** — pickup-driven abilities recovered from defeated enemies. Slot up to 4 simultaneously. Stack effects.
+- **Spell casts** — primary slotted ability with cooldown, secondary on right-click hold
+- **Cover + line of sight** — most enemies use predictable LOS so you can break sight to reset their shot timers
+
+## The escalation curve
+
+Every shard ramps wave count + projectile density on a sine curve. Quiet seconds feed dense waves. Density resets between rooms so you're never in the trough during a boss.
+
+## Why it stays fast
+
+- **Burst ECS** — IJobEntity producers fan out across worker threads
+- **Parallel event pipeline** — `NativeList.ParallelWriter.AddNoResize` for projectile spawns; capacity sized once per frame so producers never stall the main thread
+- **Component lookup hygiene** — `state.CompleteDependency()` before main-thread reads
+- **Change-gate pattern** — UI subscribers only repaint on Generation increment
+
+If you're a dev: see the [Open-source ecosystem](/game/overview/#open-source-ecosystem) on the overview page.
+
+## Where to dig deeper
+
+- [Run + Return Loop](/game/loop/) — how combat feeds the kingdom
+- [Units](/game/units/) — multi-role job system
+- [Controls](/guides/controls/) — keybindings + assist toggles
+- [The World](/game/world/) — where the combat lives

--- a/apps/rareicon/astro-rareicon/src/content/docs/game/loop.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/game/loop.mdx
@@ -1,0 +1,39 @@
+---
+title: Run + Return Loop
+description: How a RareIcon session flows — sortie out, loot, return, upgrade the kingdom, redeploy harder.
+sidebar:
+  label: Run + Return
+  order: 4
+---
+
+Every session is a loop, not a campaign. Death isn't a reset — it's a checkpoint that funnels resources back into the kingdom so the next sortie launches harder.
+
+## The four phases
+
+### 1. Loadout
+Pick Chip's gear from the kingdom armory. Inventory pulls from what previous runs banked. Slots: weapon, armor, two utility, four ability slots populated by stolen icons.
+
+### 2. Sortie
+Drop into a procgen shard. Clear waves, recover icons, raid corrupted vaults. Bullet-hell pressure scales with wave count + zone tier. See [Combat Loop](/game/combat/).
+
+### 3. Extract or die
+Hit the extract beacon to bank loot at full value. Die and bank ~40% — still a forward step. The kingdom grows either way.
+
+### 4. Kingdom turn
+Between sorties, allies you recruited handle the kingdom on their own. Builders raise structures, gatherers refill stockpiles, fighters defend the perimeter, scouts spot threats. See [Multi-Role Units](/game/units/) for how the priority-weight job system works.
+
+Then loadout + sortie again.
+
+## Why the loop compounds
+
+- **Resource flywheel** — every run banks some loot. Failed runs still feed the kingdom.
+- **Ally scaling** — recruited units keep working between runs. Kingdom output grows even when you're not playing.
+- **Ability stacking** — stolen icons stack. The build that broke last run might break the next one harder. See [Recursive abilities](/game/overview/#recursive-abilities-via-stolen-icons).
+- **Difficulty escalation** — each successful sortie nudges the next one harder. Bigger threats, bigger payouts.
+
+## Where the loop lands you
+
+- [Game Overview](/game/overview/) — full feature list
+- [Combat](/game/combat/) — moment-to-moment mechanics
+- [Units](/game/units/) — multi-role job system
+- [Steam page](/steam/) — wishlist for demo notification

--- a/apps/rareicon/astro-rareicon/src/content/docs/game/overview.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/game/overview.mdx
@@ -34,8 +34,19 @@ Uncover the truth behind the DaemonCorps and your commoditized existence. Dialog
 ### Distinct visual + audio identity
 Glitch-infused pixel art and a synthwave-driven soundtrack that mirrors the instability of the digital wastelands.
 
+### Recursive abilities via stolen icons
+Defeat enemies, recover their icons, slot up to four simultaneously. Effects stack. The build that broke last run might break the next one harder. Stolen icons also drop onto allied unit slots between sorties.
+
+### Open-source ecosystem
+RareIcon ships in the open. Source on [GitHub](https://kbve.com/github/), patch chatter on [Discord](https://kbve.com/discord/), dev streams Saturdays on [Twitch](https://kbve.com/twitch/). Issues / PRs / roadmap public.
+
 ## Where to go deeper
 
+- [The World](/game/world/) — setting + zones + sim model
+- [Run + Return Loop](/game/loop/) — sortie → loot → kingdom upgrade → next sortie
+- [Combat](/game/combat/) — moment-to-moment bullet-hell mechanics
+- [Multi-Role Units](/game/units/) — priority-weight job system
+- [Factions & Forces](/game/factions/) — DaemonCorps + the resistance
 - [kbve.com/rareicon](https://kbve.com/rareicon/) — item database, zone data, entity reference
 - [kbve.com/journal](https://kbve.com/journal/) — dev journal and patch notes
 

--- a/apps/rareicon/astro-rareicon/src/content/docs/game/units.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/game/units.mdx
@@ -1,0 +1,51 @@
+---
+title: Multi-Role Units
+description: How RareIcon's job system works — every unit carries every role; specialization is a priority weight, not a class lock-in.
+sidebar:
+  label: Units
+  order: 6
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+Every unit in RareIcon's kingdom carries every job role. **Specialization is a priority weight, not a class lock-in.** A unit you recruit as "the builder" is also a fighter, gatherer, and scout — they just default to building. When the kingdom comes under attack, every villager becomes a soldier.
+
+## The four roles
+
+<CardGrid>
+	<Card title="Builder" icon="setting">
+		Construction + repairs. Same unit handles new structures and patches up battle damage. No "engineer" vs "carpenter" split.
+	</Card>
+	<Card title="Gatherer" icon="approve-check">
+		Wood, stone, food, scrap, electronics. Unit walks priority resource lists derived from kingdom needs.
+	</Card>
+	<Card title="Fighter" icon="warning">
+		Defense + sortie escort. Highest auto-aim, dash on threat detection.
+	</Card>
+	<Card title="Scout" icon="seti:plan">
+		Reveal map, mark loot, flag intrusions. Lowest combat priority, highest movement speed.
+	</Card>
+</CardGrid>
+
+## Why one unit, every role
+
+- **No class lock-in** — recruit anyone, slot into any task
+- **Auto-rebalance** — kingdom shifts priority weight when threats spike (every villager → fighter on alarm)
+- **Mid-run flexibility** — sortie loadout changes don't strand the kingdom in a pinch
+
+## Task-offer dispatcher
+
+Tasks fan out via a dispatcher pattern: each task carries a unified score (distance + role weight + role-pressure bonus + supply hysteresis). Units pull their best-scored offer from a flat list every N ticks. Replaces per-tick role cascade. Scales to thousands of units.
+
+Per project memory: every unit has a `JobPriorities` byte. Builder = construction + repairs (one role, not two).
+
+## Stolen-icon abilities
+
+The same units carry equipment slots Chip uses on sortie. Recruited allies gain ability stacking the same way Chip does — drop a stolen icon onto an ally's slot to copy the effect.
+
+## Where to dig deeper
+
+- [Run + Return Loop](/game/loop/) — how units operate between sorties
+- [Combat](/game/combat/) — how units fight on sortie
+- [Factions](/game/factions/) — who you can recruit
+- [The World](/game/world/) — where the kingdom lives

--- a/apps/rareicon/astro-rareicon/src/content/docs/game/world.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/game/world.mdx
@@ -1,0 +1,41 @@
+---
+title: The World
+description: RareIcon's setting — collapsed galactic economy, the DaemonCorps megastructure, the data-slums, and the digital wastelands beyond.
+sidebar:
+  label: World
+  order: 3
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+The galactic economy collapsed three generations ago. The infrastructure stayed. DaemonCorps patrols the wreckage, the data-slums grew up between the cracks, and somewhere in the static the old gods are still listening.
+
+## Layered reality
+
+<CardGrid>
+	<Card title="The data-slums" icon="random">
+		Below the bright commerce of the verified network. Where Chip lives. Where debtors hide. Procgen mazes of forgotten infrastructure.
+	</Card>
+	<Card title="DaemonCorps networks" icon="setting">
+		Bright, ordered, lethal. Patrols spawn from substations and walk predictable routes — until you trip a sensor.
+	</Card>
+	<Card title="Corrupted vaults" icon="seti:shell">
+		Reality-bending storage clusters where demon-like anomalies leak through. Highest loot, lowest survival rate.
+	</Card>
+	<Card title="The kingdom" icon="rocket">
+		Your sanctuary. Where successful runs land. Build it up between sorties so the next run launches harder.
+	</Card>
+</CardGrid>
+
+## How the world keeps scaling
+
+RareIcon runs on a hex-grid sim where contained entities collapse into host-tile counts — sheltered livestock, hive bees, and pond fish destroy their entity and increment a counter on the host tile. Saves rendering, collision, AI ticks. Means the kingdom can grow without the simulation choking.
+
+Out-of-chunk regions tick on a coarser timestep. Persistent state survives across runs.
+
+## Where the lore lives
+
+- [Factions & Forces](/game/factions/) — DaemonCorps, rogue AIs, anomalies, the resistance
+- [Combat Loop](/game/combat/) — moment-to-moment bullet-hell mechanics
+- [Run + Return](/game/loop/) — sortie → loot → kingdom upgrade → next sortie
+- [kbve.com/journal](https://kbve.com/journal/) — dev journal with weekly setting drops


### PR DESCRIPTION
## Summary

Adds 4 new pages under `/game/` so the section stops feeling like a stub. Fixes 2 broken links surfaced by an internal-link audit against the built site.

## New pages

| Path | Sidebar | Focus |
|------|---------|-------|
| `/game/world/` | World (order 3) | Setting + zones + sim model. Four layered regions (data-slums / DaemonCorps networks / corrupted vaults / the kingdom). Entity-collapse pattern that keeps the hex-grid sim scaling. |
| `/game/loop/` | Run + Return (4) | Sortie → loot → kingdom upgrade → next sortie. The four-phase run loop (loadout / sortie / extract or die / kingdom turn) + why the loop compounds. |
| `/game/combat/` | Combat (5) | Moment-to-moment bullet-hell mechanics. Inputs, stolen icons, escalation curve, Burst + parallel-event-pipeline pattern keeping 60 FPS at high entity counts. |
| `/game/units/` | Units (6) | Multi-role job system. Every unit carries every role; specialization is a priority weight. Task-offer dispatcher pattern. |

`game/overview.mdx` extended to add anchor targets the new pages cross-link to (`#recursive-abilities-via-stolen-icons` + `#open-source-ecosystem`) plus a "Where to go deeper" section routing into all four new pages and the factions page.

## Link audit fixes

| Stale | Fixed |
|-------|-------|
| `/guides/getting-started/` | `/guides/introduction/` (no `getting-started.mdx` ever existed) |
| `/game/` | `/game/overview/` (no `game/index.mdx`, returned 404) |

Both were in `Footer.astro` Adventure column.

## Verification

```
[build] 1270 page(s) built in 31.03s
```

Built-site link audit harness:
```sh
grep -rohE 'href="/[^"#?]*"' dist/apps/astro-rareicon/ | sort -u | <verify-each-resolves>
```

Zero remaining broken internal links across 1270 pages.

## Test plan

- [x] `astro build` clean
- [x] Custom link-audit script passes (no broken internal hrefs)
- [ ] CI: e2e suite (PR #10623) doesn't regress
- [ ] Manual: footer "Getting Started" / "Game" links resolve to real pages
- [ ] Manual: `/game/world/`, `/game/loop/`, `/game/combat/`, `/game/units/` render with correct sidebar order