### PR TITLE
chore(axum-kbve): bump axum-server 0.8, askama 0.16, lru 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,20 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b8246bcbf8eb97abef10c2d92166449680d41d55c0fc6978a91dec2e3619608"
 dependencies = [
- "askama_macros",
+ "askama_macros 0.15.6",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
+dependencies = [
+ "askama_macros 0.16.0",
  "itoa",
  "percent-encoding",
  "serde",
@@ -660,8 +673,26 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f9670bc84a28bb3da91821ef74226949ab63f1265aff7c751634f1dd0e6f97c"
 dependencies = [
- "askama_parser",
+ "askama_parser 0.15.6",
  "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
+dependencies = [
+ "askama_parser 0.16.0",
+ "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -677,7 +708,16 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0756b45480437dded0565dfc568af62ccce146fb6cfe902e808ba86e445f44f"
 dependencies = [
- "askama_derive",
+ "askama_derive 0.15.6",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
+dependencies = [
+ "askama_derive 0.16.0",
 ]
 
 [[package]]
@@ -685,6 +725,19 @@ name = "askama_parser"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0af3691ba3af77949c0b5a3925444b85cb58a0184cc7fec16c68ba2e7be868"
+dependencies = [
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
  "rustc-hash 2.1.2",
  "serde",
@@ -1282,7 +1335,7 @@ name = "axum-cryptothrone"
 version = "0.1.5"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.15.6",
  "axum 0.8.9",
  "axum-extra",
  "dotenvy",
@@ -1308,7 +1361,7 @@ name = "axum-discordsh"
 version = "0.1.44"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.15.6",
  "axum 0.8.9",
  "axum-extra",
  "dotenvy",
@@ -1366,7 +1419,7 @@ name = "axum-herbmail"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.15.6",
  "axum 0.8.9",
  "axum-extra",
  "dotenvy",
@@ -1392,7 +1445,7 @@ name = "axum-kbve"
 version = "1.0.145"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.16.0",
  "avian3d",
  "axum 0.8.9",
  "axum-extra",
@@ -1410,7 +1463,7 @@ dependencies = [
  "kbve",
  "lightyear",
  "lightyear_avian3d",
- "lru",
+ "lru 0.18.0",
  "num_cpus",
  "prost 0.14.3",
  "prost-build 0.14.3",
@@ -1452,7 +1505,7 @@ name = "axum-memes"
 version = "0.1.8"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.15.6",
  "axum 0.8.9",
  "axum-extra",
  "dashmap 6.1.0",
@@ -1481,7 +1534,7 @@ name = "axum-rareicon"
 version = "0.1.3"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.15.6",
  "axum 0.8.9",
  "dotenvy",
  "http-body-util",
@@ -1502,12 +1555,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -1515,7 +1569,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.37",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -4978,7 +5031,7 @@ name = "discordsh-bot"
 version = "0.1.13"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.15.6",
  "axum 0.8.9",
  "bevy_battle",
  "bevy_behavior",
@@ -4996,7 +5049,7 @@ dependencies = [
  "dotenvy",
  "jedi",
  "kbve",
- "lru",
+ "lru 0.16.3",
  "poise",
  "rand 0.10.0",
  "rand_chacha 0.10.0",
@@ -7248,6 +7301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8175,7 +8239,7 @@ name = "jedi"
 version = "0.2.2"
 dependencies = [
  "ammonia",
- "askama",
+ "askama 0.15.6",
  "async-trait",
  "axum 0.8.9",
  "axum-extra",
@@ -8449,7 +8513,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "argon2",
- "askama",
+ "askama 0.15.6",
  "async-trait",
  "axum 0.8.9",
  "axum-extra",
@@ -8460,7 +8524,7 @@ dependencies = [
  "holy",
  "jedi",
  "jsonwebtoken 10.3.0",
- "lru",
+ "lru 0.16.3",
  "num-bigint",
  "once_cell",
  "pulldown-cmark 0.13.3",
@@ -9531,6 +9595,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -23,11 +23,11 @@ tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum = { version = "0.8.5", features = ["ws", "macros"] }
-axum-server = { version = "0.7", features = ["tls-rustls"] }
+axum-server = { version = "0.8", features = ["tls-rustls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-pemfile = "2"
 axum-extra = { version = "0.12.1", features = ["cookie"] }
-askama = "0.15.4"
+askama = "0.16.0"
 socket2 = "0.6.1"
 num_cpus = "1.17.0"
 dotenvy = "0.15"
@@ -46,7 +46,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 dashmap = { version = "6.1", features = ["rayon"] }
 rayon = "1.10"
 regex = "1.11"
-lru = "0.16"
+lru = "0.18"
 
 # Game server (headless Bevy + avian3d + lightyear)
 bevy = { version = "0.18", default-features = false, features = [


### PR DESCRIPTION
## Summary
- `axum-server` 0.7 → 0.8
- `askama` 0.15.4 → 0.16.0
- `lru` 0.16 → 0.18

## Test plan
- [x] `cargo check --manifest-path apps/kbve/axum-kbve/Cargo.toml` — clean
- [x] `cargo clippy --manifest-path apps/kbve/axum-kbve/Cargo.toml --no-deps` — only pre-existing `too_many_arguments` warnings, none from bumped crates