### PR TITLE
fix(firecracker-ctl): bump net-deployment manifest in lockstep

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.142",
+			"version": "1.0.143",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -96,7 +96,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.12",
+			"version": "0.1.13",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -124,7 +124,7 @@
 		{
 			"key": "firecracker_ctl",
 			"app_name": "firecracker-ctl",
-			"version": "0.1.29",
+			"version": "0.1.30",
 			"version_toml": "apps/vm/firecracker-ctl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx",
 			"version_target": "apps/vm/firecracker-ctl/Cargo.toml",
@@ -132,6 +132,9 @@
 			"runner": "arc-runner-set",
 			"image": "kbve/firecracker-ctl",
 			"deployment_yaml": "apps/kube/firecracker/manifests/firecracker-deployment.yaml",
+			"deployment_yamls": [
+				"apps/kube/firecracker/manifests/firecracker-net-deployment.yaml"
+			],
 			"has_test": false
 		},
 		{
@@ -177,7 +180,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.13",
+			"version": "0.1.14",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,13 +12,15 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.29"
+version: "0.1.30"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml
 runner: arc-runner-set
 image: kbve/firecracker-ctl
 deployment_yaml: apps/kube/firecracker/manifests/firecracker-deployment.yaml
+deployment_yamls:
+    - apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
 has_test: false
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
## Summary

PR #10759 added the \`network=true\` code path to the firecracker-ctl binary, but the v0.1.29 publish only rolled the **public sandbox** deployment. The **networked** deployment kept running \`:0.1.28\`. The dashboard's Network (VPN) checkbox routes to the networked pod, which still ignores the \`network\` field — smoke test still timed out.

## Cause

\`firecracker-ctl.mdx\` only listed the public-sandbox manifest in \`deployment_yaml\` (singular). \`utils-post-publish.yml\`'s sed iterates \`{deployment_yaml, deployment_yamls}\` (after PR #10745), so the net manifest was never patched at publish time.

## Fix

Add \`firecracker-net-deployment.yaml\` to \`deployment_yamls\` so the next publish (v0.1.30) sed-bumps both manifests in the same atom PR.

\`\`\`mdx
deployment_yaml: apps/kube/firecracker/manifests/firecracker-deployment.yaml
deployment_yamls:
    - apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
\`\`\`

Bump version 0.1.29 → 0.1.30 to trigger the publish (current 0.1.29 already matches version.toml after the previous post-publish, so without a bump the next CI run would skip publishing).

## Test plan

- [ ] CI Docker publishes \`ghcr.io/kbve/firecracker-ctl:0.1.30\`.
- [ ] \`utils-post-publish.yml\` opens an atom PR that updates **both** \`firecracker-deployment.yaml\` and \`firecracker-net-deployment.yaml\` from \`:0.1.29\` → \`:0.1.30\`.
- [ ] After atom PR merges, ArgoCD reconciles both deployments. Both pods come up on \`:0.1.30\`.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB example → poem prints, exit 0.