### PR TITLE
fix(jedi): bump logs stats LIMIT 200 -> 5000 so all namespaces surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.146"
+version = "1.0.147"
 dependencies = [
  "anyhow",
  "askama 0.16.0",

--- a/apps/kbve/edge/functions/logs/index.ts
+++ b/apps/kbve/edge/functions/logs/index.ts
@@ -117,7 +117,7 @@ async function handleStats(params: { minutes?: number }) {
       WHERE timestamp > now() - INTERVAL {minutes:UInt32} MINUTE
       GROUP BY pod_namespace, service, level
       ORDER BY cnt DESC
-      LIMIT 200
+      LIMIT 5000
     `,
     query_params: { minutes },
     format: "JSONEachRow",

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
@@ -141,7 +141,7 @@ pub fn build_stats_sql(params: &LogsStatsParams) -> String {
 		 WHERE timestamp > now() - INTERVAL {} MINUTE \
 		 GROUP BY pod_namespace, service, level \
 		 ORDER BY cnt DESC \
-		 LIMIT 200",
+		 LIMIT 5000",
         minutes
     )
 }


### PR DESCRIPTION
## Summary
- Dashboard at `/dashboard/clickhouse/` was missing namespaces on shorter time windows (30 visible at 24h, 36 at 7d).
- Root cause: `build_stats_sql` in `packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs` groups by `(pod_namespace, service, level)` with `LIMIT 200`. Quieter (namespace, service, level) triplets get dropped on short windows; longer windows surface enough rows to expose them.
- Bumped `LIMIT` to `5000`. Cluster currently ~36 namespaces × ~5 services × 4 levels ≈ 720 rows worst case, so 5000 gives plenty of headroom.
- Also bumped the dead Supabase edge function copy (`apps/kbve/edge/functions/logs/index.ts`) so the two stay aligned even though the dashboard now hits `axum-kbve` via `/dashboard/clickhouse/proxy`.

## Test plan
- [x] `cargo clippy --manifest-path packages/rust/jedi/Cargo.toml --all-targets` clean
- [x] `cargo test --manifest-path packages/rust/jedi/Cargo.toml --lib` — 41 passed
- [ ] Verify dashboard shows the same namespace count across 15m / 1h / 6h / 24h / 7d after deploy