### PR TITLE
feat(dashboard): surface firecracker-ctl OpenAPI in Scalar

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -187,6 +187,7 @@ export default defineConfig({
 						{ label: 'Forgejo', link: '/dashboard/forgejo/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'Grafana', link: '/dashboard/grafana/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'Virtual Machines', link: '/dashboard/vm/', attrs: { 'data-auth-visibility': 'staff' } },
+						{ label: 'Firecracker API', link: '/dashboard/vm/firecracker/api/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'IDE', link: '/dashboard/ide/', attrs: { 'data-auth-visibility': 'staff' } },
 					],
 				},

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroApiDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroApiDashboard.astro
@@ -1,8 +1,33 @@
 ---
-const { specUrl = '/api/openapi.json' } = Astro.props;
+interface Source {
+	url: string;
+	slug?: string;
+	title: string;
+	default?: boolean;
+}
+
+interface Props {
+	specUrl?: string;
+	sources?: Source[];
+	title?: string;
+}
+
+const {
+	specUrl = '/api/openapi.json',
+	sources,
+	title = 'KBVE API Reference',
+} = Astro.props as Props;
+
+const config = sources && sources.length > 0
+	? { sources }
+	: { url: specUrl };
 ---
 
-<div id="scalar-root" data-spec-url={specUrl}></div>
+<div
+	id="scalar-root"
+	data-config={JSON.stringify(config)}
+	data-title={title}>
+</div>
 
 <style is:global>
 	#scalar-root {
@@ -56,16 +81,23 @@ const { specUrl = '/api/openapi.json' } = Astro.props;
 
 	const root = document.getElementById('scalar-root');
 	if (root) {
-		const url = root.dataset.specUrl ?? '/api/openapi.json';
+		const raw = root.dataset.config ?? '{}';
+		const title = root.dataset.title ?? 'KBVE API Reference';
+		let parsed: Record<string, unknown> = {};
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			parsed = { url: '/api/openapi.json' };
+		}
 		createApiReference(root, {
-			url,
+			...parsed,
 			theme: 'none',
 			hideClientButton: false,
 			defaultHttpClient: {
 				targetKey: 'shell',
 				clientKey: 'curl',
 			},
-			metaData: { title: 'KBVE API Reference' },
+			metaData: { title },
 		});
 	}
 </script>

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: Live OpenAPI 3.1 specification for the public HTTP surface served by axum-kbve.
+description: Live OpenAPI 3.1 specifications for the KBVE public API and the staff-only firecracker-ctl service.
 template: splash
 tableOfContents: false
 pagefind: false
@@ -16,4 +16,10 @@ tags:
 
 import AstroApiDashboard from '@/components/dashboard/AstroApiDashboard.astro';
 
-<AstroApiDashboard />
+<AstroApiDashboard
+    title="KBVE Dashboard APIs"
+    sources={[
+        { slug: 'kbve', title: 'KBVE Public API', url: '/api/openapi.json', default: true },
+        { slug: 'firecracker', title: 'Firecracker Control', url: '/dashboard/firecracker/proxy/openapi.json' },
+    ]}
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/firecracker/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/firecracker/api.mdx
@@ -1,0 +1,24 @@
+---
+title: Firecracker API
+description: Interactive OpenAPI 3.1 reference for firecracker-ctl, served through the staff dashboard proxy.
+template: splash
+tableOfContents: false
+pagefind: false
+sidebar:
+    label: Firecracker API
+    order: 20
+editUrl: false
+tags:
+    - dashboard
+    - vm
+    - firecracker
+    - api
+    - openapi
+---
+
+import AstroApiDashboard from '@/components/dashboard/AstroApiDashboard.astro';
+
+<AstroApiDashboard
+    title="Firecracker Control API"
+    specUrl="/dashboard/firecracker/proxy/openapi.json"
+/>


### PR DESCRIPTION
## Summary
- \`AstroApiDashboard\` accepts an optional \`sources[]\` prop alongside the existing single-\`specUrl\` path, so one Scalar instance can host multiple specs with a built-in switcher
- \`/dashboard/api\` now ships both **KBVE Public API** and **Firecracker Control** as sources (KBVE default)
- New \`/dashboard/vm/firecracker/api\` page renders only the firecracker spec for staff who want the focused view
- Sidebar entry gated \`data-auth-visibility=\"staff\"\`

Both pages pull the spec from \`/dashboard/firecracker/proxy/openapi.json\` — the same DASHBOARD_VIEW-gated proxy that handles 'Try It' calls, so Scalar can fetch and exercise the API end-to-end without leaving the staff perimeter.

Closes the phase 1–3 chain: #10791 (utoipa annotations) → #10793 (server URL fix) → this PR (UI).

## Test plan
- [x] \`astro check\` clean
- [ ] Build site, visit \`/dashboard/api/\` — switcher shows KBVE + Firecracker; KBVE renders first
- [ ] Visit \`/dashboard/vm/firecracker/api/\` — single Firecracker spec renders
- [ ] As a staff user, click 'Try It' on \`GET /health\` — request hits \`/dashboard/firecracker/proxy/health\` and returns 200
- [ ] As a non-staff user, sidebar entry hidden + direct nav to \`/dashboard/vm/firecracker/api/\` denied at proxy layer