### PR TITLE
fix(firecracker-ctl): align OpenAPI servers with existing dashboard proxy

### DIFF
--- a/apps/vm/firecracker-ctl/src/openapi.rs
+++ b/apps/vm/firecracker-ctl/src/openapi.rs
@@ -49,8 +49,9 @@ impl Modify for SecurityAddon {
         license(name = "MIT")
     ),
     servers(
-        (url = "/api/firecracker", description = "Same-origin proxy on kbve.com"),
-        (url = "http://localhost:8080", description = "Local firecracker-ctl")
+        (url = "/dashboard/firecracker/proxy", description = "Same-origin staff proxy (DASHBOARD_VIEW)"),
+        (url = "/dashboard/firecracker-net/proxy", description = "Same-origin staff proxy, network-enabled VMs (DASHBOARD_MANAGE)"),
+        (url = "http://localhost:9001", description = "Local firecracker-ctl")
     ),
     tags(
         (name = "system", description = "Liveness + build identity. Used by uptime probes."),


### PR DESCRIPTION
## Summary
Follow-up to #10791. The spec shipped with `/api/firecracker` and `localhost:8080` servers, but axum-kbve already exposes firecracker-ctl through DASHBOARD_VIEW/DASHBOARD_MANAGE gates at `/dashboard/firecracker(-net)/proxy/*`. Scalar 'Try It' would 404 against the fictional prefix.

Points the spec at the real same-origin staff proxy paths (and the correct `localhost:9001` port) so the dashboard renders an interactive console once firecracker-ctl re-deploys.

## Test plan
- [x] `cargo check -p firecracker-ctl` clean
- [ ] After deploy: `curl https://kbve.com/dashboard/firecracker/proxy/openapi.json` returns the spec with the corrected `servers` block
- [ ] Phase 3 Scalar page (separate PR) renders the spec and 'Try It' hits the staff-gated proxy