### PR TITLE
feat(astro): add ruffle cdn integration

### DIFF
--- a/packages/npm/astro/README.md
+++ b/packages/npm/astro/README.md
@@ -16,14 +16,14 @@ npm install @kbve/astro @kbve/droid
 import { useDroid, useDroidEvents } from '@kbve/astro';
 
 function MyComponent() {
-  const { initialized, hasApi, hasEvents, error } = useDroid();
+	const { initialized, hasApi, hasEvents, error } = useDroid();
 
-  useDroidEvents('droid-ready', (payload) => {
-    console.log('Droid ready at', payload.timestamp);
-  });
+	useDroidEvents('droid-ready', (payload) => {
+		console.log('Droid ready at', payload.timestamp);
+	});
 
-  if (!initialized) return <div>Loading workers...</div>;
-  return <div>Workers ready!</div>;
+	if (!initialized) return <div>Loading workers...</div>;
+	return <div>Workers ready!</div>;
 }
 ```
 
@@ -36,7 +36,25 @@ import DroidStatus from '@kbve/astro/components/DroidStatus.astro';
 ---
 
 <DroidProvider>
-  <DroidStatus />
-  <slot />
+	<DroidStatus />
+	<slot />
 </DroidProvider>
 ```
+
+### Ruffle
+
+```astro
+---
+import AstroRuffle from '@kbve/astro/components/ruffle/AstroRuffle.astro';
+---
+
+<AstroRuffle
+	src="/swf/game.swf"
+	height={540}
+	config={{ autoplay: 'on', splashScreen: false }}
+/>
+```
+
+`AstroRuffle` loads Ruffle from `https://unpkg.com/@ruffle-rs/ruffle` by
+default. Use `cdn="jsdelivr"`, `version="..."`, or `scriptUrl="..."` when a
+page needs a pinned or custom CDN endpoint.

--- a/packages/npm/astro/package.json
+++ b/packages/npm/astro/package.json
@@ -39,6 +39,15 @@
 		"./components/ToastContainer.astro": "./components/ToastContainer.astro",
 		"./components/CanvasOverlay.astro": "./components/CanvasOverlay.astro",
 		"./components/Redirect.astro": "./components/Redirect.astro",
+		"./components/ruffle/AstroRuffle.astro": "./components/ruffle/AstroRuffle.astro",
+		"./components/ruffle/ReactRuffle": {
+			"import": "./components/ruffle/ReactRuffle.js",
+			"types": "./components/ruffle/ReactRuffle.d.ts"
+		},
+		"./components/ruffle/ruffle": {
+			"import": "./components/ruffle/ruffle.js",
+			"types": "./components/ruffle/ruffle.d.ts"
+		},
 		"./components/tooltip/social/SocialTooltip.astro": "./components/tooltip/social/SocialTooltip.astro",
 		"./components/tooltip/social/sttService": "./components/tooltip/social/sttService.js",
 		"./components/hero/scroll/ScrollZoomHero.astro": "./components/hero/scroll/ScrollZoomHero.astro",

--- a/packages/npm/astro/project.json
+++ b/packages/npm/astro/project.json
@@ -49,7 +49,8 @@
 					"cp packages/npm/astro/package.json dist/packages/npm/astro/package.json",
 					"cp packages/npm/astro/README.md dist/packages/npm/astro/README.md",
 					"mkdir -p dist/packages/npm/astro/components",
-					"cp packages/npm/astro/src/components/*.astro dist/packages/npm/astro/components/",
+					"cp -R packages/npm/astro/src/components/. dist/packages/npm/astro/components/",
+					"cp -R packages/npm/astro/shims/. dist/packages/npm/astro/",
 					"nx nx-release-publish astro"
 				],
 				"parallel": false

--- a/packages/npm/astro/shims/components/ruffle/ReactRuffle.js
+++ b/packages/npm/astro/shims/components/ruffle/ReactRuffle.js
@@ -1,0 +1,1 @@
+export { ReactRuffle, ReactRuffle as default } from '../../astro.es.js';

--- a/packages/npm/astro/shims/components/ruffle/ruffle.js
+++ b/packages/npm/astro/shims/components/ruffle/ruffle.js
@@ -1,0 +1,8 @@
+export {
+	RUFFLE_DEFAULT_CDN,
+	RUFFLE_DEFAULT_SCRIPT_URL,
+	RUFFLE_SCRIPT_ID,
+	getRuffleWindow,
+	mergeRuffleConfig,
+	resolveRuffleScriptUrl,
+} from '../../astro.es.js';

--- a/packages/npm/astro/src/components/ruffle/AstroRuffle.astro
+++ b/packages/npm/astro/src/components/ruffle/AstroRuffle.astro
@@ -1,0 +1,178 @@
+---
+type RuffleCdn = 'unpkg' | 'jsdelivr';
+type RuffleConfig = Record<string, unknown>;
+type RuffleLoadOptions = { url: string; [key: string]: unknown };
+
+interface Props {
+	src: string;
+	cdn?: RuffleCdn;
+	version?: string;
+	scriptUrl?: string;
+	config?: RuffleConfig;
+	loadOptions?: Omit<RuffleLoadOptions, 'url'>;
+	class?: string;
+	playerClass?: string;
+	width?: number | string;
+	height?: number | string;
+	title?: string;
+	id?: string;
+	allowFullscreen?: boolean;
+}
+
+const {
+	src,
+	cdn,
+	version,
+	scriptUrl,
+	config,
+	loadOptions,
+	class: className,
+	playerClass,
+	width = '100%',
+	height = 480,
+	title,
+	id,
+	allowFullscreen = true,
+} = Astro.props;
+
+const ruffleId = id ?? `kbve-ruffle-${Math.random().toString(36).slice(2, 10)}`;
+const cdnBaseUrl =
+	cdn === 'jsdelivr'
+		? 'https://cdn.jsdelivr.net/npm/@ruffle-rs/ruffle'
+		: 'https://unpkg.com/@ruffle-rs/ruffle';
+const resolvedScriptUrl = scriptUrl
+	? scriptUrl
+	: version
+		? `${cdnBaseUrl}@${version}`
+		: cdnBaseUrl;
+const resolvedWidth = typeof width === 'number' ? `${width}px` : width;
+const resolvedHeight = typeof height === 'number' ? `${height}px` : height;
+const options = {
+	src,
+	scriptUrl: resolvedScriptUrl,
+	config,
+	loadOptions,
+	playerClass,
+	title,
+	allowFullscreen,
+};
+---
+
+<div
+	id={ruffleId}
+	class={className}
+	data-kbve-ruffle
+	data-ruffle-status="idle"
+	style={`width: ${resolvedWidth}; height: ${resolvedHeight};`}>
+</div>
+
+<script define:vars={{ ruffleId, options }}>
+	const scriptId = 'kbve-ruffle-player-script';
+	let ruffleScriptPromise = window.__kbveRuffleScriptPromise ?? null;
+
+	function mergeConfig(baseConfig, overrideConfig) {
+		const merged = {
+			...(baseConfig ?? {}),
+			...(overrideConfig ?? {}),
+		};
+
+		return Object.keys(merged).length > 0 ? merged : undefined;
+	}
+
+	function loadRuffleScript() {
+		window.RufflePlayer = window.RufflePlayer ?? {};
+
+		const mergedConfig = mergeConfig(
+			window.RufflePlayer.config,
+			options.config,
+		);
+		if (mergedConfig) {
+			window.RufflePlayer.config = mergedConfig;
+		}
+
+		if (window.RufflePlayer.newest) {
+			return Promise.resolve();
+		}
+
+		if (ruffleScriptPromise) return ruffleScriptPromise;
+
+		ruffleScriptPromise = new Promise((resolve, reject) => {
+			const existingScript = document.querySelector(
+				`script[data-kbve-ruffle="true"], #${scriptId}`,
+			);
+			const script = existingScript ?? document.createElement('script');
+
+			const cleanup = () => {
+				script.removeEventListener('load', handleLoad);
+				script.removeEventListener('error', handleError);
+			};
+
+			const handleLoad = () => {
+				cleanup();
+				resolve();
+			};
+
+			const handleError = () => {
+				cleanup();
+				window.__kbveRuffleScriptPromise = null;
+				ruffleScriptPromise = null;
+				reject(
+					new Error(
+						`Failed to load Ruffle from ${options.scriptUrl}`,
+					),
+				);
+			};
+
+			script.addEventListener('load', handleLoad, { once: true });
+			script.addEventListener('error', handleError, { once: true });
+
+			if (!existingScript) {
+				script.id = scriptId;
+				script.dataset.kbveRuffle = 'true';
+				script.async = true;
+				script.src = options.scriptUrl;
+				document.head.appendChild(script);
+			}
+		});
+
+		window.__kbveRuffleScriptPromise = ruffleScriptPromise;
+		return ruffleScriptPromise;
+	}
+
+	async function mountRuffle() {
+		const container = document.getElementById(ruffleId);
+		if (!container || !options.src) return;
+
+		container.dataset.ruffleStatus = 'loading';
+
+		try {
+			await loadRuffleScript();
+			const ruffle = window.RufflePlayer?.newest?.();
+			if (!ruffle) {
+				throw new Error('Ruffle loaded without exposing newest().');
+			}
+
+			const player = ruffle.createPlayer();
+			player.style.width = '100%';
+			player.style.height = '100%';
+			if (options.playerClass) player.className = options.playerClass;
+			if (options.title) player.title = options.title;
+			if (options.allowFullscreen) {
+				player.setAttribute('allowfullscreen', 'true');
+			}
+
+			container.replaceChildren(player);
+
+			const source = options.loadOptions
+				? { ...options.loadOptions, url: options.src }
+				: options.src;
+			await player.ruffle().load(source);
+			container.dataset.ruffleStatus = 'ready';
+		} catch (error) {
+			container.dataset.ruffleStatus = 'error';
+			console.error(error);
+		}
+	}
+
+	void mountRuffle();
+</script>

--- a/packages/npm/astro/src/components/ruffle/ReactRuffle.tsx
+++ b/packages/npm/astro/src/components/ruffle/ReactRuffle.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import {
+	getRuffleWindow,
+	mergeRuffleConfig,
+	resolveRuffleScriptUrl,
+	RUFFLE_SCRIPT_ID,
+	type RuffleCdn,
+	type RuffleConfig,
+	type RuffleLoadOptions,
+	type RufflePlayerElement,
+} from './ruffle';
+
+type RuffleStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface ReactRuffleProps {
+	src: string;
+	cdn?: RuffleCdn;
+	version?: string;
+	scriptUrl?: string;
+	config?: RuffleConfig;
+	loadOptions?: Omit<RuffleLoadOptions, 'url'>;
+	className?: string;
+	playerClassName?: string;
+	style?: CSSProperties;
+	width?: number | string;
+	height?: number | string;
+	title?: string;
+	id?: string;
+	allowFullscreen?: boolean;
+	replaceOnSrcChange?: boolean;
+	onReady?: (player: RufflePlayerElement) => void;
+	onError?: (error: Error) => void;
+}
+
+let ruffleScriptPromise: Promise<void> | null = null;
+
+function loadRuffleScript(scriptUrl: string, config?: RuffleConfig) {
+	const ruffleWindow = getRuffleWindow();
+	ruffleWindow.RufflePlayer = ruffleWindow.RufflePlayer ?? {};
+
+	const mergedConfig = mergeRuffleConfig(
+		ruffleWindow.RufflePlayer.config,
+		config,
+	);
+	if (mergedConfig) {
+		ruffleWindow.RufflePlayer.config = mergedConfig;
+	}
+
+	if (ruffleWindow.RufflePlayer.newest) {
+		return Promise.resolve();
+	}
+
+	const existingScript = document.querySelector<HTMLScriptElement>(
+		`script[data-kbve-ruffle="true"], #${RUFFLE_SCRIPT_ID}`,
+	);
+
+	if (ruffleScriptPromise) return ruffleScriptPromise;
+
+	ruffleScriptPromise = new Promise<void>((resolve, reject) => {
+		const script = existingScript ?? document.createElement('script');
+
+		const cleanup = () => {
+			script.removeEventListener('load', handleLoad);
+			script.removeEventListener('error', handleError);
+		};
+
+		const handleLoad = () => {
+			cleanup();
+			resolve();
+		};
+
+		const handleError = () => {
+			cleanup();
+			ruffleScriptPromise = null;
+			reject(new Error(`Failed to load Ruffle from ${scriptUrl}`));
+		};
+
+		script.addEventListener('load', handleLoad, { once: true });
+		script.addEventListener('error', handleError, { once: true });
+
+		if (!existingScript) {
+			script.id = RUFFLE_SCRIPT_ID;
+			script.dataset.kbveRuffle = 'true';
+			script.async = true;
+			script.src = scriptUrl;
+			document.head.appendChild(script);
+		}
+	});
+
+	return ruffleScriptPromise;
+}
+
+function toCssSize(value?: number | string) {
+	return typeof value === 'number' ? `${value}px` : value;
+}
+
+export function ReactRuffle({
+	src,
+	cdn,
+	version,
+	scriptUrl,
+	config,
+	loadOptions,
+	className,
+	playerClassName,
+	style,
+	width = '100%',
+	height = 480,
+	title,
+	id,
+	allowFullscreen = true,
+	replaceOnSrcChange = true,
+	onReady,
+	onError,
+}: ReactRuffleProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const playerRef = useRef<RufflePlayerElement | null>(null);
+	const [status, setStatus] = useState<RuffleStatus>('idle');
+
+	const resolvedScriptUrl = useMemo(
+		() => resolveRuffleScriptUrl({ cdn, version, scriptUrl }),
+		[cdn, version, scriptUrl],
+	);
+
+	useEffect(() => {
+		let cancelled = false;
+		const container = containerRef.current;
+		if (!container || !src) return undefined;
+
+		setStatus('loading');
+
+		void loadRuffleScript(resolvedScriptUrl, config)
+			.then(() => {
+				if (cancelled) return;
+
+				const ruffle = getRuffleWindow().RufflePlayer?.newest?.();
+				if (!ruffle) {
+					throw new Error(
+						'Ruffle loaded without exposing window.RufflePlayer.newest().',
+					);
+				}
+
+				const existingPlayer = playerRef.current;
+				const player =
+					replaceOnSrcChange || !existingPlayer
+						? ruffle.createPlayer()
+						: existingPlayer;
+
+				if (replaceOnSrcChange || !existingPlayer) {
+					container.replaceChildren(player);
+					playerRef.current = player;
+				}
+
+				if (id) player.id = id;
+				if (title) player.title = title;
+				if (playerClassName) player.className = playerClassName;
+				player.style.width = '100%';
+				player.style.height = '100%';
+				if (allowFullscreen) {
+					player.setAttribute('allowfullscreen', 'true');
+				} else {
+					player.removeAttribute('allowfullscreen');
+				}
+
+				const source =
+					loadOptions && Object.keys(loadOptions).length > 0
+						? { ...loadOptions, url: src }
+						: src;
+
+				return player
+					.ruffle()
+					.load(source)
+					.then(() => {
+						if (cancelled) return;
+						setStatus('ready');
+						onReady?.(player);
+					});
+			})
+			.catch((error: unknown) => {
+				if (cancelled) return;
+				const normalizedError =
+					error instanceof Error ? error : new Error(String(error));
+				setStatus('error');
+				onError?.(normalizedError);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		allowFullscreen,
+		config,
+		id,
+		loadOptions,
+		onError,
+		onReady,
+		playerClassName,
+		replaceOnSrcChange,
+		resolvedScriptUrl,
+		src,
+		title,
+	]);
+
+	return (
+		<div
+			className={className}
+			data-ruffle-status={status}
+			style={{
+				width: toCssSize(width),
+				height: toCssSize(height),
+				...style,
+			}}>
+			<div
+				ref={containerRef}
+				style={{ width: '100%', height: '100%' }}
+				aria-label={title}
+			/>
+		</div>
+	);
+}
+
+export default ReactRuffle;

--- a/packages/npm/astro/src/components/ruffle/ruffle.spec.ts
+++ b/packages/npm/astro/src/components/ruffle/ruffle.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+	mergeRuffleConfig,
+	resolveRuffleScriptUrl,
+	RUFFLE_DEFAULT_SCRIPT_URL,
+} from './ruffle';
+
+describe('ruffle cdn helpers', () => {
+	it('defaults to the Ruffle unpkg package endpoint', () => {
+		expect(resolveRuffleScriptUrl()).toBe(RUFFLE_DEFAULT_SCRIPT_URL);
+	});
+
+	it('supports pinned package versions for supported CDN presets', () => {
+		expect(
+			resolveRuffleScriptUrl({ version: '0.2.0-nightly.2025.9.6' }),
+		).toBe('https://unpkg.com/@ruffle-rs/ruffle@0.2.0-nightly.2025.9.6');
+		expect(
+			resolveRuffleScriptUrl({
+				cdn: 'jsdelivr',
+				version: '0.2.0-nightly.2025.9.6',
+			}),
+		).toBe(
+			'https://cdn.jsdelivr.net/npm/@ruffle-rs/ruffle@0.2.0-nightly.2025.9.6',
+		);
+	});
+
+	it('lets an explicit script URL override CDN settings', () => {
+		expect(
+			resolveRuffleScriptUrl({
+				cdn: 'jsdelivr',
+				version: 'nightly',
+				scriptUrl: 'https://cdn.example.com/ruffle.js',
+			}),
+		).toBe('https://cdn.example.com/ruffle.js');
+	});
+
+	it('merges local config over page config', () => {
+		expect(
+			mergeRuffleConfig(
+				{ autoplay: 'auto', splashScreen: true },
+				{ autoplay: 'on' },
+			),
+		).toEqual({ autoplay: 'on', splashScreen: true });
+	});
+});

--- a/packages/npm/astro/src/components/ruffle/ruffle.ts
+++ b/packages/npm/astro/src/components/ruffle/ruffle.ts
@@ -1,0 +1,92 @@
+export type RuffleCdn = 'unpkg' | 'jsdelivr';
+
+export type RuffleAutoplay = 'auto' | 'on' | 'off';
+
+export interface RuffleConfig {
+	autoplay?: RuffleAutoplay;
+	unmuteOverlay?: 'visible' | 'hidden';
+	splashScreen?: boolean;
+	allowScriptAccess?: boolean;
+	letterbox?: 'fullscreen' | 'on' | 'off';
+	scale?: 'showAll' | 'noBorder' | 'exactFit' | 'noScale';
+	quality?: 'low' | 'medium' | 'high' | 'best';
+	wmode?: 'window' | 'opaque' | 'transparent' | 'direct' | 'gpu';
+	base?: string | null;
+	menu?: boolean;
+	upgradeToHttps?: boolean;
+	compatibilityRules?: boolean;
+	logLevel?: 'error' | 'warn' | 'info' | 'debug' | 'trace';
+	showSwfDownload?: boolean;
+	openUrlMode?: 'allow' | 'confirm' | 'deny';
+	allowNetworking?: 'all' | 'internal' | 'none';
+	[key: string]: unknown;
+}
+
+export interface RuffleLoadOptions {
+	url: string;
+	parameters?: Record<string, string>;
+	base?: string | null;
+	allowScriptAccess?: boolean;
+	[key: string]: unknown;
+}
+
+export interface RuffleSourceOptions {
+	cdn?: RuffleCdn;
+	version?: string;
+	scriptUrl?: string;
+}
+
+export interface RufflePlayerElement extends HTMLElement {
+	ruffle: (version?: number) => {
+		load: (source: string | RuffleLoadOptions) => Promise<void>;
+	};
+	config?: RuffleLoadOptions | Record<string, unknown>;
+	load?: (source: string | RuffleLoadOptions) => Promise<void>;
+}
+
+export interface RuffleApi {
+	createPlayer: () => RufflePlayerElement;
+}
+
+export interface RufflePlayerWindow extends Window {
+	RufflePlayer?: {
+		config?: RuffleConfig;
+		newest?: () => RuffleApi;
+	};
+}
+
+export const RUFFLE_SCRIPT_ID = 'kbve-ruffle-player-script';
+export const RUFFLE_DEFAULT_CDN: RuffleCdn = 'unpkg';
+export const RUFFLE_DEFAULT_SCRIPT_URL = 'https://unpkg.com/@ruffle-rs/ruffle';
+
+const CDN_BASE_URLS: Record<RuffleCdn, string> = {
+	unpkg: 'https://unpkg.com/@ruffle-rs/ruffle',
+	jsdelivr: 'https://cdn.jsdelivr.net/npm/@ruffle-rs/ruffle',
+};
+
+export function resolveRuffleScriptUrl({
+	cdn = RUFFLE_DEFAULT_CDN,
+	version,
+	scriptUrl,
+}: RuffleSourceOptions = {}) {
+	if (scriptUrl) return scriptUrl;
+
+	const baseUrl = CDN_BASE_URLS[cdn] ?? CDN_BASE_URLS[RUFFLE_DEFAULT_CDN];
+	return version ? `${baseUrl}@${version}` : baseUrl;
+}
+
+export function mergeRuffleConfig(
+	baseConfig?: RuffleConfig,
+	overrideConfig?: RuffleConfig,
+): RuffleConfig | undefined {
+	const merged = {
+		...(baseConfig ?? {}),
+		...(overrideConfig ?? {}),
+	};
+
+	return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+export function getRuffleWindow(win: Window = window): RufflePlayerWindow {
+	return win as RufflePlayerWindow;
+}

--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -16,6 +16,28 @@ export type { ModalOverlayProps } from './react/ModalOverlay';
 export { TooltipOverlay } from './react/TooltipOverlay';
 export type { TooltipOverlayProps } from './react/TooltipOverlay';
 
+// Ruffle
+export { ReactRuffle } from './components/ruffle/ReactRuffle';
+export type { ReactRuffleProps } from './components/ruffle/ReactRuffle';
+export {
+	RUFFLE_DEFAULT_CDN,
+	RUFFLE_DEFAULT_SCRIPT_URL,
+	RUFFLE_SCRIPT_ID,
+	getRuffleWindow,
+	mergeRuffleConfig,
+	resolveRuffleScriptUrl,
+} from './components/ruffle/ruffle';
+export type {
+	RuffleApi,
+	RuffleAutoplay,
+	RuffleCdn,
+	RuffleConfig,
+	RuffleLoadOptions,
+	RufflePlayerElement,
+	RufflePlayerWindow,
+	RuffleSourceOptions,
+} from './components/ruffle/ruffle';
+
 // Auth
 export {
 	AuthBridge,


### PR DESCRIPTION
## Summary
- add Astro and React Ruffle player components backed by CDN script loading
- add shared Ruffle CDN/config helpers with tests
- expose Ruffle package subpaths and publish shims for nested component exports
- document AstroRuffle usage in the package README

## Testing
- ./kbve.sh -nx astro:test
- ./kbve.sh -nx astro:build