### PR TITLE
fix(discordsh): cap embed action rows at 5; clearer non-owner item error

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/logic.rs
@@ -1801,9 +1801,16 @@ fn apply_item(
     target_idx: Option<u8>,
 ) -> Result<String, String> {
     {
+        let is_owner = session.owner == actor;
         let player = session.player_mut(actor);
         if !inv_contains(&player.inventory, item_id) {
-            return Err("You don't have that item.".to_owned());
+            if is_owner {
+                return Err("You don't have that item.".to_owned());
+            }
+            return Err(
+                "That item belongs to the session owner. Items shown in the shared dropdown are theirs — you can only use items from your own inventory."
+                    .to_owned(),
+            );
         }
         if inv_count(&player.inventory, item_id) == 0 {
             return Err("No more of that item remaining.".to_owned());

--- a/apps/discordsh/discordsh-bot/src/discord/game/render.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/game/render.rs
@@ -1080,6 +1080,16 @@ pub fn render_components(session: &SessionState) -> Vec<serenity::CreateActionRo
         rows.push(direction_buttons(session));
     }
 
+    if rows.len() > 5 {
+        tracing::warn!(
+            short_id = %session.short_id,
+            party_size = session.players.len(),
+            row_count = rows.len(),
+            "render_components produced > 5 rows; truncating to Discord limit"
+        );
+        rows.truncate(5);
+    }
+
     rows
 }
 
@@ -1267,6 +1277,54 @@ mod tests {
         let mut session = test_session();
         session.phase = GamePhase::City;
         assert_eq!(phase_color(&session), COLOR_CITY);
+    }
+
+    #[test]
+    fn render_components_never_exceeds_discord_row_limit() {
+        let mut session = test_session();
+        session.mode = SessionMode::Party;
+        session.phase = GamePhase::Combat;
+        session.enemies = (0..3)
+            .map(|i| EnemyState {
+                name: format!("Goblin {i}"),
+                level: 1,
+                hp: 10,
+                max_hp: 10,
+                armor: 0,
+                intent: Intent::Attack { dmg: 3 },
+                effects: Vec::new(),
+                charged: false,
+                loot_table_id: "",
+                npc_ref: "",
+                enraged: false,
+                index: i,
+                first_strike: false,
+                personality: Personality::Feral,
+            })
+            .collect();
+        for slot_id in 2u64..=4u64 {
+            let uid = serenity::UserId::new(slot_id);
+            session.party.push(uid);
+            let mut p = PlayerState::default();
+            p.class = if slot_id == 2 {
+                ClassType::Cleric
+            } else {
+                ClassType::Warrior
+            };
+            session.players.insert(uid, p);
+        }
+        session.show_items = true;
+        let owner_player = session.player_mut(OWNER);
+        owner_player.weapon = Some("worn-longsword".to_owned());
+        owner_player.armor_gear = Some("battered-chainmail".to_owned());
+        owner_player.inventory = super::super::content::starting_inventory();
+
+        let components = render_components(&session);
+        assert!(
+            components.len() <= 5,
+            "render produced {} rows; Discord allows max 5",
+            components.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two field-reported bugs from session \`b6abbb64\` (turn 60, bot v0.1.11).

## Bug 1 — non-owners couldn't tell whose inventory they were clicking
Party joiners saw the owner's inventory in the shared item dropdown and got a vague \`"You don't have that item."\` error when they clicked it. No hint that the dropdown belongs to the owner.

**Fix**: \`apply_item\` distinguishes owner vs joiner.
- Owner sees: \`"You don't have that item."\` (unchanged)
- Joiner sees: \`"That item belongs to the session owner. Items shown in the shared dropdown are theirs — you can only use items from your own inventory."\`

## Bug 2 — embed cracked when a 3rd player joined
Discord caps message components at **5 action rows**. Combat + party + Cleric heal + multi-enemy targeting + gear unequip can push past that, and Discord rejects the entire update so the embed never refreshes.

**Fix**: \`render_components\` truncates rows to 5 at the bottom of the function with a \`tracing::warn!\` pointing at the session short_id + party size when it fires. The truncate is a safety net; ideally the conditional pushes upstream stay under cap on their own.

A regression test (\`render_components_never_exceeds_discord_row_limit\`) wires combat + 4-player party + Cleric + multi-enemy + \`show_items\` + owner gear and asserts the cap holds.

## What this PR does NOT do (queued)
Per-user ephemeral inventory + gear dropdowns. The shared embed still surfaces the owner's items only. Joiners can use items they own via \`apply_item\` (their click hits their own inventory because \`actor = clicker\`), but there's no UI to discover or select from their own inventory yet. Bigger UX overhaul; separate PR.

## Test plan
- [x] \`cargo test --bin discordsh-bot\` — 711/711 (710 baseline + 1 new regression test)
- [x] \`cargo clippy --no-deps\` clean on edited regions
- [ ] Smoke in staging: 4-player dungeon, Cleric in party, multi-enemy combat → embed renders, no Discord rejection