### PR TITLE
fix(ci): post-publish git-add deployment_yamls entries

### DIFF
--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -249,6 +249,7 @@ jobs:
               id: push
               env:
                   GITHUB_TOKEN: ${{ secrets.TRIGGER_PAT }}
+                  DEPLOYMENT_YAMLS_JSON: ${{ inputs.deployment_yamls }}
               run: |
                   APP="${{ steps.validate.outputs.app }}"
                   VERSION="${{ steps.validate.outputs.version }}"
@@ -257,14 +258,33 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
-                  # Stage only the explicitly listed files
+                  # Stage only the explicitly listed files. Mirrors the
+                  # FILES iteration in the "Update kube deployment manifests"
+                  # step above so every file that step sed-bumps also lands
+                  # in the atom PR (previously the singular deployment_yaml
+                  # was added, but the deployment_yamls array was silently
+                  # dropped — only version.toml shipped).
                   git add "${{ inputs.version_toml_path }}"
                   if [ -n "${{ inputs.version_target_path }}" ] && [ -f "${{ inputs.version_target_path }}" ]; then
                     git add "${{ inputs.version_target_path }}"
                   fi
-                  if [ -n "${{ inputs.deployment_yaml }}" ] && [ -f "${{ inputs.deployment_yaml }}" ]; then
-                    git add "${{ inputs.deployment_yaml }}"
+
+                  DEPLOYMENT_FILES=""
+                  if [ -n "${{ inputs.deployment_yaml }}" ]; then
+                    DEPLOYMENT_FILES="${{ inputs.deployment_yaml }}"
                   fi
+                  if [ -n "$DEPLOYMENT_YAMLS_JSON" ]; then
+                    EXTRA=$(echo "$DEPLOYMENT_YAMLS_JSON" | jq -r '.[]' 2>/dev/null || true)
+                    DEPLOYMENT_FILES="$DEPLOYMENT_FILES $EXTRA"
+                  fi
+                  for f in $DEPLOYMENT_FILES; do
+                    [ -z "$f" ] && continue
+                    if [ -f "$f" ]; then
+                      git add "$f"
+                    else
+                      echo "::warning::deployment manifest '$f' not found at git add — skipping."
+                    fi
+                  done
 
                   if git diff --cached --quiet; then
                     echo "::notice::All files already at v${VERSION} — nothing to commit."

--- a/apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml
@@ -37,7 +37,7 @@ spec:
             restartPolicy: OnFailure
             containers:
                 - name: stage
-                  image: ghcr.io/kbve/firecracker-python-net:0.1.1
+                  image: ghcr.io/kbve/firecracker-python-net:0.1.2
                   imagePullPolicy: IfNotPresent
                   args:
                       - /rootfs.ext4


### PR DESCRIPTION
## Summary

\`utils-post-publish.yml\`'s **Update kube deployment manifests** step iterated both \`deployment_yaml\` (singular) and \`deployment_yamls\` (JSON array) when sed-bumping the image tag. The downstream **Commit and push atom branch** step did not — \`git add\` only staged \`version_toml_path\`, \`version_target_path\`, and the singular \`deployment_yaml\`.

Files listed in \`deployment_yamls\` had their \`image:\` tag rewritten in the working tree but never landed in the atom PR.

## Symptom

PR #10736 was supposed to bump \`apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml\` from \`:0.1.1\` to \`:0.1.2\` after the \`firecracker-python-net\` v0.1.2 publish. The merged commit only carried the \`version.toml\` change. The stage Job kept pulling \`:0.1.1\` (now missing from GHCR after the explicit-version-tag fix landed), the firecracker-rootfs PVC never received \`firecracker-python-net.ext4\`, and the dashboard kept failing with \`rootfs 'firecracker-python-net' not found\`.

## Fix

Two changes:

1. **\`.github/workflows/utils-post-publish.yml\`** — refactors the git-add block to mirror the \`FILES\` iteration in the sed step above it. Builds a unified \`DEPLOYMENT_FILES\` list from \`deployment_yaml\` + \`deployment_yamls\`, then loops once. Keeps the existing single-input shape for callers that still pass only \`deployment_yaml\`. Skips entries whose file is missing with a warning so a stale manifest reference does not abort the push.

2. **\`apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml\`** — one-shot manual bump from \`:0.1.1\` to \`:0.1.2\` (the tag actually present on GHCR). Future bumps are picked up by the workflow fix above.

## Test plan

- [ ] After merge, ArgoCD reconciles → \`firecracker-net-rootfs-stage\` Job pulls \`:0.1.2\`, copies \`/rootfs.ext4\` to \`/var/lib/firecracker/rootfs/firecracker-python-net.ext4\`.
- [ ] \`kubectl exec -n firecracker firecracker-ctl-net-... -- ls /var/lib/firecracker/rootfs/\` shows \`firecracker-python-net.ext4\`.
- [ ] Dashboard IDE Python Quick + Network (VPN) + 🌐 PoetryDB example prints a poem with exit 0.
- [ ] Next firecracker-python-net publish (or any other docker app with \`deployment_yamls\`) auto-bumps every listed manifest in the atom PR — not just the singular field.