### PR TITLE
fix(ci): bot validator allows deployment_yamls (plural) entries

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -222,6 +222,7 @@ jobs:
                             entry.version_toml,
                             entry.version_target,
                             entry.deployment_yaml,
+                            ...(Array.isArray(entry.deployment_yamls) ? entry.deployment_yamls : []),
                             '.github/ci-dispatch-manifest.json',
                           ]
                             .filter(Boolean)


### PR DESCRIPTION
## Summary

\`ci-auto-merge-bot-prs.yml\`'s **Validate PR against manifest** step built \`allowedFiles\` from \`{version_toml, version_target, deployment_yaml, ci-dispatch-manifest.json}\` only. The plural \`deployment_yamls\` array (introduced for multi-pin apps) was ignored — atom post-publish PRs that bumped a second manifest were rejected:

\`\`\`
PR modifies files not in manifest for 'firecracker-ctl': apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
\`\`\`

Run that hit it: https://github.com/KBVE/kbve/actions/runs/25629606411

## Fix

Spread \`entry.deployment_yamls\` into \`allowedFiles\` when present, mirroring the iteration that \`utils-post-publish.yml\`'s sed step (and its git-add fix in #10745) already does.

\`\`\`js
const allowedFiles = new Set(
  [
    entry.version_toml,
    entry.version_target,
    entry.deployment_yaml,
    ...(Array.isArray(entry.deployment_yamls) ? entry.deployment_yamls : []),
    '.github/ci-dispatch-manifest.json',
  ]
    .filter(Boolean)
    .map(sanitize)
);
\`\`\`

## Test plan

- [ ] After merge, re-run **Auto-merge bot PRs** against the next firecracker-ctl atom PR — validate step passes.
- [ ] No regression for apps using only \`deployment_yaml\` (singular) — \`Array.isArray(undefined)\` returns false, the spread is empty.