### PR TITLE
fix(firecracker-python-net): full init.sh matching cluster VM contract

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.144",
+			"version": "1.0.147",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -140,7 +140,7 @@
 		{
 			"key": "firecracker_python_net",
 			"app_name": "firecracker-python-net",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"version_toml": "packages/docker/firecracker/python/net/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx",
 			"source_path": "packages/docker/firecracker/python/net",
@@ -180,7 +180,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.14",
+			"version": "0.1.15",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",
@@ -217,7 +217,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.44",
+			"version": "1.0.46",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx
@@ -13,7 +13,7 @@ tags:
 key: firecracker_python_net
 pipeline: docker
 app_name: firecracker-python-net
-version: "0.1.2"
+version: "0.1.3"
 version_toml: packages/docker/firecracker/python/net/version.toml
 source_path: packages/docker/firecracker/python/net
 runner: ubuntu-latest

--- a/packages/docker/firecracker/python/net/Dockerfile
+++ b/packages/docker/firecracker/python/net/Dockerfile
@@ -24,6 +24,8 @@ FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
 
 RUN apk add --no-cache e2fsprogs e2fsprogs-extra
 
+COPY init.sh /tmp/init.sh
+
 RUN mkdir -p /rootfs/etc/apk && \
     cp /etc/apk/repositories /rootfs/etc/apk/repositories && \
     cp -a /etc/apk/keys /rootfs/etc/apk/ && \
@@ -40,19 +42,9 @@ RUN mkdir -p /rootfs/etc/apk && \
         py3-httpx \
         py3-urllib3 \
         py3-certifi && \
-    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log,etc} && \
+    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log,etc,mnt} && \
     printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /rootfs/etc/resolv.conf && \
-    printf '#!/bin/sh\n\
-mount -t proc proc /proc\n\
-mount -t sysfs sys /sys\n\
-mount -t devtmpfs dev /dev\n\
-ip link set lo up 2>/dev/null\n\
-ip link set eth0 up 2>/dev/null\n\
-if [ -x /entrypoint ]; then\n\
-  exec /entrypoint\n\
-else\n\
-  exec /bin/sh\n\
-fi\n' > /rootfs/init && \
+    cp /tmp/init.sh /rootfs/init && \
     chmod +x /rootfs/init && \
     dd if=/dev/zero of=/rootfs.ext4 bs=1M count=0 seek=192 && \
     mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \

--- a/packages/docker/firecracker/python/net/init.sh
+++ b/packages/docker/firecracker/python/net/init.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+mount -t tmpfs tmpfs /tmp 2>/dev/null
+
+ip link set lo up 2>/dev/null
+ip link set eth0 up 2>/dev/null
+
+ENTRYPOINT="/bin/sh"
+for param in $(cat /proc/cmdline); do
+  case "$param" in
+    fc_entrypoint=*) ENTRYPOINT="${param#fc_entrypoint=}" ;;
+  esac
+done
+
+if [ -b /dev/vdc ] && [ -b /dev/vdd ]; then
+  dd if=/dev/vdc of=/tmp/packages.raw bs=4096 2>/dev/null
+  tr -d '\0' < /tmp/packages.raw > /tmp/packages.txt
+
+  mkdir -p /mnt/packages
+  mount -o ro /dev/vdd /mnt/packages 2>/dev/null
+
+  if [ -d /mnt/packages/pip ] && command -v pip3 >/dev/null 2>&1; then
+    pip3 install --no-index --find-links /mnt/packages/pip \
+      $(cat /tmp/packages.txt) 2>/tmp/pkg-install.log || true
+  fi
+
+  umount /mnt/packages 2>/dev/null
+fi
+
+if [ -b /dev/vdb ]; then
+  dd if=/dev/vdb of=/tmp/code.raw bs=4096 2>/dev/null
+  tr -d '\0' < /tmp/code.raw > /tmp/code
+  echo "---FC_OUTPUT_START---"
+  "$ENTRYPOINT" /tmp/code
+  EC=$?
+  echo "---FC_OUTPUT_END---"
+  exit $EC
+fi
+exec /bin/sh


### PR DESCRIPTION
## Summary

After PR #10759 wired \`network=true\` on \`/vm/create\` and PR #10799 mounted \`/dev/net/tun\`, the VM finally booted with eth0 and an IP from the pool (\`172.18.0.2/30\`). Then it fell straight into a shell:

\`\`\`
mount: mounting dev on /dev failed: Resource busy
/bin/sh: can't access tty; job control turned off
\`\`\`

Two gaps in the baked \`/init\`:

1. Kernel auto-mounts \`devtmpfs\` during boot (\`devtmpfs: mounted\` shows up in dmesg). The init script's explicit \`mount\` returns \`EBUSY\`. The in-cluster build's init redirects to \`/dev/null\`; ours did not.
2. The script checked \`[ -x /entrypoint ]\` for a literal path and never parsed the kernel command line. Firecracker passes the real entrypoint via \`fc_entrypoint=/usr/bin/python3\` on \`boot_args\`. Our init fell through to \`exec /bin/sh\` — VM never ran the user code and eventually timed out.

The in-cluster \`firecracker-vm-init\` ConfigMap already carries the canonical init that handles all of this. Ship the same script as part of the docker image.

## Changes

| File | Change |
|------|--------|
| \`packages/docker/firecracker/python/net/init.sh\` | New. Mounts proc/sys/dev/tmp with errors silenced, brings up \`lo\` and \`eth0\` (no-op in sandbox mode), parses \`fc_entrypoint\` from \`/proc/cmdline\`, pulls package manifest from \`/dev/vdc\` + pip cache from \`/dev/vdd\` when both attached, installs via \`pip3 --no-index --find-links\`, reads user code from \`/dev/vdb\`, execs entrypoint, emits \`FC_OUTPUT_START/END\` markers fc-ctl uses to slice console output. |
| \`packages/docker/firecracker/python/net/Dockerfile\` | \`COPY init.sh /tmp/init.sh\` + \`cp /tmp/init.sh /rootfs/init\` replaces the inline \`printf\` placeholder. Also adds \`/mnt\` to the pre-made rootfs dirs so the pip cache mount works. |
| \`apps/kbve/astro-kbve/.../firecracker-python-net.mdx\` | \`version: 0.1.2\` → \`0.1.3\` to trigger a fresh publish. |
| \`.github/ci-dispatch-manifest.json\` | Regenerated. |

## Test plan

- [ ] Publish lands \`ghcr.io/kbve/firecracker-python-net:0.1.3\`.
- [ ] Atom PR bumps \`firecracker-net-rootfs-stage.yaml\`'s \`image:\` tag.
- [ ] ArgoCD reconciles → stage Job pulls \`:0.1.3\` → copies fresh \`firecracker-python-net.ext4\` onto the PVC.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.
- [ ] Public sandbox (no Network (VPN)) keeps booting \`alpine-python\` unchanged.