### PR TITLE
feat(discordsh): NPC pursuit AI on flee

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
@@ -1109,6 +1109,8 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+
+            pursuers: Vec::new(),
         }
     }
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/card.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/card.rs
@@ -768,6 +768,8 @@ pub struct MapTileDisplay {
     /// True for the last tile of a highlighted route — the destination.
     /// Gets a thicker stroke than intermediate route tiles.
     pub is_route_goal: bool,
+    /// Active pursuer group sits on this tile.
+    pub is_pursuer_tile: bool,
 }
 
 /// Askama SVG template for the dungeon map card.
@@ -833,6 +835,8 @@ pub fn build_map_card_with_route(session: &SessionState, route: &[MapPos]) -> Ma
 
     let route_set: std::collections::HashSet<MapPos> = route.iter().copied().collect();
     let route_goal: Option<MapPos> = route.last().copied();
+    let pursuer_set: std::collections::HashSet<MapPos> =
+        session.pursuers.iter().map(|g| g.source_pos).collect();
 
     for gy in 0..7i16 {
         for gx in 0..7i16 {
@@ -886,6 +890,7 @@ pub fn build_map_card_with_route(session: &SessionState, route: &[MapPos]) -> Ma
 
                 let is_on_route = route_set.contains(&world_pos);
                 let is_route_goal = route_goal == Some(world_pos);
+                let is_pursuer_tile = pursuer_set.contains(&world_pos);
 
                 tiles.push(MapTileDisplay {
                     tx,
@@ -905,6 +910,7 @@ pub fn build_map_card_with_route(session: &SessionState, route: &[MapPos]) -> Ma
                     cleared: tile.cleared,
                     is_on_route,
                     is_route_goal,
+                    is_pursuer_tile,
                 });
             }
         }
@@ -1284,6 +1290,7 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+            pursuers: Vec::new(),
         }
     }
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/launch.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/launch.rs
@@ -127,6 +127,8 @@ pub async fn prepare_launch(
         enemies_had_first_strike: false,
         quest_journal,
         active_dialogue: None,
+
+        pursuers: Vec::new(),
     };
 
     let components = render::render_components(&session_state);

--- a/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
@@ -5,9 +5,13 @@ use tracing::debug;
 
 use super::battle_bridge;
 use super::content;
+use super::pathfinding;
 use super::proto_bridge;
 use super::skills;
 use super::types::*;
+
+/// Player moves a fled enemy group will pursue before despawning.
+const PURSUIT_MAX_HOPS: u8 = 5;
 
 /// Result of applying a game action, including optional ECS combat snapshot.
 #[derive(Debug)]
@@ -1745,7 +1749,20 @@ fn resolve_flee(session: &mut SessionState, actor: serenity::UserId) -> Vec<Stri
     logs.extend(flee_logs);
 
     if fled {
-        // Session-level cleanup: escape to hallway
+        if !session.enemies.is_empty() {
+            let group = PursuitGroup {
+                source_pos: session.map.position,
+                origin_name: session.room.name.clone(),
+                hops_remaining: PURSUIT_MAX_HOPS,
+                enemies: std::mem::take(&mut session.enemies),
+            };
+            logs.push(format!(
+                "{} enemies break off and follow you from {}.",
+                group.enemies.len(),
+                group.origin_name
+            ));
+            session.pursuers.push(group);
+        }
         let hallway = content::generate_hallway_room(session.room.index);
         session.room = hallway;
         session.enemies.clear();
@@ -2060,6 +2077,65 @@ fn apply_move(
 
 /// Complete arrival at a tile: update position, mark visited, reveal neighbors,
 /// build RoomState, apply hazards, transition phase.
+/// Advance every active pursuer one tile toward the player and return
+/// the first group that catches up. Caught-up groups are removed; the
+/// caller is responsible for transitioning to combat with the returned
+/// enemies. Pursuers whose hops budget hits zero are pruned.
+fn tick_pursuers(session: &mut SessionState, logs: &mut Vec<String>) -> Option<PursuitGroup> {
+    if session.pursuers.is_empty() {
+        return None;
+    }
+
+    let player_pos = session.map.position;
+    let field = pathfinding::pursuit_field(&session.map, player_pos);
+
+    let mut caught: Option<PursuitGroup> = None;
+    let mut keep: Vec<PursuitGroup> = Vec::with_capacity(session.pursuers.len());
+
+    for mut group in std::mem::take(&mut session.pursuers) {
+        if caught.is_some() {
+            keep.push(group);
+            continue;
+        }
+
+        let next_step = field.as_ref().and_then(|f| f.next_step(group.source_pos));
+        match next_step {
+            Some(next) if next == player_pos => {
+                logs.push(format!(
+                    "{} pursuers close in from {}.",
+                    group.enemies.len(),
+                    group.origin_name
+                ));
+                group.source_pos = next;
+                caught = Some(group);
+            }
+            Some(next) => {
+                group.source_pos = next;
+                if group.hops_remaining > 0 {
+                    group.hops_remaining -= 1;
+                }
+                if group.hops_remaining == 0 {
+                    logs.push(format!(
+                        "Pursuers from {} lose your trail.",
+                        group.origin_name
+                    ));
+                } else {
+                    keep.push(group);
+                }
+            }
+            None => {
+                logs.push(format!(
+                    "Pursuers from {} hit a dead end and give up.",
+                    group.origin_name
+                ));
+            }
+        }
+    }
+
+    session.pursuers = keep;
+    caught
+}
+
 fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
     let mut logs = Vec::new();
 
@@ -2145,6 +2221,23 @@ fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
     if session.all_players_dead() {
         session.phase = GamePhase::GameOver(GameOverReason::Defeated);
         logs.push("The hazards proved fatal...".to_owned());
+        return logs;
+    }
+
+    let pursuit_combat = tick_pursuers(session, &mut logs);
+
+    if let Some(group) = pursuit_combat {
+        logs.push(format!(
+            "Pursuers from {} catch up — combat resumes!",
+            group.origin_name
+        ));
+        session.enemies = group.enemies;
+        session.phase = GamePhase::Combat;
+        session.enemies_had_first_strike = false;
+        for player in session.players.values_mut() {
+            player.first_attack_in_combat = true;
+            player.heals_used_this_combat = 0;
+        }
         return logs;
     }
 
@@ -2984,6 +3077,7 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+            pursuers: Vec::new(),
         }
     }
 
@@ -3004,6 +3098,93 @@ mod tests {
             first_strike: false,
             personality: Personality::Feral,
         }
+    }
+
+    #[test]
+    fn tick_pursuers_noop_when_empty() {
+        let mut session = test_session();
+        let mut logs = Vec::new();
+        let caught = tick_pursuers(&mut session, &mut logs);
+        assert!(caught.is_none());
+        assert!(logs.is_empty());
+    }
+
+    fn linear_test_map(len: i16) -> MapState {
+        let mut tiles = std::collections::HashMap::new();
+        for y in 0..len {
+            let pos = MapPos::new(0, y);
+            let mut exits = Vec::new();
+            if y > 0 {
+                exits.push(Direction::North);
+            }
+            if y < len - 1 {
+                exits.push(Direction::South);
+            }
+            tiles.insert(
+                pos,
+                MapTile {
+                    pos,
+                    room_type: RoomType::Hallway,
+                    name: format!("Hall {y}"),
+                    description: String::new(),
+                    exits,
+                    visited: true,
+                    cleared: true,
+                    landmark_ref: None,
+                },
+            );
+        }
+        MapState {
+            seed: 1,
+            position: MapPos::new(0, 0),
+            tiles,
+            tiles_visited: len as u32,
+            boss_positions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn tick_pursuers_catches_up_at_adjacent_tile() {
+        let mut session = test_session();
+        session.map = linear_test_map(2);
+        let player_pos = session.map.position;
+        let pursuer_pos = MapPos::new(0, 1);
+        let group = PursuitGroup {
+            source_pos: pursuer_pos,
+            origin_name: "Hall 1".to_owned(),
+            hops_remaining: PURSUIT_MAX_HOPS,
+            enemies: vec![test_enemy()],
+        };
+        session.pursuers.push(group);
+
+        let mut logs = Vec::new();
+        let caught = tick_pursuers(&mut session, &mut logs);
+
+        assert!(caught.is_some());
+        let group = caught.unwrap();
+        assert_eq!(group.enemies.len(), 1);
+        assert_eq!(group.source_pos, player_pos);
+        assert!(session.pursuers.is_empty());
+    }
+
+    #[test]
+    fn tick_pursuers_decrements_when_not_caught_up() {
+        let mut session = test_session();
+        session.map = linear_test_map(5);
+        let group = PursuitGroup {
+            source_pos: MapPos::new(0, 4),
+            origin_name: "Hall 4".to_owned(),
+            hops_remaining: PURSUIT_MAX_HOPS,
+            enemies: vec![test_enemy()],
+        };
+        session.pursuers.push(group);
+
+        let mut logs = Vec::new();
+        let caught = tick_pursuers(&mut session, &mut logs);
+        assert!(caught.is_none());
+        assert_eq!(session.pursuers.len(), 1);
+        assert_eq!(session.pursuers[0].hops_remaining, PURSUIT_MAX_HOPS - 1);
+        assert_eq!(session.pursuers[0].source_pos, MapPos::new(0, 3));
     }
 
     #[test]

--- a/apps/discordsh/discordsh-bot/src/discord/game/pathfinding.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/pathfinding.rs
@@ -83,6 +83,16 @@ pub fn path_to_goal(map: &MapState, from: MapPos, goal: GoalKind<'_>) -> Option<
     if path.is_empty() { None } else { Some(path) }
 }
 
+/// Build a [`PathField`] keyed on the player tile so pursuers can each
+/// query their own next-hop in one shared BFS.
+pub fn pursuit_field(map: &MapState, player: MapPos) -> Option<PathField<MapPos>> {
+    if !map.tiles.contains_key(&player) {
+        return None;
+    }
+    let graph = build_tile_graph(map);
+    Some(PathField::compute(&graph, &[player]))
+}
+
 /// Convert a tile-coordinate path into a list of cardinal moves the
 /// player must make. Useful for rendering `/path` results as
 /// `North → East → East`. Returns an empty vec when `path` has fewer

--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -1002,6 +1002,7 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+            pursuers: Vec::new(),
         }
     }
 }

--- a/apps/discordsh/discordsh-bot/src/discord/game/render.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/render.rs
@@ -1117,6 +1117,7 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+            pursuers: Vec::new(),
         }
     }
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/session.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/session.rs
@@ -147,6 +147,8 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+
+            pursuers: Vec::new(),
         }
     }
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/types.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/types.rs
@@ -855,6 +855,18 @@ pub struct SessionState {
     /// Active dialogue conversation (if player is talking to an NPC).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_dialogue: Option<ActiveDialogue>,
+    /// Enemy groups that survived a fled combat and are tracking the party.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pursuers: Vec<PursuitGroup>,
+}
+
+/// Enemy group pursuing the party after a successful flee.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PursuitGroup {
+    pub source_pos: MapPos,
+    pub origin_name: String,
+    pub hops_remaining: u8,
+    pub enemies: Vec<EnemyState>,
 }
 
 impl SessionState {
@@ -1073,6 +1085,8 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+
+            pursuers: Vec::new(),
         };
         let roster = session.roster();
         assert_eq!(roster.len(), 2);
@@ -1163,6 +1177,8 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+
+            pursuers: Vec::new(),
         };
 
         assert!(session.has_enemies());
@@ -1337,6 +1353,8 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+
+            pursuers: Vec::new(),
         };
         assert!(!session.show_inventory);
     }
@@ -1401,6 +1419,8 @@ mod tests {
             enemies_had_first_strike: false,
             quest_journal: QuestJournal::default(),
             active_dialogue: None,
+
+            pursuers: Vec::new(),
         };
 
         let json = serde_json::to_string(&session).unwrap();

--- a/apps/discordsh/discordsh-bot/templates/game/map.svg
+++ b/apps/discordsh/discordsh-bot/templates/game/map.svg
@@ -31,6 +31,11 @@
     stroke-dasharray="{% if tile.is_route_goal %}0{% else %}3,2{% endif %}"/>
   {% endif %}
 
+  {% if tile.is_pursuer_tile %}
+  <rect x="{{ tile.tx - 1 }}" y="{{ tile.ty - 1 }}" width="50" height="50" rx="7"
+    fill="none" stroke="#ef4444" stroke-width="2.5" stroke-dasharray="2,2"/>
+  {% endif %}
+
   {% if tile.is_current %}
   <rect x="{{ tile.tx - 2 }}" y="{{ tile.ty - 2 }}" width="52" height="52" rx="8"
     fill="none" stroke="#ffd700" stroke-width="2.5"/>


### PR DESCRIPTION
Closes the last Phase 2 followup from #10601.

## What
Survivors of a fled combat now track the party through the map using \`bevy_pathfinder\`, and catch-up triggers a forced encounter combat with the original enemies — no map-wide pursuer entities, no separate per-tick scheduler, just bookkeeping in \`SessionState\` plus one BFS per player move.

## Behavior
- A successful flee captures the surviving \`EnemyState\`s into a new \`PursuitGroup\` parked at the flee tile. Log: \`"N enemies break off and follow you from <room>."\`.
- On every player move, \`tick_pursuers\` runs once after hazard resolution. It builds a \`PathField<MapPos>\` keyed on the player tile via the new \`pathfinding::pursuit_field\` helper and advances each group along its next-hop. Groups that reach the player tile are pulled out as \`Some(PursuitGroup)\`.
- When \`arrive_at_tile\` sees a caught-up group it transitions the room straight to \`Combat\` with that group's enemies, overriding the natural room-type phase. Log: \`"Pursuers from <room> catch up — combat resumes!"\`.
- Groups that don't catch up decrement \`hops_remaining\`; at zero or on a dead-end (pathfinder reports no next step) they're pruned with a "lose your trail" / "give up" message.
- Map render: pursuer tiles get a **red dashed ring** (separate from the cyan route ring shipped in #10708). HUD didn't grow — the ring conveys it.

\`PURSUIT_MAX_HOPS = 5\` in \`logic.rs\` — five player moves before a stuck group despawns. Tunable.

## Code
- New \`PursuitGroup { source_pos: MapPos, origin_name: String, hops_remaining: u8, enemies: Vec<EnemyState> }\` in \`types.rs\`. \`SessionState.pursuers: Vec<PursuitGroup>\` with \`#[serde(default, skip_serializing_if = \"Vec::is_empty\")]\` so older serialisations and empty cases stay quiet.
- \`pathfinding::pursuit_field(map, player) -> Option<PathField<MapPos>>\` — thin wrapper over \`bevy_pathfinder::PathField::compute\` with the player tile as the BFS goal. Reuses the existing \`build_tile_graph\`.
- \`tick_pursuers\` consumes and rebuilds \`session.pursuers\`, returning the first caught-up group. Single-catch-up per move keeps combat triggers deterministic.
- \`MapTileDisplay.is_pursuer_tile\` + map.svg block (red \`#ef4444\`, dashed 2,2).
- Three unit tests in \`logic::tests\`: empty-pursuers no-op, catch-up at adjacent tile, decrement-and-advance when too far away. New \`linear_test_map\` helper builds a hallway-only map for path-dependent tests since \`test_map_default\` only contains the origin.
- All existing SessionState construction sites updated (production + 4 test helpers).

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo test --bin discordsh-bot\` — 708/708 pass (705 baseline + 3 new pursuit)
- [x] \`cargo clippy --no-deps\` clean on edited regions
- [ ] Smoke in staging: flee a combat → see "X enemies break off"; move 1–4 tiles → red ring on pursuer tile shifts toward you; if pursuer reaches your tile → forced combat with original enemies; if you outrun (5+ tiles or break path connectivity) → "lose your trail"

## Issue 10601 status after this lands
- Phase 1–3 + redb 4 bump merged
- Phase 2 followups: \`/dungeon route\` landmark slug (#10699), route map highlight (#10708), this PR — Phase 2 done
- Phase 4 \`bevy_supa\` skipped: marginal, blocked by \`kbve::SupabaseClient\` still alive in \`MemberCache\`
- Outstanding: \`SessionState\` resume across pod restart (Phase 3 followup), Downed mechanic (separate dungeon-redesign track)