### PR TITLE
fix(irc-gateway): require Supabase aud claim on JWT validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.140"
+version = "1.0.141"
 dependencies = [
  "anyhow",
  "askama",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_pathfinder"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bevy",
  "serde",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-task",
  "crossbeam-channel",

--- a/apps/irc/irc-gateway/src/auth/jwt.rs
+++ b/apps/irc/irc-gateway/src/auth/jwt.rs
@@ -7,6 +7,8 @@ use axum::{
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
 
+pub const SUPABASE_AUDIENCE: &str = "authenticated";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,
@@ -14,6 +16,8 @@ pub struct Claims {
     pub email: Option<String>,
     #[serde(default)]
     pub role: Option<String>,
+    #[serde(default)]
+    pub aud: Option<String>,
     pub exp: u64,
     pub iat: u64,
 }
@@ -46,7 +50,8 @@ pub fn validate_token(token: &str) -> Result<Claims, StatusCode> {
     let secret = std::env::var("JWT_SECRET").map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut validation = Validation::new(Algorithm::HS256);
-    validation.set_required_spec_claims(&["sub", "exp", "iat"]);
+    validation.set_required_spec_claims(&["sub", "exp", "iat", "aud"]);
+    validation.set_audience(&[SUPABASE_AUDIENCE]);
 
     decode::<Claims>(
         token,
@@ -88,12 +93,17 @@ mod tests {
     }
 
     fn issue(secret: &str, sub: &str, exp_offset: i64) -> String {
+        issue_with_aud(secret, sub, exp_offset, Some(SUPABASE_AUDIENCE))
+    }
+
+    fn issue_with_aud(secret: &str, sub: &str, exp_offset: i64, aud: Option<&str>) -> String {
         let iat = now_secs();
         let exp = (iat as i64 + exp_offset) as u64;
         let claims = Claims {
             sub: sub.to_string(),
             email: Some(format!("{sub}@example.com")),
             role: Some("authenticated".to_string()),
+            aud: aud.map(String::from),
             exp,
             iat,
         };
@@ -215,6 +225,40 @@ mod tests {
             StatusCode::UNAUTHORIZED,
         );
         assert_eq!(validate_token("").unwrap_err(), StatusCode::UNAUTHORIZED,);
+        std::env::remove_var("JWT_SECRET");
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_accepts_supabase_audience() {
+        std::env::set_var("JWT_SECRET", TEST_SECRET);
+        let token = issue_with_aud(TEST_SECRET, "user-aud", 3600, Some(SUPABASE_AUDIENCE));
+        let claims = validate_token(&token).expect("token should validate");
+        assert_eq!(claims.aud.as_deref(), Some(SUPABASE_AUDIENCE));
+        std::env::remove_var("JWT_SECRET");
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_rejects_wrong_audience() {
+        std::env::set_var("JWT_SECRET", TEST_SECRET);
+        let token = issue_with_aud(TEST_SECRET, "user-bad-aud", 3600, Some("service_role"));
+        assert_eq!(
+            validate_token(&token).unwrap_err(),
+            StatusCode::UNAUTHORIZED,
+        );
+        std::env::remove_var("JWT_SECRET");
+    }
+
+    #[test]
+    #[serial(jwt_env)]
+    fn validate_token_rejects_missing_audience() {
+        std::env::set_var("JWT_SECRET", TEST_SECRET);
+        let token = issue_with_aud(TEST_SECRET, "user-no-aud", 3600, None);
+        assert_eq!(
+            validate_token(&token).unwrap_err(),
+            StatusCode::UNAUTHORIZED,
+        );
         std::env::remove_var("JWT_SECRET");
     }
 }


### PR DESCRIPTION
## Summary
- jsonwebtoken 10.x defaults to `validate_aud=true` with no audience configured, which rejects any token carrying an `aud` claim. Supabase always signs `aud=\"authenticated\"`, so every browser WebSocket upgrade to chat.kbve.com was returning 401 — surfaced in the browser as `code=1006 abnormal`.
- Make the audience explicit: add `aud` to required spec claims and pin the validator to `\"authenticated\"`.
- Threaded `aud` through the test \`issue()\` helper and added three audience cases (accepts good, rejects wrong, rejects missing).

## Why this matters
Production was silently dropping every authenticated WS handshake — gateway logs were clean (the unauthorized branch returns early without an event), so the failure looked like an upstream/proxy issue. Fix is one validator config line; everything else is test scaffolding.

## Follow-ups (not in this PR)
- Lift Supabase JWT validation into a shared module on the `kbve` crate (or a small dedicated crate) so other Rust services don't redo this.
- Add an `error!` log on the auth-fail branch in `ws_handler` so future regressions surface in pod logs immediately.

## Test plan
- [x] \`cargo test --bin irc-gateway auth::jwt\` — 14 passed locally
- [x] \`cargo build --bin irc-gateway\` clean
- [ ] Post-merge: redeploy, hit \`wss://chat.kbve.com/ws?token=<supabase>\`, confirm 101 + chat connects