### PR TITLE
feat(irc): /api/v1/me identity probe + WS exponential backoff

### DIFF
--- a/apps/irc/irc-e2e/e2e/api.spec.ts
+++ b/apps/irc/irc-e2e/e2e/api.spec.ts
@@ -6,6 +6,7 @@ test.describe('API: Authentication Required', () => {
 		'/api/v1/status',
 		'/api/v1/channels',
 		'/api/v1/users',
+		'/api/v1/me',
 	];
 
 	for (const route of protectedRoutes) {
@@ -47,6 +48,79 @@ test.describe('API: Authenticated Requests', () => {
 			headers: { Authorization: `Bearer ${token}` },
 		});
 		expect(response.status()).toBe(200);
+	});
+});
+
+test.describe('API: /me identity probe', () => {
+	test('returns has_username=false when no provider username', async ({
+		request,
+	}) => {
+		const token = await signJwt();
+		const response = await request.get('/api/v1/me', {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(response.status()).toBe(200);
+		const body = await response.json();
+		expect(body.has_username).toBe(false);
+		expect(body.username).toBeNull();
+		expect(typeof body.setup_url).toBe('string');
+		expect(body.setup_url.length).toBeGreaterThan(0);
+		expect(body.sub).toBe('e2e-test-user');
+	});
+
+	test('returns username from kbve_username claim', async ({ request }) => {
+		const token = await signJwt({ kbve_username: 'h0lybyte' });
+		const response = await request.get('/api/v1/me', {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(response.status()).toBe(200);
+		const body = await response.json();
+		expect(body.has_username).toBe(true);
+		expect(body.username).toBe('h0lybyte');
+	});
+
+	test('falls back to user_metadata.preferred_username', async ({
+		request,
+	}) => {
+		const token = await signJwt({
+			user_metadata: { preferred_username: 'h0lybyte' },
+		});
+		const response = await request.get('/api/v1/me', {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(response.status()).toBe(200);
+		const body = await response.json();
+		expect(body.has_username).toBe(true);
+		expect(body.username).toBe('h0lybyte');
+	});
+
+	test('kbve_username wins over user_metadata when both present', async ({
+		request,
+	}) => {
+		const token = await signJwt({
+			kbve_username: 'kbve_h0ly',
+			user_metadata: { preferred_username: 'oauth_alt' },
+		});
+		const response = await request.get('/api/v1/me', {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(response.status()).toBe(200);
+		const body = await response.json();
+		expect(body.username).toBe('kbve_h0ly');
+	});
+
+	test('strips disallowed characters and truncates', async ({ request }) => {
+		const token = await signJwt({
+			kbve_username: 'h0ly!byte@123-extra-long-name',
+		});
+		const response = await request.get('/api/v1/me', {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(response.status()).toBe(200);
+		const body = await response.json();
+		expect(body.has_username).toBe(true);
+		expect(body.username).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(body.username.length).toBeLessThanOrEqual(16);
 	});
 });
 

--- a/apps/irc/irc-gateway/src/auth/jwt.rs
+++ b/apps/irc/irc-gateway/src/auth/jwt.rs
@@ -109,15 +109,17 @@ pub fn validate_token(token: &str) -> Result<Claims, StatusCode> {
     .map_err(|_| StatusCode::UNAUTHORIZED)
 }
 
-/// Axum middleware that requires valid JWT
-pub async fn require_auth(req: Request, next: Next) -> impl IntoResponse {
+pub async fn require_auth(mut req: Request, next: Next) -> impl IntoResponse {
     let token = match extract_token(&req) {
         Some(t) => t,
         None => return StatusCode::UNAUTHORIZED.into_response(),
     };
 
     match validate_token(&token) {
-        Ok(_claims) => next.run(req).await.into_response(),
+        Ok(claims) => {
+            req.extensions_mut().insert(claims);
+            next.run(req).await.into_response()
+        }
         Err(status) => status.into_response(),
     }
 }

--- a/apps/irc/irc-gateway/src/gateway/rest.rs
+++ b/apps/irc/irc-gateway/src/gateway/rest.rs
@@ -1,19 +1,30 @@
-use axum::{
-    routing::get,
-    response::IntoResponse,
-    Json, Router,
-    middleware,
-};
+use axum::{Extension, Json, Router, middleware, response::IntoResponse, routing::get};
 use serde_json::json;
 
-use crate::auth::jwt::require_auth;
+use crate::auth::jwt::{Claims, require_auth};
+
+const DEFAULT_USERNAME_SETUP_URL: &str = "https://kbve.com/askama/profile";
 
 pub fn api_router() -> Router {
     Router::new()
         .route("/status", get(status))
         .route("/channels", get(channels))
         .route("/users", get(users))
+        .route("/me", get(me))
         .layer(middleware::from_fn(require_auth))
+}
+
+async fn me(Extension(claims): Extension<Claims>) -> impl IntoResponse {
+    let username = claims.irc_nick();
+    let setup_url = std::env::var("KBVE_USERNAME_SETUP_URL")
+        .unwrap_or_else(|_| DEFAULT_USERNAME_SETUP_URL.to_string());
+
+    Json(json!({
+        "has_username": username.is_some(),
+        "username": username,
+        "sub": claims.sub,
+        "setup_url": setup_url,
+    }))
 }
 
 async fn status() -> impl IntoResponse {
@@ -21,7 +32,8 @@ async fn status() -> impl IntoResponse {
         .unwrap_or_else(|_| "ws://ergo-irc-service.irc.svc.cluster.local:8080".into());
     let ergo_irc = format!(
         "{}:{}",
-        std::env::var("ERGO_IRC_HOST").unwrap_or_else(|_| "ergo-irc-service.irc.svc.cluster.local".into()),
+        std::env::var("ERGO_IRC_HOST")
+            .unwrap_or_else(|_| "ergo-irc-service.irc.svc.cluster.local".into()),
         std::env::var("ERGO_IRC_PORT").unwrap_or_else(|_| "6667".into()),
     );
 

--- a/packages/npm/droid/src/lib/workers/ws-worker.spec.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { reconnectDelayMs } from './ws-worker';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('reconnectDelayMs', () => {
+	it('returns base delay on first attempt', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		expect(reconnectDelayMs(1)).toBe(1000);
+	});
+
+	it('doubles each attempt', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		expect(reconnectDelayMs(1)).toBe(1000);
+		expect(reconnectDelayMs(2)).toBe(2000);
+		expect(reconnectDelayMs(3)).toBe(4000);
+		expect(reconnectDelayMs(4)).toBe(8000);
+		expect(reconnectDelayMs(5)).toBe(16000);
+	});
+
+	it('caps at the 30s ceiling', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		expect(reconnectDelayMs(10)).toBe(30000);
+		expect(reconnectDelayMs(100)).toBe(30000);
+	});
+
+	it('adds jitter up to 500ms', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0.99999);
+		const delay = reconnectDelayMs(1);
+		expect(delay).toBeGreaterThanOrEqual(1000);
+		expect(delay).toBeLessThan(1500);
+	});
+
+	it('treats 0 and negative attempts as the first attempt', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		expect(reconnectDelayMs(0)).toBe(1000);
+		expect(reconnectDelayMs(-5)).toBe(1000);
+	});
+});

--- a/packages/npm/droid/src/lib/workers/ws-worker.ts
+++ b/packages/npm/droid/src/lib/workers/ws-worker.ts
@@ -47,12 +47,22 @@ let lastPongTime = 0;
 const HEARTBEAT_INTERVAL_MS = 30000;
 const HEARTBEAT_TIMEOUT_MS = 60000;
 
-// Reconnect
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
 let lastUrl: string | null = null;
 const MAX_RECONNECT_ATTEMPTS = 5;
-const RECONNECT_DELAY_MS = 3000;
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30000;
+const RECONNECT_JITTER_MS = 500;
+
+export function reconnectDelayMs(attempt: number): number {
+	const exp = Math.min(
+		RECONNECT_MAX_MS,
+		RECONNECT_BASE_MS * 2 ** Math.max(0, attempt - 1),
+	);
+	const jitter = Math.floor(Math.random() * RECONNECT_JITTER_MS);
+	return exp + jitter;
+}
 
 function startHeartbeat() {
 	stopHeartbeat();
@@ -104,14 +114,15 @@ function attemptReconnect() {
 	}
 
 	reconnectAttempts++;
+	const delay = reconnectDelayMs(reconnectAttempts);
 	console.log(
-		`[WS] Reconnecting (${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`,
+		`[WS] Reconnecting (${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS}) in ${delay}ms...`,
 	);
 	broadcastStatus('reconnecting');
 
 	reconnectTimer = setTimeout(() => {
 		if (lastUrl) wsInstanceAPI.connect(lastUrl);
-	}, RECONNECT_DELAY_MS);
+	}, delay);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add \`/api/v1/me\` to the gateway so the chat client can ask \"who would I be on IRC\" before opening a WebSocket — same nick logic as \`/ws\`, but reachable as plain JSON. No more relying on JWT decoding for the gate decision; clients fail closed even if the token is malformed.
- Replace the fixed 3s reconnect cadence with exponential backoff + jitter, so a flaky network stops hammering the gateway five times in 15 seconds.

## Endpoint contract
\`GET /api/v1/me\` (Bearer auth, same middleware as the other \`/api/v1/*\` routes)
\`\`\`json
{
  \"has_username\": true,
  \"username\": \"h0lybyte\",
  \"sub\": \"c154f66c-…\",
  \"setup_url\": \"https://kbve.com/askama/profile\"
}
\`\`\`
- \`setup_url\` overridable via env \`KBVE_USERNAME_SETUP_URL\`.
- \`username\` / \`has_username\` reuse \`Claims::irc_nick()\`, so the answer is in lockstep with what \`/ws\` will do.
- \`require_auth\` now stashes the validated Claims into request extensions, which keeps the handler trivial and lets future routes reuse the identity.

## Reconnect backoff
\`packages/npm/droid/src/lib/workers/ws-worker.ts\`
- \`reconnectDelayMs(attempt)\` exported as a pure function: \`1s, 2s, 4s, 8s, 16s\` capped at \`30s\`, plus up to \`500ms\` jitter.
- Same \`MAX_RECONNECT_ATTEMPTS = 5\`. After 5 strikes it still broadcasts \`status: failed\`.

## Tests
- \`apps/irc/irc-e2e/e2e/api.spec.ts\`
  - \`/api/v1/me\` joins the protected-routes list (401 without token).
  - New \`/me identity probe\` suite: no-username default, \`kbve_username\` happy path, \`user_metadata.preferred_username\` fallback, \`kbve_username\` priority over \`user_metadata\`, char-strip + 16-char cap.
- \`packages/npm/droid/src/lib/workers/ws-worker.spec.ts\` — five vitest cases on \`reconnectDelayMs\`: base, doubling, cap, jitter ceiling, non-positive clamp.

## Test plan
- [x] \`cargo test --bin irc-gateway\` — 34 passed
- [x] \`cargo build --bin irc-gateway\` clean
- [x] \`vitest run --config packages/npm/droid/vite.config.ts\` — 111 passed (12 files)
- [ ] Hit \`/api/v1/me\` on staging with a real Supabase token, verify \`username\` matches what /ws would issue
- [ ] Force WS reconnect storm (block gateway in DevTools) → confirm delays follow the exponential schedule and final state is \`failed\`, not infinite \`reconnecting\`