### PR TITLE
fix(firecracker-ctl-net): Recreate strategy to dodge resource quota

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -16,6 +16,8 @@ metadata:
         app.kubernetes.io/component: vm-runtime-net
 spec:
     replicas: 1
+    strategy:
+        type: Recreate
     selector:
         matchLabels:
             app: firecracker-ctl-net


### PR DESCRIPTION
## Summary

PR #10819 added \`FC_TUNNEL_IFACE=tun0\` to the net deployment, but the rollout stalled with ArgoCD reporting \`Deployment \"firecracker-ctl-net\" exceeded its progress deadline\` and ReplicaSet condition \`ReplicaFailure: exceeded quota\`.

\`\`\`
quota cap: 8 cpu / 8 Gi limits
used:      6500m + 6528Mi
new pod:   2500m + 2432Mi
total:     9000m + 8960Mi  ← over cap
\`\`\`

\`RollingUpdate\` (default) needs an extra pod alive during the rollout — sandbox \`firecracker-ctl\` runs 2 replicas (KEDA-scaled) so there is no room for the surge.

## Fix

Switch this deployment to \`strategy: Recreate\`. The old pod is terminated before the new one is scheduled — quota usage drops back by 2500m+2432Mi before the new pod is admitted.

\`\`\`yaml
spec:
    replicas: 1
    strategy:
        type: Recreate
\`\`\`

Brief downtime per rollout is acceptable here — \`firecracker-ctl-net\` only holds staff-facing \`/fc/*\` and the dashboard's Network (VPN) path, no public traffic. The public-sandbox \`firecracker-ctl\` keeps \`RollingUpdate\` (multiple replicas, user-facing).

## Live patch already applied

I patched the running deployment with the same strategy via \`kubectl patch\` to unblock the smoke test. ArgoCD would have reverted that on next sync; this PR makes it durable.

## Test plan

- [ ] ArgoCD reports \`firecracker-ctl\` app \`Synced / Healthy\`.
- [ ] Future env / image rollouts on this deployment do not stall on quota.