### PR TITLE
fix(astro-kbve,kubevirt): VM stop honors a 30s grace period, not 1h

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
@@ -648,10 +648,15 @@ class VMService {
 
 		this.$actionInProgress.set(`${action}:${name}`);
 		try {
+			const body =
+				action === 'stop' || action === 'restart'
+					? { gracePeriod: 30 }
+					: undefined;
 			await apiFetch(
 				token,
 				`/apis/subresources.kubevirt.io/v1/namespaces/${VM_NAMESPACE}/virtualmachines/${name}/${action}`,
 				'PUT',
+				body,
 			);
 			addToast({
 				id: `vm-${action}-${name}-${Date.now()}`,
@@ -751,9 +756,7 @@ class VMService {
 		return `${proto}//${window.location.host}/dashboard/vm/vnc/${name}?access_token=${token}`;
 	}
 
-	public async getVNCSessionInfo(
-		name: string,
-	): Promise<{
+	public async getVNCSessionInfo(name: string): Promise<{
 		vm_key: string;
 		viewers: number;
 		has_primary: boolean;

--- a/apps/kube/angelscript/manifest/vm-macos-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-macos-builder.yaml
@@ -171,7 +171,7 @@ spec:
             networks:
                 - name: default
                   pod: {}
-            terminationGracePeriodSeconds: 3600
+            terminationGracePeriodSeconds: 60
             volumes:
                 - name: opencore
                   dataVolume:

--- a/apps/kube/angelscript/manifest/vm-windows-builder.yaml
+++ b/apps/kube/angelscript/manifest/vm-windows-builder.yaml
@@ -125,7 +125,7 @@ spec:
             networks:
                 - name: default
                   pod: {}
-            terminationGracePeriodSeconds: 3600
+            terminationGracePeriodSeconds: 60
             volumes:
                 - name: rootdisk
                   persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Stopping the macOS hackintosh VM from \`/dashboard/vm/\` appeared to do nothing — the VM kept running indefinitely. Two issues compounded:

1. KubeVirt's \`/stop\` subresource without a body falls back to the VM spec's \`terminationGracePeriodSeconds\`. Both \`vm-macos-builder\` and \`vm-windows-builder\` set that to \`3600\` (1 hour). KubeVirt sends an ACPI shutdown to the guest, then waits the full hour before force-killing. macOS without a \`virtio-agent\` never ACKs ACPI, so the VM sat running for 60 minutes after every "stop" click.
2. \`vmService.ts._vmAction\` sent \`stop\`/\`restart\` with no body, so there was no per-call override to short-circuit the spec grace period.

## Changes

**\`apps/kbve/astro-kbve/src/components/dashboard/vmService.ts\`** — \`_vmAction\` now sends \`{ gracePeriod: 30 }\` for \`stop\` and \`restart\`. KubeVirt's \`StopOptions\` / \`RestartOptions\` honor that as an override regardless of the VM's \`terminationGracePeriodSeconds\`. ACPI gets a 30s window; non-responding guests (macOS, hung Windows) get force-killed at 30s.

**\`apps/kube/angelscript/manifest/vm-macos-builder.yaml\`**, **\`vm-windows-builder.yaml\`** — \`terminationGracePeriodSeconds\`: \`3600\` → \`60\`. Safety net for any path that bypasses the dashboard (\`virtctl\`, raw \`kubectl\`); neither VM is running anything that needs an hour to flush.

## Test plan

- [x] \`npx astro build\` — clean
- [ ] After deploy + ArgoCD sync of the manifest changes: click Stop on the macOS card → VM transitions Running → Stopping → Stopped within ~30s instead of waiting an hour.
- [ ] \`virtctl stop macos-builder -n angelscript\` (no override flag) terminates within ~60s instead of ~3600s.