### PR TITLE
feat(firecracker): add fastapi + uvicorn to pip cache

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-pip-packages.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-pip-packages.yaml
@@ -34,3 +34,9 @@ data:
         orjson
         tabulate
         jmespath
+        fastapi
+        uvicorn
+        starlette
+        python-multipart
+        email-validator
+        websockets

--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v9
+    name: firecracker-rootfs-init-v10
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -101,11 +101,15 @@ spec:
 
                           # --- pip package cache ---
                           # Reads package list from ConfigMap (firecracker-pip-packages).
-                          # Rebuild triggered when init job name is bumped (v8 → v9).
+                          # Rebuild triggered when init job name is bumped (v9 → v10).
                           # NOTE: firecracker-python-net.ext4 is staged by a
                           # dedicated Job (firecracker-net-rootfs-stage.yaml)
                           # that runs the published GHCR image directly.
                           echo "[5/5] pip-cache..."
+                          # Bumping the init job name forces a pip-cache rebuild
+                          # so that newly added entries in firecracker-pip-packages
+                          # land without waiting for the weekly refresh CronJob.
+                          rm -f "${OUTPUT}/pip-cache.ext4"
                           if [ ! -f "${OUTPUT}/pip-cache.ext4" ]; then
                               apk add --no-cache python3 py3-pip
                               PIPCACHE=$(mktemp -d)


### PR DESCRIPTION
## Summary
- Extends \`firecracker-pip-packages\` ConfigMap with the FastAPI stack (\`fastapi\`, \`uvicorn\`, \`starlette\`, \`python-multipart\`, \`email-validator\`, \`websockets\`).
- Persistent endpoints can now boot with \`packages: [\"fastapi\", \"uvicorn\"]\` and have them install offline from the pre-built \`pip-cache.ext4\` drive on first boot.
- Bumps the init Job name (v9 → v10) and force-removes \`pip-cache.ext4\` before the build so the new wheels land on the next ArgoCD sync rather than waiting for the weekly refresh CronJob.

## Notes
- Skipped \`uvloop\` / \`httptools\` / \`watchfiles\` (the \`uvicorn[standard]\` extras) — the cache restricts to pure-Python or musllinux wheels and those are wheel-spotty across alpine versions. Plain uvicorn workers are sufficient for the dashboard deploy flow.
- This is PR 1 of 3 for the dashboard-IDE-driven Firecracker deploy story. PR 2 introduces a dedicated \`firecracker-python-web\` image with FastAPI baked in for long-lived deploys; PR 3 mirrors the ecosystem for Node + Fastify.

## Test plan
- [ ] ArgoCD sync runs \`firecracker-rootfs-init-v10\` and the pip-cache log shows fastapi/uvicorn wheels downloaded
- [ ] \`POST /fc/deploy\` with \`packages: [\"fastapi\", \"uvicorn\"]\` and a single-file FastAPI entrypoint boots a persistent VM that serves on the configured port
- [ ] Weekly \`firecracker-pip-cache-refresh\` CronJob picks up the new packages on the next Sunday run