### PR TITLE
feat(discordsh): Downed state on 0HP + auto-revive on city arrival

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
@@ -431,7 +431,12 @@ impl CombatWorld {
             };
 
             player.hp = hp.current;
-            player.alive = !hp.is_dead();
+            if hp.is_dead() {
+                if !player.downed {
+                    player.downed = true;
+                }
+                player.hp = 0;
+            }
 
             if let Some(stats) = world.get::<CombatStats>(*entity) {
                 player.defending = stats.defending;
@@ -1030,6 +1035,7 @@ mod tests {
                 inventory: GameInventory::new(MAX_INVENTORY_SLOTS),
                 accuracy: 1.0,
                 alive: true,
+                downed: false,
                 member_status: MemberStatusTag::Guest,
                 class: ClassType::Warrior,
                 level: 1,

--- a/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
@@ -437,7 +437,6 @@ fn validate_actor(session: &SessionState, actor: serenity::UserId) -> Result<(),
         return Err("You are not part of this session.".to_owned());
     }
 
-    // Check if the player is still alive
     if let Some(player) = session.players.get(&actor)
         && !player.alive
     {
@@ -455,6 +454,16 @@ fn validate_action(
 ) -> Result<(), String> {
     if matches!(session.phase, GamePhase::GameOver(_)) {
         return Err("This session is over.".to_owned());
+    }
+
+    if let Some(player) = session.players.get(&actor)
+        && player.downed
+        && !matches!(
+            action,
+            GameAction::Move(_) | GameAction::ViewMap | GameAction::ViewInventory
+        )
+    {
+        return Err("You're Downed. Crawl back to the city to recover.".to_owned());
     }
 
     match action {
@@ -1651,7 +1660,8 @@ fn single_enemy_turn(
                 let player = session.player_mut(uid);
                 player.hp -= actual;
                 if player.hp <= 0 {
-                    player.alive = false;
+                    player.downed = true;
+                    player.hp = 0;
                 }
             }
             // No thorns reflect for AoE
@@ -1693,7 +1703,8 @@ fn single_enemy_turn(
     for uid in all_uids {
         let player = session.player_mut(uid);
         if player.hp <= 0 && player.alive {
-            player.alive = false;
+            player.downed = true;
+            player.hp = 0;
             let defeated_name = player.name.clone();
             logs.push(format!("{} has been defeated...", defeated_name));
         }
@@ -2159,6 +2170,20 @@ fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
 
     logs.push(format!("You arrive at: {}.", session.room.name));
 
+    if matches!(session.room.room_type, RoomType::UndergroundCity) {
+        for player in session.players.values_mut() {
+            if player.alive && player.downed {
+                player.downed = false;
+                player.hp = player.max_hp;
+                player.effects.clear();
+                logs.push(format!(
+                    "{} stumbles into the city hospital and is patched up. ({} HP)",
+                    player.name, player.hp
+                ));
+            }
+        }
+    }
+
     // Increment lifetime_rooms_cleared for all alive players
     let alive_ids = session.alive_player_ids();
     let depth = pos.depth();
@@ -2215,7 +2240,8 @@ fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
     for &uid in &alive_ids {
         let player = session.player_mut(uid);
         if player.hp <= 0 {
-            player.alive = false;
+            player.downed = true;
+            player.hp = 0;
         }
     }
     if session.all_players_dead() {
@@ -2336,7 +2362,7 @@ fn apply_revive(
         .get(&target_uid)
         .ok_or_else(|| "Player not found in session.".to_owned())?;
 
-    if target_player.alive {
+    if target_player.alive && !target_player.downed {
         return Err("That player is already alive!".to_owned());
     }
 
@@ -2346,6 +2372,7 @@ fn apply_revive(
     session.player_mut(actor).gold -= cost;
     let target = session.player_mut(target_uid);
     target.alive = true;
+    target.downed = false;
     target.hp = revive_hp;
     target.effects.clear();
 
@@ -2758,7 +2785,8 @@ fn apply_trap_choice(
                     let player = session.player_mut(uid);
                     player.hp -= dmg;
                     if player.hp <= 0 {
-                        player.alive = false;
+                        player.downed = true;
+                        player.hp = 0;
                     }
                 }
             }
@@ -2775,7 +2803,8 @@ fn apply_trap_choice(
                 let player = session.player_mut(uid);
                 player.hp -= reduced;
                 if player.hp <= 0 {
-                    player.alive = false;
+                    player.downed = true;
+                    player.hp = 0;
                 }
             }
         }
@@ -2840,7 +2869,8 @@ fn apply_treasure_choice(
                     player.gold += standard_gold;
                     player.lifetime_gold_earned += standard_gold as u32;
                     if player.hp <= 0 {
-                        player.alive = false;
+                        player.downed = true;
+                        player.hp = 0;
                     }
                 }
                 logs.push(format!(
@@ -9687,6 +9717,32 @@ mod tests {
         let p2 = serenity::UserId::new(2);
         let result = apply_action(&mut session, GameAction::Revive(p2), OWNER);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn downed_player_blocked_from_combat_actions() {
+        let mut session = test_session();
+        session.phase = GamePhase::Combat;
+        session.enemies.push(test_enemy());
+        session.player_mut(OWNER).downed = true;
+
+        let result = apply_action(&mut session, GameAction::Attack, OWNER);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("Downed"));
+    }
+
+    #[test]
+    fn arrive_at_city_revives_downed_player() {
+        let mut session = test_session();
+        session.player_mut(OWNER).downed = true;
+        session.player_mut(OWNER).hp = 0;
+        let prior_max = session.player(OWNER).max_hp;
+        let logs = arrive_at_tile(&mut session, MapPos::new(0, 0));
+
+        assert!(!session.player(OWNER).downed);
+        assert_eq!(session.player(OWNER).hp, prior_max);
+        assert!(logs.iter().any(|l| l.contains("city hospital")));
     }
 
     #[test]

--- a/apps/discordsh/discordsh-bot/src/discord/game/render.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/render.rs
@@ -221,6 +221,8 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
             }
             if !player.alive {
                 lines.push("**DEFEATED**".to_owned());
+            } else if player.downed {
+                lines.push("**DOWNED** \u{2014} crawl back to the city to recover.".to_owned());
             }
             let member_badge = match &player.member_status {
                 MemberStatusTag::Member { .. } => " [M]",
@@ -256,6 +258,8 @@ pub fn render_embed(session: &SessionState, with_card: bool) -> serenity::Create
         }
         if !owner.alive {
             player_lines.push("**DEFEATED**".to_owned());
+        } else if owner.downed {
+            player_lines.push("**DOWNED** \u{2014} crawl back to the city to recover.".to_owned());
         }
         embed = embed.field(
             format!("-- {} --", owner.name),

--- a/apps/discordsh/discordsh-bot/src/discord/game/types.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/types.rs
@@ -435,6 +435,8 @@ pub struct PlayerState {
     pub inventory: GameInventory,
     pub accuracy: f32,
     pub alive: bool,
+    #[serde(default)]
+    pub downed: bool,
     pub member_status: MemberStatusTag,
     pub class: ClassType,
     pub level: u8,
@@ -475,6 +477,7 @@ impl Default for PlayerState {
             inventory: GameInventory::new(MAX_INVENTORY_SLOTS),
             accuracy: 1.0,
             alive: true,
+            downed: false,
             member_status: MemberStatusTag::Guest,
             class: ClassType::Warrior,
             level: 1,
@@ -891,9 +894,8 @@ impl SessionState {
             .expect("player must exist in session")
     }
 
-    /// Check if all players are dead.
     pub fn all_players_dead(&self) -> bool {
-        self.players.values().all(|p| !p.alive)
+        self.players.values().all(|p| !p.alive || p.downed)
     }
 
     /// Ordered list of (UserId, &PlayerState) for roster display.
@@ -945,14 +947,17 @@ impl SessionState {
         dead
     }
 
-    /// Get alive player IDs in roster order.
     pub fn alive_player_ids(&self) -> Vec<serenity::UserId> {
         let mut ids = Vec::new();
-        if self.players.get(&self.owner).is_some_and(|p| p.alive) {
+        if self
+            .players
+            .get(&self.owner)
+            .is_some_and(|p| p.alive && !p.downed)
+        {
             ids.push(self.owner);
         }
         for &uid in &self.party {
-            if self.players.get(&uid).is_some_and(|p| p.alive) {
+            if self.players.get(&uid).is_some_and(|p| p.alive && !p.downed) {
                 ids.push(uid);
             }
         }


### PR DESCRIPTION
PR A of 2 in the dungeon roguelite redesign. PR B (queued) layers rescue / 30-turn / 24h timer / permadeath / profile delete on top; this one ships the **Downed** state on its own so it can be field-tested without a destructive permadeath path.

## Behavior
- Damage that drops HP to 0 now sets \`player.downed = true\` instead of \`player.alive = false\`. The player keeps \`alive == true\` so they stay in the run, but \`validate_action\` blocks every action except \`Move\` / \`ViewMap\` / \`ViewInventory\` while downed.
- \`alive_player_ids\` and \`all_players_dead\` now treat downed as incapacitated: combat / hazard / turn loops skip downed players, and \`GameOver(Defeated)\` fires when no player can act (everyone dead OR downed). Solo player going Downed in combat still ends the run (no rescue yet); party combats continue with the remaining alive members.
- Movement at 1 tile/turn still works while downed (Move only). Reaching \`RoomType::UndergroundCity\` triggers an immediate free revive: \`HP -> max\`, effects cleared, \`downed\` cleared. Logged as \`"X stumbles into the city hospital and is patched up."\`.
- Embed adds a \`"**DOWNED** — crawl back to the city to recover."\` line under the player card (solo + party).
- Existing Rest action stays as the gold-paid full-heal at city — no new \`/dungeon heal\` subcommand.

## Code
- \`PlayerState.downed: bool\` with \`#[serde(default)]\`; default initialiser sets \`false\`. Bare field, no docstring per project comment policy.
- \`validate_action\` early-exits with \`"You're Downed. Crawl back to the city to recover."\` for any non-movement action.
- \`arrive_at_tile\` runs the revive sweep immediately after the room rebuild — before hazards and the all-incapacitated game-over check, so a downed solo player crawling into the city is recovered before the empty-actor check would otherwise terminate the run.
- \`apply_revive\` (existing party hospital revive) now accepts downed targets too and clears the downed flag on revive.
- \`battle_bridge\` HP sync routes \`hp.is_dead()\` through the same downed path instead of toggling \`player.alive\`.
- All damage sites switched from \`player.alive = false;\` to \`player.downed = true; player.hp = 0;\`.

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy --no-deps\` baseline (66 pre-existing warnings, none new on edited files)
- [x] \`cargo test --bin discordsh-bot\` — 710/710 pass (708 baseline + 2 new: combat-action gate while downed, city-arrival auto-revive)
- [ ] Smoke in staging:
  - Combat solo, take fatal hit -> "DOWNED" badge instead of game-over (in party); solo runs still end since no rescuer
  - Crawl with \`/dungeon move\` while downed (other actions blocked)
  - Move into city tile -> auto-revived to full HP
  - Rest button at city still works for non-downed paid heal

## What's NOT in this PR (queued for PR B)
- 30 in-session turn timer / 24-hour wall clock
- Permadeath -> Supabase row delete + redb wipe
- Class picker re-shown on next \`/dungeon start\` after permadeath
- Party carry / drag-body mechanic (currently shared session position implicitly carries downed party members)

Closes the first half of the dungeon roguelite redesign followup work.