### PR TITLE
fix(ci): unblock bevy crate publish pipeline

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.140",
+			"version": "1.0.141",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -351,7 +351,7 @@
 			"package_name": "bevy_battle",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_battle/version.toml",
-			"version_source": "packages/rust/bevy/bevy_battle/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-battle-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_battle/Cargo.toml"
 		},
 		{
@@ -359,7 +359,7 @@
 			"package_name": "bevy_behavior",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_behavior/version.toml",
-			"version_source": "packages/rust/bevy/bevy_behavior/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-behavior-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_behavior/Cargo.toml"
 		},
 		{
@@ -367,7 +367,7 @@
 			"package_name": "bevy_cam",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_cam/version.toml",
-			"version_source": "packages/rust/bevy/bevy_cam/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-cam-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_cam/Cargo.toml"
 		},
 		{
@@ -375,7 +375,7 @@
 			"package_name": "bevy_chat",
 			"version": "0.0.0",
 			"version_toml": "packages/rust/bevy/bevy_chat/version.toml",
-			"version_source": "packages/rust/bevy/bevy_chat/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-chat-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_chat/Cargo.toml"
 		},
 		{
@@ -383,7 +383,7 @@
 			"package_name": "bevy_db",
 			"version": "0.0.0",
 			"version_toml": "packages/rust/bevy/bevy_db/version.toml",
-			"version_source": "packages/rust/bevy/bevy_db/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-db-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_db/Cargo.toml"
 		},
 		{
@@ -391,7 +391,7 @@
 			"package_name": "bevy_inventory",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_inventory/version.toml",
-			"version_source": "packages/rust/bevy/bevy_inventory/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-inventory-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_inventory/Cargo.toml"
 		},
 		{
@@ -399,7 +399,7 @@
 			"package_name": "bevy_items",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_items/version.toml",
-			"version_source": "packages/rust/bevy/bevy_items/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-items-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_items/Cargo.toml"
 		},
 		{
@@ -407,7 +407,7 @@
 			"package_name": "bevy_kbve_net",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_kbve_net/version.toml",
-			"version_source": "packages/rust/bevy/bevy_kbve_net/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-kbve-net-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_kbve_net/Cargo.toml"
 		},
 		{
@@ -415,7 +415,7 @@
 			"package_name": "bevy_mapdb",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_mapdb/version.toml",
-			"version_source": "packages/rust/bevy/bevy_mapdb/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-mapdb-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_mapdb/Cargo.toml"
 		},
 		{
@@ -423,7 +423,7 @@
 			"package_name": "bevy_npc",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_npc/version.toml",
-			"version_source": "packages/rust/bevy/bevy_npc/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-npc-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_npc/Cargo.toml"
 		},
 		{
@@ -431,7 +431,7 @@
 			"package_name": "bevy_pathfinder",
 			"version": "0.1.1",
 			"version_toml": "packages/rust/bevy/bevy_pathfinder/version.toml",
-			"version_source": "packages/rust/bevy/bevy_pathfinder/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-pathfinder-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_pathfinder/Cargo.toml"
 		},
 		{
@@ -439,7 +439,7 @@
 			"package_name": "bevy_player",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_player/version.toml",
-			"version_source": "packages/rust/bevy/bevy_player/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-player-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_player/Cargo.toml"
 		},
 		{
@@ -447,7 +447,7 @@
 			"package_name": "bevy_quests",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_quests/version.toml",
-			"version_source": "packages/rust/bevy/bevy_quests/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-quests-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_quests/Cargo.toml"
 		},
 		{
@@ -455,7 +455,7 @@
 			"package_name": "bevy_skills",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_skills/version.toml",
-			"version_source": "packages/rust/bevy/bevy_skills/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-skills-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_skills/Cargo.toml"
 		},
 		{
@@ -463,7 +463,7 @@
 			"package_name": "bevy_statemachine",
 			"version": "0.1.0",
 			"version_toml": "packages/rust/bevy/bevy_statemachine/version.toml",
-			"version_source": "packages/rust/bevy/bevy_statemachine/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-statemachine-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_statemachine/Cargo.toml"
 		},
 		{
@@ -471,7 +471,7 @@
 			"package_name": "bevy_supa",
 			"version": "0.0.0",
 			"version_toml": "packages/rust/bevy/bevy_supa/version.toml",
-			"version_source": "packages/rust/bevy/bevy_supa/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-supa-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_supa/Cargo.toml"
 		},
 		{
@@ -479,7 +479,7 @@
 			"package_name": "bevy_tasker",
 			"version": "0.1.1",
 			"version_toml": "packages/rust/bevy/bevy_tasker/version.toml",
-			"version_source": "packages/rust/bevy/bevy_tasker/Cargo.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/bevy-tasker-crate.mdx",
 			"version_target": "packages/rust/bevy/bevy_tasker/Cargo.toml"
 		},
 		{

--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -218,7 +218,12 @@ jobs:
                         core.info(`Found '${appName}' in manifest (pipeline: ${entry.pipeline})`);
 
                         const allowedFiles = new Set(
-                          [entry.version_toml, entry.version_target, entry.deployment_yaml]
+                          [
+                            entry.version_toml,
+                            entry.version_target,
+                            entry.deployment_yaml,
+                            '.github/ci-dispatch-manifest.json',
+                          ]
                             .filter(Boolean)
                             .map(sanitize)
                         );

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-battle-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-battle-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_battle
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_battle
-version_source: packages/rust/bevy/bevy_battle/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-battle-crate.mdx
+version_target: packages/rust/bevy/bevy_battle/Cargo.toml
 version_toml: packages/rust/bevy/bevy_battle/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-behavior-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-behavior-crate.mdx
@@ -14,7 +14,7 @@ pipeline: crates
 package_name: bevy_behavior
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_behavior
-version_source: packages/rust/bevy/bevy_behavior/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-behavior-crate.mdx
 version_target: packages/rust/bevy/bevy_behavior/Cargo.toml
 version_toml: packages/rust/bevy/bevy_behavior/version.toml
 author: h0lybyte

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-cam-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-cam-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_cam
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_cam
-version_source: packages/rust/bevy/bevy_cam/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-cam-crate.mdx
+version_target: packages/rust/bevy/bevy_cam/Cargo.toml
 version_toml: packages/rust/bevy/bevy_cam/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-chat-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-chat-crate.mdx
@@ -15,7 +15,7 @@ pipeline: crates
 package_name: bevy_chat
 version: "0.0.0"
 source_path: packages/rust/bevy/bevy_chat
-version_source: packages/rust/bevy/bevy_chat/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-chat-crate.mdx
 version_target: packages/rust/bevy/bevy_chat/Cargo.toml
 version_toml: packages/rust/bevy/bevy_chat/version.toml
 author: h0lybyte

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-db-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-db-crate.mdx
@@ -15,7 +15,7 @@ pipeline: crates
 package_name: bevy_db
 version: "0.0.0"
 source_path: packages/rust/bevy/bevy_db
-version_source: packages/rust/bevy/bevy_db/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-db-crate.mdx
 version_target: packages/rust/bevy/bevy_db/Cargo.toml
 version_toml: packages/rust/bevy/bevy_db/version.toml
 author: h0lybyte

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-inventory-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-inventory-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_inventory
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_inventory
-version_source: packages/rust/bevy/bevy_inventory/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-inventory-crate.mdx
+version_target: packages/rust/bevy/bevy_inventory/Cargo.toml
 version_toml: packages/rust/bevy/bevy_inventory/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-items-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-items-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_items
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_items
-version_source: packages/rust/bevy/bevy_items/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-items-crate.mdx
+version_target: packages/rust/bevy/bevy_items/Cargo.toml
 version_toml: packages/rust/bevy/bevy_items/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-kbve-net-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-kbve-net-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_kbve_net
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_kbve_net
-version_source: packages/rust/bevy/bevy_kbve_net/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-kbve-net-crate.mdx
+version_target: packages/rust/bevy/bevy_kbve_net/Cargo.toml
 version_toml: packages/rust/bevy/bevy_kbve_net/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-mapdb-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-mapdb-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_mapdb
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_mapdb
-version_source: packages/rust/bevy/bevy_mapdb/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-mapdb-crate.mdx
+version_target: packages/rust/bevy/bevy_mapdb/Cargo.toml
 version_toml: packages/rust/bevy/bevy_mapdb/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-npc-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-npc-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_npc
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_npc
-version_source: packages/rust/bevy/bevy_npc/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-npc-crate.mdx
+version_target: packages/rust/bevy/bevy_npc/Cargo.toml
 version_toml: packages/rust/bevy/bevy_npc/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-pathfinder-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-pathfinder-crate.mdx
@@ -15,7 +15,7 @@ pipeline: crates
 package_name: bevy_pathfinder
 version: "0.1.1"
 source_path: packages/rust/bevy/bevy_pathfinder
-version_source: packages/rust/bevy/bevy_pathfinder/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-pathfinder-crate.mdx
 version_target: packages/rust/bevy/bevy_pathfinder/Cargo.toml
 version_toml: packages/rust/bevy/bevy_pathfinder/version.toml
 author: h0lybyte

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-player-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-player-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_player
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_player
-version_source: packages/rust/bevy/bevy_player/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-player-crate.mdx
+version_target: packages/rust/bevy/bevy_player/Cargo.toml
 version_toml: packages/rust/bevy/bevy_player/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-quests-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-quests-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_quests
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_quests
-version_source: packages/rust/bevy/bevy_quests/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-quests-crate.mdx
+version_target: packages/rust/bevy/bevy_quests/Cargo.toml
 version_toml: packages/rust/bevy/bevy_quests/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-skills-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-skills-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_skills
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_skills
-version_source: packages/rust/bevy/bevy_skills/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-skills-crate.mdx
+version_target: packages/rust/bevy/bevy_skills/Cargo.toml
 version_toml: packages/rust/bevy/bevy_skills/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-statemachine-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-statemachine-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_statemachine
 version: "0.1.0"
 source_path: packages/rust/bevy/bevy_statemachine
-version_source: packages/rust/bevy/bevy_statemachine/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-statemachine-crate.mdx
+version_target: packages/rust/bevy/bevy_statemachine/Cargo.toml
 version_toml: packages/rust/bevy/bevy_statemachine/version.toml
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-supa-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-supa-crate.mdx
@@ -15,7 +15,7 @@ pipeline: crates
 package_name: bevy_supa
 version: "0.0.0"
 source_path: packages/rust/bevy/bevy_supa
-version_source: packages/rust/bevy/bevy_supa/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-supa-crate.mdx
 version_target: packages/rust/bevy/bevy_supa/Cargo.toml
 version_toml: packages/rust/bevy/bevy_supa/version.toml
 author: h0lybyte

--- a/apps/kbve/astro-kbve/src/content/docs/project/bevy-tasker-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/bevy-tasker-crate.mdx
@@ -13,7 +13,8 @@ pipeline: crates
 package_name: bevy_tasker
 version: "0.1.1"
 source_path: packages/rust/bevy/bevy_tasker
-version_source: packages/rust/bevy/bevy_tasker/Cargo.toml
+version_source: apps/kbve/astro-kbve/src/content/docs/project/bevy-tasker-crate.mdx
+version_target: packages/rust/bevy/bevy_tasker/Cargo.toml
 version_toml: packages/rust/bevy/bevy_tasker/version.toml
 author: h0lybyte
 license: MIT


### PR DESCRIPTION
## Summary

Two coupled bugs broke the bevy crate publish flow surfaced by issue #10718 (`bevy_tasker@0.1.0 already exists on crates.io index`):

1. **Bevy MDX `version_source` self-ref.** All 17 bevy crate MDX files set `version_source: packages/rust/bevy/<crate>/Cargo.toml` — pointing at the same file `version_target` writes. The sync step in `rust-publish-crate.yml` therefore became a no-op: it read the version from Cargo.toml (still `0.1.0`) and patched Cargo.toml to itself. When the MDX bumped to `0.1.1`, Cargo.toml never followed, so `cargo publish` reused `0.1.0` and hit the registry conflict. Fix: switch all 17 bevy MDX to `version_source: <self.mdx>` + ensure `version_target: <Cargo.toml>` is set, matching the working pattern used by `erust`/`jedi`.
2. **Auto-merge allowlist missing manifest path.** `utils-update-version-toml.yml` regenerates `.github/ci-dispatch-manifest.json` and stages it into every post-publish version-bump PR (matches the "full regen, no surgical edit" rule). `ci-auto-merge-bot-prs.yml` builds `allowedFiles` only from `entry.version_toml | version_target | deployment_yaml`, so the manifest path is rejected and PRs like #10737 stall. Fix: add `.github/ci-dispatch-manifest.json` to the allowlist literal.
3. Regenerate `.github/ci-dispatch-manifest.json` from the updated MDX.

After this lands, re-dispatch of `bevy_tasker` will: read MDX `0.1.1` → patch `Cargo.toml` `0.1.0`→`0.1.1` → `cargo publish` succeeds → post-publish PR (with manifest) auto-merges.

## Test plan

- [ ] Re-dispatch `crates / bevy_tasker` via `CI - Publish`; confirm sync step logs `Patched Cargo.toml: 0.1.0 → 0.1.1` and publish succeeds.
- [ ] Verify the post-publish version-bump PR auto-merges (allowlist now permits `.github/ci-dispatch-manifest.json`).
- [ ] Confirm PR #10737 retries cleanly once this is merged.
- [ ] Spot-check another bevy crate MDX path resolution (`bevy_pathfinder` already at `0.1.1` — re-dispatch should be a no-op due to version gate).

Closes #10718.