### PR TITLE
fix(firecracker-ctl): enable persistent on net deployment + bypass jailer for network=true

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.143",
+			"version": "1.0.144",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -124,7 +124,7 @@
 		{
 			"key": "firecracker_ctl",
 			"app_name": "firecracker-ctl",
-			"version": "0.1.30",
+			"version": "0.1.31",
 			"version_toml": "apps/vm/firecracker-ctl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx",
 			"version_target": "apps/vm/firecracker-ctl/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.30"
+version: "0.1.31"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -134,6 +134,8 @@ spec:
                         value: '10001'
                       - name: FC_JAILER_GID
                         value: '10001'
+                      - name: FC_PERSISTENT_ENDPOINTS_ENABLED
+                        value: 'true'
                   securityContext:
                       # jailer pivot_root requires Unconfined seccomp.
                       seccompProfile:

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -1121,47 +1121,35 @@ async fn run_vm_lifecycle(
         None => format!("{} fc_entrypoint={}", req.boot_args, req.entrypoint),
     };
 
-    let spawn_result = if let Some(ref jailer_cfg) = jailer {
-        if network_lease.is_some() {
-            if let Some(lease) = network_lease {
-                let _ = lease.persistent.tap_manager.destroy_tap(&lease.tap).await;
-                lease.persistent.pool.release(&lease.allocation);
-            }
-            set_vm_failed(
-                &vms,
+    let spawn_result = match (jailer.as_ref(), network_lease) {
+        (Some(jailer_cfg), None) => {
+            spawn_jailed(
+                jailer_cfg,
                 &vm_id,
-                start,
-                -1,
-                "".into(),
-                "network=true is not supported in jailed mode".into(),
-            );
-            return;
+                &rootfs_path,
+                &rootfs_dir,
+                &code_buf,
+                &boot_args,
+                &req,
+                pkg_buf.as_deref(),
+                pkg_cache_path.as_deref(),
+            )
+            .await
         }
-        spawn_jailed(
-            jailer_cfg,
-            &vm_id,
-            &rootfs_path,
-            &rootfs_dir,
-            &code_buf,
-            &boot_args,
-            &req,
-            pkg_buf.as_deref(),
-            pkg_cache_path.as_deref(),
-        )
-        .await
-    } else {
-        spawn_direct(
-            &vm_id,
-            &rootfs_path,
-            &rootfs_dir,
-            &code_buf,
-            &boot_args,
-            &req,
-            pkg_buf.as_deref(),
-            pkg_cache_path.as_deref(),
-            network_lease,
-        )
-        .await
+        (_, lease) => {
+            spawn_direct(
+                &vm_id,
+                &rootfs_path,
+                &rootfs_dir,
+                &code_buf,
+                &boot_args,
+                &req,
+                pkg_buf.as_deref(),
+                pkg_cache_path.as_deref(),
+                lease,
+            )
+            .await
+        }
     };
 
     let (mut child, cleanup) = match spawn_result {


### PR DESCRIPTION
## Summary

After v0.1.30 deployed, the dashboard's Network (VPN) checkbox returned:

\`\`\`
Firecracker API 400: {\"error\":\"network=true requires the networked deployment (firecracker-ctl-net)\",\"hint\":\"set FC_PERSISTENT_ENDPOINTS_ENABLED=true and run as firecracker-ctl-net\"}
\`\`\`

Two stacked causes uncovered by the new \`network=true\` path on \`/vm/create\`:

### 1. Net deployment never set \`FC_PERSISTENT_ENDPOINTS_ENABLED=true\`

\`AppState.persistent\` was \`None\` on the networked pod, so the new validator rejected any \`network=true\` request. The same env was missing on \`/fc/deploy\`'s pod too — that handler was simply the only thing that depended on \`persistent\` and the gap had not been exercised since persistent endpoints have not been deployed in production yet.

### 2. Net pod runs with \`FC_USE_JAILER=true\`

\`run_vm_lifecycle\`'s spawn dispatch picked \`spawn_jailed\` whenever jailer was configured. v0.1.30 added a hard rejection when a network lease was paired with jailed mode (jailer's chroot would shadow the TAP). \`/fc/deploy\` already bypasses the jailer (\`spawn_persistent\` calls firecracker directly), so \`network=true\` should follow the same pattern.

## Changes

| File | Change |
|------|--------|
| \`apps/kube/firecracker/manifests/firecracker-net-deployment.yaml\` | Add \`FC_PERSISTENT_ENDPOINTS_ENABLED=true\` env. Public sandbox unchanged. |
| \`apps/vm/firecracker-ctl/src/main.rs\` | Replace if/else dispatch with \`match (jailer.as_ref(), network_lease)\`. Jailer only fires when there is no network lease; any network request takes \`spawn_direct\` with the lease, regardless of \`FC_USE_JAILER\`. Mirrors how \`/fc/deploy\` bypasses the jailer for TAP-attached VMs. |
| \`apps/kbve/astro-kbve/.../firecracker-ctl.mdx\` | \`version: 0.1.30\` → \`0.1.31\` to trigger a fresh publish. |
| \`.github/ci-dispatch-manifest.json\` | Regenerated. |

## Test plan

- [ ] Publish lands \`ghcr.io/kbve/firecracker-ctl:0.1.31\`.
- [ ] Atom PR (#10745 fix consumed by #10770) bumps **both** \`firecracker-deployment.yaml\` and \`firecracker-net-deployment.yaml\` to \`:0.1.31\`. The bot validator (#10776) accepts the multi-file change.
- [ ] After ArgoCD reconciles, \`kubectl exec -n firecracker firecracker-ctl-net-... env\` shows \`FC_PERSISTENT_ENDPOINTS_ENABLED=true\`.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.
- [ ] Dashboard IDE: Python Quick *without* Network (VPN) on the public sandbox → unchanged behavior (\`spawn_jailed\` still picked, \`alpine-python\` rootfs, no eth0).