### PR TITLE
feat(auth,irc-gateway): provider username strict + GoTrue access-token hook

### DIFF
--- a/apps/irc/irc-gateway/src/auth/jwt.rs
+++ b/apps/irc/irc-gateway/src/auth/jwt.rs
@@ -32,6 +32,8 @@ pub struct Claims {
     #[serde(default)]
     pub aud: Option<String>,
     #[serde(default)]
+    pub kbve_username: Option<String>,
+    #[serde(default)]
     pub user_metadata: UserMetadata,
     pub exp: u64,
     pub iat: u64,
@@ -40,6 +42,7 @@ pub struct Claims {
 impl Claims {
     pub fn irc_nick(&self) -> Option<String> {
         let candidates = [
+            self.kbve_username.as_deref(),
             self.user_metadata.preferred_username.as_deref(),
             self.user_metadata.user_name.as_deref(),
             self.user_metadata.nickname.as_deref(),
@@ -148,6 +151,7 @@ mod tests {
             email: Some(format!("{sub}@example.com")),
             role: Some("authenticated".to_string()),
             aud: aud.map(String::from),
+            kbve_username: None,
             user_metadata: UserMetadata::default(),
             exp,
             iat,
@@ -313,10 +317,40 @@ mod tests {
             email: email.map(String::from),
             role: Some("authenticated".to_string()),
             aud: Some(SUPABASE_AUDIENCE.to_string()),
+            kbve_username: None,
             user_metadata: meta,
             exp: 0,
             iat: 0,
         }
+    }
+
+    #[test]
+    fn irc_nick_prefers_kbve_username() {
+        let mut c = claims_with_metadata(
+            "uuid-kbve",
+            Some("admin@kbve.com"),
+            UserMetadata {
+                preferred_username: Some("provider_name".to_string()),
+                user_name: Some("provider_alt".to_string()),
+                ..Default::default()
+            },
+        );
+        c.kbve_username = Some("h0lybyte".to_string());
+        assert_eq!(c.irc_nick().as_deref(), Some("h0lybyte"));
+    }
+
+    #[test]
+    fn irc_nick_skips_empty_kbve_username() {
+        let mut c = claims_with_metadata(
+            "uuid-kbve-empty",
+            None,
+            UserMetadata {
+                preferred_username: Some("h0lybyte".to_string()),
+                ..Default::default()
+            },
+        );
+        c.kbve_username = Some("!!!".to_string());
+        assert_eq!(c.irc_nick().as_deref(), Some("h0lybyte"));
     }
 
     #[test]

--- a/apps/irc/irc-gateway/src/auth/jwt.rs
+++ b/apps/irc/irc-gateway/src/auth/jwt.rs
@@ -8,6 +8,19 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
 
 pub const SUPABASE_AUDIENCE: &str = "authenticated";
+pub const MAX_NICK_LEN: usize = 16;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UserMetadata {
+    #[serde(default)]
+    pub preferred_username: Option<String>,
+    #[serde(default)]
+    pub user_name: Option<String>,
+    #[serde(default)]
+    pub nickname: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claims {
@@ -18,8 +31,39 @@ pub struct Claims {
     pub role: Option<String>,
     #[serde(default)]
     pub aud: Option<String>,
+    #[serde(default)]
+    pub user_metadata: UserMetadata,
     pub exp: u64,
     pub iat: u64,
+}
+
+impl Claims {
+    pub fn irc_nick(&self) -> Option<String> {
+        let candidates = [
+            self.user_metadata.preferred_username.as_deref(),
+            self.user_metadata.user_name.as_deref(),
+            self.user_metadata.nickname.as_deref(),
+        ];
+
+        candidates
+            .into_iter()
+            .flatten()
+            .map(sanitize_nick)
+            .find(|n| !n.is_empty())
+    }
+}
+
+fn sanitize_nick(raw: &str) -> String {
+    let mut nick: String = raw
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .take(MAX_NICK_LEN)
+        .collect();
+    if nick.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        nick.insert(0, '_');
+        nick.truncate(MAX_NICK_LEN);
+    }
+    nick
 }
 
 /// Extract JWT from Authorization header or query param
@@ -104,6 +148,7 @@ mod tests {
             email: Some(format!("{sub}@example.com")),
             role: Some("authenticated".to_string()),
             aud: aud.map(String::from),
+            user_metadata: UserMetadata::default(),
             exp,
             iat,
         };
@@ -260,5 +305,113 @@ mod tests {
             StatusCode::UNAUTHORIZED,
         );
         std::env::remove_var("JWT_SECRET");
+    }
+
+    fn claims_with_metadata(sub: &str, email: Option<&str>, meta: UserMetadata) -> Claims {
+        Claims {
+            sub: sub.to_string(),
+            email: email.map(String::from),
+            role: Some("authenticated".to_string()),
+            aud: Some(SUPABASE_AUDIENCE.to_string()),
+            user_metadata: meta,
+            exp: 0,
+            iat: 0,
+        }
+    }
+
+    #[test]
+    fn irc_nick_prefers_preferred_username() {
+        let meta = UserMetadata {
+            preferred_username: Some("h0lybyte".to_string()),
+            user_name: Some("ignored".to_string()),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-1", Some("admin@kbve.com"), meta);
+        assert_eq!(c.irc_nick().as_deref(), Some("h0lybyte"));
+    }
+
+    #[test]
+    fn irc_nick_falls_back_to_user_name() {
+        let meta = UserMetadata {
+            user_name: Some("h0lybyte".to_string()),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-2", Some("admin@kbve.com"), meta);
+        assert_eq!(c.irc_nick().as_deref(), Some("h0lybyte"));
+    }
+
+    #[test]
+    fn irc_nick_falls_back_to_nickname() {
+        let meta = UserMetadata {
+            nickname: Some("KBVE".to_string()),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-3", Some("admin@kbve.com"), meta);
+        assert_eq!(c.irc_nick().as_deref(), Some("KBVE"));
+    }
+
+    #[test]
+    fn irc_nick_returns_none_when_no_provider_username() {
+        let c = claims_with_metadata("uuid-4", Some("admin@kbve.com"), UserMetadata::default());
+        assert_eq!(c.irc_nick(), None);
+    }
+
+    #[test]
+    fn irc_nick_returns_none_when_email_only() {
+        let c = claims_with_metadata("uuid-5", Some("admin@kbve.com"), UserMetadata::default());
+        assert_eq!(c.irc_nick(), None);
+    }
+
+    #[test]
+    fn irc_nick_strips_disallowed_chars() {
+        let meta = UserMetadata {
+            preferred_username: Some("h0ly!byte@123".to_string()),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-6", None, meta);
+        assert_eq!(c.irc_nick().as_deref(), Some("h0lybyte123"));
+    }
+
+    #[test]
+    fn irc_nick_truncates_to_max_len() {
+        let meta = UserMetadata {
+            preferred_username: Some("a".repeat(64)),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-7", None, meta);
+        assert_eq!(c.irc_nick().unwrap().len(), MAX_NICK_LEN);
+    }
+
+    #[test]
+    fn irc_nick_prefixes_leading_digit() {
+        let meta = UserMetadata {
+            preferred_username: Some("0xCafe".to_string()),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-8", None, meta);
+        assert!(c.irc_nick().unwrap().starts_with('_'));
+    }
+
+    #[test]
+    fn irc_nick_skips_empty_candidates() {
+        let meta = UserMetadata {
+            preferred_username: Some("!!!".to_string()),
+            user_name: Some("h0lybyte".to_string()),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-9", None, meta);
+        assert_eq!(c.irc_nick().as_deref(), Some("h0lybyte"));
+    }
+
+    #[test]
+    fn irc_nick_returns_none_when_all_candidates_sanitize_empty() {
+        let meta = UserMetadata {
+            preferred_username: Some("!!!".to_string()),
+            user_name: Some("@@@".to_string()),
+            nickname: Some("###".to_string()),
+            ..Default::default()
+        };
+        let c = claims_with_metadata("uuid-10", Some("admin@kbve.com"), meta);
+        assert_eq!(c.irc_nick(), None);
     }
 }

--- a/apps/irc/irc-gateway/src/gateway/irc.rs
+++ b/apps/irc/irc-gateway/src/gateway/irc.rs
@@ -45,7 +45,9 @@ async fn handle_irc_client(client: TcpStream, peer: SocketAddr) -> Result<()> {
         Some(t) => t.to_string(),
         None => {
             writer
-                .write_all(b":irc-gateway NOTICE * :Authentication required. Send PASS jwt:<token>\r\n")
+                .write_all(
+                    b":irc-gateway NOTICE * :Authentication required. Send PASS jwt:<token>\r\n",
+                )
                 .await?;
             return Ok(());
         }
@@ -61,13 +63,15 @@ async fn handle_irc_client(client: TcpStream, peer: SocketAddr) -> Result<()> {
         }
     };
 
-    let username = claims.email
-        .as_deref()
-        .unwrap_or(&claims.sub)
-        .chars()
-        .filter(|c| c.is_alphanumeric() || *c == '_')
-        .take(32)
-        .collect::<String>();
+    let username = match claims.irc_nick() {
+        Some(n) => n,
+        None => {
+            writer
+                .write_all(b":irc-gateway NOTICE * :No provider username configured. Set one on your OAuth provider before joining IRC.\r\n")
+                .await?;
+            return Ok(());
+        }
+    };
 
     info!(peer = %peer, user = %username, "IRC client authenticated");
 

--- a/apps/irc/irc-gateway/src/gateway/websocket.rs
+++ b/apps/irc/irc-gateway/src/gateway/websocket.rs
@@ -1,16 +1,17 @@
 use axum::{
-    extract::ws::{Message, WebSocket, WebSocketUpgrade},
     extract::Request,
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
     http::StatusCode,
     response::IntoResponse,
 };
 use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::connect_async;
-use tracing::{info, error};
+use tracing::{error, info, warn};
 
 use crate::auth::jwt;
 
-/// Handle WebSocket upgrade — validate JWT first, then proxy to Ergo
+const NO_USERNAME_MSG: &str = "No provider username configured. Set a username on your OAuth provider (Discord/GitHub/Twitch) before joining IRC.";
+
 pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse {
     let token = match jwt::extract_token(&req) {
         Some(t) => t,
@@ -22,13 +23,13 @@ pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse
         Err(status) => return status.into_response(),
     };
 
-    let username = claims.email
-        .as_deref()
-        .unwrap_or(&claims.sub)
-        .chars()
-        .filter(|c| c.is_alphanumeric() || *c == '_')
-        .take(32)
-        .collect::<String>();
+    let username = match claims.irc_nick() {
+        Some(n) => n,
+        None => {
+            warn!(sub = %claims.sub, "rejecting WS upgrade: no provider username");
+            return (StatusCode::FORBIDDEN, NO_USERNAME_MSG).into_response();
+        }
+    };
 
     info!(user = %username, "WebSocket upgrade accepted");
 
@@ -55,11 +56,21 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
     let nick_cmd = format!("NICK {username}\r\n");
     let user_cmd = format!("USER {username} 0 * :{username}\r\n");
 
-    if let Err(e) = ergo_sink.send(tokio_tungstenite::tungstenite::Message::Text(nick_cmd.into())).await {
+    if let Err(e) = ergo_sink
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            nick_cmd.into(),
+        ))
+        .await
+    {
         error!("Failed to send NICK to Ergo: {e}");
         return;
     }
-    if let Err(e) = ergo_sink.send(tokio_tungstenite::tungstenite::Message::Text(user_cmd.into())).await {
+    if let Err(e) = ergo_sink
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            user_cmd.into(),
+        ))
+        .await
+    {
         error!("Failed to send USER to Ergo: {e}");
         return;
     }
@@ -70,7 +81,9 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
     let client_to_ergo = async {
         while let Some(Ok(msg)) = client_stream.next().await {
             let ergo_msg = match msg {
-                Message::Text(t) => tokio_tungstenite::tungstenite::Message::Text(t.to_string().into()),
+                Message::Text(t) => {
+                    tokio_tungstenite::tungstenite::Message::Text(t.to_string().into())
+                }
                 Message::Binary(b) => tokio_tungstenite::tungstenite::Message::Binary(b.into()),
                 Message::Ping(p) => tokio_tungstenite::tungstenite::Message::Ping(p.into()),
                 Message::Pong(p) => tokio_tungstenite::tungstenite::Message::Pong(p.into()),
@@ -85,7 +98,9 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
     let ergo_to_client = async {
         while let Some(Ok(msg)) = ergo_stream.next().await {
             let client_msg = match msg {
-                tokio_tungstenite::tungstenite::Message::Text(t) => Message::Text(t.to_string().into()),
+                tokio_tungstenite::tungstenite::Message::Text(t) => {
+                    Message::Text(t.to_string().into())
+                }
                 tokio_tungstenite::tungstenite::Message::Binary(b) => Message::Binary(b.into()),
                 tokio_tungstenite::tungstenite::Message::Ping(p) => Message::Ping(p.into()),
                 tokio_tungstenite::tungstenite::Message::Pong(p) => Message::Pong(p.into()),

--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -130,6 +130,15 @@ spec:
                       - name: GOTRUE_EXTERNAL_TWITCH_REDIRECT_URI
                         value: 'https://supabase.kbve.com/auth/v1/callback'
 
+                      # Custom Access Token hook (Postgres-backed):
+                      # injects profile.username into the JWT as
+                      # kbve_username. See migration
+                      # 20260510210000_profile_custom_access_token_hook.sql.
+                      - name: GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED
+                        value: 'true'
+                      - name: GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI
+                        value: 'pg-functions://postgres/public/custom_access_token_hook'
+
                       # Secrets from Kubernetes
                       - name: GOTRUE_JWT_EXP
                         valueFrom:

--- a/packages/data/sql/dbmate/migrations/20260510210000_profile_custom_access_token_hook.sql
+++ b/packages/data/sql/dbmate/migrations/20260510210000_profile_custom_access_token_hook.sql
@@ -1,0 +1,132 @@
+-- migrate:up
+
+BEGIN;
+
+-- ============================================================
+-- GoTrue Custom Access Token Hook: inject profile username
+--
+-- GoTrue calls public.custom_access_token_hook(event jsonb) before
+-- signing a JWT (when GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED=true).
+-- We look up profile.username for the auth user_id and embed it into
+-- the JWT as a top-level claim "kbve_username". Downstream services
+-- (irc-gateway, etc.) can then read it without a DB round-trip.
+--
+-- The hook runs as supabase_auth_admin (function is SECURITY DEFINER,
+-- owned by that role). It needs:
+--   USAGE on schema public  (to resolve the function itself)
+--   USAGE on schema profile (to resolve profile.username)
+--   SELECT on profile.username
+--   An RLS policy permitting SELECT (the table is RLS-locked to
+--   service_role by default).
+-- ============================================================
+
+GRANT USAGE  ON SCHEMA   public           TO supabase_auth_admin;
+GRANT USAGE  ON SCHEMA   profile          TO supabase_auth_admin;
+GRANT SELECT ON TABLE    profile.username TO supabase_auth_admin;
+
+DROP POLICY IF EXISTS "supabase_auth_admin_select" ON profile.username;
+CREATE POLICY "supabase_auth_admin_select"
+    ON profile.username
+    AS PERMISSIVE
+    FOR SELECT
+    TO supabase_auth_admin
+    USING (true);
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_user_id  uuid;
+    v_username text;
+    v_claims   jsonb;
+BEGIN
+    BEGIN
+        v_user_id := NULLIF(event->>'user_id', '')::uuid;
+    EXCEPTION
+        WHEN invalid_text_representation THEN
+            RETURN event;
+    END;
+
+    IF v_user_id IS NULL THEN
+        RETURN event;
+    END IF;
+
+    v_claims := COALESCE(event->'claims', '{}'::jsonb);
+
+    SELECT u.username
+      INTO v_username
+      FROM profile.username AS u
+     WHERE u.user_id = v_user_id;
+
+    IF v_username IS NOT NULL THEN
+        v_claims := jsonb_set(v_claims, '{kbve_username}', to_jsonb(v_username), true);
+    ELSE
+        v_claims := v_claims - 'kbve_username';
+    END IF;
+
+    RETURN jsonb_set(event, '{claims}', v_claims, true);
+END;
+$$;
+
+ALTER FUNCTION public.custom_access_token_hook(jsonb)
+    OWNER TO supabase_auth_admin;
+
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+    FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+    TO supabase_auth_admin;
+
+COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
+    'GoTrue access-token hook: injects profile.username into the JWT as kbve_username.';
+
+DO $$
+BEGIN
+    PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
+
+    IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public for the hook to resolve.';
+    END IF;
+
+    IF NOT has_schema_privilege('supabase_auth_admin', 'profile', 'USAGE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema profile.';
+    END IF;
+
+    IF NOT has_function_privilege('supabase_auth_admin', 'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on public.custom_access_token_hook(jsonb).';
+    END IF;
+
+    IF has_function_privilege('anon',          'public.custom_access_token_hook(jsonb)', 'EXECUTE')
+       OR has_function_privilege('authenticated','public.custom_access_token_hook(jsonb)', 'EXECUTE')
+       OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'public.custom_access_token_hook(jsonb) must not be executable by anon/authenticated/public.';
+    END IF;
+
+    IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username for the hook to read usernames.';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;
+
+-- migrate:down
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.custom_access_token_hook(jsonb);
+
+DROP POLICY IF EXISTS "supabase_auth_admin_select" ON profile.username;
+
+REVOKE SELECT ON TABLE profile.username FROM supabase_auth_admin;
+REVOKE USAGE  ON SCHEMA profile          FROM supabase_auth_admin;
+
+-- NOTE: We deliberately do NOT revoke USAGE ON SCHEMA public from
+-- supabase_auth_admin here. Other Supabase machinery and other hooks
+-- may rely on that grant; this migration does not own it.
+
+COMMIT;


### PR DESCRIPTION
## Summary

Two follow-ups stacked on top of the merged JWT \`aud\` fix (#10749, #10751). Both target the IRC username problem where browsers connected as junk nicks like \`adminkbvecom\` derived from email.

### 1. irc-gateway: provider username strict mode

- Drop email/sub fallbacks. Nick is sourced only from Supabase metadata, in priority: \`kbve_username\` → \`user_metadata.preferred_username\` → \`user_metadata.user_name\` → \`user_metadata.nickname\`.
- \`Claims::irc_nick()\` now returns \`Option<String>\`. When \`None\`, both /ws and the IRC TCP gateway refuse the connection — /ws returns 403 with a human-readable reason; IRC sends a NOTICE then closes.
- Sanitizer keeps a-z, A-Z, 0-9, '_', '-', truncates to 16 chars, and prefixes leading digits with '_'.

### 2. GoTrue Custom Access Token hook (\`profile.username\` → JWT)

New migration: \`packages/data/sql/dbmate/migrations/20260510210000_profile_custom_access_token_hook.sql\`

- \`public.custom_access_token_hook(event jsonb) returns jsonb\` — \`SECURITY DEFINER\`, owned by \`supabase_auth_admin\`, locked search_path. Reads \`profile.username\` by \`event->>'user_id'\`, writes \`kbve_username\` into the JWT claims, returns the mutated event.
- Fail-soft on malformed user_id (\`invalid_text_representation\` → return event untouched).
- Strips a stale \`kbve_username\` when the user has no profile row, so claims always reflect DB state.
- Grants USAGE on \`public\` + \`profile\` to \`supabase_auth_admin\`, plus SELECT on \`profile.username\` and a permissive RLS policy (table is otherwise service_role only).
- Verification block asserts every required privilege exists and that anon/authenticated/public can't execute the hook.
- Down migration drops the function, policy, table/schema grants on \`profile\`, but deliberately keeps USAGE on \`public\` — that grant is shared infra this migration does not own.

GoTrue manifest (\`apps/kube/auth/manifests/supabase-gotrue-auth.yaml\`):
\`\`\`yaml
- name: GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED
  value: 'true'
- name: GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI
  value: 'pg-functions://postgres/public/custom_access_token_hook'
\`\`\`

irc-gateway: adds top-level \`Claims.kbve_username\` and prepends it to the \`irc_nick()\` priority. Two new tests cover \"kbve_username wins\" and \"empty kbve_username falls through\".

## Rollout order

1. Apply migration via dbmate (function exists, hook still off — harmless).
2. Apply GoTrue manifest. Pod restart picks up the URI; new JWTs carry \`kbve_username\`.
3. Merge this PR. CI/CD rebuilds irc-gateway image; gateway prefers \`kbve_username\`.

Existing JWTs predate the hook → fall through to user_metadata until next refresh (default lifetime ~1h).

## Test plan

- [x] \`cargo test --bin irc-gateway auth::jwt\` — 26 passed locally
- [x] \`cargo build --bin irc-gateway\` clean
- [ ] Apply migration to supabase DB, verify \`SELECT public.custom_access_token_hook('{...}'::jsonb);\` returns expected event
- [ ] Roll GoTrue, sign in fresh, decode access token, confirm \`kbve_username\`
- [ ] Roll irc-gateway image, connect to chat.kbve.com/chat, confirm nick = canonical username
- [ ] User without \`profile.username\` row: confirm 403 + reason on /ws (not 1006)