### PR TITLE
fix(ci): install gtk/webkit deps in rust-publish-crate workflow

### DIFF
--- a/.github/workflows/rust-publish-crate.yml
+++ b/.github/workflows/rust-publish-crate.yml
@@ -68,8 +68,17 @@ jobs:
                     echo "Already at $VER — no patch needed"
                   fi
 
-            - name: Rust ToolChain
+            - name: Install system libraries (wry/webkit2gtk + diesel-postgres + protoc)
+              run: |
+                  sudo apt-get update -qq
+                  sudo apt-get install -y --no-install-recommends \
+                    pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+                    libpq-dev protobuf-compiler
+
+            - name: Rust ToolChain (stable)
               uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: '1.94'
 
             - name: Check version against crates.io
               id: version_check


### PR DESCRIPTION
## Summary
- `q` crate publish (#10720) failed at `cargo publish` verify step: `glib-sys` / `gobject-sys` build scripts can't find `glib-2.0.pc` / `gobject-2.0.pc` because `libglib2.0-dev` + gtk/webkit aren't installed on the runner.
- `wry` (used by `q` on Linux) transitively requires gtk-3 + webkit2gtk-4.1 — `rust-test-crate.yml` already installs these, `rust-publish-crate.yml` did not.
- Mirror the apt step from the test workflow into the publish workflow and pin toolchain to `1.94` so publish matches test.
- No version edits — CI manages `version.toml` / `Cargo.toml`. MDX (0.1.1) and Cargo.toml (0.1.1) are already aligned; crates.io max is 0.1.0, so the next dispatch will publish 0.1.1.

## Test plan
- [ ] Re-dispatch `CI - Publish` for `q` from `main` after this lands; confirm verify build succeeds and 0.1.1 lands on crates.io
- [ ] Confirm other crate publishes (`erust`, `holy`, `kbve`, etc.) still succeed with the new apt + pinned toolchain steps
- [ ] Close #10720 once green

Closes #10720