### PR TITLE
feat(mc): expose mc schema via PostgREST + lock proxy_* to service_role

### DIFF
--- a/apps/kube/postgrest/manifests/postgrest-deployment.yaml
+++ b/apps/kube/postgrest/manifests/postgrest-deployment.yaml
@@ -34,8 +34,15 @@ spec:
                                 key: PGRST_DB_URI
 
                       # PostgREST configuration
+                      # `mc` is exposed so the Minecraft mod can call
+                      # mc.service_* via Content-Profile/Accept-Profile,
+                      # but every mc.* function is locked down at the
+                      # GRANT level (service_role only on mc.service_*,
+                      # service_role only on mc.proxy_* — browsers reach
+                      # mc.proxy_* through public.proxy_* SECURITY DEFINER
+                      # wrappers). See mc_lockdown_proxy_grants migration.
                       - name: PGRST_DB_SCHEMAS
-                        value: 'public,storage,graphql_public,tracker,profile,rentearth,meme,discordsh,forum'
+                        value: 'public,storage,graphql_public,tracker,profile,rentearth,meme,discordsh,forum,mc'
                       - name: PGRST_DB_ANON_ROLE
                         value: 'anon'
                       - name: PGRST_DB_USE_LEGACY_GUCS

--- a/packages/data/sql/dbmate/migrations/20260510145108_mc_lockdown_proxy_grants.sql
+++ b/packages/data/sql/dbmate/migrations/20260510145108_mc_lockdown_proxy_grants.sql
@@ -1,0 +1,29 @@
+-- migrate:up
+
+-- Lock down direct PostgREST access to mc.proxy_* now that the `mc` schema
+-- is exposed via PGRST_DB_SCHEMAS. Browsers reach mc.proxy_* exclusively
+-- through public.proxy_* SECURITY DEFINER wrappers (owner = service_role,
+-- so the inner mc.* call runs with service_role privileges regardless of
+-- the caller's role). Pulling EXECUTE from `authenticated` keeps the schema
+-- routable for the Minecraft mod (service_role over Content-Profile: mc)
+-- while preventing user-token clients from bypassing the public wrappers.
+
+REVOKE EXECUTE ON FUNCTION mc.proxy_request_link(TEXT)  FROM authenticated;
+REVOKE EXECUTE ON FUNCTION mc.proxy_get_link_status()   FROM authenticated;
+REVOKE EXECUTE ON FUNCTION mc.proxy_unlink()            FROM authenticated;
+
+-- service_role retains EXECUTE — explicit re-grant for clarity.
+GRANT  EXECUTE ON FUNCTION mc.proxy_request_link(TEXT)  TO service_role;
+GRANT  EXECUTE ON FUNCTION mc.proxy_get_link_status()   TO service_role;
+GRANT  EXECUTE ON FUNCTION mc.proxy_unlink()            TO service_role;
+
+-- mc.service_* functions are already service_role-only; no change needed.
+
+-- migrate:down
+
+-- Restore prior grants so the proxy RPCs are callable by authenticated tokens
+-- directly (matches the state before the public wrappers landed).
+
+GRANT EXECUTE ON FUNCTION mc.proxy_request_link(TEXT)  TO authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_get_link_status()   TO authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_unlink()            TO authenticated;

--- a/packages/data/sql/schema/mc/mc.sql
+++ b/packages/data/sql/schema/mc/mc.sql
@@ -458,9 +458,9 @@ END;
 $$;
 
 REVOKE ALL ON FUNCTION mc.proxy_request_link(TEXT)
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION mc.proxy_request_link(TEXT)
-    TO authenticated, service_role;
+    TO service_role;
 ALTER FUNCTION mc.proxy_request_link(TEXT) OWNER TO service_role;
 
 -- PROXY: Authenticated user checks own link status.
@@ -511,9 +511,9 @@ END;
 $$;
 
 REVOKE ALL ON FUNCTION mc.proxy_get_link_status()
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION mc.proxy_get_link_status()
-    TO authenticated, service_role;
+    TO service_role;
 ALTER FUNCTION mc.proxy_get_link_status() OWNER TO service_role;
 COMMENT ON FUNCTION mc.proxy_get_link_status() IS
     'Authenticated RPC. Returns the caller''s Minecraft link status including lockout/expiry/attempt counters for UI feedback. Never exposes the verification code hash.';
@@ -538,9 +538,9 @@ END;
 $$;
 
 REVOKE ALL ON FUNCTION mc.proxy_unlink()
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION mc.proxy_unlink()
-    TO authenticated, service_role;
+    TO service_role;
 ALTER FUNCTION mc.proxy_unlink() OWNER TO service_role;
 
 -- PUBLIC WRAPPERS — PostgREST exposes only public/etc.; mc.* is reached via
@@ -698,14 +698,25 @@ BEGIN
         RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_get_user_by_mc_uuid';
     END IF;
 
-    IF NOT has_function_privilege('authenticated', 'mc.proxy_request_link(text)', 'EXECUTE') THEN
-        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_request_link';
+    -- mc.proxy_* are now service_role-only; authenticated callers reach
+    -- the same logic through public.proxy_* SECURITY DEFINER wrappers.
+    IF has_function_privilege('authenticated', 'mc.proxy_request_link(text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.proxy_request_link';
     END IF;
-    IF NOT has_function_privilege('authenticated', 'mc.proxy_get_link_status()', 'EXECUTE') THEN
-        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_get_link_status';
+    IF has_function_privilege('authenticated', 'mc.proxy_get_link_status()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.proxy_get_link_status';
     END IF;
-    IF NOT has_function_privilege('authenticated', 'mc.proxy_unlink()', 'EXECUTE') THEN
-        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_unlink';
+    IF has_function_privilege('authenticated', 'mc.proxy_unlink()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.proxy_unlink';
+    END IF;
+    IF NOT has_function_privilege('authenticated', 'public.proxy_request_link(text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on public.proxy_request_link';
+    END IF;
+    IF NOT has_function_privilege('authenticated', 'public.proxy_get_link_status()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on public.proxy_get_link_status';
+    END IF;
+    IF NOT has_function_privilege('authenticated', 'public.proxy_unlink()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on public.proxy_unlink';
     END IF;
 
     IF EXISTS (SELECT 1 FROM pg_proc WHERE oid = 'mc.service_request_link(uuid, text)'::regprocedure AND pg_get_userbyid(proowner) <> 'service_role') THEN

--- a/packages/data/sql/schema/mc/mc_auth.sql
+++ b/packages/data/sql/schema/mc/mc_auth.sql
@@ -558,10 +558,12 @@ BEGIN
 END;
 $$;
 
+-- Direct PostgREST access locked to service_role; authenticated callers use
+-- public.proxy_request_link (SECURITY DEFINER) which delegates to this.
 REVOKE ALL ON FUNCTION mc.proxy_request_link(TEXT)
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION mc.proxy_request_link(TEXT)
-    TO authenticated, service_role;
+    TO service_role;
 ALTER FUNCTION mc.proxy_request_link(TEXT) OWNER TO service_role;
 
 -- ===========================================
@@ -617,10 +619,12 @@ BEGIN
 END;
 $$;
 
+-- Direct PostgREST access locked to service_role; authenticated callers use
+-- public.proxy_get_link_status (SECURITY DEFINER) which delegates to this.
 REVOKE ALL ON FUNCTION mc.proxy_get_link_status()
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION mc.proxy_get_link_status()
-    TO authenticated, service_role;
+    TO service_role;
 ALTER FUNCTION mc.proxy_get_link_status() OWNER TO service_role;
 COMMENT ON FUNCTION mc.proxy_get_link_status() IS
     'Authenticated RPC. Returns the caller''s Minecraft link status including lockout/expiry/attempt counters for UI feedback. Never exposes the verification code hash.';
@@ -648,10 +652,12 @@ BEGIN
 END;
 $$;
 
+-- Direct PostgREST access locked to service_role; authenticated callers use
+-- public.proxy_unlink (SECURITY DEFINER) which delegates to this.
 REVOKE ALL ON FUNCTION mc.proxy_unlink()
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION mc.proxy_unlink()
-    TO authenticated, service_role;
+    TO service_role;
 ALTER FUNCTION mc.proxy_unlink() OWNER TO service_role;
 
 -- ===========================================
@@ -896,17 +902,28 @@ BEGIN
         RAISE EXCEPTION 'authenticated must NOT have execute on mc.service_get_user_by_mc_uuid';
     END IF;
 
-    -- Verify proxy functions are callable by authenticated
-    IF NOT has_function_privilege('authenticated', 'mc.proxy_request_link(text)', 'EXECUTE') THEN
-        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_request_link';
+    -- mc.proxy_* are now service_role-only at the GRANT level. Authenticated
+    -- callers reach the same logic through the public.proxy_* SECURITY DEFINER
+    -- wrappers; verify the wrappers are callable by authenticated and the
+    -- underlying mc.proxy_* are NOT callable by authenticated.
+    IF has_function_privilege('authenticated', 'mc.proxy_request_link(text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.proxy_request_link';
+    END IF;
+    IF has_function_privilege('authenticated', 'mc.proxy_get_link_status()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.proxy_get_link_status';
+    END IF;
+    IF has_function_privilege('authenticated', 'mc.proxy_unlink()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must NOT have execute on mc.proxy_unlink';
     END IF;
 
-    IF NOT has_function_privilege('authenticated', 'mc.proxy_get_link_status()', 'EXECUTE') THEN
-        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_get_link_status';
+    IF NOT has_function_privilege('authenticated', 'public.proxy_request_link(text)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on public.proxy_request_link';
     END IF;
-
-    IF NOT has_function_privilege('authenticated', 'mc.proxy_unlink()', 'EXECUTE') THEN
-        RAISE EXCEPTION 'authenticated must have execute on mc.proxy_unlink';
+    IF NOT has_function_privilege('authenticated', 'public.proxy_get_link_status()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on public.proxy_get_link_status';
+    END IF;
+    IF NOT has_function_privilege('authenticated', 'public.proxy_unlink()', 'EXECUTE') THEN
+        RAISE EXCEPTION 'authenticated must have execute on public.proxy_unlink';
     END IF;
 
     -- Verify ALL function ownership is service_role


### PR DESCRIPTION
## Summary

Two-part change so the Minecraft mod ([apps/mc/mc_auth](apps/mc/mc_auth/)) can keep calling `mc.service_verify_link` / `mc.service_get_user_by_mc_uuid` over `Content-Profile: mc`, while we narrow direct access to the rest of the `mc.*` surface.

- **Postgrest**: add `mc` to `PGRST_DB_SCHEMAS` in [postgrest-deployment.yaml](apps/kube/postgrest/manifests/postgrest-deployment.yaml). Without it, profile routing 404s — same failure mode the browser had before the public wrappers landed.
- **Migration**: new [20260510145108_mc_lockdown_proxy_grants.sql](packages/data/sql/dbmate/migrations/20260510145108_mc_lockdown_proxy_grants.sql) revokes EXECUTE on `mc.proxy_request_link` / `proxy_get_link_status` / `proxy_unlink` from `authenticated`. Browsers still reach those code paths via the `public.proxy_*` SECURITY DEFINER wrappers (owner = `service_role`), so the inner `mc.proxy_*` call runs with `service_role` privileges regardless of the caller's role. `mc.service_*` was already `service_role`-only.

Net access matrix after this lands:

| Caller            | `public.proxy_*`     | `mc.proxy_*` (direct) | `mc.service_*` (direct, profile header) |
|-------------------|----------------------|-----------------------|------------------------------------------|
| anon              | denied               | denied                | denied                                   |
| authenticated     | **allowed**          | denied                | denied                                   |
| service_role      | allowed              | allowed               | **allowed** (mod path)                   |

## Test plan

- [x] Local grant matrix matches the table above (verified against dev-docker postgres)
- [x] `public.proxy_*` SECURITY-DEFINER through to `mc.proxy_*` even after the revoke (owner = service_role)
- [x] mc.service_* unchanged — still service_role-only
- [ ] PostgREST pod picks up new `PGRST_DB_SCHEMAS` after ArgoCD sync
- [ ] `ci-dbmate-deploy` workflow_dispatch on `main` after merge
- [ ] Minecraft mod `/link <code>` end-to-end against prod once both land

## Notes

- ArgoCD-managed postgrest deployment ([application.yaml](apps/kube/postgrest/application.yaml)); env change triggers pod restart on next sync.
- Down migration restores prior `authenticated` grants on `mc.proxy_*` for symmetry.
- Reference SQL in `packages/data/sql/schema/mc/` updated in lockstep, including the verification block which now asserts the new grant shape.