### PR TITLE
chore: prettier ignore pnpm-lock.yaml so dependabot PRs land clean

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,5 @@ apps/kbve/astro-kbve/src/components/realtime/example.astro
 # Deno edge functions — formatted by deno fmt
 apps/kbve/edge/
 .nx/self-healing
+
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary

Repo prettier config sets \`tabWidth: 4\` (\`.prettierrc.mjs\`), and prettier reformats \`pnpm-lock.yaml\` with that. Dependabot regenerates the lock with pnpm's native 2-space output, so every dependabot PR ships an ~80k-line indentation-churn diff that buries the real version bump under noise.

We hit this twice in the last week alone — #10440 (\`fake-indexeddb\`) and #10075 (\`eslint-plugin-import\`) — and had to reapply each bump in a clean worktree to land a reviewable diff. This change makes future dep PRs land clean automatically.

## Changes

\`.prettierignore\` — add \`pnpm-lock.yaml\`.

\`lint-staged\` runs \`prettier --write\` against \`*.{json,md,yml,yaml,css,scss}\` on commit. Prettier CLI honors \`.prettierignore\`, so the glob keeps working for legitimate yaml; the lockfile is the only file we exclude from that glob.

## Test plan

- [x] \`npx prettier --check pnpm-lock.yaml\` → \`All matched files use Prettier code style!\` (i.e. ignored, no diff).
- [ ] Next dependabot PR diff size — expect ~10–200 lines instead of ~80k.