### PR TITLE
feat(discordsh): permadeath after 30-turn Downed grace + profile wipe RPC

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/battle_bridge.rs
@@ -434,6 +434,7 @@ impl CombatWorld {
             if hp.is_dead() {
                 if !player.downed {
                     player.downed = true;
+                    player.downed_at_turn = Some(session.turn);
                 }
                 player.hp = 0;
             }
@@ -1036,6 +1037,7 @@ mod tests {
                 accuracy: 1.0,
                 alive: true,
                 downed: false,
+                downed_at_turn: None,
                 member_status: MemberStatusTag::Guest,
                 class: ClassType::Warrior,
                 level: 1,

--- a/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
@@ -616,7 +616,7 @@ pub fn apply_action(
         "Applying game action"
     );
 
-    let result = match action {
+    let mut result = match action {
         GameAction::Attack => resolve_combat_turn(session, GameAction::Attack, actor),
         GameAction::AttackTarget(idx) => {
             debug!(target_idx = idx, "Attack targeting enemy index");
@@ -769,6 +769,11 @@ pub fn apply_action(
     session.turn += 1;
     session.last_action_at = std::time::Instant::now();
 
+    tick_permadeath_timer(session, &mut result.logs);
+    if session.all_players_dead() && !matches!(session.phase, GamePhase::GameOver(_)) {
+        session.phase = GamePhase::GameOver(GameOverReason::Defeated);
+    }
+
     // Trim log to last 8 entries
     for entry in &result.logs {
         session.log.push(entry.clone());
@@ -779,6 +784,31 @@ pub fn apply_action(
     }
 
     Ok(result)
+}
+
+const PERMADEATH_TURN_BUDGET: u32 = 30;
+
+fn tick_permadeath_timer(session: &mut SessionState, logs: &mut Vec<String>) {
+    let session_turn = session.turn;
+    let mut newly_dead: Vec<String> = Vec::new();
+    for player in session.players.values_mut() {
+        if !player.downed || !player.alive {
+            continue;
+        }
+        let Some(downed_at) = player.downed_at_turn else {
+            continue;
+        };
+        if session_turn.saturating_sub(downed_at) >= PERMADEATH_TURN_BUDGET {
+            player.alive = false;
+            newly_dead.push(player.name.clone());
+        }
+    }
+    for name in newly_dead {
+        logs.push(format!(
+            "{} bleeds out — character lost (permadeath).",
+            name
+        ));
+    }
 }
 
 // ── First-strike initiative ─────────────────────────────────────────
@@ -1657,9 +1687,13 @@ fn single_enemy_turn(
                     actual = actual.max(1);
                 }
 
+                let session_turn = session.turn;
                 let player = session.player_mut(uid);
                 player.hp -= actual;
                 if player.hp <= 0 {
+                    if !player.downed {
+                        player.downed_at_turn = Some(session_turn);
+                    }
                     player.downed = true;
                     player.hp = 0;
                 }
@@ -2238,8 +2272,12 @@ fn arrive_at_tile(session: &mut SessionState, pos: MapPos) -> Vec<String> {
 
     // Check if hazards killed any players
     for &uid in &alive_ids {
+        let session_turn = session.turn;
         let player = session.player_mut(uid);
         if player.hp <= 0 {
+            if !player.downed {
+                player.downed_at_turn = Some(session_turn);
+            }
             player.downed = true;
             player.hp = 0;
         }
@@ -2782,9 +2820,13 @@ fn apply_trap_choice(
                 ));
                 let alive_ids = session.alive_player_ids();
                 for &uid in &alive_ids {
+                    let session_turn = session.turn;
                     let player = session.player_mut(uid);
                     player.hp -= dmg;
                     if player.hp <= 0 {
+                        if !player.downed {
+                            player.downed_at_turn = Some(session_turn);
+                        }
                         player.downed = true;
                         player.hp = 0;
                     }
@@ -2800,9 +2842,13 @@ fn apply_trap_choice(
             ));
             let alive_ids = session.alive_player_ids();
             for &uid in &alive_ids {
+                let session_turn = session.turn;
                 let player = session.player_mut(uid);
                 player.hp -= reduced;
                 if player.hp <= 0 {
+                    if !player.downed {
+                        player.downed_at_turn = Some(session_turn);
+                    }
                     player.downed = true;
                     player.hp = 0;
                 }
@@ -2864,11 +2910,15 @@ fn apply_treasure_choice(
                 let trap_dmg = 5 + room_index as i32;
                 let alive_ids = session.alive_player_ids();
                 for &uid in &alive_ids {
+                    let session_turn = session.turn;
                     let player = session.player_mut(uid);
                     player.hp -= trap_dmg;
                     player.gold += standard_gold;
                     player.lifetime_gold_earned += standard_gold as u32;
                     if player.hp <= 0 {
+                        if !player.downed {
+                            player.downed_at_turn = Some(session_turn);
+                        }
                         player.downed = true;
                         player.hp = 0;
                     }
@@ -9717,6 +9767,49 @@ mod tests {
         let p2 = serenity::UserId::new(2);
         let result = apply_action(&mut session, GameAction::Revive(p2), OWNER);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn permadeath_timer_does_not_fire_within_budget() {
+        let mut session = test_session();
+        session.player_mut(OWNER).downed = true;
+        session.player_mut(OWNER).downed_at_turn = Some(0);
+        session.turn = PERMADEATH_TURN_BUDGET - 1;
+
+        let mut logs = Vec::new();
+        tick_permadeath_timer(&mut session, &mut logs);
+
+        assert!(session.player(OWNER).downed);
+        assert!(session.player(OWNER).alive);
+        assert!(logs.is_empty());
+    }
+
+    #[test]
+    fn permadeath_timer_kills_after_budget() {
+        let mut session = test_session();
+        session.player_mut(OWNER).downed = true;
+        session.player_mut(OWNER).downed_at_turn = Some(0);
+        session.turn = PERMADEATH_TURN_BUDGET;
+
+        let mut logs = Vec::new();
+        tick_permadeath_timer(&mut session, &mut logs);
+
+        assert!(!session.player(OWNER).alive);
+        assert!(logs.iter().any(|l| l.contains("permadeath")));
+    }
+
+    #[test]
+    fn permadeath_timer_skips_already_dead_players() {
+        let mut session = test_session();
+        session.player_mut(OWNER).alive = false;
+        session.player_mut(OWNER).downed = true;
+        session.player_mut(OWNER).downed_at_turn = Some(0);
+        session.turn = PERMADEATH_TURN_BUDGET + 5;
+
+        let mut logs = Vec::new();
+        tick_permadeath_timer(&mut session, &mut logs);
+
+        assert!(logs.is_empty());
     }
 
     #[test]

--- a/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/persistence.rs
@@ -305,6 +305,51 @@ impl ProfileStore {
         });
     }
 
+    /// Permadeath wipe — delete the profile from Supabase + the redb L2
+    /// cache. Fire-and-forget. The in-mem LRU is evicted by
+    /// [`save_all_players`] via `invalidate` after this returns. After
+    /// this runs, the player's next `/dungeon start` falls into the
+    /// class-picker path.
+    pub fn permadeath_async(&self, discord_id: u64) {
+        if let Some(db) = self.local_db.clone() {
+            let key = discord_id.to_string();
+            tokio::spawn(async move {
+                if let Err(e) = db.delete(REDB_PROFILE_TABLE, &key).await {
+                    warn!(error = %e, discord_id, "L2 redb permadeath wipe failed");
+                }
+            });
+        }
+
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let params = serde_json::json!({ "p_discord_id": discord_id as i64 });
+            match client
+                .rpc_schema("service_delete_profile", params, SCHEMA)
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    debug!(discord_id, "Profile permadeath wiped from Supabase");
+                }
+                Ok(resp) => {
+                    warn!(
+                        status = %resp.status(),
+                        discord_id,
+                        "service_delete_profile returned non-200"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        discord_id,
+                        "service_delete_profile RPC failed"
+                    );
+                }
+            }
+        });
+    }
+
     /// Try to claim the play mode lock for a player.
     ///
     /// Returns a [`ModeLockGuard`] if the lock was granted, or `Err(message)`
@@ -740,6 +785,11 @@ pub fn save_all_players(
     reason: &GameOverReason,
 ) {
     for (&uid, player) in &session.players {
+        if matches!(reason, GameOverReason::Defeated) && !player.alive {
+            profiles.permadeath_async(uid.get());
+            profiles.release_mode_async(uid.get(), session.short_id.clone());
+            continue;
+        }
         let snapshot = player.saved_snapshot.as_ref();
         let (profile, run) = extract_save_payload(
             uid.get(),
@@ -751,9 +801,6 @@ pub fn save_all_players(
             session,
         );
         profiles.save_async(profile, run);
-        // Release the play mode lock so the player can switch to isometric
-        // (or restart Discord). Each player owns their own lock keyed on
-        // the session's short_id.
         profiles.release_mode_async(uid.get(), session.short_id.clone());
     }
 

--- a/apps/discordsh/discordsh-bot/src/discord/game/types.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/types.rs
@@ -437,6 +437,8 @@ pub struct PlayerState {
     pub alive: bool,
     #[serde(default)]
     pub downed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub downed_at_turn: Option<u32>,
     pub member_status: MemberStatusTag,
     pub class: ClassType,
     pub level: u8,
@@ -478,6 +480,7 @@ impl Default for PlayerState {
             accuracy: 1.0,
             alive: true,
             downed: false,
+            downed_at_turn: None,
             member_status: MemberStatusTag::Guest,
             class: ClassType::Warrior,
             level: 1,

--- a/packages/data/sql/dbmate/migrations/20260509190000_discordsh_dungeon_permadeath.sql
+++ b/packages/data/sql/dbmate/migrations/20260509190000_discordsh_dungeon_permadeath.sql
@@ -1,0 +1,43 @@
+-- migrate:up
+
+CREATE OR REPLACE FUNCTION discordsh.service_delete_profile(
+    p_discord_id BIGINT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_deleted BIGINT;
+BEGIN
+    IF p_discord_id IS NULL THEN
+        RAISE EXCEPTION 'discord_id cannot be null'
+            USING ERRCODE = '22004';
+    END IF;
+
+    PERFORM pg_catalog.pg_advisory_xact_lock(p_discord_id);
+
+    DELETE FROM discordsh.dungeon_profiles
+    WHERE discord_id = p_discord_id;
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+    RETURN v_deleted;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_delete_profile(BIGINT) IS
+    'Permadeath wipe — deletes one dungeon profile by Discord snowflake. Returns row count: 1 if deleted, 0 if absent. dungeon_runs rows for this Discord ID are also removed via the dungeon_runs.discord_id ON DELETE CASCADE foreign key (full erasure, by design).';
+
+REVOKE ALL ON FUNCTION discordsh.service_delete_profile(BIGINT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION discordsh.service_delete_profile(BIGINT) FROM anon;
+REVOKE ALL ON FUNCTION discordsh.service_delete_profile(BIGINT) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION discordsh.service_delete_profile(BIGINT) TO service_role;
+
+ALTER FUNCTION discordsh.service_delete_profile(BIGINT) OWNER TO service_role;
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS discordsh.service_delete_profile(BIGINT);

--- a/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
+++ b/packages/data/sql/schema/discordsh/discordsh_dungeon_profiles.sql
@@ -703,6 +703,57 @@ GRANT EXECUTE ON FUNCTION discordsh.service_leaderboard(SMALLINT, INT) TO servic
 ALTER FUNCTION discordsh.service_leaderboard(SMALLINT, INT) OWNER TO service_role;
 
 -- ===========================================
+-- SERVICE FUNCTION: Permadeath profile delete
+--
+-- Wipes a Discord user's dungeon profile when their character dies in
+-- the Downed-state grace window. dungeon_runs rows for this Discord ID
+-- are also removed via the existing ON DELETE CASCADE foreign key on
+-- dungeon_runs.discord_id — full erasure, matching the "1 character per
+-- Discord user, perma-dead = never existed" design contract.
+--
+-- Schema-qualifies pg_catalog.pg_advisory_xact_lock because the function
+-- runs as SECURITY DEFINER with search_path = ''.
+-- ===========================================
+
+CREATE OR REPLACE FUNCTION discordsh.service_delete_profile(
+    p_discord_id BIGINT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_deleted BIGINT;
+BEGIN
+    IF p_discord_id IS NULL THEN
+        RAISE EXCEPTION 'discord_id cannot be null'
+            USING ERRCODE = '22004';
+    END IF;
+
+    PERFORM pg_catalog.pg_advisory_xact_lock(p_discord_id);
+
+    DELETE FROM discordsh.dungeon_profiles
+    WHERE discord_id = p_discord_id;
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+    RETURN v_deleted;
+END;
+$$;
+
+COMMENT ON FUNCTION discordsh.service_delete_profile(BIGINT) IS
+    'Permadeath wipe — deletes one dungeon profile by Discord snowflake. Returns row count: 1 if deleted, 0 if absent. dungeon_runs rows for this Discord ID are also removed via ON DELETE CASCADE (full erasure, by design).';
+
+REVOKE ALL ON FUNCTION discordsh.service_delete_profile(BIGINT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION discordsh.service_delete_profile(BIGINT) FROM anon;
+REVOKE ALL ON FUNCTION discordsh.service_delete_profile(BIGINT) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION discordsh.service_delete_profile(BIGINT) TO service_role;
+
+ALTER FUNCTION discordsh.service_delete_profile(BIGINT) OWNER TO service_role;
+
+-- ===========================================
 -- SERVICE FUNCTION: Load profile by Supabase auth UUID
 --
 -- Used by the isometric game to load a profile via JWT.
@@ -992,6 +1043,7 @@ BEGIN
     PERFORM 'discordsh.service_load_profile(bigint)'::regprocedure;
     PERFORM 'discordsh.service_upsert_profile(bigint, text, smallint, smallint, int, int, int, int, int, int, int, int, int, int, text, text, jsonb, text[], jsonb, jsonb, smallint, int, int, int, int, int, int, smallint, int)'::regprocedure;
     PERFORM 'discordsh.service_leaderboard(smallint, int)'::regprocedure;
+    PERFORM 'discordsh.service_delete_profile(bigint)'::regprocedure;
     PERFORM 'discordsh.service_load_profile_by_auth(uuid)'::regprocedure;
     PERFORM 'discordsh.service_link_auth(bigint, uuid)'::regprocedure;
     PERFORM 'discordsh.service_claim_mode(bigint, text, text, boolean)'::regprocedure;
@@ -1061,6 +1113,14 @@ BEGIN
 
     IF has_function_privilege('authenticated', 'discordsh.service_leaderboard(smallint, int)', 'EXECUTE') THEN
         RAISE EXCEPTION 'authenticated must NOT have execute on discordsh.service_leaderboard';
+    END IF;
+
+    IF has_function_privilege('anon', 'discordsh.service_delete_profile(bigint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'anon must NOT have execute on discordsh.service_delete_profile';
+    END IF;
+
+    IF has_function_privilege('authenticated', 'discordsh.service_delete_profile(bigint)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on discordsh.service_delete_profile';
     END IF;
 
     -- Verify ownership of all functions


### PR DESCRIPTION
PR B of the dungeon roguelite redesign — closes the destructive half queued in #10729. Downed players now carry a turn budget; when it runs out the character is permanently killed and the profile (plus its \`dungeon_runs\` history via \`ON DELETE CASCADE\`) is wiped from Supabase + the redb L2 cache. Next \`/dungeon start\` for that user falls into the class-picker path.

## Schema
New migration \`packages/data/sql/dbmate/migrations/20260509190000_discordsh_dungeon_permadeath.sql\` + matching change in the \`schema/discordsh\` mirror.

\`\`\`sql
discordsh.service_delete_profile(p_discord_id BIGINT) -> BIGINT
\`\`\`

- SECURITY DEFINER with \`search_path = ''\`
- Schema-qualified \`pg_catalog.pg_advisory_xact_lock(p_discord_id)\` so this delete serialises against the same per-Discord-ID lock that \`service_upsert_profile\` / \`service_claim_mode\` / \`service_release_mode\` already use
- NULL guard on \`p_discord_id\` (ERRCODE \`22004\`)
- Returns row count (1 if deleted, 0 if absent)
- \`REVOKE ALL\` from \`PUBLIC\` / \`anon\` / \`authenticated\`; \`GRANT EXECUTE\` to \`service_role\`; OWNER \`service_role\`
- \`dungeon_runs\` rows for the same Discord ID are removed via the existing \`ON DELETE CASCADE\` FK (full erasure by design — matches "1 character per Discord user, perma-dead = never existed")
- Schema mirror's verification block picks up the new function + asserts \`anon\` / \`authenticated\` still can't execute it.

## Bot
- \`PlayerState.downed_at_turn: Option<u32>\` (\`#[serde(default)]\`, skip-if-none). Stamped on the first alive-to-Downed transition only; re-hits don't reset the timer.
- \`PERMADEATH_TURN_BUDGET = 30\` player actions.
- \`tick_permadeath_timer\` runs at the end of every \`apply_action\` (right after \`session.turn += 1\`). For each player still alive AND downed it checks \`session.turn - downed_at_turn >= 30\` and flips \`alive = false\` with a \`"X bleeds out — character lost (permadeath)"\` log line. If the tick leaves no actor able to play the session transitions to \`GameOver(Defeated)\`.
- New \`ProfileStore::permadeath_async(discord_id)\` — fire-and-forget delete of the redb cache row + \`service_delete_profile\` Supabase RPC. The in-mem LRU is evicted by the existing \`invalidate\` sweep in \`save_all_players\`.
- \`save_all_players\` now routes per-player: if the run reason is \`Defeated\` AND the player is no longer alive, permadeath fires instead of the normal upsert. Other outcomes (\`Victory\` / \`Escaped\` / \`Expired\`) keep the existing save path — \`Expired\`-with-downed is a separate, less-final outcome.

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy --no-deps\` clean on edited regions (66 pre-existing warnings, none new)
- [x] \`cargo test --bin discordsh-bot\` — 713/713 (710 baseline + 3 new permadeath timer tests: within-budget no-op, at-budget kill, skip-already-dead)
- [ ] dbmate migration applies cleanly against staging Supabase
- [ ] Smoke in staging:
  - Solo player goes Downed in combat → all_players_dead fires → \`GameOver(Defeated)\` → next \`/dungeon start\` shows class picker (profile gone)
  - Party player goes Downed mid-explore, allies don't reach city in 30 actions → permadeath log + alive=false → on session-end save path Defeated routes to permadeath, profile wiped
  - Party allies DO reach city before 30 actions → downed player auto-revived, profile preserved with normal save

## Followups (not in this PR)
- 24-hour wall-clock timer alongside the 30-turn budget. Useful only with SessionState resume (Phase 3 followup from #10601), otherwise it just freezes when sessions end.
- Party carry / drag-body mechanic. Currently the shared session position implicitly carries downed party members; explicit carry would only matter once we let downed players desync from the leader.