### PR TITLE
feat(astro-rareicon): JSON-LD coverage expansion + per-icon API + JSON-LD validator

### DIFF
--- a/apps/rareicon/astro-rareicon/src/components/icons/CategoryLanding.astro
+++ b/apps/rareicon/astro-rareicon/src/components/icons/CategoryLanding.astro
@@ -152,6 +152,8 @@ const categoryLabel =
 
 	.ri-cat-landing__item {
 		margin: 0;
+		content-visibility: auto;
+		contain-intrinsic-size: 0 180px;
 	}
 
 	.ri-cat-landing__card {

--- a/apps/rareicon/astro-rareicon/src/components/starlight/Head.astro
+++ b/apps/rareicon/astro-rareicon/src/components/starlight/Head.astro
@@ -90,6 +90,26 @@ function jsonLd(obj: Record<string, unknown>): string {
 
 const structured: string[] = [];
 
+const ORG = {
+	'@type': 'Organization',
+	name: 'KBVE',
+	url: 'https://kbve.com',
+	logo: 'https://kbve.com/assets/images/brand/letter_logo.png',
+};
+
+structured.push(
+	jsonLd({
+		'@type': 'WebSite',
+		name: 'RareIcon',
+		url: SITE,
+		potentialAction: {
+			'@type': 'SearchAction',
+			target: `${SITE}/?q={search_term_string}`,
+			'query-input': 'required name=search_term_string',
+		},
+	}),
+);
+
 if (slug === 'index' || slug === '') {
 	structured.push(
 		jsonLd({
@@ -200,6 +220,56 @@ if (slug.startsWith('icons/category/')) {
 			description: pageDesc ?? 'Open-source icon catalog',
 			url: `${SITE}/icons/`,
 			isPartOf: { '@type': 'WebSite', name: 'RareIcon', url: SITE },
+		}),
+	);
+	structured.push(
+		jsonLd({
+			'@type': 'SoftwareApplication',
+			name: 'RareIcon Icon Library',
+			description:
+				'Open-source icon catalog with 1252+ terms across 19 FOSS icon packs',
+			url: `${SITE}/icons/`,
+			applicationCategory: 'DesignApplication',
+			operatingSystem: 'Web',
+			offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+			publisher: ORG,
+		}),
+	);
+}
+
+if (slug === 'press' || slug === 'press/index') {
+	structured.push(
+		jsonLd({
+			'@type': 'Article',
+			headline: pageTitle,
+			description: pageDesc,
+			url: canonical,
+			image: pageImage,
+			author: ORG,
+			publisher: ORG,
+			datePublished: '2026-05-07',
+			mainEntityOfPage: { '@type': 'WebPage', '@id': canonical },
+		}),
+	);
+}
+
+if (slug === 'steam' || slug === 'steam/index') {
+	structured.push(
+		jsonLd({
+			'@type': 'Product',
+			name: 'RareIcon',
+			description: pageDesc,
+			url: canonical,
+			image: pageImage,
+			brand: ORG,
+			offers: {
+				'@type': 'Offer',
+				url: 'https://store.steampowered.com/app/2238370/RareIcon/',
+				availability: 'https://schema.org/PreOrder',
+				priceCurrency: 'USD',
+				price: '0',
+			},
+			category: 'VideoGame',
 		}),
 	);
 }

--- a/apps/rareicon/astro-rareicon/src/pages/api/icons/[ref].json.ts
+++ b/apps/rareicon/astro-rareicon/src/pages/api/icons/[ref].json.ts
@@ -1,0 +1,49 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+
+export const prerender = true;
+
+export async function getStaticPaths() {
+	const docs = await getCollection('docs');
+	const iconEntries = docs.filter((entry: CollectionEntry<'docs'>) => {
+		const id = entry.id.replace(/\.mdx?$/, '');
+		if (!id.startsWith('icons/')) return false;
+		if (id === 'icons/index') return false;
+		if (id.startsWith('icons/category/')) return false;
+		const data = entry.data as { ref?: string; icons?: unknown[] };
+		return Boolean(data.ref) && Array.isArray(data.icons);
+	});
+	return iconEntries.map((entry: CollectionEntry<'docs'>) => {
+		const data = entry.data as { ref: string };
+		return { params: { ref: data.ref }, props: { entry } };
+	});
+}
+
+export const GET: APIRoute = async ({ props }) => {
+	const entry = props.entry as CollectionEntry<'docs'>;
+	const data = entry.data as Record<string, unknown>;
+	const ref = data.ref as string;
+
+	const body = {
+		ref,
+		name: data.name ?? data.title,
+		title: data.title,
+		description: data.description,
+		primary_category: data.primary_category,
+		categories: data.categories ?? [],
+		tags: data.tags ?? [],
+		default_license: data.default_license,
+		icons: data.icons ?? [],
+		featured: data.featured ?? false,
+		url: `https://rareicon.com/icons/${ref}/`,
+	};
+
+	return new Response(JSON.stringify(body, null, 2), {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+			'Cache-Control': 'public, max-age=300, s-maxage=3600',
+		},
+	});
+};

--- a/apps/rareicon/astro-rareicon/src/pages/api/sources.json.ts
+++ b/apps/rareicon/astro-rareicon/src/pages/api/sources.json.ts
@@ -1,0 +1,144 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { collectTermSummaries } from '@/lib/icons/terms';
+
+export const prerender = true;
+
+const PACK_META: Record<
+	string,
+	{ license: string; homeUrl: string; attribution: boolean }
+> = {
+	lucide: {
+		license: 'ISC',
+		homeUrl: 'https://lucide.dev/',
+		attribution: true,
+	},
+	'simple-icons': {
+		license: 'CC0',
+		homeUrl: 'https://simpleicons.org/',
+		attribution: false,
+	},
+	tabler: {
+		license: 'MIT',
+		homeUrl: 'https://tabler.io/icons',
+		attribution: false,
+	},
+	phosphor: {
+		license: 'MIT',
+		homeUrl: 'https://phosphoricons.com/',
+		attribution: false,
+	},
+	'game-icons': {
+		license: 'CC BY 3.0',
+		homeUrl: 'https://game-icons.net/',
+		attribution: true,
+	},
+	heroicons: {
+		license: 'MIT',
+		homeUrl: 'https://heroicons.com/',
+		attribution: false,
+	},
+	octicons: {
+		license: 'MIT',
+		homeUrl: 'https://primer.style/foundations/icons',
+		attribution: false,
+	},
+	iconoir: {
+		license: 'MIT',
+		homeUrl: 'https://iconoir.com/',
+		attribution: false,
+	},
+	carbon: {
+		license: 'Apache 2.0',
+		homeUrl: 'https://carbondesignsystem.com/guidelines/icons/library/',
+		attribution: false,
+	},
+	'material-symbols': {
+		license: 'Apache 2.0',
+		homeUrl: 'https://fonts.google.com/icons',
+		attribution: false,
+	},
+	fluent: {
+		license: 'MIT',
+		homeUrl: 'https://github.com/microsoft/fluentui-system-icons',
+		attribution: false,
+	},
+	mdi: {
+		license: 'Apache 2.0',
+		homeUrl: 'https://pictogrammers.com/library/mdi/',
+		attribution: false,
+	},
+	'akar-icons': {
+		license: 'MIT',
+		homeUrl: 'https://akaricons.com/',
+		attribution: false,
+	},
+	'radix-icons': {
+		license: 'MIT',
+		homeUrl: 'https://www.radix-ui.com/icons',
+		attribution: false,
+	},
+	'lucide-lab': {
+		license: 'ISC',
+		homeUrl: 'https://lucide.dev/lab',
+		attribution: true,
+	},
+	solar: {
+		license: 'CC BY 4.0',
+		homeUrl: 'https://solar-icons.com/',
+		attribution: true,
+	},
+	mingcute: {
+		license: 'Apache 2.0',
+		homeUrl: 'https://www.mingcute.com/',
+		attribution: false,
+	},
+	devicon: {
+		license: 'MIT',
+		homeUrl: 'https://devicon.dev/',
+		attribution: false,
+	},
+	logos: {
+		license: 'CC0',
+		homeUrl: 'https://svgporn.com/',
+		attribution: false,
+	},
+};
+
+export const GET: APIRoute = async () => {
+	const docs = await getCollection('docs');
+	const terms = collectTermSummaries(docs);
+
+	const counts = new Map<string, number>();
+	for (const t of terms) {
+		for (const pack of t.sourcePacks) {
+			counts.set(pack, (counts.get(pack) ?? 0) + 1);
+		}
+	}
+
+	const sources = Array.from(counts.entries())
+		.sort((a, b) => b[1] - a[1])
+		.map(([name, termCount]) => ({
+			name,
+			termCount,
+			...(PACK_META[name] ?? {
+				license: 'unknown',
+				homeUrl: '',
+				attribution: false,
+			}),
+		}));
+
+	const body = {
+		generatedAt: new Date().toISOString(),
+		count: sources.length,
+		sources,
+	};
+
+	return new Response(JSON.stringify(body, null, 2), {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+			'Cache-Control': 'public, max-age=300, s-maxage=3600',
+		},
+	});
+};

--- a/apps/rareicon/icons-codegen/package.json
+++ b/apps/rareicon/icons-codegen/package.json
@@ -15,6 +15,8 @@
 		"gen:categories": "node scripts/gen-category-landings.mjs",
 		"gen:all": "pnpm gen:lucide && pnpm gen:simple && pnpm gen:tabler && pnpm gen:phosphor && pnpm gen:gameicons && pnpm gen:iconify && pnpm gen:merge && pnpm gen:categories",
 		"audit:links": "node scripts/audit-links.mjs",
+		"validate:jsonld": "node scripts/validate-jsonld.mjs",
+		"audit:all": "pnpm audit:links && pnpm validate:jsonld",
 		"clean:deps": "rm -rf node_modules"
 	},
 	"dependencies": {

--- a/apps/rareicon/icons-codegen/scripts/validate-jsonld.mjs
+++ b/apps/rareicon/icons-codegen/scripts/validate-jsonld.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Walk dist/apps/astro-rareicon/, parse every
+ * <script type="application/ld+json">…</script>, and validate:
+ *
+ *   - JSON parses cleanly
+ *   - Object has @context (must be schema.org URL)
+ *   - Object has @type
+ *
+ * Reports per-page failures + summary counts. Exits 1 on any parse
+ * error so CI can gate on structured-data health alongside
+ * audit-links.mjs from phase 26.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../../..');
+const DIST_DIR = path.resolve(
+	WORKSPACE_ROOT,
+	'dist/apps/astro-rareicon',
+);
+
+const JSONLD_RE =
+	/<script\s+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
+
+function listHtmlFiles(dir, out = []) {
+	for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+		const p = path.join(dir, e.name);
+		if (e.isDirectory()) listHtmlFiles(p, out);
+		else if (e.isFile() && e.name.endsWith('.html')) out.push(p);
+	}
+	return out;
+}
+
+function distRelToRoute(filePath) {
+	const rel = path.relative(DIST_DIR, filePath);
+	const noIndex = rel.replace(/\/?index\.html$/, '/');
+	return '/' + noIndex.replace(/\/+$/, '/');
+}
+
+function main() {
+	if (!fs.existsSync(DIST_DIR)) {
+		console.error(`dist not found: ${DIST_DIR}\nRun \`astro build\` first.`);
+		process.exit(1);
+	}
+
+	const htmlFiles = listHtmlFiles(DIST_DIR);
+	console.log(`scanning ${htmlFiles.length} HTML files for JSON-LD blocks`);
+
+	let totalScripts = 0;
+	let totalPagesWithLd = 0;
+	const typeCounts = new Map();
+	const errors = [];
+
+	for (const file of htmlFiles) {
+		const route = distRelToRoute(file);
+		const html = fs.readFileSync(file, 'utf8');
+		const scripts = [];
+		let m;
+		while ((m = JSONLD_RE.exec(html))) scripts.push(m[1]);
+		if (scripts.length === 0) continue;
+		totalPagesWithLd++;
+		totalScripts += scripts.length;
+
+		for (const raw of scripts) {
+			let parsed;
+			try {
+				parsed = JSON.parse(raw);
+			} catch (e) {
+				errors.push({
+					route,
+					reason: `invalid JSON (${e.message})`,
+					sample: raw.slice(0, 80),
+				});
+				continue;
+			}
+			if (!parsed || typeof parsed !== 'object') {
+				errors.push({ route, reason: 'not an object', sample: '' });
+				continue;
+			}
+			const ctx = parsed['@context'];
+			if (!ctx || !/schema\.org/.test(String(ctx))) {
+				errors.push({
+					route,
+					reason: `missing or non-schema.org @context: ${JSON.stringify(ctx)}`,
+					sample: '',
+				});
+				continue;
+			}
+			const type = parsed['@type'];
+			if (!type) {
+				errors.push({ route, reason: 'missing @type', sample: '' });
+				continue;
+			}
+			const typeStr = Array.isArray(type) ? type.join(',') : String(type);
+			typeCounts.set(typeStr, (typeCounts.get(typeStr) ?? 0) + 1);
+		}
+	}
+
+	console.log(`\nscanned ${totalScripts} JSON-LD blocks across ${totalPagesWithLd} pages`);
+	console.log('\n--- @type distribution ---');
+	const sorted = [...typeCounts.entries()].sort((a, b) => b[1] - a[1]);
+	for (const [type, count] of sorted) {
+		console.log(`  ${count.toString().padStart(6)}  ${type}`);
+	}
+
+	if (errors.length > 0) {
+		console.error(
+			`\n!! INVALID — ${errors.length} JSON-LD block${errors.length === 1 ? '' : 's'}`,
+		);
+		for (const e of errors.slice(0, 25)) {
+			console.error(`  ${e.route}  ${e.reason}`);
+			if (e.sample) console.error(`    sample: ${e.sample}`);
+		}
+		if (errors.length > 25) {
+			console.error(`  ... +${errors.length - 25} more`);
+		}
+		process.exit(1);
+	}
+
+	console.log('\nJSON-LD audit clean.');
+}
+
+main();


### PR DESCRIPTION
## Summary

Extends the four platform-readiness layers shipped in phase 27 (#10739).

## A — JSON-LD coverage

| Where | Schema added |
|-------|--------------|
| Every page | \`WebSite\` with \`SearchAction\` (Google sitelinks search box) |
| \`/icons/\` | \`SoftwareApplication\` (catalog as free web app) |
| \`/press/\` | \`Article\` (publisher / author / datePublished) |
| \`/steam/\` | \`Product\` with \`Offer\` (PreOrder availability + Steam store URL) |

Shared \`ORG\` constant centralizes publisher/author info.

## B — CategoryLanding virtualization

\`.ri-cat-landing__item\` gets:
\`\`\`css
content-visibility: auto;
contain-intrinsic-size: 0 180px;
\`\`\`
Browser skips paint/layout for offscreen cards on category landings (e.g. \`/icons/category/ui/\` has 561 cards). Free perf win — no JS, no SEO regression (HTML still serves all cards for crawlers).

## C — API endpoints

| Endpoint | Coverage |
|----------|----------|
| \`/api/icons/<ref>.json\` | Full term incl. \`svg_body\`, 1252 endpoints emitted via \`getStaticPaths\` |
| \`/api/sources.json\` | 20 source packs with \`{ name, termCount, license, homeUrl, attribution }\` sorted by term count desc |

Plus the existing \`/api/icons.json\` (catalog dump) + \`/api/categories.json\` from phase 27.

## J — JSON-LD validator

\`scripts/validate-jsonld.mjs\` walks dist/, parses every \`<script type="application/ld+json">\`, validates JSON parses + has \`@context\` (must be schema.org URL) + has \`@type\`. Reports per-page failures + summary type counts. Exits 1 on error.

Wired as:
- \`pnpm validate:jsonld\` standalone
- \`pnpm audit:all\` chain (\`audit:links\` + \`validate:jsonld\` in one command)

## Verification

\`\`\`
scanned 2569 JSON-LD blocks across 1284 pages

--- @type distribution ---
  1284  WebSite
  1252  ImageObject
    15  CollectionPage
    14  BreadcrumbList
     1  SoftwareApplication
     1  VideoGame
     1  Article
     1  Product

JSON-LD audit clean.
link audit clean.
\`\`\`

## Test plan

- [x] \`astro build\` clean — 1284 pages
- [x] \`pnpm validate:jsonld\` exits 0 — 2569 blocks valid
- [x] \`pnpm audit:links\` exits 0 — zero broken
- [x] \`/api/icons/sword.json\` materialized in dist/
- [x] \`/api/sources.json\` shows 20 packs sorted by term count
- [ ] CI: e2e regression suite (#10623) doesn't break
- [ ] Manual: validate \`/\` + \`/icons/sword/\` + \`/icons/category/tech/\` + \`/press/\` + \`/steam/\` in [Google Rich Results Test](https://search.google.com/test/rich-results)