### PR TITLE
feat(axum-kbve): public firecracker openapi spec route

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
@@ -20,6 +20,6 @@ import AstroApiDashboard from '@/components/dashboard/AstroApiDashboard.astro';
     title="KBVE Dashboard APIs"
     sources={[
         { slug: 'kbve', title: 'KBVE Public API', url: '/api/openapi.json', default: true },
-        { slug: 'firecracker', title: 'Firecracker Control', url: '/dashboard/firecracker/proxy/openapi.json' },
+        { slug: 'firecracker', title: 'Firecracker Control', url: '/api/firecracker/openapi.json' },
     ]}
 />

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -277,6 +277,10 @@ fn router(state: AppState) -> Router {
         .route("/health.html", get(health_html))
         .route("/api/status", get(api_status))
         .route("/api/openapi.json", get(crate::openapi::openapi_json))
+        .route(
+            "/api/firecracker/openapi.json",
+            get(super::proxy::firecracker_openapi_handler),
+        )
         .route("/api/v1/osrs/{item_id}", get(osrs_api_handler))
         .route("/api/v1/profile/me", get(profile_me_handler))
         .route("/api/v1/profile/username", post(set_username_handler))

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -1716,6 +1716,27 @@ pub async fn firecracker_proxy_handler(path: Option<Path<String>>, req: Request<
     }
 }
 
+/// Public read-only proxy for the firecracker-ctl OpenAPI document.
+///
+/// Mounted at `/api/firecracker/openapi.json` so the Scalar viewer at
+/// `/dashboard/api/` can fetch the spec without an auth bridge. The
+/// document only describes endpoint shapes; the operations themselves
+/// remain staff-gated through [`firecracker_proxy_handler`].
+pub async fn firecracker_openapi_handler(req: Request<Body>) -> Response {
+    match FIRECRACKER.get() {
+        Some(proxy) => {
+            proxy
+                .handle_preauthorized(Some(Path("openapi.json".to_string())), req)
+                .await
+        }
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Firecracker proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Firecracker-Net proxy singleton (network-enabled, DASHBOARD_MANAGE gated)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Scalar at \`/dashboard/api/\` couldn't load the firecracker source because \`/dashboard/firecracker/proxy/openapi.json\` is gated by \`DASHBOARD_VIEW\`; the unauthenticated spec fetch hit 401 and surfaced as \"Document 'firecracker' could not be loaded\".
- New \`/api/firecracker/openapi.json\` route serves only the OpenAPI document via \`handle_preauthorized\`. The handlers it describes remain staff-gated through \`firecracker_proxy_handler\` — only the spec surface widens, not the operations.
- \`api.mdx\` now points the firecracker source at the new public route.

## Test plan
- [ ] \`nx run axum-kbve:lint\` clean
- [ ] \`curl -i https://kbve.com/api/firecracker/openapi.json\` returns 200 with the firecracker-ctl spec (no auth)
- [ ] \`curl -i https://kbve.com/dashboard/firecracker/proxy/<any-other-path>\` still returns 401/403 without staff JWT
- [ ] \`/dashboard/api/\` Scalar viewer shows the firecracker source without the load error
- [ ] Authenticated user can fire a Try-It call against a firecracker tool