### PR TITLE
fix(firecracker-ctl-net): allow VM subnet on INPUT chain

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.147",
+			"version": "1.0.148",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -124,7 +124,7 @@
 		{
 			"key": "firecracker_ctl",
 			"app_name": "firecracker-ctl",
-			"version": "0.1.31",
+			"version": "0.1.32",
 			"version_toml": "apps/vm/firecracker-ctl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx",
 			"version_target": "apps/vm/firecracker-ctl/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.31"
+version: "0.1.32"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/vm/firecracker-ctl/src/tap.rs
+++ b/apps/vm/firecracker-ctl/src/tap.rs
@@ -272,6 +272,28 @@ pub fn build_forward_return_check(vm_subnet: &str, tunnel_iface: &str) -> Vec<St
     v
 }
 
+pub fn build_input_accept(vm_subnet: &str) -> Vec<String> {
+    vec![
+        "-I".into(),
+        "INPUT".into(),
+        "-s".into(),
+        vm_subnet.into(),
+        "-j".into(),
+        "ACCEPT".into(),
+    ]
+}
+
+pub fn build_input_accept_check(vm_subnet: &str) -> Vec<String> {
+    vec![
+        "-C".into(),
+        "INPUT".into(),
+        "-s".into(),
+        vm_subnet.into(),
+        "-j".into(),
+        "ACCEPT".into(),
+    ]
+}
+
 // ---------------------------------------------------------------------------
 // Execution wrappers (shell-out via tokio::process::Command)
 // ---------------------------------------------------------------------------
@@ -389,6 +411,10 @@ impl TapManager {
                 &self.config.tunnel_iface,
             ))
             .await?;
+        }
+
+        if !iptables_rule_exists(&build_input_accept_check(&self.config.vm_subnet)).await? {
+            run_iptables(&build_input_accept(&self.config.vm_subnet)).await?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

VM inside the firecracker-ctl-net deployment boots with eth0 + \`172.18.0.2\`, but every outbound packet dies before it reaches the gateway. Diagnostic script inside the guest:

\`\`\`
=== ARP table ===
(empty)

=== ping 172.18.0.1 (TAP host side) ===
2 packets transmitted, 0 packets received, 100% packet loss

=== ping 1.1.1.1 ===
2 packets transmitted, 0 packets received, 100% packet loss

=== UDP DNS to 1.1.1.1 ===
TimeoutError: timed out
\`\`\`

The guest can't even ARP its own gateway. Gluetun's INPUT chain on the pod side:

\`\`\`
Chain INPUT (policy DROP)
ACCEPT  --  lo *
ACCEPT  --  *  *   ctstate RELATED,ESTABLISHED
ACCEPT  --  eth0 *  *  10.244.0.123
ACCEPT  --  eth0 *  *  tcp dpt:9001
...
\`\`\`

No rule for the VM subnet on the TAP iface. Packets from the guest to its TAP host-side IP land in INPUT (the TAP IP is the pod's own address), default DROP, killed. No reply ARP, no ping back, no DNS.

\`utils-publish-docker-image.yml\` deploy + ArgoCD reconcile of the previous fixes left this gap because Gluetun's firewall init runs before \`TapManager::init()\` and locks the policy.

## Fix

Extend \`TapManager::init()\` with a fourth idempotent rule:

\`\`\`
iptables -I INPUT -s 172.18.0.0/16 -j ACCEPT
\`\`\`

\`-I\` (insert at top) so it pre-empts the default DROP. Source-based match keeps it tight to VM subnet only — non-VM traffic continues to hit the default policy. Idempotent via the existing rule-present check.

## Test plan

- [ ] Publish lands \`ghcr.io/kbve/firecracker-ctl:0.1.32\`.
- [ ] Atom PR bumps both deployment yamls.
- [ ] After ArgoCD reconciles, \`iptables -L INPUT -n -v\` shows an ACCEPT rule for 172.18.0.0/16 above the default DROP policy.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.
- [ ] ping 172.18.0.1 and ping 1.1.1.1 from inside the VM both succeed.