### PR TITLE
fix(dbmate): satisfy kilobase-jobs-restricted Kyverno + restricted PSS

### DIFF
--- a/apps/kube/kilobase/manifests/dbmate-runner-job.yaml
+++ b/apps/kube/kilobase/manifests/dbmate-runner-job.yaml
@@ -36,7 +36,11 @@ spec:
                 kbve.com/migration-tag: '${DBMATE_VERSION_TAG}'
         spec:
             serviceAccountName: dbmate-runner
+            automountServiceAccountToken: false
             restartPolicy: Never
+            securityContext:
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: dbmate
                   image: ghcr.io/amacneil/dbmate:2.28.0
@@ -70,6 +74,8 @@ spec:
                       allowPrivilegeEscalation: false
                       capabilities:
                           drop: ['ALL']
+                      seccompProfile:
+                          type: RuntimeDefault
             volumes:
                 - name: migrations
                   configMap:


### PR DESCRIPTION
## Symptom
CI - dbmate deploy on SHA \`249da12\` blocked at the status preview Job:

\`\`\`
resource Job/kilobase/dbmate-status-status-249da12-... was blocked due to
the following policies kilobase-jobs-restricted:
  kilobase-job-must-use-dbmate-runner-sa: 'validation error: ...
  rule kilobase-job-must-use-dbmate-runner-sa failed at path
  /spec/template/spec/automountServiceAccountToken/'

Warning: would violate PodSecurity "restricted:latest":
seccompProfile (pod or container "dbmate" must set
securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
\`\`\`

The Job template was never exercised against prod admission — gaming-space migration is the first real run.

## Fix
- \`automountServiceAccountToken: false\` — dbmate doesn't talk to the kube API, no token needed; Kyverno requires the field set explicitly.
- \`seccompProfile: { type: RuntimeDefault }\` on both pod-level and container-level securityContext to satisfy restricted PSS.

## Test plan
- [ ] Re-dispatch \`CI - dbmate deploy\` with \`confirm_sha\` = post-merge HEAD
- [ ] Status Job runs, prints pending: 20260503210000_forum_gaming_space.sql
- [ ] Approve apply via \`kilobase-prod\` GitHub Environment
- [ ] Apply Job applies + dbmate.schema_migrations gets a new row
- [ ] forum.spaces has slug=gaming