### PR TITLE
feat(firecracker-ctl): expose OpenAPI 3.1 spec for staff dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.144"
+version = "1.0.145"
 dependencies = [
  "anyhow",
  "askama",
@@ -5830,7 +5830,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firecracker-ctl"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "axum 0.8.9",
  "dashmap 6.1.0",
@@ -5844,6 +5844,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
  "uuid",
 ]
 

--- a/apps/vm/firecracker-ctl/Cargo.toml
+++ b/apps/vm/firecracker-ctl/Cargo.toml
@@ -24,6 +24,7 @@ dashmap = "6"
 reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 # Used by fc_destroy to SIGTERM the VMM process via kill(2).
 libc = "0.2"
+utoipa = { version = "5", features = ["axum_extras"] }
 
 [features]
 default = []

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -16,8 +16,10 @@ use std::{
 use tokio::sync::Notify;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
+mod openapi;
 mod persistent;
 mod tap;
 
@@ -25,7 +27,7 @@ mod tap;
 // Types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateVmRequest {
     pub rootfs: String,
     #[serde(default = "default_vcpu")]
@@ -61,7 +63,7 @@ fn default_boot_args() -> String {
     "console=ttyS0 reboot=k panic=1 init=/init".to_string()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum VmStatus {
     Creating,
@@ -72,7 +74,7 @@ pub enum VmStatus {
     Destroyed,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VmInfo {
     pub vm_id: String,
     pub status: VmStatus,
@@ -82,7 +84,7 @@ pub struct VmInfo {
     pub created_at: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VmResult {
     pub vm_id: String,
     pub status: VmStatus,
@@ -153,9 +155,9 @@ struct PersistentState {
 /// consumer-side discriminator update, whereas pre-declaring them lets
 /// callers build state machines against the final shape today.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "lowercase")]
-enum EndpointStatus {
+pub enum EndpointStatus {
     /// Resources (IP + TAP) allocated; VM process not yet spawned.
     /// Phase 2c terminal state — Phase 2e transitions to Starting.
     Pending,
@@ -191,8 +193,8 @@ struct PersistentEndpoint {
 /// JSON-serialisable view of a PersistentEndpoint. Keeps the owning
 /// struct free of serde plumbing so internal fields can change without
 /// breaking the wire format.
-#[derive(Debug, Clone, Serialize)]
-struct PersistentEndpointInfo {
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct PersistentEndpointInfo {
     name: String,
     rootfs: String,
     entrypoint: String,
@@ -254,6 +256,14 @@ fn validate_entrypoint(ep: &str) -> Result<(), String> {
 // Handlers
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "system",
+    responses(
+        (status = 200, description = "Liveness probe + build identity", body = serde_json::Value)
+    )
+)]
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
     Json(serde_json::json!({
         "status": "ok",
@@ -264,6 +274,17 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/vm/create",
+    tag = "ephemeral",
+    request_body = CreateVmRequest,
+    responses(
+        (status = 201, description = "VM accepted; lifecycle running in background", body = VmInfo),
+        (status = 400, description = "Validation error or rootfs missing"),
+        (status = 429, description = "Concurrent VM cap reached")
+    )
+)]
 async fn create_vm(
     State(state): State<AppState>,
     Json(req): Json<CreateVmRequest>,
@@ -355,6 +376,16 @@ async fn create_vm(
     (StatusCode::CREATED, Json(serde_json::json!(info)))
 }
 
+#[utoipa::path(
+    get,
+    path = "/vm/{vm_id}",
+    tag = "ephemeral",
+    params(("vm_id" = String, Path, description = "Ephemeral VM identifier returned by /vm/create")),
+    responses(
+        (status = 200, description = "Current VM lifecycle state", body = VmInfo),
+        (status = 404, description = "VM not found")
+    )
+)]
 async fn get_vm_status(
     State(state): State<AppState>,
     Path(vm_id): Path<String>,
@@ -368,6 +399,17 @@ async fn get_vm_status(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/vm/{vm_id}/result",
+    tag = "ephemeral",
+    params(("vm_id" = String, Path, description = "Ephemeral VM identifier")),
+    responses(
+        (status = 200, description = "VM finished — final stdout/stderr/exit_code", body = VmResult),
+        (status = 202, description = "VM still running; poll again"),
+        (status = 404, description = "VM not found")
+    )
+)]
 async fn get_vm_result(
     State(state): State<AppState>,
     Path(vm_id): Path<String>,
@@ -391,6 +433,16 @@ async fn get_vm_result(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/vm/{vm_id}",
+    tag = "ephemeral",
+    params(("vm_id" = String, Path, description = "Ephemeral VM identifier")),
+    responses(
+        (status = 200, description = "Destroy signal sent; VM transitions to Destroyed", body = serde_json::Value),
+        (status = 404, description = "VM not found")
+    )
+)]
 async fn destroy_vm(State(state): State<AppState>, Path(vm_id): Path<String>) -> impl IntoResponse {
     match state.vms.get(&vm_id) {
         Some(record) => {
@@ -413,6 +465,14 @@ async fn destroy_vm(State(state): State<AppState>, Path(vm_id): Path<String>) ->
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/vm",
+    tag = "ephemeral",
+    responses(
+        (status = 200, description = "Snapshot of every tracked VM record", body = serde_json::Value)
+    )
+)]
 async fn list_vms(State(state): State<AppState>) -> impl IntoResponse {
     let vms: Vec<VmInfo> = state
         .vms
@@ -433,7 +493,7 @@ async fn list_vms(State(state): State<AppState>) -> impl IntoResponse {
 // lands in Phase 2d. See firecracker-ctl.mdx for the full architecture.
 
 /// Request shape for POST /fc/deploy.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct DeployFcRequest {
     /// Unique, DNS-safe endpoint name. Used in the public /fc/{name} path.
     pub name: String,
@@ -473,6 +533,18 @@ fn not_enabled() -> (StatusCode, Json<serde_json::Value>) {
     )
 }
 
+#[utoipa::path(
+    post,
+    path = "/fc/deploy",
+    tag = "persistent",
+    request_body = DeployFcRequest,
+    responses(
+        (status = 201, description = "Endpoint registered + network allocated", body = PersistentEndpointInfo),
+        (status = 400, description = "Validation error"),
+        (status = 409, description = "Endpoint name already registered"),
+        (status = 503, description = "Persistent endpoints not enabled in this deployment")
+    )
+)]
 async fn fc_deploy(
     State(state): State<AppState>,
     Json(req): Json<DeployFcRequest>,
@@ -647,6 +719,15 @@ async fn fc_deploy(
     )
 }
 
+#[utoipa::path(
+    get,
+    path = "/fc/list",
+    tag = "persistent",
+    responses(
+        (status = 200, description = "All registered persistent endpoints", body = serde_json::Value),
+        (status = 503, description = "Persistent endpoints not enabled")
+    )
+)]
 async fn fc_list(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
     let persistent = match state.persistent.as_ref() {
         Some(p) => p,
@@ -669,6 +750,17 @@ async fn fc_list(State(state): State<AppState>) -> (StatusCode, Json<serde_json:
     )
 }
 
+#[utoipa::path(
+    get,
+    path = "/fc/{name}",
+    tag = "persistent",
+    params(("name" = String, Path, description = "Persistent endpoint name")),
+    responses(
+        (status = 200, description = "Endpoint detail", body = PersistentEndpointInfo),
+        (status = 404, description = "Endpoint not found"),
+        (status = 503, description = "Persistent endpoints not enabled")
+    )
+)]
 async fn fc_get(
     State(state): State<AppState>,
     Path(name): Path<String>,
@@ -691,6 +783,17 @@ async fn fc_get(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/fc/{name}",
+    tag = "persistent",
+    params(("name" = String, Path, description = "Persistent endpoint name")),
+    responses(
+        (status = 200, description = "Endpoint torn down + resources released", body = serde_json::Value),
+        (status = 404, description = "Endpoint not found"),
+        (status = 503, description = "Persistent endpoints not enabled")
+    )
+)]
 async fn fc_destroy(
     State(state): State<AppState>,
     Path(name): Path<String>,
@@ -1859,6 +1962,13 @@ async fn list_rootfs(dir: &str) -> Vec<String> {
 
 #[tokio::main]
 async fn main() {
+    if std::env::args().any(|arg| arg == "--emit-openapi") {
+        use utoipa::OpenApi;
+        let spec = openapi::ApiDoc::openapi();
+        println!("{}", spec.to_pretty_json().expect("serialise OpenAPI"));
+        return;
+    }
+
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -2008,6 +2118,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/health", get(health))
+        .route("/openapi.json", get(openapi::openapi_json))
         .route("/vm/create", post(create_vm))
         .route("/vm", get(list_vms))
         .route("/vm/{vm_id}", get(get_vm_status))

--- a/apps/vm/firecracker-ctl/src/openapi.rs
+++ b/apps/vm/firecracker-ctl/src/openapi.rs
@@ -1,0 +1,90 @@
+//! OpenAPI spec aggregator for firecracker-ctl.
+//!
+//! Mirrors `axum-kbve/src/openapi.rs`: handlers carry `#[utoipa::path(...)]`,
+//! request/response types derive `ToSchema`, and `ApiDoc` enumerates the set
+//! that ends up in the generated spec. Mounted at `/openapi.json` so the
+//! astro side can render it via Scalar alongside the public API surface.
+//!
+//! Each new annotated handler = one line in `paths(...)`.
+
+use axum::Json;
+use utoipa::{
+    Modify, OpenApi,
+    openapi::security::{Http, HttpAuthScheme, SecurityScheme},
+};
+
+use crate::{
+    CreateVmRequest, DeployFcRequest, EndpointStatus, PersistentEndpointInfo, VmInfo, VmResult,
+    VmStatus,
+};
+
+/// Adds `bearerAuth` so `security(("bearerAuth" = []))` on handlers resolves.
+/// The actual gate lives in the front-end proxy (axum-kbve); this is purely
+/// metadata for the Scalar UI.
+pub struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .as_mut()
+            .expect("components defined in derive");
+        components.add_security_scheme(
+            "bearerAuth",
+            SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)),
+        );
+    }
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Firecracker Control API",
+        description = "Internal staff API for managing Firecracker microVMs. Surfaced through the kbve.com dashboard via a same-origin proxy; not exposed publicly.",
+        contact(
+            name = "KBVE",
+            url = "https://kbve.com",
+            email = "support@kbve.com"
+        ),
+        license(name = "MIT")
+    ),
+    servers(
+        (url = "/api/firecracker", description = "Same-origin proxy on kbve.com"),
+        (url = "http://localhost:8080", description = "Local firecracker-ctl")
+    ),
+    tags(
+        (name = "system", description = "Liveness + build identity. Used by uptime probes."),
+        (name = "ephemeral", description = "One-shot VMs that boot, run an entrypoint, capture stdout/stderr, then teardown."),
+        (name = "persistent", description = "Long-lived microVMs addressed by name with TAP networking + /proxy/{name} reverse-proxy.")
+    ),
+    paths(
+        crate::health,
+        crate::create_vm,
+        crate::get_vm_status,
+        crate::get_vm_result,
+        crate::destroy_vm,
+        crate::list_vms,
+        crate::fc_deploy,
+        crate::fc_list,
+        crate::fc_get,
+        crate::fc_destroy,
+    ),
+    components(
+        schemas(
+            CreateVmRequest,
+            VmStatus,
+            VmInfo,
+            VmResult,
+            DeployFcRequest,
+            EndpointStatus,
+            PersistentEndpointInfo,
+        )
+    ),
+    modifiers(&SecurityAddon)
+)]
+pub struct ApiDoc;
+
+/// `GET /openapi.json` — full spec served to staff dashboard Scalar viewer.
+pub async fn openapi_json() -> Json<utoipa::openapi::OpenApi> {
+    Json(ApiDoc::openapi())
+}


### PR DESCRIPTION
## Summary
- Annotate ephemeral (`/vm/*`) and persistent (`/fc/*`) handlers with `utoipa::path`
- Add `ToSchema` derives to public request/response types
- New `openapi` module aggregates the spec + declares `bearerAuth` for the planned axum-kbve proxy
- Mount `GET /openapi.json` + `--emit-openapi` CLI flag (mirrors axum-kbve pattern)

Phase 1 of the broader plan: surface firecracker-ctl as a self-documenting admin console under `kbve.com/dashboard`. Phase 2 adds a same-origin proxy on axum-kbve gated by the existing staff JWT; Phase 3 wires the Scalar UI.

`fc_proxy` is intentionally absent from `paths()` — the catchall response is per-VM and shouldn't be locked into a typed shape.

## Test plan
- [x] `cargo check -p firecracker-ctl` clean
- [x] `cargo clippy -p firecracker-ctl --no-deps` only pre-existing warnings (too-many-arguments on spawn_direct/spawn_jailed)
- [x] `cargo run -p firecracker-ctl -- --emit-openapi` produces valid OpenAPI 3.1
- [ ] Stand up firecracker-ctl locally, hit `GET /openapi.json`, confirm Scalar can render it