### PR TITLE
fix(firecracker): tag :VERSION explicitly so push step ships it to GHCR

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -137,7 +137,7 @@
 		{
 			"key": "firecracker_python_net",
 			"app_name": "firecracker-python-net",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"version_toml": "packages/docker/firecracker/python/net/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx",
 			"source_path": "packages/docker/firecracker/python/net",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
@@ -13,7 +13,7 @@ tags:
 key: firecracker_python_net
 pipeline: docker
 app_name: firecracker-python-net
-version: "0.1.1"
+version: "0.1.2"
 version_toml: packages/docker/firecracker/python/net/version.toml
 source_path: packages/docker/firecracker/python/net
 runner: ubuntu-latest

--- a/packages/docker/firecracker/python/net/project.json
+++ b/packages/docker/firecracker/python/net/project.json
@@ -17,7 +17,8 @@
 				"local": {},
 				"production": {
 					"commands": [
-						"npx nx run firecracker-python-net:containerx:production"
+						"npx nx run firecracker-python-net:containerx:production",
+						"VERSION=$(sed -n 's/^version: *\"\\([^\"]*\\)\".*/\\1/p' apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx | head -1) && docker tag ghcr.io/kbve/firecracker-python-net:latest ghcr.io/kbve/firecracker-python-net:${VERSION} && docker tag ghcr.io/kbve/firecracker-python-net:latest kbve/firecracker-python-net:${VERSION} && docker tag ghcr.io/kbve/firecracker-python-net:latest kbve/firecracker-python-net:latest && echo \"Daemon tagged :${VERSION} + :latest for both registries\""
 					]
 				}
 			}


### PR DESCRIPTION
## Summary

The PR #10692 publish ran ([run #25607821810](https://github.com/KBVE/kbve/actions/runs/25607821810)) and the post-publish hook bumped \`version.toml\` to \`0.1.1\`, but **only \`:latest\` was actually pushed to GHCR**. Skopeo confirms:

\`\`\`
\"Tags\": [\"main\", \"buildcache\", \"latest\", \"0.0.1\"]
\`\`\`

No \`:0.1.1\` tag. Result: \`firecracker-net-rootfs-stage\` Job is stuck in \`ImagePullBackOff\` because it pins \`image: ghcr.io/kbve/firecracker-python-net:0.1.1\`, which doesn't exist.

### Why \`:0.1.1\` never pushed

Buildx with \`docker-container\` driver + \`--load\` imported the image to the daemon as \`ghcr.io/kbve/firecracker-python-net:latest\` only. The shared \`utils-publish-docker-image.yml\` workflow's tag fallback loop didn't manage to create \`:VERSION\` tags in the daemon — its silent \`docker buildx build --load\` re-export warned \"Could not re-export image for daemon\" and the subsequent \`docker tag\` SRC search ended up only producing \`:latest\` cross-tags. The final push step's \`docker images | grep | docker push\` saw two entries:

\`\`\`
Pushing images:
ghcr.io/kbve/firecracker-python-net:latest
kbve/firecracker-python-net:latest
\`\`\`

Hence no \`:0.1.1\` ever shipped.

## Fix

Belt-and-suspenders explicit tagging in our container target's production chain. After \`containerx:production\` loads \`:latest\` to the daemon, run:

\`\`\`
VERSION=$(read MDX) \
  && docker tag ghcr.io/kbve/firecracker-python-net:latest ghcr.io/kbve/firecracker-python-net:${VERSION} \
  && docker tag ghcr.io/kbve/firecracker-python-net:latest kbve/firecracker-python-net:${VERSION} \
  && docker tag ghcr.io/kbve/firecracker-python-net:latest kbve/firecracker-python-net:latest
\`\`\`

This guarantees the daemon has all four tags before the shared workflow's \`docker images | grep ... | docker push\` runs, so \`:0.1.2\` lands on both registries.

VERSION is read from the MDX frontmatter (source of truth), so it tracks whatever publish is in flight without manual sync.

### Bump 0.1.1 → 0.1.2

Current \`version.toml\` is \`0.1.1\` (post-publish hook bumped it from the previous half-success). Without an MDX bump, version_check would skip the publish (\"matches version.toml\"). Bumping to \`0.1.2\` triggers a fresh publish that exercises the new tagging step.

## Test plan

- [ ] After merge, \`CI - Docker / firecracker-python-net\` publishes \`ghcr.io/kbve/firecracker-python-net:0.1.2\` AND \`:latest\`.
- [ ] \`utils-post-publish.yml\` opens an atom PR sed-bumping \`firecracker-net-rootfs-stage.yaml\`'s \`image: \` line to \`:0.1.2\`.
- [ ] Atom PR merges → ArgoCD reconciles → \`firecracker-net-rootfs-stage\` Job pulls \`:0.1.2\`, copies \`/rootfs.ext4\` to \`/var/lib/firecracker/rootfs/firecracker-python-net.ext4\`.
- [ ] Dashboard IDE Python Quick + Network (VPN) + PoetryDB smoke test prints a poem with exit 0.