### PR TITLE
fix(astro-kbve): migrate sidebar autogenerate to Starlight v0.39 shape

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -194,22 +194,22 @@ export default defineConfig({
 				{
 					label: 'Guides',
 					collapsed: true,
-					autogenerate: { directory: 'guides' },
+					items: [{ autogenerate: { directory: 'guides' } }],
 				},
 				{
 					label: 'Applications',
 					collapsed: true,
-					autogenerate: { directory: 'application' },
+					items: [{ autogenerate: { directory: 'application' } }],
 				},
 				{
 					label: 'Project',
 					collapsed: true,
-					autogenerate: { directory: 'project' },
+					items: [{ autogenerate: { directory: 'project' } }],
 				},
 				{
 					label: 'Minecraft',
 					collapsed: true,
-					autogenerate: { directory: 'mc' },
+					items: [{ autogenerate: { directory: 'mc' } }],
 				},
 				{
 					label: 'Gaming',
@@ -227,7 +227,7 @@ export default defineConfig({
 				{
 					label: 'Arcade',
 					collapsed: true,
-					autogenerate: { directory: 'arcade' },
+					items: [{ autogenerate: { directory: 'arcade' } }],
 				},
 				{
 					label: 'Assets',
@@ -235,11 +235,11 @@ export default defineConfig({
 					items: [
 						{
 							label: 'Crypto',
-							autogenerate: { directory: 'crypto' },
+							items: [{ autogenerate: { directory: 'crypto' } }],
 						},
 						{
 							label: 'Stocks',
-							autogenerate: { directory: 'stock' },
+							items: [{ autogenerate: { directory: 'stock' } }],
 						},
 					],
 				},
@@ -249,50 +249,50 @@ export default defineConfig({
 					items: [
 						{
 							label: 'GDD',
-							autogenerate: { directory: 'gdd' },
+							items: [{ autogenerate: { directory: 'gdd' } }],
 						},
 						{
 							label: 'ItemDB',
-							autogenerate: { directory: 'itemdb' },
+							items: [{ autogenerate: { directory: 'itemdb' } }],
 						},
 						{
 							label: 'QuestDB',
-							autogenerate: { directory: 'questdb' },
+							items: [{ autogenerate: { directory: 'questdb' } }],
 						},
 						{
 							label: 'MapDB',
-							autogenerate: { directory: 'mapdb' },
+							items: [{ autogenerate: { directory: 'mapdb' } }],
 						},
 						{
 							label: 'NpcDB',
-							autogenerate: { directory: 'npcdb' },
+							items: [{ autogenerate: { directory: 'npcdb' } }],
 						},
 					],
 				},
 				{
 					label: 'Theory',
 					collapsed: true,
-					autogenerate: { directory: 'theory' },
+					items: [{ autogenerate: { directory: 'theory' } }],
 				},
 				{
 					label: 'Blog',
 					collapsed: true,
-					autogenerate: { directory: 'blog' },
+					items: [{ autogenerate: { directory: 'blog' } }],
 				},
 				{
 					label: 'Journal',
 					collapsed: true,
-					autogenerate: { directory: 'journal' },
+					items: [{ autogenerate: { directory: 'journal' } }],
 				},
 				{
 					label: 'Recipe',
 					collapsed: true,
-					autogenerate: { directory: 'recipe' },
+					items: [{ autogenerate: { directory: 'recipe' } }],
 				},
 				{
 					label: 'Legal',
 					collapsed: true,
-					autogenerate: { directory: 'legal' },
+					items: [{ autogenerate: { directory: 'legal' } }],
 				},
 			],
 		}),


### PR DESCRIPTION
## Summary
- Starlight v0.39 (shipped via the recent Astro 6.3 bump) removed the legacy \`autogenerate\` + \`label\` combo on sidebar items; nesting must now go through an \`items\` array.
- The dev branch cached an older astro-kbve build so this surfaced as a CI failure on the next PR that forced a rebuild (#10820).
- Wraps every directory-backed group (Guides, Applications, Project, Minecraft, Arcade, Theory, Blog, Journal, Recipe, Legal, plus the nested Assets and Game Data children) in the new \`items: [{ autogenerate }]\` form.

## Test plan
- [ ] \`nx run astro-kbve:build\` clean
- [ ] CI \`Verify ci-dispatch-manifest is up to date\` passes
- [ ] Sidebar still renders all 17 groups with the same contents