### PR TITLE
feat(rareicon-icons): /icons/category/<cat>/ landing pages — additive SEO surface

### DIFF
--- a/apps/rareicon/astro-rareicon/src/components/icons/CategoryLanding.astro
+++ b/apps/rareicon/astro-rareicon/src/components/icons/CategoryLanding.astro
@@ -1,0 +1,223 @@
+---
+/**
+ * Category-scoped catalog landing. Pre-filters the term summaries down
+ * to one primary_category value, renders breadcrumb + count + a grid
+ * matching the global IconsBrowser layout — minus the filter chips
+ * (single category by definition) and minus the Featured row (every
+ * card is already on-topic). Direct term pages at /icons/<ref>/ stay
+ * 1:1 reachable; this is an additive landing surface.
+ */
+import { getCollection } from 'astro:content';
+import { collectTermSummaries } from '@/lib/icons/terms';
+
+interface Props {
+	category: string;
+	headline?: string;
+	lede?: string;
+}
+
+const { category, headline, lede } = Astro.props;
+const docs = await getCollection('docs');
+const allTerms = collectTermSummaries(docs);
+const terms = allTerms.filter((t) => t.primary_category === category);
+
+const categoryLabel =
+	headline ?? category.charAt(0).toUpperCase() + category.slice(1);
+---
+
+<section class="ri-cat-landing" data-category={category}>
+	<header class="ri-cat-landing__header">
+		<nav class="ri-cat-landing__crumbs" aria-label="Breadcrumb">
+			<a href="/icons/">All icons</a>
+			<span aria-hidden="true">/</span>
+			<span class="ri-cat-landing__crumbs-current">{categoryLabel}</span>
+		</nav>
+		<h1 class="ri-cat-landing__title">
+			{categoryLabel}
+			<span class="ri-cat-landing__count">{terms.length}</span>
+		</h1>
+		{lede && <p class="ri-cat-landing__lede">{lede}</p>}
+	</header>
+
+	{
+		terms.length === 0 ? (
+			<p class="ri-cat-landing__empty">
+				No icons in this category yet. Browse the
+				<a href="/icons/">full catalog</a>.
+			</p>
+		) : (
+			<ul class="ri-cat-landing__grid">
+				{terms.map((t) => (
+					<li class="ri-cat-landing__item">
+						<a
+							href={`/icons/${t.ref}/`}
+							class="ri-cat-landing__card">
+							<div
+								class="ri-cat-landing__thumb"
+								set:html={t.previewSvg ?? ''}
+							/>
+							<div class="ri-cat-landing__meta">
+								<span class="ri-cat-landing__name">
+									{t.name}
+								</span>
+								<span class="ri-cat-landing__pill">
+									{t.variantCount}
+									{t.variantCount === 1
+										? ' variant'
+										: ' variants'}
+								</span>
+							</div>
+						</a>
+					</li>
+				))}
+			</ul>
+		)
+	}
+</section>
+
+<style is:global>
+	.ri-cat-landing {
+		max-width: 72rem;
+		margin: 1.5rem auto 3rem;
+	}
+
+	.ri-cat-landing__header {
+		margin-bottom: 1.5rem;
+	}
+
+	.ri-cat-landing__crumbs {
+		display: flex;
+		gap: 0.45rem;
+		font-size: 0.8125rem;
+		color: var(--ri-text-disabled, #6b6356);
+		margin-bottom: 0.5rem;
+	}
+
+	.ri-cat-landing__crumbs a {
+		color: var(--ri-accent, #d4a73c);
+		text-decoration: none;
+	}
+
+	.ri-cat-landing__crumbs a:hover {
+		text-decoration: underline;
+	}
+
+	.ri-cat-landing__crumbs-current {
+		color: var(--ri-text-secondary, #9e9480);
+		font-weight: 500;
+	}
+
+	.ri-cat-landing__title {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin: 0;
+		font-size: clamp(1.5rem, 3vw, 2rem);
+		color: var(--ri-text-primary, #e8dcc8);
+	}
+
+	.ri-cat-landing__count {
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		padding: 0.25rem 0.6rem;
+		border-radius: 999px;
+		background: color-mix(
+			in srgb,
+			var(--ri-accent, #d4a73c) 12%,
+			transparent
+		);
+		border: 1px solid
+			color-mix(in srgb, var(--ri-accent, #d4a73c) 35%, transparent);
+		color: var(--ri-accent, #d4a73c);
+	}
+
+	.ri-cat-landing__lede {
+		margin: 0.75rem 0 0;
+		color: var(--ri-text-secondary, #9e9480);
+		font-size: 0.9375rem;
+		line-height: 1.55;
+		max-width: 56rem;
+	}
+
+	.ri-cat-landing__grid {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+		gap: 0.75rem;
+	}
+
+	.ri-cat-landing__item {
+		margin: 0;
+	}
+
+	.ri-cat-landing__card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		border-radius: 8px;
+		background: var(--ri-bg-panel, #15131c);
+		border: 1px solid var(--ri-border, #2a2a33);
+		text-decoration: none !important;
+		color: var(--ri-text-primary, #e8dcc8);
+		transition:
+			border-color 0.15s,
+			box-shadow 0.15s,
+			transform 0.15s;
+	}
+
+	.ri-cat-landing__card:hover {
+		border-color: var(--ri-accent, #d4a73c);
+		box-shadow: 0 0 24px rgba(212, 167, 60, 0.15);
+		transform: translateY(-2px);
+	}
+
+	.ri-cat-landing__thumb {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		background: var(--ri-bg-panel-elevated, #1a1a1f);
+		border-radius: 6px;
+		color: var(--ri-accent, #d4a73c);
+		min-height: 80px;
+	}
+
+	.ri-cat-landing__thumb svg {
+		width: 48px;
+		height: 48px;
+	}
+
+	.ri-cat-landing__meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.ri-cat-landing__name {
+		font-weight: 600;
+		flex: 1 1 auto;
+	}
+
+	.ri-cat-landing__pill {
+		font-size: 0.6875rem;
+		padding: 0.125rem 0.45rem;
+		border-radius: 999px;
+		background: var(--ri-bg-app, #0c0c10);
+		border: 1px solid var(--ri-border, #2a2a33);
+		color: var(--ri-text-disabled, #6b6356);
+	}
+
+	.ri-cat-landing__empty {
+		padding: 2rem;
+		text-align: center;
+		color: var(--ri-text-disabled, #6b6356);
+		border: 1px dashed var(--ri-border, #2a2a33);
+		border-radius: 8px;
+	}
+</style>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/action.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/action.mdx
@@ -1,0 +1,18 @@
+---
+title: Actions & affordances
+description: Plus, minus, check, close, edit, trash, save, share.
+sidebar:
+  label: Actions & affordances
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="action"
+  headline="Actions & affordances"
+  lede="Plus, minus, check, close, edit, trash, save, share. The verb-shaped half of the catalog."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/commerce.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/commerce.mdx
@@ -1,0 +1,18 @@
+---
+title: Commerce & money
+description: Cart, wallet, payments, currencies, gifts, subscriptions.
+sidebar:
+  label: Commerce & money
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="commerce"
+  headline="Commerce & money"
+  lede="Cart, wallet, payments, currencies, gifts, subscriptions. Brand glyphs (Patreon, Ko-fi, GitHub Sponsors, etc.) under Tier 1 attribution."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/comms.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/comms.mdx
@@ -1,0 +1,18 @@
+---
+title: Communication
+description: Mail, chat, bell, phone, megaphone — every way users notify and respond.
+sidebar:
+  label: Communication
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="comms"
+  headline="Communication"
+  lede="Mail, chat, bell, phone, megaphone — every way users notify and respond."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/file.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/file.mdx
@@ -1,0 +1,18 @@
+---
+title: Files & storage
+description: File / folder / archive / clipboard / book glyphs.
+sidebar:
+  label: Files & storage
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="file"
+  headline="Files & storage"
+  lede="File / folder / archive / clipboard / book glyphs."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/game.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/game.mdx
@@ -1,0 +1,18 @@
+---
+title: Gamedev & roguelike
+description: Weapons, classes, monsters, magic, dungeon dressing.
+sidebar:
+  label: Gamedev & roguelike
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="game"
+  headline="Gamedev & roguelike"
+  lede="Weapons, classes, monsters, magic, dungeon dressing. Curated from Game Icons (CC BY 3.0) plus Lucide / Phosphor / Tabler complements."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/gaming.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/gaming.mdx
@@ -1,0 +1,18 @@
+---
+title: Gaming platforms
+description: Steam, itch, GOG, Epic, PlayStation, Nintendo Switch, Game Jolt, Roblox.
+sidebar:
+  label: Gaming platforms
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="gaming"
+  headline="Gaming platforms"
+  lede="Steam, itch, GOG, Epic, PlayStation, Nintendo Switch, Game Jolt, Roblox. Plus engine icons — Unity, Unreal, Godot, Bevy, GameMaker, Construct 3."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/media.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/media.mdx
@@ -1,0 +1,18 @@
+---
+title: Media & playback
+description: Play, pause, audio, video, image, microphone.
+sidebar:
+  label: Media & playback
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="media"
+  headline="Media & playback"
+  lede="Play, pause, audio, video, image, microphone. Playback controls + brand glyphs for streaming platforms."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/navigation.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/navigation.mdx
@@ -1,0 +1,18 @@
+---
+title: Navigation & wayfinding
+description: Home, compass, map, breadcrumb, transit, travel — orient and route the user.
+sidebar:
+  label: Navigation & wayfinding
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="navigation"
+  headline="Navigation & wayfinding"
+  lede="Home, compass, map, breadcrumb, transit, travel — orient and route the user."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/sci-fi.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/sci-fi.mdx
@@ -1,0 +1,18 @@
+---
+title: Sci-fi
+description: Niche sci-fi-specific glyphs.
+sidebar:
+  label: Sci-fi
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="sci-fi"
+  headline="Sci-fi"
+  lede="Niche sci-fi-specific glyphs."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/social.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/social.mdx
@@ -1,0 +1,18 @@
+---
+title: Social & community
+description: User / group / mood / character glyphs across multiple icon packs.
+sidebar:
+  label: Social & community
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="social"
+  headline="Social & community"
+  lede="User / group / mood / character glyphs across multiple icon packs. Layered styles for product profile UI."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/tech.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/tech.mdx
@@ -1,0 +1,18 @@
+---
+title: Tech & infrastructure
+description: Languages, frameworks, runtimes, databases, devops, AI/ML brands.
+sidebar:
+  label: Tech & infrastructure
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="tech"
+  headline="Tech & infrastructure"
+  lede="Languages, frameworks, runtimes, databases, devops, AI/ML brands. Multi-source-merged variants from Lucide outline through Devicon brand glyphs and SVG Logos full-color."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/ui.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/ui.mdx
@@ -1,0 +1,18 @@
+---
+title: UI & general icons
+description: Buttons, toggles, layout chrome, status indicators.
+sidebar:
+  label: UI & general icons
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="ui"
+  headline="UI & general icons"
+  lede="Buttons, toggles, layout chrome, status indicators. The Lucide-driven baseline that most product surfaces rely on."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/weapon.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/weapon.mdx
@@ -1,0 +1,18 @@
+---
+title: Weapons
+description: Hand-curated weapon glyphs.
+sidebar:
+  label: Weapons
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="weapon"
+  headline="Weapons"
+  lede="Hand-curated weapon glyphs. Most gamedev weapons live under the Gamedev category — this one is for catalog terms specifically tagged primary_category=weapon."
+/>

--- a/apps/rareicon/astro-rareicon/src/content/docs/icons/category/weather.mdx
+++ b/apps/rareicon/astro-rareicon/src/content/docs/icons/category/weather.mdx
@@ -1,0 +1,18 @@
+---
+title: Weather & nature
+description: Sun, moon, cloud, rain, snow, wind, leaf, tree, recycle.
+sidebar:
+  label: Weather & nature
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category="weather"
+  headline="Weather & nature"
+  lede="Sun, moon, cloud, rain, snow, wind, leaf, tree, recycle. Eco + climate icons."
+/>

--- a/apps/rareicon/icons-codegen/package.json
+++ b/apps/rareicon/icons-codegen/package.json
@@ -12,7 +12,8 @@
 		"gen:gameicons": "node scripts/gen-gameicons.mjs",
 		"gen:iconify": "node scripts/gen-iconify-icons.mjs",
 		"gen:merge": "node scripts/gen-merge-variants.mjs",
-		"gen:all": "pnpm gen:lucide && pnpm gen:simple && pnpm gen:tabler && pnpm gen:phosphor && pnpm gen:gameicons && pnpm gen:iconify && pnpm gen:merge",
+		"gen:categories": "node scripts/gen-category-landings.mjs",
+		"gen:all": "pnpm gen:lucide && pnpm gen:simple && pnpm gen:tabler && pnpm gen:phosphor && pnpm gen:gameicons && pnpm gen:iconify && pnpm gen:merge && pnpm gen:categories",
 		"clean:deps": "rm -rf node_modules"
 	},
 	"dependencies": {

--- a/apps/rareicon/icons-codegen/scripts/gen-category-landings.mjs
+++ b/apps/rareicon/icons-codegen/scripts/gen-category-landings.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Generate one MDX landing page per `primary_category` value found in
+ * the catalog. Each landing renders `<CategoryLanding />` pre-filtered
+ * to that category — adds 14 high-traffic SEO entry points without
+ * touching the existing 1270 direct term pages.
+ *
+ * Output: apps/rareicon/astro-rareicon/src/content/docs/icons/category/<slug>.mdx
+ *
+ * Cleanup pass walks the output dir and removes any stale category
+ * file before regen so adding / dropping a category from the catalog
+ * stays a one-command refresh.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../../..');
+const ICONS_DIR = path.resolve(
+	WORKSPACE_ROOT,
+	'apps/rareicon/astro-rareicon/src/content/docs/icons',
+);
+const CAT_DIR = path.resolve(ICONS_DIR, 'category');
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+
+/**
+ * Curated headline + lede copy per known category. Categories not in
+ * this map fall back to title-case headline + a generic lede.
+ */
+const COPY = {
+	ui: {
+		headline: 'UI & general icons',
+		lede: 'Buttons, toggles, layout chrome, status indicators. The Lucide-driven baseline that most product surfaces rely on.',
+	},
+	tech: {
+		headline: 'Tech & infrastructure',
+		lede: 'Languages, frameworks, runtimes, databases, devops, AI/ML brands. Multi-source-merged variants from Lucide outline through Devicon brand glyphs and SVG Logos full-color.',
+	},
+	game: {
+		headline: 'Gamedev & roguelike',
+		lede: 'Weapons, classes, monsters, magic, dungeon dressing. Curated from Game Icons (CC BY 3.0) plus Lucide / Phosphor / Tabler complements.',
+	},
+	gaming: {
+		headline: 'Gaming platforms',
+		lede: 'Steam, itch, GOG, Epic, PlayStation, Nintendo Switch, Game Jolt, Roblox. Plus engine icons — Unity, Unreal, Godot, Bevy, GameMaker, Construct 3.',
+	},
+	social: {
+		headline: 'Social & community',
+		lede: 'User / group / mood / character glyphs across multiple icon packs. Layered styles for product profile UI.',
+	},
+	commerce: {
+		headline: 'Commerce & money',
+		lede: 'Cart, wallet, payments, currencies, gifts, subscriptions. Brand glyphs (Patreon, Ko-fi, GitHub Sponsors, etc.) under Tier 1 attribution.',
+	},
+	navigation: {
+		headline: 'Navigation & wayfinding',
+		lede: 'Home, compass, map, breadcrumb, transit, travel — orient and route the user.',
+	},
+	media: {
+		headline: 'Media & playback',
+		lede: 'Play, pause, audio, video, image, microphone. Playback controls + brand glyphs for streaming platforms.',
+	},
+	action: {
+		headline: 'Actions & affordances',
+		lede: 'Plus, minus, check, close, edit, trash, save, share. The verb-shaped half of the catalog.',
+	},
+	weather: {
+		headline: 'Weather & nature',
+		lede: 'Sun, moon, cloud, rain, snow, wind, leaf, tree, recycle. Eco + climate icons.',
+	},
+	comms: {
+		headline: 'Communication',
+		lede: 'Mail, chat, bell, phone, megaphone — every way users notify and respond.',
+	},
+	file: {
+		headline: 'Files & storage',
+		lede: 'File / folder / archive / clipboard / book glyphs.',
+	},
+	weapon: {
+		headline: 'Weapons',
+		lede: 'Hand-curated weapon glyphs. Most gamedev weapons live under the Gamedev category — this one is for catalog terms specifically tagged primary_category=weapon.',
+	},
+	'sci-fi': {
+		headline: 'Sci-fi',
+		lede: 'Niche sci-fi-specific glyphs.',
+	},
+};
+
+function titleCase(str) {
+	return str
+		.split('-')
+		.map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+		.join(' ');
+}
+
+function discoverCategories() {
+	const cats = new Set();
+	const re = /^primary_category:\s*(\S+)/m;
+	for (const f of fs.readdirSync(ICONS_DIR)) {
+		if (!f.endsWith('.mdx') || f === 'index.mdx') continue;
+		const fp = path.join(ICONS_DIR, f);
+		if (fs.statSync(fp).isDirectory()) continue;
+		const head = fs.readFileSync(fp, 'utf8').slice(0, 800);
+		const m = head.match(re);
+		if (m) cats.add(m[1].trim());
+	}
+	return Array.from(cats).sort();
+}
+
+function emitMdx(cat) {
+	const meta = COPY[cat] ?? {
+		headline: titleCase(cat),
+		lede: `Catalog terms tagged primary_category=${cat}.`,
+	};
+	const headline = meta.headline.replace(/"/g, '\\"');
+	const ledeJs = JSON.stringify(meta.lede);
+	return `---
+title: ${headline}
+description: ${meta.lede.split('.')[0]}.
+sidebar:
+  label: ${headline}
+editUrl: false
+lastUpdated: false
+prev: false
+next: false
+---
+
+import CategoryLanding from '@/components/icons/CategoryLanding.astro';
+
+<CategoryLanding
+  category=${JSON.stringify(cat)}
+  headline=${JSON.stringify(meta.headline)}
+  lede=${ledeJs}
+/>
+`;
+}
+
+function cleanCategoryDir() {
+	if (!fs.existsSync(CAT_DIR)) return 0;
+	let removed = 0;
+	for (const f of fs.readdirSync(CAT_DIR)) {
+		if (!f.endsWith('.mdx')) continue;
+		if (!dryRun) fs.unlinkSync(path.join(CAT_DIR, f));
+		removed++;
+	}
+	return removed;
+}
+
+function main() {
+	if (!fs.existsSync(ICONS_DIR)) {
+		console.error(`icons dir missing: ${ICONS_DIR}`);
+		process.exit(1);
+	}
+
+	const cats = discoverCategories();
+	console.log(`discovered ${cats.length} categories: ${cats.join(', ')}`);
+
+	if (!fs.existsSync(CAT_DIR)) {
+		if (!dryRun) fs.mkdirSync(CAT_DIR, { recursive: true });
+	} else {
+		const removed = cleanCategoryDir();
+		console.log(`cleaned ${removed} previous category landings`);
+	}
+
+	let written = 0;
+	for (const cat of cats) {
+		const file = path.join(CAT_DIR, `${cat}.mdx`);
+		const mdx = emitMdx(cat);
+		if (!dryRun) fs.writeFileSync(file, mdx);
+		written++;
+	}
+
+	console.log(`wrote ${written} category landing pages${dryRun ? ' (dry-run)' : ''}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds 14 category-scoped landing pages, one per distinct \`primary_category\` value in the catalog. Direct term pages at \`/icons/<ref>/\` stay 1:1 reachable — these are an **additive** SEO + UX layer, not a replacement.

| Before | After |
|--------|-------|
| 1270 pages | **1284 pages** |
| Single \`/icons/\` landing | Plus 14 category-scoped landings |

## What's new

\`/icons/category/<cat>/\` for each of:

| Category | Term count |
|----------|------------|
| ui | 561 |
| tech | 227 |
| game | 196 |
| social | 54 |
| commerce | 45 |
| navigation | 38 |
| media | 33 |
| action | 29 |
| weather | 21 |
| gaming | 19 |
| comms | 19 |
| file | 6 |
| weapon | 2 |
| sci-fi | 2 |

## Components

- \`CategoryLanding.astro\` — takes \`category\` + optional \`headline\` / \`lede\` props, pulls \`collectTermSummaries\`, filters to one category, renders breadcrumb + count badge + clean grid (no chip filter UI — single category)
- \`gen-category-landings.mjs\` — discovers categories by grep'ing \`primary_category\` from \`icons/*.mdx\` (no \`node_modules\` required), emits one mdx per category with curated copy from a COPY map. Wired into \`icons-codegen\` \`gen:categories\` + \`gen:all\` chain runs it last.

Curated headline + lede per category, so each landing reads distinct from the others (e.g. tech: "Multi-source-merged variants from Lucide outline through Devicon brand glyphs and SVG Logos full-color"; game: "Curated from Game Icons (CC BY 3.0) plus Lucide / Phosphor / Tabler complements").

## Verification

- Built-site spot check: \`/icons/category/{tech,game,social,commerce}/index.html\` all resolve
- \`/icons/<ref>/\` direct term pages unchanged (sword/python/react/steam spot-checked)
- Internal-link audit clean across **1284 pages**
- Pagefind index rebuilt, sitemap regenerated

## Test plan

- [x] \`astro build\` clean
- [x] Direct term page resolution unchanged
- [x] Link audit zero broken
- [ ] CI: e2e regression suite (#10623) doesn't break
- [ ] Manual: navigate \`/icons/category/tech/\` → click into a term card → confirm direct page loads