### PR TITLE
fix(ci-mc-smoke): kill runClient process group so client step exits

### DIFF
--- a/apps/mc/scripts/headless-client-smoke.sh
+++ b/apps/mc/scripts/headless-client-smoke.sh
@@ -7,27 +7,72 @@ set -euo pipefail
 # software-GL quirks, because the bug class we care about (mixin spec
 # violations, missing targets, signature drift) trips during class load,
 # well before window creation.
+#
+# Process management: launch the whole xvfb-run + gradle + JVM stack inside
+# a fresh process group via setsid, then on exit/timeout signal the PG so
+# every descendant (Xvfb, gradle daemon, forked client JVM) goes down. A
+# bare `kill $PID` only kills the immediate child, leaving the JVM as an
+# orphan that holds the GH Actions step alive until the 25min job ceiling.
 
 JAVA_DIR="${JAVA_DIR:-apps/mc/behavior_statetree/java}"
-TIMEOUT_SECS="${TIMEOUT_SECS:-180}"
+TIMEOUT_SECS="${TIMEOUT_SECS:-300}"
 LOG_FILE="${LOG_FILE:-/tmp/mc-headless-client.log}"
+GRACE_SECS="${GRACE_SECS:-5}"
 
 if ! command -v xvfb-run >/dev/null 2>&1; then
     echo "xvfb-run not found — install xvfb" >&2
     exit 2
 fi
+if ! command -v setsid >/dev/null 2>&1; then
+    echo "setsid not found — install util-linux" >&2
+    exit 2
+fi
 
 cd "$JAVA_DIR"
-
 : > "$LOG_FILE"
 
-(
-    xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
+setsid bash -c "
+    exec xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
         ./gradlew runClient --no-daemon --console=plain \
-        -Pfabric.client.gameDir=run/smoke \
-        2>&1 || true
-) | tee "$LOG_FILE" &
-GRADLE_PID=$!
+        -Pfabric.client.gameDir=run/smoke
+" >"$LOG_FILE" 2>&1 &
+RUN_PID=$!
+
+PGID=""
+for _ in 1 2 3 4 5; do
+    PGID=$(ps -o pgid= -p "$RUN_PID" 2>/dev/null | tr -d ' ' || true)
+    [ -n "$PGID" ] && break
+    sleep 0.2
+done
+if [ -z "$PGID" ]; then
+    echo "[smoke] could not resolve PGID for $RUN_PID — falling back to single-process kill" >&2
+    PGID="$RUN_PID"
+fi
+echo "[smoke] launched runClient pid=$RUN_PID pgid=$PGID, watching $LOG_FILE (timeout=${TIMEOUT_SECS}s)"
+
+kill_group() {
+    local sig="${1:-TERM}"
+    if [ "$PGID" = "$RUN_PID" ]; then
+        kill "-${sig}" "$RUN_PID" 2>/dev/null || true
+    else
+        kill "-${sig}" -- "-${PGID}" 2>/dev/null || true
+    fi
+}
+
+shutdown_and_exit() {
+    local code="$1"
+    kill_group TERM
+    local waited=0
+    while kill -0 "$RUN_PID" 2>/dev/null && [ "$waited" -lt "$GRACE_SECS" ]; do
+        sleep 1
+        waited=$(( waited + 1 ))
+    done
+    kill_group KILL
+    wait "$RUN_PID" 2>/dev/null || true
+    exit "$code"
+}
+
+trap 'shutdown_and_exit 130' INT TERM
 
 SUCCESS_MARKERS=(
     "Sound engine started"
@@ -48,51 +93,44 @@ FAIL_MARKERS=(
 
 deadline=$(( SECONDS + TIMEOUT_SECS ))
 
-while kill -0 "$GRADLE_PID" 2>/dev/null; do
+while kill -0 "$RUN_PID" 2>/dev/null; do
     if [ "$SECONDS" -ge "$deadline" ]; then
-        echo "[smoke] timeout reached after ${TIMEOUT_SECS}s — killing client" >&2
+        echo "[smoke] timeout reached after ${TIMEOUT_SECS}s — killing process group $PGID" >&2
         break
     fi
 
     for m in "${FAIL_MARKERS[@]}"; do
-        if grep -q -- "$m" "$LOG_FILE"; then
+        if grep -q -F -- "$m" "$LOG_FILE"; then
             echo "[smoke] FAIL marker detected: $m" >&2
-            kill "$GRADLE_PID" 2>/dev/null || true
-            wait "$GRADLE_PID" 2>/dev/null || true
-            exit 1
+            shutdown_and_exit 1
         fi
     done
 
     for m in "${SUCCESS_MARKERS[@]}"; do
-        if grep -q -- "$m" "$LOG_FILE"; then
+        if grep -q -F -- "$m" "$LOG_FILE"; then
             echo "[smoke] SUCCESS marker detected: $m"
-            kill "$GRADLE_PID" 2>/dev/null || true
-            wait "$GRADLE_PID" 2>/dev/null || true
-            exit 0
+            shutdown_and_exit 0
         fi
     done
 
     sleep 2
 done
 
-kill "$GRADLE_PID" 2>/dev/null || true
-wait "$GRADLE_PID" 2>/dev/null || true
-
 for m in "${FAIL_MARKERS[@]}"; do
-    if grep -q -- "$m" "$LOG_FILE"; then
+    if grep -q -F -- "$m" "$LOG_FILE"; then
         echo "[smoke] FAIL marker detected post-exit: $m" >&2
-        exit 1
+        shutdown_and_exit 1
     fi
 done
 
 for m in "${SUCCESS_MARKERS[@]}"; do
-    if grep -q -- "$m" "$LOG_FILE"; then
+    if grep -q -F -- "$m" "$LOG_FILE"; then
         echo "[smoke] SUCCESS marker detected post-exit: $m"
-        exit 0
+        shutdown_and_exit 0
     fi
 done
 
 echo "[smoke] no success/fail marker found within ${TIMEOUT_SECS}s — treating as failure" >&2
 echo "[smoke] last 60 lines of log:" >&2
 tail -n 60 "$LOG_FILE" >&2 || true
-exit 1
+shutdown_and_exit 1


### PR DESCRIPTION
## Summary
Run [#25651996386](https://github.com/KBVE/kbve/actions/runs/25651996386) cancelled the `client-smoke` job at the 25min ceiling. Log shows the SUCCESS marker fired ~3min in:

```
05:27:31 [smoke] SUCCESS marker detected: Setting user:
...
05:50:53 ##[error]The operation was canceled.
05:50:54 Terminate orphan process: pid (3152) (java)
05:50:54 Terminate orphan process: pid (3222) (java)
05:50:54 Terminate orphan process: pid (3876) (java)
```

The script killed only the immediate child PID, so `xvfb-run`, the gradle process, and the forked client JVM became orphans (reparented to PID 1) and held the GH Actions step alive until `Complete job` reaped them.

## Fix
Launch the runClient stack inside a fresh process group via `setsid`, resolve PGID, and on every exit path signal the whole group (`kill -TERM -- -PGID`, brief grace, `kill -KILL`). Drop the `| tee` pipe — direct file redirect makes process supervision unambiguous. Add a TERM trap so manual cancellation also tears the group down.

## Test plan
- [ ] CI - MC Smoke `client-smoke` job exits within `TIMEOUT_SECS` (default 300s) instead of the 25min job ceiling
- [ ] Successful boot still produces the SUCCESS marker line