### PR TITLE
feat(dashboard): PoetryDB network smoke example + requires_network hint

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
@@ -442,6 +442,9 @@ export default function ReactCodeIDE() {
 									);
 									if (ex) {
 										ideService.$code.set(ex.code);
+										if (ex.requires_network) {
+											ideService.$useNetwork.set(true);
+										}
 										if (viewRef.current) {
 											viewRef.current.dispatch({
 												changes: {
@@ -469,7 +472,9 @@ export default function ReactCodeIDE() {
 								</option>
 								{langExamples.map((ex) => (
 									<option key={ex.id} value={ex.id}>
-										{ex.label}
+										{ex.requires_network
+											? `🌐 ${ex.label}`
+											: ex.label}
 									</option>
 								))}
 							</select>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ideService.ts
@@ -169,6 +169,13 @@ export interface CodeExample {
 	label: string;
 	language: string;
 	code: string;
+	/**
+	 * Hint to the UI that the example expects outbound network. When `true`,
+	 * the rootfs picker auto-swaps to `firecracker-python-net` and the
+	 * Network (VPN) checkbox should be on. Examples without this flag run
+	 * fine in the no-network sandbox.
+	 */
+	requires_network?: boolean;
 }
 
 export const EXAMPLES: CodeExample[] = [
@@ -237,6 +244,80 @@ elapsed = time.time() - start
 print(f"Found {len(primes):,} primes up to 1,000,000")
 print(f"Elapsed: {elapsed:.3f}s")
 print(f"Last 10: {primes[-10:]}")
+`,
+	},
+	{
+		id: 'py-poetry-net',
+		label: 'PoetryDB (Network)',
+		language: 'python',
+		requires_network: true,
+		code: `"""Network smoke test — fetch a random poem from PoetryDB.
+
+Verifies DNS resolution, TLS handshake, the requests library, and JSON
+parsing end-to-end. Requires the Network (VPN) checkbox to be on so the
+VM boots the firecracker-python-net rootfs (DNS configured, requests
+baked in). Without the network, the request fails fast with a clear
+[fail] connection message and a non-zero exit code.
+
+Hardening notes:
+  * HTTPS-only URL constant (no SSRF surface — URL is not user-input).
+  * Explicit timeout (avoids hung sockets).
+  * Narrow except branches (TLS / Timeout / Connection / generic
+    RequestException) — never catches BaseException.
+  * JSON / shape errors handled separately so a malformed payload does
+    not look like a network failure.
+"""
+
+import sys
+
+import requests
+
+URL = "https://poetrydb.org/random/1"
+TIMEOUT_SECONDS = 10
+
+
+def main() -> int:
+    try:
+        response = requests.get(URL, timeout=TIMEOUT_SECONDS)
+        response.raise_for_status()
+    except requests.exceptions.SSLError as exc:
+        print(f"[fail] TLS handshake: {exc}", file=sys.stderr)
+        return 4
+    except requests.exceptions.Timeout:
+        print(f"[fail] timed out after {TIMEOUT_SECONDS}s", file=sys.stderr)
+        return 2
+    except requests.exceptions.ConnectionError as exc:
+        print(f"[fail] connection: {exc}", file=sys.stderr)
+        return 1
+    except requests.exceptions.RequestException as exc:
+        print(f"[fail] request: {type(exc).__name__}", file=sys.stderr)
+        return 3
+
+    try:
+        payload = response.json()
+        poem = payload[0]
+        title = poem["title"]
+        author = poem["author"]
+        lines = poem["lines"]
+        line_count = poem.get("linecount", len(lines))
+    except (ValueError, IndexError, KeyError, TypeError) as exc:
+        print(
+            f"[fail] parse: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 5
+
+    print("[ok] DNS + TLS + requests + JSON all working\\n")
+    print(f"=== {title} ===")
+    print(f"by {author}\\n")
+    for line in lines:
+        print(line)
+    print(f"\\n[meta] {line_count} lines, fetched from {URL}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
 `,
 	},
 	{


### PR DESCRIPTION
## Summary

Adds a hardened Python example that exercises the \`firecracker-python-net\` rootfs end-to-end (DNS, TLS, \`requests\`, JSON). Selecting it from the **Examples** dropdown auto-toggles the **Network (VPN)** checkbox so the run boots the network-capable rootfs.

## CodeQL hardening over the original draft

- **Narrow except branches** — splits \`SSLError\`, \`Timeout\`, \`ConnectionError\`, \`RequestException\` with distinct exit codes (1-5). Never catches \`BaseException\` (\`py/catch-base-exception\`).
- **JSON / payload-shape errors handled separately** so a malformed response is not misreported as a network failure.
- **URL is a module-level constant** (no SSRF surface — never sourced from user input; \`py/full-ssrf\` clean).
- **Explicit timeout** (avoids hung sockets on misbehaving peers; \`py/request-without-timeout\` clean).
- \`if __name__ == \"__main__\"\` guard + typed \`main() -> int\` so the structure matches CodeQL \`py/code-organization\` expectations.

## Safe for general deployments

When the public sandbox runs it without the network (no VPN box), the request fails fast with exit code 1 and a clear \`[fail] connection\` message — no crash, no silent hang, no leakage of unexpected internal state.

## UI changes

- \`CodeExample.requires_network?: boolean\` — opt-in flag on the interface so future network examples can reuse the wiring.
- Example picker auto-sets \`$useNetwork = true\` when the selected example carries the flag, matching the existing rootfs swap in \`IdeService.run\` (\`alpine-python\` → \`firecracker-python-net\`).
- Examples dropdown prefixes network-bound examples with 🌐 so users see at a glance which entries require the VPN deployment.

## Files

- \`apps/kbve/astro-kbve/src/components/dashboard/ideService.ts\` — new EXAMPLES entry + interface field.
- \`apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx\` — auto-toggle + 🌐 prefix.

## Test plan

- [ ] Pick **Python Quick** preset.
- [ ] Open the Examples dropdown — \`🌐 PoetryDB (Network)\` shows in the list.
- [ ] Select it — code populates and Network (VPN) checkbox flips on automatically.
- [ ] Run — poem prints, exit 0.
- [ ] Untick Network (VPN) without changing the code, run again — clean \`[fail] connection\` + exit 1, no crash.