### PR TITLE
feat(astro-irc): hero CTA + client-side no-username gate

### DIFF
--- a/apps/irc/astro-irc/src/components/chat/ReactChatRoom.tsx
+++ b/apps/irc/astro-irc/src/components/chat/ReactChatRoom.tsx
@@ -458,6 +458,54 @@ const PROVIDERS: { id: OAuthProvider; label: string }[] = [
 	{ id: 'twitch', label: 'Twitch' },
 ];
 
+const USERNAME_SETUP_URL = 'https://kbve.com/askama/profile';
+
+function decodeJwtUsername(token: string): string | null {
+	const parts = token.split('.');
+	if (parts.length < 2) return null;
+	try {
+		const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+		const padLen = padded.length + ((4 - (padded.length % 4)) % 4);
+		const payload = JSON.parse(atob(padded.padEnd(padLen, '=')));
+		const value = payload?.kbve_username;
+		return typeof value === 'string' && value.trim().length > 0
+			? value
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+const NoUsernamePrompt: React.FC = () => (
+	<div className="flex flex-col items-center justify-center gap-6 p-8 text-center h-full">
+		<div>
+			<h2 className="text-xl font-bold text-[var(--sl-color-text)] mb-2">
+				Pick a username first
+			</h2>
+			<p className="text-sm text-[var(--sl-color-gray-3)] max-w-md">
+				IRC needs a canonical username before you can join. Your OAuth
+				display name isn't reused here — set one once on your KBVE
+				profile and you'll keep it across every service.
+			</p>
+		</div>
+		<a
+			href={USERNAME_SETUP_URL}
+			target="_blank"
+			rel="noopener noreferrer"
+			className={cn(
+				'px-4 py-3 rounded-lg text-sm font-medium transition-colors',
+				'bg-[var(--sl-color-accent)] text-white',
+				'hover:opacity-90',
+			)}>
+			Set a username on kbve.com
+		</a>
+		<p className="text-xs text-[var(--sl-color-gray-4)]">
+			After saving, refresh this page or sign back in to pick up the new
+			identity.
+		</p>
+	</div>
+);
+
 const LoginPrompt: React.FC = () => {
 	const [loading, setLoading] = useState(false);
 
@@ -510,9 +558,9 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 }) => {
 	const [sidebarOpen, setSidebarOpen] = useState(false);
 	const [usersOpen, setUsersOpen] = useState(false);
-	const [authState, setAuthState] = useState<'loading' | 'auth' | 'anon'>(
-		'loading',
-	);
+	const [authState, setAuthState] = useState<
+		'loading' | 'auth' | 'anon' | 'no-username'
+	>('loading');
 	const [token, setToken] = useState('');
 
 	// Boot droid workers (provides window.kbve.ws) + check Supabase session
@@ -524,25 +572,28 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 				await bootChat();
 				if (cancelled) return;
 
-				// 1. Check IDB session (same-origin, from direct OAuth on chat.kbve.com)
+				const applyToken = (next: string) => {
+					if (cancelled) return;
+					setToken(next);
+					setAuthState(
+						decodeJwtUsername(next) ? 'auth' : 'no-username',
+					);
+				};
+
 				const { authBridge } = await import('../../lib/supa');
 				const session = await authBridge.getSession();
 				if (!cancelled && session?.access_token) {
-					setToken(session.access_token);
-					setAuthState('auth');
+					applyToken(session.access_token);
 					return;
 				}
 
-				// 2. Check shared cookie (cross-origin, from OAuth on kbve.com)
 				const { getSharedToken } = await import('@kbve/astro');
 				const sharedToken = getSharedToken();
 				if (!cancelled && sharedToken) {
-					setToken(sharedToken);
-					setAuthState('auth');
+					applyToken(sharedToken);
 					return;
 				}
 
-				// 3. No session anywhere — show login
 				if (!cancelled) setAuthState('anon');
 			} catch (err) {
 				console.error('[chat] Boot failed:', err);
@@ -623,6 +674,23 @@ export const ReactChatRoom: React.FC<ReactChatRoomProps> = ({
 					'shadow-lg shadow-black/10',
 				)}>
 				<LoginPrompt />
+			</div>
+		);
+	}
+
+	if (authState === 'no-username') {
+		return (
+			<div
+				className={cn(
+					'flex flex-col',
+					'w-full h-full',
+					'rounded-xl overflow-hidden',
+					'border border-[var(--sl-color-border)]',
+					'border-t-2 border-t-[var(--sl-color-accent)]',
+					'bg-[var(--sl-color-bg)]',
+					'shadow-lg shadow-black/10',
+				)}>
+				<NoUsernamePrompt />
 			</div>
 		);
 	}

--- a/apps/irc/astro-irc/src/content/docs/index.mdx
+++ b/apps/irc/astro-irc/src/content/docs/index.mdx
@@ -5,7 +5,12 @@ template: splash
 hero:
   tagline: Sign in with your KBVE account to start chatting.
   actions:
+    - text: Open Chat
+      link: /chat/
+      icon: right-arrow
+      variant: primary
     - text: Getting Started
       link: /guides/getting-started/
       icon: right-arrow
+      variant: minimal
 ---


### PR DESCRIPTION
## Summary
- Add an \"Open Chat\" primary action to the chat.kbve.com splash hero so users at the root have a one-click path to /chat.
- Decode the access token on boot and short-circuit to a \"Set a username\" prompt when \`kbve_username\` is missing, instead of looping into 1006 reconnects.

## Why
The gateway now rejects WebSocket upgrades when no provider username is configured (gateway PR #10781). The browser WS API can't read the 403 body — it surfaces as code=1006 abnormal and the client retries forever. Detecting the missing claim client-side gives users an actionable next step (https://kbve.com/askama/profile) and stops the noisy reconnect loop.

## Changes
- \`apps/irc/astro-irc/src/content/docs/index.mdx\` — second hero action plus variants.
- \`apps/irc/astro-irc/src/components/chat/ReactChatRoom.tsx\` — \`decodeJwtUsername()\` parses the base64url JWT payload (no signature verification, gateway is still the trust boundary); new \`authState === 'no-username'\` renders \`NoUsernamePrompt\` with the kbve.com profile link; auto-connect stays gated on \`'auth'\`.

## Test plan
- [ ] Sign in fresh (post-GoTrue-hook rollout) → chat connects with correct nick.
- [ ] Sign in with a stale token / user without a \`profile.username\` row → gate appears, no WS attempts in network panel.
- [ ] After saving a username on kbve.com, refresh → connects without reload of the chat tab feels acceptable.
- [ ] chat.kbve.com root shows two hero actions, primary navigates to /chat.

## Follow-up (separate PR)
- Gateway \`/api/v1/me\` so the client can fail closed even when JWT decoding misbehaves.
- Reconnect backoff cap on the WS client.