### PR TITLE
feat(rareicon-icons): wire /icons/ category chips to category landings

### DIFF
--- a/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.astro
+++ b/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.astro
@@ -127,6 +127,8 @@ const synonyms = buildSynonymMap();
 		border: 1px solid var(--ri-border);
 		cursor: pointer;
 		transition: all 0.15s;
+		text-decoration: none !important;
+		display: inline-block;
 	}
 
 	.ri-icons-browser__chip:hover {

--- a/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.tsx
+++ b/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.tsx
@@ -137,6 +137,7 @@ export default function IconsBrowser({
 				values={categories}
 				active={activeCategory}
 				onToggle={(v) => toggle(activeCategory, v, setActiveCategory)}
+				linkBase="/icons/category"
 			/>
 			<ChipRow
 				label="Style"
@@ -270,10 +271,25 @@ interface ChipRowProps {
 	values: string[];
 	active: string | null;
 	onToggle: (value: string) => void;
+	linkBase?: string;
 }
 
-function ChipRow({ label, values, active, onToggle }: ChipRowProps) {
+function ChipRow({ label, values, active, onToggle, linkBase }: ChipRowProps) {
 	if (values.length === 0) return null;
+
+	const handleChipClick = (e: React.MouseEvent, value: string) => {
+		if (
+			linkBase &&
+			(e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1)
+		) {
+			return;
+		}
+		if (!linkBase) {
+			e.preventDefault();
+			onToggle(value);
+		}
+	};
+
 	return (
 		<div
 			className="ri-icons-browser__chip-row"
@@ -282,6 +298,19 @@ function ChipRow({ label, values, active, onToggle }: ChipRowProps) {
 			<span className="ri-icons-browser__chip-label">{label}</span>
 			{values.map((v) => {
 				const isActive = active === v;
+				if (linkBase) {
+					return (
+						<a
+							key={v}
+							href={`${linkBase}/${v}/`}
+							className="ri-icons-browser__chip"
+							data-active={isActive ? 'true' : undefined}
+							onClick={(e) => handleChipClick(e, v)}
+							onAuxClick={(e) => handleChipClick(e, v)}>
+							{v}
+						</a>
+					);
+				}
 				return (
 					<button
 						key={v}


### PR DESCRIPTION
## Summary

Category chips on \`/icons/\` now navigate to \`/icons/category/<cat>/\` (added in phase 23) instead of only toggling an in-memory filter.

| Before | After |
|--------|-------|
| Click chip → in-memory filter only | Click chip → navigate to category landing |
| Filter state lost on reload | URL is shareable, survives reload |
| No SEO from category browse | Category landings indexed by Pagefind |
| Power-user multi-filter unreachable | Cmd/Ctrl/Shift/Middle click → in-place toggle (preserves prior UX) |

## Implementation

\`ChipRow\` gains optional \`linkBase\` prop:

- \`linkBase\` set → chips render as \`<a href="\${linkBase}/\${value}/">\`
- Modifier-key click (cmd / ctrl / shift / middle) skips the navigation, lets power users still narrow filters in-page
- \`linkBase\` unset → chips stay \`<button>\` with \`onClick\` toggle

\`IconsBrowser\` passes \`linkBase="/icons/category"\` only on the **Category** chip row. **Style / Theme / Source / multi-source / attribution** chips keep the in-memory toggle (no dedicated landing exists for those yet, so no URL to navigate to).

CSS: chip class gets \`text-decoration: none\` + \`display: inline-block\` so the anchor variant matches the button visually.

## Verification

- \`astro build\` clean — 1284 pages, no regressions
- Direct term pages \`/icons/<ref>/\` still resolve
- Category landings \`/icons/category/<cat>/\` still resolve
- Modifier-key click still toggles in-place filter

## Test plan

- [x] \`astro build\` — 1284 pages
- [ ] CI: e2e suite (PR #10623) catches no regressions
- [ ] Manual: click "tech" category chip → lands on \`/icons/category/tech/\`
- [ ] Manual: cmd-click "tech" → in-place filter, URL unchanged
- [ ] Manual: anchor chip styling matches button chip (no underline / browser link color)