### PR TITLE
fix(kasm): mount /dev/net/tun for gluetun so wireguard tunnel can form

### DIFF
--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -88,6 +88,10 @@ spec:
                               - ALL
                           add:
                               - NET_ADMIN
+                              - MKNOD
+                  volumeMounts:
+                      - name: dev-net-tun
+                        mountPath: /dev/net/tun
                   ports:
                       - name: kasm-web
                         containerPort: 6901
@@ -174,6 +178,10 @@ spec:
                 - name: discord-profile
                   persistentVolumeClaim:
                       claimName: kasm-discord-profile
+                - name: dev-net-tun
+                  hostPath:
+                      path: /dev/net/tun
+                      type: CharDevice
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary

\`kasm-vpn\` has been stuck \`Starting\` (gluetun \`CrashLoopBackOff\`, 39 restarts at the time of diagnosis) since deploy. The dashboard surfaced this as \`Starting / VPN: disconnected\` indefinitely.

## Diagnosis

\`\`\`
$ kubectl logs -n kasm -l app=kasm-vpn -c gluetun
...
2026-05-09T20:52:10Z INFO TUN device is not available: open /dev/net/tun: no such file or directory; creating it...
2026-05-09T20:52:10Z ERROR creating tun device: creating TUN device file node: operation not permitted
2026-05-09T20:52:10Z INFO Shutdown successful
\`\`\`

\`gluetun\` exits 2s after start. It has \`NET_ADMIN\` but no \`MKNOD\` capability and no \`/dev/net/tun\` device, so its fallback "create the TUN device file myself" path fails on \`mknod()\` and the VPN can't establish. \`workspace\` container ran fine, but readiness gated on gluetun's \`:9999\` health endpoint stayed failing.

Cilium egress lockdown, RBAC, init containers all check out.

## Changes

\`apps/kube/kasm/manifest/deployment.yaml\`:

- \`hostPath\`-mount the host's \`/dev/net/tun\` (\`CharDevice\` type) into the \`gluetun\` container at \`/dev/net/tun\`. Talos loads the \`tun\` kernel module by default (for KubeVirt), so every node has the device.
- Add \`MKNOD\` to the \`gluetun\` capability set as a belt-and-suspenders for nodes that don't pre-create \`/dev/net/tun\`.

## Test plan

- [ ] After ArgoCD sync, \`kubectl get pods -n kasm -l app=kasm-vpn\` shows \`2/2 Running\`.
- [ ] \`kubectl logs -n kasm -l app=kasm-vpn -c gluetun\` shows wireguard tunnel up + healthcheck passing.
- [ ] Dashboard card flips \`Starting → Running\` with \`VPN: connected\`.