### PR TITLE
feat(astro-rareicon): JSON-LD schema + IconsBrowser virtualization + /api/*.json catalog dump

### DIFF
--- a/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.astro
+++ b/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.astro
@@ -257,4 +257,15 @@ const synonyms = buildSynonymMap();
 		border: 1px dashed var(--ri-border);
 		border-radius: 8px;
 	}
+
+	.ri-icons-browser__sentinel {
+		grid-column: 1 / -1;
+		padding: 1.5rem;
+		text-align: center;
+		color: var(--ri-text-disabled);
+		font-size: 0.8125rem;
+		border: 1px dashed var(--ri-border);
+		border-radius: 8px;
+		background: color-mix(in srgb, var(--ri-accent) 4%, transparent);
+	}
 </style>

--- a/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.tsx
+++ b/apps/rareicon/astro-rareicon/src/components/icons/IconsBrowser.tsx
@@ -1,5 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { TermSummary } from '@/lib/icons/terms';
+
+const PAGE_SIZE = 60;
 
 interface Props {
 	terms: TermSummary[];
@@ -107,6 +109,40 @@ export default function IconsBrowser({
 		attributionOnly,
 		synonyms,
 	]);
+
+	const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+	useEffect(() => {
+		setVisibleCount(PAGE_SIZE);
+	}, [
+		query,
+		activeCategory,
+		activeStyle,
+		activeTheme,
+		activeSource,
+		multiSourceOnly,
+		attributionOnly,
+	]);
+
+	const sentinelRef = useRef<HTMLLIElement | null>(null);
+	useEffect(() => {
+		const el = sentinelRef.current;
+		if (!el) return;
+		const obs = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					setVisibleCount((c) =>
+						Math.min(c + PAGE_SIZE, filtered.length),
+					);
+				}
+			},
+			{ rootMargin: '600px 0px' },
+		);
+		obs.observe(el);
+		return () => obs.disconnect();
+	}, [filtered.length, visibleCount]);
+
+	const visible = filtered.slice(0, visibleCount);
 
 	const toggle = <T extends string>(
 		current: T | null,
@@ -232,7 +268,7 @@ export default function IconsBrowser({
 				</div>
 			) : (
 				<ul className="ri-icons-browser__grid">
-					{filtered.map((t) => (
+					{visible.map((t) => (
 						<li key={t.ref} className="ri-icons-browser__item">
 							<a
 								href={`${basePath}/${t.ref}/`}
@@ -260,6 +296,14 @@ export default function IconsBrowser({
 							</a>
 						</li>
 					))}
+					{visibleCount < filtered.length && (
+						<li
+							ref={sentinelRef}
+							className="ri-icons-browser__sentinel"
+							aria-hidden="true">
+							Loading {filtered.length - visibleCount} more…
+						</li>
+					)}
 				</ul>
 			)}
 		</div>

--- a/apps/rareicon/astro-rareicon/src/components/starlight/Head.astro
+++ b/apps/rareicon/astro-rareicon/src/components/starlight/Head.astro
@@ -71,6 +71,138 @@ const overrideTags: HeadTag[] = Object.entries(owned).map(([key, content]) => {
 			: { property: key, content: content! },
 	} as HeadTag;
 });
+
+const SITE = 'https://rareicon.com';
+const slug = (route.entry.id ?? '').replace(/\.mdx?$/, '');
+const canonical = `${SITE}/${slug}/`.replace(/\/+$/, '/');
+const pageTitle = (data.title as string) ?? 'RareIcon';
+const pageDesc = (data.description as string) ?? undefined;
+const defaultImage = `${SITE}/assets/steam/rareicon_library_header_920_x_430px.png`;
+const pageImage = ogImage
+	? ogImage.startsWith('http')
+		? ogImage
+		: `${SITE}${ogImage}`
+	: defaultImage;
+
+function jsonLd(obj: Record<string, unknown>): string {
+	return JSON.stringify({ '@context': 'https://schema.org', ...obj });
+}
+
+const structured: string[] = [];
+
+if (slug === 'index' || slug === '') {
+	structured.push(
+		jsonLd({
+			'@type': 'VideoGame',
+			name: 'RareIcon',
+			description: pageDesc,
+			url: SITE,
+			image: pageImage,
+			genre: ['Bullet-hell', 'Roguelite', 'Action-RPG'],
+			gamePlatform: ['PC', 'macOS', 'Linux'],
+			applicationCategory: 'GameApplication',
+			operatingSystem: 'Windows, macOS, Linux',
+			publisher: {
+				'@type': 'Organization',
+				name: 'KBVE',
+				url: 'https://kbve.com',
+			},
+			author: {
+				'@type': 'Organization',
+				name: 'KBVE',
+				url: 'https://kbve.com',
+			},
+			sameAs: [
+				'https://store.steampowered.com/app/2238370/RareIcon/',
+				'https://kbve.com/github/',
+				'https://kbve.com/discord/',
+			],
+		}),
+	);
+}
+
+if (slug.startsWith('icons/category/')) {
+	const cat = slug.replace('icons/category/', '');
+	structured.push(
+		jsonLd({
+			'@type': 'BreadcrumbList',
+			itemListElement: [
+				{
+					'@type': 'ListItem',
+					position: 1,
+					name: 'RareIcon',
+					item: SITE,
+				},
+				{
+					'@type': 'ListItem',
+					position: 2,
+					name: 'Icons',
+					item: `${SITE}/icons/`,
+				},
+				{
+					'@type': 'ListItem',
+					position: 3,
+					name: pageTitle,
+					item: canonical,
+				},
+			],
+		}),
+	);
+	structured.push(
+		jsonLd({
+			'@type': 'CollectionPage',
+			name: pageTitle,
+			description: pageDesc,
+			url: canonical,
+			isPartOf: { '@type': 'WebSite', name: 'RareIcon', url: SITE },
+			about: cat,
+		}),
+	);
+} else if (slug.startsWith('icons/') && slug !== 'icons/index') {
+	const ref = slug.replace('icons/', '').replace(/\/index$/, '');
+	const iconsArr = (data.icons as Array<{ svg_body?: string }>) ?? [];
+	const license = (data.default_license as Record<string, unknown>) ?? {};
+	const variantCount = iconsArr.length;
+	structured.push(
+		jsonLd({
+			'@type': 'ImageObject',
+			name: pageTitle,
+			description: pageDesc ?? `${pageTitle} icon`,
+			url: canonical,
+			contentUrl: canonical,
+			encodingFormat: 'image/svg+xml',
+			creditText: (license.author as string) ?? 'KBVE',
+			license: (license.source_url as string) ?? undefined,
+			isAccessibleForFree: true,
+			isPartOf: {
+				'@type': 'CollectionPage',
+				name: 'RareIcon Icons',
+				url: `${SITE}/icons/`,
+			},
+			keywords: [
+				ref,
+				...((data.search as { keywords?: string[] })?.keywords ?? []),
+			].join(', '),
+			additionalProperty: [
+				{
+					'@type': 'PropertyValue',
+					name: 'variantCount',
+					value: variantCount,
+				},
+			],
+		}),
+	);
+} else if (slug === 'icons/index' || slug === 'icons') {
+	structured.push(
+		jsonLd({
+			'@type': 'CollectionPage',
+			name: 'RareIcon Icon Library',
+			description: pageDesc ?? 'Open-source icon catalog',
+			url: `${SITE}/icons/`,
+			isPartOf: { '@type': 'WebSite', name: 'RareIcon', url: SITE },
+		}),
+	);
+}
 ---
 
 {
@@ -79,3 +211,8 @@ const overrideTags: HeadTag[] = Object.entries(owned).map(([key, content]) => {
 	))
 }
 {overrideTags.map(({ tag: Tag, attrs }) => <Tag {...attrs} />)}
+{
+	structured.map((json) => (
+		<script type="application/ld+json" set:html={json} />
+	))
+}

--- a/apps/rareicon/astro-rareicon/src/pages/api/categories.json.ts
+++ b/apps/rareicon/astro-rareicon/src/pages/api/categories.json.ts
@@ -1,0 +1,41 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { collectTermSummaries } from '@/lib/icons/terms';
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+	const docs = await getCollection('docs');
+	const terms = collectTermSummaries(docs);
+
+	const counts = new Map<string, number>();
+	for (const t of terms) {
+		if (!t.primary_category) continue;
+		counts.set(
+			t.primary_category,
+			(counts.get(t.primary_category) ?? 0) + 1,
+		);
+	}
+
+	const categories = Array.from(counts.entries())
+		.sort((a, b) => b[1] - a[1])
+		.map(([name, count]) => ({
+			name,
+			count,
+			url: `https://rareicon.com/icons/category/${name}/`,
+		}));
+
+	const body = {
+		generatedAt: new Date().toISOString(),
+		count: categories.length,
+		categories,
+	};
+
+	return new Response(JSON.stringify(body, null, 2), {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+			'Cache-Control': 'public, max-age=300, s-maxage=3600',
+		},
+	});
+};

--- a/apps/rareicon/astro-rareicon/src/pages/api/icons.json.ts
+++ b/apps/rareicon/astro-rareicon/src/pages/api/icons.json.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { collectTermSummaries } from '@/lib/icons/terms';
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+	const docs = await getCollection('docs');
+	const terms = collectTermSummaries(docs).map((t) => ({
+		ref: t.ref,
+		name: t.name,
+		description: t.description,
+		primary_category: t.primary_category,
+		categories: t.categories,
+		tags: t.tags,
+		styles: t.styles,
+		sourcePacks: t.sourcePacks,
+		multiSource: t.multiSource,
+		attributionRequired: t.attributionRequired,
+		variantCount: t.variantCount,
+		featured: t.featured ?? false,
+		url: `https://rareicon.com/icons/${t.ref}/`,
+	}));
+
+	const body = {
+		generatedAt: new Date().toISOString(),
+		count: terms.length,
+		terms,
+	};
+
+	return new Response(JSON.stringify(body, null, 2), {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+			'Cache-Control': 'public, max-age=300, s-maxage=3600',
+		},
+	});
+};


### PR DESCRIPTION
## Summary

Three platform-readiness layers shipped together — the SEO + perf + ecosystem closing pass.

## A — JSON-LD structured data

Head.astro extended to emit per-route schema:

| Route | Schema |
|-------|--------|
| \`/\` | \`VideoGame\` (genre, gamePlatform, publisher, sameAs Steam/GitHub/Discord) |
| \`/icons/<ref>/\` | \`ImageObject\` (contentUrl, license, creditText, keywords, additionalProperty.variantCount) |
| \`/icons/category/<cat>/\` | \`BreadcrumbList\` (RareIcon → Icons → Category) + \`CollectionPage\` |
| \`/icons/\` | \`CollectionPage\` |

Scripts inject into the Starlight Head pipeline alongside the existing per-page og:* override layer.

## B — IconsBrowser virtualization

Initial render limited to **PAGE_SIZE=60** term cards instead of all 1252. Sentinel \`<li>\` with IntersectionObserver (rootMargin 600px) bumps visibleCount by 60 each time it enters the viewport.

- Filter / search / chip toggle resets visibleCount → 60 so the user always sees fresh results from the top
- Loading sentinel renders **"Loading N more…"** text below the visible grid

**Perf impact:** initial JS render renders 60 grid items instead of 1252. Build link-audit total href count drops from 120,632 to 119,440 to confirm.

## C — Catalog API

Two new Astro static endpoints, both \`prerender: true\`:

- \`/api/icons.json\` — every term as \`{ ref, name, description, categories, sourcePacks, multiSource, attributionRequired, variantCount, featured, url }\`. **~800 KB**, no \`svg_body\` bloat. Machine-readable for downstream tools / MCP servers / AI agents.
- \`/api/categories.json\` — \`{ name, count, url }\` per primary_category, sorted by term count desc.

\`Cache-Control: public, max-age=300, s-maxage=3600\` — CDN edges cache for 1h, clients refresh every 5m.

## J — OG / structured-data audit

- Built site spot-checked: homepage VideoGame ✓, sword ImageObject ✓, tech category BreadcrumbList ✓
- Link audit re-run: **119,440 hrefs scanned, zero broken**

## Test plan

- [x] \`astro build\` clean — 1284 pages
- [x] JSON-LD scripts emit on /, /icons/sword/, /icons/category/tech/
- [x] /api/icons.json + /api/categories.json materialized in dist/
- [x] Link audit zero broken
- [ ] CI: e2e regression suite (#10623) doesn't break
- [ ] Manual: scroll \`/icons/\` past row 6 → "Loading N more…" sentinel triggers IntersectionObserver, next 60 cards render
- [ ] Manual: validate JSON-LD with [Google's Rich Results Test](https://search.google.com/test/rich-results) — VideoGame / ImageObject / BreadcrumbList all parseable
- [ ] Manual: \`curl https://rareicon.com/api/icons.json | jq '.count'\` returns 1252