### PR TITLE
fix(firecracker-ctl-net): point FC_TUNNEL_IFACE at Gluetun's tun0

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -136,6 +136,8 @@ spec:
                         value: '10001'
                       - name: FC_PERSISTENT_ENDPOINTS_ENABLED
                         value: 'true'
+                      - name: FC_TUNNEL_IFACE
+                        value: 'tun0'
                   securityContext:
                       # jailer pivot_root requires Unconfined seccomp.
                       seccompProfile:


### PR DESCRIPTION
## Summary

After PRs #10759, #10779, #10799, #10816, the VM finally boots with \`eth0\` + \`172.18.0.2\` and runs user code. Next failure:

\`\`\`
[fail] connection: HTTPSConnectionPool(host='poetrydb.org', port=443): Max retries exceeded with url: /random/1 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object ...>: Failed to establish a new connection: [Errno -3] Try again'))
\`\`\`

\`-3\` = \`EAI_AGAIN\` — DNS resolver timed out.

\`\`\`
$ kubectl exec -n firecracker firecracker-ctl-net-... -c firecracker-ctl -- iptables -t nat -L POSTROUTING -n -v
Chain POSTROUTING (policy ACCEPT 426 packets, 32041 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 MASQUERADE  0    --  *      wg0     172.18.0.0/16        0.0.0.0/0
\`\`\`

\`\`\`
$ kubectl exec ... -- ip link show
5: tun0: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1320 ...
\`\`\`

The MASQUERADE rule targets \`wg0\`. Gluetun's WireGuard tunnel comes up as \`tun0\` instead. The pod has no \`wg0\` interface, so the NAT rule matches nothing — VM egress either drops or escapes unmasqueraded; DNS replies never come back.

\`fc-ctl\`'s tap manager defaults \`FC_TUNNEL_IFACE=wg0\` (see [tap.rs:137](apps/vm/firecracker-ctl/src/tap.rs#L137)).

## Fix

Set \`FC_TUNNEL_IFACE=tun0\` on the net deployment so \`TapManager::init()\` installs the MASQUERADE + FORWARD rules against the actual Gluetun interface. The old \`wg0\` rule remains harmless (matches nothing).

\`\`\`yaml
env:
  - name: FC_PERSISTENT_ENDPOINTS_ENABLED
    value: 'true'
  - name: FC_TUNNEL_IFACE
    value: 'tun0'
\`\`\`

YAML-only. No version bump needed.

## Test plan

- [ ] After merge, ArgoCD reconciles → fc-ctl-net pod restarts.
- [ ] \`iptables -t nat -L POSTROUTING -n -v\` inside the new pod shows a MASQUERADE rule targeting \`tun0\`.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.