### PR TITLE
fix(firecracker-ctl-net): mount /dev/net/tun for TAP creation

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -163,6 +163,8 @@ spec:
                         mountPath: /var/lib/firecracker/scratch
                       - name: tmp
                         mountPath: /tmp
+                      - name: tun-device
+                        mountPath: /dev/net/tun
                   # No probes — port 9001 is owned by Gluetun (shared netns).
             volumes:
                 - name: rootfs-cache
@@ -174,3 +176,7 @@ spec:
                 - name: tmp
                   emptyDir:
                       sizeLimit: 64Mi
+                - name: tun-device
+                  hostPath:
+                      path: /dev/net/tun
+                      type: CharDevice


### PR DESCRIPTION
## Summary

After PR #10779 fixed \`FC_PERSISTENT_ENDPOINTS_ENABLED\` + jailer bypass, the next \`/vm/create\` with \`network=true\` died at TAP creation:

\`\`\`
TAP creation failed: ip [\"tuntap\", \"add\", \"dev\", \"fctap-0\", \"mode\", \"tap\", \"user\", \"10001\"] exited with 1: open: No such file or directory
\`\`\`

\`/dev/net/tun\` was not exposed inside the container. \`ip tuntap add\` opens that char device to create new TAPs and hits ENOENT when it is missing. \`NET_ADMIN\` was already in the cap set, so this is the last missing piece.

\`/fc/deploy\` was never exercised end-to-end against the cluster after the deployment manifest landed, which is why this gap was not caught before.

## Fix

Mount \`/dev/net/tun\` from the host as a \`CharDevice\` volume.

\`\`\`yaml
volumeMounts:
  - name: tun-device
    mountPath: /dev/net/tun
volumes:
  - name: tun-device
    hostPath:
      path: /dev/net/tun
      type: CharDevice
\`\`\`

## Test plan

- [ ] After merge, ArgoCD reconciles \`firecracker-ctl-net\` deployment. Pod restarts with the new mount.
- [ ] \`kubectl exec -n firecracker firecracker-ctl-net-... -- ls /dev/net/tun\` returns the device (no ENOENT).
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → \`ip tuntap add\` succeeds → eth0 comes up → poem prints, exit 0.